### PR TITLE
fix(ui): show permission option icons in WebKit chat composer

### DIFF
--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -3029,6 +3029,8 @@
   color: var(--muted);
 }
 
+.chat-controls__permission-icon svg,
+.chat-controls__permission-lock svg,
 .chat-controls__permission-option-icon svg {
   width: 100%;
   height: 100%;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2823,12 +2823,6 @@ button.chat-pr__diff {
     height: 16px;
     flex-basis: 16px;
   }
-
-  .agent-chat__input--chat .chat-controls__permission-icon svg,
-  .agent-chat__input--chat .chat-controls__permission-lock svg {
-    width: 100%;
-    height: 100%;
-  }
 }
 @media (max-width: 560px) {
   .agent-chat__input--chat .chat-mobile-primary-action {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users see a blank space instead of the selected permission option icon in the desktop chat composer in WebKit, including Default (Full Access).

## Why This Change Was Made

The permission wrapper has a fixed size, but its SVG only received explicit dimensions in narrow chat layouts. WebKit resolved the unsized desktop SVG to 0×0. Move the existing 100% SVG sizing into the shared permission icon rule and remove the redundant narrow-container rule.

## User Impact

The selected option's icon is visible beside its label in WebKit. Existing mode-specific icons, default inheritance, colors, pending/disabled behavior, menu layout, and mobile sizing are preserved. No permission policy or selection logic changes.

## Evidence

- Reproduced on baseline `dc0d0b09be873ebdced3054d30bc29b5aa9324fa`; candidate `10d7b8a0a9275e10f85ac4ebb6d00576dd9ebeb5`.
- Real Control UI with isolated Vite and deterministic mock Gateway, WebKit and Chromium, desktop 1440×900 and mobile 390×844. No production Gateway changes.
- 32 states per revision: inherited Full Access, each explicit mode, return to Default, pending save, and empty/read-only-operator disabled state. Actual sessions.patch selections asserted. Candidate SVGs have visible nonzero dimensions; desktop WebKit changes from 0×0 to 16×16.
- Inspected before/after composer screenshots plus full-page/menu-open context. Longest inherited label and option descriptions covered. Pending represents loading; unrelated error rendering is unchanged. Stable geometry is demonstrated with screenshots, not video.
- 29 existing chat-pane-session-controls tests pass. Targeted stylelint, formatting, git diff --check, preliminary changed guards/i18n, and production UI build pass.
- Exact-head hosted CI passed all 53 checks, including UI/core typechecks and the real-Gateway end-to-end suite: https://github.com/openclaw/openclaw/actions/runs/34532720195 . Local typechecks were unavailable because declaration validation rejected the worktree's borrowed compiler dependency.
- Independent source/cascade review and exact-head ClawSweeper review: no actionable findings; ClawSweeper accepted the screenshot proof. The CLI autoreview attempt failed before producing a report and is not counted as a clean result.

### WebKit desktop — before left, after right

![WebKit desktop permission choices](https://github.com/user-attachments/assets/9bf4f204-5f5b-4e1b-9ce8-aca1807abe2c)

<details>
<summary>Mobile and Chromium comparisons</summary>

![WebKit mobile](https://github.com/user-attachments/assets/2f88bbf3-9a77-48c8-b221-7052ee1dc2c1)

![Chromium desktop](https://github.com/user-attachments/assets/3758f2ea-d1a0-4967-9a9d-9841afd2fc97)

![Chromium mobile](https://github.com/user-attachments/assets/928a6e5d-e386-4e6c-a2c7-667e8ef4b90b)

</details>
