### PR TITLE
docs: remove duplicate message prefix migration row

### DIFF
--- a/docs/gateway/doctor/config-migrations.md
+++ b/docs/gateway/doctor/config-migrations.md
@@ -133,7 +133,6 @@ beyond the grace period.
     | `gateway.controlUi.chatMessageMaxWidth`, presentation-only `ui.prefs` keys                       | removed (text scale, chat width, and live sidebar activity are browser-local) |
     | `agents.list`                                                                                    | keyed `agents.entries`                                                        |
     | top-level `defaultModel`                                                                         | `agents.defaults.model`                                                      |
-    | `messages.messagePrefix`                                                                         | `channels.whatsapp.responsePrefix`                                            |
     | `session.maintenance.pruneDays`, `session.resetByType.dm`                                        | `session.maintenance.pruneAfter`, `session.resetByType.direct`               |
     | top-level `tui`                                                                                  | removed (the TUI footer uses the compact default)                            |
     | `plugins.entries.codex.config.codexDynamicToolsProfile`                                          | removed (Codex app-server always keeps Codex-native workspace tools native) |


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of [Config migrations](https://docs.openclaw.ai/gateway/doctor/config-migrations) find the same message-prefix migration listed twice in the reference table.

## Why This Change Was Made

Remove the standalone messages.messagePrefix row. The combined row still explicitly maps that legacy key and channels.whatsapp.messagePrefix to channels.whatsapp.responsePrefix.

## User Impact

The table lists the mapping once and retains both source keys and the destination.

## Evidence

`node scripts/check-docs-mdx.mjs docs/gateway/doctor/config-migrations.md` and `git diff --check origin/main...HEAD` passed. The changed source was rechecked after rebasing.

Before and after use the real `openclaw/docs` publisher in a local seven-page preview. These are focused rendering checks, not a deployed change or a full site build. The after source matches this PR's head.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/c50fdb72-1175-4190-ad0d-a2c1ac864c63) | ![After](https://github.com/user-attachments/assets/3235e6e4-34c4-4dcf-9e93-43f5b0c8278e) |
