### PR TITLE
refactor(config): derive session types from schema

### DIFF
--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -1,5 +1,6 @@
 // Defines base configuration types shared by multiple config sections.
-import type { ChatType } from "../channels/chat-type.js";
+import type { z } from "zod";
+import type { SessionSchema } from "./zod-schema.session-config.js";
 
 /** Reply handling mode for chat command surfaces. */
 export type ReplyMode = "text" | "command";
@@ -141,142 +142,25 @@ export type HumanDelayConfig = {
   maxMs?: number;
 };
 
-export type SessionSendPolicyAction = "allow" | "deny";
-export type SessionSendPolicyMatch = {
-  /** Channel/provider id match. */
-  channel?: string;
-  /** Direct/group/thread classification when the caller has channel metadata. */
-  chatType?: ChatType;
-  /**
-   * Session key prefix match.
-   * Note: some consumers match against a normalized key (for example, stripping `agent:<id>:`).
-   */
-  keyPrefix?: string;
-  /** Optional raw session-key prefix match for consumers that normalize session keys. */
-  rawKeyPrefix?: string;
-};
-export type SessionSendPolicyRule = {
-  /** Action applied when match criteria select this rule. */
-  action: SessionSendPolicyAction;
-  /** Optional match filter; omitted match behaves as a catch-all rule. */
-  match?: SessionSendPolicyMatch;
-};
-export type SessionSendPolicyConfig = {
-  /** Fallback action when no send-policy rule matches. */
-  default?: SessionSendPolicyAction;
-  /** Ordered allow/deny rules; first matching rule wins. */
-  rules?: SessionSendPolicyRule[];
-};
+type SessionSchemaInput = NonNullable<z.input<typeof SessionSchema>>;
 
-export type SessionResetMode = "none" | "daily" | "idle";
-export type SessionResetConfig = {
-  mode?: SessionResetMode;
-  /** Local hour (0-23) for the daily reset boundary. */
-  atHour?: number;
-  /** Sliding idle window (minutes). When set with daily mode, whichever expires first wins. */
-  idleMinutes?: number;
-};
-export type SessionResetByTypeConfig = {
-  direct?: SessionResetConfig;
-  group?: SessionResetConfig;
-  thread?: SessionResetConfig;
-};
+export type SessionSendPolicyConfig = NonNullable<SessionSchemaInput["sendPolicy"]>;
+export type SessionSendPolicyAction = NonNullable<SessionSendPolicyConfig["default"]>;
+export type SessionSendPolicyRule = NonNullable<SessionSendPolicyConfig["rules"]>[number];
+export type SessionSendPolicyMatch = NonNullable<SessionSendPolicyRule["match"]>;
 
-export type SessionThreadBindingsConfig = {
-  /**
-   * Master switch for thread-bound session routing features.
-   * Channel/provider keys can override this default.
-   */
-  enabled?: boolean;
-  /**
-   * Inactivity window for thread-bound sessions (hours).
-   * Binding expires after this amount of idle time. Set to 0 to disable. Default: 24.
-   */
-  idleHours?: number;
-  /**
-   * Optional hard max age for thread-bound sessions (hours).
-   * Binding expires once this age is reached even if active. Set to 0 to disable. Default: 0.
-   */
-  maxAgeHours?: number;
-  /**
-   * Allow channel integrations to create thread-bound work sessions from
-   * sessions_spawn or native ACP spawn flows. Channel/account keys can override.
-   * Default: true when thread bindings are enabled.
-   */
-  spawnSessions?: boolean;
-  /**
-   * Default context mode for native subagents spawned into a bound thread.
-   * Default: "fork" so the child starts from the requester transcript.
-   */
-  defaultSpawnContext?: "isolated" | "fork";
-};
+export type SessionResetConfig = NonNullable<SessionSchemaInput["reset"]>;
+export type SessionResetMode = NonNullable<SessionResetConfig["mode"]>;
+export type SessionResetByTypeConfig = NonNullable<SessionSchemaInput["resetByType"]>;
 
-export type SessionSharingConfig = {
-  /** Allow owners/admins to set sessions read-only. Default: true. */
-  readOnly?: boolean;
-  /** Allow owners/admins to select suggest mode. Default: true. */
-  suggest?: boolean;
-  /** Allow owners/admins to hide draft sessions from other operators. Default: true. */
-  drafts?: boolean;
-};
+export type SessionThreadBindingsConfig = NonNullable<SessionSchemaInput["threadBindings"]>;
 
-export type SessionConfig = {
-  scope?: SessionScope;
-  /** DM session scoping (default: "main"). */
-  dmScope?: DmScope;
-  /** Group/channel session scoping (default: "per-group"). */
-  groupScope?: GroupScope;
-  /** Map platform-prefixed identities (e.g. "telegram:123") to canonical DM peers. */
-  identityLinks?: Record<string, string[]>;
-  resetTriggers?: string[];
-  reset?: SessionResetConfig;
-  resetByType?: SessionResetByTypeConfig;
-  /** Channel-specific reset overrides (e.g. { discord: { mode: "idle", idleMinutes: 10080 } }). */
-  resetByChannel?: Record<string, SessionResetConfig>;
-  store?: string;
-  mainKey?: string;
-  sendPolicy?: SessionSendPolicyConfig;
-  /** Shared defaults for thread-bound session routing across channels/providers. */
-  threadBindings?: SessionThreadBindingsConfig;
-  /** Collaboration modes owners and administrators may select. */
-  sharing?: SessionSharingConfig;
-  /** Automatic session store maintenance (pruning, capping, archive retention, disk budget). */
-  maintenance?: SessionMaintenanceConfig;
-};
+export type SessionSharingConfig = NonNullable<SessionSchemaInput["sharing"]>;
 
-export type SessionMaintenanceMode = "enforce" | "warn";
+export type SessionConfig = SessionSchemaInput;
 
-/** Session-store cleanup policy for transcript count, age, archives, and disk budget. */
-export type SessionMaintenanceConfig = {
-  /** Whether to enforce maintenance or warn only. Default: "enforce". */
-  mode?: SessionMaintenanceMode;
-  /** Archive eligible conversations and remove disposable entries older than this duration. Default: "30d". */
-  pruneAfter?: string | number;
-  /** Archive inactive dashboard sessions after this duration. Default: "7d"; false or 0 disables. */
-  archiveDashboardAfter?: string | number | false;
-  /** Maximum unarchived entries when protection permits; durable overflow is archived. Default: 5000. */
-  maxEntries?: number;
-  /** Protect interactive sessions active within this duration. Default and false: disabled. */
-  preserveRecent?: string | number | false;
-  /**
-   * Age-based retention for archived transcripts (`*.reset.<timestamp>` and
-   * `*.deleted.<timestamp>`). Default and `false`: keep archives until the
-   * disk budget evicts them oldest-first; a duration opts into deletion.
-   */
-  resetArchiveRetention?: string | number | false;
-  /**
-   * Per-agent physical budget for SQLite main/WAL and counted session-directory artifacts. Default: "10gb".
-   * Warn mode reports pressure; enforce mode applies oldest-first cleanup.
-   * Protected data may exceed the target. Set `false`, `0`, or `"0"` to disable.
-   */
-  maxDiskBytes?: number | string | false;
-  /**
-   * Target size after disk-budget cleanup (high-water mark), e.g. "400mb".
-   * Default: 80% of maxDiskBytes. A value that resolves to zero falls back to
-   * the default instead of clearing history; negative values are invalid.
-   */
-  highWaterBytes?: number | string;
-};
+export type SessionMaintenanceConfig = NonNullable<SessionSchemaInput["maintenance"]>;
+export type SessionMaintenanceMode = NonNullable<SessionMaintenanceConfig["mode"]>;
 
 export type LoggingConfig = {
   level?: "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace";

--- a/src/config/zod-schema.session-config.ts
+++ b/src/config/zod-schema.session-config.ts
@@ -1,0 +1,121 @@
+import { normalizeStringifiedOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { z } from "zod";
+import { parseByteSize } from "../cli/parse-bytes.js";
+import { parseDurationMs } from "../cli/parse-duration.js";
+import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
+
+const SessionResetConfigSchema = z
+  .object({
+    mode: z.union([z.literal("none"), z.literal("daily"), z.literal("idle")]).optional(),
+    atHour: z.number().int().min(0).max(23).optional(),
+    idleMinutes: z.number().int().positive().optional(),
+  })
+  .strict();
+
+const PositiveDurationSchema = z.union([z.string(), z.number()]).superRefine((value, ctx) => {
+  try {
+    const ms = parseDurationMs(normalizeStringifiedOptionalString(value) ?? "", {
+      defaultUnit: "d",
+    });
+    if (ms <= 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "duration must be positive (use ms, s, m, h, d), e.g. 30d",
+      });
+    }
+  } catch {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "invalid duration (use ms, s, m, h, d)",
+    });
+  }
+});
+
+const SessionSendPolicySchema = createAllowDenyChannelRulesSchema();
+
+export const SessionSchema = z
+  .object({
+    scope: z.union([z.literal("per-sender"), z.literal("global")]).optional(),
+    dmScope: z
+      .enum(["main", "per-peer", "per-channel-peer", "per-account-channel-peer"])
+      .optional(),
+    groupScope: z.enum(["main", "per-group"]).optional(),
+    identityLinks: z.record(z.string(), z.array(z.string())).optional(),
+    resetTriggers: z.array(z.string()).optional(),
+    reset: SessionResetConfigSchema.optional(),
+    resetByType: z
+      .object({
+        direct: SessionResetConfigSchema.optional(),
+        group: SessionResetConfigSchema.optional(),
+        thread: SessionResetConfigSchema.optional(),
+      })
+      .strict()
+      .optional(),
+    resetByChannel: z.record(z.string(), SessionResetConfigSchema).optional(),
+    store: z.string().optional(),
+    mainKey: z.string().optional(),
+    sendPolicy: SessionSendPolicySchema.optional(),
+    threadBindings: z
+      .object({
+        enabled: z.boolean().optional(),
+        idleHours: z.number().nonnegative().optional(),
+        maxAgeHours: z.number().nonnegative().optional(),
+        spawnSessions: z.boolean().optional(),
+        defaultSpawnContext: z.enum(["isolated", "fork"]).optional(),
+      })
+      .strict()
+      .optional(),
+    sharing: z
+      .object({
+        readOnly: z.boolean().optional(),
+        suggest: z.boolean().optional(),
+        drafts: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    maintenance: z
+      .object({
+        mode: z.enum(["enforce", "warn"]).optional(),
+        pruneAfter: PositiveDurationSchema.optional(),
+        archiveDashboardAfter: z
+          .union([PositiveDurationSchema, z.literal(false), z.literal(0)])
+          .optional(),
+        maxEntries: z.number().int().positive().optional(),
+        preserveRecent: z.union([PositiveDurationSchema, z.literal(false)]).optional(),
+        resetArchiveRetention: z.union([PositiveDurationSchema, z.literal(false)]).optional(),
+        maxDiskBytes: z.union([z.string(), z.number(), z.literal(false)]).optional(),
+        highWaterBytes: z.union([z.string(), z.number()]).optional(),
+      })
+      .strict()
+      .superRefine((val, ctx) => {
+        if (val.maxDiskBytes !== undefined && val.maxDiskBytes !== false) {
+          try {
+            parseByteSize(normalizeStringifiedOptionalString(val.maxDiskBytes) ?? "", {
+              defaultUnit: "b",
+            });
+          } catch {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["maxDiskBytes"],
+              message: "invalid size (use b, kb, mb, gb, tb)",
+            });
+          }
+        }
+        if (val.highWaterBytes !== undefined) {
+          try {
+            parseByteSize(normalizeStringifiedOptionalString(val.highWaterBytes) ?? "", {
+              defaultUnit: "b",
+            });
+          } catch {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["highWaterBytes"],
+              message: "invalid size (use b, kb, mb, gb, tb)",
+            });
+          }
+        }
+      })
+      .optional(),
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -1,10 +1,6 @@
 // Defines session-related Zod schema fragments for config parsing.
-import { normalizeStringifiedOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { z } from "zod";
-import { parseByteSize } from "../cli/parse-bytes.js";
-import { parseDurationMs } from "../cli/parse-duration.js";
 import { ElevatedAllowFromSchema } from "./zod-schema.agent-runtime.js";
-import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
 import {
   GroupChatSchema,
   InboundDebounceSchema,
@@ -13,121 +9,7 @@ import {
   VisibleRepliesSchema,
 } from "./zod-schema.core.js";
 
-const SessionResetConfigSchema = z
-  .object({
-    mode: z.union([z.literal("none"), z.literal("daily"), z.literal("idle")]).optional(),
-    atHour: z.number().int().min(0).max(23).optional(),
-    idleMinutes: z.number().int().positive().optional(),
-  })
-  .strict();
-
-const PositiveDurationSchema = z.union([z.string(), z.number()]).superRefine((value, ctx) => {
-  try {
-    const ms = parseDurationMs(normalizeStringifiedOptionalString(value) ?? "", {
-      defaultUnit: "d",
-    });
-    if (ms <= 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "duration must be positive (use ms, s, m, h, d), e.g. 30d",
-      });
-    }
-  } catch {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "invalid duration (use ms, s, m, h, d)",
-    });
-  }
-});
-
-const SessionSendPolicySchema = createAllowDenyChannelRulesSchema();
-
-export const SessionSchema = z
-  .object({
-    scope: z.union([z.literal("per-sender"), z.literal("global")]).optional(),
-    dmScope: z
-      .enum(["main", "per-peer", "per-channel-peer", "per-account-channel-peer"])
-      .optional(),
-    groupScope: z.enum(["main", "per-group"]).optional(),
-    identityLinks: z.record(z.string(), z.array(z.string())).optional(),
-    resetTriggers: z.array(z.string()).optional(),
-    reset: SessionResetConfigSchema.optional(),
-    resetByType: z
-      .object({
-        direct: SessionResetConfigSchema.optional(),
-        group: SessionResetConfigSchema.optional(),
-        thread: SessionResetConfigSchema.optional(),
-      })
-      .strict()
-      .optional(),
-    resetByChannel: z.record(z.string(), SessionResetConfigSchema).optional(),
-    store: z.string().optional(),
-    mainKey: z.string().optional(),
-    sendPolicy: SessionSendPolicySchema.optional(),
-    threadBindings: z
-      .object({
-        enabled: z.boolean().optional(),
-        idleHours: z.number().nonnegative().optional(),
-        maxAgeHours: z.number().nonnegative().optional(),
-        spawnSessions: z.boolean().optional(),
-        defaultSpawnContext: z.enum(["isolated", "fork"]).optional(),
-      })
-      .strict()
-      .optional(),
-    sharing: z
-      .object({
-        readOnly: z.boolean().optional(),
-        suggest: z.boolean().optional(),
-        drafts: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-    maintenance: z
-      .object({
-        mode: z.enum(["enforce", "warn"]).optional(),
-        pruneAfter: PositiveDurationSchema.optional(),
-        archiveDashboardAfter: z
-          .union([PositiveDurationSchema, z.literal(false), z.literal(0)])
-          .optional(),
-        maxEntries: z.number().int().positive().optional(),
-        preserveRecent: z.union([PositiveDurationSchema, z.literal(false)]).optional(),
-        resetArchiveRetention: z.union([PositiveDurationSchema, z.literal(false)]).optional(),
-        maxDiskBytes: z.union([z.string(), z.number(), z.literal(false)]).optional(),
-        highWaterBytes: z.union([z.string(), z.number()]).optional(),
-      })
-      .strict()
-      .superRefine((val, ctx) => {
-        if (val.maxDiskBytes !== undefined && val.maxDiskBytes !== false) {
-          try {
-            parseByteSize(normalizeStringifiedOptionalString(val.maxDiskBytes) ?? "", {
-              defaultUnit: "b",
-            });
-          } catch {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ["maxDiskBytes"],
-              message: "invalid size (use b, kb, mb, gb, tb)",
-            });
-          }
-        }
-        if (val.highWaterBytes !== undefined) {
-          try {
-            parseByteSize(normalizeStringifiedOptionalString(val.highWaterBytes) ?? "", {
-              defaultUnit: "b",
-            });
-          } catch {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ["highWaterBytes"],
-              message: "invalid size (use b, kb, mb, gb, tb)",
-            });
-          }
-        }
-      })
-      .optional(),
-  })
-  .strict()
-  .optional();
+export { SessionSchema } from "./zod-schema.session-config.js";
 
 const ResponseUsageModeSchema = z.enum(["on", "off", "tokens", "full"]);
 


### PR DESCRIPTION
## Summary

- move the unchanged session validator into a dependency-light schema owner
- preserve the existing aggregate schema export
- derive the public session/reset/send-policy/thread-binding/sharing/maintenance authoring types from schema input

This removes 113 production lines and gives runtime validation sole ownership of the aligned session config contract.

## Validation

- `pnpm check:changed`
- Plugin SDK declaration build
- core production and all test-type shards
- 100 focused reset, sharing, and maintenance tests
- runtime/Madge cycle and dead-export scans

## Compatibility

Schema behavior, public export names, authoring optionality, duration/byte-size validation, and persisted config semantics are unchanged.

Upgrade compatibility is verified by 100 passing reset/sharing/maintenance tests and the unchanged generated config baselines on this exact head. Existing persisted session settings continue through the byte-for-byte moved validator expressions with identical defaults, duration/byte-size parsing, and normalized runtime values.
