### PR TITLE
docs: fix repeated wording in personal account labels

### DIFF
--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -96,7 +96,7 @@ The page reports the exact sign-in operation as pending, connected, cancelled, e
 
 Open the model menu in **New session** or an existing chat. Use **Account for this chat** to choose one of your saved accounts for the selected provider. The account picker remains available when **Automatic** has no eligible models. In New session, choosing an account previews eligible models before your first message. The selection applies to the session you create and can also be used for [draft-title preparation](/web/control-ui/sessions-and-sidebar#new-session-names) before you press Start. It does not change your new-chat default or saved model preference. Changing accounts discards the old title suggestion. In an existing chat, it changes that chat's selection.
 
-The account control shows a person a person-level label for someone else's personal account, not its private email, provider account label, or account id. The label describes the selection, not a billing receipt: configured shared failover accounts can still be used.
+The account control shows a person-level label for someone else's personal account, not its private email, provider account label, or account id. The label describes the selection, not a billing receipt: configured shared failover accounts can still be used.
 
 Chat status and model listings identify a selected personal credential as **personal account**, without exposing its private label, email, or account id.
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of [Multi-user](https://docs.openclaw.ai/concepts/multi-user) read a repeated phrase in the description of personal account labels.

## Why This Change Was Made

Remove the extra “a person” from “a person a person-level label.”

## User Impact

Readers get a grammatical description of the existing account label behavior.

## Evidence

`node scripts/check-docs-mdx.mjs docs/concepts/multi-user.md` and `git diff --check origin/main...HEAD` passed. The changed source was rechecked after rebasing.

Before and after use the real `openclaw/docs` publisher in a local seven-page preview. These are focused rendering checks, not a deployed change or a full site build. The after source matches this PR's head.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/d12534f2-ff27-4d76-acd9-2e7fe5be67df) | ![After](https://github.com/user-attachments/assets/c742194b-e883-44f2-989e-6e23acebdf77) |
