### PR TITLE
fix(agents): normalize bare model defaults with captured metadata

### DIFF
--- a/src/agents/model-selection-manifest-workspace.test.ts
+++ b/src/agents/model-selection-manifest-workspace.test.ts
@@ -31,6 +31,17 @@ vi.mock("./provider-model-normalization.runtime.js", () => ({
   normalizeProviderModelIdWithRuntime: normalizeProviderModelIdWithRuntimeMock,
 }));
 
+const defaultNormalizationSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "default-normalizer",
+      modelIdNormalization: {
+        providers: { openai: { aliases: { entry: "middle", middle: "final" } } },
+      },
+    },
+  ],
+});
+
 describe("configured model manifest workspace scope", () => {
   beforeEach(() => {
     loadManifestMetadataSnapshotMock.mockReset();
@@ -399,6 +410,149 @@ describe("configured model manifest workspace scope", () => {
     ).toEqual({ provider: "openai", model: "ops" });
     expect(loadManifestMetadataSnapshotMock.mock.calls.length).toBe(1);
   });
+
+  it.each(["snapshot", "plugins"] as const)(
+    "normalizes unresolved bare defaults once with captured %s metadata",
+    (source) => {
+      const snapshot = defaultNormalizationSnapshot;
+      const manifestPlugins = source === "snapshot" ? snapshot : snapshot.plugins;
+      for (const primary of ["entry", "entry@work"]) {
+        expect(
+          resolveConfiguredModelRef({
+            cfg: { agents: { defaults: { model: { primary } } } },
+            defaultProvider: "openai",
+            defaultModel: "unused",
+            manifestPlugins,
+            allowPluginNormalization: false,
+          }),
+        ).toEqual({ provider: "openai", model: "middle" });
+      }
+      expect(getCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+      expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
+      expect(normalizeProviderModelIdWithRuntimeMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { name: "explicit", primary: "openai/entry", models: undefined },
+    { name: "inferred", primary: "entry", models: { "openai/entry": {} } },
+    {
+      name: "configured alias",
+      primary: "friendly",
+      models: { "openai/entry": { alias: "friendly" } },
+    },
+  ])("does not renormalize the $name selection", ({ primary, models }) => {
+    const manifestPlugins = defaultNormalizationSnapshot;
+    expect(
+      resolveConfiguredModelRef({
+        cfg: { agents: { defaults: { model: { primary }, models } } },
+        defaultProvider: "openai",
+        defaultModel: "unused",
+        manifestPlugins,
+        allowPluginNormalization: false,
+      }),
+    ).toEqual({ provider: "openai", model: "middle" });
+  });
+
+  it.each([false, true])(
+    "keeps absent metadata raw and honors explicitly empty metadata (captured=%s)",
+    (captured) => {
+      normalizeProviderModelIdWithRuntimeMock.mockReturnValue("runtime-entry");
+      expect(
+        resolveConfiguredModelRef({
+          cfg: { agents: { defaults: { model: "entry" } } },
+          defaultProvider: "openai",
+          defaultModel: "unused",
+          ...(captured ? { manifestPlugins: [] } : {}),
+        }),
+      ).toEqual({ provider: "openai", model: captured ? "runtime-entry" : "entry" });
+      expect(normalizeProviderModelIdWithRuntimeMock).toHaveBeenCalledTimes(captured ? 1 : 0);
+      expect(getCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+      expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { manifest: true, runtime: true, expected: "runtime-middle" },
+    { manifest: true, runtime: false, expected: "middle" },
+    { manifest: false, runtime: true, expected: "runtime-entry" },
+    { manifest: false, runtime: false, expected: "entry" },
+  ])(
+    "honors captured normalization flags (manifest=$manifest, runtime=$runtime)",
+    ({ manifest, runtime, expected }) => {
+      normalizeProviderModelIdWithRuntimeMock.mockImplementation(
+        ({ context }: { context: { modelId: string } }) => `runtime-${context.modelId}`,
+      );
+      expect(
+        resolveConfiguredModelRef({
+          cfg: { agents: { defaults: { model: "entry" } } },
+          defaultProvider: "openai",
+          defaultModel: "unused",
+          manifestPlugins: defaultNormalizationSnapshot,
+          allowManifestNormalization: manifest,
+          allowPluginNormalization: runtime,
+        }),
+      ).toEqual({ provider: "openai", model: expected });
+      expect(normalizeProviderModelIdWithRuntimeMock).toHaveBeenCalledTimes(runtime ? 1 : 0);
+      expect(getCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+      expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reuses metadata captured during unsuccessful provider inference", () => {
+    loadManifestMetadataSnapshotMock.mockReturnValue(defaultNormalizationSnapshot);
+    expect(
+      resolveConfiguredModelRef({
+        cfg: { agents: { defaults: { model: "entry", models: { "custom/unrelated": {} } } } },
+        defaultProvider: "openai",
+        defaultModel: "unused",
+        allowPluginNormalization: false,
+      }),
+    ).toEqual({ provider: "openai", model: "middle" });
+    expect(loadManifestMetadataSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the configured native API owner for a captured bare default", () => {
+    normalizeProviderModelIdWithRuntimeMock.mockReturnValue("wrong-runtime-model");
+    expect(
+      resolveConfiguredModelRef({
+        cfg: {
+          agents: { defaults: { model: "entry@work" } },
+          models: {
+            providers: {
+              openai: { api: "ollama", baseUrl: "https://fixture.invalid", models: [] },
+            },
+          },
+        },
+        defaultProvider: "openai",
+        defaultModel: "unused",
+        manifestPlugins: defaultNormalizationSnapshot,
+      }),
+    ).toEqual({ provider: "openai", model: "middle" });
+    expect(normalizeProviderModelIdWithRuntimeMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { primary: "@work", expected: "@work" },
+    { primary: "entry@", expected: "entry@" },
+    { primary: "   ", expected: "unused" },
+    { primary: "/", expected: "unused" },
+  ])(
+    "keeps existing parser behavior for captured malformed input '$primary'",
+    ({ primary, expected }) => {
+      expect(
+        resolveConfiguredModelRef({
+          cfg: { agents: { defaults: { model: { primary } } } },
+          defaultProvider: "openai",
+          defaultModel: "unused",
+          manifestPlugins: [],
+          allowPluginNormalization: false,
+        }),
+      ).toEqual({ provider: "openai", model: expected });
+      expect(getCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+      expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not load manifest metadata for statically resolved primary models", () => {
     const cases: Array<{ cfg: OpenClawConfig; expected: { provider: string; model: string } }> = [

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -889,7 +889,9 @@ export function resolveConfiguredModelRef(
       getLog().warn(
         `Model "${safeTrimmed}" specified without provider. Falling back to "${safeResolved}". Please use "${safeResolved}" in your config.`,
       );
-      return { provider: params.defaultProvider, model: trimmed };
+      if (inferredProviderManifestPlugins === undefined) {
+        return { provider: params.defaultProvider, model: trimmed };
+      }
     }
 
     const resolved = resolveModelRefFromString({

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -308,3 +308,61 @@ it("acquires the canonical manifest-derived utility model selection", async () =
     }
   }
 });
+
+it.each(["/", "entry"])(
+  "materializes a bare default once through actual agent acquisition (override=%s)",
+  async (modelRef) => {
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "default-normalizer",
+          modelIdNormalization: {
+            providers: { openai: { aliases: { entry: "middle", middle: "final" } } },
+          },
+        },
+      ],
+    });
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue(metadataSnapshot);
+    mocks.getApiKeyForModel.mockResolvedValue({
+      apiKey: "ollama-local",
+      source: "local marker",
+      mode: "api-key",
+    });
+    const release = vi.fn();
+    mocks.acquireRuntimeLease.mockResolvedValue({ snapshot: preparedModelRuntime, release });
+    const resolveModel = createOllamaModelResolver();
+    const modelResolver: SimpleCompletionModelResolver = async (...args) => {
+      const resolved = await resolveModel(...args);
+      return args[1] === "middle"
+        ? resolved
+        : { ...resolved, model: undefined, error: `Unexpected selected model: ${args[1]}` };
+    };
+    const result = await acquireSimpleCompletionModelForAgent({
+      cfg: { agents: { entries: { main: {} }, defaults: { model: "entry" } } },
+      agentId: "main",
+      modelRef,
+      modelResolver,
+    });
+
+    try {
+      expect(result).toMatchObject({
+        selection: { provider: "openai", modelId: "middle" },
+        model: { provider: "openai", id: "middle", contextWindow: 8192 },
+      });
+      expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runtimePluginSelections: [{ provider: "openai", modelId: "middle", agentId: "main" }],
+        }),
+        expect.objectContaining({
+          catalogMode: "static",
+          pluginMetadataSnapshot: metadataSnapshot,
+        }),
+      );
+    } finally {
+      if (!("error" in result)) {
+        result.release();
+      }
+    }
+    expect(release).toHaveBeenCalledOnce();
+  },
+);


### PR DESCRIPTION
Related: #130706. Prerequisite for the bare-default cases held in #144354 and CLI model validation.

## What Problem This Solves

Fixes an issue where a simple completion falling back to a bare configured primary could reject the model or use the wrong metadata, despite already having the provider's normalization policy. For `entry → middle → final`, the fallback could retain raw `entry` while later preparation treated it as fully selected.

## Why This Change Was Made

Captured bare defaults now continue through the existing model-reference parser. It reuses cached metadata, normalization flags, auth-profile parsing and configured API-owner handling. Callers without captured metadata keep the existing cheap raw path; already resolved branches return before this point. The production change is **two added lines**.

## User Impact

Default fallback selection uses the provider's intended model without resolving an already-selected alias twice. No configuration, schema, persisted fields, imports, or public API options are added, and this change introduces no new metadata discovery.

## Evidence

Validated `62675418c10dc22d7f1b673c3b20145543c3acf3` against main `f9976d6de6a086c3b19edbfaeb7412db47b50bb7`.

- Unmodified-main source baseline: nine intended failures and 35 passing controls.
- **265 focused tests across seven files passed**, followed by the full pinned changed-file gate and fresh independent P2 review.
- One normal full build passed with natural metadata bound to the candidate commit.
- **Five fresh public SDK processes made five real loopback HTTP requests.** Invalid-override fallback, valid override, inherited default, raw next-hop and exact-ID cases verified selection, materialized context, response text and request model. Nine public model-config checks covered metadata/normalization modes.
- All **14,636 build outputs** and source stayed unchanged; **3,983 executed files** were verified. Source-import rejection controls passed, all five processes exited naturally, and owned runtime state was removed.

Two earlier compiled fixture attempts remain failed and preserved: an explicit configured API mapping treated `/` as a literal ID, and a disabled canonical provider owner prevented the synthetic plugin from loading. The final fixture verifies the invalid-override precondition and enables its isolated synthetic provider replacement. Source and build were unchanged between attempts. This is compiled SDK/loopback proof, not external vendor inference; it does not borrow the unlanded TTS patch.
