### PR TITLE
fix(ci): speed up frozen-source admission checks

### DIFF
--- a/scripts/lib/frozen-target-source.mjs
+++ b/scripts/lib/frozen-target-source.mjs
@@ -63,10 +63,16 @@ export function createFrozenTargetSource(root, sha) {
     }
     return content;
   };
+  // Trees belong to this pinned reader; retain only entries verified within its read budget.
+  const trees = new Map();
   const readTree = (oid) => {
+    const cached = trees.get(oid);
+    if (cached && Date.now() < deadline && remainingBytes > 0) {
+      return cached;
+    }
     readObject(oid, "tree");
     const names = new Set();
-    return textDecoder
+    const entries = textDecoder
       .decode(git("ls-tree", "-z", oid))
       .split("\0")
       .filter(Boolean)
@@ -78,6 +84,8 @@ export function createFrozenTargetSource(root, sha) {
         names.add(match[4]);
         return { mode: match[1], type: match[2], oid: match[3], name: match[4] };
       });
+    trees.set(oid, entries);
+    return entries;
   };
   const commit = readObject(sha, "commit");
   const rootTree = /^tree ([0-9a-f]{40})\n/.exec(textDecoder.decode(commit))?.[1];

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -276,6 +276,7 @@ describe("frozen committed source errors", () => {
     expect(reader.readText("scripts/absent.ts")).toBeNull();
 
     removeObject(source, `${source.sha}:${metadata}`);
+    expect(() => reader.readText(metadata)).toThrow();
     const freshReader = createFrozenTargetSource(source.root, source.sha);
     expect(() => freshReader.readText(metadata)).toThrow();
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where frozen-source workflow admission performs enough repeated Git work to make package-acceptance checks unnecessarily slow. One existing workflow case hit its two-minute timeout locally.

## Why This Change Was Made

Retain successfully verified, parsed Git tree entries inside the existing pinned source reader so sibling paths reuse their common ancestors. Like the reader's existing root entries, these entries belong to one immutable source snapshot. Blob contents remain freshly read and verified, and each evaluation keeps its independent reader and path-specific provenance. Deadline and read-budget failures retain the existing path.

## User Impact

Faster existing frozen-target admission and its workflow tests. The optimization adds no persistent cache or configuration. Directory entries already verified by a reader can survive removal of that intermediate object during the same reader's lifetime; fresh readers and unread objects still fail on missing or corrupt source.

## Evidence

The exact existing mobile-pairing/published-upgrade-survivor workflow case, including real Git acquisition and all assertions, used the same local source base, dependencies, Node version, worker count and test limits:

| Result | Original | Candidate |
| --- | --- | --- |
| Test outcome | Existing 120s timeout | Passed in 44.674s |
| Whole command, including cleanup | 182.89s | 46.45s |

This is a local reproduction, not a promised whole-CI speedup. The original failure and both command logs were retained; no timeouts, fixtures, assertions or test selections were weakened.

All 40 existing frozen-source error cases and all 94 frozen-admission cases passed. The existing imported-reader test also now checks missing-blob rejection through the already-used reader, and that strengthened case passed. Selected changed-file checks and independent P2 review passed with no findings. Exact-head CI remains required before landing.

Production delta is +8 lines for reader-owned tree reuse; the test delta is one assertion. No tests are removed or extra CI shards added.
