### PR TITLE
fix(ci): keep catalog UI recordings opt-in

### DIFF
--- a/ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts
@@ -14,6 +14,7 @@ import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
 } from "../../../test/helpers/openclaw-test-instance.ts";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { pickerValue } from "../test-helpers/select-picker-e2e.ts";
 import {
@@ -21,6 +22,8 @@ import {
   selectAgentFileWorkspace,
 } from "./agent-file-lifecycle.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const captureEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI agent file lifecycle with a real Gateway",
@@ -158,7 +161,7 @@ catalogSuite.define(() => {
           locale: "en-US",
           serviceWorkers: "block",
           viewport: { height: 1000, width: 1440 },
-          recordVideo: { dir: catalogSuite.artifactDir },
+          ...(captureEnabled ? { recordVideo: { dir: catalogSuite.artifactDir } } : {}),
         },
         async ({ page }) => {
           await page.routeWebSocket(`ws://127.0.0.1:${owner.port}/**`, (socket) => {
@@ -240,7 +243,9 @@ catalogSuite.define(() => {
             })
             .toEqual({ primary: "fixture/selected", fallbacks: ["fixture/anchor"] });
           const writesBeforePublication = [...mutations];
-          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "initial.png") });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(catalogSuite.artifactDir, "initial.png") });
+          }
 
           await publish("published");
           await expect
@@ -249,7 +254,9 @@ catalogSuite.define(() => {
           expect(
             await picker.locator('[role="option"][data-value="fixture/retiring"]').count(),
           ).toBe(0);
-          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "published.png") });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(catalogSuite.artifactDir, "published.png") });
+          }
 
           inventoryModel = "inventory-after";
           const refreshed = await owner.cli(refreshInventoryArgs);
@@ -280,9 +287,22 @@ catalogSuite.define(() => {
           for (const release of heldCatalogs) {
             release();
           }
-          await page.screenshot({
-            path: path.join(catalogSuite.artifactDir, "latest-publication.png"),
+          // Fence the released replies on this connection before checking that stale data was ignored.
+          await page.evaluate(async () => {
+            // SAFETY: Gateway readiness above establishes this app's connected runtime.
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime: { context: { gateway: { snapshot: { client: GatewayBrowserClient } } } };
+            };
+            await app.runtime.context.gateway.snapshot.client.request("health", {});
+            await new Promise<void>((resolve) => {
+              requestAnimationFrame(() => resolve());
+            });
           });
+          if (captureEnabled) {
+            await page.screenshot({
+              path: path.join(catalogSuite.artifactDir, "latest-publication.png"),
+            });
+          }
           expect(
             await picker.locator('[role="option"][data-value="ollama/inventory-latest"]').count(),
           ).toBe(1);
@@ -299,7 +319,11 @@ catalogSuite.define(() => {
           expect(
             await picker.locator('[role="option"][data-value="fixture/published"]').count(),
           ).toBe(1);
-          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "read-failure.png") });
+          if (captureEnabled) {
+            await page.screenshot({
+              path: path.join(catalogSuite.artifactDir, "read-failure.png"),
+            });
+          }
 
           rejectCatalog = false;
           await publish("recovered");
@@ -335,7 +359,9 @@ catalogSuite.define(() => {
           commands.push(persisted);
           expect(persisted.code, persisted.stderr).toBe(0);
           expect(JSON.parse(persisted.stdout)).toBe("fixture/anchor");
-          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "recovered.png") });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(catalogSuite.artifactDir, "recovered.png") });
+          }
         },
       );
     } finally {

--- a/ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts
@@ -132,7 +132,7 @@ catalogSuite.define(() => {
           locale: "en-US",
           serviceWorkers: "block",
           viewport: { height: 900, width: 1280 },
-          recordVideo: { dir: catalogSuite.artifactDir },
+          ...(captureEnabled ? { recordVideo: { dir: catalogSuite.artifactDir } } : {}),
         },
         async ({ page }) => {
           await page.routeWebSocket(`ws://127.0.0.1:${owner.port}/**`, (socket) => {
@@ -187,13 +187,17 @@ catalogSuite.define(() => {
           await expect
             .poll(() => picker.locator('[role="option"][data-value="retiring"]').count())
             .toBe(1);
-          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "initial.png") });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(catalogSuite.artifactDir, "initial.png") });
+          }
           await publish("published");
           await expect
             .poll(() => picker.locator('[role="option"][data-value="published"]').count())
             .toBe(1);
           expect(await picker.locator('[role="option"][data-value="retiring"]').count()).toBe(0);
-          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "published.png") });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(catalogSuite.artifactDir, "published.png") });
+          }
 
           rejectCatalogReplies = true;
           await publish("held");
@@ -202,7 +206,11 @@ catalogSuite.define(() => {
           await error.waitFor({ state: "visible" });
           expect(await error.textContent()).toContain("Catalog transport unavailable");
           expect(await picker.locator('[role="option"][data-value="published"]').count()).toBe(1);
-          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "read-failure.png") });
+          if (captureEnabled) {
+            await page.screenshot({
+              path: path.join(catalogSuite.artifactDir, "read-failure.png"),
+            });
+          }
 
           rejectCatalogReplies = false;
           await publish("recovered");
@@ -214,7 +222,9 @@ catalogSuite.define(() => {
           expect(await page.locator("#cron-payload-text").inputValue()).toBe(
             "Do not submit this draft",
           );
-          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "recovered.png") });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(catalogSuite.artifactDir, "recovered.png") });
+          }
         },
       );
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Agents and automation catalog scenarios recorded videos and success screenshots during ordinary CI even when proof capture was disabled.

## Why This Change Was Made

Apply the existing proof-capture opt-in to both catalog scenarios. Their automatic assertion-failure screenshot/JSON capture and unconditional publication/Gateway logs retain their existing ownership and cleanup order. After releasing delayed catalog replies, use a read on the same Gateway connection and a rendered frame before the stale-reply assertions, so optional screenshot latency is not the synchronization mechanism.

## User Impact

Ordinary runs avoid two recordings and nine success screenshots. Explicit proof runs retain their stage filenames, artifact owners, viewports and recording options. This changes test work only; all existing UI assertions, real Gateway operations, persisted CLI readback and test cases remain.

## Evidence

After a fresh canonical CI artifact build at the source base:

- All seven existing real-Gateway cases passed with capture disabled. Their retained directories contained publication/Gateway logs and no success PNGs or videos.
- Both catalog cases passed with capture enabled, producing all nine valid PNGs at the original viewport sizes and two finalized VP8 videos.
- All seven existing failure-capture/readiness helper tests passed with capture disabled.
- Selected type, boundary, format, i18n, dead-export and lint checks passed. The only initial gate failure was the Promise executor's ignored return; a block-bodied executor fixed lint without changing its callback or behavior.
- Independent P2 review of the final diff found no actionable issues. Exact-head CI remains required before landing.

No whole-job timing improvement is claimed from these functional runs. Runtime implementation delta is zero; the test changes remove optional artifact work and make reply ordering explicit.
