### PR TITLE
refactor(gateway): remove device event forwarder

### DIFF
--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -115,21 +115,6 @@ function shouldReturnRotatedDeviceToken(authz: DeviceManagementAuthz): boolean {
   return Boolean(authz.callerDeviceId && authz.callerDeviceId === authz.normalizedTargetDeviceId);
 }
 
-function emitDeviceSecurityEvent(params: {
-  action: string;
-  outcome: DiagnosticSecurityEventInput["outcome"];
-  severity: DiagnosticSecurityEventInput["severity"];
-  authz: DeviceSessionAuthz;
-  targetDeviceId?: string;
-  policyId: string;
-  decision: NonNullable<DiagnosticSecurityEventInput["policy"]>["decision"];
-  controlId: string;
-  reason?: string;
-  attributes?: Record<string, string | number | boolean>;
-}) {
-  emitDeviceManagementSecurityEvent(params);
-}
-
 function emitDevicePairingDeniedSecurityEvent(params: {
   authz: DeviceSessionAuthz;
   targetDeviceId?: string;
@@ -137,7 +122,7 @@ function emitDevicePairingDeniedSecurityEvent(params: {
   reason: string;
   severity?: DiagnosticSecurityEventInput["severity"];
 }) {
-  emitDeviceSecurityEvent({
+  emitDeviceManagementSecurityEvent({
     action: "device.pairing.denied",
     outcome: "denied",
     severity: params.severity ?? "medium",
@@ -162,7 +147,7 @@ function emitDevicePairingLifecycleSecurityEvent(params: {
   controlId: string;
   attributes?: Record<string, string | number | boolean>;
 }) {
-  emitDeviceSecurityEvent({
+  emitDeviceManagementSecurityEvent({
     action: params.action,
     outcome: "success",
     severity: params.severity,
@@ -183,7 +168,7 @@ function emitDeviceTokenDeniedSecurityEvent(params: {
   reason: string;
   role: string;
 }) {
-  emitDeviceSecurityEvent({
+  emitDeviceManagementSecurityEvent({
     action: params.action,
     outcome: "denied",
     severity: "medium",
@@ -206,7 +191,7 @@ function emitDeviceTokenLifecycleSecurityEvent(params: {
   role: string;
   scopeCount?: number;
 }) {
-  emitDeviceSecurityEvent({
+  emitDeviceManagementSecurityEvent({
     action: params.action,
     outcome: "success",
     severity: params.severity,


### PR DESCRIPTION
## What Problem This Solves

Device-management security-event reporting retained a redundant private forwarding layer despite already having a shared event owner. That added a second parameter declaration to maintain without adding behavior.

## Why This Change Was Made

The four existing event assemblers now call the existing shared owner directly. This removes only the private identity forwarder and its copied parameter shape; argument construction, field presence, evaluation order, synchronous dispatch and trusted-event routing stay unchanged.

Production: **+4/-19, net 15 lines removed**. Tests: **unchanged**. No new helper, dependency, authentication or authorization policy, trust boundary, configuration, persistence, protocol, or public API change.

## User Impact

No intended operator-visible change. Pairing and token operations retain their existing responses, token-delivery rules, redacted event payloads, persistence and lifecycle cleanup.

## Evidence

- Original, candidate and restored-candidate runs each passed the same 69 device, device-lifecycle and node tests. Case identities and order within each file matched. A single nonshipping omission control failed the existing event-count assertion as intended (expected one event, received zero), after the unchanged denial-response and no-mutation assertions passed. Exact restoration passed all 69 cases again. Normal runner file ordering adapted after the control; no scheduling or cache override was used.
- One existing candidate-only positive loopback WebSocket/RPC case passed; seven other cases were intentionally unselected. It exercised authenticated connection, device-pair approval and synthetic persisted operator scopes. It did not compare original RPC behavior or observe diagnostic events end to end. The observed processes, listener and fixture home were closed; passive sampling can miss short-lived resources, and fixture logging is normally silent.
- Normal formatting made no further change; standalone targeted lint and source typing passed. All 28 configured changed checks passed on Linux Node 24.19.0, including both type graphs, three dead-export scans and targeted lint with zero warnings/errors. [Configured Testbox run](https://github.com/openclaw/openclaw/actions/runs/34528984236). The native delegated result was successful and its lease/snapshot were cleaned up; the backing Actions holder may show cancelled during normal cleanup and is not the command verdict.
- Managed P2 precommit review and a separate exact-commit P2 review completed without actionable findings. The signed commit's complete tree matches the tested one-file candidate.

No build was run for this private call-path deletion, and no deployed-account or live security-policy validation is claimed. Exact-head hosted PR CI is separate from the configured local-change gate.
