### PR TITLE
fix(ui): match Side chat typography to the main conversation

### DIFF
--- a/ui/src/e2e/chat-side-chat-typography.e2e.test.ts
+++ b/ui/src/e2e/chat-side-chat-typography.e2e.test.ts
@@ -1,0 +1,104 @@
+import type { Locator } from "playwright";
+import { expect, it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "side-chat typography" });
+const questionText = "What changed?";
+const question = `${questionText}\n\n\`\`\`text\none\ntwo\nthree\nfour\nfive\nsix\nseven\neight\n\`\`\``;
+const answerCode = `const detail = "${"A long line in a narrow side chat. ".repeat(6)}";`;
+const answer = `The same readable answer in both conversations.\n\n\`\`\`ts\n${answerCode}\n\`\`\``;
+
+function typography(element: Locator) {
+  return element.evaluate((node) => {
+    const style = getComputedStyle(node);
+    return {
+      family: style.fontFamily,
+      size: style.fontSize,
+      lineHeight: style.lineHeight,
+      weight: style.fontWeight,
+      smoothing: style.getPropertyValue("-webkit-font-smoothing"),
+    };
+  });
+}
+
+suite.define(() => {
+  for (const width of [1440, 390]) {
+    it(`matches main-chat typography and keeps code controls usable at ${width}px`, async () => {
+      await suite.withPage(
+        {
+          viewport: { width, height: 900 },
+          permissions: ["clipboard-read", "clipboard-write"],
+        },
+        async ({ page }) => {
+          const sessionKey = "agent:main:side-chat-typography";
+          await installMockGateway(page, {
+            sessionKey,
+            historyMessages: [
+              { role: "user", content: question },
+              { role: "assistant", content: answer },
+            ],
+            methodResponses: {
+              "config.get": {
+                config: { ui: { prefs: { theme: "dash", themeMode: "dark" } } },
+                hash: "side-chat-typography",
+                valid: true,
+              },
+              "sessions.companion.state": {
+                exchanges: [{ question, answer, ts: 1_000 }],
+              },
+            },
+          });
+          await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+          const main = page.locator(".chat-thread");
+          await main.getByText("The same readable answer in both conversations.").waitFor();
+          await openChatSidePanelType(page, "Side chat");
+          const side = page.locator("openclaw-chat-session-rail");
+          await side.getByText("The same readable answer in both conversations.").waitFor();
+          await page.evaluate(() => document.fonts.ready);
+
+          for (const text of [questionText, "The same readable answer in both conversations."]) {
+            const expected = await typography(main.getByText(text, { exact: true }));
+            expect(expected.family).toContain("Fraunces");
+            expect(await typography(side.getByText(text, { exact: true }))).toEqual(expected);
+          }
+          // The common scale owner must affect both reading surfaces, not only the main thread.
+          await page.evaluate(() =>
+            document.documentElement.style.setProperty("--control-ui-text-scale", "1.25"),
+          );
+          expect(await typography(side.getByText(questionText, { exact: true }))).toEqual(
+            await typography(main.getByText(questionText, { exact: true })),
+          );
+          expect(await typography(side.getByRole("textbox"))).toEqual(
+            await typography(page.getByRole("textbox", { name: "Chat composer", exact: true })),
+          );
+          await side.getByRole("button", { name: "Copy code", exact: true }).click();
+          await expect
+            .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+            .toBe(answerCode);
+          const wrap = side.locator(".code-block-wrap");
+          await expect.poll(() => wrap.isVisible()).toBe(true);
+          await wrap.click();
+          expect(await wrap.getAttribute("aria-pressed")).toBe("true");
+          expect(
+            await side
+              .locator(".code-block-viewport code")
+              .evaluate((node) => getComputedStyle(node).whiteSpace),
+          ).toBe("pre-wrap");
+          // Questions use the same plain, non-collapsing code presentation as main-chat users.
+          for (const surface of [main, side]) {
+            const user = surface.locator(".chat-group.user");
+            expect(await user.locator(".code-block-wrapper").count()).toBe(0);
+            expect(await user.locator("pre code").textContent()).toContain("eight");
+          }
+          const thread = await side.locator(".chat-session-rail__thread").evaluate((node) => ({
+            width: node.clientWidth,
+            contentWidth: node.scrollWidth,
+          }));
+          expect(thread.contentWidth).toBeLessThanOrEqual(thread.width + 1);
+        },
+      );
+    });
+  }
+});

--- a/ui/src/pages/chat/chat-session-rail.test.ts
+++ b/ui/src/pages/chat/chat-session-rail.test.ts
@@ -539,6 +539,7 @@ describe("ChatSessionRailElement", () => {
     };
     await element.updateComplete;
     expect(element.textContent).toContain("Couldn't load this session's history.");
+    expect(element.querySelector("openclaw-panel-empty-state")).toBeNull();
     (element.querySelector(".chat-session-rail__retry") as HTMLButtonElement).click();
     expect(onSubmit).toHaveBeenCalledWith("What changed?");
   });

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -1,18 +1,17 @@
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ref } from "lit/directives/ref.js";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { SessionObserverDigest } from "../../../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { ControlUiSessionPullRequest } from "../../../../../src/gateway/control-ui-contract.js";
 import { icons } from "../../../components/icons.ts";
-import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
+import { markdownBlocks } from "../../../components/markdown-blocks.ts";
+import { handleMarkdownCodeBlockClick } from "../../../components/markdown-code-blocks.ts";
 import { renderPanelEmptyState } from "../../../components/panel-empty-state.ts";
 import { renderPanelLoadingSkeleton } from "../../../components/panel-loading-skeleton.ts";
 import "../../../components/tooltip.ts";
 import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatDurationCompact, formatTimeAgo, formatTimeMs } from "../../../lib/format.ts";
-import { detectTextDirection } from "../../../lib/text-direction.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import {
   type ChatObserverDisplayPreference,
@@ -20,6 +19,7 @@ import {
   storeChatObserverDisplayPreference,
 } from "../chat-observer-display.ts";
 import type { ChatSessionCompanionThread } from "../chat-session-companion.ts";
+import { renderMessageMarkdown } from "./chat-message-text.ts";
 
 export type SessionRailMode = "hidden" | "pill" | "expanded";
 
@@ -419,14 +419,34 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
     `;
   }
 
+  private renderQuestion(question: string) {
+    return html`
+      <div class="chat-group user chat-session-rail__message">
+        <div class="chat-bubble chat-session-rail__question">
+          ${renderMessageMarkdown(
+            question,
+            question,
+            { role: "user", isStreaming: false },
+            { codeBlockChrome: "none", codeBlockInteraction: "static" },
+          )}
+        </div>
+      </div>
+    `;
+  }
+
   private renderExchange(question: string, answer: string, ts: number) {
     return html`
       <article class="chat-session-rail__exchange">
-        <div class="chat-session-rail__question" dir=${detectTextDirection(question)}>
-          ${question}
-        </div>
-        <div class="chat-session-rail__answer" dir=${detectTextDirection(answer)}>
-          ${unsafeHTML(toSanitizedMarkdownHtml(answer))}
+        ${this.renderQuestion(question)}
+        <div class="chat-group assistant chat-session-rail__message">
+          <div class="chat-bubble chat-session-rail__answer">
+            ${renderMessageMarkdown(
+              answer,
+              String(ts),
+              { role: "assistant", isStreaming: false },
+              { codeBlockInteraction: "interactive" },
+            )}
+          </div>
         </div>
         <time class="chat-session-rail__timestamp" datetime=${new Date(ts).toISOString()}>
           ${t("chat.rail.asOf", {
@@ -473,7 +493,13 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
       element.scrollTop = element.scrollHeight;
     };
     return html`
-      <div class="chat-session-rail__thread" aria-live="polite" ${ref(syncScroll)}>
+      <div
+        class="chat-session-rail__thread"
+        aria-live="polite"
+        @click=${handleMarkdownCodeBlockClick}
+        ${markdownBlocks()}
+        ${ref(syncScroll)}
+      >
         ${
           this.companion.loading && this.companion.exchanges.length === 0
             ? renderPanelLoadingSkeleton("chat", t("chat.thread.loading"))
@@ -482,7 +508,8 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
         ${
           !this.companion.loading &&
           this.companion.exchanges.length === 0 &&
-          !this.companion.pendingQuestion
+          !this.companion.pendingQuestion &&
+          !(this.companion.failedQuestion && this.companion.hint)
             ? renderPanelEmptyState({
                 icon: icons.bot,
                 heading: t("chat.sidePanel.companion"),
@@ -497,7 +524,7 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
           this.companion.failedQuestion && this.companion.hint
             ? html`
                 <article class="chat-session-rail__exchange chat-session-rail__exchange--error">
-                  <div class="chat-session-rail__question">${this.companion.failedQuestion}</div>
+                  ${this.renderQuestion(this.companion.failedQuestion)}
                   <div class="chat-session-rail__hint">
                     ${t(companionHintKey(this.companion.hint))}
                   </div>
@@ -522,7 +549,7 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
           this.companion.pendingQuestion
             ? html`
                 <article class="chat-session-rail__exchange chat-session-rail__exchange--pending">
-                  <div class="chat-session-rail__question">${this.companion.pendingQuestion}</div>
+                  ${this.renderQuestion(this.companion.pendingQuestion)}
                   <div class="chat-session-rail__hint">${t("chat.rail.askPending")}</div>
                 </article>
               `

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -714,7 +714,7 @@ img.chat-avatar.chat-avatar--logo {
   overflow-wrap: break-word;
 }
 
-.chat-thread .chat-bubble {
+:is(.chat-thread, .chat-session-rail__thread) .chat-bubble {
   letter-spacing: 0; /* Custodian shares .chat-bubble but keeps the application-wide tracking. */
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2573,9 +2573,8 @@ openclaw-chat-session-rail {
 
 .chat-session-rail__exchange {
   display: grid;
-  gap: 6px;
-  font-size: 12.5px;
-  line-height: 1.5;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--chat-block-gap);
 }
 
 .chat-session-rail__exchange + .chat-session-rail__exchange {
@@ -2583,35 +2582,27 @@ openclaw-chat-session-rail {
   border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
 }
 
-.chat-session-rail__question {
-  justify-self: end;
+/* Share the main chat's bubble and Markdown skins; only the panel's column
+   geometry differs. It has no avatar gutter or transcript footer to reserve. */
+.chat-session-rail__message.chat-group {
+  display: block;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.chat-session-rail__message .chat-session-rail__question {
+  width: fit-content;
   max-width: 90%;
-  padding: 6px 9px;
-  border-radius: var(--radius-md) var(--radius-md) 3px var(--radius-md);
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: var(--text);
-  font-weight: 600;
-  overflow-wrap: anywhere;
-}
-
-.chat-session-rail__answer {
-  color: var(--text);
-}
-
-.chat-session-rail__answer > :first-child {
-  margin-top: 0;
-}
-
-.chat-session-rail__answer > :last-child {
-  margin-bottom: 0;
+  margin-inline-start: auto;
 }
 
 .chat-session-rail__timestamp {
-  font-size: 10.5px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .chat-session-rail__hint {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .chat-session-rail__exchange--error .chat-session-rail__hint {
@@ -2640,27 +2631,6 @@ openclaw-chat-session-rail {
 .chat-session-rail__prompt {
   min-width: 0;
   flex: 1 1 auto;
-}
-
-.chat-session-rail__input {
-  width: 100%;
-  min-height: 34px;
-  padding: 7px 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--card);
-  color: var(--text);
-  font: inherit;
-  font-size: 12.5px;
-}
-
-.chat-session-rail__input:focus {
-  border-color: var(--border-strong);
-  outline: none;
-}
-
-.chat-session-rail__input::placeholder {
-  color: var(--muted);
 }
 
 /* The docked form: a real column in the pane's flex row. It claims layout space


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading Side chat see smaller text and a different font and message presentation from the main conversation. Long code also overflows the narrow panel, and a first failed question can overlap the empty-state placeholder on mobile.

## Why This Change Was Made

Side chat now uses the existing main-chat message renderer, bubble/Markdown styles, shared typography tokens, and Markdown code-block lifecycle. Remove its duplicate text, bubble, and input styling; keep only the panel-specific column geometry.

Preserve the compact single-line composer, companion permissions/RPCs, and existing file/session navigation behavior. This does not copy the main transcript's avatars, message actions, or history controls into the companion.

## User Impact

- The sidebar follows the same chat font, text size, line height, and scaling as the main session.
- Questions, pending/retry states, paragraphs, lists, tables, and code use the shared chat presentation.
- Assistant code supports the existing Copy and Wrap controls; user code stays plain and uncollapsed like main-chat user messages.
- A failed first question displays cleanly without the empty-state placeholder.

## Evidence

**Before is on the left; after is on the right.** Real Control UI browser renders with synthetic data through the repository's mock Gateway, not a live production conversation. Baseline: `dc0d0b09be873ebdced3054d30bc29b5aa9324fa`.

Desktop, dark/serif, 1440×900:

![Desktop before and after](https://github.com/user-attachments/assets/abd9ac16-67bd-4724-b77b-09fa110bb9e2)

Mobile, 390×844:

![Mobile before and after](https://github.com/user-attachments/assets/b0a200eb-2621-4704-8c07-0a8d6365428e)

Long Markdown and code:

![Rich content before and after](https://github.com/user-attachments/assets/4e7856ff-e992-441d-b538-716c0bc30e3b)

Measured dark-theme answer text: **12.5px / 18.75px DM Sans → 14px / 21px Fraunces**, matching main chat. Light-theme answers also match main chat at 14px / 21px. Desktop and mobile panel scroll widths equal their client widths after the change. Separate bundled browser coverage compares both surfaces at 125% text scale and exercises clipboard/wrapping.

<details>
<summary>Full before/after state matrix</summary>

| State | Desktop dark | Mobile dark | Desktop light |
| --- | --- | --- | --- |
| loading | [Before / after](https://github.com/user-attachments/assets/872d521f-9d3e-4fd4-ae06-be86229a1a6a) | [Before / after](https://github.com/user-attachments/assets/b5314f99-61ab-41e5-a820-8886b346bcdc) | [Before / after](https://github.com/user-attachments/assets/1dd24b62-8a05-4a7e-91e1-da9525a0982b) |
| empty | [Before / after](https://github.com/user-attachments/assets/6950eec7-d30b-4127-9b38-6c59892f4d6c) | [Before / after](https://github.com/user-attachments/assets/faaa9976-ae17-4f2d-ac7d-914811720f2f) | [Before / after](https://github.com/user-attachments/assets/b91403d1-53cf-4fe5-8759-a8e0938d2d96) |
| pending | [Before / after](https://github.com/user-attachments/assets/656161ce-bdb7-4c51-8f09-863d0e54eb89) | [Before / after](https://github.com/user-attachments/assets/e1bb8eb2-9d90-4b20-8fbb-b597db924f07) | [Before / after](https://github.com/user-attachments/assets/4cfb8fa0-1194-4982-b863-90c1af579b65) |
| error | [Before / after](https://github.com/user-attachments/assets/5694f43f-e779-4e2a-8283-b32736ac163e) | [Before / after](https://github.com/user-attachments/assets/eb148cd5-6953-4cc8-a406-931eed97d7ad) | [Before / after](https://github.com/user-attachments/assets/142eaa78-6597-46b6-b17f-59f5091212c9) |
| typical | [Before / after](https://github.com/user-attachments/assets/abd9ac16-67bd-4724-b77b-09fa110bb9e2) | [Before / after](https://github.com/user-attachments/assets/b0a200eb-2621-4704-8c07-0a8d6365428e) | [Before / after](https://github.com/user-attachments/assets/fa4e5218-c640-43cf-974a-a6f29f967247) |
| heavy-top | [Before / after](https://github.com/user-attachments/assets/cfd2104a-0ac1-487e-9ae7-d235820ccc20) | [Before / after](https://github.com/user-attachments/assets/6221ccfc-5b98-4969-b149-deaffc0f2385) | [Before / after](https://github.com/user-attachments/assets/6eec9780-1a8f-457d-bcd8-af036b3b8f0e) |
| heavy-bottom | [Before / after](https://github.com/user-attachments/assets/4e7856ff-e992-441d-b538-716c0bc30e3b) | [Before / after](https://github.com/user-attachments/assets/74e01ef9-b512-4bed-a0f1-ee19a7146959) | [Before / after](https://github.com/user-attachments/assets/54fd21b0-69c9-4c95-bc54-7432a1f4368d) |

</details>

Validation:

- Bundled browser: typography, 125% scale, code copy/wrap, plain user fences at 1440px and 390px; companion reset success/error and session-change isolation — 4 tests passed.
- Rail and companion lifecycle unit tests — 45 passed.
- Existing responsive rail/composer cases — 5 passed (targeted filter).
- Repository changed-file gates — passed (format, core-test/UI types, lint, CSS lint, i18n, dead exports, and repository guards).
- Independent native audit findings fixed and rechecked. CLI review suggestions about transcript-only navigation and long-question disclosure were checked against the existing companion contract and left outside this presentation change (400-character single-line composer).
