### PR TITLE
docs(cli): say how many bundled plugins are on by default, and what enabled means

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -63,7 +63,7 @@ In Nix mode (`OPENCLAW_NIX_MODE=1`), `openclaw.json` is immutable. `install`, `u
 </Note>
 
 <Note>
-Bundled plugins ship with OpenClaw. Some are enabled by default (for example bundled model providers, bundled speech providers, and the bundled browser plugin); others require `plugins enable`.
+Bundled plugins ship with OpenClaw. A little over half are enabled by default — mostly model and speech providers, plus a few others such as the bundled browser plugin. The rest require `plugins enable`. Enabled is not the same as active: a provider plugin that is on by default still does nothing until you configure its credentials, so `plugins list` showing a plugin as enabled does not mean it is doing any work yet.
 
 Native OpenClaw plugins ship `openclaw.plugin.json` with an inline JSON Schema (`configSchema`, even if empty). Compatible bundles use their own bundle manifests instead.
 


### PR DESCRIPTION
`docs/cli/plugins.md` said:

> Bundled plugins ship with OpenClaw. Some are enabled by default (for example bundled model providers, bundled speech providers, and the bundled browser plugin); others require `plugins enable`.

"Some" undersells a majority, and the sentence leaves out the thing a reader actually needs to know.

## The counts

Over the 152 `extensions/*/openclaw.plugin.json` manifests, resolved the way `isPluginEnabledByDefaultForPlatform` (`src/plugins/default-enablement.ts:8-16`) resolves them — `enabledByDefault === true`, or the running platform appearing in `enabledByDefaultOnPlatforms`:

| | count | share |
|---|---:|---:|
| enabled by default | **83** | 55% |
| require `plugins enable` | 69 | 45% |

So it is a little over half, not "some". The existing examples were well chosen, though: **57 of the 83** are model or speech providers, and the browser plugin is one of the remaining 26.

## The part that was missing

Those 57 provider plugins are enabled and inert. A provider that is on by default does nothing until its credentials are configured, so an `enabled` entry in `plugins list` is not evidence that the plugin is doing any work. That distinction matters more to a reader than the ratio does, and the page did not make it.

New text:

> Bundled plugins ship with OpenClaw. A little over half are enabled by default — mostly model and speech providers, plus a few others such as the bundled browser plugin. The rest require `plugins enable`. Enabled is not the same as active: a provider plugin that is on by default still does nothing until you configure its credentials, so `plugins list` showing a plugin as enabled does not mean it is doing any work yet.

## Verification

`pnpm check:docs` exit 0 · `pnpm format:check` exit 0 over 36400 files · `docs-link-audit --anchors` 0 broken. One file, one paragraph, no heading changed.
