### PR TITLE
feat(ui): compact the Mentions footer and surface Inbox settings

### DIFF
--- a/ui/src/components/sidebar-attention-layout.browser.test.ts
+++ b/ui/src/components/sidebar-attention-layout.browser.test.ts
@@ -457,10 +457,12 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
       <section class="sidebar-issues-panel">
         <div class="sidebar-issues-panel__grabber"></div>
         <header class="sidebar-issues-panel__header">
-          <button class="sidebar-issues-panel__dismiss-shown" type="button">Dismiss shown</button>
-          <button class="sidebar-brand__icon sidebar-issues-panel__mobile-close" type="button">
-            Close
-          </button>
+          <div class="sidebar-issues-panel__header-actions">
+            <button class="sidebar-issues-panel__dismiss-shown" type="button">Dismiss shown</button>
+            <button class="sidebar-brand__icon sidebar-issues-panel__mobile-close" type="button">
+              Close
+            </button>
+          </div>
         </header>
         <div class="sidebar-issues-panel__list-wrap"></div>
         <div class="sidebar-issues-panel__summary">

--- a/ui/src/components/sidebar-attention-panel.runtime.ts
+++ b/ui/src/components/sidebar-attention-panel.runtime.ts
@@ -172,6 +172,21 @@ export function renderSidebarAttentionPanel(params: SidebarAttentionPanelParams)
             >
               ${t("attention.dismissShown")}
             </button>
+            <openclaw-tooltip .content=${t("attention.mentions.notifications")}>
+              <a
+                class="sidebar-brand__icon"
+                aria-label=${t("attention.mentions.notifications")}
+                href=${pathForRoute("notifications", params.context.basePath)}
+                @click=${(event: MouseEvent) => {
+                  if (!shouldHandleNavigationClick(event)) {
+                    return;
+                  }
+                  event.preventDefault();
+                  params.onNavigate("notifications");
+                }}
+                >${icons.settings}</a
+              >
+            </openclaw-tooltip>
             <button
               type="button"
               class="sidebar-brand__icon sidebar-issues-panel__mobile-close"
@@ -271,17 +286,6 @@ export function renderSidebarAttentionPanel(params: SidebarAttentionPanelParams)
           mentionsTab
             ? html`<footer class="sidebar-issues-panel__mentions-note">
                 <span>${t("attention.mentions.retention")}</span>
-                <a
-                  href=${pathForRoute("notifications", params.context.basePath)}
-                  @click=${(event: MouseEvent) => {
-                    if (!shouldHandleNavigationClick(event)) {
-                      return;
-                    }
-                    event.preventDefault();
-                    params.onNavigate("notifications");
-                  }}
-                  >${t("attention.mentions.notifications")}</a
-                >
               </footer>`
             : nothing
         }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4067,8 +4067,7 @@ export const en: TranslationMap & {
       dismissing: "Dismissing…",
       emptyTitle: "No mentions yet",
       emptyBody: "When someone mentions you in a chat, it appears here.",
-      retention:
-        "Mentions are kept for up to seven days. Gateway restarts preserve your Inbox and dismissals.",
+      retention: "Mentions expire after 7 days.",
       notifications: "Notification settings",
       loading: "Loading mentions…",
       unavailable: "Sign in and connect to the Gateway to see your mentions.",

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -121,7 +121,7 @@
   display: none;
 }
 
-.shell--mobile-nav .sidebar-issues-panel__mobile-close {
+.shell--mobile-nav .sidebar-issues-panel__header-actions .sidebar-brand__icon {
   display: inline-grid;
   width: 36px;
   height: 36px;
@@ -132,7 +132,7 @@
   transition: transform 140ms var(--ease-out);
 }
 
-.shell--mobile-nav .sidebar-issues-panel__mobile-close:active {
+.shell--mobile-nav .sidebar-issues-panel__header-actions .sidebar-brand__icon:active {
   transform: scale(0.97);
 }
 
@@ -303,7 +303,9 @@
 }
 
 footer.sidebar-issues-panel__mentions-note {
+  padding: 12px;
   border-block-start: 1px solid var(--border);
+  font-size: var(--control-ui-text-sm);
 }
 
 .sidebar-issues-panel__update > .sidebar-issues-panel__details {


### PR DESCRIPTION
Closes #144403

## What Problem This Solves

The Mentions tab uses several lines for retention/restart copy and an orange settings link, leaving less room for Inbox entries. The link also makes shared notification preferences look specific to Mentions.

## Why This Change Was Made

The footer now reads “Mentions expire after 7 days.” in one muted 12px line, with the same 12px padding as the header. The existing notification settings destination moves to a Lucide settings icon with the shared tooltip and accessible label in the Inbox header. On mobile it sits immediately left of the X and reuses the same existing 36px control styling.

The destination serves approval, agent, mention, and task-failure notification preferences; #144403 records the source references and decision. It does not control Inbox retention or every System incident. The former OpenClaw header shortcut was intentionally removed in #135008, so current header states contain no such icon.

## User Impact

The measured footer shrinks from 75.2px to 41.8px (44% less height). Notification settings remain available from every Inbox tab. Navigation, dismissals, notification delivery, and retention behavior are unchanged. The existing i18n key is updated; the restart sentence was part of that same value, with no separate unused key to remove.

## Evidence

- Real Control UI and fonts on an isolated mock server, driven through persistent Chrome over CDP. Desktop 1440×1000 and mobile 390×844; dark/light; empty and populated Mentions. Panel crops below preserve original scale; each comparison places **before on the left and after on the right**, with empty Mentions, populated Mentions, and System rows.
- All eight Mentions combinations measured a 41.8px footer, 12px text, and padding equal to the header. Mobile settings and X both measured 36×36px, in the requested order.
- Verified the settings icon remains visible on All, Approvals, Automations, and System; keyboard tooltip and navigation to `/settings/notifications` passed in both themes and viewports.
- Existing focused tests: **56 passed** across sidebar attention logic, notification preferences, browser layout, and the mobile Inbox E2E flow. Only the existing layout fixture needed its real header-actions wrapper restored; no assertions were weakened and no new template tests were added.
- Formatting, `git diff --check`, keyless i18n baseline/verification, and the full `check:changed` gate: **passed**. The local dependency installation initially pointed to proxyline 0.3.11 while the unchanged lockfile required 0.3.12; `pnpm install --frozen-lockfile` synchronized that one package and the complete gate passed on retry.
- CI attempt 1: all UI/browser/E2E, i18n, performance, production-type, and core-test-type jobs passed. `checks-node-compact-small-25` timed out after 120s while bundling the worker in `worker-deploy-build-plugin.test.ts`. Its worker entry point, test, and build configuration are unchanged by this UI diff. The failed-job rerun passed without code changes; attempt 2 and the required `openclaw/ci-gate` are green for `09211aa9937037ebef9291fee196aec1bafff223` ([successful CI](https://github.com/openclaw/openclaw/actions/runs/34529027932/attempts/2)); [original failure log](https://github.com/openclaw/openclaw/actions/runs/34529027932/job/103045256647).
- Independent autoreview: **scoped-clean through P2**, no actionable findings.

**Desktop — dark**

![Desktop dark before and after](https://github.com/user-attachments/assets/e922e4d8-942b-4b6a-b0c0-fac7f6bd2663)


**Desktop — light**

![Desktop light before and after](https://github.com/user-attachments/assets/ad005642-7eb6-4165-8c46-b181689b3797)


**Mobile 390 — dark**

![Mobile dark before and after](https://github.com/user-attachments/assets/c4d007b0-b0aa-4bbe-be3f-dd3aec719de4)


**Mobile 390 — light**

![Mobile light before and after](https://github.com/user-attachments/assets/09a03f0e-a2bf-4bf2-963b-981b75d2ec17)


Proof boundary: synthetic Gateway data; no live Gateway or notification delivery was exercised. The current source has no OpenClaw shortcut in the Inbox header, so the retired “with OpenClaw icon” state is not represented. Foreign locale generation follows the normal post-merge pipeline.


