### PR TITLE
fix(agents): keep silent heartbeat turns from re-delivering the previous final reply

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts
@@ -1,0 +1,38 @@
+// Heartbeat turns that captured no assistant output of their own must be a true
+// no-op: no reply payload may be built from an older assistant message, which
+// would re-commit and re-deliver the previous final reply (#143787).
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { buildPayloads } from "./payloads.test-helpers.js";
+
+const previousFinalReply = {
+  role: "assistant",
+  stopReason: "stop",
+  content: [{ type: "text", text: "Ship it: the release notes are ready." }],
+} as unknown as AssistantMessage;
+
+describe("buildEmbeddedRunPayloads heartbeat silence", () => {
+  it("does not resurrect the previous final reply for a yielded heartbeat attempt", () => {
+    const payloads = buildPayloads({
+      isHeartbeatTrigger: true,
+      // A yielded attempt ends before message_end: no assistant message of its
+      // own was captured for this turn.
+      currentAssistant: null,
+      // The session snapshot's newest assistant is the previous turn's final.
+      lastAssistant: previousFinalReply,
+    });
+
+    expect(payloads).toEqual([]);
+  });
+
+  it("keeps a captured heartbeat reply deliverable", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Build needs credentials."],
+      isHeartbeatTrigger: true,
+      currentAssistant: null,
+      lastAssistant: previousFinalReply,
+    });
+
+    expect(payloads.map((payload) => payload.text)).toEqual(["Build needs credentials."]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -199,8 +199,16 @@ export function buildEmbeddedRunPayloads(params: {
     .map((text) => sanitizeAssistantVisibleStreamText(text))
     .filter((text) => text.trim().length > 0);
   const currentAssistant = params.currentAssistant ?? undefined;
+  // `lastAssistant` is the session snapshot's newest assistant, which after a
+  // turn that produced no assistant message of its own is the previous final
+  // reply. An internal heartbeat turn must never adopt it: the previous reply
+  // would be re-committed to history and re-delivered as this turn's answer,
+  // so NO_REPLY has to stay a true no-op (#143787).
   const assistantForPayload =
-    currentAssistant ?? (nonEmptyAssistantTexts.length === 1 ? undefined : params.lastAssistant);
+    currentAssistant ??
+    (params.isHeartbeatTrigger === true || nonEmptyAssistantTexts.length === 1
+      ? undefined
+      : params.lastAssistant);
   // Pre-upgrade recovered messages have no stored facts, and recovery intentionally does not
   // reparse text; one in-flight reply can lose delivery or speech intent across this boundary.
   const storedDelivery = assistantForPayload?.openclawDelivery;


### PR DESCRIPTION
## What Problem This Solves

A heartbeat poll that correctly returns the silent token (`NO_REPLY`) is not a
true no-op: the session's **previous final assistant reply is adopted as the
current turn's reply payload**, so it is committed to history and delivered to
the channel again (reported as user-visible duplicate messages ~3s after every
silent heartbeat in direct chats).

`buildEmbeddedRunPayloads` owns the reply payload for every embedded attempt.
When a turn captured no assistant message of its own (`currentAssistant` is
null/undefined — the shape a yielded attempt produces), it falls back to
`params.lastAssistant`, which is the **session snapshot's newest assistant**.
After a quiet turn that assistant *is* the previous turn's final reply, so the
builder emits the previous final as this turn's payload — the commit/deliver
layers then re-commit and re-deliver it. A heartbeat ack carries no
`heartbeatToolResponse`, so nothing downstream marks that stale payload as
"already delivered": `NO_REPLY` never became a real no-op.

Fix: heartbeat turns keep their silence contract at the payload boundary — a
heartbeat turn never adopts a session-level assistant message as its own reply.
The turn's own captured assistant message (`currentAssistant`) and its own
streamed texts stay untouched, so real heartbeat alerts (including alerts that
arrive with no structured tool response) still deliver.

## Evidence

Reproduced without Telegram and without a model, at the payload boundary:

```
$ pnpm exec vitest run --config test/vitest/vitest.unit-fast-root.config.ts \
    src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts
# before the fix (red):
FAIL  > buildEmbeddedRunPayloads heartbeat silence > does not resurrect the previous final reply for a yielded heartbeat attempt
   → expected [ { …(2) } ] to deeply equal []
# the emitted payload is the previous turn's final answer:
[{"text":"Ship it: the release notes are ready.","replyToTag":false}]
```

Call shape (identical to what `prepareEmbeddedRunTerminal` builds for an
attempt that ended before `message_end`, `trigger: "heartbeat"`):

```ts
buildPayloads({ isHeartbeatTrigger: true, currentAssistant: null, lastAssistant: previousFinalReply })
// before: [{ text: "Ship it: the release notes are ready." }]
// after:  []
```

## Verification

```
$ pnpm exec vitest run --config test/vitest/vitest.unit-fast-root.config.ts \
    src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts \
    src/agents/embedded-agent-runner/run/payloads.test.ts
 Test Files  2 passed (2)
      Tests  53 passed (53)

$ pnpm exec vitest run --config test/vitest/vitest.agents-embedded-agent-run.config.ts \
    src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
 Test Files  1 passed (1)
      Tests  39 passed (39)

$ pnpm exec vitest run --config test/vitest/vitest.unit-fast-root.config.ts \
    src/agents/embedded-agent-runner/run/payloads.errors.test.ts \
    src/agents/embedded-agent-runner/run/payloads.delivery-recovery.test.ts
 Test Files  2 passed (2)
      Tests  7 passed (7)
```

The new test was red before the change and green after. Two independent
sabotages of the guard (scoping it to the cron trigger, and inverting the
heartbeat condition) each turn it red again.

Lint/format on the touched files:

```
$ npx oxlint src/agents/embedded-agent-runner/run/payloads.ts \
    src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts   # exit 0
$ npx oxfmt --check src/agents/embedded-agent-runner/run/payloads.ts \
    src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts
All matched files use the correct format.
```

## Scope

Minimal change: one shared helper (`buildEmbeddedRunPayloads`, the payload
boundary every trigger routes through) plus one regression test. No new
dependencies. Heartbeat alert delivery, `heartbeat_respond` handling, and the
paused-turn/yield payload owner contract are unchanged.

Partial fix for #143787 — the reporter's runtime Telegram reproduction was not
available in this environment; the leak is pinned at the payload boundary where
the previous final re-enters as a new turn's reply.
