### PR TITLE
fix(codex): permit session deletion of predecessor retired tombstones (#144179)

### DIFF
--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -178,6 +178,86 @@ describe("Codex app-server binding store", () => {
     }
   });
 
+  it("removes retired fences from predecessor generations during session deletion (#144179)", async () => {
+    const { state, values } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const predecessor = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "predecessor-uuid-1",
+      sessionKey: "agent:main:cron:rotated",
+    };
+    await store.mutate(predecessor, {
+      kind: "set",
+      binding: { threadId: "thread-1", cwd: "/repo" },
+    });
+    await store.retireSessionGeneration(predecessor);
+    expect(values.get(bindingStoreKey(predecessor))).toMatchObject({
+      state: "cleared",
+      retired: true,
+      sessionId: "predecessor-uuid-1",
+    });
+
+    const successor = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "successor-uuid-2",
+      sessionKey: "agent:main:cron:rotated",
+    };
+
+    // Deletion under successor identity successfully removes the retired tombstone of predecessor
+    await store.withSessionDeletion(
+      successor,
+      () => {},
+      async (binding, mutation) => {
+        expect(binding).toBeUndefined();
+        mutation.commit();
+      },
+    );
+    expect(values.size).toBe(0);
+
+    // Rollback properly restores the retired tombstone
+    const tombstone = {
+      version: 1 as const,
+      state: "cleared" as const,
+      retired: true as const,
+      sessionId: "predecessor-uuid-1",
+    };
+    state.register(bindingStoreKey(successor), tombstone);
+    await store.withSessionDeletion(
+      successor,
+      () => {},
+      async (_binding, mutation) => {
+        mutation.commit();
+        expect(values.size).toBe(0);
+        mutation.rollback();
+      },
+    );
+    expect(values.get(bindingStoreKey(successor))).toMatchObject({
+      state: "cleared",
+      retired: true,
+      sessionId: "predecessor-uuid-1",
+    });
+
+    // An active successor belonging to a different session is still protected and rejected
+    const activeDifferentGeneration = {
+      version: 1 as const,
+      state: "active" as const,
+      sessionId: "other-session-uuid",
+      binding: { threadId: "active-thread", cwd: "/repo" },
+    };
+    state.register(bindingStoreKey(successor), activeDifferentGeneration);
+    await expect(
+      store.withSessionDeletion(
+        successor,
+        () => {},
+        async (_binding, mutation) => {
+          mutation.commit();
+        },
+      ),
+    ).rejects.toThrow("Codex binding generation changed before session deletion");
+  });
+
   it("rejects revoked deletion authority and never restores over a successor", async () => {
     const { state, values } = createStateStore();
     const store = createCodexAppServerBindingStore(state);

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -1109,7 +1109,12 @@ export function createCodexAppServerBindingStore(
             const owner = leaseContext.getStore()!.get(key)!;
             const expected = state.lookup(key);
             const stored = readStoredCodexAppServerBinding(expected);
-            if (!stored || !ownsStoredSessionGeneration(identity, stored)) {
+            const isRetiredGenerationTombstone =
+              stored?.state === "cleared" && stored.retired === true;
+            if (
+              !stored ||
+              (!ownsStoredSessionGeneration(identity, stored) && !isRetiredGenerationTombstone)
+            ) {
               throw new Error("Codex binding generation changed before session deletion");
             }
             const { lease: _lease, ...expectedValue } = stored;


### PR DESCRIPTION
## What Problem This Solves

Fixes #144179

A session key whose `app-server-thread-bindings` row in `plugin_state_entries` carries a cleared, retired tombstone (`{"version":1,"state":"cleared","sessionId":"<OLD>","retired":true}`) permanently vetoes `openclaw sessions delete` when the session has rotated or moved to a non-Codex runtime:

```text
Error: Codex binding generation changed before session deletion
```

On non-Codex sessions, nothing ever reaches the turn-path reclaim (`reclaimCurrentCodexSessionGeneration`), leaving the stale tombstone in place indefinitely and permanently blocking deletion of the session.

In `createCodexAppServerBindingStore.withSessionDeletion`:
- Line 1171 already acquires the binding lease with `{ allowRetired: true }`.
- However, line 1112 previously rejected any `sessionId` mismatch unconditionally via `ownsStoredSessionGeneration(identity, stored)`.
- When the stored row is a cleared, retired tombstone (`stored.state === "cleared" && stored.retired === true`), it contains no live app-server thread or active execution authority. It must not block deletion of a successor generation for that session key.
- Active bindings (`stored.state === "active"`) continue to strictly enforce `ownsStoredSessionGeneration` so active threads belonging to other generations remain protected.

## Evidence

### Unit & Regression Suite Execution
Ran focused regression in `extensions/codex/src/app-server/session-binding.test.ts`:
```text
✓ extension-codex extensions/codex/src/app-server/session-binding.test.ts > Codex app-server binding store > removes retired fences from predecessor generations during session deletion (#144179) 6ms
```

### Static Analysis
```text
npx oxlint extensions/codex/src/app-server/session-binding.ts extensions/codex/src/app-server/session-binding.test.ts
Found 0 warnings and 0 errors.
Finished in 1.0s on 2 files with 230 rules using 12 threads.
```

### Whitespace & Git Check
```text
git diff --check
(clean, 0 warnings)
```
