### PR TITLE
fix: avoid shutdown hangs after database verifier IPC errors

### DIFF
--- a/docs/reference/database-schemas/integrity-and-recovery.md
+++ b/docs/reference/database-schemas/integrity-and-recovery.md
@@ -32,6 +32,13 @@ Quarantine decisions live only in a dedicated `openclaw-quarantine.sqlite` store
 
 Background verification errors retain the original name and message and append bounded Node `code` and SQLite `errcode` values from up to eight cause-chain nodes. These diagnostics do not change the verdict: I/O failures remain inconclusive, while proven corruption is reconfirmed by the database owner before quarantine. A generic `disk I/O error` (`errcode=10`) does not establish disk exhaustion.
 
+The background verifier retains its child through native exit and IPC disconnect,
+including when sending work fails. Failed native launches settle after closure
+without requiring an exit event. If the operating system refuses a termination
+request, the verifier logs the failure and keeps waiting for native exit; an
+undelivered signal does not mean the child has stopped. The original worker or
+IPC error remains the reported failure even if termination also fails.
+
 Agent database maintenance fences other writers with a 60-second lease in the shared state database. A dedicated worker renews that lease during synchronous integrity scans and migration phases. Maintenance still checks the exact persisted owner before mutations and commit, and stops if the heartbeat fails or ownership expires or changes. Finishing or cancelling maintenance stops renewal before releasing the lease; process death leaves at most the remaining lease duration.
 
 Asynchronous agent-database admission and maintenance run their initial full-file integrity check in a read-only child process when that check is outside a write transaction. The connection and owning scope remain held until the child closes, including on cancellation or timeout. Schema changes, index repairs, and compaction retain their synchronous phases.

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -41,6 +41,84 @@ function isVerifyResult(value: unknown): value is OpenClawDatabaseVerifyResult {
   );
 }
 
+type DatabaseVerifyWorkerExit = { code: number | null; signal: NodeJS.Signals | null };
+type DatabaseVerifyWorkerLifecycle = {
+  settled: Promise<DatabaseVerifyWorkerExit>;
+  requestTermination: () => void;
+};
+const workerLifecycles = new WeakMap<ChildProcess, DatabaseVerifyWorkerLifecycle>();
+
+function ownDatabaseVerifyWorker(worker: ChildProcess): DatabaseVerifyWorkerLifecycle {
+  let terminationRequested = false;
+  const settled = new Promise<DatabaseVerifyWorkerExit>((resolve) => {
+    let exit: DatabaseVerifyWorkerExit | undefined;
+    let disconnected = !worker.connected;
+    const finish = () => {
+      if (!exit || !disconnected) {
+        return;
+      }
+      worker.off("exit", onExit);
+      worker.off("disconnect", onDisconnect);
+      worker.off("close", onClose);
+      resolve(exit);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      exit = { code, signal };
+      finish();
+    };
+    const onDisconnect = () => {
+      disconnected = true;
+      finish();
+    };
+    const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+      // Failed launches emit error then close without exit. Spawned children
+      // need exit+disconnect because parent disconnect can suppress close.
+      if (worker.pid === undefined) {
+        exit = { code, signal };
+        disconnected = true;
+        finish();
+      }
+    };
+    worker.once("exit", onExit);
+    worker.once("disconnect", onDisconnect);
+    worker.once("close", onClose);
+  });
+  const lifecycle = {
+    settled,
+    requestTermination: () => {
+      if (
+        terminationRequested ||
+        worker.pid === undefined ||
+        worker.exitCode !== null ||
+        worker.signalCode !== null
+      ) {
+        return;
+      }
+      terminationRequested = true;
+      let signalError: Error | undefined;
+      const onSignalError = (error: Error) => {
+        signalError = error;
+      };
+      worker.on("error", onSignalError);
+      try {
+        if (worker.kill()) {
+          return;
+        }
+      } catch (error) {
+        signalError = toStructuredErrorObject(error);
+      } finally {
+        worker.off("error", onSignalError);
+      }
+      log.error("database verification worker termination failed; waiting for native exit", {
+        pid: worker.pid,
+        error: signalError?.message ?? "signal was not delivered",
+      });
+    },
+  };
+  workerLifecycles.set(worker, lifecycle);
+  return lifecycle;
+}
+
 export function runDatabaseVerifyWorker(
   targets: readonly OpenClawDatabaseVerifyTarget[],
   options: { onWorker?: (worker: ChildProcess | undefined) => void; workerUrl?: URL } = {},
@@ -59,86 +137,68 @@ export function runDatabaseVerifyWorker(
   } catch (error) {
     return Promise.reject(toStructuredErrorObject(error));
   }
+  // Capture the lifetime before publishing the child so stop joins this same boundary.
+  const lifecycle = ownDatabaseVerifyWorker(worker);
+  let result: OpenClawDatabaseVerifyResult[] | undefined;
+  let failure: Error | undefined;
+  let settled = false;
+  const fail = (error: unknown) => {
+    if (settled) {
+      return;
+    }
+    // kill() can emit another error synchronously. Preserve the triggering failure.
+    failure ??= toStructuredErrorObject(error);
+    lifecycle.requestTermination();
+  };
+  const onMessage = (message: unknown) => {
+    if (!Array.isArray(message) || !message.every(isVerifyResult)) {
+      fail(new Error("database verification worker returned invalid results"));
+      return;
+    }
+    result = message;
+  };
+  worker.once("message", onMessage);
+  worker.on("error", fail);
+  const completion = lifecycle.settled.then((exit) => {
+    settled = true;
+    worker.off("message", onMessage);
+    worker.off("error", fail);
+    options.onWorker?.(undefined);
+    if (failure) {
+      throw failure;
+    }
+    if (exit.code !== 0) {
+      throw new Error(
+        `database verification worker exited with ${exit.signal ? `signal ${exit.signal}` : `code ${exit.code}`}`,
+      );
+    }
+    if (!result) {
+      throw new Error("database verification worker exited without results");
+    }
+    return result;
+  });
   options.onWorker?.(worker);
-
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    let result: OpenClawDatabaseVerifyResult[] | undefined;
-    let protocolError: Error | undefined;
-    let exit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
-    let disconnected = !worker.connected;
-    const settle = (finish: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      worker.removeAllListeners();
-      options.onWorker?.(undefined);
-      finish();
-    };
-    const settleAfterExitAndDisconnect = () => {
-      const completedExit = exit;
-      if (!completedExit || !disconnected) {
-        return;
-      }
-      settle(() => {
-        if (protocolError) {
-          reject(toStructuredErrorObject(protocolError));
-        } else if (completedExit.code !== 0) {
-          reject(
-            new Error(
-              `database verification worker exited with ${
-                completedExit.signal
-                  ? `signal ${completedExit.signal}`
-                  : `code ${completedExit.code}`
-              }`,
-            ),
-          );
-        } else if (!result) {
-          reject(new Error("database verification worker exited without results"));
-        } else {
-          resolve(result);
+  if (worker.pid !== undefined) {
+    try {
+      worker.send(targets, (error) => {
+        if (error) {
+          fail(error);
         }
       });
-    };
-    worker.once("message", (message: unknown) => {
-      if (!Array.isArray(message) || !message.every(isVerifyResult)) {
-        protocolError = new Error("database verification worker returned invalid results");
-        worker.kill();
-        return;
-      }
-      result = message;
-    });
-    worker.once("error", (error) => settle(() => reject(toStructuredErrorObject(error))));
-    worker.once("disconnect", () => {
-      disconnected = true;
-      settleAfterExitAndDisconnect();
-    });
-    worker.once("exit", (code, signal) => {
-      exit = { code, signal };
-      disconnected ||= !worker.connected;
-      settleAfterExitAndDisconnect();
-    });
-    worker.send(targets, (error) => {
-      if (!error) {
-        return;
-      }
-      worker.kill();
-      settle(() => reject(toStructuredErrorObject(error)));
-    });
-  });
+    } catch (error) {
+      fail(error);
+    }
+  }
+  return completion;
 }
 
 export async function terminateDatabaseVerifyWorker(worker: ChildProcess): Promise<void> {
-  if (worker.exitCode !== null || worker.signalCode !== null) {
-    return;
+  const lifecycle = workerLifecycles.get(worker);
+  if (!lifecycle) {
+    throw new Error("database verification worker is not owned by this verifier");
   }
-  await new Promise<void>((resolve) => {
-    worker.once("exit", () => resolve());
-    if (!worker.kill()) {
-      resolve();
-    }
-  });
+  lifecycle.requestTermination();
+  await lifecycle.settled;
 }
 
 /** Resolve the state database and current registered agent database paths. */

--- a/src/state/openclaw-database-verify.process.test.ts
+++ b/src/state/openclaw-database-verify.process.test.ts
@@ -1,4 +1,4 @@
-import { fork } from "node:child_process";
+import { fork, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -8,7 +8,10 @@ import * as nodeSqlite from "../infra/node-sqlite.js";
 import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import * as sqliteLocation from "../infra/sqlite-readonly-location.js";
-import { runDatabaseVerifyWorker } from "./openclaw-database-verify.impl.js";
+import {
+  runDatabaseVerifyWorker,
+  terminateDatabaseVerifyWorker,
+} from "./openclaw-database-verify.impl.js";
 import { verifyOpenClawDatabases } from "./openclaw-database-verify.worker.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -99,6 +102,190 @@ describe("database verifier child process entrypoint", () => {
     await expect(importVerifierInUnrelatedFork()).resolves.toEqual([
       { echo: { type: "unrelated" } },
     ]);
+  });
+});
+
+describe("database verifier worker lifetime", () => {
+  function createWorkerFixture(): URL {
+    const fixtureDir = tempDirs.make("openclaw-database-verify-lifetime-");
+    const fixturePath = path.join(fixtureDir, "worker.mjs");
+    fs.writeFileSync(
+      fixturePath,
+      `process.once("message", () => {
+        process.send([], () => process.disconnect());
+      });`,
+    );
+    return pathToFileURL(fixturePath);
+  }
+
+  it("retains a failed IPC worker until exit without losing a concurrent stop waiter", async () => {
+    let worker: ChildProcess | undefined;
+    let releasedWhileAlive: boolean | undefined;
+    const verification = runDatabaseVerifyWorker([], {
+      workerUrl: createWorkerFixture(),
+      onWorker: (current) => {
+        if (current) {
+          worker = current;
+          current.disconnect();
+        } else {
+          releasedWhileAlive = worker?.exitCode === null && worker.signalCode === null;
+        }
+      },
+    }).catch((error: unknown) => error);
+    if (!worker) {
+      throw new Error("verifier did not publish its child");
+    }
+    const child = worker;
+    let stopCompleted = false;
+    void terminateDatabaseVerifyWorker(child).then(() => {
+      stopCompleted = true;
+    });
+
+    await vi.waitFor(() => expect(child.exitCode ?? child.signalCode).not.toBeNull());
+    const error = await verification;
+
+    expect(error).toMatchObject({ code: "ERR_IPC_CHANNEL_CLOSED", message: "Channel closed" });
+    expect({ releasedWhileAlive, stopCompleted }).toEqual({
+      releasedWhileAlive: false,
+      stopCompleted: true,
+    });
+  });
+
+  it.each(["not delivered", "throws"])(
+    "waits for native exit when termination %s",
+    async (mode) => {
+      let worker: ChildProcess | undefined;
+      const verification = runDatabaseVerifyWorker([], {
+        workerUrl: createWorkerFixture(),
+        onWorker: (current) => {
+          worker ??= current;
+        },
+      });
+      if (!worker) {
+        throw new Error("verifier did not publish its child");
+      }
+      const child = worker;
+      const kill = vi.spyOn(child, "kill").mockImplementation(() => {
+        if (mode === "throws") {
+          throw Object.assign(new Error("signal unsupported"), { code: "ENOSYS" });
+        }
+        return false;
+      });
+      try {
+        const stoppedWhileAlive = await terminateDatabaseVerifyWorker(child).then(
+          () => child.exitCode === null && child.signalCode === null,
+        );
+        await expect(verification).resolves.toEqual([]);
+        expect(stoppedWhileAlive).toBe(false);
+      } finally {
+        kill.mockRestore();
+        await verification;
+      }
+    },
+  );
+
+  it("preserves a native spawn failure without waiting for an exit event", async () => {
+    const executable = process.execPath;
+    let worker: ChildProcess | undefined;
+    let closed = false;
+    let releasedAfterClose = false;
+    let verification: Promise<unknown>;
+    try {
+      process.execPath = path.join(tempDirs.make("openclaw-verifier-spawn-"), "missing-node");
+      verification = runDatabaseVerifyWorker([], {
+        workerUrl: createWorkerFixture(),
+        onWorker: (current) => {
+          if (current) {
+            worker = current;
+            current.once("close", () => {
+              closed = true;
+            });
+          } else {
+            releasedAfterClose = closed;
+          }
+        },
+      });
+    } finally {
+      process.execPath = executable;
+    }
+
+    await expect(verification).rejects.toMatchObject({ code: "ENOENT" });
+    expect(worker?.pid).toBeUndefined();
+    expect(worker?.exitCode).toBeLessThan(0);
+    expect(releasedAfterClose).toBe(true);
+  });
+
+  it("preserves the IPC failure when termination reports a second error", async () => {
+    let worker: ChildProcess | undefined;
+    let restoreKill: (() => void) | undefined;
+    const verification = runDatabaseVerifyWorker([], {
+      workerUrl: createWorkerFixture(),
+      onWorker: (current) => {
+        if (current) {
+          worker = current;
+          const kill = vi.spyOn(current, "kill").mockImplementation(() => {
+            current.emit("error", Object.assign(new Error("signal refused"), { code: "EPERM" }));
+            return false;
+          });
+          restoreKill = () => kill.mockRestore();
+          current.disconnect();
+        }
+      },
+    });
+    try {
+      await expect(verification).rejects.toMatchObject({ code: "ERR_IPC_CHANNEL_CLOSED" });
+    } finally {
+      restoreKill?.();
+      await vi.waitFor(() => expect(worker?.exitCode ?? worker?.signalCode).not.toBeNull());
+    }
+  });
+
+  it("keeps stop joined while the native IPC disconnect notification is pending", async () => {
+    let worker: ChildProcess | undefined;
+    let releaseDisconnect: (() => void) | undefined;
+    let restoreEmit: (() => void) | undefined;
+    let verificationCompleted = false;
+    const verification = runDatabaseVerifyWorker([], {
+      workerUrl: createWorkerFixture(),
+      onWorker: (current) => {
+        if (current) {
+          worker = current;
+          const emit = current.emit.bind(current);
+          const spy = vi.spyOn(current, "emit").mockImplementation((event, ...args) => {
+            if (event === "disconnect") {
+              releaseDisconnect = () => {
+                emit(event, ...args);
+              };
+              return true;
+            }
+            return emit(event, ...args);
+          });
+          restoreEmit = () => spy.mockRestore();
+        }
+      },
+    }).then(() => {
+      verificationCompleted = true;
+    });
+    if (!worker) {
+      throw new Error("verifier did not publish its child");
+    }
+    const child = worker;
+    let stopCompleted = false;
+    await vi.waitFor(() => expect(child.exitCode ?? child.signalCode).not.toBeNull());
+    const termination = terminateDatabaseVerifyWorker(child).then(() => {
+      stopCompleted = true;
+    });
+    try {
+      await vi.waitFor(() => expect(releaseDisconnect).toBeTypeOf("function"));
+      expect({ stopCompleted, verificationCompleted }).toEqual({
+        stopCompleted: false,
+        verificationCompleted: false,
+      });
+    } finally {
+      releaseDisconnect?.();
+      restoreEmit?.();
+      await Promise.all([verification, termination]);
+    }
   });
 });
 


### PR DESCRIPTION
Related: #121735 (test-runner isolation; this PR repairs production worker custody).

## What Problem This Solves

Fixes an issue where operators stopping the Gateway could hang after the background database verifier lost its IPC connection. Failed signal delivery could also complete the verifier's shutdown step while its child was still alive.

## Why This Change Was Made

Verification and stop now share one child lifecycle, recorded before the child is exposed to callers. A spawned child completes after native exit and IPC disconnect; a failed native launch completes after close. Cleanup removes only the verifier's listeners, preserves the original failure when termination also errors, and reports refused or thrown signals while retaining ownership.

Full integrity and foreign-key checks, generation-bound quarantine, schemas, and daily scheduling are unchanged. No new timeout or signal escalation is introduced.

## User Impact

Gateway shutdown remains joined to the database verifier, and diagnostics retain the failure that triggered cleanup. A termination request that the operating system refuses remains visible and pending until the child exits.

## Evidence

- Four regressions failed on the original production source: premature release and a lost stop waiter, undelivered termination, failed-spawn closure, and masking the original IPC error. Two additional review regressions reproduced a thrown signal error and completion before IPC disconnect.
- All six lifetime cases and the existing verifier coverage pass: **49/49 locally on Node 26.8.1 and 49/49 on Linux Node 24.19.0**. Tests use real child processes with explicit IPC, signal-failure, and notification-order fault injection.
- The scoped `check:changed` gate passes, including core/test typechecks, lint, formatting, schema guards, and import-cycle checks.
- Independent autoreview is clean through P2 after addressing both findings.
- [Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34536114016): the focused command exited zero and the lease was closed. The hosting workflow was cancelled during external lease cleanup; that is separate from the successful test command.
