### PR TITLE
fix(ui): group session catalog projects reliably

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -471,6 +471,8 @@ function renderCatalogHostGroup(
                 projectGroups.groups,
                 (group) => group.key,
                 (group) => {
+                  const label = group.labelKey ? t(group.labelKey) : group.label;
+                  const title = group.labelKey ? label : group.title;
                   const sectionId = `catalog-${group.kind}:${catalog.id}:${host.hostId}:${group.key}`;
                   const legacySectionId = group.legacySectionKey
                     ? `catalog-project:${catalog.id}:${host.hostId}:${group.legacySectionKey}`
@@ -488,13 +490,13 @@ function renderCatalogHostGroup(
                         class="sidebar-session-catalog-project__head"
                         data-session-catalog-project=${group.key}
                         aria-expanded=${String(!collapsed)}
-                        title=${group.title}
+                        title=${title}
                         @click=${() => params.onToggleSection(collapsedSectionId ?? sectionId)}
                       >
                         <span class="sidebar-session-catalog-project__icon" aria-hidden="true"
                           >${collapsed ? icons.chevronRight : icons.chevronDown}</span
                         >
-                        <span class="sidebar-session-catalog-project__label">${group.label}</span>
+                        <span class="sidebar-session-catalog-project__label">${label}</span>
                         <span class="sidebar-session-catalog-project__count" aria-hidden="true"
                           >${group.sessions.length}</span
                         >
@@ -505,7 +507,7 @@ function renderCatalogHostGroup(
                           : html`<div
                                 class="sidebar-session-catalog-project__sessions"
                                 role="list"
-                                aria-label=${`${host.label}: ${group.label}`}
+                                aria-label=${`${host.label}: ${label}`}
                               >
                                 ${renderVisibleRows(group.sessions, sectionId, true)}
                               </div>

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5254,6 +5254,7 @@ export const en: TranslationMap & {
       showSessionSection: "Show",
       catalogGroupByProject: "Project",
       catalogGroupByPerson: "Person",
+      catalogTemporaryProjects: "Tests/Temporary",
       openSessionMenu: "Open session menu",
       sortBy: "Sort by",
       sortCreated: "Created",

--- a/ui/src/lib/sessions/catalog-project-grouping.test.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.test.ts
@@ -89,6 +89,7 @@ describe("groupCatalogSessionsByProject", () => {
     ["/Users/dev/openclaw/.claude/worktrees/fix-1", "/Users/dev/openclaw"],
     ["/Users/dev/openclaw/.claude/worktrees/fix-1/ui/src", "/Users/dev/openclaw"],
     ["C:\\Users\\dev\\openclaw\\.claude\\worktrees\\fix-1", "C:\\Users\\dev\\openclaw"],
+    ["C:\\Users\\dev\\openclaw\\.claude\\worktrees\\fix-1\\ui\\src", "C:\\Users\\dev\\openclaw"],
   ])("folds worktree cwd %s into %s", (worktreeCwd, expectedProject) => {
     const result = groupCatalogSessionsByProject([
       session("direct", expectedProject),
@@ -108,6 +109,249 @@ describe("groupCatalogSessionsByProject", () => {
     ]);
 
     expect(result.ungrouped.map((item) => item.threadId)).toEqual(["missing", "blank"]);
+  });
+
+  it.each([
+    ["/home/dev/.codex/worktrees/a123/repo", "/work/repo", "repo"],
+    ["/home/dev/.codex/worktrees/a123/repo/ui/src", "/work/repo", "repo"],
+    ["C:\\Users\\dev\\.codex\\worktrees\\a123\\repo", "E:\\work\\repo", "repo"],
+    ["C:\\Users\\dev\\.codex\\worktrees\\a123\\repo\\ui\\src", "E:\\work\\repo", "repo"],
+    ["C:\\Users\\dev\\.codex\\worktrees\\a123\\REPO\\ui", "E:\\work\\Repo", "Repo"],
+    ["C:/Users/dev/.codex/worktrees/a123/Repo/ui", "E:/work/repo", "repo"],
+    ["\\\\host\\home\\.codex\\worktrees\\a123\\REPO", "\\\\host\\work\\Repo", "Repo"],
+  ])("folds Codex cwd %s only with a unique origin", (cwd, origin, label) => {
+    const worktree = Object.freeze(session("worktree", cwd));
+    const direct = Object.freeze(session("direct", origin));
+    const result = groupCatalogSessionsByProject([
+      worktree,
+      direct,
+      session("claude", `${origin}/.claude/worktrees/fix/ui`),
+      session("duplicate", origin),
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toMatchObject({
+      key: `project:${origin}`,
+      legacySectionKey: origin,
+      label,
+      title: origin,
+      sessions: [
+        { threadId: "worktree" },
+        { threadId: "direct" },
+        { threadId: "claude" },
+        { threadId: "duplicate" },
+      ],
+    });
+    expect(result.groups[0]?.sessions[0]).toBe(worktree);
+    expect(worktree.cwd).toBe(cwd);
+  });
+
+  it.each([
+    { origins: [] },
+    { origins: ["/one/repo", "/two/repo"] },
+    { origins: ["C:\\one\\repo", "D:\\two\\repo"] },
+    { origins: ["/home/dev/.codex/worktrees/repo"] },
+    { origins: ["repo"] },
+    { origins: ["/work/../repo"] },
+    { origins: ["/work/Repo"] },
+  ])(
+    "uses a synthetic Codex group without a trustworthy unique origin: $origins",
+    ({ origins }) => {
+      const cwd = "/home/dev/.codex/worktrees/a123/repo/ui";
+      const result = groupCatalogSessionsByProject([
+        session("worktree", cwd),
+        ...origins.map((origin, index) => session(`origin-${index}`, origin)),
+      ]);
+      expect(result.groups[0]).toMatchObject({
+        key: 'codex-worktree:["/home/dev/.codex","repo"]',
+        title: "/home/dev/.codex/worktrees/repo",
+        sessions: [{ threadId: "worktree" }],
+      });
+      expect(result.groups[0]?.sessions).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    { origins: ["C:\\one\\repo", "D:\\two\\REPO"] },
+    { origins: ["C:\\work\\repo", "C:\\work\\REPO"] },
+    { origins: ["C:\\work\\repo", "C:/work/repo"] },
+  ])("uses a synthetic Windows group when distinct origin keys match: $origins", ({ origins }) => {
+    const cwd = "C:\\Users\\dev\\.codex\\worktrees\\a123\\repo\\ui";
+    const paths = [cwd, ...origins];
+    const result = groupCatalogSessionsByProject(paths.map((path, i) => session(String(i), path)));
+    expect(result.groups.map((group) => group.key)).toEqual([
+      'codex-worktree:["c:/users/dev/.codex","repo"]',
+      ...origins.map((path) => `project:${path}`),
+    ]);
+    expect(result.groups[0]?.sessions.map((item) => item.threadId)).toEqual(["0"]);
+  });
+
+  it.each([
+    ["/home/dev/.codex", "/home/dev/.codex", "repo", "repo"],
+    ["C:\\Users\\Dev\\.codex", "c:/users/dev/.CODEX", "Repo", "repo"],
+    ["\\\\HOST\\Home\\.codex", "//host/home/.codex", "REPO", "repo"],
+  ])(
+    "groups sibling worktrees under %s with stable keys and original rows",
+    (owner, alias, repo, otherRepo) => {
+      const first = Object.freeze(session("first", `${owner}/worktrees/a123/${repo}/ui`));
+      const second = Object.freeze(session("second", `${alias}/worktrees/b456/${otherRepo}/src/`));
+      const custom = Object.freeze({ ...session("custom", first.cwd), customGroup: "Release" });
+      const ordinary = Object.freeze(session("ordinary", "/work/other"));
+      const missing = Object.freeze(session("missing"));
+      const rows = Object.freeze([first, ordinary, custom, second, missing]);
+      const result = groupCatalogSessionsByProject(rows);
+      expect(result.groups.map((group) => group.sessions.map((row) => row.threadId))).toEqual([
+        ["custom"],
+        ["first", "second"],
+        ["ordinary"],
+      ]);
+      expect(result.groups[0]?.sessions[0]).toBe(custom);
+      expect(result.groups[1]?.sessions[0]).toBe(first);
+      expect(result.groups[1]?.sessions[1]).toBe(second);
+      expect(result.groups[2]?.sessions[0]).toBe(ordinary);
+      expect(result.ungrouped[0]).toBe(missing);
+      const key = result.groups[1]?.key;
+      expect(result.groups[1]?.label).toBe(otherRepo);
+      expect(groupCatalogSessionsByProject([second, first]).groups[0]?.key).toBe(key);
+      expect(groupCatalogSessionsByProject([second]).groups[0]?.key).toBe(key);
+    },
+  );
+
+  it.each([false, true])(
+    "isolates same-name repositories across Codex owners (direct origin: %s)",
+    (withOrigin) => {
+      const rows = [
+        session("alice", "/home/alice/.codex/worktrees/a/repo/ui"),
+        session("bob", "/home/bob/.codex/worktrees/b/repo/src"),
+        session("alice-again", "/home/alice/.codex/worktrees/c/repo"),
+        ...(withOrigin ? [session("direct", "/work/repo")] : []),
+      ];
+      const result = groupCatalogSessionsByProject(rows);
+      expect(result.groups.map((group) => group.sessions.map((row) => row.threadId))).toEqual([
+        ["alice", "alice-again"],
+        ["bob"],
+        ...(withOrigin ? [["direct"]] : []),
+      ]);
+      expect(new Set(result.groups.map((group) => group.key)).size).toBe(result.groups.length);
+    },
+  );
+
+  it("disambiguates Windows labels without changing case, keys, or POSIX semantics", () => {
+    const paths = [
+      "C:/one/SRC/Repo",
+      "D:/two/src/repo",
+      "/three/Repo",
+      "/unix/Alpha",
+      "/unix/alpha",
+    ];
+    const result = groupCatalogSessionsByProject(paths.map((path, i) => session(String(i), path)));
+    expect(result.groups.map((group) => group.label)).toEqual([
+      "one/SRC/Repo",
+      "two/src/repo",
+      "three/Repo",
+      "Alpha",
+      "alpha",
+    ]);
+    expect(result.groups.map((group) => group.key)).toEqual(paths.map((path) => `project:${path}`));
+  });
+
+  it("uses shortest unique path suffixes without changing project keys", () => {
+    const paths = [
+      "C:\\one\\src\\repo",
+      "D:\\one\\src\\repo",
+      "/two/src/repo",
+      "/other/repo",
+      "/work/unique",
+    ];
+    const result = groupCatalogSessionsByProject(paths.map((path, i) => session(String(i), path)));
+    expect(result.groups.map((group) => group.label)).toEqual([
+      "C:/one/src/repo",
+      "D:/one/src/repo",
+      "two/src/repo",
+      "other/repo",
+      "unique",
+    ]);
+    expect(result.groups.map((group) => group.key)).toEqual(paths.map((path) => `project:${path}`));
+    expect(result.groups.map((group) => group.title)).toEqual(paths);
+  });
+
+  it.each([
+    "/tmp",
+    "/var/tmp",
+    "/private/tmp",
+    "/private/var/tmp",
+    "/var/folders/ab/user-cache/T",
+    "/private/var/folders/ab/user-cache/T",
+    "C:\\Users\\dev\\AppData\\Local\\Temp",
+    "C:\\Windows\\Temp",
+    "C:/Temp",
+  ])("collects only generated projects immediately under %s", (root) => {
+    const separator = root.includes("\\") ? "\\" : "/";
+    const prefixes = ["zhc-", "dual-agent-", "dad-", "claude-bridge-", "openclaw-usage-probe"];
+    const generated = prefixes.map((prefix, i) =>
+      session(`generated-${i}`, `${root}${separator}${prefix}123${separator}src`),
+    );
+    const ordinary = `${root}${separator}my-project`;
+    const nested = `${ordinary}${separator}zhc-user-project`;
+    const result = groupCatalogSessionsByProject([
+      ...generated,
+      session("ordinary", ordinary),
+      session("nested", nested),
+      { ...session("custom", `${root}${separator}zhc-custom`), customGroup: "Release" },
+    ]);
+    expect(result.groups.map((group) => group.label)).toEqual([
+      "Release",
+      "Tests/Temporary",
+      "my-project",
+      "zhc-user-project",
+    ]);
+    expect(result.groups[1]).toMatchObject({ kind: "project", key: "temporary:tests" });
+    expect(result.groups[1]?.sessions).toEqual(generated);
+    expect(result.groups.slice(2).map((group) => group.key)).toEqual([
+      `project:${ordinary}`,
+      `project:${nested}`,
+    ]);
+  });
+
+  it("combines generated projects across temp roots and excludes them as Codex origins", () => {
+    const cwd = "/home/dev/.codex/worktrees/a123/zhc-probe/src";
+    const result = groupCatalogSessionsByProject([
+      session("windows", "C:\\Users\\dev\\AppData\\Local\\Temp\\zhc-probe"),
+      session("posix", "/tmp/dad-probe"),
+      session("codex", cwd),
+    ]);
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups[0]?.sessions.map((item) => item.threadId)).toEqual(["windows", "posix"]);
+    expect(result.groups[1]?.key).toBe('codex-worktree:["/home/dev/.codex","zhc-probe"]');
+  });
+
+  it.each([
+    "/work/zhc-project",
+    "/work/Temp/dual-agent-project",
+    "/home/dev/tmp/dad-project",
+    "E:\\projects\\Temp\\claude-bridge-project",
+    "/var/folders/ab/user-cache/T/ordinary/dad-project",
+    "C:\\Users\\dev\\AppData\\Local\\Temp\\ordinary\\zhc-project",
+    "C:/Temporary/zhc-project",
+    "/tmp/ordinary",
+    "/TMP/zhc-user-project",
+    "/tmp/zhc-probe/../ordinary",
+    "/work/.codex/worktrees",
+    "/work/.codex/worktrees/id",
+    "/work/.claude/worktrees",
+    "/work/repo/src",
+    "relative/repo",
+    "relative/.codex/worktrees/id/repo",
+    "/home/dev/.codex/worktrees/id/../repo",
+    "/home/../dev/.codex/worktrees/id/repo",
+  ])("preserves ordinary project identity %s", (cwd) => {
+    const result = groupCatalogSessionsByProject([session("ordinary", cwd)]);
+    expect(result.groups[0]).toMatchObject({
+      key: `project:${cwd}`,
+      legacySectionKey: cwd,
+      title: cwd,
+    });
+    expect(result.groups[0]?.label).not.toBe("Tests/Temporary");
   });
 
   it.each([

--- a/ui/src/lib/sessions/catalog-project-grouping.test.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.test.ts
@@ -299,9 +299,9 @@ describe("groupCatalogSessionsByProject", () => {
       session("nested", nested),
       { ...session("custom", `${root}${separator}zhc-custom`), customGroup: "Release" },
     ]);
-    expect(result.groups.map((group) => group.label)).toEqual([
+    expect(result.groups.map((group) => group.labelKey ?? group.label)).toEqual([
       "Release",
-      "Tests/Temporary",
+      "chat.sidebar.catalogTemporaryProjects",
       "my-project",
       "zhc-user-project",
     ]);
@@ -351,7 +351,7 @@ describe("groupCatalogSessionsByProject", () => {
       legacySectionKey: cwd,
       title: cwd,
     });
-    expect(result.groups[0]?.label).not.toBe("Tests/Temporary");
+    expect(result.groups[0]?.labelKey).toBeUndefined();
   });
 
   it.each([

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -41,6 +41,95 @@ export function checkoutDisplayName(path: string): string {
   return path.split(/[\\/]/).findLast(Boolean) ?? path;
 }
 
+function codexWorktreeProject(path: string) {
+  if (
+    !/^(?:\/|[a-z]:[\\/]|\\\\)/i.test(path) ||
+    path.split(/[\\/]/).some((part) => part === "." || part === "..")
+  ) {
+    return undefined;
+  }
+  const normalized = repoNameForMatching(path, path.replaceAll("\\", "/"));
+  const match = normalized.match(/^(.*?\/\.codex)\/worktrees\/[^/]+\/([^/]+)(?:\/|$)/);
+  if (!match) {
+    return undefined;
+  }
+  const ownerRoot = match[1]!;
+  const repoName = match[2]!;
+  // The catalog carries cwd, but no Git common-directory identity. Keep this
+  // display-only fallback independent of the worktree id and descendant cwd.
+  return {
+    ownerRoot,
+    repoName,
+    key: `codex-worktree:${JSON.stringify([ownerRoot, repoName])}`,
+    title: `${ownerRoot}/worktrees/${repoName}`,
+  };
+}
+
+function repoNameForMatching(path: string, name: string): string {
+  // Case folding is for comparison; direct project keys retain original paths.
+  return isWindowsProjectPath(path) ? name.toLowerCase() : name;
+}
+
+function isWindowsProjectPath(path: string): boolean {
+  return /^(?:[a-z]:[\\/]|[\\/]{2})/i.test(path);
+}
+
+function isTemporaryProject(path: string): boolean {
+  const normalized = path.replaceAll("\\", "/");
+  if (normalized.split("/").some((part) => part === "." || part === "..")) {
+    return false;
+  }
+  // Match the generated directory at the OS temp root, never a Temp folder
+  // somewhere inside a user checkout. Descendant cwds belong to that project.
+  const relative =
+    normalized.match(
+      /^(?:\/private)?\/(?:tmp|var\/tmp|var\/folders\/[^/]+\/[^/]+\/T)\/(.+)$/,
+    )?.[1] ??
+    normalized.match(
+      /^[a-z]:\/(?:Users\/[^/]+\/AppData\/Local\/Temp|Windows\/Temp|Temp)\/(.+)$/i,
+    )?.[1];
+  return (
+    relative !== undefined &&
+    /^(?:zhc-|dual-agent-|dad-|claude-bridge-|openclaw-usage-probe)/.test(relative)
+  );
+}
+
+function labelProjectGroups(groups: CatalogProjectGroup[]): void {
+  const parts = groups.map((group) => group.title.split(/[\\/]/));
+  const suffixCounts = new Map<string, number>();
+  const foldedSuffixCounts = new Map<string, number>();
+  const windowsSuffixes = new Set<string>();
+  for (const [index, path] of parts.entries()) {
+    for (let depth = 1; depth <= path.length; depth++) {
+      const suffix = path.slice(-depth).join("/");
+      const folded = suffix.toLowerCase();
+      suffixCounts.set(suffix, (suffixCounts.get(suffix) ?? 0) + 1);
+      foldedSuffixCounts.set(folded, (foldedSuffixCounts.get(folded) ?? 0) + 1);
+      if (isWindowsProjectPath(groups[index]!.title)) {
+        windowsSuffixes.add(folded);
+      }
+    }
+  }
+  for (const [index, group] of groups.entries()) {
+    const path = parts[index]!;
+    // Full original paths still distinguish keys that differ only in separators.
+    group.label = group.title;
+    for (let depth = 1; depth <= path.length; depth++) {
+      const suffix = path.slice(-depth).join("/");
+      const folded = suffix.toLowerCase();
+      // Compare mixed-platform collisions symmetrically while keeping purely
+      // POSIX suffixes case sensitive.
+      const count = windowsSuffixes.has(folded)
+        ? foldedSuffixCounts.get(folded)
+        : suffixCounts.get(suffix);
+      if (count === 1) {
+        group.label = suffix;
+        break;
+      }
+    }
+  }
+}
+
 type CatalogProjectGroup = {
   kind: "custom" | "project" | "person";
   key: string;
@@ -64,8 +153,43 @@ export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogS
   const customGroupsByName = new Map<string, CatalogProjectGroup>();
   const projectGroupsByPath = new Map<string, CatalogProjectGroup>();
   const ungrouped: SessionCatalogSession[] = [];
+  let temporaryGroup: CatalogProjectGroup | undefined;
+  const projects = sessions.map((session) => {
+    const cwd = session.cwd?.trim();
+    const path = cwd ? foldWorktreeCheckoutPath(cwd) : null;
+    return {
+      path,
+      codexProject: path ? codexWorktreeProject(path) : undefined,
+      temporary: path ? isTemporaryProject(path) : false,
+    };
+  });
+  const origins = new Map<string, Set<string>>();
+  const codexOwners = new Map<string, Set<string>>();
+  for (const { path, codexProject, temporary } of projects) {
+    if (codexProject && !temporary) {
+      const owners = codexOwners.get(codexProject.repoName) ?? new Set<string>();
+      owners.add(codexProject.ownerRoot);
+      codexOwners.set(codexProject.repoName, owners);
+    }
+    // A basename alone is insufficient evidence. Only distinct absolute project
+    // identities outside managed Codex worktrees and generated temp projects count.
+    if (
+      !path ||
+      codexProject ||
+      /(?:^|[\\/])\.codex[\\/]worktrees(?:[\\/]|$)/.test(repoNameForMatching(path, path)) ||
+      temporary ||
+      !/^(?:\/|[a-z]:[\\/]|\\\\)/i.test(path) ||
+      path.split(/[\\/]/).some((part) => part === "." || part === "..")
+    ) {
+      continue;
+    }
+    const name = repoNameForMatching(path, checkoutDisplayName(path));
+    const paths = origins.get(name) ?? new Set<string>();
+    paths.add(path);
+    origins.set(name, paths);
+  }
 
-  for (const session of sessions) {
+  for (const [index, session] of sessions.entries()) {
     const customGroup = session.customGroup?.trim();
     if (customGroup) {
       const key = `custom:${customGroup}`;
@@ -87,28 +211,53 @@ export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogS
     }
     // Paths without a project identity fall to the ungrouped flat tail;
     // do not invent a project name when canonicalization returns no origin.
-    const trimmedPath = session.cwd?.trim();
-    const projectPath = trimmedPath ? foldWorktreeCheckoutPath(trimmedPath) : null;
-    if (!projectPath) {
+    const { path, codexProject, temporary } = projects[index]!;
+    if (!path) {
       ungrouped.push(session);
       continue;
     }
-    let group = projectGroupsByPath.get(projectPath);
+    if (temporary) {
+      if (!temporaryGroup) {
+        temporaryGroup = {
+          kind: "project",
+          key: "temporary:tests",
+          label: "Tests/Temporary",
+          title: "Tests/Temporary",
+          sessions: [],
+        };
+        projectGroups.push(temporaryGroup);
+      }
+      temporaryGroup.sessions.push(session);
+      continue;
+    }
+    const candidates = codexProject ? origins.get(codexProject.repoName) : undefined;
+    // One direct basename cannot attribute same-name repositories to different
+    // managed owners. In that case each owner retains its synthetic group.
+    const origin =
+      codexProject && codexOwners.get(codexProject.repoName)?.size === 1 && candidates?.size === 1
+        ? candidates.values().next().value
+        : undefined;
+    const projectPath = origin ?? path;
+    const synthetic = origin ? undefined : codexProject;
+    const key = synthetic?.key ?? `project:${projectPath}`;
+    const title = synthetic?.title ?? projectPath;
+    let group = projectGroupsByPath.get(key);
     if (!group) {
       group = {
         kind: "project",
-        key: `project:${projectPath}`,
-        legacySectionKey: projectPath,
-        label: checkoutDisplayName(projectPath),
-        title: projectPath,
+        key,
+        ...(!synthetic ? { legacySectionKey: projectPath } : {}),
+        label: checkoutDisplayName(title),
+        title,
         sessions: [],
       };
-      projectGroupsByPath.set(projectPath, group);
+      projectGroupsByPath.set(key, group);
       projectGroups.push(group);
     }
     group.sessions.push(session);
   }
 
+  labelProjectGroups([...projectGroupsByPath.values()]);
   return { groups: [...customGroups, ...projectGroups], ungrouped };
 }
 

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -136,6 +136,7 @@ type CatalogProjectGroup = {
   // Collapse ids predate the group-kind namespace. Read the old suffix until
   // the next toggle migrates that section to its canonical id.
   legacySectionKey?: string;
+  labelKey?: "chat.sidebar.catalogTemporaryProjects";
   label: string;
   title: string;
   sessions: SessionCatalogSession[];
@@ -221,8 +222,9 @@ export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogS
         temporaryGroup = {
           kind: "project",
           key: "temporary:tests",
-          label: "Tests/Temporary",
-          title: "Tests/Temporary",
+          labelKey: "chat.sidebar.catalogTemporaryProjects",
+          label: "",
+          title: "",
           sessions: [],
         };
         projectGroups.push(temporaryGroup);

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-project-activity.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-project-activity.ts
@@ -1,9 +1,90 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { i18n } from "../../i18n/index.ts";
 import { createGateway, createSessions, mountSidebar } from "../app-sidebar.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar project session activity", () => {
+  it("localizes temporary project headings without changing section or session identity", async () => {
+    await i18n.setLocale("en");
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    sidebar.sessionData.sessionCatalogs = [
+      {
+        id: "codex",
+        label: "Codex",
+        capabilities: { continueSession: true, archive: true },
+        hosts: [
+          {
+            hostId: "gateway:local",
+            label: "Local Codex",
+            kind: "gateway",
+            connected: true,
+            sessions: [
+              {
+                threadId: "temporary-thread",
+                name: "Temporary session",
+                cwd: "/tmp/zhc-probe/src",
+                status: "idle",
+                archived: false,
+                canContinue: true,
+                canArchive: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    sidebar.sessionData.requestSessionDataUpdate();
+    await sidebar.updateComplete;
+
+    const heading = sidebar.querySelector<HTMLButtonElement>(
+      '[data-session-catalog-project="temporary:tests"]',
+    );
+    const label = heading?.querySelector(".sidebar-session-catalog-project__label");
+    const row = sidebar.querySelector('[data-session-key*="temporary-thread"]');
+    const link = row?.querySelector("a");
+    const sessionKey = row?.getAttribute("data-session-key");
+    const href = link?.getAttribute("href");
+    expect(heading).not.toBeNull();
+    expect(row).not.toBeNull();
+    expect(href).toBeTruthy();
+    expect(label?.textContent).toBe("Tests/Temporary");
+    expect(heading?.title).toBe("Tests/Temporary");
+    expect(row?.closest('[role="list"]')?.getAttribute("aria-label")).toBe(
+      "Local Codex: Tests/Temporary",
+    );
+
+    const translate = i18n.t.bind(i18n);
+    const translation = vi
+      .spyOn(i18n, "t")
+      .mockImplementation((key, params) =>
+        key === "chat.sidebar.catalogTemporaryProjects"
+          ? "Temporary projects translated"
+          : translate(key, params),
+      );
+    try {
+      sidebar.requestUpdate();
+      await sidebar.updateComplete;
+      expect(label?.textContent).toBe("Temporary projects translated");
+      expect(heading?.title).toBe("Temporary projects translated");
+      expect(row?.closest('[role="list"]')?.getAttribute("aria-label")).toBe(
+        "Local Codex: Temporary projects translated",
+      );
+      expect(sidebar.querySelector('[data-session-key*="temporary-thread"]')).toBe(row);
+      expect(row?.getAttribute("data-session-key")).toBe(sessionKey);
+      expect(link?.getAttribute("href")).toBe(href);
+      heading?.click();
+      await sidebar.updateComplete;
+      expect(heading?.getAttribute("aria-expanded")).toBe("false");
+      expect(
+        JSON.parse(localStorage.getItem("openclaw:sidebar:sessions:collapsed-sections") ?? "[]"),
+      ).toContain("catalog-project:codex:gateway:local:temporary:tests");
+    } finally {
+      translation.mockRestore();
+    }
+  });
+
   it("preserves collapsed project sections stored by earlier versions", async () => {
     localStorage.setItem(
       "openclaw:sidebar:sessions:collapsed-sections",


### PR DESCRIPTION
## What Problem This Solves 
 
Native session catalogs can expose several worktree cwd values for one logical repository, which splits related sessions into duplicate project groups. Generated probe directories also add noise, while equal repository basenames need readable disambiguation. 
 
## Summary 
 
- Group Codex managed worktrees by stable owner and repository identity, with a unique direct repository root taking precedence. 
- Collapse known generated temporary probe projects into a localized Tests/Temporary group without capturing ordinary temp-root projects. 
- Disambiguate duplicate project labels with shortest unique path suffixes and Windows case-insensitive matching. 
 
## Safety 
 
- Preserve session IDs, resume links, catalog history, ordering, and session object identity. 
- Change only the derived Control UI grouping and rendering projection. 
 
## Evidence 
 
- Catalog grouping tests: 75 passed. 
- Sidebar rendering and behavior tests: 353 passed. 
- pnpm ui:i18n:verify passed without raw-copy baseline changes. 
- pnpm tsgo:ui passed. 
- Focused oxfmt and type-aware oxlint passed. 
- git diff --check passed. 
- Prior large-10 failure was an unrelated timeout in setup-inference-activate.test.ts and was not modified or masked. 
