### PR TITLE
refactor(reply): share exported session tree layout

### DIFF
--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -189,40 +189,15 @@
     return current.entry.id;
   }
 
-  /**
-   * Flatten tree into list with indentation and connector info.
-   * Returns array of { node, indent, showConnector, isLast, gutters, isVirtualRootChild, multipleRoots }.
-   * Matches tree-selector.ts logic exactly.
-   */
-  function flattenTree(roots, activePathIds) {
-    const result = [];
+  /** Lay out ordered children into caller-owned records without replacing their node identity. */
+  function layoutTree(roots, getChildren, getLayoutTarget) {
     const multipleRoots = roots.length > 1;
-
-    // Mark which subtrees contain the active leaf
-    const containsActive = new Map();
-    function markActive(node) {
-      let has = activePathIds.has(node.entry.id);
-      for (const child of node.children) {
-        if (markActive(child)) {
-          has = true;
-        }
-      }
-      containsActive.set(node, has);
-      return has;
-    }
-    roots.forEach(markActive);
-
     // Stack: [node, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild]
     const stack = [];
-
-    // Add roots (prioritize branch containing active leaf)
-    const orderedRoots = [...roots].toSorted(
-      (a, b) => Number(containsActive.get(b)) - Number(containsActive.get(a)),
-    );
-    for (let i = orderedRoots.length - 1; i >= 0; i--) {
-      const isLast = i === orderedRoots.length - 1;
+    for (let i = roots.length - 1; i >= 0; i--) {
+      const isLast = i === roots.length - 1;
       stack.push([
-        orderedRoots[i],
+        roots[i],
         multipleRoots ? 1 : 0,
         multipleRoots,
         multipleRoots,
@@ -236,25 +211,19 @@
       const [node, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild] =
         stack.pop();
 
-      result.push({
-        node,
-        indent,
-        showConnector,
-        isLast,
-        gutters,
-        isVirtualRootChild,
-        multipleRoots,
-      });
+      const target = getLayoutTarget(node);
+      if (!target) {
+        continue;
+      }
+      target.indent = indent;
+      target.showConnector = showConnector;
+      target.isLast = isLast;
+      target.gutters = gutters;
+      target.isVirtualRootChild = isVirtualRootChild;
+      target.multipleRoots = multipleRoots;
 
-      const children = node.children;
+      const children = getChildren(node);
       const multipleChildren = children.length > 1;
-
-      // Order children (active branch first)
-      const orderedChildren = [...children].toSorted(
-        (a, b) => Number(containsActive.get(b)) - Number(containsActive.get(a)),
-      );
-
-      // Calculate child indent (matches tree-selector.ts)
       let childIndent;
       if (multipleChildren) {
         // Parent branches: children get +1
@@ -276,10 +245,10 @@
         : gutters;
 
       // Add children in reverse order for stack
-      for (let i = orderedChildren.length - 1; i >= 0; i--) {
-        const childIsLast = i === orderedChildren.length - 1;
+      for (let i = children.length - 1; i >= 0; i--) {
+        const childIsLast = i === children.length - 1;
         stack.push([
-          orderedChildren[i],
+          children[i],
           childIndent,
           multipleChildren,
           multipleChildren,
@@ -289,7 +258,34 @@
         ]);
       }
     }
+  }
 
+  /** Flatten the full tree with the active branch first at each level. */
+  function flattenTree(roots, activePathIds) {
+    const result = [];
+    const containsActive = new Map();
+    function markActive(node) {
+      let has = activePathIds.has(node.entry.id);
+      for (const child of node.children) {
+        if (markActive(child)) {
+          has = true;
+        }
+      }
+      containsActive.set(node, has);
+      return has;
+    }
+    roots.forEach(markActive);
+
+    const activeFirst = (a, b) => Number(containsActive.get(b)) - Number(containsActive.get(a));
+    layoutTree(
+      [...roots].toSorted(activeFirst),
+      (node) => [...node.children].toSorted(activeFirst),
+      (node) => {
+        const target = { node };
+        result.push(target);
+        return target;
+      },
+    );
     return result;
   }
 
@@ -499,7 +495,7 @@
    * Recompute indentation/connectors for the filtered view
    *
    * Filtering can hide intermediate entries; descendants attach to the nearest visible ancestor.
-   * Keep indentation semantics aligned with flattenTree() so single-child chains don't drift right.
+   * Reuse the shared layout without rewriting the original tree or filtered record identities.
    */
   function recalculateVisualStructure(filteredNodes, allFlatNodes) {
     if (filteredNodes.length === 0) {
@@ -528,14 +524,12 @@
     }
 
     // Build visible tree structure
-    const visibleParent = new Map();
     const visibleChildren = new Map();
     visibleChildren.set(null, []); // root-level nodes
 
     for (const flatNode of filteredNodes) {
       const nodeId = flatNode.node.entry.id;
       const ancestorId = findVisibleAncestor(nodeId);
-      visibleParent.set(nodeId, ancestorId);
 
       if (!visibleChildren.has(ancestorId)) {
         visibleChildren.set(ancestorId, []);
@@ -543,9 +537,7 @@
       visibleChildren.get(ancestorId).push(nodeId);
     }
 
-    // Update multipleRoots based on visible roots
     const visibleRootIds = visibleChildren.get(null);
-    const multipleRoots = visibleRootIds.length > 1;
 
     // Build a map for quick lookup: nodeId → FlatNode
     const filteredNodeMap = new Map();
@@ -553,80 +545,12 @@
       filteredNodeMap.set(flatNode.node.entry.id, flatNode);
     }
 
-    // DFS traversal of visible tree, applying same indentation rules as flattenTree()
-    // Stack items: [nodeId, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild]
-    const stack = [];
-
-    // Add visible roots in reverse order (to process in forward order via stack)
-    for (let i = visibleRootIds.length - 1; i >= 0; i--) {
-      const isLast = i === visibleRootIds.length - 1;
-      stack.push([
-        visibleRootIds[i],
-        multipleRoots ? 1 : 0,
-        multipleRoots,
-        multipleRoots,
-        isLast,
-        [],
-        multipleRoots,
-      ]);
-    }
-
-    while (stack.length > 0) {
-      const [nodeId, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild] =
-        stack.pop();
-
-      const flatNode = filteredNodeMap.get(nodeId);
-      if (!flatNode) {
-        continue;
-      }
-
-      // Update this node's visual properties
-      flatNode.indent = indent;
-      flatNode.showConnector = showConnector;
-      flatNode.isLast = isLast;
-      flatNode.gutters = gutters;
-      flatNode.isVirtualRootChild = isVirtualRootChild;
-      flatNode.multipleRoots = multipleRoots;
-
-      // Get visible children of this node
-      const children = visibleChildren.get(nodeId) || [];
-      const multipleChildren = children.length > 1;
-
-      // Calculate child indent using same rules as flattenTree():
-      // - Parent branches (multiple children): children get +1
-      // - Just branched and indent > 0: children get +1 for visual grouping
-      // - Single-child chain: stay flat
-      let childIndent;
-      if (multipleChildren) {
-        childIndent = indent + 1;
-      } else if (justBranched && indent > 0) {
-        childIndent = indent + 1;
-      } else {
-        childIndent = indent;
-      }
-
-      // Build gutters for children (same logic as flattenTree)
-      const connectorDisplayed = showConnector && !isVirtualRootChild;
-      const currentDisplayIndent = multipleRoots ? Math.max(0, indent - 1) : indent;
-      const connectorPosition = Math.max(0, currentDisplayIndent - 1);
-      const childGutters = connectorDisplayed
-        ? [...gutters, { position: connectorPosition, show: !isLast }]
-        : gutters;
-
-      // Add children in reverse order (to process in forward order via stack)
-      for (let i = children.length - 1; i >= 0; i--) {
-        const childIsLast = i === children.length - 1;
-        stack.push([
-          children[i],
-          childIndent,
-          multipleChildren,
-          multipleChildren,
-          childIsLast,
-          childGutters,
-          false,
-        ]);
-      }
-    }
+    // Filtering preserves the full traversal's order; update the original last-ID records.
+    layoutTree(
+      visibleRootIds,
+      (nodeId) => visibleChildren.get(nodeId) || [],
+      (nodeId) => filteredNodeMap.get(nodeId),
+    );
   }
 
   // ============================================================

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -197,6 +197,16 @@ describe("export html sidebar trigger affordance", () => {
 
 describe("export html security hardening", () => {
   it.each(["consult", "answer"])("honors hidden input with %s selected while preserving raw export", async (leafId) => {
+    function message(id: string, parentId: string | null, content: string, role = "assistant") {
+      return {
+        id,
+        parentId,
+        timestamp: now(),
+        type: "message",
+        message: { role, content },
+      };
+    }
+
     const session: SessionData = {
       header: { id: "session-hidden-input", timestamp: now() },
       entries: [
@@ -209,13 +219,7 @@ describe("export html security hardening", () => {
           content: "Hidden root context",
           display: false,
         },
-        {
-          id: "speech",
-          parentId: "hidden-root",
-          timestamp: now(),
-          type: "message",
-          message: { role: "user", content: "Explain the change. Context: Spoken style:" },
-        },
+        message("speech", "hidden-root", "Explain the change. Context: Spoken style:", "user"),
         {
           id: "consult",
           parentId: "speech",
@@ -228,13 +232,9 @@ describe("export html security hardening", () => {
             provenance: { kind: "internal_system", sourceTool: "openclaw_agent_consult" },
           },
         },
-        {
-          id: "answer",
-          parentId: "consult",
-          timestamp: now(),
-          type: "message",
-          message: { role: "assistant", content: "The change is ready." },
-        },
+        message("answer", "consult", "The change is ready."),
+        message("alternative", "speech", "An alternative reply."),
+        message("other-root", null, "Another conversation."),
       ],
       leafId,
       systemPrompt: "",
@@ -249,12 +249,23 @@ describe("export html security hardening", () => {
     expect(document.getElementById("entry-consult")).toBeNull();
     expect(document.getElementById("entry-hidden-root")).toBeNull();
     const treeIds = () => Array.from(document.querySelectorAll(".tree-node"), (node) => node.getAttribute("data-id"));
-    expect(treeIds()).toEqual(["speech", "answer"]);
+    const treePrefixes = () =>
+      Array.from(document.querySelectorAll(".tree-prefix"), (node) => node.textContent);
+    expect(treeIds()).toEqual(["speech", "answer", "alternative", "other-root"]);
+    expect(treePrefixes()).toEqual(["", "├─ ", "└─ ", ""]);
     const selectFilter = (filter: string) => requireElement(
       document.querySelector<HTMLButtonElement>(`[data-filter="${filter}"]`), "filter missing",
     ).click();
     selectFilter("all");
-    expect(treeIds()).toEqual(["hidden-root", "speech", "consult", "answer"]);
+    expect(treeIds()).toEqual([
+      "hidden-root",
+      "speech",
+      "consult",
+      "answer",
+      "alternative",
+      "other-root",
+    ]);
+    expect(treePrefixes()).toEqual(["", "   ", "   ├─ ", "   │     ", "   └─ ", ""]);
     expect(document.querySelector('[data-id="consult"]')?.textContent).toContain("[hidden] user:");
     requireElement(document.querySelector<HTMLElement>('[data-id="consult"]'), "hidden tree entry missing").click();
     expect(document.getElementById("entry-answer")?.textContent).toContain("The change is ready.");
@@ -262,8 +273,9 @@ describe("export html security hardening", () => {
     selectFilter("user-only");
     expect(treeIds()).not.toContain("consult");
     selectFilter("default");
-    expect(treeIds()).toEqual(["speech", "answer"]);
-    expect(document.getElementById("header-container")?.textContent).toContain("2 user, 1 assistant, 1 custom");
+    expect(treeIds()).toEqual(["speech", "answer", "alternative", "other-root"]);
+    expect(treePrefixes()).toEqual(["", "├─ ", "└─ ", ""]);
+    expect(document.getElementById("header-container")?.textContent).toContain("2 user, 3 assistant, 1 custom");
     const encoded = requireElement(document.getElementById("session-data"), "session data missing");
     expect(JSON.parse(Buffer.from(encoded.textContent ?? "", "base64").toString("utf8"))).toEqual(
       session,


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of the HTML session export tree. Full and filtered views duplicate the same layout rules, so changes must be kept in sync.

## Why This Change Was Made

Use one iterative walker for indentation, connectors, and gutters, with the existing active-order and visible-parent adapters. Preserve original node records and filtered lookup behavior, and remove an unused parent map. The existing rendered-template fixture gains branch and multiple-root assertions; shared fixture construction keeps every input and assertion intact.

## User Impact

No intended visual or behavioral change. Filtering, branch navigation, hidden inputs, and raw JSONL exports retain their behavior.

## Evidence

- Extended hidden-input regression passed on the original code. Final validation: 65 template/export-command tests, all 29 changed checks, packaging build, and independent P2 review with no findings.
- Isolated Linux Chromium 144 passed 14 steps per version, full DOM parity, and exact raw JSONL equality. The attached before/after PNGs are byte-identical.
- Browser scope: standalone pages assembled from production templates/assets and synthetic session data. CLI/Gateway export execution was outside this proof. Artifact transfer ended with wrapper exit 7 after browser success; the complete report and initial screenshot pair were recovered. Six extra screenshots and the original raw file were not retrieved; both download hashes remain recorded in the complete report.

| Before | After |
| --- | --- |
| ![Before: synthetic session export](https://github.com/user-attachments/assets/1c100783-4544-42c5-87c2-00bba7051c4c) | ![After: synthetic session export](https://github.com/user-attachments/assets/e1c208d5-00af-48d4-84c2-c25f273dd834) |
