### PR TITLE
fix(cli): validate the selected model during config writes

### DIFF
--- a/src/agents/embedded-agent-runner/compact.delegate-resources.test.ts
+++ b/src/agents/embedded-agent-runner/compact.delegate-resources.test.ts
@@ -120,8 +120,7 @@ vi.mock("../prepared-model-runtime.js", async (importOriginal) => {
                   { provider: providerId, modelId: "model", agentId: "main" },
                 ],
               },
-              options?.abortSignal,
-              "static",
+              { abortSignal: options?.abortSignal, catalogMode: "static" },
             );
       try {
         expect(current.registrations.length).toBe(1);

--- a/src/agents/embedded-agent-runner/compact.foreground-resources.test.ts
+++ b/src/agents/embedded-agent-runner/compact.foreground-resources.test.ts
@@ -47,8 +47,7 @@ vi.mock("../prepared-model-runtime.js", async (importOriginal) => {
           loadRuntimePlugins: true,
           runtimePluginSelections: [{ provider, modelId: "model", agentId: "main" }],
         },
-        options?.abortSignal,
-        "static",
+        { abortSignal: options?.abortSignal, catalogMode: "static" },
       );
     },
   };

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -338,11 +338,10 @@ async function runEmbeddedAgentInternal(
         const preparedModelRuntimeLease = await (
           params.preparedModelRuntimeMode === "isolated-read-only"
             ? // Probe homes outlive only the attempt client, not independent live catalog clients.
-              acquireReadOnlyPreparedModelRuntime(
-                preparedInput,
-                laneController.abortSignal,
-                "static",
-              )
+              acquireReadOnlyPreparedModelRuntime(preparedInput, {
+                abortSignal: laneController.abortSignal,
+                catalogMode: "static",
+              })
             : acquireAgentRunPreparedModelRuntime(preparedInput, {
                 retainIdleRunOwner,
                 // Turns need only configured admission facts. Full live model inventory remains

--- a/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
@@ -42,7 +42,10 @@ import {
   getPreparedModelRuntimeBorrowedSnapshot,
   withPreparedModelRuntimePluginGenerationScope,
 } from "../prepared-model-runtime-generation-scope.js";
-import type { PreparedModelRuntimePluginGeneration } from "../prepared-model-runtime.types.js";
+import type {
+  PreparedModelRuntimeLeaseOptions,
+  PreparedModelRuntimePluginGeneration,
+} from "../prepared-model-runtime.types.js";
 import { markCoreTtsAttemptResult } from "../tools/tts-tool-result-provenance.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
@@ -879,7 +882,8 @@ describe("prepared harness source delivery", () => {
       let acquisitionSignal: AbortSignal | undefined;
       mockedAcquireAgentRunPreparedModelRuntime.mockClear();
       mockedAcquireAgentRunPreparedModelRuntime.mockImplementationOnce(
-        async (_input, signal?: AbortSignal) => {
+        async (_input, options?: PreparedModelRuntimeLeaseOptions) => {
+          const signal = options?.abortSignal;
           acquisitionSignal = signal;
           acquisitionStarted.resolve();
           await resumeAcquisition.promise;
@@ -936,8 +940,7 @@ describe("prepared harness source delivery", () => {
         expect(mockedRunEmbeddedAttempt).not.toHaveBeenCalled();
         expect(mockedAcquireAgentRunPreparedModelRuntime).toHaveBeenCalledExactlyOnceWith(
           expect.objectContaining({ config, loadRuntimePlugins: true, workspaceDir }),
-          acquisitionSignal,
-          "static",
+          { abortSignal: acquisitionSignal, catalogMode: "static" },
         );
 
         if (outcome === "complete") {

--- a/src/agents/prepared-model-catalog.resources.test.ts
+++ b/src/agents/prepared-model-catalog.resources.test.ts
@@ -111,7 +111,7 @@ module.exports = {
           let replacement: typeof first;
           let projection: Promise<string[]> | undefined;
           try {
-            first = await acquireReadOnlyPreparedModelRuntime(input, undefined, "static");
+            first = await acquireReadOnlyPreparedModelRuntime(input, { catalogMode: "static" });
             expect(connections).toHaveLength(1);
             const original = expectDefined(connections[0], "original provider registration");
             selectedSource.input = input;
@@ -145,7 +145,9 @@ module.exports = {
             if (!releaseBeforeCallback) {
               first.release();
             }
-            replacement = await acquireReadOnlyPreparedModelRuntime(input, undefined, "static");
+            replacement = await acquireReadOnlyPreparedModelRuntime(input, {
+              catalogMode: "static",
+            });
             expect(connections).toHaveLength(2);
             const successor = expectDefined(connections[1], "replacement provider registration");
             expect(original.database.isOpen).toBe(true);

--- a/src/agents/prepared-model-runtime.cancelled-admission.test.ts
+++ b/src/agents/prepared-model-runtime.cancelled-admission.test.ts
@@ -79,7 +79,10 @@ const coldAdmissionCases: Array<{
   {
     name: "ephemeral",
     acquire: async (input, signal) =>
-      await acquireReadOnlyPreparedModelRuntime(input, signal, "static"),
+      await acquireReadOnlyPreparedModelRuntime(input, {
+        abortSignal: signal,
+        catalogMode: "static",
+      }),
   },
 ];
 

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -190,8 +190,7 @@ describe("prepared model runtime owner selection", () => {
           workspaceDir: state.workspaceDir,
           loadRuntimePlugins: true,
         },
-        undefined,
-        catalogMode,
+        { catalogMode },
       );
       try {
         expect(lease.snapshot.modelCatalog.entries.map(({ id }) => id)).toEqual(

--- a/src/agents/prepared-model-runtime.published-resources.test.ts
+++ b/src/agents/prepared-model-runtime.published-resources.test.ts
@@ -218,7 +218,7 @@ module.exports = {
           const cancellationReason = new Error("BTW parent closed");
           let sideQuestion: ReturnType<typeof runBtwSideQuestion> | undefined;
           try {
-            first = await acquireReadOnlyPreparedModelRuntime(input, undefined, "static");
+            first = await acquireReadOnlyPreparedModelRuntime(input, { catalogMode: "static" });
             expect(connections).toHaveLength(1);
             const original = expectDefined(connections[0], "original provider registration");
             if (mode === "published borrow") {
@@ -280,7 +280,9 @@ module.exports = {
               first.release();
             }
             expect(original.database.isOpen).toBe(true);
-            replacement = await acquireReadOnlyPreparedModelRuntime(input, undefined, "static");
+            replacement = await acquireReadOnlyPreparedModelRuntime(input, {
+              catalogMode: "static",
+            });
             expect(connections).toHaveLength(2);
             const successor = expectDefined(connections[1], "replacement provider registration");
             expect(original.database.prepare("SELECT value FROM answer").get()?.value).toBe(42);

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -62,10 +62,7 @@ import {
 } from "./prepared-model-runtime.refresh-scope.js";
 import { closeEphemeralPreparedModelRuntimeResources } from "./prepared-model-runtime.resources.js";
 import { PreparedModelRuntimeOwnerRetention } from "./prepared-model-runtime.retention.js";
-import type {
-  PreparedModelRuntimeCatalogMode,
-  PreparedModelRuntimeLeaseOptions,
-} from "./prepared-model-runtime.types.js";
+import type { PreparedModelRuntimeLeaseOptions } from "./prepared-model-runtime.types.js";
 import { PreparedReplyDispatchPublicationOwner } from "./prepared-reply-dispatch-runtime.js";
 export {
   PreparedModelRuntimeOwnerNotPublishedError,
@@ -395,14 +392,13 @@ export async function acquireAgentRunPreparedModelRuntime(
 /** Acquires an exact read-only generation scoped to the returned lease. */
 export async function acquireReadOnlyPreparedModelRuntime(
   rawInput: PreparedModelRuntimeInput,
-  abortSignal?: AbortSignal,
-  catalogMode: PreparedModelRuntimeCatalogMode = "live",
+  options: PreparedModelRuntimeLeaseOptions = {},
 ): Promise<PreparedModelRuntimeLease> {
   return await acquirePreparedModelRuntimeLeaseFromOwners(
     { ...rawInput, readOnly: true },
     "ephemeral",
     preparedModelRuntimeLeaseContext,
-    { abortSignal, catalogMode },
+    { ...options, catalogMode: options.catalogMode ?? "live" },
   );
 }
 

--- a/src/agents/tools-effective-inventory.cold-provider.test.ts
+++ b/src/agents/tools-effective-inventory.cold-provider.test.ts
@@ -599,7 +599,7 @@ describe("cold dynamic-model effective inventory", () => {
       expect(fixture.connections).toHaveLength(1);
       const rootConnection = fixture.connections[0]!;
       const controller = new AbortController();
-      const first = acquireReadOnlyPreparedModelRuntime(input, controller.signal);
+      const first = acquireReadOnlyPreparedModelRuntime(input, { abortSignal: controller.signal });
       let replacement: Awaited<ReturnType<typeof acquireReadOnlyPreparedModelRuntime>> | undefined;
       let pendingReplacement: ReturnType<typeof acquireReadOnlyPreparedModelRuntime> | undefined;
       try {

--- a/src/agents/tools/pdf-tool.resources.test.ts
+++ b/src/agents/tools/pdf-tool.resources.test.ts
@@ -223,8 +223,7 @@ module.exports = { id: ${JSON.stringify(id)}, register(api) {
                 skipCredentials: true,
                 runtimePluginSelections: [{ provider: id, modelId: "pdf-model" }],
               },
-              undefined,
-              "static",
+              { catalogMode: "static" },
             );
             try {
               await test();

--- a/src/cli/config-model-validation.runtime.test.ts
+++ b/src/cli/config-model-validation.runtime.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveModelAsync } from "../agents/embedded-agent-runner/model.js";
 import {
   acquireReadOnlyPreparedModelRuntime,
@@ -35,7 +36,13 @@ async function withProviderFixtures(
     config: OpenClawConfig;
     state: OpenClawTestState;
     imported: (provider: string) => boolean;
+    resolved: (provider: string) => unknown;
   }) => Promise<void>,
+  options: {
+    aliases?: Record<string, string>;
+    runtimeAliases?: Record<string, string>;
+    provider?: string;
+  } = {},
 ) {
   await withOpenClawTestState(
     {
@@ -47,12 +54,36 @@ async function withProviderFixtures(
     },
     async (state) => {
       const imported = (provider: string) => fs.existsSync(state.path(`${provider}.imported`));
-      const plugins = providerIds.map((id) => {
+      const resolved = (provider: string): unknown => {
+        const file = state.path(`${provider}.resolved`);
+        return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, "utf8")) : undefined;
+      };
+      const normalizationProvider = options.provider ?? "pin-alpha";
+      const fixtureProviderIds = [normalizationProvider, "pin-beta", "pin-unrelated"];
+      const plugins = fixtureProviderIds.map((id) => {
+        const modelContexts =
+          id === normalizationProvider && (options.aliases || options.runtimeAliases)
+            ? {
+                "exact-supported": 65536,
+                middle: 32000,
+                final: 4096,
+                ...(options.runtimeAliases
+                  ? {
+                      entry: 12000,
+                      "runtime-selected": 48000,
+                      "middle-runtime": 64000,
+                      "final-runtime": 96000,
+                    }
+                  : {}),
+              }
+            : { "exact-supported": 32000 };
         const plugin = writePlugin({
           id,
           dir: state.path("plugins", id),
           body: `
 const fs = require("node:fs");
+const modelContexts = ${JSON.stringify(modelContexts)};
+const runtimeAliases = ${JSON.stringify(id === normalizationProvider ? options.runtimeAliases : undefined)};
 fs.writeFileSync(${JSON.stringify(state.path(`${id}.imported`))}, "loaded");
 module.exports = {
   id: ${JSON.stringify(id)},
@@ -61,11 +92,19 @@ module.exports = {
       id: ${JSON.stringify(id)},
       label: ${JSON.stringify(id)},
       auth: [],
+      ...(runtimeAliases ? { normalizeModelId({ modelId }) { return runtimeAliases[modelId]; } } : {}),
+      normalizeResolvedModel({ model }) {
+        fs.writeFileSync(${JSON.stringify(state.path(`${id}.resolved`))}, JSON.stringify({
+          provider: model.provider, id: model.id, contextWindow: model.contextWindow,
+        }));
+        return model;
+      },
       resolveDynamicModel({ modelId }) {
         if (modelId === "resolution-error") {
           throw new Error("fixture dynamic resolution failed");
         }
-        if (modelId !== "exact-supported") return undefined;
+        const contextWindow = modelContexts[modelId];
+        if (contextWindow === undefined) return undefined;
         return {
           id: modelId,
           name: modelId,
@@ -74,7 +113,7 @@ module.exports = {
           baseUrl: "https://provider.invalid/v1",
           reasoning: false,
           input: ["text"],
-          contextWindow: 32000,
+          contextWindow,
           maxTokens: 4096,
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         };
@@ -90,6 +129,9 @@ module.exports = {
             configSchema: { type: "object", additionalProperties: false, properties: {} },
             providers: [id],
             modelCatalog: { providers: { [id]: { models: [{ id: "catalog-model" }] } } },
+            ...(id === normalizationProvider && options.aliases
+              ? { modelIdNormalization: { providers: { [id]: { aliases: options.aliases } } } }
+              : {}),
           }),
         );
         return plugin;
@@ -100,13 +142,13 @@ module.exports = {
           entries: { main: { default: true } },
         },
         plugins: {
-          allow: [...providerIds],
+          allow: fixtureProviderIds,
           load: { paths: plugins.map((plugin) => plugin.file) },
-          entries: Object.fromEntries(providerIds.map((id) => [id, { enabled: true }])),
+          entries: Object.fromEntries(fixtureProviderIds.map((id) => [id, { enabled: true }])),
         },
       };
       try {
-        await run({ config, state, imported });
+        await run({ config, state, imported, resolved });
       } finally {
         await clearRuntimeState();
       }
@@ -132,6 +174,126 @@ describe("config model validation with provider runtime", () => {
   });
 
   afterAll(cleanupPluginLoaderFixturesForTest);
+
+  it.each(
+    (["primary", "fallback"] as const).flatMap((kind) =>
+      [
+        { input: "entry", expected: "middle", contextWindow: 32000 },
+        { input: "middle", expected: "final", contextWindow: 4096 },
+        { input: "exact-supported", expected: "exact-supported", contextWindow: 65536 },
+      ].map((model) => Object.assign({ kind }, model)),
+    ),
+  )(
+    "materializes cold $kind input $input exactly once",
+    async ({ kind, input, expected, contextWindow }) => {
+      await withProviderFixtures(
+        async ({ config, imported, resolved }) => {
+          const value = `pin-alpha/${input}`;
+          config.agents!.defaults!.model =
+            kind === "primary" ? { primary: value } : { primary, fallbacks: [value] };
+          const original = structuredClone(config);
+          expect(providerIds.some(imported)).toBe(false);
+
+          const result = await checkTouchedTextModelRefs({
+            config,
+            touchedPaths: [
+              ["agents", "defaults", "model", kind === "primary" ? "primary" : "fallbacks"],
+            ],
+          });
+
+          expect(result).toEqual({ refsChecked: 1, refsTotal: 1, errors: [] });
+          expect(resolved("pin-alpha")).toEqual({
+            provider: "pin-alpha",
+            id: expected,
+            contextWindow,
+          });
+          expect(config).toEqual(original);
+          expect(imported("pin-unrelated")).toBe(false);
+        },
+        { aliases: { entry: "middle", middle: "final" } },
+      );
+    },
+  );
+
+  it.each(
+    (["primary", "fallback"] as const).flatMap((kind) =>
+      [
+        { ambient: "matching", mixed: false, expected: "runtime-selected", contextWindow: 48000 },
+        { ambient: "matching", mixed: true, expected: "middle-runtime", contextWindow: 64000 },
+        { ambient: "foreign", mixed: false, expected: "entry", contextWindow: 12000 },
+        { ambient: "foreign", mixed: true, expected: "middle", contextWindow: 32000 },
+      ].map((mode) => Object.assign({ kind }, mode)),
+    ),
+  )(
+    "applies manifest normalization before runtime hooks for $kind ($ambient, mixed: $mixed)",
+    async ({ kind, ambient, mixed, expected, contextWindow }) => {
+      await withProviderFixtures(
+        async ({ config, state, imported, resolved }) => {
+          config.agents!.defaults!.model =
+            kind === "primary"
+              ? { primary: "pin-alpha/entry" }
+              : { primary, fallbacks: ["pin-alpha/entry"] };
+          const original = structuredClone(config);
+          const ambientConfig = structuredClone(config);
+          if (ambient === "foreign") {
+            ambientConfig.plugins!.entries!["pin-alpha"] = { enabled: false };
+          }
+          loadOpenClawPlugins({
+            config: ambientConfig,
+            workspaceDir: state.workspaceDir,
+            onlyPluginIds: [ambient === "matching" ? "pin-alpha" : "pin-beta"],
+            activate: true,
+          });
+
+          const result = await checkTouchedTextModelRefs({
+            config,
+            touchedPaths: [
+              ["agents", "defaults", "model", kind === "primary" ? "primary" : "fallbacks"],
+            ],
+          });
+
+          expect(result).toEqual({ refsChecked: 1, refsTotal: 1, errors: [] });
+          expect(resolved("pin-alpha")).toEqual({
+            provider: "pin-alpha",
+            id: expected,
+            contextWindow,
+          });
+          expect(config).toEqual(original);
+          expect(imported("pin-unrelated")).toBe(false);
+        },
+        {
+          ...(mixed ? { aliases: { entry: "middle", middle: "final" } } : {}),
+          runtimeAliases: {
+            entry: "runtime-selected",
+            middle: "middle-runtime",
+            final: "final-runtime",
+          },
+        },
+      );
+    },
+  );
+
+  it("normalizes an unqualified primary through the default provider before validation", async () => {
+    await withProviderFixtures(
+      async ({ config, resolved, imported }) => {
+        config.agents!.defaults!.model = { primary: "entry" };
+        const original = structuredClone(config);
+        const result = await checkTouchedTextModelRefs({
+          config,
+          touchedPaths: [["agents", "defaults", "model", "primary"]],
+        });
+        expect(result).toEqual({ refsChecked: 1, refsTotal: 1, errors: [] });
+        expect(resolved(DEFAULT_PROVIDER)).toEqual({
+          provider: DEFAULT_PROVIDER,
+          id: "middle",
+          contextWindow: 32000,
+        });
+        expect(config).toEqual(original);
+        expect(imported("pin-unrelated")).toBe(false);
+      },
+      { provider: DEFAULT_PROVIDER, aliases: { entry: "middle", middle: "final" } },
+    );
+  });
 
   it("resolves an uncataloged fixture pin when its provider runtime is prepared", async () => {
     await withProviderFixtures(async ({ config, state, imported }) => {

--- a/src/cli/config-model-validation.ts
+++ b/src/cli/config-model-validation.ts
@@ -8,6 +8,7 @@ import {
 } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
+import type { ModelManifestNormalizationContext } from "../agents/model-ref-shared.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection-config.js";
 import {
   buildModelAliasIndex,
@@ -254,6 +255,7 @@ function collectTouchedTextModelRefs(params: {
 function resolveCanonicalPrimaryRef(
   config: OpenClawConfig,
   value: string,
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"],
 ): { provider: string; model: string } | undefined {
   const validationConfig: OpenClawConfig = {
     ...config,
@@ -270,12 +272,17 @@ function resolveCanonicalPrimaryRef(
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: "",
     allowPluginNormalization: true,
+    manifestPlugins,
   });
   return resolved.model ? resolved : undefined;
 }
 
-function resolveFallbackRef(config: OpenClawConfig, value: string) {
-  const defaultProvider = resolveDefaultModelForAgent({ cfg: config }).provider;
+function resolveFallbackRef(
+  config: OpenClawConfig,
+  value: string,
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"],
+) {
+  const defaultProvider = resolveDefaultModelForAgent({ cfg: config, manifestPlugins }).provider;
   return resolveModelRefFromString({
     cfg: config,
     raw: value,
@@ -284,16 +291,19 @@ function resolveFallbackRef(config: OpenClawConfig, value: string) {
       cfg: config,
       defaultProvider,
       allowPluginNormalization: true,
+      manifestPlugins,
     }),
     allowPluginNormalization: true,
+    manifestPlugins,
   });
 }
 
 function resolveCanonicalFallbackRef(
   config: OpenClawConfig,
   value: string,
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"],
 ): { provider: string; model: string } | undefined {
-  return resolveFallbackRef(config, value)?.ref;
+  return resolveFallbackRef(config, value, manifestPlugins)?.ref;
 }
 
 function hasUnresolvedInheritedFallbackProvider(
@@ -411,15 +421,13 @@ async function createRuntimeModelRefResolver(): Promise<ConfigModelRefResolver> 
     ]));
 
   return async ({ config, ref }) => {
-    const resolvedRef = ref.fallback
-      ? resolveCanonicalFallbackRef(config, ref.value)
-      : resolveCanonicalPrimaryRef(config, ref.value);
+    const resolveRef = ref.fallback ? resolveCanonicalFallbackRef : resolveCanonicalPrimaryRef;
+    let resolvedRef = resolveRef(config, ref.value);
     if (!resolvedRef) {
       return `Unknown model: ${ref.value}`;
     }
-    const { provider, model } = resolvedRef;
     // CLI backends validate their own ids and do not require a roster-owned catalog.
-    if (modelSelection.isCliProvider(provider, config)) {
+    if (modelSelection.isCliProvider(resolvedRef.provider, config)) {
       return undefined;
     }
     const targetAgentId =
@@ -431,18 +439,34 @@ async function createRuntimeModelRefResolver(): Promise<ConfigModelRefResolver> 
     const [modelRuntime, preparedRuntime] = await loadModelModules();
 
     // Exact pins need provider hooks in their generation; a catalog-only snapshot cannot load them.
-    const lease = await preparedRuntime.acquireReadOnlyPreparedModelRuntime({
-      agentId: targetAgentId,
-      agentDir,
-      config,
-      workspaceDir,
-      loadRuntimePlugins: true,
-      runtimePluginSelections: [{ provider, modelId: model, agentId: targetAgentId }],
-    });
+    const lease = await preparedRuntime.acquireReadOnlyPreparedModelRuntime(
+      {
+        agentId: targetAgentId,
+        agentDir,
+        config,
+        workspaceDir,
+        loadRuntimePlugins: true,
+      },
+      {
+        deriveRuntimePluginSelections: ({ config: admittedConfig, metadataSnapshot }) => {
+          resolvedRef = resolveRef(admittedConfig, ref.value, metadataSnapshot);
+          if (!resolvedRef) {
+            return [];
+          }
+          const { provider, model } = resolvedRef;
+          return [{ provider, modelId: model, agentId: targetAgentId }];
+        },
+      },
+    );
     try {
+      if (!resolvedRef) {
+        return `Unknown model: ${ref.value}`;
+      }
+      const { provider, model } = resolvedRef;
       const stores = lease.snapshot.createStores();
       const resolution = await modelRuntime.resolveModelAsync(provider, model, agentDir, config, {
         ...stores,
+        modelIdSource: "selected",
         agentId: targetAgentId,
         allowBundledStaticCatalogFallback: true,
         ...(ref.authProfileId ? { authProfileId: ref.authProfileId } : {}),

--- a/src/media-understanding/image.resources.test.ts
+++ b/src/media-understanding/image.resources.test.ts
@@ -261,8 +261,7 @@ function acquireFixtureRuntime(fixture: ReturnType<typeof nativeImageFixture>, m
       skipCredentials: true,
       runtimePluginSelections: [{ provider: fixture.id, modelId }],
     },
-    undefined,
-    "static",
+    { catalogMode: "static" },
   );
 }
 

--- a/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
+++ b/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
@@ -430,11 +430,10 @@ it.each([
             vi
               .spyOn(preparedRuntimes, "acquireAgentRunPreparedModelRuntime")
               .mockImplementation((runtimeInput, options) =>
-                preparedRuntimes.acquireReadOnlyPreparedModelRuntime(
-                  runtimeInput,
-                  options?.abortSignal,
-                  options?.catalogMode ?? "static",
-                ),
+                preparedRuntimes.acquireReadOnlyPreparedModelRuntime(runtimeInput, {
+                  abortSignal: options?.abortSignal,
+                  catalogMode: options?.catalogMode ?? "static",
+                }),
               ),
           );
           Object.defineProperty(globalThis, setupKey, {

--- a/src/tts/tts-summary.resources.test.ts
+++ b/src/tts/tts-summary.resources.test.ts
@@ -256,8 +256,7 @@ module.exports = { id: ${JSON.stringify(id)}, register(api) {
                 skipCredentials: true,
                 runtimePluginSelections: [{ provider: id, modelId: "summary-model" }],
               },
-              undefined,
-              "static",
+              { catalogMode: "static" },
             );
             acquire = vi
               .spyOn(preparedRuntime, "acquireAgentRunPreparedModelRuntime")


### PR DESCRIPTION
Related: #130706. Builds on #144429.

## What Problem This Solves

Fixes an issue where CLI config validation can resolve an authored model alias twice and validate a different model. With `entry → middle → final`, a cold primary can materialize `final` at 4,096 tokens instead of `middle` at 32,000. A matching warm fallback can call its runtime normalizer before applying the manifest alias.

## Why This Change Was Made

Derive primary and fallback references from metadata captured during read-only runtime admission, then materialize the selected model without another input-alias pass. The existing helpers receive that snapshot explicitly, including bare defaults repaired by #144429. The read-only acquisition facade reuses the existing lease-options contract while preserving ephemeral ownership, live defaults, cancellation and release. Production delta: **+19 lines**.

## User Impact

Config writes validate the intended model while preserving the authored reference. Cold and warm validation use the same static-before-runtime normalization order, and rejected writes leave config bytes unchanged.

## Evidence

Production/runtime validation is bound to `8216e47759774f63abb1f8ff284bce3cbb12417c` against the actual #144429 merge, `cc748884201771eeac74dc6d8cf0c5b758bade76`.

- Matching baseline: three intended failures and 20 passing controls. Candidate: 201 tests across 10 files, full pinned changed-file gate and clean independent P2 review.
- One normal full build passed with natural metadata bound to the committed source.
- All 21 compiled CLI cases passed using 21 ordinary validation commands and 10 fixture installs. Eighteen accepted writes preserved authored refs; three rejected writes left config bytes identical.
- Covered cold aliases/exact IDs, bare defaults, batch enable/disable, native API ownership, runtime-only and foreign controls, and actual warm primary/fallback commands. The matching warm fallback receives `middle` before its runtime hook and materializes `middle-runtime` at 64,000 tokens. Native cases retain configured `pin-customer` while the admitted `ollama` hook runs.
- All 31 children joined without timeout. All 14,639 build outputs and source remained unchanged; 3,387 executed files verified. Successful-case state was removed after exit.

The first compiled matrix passed 19/21 cases but lacked native hook observations because its fixture did not declare the configured logical namespace. That failed attempt remains recorded. The final matrix corrected only external manifest ownership and strengthened namespace assertions; source and build stayed unchanged. This proves compiled CLI/config-write and provider-hook behavior, not hosted vendor inference.

Current test-only follow-up: `7a4d91c8a9a990777de0c1dfa6f8c6efe0d58420`. CI found a missed adapter in an existing isolated-probe fixture: it still treated the new options object as a positional AbortSignal. The fixture now reads `options.abortSignal` and expects the exact `{ abortSignal, catalogMode: "static" }` call, preserving all cancellation, isolation, release and queue-cleanup assertions. The local baseline reproduced all three failures; the correction passed 61 affected/sibling tests, the full changed-file gate and fresh P2 review. Production and package inputs are identical; the original 8216 build and 21-case/31-child compiled proof are explicitly carried after byte verification. No build was repeated or restamped. Fresh CI is required for this updated head.
