### PR TITLE
fix: focus side-chat input when opening its panel

### DIFF
--- a/ui/src/e2e/chat-session-companion-focus.e2e.test.ts
+++ b/ui/src/e2e/chat-session-companion-focus.e2e.test.ts
@@ -1,0 +1,66 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "side-chat input focus" });
+
+suite.define(() => {
+  for (const viewport of [
+    { width: 1440, height: 900 },
+    { width: 390, height: 844 },
+  ]) {
+    it(`focuses Side chat on open, reopen, and tab activation at ${viewport.width}px`, async () => {
+      await suite.withPage({ viewport }, async ({ page }) => {
+        await installMockGateway(page);
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await openChatSidePanelType(page, "Side chat");
+        const input = page.getByRole("textbox", { name: "Ask in side chat", exact: true });
+        await expect
+          .poll(() => input.evaluate((element) => document.activeElement === element))
+          .toBe(true);
+        await page.keyboard.type("Ready to ask");
+        expect(await input.inputValue()).toBe("Ready to ask");
+
+        await page.locator(".side-panel__minimize").click();
+        await page.locator(".chat-side-panel-toggle").click();
+        await expect
+          .poll(() => input.evaluate((element) => document.activeElement === element))
+          .toBe(true);
+        expect(await input.inputValue()).toBe("Ready to ask");
+
+        await openChatSidePanelType(page, "Tasks");
+        await page.getByRole("tab", { name: "Side chat", exact: true }).click();
+        await expect
+          .poll(() => input.evaluate((element) => document.activeElement === element))
+          .toBe(true);
+        await page.keyboard.type(" again");
+        expect(await input.inputValue()).toBe("Ready to ask again");
+      });
+    });
+  }
+
+  it("does not steal focus back when the side-chat history finishes loading", async () => {
+    await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["sessions.companion.state"],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("sessions.companion.state");
+      await openChatSidePanelType(page, "Side chat");
+      const input = page.getByRole("textbox", { name: "Ask in side chat", exact: true });
+      await expect
+        .poll(() => input.evaluate((element) => document.activeElement === element))
+        .toBe(true);
+      const mainInput = page.locator(".agent-chat__composer-combobox textarea");
+      await mainInput.fill("Keep typing here");
+      await gateway.resolveDeferred("sessions.companion.state", {
+        exchanges: [{ question: "What changed?", answer: "The introduction is ready.", ts: 1 }],
+      });
+      await page.getByText("The introduction is ready.", { exact: true }).waitFor();
+      expect(await mainInput.evaluate((element) => document.activeElement === element)).toBe(true);
+      await page.keyboard.type(".");
+      expect(await mainInput.inputValue()).toBe("Keep typing here.");
+    });
+  });
+});

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -51,6 +51,7 @@ type SidebarPanelDefinitionParams = {
   lastReadAt: number | undefined;
   pullRequests: ControlUiSessionPullRequest[];
   companion: ChatSessionCompanionThread;
+  companionPresented: boolean;
   onCompanionSubmit: (question: string) => void;
   onCompanionDraftChange: (draft: string) => void;
   onCompanionVisibilityChange: (visible: boolean) => void;
@@ -158,6 +159,7 @@ export function sidebarPanelDefinitions(
   const companion = params
     ? html`<openclaw-chat-session-rail
         embedded
+        .presented=${params.companionPresented}
         .sessionKey=${state?.sessionKey}
         .digest=${params.digest}
         .running=${Boolean(params.activeRunId)}

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -206,6 +206,10 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       lastReadAt: selectedSession?.lastReadAt,
       pullRequests: this.sessionPullRequests,
       companion: companionThread,
+      companionPresented:
+        this.presented &&
+        this.visuallyPresented &&
+        isSidebarSlotVisible(sidebarLayout, "companion"),
       onCompanionSubmit: (question) => void this.submitSessionCompanionQuestion(question),
       onCompanionDraftChange: (draft) =>
         this.sessionCompanionThreads.setDraft(state.sessionKey, draft, currentAgentId),

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -237,6 +237,7 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
   @property({ attribute: false }) onModeChange?: (mode: SessionRailMode) => void;
   @property({ attribute: false }) onVisibilityChange?: (visible: boolean) => void;
   @property({ type: Boolean }) embedded = false;
+  @property({ type: Boolean }) presented = false;
   @state() private now = Date.now();
 
   private readonly railState = new ChatSessionRailState();
@@ -293,7 +294,14 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
     this.onVisibilityChange?.(true);
   }
 
-  override updated() {
+  override updated(changedProperties: PropertyValues<this>) {
+    // Retained tabs stay mounted while hidden. Only a presentation edge owns
+    // focus; history, replies, and reconnects must not interrupt another input.
+    if (changedProperties.has("presented") && this.presented) {
+      this.querySelector<HTMLInputElement>(".chat-session-rail__input:not(:disabled)")?.focus({
+        preventScroll: true,
+      });
+    }
     if (this.running && this.startedAt != null && visibleDigest(this.input())) {
       this.scheduleClock();
     } else {

--- a/ui/src/pages/chat/components/chat-sidebar-region.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.test.ts
@@ -269,6 +269,7 @@ describe("chat sidebar region", () => {
         themeMode: "dark",
         agentId: "main",
         browserPresented: false,
+        companionPresented: false,
         browserRefreshOnPresentation: false,
         desktopPresented: false,
         desktopRefreshOnPresentation: false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Side chat in the right-hand panel could not type into it immediately. Keyboard focus stayed elsewhere, so typing could enter the main chat instead.

## Why This Change Was Made

Side chat remains mounted while its tab or panel is hidden. Pass the pane's existing presentation state to the rail and focus its enabled input when it becomes visible. History loads, replies, and reconnects do not refocus it.

## User Impact

Opening, reopening, or switching to Side chat puts the cursor in its input without an extra click. Existing drafts are retained, and later updates do not interrupt typing in another input.

## Evidence

- Baseline: `dc0d0b09be873ebdced3054d30bc29b5aa9324fa`; candidate: `75061de0554945bd26ee7aee5354b4825ae81b62`.
- Real Chromium Control UI with deterministic **mocked Gateway** responses and synthetic fixtures. Same `/chat` route, dark theme, locale, viewport, and open-then-type sequence; no production gateway changes.
- Desktop/mobile browser regressions fail at the initial focus assertion on the baseline. All **3 candidate E2E tests pass**: initial opening, reopening, tab activation, retained draft, and delayed history without focus theft.
- **145 neighboring tests pass**, covering rail behavior, embedded panels, keyboard focus, and the sidebar region.
- **8/8 before/after scenarios**: before = input unfocused and empty; after = input focused and receives `Ready to ask` without a click.
- Pending-answer probe passes: a disabled input is not focused on reopening, and the completed reply does not reclaim main-input focus.
- Fresh grouped UI build and independent P2 autoreview pass. All selected changed-file gates pass, including core-test/UI typechecks, formatting, lint, i18n, and repository guards. The final typed-fixture recheck also passes (26 tests).

### Interaction recordings

Before — typing lands in the main chat:

https://github.com/user-attachments/assets/dcfb7bd6-7df0-41ef-b010-efdf4e1ea895

After — Side chat receives typing immediately:

https://github.com/user-attachments/assets/90059b9c-5c21-4245-9a35-b4fcda286c58

### Before / after

| State | Viewport | Before | After |
|---|---|---|---|
| empty | 1440×900 | ![Before empty](https://github.com/user-attachments/assets/735c092d-06de-49d2-94f3-50483611522c) | ![After empty](https://github.com/user-attachments/assets/0ac84fce-1a2b-497b-95e4-e89c17ee8dd7) |
| loading | 1440×900 | ![Before loading](https://github.com/user-attachments/assets/bdbca521-d7e8-4394-942d-148228e92fd0) | ![After loading](https://github.com/user-attachments/assets/86dd842d-c302-4efa-9288-97cf03d23154) |
| typical | 1440×900 | ![Before typical](https://github.com/user-attachments/assets/057fa6eb-fb38-4717-9b47-279e2ca96aef) | ![After typical](https://github.com/user-attachments/assets/cd336ee6-7e71-4bae-bf9c-04add843df72) |
| heavy | 1440×900 | ![Before heavy](https://github.com/user-attachments/assets/cdcd1e28-49e0-4628-b7f6-866c67592ba0) | ![After heavy](https://github.com/user-attachments/assets/a98675b7-183c-4176-8246-6dc28d6e1ef8) |
| empty | 390×844 | ![Before empty](https://github.com/user-attachments/assets/d7badd2a-dd23-46ca-8c67-6aa3451785f3) | ![After empty](https://github.com/user-attachments/assets/64938309-1357-4ce6-9b67-d02de59cb361) |
| loading | 390×844 | ![Before loading](https://github.com/user-attachments/assets/79ccf841-e367-4782-9fb8-a2eb160e8f4e) | ![After loading](https://github.com/user-attachments/assets/854a95a6-e66e-4eab-a6b5-df2350fab83a) |
| typical | 390×844 | ![Before typical](https://github.com/user-attachments/assets/e9758295-3a05-4f6f-abe1-9b49abf99241) | ![After typical](https://github.com/user-attachments/assets/9ca3d98d-cc62-406f-8fe1-21ebf938eee0) |
| heavy | 390×844 | ![Before heavy](https://github.com/user-attachments/assets/bac16b53-1d78-4df0-8c77-8002294dc8cc) | ![After heavy](https://github.com/user-attachments/assets/a15c9c4a-8e43-41db-9a12-d1528615422d) |

<details>
<summary>Verification commands and proof boundaries</summary>

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-session-companion-focus.e2e.test.ts
node scripts/run-vitest.mjs ui/src/pages/chat/chat-session-rail.test.ts ui/src/pages/chat/chat-pane-embedded-panels.test.ts ui/src/pages/chat/chat-pane-keyboard-focus.test.ts ui/src/pages/chat/components/chat-sidebar-region.test.ts
node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-session-rail.ts ui/src/pages/chat/chat-pane-layout-render.ts ui/src/pages/chat/chat-pane-embedded-panels.ts ui/src/e2e/chat-session-companion-focus.e2e.test.ts ui/src/pages/chat/components/chat-sidebar-region.test.ts
```

Captures and assertion scripts use the repository's Control UI E2E/mock helpers; recordings retain their original WebM and timing cues. Captioned output, full-timeline frames, and all screenshots were inspected. Captured production-file hashes match the candidate commit.

Error-specific screenshots are omitted because error copy/layout is unchanged; disabled behavior is verified by the pending-answer probe. Real-device virtual keyboards and live model calls are outside this DOM-focus change. No deployment or gateway restart.

</details>
