### PR TITLE
fix(usage): refresh details after a session is recreated

### DIFF
--- a/docs/web/control-ui/feature-reference.md
+++ b/docs/web/control-ui/feature-reference.md
@@ -93,6 +93,7 @@ Control UI capabilities grouped by area, each with the Gateway RPC methods behin
     - A provider usage failure does not block the session/cost dashboard; unavailable provider cards show their own error state.
     - Incomplete session/cost totals stay readable while the visible, focused page checks for updates. Automatic checks are bounded; if they pause, select **Refresh** to check again.
     - **Refresh** also reloads the selected session's timeline, conversation, and system-prompt breakdown.
+    - If a selected session is deleted and recreated, its new details replace the old ones without clearing your selection. Context details from a different session instance show an error and can be retried with **Refresh**.
     - The overview loads session summaries first. Full system-prompt breakdowns load when you select a session; the `has:context` filter still works before opening details.
     - JSON exports keep the displayed usage snapshot and load prompt details for the same session instance. If that session has been replaced, refresh Usage and export again.
 

--- a/ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
+++ b/ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
@@ -1,12 +1,18 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 import type { GatewayServer } from "../../../src/gateway/server-public.ts";
+import { resetLogger, setLoggerOverride } from "../../../src/logging/logger.ts";
+import type { SessionsUsageResult } from "../../../src/shared/usage-types.ts";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../../src/test-utils/openclaw-test-state.ts";
 import { getFreePort } from "../../../src/test-utils/ports.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { COMMUNITY_INVITE_KEY } from "../components/community-invite-state.ts";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -27,11 +33,38 @@ async function capture(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
+  expect(await page.locator(".community-invite-card").count()).toBe(0);
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
     path: path.join(suite.artifactDir, name),
   });
+}
+
+async function prepareUsageProofPage(page: Page) {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(key, JSON.stringify({ dismissedAtMs: 1770000000000 }));
+  }, COMMUNITY_INVITE_KEY);
+}
+
+async function requestGateway<T>(
+  page: Page,
+  methodName: string,
+  requestParams: Record<string, unknown>,
+) {
+  return await page.evaluate(
+    async ({ method, params }) => {
+      const app = document.querySelector("openclaw-app") as
+        | (HTMLElement & { runtime?: { context: ApplicationContext } })
+        | null;
+      const client = app?.runtime?.context.gateway.snapshot.client;
+      if (!client) {
+        throw new Error("Usage proof has no connected Gateway client");
+      }
+      return await client.request<T>(method, params);
+    },
+    { method: methodName, params: requestParams },
+  );
 }
 
 suite.define(() => {
@@ -48,6 +81,7 @@ suite.define(() => {
         },
         release: async () => {
           await fixture?.cleanup();
+          resetLogger();
         },
         run: async (signal) => {
           const port = await getFreePort();
@@ -66,6 +100,11 @@ suite.define(() => {
             },
           });
           fixture = state;
+          setLoggerOverride({
+            file: state.path("gateway.log"),
+            level: "silent",
+            consoleLevel: "silent",
+          });
           signal.throwIfAborted();
 
           const { startGatewayServer } = await import("../../../src/gateway/server.js");
@@ -156,6 +195,7 @@ suite.define(() => {
               viewport,
             },
             async ({ page }) => {
+              await prepareUsageProofPage(page);
               const pageErrors: string[] = [];
               page.on("pageerror", (error) => pageErrors.push(String(error)));
 
@@ -202,4 +242,305 @@ suite.define(() => {
       });
     },
   );
+
+  it("replaces selected details when the same agent recreates a deleted session key", async (context) => {
+    let fixture: OpenClawTestState | undefined;
+    let gateway: Promise<GatewayServer> | undefined;
+    let restoreClock: (() => void) | undefined;
+    await suite.runScenario(context, {
+      retainedState: () => fixture?.root,
+      close: async () => {
+        await (await gateway)?.close({ reason: "usage detail instance e2e cleanup" });
+      },
+      release: async () => {
+        restoreClock?.();
+        await fixture?.cleanup();
+        resetLogger();
+      },
+      run: async (signal) => {
+        const port = await getFreePort();
+        signal.throwIfAborted();
+        const state = await createOpenClawTestState({
+          label: "usage-detail-instance",
+          env: {
+            OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+            OPENCLAW_SKIP_CANVAS_HOST: "1",
+            OPENCLAW_SKIP_CHANNELS: "1",
+            OPENCLAW_SKIP_CRON: "1",
+            OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+            OPENCLAW_SKIP_PROVIDERS: "1",
+            OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+            VITEST: "1",
+          },
+        });
+        fixture = state;
+        setLoggerOverride({
+          file: state.path("gateway.log"),
+          level: "silent",
+          consoleLevel: "silent",
+        });
+        signal.throwIfAborted();
+        await state.writeConfig({
+          agents: {
+            ownership: "explicit",
+            defaults: { workspace: state.workspaceDir },
+            entries: { main: {}, opus: {} },
+          },
+          gateway: {
+            mode: "local",
+            port,
+            bind: "loopback",
+            auth: { mode: "none" },
+            controlUi: { enabled: false },
+          },
+          plugins: { enabled: false },
+        });
+        const { startGatewayServer } = await import("../../../src/gateway/server.js");
+        const { persistSessionTranscriptTurn } =
+          await import("../../../src/config/sessions/session-accessor.js");
+        const { ensureGatewayOwnerProfile } = await import("../../../src/state/user-profiles.js");
+        ensureGatewayOwnerProfile("Usage Proof", { env: state.env });
+        signal.throwIfAborted();
+        gateway = startGatewayServer(port, {
+          auth: { mode: "none" },
+          bind: "loopback",
+          controlUiEnabled: false,
+          sidecarStartup: "defer",
+        });
+        await gateway;
+        signal.throwIfAborted();
+
+        await suite.withPage(
+          { locale: "en-US", timezoneId: "UTC", serviceWorkers: "block", viewport },
+          async ({ page }) => {
+            await prepareUsageProofPage(page);
+            const key = "agent:opus:usage-instance-proof";
+            const gatewayUrl = new URL(`ws://127.0.0.1:${port}`).href;
+            const pageErrors: string[] = [];
+            const overviewRequests = new Map<string, Record<string, unknown>>();
+            const observedOverviews: Array<{
+              requestId: string;
+              params: Record<string, unknown>;
+              session?: { key: string; agentId?: string; sessionId?: string; tokens?: number };
+            }> = [];
+            let connections = 0;
+            page.on("pageerror", (error) => pageErrors.push(String(error)));
+            page.on("websocket", (socket) => {
+              if (socket.url() !== gatewayUrl) {
+                return;
+              }
+              connections++;
+              socket.on("framesent", ({ payload }) => {
+                const frame: {
+                  type: string;
+                  id: string;
+                  method?: string;
+                  params?: Record<string, unknown>;
+                } = JSON.parse(payload.toString());
+                if (
+                  frame.type === "req" &&
+                  frame.method === "sessions.usage" &&
+                  frame.params &&
+                  frame.params.key === undefined
+                ) {
+                  overviewRequests.set(frame.id, frame.params);
+                }
+              });
+              socket.on("framereceived", ({ payload }) => {
+                const frame: {
+                  type: string;
+                  id: string;
+                  ok?: boolean;
+                  payload?: SessionsUsageResult;
+                } = JSON.parse(payload.toString());
+                const params = overviewRequests.get(frame.id);
+                if (frame.type !== "res" || !frame.ok || !params || !frame.payload) {
+                  return;
+                }
+                const session = frame.payload.sessions.find((entry) => entry.key === key);
+                observedOverviews.push({
+                  requestId: frame.id,
+                  params,
+                  ...(session
+                    ? {
+                        session: {
+                          key: session.key,
+                          agentId: session.agentId,
+                          sessionId: session.sessionId,
+                          tokens: session.usage?.totalTokens,
+                        },
+                      }
+                    : {}),
+                });
+              });
+            });
+            const url = new URL("settings/general", suite.server.baseUrl);
+            url.searchParams.set("gatewayUrl", gatewayUrl);
+            await page.goto(url.toString());
+            await page
+              .locator("openclaw-gateway-url-confirmation")
+              .getByRole("button", { name: `Switch to 127.0.0.1:${port}`, exact: true })
+              .click();
+            await waitForControlUiGatewayReady(page);
+
+            const date = new Date().toISOString().slice(0, 10);
+            const timestamp = Date.parse(`${date}T12:00:00Z`);
+            const createSession = async (label: string, tokens: number) => {
+              const created = await requestGateway<{ ok: boolean; key: string; sessionId: string }>(
+                page,
+                "sessions.create",
+                { key, agentId: "opus", label: `${label} usage session` },
+              );
+              expect(created.ok).toBe(true);
+              expect(created.key).toBe(key);
+              expect(created.sessionId).toBeTruthy();
+              signal.throwIfAborted();
+              await persistSessionTranscriptTurn(
+                { agentId: "opus", sessionKey: key, sessionId: created.sessionId, env: state.env },
+                {
+                  cwd: state.workspaceDir,
+                  updateMode: "none",
+                  messages: [0, 1].map((index) => ({
+                    now: timestamp + index * 1_000,
+                    message: {
+                      role: "assistant",
+                      content: [{ type: "text", text: `${label} reply ${index + 1}` }],
+                      api: "openai-responses",
+                      provider: "fixture",
+                      model: "usage-proof",
+                      stopReason: "stop",
+                      timestamp: timestamp + index * 1_000,
+                      usage: {
+                        input: tokens,
+                        output: 0,
+                        cacheRead: 0,
+                        cacheWrite: 0,
+                        totalTokens: tokens,
+                        cost: { input: 0.01, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.01 },
+                      },
+                    },
+                  })),
+                },
+              );
+              return created.sessionId;
+            };
+            const originalId = await createSession("Original", 100);
+            await page.goto(new URL("usage", suite.server.baseUrl).toString());
+            await waitForControlUiGatewayReady(page);
+            const selected = page.locator(
+              `.session-bar-row[title="${key}"] .session-bar-selection`,
+            );
+            await selected.click();
+            const panel = page.locator(".session-detail-panel");
+            const readDetails = async () => ({
+              timeline: await panel.locator(".timeseries-summary").textContent(),
+              conversation: await panel.locator(".session-log-content").allTextContents(),
+            });
+            await expect.poll(readDetails).toEqual({
+              timeline: expect.stringContaining("200"),
+              conversation: ["Original reply 1", "Original reply 2"],
+            });
+            const initialOverview = observedOverviews.findLast(
+              (overview) => overview.session?.sessionId === originalId,
+            );
+            if (!initialOverview) {
+              throw new Error("The Usage page did not receive its original session overview");
+            }
+            await capture(page, "01-original-instance-details.png");
+            const selectedConnections = connections;
+
+            const deleted = await requestGateway<{ deleted: boolean }>(page, "sessions.delete", {
+              key,
+              agentId: "opus",
+              expectedSessionId: originalId,
+              deleteTranscript: true,
+            });
+            expect(deleted.deleted).toBe(true);
+            const replacementId = await createSession("Replacement", 300);
+            expect(replacementId).not.toBe(originalId);
+
+            // Age the real cache without replacing its loader or advancing asynchronous timers.
+            const realNow = Date.now.bind(Date);
+            const clock = vi.spyOn(Date, "now").mockImplementation(() => realNow() + 31_000);
+            restoreClock = () => clock.mockRestore();
+            const overviewParams = initialOverview.params;
+            // The first stale-while-refresh read may still return the retired instance.
+            await expect
+              .poll(async () => {
+                const overview = await requestGateway<SessionsUsageResult>(
+                  page,
+                  "sessions.usage",
+                  overviewParams,
+                );
+                const current = overview.sessions.find((session) => session.key === key);
+                return { sessionId: current?.sessionId, tokens: current?.usage?.totalTokens };
+              })
+              .toEqual({ sessionId: replacementId, tokens: 600 });
+            const focusOverviewStart = observedOverviews.length;
+
+            // Keep the real connection active while aging the browser's five-minute focus TTL.
+            const browserNow = await page.evaluate(() => Date.now());
+            for (let step = 1; step <= 31; step++) {
+              await page.clock.setFixedTime(new Date(browserNow + step * 10_000));
+              await requestGateway(page, "health", {});
+            }
+            await page.bringToFront();
+            await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+            await expect
+              .poll(() => panel.locator(".session-detail-title").textContent())
+              .toContain("Replacement usage session");
+            await expect
+              .poll(() => panel.locator(".session-detail-stats").textContent())
+              .toContain("600");
+            const selectedReplacement = page.locator(
+              ".session-bar-row.selected .session-bar-selection",
+            );
+            expect(await selectedReplacement.count()).toBe(1);
+            expect(await selectedReplacement.getAttribute("aria-pressed")).toBe("true");
+            expect(await selectedReplacement.getAttribute("aria-label")).toBe(
+              "Replacement usage session",
+            );
+            expect(
+              observedOverviews
+                .slice(focusOverviewStart)
+                .some((overview) => overview.session?.sessionId === replacementId),
+            ).toBe(true);
+            expect(connections).toBe(selectedConnections);
+            try {
+              await expect.poll(readDetails).toEqual({
+                timeline: expect.stringContaining("600"),
+                conversation: ["Replacement reply 1", "Replacement reply 2"],
+              });
+            } finally {
+              await capture(page, "02-replacement-instance-details.png");
+              await panel.locator(".session-log-content").last().scrollIntoViewIfNeeded();
+              await capture(page, "03-replacement-instance-conversation.png");
+              if (captureUiProof) {
+                await writeFile(
+                  path.join(suite.artifactDir, "instance-replacement.json"),
+                  JSON.stringify({
+                    key,
+                    agentId: "opus",
+                    originalId,
+                    replacementId,
+                    selection: {
+                      pressed: await selectedReplacement.getAttribute("aria-pressed"),
+                      label: await selectedReplacement.getAttribute("aria-label"),
+                    },
+                    initialOverview,
+                    focusOverviews: observedOverviews.slice(focusOverviewStart),
+                    selectedConnections,
+                    connections,
+                    ...(await readDetails()),
+                  }),
+                );
+              }
+            }
+            expect(connections).toBe(selectedConnections);
+            expect(pageErrors).toEqual([]);
+          },
+        );
+      },
+    });
+  });
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4652,6 +4652,7 @@ export const en: TranslationMap & {
       tokensWrittenToCache: "Tokens written to cache",
       tokensReadFromCache: "Tokens read from cache",
       noContextData: "No context data",
+      contextOutOfDate: "These context details are out of date. Refresh usage and try again.",
       systemPromptBreakdown: "System Prompt Breakdown",
       collapse: "Collapse",
       collapseAll: "Collapse All",

--- a/ui/src/pages/usage/detail-controller.ts
+++ b/ui/src/pages/usage/detail-controller.ts
@@ -7,6 +7,7 @@ import {
   createPanelRefreshStatus,
   failPanelRefresh,
 } from "../../components/panel-refresh-status.ts";
+import { t } from "../../i18n/index.ts";
 import { isGatewayAvailable } from "../../lib/gateway-availability.ts";
 import {
   requestSessionUsage,
@@ -20,8 +21,10 @@ import { failUsageDetailRefresh } from "./detail-refresh.ts";
 import { createUsageRequest } from "./request.ts";
 import type { SessionLogEntry, UsageSessionEntry } from "./types.ts";
 
-function sameUsageTarget(a: SessionUsageTarget | undefined, b: SessionUsageTarget): boolean {
-  return a?.key === b.key && a.agentId === b.agentId;
+type UsageDetailTarget = Pick<UsageSessionEntry, "key" | "agentId" | "sessionId">;
+
+function sameUsageTarget(a: UsageDetailTarget | undefined, b: UsageDetailTarget): boolean {
+  return a?.key === b.key && a.agentId === b.agentId && a.sessionId === b.sessionId;
 }
 
 function createUsageDetailRequest<T>(
@@ -31,17 +34,18 @@ function createUsageDetailRequest<T>(
     client: GatewayBrowserClient,
     target: SessionUsageTarget,
     signal: AbortSignal,
+    sessionId: string | undefined,
   ) => Promise<T>,
-  resolveTarget: (key: string) => SessionUsageTarget,
+  resolveTarget: (key: string) => UsageDetailTarget,
   canLoad?: (key: string) => boolean,
 ) {
-  let value: { target: SessionUsageTarget; data?: T } | null = null;
+  let value: { target: UsageDetailTarget; data?: T } | null = null;
   let status = createPanelRefreshStatus();
   let pending: Promise<void> | null = null;
   let generation = 0;
   const task = createUsageRequest(host, {
     task: async (
-      [client, target]: readonly [GatewayBrowserClient, SessionUsageTarget],
+      [client, target]: readonly [GatewayBrowserClient, UsageDetailTarget],
       { signal },
     ) => ({
       target,
@@ -49,8 +53,14 @@ function createUsageDetailRequest<T>(
       // Keep key-only wire routing while retaining the full local target identity.
       data: await request(
         client,
-        parseAgentSessionKeyParts(target.key.trim()) ? { key: target.key } : target,
+        {
+          key: target.key,
+          ...(!parseAgentSessionKeyParts(target.key.trim()) && target.agentId
+            ? { agentId: target.agentId }
+            : {}),
+        },
         signal,
+        target.sessionId,
       ),
     }),
     onComplete: (result) => {
@@ -144,9 +154,10 @@ export class UsageDetailsController {
     query: () => SessionUsageQuery,
     sessions: () => UsageSessionEntry[],
   ) {
-    const resolveTarget = (key: string): SessionUsageTarget => {
-      const agentId = sessions().find((session) => session.key === key)?.agentId ?? query().agentId;
-      return { key, ...(agentId ? { agentId } : {}) };
+    const resolveTarget = (key: string): UsageDetailTarget => {
+      const session = sessions().find((entry) => entry.key === key);
+      const agentId = session?.agentId ?? query().agentId;
+      return { key, ...(agentId ? { agentId } : {}), sessionId: session?.sessionId };
     };
     this.timeSeries = createUsageDetailRequest(
       host,
@@ -167,7 +178,7 @@ export class UsageDetailsController {
     this.contextWeight = createUsageDetailRequest(
       host,
       gateway,
-      async (client, target, signal) => {
+      async (client, target, signal, sessionId) => {
         const result = await requestSessionUsage(
           client,
           { ...query(), agentId: target.agentId },
@@ -177,7 +188,15 @@ export class UsageDetailsController {
             signal,
           },
         );
-        return result.sessions[0]?.contextWeight;
+        const session = result.sessions[0];
+        if (
+          sessionId !== undefined &&
+          session?.sessionId !== undefined &&
+          session.sessionId !== sessionId
+        ) {
+          throw new Error(t("usage.details.contextOutOfDate"));
+        }
+        return session?.contextWeight;
       },
       resolveTarget,
       (key) => sessions().some((session) => session.key === key && session.hasContextWeight),

--- a/ui/src/pages/usage/usage-page-detail-identity.test.ts
+++ b/ui/src/pages/usage/usage-page-detail-identity.test.ts
@@ -1,0 +1,226 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionUsageTimeSeries } from "../../../../src/shared/session-usage-timeseries-types.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import {
+  cacheSnapshot,
+  cleanupUsagePageTest,
+  contextWithClient,
+  contextWeight,
+  createPage,
+  deferred,
+  preloadUsage,
+  refreshButton,
+} from "./usage-page.test-support.ts";
+
+afterEach(cleanupUsagePageTest);
+
+describe("UsagePage detail identity", () => {
+  it.each([
+    { replacement: "owner", refresh: "manual" },
+    { replacement: "owner", refresh: "automatic" },
+    { replacement: "instance", refresh: "manual" },
+    { replacement: "instance", refresh: "automatic" },
+  ])(
+    "retires old-$replacement details and pending recovery during $refresh overview refresh",
+    async ({ replacement, refresh }) => {
+      const snapshot = cacheSnapshot("sessions", "fresh");
+      const retired = deferred<SessionUsageTimeSeries>();
+      let agentId = "main";
+      let sessionId = "original-instance";
+      let holdOriginal = false;
+      let replaced = false;
+      const request = vi.fn(async (method: string, _params?: Record<string, unknown>) => {
+        if (method === "sessions.usage") {
+          return {
+            ...snapshot.result,
+            sessions: [
+              {
+                key: "global",
+                agentId,
+                sessionId,
+                label: replaced ? "Replacement session" : "Original session",
+                usage: snapshot.result.totals,
+              },
+            ],
+          };
+        }
+        if (method === "sessions.usage.logs" || method === "sessions.usage.timeseries") {
+          if (replaced) {
+            throw new Error("Replacement details unavailable");
+          }
+          if (holdOriginal) {
+            return retired.promise;
+          }
+          return method === "sessions.usage.logs"
+            ? { logs: [{ timestamp: 1, role: "user", content: "Original turn" }] }
+            : { sessionId: "original-instance", points: [] };
+        }
+        return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const context = contextWithClient(client);
+      const page = await createPage(client, true, context);
+      await preloadUsage(page);
+      page.querySelector<HTMLButtonElement>(".session-bar-selection")!.click();
+      await vi.waitFor(() => expect(page.textContent).toContain("Original turn"));
+      expect(page.details.timeSeries.data?.sessionId).toBe("original-instance");
+
+      holdOriginal = true;
+      const oldLoad = page.details.timeSeries.load("global");
+      context.setGatewaySnapshot({ suspensionPhase: "draining" });
+      context.setGatewaySnapshot({ suspensionPhase: "accepting" });
+      replaced = true;
+      if (replacement === "owner") {
+        agentId = "opus";
+      } else {
+        sessionId = "replacement-instance";
+      }
+      const beforeRefresh = request.mock.calls.length;
+      if (refresh === "manual") {
+        refreshButton(page).click();
+      } else {
+        await page.loadUsage();
+      }
+      await vi.waitFor(() =>
+        expect(page.querySelector(".session-bar-selection")?.textContent).toContain(
+          "Replacement session",
+        ),
+      );
+      expect.soft(page.usageSelectedSessions).toEqual(["global"]);
+      expect.soft(page.details.timeSeries.data).toBeNull();
+      expect.soft(page.details.sessionLogs.data).toBeNull();
+      retired.resolve({ sessionId: "retired-instance", points: [] });
+      await oldLoad;
+      await vi.waitFor(() => {
+        expect(page.details.timeSeries.loading).toBe(false);
+        expect(page.details.sessionLogs.loading).toBe(false);
+      });
+      expect.soft(page.details.timeSeries.data).toBeNull();
+      expect.soft(page.details.sessionLogs.data).toBeNull();
+      expect.soft(page.details.timeSeries.status.error).toBe("Replacement details unavailable");
+      expect.soft(page.details.sessionLogs.status.error).toBe("Replacement details unavailable");
+      for (const method of ["sessions.usage.timeseries", "sessions.usage.logs"]) {
+        const requests = request.mock.calls
+          .slice(beforeRefresh)
+          .filter(([name]) => name === method);
+        expect.soft(requests, method).toHaveLength(1);
+        expect.soft(requests[0]?.[1], method).toEqual({
+          key: "global",
+          agentId,
+          ...(method === "sessions.usage.logs" ? { limit: 1000 } : {}),
+        });
+      }
+    },
+  );
+
+  it.each([undefined, "stable-instance"])(
+    "retains healthy details during automatic refresh of the same optional instance %s",
+    async (sessionId) => {
+      const snapshot = cacheSnapshot("sessions", "fresh");
+      let label = "Original summary";
+      const request = vi.fn(async (method: string) => {
+        if (method === "sessions.usage") {
+          return {
+            ...snapshot.result,
+            sessions: [
+              { key: "global", agentId: "main", sessionId, label, usage: snapshot.result.totals },
+            ],
+          };
+        }
+        if (method === "sessions.usage.logs") {
+          return { logs: [{ timestamp: 1, role: "user", content: "Retained turn" }] };
+        }
+        if (method === "sessions.usage.timeseries") {
+          return { sessionId, points: [] };
+        }
+        return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
+      });
+      const page = await createPage({ request } as unknown as GatewayBrowserClient, true);
+      await preloadUsage(page);
+      page.querySelector<HTMLButtonElement>(".session-bar-selection")!.click();
+      await vi.waitFor(() => expect(page.textContent).toContain("Retained turn"));
+      const timeSeries = page.details.timeSeries.data;
+      const logs = page.details.sessionLogs.data;
+      label = "Refreshed summary";
+      await page.loadUsage();
+      await page.updateComplete;
+      expect(page.querySelector(".session-bar-selection")?.textContent).toContain(label);
+      expect(page.usageSelectedSessions).toEqual(["global"]);
+      expect(page.details.timeSeries.data).toEqual(timeSeries);
+      expect(page.details.sessionLogs.data).toEqual(logs);
+      for (const method of ["sessions.usage.timeseries", "sessions.usage.logs"]) {
+        expect(
+          request.mock.calls.filter(([name]) => name === method),
+          method,
+        ).toHaveLength(1);
+      }
+    },
+  );
+  it.each([
+    { captured: "selected-instance", returned: "retired-instance", conflict: true },
+    { captured: "selected-instance", returned: "selected-instance", conflict: false },
+    { captured: "selected-instance", returned: undefined, conflict: false },
+    { captured: undefined, returned: "selected-instance", conflict: false },
+  ])(
+    "binds context response $returned to optional captured instance $captured",
+    async ({ captured, returned, conflict }) => {
+      const snapshot = cacheSnapshot("sessions", "fresh");
+      let returnedId = returned;
+      let report = "Initial context";
+      const session = {
+        key: "global",
+        agentId: "opus",
+        sessionId: captured,
+        hasContextWeight: true,
+        usage: snapshot.result.totals,
+      };
+      const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "sessions.usage") {
+          return {
+            ...snapshot.result,
+            sessions: [
+              params?.key
+                ? { ...session, sessionId: returnedId, contextWeight: contextWeight(report) }
+                : session,
+            ],
+          };
+        }
+        return method === "usage.cost"
+          ? snapshot.costSummary
+          : { providers: [], logs: [], points: [] };
+      });
+      const page = await createPage({ request } as unknown as GatewayBrowserClient, true);
+      await preloadUsage(page);
+      page.querySelector<HTMLButtonElement>(".session-bar-selection")!.click();
+      await vi.waitFor(() => expect(page.details.contextWeight.loading).toBe(false));
+      await page.updateComplete;
+      if (conflict) {
+        expect.soft(page.details.contextWeight.data).toBeNull();
+        expect
+          .soft(page.details.contextWeight.status.error)
+          .toBe("These context details are out of date. Refresh usage and try again.");
+        expect
+          .soft(page.querySelector(".context-details-panel")?.textContent)
+          .not.toContain(report);
+      } else {
+        expect(page.details.contextWeight.data).toEqual(contextWeight(report));
+        expect(page.details.contextWeight.status.error).toBeNull();
+      }
+      returnedId = captured;
+      report = "Recovered context";
+      refreshButton(page).click();
+      await vi.waitFor(() =>
+        expect(page.details.contextWeight.data).toEqual(contextWeight(report)),
+      );
+      expect(page.details.contextWeight.status.error).toBeNull();
+      expect(page.usageSelectedSessions).toEqual(["global"]);
+      for (const [method, params] of request.mock.calls) {
+        if (method === "sessions.usage" && params?.key) {
+          expect(params).not.toHaveProperty("sessionId");
+        }
+      }
+    },
+  );
+});

--- a/ui/src/pages/usage/usage-page-details.test.ts
+++ b/ui/src/pages/usage/usage-page-details.test.ts
@@ -13,6 +13,7 @@ import {
   cacheSnapshot,
   cleanupUsagePageTest,
   contextWithClient,
+  contextWeight,
   createPage,
   deferred,
   focusDocument,
@@ -22,17 +23,6 @@ import {
 import type { UsageRouteData } from "./usage-page.ts";
 
 afterEach(cleanupUsagePageTest);
-
-function contextWeight(name: string): NonNullable<UsageSessionEntry["contextWeight"]> {
-  return {
-    source: "run",
-    generatedAt: 1,
-    systemPrompt: { chars: 80, projectContextChars: 20, nonProjectContextChars: 60 },
-    skills: { promptChars: 10, entries: [{ name, blockChars: 10 }] },
-    tools: { listChars: 0, schemaChars: 0, entries: [] },
-    injectedWorkspaceFiles: [],
-  };
-}
 
 describe("UsagePage detail requests", () => {
   it.each([
@@ -71,82 +61,12 @@ describe("UsagePage detail requests", () => {
       for (const method of ["sessions.usage", "sessions.usage.timeseries", "sessions.usage.logs"]) {
         const detail = request.mock.calls.find(([name, params]) => name === method && params?.key);
         expect.soft(detail?.[1], method).toMatchObject({ key });
+        expect.soft(detail?.[1], method).not.toHaveProperty("sessionId");
         if (needsOwnerHint) {
           expect.soft(detail?.[1], method).toHaveProperty("agentId", agentId);
         } else {
           expect.soft(detail?.[1], method).not.toHaveProperty("agentId");
         }
-      }
-    },
-  );
-
-  it.each(["manual", "automatic"])(
-    "retires old-owner details and pending recovery during %s overview refresh",
-    async (refresh) => {
-      const snapshot = cacheSnapshot("sessions", "fresh");
-      const retired = deferred<SessionUsageTimeSeries>();
-      let agentId = "main";
-      let holdMain = false;
-      const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
-        if (method === "sessions.usage") {
-          return {
-            ...snapshot.result,
-            sessions: [
-              { key: "global", agentId, label: `${agentId} global`, usage: snapshot.result.totals },
-            ],
-          };
-        }
-        if (method === "sessions.usage.logs" || method === "sessions.usage.timeseries") {
-          if (params?.agentId === "opus") {
-            throw new Error("Opus details unavailable");
-          }
-          if (holdMain) {
-            return retired.promise;
-          }
-          return method === "sessions.usage.logs"
-            ? { logs: [{ timestamp: 1, role: "user", content: "Main turn" }] }
-            : { sessionId: "main-instance", points: [] };
-        }
-        return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
-      });
-      const client = { request } as unknown as GatewayBrowserClient;
-      const context = contextWithClient(client);
-      const page = await createPage(client, true, context);
-      await preloadUsage(page);
-      page.querySelector<HTMLButtonElement>(".session-bar-selection")!.click();
-      await vi.waitFor(() => expect(page.textContent).toContain("Main turn"));
-      expect(page.details.timeSeries.data?.sessionId).toBe("main-instance");
-
-      holdMain = true;
-      const oldLoad = page.details.timeSeries.load("global");
-      context.setGatewaySnapshot({ suspensionPhase: "draining" });
-      context.setGatewaySnapshot({ suspensionPhase: "accepting" });
-      agentId = "opus";
-      if (refresh === "manual") {
-        refreshButton(page).click();
-      } else {
-        await page.loadUsage();
-      }
-      await vi.waitFor(() =>
-        expect(page.querySelector(".session-bar-selection")?.textContent).toContain("opus global"),
-      );
-      expect.soft(page.details.timeSeries.data).toBeNull();
-      expect.soft(page.details.sessionLogs.data).toBeNull();
-      retired.resolve({ sessionId: "retired-main", points: [] });
-      await oldLoad;
-      await vi.waitFor(() => {
-        expect(page.details.timeSeries.loading).toBe(false);
-        expect(page.details.sessionLogs.loading).toBe(false);
-      });
-      expect.soft(page.details.timeSeries.data).toBeNull();
-      expect.soft(page.details.sessionLogs.data).toBeNull();
-      expect.soft(page.details.timeSeries.status.error).toBe("Opus details unavailable");
-      expect.soft(page.details.sessionLogs.status.error).toBe("Opus details unavailable");
-      for (const method of ["sessions.usage.timeseries", "sessions.usage.logs"]) {
-        const ownerRequests = request.mock.calls.filter(
-          ([name, params]) => name === method && params?.agentId === "opus",
-        );
-        expect.soft(ownerRequests, method).toHaveLength(1);
       }
     },
   );

--- a/ui/src/pages/usage/usage-page.test-support.ts
+++ b/ui/src/pages/usage/usage-page.test-support.ts
@@ -6,6 +6,7 @@ import type { CostUsageSummary, SessionsUsageResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { UsageDetailsController } from "./detail-controller.ts";
 import { page as usageRoute } from "./route.ts";
+import type { UsageSessionEntry } from "./types.ts";
 import type { UsageRouteData } from "./usage-page.ts";
 import "./usage-page.ts";
 
@@ -105,6 +106,17 @@ export function cleanupUsagePageTest(): void {
   document.body.replaceChildren();
   vi.useRealTimers();
   vi.restoreAllMocks();
+}
+
+export function contextWeight(name: string): NonNullable<UsageSessionEntry["contextWeight"]> {
+  return {
+    source: "run",
+    generatedAt: 1,
+    systemPrompt: { chars: 80, projectContextChars: 20, nonProjectContextChars: 60 },
+    skills: { promptChars: 10, entries: [{ name, blockChars: 10 }] },
+    tools: { listChars: 0, schemaChars: 0, entries: [] },
+    injectedWorkspaceFiles: [],
+  };
 }
 
 export function cacheSnapshot(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI Usage page showed the previous session's timeline and conversation after the selected session was deleted and recreated under the same key and agent. The overview could show the replacement's 600 tokens while its details still showed the old 200-token conversation.

## Why This Change Was Made

Bind the existing detail cache and pending recovery to the overview row's optional session ID. Reject a context response that explicitly belongs to a different instance through the existing localized error/recovery flow. Logical selection, Gateway request parameters, missing-ID compatibility and server cache timing retain their current behavior.

## User Impact

Once the overview adopts the replacement session, its details refresh without clearing selection. A mismatched context response shows an error with a Refresh instruction instead of displaying another instance's details.

## Evidence

Three owner-level failures reproduce before the fix, with nine passing controls. All 83 final owner/sibling/browser cases and 20 selected changed-file checks pass; independent review found no actionable issue. The keyless i18n check leaves generated and baseline files unchanged.

The real Gateway/browser flow creates a synthetic session, deletes it, recreates the same key with a different session ID, and refreshes Usage on the same WebSocket connection. It verifies the replacement overview, retained selection, and corrected timeline/conversation. The existing server cache is allowed to refresh; this does not claim immediate backend freshness. Stale context response rejection and recovery are covered at the mounted page owner boundary.

The four inspected synthetic captures below show the selected replacement's overview before/after, followed by its timeline and conversation before/after. The first pair keeps the 600-token replacement selected; the second shows the stale 200-token Original replies becoming the replacement's 600-token Replacement replies. Dates and version labels are fixed fixture metadata. Initial fixture-preparation failures are retained separately and excluded from behavioral evidence; final proof uses an explicit private log target and silent startup logging.

![Before: the replacement session is selected with 600 tokens but retains the old timeline](https://github.com/user-attachments/assets/dda6bfaf-b1f6-4bf3-8d65-f3a9573dbc66)

![After: the same selected replacement shows its matching timeline](https://github.com/user-attachments/assets/1b83b5ad-562d-430e-b0b0-60456af8d3b6)

![Before: stale 200-token timeline and Original replies remain](https://github.com/user-attachments/assets/5879ac4c-34ed-42ee-86e5-1f6008d07553)

![After: replacement 600-token timeline and Replacement replies appear](https://github.com/user-attachments/assets/37fb2984-268d-4f01-b33c-0d4c6f7a6b94)