### PR TITLE
fix: stabilize paginated history eviction coverage

### DIFF
--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -585,6 +585,7 @@ suite.define(() => {
       const activePane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
       const thread = activePane.locator(".chat-thread");
       await thread.hover();
+      const previousScrollHeight = await thread.evaluate((element) => element.scrollHeight);
       await page.mouse.wheel(0, -1_000_000);
       await expect
         .poll(() =>
@@ -595,6 +596,16 @@ suite.define(() => {
           ),
         )
         .toBe(140);
+      await expect
+        .poll(() =>
+          thread.evaluate(
+            (element, previousHeight) =>
+              element.scrollHeight > previousHeight && element.scrollTop > 0,
+            previousScrollHeight,
+          ),
+        )
+        .toBe(true);
+      await waitForChatScrollIdle(page);
       // Prepending preserves the visible anchor. A renewed upward gesture
       // reaches the newly loaded start instead of teleporting the reader.
       await page.mouse.wheel(0, -1_000_000);


### PR DESCRIPTION
Related: #144359

## What Problem This Solves

Fixes an intermittent failure in the paginated-history eviction E2E test: its second upward scroll could arrive before the newly loaded history reached the rendered viewport, leaving the test at the retained message rather than the newly loaded start.

## Why This Change Was Made

The test's 140-message model check can pass while the virtualizer deliberately retains the previous rows during scrolling. Require observable scroll-extent growth and a restored anchor, then reuse the existing scroll-idle helper before the same second gesture. The normal poll settings, timeouts, two gestures, message-count check, visibility check, and eviction assertions remain unchanged. No diagnostic instrumentation is included.

## User Impact

More reliable UI regression coverage without changing production behavior. This is separate from the CI-routing change where the failure surfaced.

## Evidence

- Original Linux CI failed waiting for the older first message before reaching eviction assertions; 341 other cases passed.
- A bounded local timing control changed only the model poll interval to 1 ms on both versions, retaining the configured 15-second poll timeout. The original failed at the same visibility assertion with the second wheel captured before the prepend committed; the candidate passed the visibility and eviction contract.
- Uninstrumented history-recovery and prepend-anchor E2E suites: all 15 cases passed before and after at normal polling settings, with identical ordered cases per file.
- Changed-file gate and independent review passed. Removing the 11 added lines restores the original test byte for byte.

Local proof used Node 26.8.1 and Chromium via Playwright 1.62.1 on macOS. It reproduces the timing mechanism, not the exact Linux CI environment. No full-suite runtime improvement is claimed.
