### PR TITLE
docs: remove repeated MCP Apps introduction

### DIFF
--- a/docs/cli/mcp/apps.md
+++ b/docs/cli/mcp/apps.md
@@ -6,9 +6,6 @@ read_when:
   - Reviewing the sandbox origin, listener port, and security boundaries for Apps
 ---
 
-OpenClaw can render tools that implement the MCP Apps extension. Apps are
-opt-in because their HTML comes from the configured MCP server.
-
 ## MCP Apps
 
 OpenClaw can render tools that implement the stable [MCP Apps extension](https://modelcontextprotocol.io/extensions/apps). Apps are opt-in because their HTML comes from the configured MCP server. A view with current App-interaction authority can request app-visible tools and resources from that same server.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of [MCP Apps](https://docs.openclaw.ai/cli/mcp/apps) read the introductory explanation twice before reaching setup.

## Why This Change Was Made

Remove the short opening paragraph and retain the fuller paragraph under MCP Apps, including its specification link and interaction-authority detail. Preserve the heading and anchor.

## User Impact

Readers reach the setup instructions without rereading the introduction.

## Evidence

`node scripts/check-docs-mdx.mjs docs/cli/mcp/apps.md` and `git diff --check origin/main...HEAD` passed. The changed source was rechecked after rebasing.

Before and after use the real `openclaw/docs` publisher in a local seven-page preview. These are focused rendering checks, not a deployed change or a full site build. The after source matches this PR's head.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/e9be063a-9cf8-49ae-96aa-a9c21b75bd3d) | ![After](https://github.com/user-attachments/assets/7614c46e-da95-4d50-96cd-41fd5871c67e) |
