### PR TITLE
fix(tasks): reconcile TaskFlows gated on a missing child task

### DIFF
--- a/src/tasks/task-flow-registry.maintenance.test.ts
+++ b/src/tasks/task-flow-registry.maintenance.test.ts
@@ -285,6 +285,182 @@ describe("task-flow-registry maintenance", () => {
     });
   });
 
+  it("reconciles a flow gated on a child task that no longer exists", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const blockedAt = Date.now() - 60 * 60_000;
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Wait on a child task that vanished",
+        status: "running",
+        createdAt: blockedAt,
+        updatedAt: blockedAt,
+      });
+      const blocked = setFlowWaiting({
+        flowId: flow.flowId,
+        expectedRevision: flow.revision,
+        blockedTaskId: "task-vanished",
+        blockedSummary: "Waiting for child task",
+        updatedAt: blockedAt,
+      });
+      expect(blocked.applied).toBe(true);
+      expect(getInspectableTaskFlowAuditSummary().byCode.blocked_task_missing).toBe(1);
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({ reconciled: 1, pruned: 0 });
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({ reconciled: 1, pruned: 0 });
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        status: "lost",
+        blockedTaskId: undefined,
+        blockedSummary: undefined,
+      });
+      expect(getTaskFlowById(flow.flowId)?.endedAt).toBeTypeOf("number");
+      expect(getInspectableTaskFlowAuditSummary().byCode.blocked_task_missing).toBe(0);
+    });
+  });
+
+  it("keeps flows blocked on an existing child task or inside the dangling grace window", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const staleAt = Date.now() - 60 * 60_000;
+      const linkedFlow = createManagedTaskFlow({
+        ownerKey: "agent:main:linked",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Wait on a live child task",
+        status: "running",
+        createdAt: staleAt,
+        updatedAt: staleAt,
+      });
+      const child = createRunningTaskRun({
+        runtime: "acp",
+        ownerKey: "agent:main:linked",
+        scopeKind: "session",
+        parentFlowId: linkedFlow.flowId,
+        childSessionKey: "agent:main:linked:child",
+        runId: "run-live-child",
+        task: "Inspect repo",
+        startedAt: staleAt,
+        lastEventAt: staleAt,
+      });
+      expect(
+        setFlowWaiting({
+          flowId: linkedFlow.flowId,
+          expectedRevision: linkedFlow.revision,
+          blockedTaskId: child.taskId,
+          updatedAt: staleAt,
+        }).applied,
+      ).toBe(true);
+
+      const freshFlow = createManagedTaskFlow({
+        ownerKey: "agent:main:fresh",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Wait on a child task registered moments ago",
+        status: "running",
+        createdAt: staleAt,
+        updatedAt: staleAt,
+      });
+      expect(
+        setFlowWaiting({
+          flowId: freshFlow.flowId,
+          expectedRevision: freshFlow.revision,
+          blockedTaskId: "task-pending-registration",
+          updatedAt: Date.now(),
+        }).applied,
+      ).toBe(true);
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({ reconciled: 0, pruned: 0 });
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({ reconciled: 0, pruned: 0 });
+      expect(getTaskFlowById(linkedFlow.flowId)).toMatchObject({
+        status: "blocked",
+        blockedTaskId: child.taskId,
+      });
+      expect(getTaskFlowById(freshFlow.flowId)).toMatchObject({
+        status: "blocked",
+        blockedTaskId: "task-pending-registration",
+      });
+    });
+  });
+
+  it("preserves dangling-blocker flows while a sibling child is still unsettled", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const staleAt = Date.now() - 60 * 60_000;
+      const activeFlow = createManagedTaskFlow({
+        ownerKey: "agent:main:active-sibling",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Missing blocker with a running sibling",
+        status: "running",
+        createdAt: staleAt,
+        updatedAt: staleAt,
+      });
+      createRunningTaskRun({
+        runtime: "acp",
+        ownerKey: "agent:main:active-sibling",
+        scopeKind: "session",
+        parentFlowId: activeFlow.flowId,
+        childSessionKey: "agent:main:active-sibling:child",
+        runId: "run-dangling-active-sibling",
+        task: "Still running",
+        startedAt: staleAt,
+        lastEventAt: staleAt,
+      });
+      expect(
+        setFlowWaiting({
+          flowId: activeFlow.flowId,
+          expectedRevision: activeFlow.revision,
+          blockedTaskId: "task-vanished",
+          blockedSummary: "Waiting for child task",
+          updatedAt: staleAt,
+        }).applied,
+      ).toBe(true);
+
+      const provisionalFlow = createManagedTaskFlow({
+        ownerKey: "agent:main:provisional-sibling",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Missing blocker with a provisional kill sibling",
+        status: "running",
+        createdAt: staleAt,
+        updatedAt: staleAt,
+      });
+      const provisionalChild = createRunningTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:provisional-sibling",
+        scopeKind: "session",
+        parentFlowId: provisionalFlow.flowId,
+        childSessionKey: "agent:main:provisional-sibling:child",
+        runId: "run-dangling-provisional-sibling",
+        task: "Kill racing",
+        startedAt: staleAt,
+        lastEventAt: staleAt,
+      });
+      finalizeTaskRecordByRunId({
+        runId: provisionalChild.runId!,
+        runtime: "subagent",
+        sessionKey: provisionalChild.childSessionKey,
+        status: "cancelled",
+        endedAt: staleAt + 1,
+        error: SUBAGENT_KILL_TASK_ERROR,
+      });
+      expect(
+        setFlowWaiting({
+          flowId: provisionalFlow.flowId,
+          expectedRevision: provisionalFlow.revision,
+          blockedTaskId: "task-vanished",
+          blockedSummary: "Waiting for child task",
+          updatedAt: staleAt,
+        }).applied,
+      ).toBe(true);
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({ reconciled: 0, pruned: 0 });
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({ reconciled: 0, pruned: 0 });
+      expect(getTaskFlowById(activeFlow.flowId)).toMatchObject({
+        status: "blocked",
+        blockedTaskId: "task-vanished",
+      });
+      expect(getTaskFlowById(provisionalFlow.flowId)).toMatchObject({
+        status: "blocked",
+        blockedTaskId: "task-vanished",
+      });
+    });
+  });
+
   it("does not finalize cancel-requested flows while a child task is still active", async () => {
     await withTaskFlowMaintenanceStateDir(async () => {
       const flow = createManagedTaskFlow({

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -1,4 +1,5 @@
 // Reconciles stale task-flow records with their child task state.
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { listTasksForFlowId } from "./runtime-internal.js";
 import { isTaskFlowCancellationPending } from "./task-cancellation-state.js";
 import {
@@ -16,6 +17,14 @@ import {
 import { isTerminalTaskFlow, type TaskFlowRecord } from "./task-flow-registry.types.js";
 
 const TASK_FLOW_RETENTION_MS = 7 * 24 * 60 * 60_000;
+
+// A flow gated on a child task id that no longer exists can never be resumed by
+// its controller, so it stays non-terminal (and an active execution owner)
+// forever. Reconcile that dangling gate, but only once it is clearly stale so a
+// controller that is still registering the blocking task keeps its window.
+const TASK_FLOW_DANGLING_BLOCKER_GRACE_MS = 30 * 60_000;
+
+const log = createSubsystemLogger("tasks/flow-maintenance");
 
 /** Counts task-flow registry maintenance actions without exposing individual records. */
 type TaskFlowRegistryMaintenanceSummary = {
@@ -90,6 +99,60 @@ function finalizeCancelledFlow(flow: TaskFlowRecord, now: number): boolean {
   return false;
 }
 
+// A blocking child id that is no longer linked to the flow can never be resumed
+// by its controller, so the flow would stay gated forever.
+function resolveDanglingBlockedTaskId(flow: TaskFlowRecord, now: number): string | undefined {
+  if (flow.endedAt != null || isTerminalTaskFlow(flow)) {
+    return undefined;
+  }
+  const blockedTaskId = flow.blockedTaskId?.trim();
+  if (!blockedTaskId) {
+    return undefined;
+  }
+  if (now - Math.max(flow.updatedAt, flow.createdAt) < TASK_FLOW_DANGLING_BLOCKER_GRACE_MS) {
+    return undefined;
+  }
+  // ponytail: reuse the shared unsettled-child guard so a missing blocker never
+  // terminalizes a flow whose other children are still queued/running/provisional.
+  if (hasActiveLinkedTasks(flow.flowId)) {
+    return undefined;
+  }
+  return listTasksForFlowId(flow.flowId).some((task) => task.taskId === blockedTaskId)
+    ? undefined
+    : blockedTaskId;
+}
+
+function reconcileDanglingBlockedFlow(
+  flow: TaskFlowRecord,
+  blockedTaskId: string,
+  now: number,
+): boolean {
+  const endedAt = Math.max(now, flow.updatedAt, flow.createdAt);
+  const result = updateFlowRecordByIdExpectedRevision({
+    flowId: flow.flowId,
+    expectedRevision: flow.revision,
+    patch: {
+      status: "lost",
+      blockedTaskId: null,
+      blockedSummary: null,
+      waitJson: null,
+      endedAt,
+      updatedAt: endedAt,
+    },
+  });
+  if (!result.applied) {
+    return false;
+  }
+  log.warn("Reconciled TaskFlow gated on a missing child task", {
+    flowId: flow.flowId,
+    blockedTaskId,
+    ownerKey: flow.ownerKey,
+    controllerId: flow.controllerId,
+    consoleMessage: `TaskFlow ${flow.flowId} was blocked on missing task ${blockedTaskId}; marked lost so its owner is no longer gated.`,
+  });
+  return true;
+}
+
 function shouldRepairTerminalMirroredFlowTimestamp(flow: TaskFlowRecord): boolean {
   if (flow.syncMode !== "task_mirrored" || !isTerminalTaskFlow(flow)) {
     return false;
@@ -141,6 +204,10 @@ export function previewTaskFlowRegistryMaintenance(): TaskFlowRegistryMaintenanc
       reconciled += 1;
       continue;
     }
+    if (resolveDanglingBlockedTaskId(flow, now)) {
+      reconciled += 1;
+      continue;
+    }
     if (shouldPruneFlow(flow, now)) {
       pruned += 1;
     }
@@ -165,6 +232,13 @@ export async function runTaskFlowRegistryMaintenance(): Promise<TaskFlowRegistry
     }
     if (shouldFinalizeCancelledFlow(current)) {
       if (finalizeCancelledFlow(current, now)) {
+        reconciled += 1;
+      }
+      continue;
+    }
+    const danglingBlockedTaskId = resolveDanglingBlockedTaskId(current, now);
+    if (danglingBlockedTaskId) {
+      if (reconcileDanglingBlockedFlow(current, danglingBlockedTaskId, now)) {
         reconciled += 1;
       }
       continue;


### PR DESCRIPTION
## What Problem This Solves

Issue #143739 reports an agent that intermittently stops replying on WhatsApp: inbound messages are received but no reply is ever sent. `openclaw doctor` reported four blocked TaskFlows, each one pointing at a child task id that no longer exists, and the only recovery the reporter found was the manual `openclaw tasks flow cancel <id>`.

A managed flow enters `blocked` when its controller gates it on a child task (`setFlowWaiting({ blockedTaskId, ... })`, `src/tasks/task-flow-registry.ts:524-552`). Managed `blocked` is deliberately non-terminal while the controller waits (`src/tasks/task-flow-registry.types.ts:68-78`), which means:

- it is never pruned, because pruning requires a terminal flow (`src/tasks/task-flow-registry.maintenance.ts:43-51`);
- it keeps counting as an active execution owner (`isFlowExecutionOwnerActive`, `src/tasks/task-flow-registry.store.sqlite.ts:75-92`), and that binding is only dropped when the flow ends or its record is deleted (`:307`);
- nothing in core can resume it: clearing the gate belongs to the controller, and the child task that would have signalled it is gone.

Detection already existed, repair did not. `blocked_task_missing` is raised by the flow audit (`src/tasks/task-flow-registry.audit.ts:234-247`) and surfaced by doctor as *"blocked TaskFlow points at missing task ...; inspect before retrying"* (`src/commands/doctor-workspace-status.ts:68-78`), whose fixHint is limited to manual `tasks flow show` / `tasks flow cancel` (`:211-215`). The automated repair path — `openclaw tasks maintenance --apply` and the gateway's 60s sweep (`src/gateway/server-startup-early.ts:115` -> `startScheduledSweep` -> `runTaskFlowRegistryMaintenance`, `src/tasks/task-registry.maintenance.ts:1045-1060,1181-1193`) — only repaired terminal mirrored timestamps, finalized cancel-requested flows, and pruned 7-day-old terminal flows. A flow whose blocking child vanished had no path back to a terminal state, so it stayed wedged indefinitely and every consumer still waiting on that flow stayed gated.

The reporter's own recovery is the proof that core can resolve this: `cancelFlowById` (`src/tasks/task-executor.ts:483-599`) ends the flow, and ending it is what released the owner.

This change teaches the existing reconcile pass the missing rule, in the one place every repair caller routes through:

- `resolveDanglingBlockedTaskId` identifies a non-terminal flow whose `blockedTaskId` is no longer linked to any task. Two guards keep it conservative: the gate must be at least 30 minutes stale (`TASK_FLOW_DANGLING_BLOCKER_GRACE_MS`, matching the audit's own stale-blocked horizon) so a controller that is still registering its blocking task is not preempted, and a linked task with that id is left untouched.
- `reconcileDanglingBlockedFlow` finalizes it as `lost` with the blocker and wait state cleared and `endedAt` set, and emits a `tasks/flow-maintenance` warning naming the flow, the missing task, its owner and controller, so the automatic recovery is observable in the gateway log.

Flow records that are already terminal, already cancelled, or blocked on a live child task are untouched, as is the existing cancel-requested precedence. No new dependency, no CLI or config surface change, and the summary counters keep their existing shape: the new repair is reported through the existing `reconciled` count in `openclaw tasks maintenance` preview/apply output.

## Evidence

- Path A (permanent gate): managed `blocked` is non-terminal by design and is an active execution owner until `ended_at` is set — `src/tasks/task-flow-registry.types.ts:70-78`, `src/tasks/task-flow-registry.store.sqlite.ts:75-92`.
- Path B (no automatic repair): `runTaskFlowRegistryMaintenance` reconciled only mirrored terminal timestamps and cancel-requested flows, then pruned terminal flows — `src/tasks/task-flow-registry.maintenance.ts` (pre-change `:93-177`).
- Path C (report-only diagnostics): audit `blocked_task_missing` at `src/tasks/task-flow-registry.audit.ts:234-247`; doctor finding and manual fixHint at `src/commands/doctor-workspace-status.ts:68-78,203-216`.
- Path D (the reporter's manual recovery works in code): `cancelFlowById` sets `status: "cancelled"` with `endedAt` and nulled blocker — `src/tasks/task-executor.ts:270-293,483-599`.
- Call sites swept for this rule: `runTaskFlowRegistryMaintenance` / `previewTaskFlowRegistryMaintenance` are reached from the gateway sweep (`src/tasks/task-registry.maintenance.ts:1045-1060,1181-1193`), `openclaw tasks maintenance` apply/preview (`src/commands/tasks.ts:545-575`), and nothing else (`git grep` over `src`, `packages`).

## Verification

Local, offline — no channel, gateway process, or provider involved; the tests drive the real registry, audit, and maintenance code over a temporary state dir.

- `node --import ./scripts/tsx.mjs scripts/test-projects.mts src/tasks/task-flow-registry.maintenance.test.ts` -> **12 passed** with the fix, including:
  - `reconciles a flow gated on a child task that no longer exists`: flow blocked on `task-vanished` is reported by the audit (`blocked_task_missing == 1`), maintenance preview/apply both report `{ reconciled: 1, pruned: 0 }`, the flow lands on `status: "lost"` with `endedAt` set and no blocker, and the audit finding drops to 0.
  - `keeps flows blocked on an existing child task or inside the dangling grace window`: a flow blocked on a live child task and a flow whose gate is seconds old both stay `blocked`, with maintenance `{ reconciled: 0, pruned: 0 }`.
- Red first: with the new rule reverted (source stashed, tests kept), the first test failed — `expected { reconciled: 1, pruned: 0 }` vs received `{ reconciled: 0, pruned: 0 }`, `1 failed | 11 passed`.
- Sabotage 1 (existence check removed so any set `blockedTaskId` counts as dangling): the guard test failed at its preview assertion — `expected { reconciled: 0, pruned: 0 }` vs received `{ reconciled: 1, pruned: 0 }`.
- Sabotage 2 (30-minute grace window removed): the same guard test failed the same way, so a freshly registered gate can no longer be torn down early.
- `./node_modules/.bin/oxlint -c .oxlintrc.json src/tasks/task-flow-registry.maintenance.ts src/tasks/task-flow-registry.maintenance.test.ts` -> exit 0, no diagnostics.
- `./node_modules/.bin/oxfmt --check src/tasks/task-flow-registry.maintenance.ts src/tasks/task-flow-registry.maintenance.test.ts` -> exit 0, "All matched files use the correct format."
- Not runnable in this checkout: the repo wrapper `node scripts/run-oxlint.mjs ...` aborts inside `prepare-extension-package-boundary-artifacts` with `Error: Declaration input escapes checkout: D:\code\wt-oc-143262\node_modules\.pnpm\@typescript+native-preview@7.0.0-dev.20260707.2\node_modules\@typescript\native-preview\package.json -> ...`, because this worktree's `node_modules` is junctioned from a sibling checkout and the repo requires declaration dependencies to live physically inside the checkout. Repository lint CI is the authority for the wrapper path.

Expected operator-visible effect: the gateway sweep that runs 5 seconds after startup and then every 60 seconds now ends such a flow once its gate has been stale for 30 minutes, and `openclaw tasks maintenance --apply` does it on demand, so the recovery no longer depends on an operator noticing the doctor hint and cancelling the flow by hand.

Partial fix for #143739.

---

# Evidence: real CLI + real Gateway restart recovery for PR #144475

PR: openclaw/openclaw#144475 — `fix(tasks): reconcile TaskFlows gated on a missing child task`
Head under test: `8ca2e6e07e5d4026cf33f8cad1b62fb27a5b0377` (branch `fix/oc-143739-descr`)
Pre-fix parent of the touched source file: `5501fa9657bfcea6de967b9d3ac461b5ab69e7c4`
Worktree: `D:\code\wt-oc-143739`
Host: Windows 11 (build 26200), Node `v26.4.0`
Run date: 2026-09-13 (UTC), local UTC+08:00

Requirement this evidence answers (ClawSweeper review of #144475):

> supplied evidence exercises the maintenance owner through isolated registry tests, without
> **after-fix CLI or scheduled Gateway recovery in a real setup**. Add redacted output showing
> **persisted-flow recovery and preservation of unaffected flows across restart**.

---

## 1. What is exercised

Source file under test (the only source file the PR changes):

| version | sha256 of `src/tasks/task-flow-registry.maintenance.ts` |
|---|---|
| before (parent `5501fa96…`) | `29f70f79ec5ed6e822e93ee0ff67e37d02de1cd3b9f8687cd54051bdec02d33d` |
| after (head `8ca2e6e0…`) | `b44affeb31d8565a9245f00759c840a1eab9b12b9e48c8fed1627311798c6038` |

Process model — each scenario is a genuine cross-process restart, all state on disk:

1. **Process 1 (controller, exits):** seeds TaskFlow/Task records into an isolated
   `OPENCLAW_STATE_DIR` and dies. Everything is persisted in the real OpenClaw state SQLite
   (`…/state/state/openclaw.sqlite`, table `flow_runs`).
2. **Process 2 (recovery owner):** starts fresh against that persisted state and performs the
   maintenance sweep. Two real entry points are exercised:
   * **real CLI:** `node --import <wt>/scripts/tsx.mjs <wt>/src/entry.ts tasks maintenance --apply --json`
     (`src/entry.ts` is the same entry point as `dist/entry.js`), and
   * **real Gateway:** `openclaw gateway run --allow-unconfigured --port <p>`, whose startup calls
     `startTaskRegistryMaintenance()` (`src/gateway/server-startup-early.ts`) → `startScheduledSweep()`
     → `runTaskFlowRegistryMaintenance()` 5 s after boot and every 60 s (`TASK_SWEEP_INTERVAL_MS`).
3. Every read-back (`dump`, row-level SQLite dump, `openclaw tasks flow list --json`) is again a
   **separate OS process** (distinct PIDs are recorded in the dumps).

Isolated state, real commands — no test doubles, no in-repo test files:

```
OPENCLAW_HOME=<temp>/ocproof-144475/run-<label>/home
OPENCLAW_STATE_DIR=<temp>/ocproof-144475/run-<label>/state
OPENCLAW_NO_RESPAWN=1
```

**Honest scope note:** the four pre-existing records are written by process 1 through the same
registry/runtime API surface a managed-flow controller uses
(`createManagedTaskFlow` / `setFlowWaiting` from `src/tasks/task-flow-runtime-internal.ts`,
`createTaskRecord` from `src/tasks/runtime-internal.ts`) — not through a plugin turn or an agent
session. The *recovery* being reviewed (the code under test) is exercised end-to-end by the real
CLI and the real Gateway process against that persisted state.

### Seeded state (identical in every leg)

| # | goal | syncMode | status before recovery | blocker |
|---|---|---|---|---|
| A | `ocproof: flow gated on a child task that vanished` | managed | `blocked`, `revision 1`, `endedAt null`, `updatedAt` = now − 2 h 30 m | `blockedTaskId=task-ocproof-metadata-export-writeback` — a child task id that **does not exist** (past the 30-minute grace) |
| H1 | `ocproof: healthy in-flight flow (no blocker)` | managed | `running`, fresh, no blocker | — |
| H2 | `ocproof: healthy flow gated on a live child task` | managed | `blocked` (stale) on a child task that **still exists** (`running`, linked) | must keep its gate |
| H3 | `ocproof: healthy flow with a fresh dangling gate (inside grace)` | managed | `blocked` on a missing id, but `updatedAt` = now − 60 s | must be left alone inside the 30-minute grace window |

A is the bug case (a managed `blocked` flow that no controller can ever resume, still counting as an
active execution owner). H1/H2/H3 are the "unaffected flows" that must survive the restart untouched.

## 2. Reproduction

Scripts (outside the repo): `%LOCALAPPDATA%\Temp\ocproof-144475\`
`flows-driver.mts` (seed/dump), `sqlite-dump.mjs` (row-level), `check-preservation.mjs` (assertions),
`run-scenario.sh` (orchestrator, preflights stale processes).

```bash
# after (fix in place)
bash %LOCALAPPDATA%/Temp/ocproof-144475/run-scenario.sh after-cli   cli
bash %LOCALAPPDATA%/Temp/ocproof-144475/run-scenario.sh after-gateway gateway

# before (revert only the PR source file, then the same flows)
cd D:/code/wt-oc-143739
git checkout 5501fa9657bfcea6de967b9d3ac461b5ab69e7c4 -- src/tasks/task-flow-registry.maintenance.ts
bash %LOCALAPPDATA%/Temp/ocproof-144475/run-scenario.sh before-cli   cli
bash %LOCALAPPDATA%/Temp/ocproof-144475/run-scenario.sh before-gateway gateway
git checkout HEAD -- src/tasks/task-flow-registry.maintenance.ts     # restore
git status --porcelain                                               # → empty (verified)
```

---

## 3. After the fix (head `8ca2e6e0…`, sha256 `b44affeb…`)

### 3a. Real CLI recovery — `openclaw tasks maintenance --apply --json` (exit 0)

Entry-level dump, persisted state written by process 1 and read back by process 2 (restart #1):

```
2026-09-13T16:17:34.093Z pid=31012 flowCount=4
A   flowId=ee382c9c-9537-4019-a16b-fc75915089c1 status=blocked revision=1 blockedTaskId=task-ocproof-metadata-export-writeback endedAt=null updatedAt=1789307246857 links=-
H2  flowId=a89e3609-6cf9-4bfa-872d-ba75c56a0c1c status=blocked revision=1 blockedTaskId=294f7545-8c24-48ea-9a3d-5ef6b40a04bb      endedAt=null updatedAt=1789307246857 links=running
H3  flowId=e643ad6a-d8e2-417b-9771-a685a26203ba status=blocked revision=1 blockedTaskId=task-ocproof-fresh-missing-child            endedAt=null updatedAt=1789316186857 links=-
H1  flowId=ae85f6ff-9213-45cf-a5bd-be4425fd066f status=running revision=0 blockedTaskId=null                                       endedAt=null updatedAt=1789316186857 links=-
```

The real CLI command (recovery in the after-fix build):

```
[tasks/flow-maintenance] TaskFlow ee382c9c-9537-4019-a16b-fc75915089c1 was blocked on missing task
task-ocproof-metadata-export-writeback; marked lost so its owner is no longer gated.           (stderr)

mode=apply
maintenance.taskFlows={"reconciled":1,"pruned":0}
auditBefore.taskFlows.byCode={"stale_blocked":2,"blocked_task_missing":2, …}
auditAfter.taskFlows.byCode ={"stale_blocked":1,"blocked_task_missing":1, …}
```

`blocked_task_missing` drops 2 → 1: the stale dangling gate was reconciled; the remaining one is the
deliberately fresh H3 gate that the 30-minute grace must protect.

State after recovery, re-read by another process (restart #2):

```
2026-09-13T16:18:10.319Z pid=31732 flowCount=4
A   status=lost    revision=2 blockedTaskId=null                              endedAt=1789316274115 updatedAt=1789316274115
H2  status=blocked revision=1 blockedTaskId=294f7545-8c24-48ea-9a3d-5ef6b40a04bb endedAt=null updatedAt=1789307246857 links=running
H3  status=blocked revision=1 blockedTaskId=task-ocproof-fresh-missing-child  endedAt=null updatedAt=1789316186857
H1  status=running revision=0 blockedTaskId=null                              endedAt=null updatedAt=1789316186857
```

Row-level dump straight from the persisted SQLite (`SELECT … FROM flow_runs WHERE goal LIKE 'ocproof%'`):

```
flow_id=ee382c9c-… status=lost    revision=2 blocked_task_id=null created_at=1789307246857 updated_at=1789316274115 ended_at=1789316274115 goal="ocproof: flow gated on a child task that vanished"
flow_id=a89e3609-… status=blocked revision=1 blocked_task_id=294f7545-… ended_at=null goal="ocproof: healthy flow gated on a live child task"
flow_id=e643ad6a-… status=blocked revision=1 blocked_task_id=task-ocproof-fresh-missing-child ended_at=null goal="ocproof: healthy flow with a fresh dangling gate (inside grace)"
flow_id=ae85f6ff-… status=running revision=0 blocked_task_id=null ended_at=null goal="ocproof: healthy in-flight flow (no blocker)"
rows=4
```

Assertions (before vs after dump, `check-preservation.mjs`): **RESULT: all checks passed (exit 0)** —
affected flow `blocked`→`lost` with the blocker cleared, and all three healthy flows byte-identical
(`flowId`, `status`, `revision`, `blockedTaskId`, `blockedSummary`, `endedAt`, `createdAt`, `updatedAt`
all equal; link sets equal).

### 3b. Real Gateway scheduled recovery — `openclaw gateway run` (no CLI involved)

Fresh run dir, same seed. The Gateway process alone performed the recovery, from its own startup
sweep, with no maintenance command issued:

```
00:13:55.658 [gateway] starting...
00:14:31.893 [gateway] http server listening (…; 34.6s)
00:14:39.697 [gateway] ready
00:14:39.995 [tasks/flow-maintenance] TaskFlow 3dfaa81d-6969-4d33-9fc1-79b20296f6e0 was blocked on
             missing task task-ocproof-metadata-export-writeback; marked lost so its owner is no longer gated.
```

The polling reader (separate process) saw the affected flow terminal ~30 s after Gateway start
(`affected flow is terminal after ~30s (scheduled Gateway sweep)`), i.e. 0.3 s after the sweep fired.
`[tasks/flow-maintenance]` appears exactly **once** in the whole Gateway log (later 60 s sweeps have
nothing left to do).

Post-recovery state (separate process) and the row-level SQLite dump:

```
A   status=lost    revision=2 blockedTaskId=null                             endedAt=1789316079985
H2  status=blocked revision=1 blockedTaskId=7cb6caba-9965-4dce-9898-e3b82b24db3e updatedAt=1789306997341 links=running
H3  status=blocked revision=1 blockedTaskId=task-ocproof-fresh-missing-child updatedAt=1789315937341
H1  status=running revision=0 blockedTaskId=null                             updatedAt=1789315937341
rows=4 (flow_runs)
```

The Gateway was then left running for further 60 s sweep cycles; the additional dump taken after those
cycles is identical for H1/H2/H3 (`2c-gateway-after-more-sweeps.json`), i.e. healthy flows stay
untouched across repeated sweeps and across process restarts.

Assertions: **RESULT: all checks passed (exit 0)**.

---

## 4. Before the fix (parent source `5501fa96…`, sha256 `29f70f79…`) — same scenario, same state

### 4a. Real CLI (`tasks maintenance --apply --json`, exit 0)

```
mode=apply
maintenance.taskFlows={"reconciled":0,"pruned":0}
auditBefore.taskFlows.byCode={"stale_blocked":2,"blocked_task_missing":2, …}
auditAfter.taskFlows.byCode ={"stale_blocked":2,"blocked_task_missing":2, …}   ← unchanged
stderr: (empty — no maintenance log line)
```

Persisted state after the old CLI ran (separate process):

```
A   status=blocked revision=1 blockedTaskId=task-ocproof-metadata-export-writeback endedAt=null updatedAt=1789306937900
H2  status=blocked revision=1 blockedTaskId=8b48a6f1-0010-49dc-a2de-9a33faec8516  endedAt=null updatedAt=1789306937900 links=running
H3  status=blocked revision=1 blockedTaskId=task-ocproof-fresh-missing-child     endedAt=null updatedAt=1789315877900
H1  status=running revision=0 blockedTaskId=null                                 endedAt=null updatedAt=1789315877900
rows=4 (flow_runs) — identical values to the pre-run dump
```

Assertions: **RESULT: 1 check(s) failed (exit 1)** — the failing check is exactly
`affected flow recovered: marked lost, blocker cleared, endedAt set :: blocked … endedAt=null`; every
healthy-flow check passes. The affected flow is stuck forever, exactly as the PR describes.

### 4b. Real Gateway (old source) — no recovery, ever

```
### [before-gateway] step 3 - real Gateway process start: openclaw gateway run --allow-unconfigured --port 45893
### [before-gateway] gateway recovery: NOT OBSERVED within 200s
00:03:08 [gateway] ready          (old build; no [tasks/flow-maintenance] line in the whole log)
```

Post-run state (separate process) — identical to pre-run, affected flow still gated, `flowCount=4`:

```
A   status=blocked revision=1 blockedTaskId=task-ocproof-metadata-export-writeback endedAt=null updatedAt=1789306304952
H2  status=blocked revision=1 blockedTaskId=7d09f2a9-6c5b-49f3-9aa7-fe569bdde3a9  endedAt=null updatedAt=1789306304952 links=lost*
H3  status=blocked revision=1 blockedTaskId=task-ocproof-fresh-missing-child     endedAt=null updatedAt=1789315244952
H1  status=running revision=0 blockedTaskId=null                                 endedAt=null updatedAt=1789315244952
rows=4 (flow_runs)
```

\* the *linked child task* reached its own terminal state under the task sweep; the **flow record**
(H2) is unchanged, which is what "unaffected" means here — the assertion compares the flow's fields
and its link-id set.

Assertions: **RESULT: 1 check(s) failed (exit 1)** — only the affected-flow recovery check.

---

## 5. Claims

**Verified by this evidence**

1. Against persisted state, the after-fix **real CLI** (`openclaw tasks maintenance --apply --json`)
   reconciles the stale flow gated on a missing child task: `maintenance.taskFlows.reconciled=1`,
   the flow becomes `status=lost`, `blockedTaskId=null`, `endedAt` set, and the subsystem log line
   names the flow and the missing task id.
2. The after-fix **real Gateway** performs the same recovery purely from its scheduled startup sweep
   (no CLI, no RPC), 0.3 s after `[gateway] ready`, logged once via `[tasks/flow-maintenance]`.
3. **Preservation of unaffected flows across restart:** a fresh in-flight flow, a flow gated on a
   live child task, and a flow with a fresh (inside-grace) dangling gate are unchanged — same
   `flowId/status/revision/blockedTaskId/blockedSummary/createdAt/updatedAt/endedAt`, same link-id
   set — in the before/after dumps, in the `flow_runs` rows, and after additional 60 s Gateway sweeps.
4. With the pre-fix source file (only that file reverted), the same CLI and Gateway runs recover
   nothing (`reconciled=0`, `blocked_task_missing` stays 2, no log line) and the affected flow keeps
   its dead gate after a 200 s Gateway run; the assertion suite fails exactly one check (recovery) and
   passes every preservation check.
5. The repository working tree was left clean: `git status --porcelain` is empty after
   `git checkout HEAD -- src/tasks/task-flow-registry.maintenance.ts`.

**Not claimed**

* No plugin-driven or agent-turn-driven flow creation was used; the persisted records were written by
  a separate controller process calling the same registry/runtime API surface (see §1).
* No CI runs, no full test suite, no push, no change to the PR. The PR's own unit tests were not
  re-run here.
* The `@openclaw/…`-level behaviour of `flow list` rendering is not evaluated; `tasks flow list --json`
  is used only as a second, real-CLI read-back.

**Environment notes**

* One transient Node `v8::Fatal … unreachable code` crash occurred in a `tasks flow list --json`
  invocation of an earlier attempt; that whole leg was re-run and is clean (exit 0). Nothing in the
  maintenance path itself crashed in any leg.
* The Gateway emits unrelated startup noise in its state dir (heartbeat/embedded runner); the flow
  registry itself stayed at exactly the 4 seeded flows in all legs (`flowCount=4` in every dump).

## 6. Artifacts

```
%LOCALAPPDATA%\Temp\ocproof-144475\
  flows-driver.mts        seed / dump driver (TS, runs through the worktree tsx loader)
  sqlite-dump.mjs         row-level dump of flow_runs
  check-preservation.mjs  before-vs-after assertions (exit code is the verdict)
  run-scenario.sh         orchestrator: seed → persisted dump → real CLI|Gateway → dump → rows → checks
  summarize.mjs           compact redacted summary of a dump / maintenance JSON
  scenario-after-cli.out      full console log, after-fix CLI leg
  scenario-after-gateway.out  full console log, after-fix Gateway leg
  scenario-before-cli.out     full console log, pre-fix CLI leg
  scenario-before-gateway.out full console log, pre-fix Gateway leg
  run-after-cli\          {1-seed,2-persisted-before,3/5-flow-list,4-cli-maintenance(+stderr),
                          7-after-recovery}.json, 8-sqlite-rows.txt, 6-gateway.log n/a, state\..., home\
  run-after-gateway\      2-persisted-before.json, 2b-gateway-poll-N.json, 2c-gateway-after-more-sweeps.json,
                          6-gateway.log, 7-after-recovery.json, 8-sqlite-rows.txt, state\..., home\
  run-before-cli\         same layout as run-after-cli\
  run-before-gateway\     same layout as run-after-gateway\
```

Raw evidence (unmodified) — the run dumps above carry process PIDs and UTC timestamps per step;
flow ids and task ids are real ids from the isolated state dir, not secrets.

### Re-ran by the author

The preservation checker was re-run by hand on the AFTER gateway run (`run-after-gateway`, `2-persisted-before.json` vs `7-after-recovery.json`): `RESULT: all checks passed` — the affected flow recovered (blocked -> lost, blocker cleared, `endedAt` set) while every healthy flow is field-for-field identical. Before legs end in `FAIL affected flow recovered` (still `blocked`, `endedAt=null`, assertions exit=1). Tree restored, clean.

