### PR TITLE
fix(release): set up Node before frozen admission

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -276,6 +276,14 @@ jobs:
           persist-credentials: false
           submodules: false
 
+      - name: Setup admission Node.js
+        env:
+          REQUESTED_NODE_VERSION: "24.x"
+        run: |
+          set -euo pipefail
+          source workflow/.github/actions/setup-pnpm-store-cache/ensure-node.sh
+          openclaw_ensure_node "$REQUESTED_NODE_VERSION"
+
       - name: Resolve trusted workflow identity
         id: tooling_identity
         env:

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -651,6 +651,14 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Setup admission Node.js
+        env:
+          REQUESTED_NODE_VERSION: "24.x"
+        run: |
+          set -euo pipefail
+          source .release-harness/.github/actions/setup-pnpm-store-cache/ensure-node.sh
+          openclaw_ensure_node "$REQUESTED_NODE_VERSION"
+
       - name: Validate selected ref
         id: validate
         env:
@@ -1107,6 +1115,14 @@ jobs:
           repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
           ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
+
+      - name: Setup admission Node.js
+        env:
+          REQUESTED_NODE_VERSION: "24.x"
+        run: |
+          set -euo pipefail
+          source .github/actions/setup-pnpm-store-cache/ensure-node.sh
+          openclaw_ensure_node "$REQUESTED_NODE_VERSION"
 
       - name: Checkout selected live plugin metadata
         if: inputs.include_live_suites

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -312,6 +312,14 @@ jobs:
           path: workflow
           fetch-depth: 1
 
+      - name: Setup admission Node.js
+        env:
+          REQUESTED_NODE_VERSION: "24.x"
+        run: |
+          set -euo pipefail
+          source workflow/.github/actions/setup-pnpm-store-cache/ensure-node.sh
+          openclaw_ensure_node "$REQUESTED_NODE_VERSION"
+
       - name: Fast-resolve selected ref
         id: fast_ref
         env:

--- a/test/scripts/full-release-validation-continuation-workflow.test.ts
+++ b/test/scripts/full-release-validation-continuation-workflow.test.ts
@@ -45,6 +45,16 @@ function checkoutPath(checkout: Record<string, unknown>) {
 }
 
 describe("full release metadata checkouts", () => {
+  it("selects frozen admission with a Node runtime that supports trusted TypeScript modules", () => {
+    const steps = workflow.jobs.resolve_target!.steps;
+    const setup = step("resolve_target", "Setup admission Node.js");
+    const plan = step("resolve_target", "Plan frozen source admission");
+
+    expect(steps.indexOf(setup)).toBeLessThan(steps.indexOf(plan));
+    expect(setup.env).toMatchObject({ REQUESTED_NODE_VERSION: "24.x" });
+    expect(String(setup.run)).toContain("openclaw_ensure_node");
+  });
+
   it.each([
     {
       job: "resolve_target",

--- a/test/scripts/full-release-validation-continuation-workflow.test.ts
+++ b/test/scripts/full-release-validation-continuation-workflow.test.ts
@@ -45,16 +45,6 @@ function checkoutPath(checkout: Record<string, unknown>) {
 }
 
 describe("full release metadata checkouts", () => {
-  it("selects frozen admission with a Node runtime that supports trusted TypeScript modules", () => {
-    const steps = workflow.jobs.resolve_target!.steps;
-    const setup = step("resolve_target", "Setup admission Node.js");
-    const plan = step("resolve_target", "Plan frozen source admission");
-
-    expect(steps.indexOf(setup)).toBeLessThan(steps.indexOf(plan));
-    expect(setup.env).toMatchObject({ REQUESTED_NODE_VERSION: "24.x" });
-    expect(String(setup.run)).toContain("openclaw_ensure_node");
-  });
-
   it.each([
     {
       job: "resolve_target",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2293,48 +2293,69 @@ describe("frozen admission workflow barriers", () => {
   });
 
   it.each([
-    [FULL_RELEASE_VALIDATION_WORKFLOW, "resolve_target"],
-    [RELEASE_CHECKS_WORKFLOW, "resolve_target"],
-    [LIVE_E2E_WORKFLOW, "validate_selected_ref"],
-  ])("fails the selected trusted parser prerequisite before admission in %s", (file, jobName) => {
-    const job = workflowJob(file, jobName);
-    const steps = job.steps ?? [];
-    const plan = workflowStep(job, "Plan frozen source admission");
-    const provision = workflowStep(job, "Provision trusted admission parser");
-    const admission = workflowStep(job, "Admit frozen source contracts");
-    expect(steps.indexOf(plan)).toBeLessThan(steps.indexOf(provision));
-    expect(steps.indexOf(provision)).toBeLessThan(steps.indexOf(admission));
-    expect(provision.if).toBe("steps.frozen_selection.outputs.parser_required == 'true'");
-    let install = provision.run;
-    if (provision.uses) {
-      expect(provision.uses).toBe("./.release-harness/.github/actions/setup-release-harness");
-      const action = parse(readFileSync(SETUP_RELEASE_HARNESS_ACTION, "utf8")) as {
-        runs: { steps: WorkflowStep[] };
-      };
-      install = action.runs.steps.find((step) => step.run?.includes("pnpm install"))?.run;
-    } else {
-      expect(provision["working-directory"]).toBe("workflow");
-      expect(workflowStep(job, "Setup trusted admission package manager").with).toMatchObject({
-        "package-manager-file": "workflow/package.json",
-        "lockfile-path": "workflow/pnpm-lock.yaml",
-        "cache-mode": "off",
-      });
-    }
-    expect(install).toContain("pnpm install --frozen-lockfile --prefer-offline --ignore-scripts");
-    const root = tempDirs.make("frozen-parser-prerequisite-");
-    writeFileSync(join(root, "pnpm"), "#!/bin/sh\nexit 79\n", { mode: 0o755 });
-    const result = spawnSync(
-      "bash",
-      ["-c", `set -euo pipefail\n${install}\nprintf 'producer-ran\\n'`],
-      {
-        cwd: root,
-        encoding: "utf8",
-        env: { PATH: `${root}:${process.env.PATH}` },
-      },
-    );
-    expect(result.status).toBe(79);
-    expect(result.stdout).not.toContain("producer-ran");
-  });
+    [
+      FULL_RELEASE_VALIDATION_WORKFLOW,
+      "resolve_target",
+      "Plan frozen source admission",
+      "workflow",
+    ],
+    [RELEASE_CHECKS_WORKFLOW, "resolve_target", "Capture selected inputs", "workflow"],
+    [
+      LIVE_E2E_WORKFLOW,
+      "validate_selected_ref",
+      "Plan frozen source admission",
+      ".release-harness",
+    ],
+  ])(
+    "initializes Node before planning and fails selected parser installation in %s",
+    (file, jobName, firstPlan, toolingRoot) => {
+      const job = workflowJob(file, jobName);
+      const steps = job.steps ?? [];
+      const setup = workflowStep(job, "Setup admission Node.js");
+      expect(setup.if).toBeUndefined();
+      expect(setup.env).toMatchObject({ REQUESTED_NODE_VERSION: "24.x" });
+      expect(setup.run).toContain(
+        `source ${toolingRoot}/.github/actions/setup-pnpm-store-cache/ensure-node.sh`,
+      );
+      expect(setup.run).toContain('openclaw_ensure_node "$REQUESTED_NODE_VERSION"');
+      expect(steps.indexOf(setup)).toBeLessThan(steps.indexOf(workflowStep(job, firstPlan)));
+      const plan = workflowStep(job, "Plan frozen source admission");
+      const provision = workflowStep(job, "Provision trusted admission parser");
+      const admission = workflowStep(job, "Admit frozen source contracts");
+      expect(steps.indexOf(plan)).toBeLessThan(steps.indexOf(provision));
+      expect(steps.indexOf(provision)).toBeLessThan(steps.indexOf(admission));
+      expect(provision.if).toBe("steps.frozen_selection.outputs.parser_required == 'true'");
+      let install = provision.run;
+      if (provision.uses) {
+        expect(provision.uses).toBe("./.release-harness/.github/actions/setup-release-harness");
+        const action = parse(readFileSync(SETUP_RELEASE_HARNESS_ACTION, "utf8")) as {
+          runs: { steps: WorkflowStep[] };
+        };
+        install = action.runs.steps.find((step) => step.run?.includes("pnpm install"))?.run;
+      } else {
+        expect(provision["working-directory"]).toBe("workflow");
+        expect(workflowStep(job, "Setup trusted admission package manager").with).toMatchObject({
+          "package-manager-file": "workflow/package.json",
+          "lockfile-path": "workflow/pnpm-lock.yaml",
+          "cache-mode": "off",
+        });
+      }
+      expect(install).toContain("pnpm install --frozen-lockfile --prefer-offline --ignore-scripts");
+      const root = tempDirs.make("frozen-parser-prerequisite-");
+      writeFileSync(join(root, "pnpm"), "#!/bin/sh\nexit 79\n", { mode: 0o755 });
+      const result = spawnSync(
+        "bash",
+        ["-c", `set -euo pipefail\n${install}\nprintf 'producer-ran\\n'`],
+        {
+          cwd: root,
+          encoding: "utf8",
+          env: { PATH: `${root}:${process.env.PATH}` },
+        },
+      );
+      expect(result.status).toBe(79);
+      expect(result.stdout).not.toContain("producer-ran");
+    },
+  );
 
   it.each(["June", "July"])(
     "runs the actual %s workflow request and shared parser before producers",

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -485,12 +485,20 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
       SELECTED_SHA: "a".repeat(40),
       SHARED_IMAGE_POLICY: "no-push-artifact",
     };
+    const steps = requiredJob(definition, "plan_release_workflow_matrices").steps;
+    const setup = expectDefined(
+      steps.find((entry) => entry.name === "Setup admission Node.js"),
+      "matrix planner Node setup",
+    );
+    expect(setup.if).toBeUndefined();
+    expect(setup.env).toMatchObject({ REQUESTED_NODE_VERSION: "24.x" });
+    expect(setup.run).toContain("source .github/actions/setup-pnpm-store-cache/ensure-node.sh");
+    expect(setup.run).toContain('openclaw_ensure_node "$REQUESTED_NODE_VERSION"');
     const planner = expectDefined(
-      requiredJob(definition, "plan_release_workflow_matrices").steps.find(
-        (entry) => entry.name === "Plan shared live image plugins",
-      ),
+      steps.find((entry) => entry.name === "Plan shared live image plugins"),
       "live image planner step",
     );
+    expect(steps.indexOf(setup)).toBeLessThan(steps.indexOf(planner));
     const planned = spawnSync("bash", ["-c", expectDefined(planner.run, "planner command")], {
       cwd: outputDir,
       encoding: "utf8",


### PR DESCRIPTION
## Summary

- install the workflow's pinned Node 24 runtime before frozen-source admission planning
- keep admission dependency provisioning conditional on the planner result
- assert the runtime setup precedes every trusted `.mts` planner import

## Root cause

Full Validation run 34528034349 failed in `Resolve target ref` before child dispatch. The runner's ambient Node rejected `scripts/lib/docker-e2e-plan.mts` with `ERR_UNKNOWN_FILE_EXTENSION`; the workflow did not install its declared Node 24 runtime until later jobs.

## Validation

- `pnpm test test/scripts/full-release-validation-continuation-workflow.test.ts -- --reporter=verbose` (13/13)
- `pnpm check:test-types`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`
