### PR TITLE
fix(gateway): cap cloud workspace staging re-read

### DIFF
--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -7,7 +7,6 @@ import {
   DEFAULT_SECRET_PROVIDER_ALIAS,
   ENV_SECRET_REF_ID_RE,
   isSecretRef,
-  isValidEnvSecretRefId,
   type SecretRef,
   type SecretRefSource,
 } from "../secrets/ref-contract.js";

--- a/src/gateway/worker-environments/workspace-actual-manifest.ts
+++ b/src/gateway/worker-environments/workspace-actual-manifest.ts
@@ -25,7 +25,7 @@ import {
 import { isDerivedWorkspacePath } from "./workspace-path-exclusions.js";
 
 type WorkspaceFileSnapshot =
-  | { type: "file"; mode: number; size: number; sha256: string }
+  | { type: "file"; mode: number; size: number; sha256: string; content?: Buffer }
   | { type: "unsupported" };
 
 function localPath(root: string, relative: string): string {
@@ -54,6 +54,7 @@ export async function readWorkspaceFileSnapshotWithLimit(
   maxBytes: number | ((openedSize: number) => number),
   root?: string,
   signal?: AbortSignal,
+  options?: { includeContent?: boolean },
 ): Promise<WorkspaceFileSnapshot> {
   signal?.throwIfAborted();
   const handle = await fs.open(
@@ -75,8 +76,10 @@ export async function readWorkspaceFileSnapshotWithLimit(
       return { type: "unsupported" };
     }
     const identity = workspaceStatIdentity(owner, before);
-    let sha256 = hashMemo?.get(identity);
+    const includeContent = options?.includeContent === true;
+    let sha256 = includeContent ? undefined : hashMemo?.get(identity);
     let size = Number(before.size);
+    let content: Buffer | undefined;
     if (sha256) {
       if (metrics) {
         metrics.memoHitCount += 1;
@@ -85,6 +88,7 @@ export async function readWorkspaceFileSnapshotWithLimit(
       const hashStartedAt = performance.now();
       const hash = createHash("sha256");
       const buffer = Buffer.allocUnsafe(64 * 1024);
+      const chunks: Buffer[] = [];
       size = 0;
       for (;;) {
         signal?.throwIfAborted();
@@ -99,9 +103,16 @@ export async function readWorkspaceFileSnapshotWithLimit(
           }
           return { type: "unsupported" };
         }
-        hash.update(buffer.subarray(0, bytesRead));
+        const chunk = buffer.subarray(0, bytesRead);
+        hash.update(chunk);
+        if (includeContent) {
+          chunks.push(Buffer.from(chunk));
+        }
       }
       sha256 = hash.digest("hex");
+      if (includeContent) {
+        content = Buffer.concat(chunks, size);
+      }
       if (metrics) {
         metrics.contentHashCount += 1;
         metrics.contentHashDurationMs += performance.now() - hashStartedAt;
@@ -118,10 +129,35 @@ export async function readWorkspaceFileSnapshotWithLimit(
       mode: gitFileMode(Number(after.mode & 0o777n)),
       size,
       sha256,
+      ...(content ? { content } : {}),
     };
   } finally {
     await handle.close();
   }
+}
+
+export async function readWorkspaceFileBytesWithLimit(
+  expectedPath: string,
+  maxBytes: number,
+  root?: string,
+  signal?: AbortSignal,
+): Promise<
+  | { type: "file"; mode: number; size: number; sha256: string; content: Buffer }
+  | { type: "unsupported" }
+> {
+  const snapshot = await readWorkspaceFileSnapshotWithLimit(expectedPath, maxBytes, root, signal, {
+    includeContent: true,
+  });
+  if (snapshot.type !== "file" || !snapshot.content) {
+    return { type: "unsupported" };
+  }
+  return {
+    type: "file",
+    mode: snapshot.mode,
+    size: snapshot.size,
+    sha256: snapshot.sha256,
+    content: snapshot.content,
+  };
 }
 
 export async function readActualWorkspaceManifestImpl(params: {

--- a/src/gateway/worker-environments/workspace-result-staging.concurrent.test.ts
+++ b/src/gateway/worker-environments/workspace-result-staging.concurrent.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -6,10 +7,18 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as commandRuntime from "../../process/exec.js";
 import {
+  MAX_RECONCILIATION_FILE_BYTES,
+  serializeWorkerWorkspaceManifest,
+  type WorkerWorkspaceManifest,
+  type WorkerWorkspaceManifestEntry,
+} from "./workspace-manifest.js";
+import * as workspaceReconcileFs from "./workspace-reconcile-fs.js";
+import {
   deleteStagedWorkerWorkspaceResult,
   hasWorkerWorkspaceResultRef,
   preparedWorkerWorkspaceResultRef,
   workerWorkspaceResultRef,
+  workerWorkspaceResultStaging,
 } from "./workspace-result-staging.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -105,5 +114,50 @@ describe("worker workspace result Git ownership", () => {
       await Promise.allSettled(operations);
       spy.mockRestore();
     }
+  });
+});
+
+describe("worker workspace result staging cap", () => {
+  it("rejects a file that grows past the reconciliation cap after the hash match", async () => {
+    const { stageWorkerWorkspaceResult } = workerWorkspaceResultStaging;
+    const root = tempDirs.make("workspace-staged-oversize-reread-");
+    const local = path.join(root, "local");
+    const payload = path.join(root, "payload");
+    await initializeRepository(local);
+    await fs.mkdir(payload);
+    await fs.writeFile(path.join(payload, "result.txt"), "worker\n");
+    const entries: WorkerWorkspaceManifestEntry[] = [];
+    for (const name of (await fs.readdir(payload)).toSorted()) {
+      const content = await fs.readFile(path.join(payload, name));
+      entries.push({
+        path: name,
+        type: "file",
+        mode: 0o644,
+        size: content.length,
+        sha256: createHash("sha256").update(content).digest("hex"),
+      });
+    }
+    const encode = (manifest: WorkerWorkspaceManifest) => {
+      const raw = serializeWorkerWorkspaceManifest(manifest);
+      return { raw, ref: `sha256:${createHash("sha256").update(raw).digest("hex")}` };
+    };
+    const base = encode({ version: 1, baseCommit: null, entries: [], directories: [] });
+    const current = encode({ version: 1, baseCommit: null, entries, directories: [] });
+    vi.spyOn(workspaceReconcileFs, "absoluteEntryMatches").mockImplementation(async (absolute) => {
+      await fs.truncate(absolute, MAX_RECONCILIATION_FILE_BYTES + 1);
+      return true;
+    });
+
+    await expect(
+      stageWorkerWorkspaceResult({
+        root: local,
+        stagingRoot: payload,
+        stagedResultRef: workerWorkspaceResultRef("claim-oversize-reread"),
+        baseManifestRef: base.ref,
+        currentManifestRef: current.ref,
+        baseManifestRaw: base.raw,
+        currentManifestRaw: current.raw,
+      }),
+    ).rejects.toThrow("exceeds its byte limit");
   });
 });

--- a/src/gateway/worker-environments/workspace-result-staging.ts
+++ b/src/gateway/worker-environments/workspace-result-staging.ts
@@ -43,6 +43,7 @@ import {
   parseChangedWorkspaceResult,
   readStagedWorkerWorkspaceEntry,
 } from "./workspace-result-inventory.runtime.js";
+import { readCappedStagedFile } from "./workspace-staged-file-read.js";
 
 const WORKER_RESULT_CLAIM_ID_PATTERN = /^[A-Za-z0-9-]+$/u;
 const workspaceLog = createSubsystemLogger("gateway/worker-workspace");
@@ -218,7 +219,7 @@ async function stageWorkerWorkspaceResult(params: {
       throw new Error(`Cloud workspace staged payload is invalid: ${entry.path}`);
     }
     const content =
-      entry.type === "symlink" ? Buffer.from(entry.target) : await fs.readFile(source);
+      entry.type === "symlink" ? Buffer.from(entry.target) : await readCappedStagedFile(source);
     if (
       entry.type === "file" &&
       (content.byteLength !== entry.size ||

--- a/src/gateway/worker-environments/workspace-staged-file-read.ts
+++ b/src/gateway/worker-environments/workspace-staged-file-read.ts
@@ -1,0 +1,10 @@
+import { readWorkspaceFileBytesWithLimit } from "./workspace-actual-manifest.js";
+import { MAX_RECONCILIATION_FILE_BYTES } from "./workspace-manifest.js";
+
+export async function readCappedStagedFile(source: string): Promise<Buffer> {
+  const snapshot = await readWorkspaceFileBytesWithLimit(source, MAX_RECONCILIATION_FILE_BYTES);
+  if (snapshot.type !== "file") {
+    throw new Error("Cloud workspace staged result exceeds its byte limit");
+  }
+  return snapshot.content;
+}


### PR DESCRIPTION
## What Problem This Solves

Cloud workspace staging already hashes each matched file under a 64 MiB cap. After that match it used to call uncapped `fs.readFile` to load the same path for the git fast-import payload. A worker that grows or replaces the file in that window can make the gateway allocate the new size before the later size/hash check throws. The gateway should refuse the over-cap file without loading it.

## Evidence

Live `tsx` on this branch compared the old uncapped `fs.readFile` with the new capped reader on a sparse file grown to 64 MiB + 1 after a valid small hash.

```console
$ pnpm exec tsx /tmp/proof-f075.mjs
node v26.7.0
capBytes 67108864
small.type file
small.size 7
huge.snapshot unsupported
uncapped.byteLength 67108865
uncapped.ms 10.7
capped.error Cloud workspace staged result exceeds its byte limit
capped.ms 0.3
```

Uncapped `fs.readFile` returned 67,108,865 bytes. The capped reader returned `unsupported` and threw `Cloud workspace staged result exceeds its byte limit` in 0.3ms.

## Real behavior proof

- **Behavior or issue addressed:** Cloud workspace staging no longer re-reads a just-hashed worker file with uncapped `fs.readFile`. An over-cap replacement is rejected as exceeding the byte limit instead of being loaded into the gateway process.
- **Real environment tested:** macOS, Node v26.7.0, worktree `/tmp/oc-f075` at `origin/main` `f9976d6de6a`, invoked with `pnpm exec tsx /tmp/proof-f075.mjs`.
- **Exact steps or command run after this patch:** `pnpm exec tsx /tmp/proof-f075.mjs` after writing a 7-byte file, hashing it, then truncating a sibling path to 64 MiB + 1.
- **Evidence after fix:** terminal output copied below.

```console
$ pnpm exec tsx /tmp/proof-f075.mjs
node v26.7.0
capBytes 67108864
small.type file
small.size 7
huge.snapshot unsupported
uncapped.byteLength 67108865
uncapped.ms 10.7
capped.error Cloud workspace staged result exceeds its byte limit
capped.ms 0.3
```

- **Observed result after fix:** The capped staging read fails closed on the grown file. The same path still loads 67,108,865 bytes when `fs.readFile` is called directly, which is the allocation the patch removes from `stageWorkerWorkspaceResult`.
- **What was not tested:** A live cloud worker process growing a file during an in-flight gateway stage. The proof uses the production readers and a truncate in the hash-then-read window.

## Summary

`absoluteEntryMatches` already uses `readWorkspaceFileSnapshotWithLimit`. Staging now loads payload bytes through the same cap (`readCappedStagedFile` / `readWorkspaceFileBytesWithLimit`) and throws `Cloud workspace staged result exceeds its byte limit` when the snapshot is unsupported. Under-cap size or hash drift still throws `changed while reading`.

This bug landed in [7a7d6bb51f42](https://github.com/openclaw/openclaw/commit/7a7d6bb51f42) / [#110952](https://github.com/openclaw/openclaw/pull/110952) (2026-07-18). No competing PR owns `workspace-result-staging.ts` for this re-read.

No changelog entry. The repo generates those.
