### PR TITLE
fix(cli-runner): keep fresh and resumed Claude CLI runs on one session lane

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -822,17 +822,24 @@ describe("resolveCliRunQueueKey", () => {
     ).toBe("claude-cli:session:claude-session-123");
   });
 
-  it("prefers cliSessionId over ownerKey when resuming", () => {
-    expect(
-      resolveCliRunQueueKey({
-        backendId: "claude-cli",
-        serialize: true,
-        runId: "run-2b",
-        workspaceDir: "/tmp/project-a",
-        cliSessionId: "claude-session-123",
-        ownerKey: "abcd1234",
-      }),
-    ).toBe("claude-cli:session:claude-session-123");
+  it("keeps fresh and resumed runs of one Claude CLI session owner on the same lane", () => {
+    const fresh = resolveCliRunQueueKey({
+      backendId: "claude-cli",
+      serialize: true,
+      runId: "run-fresh",
+      workspaceDir: "/tmp/project-a",
+      ownerKey: "abcd1234",
+    });
+    const resumed = resolveCliRunQueueKey({
+      backendId: "claude-cli",
+      serialize: true,
+      runId: "run-resumed",
+      workspaceDir: "/tmp/project-a",
+      cliSessionId: "claude-session-123",
+      ownerKey: "abcd1234",
+    });
+    expect(resumed).toBe("claude-cli:owner:abcd1234");
+    expect(resumed).toBe(fresh);
   });
 
   it("keeps non-Claude backends on the provider lane when serialized", () => {

--- a/src/agents/cli-runner/execute.cli-run-lane.test.ts
+++ b/src/agents/cli-runner/execute.cli-run-lane.test.ts
@@ -1,0 +1,191 @@
+// A fresh (non-resumed) CLI run for a session must not start a second CLI
+// process beside that session's in-flight run. The shared session-owner lane is
+// what makes the new turn queue behind the predecessor (or drop, if its own
+// admission is gone) instead of answering the same conversation context-free.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createProcessAdapterEvents } from "../../process/supervisor/adapters/process-events.js";
+import { createProcessSupervisor } from "../../process/supervisor/supervisor.js";
+import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
+import { executeDeps } from "./execute-deps.js";
+import { executePreparedCliRun as executePreparedCliRunImpl } from "./execute.js";
+import {
+  setCliRunnerExecuteTestDeps,
+  wrapPreparedCliRunWithTestAdmission,
+} from "./execute.test-support.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+const executePreparedCliRun = wrapPreparedCliRunWithTestAdmission(executePreparedCliRunImpl);
+
+// A queued run only observes its turn after the lane releases; the window below
+// is the time a second process would have been spawned under the old keying.
+const LANE_OBSERVATION_MS = 100;
+
+const { createChildAdapterMock } = vi.hoisted(() => ({
+  createChildAdapterMock:
+    vi.fn<typeof import("../../process/supervisor/adapters/child.js").createChildAdapter>(),
+}));
+
+vi.mock("../../process/supervisor/adapters/child.js", () => ({
+  createChildAdapter: createChildAdapterMock,
+}));
+
+type ChildAdapter = Awaited<
+  ReturnType<typeof import("../../process/supervisor/adapters/child.js").createChildAdapter>
+>;
+
+type TestAdapter = ChildAdapter & {
+  emitStdout: (chunk: string) => void;
+  settle: (code: number | null, signal?: NodeJS.Signals | null) => void;
+};
+
+function createTestAdapter(): TestAdapter {
+  const exit = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+  const events = createProcessAdapterEvents();
+  let settled = false;
+  const settle: TestAdapter["settle"] = (code, signal = null) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    events.emitExit(code, signal);
+    exit.resolve({ code, signal });
+  };
+  let stdoutListener: ((chunk: string) => void) | undefined;
+  const adapter: TestAdapter = {
+    pid: 1234,
+    supportsRawOutput: false,
+    onExit: events.onExit,
+    onError: events.onError,
+    onStdout: vi.fn((listener) => {
+      stdoutListener = listener;
+    }),
+    onStderr: vi.fn(),
+    wait: async () => await exit.promise,
+    kill: vi.fn((signal?: NodeJS.Signals) => {
+      settle(null, signal ?? "SIGTERM");
+    }),
+    dispose: vi.fn(() => events.clear()),
+    emitStdout: (chunk) => stdoutListener?.(chunk),
+    settle,
+  };
+  return adapter;
+}
+
+function createRunContext(params: {
+  runId: string;
+  signal?: AbortSignal;
+  assertCurrent?: () => void;
+}): PreparedCliRunContext {
+  const backend = {
+    command: "claude",
+    args: ["-p"],
+    resumeArgs: ["-p", "--resume", "{sessionId}"],
+    output: "text" as const,
+    input: "stdin" as const,
+    serialize: true,
+  };
+
+  return {
+    params: {
+      admittedRunContext: createTestAdmittedRunContext(params.runId),
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      sessionFile: "/tmp/openclaw-cli-lane-test.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hello",
+      provider: "claude-cli",
+      model: "claude-sonnet-5",
+      timeoutMs: 60_000,
+      runId: params.runId,
+      ...(params.signal ? { abortSignal: params.signal } : {}),
+      ...(params.assertCurrent ? { assertCurrent: params.assertCurrent } : {}),
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: "claude-cli",
+      config: backend,
+      bundleMcp: false,
+    },
+    executionTarget: { kind: "process" },
+    preparedBackend: { backend, env: {} },
+    reusableCliSession: { mode: "none" },
+    hadSessionFile: true,
+    contextEngineConfig: {},
+    modelId: "claude-sonnet-5",
+    normalizedModel: "claude-sonnet-5",
+    systemPrompt: "system",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    claudeSkillsPluginArgs: [],
+    authEpochVersion: 2,
+  };
+}
+
+function sleepLaneWindow(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, LANE_OBSERVATION_MS);
+  });
+}
+
+describe("CLI run lane ownership for one session", () => {
+  const restoreProcessSupervisor = executeDeps.getProcessSupervisor;
+  let supervisor: ReturnType<typeof createProcessSupervisor>;
+  let adapters: TestAdapter[];
+
+  beforeEach(() => {
+    createChildAdapterMock.mockReset();
+    adapters = [];
+    createChildAdapterMock.mockImplementation(async () => {
+      const adapter = createTestAdapter();
+      adapters.push(adapter);
+      return adapter;
+    });
+    supervisor = createProcessSupervisor();
+    setCliRunnerExecuteTestDeps({ getProcessSupervisor: () => supervisor });
+  });
+
+  afterEach(() => {
+    setCliRunnerExecuteTestDeps({ getProcessSupervisor: restoreProcessSupervisor });
+    vi.restoreAllMocks();
+  });
+
+  it("queues a fresh run behind the session's in-flight resumed process", async () => {
+    const resumed = executePreparedCliRun(createRunContext({ runId: "resumed-run" }), "resume-1");
+    await vi.waitFor(() => expect(createChildAdapterMock).toHaveBeenCalledTimes(1));
+    adapters[0]!.emitStdout("resumed reply");
+
+    const fresh = executePreparedCliRun(createRunContext({ runId: "fresh-run" }));
+    await sleepLaneWindow();
+    // Observation only; cleanup below must still settle every started process.
+    const processesWhileResumedInFlight = createChildAdapterMock.mock.calls.length;
+
+    adapters[0]!.settle(0);
+    await vi.waitFor(() => expect(adapters.length).toBe(2));
+    adapters[1]!.emitStdout("fresh reply");
+    adapters[1]!.settle(0);
+
+    await expect(resumed).resolves.toMatchObject({ text: "resumed reply" });
+    await expect(fresh).resolves.toMatchObject({ text: "fresh reply" });
+    expect(processesWhileResumedInFlight).toBe(1);
+  });
+
+  it("never spawns a queued fresh run whose own turn is gone", async () => {
+    const controller = new AbortController();
+    const resumed = executePreparedCliRun(createRunContext({ runId: "lane-holder" }), "resume-1");
+    await vi.waitFor(() => expect(createChildAdapterMock).toHaveBeenCalledTimes(1));
+    adapters[0]!.emitStdout("held reply");
+
+    const queued = executePreparedCliRun(
+      createRunContext({ runId: "queued-fresh", signal: controller.signal }),
+    );
+    await sleepLaneWindow();
+    controller.abort();
+    adapters[0]!.settle(0);
+
+    await expect(resumed).resolves.toMatchObject({ text: "held reply" });
+    await expect(queued).rejects.toMatchObject({ name: "AbortError" });
+    expect(adapters).toHaveLength(1);
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -83,12 +83,16 @@ export function resolveCliRunQueueKey(params: {
     return `${params.backendId}:owner:${ownerKey}`;
   }
   if (isClaudeCliBackendId(params.backendId)) {
+    // The conversation owner, not the CLI's own session id, is the lane: a fresh
+    // run for a session (recovery retry, dropped CLI session id) carries no
+    // --resume and would otherwise spawn a second CLI process beside the
+    // session's in-flight run instead of queueing behind it.
+    if (ownerKey) {
+      return `${params.backendId}:owner:${ownerKey}`;
+    }
     const sessionId = params.cliSessionId?.trim();
     if (sessionId) {
       return `${params.backendId}:session:${sessionId}`;
-    }
-    if (ownerKey) {
-      return `${params.backendId}:owner:${ownerKey}`;
     }
     const workspaceDir = params.workspaceDir.trim();
     if (workspaceDir) {

--- a/src/process/supervisor/supervisor.watchdog-tree.real.test.ts
+++ b/src/process/supervisor/supervisor.watchdog-tree.real.test.ts
@@ -1,0 +1,99 @@
+// The no-output watchdog must remove the whole CLI process tree, not just the
+// wrapped root: a surviving `claude -p` child would keep answering the session.
+// A leaked descendant that still holds the inherited pipes must also deliver
+// nothing after settlement.
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { waitForDead } from "../../../test/helpers/process-wait.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { killPidIfAlive, waitForPidFile } from "../../test-utils/process-tree.js";
+import { createProcessSupervisor } from "./supervisor.js";
+
+const WATCHDOG_TEST_TIMEOUT_MS = 60_000;
+const LATE_OUTPUT_OBSERVATION_MS = 400;
+const NO_OUTPUT_TIMEOUT_MS = 1_500;
+
+const activePids = new Set<number>();
+const tempDirs = createTempDirTracker();
+
+afterEach(async () => {
+  for (const pid of activePids) {
+    killPidIfAlive(pid);
+  }
+  await Promise.all([...activePids].map((pid) => waitForDead(pid, 5_000).catch(() => {})));
+  activePids.clear();
+  tempDirs.cleanup();
+});
+
+async function createFakeCli() {
+  const cwd = tempDirs.make("openclaw-watchdog-tree-");
+  const cliPath = path.join(cwd, "fake-cli.cjs");
+  const pidPath = path.join(cwd, "cli.pid");
+  const descendantPidPath = path.join(cwd, "descendant.pid");
+  await writeFile(
+    cliPath,
+    `
+      const { spawn } = require("node:child_process");
+      const { writeFileSync } = require("node:fs");
+      writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
+      // The shipped CLI shape: a subprocess descendant of the root keeps the
+      // conversation alive after the wrapper is signalled, so the watchdog must
+      // remove it through the tree walk, not only the root.
+      const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+        stdio: "ignore",
+      });
+      writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid));
+      process.stdout.write("fake-cli-start\\n");
+      // Silent afterwards: this is what arms the no-output watchdog.
+      setInterval(() => {}, 1_000);
+    `,
+    "utf8",
+  );
+  return { cwd, cliPath, pidPath, descendantPidPath };
+}
+
+describe("supervisor no-output watchdog process tree", () => {
+  it(
+    "terminates the CLI descendant tree and delivers nothing after settlement",
+    async () => {
+      const { cwd, cliPath, pidPath, descendantPidPath } = await createFakeCli();
+      const delivered: string[] = [];
+      const supervisor = createProcessSupervisor();
+      const run = await supervisor.spawn({
+        mode: "child",
+        runId: "watchdog-tree",
+        argv: [process.execPath, cliPath],
+        cwd,
+        noOutputTimeoutMs: NO_OUTPUT_TIMEOUT_MS,
+        timeoutMs: 30_000,
+        captureOutput: false,
+        onStdout: (chunk: string) => delivered.push(chunk.trim()),
+        onStderr: (chunk: string) => delivered.push(chunk.trim()),
+      });
+      if (run.pid !== undefined) {
+        activePids.add(run.pid);
+      }
+      const descendantPid = await waitForPidFile(descendantPidPath, 15_000);
+      activePids.add(descendantPid);
+      expect(await waitForPidFile(pidPath, 15_000)).toBe(run.pid);
+
+      const exit = await run.wait();
+      const settledDelivered = [...delivered];
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, LATE_OUTPUT_OBSERVATION_MS);
+      });
+
+      expect(exit.reason).toBe("no-output-timeout");
+      expect(exit.noOutputTimedOut).toBe(true);
+      await waitForDead(descendantPid, 10_000);
+      if (run.pid !== undefined) {
+        await waitForDead(run.pid, 10_000);
+      }
+      expect(delivered).toEqual(settledDelivered);
+      expect(delivered).toContain("fake-cli-start");
+      await supervisor.shutdown();
+    },
+    WATCHDOG_TEST_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
## What Problem This Helps

A claude-cli turn and the next inbound turn for the *same* session could own two different serialization lanes. `resolveCliRunQueueKey` keyed a resumed run on the CLI session id (`claude-cli:session:<id>`) but a fresh run — a recovery retry, or any turn whose CLI session id is not available yet — on the conversation owner (`claude-cli:owner:<ownerKey>`). Different lanes means no mutual exclusion, so a fresh `claude -p` process without `--resume` can be spawned while the session's previous CLI process is still running, which is the coexistence in #144137's `ps` output (PID 25087, no `--resume`, started 11:17; PID 25213 with `--resume 6faa51d1-...`, started 11:18; both alive). The context-free process answers on the channel while the session's own transcript only carries the resumed conversation, which is the shape of "delivered to the user but absent from `sessions_history`".

The change: for `claude-cli`, the conversation owner is the lane for fresh and resumed runs alike; the CLI session id stays as the fallback when no owner identity exists. A fresh run therefore queues behind the session's in-flight run and re-checks its own admission before spawning, so a turn that was superseded while it waited never starts a CLI process.

- `src/agents/cli-runner/helpers.ts:85-95` — lane resolution (`owner:` now precedes `session:`)
- `src/agents/cli-runner/execute.ts:255-263` — lane inputs (`cliSessionId: useResume ? resolvedSessionId : undefined`); `execute.ts:654` is the `enqueueCliRun` that wraps the process execution
- `src/agents/cli-runner/execute-process.ts:276-294` — the supervisor spawn this lane guards

## Evidence

Windows 11, this worktree. `node scripts/run-oxlint.mjs` cannot run here (junctioned `node_modules` escapes the checkout), so the unwrapped binaries were used for the gates below. The lane test drives the real `executePreparedCliRun`, the real `KeyedAsyncQueue` lane and the real process supervisor, with the child adapter doubled (as the neighbouring `execute.pending-cancellation.test.ts` does).

1. Red, fix reverted at byte level (sha256 checked before/after):

```
node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/cli-runner/execute.cli-run-lane.test.ts
```
```
FAIL ... queues a fresh run behind the session's in-flight resumed process
AssertionError: expected 2 to be 1 // Object.is equality
FAIL ... never spawns a queued fresh run whose own turn is gone
AssertionError: expected [ { pid: 1234, …(10) }, …(1) ] to have a length of 1 but got 2
Tests  2 failed (2)
```

2. Green, fix applied: same command → `Test Files 1 passed (1)`, `Tests 2 passed (2)`.

3. Sabotage of the mechanism itself (`enqueueCliRun` bypassing `KeyedAsyncQueue`) → both lane tests red again (`expected 2 to be 1`, `length of 1 but got 2`); file restored to the byte-identical sha256.

4. Real fake-CLI process probe, `src/process/supervisor/supervisor.watchdog-tree.real.test.ts` (3/3 runs passed): a fake CLI spawns a subprocess descendant, prints one line and then goes silent; the watchdog reports `no-output-timeout`, both the CLI root and its descendant are gone, and no stdout/stderr chunk is delivered after settlement.

5. Neighbour sanity (`src/agents/cli-runner.reliability.test.ts`): 43 failed | 61 passed both with and without this patch, with the same failure signatures (32 × `EPERM` temp-dir cleanup, plus `CLI backend executable could not be resolved`). Those are this-box environment failures, not lane behaviour.

## Verification

- Lane regression tests: red without the fix, green with it (commands above).
- Two independent sabotages turn the shipped tests red; both source files restored to byte-identical sha256 (`helpers.ts` unchanged at `eab89219f3ed12eced8c2dc77990dc7d0a2b0f14cc182b5453fa5241c27d6927` across all reverts).
- `node node_modules/oxlint/bin/oxlint` on the four touched files: exit 0. `node node_modules/oxfmt/bin/oxfmt --check` on the same four: clean.
- Scope boundary: this removes the concurrent admission of a fresh CLI run beside the session's in-flight run, which is the coexistence the report's process list shows. It deliberately does not make `--resume` a delivery-authorization rule. A fresh CLI process still has no supervisor scope key (`buildCliSupervisorScopeKey` returns `undefined` without a CLI session id, `src/agents/cli-runner/reliability.ts:120-132`), so a successor still cannot evict a process the host has already abandoned; that remains a follow-up.
- Not verified in this worktree: `src/agents/cli-runner/execute.pending-cancellation.test.ts` cannot load (`Cannot find package 'commander'` from the junctioned `node_modules`), so it was not exercised.

Partial fix for #144137. The closing keyword is intentionally not used.
