### PR TITLE
refactor(google): share media understanding metadata

### DIFF
--- a/extensions/google/generation-provider-metadata.ts
+++ b/extensions/google/generation-provider-metadata.ts
@@ -1,5 +1,5 @@
-// Google provider module implements model/runtime integration.
 import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
+import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
 import type { MusicGenerationProvider } from "openclaw/plugin-sdk/music-generation";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import type {
@@ -10,6 +10,12 @@ import type {
 
 export const DEFAULT_GOOGLE_IMAGE_MODEL = "gemini-3.1-flash-image";
 export const GOOGLE_MAX_IMAGE_RESULTS = 4;
+
+export const GOOGLE_MEDIA_UNDERSTANDING_DEFAULT_MODELS = {
+  image: "gemini-3-flash-preview",
+  audio: "gemini-3-flash-preview",
+  video: "gemini-3-flash-preview",
+} as const;
 
 export const DEFAULT_GOOGLE_MUSIC_MODEL = "lyria-3-clip-preview";
 export const GOOGLE_PRO_MUSIC_MODEL = "lyria-3-pro-preview";
@@ -67,6 +73,21 @@ export function createGoogleImageGenerationProviderMetadata(): Omit<
         resolutions: ["1K", "2K", "4K"],
       },
     },
+  };
+}
+
+export function createGoogleMediaUnderstandingProviderMetadata(): Omit<
+  MediaUnderstandingProvider,
+  "transcribeAudio" | "describeVideo"
+> {
+  return {
+    id: "google",
+    capabilities: ["image", "audio", "video"],
+    defaultModels: { ...GOOGLE_MEDIA_UNDERSTANDING_DEFAULT_MODELS },
+    autoPriority: { image: 30, audio: 40, video: 10 },
+    nativeDocumentInputs: ["pdf"],
+    describeImage: undefined,
+    describeImages: undefined,
   };
 }
 

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -1,4 +1,3 @@
-// Google plugin entrypoint registers its OpenClaw integration.
 import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
 import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
 import type { MusicGenerationProvider } from "openclaw/plugin-sdk/music-generation";
@@ -8,6 +7,7 @@ import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { registerGoogleGeminiCliProvider } from "./gemini-cli-provider.js";
 import {
   createGoogleImageGenerationProviderMetadata,
+  createGoogleMediaUnderstandingProviderMetadata,
   createGoogleMusicGenerationProviderMetadata,
   createGoogleVideoGenerationProviderMetadata,
 } from "./generation-provider-metadata.js";
@@ -79,17 +79,7 @@ function createLazyGoogleImageGenerationProvider(): ImageGenerationProvider {
 
 function createLazyGoogleMediaUnderstandingProvider(): MediaUnderstandingProvider {
   return {
-    id: "google",
-    capabilities: ["image", "audio", "video"],
-    defaultModels: {
-      image: "gemini-3-flash-preview",
-      audio: "gemini-3-flash-preview",
-      video: "gemini-3-flash-preview",
-    },
-    autoPriority: { image: 30, audio: 40, video: 10 },
-    nativeDocumentInputs: ["pdf"],
-    describeImage: undefined,
-    describeImages: undefined,
+    ...createGoogleMediaUnderstandingProviderMetadata(),
     transcribeAudio: async (...args) =>
       await (await loadGoogleRequiredMediaUnderstandingProvider()).transcribeAudio(...args),
     describeVideo: async (...args) =>

--- a/extensions/google/media-understanding-provider.ts
+++ b/extensions/google/media-understanding-provider.ts
@@ -1,4 +1,3 @@
-// Google provider module implements model/runtime integration.
 import type {
   AudioTranscriptionRequest,
   AudioTranscriptionResult,
@@ -13,13 +12,15 @@ import {
   type ProviderRequestTransportOverrides,
 } from "openclaw/plugin-sdk/provider-http";
 import {
+  createGoogleMediaUnderstandingProviderMetadata,
+  GOOGLE_MEDIA_UNDERSTANDING_DEFAULT_MODELS,
+} from "./generation-provider-metadata.js";
+import {
   DEFAULT_GOOGLE_API_BASE_URL,
   normalizeGoogleModelId,
   resolveGoogleGenerativeAiHttpRequestConfig,
 } from "./runtime-api.js";
 
-const DEFAULT_GOOGLE_AUDIO_MODEL = "gemini-3-flash-preview";
-const DEFAULT_GOOGLE_VIDEO_MODEL = "gemini-3-flash-preview";
 const DEFAULT_GOOGLE_AUDIO_PROMPT = "Transcribe the audio.";
 const DEFAULT_GOOGLE_VIDEO_PROMPT = "Describe the video.";
 
@@ -123,7 +124,7 @@ export async function transcribeGeminiAudio(
   const { text, model } = await generateGeminiInlineDataText({
     ...params,
     defaultBaseUrl: DEFAULT_GOOGLE_API_BASE_URL,
-    defaultModel: DEFAULT_GOOGLE_AUDIO_MODEL,
+    defaultModel: GOOGLE_MEDIA_UNDERSTANDING_DEFAULT_MODELS.audio,
     defaultPrompt: DEFAULT_GOOGLE_AUDIO_PROMPT,
     defaultMime: "audio/wav",
     httpErrorLabel: "Audio transcription failed",
@@ -138,7 +139,7 @@ export async function describeGeminiVideo(
   const { text, model } = await generateGeminiInlineDataText({
     ...params,
     defaultBaseUrl: DEFAULT_GOOGLE_API_BASE_URL,
-    defaultModel: DEFAULT_GOOGLE_VIDEO_MODEL,
+    defaultModel: GOOGLE_MEDIA_UNDERSTANDING_DEFAULT_MODELS.video,
     defaultPrompt: DEFAULT_GOOGLE_VIDEO_PROMPT,
     defaultMime: "video/mp4",
     httpErrorLabel: "Video description failed",
@@ -148,17 +149,7 @@ export async function describeGeminiVideo(
 }
 
 export const googleMediaUnderstandingProvider: MediaUnderstandingProvider = {
-  id: "google",
-  capabilities: ["image", "audio", "video"],
-  defaultModels: {
-    image: DEFAULT_GOOGLE_VIDEO_MODEL,
-    audio: DEFAULT_GOOGLE_AUDIO_MODEL,
-    video: DEFAULT_GOOGLE_VIDEO_MODEL,
-  },
-  autoPriority: { image: 30, audio: 40, video: 10 },
-  nativeDocumentInputs: ["pdf"],
-  describeImage: undefined,
-  describeImages: undefined,
+  ...createGoogleMediaUnderstandingProviderMetadata(),
   transcribeAudio: transcribeGeminiAudio,
   describeVideo: describeGeminiVideo,
 };

--- a/extensions/google/media-understanding-registration.test.ts
+++ b/extensions/google/media-understanding-registration.test.ts
@@ -1,0 +1,110 @@
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import type {
+  AudioTranscriptionRequest,
+  MediaUnderstandingProvider,
+  VideoDescriptionRequest,
+} from "openclaw/plugin-sdk/media-understanding";
+import { createCapturedPluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { expect, it, vi } from "vitest";
+import googlePlugin from "./index.js";
+
+const runtime = vi.hoisted(() => {
+  const state: { moduleLoads: number; provider?: MediaUnderstandingProvider } = { moduleLoads: 0 };
+  return {
+    state,
+    transcribeAudio: vi.fn<NonNullable<MediaUnderstandingProvider["transcribeAudio"]>>(),
+    describeVideo: vi.fn<NonNullable<MediaUnderstandingProvider["describeVideo"]>>(),
+  };
+});
+
+vi.mock("./media-understanding-provider.js", async (importOriginal) => {
+  runtime.state.moduleLoads += 1;
+  const original = await importOriginal<typeof import("./media-understanding-provider.js")>();
+  runtime.state.provider = original.googleMediaUnderstandingProvider;
+  return {
+    ...original,
+    googleMediaUnderstandingProvider: {
+      ...original.googleMediaUnderstandingProvider,
+      transcribeAudio: runtime.transcribeAudio,
+      describeVideo: runtime.describeVideo,
+    },
+  };
+});
+
+function registerMediaProvider() {
+  const captured = createCapturedPluginRegistration({ id: "google" });
+  googlePlugin.register(captured.api);
+  return expectDefined(
+    captured.mediaUnderstandingProviders.find((provider) => provider.id === "google"),
+    "registered Google media provider",
+  );
+}
+
+it("registers independent media metadata and defers audio/video handlers until use", async () => {
+  const provider = registerMediaProvider();
+  const { transcribeAudio: _audio, describeVideo: _video, ...metadata } = provider;
+  const expectedMetadata = {
+    id: "google",
+    capabilities: ["image", "audio", "video"],
+    defaultModels: {
+      image: "gemini-3-flash-preview",
+      audio: "gemini-3-flash-preview",
+      video: "gemini-3-flash-preview",
+    },
+    autoPriority: { image: 30, audio: 40, video: 10 },
+    nativeDocumentInputs: ["pdf"],
+    describeImage: undefined,
+    describeImages: undefined,
+  };
+  expect(metadata).toEqual(expectedMetadata);
+
+  const second = registerMediaProvider();
+  expect(second).toMatchObject(expectedMetadata);
+  expectDefined(second.capabilities, "second provider capabilities").push("image");
+  expectDefined(second.defaultModels, "second provider defaults").audio = "fixture-model";
+  expectDefined(second.autoPriority, "second provider priorities").audio = 99;
+  expectDefined(second.nativeDocumentInputs, "second provider document inputs").push("pdf");
+  expect(metadata).toEqual(expectedMetadata);
+  expect(runtime.state.moduleLoads).toBe(0);
+
+  const audioRequest: AudioTranscriptionRequest = {
+    buffer: Buffer.from("synthetic audio bytes"),
+    fileName: "recording.wav",
+    mime: "audio/wav",
+    apiKey: "fixture-api-key",
+    timeoutMs: 15_000,
+  };
+  const videoRequest: VideoDescriptionRequest = {
+    buffer: Buffer.from("synthetic video bytes"),
+    fileName: "clip.mp4",
+    mime: "video/mp4",
+    apiKey: "fixture-api-key",
+    timeoutMs: 15_000,
+  };
+  const audioResult = { text: "Spoken fixture sentence.", model: "gemini-3-flash-preview" };
+  const videoResult = { text: "A fixture landscape.", model: "gemini-3-flash-preview" };
+  runtime.transcribeAudio.mockResolvedValue(audioResult);
+  runtime.describeVideo.mockResolvedValue(videoResult);
+
+  expect(
+    await Promise.all([
+      provider.transcribeAudio?.(audioRequest),
+      second.describeVideo?.(videoRequest),
+    ]),
+  ).toEqual([audioResult, videoResult]);
+  expect(runtime.state.moduleLoads).toBe(1);
+  expect(runtime.transcribeAudio).toHaveBeenCalledOnce();
+  expect(runtime.transcribeAudio).toHaveBeenCalledWith(audioRequest);
+  expect(runtime.describeVideo).toHaveBeenCalledOnce();
+  expect(runtime.describeVideo).toHaveBeenCalledWith(videoRequest);
+
+  const loaded = expectDefined(runtime.state.provider, "loaded Google media provider");
+  const { transcribeAudio: _loadedAudio, describeVideo: _loadedVideo, ...loadedMetadata } = loaded;
+  expect(loadedMetadata).toEqual(expectedMetadata);
+  for (const entry of [provider, second, loaded]) {
+    for (const hook of ["describeImage", "describeImages"] as const) {
+      expect(Object.hasOwn(entry, hook)).toBe(true);
+      expect(entry[hook]).toBeUndefined();
+    }
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

Google's lazy media-understanding registration and loaded provider repeat the same capability, priority, document-input and model-default facts. Audio/video request fallbacks separately repeat their advertised defaults.

## Why This Change Was Made

Move those runtime facts into the existing lightweight Google metadata owner and migrate both registrations and request defaults together. The factory gives each registration independent nested metadata while preserving the explicit empty image hooks used to clear earlier handlers. The static manifest continues to serve its separate discovery contract before runtime loading.

## User Impact

No intended behavior change: advertised capabilities, model defaults, request construction and deferred handler loading stay consistent. The typed shared factory and explicit per-capability defaults add two production lines overall while removing the duplicated descriptors and private constants.

## Evidence

The same five focused cases pass before and after: actual media registration, independent metadata, deferred handler evaluation, audio/video default requests, video payload construction and the image-registration sibling. Five other cases in the existing video file were deliberately outside this selection. All 25 selected changed-file checks pass, including types, lint, boundaries and import-cycle checks. Independent review found no actionable issue.

The registration test calls the real plugin entry point and retains the real loaded provider's metadata; its outbound handlers are mocked. This is preservation coverage, with no live-provider or full-suite claim. The local five-case runs and 25 selected checks passed without retries.

CI run 34539632419 initially failed during dependency setup: Matrix's native-library download returned HTTP 500, followed by an error in that dependency's postinstall handler. The plugin contract tests never started in that job. The exact asset now returns HTTP 200 to an anonymous HEAD check, and the single failed-job retry passed on the unchanged PR head, including the plugin-contract test step. No dependency or source change was made.
