### PR TITLE
fix: report saved credentials and auth refresh failures

### DIFF
--- a/extensions/telegram/src/bot-native-command-login.test.ts
+++ b/extensions/telegram/src/bot-native-command-login.test.ts
@@ -5,7 +5,10 @@ import {
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import type { ModelsAuthLoginFlowOptions } from "openclaw/plugin-sdk/provider-auth-login-flow-runtime";
+import {
+  type ModelsAuthLoginFlowOptions,
+  ProviderAuthConfigApplyError,
+} from "openclaw/plugin-sdk/provider-auth-login-flow-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -153,6 +156,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
       };
     });
@@ -186,6 +190,42 @@ describe("registerTelegramNativeCommands /login", () => {
     expect(texts.at(-1)).toContain("Codex login complete. Try your request again now.");
   });
 
+  it.each([
+    {
+      authRefresh: "gateway-rejected",
+      message:
+        "Codex credentials saved, but the Gateway could not apply the auth update. Check the Gateway logs, restart the Gateway, then use /models.",
+    },
+    {
+      authRefresh: "gateway-unreachable",
+      message:
+        "Codex credentials saved, but the Gateway could not be reached to apply them. Restart the Gateway, then use /models.",
+    },
+  ] as const)(
+    "reports saved credentials without immediate retry guidance when refresh is $authRefresh",
+    async ({ authRefresh, message }) => {
+      const loginFlow = vi.fn(async () => ({
+        providerId: "openai",
+        methodId: "device-code",
+        authRefresh,
+        profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
+      }));
+      const { handler, sendMessage } = registerLoginCommand({
+        cfg: { commands: { native: true, ownerAllowFrom: ["200"] } },
+        loginFlow,
+      });
+
+      await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
+
+      expect(sendMessage).toHaveBeenCalledWith(100, message, {});
+      expect(sendMessage).not.toHaveBeenCalledWith(
+        100,
+        "Codex login complete. Try your request again now.",
+        expect.any(Object),
+      );
+    },
+  );
+
   it("releases the chat lane only after structured device-code delivery", async () => {
     const allowDeviceCode = createDeferred<void>();
     const finishLogin = createDeferred<void>();
@@ -207,6 +247,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
       };
     });
@@ -266,6 +307,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
       };
     });
@@ -326,6 +368,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
       };
     });
@@ -356,6 +399,7 @@ describe("registerTelegramNativeCommands /login", () => {
     const loginFlow = vi.fn(async () => ({
       providerId: "openai",
       methodId: "device-code",
+      authRefresh: "refreshed",
       profiles: [],
     }));
     const { handler, sendMessage } = registerLoginCommand({
@@ -390,6 +434,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
       };
     });
@@ -443,6 +488,28 @@ describe("registerTelegramNativeCommands /login", () => {
     ).toHaveLength(2);
   });
 
+  it("reports saved credentials when provider settings fail after device login", async () => {
+    const loginFlow = vi.fn(async (params: ModelsAuthLoginFlowOptions) => {
+      await params.prompter.deviceCode?.({ title: "Codex login", code: "SAVED-CODE" });
+      throw new ProviderAuthConfigApplyError(new Error("provider config write failed"));
+    });
+    const { handler, sendMessage } = registerLoginCommand({
+      cfg: { commands: { native: true, ownerAllowFrom: ["200"] } },
+      loginFlow,
+    });
+
+    await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
+
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(2));
+    expect(sendMessage.mock.calls[0]?.[1]).toContain("Code: <code>SAVED-CODE</code>");
+    expect(sendMessage).toHaveBeenLastCalledWith(
+      100,
+      "Codex credentials saved, but provider settings could not be applied. Review the provider settings and check the Gateway logs before trying again.",
+      {},
+    );
+    expect(loginSessionMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+  });
+
   it("does not report auth failure when only the terminal notification fails", async () => {
     const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
     const loginFlow = vi.fn(async (params: ModelsAuthLoginFlowOptions) => {
@@ -450,6 +517,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
       };
     });
@@ -533,6 +601,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
       };
     });
@@ -581,6 +650,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [
           { profileId: "openai:new-owner@example.com", provider: "openai", mode: "oauth" },
         ],
@@ -655,6 +725,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [
           { profileId: "openai:new-owner@example.com", provider: "openai", mode: "oauth" },
         ],
@@ -718,6 +789,7 @@ describe("registerTelegramNativeCommands /login", () => {
       return {
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [{ profileId: "openai:login-profile", provider: "openai", mode: "oauth" }],
       };
     });
@@ -744,7 +816,7 @@ describe("registerTelegramNativeCommands /login", () => {
     await vi.waitFor(() =>
       expect(sendMessage).toHaveBeenCalledWith(
         100,
-        "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
+        "Codex login completed, but this session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
         {},
       ),
     );
@@ -769,6 +841,7 @@ describe("registerTelegramNativeCommands /login", () => {
     const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async () => ({
       providerId: "openai",
       methodId: "device-code",
+      authRefresh: "refreshed",
       profiles: [{ profileId: "openai:owner@example.com", provider: "openai", mode: "oauth" }],
     }));
     const { handler } = registerLoginCommand({
@@ -811,47 +884,71 @@ describe("registerTelegramNativeCommands /login", () => {
     ).toBeNull();
   });
 
-  it("reports partial success when Telegram cannot persist the returned profile", async () => {
-    loginSessionMocks.loadSessionStore.mockReturnValue({
-      "agent:main:main": {
-        authProfileOverride: "openai:old-owner@example.com",
-        sessionId: "sess-main",
-        updatedAt: 1,
-      },
-    });
-    loginSessionMocks.updateSessionStoreEntry.mockRejectedValueOnce(new Error("write failed"));
-    const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async () => ({
-      providerId: "openai",
-      methodId: "device-code",
-      profiles: [{ profileId: "openai:new-owner@example.com", provider: "openai", mode: "oauth" }],
-    }));
-    const { handler, sendMessage } = registerLoginCommand({
-      accountId: "default",
-      cfg: {
-        commands: { native: true, ownerAllowFrom: ["200"] },
-      } as OpenClawConfig,
-      allowFrom: ["200"],
-      loginFlow: runModelsAuthLoginFlow,
-    });
+  it.each([
+    {
+      authRefresh: "refreshed",
+      message:
+        "Codex login completed, but this session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
+    },
+    {
+      authRefresh: "gateway-rejected",
+      message:
+        "Codex credentials saved, but the Gateway could not apply the auth update. Check the Gateway logs, restart the Gateway, then use /models.",
+    },
+    {
+      authRefresh: "gateway-unreachable",
+      message:
+        "Codex credentials saved, but the Gateway could not be reached to apply them. Restart the Gateway, then use /models.",
+    },
+  ] as const)(
+    "preserves $authRefresh when Telegram cannot persist the returned session profile",
+    async ({ authRefresh, message }) => {
+      loginSessionMocks.loadSessionStore.mockReturnValue({
+        "agent:main:main": {
+          authProfileOverride: "openai:old-owner@example.com",
+          sessionId: "sess-main",
+          updatedAt: 1,
+        },
+      });
+      loginSessionMocks.updateSessionStoreEntry.mockRejectedValueOnce(new Error("write failed"));
+      const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async () => ({
+        providerId: "openai",
+        methodId: "device-code",
+        authRefresh,
+        profiles: [
+          { profileId: "openai:new-owner@example.com", provider: "openai", mode: "oauth" },
+        ],
+      }));
+      const { handler, sendMessage } = registerLoginCommand({
+        accountId: "default",
+        cfg: {
+          commands: { native: true, ownerAllowFrom: ["200"] },
+        } as OpenClawConfig,
+        allowFrom: ["200"],
+        loginFlow: runModelsAuthLoginFlow,
+      });
 
-    await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
+      await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
 
-    expect(sendMessage).toHaveBeenCalledWith(
-      100,
-      "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
-      {},
-    );
-    expect(sendMessage).not.toHaveBeenCalledWith(
-      100,
-      "Codex login complete. Try your request again now.",
-      expect.any(Object),
-    );
-  });
+      expect(sendMessage).toHaveBeenCalledWith(100, expect.stringContaining(message), {});
+      expect(sendMessage).toHaveBeenCalledWith(
+        100,
+        expect.stringContaining("could not switch"),
+        {},
+      );
+      expect(sendMessage).not.toHaveBeenCalledWith(
+        100,
+        "Codex login complete. Try your request again now.",
+        expect.any(Object),
+      );
+    },
+  );
 
   it("reports partial success when Telegram login returns no OpenAI profile", async () => {
     const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async () => ({
       providerId: "openai",
       methodId: "device-code",
+      authRefresh: "refreshed",
       profiles: [],
     }));
     const { handler, sendMessage } = registerLoginCommand({
@@ -867,7 +964,7 @@ describe("registerTelegramNativeCommands /login", () => {
 
     expect(sendMessage).toHaveBeenCalledWith(
       100,
-      "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
+      "Codex login completed, but this session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
       {},
     );
     expect(sendMessage).not.toHaveBeenCalledWith(
@@ -899,6 +996,7 @@ describe("registerTelegramNativeCommands /login", () => {
     const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async () => ({
       providerId: "openai",
       methodId: "device-code",
+      authRefresh: "refreshed",
       profiles: [{ profileId: "openai:owner@example.com", provider: "openai", mode: "oauth" }],
     }));
     const { handler, sendMessage } = registerLoginCommand({
@@ -914,7 +1012,7 @@ describe("registerTelegramNativeCommands /login", () => {
 
     expect(sendMessage).toHaveBeenCalledWith(
       100,
-      "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
+      "Codex login completed, but this session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
       {},
     );
     expect(sendMessage).not.toHaveBeenCalledWith(

--- a/extensions/telegram/src/bot-native-command-login.ts
+++ b/extensions/telegram/src/bot-native-command-login.ts
@@ -135,8 +135,6 @@ export async function executeTelegramLoginCommand(params: {
   // Device-code delivery releases Telegram's serialized chat lane. The
   // reservation and account signal still own polling through completion.
   const completion = (async () => {
-    const sessionSwitchFailedMessage =
-      "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.";
     let terminalMessage: string;
     const loginFlow =
       dispatch.telegramDeps.runModelsAuthLoginFlow ??
@@ -170,10 +168,8 @@ export async function executeTelegramLoginCommand(params: {
       const nextProfileId = loginResult.profiles.find(
         (profile) => profile.provider === loginProvider,
       )?.profileId;
-      terminalMessage = "Codex login complete. Try your request again now.";
-      if (!nextProfileId) {
-        terminalMessage = sessionSwitchFailedMessage;
-      } else {
+      let sessionSwitchFailed = !nextProfileId;
+      if (nextProfileId) {
         const storePath = resolveStorePath(dispatch.runtimeCfg.session?.store, {
           agentId: dispatch.route.agentId,
         });
@@ -228,7 +224,7 @@ export async function executeTelegramLoginCommand(params: {
               persisted.authProfileOverrideSource !== "user" ||
               persisted.authProfileOverrideCompactionCount !== undefined)
           ) {
-            terminalMessage = sessionSwitchFailedMessage;
+            sessionSwitchFailed = true;
           }
         } catch (error) {
           flowSignal.throwIfAborted();
@@ -239,15 +235,19 @@ export async function executeTelegramLoginCommand(params: {
               )}`,
             ),
           );
-          terminalMessage = sessionSwitchFailedMessage;
+          sessionSwitchFailed = true;
         }
       }
+      terminalMessage = codexChannelLoginRuntime.formatCompletion(
+        loginResult.authRefresh,
+        sessionSwitchFailed,
+      );
     } catch (error) {
       if (flowSignal.aborted) {
         return;
       }
       dispatch.runtime.error?.(danger(`telegram /login codex failed: ${String(error)}`));
-      terminalMessage = "Codex login did not complete. Send `/login codex` to request a new code.";
+      terminalMessage = codexChannelLoginRuntime.formatFailure(error);
     }
     if (flowSignal.aborted) {
       return;

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -2241,6 +2241,7 @@ describe("createTelegramBot", () => {
         return {
           providerId: "openai",
           methodId: "device-code",
+          authRefresh: "refreshed",
           profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
         };
       });

--- a/src/auto-reply/reply/commands-login.test.ts
+++ b/src/auto-reply/reply/commands-login.test.ts
@@ -3,6 +3,7 @@ import type { ModelsAuthLoginFlowOptions } from "../../commands/models/auth.js";
 import type { SessionEntryUpdateOptions } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { ProviderAuthConfigApplyError } from "../../plugin-sdk/provider-auth-login-flow-runtime.js";
 import { buildBuiltinChatCommands } from "../commands-registry.shared.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { buildCommandTestParams } from "./commands.test-harness.js";
@@ -87,7 +88,7 @@ function buildLoginParams(
   return params;
 }
 
-function mockSuccessfulLoginFlow(profileId = "openai:owner"): void {
+function mockSuccessfulLoginFlow(profileId = "openai:owner", authRefresh = "refreshed"): void {
   runModelsAuthLoginFlowMock.mockImplementation(async (opts: ModelsAuthLoginFlowOptions) => {
     await opts.prompter.note?.(
       "Open https://auth.openai.com/device and enter code ABCD-EFGH. Never share this code.",
@@ -96,6 +97,7 @@ function mockSuccessfulLoginFlow(profileId = "openai:owner"): void {
     return {
       providerId: "openai",
       methodId: "device-code",
+      authRefresh,
       profiles: [{ profileId, provider: "openai", mode: "oauth" }],
     };
   });
@@ -206,6 +208,53 @@ describe("handleLoginCommand", () => {
     },
   );
 
+  it.each([
+    [
+      "gateway-rejected",
+      "Codex credentials saved, but the Gateway could not apply the auth update. Check the Gateway logs, restart the Gateway, then use /models.",
+    ],
+    [
+      "gateway-unreachable",
+      "Codex credentials saved, but the Gateway could not be reached to apply them. Restart the Gateway, then use /models.",
+    ],
+  ])("reports saved credentials when auth refresh is %s", async (outcome, message) => {
+    mockSuccessfulLoginFlow("openai:owner", outcome);
+    const result = await handleLoginCommand(
+      buildLoginParams("/login codex", { opts: blockReplyOpts() }),
+      true,
+    );
+    expect(result?.reply?.text).toBe(message);
+  });
+
+  it("distinguishes saved credentials from failed provider settings", async () => {
+    runModelsAuthLoginFlowMock.mockRejectedValue(
+      new ProviderAuthConfigApplyError(new Error("config write failed")),
+    );
+    const result = await handleLoginCommand(
+      buildLoginParams("/login codex", { opts: blockReplyOpts() }),
+      true,
+    );
+    expect(result?.reply?.text).toBe(
+      "Codex credentials saved, but provider settings could not be applied. Review the provider settings and check the Gateway logs before trying again.",
+    );
+  });
+
+  it.each([undefined, "unknown"])("rejects an invalid refresh outcome %s", async (authRefresh) => {
+    runModelsAuthLoginFlowMock.mockResolvedValue({
+      providerId: "openai",
+      methodId: "device-code",
+      authRefresh,
+      profiles: [{ profileId: "openai:owner", provider: "openai", mode: "oauth" }],
+    });
+    const result = await handleLoginCommand(
+      buildLoginParams("/login codex", { opts: blockReplyOpts() }),
+      true,
+    );
+    expect(result?.reply?.text).toBe(
+      "Codex login did not complete. Send `/login codex` to request a new code.",
+    );
+  });
+
   it("rejects dispatcher-less contexts before starting device-code polling", async () => {
     mockSuccessfulLoginFlow();
 
@@ -293,6 +342,7 @@ describe("handleLoginCommand", () => {
     runModelsAuthLoginFlowMock.mockResolvedValue({
       providerId: "openai",
       methodId: "device-code",
+      authRefresh: "refreshed",
       profiles: [],
     });
 
@@ -310,6 +360,7 @@ describe("handleLoginCommand", () => {
     runModelsAuthLoginFlowMock.mockResolvedValue({
       providerId: "openai",
       methodId: "device-code",
+      authRefresh: "refreshed",
       profiles: [{ profileId: " ", provider: "openai", mode: "oauth" }],
     });
 
@@ -327,6 +378,7 @@ describe("handleLoginCommand", () => {
     runModelsAuthLoginFlowMock.mockResolvedValue({
       providerId: " openai ",
       methodId: " device-code ",
+      authRefresh: "refreshed",
       defaultModel: " openai/gpt-5.4 ",
       profiles: [{ profileId: " openai:owner@example.com ", provider: " openai ", mode: "oauth" }],
     });
@@ -505,6 +557,7 @@ describe("handleLoginCommand", () => {
             resolve({
               providerId: "openai",
               methodId: "device-code",
+              authRefresh: "refreshed",
               profiles: [],
             });
         }),
@@ -554,6 +607,7 @@ describe("handleLoginCommand", () => {
       .mockResolvedValueOnce({
         providerId: "openai",
         methodId: "device-code",
+        authRefresh: "refreshed",
         profiles: [],
       });
 

--- a/src/auto-reply/reply/commands-login.ts
+++ b/src/auto-reply/reply/commands-login.ts
@@ -21,10 +21,6 @@ const activeCodexLoginFlows = codexChannelLoginRuntime.createFlowRegistry();
 
 type RunLoginFlow = (opts: ModelsAuthLoginFlowOptions) => Promise<unknown>;
 
-const LOGIN_COMPLETE_MESSAGE = "Codex login complete. Try your request again now.";
-const LOGIN_SESSION_SWITCH_FAILED_MESSAGE =
-  "Codex login completed, but this session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.";
-
 function parseLoginCommand(commandBodyNormalized: string): { providerInput: string } | null {
   const match = commandBodyNormalized.trim().match(/^\/login(?:\s+(.+))?$/u);
   if (!match) {
@@ -257,18 +253,20 @@ async function runChannelCodexLogin(params: {
       (profile) => profile.provider === params.provider,
     )?.profileId;
     if (!nextProfileId) {
-      return { text: LOGIN_SESSION_SWITCH_FAILED_MESSAGE };
+      return { text: codexChannelLoginRuntime.formatCompletion(loginResult.authRefresh, true) };
     }
     const switchResult = await switchLoginSessionProfile({
       commandParams: params.commandParams,
       nextProfileId,
     });
     return {
-      text:
-        switchResult === "failed" ? LOGIN_SESSION_SWITCH_FAILED_MESSAGE : LOGIN_COMPLETE_MESSAGE,
+      text: codexChannelLoginRuntime.formatCompletion(
+        loginResult.authRefresh,
+        switchResult === "failed",
+      ),
     };
-  } catch {
-    return { text: "Codex login did not complete. Send `/login codex` to request a new code." };
+  } catch (error) {
+    return { text: codexChannelLoginRuntime.formatFailure(error) };
   } finally {
     codexChannelLoginRuntime.releaseFlow({
       flows: activeCodexLoginFlows,

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { ProviderPlugin } from "../../plugins/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import { ProviderAuthConfigApplyError } from "../../shared/provider-auth-result.js";
 
 type AuthRunCall = {
   agentDir?: string;
@@ -66,6 +67,7 @@ const mocks = vi.hoisted(() => ({
   isRemoteEnvironment: vi.fn(() => false),
   validateAnthropicSetupToken: vi.fn<() => string | undefined>(() => undefined),
   promoteAuthProfileInOrder: vi.fn(),
+  tryImportProviderCredential: vi.fn(),
   callGateway: vi.fn(),
   isImplicitLocalGatewayTarget: vi.fn(() => Promise.resolve(true)),
   resolvePluginSetupProviderCore: vi.fn(),
@@ -94,6 +96,10 @@ vi.mock("../../agents/auth-profiles/profiles.js", () => ({
 
 vi.mock("../../plugins/provider-auth-persistence.js", () => ({
   persistProviderAuthProfilesAfterLogin: mocks.persistProviderAuthProfilesAfterLogin,
+}));
+
+vi.mock("./auth-credential-import.js", () => ({
+  tryImportProviderCredential: mocks.tryImportProviderCredential,
 }));
 
 vi.mock("../../plugins/provider-auth-helpers.js", () => ({
@@ -401,6 +407,8 @@ describe("modelsAuthLoginCommand", () => {
       ok: true,
       value: { version: 1, profiles: {} },
     });
+    mocks.tryImportProviderCredential.mockReset();
+    mocks.tryImportProviderCredential.mockResolvedValue(undefined);
     mocks.removeProviderAuthProfilesWithLock.mockReset();
     mocks.removeProviderAuthProfilesWithLock.mockResolvedValue({ version: 1, profiles: {} });
 
@@ -484,8 +492,13 @@ describe("modelsAuthLoginCommand", () => {
   it("runs plugin-owned openai login", async () => {
     const runtime = createRuntime();
 
-    await modelsAuthLoginCommand({ provider: "openai" }, runtime);
+    const result = await runModelsAuthLoginFlowCore({
+      provider: "openai",
+      runtime,
+      prompter: mocks.createClackPrompter(),
+    });
 
+    expect(result).toMatchObject({ authRefresh: "refreshed" });
     expect(runProviderAuth).toHaveBeenCalledOnce();
     const persistCall = readMockCallArg(
       mocks.persistProviderAuthProfilesAfterLogin,
@@ -610,24 +623,98 @@ describe("modelsAuthLoginCommand", () => {
     expect(mocks.promoteAuthProfileInOrder).not.toHaveBeenCalled();
   });
 
-  it("keeps login successful when the running gateway cannot refresh auth state", async () => {
-    const runtime = createRuntime();
+  it.each([
+    { connected: true, outcome: "gateway-rejected", target: "running" },
+    { connected: false, outcome: "gateway-unreachable", target: "local" },
+  ])(
+    "keeps saved login credentials when refresh is $outcome",
+    async ({ connected, outcome, target }) => {
+      const runtime = createRuntime();
+      mocks.callGateway.mockImplementationOnce(async (options: { onHelloOk?: () => void }) => {
+        if (connected) {
+          options.onHelloOk?.();
+        }
+        throw new Error("refresh rejected");
+      });
+
+      await expect(
+        runModelsAuthLoginFlowCore({
+          provider: "openai",
+          runtime,
+          prompter: mocks.createClackPrompter(),
+        }),
+      ).resolves.toMatchObject({ authRefresh: outcome });
+
+      expect(mocks.persistProviderAuthProfilesAfterLogin).toHaveBeenCalledOnce();
+      expect(mocks.callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: { operation: "login", agentId: "main" },
+        }),
+      );
+      expect(runtime.error).toHaveBeenCalledWith(
+        `Warning: Model auth changes were saved, but the ${target} Gateway could not refresh them. Run \`openclaw gateway restart\` to apply the saved changes.`,
+      );
+    },
+  );
+
+  it("returns the refresh outcome after importing a provider credential", async () => {
+    mocks.tryImportProviderCredential.mockResolvedValueOnce({
+      profileId: "openai:imported",
+      provider: "openai",
+      mode: "oauth",
+      configUpdated: false,
+    });
     mocks.callGateway.mockImplementationOnce(async (options: { onHelloOk?: () => void }) => {
       options.onHelloOk?.();
       throw new Error("refresh rejected");
     });
 
-    await expect(modelsAuthLoginCommand({ provider: "openai" }, runtime)).resolves.toBeUndefined();
+    const result = await runModelsAuthLoginFlowCore({
+      provider: "openai",
+      runtime: createRuntime(),
+      prompter: mocks.createClackPrompter(),
+    });
 
-    expect(mocks.persistProviderAuthProfilesAfterLogin).toHaveBeenCalledOnce();
-    expect(mocks.callGateway).toHaveBeenCalledWith(
+    expect(result).toMatchObject({
+      imported: true,
+      authRefresh: "gateway-rejected",
+      profiles: [{ profileId: "openai:imported", provider: "openai", mode: "oauth" }],
+    });
+    expect(runProviderAuth).not.toHaveBeenCalled();
+    expect(mocks.persistProviderAuthProfilesAfterLogin).not.toHaveBeenCalled();
+    expect(mocks.promoteAuthProfileInOrder).toHaveBeenCalledWith(
       expect.objectContaining({
-        params: { operation: "login", agentId: "main" },
+        profileId: "openai:imported",
       }),
     );
-    expect(runtime.error).toHaveBeenCalledWith(
-      "Warning: Model auth changes were saved, but the running Gateway could not refresh them. Run `openclaw gateway restart` to apply the saved changes.",
-    );
+  });
+
+  it("identifies a config failure after credentials are saved and preserves its cause", async () => {
+    const cause = new Error("config write failed");
+    runProviderAuth.mockResolvedValueOnce({
+      profiles: [
+        {
+          profileId: "openai:saved",
+          credential: { type: "token", provider: "openai", token: "fixture-token" },
+        },
+      ],
+      configPatch: { logging: { level: "debug" } },
+    });
+    mocks.updateConfig.mockRejectedValueOnce(cause);
+
+    const login = runModelsAuthLoginFlowCore({
+      provider: "openai",
+      runtime: createRuntime(),
+      prompter: mocks.createClackPrompter(),
+    });
+    await expect(login).rejects.toBeInstanceOf(ProviderAuthConfigApplyError);
+    await expect(login).rejects.toMatchObject({
+      name: "ProviderAuthConfigApplyError",
+      message: "Credentials saved, but provider settings could not be applied: config write failed",
+      cause,
+    });
+    expect(mocks.persistProviderAuthProfilesAfterLogin).toHaveBeenCalledOnce();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
   });
 
   it("creates store order for relogin when configured profiles would shadow the new profile", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -59,6 +59,7 @@ import type {
   ProviderPlugin,
 } from "../../plugins/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import { ProviderAuthConfigApplyError } from "../../shared/provider-auth-result.js";
 import { isRecord } from "../../utils.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
@@ -67,7 +68,7 @@ import { validateAnthropicSetupToken } from "../auth-token.js";
 import { repairCodexRuntimePluginInstallForModelSelection } from "../codex-runtime-plugin-install.js";
 import { repairCopilotRuntimePluginInstallForModelSelection } from "../copilot-runtime-plugin-install.js";
 import { tryImportProviderCredential } from "./auth-credential-import.js";
-import { refreshRunningGatewayAuthState } from "./auth-refresh.js";
+import { refreshRunningGatewayAuthState, type ModelAuthRefreshOutcome } from "./auth-refresh.js";
 import {
   loadValidConfigSnapshotOrThrow,
   resolveModelsTargetAgent,
@@ -423,7 +424,7 @@ async function persistProviderAuthResult(params: {
   setDefault?: boolean;
   env?: NodeJS.ProcessEnv;
   beforePersistentEffect?: () => void | Promise<void>;
-}): Promise<ProviderAuthResult["profiles"]> {
+}): Promise<{ profiles: ProviderAuthResult["profiles"]; authRefresh: ModelAuthRefreshOutcome }> {
   const defaultModel = params.result.defaultModel
     ? normalizeAgentModelRefForConfig(params.result.defaultModel)
     : undefined;
@@ -503,10 +504,7 @@ async function persistProviderAuthResult(params: {
       if (persistedProfiles.length === 0) {
         throw error;
       }
-      throw new Error(
-        `Credentials saved, but provider settings could not be applied: ${error instanceof Error ? error.message : String(error)}`,
-        { cause: error },
-      );
+      throw new ProviderAuthConfigApplyError(error);
     });
     if (defaultModel) {
       const repaired = await repairCodexRuntimePluginInstallForModelSelection({
@@ -524,7 +522,7 @@ async function persistProviderAuthResult(params: {
     logConfigUpdated(params.runtime);
   }
 
-  await refreshRunningGatewayAuthState(params.agentId, "login", params.runtime);
+  const authRefresh = await refreshRunningGatewayAuthState(params.agentId, "login", params.runtime);
 
   for (const profile of persistedProfiles) {
     params.runtime.log(
@@ -541,7 +539,7 @@ async function persistProviderAuthResult(params: {
   if (params.result.notes && params.result.notes.length > 0) {
     await params.prompter.note(params.result.notes.join("\n"), "Provider notes");
   }
-  return persistedProfiles;
+  return { profiles: persistedProfiles, authRefresh };
 }
 
 function resolveConfiguredAuthSelectionForProvider(
@@ -607,7 +605,11 @@ async function runProviderAuthMethod(params: {
   signal?: AbortSignal;
   openUrl?: (url: string) => Promise<void>;
   beforePersistentEffect?: () => void | Promise<void>;
-}): Promise<{ result: ProviderAuthResult; profiles: ProviderAuthResult["profiles"] }> {
+}): Promise<{
+  result: ProviderAuthResult;
+  profiles: ProviderAuthResult["profiles"];
+  authRefresh: ModelAuthRefreshOutcome;
+}> {
   params.signal?.throwIfAborted();
   const result = await params.method.run({
     config: params.config,
@@ -635,7 +637,7 @@ async function runProviderAuthMethod(params: {
     requestedProfileId: params.profileId,
   });
 
-  const persistedProfiles = await persistProviderAuthResult({
+  const { profiles: persistedProfiles, authRefresh } = await persistProviderAuthResult({
     result,
     profiles,
     config: params.config,
@@ -648,7 +650,7 @@ async function runProviderAuthMethod(params: {
     env: params.env ?? process.env,
     beforePersistentEffect: params.beforePersistentEffect,
   });
-  return { result, profiles: persistedProfiles };
+  return { result, profiles: persistedProfiles, authRefresh };
 }
 
 /** Runs an interactive provider setup-token auth flow. */
@@ -962,6 +964,7 @@ type LoginOptions = {
 export type ModelsAuthLoginFlowResult = {
   providerId: string;
   methodId: string;
+  authRefresh: ModelAuthRefreshOutcome;
   defaultModel?: string;
   imported?: boolean;
   profiles: Array<{
@@ -1130,7 +1133,11 @@ export async function runModelsAuthLoginFlowCore(
       provider: imported.provider,
       profileId: imported.profileId,
     });
-    await refreshRunningGatewayAuthState(context.agentId, "login", opts.runtime);
+    const authRefresh = await refreshRunningGatewayAuthState(
+      context.agentId,
+      "login",
+      opts.runtime,
+    );
     if (imported.configUpdated) {
       logConfigUpdated(opts.runtime);
     }
@@ -1140,6 +1147,7 @@ export async function runModelsAuthLoginFlowCore(
     return {
       providerId: selectedProvider.id,
       methodId: chosenMethod.id,
+      authRefresh,
       imported: true,
       profiles: [
         { profileId: imported.profileId, provider: imported.provider, mode: imported.mode },
@@ -1181,7 +1189,7 @@ export async function runModelsAuthLoginFlowCore(
     await refreshRunningGatewayAuthState(context.agentId, "logout", opts.runtime);
   }
 
-  const { result, profiles } = await runProviderAuthMethod({
+  const { result, profiles, authRefresh } = await runProviderAuthMethod({
     config: context.config,
     configSnapshot: context.configSnapshot,
     agentId: context.agentId,
@@ -1203,6 +1211,7 @@ export async function runModelsAuthLoginFlowCore(
   return {
     providerId: selectedProvider.id,
     methodId: chosenMethod.id,
+    authRefresh,
     ...(result.defaultModel ? { defaultModel: result.defaultModel } : {}),
     profiles: profiles.map((profile) => ({
       profileId: profile.profileId,

--- a/src/plugin-sdk/provider-auth-login-flow-runtime.ts
+++ b/src/plugin-sdk/provider-auth-login-flow-runtime.ts
@@ -7,6 +7,7 @@ import type {
   ModelsAuthLoginFlowResult,
 } from "../commands/models/auth.js";
 import { createLazyRuntimeMethodBinder, createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { ProviderAuthConfigApplyError } from "../shared/provider-auth-result.js";
 import type { OpenClawConfig } from "./config-contracts.js";
 import type { RuntimeEnv } from "./runtime-env.js";
 
@@ -14,6 +15,7 @@ export type {
   ModelsAuthLoginFlowOptions,
   ModelsAuthLoginFlowResult,
 } from "../commands/models/auth.js";
+export { ProviderAuthConfigApplyError };
 
 type ProviderAuthLoginFlowRuntime = typeof import("../commands/models/auth.js");
 type RunModelsAuthLoginFlow = (opts: ModelsAuthLoginFlowOptions) => Promise<unknown>;
@@ -170,6 +172,14 @@ function parseModelsAuthLoginFlowResult(value: unknown): ModelsAuthLoginFlowResu
   };
   const providerId = parseRequiredString(result.providerId, "provider id");
   const methodId = parseRequiredString(result.methodId, "method id");
+  const authRefresh = result.authRefresh;
+  if (
+    authRefresh !== "refreshed" &&
+    authRefresh !== "gateway-rejected" &&
+    authRefresh !== "gateway-unreachable"
+  ) {
+    throw new Error("Provider login returned an invalid auth refresh outcome.");
+  }
   const profiles = result.profiles.map((profile): ModelsAuthLoginFlowResult["profiles"][number] => {
     if (!profile || typeof profile !== "object") {
       throw new Error("Provider login returned an invalid profile.");
@@ -194,6 +204,7 @@ function parseModelsAuthLoginFlowResult(value: unknown): ModelsAuthLoginFlowResu
   return {
     providerId,
     methodId,
+    authRefresh,
     ...(defaultModel ? { defaultModel } : {}),
     profiles,
   };
@@ -219,6 +230,7 @@ async function runCodexDeviceLoginFlow(params: {
     config: params.config,
     runtime: params.runtime,
     signal: params.signal,
+    beforePersistentEffect: () => params.signal?.throwIfAborted(),
     prompter: buildCodexDeviceLoginPrompter({
       sendMessage: params.sendMessage,
       sendDeviceCode: params.sendDeviceCode,
@@ -239,4 +251,25 @@ export const codexChannelLoginRuntime = {
   reserveFlow: reserveCodexLoginFlow,
   releaseFlow: releaseCodexLoginFlow,
   runDeviceLoginFlow: runCodexDeviceLoginFlow,
+  formatCompletion: (
+    authRefresh: ModelsAuthLoginFlowResult["authRefresh"],
+    sessionSwitchFailed = false,
+  ): string => {
+    const sessionFailure =
+      "this session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.";
+    if (authRefresh === "refreshed") {
+      return sessionSwitchFailed
+        ? `Codex login completed, but ${sessionFailure}`
+        : "Codex login complete. Try your request again now.";
+    }
+    const message =
+      authRefresh === "gateway-rejected"
+        ? "Codex credentials saved, but the Gateway could not apply the auth update. Check the Gateway logs, restart the Gateway, then use /models."
+        : "Codex credentials saved, but the Gateway could not be reached to apply them. Restart the Gateway, then use /models.";
+    return sessionSwitchFailed ? `${message} Also, ${sessionFailure}` : message;
+  },
+  formatFailure: (error: unknown): string =>
+    error instanceof ProviderAuthConfigApplyError
+      ? "Codex credentials saved, but provider settings could not be applied. Review the provider settings and check the Gateway logs before trying again."
+      : "Codex login did not complete. Send `/login codex` to request a new code.",
 };

--- a/src/shared/provider-auth-result.ts
+++ b/src/shared/provider-auth-result.ts
@@ -1,0 +1,10 @@
+/** A provider login committed credentials before its settings write failed. */
+export class ProviderAuthConfigApplyError extends Error {
+  constructor(cause: unknown) {
+    super(
+      `Credentials saved, but provider settings could not be applied: ${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause },
+    );
+    this.name = "ProviderAuthConfigApplyError";
+  }
+}


### PR DESCRIPTION
Related: #136257, #144181.

## What Problem This Solves

Fixes an issue where private-chat login reported completion after saving credentials even when the Gateway rejected authentication refresh or could not be reached. Settings-write failures also hid that credentials were already saved.

## Why This Change Was Made

The login result carries refresh outcomes and saved-credential state. The shared login runtime owns completion and failure wording for generic chat and native Telegram while retaining cancellation, session switching and delivery behavior.

## User Impact

Users receive accurate saved-credential and recovery guidance after partial success. Successful refresh keeps existing retry guidance. No configuration or permission change.

Consumers: generic chat and native Telegram render the shared login outcome.

## Evidence

Producer and presentation regressions failed before the fix; 106 focused tests passed. Five real Telegram recordings verified acknowledged, rejected and unreachable refresh, rejected settings, and failure before save. Credentials were checked before and after each result. Synthetic login credentials were used; external authentication was not proved.
