### PR TITLE
refactor(memory): derive resolved config from producer

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -3,16 +3,13 @@
  */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/config.js";
-import type { SecretInput } from "../config/types.secrets.js";
 import {
   normalizeConfiguredMemoryExtraPaths,
   resolveRememberAcrossConversations,
 } from "../memory-host-sdk/host/config-utils.js";
-import type { MemoryExtraPath } from "../memory-host-sdk/host/types.js";
 import {
   isMemoryMultimodalEnabled,
   normalizeMemoryMultimodalSettings,
-  type MemoryMultimodalSettings,
 } from "../memory-host-sdk/multimodal.js";
 import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-provider-runtime.js";
 import { assertSecretOwnerAvailable } from "../secrets/runtime-degraded-state.js";
@@ -22,92 +19,41 @@ import { clampNumber } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { resolveMemorySearchSourcePolicy } from "./memory-search-source-policy.js";
 
-export type ResolvedMemorySearchConfig = {
-  enabled: boolean;
-  rememberAcrossConversations: boolean;
-  /** Sources indexed by the manager. */
-  sources: Array<"memory" | "sessions">;
-  /** Sources searched when memory_search omits an explicit corpus. */
-  searchSources: Array<"memory" | "sessions">;
-  extraPaths: MemoryExtraPath[];
-  multimodal: MemoryMultimodalSettings;
-  provider: string;
-  remote?: {
-    baseUrl?: string;
-    apiKey?: SecretInput;
-    headers?: Record<string, string>;
-    nonBatchConcurrency?: number;
-    batch?: {
-      enabled: boolean;
-      wait: boolean;
-      concurrency: number;
-      pollIntervalMs: number;
-      timeoutMinutes: number;
-    };
-  };
-  experimental: {
-    sessionMemory: boolean;
-  };
-  fallback: string;
-  model: string;
+type ProducedMemorySearchConfig = NonNullable<ReturnType<typeof produceMemorySearchConfig>>;
+
+export type ResolvedMemorySearchConfig = Omit<
+  ProducedMemorySearchConfig,
+  | "cache"
+  | "documentInputType"
+  | "inputType"
+  | "local"
+  | "outputDimensionality"
+  | "queryInputType"
+  | "remote"
+  | "store"
+  | "sync"
+> & {
   inputType?: string;
   queryInputType?: string;
   documentInputType?: string;
   outputDimensionality?: number;
-  local: {
+  cache: Omit<ProducedMemorySearchConfig["cache"], "maxEntries"> & { maxEntries?: number };
+  local: Omit<ProducedMemorySearchConfig["local"], "modelPath"> & {
     modelPath?: string;
     modelCacheDir?: string;
     contextSize?: number | "auto";
   };
-  store: {
-    driver: "sqlite";
-    databasePath: string;
-    fts: {
-      tokenizer: "unicode61" | "trigram";
-    };
-    vector: {
-      enabled: boolean;
+  remote?: Omit<Partial<NonNullable<ProducedMemorySearchConfig["remote"]>>, "batch"> & {
+    batch?: NonNullable<ProducedMemorySearchConfig["remote"]>["batch"];
+    nonBatchConcurrency?: number;
+  };
+  store: Omit<ProducedMemorySearchConfig["store"], "vector"> & {
+    vector: Omit<ProducedMemorySearchConfig["store"]["vector"], "extensionPath"> & {
       extensionPath?: string;
     };
   };
-  chunking: {
-    tokens: number;
-    overlap: number;
-  };
-  sync: {
-    onSessionStart: boolean;
-    onSearch: boolean;
-    watch: boolean;
-    watchDebounceMs: number;
-    intervalMinutes: number;
+  sync: Omit<ProducedMemorySearchConfig["sync"], "embeddingBatchTimeoutSeconds"> & {
     embeddingBatchTimeoutSeconds: number | undefined;
-    sessions: {
-      deltaBytes: number;
-      deltaMessages: number;
-      postCompactionForce: boolean;
-    };
-  };
-  query: {
-    maxResults: number;
-    minScore: number;
-    hybrid: {
-      enabled: boolean;
-      vectorWeight: number;
-      textWeight: number;
-      candidateMultiplier: number;
-      mmr: {
-        enabled: boolean;
-        lambda: number;
-      };
-      temporalDecay: {
-        enabled: boolean;
-        halfLifeDays: number;
-      };
-    };
-  };
-  cache: {
-    enabled: boolean;
-    maxEntries?: number;
   };
 };
 
@@ -202,10 +148,7 @@ export function resolveMemorySearchIndexConfig(cfg: OpenClawConfig, agentId: str
   };
 }
 
-export function resolveMemorySearchConfig(
-  cfg: OpenClawConfig,
-  agentId: string,
-): ResolvedMemorySearchConfig | null {
+function produceMemorySearchConfig(cfg: OpenClawConfig, agentId: string) {
   const indexConfig = resolveMemorySearchIndexConfig(cfg, agentId);
   if (!indexConfig) {
     return null;
@@ -291,7 +234,7 @@ export function resolveMemorySearchConfig(
     maxEntries: DEFAULT_CACHE_MAX_ENTRIES,
   };
 
-  const resolved: ResolvedMemorySearchConfig = {
+  const resolved = {
     ...indexConfig,
     multimodal,
     provider,
@@ -327,7 +270,14 @@ export function resolveMemorySearchConfig(
   return resolved;
 }
 
-function resolveSyncConfig(): ResolvedMemorySearchSyncConfig {
+export function resolveMemorySearchConfig(
+  cfg: OpenClawConfig,
+  agentId: string,
+): ResolvedMemorySearchConfig | null {
+  return produceMemorySearchConfig(cfg, agentId);
+}
+
+function resolveSyncConfig() {
   return {
     onSessionStart: true,
     onSearch: true,

--- a/src/plugin-sdk/memory-core-host-engine-foundation.contract.test.ts
+++ b/src/plugin-sdk/memory-core-host-engine-foundation.contract.test.ts
@@ -1,0 +1,51 @@
+import { describe, expectTypeOf, it } from "vitest";
+import {
+  resolveMemorySearchConfig,
+  resolveMemorySearchSyncConfig,
+  type ResolvedMemorySearchConfig,
+} from "./memory-core-host-engine-foundation.js";
+
+type IsOptional<T, K extends keyof T> = Pick<T, K> extends Required<Pick<T, K>> ? false : true;
+
+describe("memory core host engine foundation contracts", () => {
+  it("preserves the released resolved-config authoring shapes", () => {
+    expectTypeOf<IsOptional<ResolvedMemorySearchConfig, "inputType">>().toEqualTypeOf<true>();
+    expectTypeOf<IsOptional<ResolvedMemorySearchConfig, "queryInputType">>().toEqualTypeOf<true>();
+    expectTypeOf<
+      IsOptional<ResolvedMemorySearchConfig, "documentInputType">
+    >().toEqualTypeOf<true>();
+    expectTypeOf<
+      IsOptional<ResolvedMemorySearchConfig, "outputDimensionality">
+    >().toEqualTypeOf<true>();
+    expectTypeOf<
+      IsOptional<ResolvedMemorySearchConfig["local"], "modelPath">
+    >().toEqualTypeOf<true>();
+    expectTypeOf<
+      IsOptional<ResolvedMemorySearchConfig["store"]["vector"], "extensionPath">
+    >().toEqualTypeOf<true>();
+    expectTypeOf<
+      ResolvedMemorySearchConfig["sync"]["embeddingBatchTimeoutSeconds"]
+    >().toEqualTypeOf<number | undefined>();
+
+    const local: ResolvedMemorySearchConfig["local"] = {};
+    const vector: ResolvedMemorySearchConfig["store"]["vector"] = { enabled: true };
+    expectTypeOf(local).toMatchTypeOf<ResolvedMemorySearchConfig["local"]>();
+    expectTypeOf(vector).toMatchTypeOf<ResolvedMemorySearchConfig["store"]["vector"]>();
+  });
+
+  it("preserves the released resolver return contracts", () => {
+    expectTypeOf<
+      ReturnType<typeof resolveMemorySearchConfig>
+    >().toEqualTypeOf<ResolvedMemorySearchConfig | null>();
+    expectTypeOf<ReturnType<typeof resolveMemorySearchSyncConfig>>().toEqualTypeOf<
+      ResolvedMemorySearchConfig["sync"] | null
+    >();
+
+    expectTypeOf<
+      NonNullable<ReturnType<typeof resolveMemorySearchConfig>>["local"]["contextSize"]
+    >().toEqualTypeOf<number | "auto" | undefined>();
+    expectTypeOf<
+      NonNullable<ReturnType<typeof resolveMemorySearchSyncConfig>>["embeddingBatchTimeoutSeconds"]
+    >().toEqualTypeOf<number | undefined>();
+  });
+});


### PR DESCRIPTION
## Summary

- derive the exported resolved memory-search contract from its sole runtime producer
- retain the complete released SDK optionality for input modes, local/store paths, cache, partial remote settings, and sync timeouts
- preserve the released nullable return contracts of both public resolver functions
- remove the handwritten duplicate model and now-unused imports/annotations

This removes 50 production lines and prevents the resolved contract from drifting from the producer.

## Validation

- `pnpm check:changed`
- Plugin SDK declaration build
- core production and all test-type shards
- five focused memory, config, Doctor, cron, Gateway, and extension test shards
- public SDK compile-time compatibility assertions for omitted fields, numeric sync timeouts, and both resolver return signatures
- runtime/Madge cycle and dead-export scans

## Compatibility

The exported type names, nullable resolver return signatures, runtime construction, shipped optional authoring fields, partial remote fixtures, and numeric sync timeout contract remain unchanged. No stored data, parser, serializer, or migration path changes.

Upgrade compatibility is verified by the existing persisted-config migration suite: all 8 legacy migration/idempotent-reload cases pass on this exact head, including effective memory-setting migration. Existing stored configurations continue through the unchanged parser and migration readers into the same resolved runtime values.
