### PR TITLE
fix(ui): limit chat integration descriptions to two lines

### DIFF
--- a/ui/src/styles/chat/clawhub-card.css
+++ b/ui/src/styles/chat/clawhub-card.css
@@ -56,6 +56,13 @@ openclaw-chat-clawhub-card {
   gap: var(--space-2);
 }
 
+.chat-clawhub-card .card-sub {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
 .chat-clawhub-card__actions {
   display: flex;
   flex-shrink: 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing app-integration recommendations in chat see oversized cards when a catalog description is long. The reported description occupies four lines on desktop and seven on mobile in the reproduction.

## Why This Change Was Made

Clamp only the recommendation-card description to two lines with an ellipsis, using the existing CSS pattern. Keep the full text in the DOM and preserve the title, status, and actions. No catalog data, install behavior, or other card descriptions change.

## User Impact

Integration recommendations stay compact on desktop and mobile. Short descriptions and cards without descriptions retain their existing layout.

## Evidence

Inspected before/after captures from the real Control UI at `/chat`, using the repository's isolated Vite + Playwright mock-Gateway harness and synthetic catalog responses. Same fixtures, dark theme, locale, Chromium, and viewport on both revisions; no production Gateway changes.

- Baseline: `d2cf02d0bf2`.
- Candidate: `8acedba7ec23b3672df5ead58d0185403ef571b1`.
- Browser assertions: long descriptions are exactly two visible lines after the change (desktop 4 → 2, mobile 7 → 2); full description text remains intact; cards stay within the viewport; View details navigates to the listing without installing; Dismiss removes the card.
- Loading, empty-description, typical, and content-heavy states captured at both viewports. Error/installed action variants use the same description element; their unchanged action logic is outside this CSS-only fix. No animation or timing change, so screenshots are the relevant proof.
- All 13 existing `chat-clawhub-card.test.ts` tests passed. Full selected `check:changed` passed, including core/UI typechecks, i18n, formatting, and scoped stylelint. `git diff --check` and independent read-only review passed. Exact-head hosted [CI passed](https://github.com/openclaw/openclaw/actions/runs/34535753269), including the real-Gateway UI suite. ClawSweeper completed with no findings and accepted the visual proof.

| Viewport | Before/after matrix | Result |
| --- | --- | --- |
| Desktop `1440×900` | Heavy, loading, typical, empty | Long copy 4 → 2 lines; loading copy 3 → 2; short and empty unchanged |
| Mobile `390×844` | Heavy, loading, typical, empty | Long copy 7 → 2 lines; loading copy 6 → 2; short and empty unchanged |

### Desktop

![Desktop before and after: long and loading descriptions clamp to two lines; typical and empty states are unchanged](https://github.com/user-attachments/assets/76e7e299-7541-47d5-83ae-d82ccc97cd07)

### Mobile

![Mobile before and after: long and loading descriptions clamp to two lines while actions remain visible](https://github.com/user-attachments/assets/23a1da56-f91d-4bcb-a158-a8e82cdf9581)
