### PR TITLE
fix(compaction): preserve configured fallback model selection

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -20,6 +20,7 @@ import {
   agentSessionSetContextReplacementHook,
 } from "../sessions/agent-session-compaction.js";
 import type { SessionManager } from "../sessions/session-manager.js";
+import type { resolveModelAsync } from "./model.js";
 import type { attemptServerEndpointCompaction } from "./server-endpoint-compaction.js";
 import type { buildEmbeddedSystemPrompt } from "./system-prompt.js";
 
@@ -80,8 +81,13 @@ export const resolveModelMock: Mock<
   modelRegistry: {},
 }));
 export const resolveModelAsyncMock = vi.fn(
-  async (provider: string, modelId: string, agentDir?: string, cfg?: unknown, _options?: unknown) =>
-    resolveModelMock(provider, modelId, agentDir, cfg),
+  async (
+    provider: string,
+    modelId: string,
+    agentDir?: string,
+    cfg?: unknown,
+    _options?: Parameters<typeof resolveModelAsync>[4],
+  ) => resolveModelMock(provider, modelId, agentDir, cfg),
 );
 export const sessionCompactImpl = vi.fn(async () => ({
   summary: "summary",
@@ -648,7 +654,7 @@ export function resetCompactHooksHarnessMocks(workspaceDir: string): void {
       modelId: string,
       agentDir?: string,
       cfg?: unknown,
-      _options?: unknown,
+      _options?: Parameters<typeof resolveModelAsync>[4],
     ) => resolveModelMock(provider, modelId, agentDir, cfg),
   );
   resolveAgentHarnessPolicyMock.mockReset();

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1900,61 +1900,118 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
   });
 
-  it("uses the session model fallback chain when overflow compaction fails", async () => {
-    sessionCompactImpl
-      .mockRejectedValueOnce(
-        Object.assign(new Error("primary compaction rate limited"), {
-          status: 429,
-          code: "rate_limit_exceeded",
-        }),
-      )
-      .mockResolvedValueOnce({
-        summary: "overflow fallback summary",
-        firstKeptEntryId: "entry-fallback",
-        tokensBefore: 120,
-        details: { ok: true },
-      });
-
-    const result = await compactEmbeddedAgentSessionDirect({
-      sessionId: "session-1",
-      sessionKey: TEST_SESSION_KEY,
-      sessionFile: TEST_SESSION_KEY,
-      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
-      provider: "openai",
-      model: "gpt-primary",
-      trigger: "overflow",
-      modelFallbacksOverride: ["anthropic/claude-fallback"],
-      config: {
-        agents: {
-          defaults: {
-            model: {
-              primary: "openai/gpt-primary",
-              fallbacks: [],
+  it.each([false, true])(
+    "preserves configured fallback identity through compaction (credential refresh=%s)",
+    async (credentialRefresh) => {
+      const provider = "compaction-fallback-fixture";
+      const metadataSnapshot = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: provider,
+            providers: [provider],
+            modelIdNormalization: {
+              providers: { [provider]: { aliases: { entry: "middle", middle: "final" } } },
             },
           },
+        ],
+      });
+      const { normalizeStaticProviderModelId } =
+        await vi.importActual<typeof import("../model-ref-shared.js")>("../model-ref-shared.js");
+      const { shouldPreferProviderRuntimeResolvedModel } =
+        await import("../../plugins/provider-runtime.js");
+      const acquire = expectDefined(
+        acquireAgentRunPreparedModelRuntimeMock.getMockImplementation(),
+        "prepared runtime fixture",
+      );
+      const resolveModel = expectDefined(
+        resolveModelAsyncMock.getMockImplementation(),
+        "model resolver fixture",
+      );
+      const preferRuntime = expectDefined(
+        vi.mocked(shouldPreferProviderRuntimeResolvedModel).getMockImplementation(),
+        "runtime metadata fixture",
+      );
+      const materializedModels: string[] = [];
+      acquireAgentRunPreparedModelRuntimeMock.mockImplementation(async (...args) => {
+        const lease = await acquire(...args);
+        return {
+          ...lease,
+          snapshot: {
+            ...lease.snapshot,
+            metadataSnapshot: { ...metadataSnapshot, workspaceDir: lease.snapshot.workspaceDir },
+          },
+        };
+      });
+      // Model the resolver's raw-input contract with the real captured alias policy.
+      resolveModelAsyncMock.mockImplementation(
+        async (providerId, modelId, agentDir, config, options) => {
+          const resolvedId =
+            options?.modelIdSource === "selected"
+              ? modelId
+              : normalizeStaticProviderModelId(providerId, modelId, {
+                  manifestPlugins: metadataSnapshot,
+                });
+          materializedModels.push(resolvedId);
+          return resolveModel(providerId, resolvedId, agentDir, config, options);
         },
-      } as never,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(result.result?.summary).toBe("overflow fallback summary");
-    const primaryCall = findMockCall(
-      resolveModelMock,
-      ([provider, modelId]) => provider === "openai" && modelId === "gpt-primary",
-    );
-    expect(primaryCall[2]).toBeTypeOf("string");
-    if (primaryCall[3] === undefined) {
-      throw new Error("Expected primary resolve-model options");
-    }
-    const fallbackCall = findMockCall(
-      resolveModelMock,
-      ([provider, modelId]) => provider === "anthropic" && modelId === "claude-fallback",
-    );
-    expect(fallbackCall[2]).toBeTypeOf("string");
-    if (fallbackCall[3] === undefined) {
-      throw new Error("Expected fallback resolve-model options");
-    }
-  });
+      );
+      vi.mocked(shouldPreferProviderRuntimeResolvedModel).mockImplementation(
+        ({ provider: candidateProvider }) => credentialRefresh && candidateProvider === provider,
+      );
+      resolveProviderEntryApiKeyProfileReferenceMock.mockReturnValue({ kind: "literal" });
+      sessionCompactImpl
+        .mockRejectedValueOnce(
+          Object.assign(new Error("primary compaction rate limited"), {
+            status: 429,
+            code: "rate_limit_exceeded",
+          }),
+        )
+        .mockResolvedValueOnce({
+          summary: "overflow fallback summary",
+          firstKeptEntryId: "entry-fallback",
+          tokensBefore: 120,
+          details: { ok: true },
+        });
+      try {
+        const result = await compactEmbeddedAgentSessionDirect({
+          ...wrappedCompactionArgs({ provider, model: "primary" }),
+          trigger: "overflow",
+          modelFallbacksOverride: [`${provider}/entry`],
+          config: {
+            agents: { defaults: { model: { primary: `${provider}/primary`, fallbacks: [] } } },
+            models: {
+              providers: {
+                [provider]: {
+                  auth: "api-key",
+                  apiKey: "synthetic-fixture",
+                  baseUrl: "http://127.0.0.1:1/v1",
+                  models: [],
+                },
+              },
+            },
+          },
+        });
+        expect(result, result.reason).toMatchObject({
+          ok: true,
+          result: { summary: "overflow fallback summary" },
+        });
+        expect(createAgentSessionMock.mock.calls.map(([input]) => input)).toEqual([
+          expect.objectContaining({ model: expect.objectContaining({ id: "primary" }) }),
+          expect.objectContaining({ model: expect.objectContaining({ id: "middle" }) }),
+        ]);
+        expect(materializedModels).not.toContain("final");
+        if (credentialRefresh) {
+          expect(
+            materializedModels.filter((model) => model === "middle").length,
+          ).toBeGreaterThanOrEqual(2);
+        }
+      } finally {
+        acquireAgentRunPreparedModelRuntimeMock.mockImplementation(acquire);
+        resolveModelAsyncMock.mockImplementation(resolveModel);
+        vi.mocked(shouldPreferProviderRuntimeResolvedModel).mockImplementation(preferRuntime);
+      }
+    },
+  );
 
   describe("safeguard failure provenance", () => {
     registerAgentSessionLoopTestLifecycle();
@@ -2708,34 +2765,50 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
   });
 
-  it("does not reuse a source-provider profile for cross-provider compaction", async () => {
-    const result = await compactEmbeddedAgentSessionDirect({
-      ...wrappedCompactionArgs(),
-      provider: "openai",
-      model: "gpt-5.5",
-      authProfileId: "openai:work",
-      runtimeAuthPlan: {
-        providerForAuth: "openai",
-        modelId: "gpt-5.5",
-        authProfileProviderForAuth: "openai",
-        forwardedAuthProfileId: "openai:work",
-      },
-      config: {
-        agents: {
-          defaults: {
-            compaction: { model: "github-copilot/gpt-5.6-sol" },
+  it.each(["override", "fallback"] as const)(
+    "does not reuse a source-provider profile for cross-provider compaction (%s)",
+    async (targetSource) => {
+      const targetModel = "github-copilot/gpt-5.6-sol";
+      if (targetSource === "fallback") {
+        sessionCompactImpl.mockRejectedValueOnce(
+          Object.assign(new Error("primary compaction rate limited"), {
+            status: 429,
+            code: "rate_limit_exceeded",
+          }),
+        );
+      }
+      const result = await compactEmbeddedAgentSessionDirect({
+        ...wrappedCompactionArgs(),
+        provider: "openai",
+        model: "gpt-5.5",
+        authProfileId: "openai:test",
+        runtimeAuthPlan: {
+          providerForAuth: "openai",
+          modelId: "gpt-5.5",
+          authProfileProviderForAuth: "openai",
+          forwardedAuthProfileId: "openai:test",
+        },
+        config: {
+          agents: {
+            defaults:
+              targetSource === "override"
+                ? { compaction: { model: targetModel } }
+                : { model: { primary: "openai/gpt-5.5", fallbacks: [targetModel] } },
           },
         },
-      } as never,
-    });
+      });
 
-    expect(result.ok).toBe(true);
-    const initialResolveCall = resolveModelAsyncMock.mock.calls[0] as
-      | [string, string, string, unknown, { authProfileId?: string }?]
-      | undefined;
-    expect(initialResolveCall?.[0]).toBe("github-copilot");
-    expect(initialResolveCall?.[4]?.authProfileId).toBeUndefined();
-  });
+      expect(result, result.reason).toMatchObject({ ok: true, compacted: true });
+      const targetResolveCall = resolveModelAsyncMock.mock.calls.find(
+        ([provider]) => provider === "github-copilot",
+      );
+      expect(targetResolveCall).toBeDefined();
+      expect(targetResolveCall?.[4]?.authProfileId).toBeUndefined();
+      expectRecordFields(resolveEmbeddedAgentStreamMock.mock.lastCall?.[0], {
+        authProfileId: undefined,
+      });
+    },
+  );
 
   it("materializes subscription-auth OpenAI compaction while preserving logical context", async () => {
     resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "openclaw" });

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -544,6 +544,7 @@ export async function compactEmbeddedAgentSessionDirect(
               ...params,
               provider,
               model,
+              requestedRouteResolution: isPrimaryCandidate ? undefined : "resolved",
               authProfileId,
               authProfileIdSource: preservesPrimaryAuth ? params.authProfileIdSource : undefined,
               // The primary attempt retains its already prepared atomic plan. An

--- a/src/agents/embedded-agent-runner/direct-compaction-preparation.ts
+++ b/src/agents/embedded-agent-runner/direct-compaction-preparation.ts
@@ -50,6 +50,7 @@ import type { EmbeddedAgentCompactResult } from "./types.js";
 export type PreparedCompactEmbeddedAgentSessionParams = CompactEmbeddedAgentSessionRuntimeParams & {
   sessionFile: string;
   preparedModelRuntime: PreparedModelRuntimeSnapshot;
+  requestedRouteResolution?: "resolved";
   transcriptBytePreflightAuthority?: true;
   transcriptByteCompactionPersistence?: TranscriptByteCompactionPersistence;
 };
@@ -142,6 +143,7 @@ export async function prepareDirectCompactionAttempt(
   const { resolution: modelResolution } = await resolveTieredModel({
     provider: runtimeProvider,
     modelId,
+    requestedRouteResolution: params.requestedRouteResolution,
     agentDir,
     config: params.config,
     workspaceDir: resolvedWorkspace,
@@ -192,6 +194,7 @@ export async function prepareDirectCompactionAttempt(
   >[0]) =>
     resolveModelAsync(runtimeProvider, modelId, agentDir, config, {
       ...modelResolutionOptions,
+      modelIdSource: params.requestedRouteResolution === "resolved" ? "selected" : "input",
       skipAgentDiscovery: true,
       allowBundledStaticCatalogFallback: true,
       preferBundledStaticCatalogTransport: true,


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

When the primary compaction model fails, a configured fallback alias can be normalized twice. An alias chain such as `entry → middle → final` can therefore summarize with `final`, or fail while refreshing model metadata, even though fallback selection chose `middle`.

## Why This Change Was Made

Carry the selected identity of private non-primary fallback candidates through initial model resolution and credential refresh. The existing candidate builder owns alias selection; these consumers now preserve its choice. Primary/raw inputs and provider-auth separation retain their existing behavior.

The production change is four lines across two files. It stands on current main without a separate candidate-marker change.

## User Impact

Compaction uses the configured fallback model consistently after a primary failure, including when account-specific model metadata must be refreshed.

## Evidence

- The same regression tests on unmodified main fail in the two expected ways: ordinary compaction reaches `final`; credential refresh rejects rematerialization for selected `middle`. Four primary-plan and same-/cross-provider auth controls pass on that baseline.
- All 228 focused tests across seven files pass on the candidate. The complete changed gate is pinned to the main base, and fresh P2 review is clean.
- One normal full `pnpm build` passed, including SDK declarations and export validation.
- Five compiled direct-compaction scenarios pass: ordinary fallback, credential refresh, same-provider profile, cross-provider profile, and raw-primary preservation. The final run records four primary 429 responses, five successful completions, correct auth labels, and five persisted summaries read back through the canonical session API. All 11,943 build outputs and the committed source remain unchanged.

The first compiled attempt met its routing assertions but used an unsupported `reserveTokens` fixture key and a noncanonical store address. It is retained as superseded diagnostics, not final proof. After correcting only the fixture, all five scenarios were rerun against the same unchanged build. Provider responses came from a synthetic loopback endpoint; no external vendor inference is claimed.
