### PR TITLE
fix(ui): keep the model picker open across pane updates

### DIFF
--- a/ui/src/e2e/chat-composer-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-catalog.e2e.test.ts
@@ -687,6 +687,12 @@ suite.define(() => {
   it("reads a newer account catalog on reopen without a cooldown or provider discovery", async () => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
       const existing = { id: "existing", name: "Existing", provider: "example", available: true };
+      const firstOpen = {
+        id: "first-open",
+        name: "First open",
+        provider: "example",
+        available: true,
+      };
       const published = {
         id: "published",
         name: "Published",
@@ -702,17 +708,71 @@ suite.define(() => {
       await expect
         .poll(() => composer.locator('[data-chat-model-option="example/existing"]').count())
         .toBe(1);
+      const picker = composer.locator("details.chat-controls__model-picker");
       const trigger = composer.locator('[data-chat-model-select="true"]');
+      await gateway.setMethodResponse("models.list", { models: [existing, firstOpen] });
       await trigger.click();
-      await gateway.waitForRequest("models.list", { after: 1 });
-      await trigger.click();
-      await gateway.setMethodResponse("models.list", { models: [existing, published] });
+      await expect
+        .poll(() => composer.locator('[data-chat-model-option="example/first-open"]').isVisible())
+        .toBe(true);
+      await gateway.setMethodResponse("models.list", { models: [existing, firstOpen, published] });
       const previousRequestCount = (await gateway.getRequests("models.list")).length;
-      await trigger.click();
+
+      const reopened = await picker.evaluate(async (details: HTMLDetailsElement) => {
+        const pane = details.closest<
+          HTMLElement & { requestUpdate(): void; updateComplete: Promise<boolean> }
+        >("openclaw-chat-pane");
+        const summary = details.querySelector<HTMLElement>(":scope > summary");
+        if (!pane || !summary) {
+          throw new Error("Expected the native picker and its chat pane");
+        }
+        if (document.visibilityState !== "visible") {
+          throw new Error("Expected a visible document before native picker activation");
+        }
+        await pane.updateComplete;
+        if (!details.open || !details.isConnected) {
+          throw new Error("Expected the first-open catalog to remain rendered");
+        }
+        const listeners = new Set<() => void>();
+        const nextToggle = () =>
+          new Promise<void>((resolve) => {
+            const listener = () => {
+              listeners.delete(listener);
+              resolve();
+            };
+            listeners.add(listener);
+            details.addEventListener("toggle", listener, { once: true });
+          });
+        try {
+          const closed = nextToggle();
+          summary.click();
+          if (details.open) {
+            throw new Error("Expected native close activation to close the picker");
+          }
+          await closed;
+          const opened = nextToggle();
+          summary.click();
+          if (!details.open) {
+            throw new Error("Expected native reopen activation to open the picker");
+          }
+          // A normal render must not overwrite a newer native open before its queued toggle.
+          pane.requestUpdate();
+          await pane.updateComplete;
+          await opened;
+          return { open: details.open, connected: details.isConnected };
+        } finally {
+          for (const listener of listeners) {
+            details.removeEventListener("toggle", listener);
+          }
+        }
+      });
+
+      expect(reopened).toEqual({ open: true, connected: true });
       await gateway.waitForRequest("models.list", { after: previousRequestCount });
       await expect
         .poll(() => composer.locator('[data-chat-model-option="example/published"]').isVisible())
         .toBe(true);
+      expect(await gateway.getRequests("models.list")).toHaveLength(previousRequestCount + 1);
       for (const request of await gateway.getRequests("models.list")) {
         expect(request.params).toMatchObject({
           view: "configured",

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -221,6 +221,8 @@ export function renderChatPaneComposerControls(params: {
           onModelPickerOpen: () => refreshChatModelCatalogOnDemand(state),
           onModelPickerOpenChange: (open) => {
             state.chatModelPickerOpenSessionKey = open ? state.sessionKey : null;
+            // Closing also needs a render; catalog refresh only invalidates on open.
+            state.requestUpdate?.();
           },
           onModelSelect: (next, targetSessionKey) =>
             modelAccess.allowed


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reopening the chat model picker could immediately close it again and leave newly available models out of view during a concurrent UI update.

## Why This Change Was Made

The picker records native open/close events in non-reactive pane state. Closing did not request a render, so Lit could retain the previous committed open value and later overwrite a native reopen before its queued toggle refreshed the catalog.

Invalidate through the existing pane render owner on both transitions. This adds one executable line and one invariant comment (**production +2/-0**), without changing catalog scope, discovery policy, configuration, or persistence. Extend the existing reopen case rather than adding a parallel harness (**tests +64/-4**).

## User Impact

The picker stays open through this update ordering and displays the newly fetched configured catalog, without reloading the page, adding a cooldown, or forcing provider discovery.

## Evidence

- The permanent regression itself failed on the original owner and passed with the one-line fix. It uses native summary clicks and real toggle events, a visible first-open catalog marker, a normal public pane update, and an exact one-new-request assertion.
- Main-base validation on `639d93071c3b`: 331 tests across five focused files passed; normal `pnpm ui:build` passed; fresh Linux Node 24.19.0, Playwright 1.62.1, and system Chromium 144.0.7559.0 ran the complete 11-case catalog file successfully. [Browser proof run](https://github.com/openclaw/openclaw/actions/runs/34517494373).
- The first changed gate caught four missing-brace lint errors in the test. The correction is exactly four brace-only bodies, verified by exact replacement and normalized TypeScript control-flow comparison. Targeted oxlint/stylelint passed; the browser was not rerun for that mechanical change.
- All 20 normal configured changed checks then passed on tree `316d4bdf3a28`, preserved by signed commit `390778f99332`. [Changed-check proof run](https://github.com/openclaw/openclaw/actions/runs/34524517513). Source/dependency fences and owned cleanup were verified. These links identify native Testbox proof; its one-shot holder may show cancelled after successful cleanup and is not PR-head hosted CI.
- Fresh precommit and separate exact-commit P2 reviews are scoped-clean; the exact review covered signed commit `390778f99332`.

The screenshots below are a separate, deliberately scheduled controlled reproduction on original CI merge base `42da952e4c6`: original owner before, one-line invalidation after. They are not captures of the current commit or proof of the historical CI event schedule. The `639d93071c3b` main-base full 11-case validation is recorded separately above.

**Before — controlled reproduction at 42da with original owner:** an ordinary pane render closes the reopened picker.

![Before: controlled reproduction at 42da with original owner, reopened picker closes](https://github.com/user-attachments/assets/db2bf581-94f8-4f78-ac8b-7e10cce270b8)

**After — the same controlled reproduction at 42da with one-line owner invalidation:** the picker remains open and displays the new “Reopened marker” row.

![After: controlled reproduction at 42da with one-line owner invalidation, picker stays open with refreshed row](https://github.com/user-attachments/assets/dd32f68a-6757-4283-a704-7fc95497c8fa)

Proof is scoped to the connected, visible pane and covered native-render ordering—not every race, hidden-page or pointer behavior, real Gateway delivery, or continuous video. Existing warning-only temp-directory notices outside this two-file patch remain in the retained gate log.
