### PR TITLE
fix(pr): recover partially written review transitions

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -155,6 +155,8 @@ const repositoryScriptEntries = [
   "scripts/pr-lib/gh-api-preflight.mjs!",
   "scripts/pr-lib/merge-body.mjs!",
   "scripts/pr-lib/review-artifacts.mjs!",
+  // worktree.sh invokes this journal-state validator by path before native replay.
+  "scripts/pr-lib/review-transition-state.mjs!",
   "scripts/pr-lib/process-group-runner.mjs!",
   "scripts/pre-commit/filter-staged-files.mjs!",
   "scripts/print-live-docker-plugin-selection.mjs!",

--- a/scripts/pr-lib/review-transition-state.mjs
+++ b/scripts/pr-lib/review-transition-state.mjs
@@ -1,0 +1,182 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+
+const [source, target] = process.argv.slice(2);
+const readBuffer = Buffer.alloc(128 * 1024);
+
+function git(...args) {
+  const output = execFileSync(
+    "git",
+    ["-c", "core.fsmonitor=false", "-c", "core.untrackedCache=false", ...args],
+    { maxBuffer: 64 * 1024 * 1024 },
+  );
+  return new TextDecoder("utf-8", { fatal: true }).decode(output);
+}
+
+function records(...args) {
+  return git(...args)
+    .split("\0")
+    .filter(Boolean);
+}
+
+function tree(commit) {
+  return new Map(
+    records("ls-tree", "-r", "-z", commit).map((record) => {
+      const match = /^([0-7]{6}) (?:blob|commit) ([a-f0-9]{40})\t([\s\S]+)$/.exec(record);
+      if (!match) {
+        throw new Error("Invalid transition tree entry");
+      }
+      return [match[3], `${match[1]} ${match[2]}`];
+    }),
+  );
+}
+
+function stat(pathname) {
+  try {
+    return fs.lstatSync(pathname);
+  } catch (error) {
+    if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function worktreeEntry(pathname) {
+  const parts = pathname.split("/");
+  // A source file/symlink can occupy a target directory. Never follow it to
+  // inspect target descendants outside the worktree.
+  for (let count = 1; count < parts.length; count += 1) {
+    if (!stat(parts.slice(0, count).join("/"))?.isDirectory()) {
+      return undefined;
+    }
+  }
+  const before = stat(pathname);
+  if (!before || before.isDirectory()) {
+    return undefined;
+  }
+  const mode = before.isSymbolicLink()
+    ? "120000"
+    : before.isFile()
+      ? before.mode & 0o100
+        ? "100755"
+        : "100644"
+      : undefined;
+  if (!mode) {
+    throw new Error(`Unsupported working-tree entry ${JSON.stringify(pathname)}`);
+  }
+  const hash = createHash("sha1");
+  if (before.isSymbolicLink()) {
+    const bytes = fs.readlinkSync(pathname, { encoding: "buffer" });
+    hash.update(`blob ${bytes.length}\0`).update(bytes);
+  } else {
+    hash.update(`blob ${before.size}\0`);
+    const fd = fs.openSync(pathname, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    try {
+      const opened = fs.fstatSync(fd);
+      if (opened.dev !== before.dev || opened.ino !== before.ino) {
+        throw new Error("Transition file changed while opening");
+      }
+      let count;
+      while ((count = fs.readSync(fd, readBuffer, 0, readBuffer.length, null)) > 0) {
+        hash.update(readBuffer.subarray(0, count));
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+  const after = stat(pathname);
+  if (
+    !after ||
+    ["dev", "ino", "mode", "size", "mtimeMs", "ctimeMs"].some((key) => before[key] !== after[key])
+  ) {
+    throw new Error(`Transition file changed while reading ${JSON.stringify(pathname)}`);
+  }
+  return `${mode} ${hash.digest("hex")}`;
+}
+
+try {
+  if (
+    process.argv.length !== 4 ||
+    !/^[a-f0-9]{40}$/.test(source) ||
+    !/^[a-f0-9]{40}$/.test(target)
+  ) {
+    throw new Error("Invalid transition endpoints");
+  }
+  const from = tree(source);
+  const to = tree(target);
+  const index = new Map(
+    records("ls-files", "--stage", "-z").map((record) => {
+      const match = /^([0-7]{6}) ([a-f0-9]{40}) 0\t([\s\S]+)$/.exec(record);
+      if (!match) {
+        throw new Error("Unmerged transition index");
+      }
+      return [match[3], `${match[1]} ${match[2]}`];
+    }),
+  );
+  // Intent-to-add has a normal H tag and can match an empty endpoint blob.
+  // Compare both Git views; retain all hidden flags and conflict metadata on refusal.
+  const indexDiff = [
+    "diff",
+    "--cached",
+    "--raw",
+    "--no-ext-diff",
+    "--no-textconv",
+    "--no-renames",
+    "-z",
+  ];
+  if (
+    records("ls-files", "-v", "-z").some((record) => record[0] !== "H") ||
+    records("ls-files", "--resolve-undo", "-z").length > 0 ||
+    git(...indexDiff, "--ita-visible-in-index", source) !==
+      git(...indexDiff, "--ita-invisible-in-index", source)
+  ) {
+    throw new Error("Transition index contains hidden or unsupported entries");
+  }
+  const inspect = new Set(
+    records(
+      "-c",
+      "core.filemode=true",
+      "-c",
+      "core.ignoreStat=false",
+      "diff-files",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--no-renames",
+      "--name-only",
+      "-z",
+    ),
+  );
+  for (const pathname of new Set([...from.keys(), ...to.keys(), ...index.keys()])) {
+    const entry = index.get(pathname);
+    if (entry !== from.get(pathname) && entry !== to.get(pathname)) {
+      throw new Error(
+        `Index entry ${JSON.stringify(pathname)} is neither its journaled source nor target entry`,
+      );
+    }
+    if (from.get(pathname) !== to.get(pathname)) {
+      inspect.add(pathname);
+    }
+  }
+  for (const pathname of records("ls-files", "--others", "--exclude-standard", "-z")) {
+    if (pathname === ".local" || pathname.startsWith(".local/")) {
+      continue;
+    }
+    if (!from.has(pathname) && !to.has(pathname)) {
+      throw new Error(`Untracked entry ${JSON.stringify(pathname)} is not owned by the transition`);
+    }
+    inspect.add(pathname);
+  }
+  for (const pathname of inspect) {
+    const entry = worktreeEntry(pathname);
+    if (entry !== from.get(pathname) && entry !== to.get(pathname)) {
+      throw new Error(
+        `Working-tree entry ${JSON.stringify(pathname)} is neither its journaled source nor target entry`,
+      );
+    }
+  }
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}

--- a/scripts/pr-lib/review-transition-state.mjs
+++ b/scripts/pr-lib/review-transition-state.mjs
@@ -11,7 +11,8 @@ function git(...args) {
     ["-c", "core.fsmonitor=false", "-c", "core.untrackedCache=false", ...args],
     { maxBuffer: 64 * 1024 * 1024 },
   );
-  return new TextDecoder("utf-8", { fatal: true }).decode(output);
+  // Git emits filenames, so an initial U+FEFF belongs to the first path.
+  return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(output);
 }
 
 function records(...args) {

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -104,23 +104,17 @@ validate_review_transition_state() {
   local current
   current=$(git rev-parse HEAD)
   if { [ "$current" != "$source" ] && [ "$current" != "$target" ]; } ||
-    [ -n "$(git ls-files -u)" ] || ! git diff --quiet ||
-    ! require_no_foreign_untracked "$pr"
+    [ -n "$(git ls-files -u)" ]
   then
     refuse_review_transition "$pr" "the journaled transition state is ambiguous."
     return 1
   fi
   require_no_ignored_transition_paths "$pr" "$source" "$target" || return 1
 
-  # A path changed from source is owned only when its index mode and blob match target.
-  local file
-  git diff --cached --name-only --no-renames -z "$source" |
-    while IFS= read -r -d '' file; do
-      if ! git diff --cached --quiet "$target" -- ":(literal)$file"; then
-        refuse_review_transition "$pr" "'$file' is neither its journaled source nor target entry."
-        return 1
-      fi
-    done
+  node "$(dirname "${BASH_SOURCE[0]}")/review-transition-state.mjs" "$source" "$target" || {
+    refuse_review_transition "$pr" "the index or working tree contains unowned transition state."
+    return 1
+  }
 }
 
 write_review_transition_journal() {
@@ -170,10 +164,11 @@ recover_review_transition() {
   fi
 
   validate_review_transition_state "$pr" "$source" "$target" || return 1
-  # Completed deletions are absent from both index and target, so replay only
-  # remaining entries rather than passing already-removed paths to restore.
-  if ! git diff --cached --quiet "$target"; then
-    git diff --cached --name-only --no-renames -z "$target" |
+  # Restore can write files before committing its index. Rebuild the validated
+  # source index so replay also owns source-only files left after index deletion.
+  git read-tree "$source" || return 1
+  if ! git diff --quiet "$source" "$target"; then
+    git diff --name-only --no-renames -z "$source" "$target" |
       git --literal-pathspecs restore --source="$target" --staged --worktree \
         --pathspec-from-file=- --pathspec-file-nul || return 1
   fi

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -755,7 +755,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
     ["ls-files --others --exclude-standard -z", "require_no_foreign_untracked"],
     ["diff --name-only --no-renames -z", "require_no_ignored_transition_paths"],
     ["ls-files --others --ignored --exclude-standard -z", "require_no_ignored_transition_paths"],
-    ["diff --cached --name-only --no-renames -z", "validate_review_transition_state"],
+    ["ls-tree -r -z", "validate_review_transition_state"],
   ])("rejects failed %s reads in %s", (query, guard) => {
     const repoDir = createRepo();
     const head = refOid(repoDir, "HEAD");
@@ -767,8 +767,10 @@ describePosix("scripts/pr per-PR operation lock", () => {
     const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
     const proxy = writeFixtureFile(binDir, "git", [
       "#!/usr/bin/env bash",
+      'args=("$@")',
+      'while [ "${1:-}" = -c ]; do shift 2; done',
       `case "$*" in ${JSON.stringify(query)}*) echo 'fixture query failed' >&2; exit 7 ;; esac`,
-      `exec '${realGit}' "$@"`,
+      `exec '${realGit}' "\${args[@]}"`,
     ]);
     chmodSync(proxy, 0o755);
     const result = runLockShell(repoDir, [
@@ -2066,49 +2068,66 @@ describePosix("scripts/pr per-PR operation lock", () => {
   });
   it("joins Git read producers before releasing a successful operation lock", async () => {
     const repoDir = createRepo();
-    const producerExited = join(repoDir, "worktree-producer-exited");
+    mkdirSync(join(repoDir, ".local"));
+    const producerExited = join(repoDir, ".local", "worktree-producer-exited");
     const binDir = tempDirs.make("openclaw-pr-joined-query-");
     const queryExited = join(binDir, "query-exited");
+    const validatorStarted = join(binDir, "validator-started");
+    const validatorExited = join(binDir, "validator-exited");
     const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
     const proxy = writeFixtureFile(binDir, "git", [
       "#!/usr/bin/env bash",
+      'args=("$@")',
+      'while [ "${1:-}" = -c ]; do shift 2; done',
+      'if [ "$1" = ls-tree ]; then',
+      `  printf '%s\\n' "$$" >> '${validatorStarted}'`,
+      `  '${realGit}' "\${args[@]}" || exit $?`,
+      "  exec 1>&-",
+      "  sleep 0.1",
+      `  printf '%s\\n' "$$" >> '${validatorExited}'`,
+      "  exit 0",
+      "fi",
       'if [ "$1" = ls-files ] && [ "${3:-}" = --ignored ]; then',
       "  exec 1>&-",
       "  sleep 0.1",
       `  : > '${queryExited}'`,
       "  exit 0",
       "fi",
-      `exec '${realGit}' "$@"`,
+      `exec '${realGit}' "\${args[@]}"`,
     ]);
     chmodSync(proxy, 0o755);
-    const result = await runSupervisedOperation(repoDir, "joined-worktree-operation.sh", [
+    const result = await runSupervisedOperation(repoDir, ".local/joined-worktree-operation.sh", [
       `export PATH='${binDir}':"$PATH"`,
       "acquire_pr_operation_lock 42",
       "git() {",
       '  case "$*" in',
       '    "worktree list"*) printf \'worktree %s\\0branch refs/heads/pr-42\\0\\0\' "$PWD" ;;',
       "    \"diff --name-only --no-renames -z \"*) printf 'base.txt\\0' ;;",
-      '    "ls-files --others --exclude-standard -z"|"diff --cached --name-only --no-renames -z "*) ;;',
+      '    "ls-files --others --exclude-standard -z") ;;',
       '    *) command git "$@"; return $? ;;',
       "  esac",
       "  exec 1>&-",
       "  sleep 0.1",
-      "  : >worktree-producer-exited",
+      "  : >.local/worktree-producer-exited",
       "}",
       'worktree_is_registered "$PWD"',
-      "test -f worktree-producer-exited",
-      "rm worktree-producer-exited",
+      "test -f .local/worktree-producer-exited",
+      "rm .local/worktree-producer-exited",
       'resolved="$(worktree_path_for_branch pr-42)"',
       'test "$resolved" = "$PWD"',
-      "test -f worktree-producer-exited",
+      "test -f .local/worktree-producer-exited",
       'head="$(git rev-parse HEAD)"',
       "for guard in require_no_foreign_untracked require_no_ignored_transition_paths validate_review_transition_state; do",
-      "  rm worktree-producer-exited",
+      "  rm .local/worktree-producer-exited",
       '  "$guard" 42 "$head" "$head" || exit $?',
-      "  test -f worktree-producer-exited",
+      "  test -f .local/worktree-producer-exited",
       '  if [ "$guard" != require_no_foreign_untracked ]; then',
       `    test -f '${queryExited}'`,
       `    rm '${queryExited}'`,
+      "  fi",
+      '  if [ "$guard" = validate_review_transition_state ]; then',
+      `    test -s '${validatorStarted}'`,
+      `    test "$(sort '${validatorStarted}')" = "$(sort '${validatorExited}')"`,
       "  fi",
       "done",
     ]);

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -674,6 +674,16 @@ describePosix("scripts/pr worktree containment", () => {
       dirtyFile: "main-only.txt",
       dirtyContent: "foreign addition\n",
     },
+    {
+      name: "BOM-prefixed untracked target lookalike",
+      setup: [
+        'printf "/.local/\\n" >> "$(git rev-parse --git-path info/exclude)"',
+        "printf 'foreign BOM\\n' > '\ufeffmain-only.txt'",
+      ],
+      expectedStatus: "main-only.txt",
+      dirtyFile: "\ufeffmain-only.txt",
+      dirtyContent: "foreign BOM\n",
+    },
   ]) {
     it(`refuses and preserves ${testCase.name} foreign state`, () => {
       const fixture = createReviewFixture();

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -197,6 +197,7 @@ function reviewState(worktree: string) {
     head: git(worktree, "rev-parse", "HEAD"),
     branch: git(worktree, "branch", "--show-current"),
     index: git(worktree, "write-tree"),
+    resolveUndo: git(worktree, "ls-files", "--resolve-undo"),
     status: git(worktree, "status", "--porcelain=v1"),
     diff: git(worktree, "diff", "HEAD"),
     journal: existsSync(join(worktree, ".local", "review-transition.json"))
@@ -560,6 +561,13 @@ describePosix("scripts/pr worktree containment", () => {
   for (const mode of ["branch", "detached"] as const) {
     it.each([
       {
+        name: "worktree writes before the index commit",
+        setup: [
+          'git restore --source="$target_sha" --worktree -- transition-a.txt main-only.txt pr-only.txt',
+          'git diff --cached --quiet "$source_sha"',
+        ],
+      },
+      {
         name: "partially restored index",
         setup: ['git restore --source="$target_sha" --staged --worktree -- pr-only.txt'],
       },
@@ -602,6 +610,32 @@ describePosix("scripts/pr worktree containment", () => {
       expect(existsSync(join(worktree, ".local", "review-transition.json"))).toBe(false);
       expectCanonicalCheckoutUnchanged(fixture);
     });
+
+    it(`recovers target index entries with source worktree entries (${mode})`, () => {
+      const fixture = createReviewFixture();
+      const worktree = join(fixture.root, ".worktrees", "pr-42");
+      const result = runShell(fixture, [
+        "review_init 42",
+        "review_checkout_pr 42",
+        "source_sha=$(git rev-parse HEAD)",
+        "target_sha=$(git rev-parse origin/main)",
+        `write_review_transition_journal 42 "$source_sha" "$target_sha" ${mode} temp/pr-42`,
+        'git restore --source="$target_sha" --staged -- .',
+        'git diff --cached --quiet "$target_sha"',
+        "test -f pr-only.txt",
+        "test ! -e main-only.txt",
+        "recover_review_transition 42",
+      ]);
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(git(worktree, "rev-parse", "HEAD")).toBe(fixture.mainSha);
+      expect(git(worktree, "branch", "--show-current")).toBe(mode === "branch" ? "temp/pr-42" : "");
+      expect(git(worktree, "status", "--porcelain=v1", "--untracked-files=no")).toBe("");
+      expect(existsSync(join(worktree, "pr-only.txt"))).toBe(false);
+      expect(readFileSync(join(worktree, "main-only.txt"), "utf8")).toBe("main-only\n");
+      expect(existsSync(join(worktree, ".local", "review-transition.json"))).toBe(false);
+      expectCanonicalCheckoutUnchanged(fixture);
+    });
   }
 
   for (const testCase of [
@@ -620,11 +654,25 @@ describePosix("scripts/pr worktree containment", () => {
       dirtyContent: "foreign unstaged\n",
     },
     {
+      name: "zero-byte non-endpoint",
+      setup: [": > overlap.txt"],
+      expectedStatus: "M overlap.txt",
+      dirtyFile: "overlap.txt",
+      dirtyContent: "",
+    },
+    {
       name: "untracked",
       setup: ['printf "foreign untracked\\n" > foreign.txt'],
       expectedStatus: "?? foreign.txt",
       dirtyFile: "foreign.txt",
       dirtyContent: "foreign untracked\n",
+    },
+    {
+      name: "untracked target path with foreign bytes",
+      setup: ['printf "foreign addition\\n" > main-only.txt'],
+      expectedStatus: "?? main-only.txt",
+      dirtyFile: "main-only.txt",
+      dirtyContent: "foreign addition\n",
     },
   ]) {
     it(`refuses and preserves ${testCase.name} foreign state`, () => {
@@ -654,6 +702,80 @@ describePosix("scripts/pr worktree containment", () => {
       expectCanonicalCheckoutUnchanged(fixture);
     });
   }
+
+  it.each([
+    { name: "executable bit", setup: ["chmod +x overlap.txt"], symlink: false },
+    {
+      name: "symlink with a known blob but foreign mode",
+      setup: ["rm overlap.txt", "ln -s $'pr-a-overlap\\n' overlap.txt"],
+      symlink: true,
+    },
+    {
+      name: "assume-unchanged flag hiding foreign bytes",
+      setup: [
+        "git update-index --assume-unchanged overlap.txt",
+        'printf "foreign hidden\\n" > overlap.txt',
+      ],
+      symlink: false,
+    },
+  ])("refuses and preserves a foreign $name", ({ setup, symlink }) => {
+    const fixture = createReviewFixture();
+    const worktree = join(fixture.root, ".worktrees", "pr-42");
+    const prepared = runShell(fixture, [
+      "review_init 42",
+      "review_checkout_pr 42",
+      `write_review_transition_journal 42 ${fixture.prASha} ${fixture.mainSha} detached ''`,
+      ...setup,
+    ]);
+    expect(prepared.status, prepared.stdout + prepared.stderr).toBe(0);
+    const before = reviewState(worktree);
+    const pathname = join(worktree, "overlap.txt");
+    const bytes = symlink ? readlinkSync(pathname) : readFileSync(pathname, "utf8");
+    const result = runShell(fixture, ["review_init 42"]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Refusing scripts/pr transition for PR #42");
+    expect(reviewState(worktree)).toEqual(before);
+    expect(symlink ? readlinkSync(pathname) : readFileSync(pathname, "utf8")).toBe(bytes);
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
+  it.each(["intent-to-add", "resolve-undo"])(
+    "refuses and preserves hidden %s index metadata on endpoint entries",
+    (metadata) => {
+      const fixture = createReviewFixture();
+      if (metadata === "intent-to-add") {
+        git(fixture.root, "checkout", "main");
+        writeFileSync(join(fixture.root, "main-only.txt"), "");
+        git(fixture.root, "commit", "-am", "empty target fixture");
+        fixture.mainSha = git(fixture.root, "rev-parse", "HEAD");
+        git(fixture.root, "checkout", fixture.siblingBranch);
+      }
+      const worktree = join(fixture.root, ".worktrees", "pr-42");
+      const prepared = runShell(fixture, [
+        "review_init 42",
+        "review_checkout_pr 42",
+        `write_review_transition_journal 42 ${fixture.prASha} ${fixture.mainSha} detached ''`,
+        ...(metadata === "intent-to-add"
+          ? [": > main-only.txt", "git add --intent-to-add main-only.txt"]
+          : [
+              `base_blob=$(git rev-parse ${fixture.mainSha}:overlap.txt)`,
+              `ours_blob=$(git rev-parse ${fixture.prASha}:overlap.txt)`,
+              'printf "0 %040d\\toverlap.txt\\n100644 %s 1\\toverlap.txt\\n100644 %s 2\\toverlap.txt\\n100644 %s 3\\toverlap.txt\\n" 0 "$base_blob" "$ours_blob" "$base_blob" | git update-index --index-info',
+              "git add overlap.txt",
+              'test -n "$(git ls-files --resolve-undo)"',
+            ]),
+      ]);
+      expect(prepared.status, prepared.stdout + prepared.stderr).toBe(0);
+      const before = reviewState(worktree);
+      const result = runShell(fixture, ["review_init 42"]);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Refusing scripts/pr transition for PR #42");
+      expect(reviewState(worktree)).toEqual(before);
+      expectCanonicalCheckoutUnchanged(fixture);
+    },
+  );
 
   for (const recovery of [false, true]) {
     it.each([


### PR DESCRIPTION
Related: #143802

## What Problem This Solves

Fixes an issue where maintainers could not resume a journaled review checkout after Git wrote target files without committing the index. Additions, deletions, and target index entries whose files still matched the source also needed safe recovery.

## Why This Change Was Made

Recovery independently verifies index entries and working files against the journaled source and target blobs and modes, reconstructs the validated source index, and replays the same transition through native Git. This lets completed index deletions remove their remaining source files while preserving unrelated state.

The guard refuses unknown bytes, unrelated untracked paths, ignored overlaps, unmerged entries, intent-to-add, resolve-undo, and other hidden index flags. It preserves leading Unicode BOM characters in pathname records so a foreign lookalike cannot pass admission under a different name. The existing reserved `.local` artifact namespace remains preserved and is prohibited in transition endpoints.

Native wrapper materialization includes and verifies the matching helper. Knip now models its actual shell-owned executable entry. Existing operation-lock fixtures target the new reader path and verify that all started readers exit before successful lock release, including after stdout closes.

## User Impact

Maintainers can resume fully classified partial review transitions without manual index repair. Truncated or otherwise unknown files still stop recovery before replay. This does not itself reconcile the separate non-endpoint empty file observed while investigating #143802.

## Evidence

Native Git fixtures exercise both branch and detached recovery. Raw before/after excerpts:

```text
# Worktree-first and index-first recovery
Tests  4 failed | 55 skipped (59)
Tests  4 passed | 55 skipped (59)

# Intent-to-add and retained resolve-undo refusal
Tests  2 failed | 64 skipped (66)
Tests  2 passed | 64 skipped (66)

# BOM-prefixed untracked lookalike: previously changed HEAD before final refusal
Tests  1 failed | 66 skipped (67)
Tests  1 passed | 66 skipped (67)

# Operation-lock reader failure and producer settlement fixtures
Tests  2 failed | 3 passed | 110 skipped (115)
Tests  5 passed | 110 skipped (115)
```

Final local suites:

```text
node scripts/run-vitest.mjs test/scripts/pr-worktree-containment.test.ts
Tests  67 passed (67)

node scripts/run-vitest.mjs test/scripts/pr-operation-lock.test.ts
Tests  114 passed | 1 skipped (115)
```

The operation-lock skip is the Linux-only zombie-process case on macOS. Complete changed checks, both unused-file scans, formatting, syntax, and `git diff --check` pass. Independent review's intent-to-add finding was fixed; the later `.local` suggestion was rejected because it would break the unchanged reserved-artifact contract. Focused reviews of the Knip declaration, lock fixtures, and BOM correction are clean.

The maintained Crabbox route also passed all 66 original owner cases on Linux at `caa6aeacb52ad1194e5e537d0c323c5e00de737f`, with Git 2.52.0 and Node 24.19.0 after a frozen install. Testbox `tbx_01m26mewv06wh3f7ef51ry86ac` reported `exitCode:0`, `runStatus:succeeded`, and stopped successfully. [Backing Testbox run](https://github.com/openclaw/openclaw/actions/runs/34533814834); its delegated session may appear cancelled after successful external lease cleanup. The subsequent BOM correction has local fail-before/pass-after proof and is covered by required Linux CI on the final head.

CI identified the missing Knip entry and two stale operation-lock fixtures; both were repaired without relaxing checks, assertions, or deadlines. The preceding head reached green CI. Exact-head CI and current ClawSweeper review remain required before landing the final correction.

Tooling: 195 added / 15 removed lines. Tests: 163 added / 12 removed lines. No Gateway, configuration option, schema, or dependency changes.
