### PR TITLE
docs: remove repeated Docker plugin test summary

### DIFF
--- a/docs/help/testing/docker.md
+++ b/docs/help/testing/docker.md
@@ -65,7 +65,6 @@ without mutating the host auth store:
 - Plugin update unchanged smoke: `pnpm test:docker:plugin-update` (script: `scripts/e2e/plugin-update-unchanged-docker.sh`)
 - Plugin lifecycle matrix smoke: `pnpm test:docker:plugin-lifecycle-matrix` installs the packed OpenClaw tarball in a bare container, installs an npm plugin, toggles enable/disable, upgrades and downgrades it through a local npm registry, deletes the installed code, then verifies uninstall still removes stale state while logging RSS/CPU metrics for each lifecycle phase.
 - Config reload metadata smoke: `pnpm test:docker:config-reload` (script: `scripts/e2e/config-reload-source-docker.sh`)
-- Plugins: `pnpm test:docker:plugins` covers install/update smoke for local path, `file:`, npm registry with hoisted dependencies, git moving refs, ClawHub fixtures, marketplace updates, and Claude-bundle enable/inspect. `pnpm test:docker:plugin-update` covers unchanged update behavior for installed plugins. `pnpm test:docker:plugin-lifecycle-matrix` covers resource-tracked npm plugin install, enable, disable, upgrade, downgrade, and missing-code uninstall.
 
 To prebuild and reuse the shared functional image manually:
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of [Docker testing](https://docs.openclaw.ai/help/testing/docker) encounter a second summary of the same three plugin test lanes.

## Why This Change Was Made

Remove the final Plugins bullet. The existing detailed bullets retain all three commands, coverage, and environment settings.

## User Impact

Readers can scan each plugin test lane once.

## Evidence

`node scripts/check-docs-mdx.mjs docs/help/testing/docker.md` and `git diff --check origin/main...HEAD` passed. The changed source was rechecked after rebasing.

Before and after use the real `openclaw/docs` publisher in a local seven-page preview. These are focused rendering checks, not a deployed change or a full site build. The after source matches this PR's head.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/8f96949f-a821-4847-9d1e-e036fec96a02) | ![After](https://github.com/user-attachments/assets/d7c48411-8c98-42e3-a9b7-957b43d59807) |
