### PR TITLE
refactor(ui): reuse cron test element helper

### DIFF
--- a/ui/src/pages/cron/view-run-history.test.ts
+++ b/ui/src/pages/cron/view-run-history.test.ts
@@ -1,19 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CronRunLogEntry } from "../../api/types.ts";
-import { createCronViewJob, renderCronView as renderView } from "./view.test-support.ts";
-
-function getElement<T extends Element>(
-  container: Element,
-  selector: string,
-  constructor: new () => T,
-): T {
-  const element = container.querySelector<T>(selector);
-  expect(element).toBeInstanceOf(constructor);
-  if (!(element instanceof constructor)) {
-    throw new Error(`Expected ${selector} to match ${constructor.name}`);
-  }
-  return element;
-}
+import {
+  createCronViewJob,
+  getElement,
+  renderCronView as renderView,
+} from "./view.test-support.ts";
 
 describe("cron view run history", () => {
   it("renders runs sorted newest first and wires run filters", () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Cron run-history tests duplicate a shared DOM query helper, leaving two identical copies to maintain.

## Why This Change Was Made

Import `getElement` from the already-used `view.test-support.ts` module and remove the private copy. All five calls and all eight run-history cases remain unchanged; this adds no module load or shared state.

## User Impact

No user-visible or production behavior change. This test-support-only refactor removes nine net lines without removing any test cases.

## Evidence

- Normal UI cohort: 73 passed, 0 skipped across `view-run-history.test.ts` (8), `view.test.ts` (17), `view.editor.test.ts` (28), and `view-description.test.ts` (20).
- All 18 selected changed-file checks passed, including formatting, UI test typechecking, three export scans, and final lint.
- One scoped P2 review completed with no findings.
- The test body and all callers remain byte-identical; the imported helper has the same implementation.

No browser, live Gateway, performance, packaging, or local full-repository test proof is claimed.
