### PR TITLE
refactor(config): derive gateway IO types from schema

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -1,23 +1,16 @@
+import type { z } from "zod";
 import type { ControlUiEnvironment } from "../gateway/control-ui-bootstrap-contract.js";
 // Defines gateway runtime and networking configuration types.
 import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { SecretInput } from "./types.secrets.js";
+import type { GatewayConfigSchema } from "./zod-schema.gateway.js";
+
+type GatewayConfigInput = NonNullable<z.input<typeof GatewayConfigSchema>>;
 
 /** Gateway bind-address policy for local server startup. */
-export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet";
+export type GatewayBindMode = NonNullable<GatewayConfigInput["bind"]>;
 
-export type GatewayTlsConfig = {
-  /** Enable TLS for the gateway server. */
-  enabled?: boolean;
-  /** Auto-generate a self-signed cert if cert/key are missing (default: true). */
-  autoGenerate?: boolean;
-  /** PEM certificate path for the gateway server. */
-  certPath?: string;
-  /** PEM private key path for the gateway server. */
-  keyPath?: string;
-  /** Optional PEM CA bundle for TLS clients (mTLS or custom roots). */
-  caPath?: string;
-};
+export type GatewayTlsConfig = NonNullable<GatewayConfigInput["tls"]>;
 
 export type WideAreaDiscoveryConfig = {
   /** Optional unicast DNS-SD domain (e.g. "openclaw.internal"). */
@@ -273,28 +266,7 @@ export type GatewayTailscaleConfig = {
   preserveFunnel?: boolean;
 };
 
-export type GatewayRemoteConfig = {
-  /** Remote Gateway WebSocket URL (ws:// or wss://). */
-  url?: string;
-  /** Desktop companion transport (SSH tunnel or direct WS); core validates/preserves but does not read it. */
-  transport?: "ssh" | "direct";
-  /** Desktop companion remote SSH port (default 18789); core validates/preserves but does not read it. */
-  remotePort?: number;
-  /** Token for remote auth (when the gateway requires token auth). */
-  token?: SecretInput;
-  /** Password for remote auth (when the gateway requires password auth). */
-  password?: SecretInput;
-  /** Headers presented to an identity-aware proxy in front of the Gateway (values are secrets). */
-  edgeAuth?: Record<string, SecretInput>;
-  /** Expected TLS certificate fingerprint (sha256) for remote gateways. */
-  tlsFingerprint?: string;
-  /** SSH target for tunneling remote Gateway (user@host). */
-  sshTarget?: string;
-  /** SSH identity file path for tunneling remote Gateway. */
-  sshIdentity?: string;
-  /** macOS app-only; core validates/preserves but does not read it. Defaults to strict; see docs/platforms/mac/remote.md. */
-  sshHostKeyPolicy?: "strict" | "openssh";
-};
+export type GatewayRemoteConfig = NonNullable<GatewayConfigInput["remote"]>;
 
 /**
  * Operator terminal surface served to Control UI and mobile clients.
@@ -336,140 +308,35 @@ export type GatewayReloadConfig = {
   mode?: GatewayReloadMode;
 };
 
-export type GatewayHttpChatCompletionsConfig = {
-  /**
-   * If false, the Gateway will not serve `POST /v1/chat/completions`.
-   * Default: false when absent.
-   */
-  enabled?: boolean;
-  /** Image input controls for `image_url` parts. */
-  images?: GatewayHttpChatCompletionsImagesConfig;
-};
+type GatewayHttpConfigInput = NonNullable<GatewayConfigInput["http"]>;
+type GatewayHttpEndpointsConfigInput = NonNullable<GatewayHttpConfigInput["endpoints"]>;
 
-export type GatewayHttpChatCompletionsImagesConfig = {
-  /** Allow URL fetches for `image_url` parts. Default: false. */
-  allowUrl?: boolean;
-  /**
-   * Optional hostname allowlist for URL fetches.
-   * Supports exact hosts and `*.example.com` wildcards.
-   */
-  urlAllowlist?: string[];
-  /** Allowed MIME types (case-insensitive). */
-  allowedMimes?: string[];
-  /** Max bytes per image. Default: 10MB. */
-  maxBytes?: number;
-  /** Max redirects when fetching a URL. Default: 3. */
-  maxRedirects?: number;
-  /** Fetch timeout in ms. Default: 10s. */
-  timeoutMs?: number;
-};
+export type GatewayHttpChatCompletionsConfig = NonNullable<
+  GatewayHttpEndpointsConfigInput["chatCompletions"]
+>;
+export type GatewayHttpChatCompletionsImagesConfig = NonNullable<
+  GatewayHttpChatCompletionsConfig["images"]
+>;
 
-export type GatewayHttpResponsesConfig = {
-  /**
-   * If false, the Gateway will not serve `POST /v1/responses` (OpenResponses API).
-   * Default: false when absent.
-   */
-  enabled?: boolean;
-  /**
-   * Max number of URL-based `input_file` + `input_image` parts per request.
-   * Default: 8.
-   */
-  maxUrlParts?: number;
-  /** File inputs (input_file). */
-  files?: GatewayHttpResponsesFilesConfig;
-  /** Image inputs (input_image). */
-  images?: GatewayHttpResponsesImagesConfig;
-};
+export type GatewayHttpResponsesConfig = NonNullable<GatewayHttpEndpointsConfigInput["responses"]>;
 
-export type GatewayHttpResponsesFilesConfig = {
-  /** Allow URL fetches for input_file. Default: true. */
-  allowUrl?: boolean;
-  /**
-   * Optional hostname allowlist for URL fetches.
-   * Supports exact hosts and `*.example.com` wildcards.
-   */
-  urlAllowlist?: string[];
-  /** Allowed MIME types (case-insensitive). */
-  allowedMimes?: string[];
-  /** Max bytes per file. Default: 5MB. */
-  maxBytes?: number;
-  /** Max decoded characters per file. Default: 200k. */
-  maxChars?: number;
-  /** Max redirects when fetching a URL. Default: 3. */
-  maxRedirects?: number;
-  /** Fetch timeout in ms. Default: 10s. */
-  timeoutMs?: number;
-  /** PDF handling (application/pdf). */
-  pdf?: GatewayHttpResponsesPdfConfig;
-};
+export type GatewayHttpResponsesFilesConfig = NonNullable<GatewayHttpResponsesConfig["files"]>;
 
-export type GatewayHttpResponsesPdfConfig = {
-  /** Max pages to parse/render. Default: 4. */
-  maxPages?: number;
-  /** Max pixels per rendered page. Default: 4M. */
-  maxPixels?: number;
-  /** Minimum extracted text length to skip rasterization. Default: 200 chars. */
-  minTextChars?: number;
-};
+export type GatewayHttpResponsesPdfConfig = NonNullable<GatewayHttpResponsesFilesConfig["pdf"]>;
 
-export type GatewayHttpResponsesImagesConfig = {
-  /** Allow URL fetches for input_image. Default: true. */
-  allowUrl?: boolean;
-  /**
-   * Optional hostname allowlist for URL fetches.
-   * Supports exact hosts and `*.example.com` wildcards.
-   */
-  urlAllowlist?: string[];
-  /** Allowed MIME types (case-insensitive). */
-  allowedMimes?: string[];
-  /** Max bytes per image. Default: 10MB. */
-  maxBytes?: number;
-  /** Max redirects when fetching a URL. Default: 3. */
-  maxRedirects?: number;
-  /** Fetch timeout in ms. Default: 10s. */
-  timeoutMs?: number;
-};
+export type GatewayHttpResponsesImagesConfig = NonNullable<GatewayHttpResponsesConfig["images"]>;
 
-export type GatewayHttpEndpointsConfig = {
-  /** OpenAI-compatible chat completions endpoint controls. */
-  chatCompletions?: GatewayHttpChatCompletionsConfig;
-  /** OpenResponses-compatible responses endpoint controls. */
-  responses?: GatewayHttpResponsesConfig;
-};
+export type GatewayHttpEndpointsConfig = GatewayHttpEndpointsConfigInput;
 
-export type GatewayHttpSecurityHeadersConfig = {
-  /**
-   * Value for the Strict-Transport-Security response header.
-   * Set to false to disable explicitly.
-   *
-   * Example: "max-age=31536000; includeSubDomains"
-   */
-  strictTransportSecurity?: string | false;
-};
+export type GatewayHttpSecurityHeadersConfig = NonNullable<
+  GatewayHttpConfigInput["securityHeaders"]
+>;
 
-export type GatewayHttpConfig = {
-  /** Per-endpoint HTTP API controls. */
-  endpoints?: GatewayHttpEndpointsConfig;
-  /** HTTP security header overrides. */
-  securityHeaders?: GatewayHttpSecurityHeadersConfig;
-};
+export type GatewayHttpConfig = GatewayHttpConfigInput;
 
-export type GatewayPushApnsRelayConfig = {
-  /** Base HTTPS URL for the external iOS APNs relay service. */
-  baseUrl?: string;
-  /** Timeout in milliseconds for relay send requests (default: 10000). */
-  timeoutMs?: number;
-};
-
-export type GatewayPushApnsConfig = {
-  /** External APNs relay used by iOS/mobile notification flows. */
-  relay?: GatewayPushApnsRelayConfig;
-};
-
-export type GatewayPushConfig = {
-  /** Apple Push Notification Service settings. */
-  apns?: GatewayPushApnsConfig;
-};
+export type GatewayPushConfig = NonNullable<GatewayConfigInput["push"]>;
+export type GatewayPushApnsConfig = NonNullable<GatewayPushConfig["apns"]>;
+export type GatewayPushApnsRelayConfig = NonNullable<GatewayPushApnsConfig["relay"]>;
 
 export type GatewayNodePairingConfig = {
   /**

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -12,12 +12,12 @@ import {
   TALK_SECRETS_SCOPE,
   WRITE_SCOPE,
 } from "../gateway/operator-scopes.js";
-import { SecretInputSchema } from "./zod-schema.core.js";
 import {
   GatewayRemoteConfigSchema,
   ResponsesEndpointUrlFetchShape,
   validateHttpOrigin,
 } from "./zod-schema.root-support.js";
+import { SecretInputSchema } from "./zod-schema.secret-input.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
 const OperatorScopeSchema = z.enum([

--- a/src/config/zod-schema.root-support.ts
+++ b/src/config/zod-schema.root-support.ts
@@ -1,12 +1,10 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { z } from "zod";
 import { findEdgeAuthIssue } from "../shared/gateway-edge-auth-headers.js";
-import type { ConfigSchemaShape } from "./schema.field-metadata.js";
-import type { GatewayRemoteConfig } from "./types.gateway.js";
-import { SecretInputSchema } from "./zod-schema.core.js";
 import { McpServerSchema } from "./zod-schema.mcp-server.js";
 import { MemorySearchSchema } from "./zod-schema.memory-search.js";
 import { NodeHostAgentRunsSchema, NodeHostWorkerRunsSchema } from "./zod-schema.node-host.js";
+import { SecretInputSchema } from "./zod-schema.secret-input.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
 const EdgeAuthHeadersSchema = z
@@ -38,7 +36,7 @@ const GatewayRemoteSchemaShape = {
   sshTarget: z.string().optional(),
   sshIdentity: z.string().optional(),
   sshHostKeyPolicy: z.union([z.literal("strict"), z.literal("openssh")]).optional(),
-} satisfies ConfigSchemaShape<GatewayRemoteConfig>;
+};
 
 export const GatewayRemoteConfigSchema = z.strictObject(GatewayRemoteSchemaShape).optional();
 


### PR DESCRIPTION
## Summary

- derive bounded Gateway bind, TLS, remote, HTTP, security-header, and APNs authoring contracts from the canonical validator
- retain auth, roles, nodes, reload compatibility, and the top-level Gateway model with their existing owners
- use the existing dependency-safe SecretInput leaf and remove the redundant remote-shape parity assertion

This removes 135 production lines while tightening schema/type ownership at the Gateway IO boundary.

## Validation

- `pnpm check:changed`
- Plugin SDK declaration build
- core production and all test-type shards
- 335 focused Gateway HTTP, OpenResponses, TLS, and APNs tests
- runtime/Madge cycle and dead-export scans

## Compatibility

Public authoring optionality, SecretInput handling, TLS/remote/HTTP/APNs validation, and the deliberately separate resolved/security contracts are unchanged.

Upgrade compatibility is verified by 335 passing Gateway HTTP/OpenResponses/TLS/APNs tests and the unchanged generated config baselines on this exact head. Existing persisted Gateway settings continue through the same validator expressions and SecretInput schema into identical runtime values; auth, roles, nodes, reload compatibility, and migration owners are unchanged.
