### PR TITLE
refactor(reply): remove duplicate follow-up context

### DIFF
--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -644,7 +644,6 @@ export async function prepareReplyAgentPayloads(state: {
     kind: "continue" as const,
     activeSessionEntry,
     completedSourceReplyDelivery,
-    didLogHeartbeatStrip,
     guardedReplyPayloads,
     responseUsageLine,
   };

--- a/src/auto-reply/reply/followup-turn-admission.test.ts
+++ b/src/auto-reply/reply/followup-turn-admission.test.ts
@@ -193,7 +193,7 @@ describe("admitFollowupTurn", () => {
         sessionFile: "main",
         modelSelectionLocked: true,
       });
-      expect(result.turn.currentInboundContext).toEqual({ text: "fresh goal" });
+      expect(result.turn.queued.currentInboundContext).toEqual({ text: "fresh goal" });
       expect(result.turn.sendPolicy).toBe("deny");
       expect(result.turn.session.current()).toBe(admittedEntry);
     }
@@ -760,7 +760,6 @@ describe("admitFollowupTurn", () => {
       kind: "admitted",
       turn: {
         sendPolicy: "deny",
-        currentInboundContext: { text: "compacted-session" },
         queued: { currentInboundContext: { text: "compacted-session" } },
       },
     });

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import type { CurrentInboundPromptContext } from "../../agents/embedded-agent-runner/run/params.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -80,7 +79,6 @@ export type AdmittedFollowupTurn = {
   config: OpenClawConfig;
   session: FollowupSessionOwner;
   sessionStore?: Record<string, SessionEntry>;
-  currentInboundContext?: CurrentInboundPromptContext;
   sendPolicy: "allow" | "deny";
   preflightCompactionApplied: boolean;
   preflightFailurePayload?: ReplyPayload;
@@ -115,7 +113,7 @@ function isSameSessionGeneration(
   );
 }
 
-/** Resolves one queued item into an immutable admitted turn. */
+/** Resolves one queued item into an admitted turn. */
 export async function admitFollowupTurn(params: {
   queued: FollowupRun;
   defaults: FollowupRunnerParams;
@@ -299,7 +297,6 @@ export async function admitFollowupTurn(params: {
       config,
       session,
       sessionStore,
-      currentInboundContext,
       sendPolicy: resolveTurnSendPolicy(activeEntry),
       preflightCompactionApplied: false,
     };
@@ -309,7 +306,6 @@ export async function admitFollowupTurn(params: {
           ? params.queued.currentInboundContext
           : refreshActiveGoalContext(params.queued.currentInboundContext, entry);
       turn.sendPolicy = resolveTurnSendPolicy(entry, turn.queued);
-      turn.currentInboundContext = refreshedInboundContext;
       turn.queued = { ...turn.queued, currentInboundContext: refreshedInboundContext };
     };
     const readTurnSessionEntry = () =>


### PR DESCRIPTION
## What Problem This Solves

Follow-up admission keeps a second copy of inbound context even though execution reads it from the queued turn. Payload preparation also returns a heartbeat logging flag that its completion consumer never reads.

## Why This Change Was Made

Remove the unused context mirror and its writes, leaving the queued turn as the single context source. Remove only the unused final returned logging field; payload construction keeps its live state for avoiding duplicate heartbeat-strip logs. Existing admission and compaction assertions now check the actual execution input.

## User Impact

No intended user-visible behavior change. This removes five production lines and a duplicate assertion while preserving context refresh, compaction and heartbeat presentation.

## Evidence

Two existing context-preservation controls pass before the cleanup. Afterward, all 85 selected admission, execution, presentation and ordinary-finalizer test rows pass, along with 29 selected changed-file checks. The final comment correction has identical emitted JavaScript and is included in the passing checks.

The initial combined JSON test invocation stopped at the runner's project/reporter guard after 84 valid passes, before its finalizer case ran. That one unexecuted case then passed in a separate supported invocation. Both required runtime prebuilds and the initial guard failure are retained; no assertion or deadline changed.
