### PR TITLE
refactor(config): derive message types from schemas

### DIFF
--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -1,142 +1,51 @@
 // Defines message queue and delivery configuration types.
-import type { QueueMode } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
-import type { QueueDropPolicy, QueueModeByProvider } from "./types.queue.js";
+import type { z } from "zod";
+import type {
+  BroadcastSchema,
+  DmConfigSchema,
+  GroupChatSchema,
+  InboundDebounceSchema,
+  MentionPatternsPolicySchema,
+  MessagesSchema,
+  ProviderCommandsSchema,
+  QueueSchema,
+} from "./zod-schema.messages.js";
 
-export type MentionPatternsMode = "allow" | "deny";
+type DefinedSchemaInput<T extends z.ZodType> = NonNullable<z.input<T>>;
 
-export type MentionPatternsPolicyConfig = {
-  mode?: MentionPatternsMode;
-  allowIn?: string[];
-  denyIn?: string[];
-};
+export type MentionPatternsPolicyConfig = DefinedSchemaInput<typeof MentionPatternsPolicySchema>;
+export type MentionPatternsMode = NonNullable<MentionPatternsPolicyConfig["mode"]>;
 
-export type GroupChatConfig = {
-  mentionPatterns?: string[];
-  historyLimit?: number;
-  /**
-   * Controls how unmentioned always-on group chatter is submitted.
-   * Default: "user_request".
-   */
-  unmentionedInbound?: "user_request" | "room_event";
-  /**
-   * Controls how group/channel inbound events produce model-authored room replies.
-   * The message-tool mode requires explicit message sends for normal assistant
-   * output; explicitly host-owned runtime output remains deliverable except for
-   * ambient room events.
-   * Default: "automatic".
-   */
+type GroupChatSchemaInput = DefinedSchemaInput<typeof GroupChatSchema>;
+
+export type GroupChatConfig = Omit<GroupChatSchemaInput, "visibleReplies"> & {
   visibleReplies?: "automatic" | "message_tool";
 };
 
-export type DmConfig = {
-  historyLimit?: number;
-};
+export type DmConfig = DefinedSchemaInput<typeof DmConfigSchema>;
+export type QueueConfig = DefinedSchemaInput<typeof QueueSchema>;
+export type InboundDebounceConfig = DefinedSchemaInput<typeof InboundDebounceSchema>;
+export type InboundDebounceByProvider = NonNullable<InboundDebounceConfig["byChannel"]>;
 
-export type QueueConfig = {
-  mode?: QueueMode;
-  byChannel?: QueueModeByProvider;
-  /** Per-channel debounce overrides (ms). */
-  debounceMsByChannel?: InboundDebounceByProvider;
-  cap?: number;
-  drop?: QueueDropPolicy;
-};
-
-export type InboundDebounceByProvider = Record<string, number>;
-
-export type InboundDebounceConfig = {
-  debounceMs?: number;
-  byChannel?: InboundDebounceByProvider;
-};
-
-export type BroadcastStrategy = "parallel" | "sequential";
-
+export type BroadcastStrategy = NonNullable<DefinedSchemaInput<typeof BroadcastSchema>["strategy"]>;
 export type BroadcastConfig = {
-  /** Default processing strategy for broadcast peers. */
   strategy?: BroadcastStrategy;
-  /**
-   * Map peer IDs to arrays of agent IDs that should ALL process messages.
-   *
-   * Note: the index signature includes `undefined` so `strategy?: ...` remains type-safe.
-   */
   [peerId: string]: string[] | BroadcastStrategy | undefined;
 };
 
-export type StatusReactionsConfig = {
-  /** Enable lifecycle status reactions (default: false). */
-  enabled?: boolean;
-};
+type MessagesSchemaInput = DefinedSchemaInput<typeof MessagesSchema>;
 
-export type MessagesConfig = {
+export type MessagesConfig = Omit<MessagesSchemaInput, "groupChat" | "visibleReplies"> & {
   /** @deprecated Doctor-only legacy input. */
   removeAckAfterReply?: boolean;
-  /**
-   * Controls how source inbound events produce visible replies across direct,
-   * group, and channel conversations. Group/channel events still default to
-   * `groupChat.visibleReplies` when it is set.
-   *
-   * Default: "automatic". In group/channel rooms, "message_tool" keeps normal
-   * assistant output private unless the model sends visibly through the message
-   * tool; explicitly host-owned runtime output remains deliverable.
-   */
   visibleReplies?: "automatic" | "message_tool";
-  /**
-   * Prefix auto-added to all outbound replies.
-   *
-   * - string: explicit prefix (may include template variables)
-   * - special value: `"auto"` derives `[{agents.entries.*.identity.name}]` for the routed agent (when set)
-   *
-   * Supported template variables (case-insensitive):
-   * - `{model}` - short model name (e.g., `claude-opus-4-6`, `gpt-4o`)
-   * - `{modelFull}` - full model identifier (e.g., `anthropic/claude-opus-4-6`)
-   * - `{provider}` - provider name (e.g., `anthropic`, `openai`)
-   * - `{thinkingLevel}` or `{think}` - current thinking level (`high`, `low`, `off`)
-   * - `{identity.name}` or `{identityName}` - agent identity name
-   *
-   * Example: `"[{model} | think:{thinkingLevel}]"` → `"[claude-opus-4-6 | think:high]"`
-   *
-   * Unresolved variables remain as literal text (e.g., `{model}` if context unavailable).
-   *
-   * Default: none
-   */
-  responsePrefix?: string;
-  /** Custom `/usage full` footer template, inline or JSON file path. */
-  usageTemplate?: string | Record<string, unknown>;
-  /**
-   * Default per-reply usage footer mode (`responseUsage`) seeded into any session
-   * that has not set its own via `/usage`. Precedence: session value → channel entry
-   * → `default` → `off`. Absent ⇒ `off` (unchanged behavior).
-   *
-   * - string: one default for every channel, e.g. `"full"`.
-   * - object: per-channel with a fallback, e.g. `{ "default": "off", "discord": "full" }`.
-   */
-  responseUsage?:
-    | "on"
-    | "off"
-    | "tokens"
-    | "full"
-    | {
-        default?: "on" | "off" | "tokens" | "full";
-        [channel: string]: "on" | "off" | "tokens" | "full" | undefined;
-      };
   groupChat?: GroupChatConfig;
-  queue?: QueueConfig;
-  /** Debounce rapid inbound messages per sender (global + per-channel overrides). */
-  inbound?: InboundDebounceConfig;
-  /** Emoji reaction used to acknowledge inbound messages (empty disables). */
-  ackReaction?: string;
-  /** When to send ack reactions. Default: "group-mentions". */
-  ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all" | "off" | "none";
-  /** Lifecycle status reactions configuration. */
-  statusReactions?: StatusReactionsConfig;
 };
+
+export type StatusReactionsConfig = NonNullable<MessagesConfig["statusReactions"]>;
 
 export type NativeCommandsSetting = boolean | "auto";
 
-/**
- * Per-provider allowlist for command authorization.
- * Keys are channel IDs (e.g., "discord", "whatsapp") or "*" for global default.
- * Values are arrays of sender IDs allowed to use commands on that channel.
- */
 export type CommandAllowFrom = Record<string, Array<string | number>>;
 
 export type CommandsConfig = {
@@ -144,41 +53,18 @@ export type CommandsConfig = {
   ownerDisplay?: "raw" | "hash";
   /** @deprecated Doctor-only legacy input. */
   ownerDisplaySecret?: string;
-  /** Enable native command registration when supported (default: "auto"). */
   native?: NativeCommandsSetting;
-  /** Enable native skill command registration when supported (default: "auto"). */
   nativeSkills?: NativeCommandsSetting;
-  /** Enable text command parsing (default: true). */
   text?: boolean;
-  /** Allow bash chat command (`!`; `/bash` alias) (default: false). */
   bash?: boolean;
-  /** How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately). */
   bashForegroundMs?: number;
-  /** Allow /config command (default: false). */
   config?: boolean;
-  /** Allow /mcp command for OpenClaw-managed MCP settings (default: false). */
   mcp?: boolean;
-  /** Allow /plugins command for plugin listing and enablement toggles (default: false). */
   plugins?: boolean;
-  /** Allow /debug command (default: false). */
   debug?: boolean;
-  /** Allow restart commands/tools and /update (default: true). */
   restart?: boolean;
-  /** Explicit owner allowlist for owner-scoped commands (channel-native IDs). */
   ownerAllowFrom?: Array<string | number>;
-  /** How owner IDs are rendered in system prompts. */
-  /**
-   * Per-provider allowlist restricting who can use slash commands.
-   * If set, overrides the channel's allowFrom for command authorization.
-   * Use "*" key for global default, provider-specific keys override the global.
-   * Example: { "*": ["user1"], discord: ["user:123"] }
-   */
   allowFrom?: CommandAllowFrom;
 };
 
-export type ProviderCommandsConfig = {
-  /** Override native command registration for this provider (bool or "auto"). */
-  native?: NativeCommandsSetting;
-  /** Override native skill command registration for this provider (bool or "auto"). */
-  nativeSkills?: NativeCommandsSetting;
-};
+export type ProviderCommandsConfig = DefinedSchemaInput<typeof ProviderCommandsSchema>;

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -6,6 +6,8 @@ import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
 import { AgentEntrySchema } from "./zod-schema.agent-runtime.js";
 
+export { BroadcastSchema } from "./zod-schema.messages.js";
+
 const AgentEntryConfigSchema = z.preprocess(
   (value, ctx) => {
     if (value && typeof value === "object" && !Array.isArray(value)) {
@@ -152,12 +154,3 @@ const AcpBindingSchema = z
   });
 
 export const BindingsSchema = z.array(z.union([RouteBindingSchema, AcpBindingSchema])).optional();
-
-const BroadcastStrategySchema = z.enum(["parallel", "sequential"]);
-
-export const BroadcastSchema = z
-  .object({
-    strategy: BroadcastStrategySchema.optional(),
-  })
-  .catchall(z.array(z.string()))
-  .optional();

--- a/src/config/zod-schema.core.test.ts
+++ b/src/config/zod-schema.core.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { GroupChatSchema, MentionPatternsPolicySchema } from "./zod-schema.core.js";
+import { GroupChatSchema, MentionPatternsPolicySchema } from "./zod-schema.messages.js";
 
 describe("GroupChatSchema", () => {
   it("accepts historyLimit: 0", () => {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -11,10 +11,17 @@ import type { ModelCompatConfig } from "./types.models.js";
 import { MODEL_APIS, MODEL_THINKING_FORMATS } from "./types.models.js";
 import { ENV_SECRET_REF_ID_RE } from "./types.secrets.js";
 import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
+import { DmConfigSchema } from "./zod-schema.messages.js";
 import { SecretInputSchema } from "./zod-schema.secret-input.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
 export { isBuiltInModelProviderOverlayId } from "./model-provider-config.js";
+export {
+  DmConfigSchema,
+  GroupChatSchema,
+  MentionPatternsPolicySchema,
+  ProviderCommandsSchema,
+} from "./zod-schema.messages.js";
 export { SecretInputSchema, SecretRefSchema } from "./zod-schema.secret-input.js";
 
 const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
@@ -542,47 +549,6 @@ export const ModelsConfigSchema = z
   .strict()
   .optional();
 
-const VisibleRepliesValueSchema = z.enum(["automatic", "message_tool"]);
-const AmbientGroupInboundSchema = z.enum(["user_request", "room_event"]);
-
-export const VisibleRepliesSchema = z
-  .union([VisibleRepliesValueSchema, z.boolean()])
-  .overwrite((value) => {
-    if (value === true) {
-      return "automatic";
-    }
-    if (value === false) {
-      return "message_tool";
-    }
-    return value;
-  });
-
-const MentionPatternsModeSchema = z.union([z.literal("allow"), z.literal("deny")]);
-
-export const MentionPatternsPolicySchema = z
-  .object({
-    mode: MentionPatternsModeSchema.optional(),
-    allowIn: z.array(z.string()).optional(),
-    denyIn: z.array(z.string()).optional(),
-  })
-  .strict();
-
-export const GroupChatSchema = z
-  .object({
-    mentionPatterns: z.array(z.string()).optional(),
-    historyLimit: z.number().int().min(0).optional(),
-    unmentionedInbound: AmbientGroupInboundSchema.optional(),
-    visibleReplies: VisibleRepliesSchema.optional(),
-  })
-  .strict()
-  .optional();
-
-export const DmConfigSchema = z
-  .object({
-    historyLimit: z.number().int().min(0).optional(),
-  })
-  .strict();
-
 export const IdentitySchema = z
   .object({
     name: z.string().optional(),
@@ -593,13 +559,6 @@ export const IdentitySchema = z
   .strict()
   .optional();
 
-const QueueModeSchema = z.union([
-  z.literal("steer"),
-  z.literal("followup"),
-  z.literal("collect"),
-  z.literal("interrupt"),
-]);
-const QueueDropSchema = z.union([z.literal("old"), z.literal("new"), z.literal("summarize")]);
 export const ReplyToModeSchema = z.union([
   z.literal("off"),
   z.literal("first"),
@@ -813,45 +772,6 @@ export const requireAllowlistAllowFrom = (params: {
 
 export const MSTeamsReplyStyleSchema = z.enum(["thread", "top-level"]);
 
-const QueueModeBySurfaceSchema = z
-  .object({
-    whatsapp: QueueModeSchema.optional(),
-    telegram: QueueModeSchema.optional(),
-    discord: QueueModeSchema.optional(),
-    irc: QueueModeSchema.optional(),
-    googlechat: QueueModeSchema.optional(),
-    slack: QueueModeSchema.optional(),
-    mattermost: QueueModeSchema.optional(),
-    signal: QueueModeSchema.optional(),
-    imessage: QueueModeSchema.optional(),
-    msteams: QueueModeSchema.optional(),
-    webchat: QueueModeSchema.optional(),
-    matrix: QueueModeSchema.optional(),
-  })
-  .strict()
-  .optional();
-
-const DebounceMsBySurfaceSchema = z.record(z.string(), z.number().int().nonnegative()).optional();
-
-export const QueueSchema = z
-  .object({
-    mode: QueueModeSchema.optional(),
-    byChannel: QueueModeBySurfaceSchema,
-    debounceMsByChannel: DebounceMsBySurfaceSchema,
-    cap: z.number().int().positive().optional(),
-    drop: QueueDropSchema.optional(),
-  })
-  .strict()
-  .optional();
-
-export const InboundDebounceSchema = z
-  .object({
-    debounceMs: z.number().int().nonnegative().optional(),
-    byChannel: DebounceMsBySurfaceSchema,
-  })
-  .strict()
-  .optional();
-
 export const HexColorSchema = z.string().regex(/^#?[0-9a-fA-F]{6}$/, "expected hex color (RRGGBB)");
 
 export const ExecutableTokenSchema = z
@@ -965,13 +885,4 @@ export const ToolsLinksSchema = z
   .strict()
   .optional();
 
-export const NativeCommandsSettingSchema = z.union([z.boolean(), z.literal("auto")]);
-
-export const ProviderCommandsSchema = z
-  .object({
-    native: NativeCommandsSettingSchema.optional(),
-    nativeSkills: NativeCommandsSettingSchema.optional(),
-  })
-  .strict()
-  .optional();
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/config/zod-schema.messages.ts
+++ b/src/config/zod-schema.messages.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+
+const VisibleRepliesValueSchema = z.enum(["automatic", "message_tool"]);
+
+const VisibleRepliesSchema = z
+  .union([VisibleRepliesValueSchema, z.boolean()])
+  .overwrite((value) => {
+    if (value === true) {
+      return "automatic";
+    }
+    if (value === false) {
+      return "message_tool";
+    }
+    return value;
+  });
+
+export const MentionPatternsPolicySchema = z
+  .object({
+    mode: z.union([z.literal("allow"), z.literal("deny")]).optional(),
+    allowIn: z.array(z.string()).optional(),
+    denyIn: z.array(z.string()).optional(),
+  })
+  .strict();
+
+export const GroupChatSchema = z
+  .object({
+    mentionPatterns: z.array(z.string()).optional(),
+    historyLimit: z.number().int().min(0).optional(),
+    unmentionedInbound: z.enum(["user_request", "room_event"]).optional(),
+    visibleReplies: VisibleRepliesSchema.optional(),
+  })
+  .strict()
+  .optional();
+
+export const DmConfigSchema = z
+  .object({
+    historyLimit: z.number().int().min(0).optional(),
+  })
+  .strict();
+
+const QueueModeSchema = z.union([
+  z.literal("steer"),
+  z.literal("followup"),
+  z.literal("collect"),
+  z.literal("interrupt"),
+]);
+const QueueDropSchema = z.union([z.literal("old"), z.literal("new"), z.literal("summarize")]);
+const QueueModeBySurfaceSchema = z
+  .object({
+    whatsapp: QueueModeSchema.optional(),
+    telegram: QueueModeSchema.optional(),
+    discord: QueueModeSchema.optional(),
+    irc: QueueModeSchema.optional(),
+    googlechat: QueueModeSchema.optional(),
+    slack: QueueModeSchema.optional(),
+    mattermost: QueueModeSchema.optional(),
+    signal: QueueModeSchema.optional(),
+    imessage: QueueModeSchema.optional(),
+    msteams: QueueModeSchema.optional(),
+    webchat: QueueModeSchema.optional(),
+    matrix: QueueModeSchema.optional(),
+  })
+  .strict()
+  .optional();
+const DebounceMsBySurfaceSchema = z.record(z.string(), z.number().int().nonnegative()).optional();
+
+export const QueueSchema = z
+  .object({
+    mode: QueueModeSchema.optional(),
+    byChannel: QueueModeBySurfaceSchema,
+    debounceMsByChannel: DebounceMsBySurfaceSchema,
+    cap: z.number().int().positive().optional(),
+    drop: QueueDropSchema.optional(),
+  })
+  .strict()
+  .optional();
+
+export const InboundDebounceSchema = z
+  .object({
+    debounceMs: z.number().int().nonnegative().optional(),
+    byChannel: DebounceMsBySurfaceSchema,
+  })
+  .strict()
+  .optional();
+
+export const NativeCommandsSettingSchema = z.union([z.boolean(), z.literal("auto")]);
+
+export const ProviderCommandsSchema = z
+  .object({
+    native: NativeCommandsSettingSchema.optional(),
+    nativeSkills: NativeCommandsSettingSchema.optional(),
+  })
+  .strict()
+  .optional();
+
+const ResponseUsageModeSchema = z.enum(["on", "off", "tokens", "full"]);
+
+export const MessagesSchema = z
+  .object({
+    visibleReplies: VisibleRepliesSchema.optional(),
+    responsePrefix: z.string().optional(),
+    usageTemplate: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
+    responseUsage: z
+      .union([ResponseUsageModeSchema, z.record(z.string(), ResponseUsageModeSchema)])
+      .optional(),
+    groupChat: GroupChatSchema,
+    queue: QueueSchema,
+    inbound: InboundDebounceSchema,
+    ackReaction: z.string().optional(),
+    ackReactionScope: z
+      .enum(["group-mentions", "group-all", "direct", "all", "off", "none"])
+      .optional(),
+    statusReactions: z.object({ enabled: z.boolean().optional() }).strict().optional(),
+  })
+  .strict()
+  .optional();
+
+export const BroadcastSchema = z
+  .object({ strategy: z.enum(["parallel", "sequential"]).optional() })
+  .catchall(z.array(z.string()))
+  .optional();

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -1,42 +1,10 @@
 // Defines session-related Zod schema fragments for config parsing.
 import { z } from "zod";
 import { ElevatedAllowFromSchema } from "./zod-schema.agent-runtime.js";
-import {
-  GroupChatSchema,
-  InboundDebounceSchema,
-  NativeCommandsSettingSchema,
-  QueueSchema,
-  VisibleRepliesSchema,
-} from "./zod-schema.core.js";
+import { NativeCommandsSettingSchema } from "./zod-schema.messages.js";
 
+export { MessagesSchema } from "./zod-schema.messages.js";
 export { SessionSchema } from "./zod-schema.session-config.js";
-
-const ResponseUsageModeSchema = z.enum(["on", "off", "tokens", "full"]);
-
-export const MessagesSchema = z
-  .object({
-    visibleReplies: VisibleRepliesSchema.optional(),
-    responsePrefix: z.string().optional(),
-    usageTemplate: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
-    responseUsage: z
-      .union([ResponseUsageModeSchema, z.record(z.string(), ResponseUsageModeSchema)])
-      .optional(),
-    groupChat: GroupChatSchema,
-    queue: QueueSchema,
-    inbound: InboundDebounceSchema,
-    ackReaction: z.string().optional(),
-    ackReactionScope: z
-      .enum(["group-mentions", "group-all", "direct", "all", "off", "none"])
-      .optional(),
-    statusReactions: z
-      .object({
-        enabled: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-  })
-  .strict()
-  .optional();
 
 export const CommandsSchema = z
   .object({
@@ -55,11 +23,4 @@ export const CommandsSchema = z
   })
   .strict()
   .optional()
-  .default(
-    () =>
-      ({
-        native: "auto",
-        nativeSkills: "auto",
-        restart: true,
-      }) as const,
-  );
+  .default(() => ({ native: "auto", nativeSkills: "auto", restart: true }) as const);


### PR DESCRIPTION
## Summary

- extract the canonical messages, queue, inbound debounce, and broadcast validators into a dependency-light schema module
- derive the matching public authoring types from schema input while preserving normalized and Doctor-only compatibility overlays
- retain the runtime-dependent commands contract with its existing owner

This removes 127 production lines and prevents the message config types from drifting from runtime validation.

## Validation

- `pnpm check:changed`
- Plugin SDK declaration build
- core production and all test-type shards
- 219 focused schema, config, and Doctor migration tests
- runtime/Madge cycle and dead-export scans

## Compatibility

The patch preserves string-only `visibleReplies`, the broadcast index signature, Doctor-only `messages.removeAckAfterReply`, existing commands legacy fields, and the prior aggregate schema exports.

Upgrade compatibility is verified by 219 passing schema/config/Doctor-migration tests and the unchanged generated config baselines on this exact head. Existing configurations continue through the same validator expressions and Doctor legacy-field handling into the same normalized runtime values.
