### PR TITLE
test: share active placement abandonment fixtures

### DIFF
--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -17,6 +17,21 @@ import { forceAbandonWorkerEnvironment } from "./placement-force-abandon.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { seedAttachedPlacementEnvironment } from "./placement-test-fixtures.js";
 
+function createActiveAbandonmentFixture(database: OpenClawStateDatabase) {
+  const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+  const { environmentId } = createDispatchEnvironmentFixtures();
+  seedAttachedPlacementEnvironment(database, {
+    environmentId,
+    sessionId: REQUEST.sessionId,
+    ownerEpoch: 2,
+  });
+  const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
+  if (active.state !== "active") {
+    throw new Error("active placement fixture was not active");
+  }
+  return { store, environmentId, active };
+}
+
 describe("forced worker environment abandonment", () => {
   let root: string;
   let database: OpenClawStateDatabase;
@@ -32,17 +47,7 @@ describe("forced worker environment abandonment", () => {
   });
 
   it("drains nested operations before recording result loss and releasing the claim", async () => {
-    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
-    const { environmentId } = createDispatchEnvironmentFixtures();
-    seedAttachedPlacementEnvironment(database, {
-      environmentId,
-      sessionId: REQUEST.sessionId,
-      ownerEpoch: 2,
-    });
-    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
-    if (active.state !== "active") {
-      throw new Error("active placement fixture was not active");
-    }
+    const { store, environmentId } = createActiveAbandonmentFixture(database);
     const claim = store.claimTurn({
       ...REQUEST,
       claimId: "forced-claim",
@@ -94,17 +99,7 @@ describe("forced worker environment abandonment", () => {
   });
 
   it("releases a pending reclaim claim when its workspace is already gone", async () => {
-    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
-    const { environmentId } = createDispatchEnvironmentFixtures();
-    seedAttachedPlacementEnvironment(database, {
-      environmentId,
-      sessionId: REQUEST.sessionId,
-      ownerEpoch: 2,
-    });
-    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
-    if (active.state !== "active") {
-      throw new Error("active placement fixture was not active");
-    }
+    const { store, environmentId, active } = createActiveAbandonmentFixture(database);
     store.startDrain({
       sessionId: active.sessionId,
       environmentId,
@@ -137,17 +132,7 @@ describe("forced worker environment abandonment", () => {
   });
 
   it("deletes a stale journal without replaying it into the current workspace", async () => {
-    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
-    const { environmentId } = createDispatchEnvironmentFixtures();
-    seedAttachedPlacementEnvironment(database, {
-      environmentId,
-      sessionId: REQUEST.sessionId,
-      ownerEpoch: 2,
-    });
-    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
-    if (active.state !== "active") {
-      throw new Error("active placement fixture was not active");
-    }
+    const { store, environmentId, active } = createActiveAbandonmentFixture(database);
     const owner = {
       sessionId: active.sessionId,
       environmentId: active.environmentId,
@@ -194,17 +179,7 @@ describe("forced worker environment abandonment", () => {
   });
 
   it("retains a current journal when its best-effort rollback fails", async () => {
-    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
-    const { environmentId } = createDispatchEnvironmentFixtures();
-    seedAttachedPlacementEnvironment(database, {
-      environmentId,
-      sessionId: REQUEST.sessionId,
-      ownerEpoch: 2,
-    });
-    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
-    if (active.state !== "active") {
-      throw new Error("active placement fixture was not active");
-    }
+    const { store, environmentId, active } = createActiveAbandonmentFixture(database);
     const owner = {
       sessionId: active.sessionId,
       environmentId: active.environmentId,
@@ -246,17 +221,7 @@ describe("forced worker environment abandonment", () => {
   });
 
   it("retains a current journal when loading it fails", async () => {
-    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
-    const { environmentId } = createDispatchEnvironmentFixtures();
-    seedAttachedPlacementEnvironment(database, {
-      environmentId,
-      sessionId: REQUEST.sessionId,
-      ownerEpoch: 2,
-    });
-    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
-    if (active.state !== "active") {
-      throw new Error("active placement fixture was not active");
-    }
+    const { store, environmentId, active } = createActiveAbandonmentFixture(database);
     const owner = {
       sessionId: active.sessionId,
       environmentId: active.environmentId,


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Five forced-abandonment scenarios repeat identical active-placement construction, obscuring the journal and cleanup conditions each case exercises.

## Why This Change Was Made

Reuse the existing placement seed helpers through one private fixture that returns the original store, environment ID and active record. Keep journal writes, generation transitions, abandonment calls, failure injection and all assertions explicit in each case.

## User Impact

No production behavior change. This removes 35 net test lines while preserving every scenario, fresh per-test state and the active-state guard. No runtime improvement is claimed.

## Evidence

- Complete abandonment and forced-destroy files: all nine cases passed before and after, with identical ordered names and statuses.
- One-off structural expansion restored all five original setup sequences and the remaining complete source.
- Changed-file gate and independent review passed.
