### PR TITLE
fix: align provider discovery tests with loader-owned roots

### DIFF
--- a/src/plugins/provider-discovery.runtime.test.ts
+++ b/src/plugins/provider-discovery.runtime.test.ts
@@ -240,7 +240,7 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
     mocks.loadSource.mockReturnValue(staticProvider);
 
     expect(resolvePluginDiscoveryProvidersRuntime({})).toEqual([
-      { ...staticProvider, pluginId: "deepseek" },
+      { ...staticProvider, pluginId: "deepseek", pluginRoot: "/tmp/deepseek" },
     ]);
     expect(mocks.resolvePluginProvidersCore).not.toHaveBeenCalled();
   });
@@ -465,7 +465,7 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
     mocks.loadSource.mockReturnValue(staticProvider);
 
     expect(resolvePluginDiscoveryProvidersRuntime({})).toEqual([
-      { ...staticProvider, pluginId: "deepseek" },
+      { ...staticProvider, pluginId: "deepseek", pluginRoot: "/tmp/deepseek" },
     ]);
 
     expect(mocks.getCachedPluginModuleLoader).toHaveBeenCalledOnce();
@@ -528,8 +528,8 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
         env: { KILOCODE_API_KEY: "sk-test" } as NodeJS.ProcessEnv,
       }),
     ).toEqual([
-      { ...codexEntryProvider, pluginId: "codex" },
-      { ...deepseekEntryProvider, pluginId: "deepseek" },
+      { ...codexEntryProvider, pluginId: "codex", pluginRoot: "/tmp/codex" },
+      { ...deepseekEntryProvider, pluginId: "deepseek", pluginRoot: "/tmp/deepseek" },
       ...fullProviders,
     ]);
     expect(mocks.resolvePluginProvidersCore).toHaveBeenCalledTimes(1);
@@ -561,7 +561,10 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
       resolvePluginDiscoveryProvidersRuntime({
         env: { KILOCODE_API_KEY: "sk-test" } as NodeJS.ProcessEnv,
       }),
-    ).toEqual([{ ...codexEntryProvider, pluginId: "codex" }, ...fullProviders]);
+    ).toEqual([
+      { ...codexEntryProvider, pluginId: "codex", pluginRoot: "/tmp/codex" },
+      ...fullProviders,
+    ]);
     expect(mocks.resolvePluginProvidersCore).toHaveBeenCalledTimes(1);
     const params = requireResolvePluginProvidersParams();
     expect(params.onlyPluginIds).toEqual(["kilocode"]);

--- a/src/plugins/providers.setup-trust.test.ts
+++ b/src/plugins/providers.setup-trust.test.ts
@@ -170,6 +170,7 @@ describe("setup provider workspace trust", () => {
           label: "Setup Trust Provider",
           auth: [],
           pluginId: "setup-trusted-provider",
+          pluginRoot: path.join(workspaceDir, ".openclaw", "extensions", "setup-trusted-provider"),
         },
       ]);
     });


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves five plugin discovery and setup-trust test failures after provider descriptors gained their loader-owned dependency root.

## Why This Change Was Made

Include the six expected plugin roots in the existing exact-equality assertions. Preserve catalog loading, full-provider fallback, workspace trust and synthetic-auth behavior; production code is unchanged.

## User Impact

No user-visible behavior change. The tests now validate the complete current provider descriptor contract.

## Evidence

The original three-file focused run reproduced all five failures (37/42 passed). The same 42 cases then passed with identical full names and per-file order, including the synthetic-auth root sibling. The required changed gate and independent review passed. Parser-based preservation checks confirm the six expected properties are the only structural changes.
