### PR TITLE
fix(agents): preserve captured fallback model selections

### DIFF
--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -278,7 +278,7 @@ describe("embedded model resolution consistency", () => {
         provider: "custom-provider",
         model: "modern-model",
         routeOrigin: "requested",
-        routeResolution: "raw",
+        routeResolution: "resolved",
       },
     ]);
     expect(normalizeProviderModelIdWithRuntimeMock).toHaveBeenCalledWith({

--- a/src/agents/model-fallback-candidates.generation.test.ts
+++ b/src/agents/model-fallback-candidates.generation.test.ts
@@ -1,6 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
+import {
+  adoptCurrentPluginMetadataSnapshotIfAbsent,
+  withPluginMetadataSnapshotScope,
+} from "../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import { projectPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -13,9 +18,133 @@ import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.
 describe("fallback candidates across provider generations", () => {
   afterEach(() => resetPluginRuntimeStateForTest());
 
+  describe("captured requested policy", () => {
+    const provider = "captured-policy";
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { models: {} } },
+      plugins: { load: { paths: ["/tmp/fallback-captured-policy/plugin"] } },
+    };
+    const createMetadata = () =>
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: provider,
+            providers: [provider],
+            modelIdNormalization: {
+              providers: { [provider]: { aliases: { entry: "middle", middle: "final" } } },
+            },
+          },
+        ],
+      });
+    const resolveRequested = (model = "entry", requestedRouteResolution?: "raw" | "resolved") =>
+      resolveModelCandidateChain({
+        cfg,
+        provider,
+        model,
+        requestedRouteResolution,
+        fallbacksOverride: [],
+      });
+
+    it("keeps cold requests raw until captured policy can normalize them once", () => {
+      const metadata = createMetadata();
+      const narrowed = projectPluginMetadataSnapshot(metadata, []);
+      withPluginCache(createPluginCache(), () => {
+        const cold = expectDefined(resolveRequested()[0], "cold candidate");
+        expect(cold).toEqual({
+          provider,
+          model: "entry",
+          routeOrigin: "requested",
+          routeResolution: "raw",
+        });
+        for (const [metadataSnapshot, model] of [
+          [metadata, "middle"],
+          [narrowed, "entry"],
+          [metadata, "middle"],
+        ] as const) {
+          withPluginRuntimeGenerationScope({ metadataSnapshot }, () => {
+            const selected = expectDefined(
+              resolveRequested(cold.model, cold.routeResolution)[0],
+              "captured candidate",
+            );
+            expect(selected).toEqual({
+              provider,
+              model,
+              routeOrigin: "requested",
+              routeResolution: "resolved",
+            });
+            expect(resolveRequested(selected.model, selected.routeResolution)).toEqual([selected]);
+          });
+        }
+        expect(resolveRequested()).toEqual([cold]);
+        expect(resolveRequested("middle", "resolved")).toEqual([
+          { provider, model: "middle", routeOrigin: "requested", routeResolution: "resolved" },
+        ]);
+      });
+    });
+
+    it.each(["compatible", "foreign", "configless"] as const)(
+      "captures only compatible ordinary metadata: %s",
+      (context) => {
+        const metadata = createMetadata();
+        adoptCurrentPluginMetadataSnapshotIfAbsent(metadata, {
+          config: cfg,
+          compatibleConfigs: [cfg],
+        });
+        const requestConfig =
+          context === "compatible"
+            ? cfg
+            : context === "foreign"
+              ? { ...cfg, plugins: { load: { paths: ["/tmp/fallback-captured-policy/other"] } } }
+              : undefined;
+        const candidates = resolveModelCandidateChain({
+          cfg: requestConfig,
+          provider,
+          model: "entry",
+          fallbacksOverride: [],
+        });
+        const selected = expectDefined(candidates[0], "ordinary metadata candidate");
+        expect(selected).toEqual({
+          provider,
+          model: context === "compatible" ? "middle" : "entry",
+          routeOrigin: "requested",
+          routeResolution: context === "compatible" ? "resolved" : "raw",
+        });
+        withPluginRuntimeGenerationScope({ metadataSnapshot: metadata }, () => {
+          expect(resolveRequested(selected.model, selected.routeResolution)).toEqual([
+            { provider, model: "middle", routeOrigin: "requested", routeResolution: "resolved" },
+          ]);
+        });
+      },
+    );
+
+    it("honors explicit empty policy inside a full generation", () => {
+      const metadataSnapshot = createMetadata();
+      withPluginRuntimeGenerationScope({ metadataSnapshot }, () => {
+        expect(resolveRequested()).toEqual([
+          { provider, model: "middle", routeOrigin: "requested", routeResolution: "resolved" },
+        ]);
+        const candidates = resolveModelCandidateChain({
+          cfg,
+          provider,
+          model: "entry",
+          fallbacksOverride: [],
+          manifestPlugins: [],
+        });
+        const selected = expectDefined(candidates[0], "empty policy candidate");
+        expect(selected).toEqual({
+          provider,
+          model: "entry",
+          routeOrigin: "requested",
+          routeResolution: "resolved",
+        });
+        expect(resolveRequested(selected.model, selected.routeResolution)).toEqual([selected]);
+      });
+    });
+  });
+
   it.each(
     (["generation", "request"] as const).flatMap((scope) =>
-      (["configured-fallback", "configured-primary"] as const).flatMap((origin) =>
+      (["requested", "configured-fallback", "configured-primary"] as const).flatMap((origin) =>
         [false, true].map((manifestAlias) => ({ scope, origin, manifestAlias })),
       ),
     ),
@@ -23,7 +152,8 @@ describe("fallback candidates across provider generations", () => {
     "uses the $scope registry for $origin with manifest alias=$manifestAlias",
     ({ scope, origin, manifestAlias }) => {
       const provider = `fallback-${scope}`;
-      const requestedModel = origin === "configured-primary" ? "other" : "primary";
+      const requestedModel =
+        origin === "requested" ? "latest" : origin === "configured-primary" ? "other" : "primary";
       const runtimeInput = manifestAlias ? "release" : "latest";
       const cfg: OpenClawConfig = {
         agents: {
@@ -76,11 +206,38 @@ describe("fallback candidates across provider generations", () => {
       const empty = { metadataSnapshot, pluginRegistry: createEmptyPluginRegistry() };
       const active = createGeneration("model-active");
       setActivePluginRegistry(active.pluginRegistry, "fallback-generation-fixture");
-      const resolve = () => resolveModelCandidateChain({ cfg, provider, model: requestedModel });
-      const expected = (model: string) => [
-        { provider, model: requestedModel, routeOrigin: "requested", routeResolution: "raw" },
-        { provider, model, routeOrigin: origin, routeResolution: "resolved" },
-      ];
+      const resolve = () => {
+        const candidates = resolveModelCandidateChain({
+          cfg,
+          provider,
+          model: requestedModel,
+          ...(origin === "requested" ? { fallbacksOverride: [] } : {}),
+        });
+        for (const candidate of candidates) {
+          expect(
+            resolveModelCandidateChain({
+              cfg,
+              provider,
+              model: candidate.model,
+              requestedRouteResolution: candidate.routeResolution,
+              fallbacksOverride: [],
+            }),
+          ).toEqual([{ ...candidate, routeOrigin: "requested" }]);
+        }
+        return candidates;
+      };
+      const expected = (model: string) =>
+        origin === "requested"
+          ? [{ provider, model, routeOrigin: "requested", routeResolution: "resolved" }]
+          : [
+              {
+                provider,
+                model: requestedModel,
+                routeOrigin: "requested",
+                routeResolution: "resolved",
+              },
+              { provider, model, routeOrigin: origin, routeResolution: "resolved" },
+            ];
       for (const [generation, model] of [
         [a, "model-a"],
         [b, "model-b"],
@@ -100,7 +257,7 @@ describe("fallback candidates across provider generations", () => {
         for (const candidate of candidates) {
           candidate.model = "caller-mutation";
           candidate.routeOrigin = "configured-primary";
-          candidate.routeResolution = "resolved";
+          candidate.routeResolution = "raw";
         }
       }
       expect(
@@ -223,32 +380,58 @@ describe("fallback candidates across provider generations", () => {
     ]);
   });
 
-  it("keeps narrowed manifest policies separate when the runtime registry is shared", () => {
-    const provider = "fallback-manifest";
-    const metadata = createPluginMetadataSnapshotFixture({
-      plugins: [
-        {
-          id: provider,
-          providers: [provider],
-          modelIdNormalization: {
-            providers: { [provider]: { aliases: { latest: "model-full" } } },
+  it.each([true, false])(
+    "keeps captured manifest policies separate (runtime hooks=%s)",
+    (allowPluginNormalization) => {
+      const provider = "fallback-manifest";
+      const metadata = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: provider,
+            providers: [provider],
+            modelIdNormalization: {
+              providers: { [provider]: { aliases: { latest: "model-full" } } },
+            },
           },
+        ],
+      });
+      const narrowed = projectPluginMetadataSnapshot(metadata, []);
+      const pluginRegistry = createEmptyPluginRegistry();
+      const normalizeModelId = vi.fn(() => undefined);
+      pluginRegistry.providers.push({
+        pluginId: provider,
+        source: "synthetic",
+        provider: {
+          id: provider,
+          label: provider,
+          auth: [],
+          normalizeModelId,
         },
-      ],
-    });
-    const narrowed = projectPluginMetadataSnapshot(metadata, []);
-    const pluginRegistry = createEmptyPluginRegistry();
-    const cfg: OpenClawConfig = {};
-    for (const [metadataSnapshot, model] of [
-      [metadata, "model-full"],
-      [narrowed, "latest"],
-      [metadata, "model-full"],
-    ] as const) {
-      expect(
-        withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () =>
-          resolveModelCandidateChain({ cfg, provider, model: "latest", fallbacksOverride: [] }),
-        ),
-      ).toEqual([{ provider, model, routeOrigin: "requested", routeResolution: "raw" }]);
-    }
-  });
+      });
+      const cfg: OpenClawConfig = {};
+      for (const [metadataSnapshot, model] of [
+        [metadata, "model-full"],
+        [narrowed, "latest"],
+        [metadata, "model-full"],
+      ] as const) {
+        expect(
+          withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () =>
+            resolveModelCandidateChain({
+              cfg,
+              provider,
+              model: "latest",
+              fallbacksOverride: [],
+              allowPluginNormalization,
+              ...(!allowPluginNormalization ? { manifestPlugins: metadataSnapshot } : {}),
+            }),
+          ),
+        ).toEqual([{ provider, model, routeOrigin: "requested", routeResolution: "resolved" }]);
+      }
+      if (allowPluginNormalization) {
+        expect(normalizeModelId).toHaveBeenCalled();
+      } else {
+        expect(normalizeModelId).not.toHaveBeenCalled();
+      }
+    },
+  );
 });

--- a/src/agents/model-fallback-candidates.test.ts
+++ b/src/agents/model-fallback-candidates.test.ts
@@ -73,9 +73,31 @@ describe("resolveModelCandidateChain", () => {
     },
   );
 
-  it.each(["raw", "resolved", "configured-fallback", "configured-primary"] as const)(
-    "does not reapply manifest aliases after resolving the %s route",
-    (origin) => {
+  it.each([
+    { source: "raw", model: "latest", inputResolution: "raw", origin: "requested" },
+    { source: "resolved", model: "release", inputResolution: "resolved", origin: "requested" },
+    {
+      source: "provider prefix",
+      model: "candidate/latest",
+      inputResolution: "raw",
+      origin: "requested",
+    },
+    { source: "config alias", model: "shortcut", inputResolution: "raw", origin: "requested" },
+    {
+      source: "configured-fallback",
+      model: "unrelated",
+      inputResolution: "resolved",
+      origin: "configured-fallback",
+    },
+    {
+      source: "configured-primary",
+      model: "unrelated",
+      inputResolution: "resolved",
+      origin: "configured-primary",
+    },
+  ] as const)(
+    "preserves the resolved $source output when reused as input",
+    ({ source, model, inputResolution, origin }) => {
       const primary = origin === "configured-primary" ? "latest" : "unrelated";
       const cfg: OpenClawConfig = {
         agents: {
@@ -84,30 +106,55 @@ describe("resolveModelCandidateChain", () => {
               primary: `candidate/${primary}`,
               fallbacks: origin === "configured-fallback" ? ["candidate/latest"] : [],
             },
+            ...(source === "config alias"
+              ? { models: { "candidate/latest": { alias: "shortcut" } } }
+              : {}),
           },
         },
       };
+      const manifestPlugins = [
+        {
+          modelIdNormalization: {
+            providers: { candidate: { aliases: { latest: "release", release: "stable" } } },
+          },
+        },
+      ];
       const candidates = resolveModelCandidateChain({
         cfg,
         provider: "candidate",
-        model: origin === "raw" ? "latest" : origin === "resolved" ? "release" : "unrelated",
-        requestedRouteResolution: origin === "raw" ? "raw" : "resolved",
-        manifestPlugins: [
-          {
-            modelIdNormalization: {
-              providers: { candidate: { aliases: { latest: "release", release: "stable" } } },
-            },
-          },
-        ],
+        model,
+        requestedRouteResolution: inputResolution,
+        manifestPlugins,
       });
-
-      expect(candidates).toContainEqual({
+      const selected = candidates.find((candidate) => candidate.routeOrigin === origin);
+      expect(selected).toMatchObject({
         provider: "candidate",
         model: "release",
-        routeOrigin: origin === "raw" || origin === "resolved" ? "requested" : origin,
-        routeResolution: origin === "raw" ? "raw" : "resolved",
+        routeOrigin: origin,
       });
-      expect(candidates.some(({ model }) => model === "stable")).toBe(false);
+      expect(candidates.some(({ model: candidateModel }) => candidateModel === "stable")).toBe(
+        false,
+      );
+      if (!selected) {
+        throw new Error("Expected selected candidate");
+      }
+      expect(
+        resolveModelCandidateChain({
+          cfg,
+          provider: selected.provider,
+          model: selected.model,
+          requestedRouteResolution: selected.routeResolution,
+          fallbacksOverride: [],
+          manifestPlugins,
+        }),
+      ).toEqual([
+        {
+          provider: "candidate",
+          model: "release",
+          routeOrigin: "requested",
+          routeResolution: "resolved",
+        },
+      ]);
     },
   );
 });

--- a/src/agents/model-fallback-candidates.ts
+++ b/src/agents/model-fallback-candidates.ts
@@ -160,20 +160,19 @@ export function resolveImageFallbackDefaultProvider(cfg: OpenClawConfig | undefi
 export function resolveModelCandidateChain(
   params: ModelCandidateChainParams,
 ): ModelFallbackCandidate[] {
-  const cacheKey = resolveFallbackCandidateCacheKey(params);
-  if (!cacheKey) {
-    return resolveFallbackCandidatesUncached(params);
-  }
-  const cached = fallbackCandidateCache.get(cacheKey);
+  const { cacheKey, manifestPlugins } = resolveFallbackCandidateContext(params);
+  const cached = cacheKey ? fallbackCandidateCache.get(cacheKey) : undefined;
   if (cached) {
     return cached.map((candidate) => Object.assign({}, candidate));
   }
-  const candidates = resolveFallbackCandidatesUncached(params);
-  fallbackCandidateCache.set(
-    cacheKey,
-    candidates.map((candidate) => Object.assign({}, candidate)),
-  );
-  pruneMapToMaxSize(fallbackCandidateCache, MAX_FALLBACK_CANDIDATE_CACHE_ENTRIES);
+  const candidates = resolveFallbackCandidatesUncached({ ...params, manifestPlugins });
+  if (cacheKey) {
+    fallbackCandidateCache.set(
+      cacheKey,
+      candidates.map((candidate) => Object.assign({}, candidate)),
+    );
+    pruneMapToMaxSize(fallbackCandidateCache, MAX_FALLBACK_CANDIDATE_CACHE_ENTRIES);
+  }
   return candidates;
 }
 
@@ -187,9 +186,9 @@ function getFallbackContextId(value: object): number {
   return id;
 }
 
-function resolveFallbackCandidateCacheKey(params: ModelCandidateChainParams): string | null {
-  if (params.manifestPlugins) {
-    return null;
+function resolveFallbackCandidateContext(params: ModelCandidateChainParams) {
+  if (params.manifestPlugins !== undefined) {
+    return { cacheKey: null, manifestPlugins: params.manifestPlugins };
   }
   const workspaceDir = getActivePluginRegistryWorkspaceDirFromState();
   const env = process.env;
@@ -203,6 +202,7 @@ function resolveFallbackCandidateCacheKey(params: ModelCandidateChainParams): st
     env,
     workspaceDir,
     allowWorkspaceScopedSnapshot: true,
+    requireDefaultDiscoveryContext: params.cfg === undefined,
   });
   if (
     isPluginProvidersLoadInFlight({
@@ -213,13 +213,13 @@ function resolveFallbackCandidateCacheKey(params: ModelCandidateChainParams): st
       activate: false,
     })
   ) {
-    return null;
+    return { cacheKey: null, manifestPlugins: providerLoadMetadata };
   }
   const registryState = getPluginRegistryState();
   const registry = getPluginRuntimeGenerationRegistry() ?? getPluginRegistryForContext();
   const agentConfig =
     params.cfg && params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined;
-  return JSON.stringify({
+  const cacheKey = JSON.stringify({
     agentId: params.agentId,
     agentModel: agentConfig?.model,
     agentModels: agentConfig?.models,
@@ -240,11 +240,15 @@ function resolveFallbackCandidateCacheKey(params: ModelCandidateChainParams): st
     // Fingerprints omit executable hooks and narrowed metadata views. Weak ids
     // isolate both without retaining retired registries or growing the cache bound.
     pluginMetadataIdentity: pluginMetadata ? getFallbackContextId(pluginMetadata) : null,
+    normalizationMetadataIdentity: providerLoadMetadata
+      ? getFallbackContextId(providerLoadMetadata)
+      : null,
     pluginRegistryIdentity: registry ? getFallbackContextId(registry) : null,
     pluginRegistryKey: registryState?.key ?? null,
     pluginRegistryVersion: registryState?.activeVersion ?? null,
     pluginWorkspaceDir: workspaceDir ?? null,
   });
+  return { cacheKey, manifestPlugins: providerLoadMetadata };
 }
 
 function resolveFallbackCandidateModelProviderCacheParts(cfg: OpenClawConfig | undefined): unknown {
@@ -332,7 +336,11 @@ function resolveFallbackCandidatesUncached(
         manifestPlugins: params.manifestPlugins,
       }) ?? normalizedPrimary;
   }
-  addCandidate(requestedCandidate, "requested", requestedRouteResolution);
+  addCandidate(
+    requestedCandidate,
+    "requested",
+    params.manifestPlugins !== undefined ? "resolved" : requestedRouteResolution,
+  );
 
   const modelFallbacks =
     params.fallbacksOverride !== undefined

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1295,7 +1295,7 @@ describe("runWithModelFallback", () => {
         provider: "google",
         model: "gemini-2.5-flash-lite",
         routeOrigin: "requested",
-        routeResolution: "raw",
+        routeResolution: "resolved",
       },
       {
         provider: "anthropic",


### PR DESCRIPTION
Related: #130706, #143961.

## What Problem This Solves

Fixes an issue where a requested fallback model can consume an alias during selection and then consume it again during materialization. With `entry → middle → final`, the selected `middle` can incorrectly become `final`.

## Why This Change Was Made

Use the config-compatible metadata already captured for candidate construction as its normalization policy and cache identity. Mark the requested output resolved only when that policy was captured. Cold requests remain raw until acquisition, and an explicit empty policy remains authoritative. The existing owner changes by **+8 production lines**.

## User Impact

Fallback execution preserves the model actually selected without breaking cold model acquisition, runtime-only fallbacks, or explicit metadata views.

## Evidence

Runtime validation is bound to `f0f3753eea4402601b52ecaee1123d4fd80662fd` against `0d1dabc08f4b598a17b4cb1028cd499913a6d353`.

- 204 focused candidate/fallback tests passed; all 25 generation cases passed again after test type and scope corrections.
- Complete changed-file gate and fresh independent P2 review passed, followed by one normal full build.
- Nine compiled loopback HTTP requests covered selected requests, runtime-only configured fallbacks and appended primaries, cold acquisition, captured-full and warm policies, and explicit empty policy.
- Baseline acquisition sent `middle / final / final / middle` for cold / full / warm / empty; corrected source and compiled code sent `middle / middle / middle / entry`.
- All 11,604 emitted files across 16 output roots retained names, hashes, and modification times. Import audits recorded no product source imports. All owned children joined and runtime leases and servers closed.

This proof covers the internal candidate producer, acquired-runtime materializer, and loopback transport. It does not claim ordinary Gateway/SDK marker forwarding or external vendor inference. The earlier unconditional-marker proposal and failed fixture/test attempts remain preserved and are not used as passing evidence.

Current CI repair head: `8bbc416a44d313d150e0bccc130992043267c582`.

CI found one missed expected marker in the existing embedded model consistency test. Its initial phase still verifies static resolution without metadata or runtime hooks; its second phase explicitly supplies manifest policy. That normalized output now correctly expects `resolved`. The raw input and all initial-resolution and runtime-callback assertions remain intact.

The follow-up changes one test line and no production code. All 213 consistency/candidate/fallback tests, the complete changed-test gate, and fresh P2 review passed. The normal build and nine compiled HTTP requests remain bound to `f0f3753eea4402601b52ecaee1123d4fd80662fd`; their evidence carries to this test-only head because all 40,749 other tracked inputs are identical and all 11,604 emitted files remain unchanged. Exact-head CI passed on the updated PR head.

A later [CI job](https://github.com/openclaw/openclaw/actions/runs/34537016453/job/103072371589) timed out in an unchanged maintenance integration test. The unchanged two-case file passed on both this candidate and pre-marker main; the recorded predecessor sequence then passed 249 tests on each, with first-case times 23.200s and 23.325s. Native order and 60s limits were preserved. One controlled same-head failed-job retry passed in [CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/34537016453/attempts/2). The original Linux timeout cause remains unproven; no source or timeout change was made for that retry.
