### PR TITLE
docs: correct token rate units in Prometheus example

### DIFF
--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -304,7 +304,7 @@ histogram_quantile(
   sum by (le, method) (rate(openclaw_gateway_rpc_queue_wait_seconds_bucket[5m]))
 )
 
-# Tokens per minute, split by provider
+# Tokens per second, split by provider
 sum by (provider) (rate(openclaw_model_tokens_total[1m]))
 
 # Spend (USD) over the last hour, by model


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of [Prometheus](https://docs.openclaw.ai/gateway/prometheus) see a token-rate expression labeled per minute even though it returns a per-second rate.

## Why This Change Was Made

Change the comment to “Tokens per second, split by provider.” Keep the query and its one-minute averaging window unchanged. [Prometheus documents rate() as per-second](https://prometheus.io/docs/prometheus/3.5/querying/functions/#rate).

## User Impact

Operators can interpret the token-rate query using the correct unit.

## Evidence

`node scripts/check-docs-mdx.mjs docs/gateway/prometheus.md` and `git diff --check origin/main...HEAD` passed. The changed source was rechecked after rebasing.

Before and after use the real `openclaw/docs` publisher in a local seven-page preview. These are focused rendering checks, not a deployed change or a full site build. The after source matches this PR's head.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/471ca1d0-70f9-4411-8a02-639fe8e4006b) | ![After](https://github.com/user-attachments/assets/70922852-0e23-4b43-9857-736482bae56b) |
