### PR TITLE
fix(claws): disclose memory source expansion from empty defaults

### DIFF
--- a/src/agents/memory-search-source-policy.ts
+++ b/src/agents/memory-search-source-policy.ts
@@ -1,0 +1,47 @@
+type MemorySearchSource = "memory" | "sessions";
+
+const DEFAULT_SOURCES: MemorySearchSource[] = ["memory"];
+
+function normalizeSources(
+  sources: readonly MemorySearchSource[] | undefined,
+  sessionMemoryEnabled: boolean,
+): MemorySearchSource[] {
+  const normalized = new Set<MemorySearchSource>();
+  const input = sources?.length ? sources : DEFAULT_SOURCES;
+  for (const source of input) {
+    if (source === "memory") {
+      normalized.add("memory");
+    }
+    if (source === "sessions" && sessionMemoryEnabled) {
+      normalized.add("sessions");
+    }
+  }
+  if (normalized.size === 0) {
+    normalized.add("memory");
+  }
+  return Array.from(normalized);
+}
+
+/** Resolve query and indexed sources from already-selected memory policy facts. */
+export function resolveMemorySearchSourcePolicy(params: {
+  configuredSources?: readonly MemorySearchSource[];
+  rememberAcrossConversations: boolean;
+  configuredSessionMemory: boolean;
+}): {
+  sources: MemorySearchSource[];
+  searchSources: MemorySearchSource[];
+  sessionMemory: boolean;
+} {
+  const { configuredSources, rememberAcrossConversations, configuredSessionMemory } = params;
+  const sessionMemory = rememberAcrossConversations || configuredSessionMemory;
+  const searchSources = normalizeSources(
+    configuredSources,
+    configuredSessionMemory ||
+      (rememberAcrossConversations && configuredSources?.includes("sessions") === true),
+  );
+  const sources = normalizeSources(
+    rememberAcrossConversations ? [...searchSources, "sessions"] : configuredSources,
+    sessionMemory,
+  );
+  return { sources, searchSources, sessionMemory };
+}

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -20,6 +20,7 @@ import { runtimeMemorySecretOwnerId } from "../secrets/runtime-memory-secret-own
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { clampNumber } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveMemorySearchSourcePolicy } from "./memory-search-source-policy.js";
 
 export type ResolvedMemorySearchConfig = {
   enabled: boolean;
@@ -133,30 +134,9 @@ const DEFAULT_CACHE_ENABLED = true;
 // without limit. Must stay above a typical live chunk count: a cap below the working set
 // evicts rows the next sync needs and forces paid re-embedding.
 const DEFAULT_CACHE_MAX_ENTRIES = 50_000;
-const DEFAULT_SOURCES: Array<"memory" | "sessions"> = ["memory"];
 const DEFAULT_MEMORY_EMBEDDING_PROVIDER = "openai";
 const DEFAULT_REMOTE_BATCH_POLL_INTERVAL_MS = 2_000;
 const DEFAULT_REMOTE_BATCH_TIMEOUT_MINUTES = 60;
-
-function normalizeSources(
-  sources: Array<"memory" | "sessions"> | undefined,
-  sessionMemoryEnabled: boolean,
-): Array<"memory" | "sessions"> {
-  const normalized = new Set<"memory" | "sessions">();
-  const input = sources?.length ? sources : DEFAULT_SOURCES;
-  for (const source of input) {
-    if (source === "memory") {
-      normalized.add("memory");
-    }
-    if (source === "sessions" && sessionMemoryEnabled) {
-      normalized.add("sessions");
-    }
-  }
-  if (normalized.size === 0) {
-    normalized.add("memory");
-  }
-  return Array.from(normalized);
-}
 
 function getConfiguredMemoryEmbeddingProvider(providerId: string, cfg: OpenClawConfig) {
   // `none` is the built-in FTS-only sentinel, never a plugin capability.
@@ -179,17 +159,12 @@ export function resolveMemorySearchIndexConfig(cfg: OpenClawConfig, agentId: str
   const rememberAcrossConversations = resolveRememberAcrossConversations(cfg, agentId);
   const configuredSessionMemory =
     overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
-  const sessionMemory = rememberAcrossConversations || configuredSessionMemory;
   const configuredSources = overrides?.sources ?? defaults?.sources;
-  const searchSources = normalizeSources(
+  const { sessionMemory, searchSources, sources } = resolveMemorySearchSourcePolicy({
     configuredSources,
-    configuredSessionMemory ||
-      (rememberAcrossConversations && configuredSources?.includes("sessions") === true),
-  );
-  const sources = normalizeSources(
-    rememberAcrossConversations ? [...searchSources, "sessions"] : configuredSources,
-    sessionMemory,
-  );
+    rememberAcrossConversations,
+    configuredSessionMemory,
+  });
   return {
     enabled,
     rememberAcrossConversations,

--- a/src/claws/update-capability-changes.ts
+++ b/src/claws/update-capability-changes.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";
 import { listAgentEntries, toAgentEntriesRecord } from "../agents/agent-scope.js";
+import { resolveMemorySearchSourcePolicy } from "../agents/memory-search-source-policy.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
 import { expandToolGroups, resolveToolProfilePolicy } from "../agents/tool-policy-shared.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
@@ -422,23 +423,13 @@ function resolvePortableMemorySearch(config: OpenClawConfig, agentId: string): u
   const overrides = listAgentEntries(config).find((agent) => agent.id === agentId)?.memory?.search;
   const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
   const rememberAcrossConversations = resolveRememberAcrossConversations(config, agentId);
-  const sessionMemory =
-    rememberAcrossConversations ||
-    (overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false);
-  const configuredSources = overrides?.sources ?? defaults?.sources ?? ["memory"];
-  const sources = new Set<"memory" | "sessions">();
-  for (const source of configuredSources) {
-    if (source === "memory" || (source === "sessions" && sessionMemory)) {
-      sources.add(source);
-    }
-  }
-  if (rememberAcrossConversations) {
-    sources.add("sessions");
-  }
-  if (sources.size === 0) {
-    sources.add("memory");
-  }
-  return { enabled, rememberAcrossConversations, sources: [...sources].toSorted() };
+  const { sources } = resolveMemorySearchSourcePolicy({
+    configuredSources: overrides?.sources ?? defaults?.sources,
+    rememberAcrossConversations,
+    configuredSessionMemory:
+      overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false,
+  });
+  return { enabled, rememberAcrossConversations, sources: sources.toSorted() };
 }
 
 function prepareCapabilityComparisonConfig(

--- a/src/claws/update-plan.test-helpers.ts
+++ b/src/claws/update-plan.test-helpers.ts
@@ -7,7 +7,7 @@ import { buildClawAddPlan } from "./lifecycle.js";
 import { installClawMcpServers } from "./mcp.js";
 import { persistClawPackageRef } from "./provenance.js";
 import { parseClawManifest } from "./schema.js";
-import type { ClawSourceIdentity, ResolvedClawPackage } from "./types.js";
+import type { ClawOpenClawProfile, ClawSourceIdentity, ResolvedClawPackage } from "./types.js";
 
 export const packagePreflight = async (pkg: { kind: "skill" | "plugin"; ref: string }) => ({
   ok: true as const,
@@ -16,7 +16,10 @@ export const packagePreflight = async (pkg: { kind: "skill" | "plugin"; ref: str
   ...(pkg.kind === "plugin" ? { installId: pkg.ref } : {}),
 });
 
-export async function createUpdatePlanFixture(root: string) {
+export async function createUpdatePlanFixture(
+  root: string,
+  fixtureOptions: { config?: OpenClawConfig; openClawProfile?: ClawOpenClawProfile } = {},
+) {
   await writeFile(join(root, "SOUL.md"), "base soul\n", "utf8");
   await writeFile(join(root, "OLD.md"), "old\n", "utf8");
   const raw = {
@@ -67,13 +70,14 @@ export async function createUpdatePlanFixture(root: string) {
   const env = { OPENCLAW_STATE_DIR: join(root, "state") };
   const addPlan = await buildClawAddPlan({
     manifest: parsed.manifest,
+    openClawProfile: fixtureOptions.openClawProfile,
     source,
     context: { workspace: join(root, "workspace-worker"), packagePreflight },
   });
   if (addPlan.blockers.length > 0) {
     throw new Error(JSON.stringify(addPlan.blockers));
   }
-  let config: OpenClawConfig = {};
+  let config: OpenClawConfig = fixtureOptions.config ?? {};
   await applyClawAddPlan(addPlan, {
     consentPlanIntegrity: addPlan.planIntegrity,
     env,

--- a/src/claws/update-plan.test.ts
+++ b/src/claws/update-plan.test.ts
@@ -24,9 +24,9 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => closeOpenClawStateDatabaseForTest());
 
-async function fixture() {
+async function fixture(options?: Parameters<typeof createUpdatePlanFixture>[1]) {
   const root = tempDirs.make("openclaw-claw-update-");
-  return await createUpdatePlanFixture(root);
+  return await createUpdatePlanFixture(root, options);
 }
 
 describe("buildClawUpdatePlan", () => {
@@ -238,6 +238,53 @@ describe("buildClawUpdatePlan", () => {
       ]),
     );
   });
+
+  it.each([true, false])(
+    "discloses inherited default memory sources when enabled=%s",
+    async (enabled) => {
+      const current = await fixture({
+        config: { memory: { search: { sources: [], rememberAcrossConversations: true } } },
+        openClawProfile: {
+          schemaVersion: 1,
+          agent: {
+            memory: {
+              search: { enabled, rememberAcrossConversations: true, sources: ["sessions"] },
+            },
+          },
+        },
+      });
+      const plan = await buildClawUpdatePlan({
+        agentId: "worker",
+        targetManifest: current.manifest,
+        targetOpenClawProfile: {
+          schemaVersion: 1,
+          agent: { memory: { search: { enabled, rememberAcrossConversations: true } } },
+        },
+        targetSource: targetSource(current.root, "2.0.0", "sha256:target"),
+        config: current.config,
+        sourceMcpServers: current.config.mcp?.servers ?? {},
+        stateOptions: { env: current.env },
+        packagePreflight,
+      });
+
+      expect(plan.blockers).toEqual([]);
+      expect(plan.actions).toContainEqual(
+        expect.objectContaining({ kind: "agent", action: "change", blocked: false }),
+      );
+      expect(plan.capabilityChanges).toContainEqual(
+        expect.objectContaining({
+          path: "agent.memory.search.sources",
+          classification: "escalation",
+          requiresDistinctConsent: true,
+          effect: {
+            path: "memory.search.sources",
+            current: ["sessions"],
+            desired: ["memory", "sessions"],
+          },
+        }),
+      );
+    },
+  );
 
   it("plans grouped add, change, and removal actions", async () => {
     const current = await fixture();


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users previewing a valid Claw update would miss a memory source capability change when the target inherited an empty root `memory.search.sources` list with `rememberAcrossConversations` enabled. Effective indexed sources expanded from `["sessions"]` to `["memory", "sessions"]`, but the preview omitted that disclosure. The update still required exact-plan consent.

## Why This Change Was Made

Share the runtime's pure source-policy calculation with Claw capability reporting, removing the divergent copy. Runtime source/query ordering, configuration precedence, legacy flags, disabled `null` results and secret-owner checks remain unchanged, as do configuration, schema, persistence and audit policy.

## User Impact

Update previews disclose the effective memory source addition before users apply the plan. Configured capabilities remain reportable for disabled profiles; disabled memory remains disabled.

## Evidence

Integrated onto `f9976d6de6a086c3b19edbfaeb7412db47b50bb7` with the reviewed five-file patch unchanged. Local proof from `17380c1e9b65de8a34ddbb5d7a5e44e9396ef62f`:

- The real-planner regression fails on original production at the missing capability record after setup and action preconditions pass; both enabled/disabled cases pass with the fix.
- All 88 tests pass across the update planner, capability reporting and memory configuration suites.
- The complete changed gate, full `pnpm build` and independent P2 review pass. Post-build source hashes match the reviewed candidate.
- Complete measured growth: **+10 production and +49 test/support code lines (+64 physical lines)**. This is a correctness repair with real growth, measured by cloc 2.10 in both counting modes.
