### PR TITLE
fix(pdf): keep model selection and reporting consistent

### DIFF
--- a/src/agents/model-fallback-candidates.test.ts
+++ b/src/agents/model-fallback-candidates.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import {
   resolveImageFallbackCandidates,
   resolveModelCandidateChain,
 } from "./model-fallback-candidates.js";
+import { runWithImageModelFallback } from "./model-fallback-image.js";
 import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.js";
 
 const customProvider: ModelProviderConfig = {
@@ -113,6 +116,88 @@ describe("resolveModelCandidateChain", () => {
 });
 
 describe("resolveImageFallbackCandidates", () => {
+  it.each(
+    (["override", "fallback"] as const).flatMap((kind) =>
+      ([undefined, "openai-completions"] as const).map((api) => ({ kind, api })),
+    ),
+  )("uses one captured view for a bare $kind with provider API $api", async ({ kind, api }) => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          imageModel: { primary: "pick", fallbacks: ["backup"] },
+          models: {
+            "custom/first": { alias: "pick" },
+            "custom/second": { alias: "other" },
+          },
+        },
+      },
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            models: [],
+            ...(api ? { api } : {}),
+          },
+        },
+      },
+    };
+    const foreignMetadata = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "custom",
+          modelIdNormalization: {
+            providers: { custom: { aliases: { first: "shared", second: "shared" } } },
+          },
+        },
+      ],
+    });
+    const run = vi.fn(async (provider: string, model: string) => {
+      if (kind === "fallback" && model === "first") {
+        throw new Error("primary unavailable");
+      }
+      return `${provider}/${model}`;
+    });
+    const result = await withPluginRuntimeGenerationScope(
+      { metadataSnapshot: foreignMetadata },
+      () =>
+        runWithImageModelFallback({
+          cfg,
+          manifestPlugins: [],
+          ...(kind === "override" ? { modelOverride: "backup" } : {}),
+          run,
+        }),
+    );
+    expect(result.result).toBe("custom/backup");
+    expect(run.mock.calls.map(([provider, model]) => [provider, model])).toEqual(
+      kind === "override"
+        ? [["custom", "backup"]]
+        : [
+            ["custom", "first"],
+            ["custom", "backup"],
+          ],
+    );
+  });
+
+  it("retains provider-qualified aliases from bare configured model keys", async () => {
+    const result = await withPluginRuntimeGenerationScope(
+      { metadataSnapshot: createPluginMetadataSnapshotFixture() },
+      () =>
+        runWithImageModelFallback({
+          cfg: {
+            agents: {
+              defaults: {
+                imageModel: { primary: "custom/pick" },
+                models: { underlying: { alias: "pick" } },
+              },
+            },
+          },
+          manifestPlugins: [],
+          run: async (provider, model) => `${provider}/${model}`,
+        }),
+    );
+    expect(result.result).toBe("custom/underlying");
+  });
+
   it("keeps distinct literal model namespaces while removing duplicate routes", () => {
     const cfg: OpenClawConfig = {
       agents: {
@@ -129,9 +214,7 @@ describe("resolveImageFallbackCandidates", () => {
         },
       },
     };
-    expect(
-      resolveImageFallbackCandidates({ cfg, defaultProvider: "custom", manifestPlugins: [] }),
-    ).toEqual([
+    expect(resolveImageFallbackCandidates({ cfg, manifestPlugins: [] })).toEqual([
       {
         provider: "custom",
         model: "model",
@@ -164,7 +247,6 @@ describe("resolveImageFallbackCandidates", () => {
       expect(
         resolveImageFallbackCandidates({
           cfg,
-          defaultProvider: "openai",
         }),
       ).toEqual([
         {
@@ -206,7 +288,6 @@ describe("resolveImageFallbackCandidates", () => {
       expect(
         resolveImageFallbackCandidates({
           cfg,
-          defaultProvider: "openai",
         }),
       ).toHaveLength(2);
       expect(await warnLogs.findText("Unresolved image model")).toBeUndefined();

--- a/src/agents/model-fallback-candidates.ts
+++ b/src/agents/model-fallback-candidates.ts
@@ -91,13 +91,29 @@ function createModelCandidateCollector() {
 export function resolveImageFallbackCandidates(
   params: {
     cfg: OpenClawConfig | undefined;
-    defaultProvider: string;
     modelOverride?: string;
   } & ModelManifestNormalizationContext,
 ): ModelFallbackCandidate[] {
+  const primary = resolveAgentModelPrimaryValue(params.cfg?.agents?.defaults?.imageModel);
+  let defaultProvider = DEFAULT_PROVIDER;
+  if (primary?.trim()) {
+    const primaryAliasIndex = buildModelAliasIndex({
+      cfg: params.cfg ?? {},
+      defaultProvider: DEFAULT_PROVIDER,
+      manifestPlugins: params.manifestPlugins,
+    });
+    const resolvedPrimary = resolveModelRefFromString({
+      cfg: params.cfg,
+      raw: primary,
+      defaultProvider: DEFAULT_PROVIDER,
+      aliasIndex: primaryAliasIndex,
+      manifestPlugins: params.manifestPlugins,
+    });
+    defaultProvider = resolvedPrimary?.ref.provider || DEFAULT_PROVIDER;
+  }
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},
-    defaultProvider: params.defaultProvider,
+    defaultProvider,
     manifestPlugins: params.manifestPlugins,
   });
   const { candidates, addCandidate } = createModelCandidateCollector();
@@ -106,7 +122,7 @@ export function resolveImageFallbackCandidates(
     const resolved = resolveModelRefFromString({
       cfg: params.cfg,
       raw,
-      defaultProvider: params.defaultProvider,
+      defaultProvider,
       aliasIndex,
       manifestPlugins: params.manifestPlugins,
     });
@@ -121,11 +137,8 @@ export function resolveImageFallbackCandidates(
 
   if (params.modelOverride?.trim()) {
     addRaw(params.modelOverride, "requested");
-  } else {
-    const primary = resolveAgentModelPrimaryValue(params.cfg?.agents?.defaults?.imageModel);
-    if (primary?.trim()) {
-      addRaw(primary, "configured-primary");
-    }
+  } else if (primary?.trim()) {
+    addRaw(primary, "configured-primary");
   }
 
   const imageFallbacks = resolveAgentModelFallbackValues(params.cfg?.agents?.defaults?.imageModel);
@@ -135,26 +148,6 @@ export function resolveImageFallbackCandidates(
     addRaw(raw, "configured-fallback");
   }
   return candidates;
-}
-
-export function resolveImageFallbackDefaultProvider(cfg: OpenClawConfig | undefined): string {
-  const configuredPrimary = resolveAgentModelPrimaryValue(cfg?.agents?.defaults?.imageModel);
-  if (configuredPrimary?.trim()) {
-    const aliasIndex = buildModelAliasIndex({
-      cfg: cfg ?? {},
-      defaultProvider: DEFAULT_PROVIDER,
-    });
-    const resolved = resolveModelRefFromString({
-      cfg,
-      raw: configuredPrimary,
-      defaultProvider: DEFAULT_PROVIDER,
-      aliasIndex,
-    });
-    if (resolved?.ref.provider) {
-      return resolved.ref.provider;
-    }
-  }
-  return DEFAULT_PROVIDER;
 }
 
 export function resolveModelCandidateChain(

--- a/src/agents/model-fallback-image.ts
+++ b/src/agents/model-fallback-image.ts
@@ -7,23 +7,22 @@ import {
   runFallbackAttempt,
   throwFallbackFailureSummary,
 } from "./model-fallback-attempt.js";
-import {
-  resolveImageFallbackCandidates,
-  resolveImageFallbackDefaultProvider,
-} from "./model-fallback-candidates.js";
+import { resolveImageFallbackCandidates } from "./model-fallback-candidates.js";
 import type { FallbackAttempt } from "./model-fallback.types.js";
+import type { ModelManifestNormalizationContext } from "./model-ref-shared.js";
 
 export async function runWithImageModelFallback<T>(params: {
   cfg: OpenClawConfig | undefined;
   modelOverride?: string;
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
   run: (provider: string, model: string) => Promise<T>;
   onError?: ModelFallbackErrorHandler;
   abortSignal?: AbortSignal;
 }): Promise<ModelFallbackRunResult<T>> {
   const candidates = resolveImageFallbackCandidates({
     cfg: params.cfg,
-    defaultProvider: resolveImageFallbackDefaultProvider(params.cfg),
     modelOverride: params.modelOverride,
+    manifestPlugins: params.manifestPlugins,
   });
   if (candidates.length === 0) {
     throw new Error(

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -34,10 +34,7 @@ import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { isMinimaxVlmProvider } from "../minimax-vlm.js";
-import {
-  resolveImageFallbackCandidates,
-  resolveImageFallbackDefaultProvider,
-} from "../model-fallback-candidates.js";
+import { resolveImageFallbackCandidates } from "../model-fallback-candidates.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { optionalFiniteNumberSchema, optionalPositiveIntegerSchema } from "../schema/typebox.js";
 import { readFiniteNumberParam, readPositiveIntegerParam } from "./common.js";
@@ -438,10 +435,7 @@ function resolveCompressionModelCandidates(params: {
   const effectiveCfg = effectiveImageModelConfig
     ? applyImageModelConfigDefaults(params.cfg, effectiveImageModelConfig)
     : params.cfg;
-  return resolveImageFallbackCandidates({
-    cfg: effectiveCfg,
-    defaultProvider: resolveImageFallbackDefaultProvider(effectiveCfg),
-  });
+  return resolveImageFallbackCandidates({ cfg: effectiveCfg });
 }
 
 async function resolveCompressionModelPolicyWithHooks(params: {

--- a/src/agents/tools/pdf-tool.static-runtime.test.ts
+++ b/src/agents/tools/pdf-tool.static-runtime.test.ts
@@ -1,5 +1,6 @@
 // PDF model resolution must consume configured facts from static prepared runtimes.
 import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadConfig } from "../../config/config.js";
 import * as pdfExtractModule from "../../media/pdf-extract.js";
@@ -23,6 +24,137 @@ describe("PDF tool static prepared runtime", () => {
     completeMock.mockReset();
     vi.restoreAllMocks();
   });
+
+  it.each([undefined, "openai-completions"] as const)(
+    "selects a captured PDF alias once with provider API %s",
+    async (api) => {
+      await withOpenClawTestState(
+        {
+          label: "pdf-static-model-alias",
+          env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+        },
+        async (state) => {
+          const provider = "pdf-captured-model";
+          const baseUrl = "http://127.0.0.1:9/v1";
+          const pluginDir = path.join(state.root, "provider");
+          await fs.mkdir(pluginDir);
+          await fs.writeFile(
+            path.join(pluginDir, "openclaw.plugin.json"),
+            JSON.stringify({
+              id: provider,
+              providers: [provider],
+              configSchema: { type: "object", properties: {}, additionalProperties: false },
+              modelIdNormalization: {
+                providers: { [provider]: { aliases: { entry: "middle", middle: "final" } } },
+              },
+              modelCatalog: {
+                discovery: { [provider]: "static" },
+                providers: {
+                  [provider]: {
+                    api: "openai-completions",
+                    baseUrl,
+                    models: ["middle", "final"].map((id) => ({
+                      id,
+                      name: id,
+                      api: "openai-completions",
+                      reasoning: false,
+                      input: ["text"],
+                      contextWindow: 16_000,
+                      maxTokens: 4096,
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    })),
+                  },
+                },
+              },
+            }),
+          );
+          await fs.writeFile(
+            path.join(pluginDir, "index.cjs"),
+            `module.exports = { id: ${JSON.stringify(provider)}, register(api) { api.registerProvider({ id: ${JSON.stringify(provider)}, label: "PDF alias fixture", auth: [] }); } };`,
+          );
+          await state.writeConfig({
+            agents: {
+              entries: { main: {} },
+              defaults: {
+                workspace: state.workspaceDir,
+                model: { primary: `${provider}/entry` },
+                pdfModel: { primary: `${provider}/entry` },
+              },
+            },
+            models: {
+              providers: {
+                [provider]: {
+                  baseUrl,
+                  apiKey: "synthetic-fixture",
+                  models: [],
+                  ...(api ? { api } : {}),
+                },
+              },
+            },
+            plugins: {
+              allow: [provider],
+              entries: { [provider]: { enabled: true } },
+              load: { paths: [path.join(pluginDir, "index.cjs")] },
+              slots: { memory: "none" },
+            },
+          });
+          const config = loadConfig({
+            pin: false,
+            skipPluginValidation: true,
+            skipShellEnvFallback: true,
+          });
+          const agentDir = state.agentDir();
+          await fs.mkdir(agentDir, { recursive: true });
+          const lease = await acquireAgentRunPreparedModelRuntime(
+            { agentDir, config, workspaceDir: state.workspaceDir },
+            { catalogMode: "static" },
+          );
+          try {
+            vi.spyOn(webMedia, "loadWebMediaRaw").mockResolvedValue({
+              kind: "document",
+              buffer: Buffer.from("%PDF-1.4 alias fixture"),
+              contentType: "application/pdf",
+              fileName: "alias.pdf",
+            });
+            vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+              text: "Captured model fixture",
+              images: [],
+            });
+            completeMock.mockResolvedValue({
+              role: "assistant",
+              stopReason: "stop",
+              content: [{ type: "text", text: "selected middle" }],
+            });
+            const { createPdfTool } = await import("./pdf-tool.js");
+            const tool = createPdfTool({
+              config,
+              agentDir,
+              workspaceDir: state.workspaceDir,
+              preparedModelRuntime: lease.snapshot,
+            });
+            if (!tool) {
+              throw new Error("expected PDF tool");
+            }
+            const result = await tool.execute("pdf-static-alias", {
+              prompt: "Summarize",
+              pdf: path.join(state.workspaceDir, "alias.pdf"),
+            });
+            expect(completeMock).toHaveBeenCalledExactlyOnceWith(
+              expect.objectContaining({ provider, id: "middle", api: "openai-completions" }),
+              expect.any(Object),
+              expect.any(Object),
+            );
+            expect(result.details).toMatchObject({
+              model: `${provider}/middle`,
+              native: false,
+            });
+          } finally {
+            lease.release();
+          }
+        },
+      );
+    },
+  );
 
   it("resolves a configured model from the static prepared registry", async () => {
     await withOpenClawTestState(

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -220,11 +220,13 @@ async function runPdfPrompt(params: {
 
   const result = await runWithImageModelFallback({
     cfg: effectiveCfg,
+    manifestPlugins: preparedRuntime.metadataSnapshot,
     modelOverride: params.modelOverride,
     abortSignal: params.signal,
     run: async (provider, modelId) => {
       // Static snapshots serve configured models through prepared facts; a fresh registry can be empty.
       const resolved = await resolveModelAsync(provider, modelId, runtimeAgentDir, effectiveCfg, {
+        modelIdSource: "selected",
         allowBundledStaticCatalogFallback: true,
         ...preparedStores,
         preparedModelRuntime: preparedRuntime,


### PR DESCRIPTION
Related: #130706.

## What Problem This Solves

Fixes an issue where PDF analysis could plan a bare model reference under the wrong provider when captured and ambient metadata differed. Results could also report a raw alias while completion used its selected model: `entry` dispatched `middle`, but details still said `entry`.

## Why This Change Was Made

The candidate planner now owns default-provider derivation and candidate parsing under one metadata view. PDF supplies its acquired metadata and preserves the selected logical ID during materialization. Both existing alias-index phases remain; runtime provider hooks still own wire-model normalization.

The obsolete default-provider helper and redundant internal argument are removed. Production code is **12 lines smaller**. Image compression only receives the mechanical caller cleanup; its separate model handoff behavior is outside this fix.

## User Impact

PDF results identify the selected logical model consistently. Arcee still reports `arcee/trinity-large-thinking` while OpenRouter receives `arcee-ai/trinity-large-thinking`. Native PDF behavior and resource/cancellation ownership retain their existing contracts. No configuration, schema, or persisted fields are added.

## Evidence

Validated commit `563b907724483e606e30eb77660238bf426cbfde` against main `a41bd428af45d2cd8538fbfee860572a47cf0850`.

- Original production reproduced four wrong-provider planning failures and two PDF reporting failures; both preservation controls passed.
- **197 focused and sibling tests passed**, including seven new cases plus existing image, native PDF, supplied-runtime, and cancellation coverage.
- The full changed-file gate and fresh P2 review passed with no findings. One normal full build passed.
- **Eleven final compiled cases passed** through the real tool builder and document extractor: six cold API/alias cases, matching/empty/foreign supplied snapshots, and routed/direct Arcee controls. Source imports were rejected, payload bytes stayed unchanged, and selected provider ownership/policies were verified.
- All **14,104 build files** stayed unchanged. Every runtime child joined; listeners, sockets, and owned runtime state were cleaned up.

The transport fixture retains canonical provider URLs for classification and sends unchanged payload bytes to an isolated loopback responder. It retains hostname policy checks but does not prove DNS pinning or external vendor transport. Source/built metadata differ because packaging adds channel schemas; that enrichment is checked separately from selected PDF ownership, without claiming global owner-map equivalence. Earlier failed harness records remain unchanged, and all eleven compiled cases passed in a fresh run after the metadata assertions were corrected.
