### PR TITLE
fix(media-core): keep prototype-named Content-Type values out of MIME lookup tables

### DIFF
--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -590,3 +590,80 @@ describe("mediaKindFromMime", () => {
     expect(kindFromMime(mime)).toBe(expected);
   });
 });
+
+// A remote sender controls the Content-Type header, so a header value that names
+// an Object.prototype member must classify like any other unknown type instead of
+// resolving to an inherited object/function that breaks the next string operation.
+describe("prototype-named MIME values", () => {
+  it.each([
+    "__proto__",
+    "constructor",
+    "__defineGetter__",
+    "__lookupSetter__",
+    "toString",
+    "valueOf",
+    "hasOwnProperty",
+    "isPrototypeOf",
+    "propertyIsEnumerable",
+  ] as const)("treats %s as an unknown MIME type", (raw) => {
+    const normalized = normalizeMimeType(raw);
+    expect(typeof normalized).toBe("string");
+    expect(normalized).toBe(raw.toLowerCase());
+    expect(extensionForMime(raw)).toBeUndefined();
+    expect(kindFromMime(raw)).toBeUndefined();
+  });
+
+  it.each([
+    { raw: "__proto__; charset=utf-8", expected: "__proto__" },
+    { raw: " Constructor ; charset=utf-8", expected: "constructor" },
+    { raw: "   ", expected: undefined },
+    { raw: "", expected: undefined },
+  ] as const)("normalizes parameterized prototype name $raw", ({ raw, expected }) => {
+    expect(normalizeMimeType(raw)).toBe(expected);
+    expect(extensionForMime(raw)).toBeUndefined();
+    expect(kindFromMime(raw)).toBeUndefined();
+  });
+
+  it("does not leak an inherited value for an oversized prototype-named header", () => {
+    const raw = `constructor${"x".repeat(64 * 1024)}`;
+    expect(normalizeMimeType(raw)).toBe(raw);
+    expect(extensionForMime(raw)).toBeUndefined();
+  });
+
+  it("never returns an inherited value from detectMime header hints", async () => {
+    // detectMime keeps the normalized header as its last-resort fallback, so the
+    // contract is "a plain unknown-type string", never an inherited object.
+    for (const headerMime of ["__proto__", "constructor"] as const) {
+      const detected = await detectMime({ headerMime });
+      expect(typeof detected).toBe("string");
+      expect(detected).toBe(headerMime);
+      expect(kindFromMime(detected)).toBeUndefined();
+      expect(extensionForMime(detected)).toBeUndefined();
+    }
+  });
+});
+
+describe("known MIME types are unchanged", () => {
+  it.each([
+    { mime: "image/png", ext: ".png", kind: "image" },
+    { mime: "text/html", ext: ".html", kind: "document" },
+    { mime: "text/html; charset=utf-8", ext: ".html", kind: "document" },
+    { mime: "application/pdf", ext: ".pdf", kind: "document" },
+    { mime: "text/csv", ext: ".csv", kind: "document" },
+    { mime: "text/plain", ext: ".txt", kind: "document" },
+    { mime: "image/apng", ext: ".png", kind: "image" },
+  ] as const)("keeps $mime mapped to $ext", ({ mime, ext, kind }) => {
+    expect(extensionForMime(mime)).toBe(ext);
+    expect(kindFromMime(mime)).toBe(kind);
+  });
+
+  it.each([
+    { filePath: "note.html", expected: "text/html" },
+    { filePath: "note.txt", expected: "text/plain" },
+    { filePath: "sheet.csv", expected: "text/csv" },
+    { filePath: "doc.pdf", expected: "application/pdf" },
+    { filePath: "no-extension", expected: undefined },
+  ] as const)("maps $filePath to $expected", ({ filePath, expected }) => {
+    expect(mimeTypeFromFilePath(filePath)).toBe(expected);
+  });
+});

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -175,7 +175,10 @@ export function normalizeMimeType(mime?: string | null): string | undefined {
   if (!cleaned) {
     return undefined;
   }
-  return MIME_SYNONYMS[cleaned] ?? cleaned;
+  // Own keys only: a remote Content-Type that names a prototype member (e.g.
+  // "__proto__", "constructor") must fold like any other unknown type instead of
+  // resolving to an inherited object/function and breaking downstream string ops.
+  return Object.hasOwn(MIME_SYNONYMS, cleaned) ? MIME_SYNONYMS[cleaned] : cleaned;
 }
 
 /** Returns the bounded buffer prefix used for dependency MIME sniffing. */
@@ -290,7 +293,9 @@ export function extensionForMime(mime?: string | null): string | undefined {
   if (!normalized) {
     return undefined;
   }
-  return EXT_BY_MIME[normalized];
+  // Same own-keys rule as normalizeMimeType: EXT_BY_MIME["__proto__"] would
+  // otherwise hand callers an inherited object instead of an extension string.
+  return Object.hasOwn(EXT_BY_MIME, normalized) ? EXT_BY_MIME[normalized] : undefined;
 }
 
 /** Returns true when content type or filename identifies GIF media. */


### PR DESCRIPTION
Fixes #143673

## What Problem This Solves

A remote sender controls a media response's `Content-Type` header, and that raw value flows
into the MIME normalization tables in `packages/media-core/src/mime.ts`. Both value-returning
tables were plain object literals indexed with the untrusted string:

```ts
return MIME_SYNONYMS[cleaned] ?? cleaned;   // normalizeMimeType
return EXT_BY_MIME[normalized];             // extensionForMime
```

So a header value that happens to name an `Object.prototype` member resolved to the inherited
member instead of a string:

- `Content-Type: __proto__` -> `normalizeMimeType` returned `[object Object]`
- `Content-Type: constructor` -> `normalizeMimeType` returned `Object` (a function)

Every consumer that then treats the result as a string crashed deterministically:
`store.ts isImageHeaderMime` (`TypeError: ... .startsWith is not a function`),
`mediaKindFromMime` (`TypeError: mime.startsWith is not a function`), and the remote fetch
path where `extensionForMime` is called for an extensionless filename
(`src/media/fetch.ts`). One hostile header killed that media operation on every trigger
across web fetch, channel attachments, and `file.fetch` payloads.

## Evidence

Real run against the unpatched source, driving the same functions the production callers use
(`normalizeMimeType`, `extensionForMime`, `kindFromMime`, `detectMime`, plus the
`store.ts:isImageHeaderMime` shape `normalizeMimeType(ct)?.startsWith("image/")`):

```bash
node --import ./scripts/tsx.mjs <repro>.mts
```

Before the patch:

```
Content-Type: "__proto__"
  normalizeMimeType -> [object] [object Object]
  isImageHeaderMime THREW TypeError: normalizeMimeType(...)?.startsWith is not a function
  extensionForMime -> [undefined] undefined
  kindFromMime THREW TypeError: mime.startsWith is not a function
  detectMime -> [object] [object Object]

Content-Type: "constructor"
  normalizeMimeType -> [function] function Object() { [native code] }
  isImageHeaderMime THREW TypeError: normalizeMimeType(...)?.startsWith is not a function
  kindFromMime THREW TypeError: mime.startsWith is not a function
  detectMime -> [function] function Object() { [native code] }

Content-Type: "text/html; charset=utf-8"
  normalizeMimeType -> "text/html"   extensionForMime -> ".html"   kindFromMime -> document
Content-Type: "image/png"
  normalizeMimeType -> "image/png"   extensionForMime -> ".png"    kindFromMime -> image
```

After the patch, the identical script:

```
Content-Type: "__proto__"
  normalizeMimeType -> [string] "__proto__"
  isImageHeaderMime -> false
  extensionForMime -> undefined
  kindFromMime -> undefined
  detectMime -> [string] "__proto__"

Content-Type: "constructor"
  normalizeMimeType -> [string] "constructor"
  isImageHeaderMime -> false
  extensionForMime -> undefined
  kindFromMime -> undefined
  detectMime -> [string] "constructor"

Content-Type: constructorxxxxxxxxxxxxx…(71691 chars)   -> plain unknown type, no throw
Content-Type: ""  /  "   "                             -> undefined, no throw
```

Known types are byte-for-byte identical to before (`text/html` -> `.html`/`document`,
`image/png` -> `.png`/`image`, `application/pdf` -> `.pdf`/`document`).

Regression tests, run through the repo's pnpm:

```bash
pnpm exec vitest run --config test/vitest/vitest.unit-fast.config.ts packages/media-core/src/mime.test.ts
```

- Pre-fix (new tests in place): `Tests 5 failed | 214 passed (219)` — failures are the
  prototype-named cases returning `[object Object]` / `Function Object`.
- Post-fix: `Tests 219 passed (219)`.
- Whole package project: `pnpm exec vitest run --config test/vitest/vitest.unit-fast.config.ts packages/media-core/src`
  -> `Test Files 7 passed (7)`, `Tests 325 passed (325)`.

## Verification

- Root cause, not symptom: `git grep` over the whole tree shows the only indexed lookup tables
  reached by an untrusted MIME string are `MIME_SYNONYMS` (via `normalizeMimeType`) and
  `EXT_BY_MIME` (via `extensionForMime`). Both are now own-key-only, so the roughly 100 call
  sites of those two helpers outside tests (across `src/` and `extensions/`) get the string
  contract back. Two sibling tables need no guard
  and were left alone: `MIME_BY_EXT` is only keyed by a path extension (always `""` or
  `.something`), and `AMBIGUOUS_VIDEO_MIME_BY_AUDIO_MIME` feeds a strict-equality comparison
  and never returns the looked-up value.
- Two-way regression tests in `packages/media-core/src/mime.test.ts`: prototype-named values
  (`__proto__`, `constructor`, `__defineGetter__`, `__lookupSetter__`, `toString`, `valueOf`,
  `hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable`), parameterized/empty/whitespace
  values, an oversized (64 KiB) value, `detectMime` header hints, and the known-type matrix
  (`image/png`, `text/html`, `text/html; charset=utf-8`, `application/pdf`, `text/csv`,
  `text/plain`, `image/apng`, plus `.html`/`.txt`/`.csv`/`.pdf` path mapping).
- Sabotage checks: reverting only the `normalizeMimeType` guard -> `5 failed | 214 passed`;
  reverting only the `extensionForMime` guard -> `5 failed | 214 passed` (the lookup returns
  the inherited `Object.prototype`/`Function`, which is why both guards are required). Both
  files restored byte-identical (sha256 verified) after each revert.
- `pnpm exec oxfmt --check packages/media-core/src/mime.ts packages/media-core/src/mime.test.ts`
  -> "All matched files use the correct format."
- `pnpm exec oxlint --config .oxlintrc.json packages/media-core/src/mime.ts packages/media-core/src/mime.test.ts`
  -> exit 0, no findings.
- No new dependency, no API/config change: two lookups are guarded with `Object.hasOwn`, the
  same pattern already used for alias tables (`extensions/a2a/src/protocol.ts`). Diff is
  `2 files changed, 84 insertions(+), 2 deletions(-)`.

---

# PR #144458 — real remote-media reader/storage entry proof (before/after)

Repo: `openclaw/openclaw` @ worktree `D:/code/wt-oc-143673` (branch `fix/oc-143673-descr`)
HEAD (after): `ca7576db80b6dd2da1119d7dc414c03f10109203` — "fix(media-core): keep prototype-named Content-Type values out of MIME tables"
Parent (before): `28589e76ead3876ef73c5675d0fce19f1bbf6e16`
Host: Windows, git-bash, `node v26.4.0`, harness run through the repo's own tsx preload (`node --import ./scripts/tsx.mjs`).

Answer to the ClawSweeper request ("real behavior proof through the remote-media reader or storage
entrypoint; direct helper calls and a copied predicate do not demonstrate that production flow"):
both real entrypoints below are driven against a real local HTTP endpoint. No helper
(`normalizeMimeType` / `extensionForMime` / `detectMime`) is called by the harness at all.

## What the PR changes (before → after)

`packages/media-core/src/mime.ts` is the only source file in the commit. A remote sender controls
`Content-Type`, and both lookup tables are plain object literals.

before (parent, lines 174–178):

```ts
  const cleaned = mime.split(";")[0]?.trim().toLowerCase();
  if (!cleaned) {
    return undefined;
  }
  return MIME_SYNONYMS[cleaned] ?? cleaned;      // "__proto__" -> Object.prototype (truthy, so ?? never fires)
```

after (HEAD, lines 175–181 + 291–299):

```ts
  return Object.hasOwn(MIME_SYNONYMS, cleaned) ? MIME_SYNONYMS[cleaned] : cleaned;
  ...
  return Object.hasOwn(EXT_BY_MIME, normalized) ? EXT_BY_MIME[normalized] : undefined;
```

So before the fix `normalizeMimeType("__proto__")` returned `Object.prototype` and
`normalizeMimeType("constructor")` returned the `Object` constructor — both typed `string`, neither a
string. The next string operation on the result (`mime.split`) throws `TypeError: mime.split is not
a function`.

## Real entrypoints driven (production callers, not helpers)

| flow | entrypoint | source | production callers |
| --- | --- | --- | --- |
| storage (URL → media store on disk) | `saveRemoteMedia()` | `src/media/fetch.ts:667` | `extensions/slack/src/monitor/media.ts:126`, `extensions/telegram/src/bot/delivery.resolve-media.ts:350`, `extensions/discord/src/monitor/message-media.ts`, `extensions/msteams/src/attachments/remote-media.ts`, `extensions/sms/src/media.ts`, `extensions/tlon/src/monitor/media.ts`, `src/media/store.remote.runtime.ts:46` (`saveRemoteMediaForStore`) — 22 call sites in total |
| reader (URL → in-memory media result) | `loadWebMediaRaw()` | `src/media/web-media.ts:1211` | `src/agents/tools/image-tool.ts`, `src/agents/tools/pdf-tool.ts`, `src/plugin-sdk/web-media.ts`, discord/matrix/msteams/telegram/whatsapp extensions |

The failing call chain the harness exercises (unchanged by the PR, only its input changes):
`saveRemoteMedia` → `saveOkMediaResponse` → `saveMediaStream` → `extensionForAuthoritativeHeaderMime`
(`src/media/store.ts:376`) → `extensionForMime`; and `loadWebMediaRaw` → `readRemoteMediaBuffer` →
`detectMime` header fallback (`packages/media-core/src/mime.ts:287`) → `kindFromMime`
(`src/media/web-media.ts:1080`).

## Harness (outside the repo, re-runnable)

- `%LOCALAPPDATA%/Temp/ocproof-144458/prove.mts` — starts a real `node:http` server on
  `127.0.0.1:0` and serves three routes with the raw header values
  `Content-Type: __proto__` (body `PROTO-BODY`), `Content-Type: constructor` (body `CTOR-BODY`) and a
  control `Content-Type: image/png` (a real 70-byte 1x1 PNG). Real TCP, real header bytes; the
  harness passes no `fetchImpl`, installs no interceptor and imports no `@openclaw/media-core`
  symbol — it only imports the two entry modules.
  Each case runs the storage entry and then the reader entry and prints the returned values, the
  bytes, and the media-store directory listing (`OPENCLAW_STATE_DIR` points the store at the proof
  workspace, so `~/.openclaw` is not touched).
  Loopback is exempted from the SSRF guard with `ssrfPolicy: { allowedHostnames: ["127.0.0.1"] }` —
  the same knob production config uses for local gateways (`buildTelegramMediaSsrfPolicy`).
- `%LOCALAPPDATA%/Temp/ocproof-144458/run-both.sh` — after run, then
  `git checkout 28589e76ead3876ef73c5675d0fce19f1bbf6e16 -- packages/media-core/src/mime.ts`
  (that one file, nothing else), before run, then `git checkout HEAD --` the same file and prints the
  porcelain state.

```bash
cd /d/code/wt-oc-143673
bash "$LOCALAPPDATA/Temp/ocproof-144458/run-both.sh" 2>&1 | tee "$LOCALAPPDATA/Temp/ocproof-144458/run-both.log"
```

sha256: `prove.mts ff8b425ee498dddf2bb60a99bff44e9a2abdd7b93dbcd45ad9daa8bba8ac7281`,
`run-both.sh cb0832f7a4a8f480974cc3e60d63d75b17b3e2cf09ac2e7d1db27af6a368ddf3`,
`run-both.log 6c88cbba79f26294d0c8138f7a1e2ea8334ebe5b809693169493787fd31db50b`.

## Raw output (exact, from `run-both.log`)

```
### repo=/d/code/wt-oc-143673
### branch=fix/oc-143673-descr head=ca7576db80b6dd2da1119d7dc414c03f10109203
### porcelain before: <clean>

############ AFTER (HEAD) ############
=== AFTER ===
local server: http://127.0.0.1:6351 (real node:http, 127.0.0.1, header Content-Type sent per case)

--- case /proto  Content-Type: "__proto__"  url=http://127.0.0.1:6351/proto
[storage saveRemoteMedia] OK id=d74ecae0-1d9a-4974-b99e-ede8ca198618 size=10 contentType="__proto__" (typeof string)
[storage on-disk] media\inbound\d74ecae0-1d9a-4974-b99e-ede8ca198618 bytes=10 hex=50524f544f2d424f4459 content="PROTO-BODY"
[storage media/inbound dir] ["d74ecae0-1d9a-4974-b99e-ede8ca198618"]
[reader loadWebMediaRaw] OK bytes=10 hex=50524f544f2d424f4459 contentType="__proto__" (typeof string) kind=undefined fileName="proto"

--- case /ctor  Content-Type: "constructor"  url=http://127.0.0.1:6351/ctor
[storage saveRemoteMedia] OK id=c20450a1-5a9a-4cad-9b35-7de0008d74aa size=9 contentType="constructor" (typeof string)
[storage on-disk] media\inbound\c20450a1-5a9a-4cad-9b35-7de0008d74aa bytes=9 hex=43544f522d424f4459 content="CTOR-BODY"
[storage media/inbound dir] ["c20450a1-5a9a-4cad-9b35-7de0008d74aa","d74ecae0-1d9a-4974-b99e-ede8ca198618"]
[reader loadWebMediaRaw] OK bytes=9 hex=43544f522d424f4459 contentType="constructor" (typeof string) kind=undefined fileName="ctor"

--- case /png  Content-Type: "image/png"  url=http://127.0.0.1:6351/png
[storage saveRemoteMedia] OK id=89cbda19-fcc8-4724-936d-055842a48561.png size=70 contentType="image/png" (typeof string)
[storage on-disk] media\inbound\89cbda19-fcc8-4724-936d-055842a48561.png bytes=70 hex=89504e470d0a1a0a0000 content="<PNG…>"
[storage media/inbound dir] ["89cbda19-fcc8-4724-936d-055842a48561.png","c20450a1-5a9a-4cad-9b35-7de0008d74aa","d74ecae0-1d9a-4974-b99e-ede8ca198618"]
[reader loadWebMediaRaw] OK bytes=70 hex=89504e470d0a1a0a0000 contentType="image/png" (typeof string) kind="image" fileName="png.png"

=== end AFTER ===

############ BEFORE (parent 28589e76ead3876ef73c5675d0fce19f1bbf6e16 source only) ############
### reverted source: M  packages/media-core/src/mime.ts
=== BEFORE ===
local server: http://127.0.0.1:6359 (real node:http, 127.0.0.1, header Content-Type sent per case)

--- case /proto  Content-Type: "__proto__"  url=http://127.0.0.1:6359/proto
[storage saveRemoteMedia] FAIL {"name":"MediaFetchError","code":"fetch_failed","message":"Failed to fetch media from http://127.0.0.1:6359/proto: mime.split is not a function","cause":{"name":"TypeError","message":"mime.split is not a function"}}
[storage media/inbound dir] []
[reader loadWebMediaRaw] FAIL {"name":"TypeError","message":"mime.split is not a function"}

--- case /ctor  Content-Type: "constructor"  url=http://127.0.0.1:6359/ctor
[storage saveRemoteMedia] FAIL {"name":"MediaFetchError","code":"fetch_failed","message":"Failed to fetch media from http://127.0.0.1:6359/ctor: mime.split is not a function","cause":{"name":"TypeError","message":"mime.split is not a function"}}
[storage media/inbound dir] []
[reader loadWebMediaRaw] FAIL {"name":"TypeError","message":"mime.split is not a function"}

--- case /png  Content-Type: "image/png"  url=http://127.0.0.1:6359/png
[storage saveRemoteMedia] OK id=4b931453-1d89-4494-a5a3-0d4e4232eadd.png size=70 contentType="image/png" (typeof string)
[storage on-disk] media\inbound\4b931453-1d89-4494-a5a3-0d4e4232eadd.png bytes=70 hex=89504e470d0a1a0a0000 content="<PNG…>"
[storage media/inbound dir] ["4b931453-1d89-4494-a5a3-0d4e4232eadd.png"]
[reader loadWebMediaRaw] OK bytes=70 hex=89504e470d0a1a0a0000 contentType="image/png" (typeof string) kind="image" fileName="png.png"

=== end BEFORE ===

############ RESTORE ############
### porcelain after restore: <clean>
```

(`<PNG…>` abbreviates the truncated PNG text rendering; the full log keeps the original bytes line.)

## Result

| case (real `Content-Type`) | before (parent mime.ts) | after (HEAD) |
| --- | --- | --- |
| `__proto__` — storage `saveRemoteMedia` | FAIL `MediaFetchError{fetch_failed}`, cause `TypeError: mime.split is not a function`; **0 bytes written** to `media/inbound` | OK, `contentType` is a plain string `"__proto__"`, 10 bytes on disk |
| `__proto__` — reader `loadWebMediaRaw` | FAIL `TypeError: mime.split is not a function` | OK, `bytes=10`, `kind=undefined`, `fileName="proto"` |
| `constructor` — storage | FAIL, same TypeError, 0 bytes written | OK, `"constructor"`, 9 bytes on disk |
| `constructor` — reader | FAIL, same TypeError | OK, `bytes=9`, `kind=undefined` |
| `image/png` (control) | OK | OK (identical: `.png` suffix, `kind="image"`) |

Both prototype-named headers break *both* production flows before the fix (a remote-controlled
`Content-Type` turns a normal inbound media save/download into a hard failure), and both classify as
unknown types after it, while normal MIME types are byte-for-byte unchanged (control case).

## True / false claims

True:

- The endpoint is a real `node:http` server on `127.0.0.1` with an ephemeral port; the harness fetches
  it over real TCP through the production SSRF-guarded fetch (no `fetchImpl`, no interceptor, no
  replay of captured bytes).
- The entrypoints are the unmodified production exports `saveRemoteMedia` (`src/media/fetch.ts`) and
  `loadWebMediaRaw` (`src/media/web-media.ts`), loaded from the live TypeScript sources through the
  repo's own tsx preload; the harness contains no `@openclaw/media-core` import and no direct helper
  call.
- The "on-disk" lines are files read back from the media store directory (`OPENCLAW_STATE_DIR` →
  `%LOCALAPPDATA%/Temp/ocproof-144458/state/<after|before>/media/inbound`); the bytes match the served
  bodies.
- "before" is exactly the parent commit's `packages/media-core/src/mime.ts` applied to that single
  file; the log records the reverted file and the clean porcelain after restore
  (`### porcelain after restore: <clean>`). Nothing was pushed or committed; PR #144458 untouched.

False / limits (stated plainly):

- This is not a full product run: no Slack/Telegram transport, no agent turn, no CLI session. It is
  the library entrypoints those callers invoke, driven with production-shaped options.
- Only `Content-Type` headers are exercised (one header per case); the PR's unit tests cover the
  remaining prototype member names (`__defineGetter__`, `toString`, `valueOf`, …) and oversized values.
- Loopback needs the `allowedHostnames: ["127.0.0.1"]` SSRF exemption to be reachable at all; the
  guard is configured, not mocked or bypassed.
- Windows/git-bash host; a Linux run should be identical but was not executed here.

## Conclusion

The fix is observable end-to-end at the production boundary: a hostile `Content-Type` of `__proto__`
or `constructor` used to make the remote-media storage entry fail (`MediaFetchError`/`TypeError`, no
file persisted) and the remote-media reader throw, and after the fix both entries classify it as an
unknown type, return a plain string, and persist/return the real bytes. The before/after difference is
attributable solely to `packages/media-core/src/mime.ts`, and the worktree was restored to a clean
state afterwards.

### Re-ran by the author

`bash run-both.sh` was re-run by hand on this branch (`143673` tree). AFTER: `Content-Type: __proto__` → storage `saveRemoteMedia` OK (`contentType="__proto__"`, typeof string, 10 bytes written) and reader `loadWebMediaRaw` OK (`kind=undefined`); `constructor` likewise; `image/png` control unchanged. BEFORE (only `packages/media-core/src/mime.ts` reverted): both entries fail with `TypeError: mime.split is not a function` at both entrypoints, 0 bytes persisted. `porcelain` clean after restore.

