### PR TITLE
docs: remove duplicate secret placeholder guidance

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -19,7 +19,6 @@ This directory owns docs authoring, published link rules, and docs i18n policy.
 - README and other GitHub-rendered docs should keep absolute docs URLs so links work outside the docs site.
 - Docs content must stay generic: no personal device names, hostnames, or local paths. Use placeholders like `user@gateway-host` and `~/path/to/skills`.
 - For tokens, API keys, and credential snippets, follow [Secret Placeholder Conventions](/reference/secret-placeholder-conventions). Keep example values obviously fake so secret scanners stay quiet.
-- For tokens, API keys, and credential snippets, follow [Secret Placeholder Conventions](/reference/secret-placeholder-conventions). Keep example values obviously fake so secret scanners stay quiet.
 
 ## Docs Content Rules
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of [Docs authoring guide](https://docs.openclaw.ai/CLAUDE) see the same secret-placeholder instruction twice in consecutive bullets.

## Why This Change Was Made

Remove one identical bullet in the canonical docs/AGENTS.md. Its CLAUDE.md symlink continues to use the same source.

## User Impact

Contributors receive the same guidance once, with the original reference link intact.

## Evidence

`node scripts/check-docs-mdx.mjs docs/AGENTS.md` and `git diff --check origin/main...HEAD` passed. The changed source was rechecked after rebasing.

Before and after use the real `openclaw/docs` publisher in a local seven-page preview. These are focused rendering checks, not a deployed change or a full site build. The after source matches this PR's head.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/4e18ba05-66e4-47e7-8d93-b9d8bae91ad1) | ![After](https://github.com/user-attachments/assets/f50d0677-ff47-4a9e-8bb9-6eeea0e75ed9) |
