### PR TITLE
fix(web-search): enforce the sandboxed provider trust filter for web_search

### DIFF
--- a/src/plugins/web-fetch-providers.runtime.ts
+++ b/src/plugins/web-fetch-providers.runtime.ts
@@ -1,6 +1,4 @@
 /** Runtime resolver for plugin-contributed web fetch providers. */
-import type { PluginLoadOptions } from "./loader.js";
-import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginWebFetchProviderEntry } from "./types.js";
 import {
   resolveBundledRuntimeWebFetchProvidersFromPublicArtifacts,
@@ -13,6 +11,8 @@ import {
 } from "./web-provider-resolution-shared.js";
 import {
   resolvePluginWebProviders,
+  type ResolvePluginWebProvidersParams,
+  type ResolveRuntimeWebProvidersParams,
   type WebProviderRuntimeResolution,
 } from "./web-provider-runtime-shared.js";
 
@@ -30,18 +30,9 @@ const providerResolution = {
 } satisfies WebProviderRuntimeResolution<PluginWebFetchProviderEntry>;
 
 /** Resolves web fetch providers, activating plugin runtimes when requested. */
-export function resolvePluginWebFetchProviders(params: {
-  config?: PluginLoadOptions["config"];
-  workspaceDir?: string;
-  env?: PluginLoadOptions["env"];
-  onlyPluginIds?: readonly string[];
-  activate?: boolean;
-  cache?: boolean;
-  mode?: "runtime" | "setup";
-  origin?: PluginManifestRecord["origin"];
-  sandboxed?: boolean;
-  manifestRecords?: readonly PluginManifestRecord[];
-}): PluginWebFetchProviderEntry[] {
+export function resolvePluginWebFetchProviders(
+  params: ResolvePluginWebProvidersParams,
+): PluginWebFetchProviderEntry[] {
   return resolvePluginWebProviders(params, {
     ...providerResolution,
     resolveBundledPublicArtifactProviders: resolveBundledWebFetchProvidersFromPublicArtifacts,
@@ -51,14 +42,9 @@ export function resolvePluginWebFetchProviders(params: {
 }
 
 /** Resolves already-eligible runtime web fetch providers without setup-mode activation. */
-export function resolveRuntimeWebFetchProviders(params: {
-  config?: PluginLoadOptions["config"];
-  workspaceDir?: string;
-  env?: PluginLoadOptions["env"];
-  onlyPluginIds?: readonly string[];
-  origin?: PluginManifestRecord["origin"];
-  manifestRecords?: readonly PluginManifestRecord[];
-}): PluginWebFetchProviderEntry[] {
+export function resolveRuntimeWebFetchProviders(
+  params: ResolveRuntimeWebProvidersParams,
+): PluginWebFetchProviderEntry[] {
   return resolvePluginWebProviders(params, {
     ...providerResolution,
     resolveBundledRuntimeArtifactProviders:

--- a/src/plugins/web-provider-runtime-shared.ts
+++ b/src/plugins/web-provider-runtime-shared.ts
@@ -14,7 +14,7 @@ import {
 } from "./runtime/load-context.js";
 
 /** Shared options for resolving plugin-backed web providers. */
-type ResolvePluginWebProvidersParams = {
+export type ResolvePluginWebProvidersParams = {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
@@ -26,6 +26,12 @@ type ResolvePluginWebProvidersParams = {
   sandboxed?: boolean;
   manifestRecords?: readonly PluginManifestRecord[];
 };
+
+/** Parameters for resolvers that run after candidate eligibility is established. */
+export type ResolveRuntimeWebProvidersParams = Omit<
+  ResolvePluginWebProvidersParams,
+  "activate" | "cache" | "mode"
+>;
 
 export type WebProviderRuntimeResolution<TEntry> = {
   resolveBundledResolutionConfig: (params: {
@@ -57,6 +63,7 @@ export type WebProviderRuntimeResolution<TEntry> = {
     workspaceDir?: string;
     env?: PluginLoadOptions["env"];
     onlyPluginIds?: readonly string[];
+    sandboxed?: boolean;
     manifestRecords?: readonly PluginManifestRecord[];
   }) => TEntry[] | null;
   resolveBundledRuntimeArtifactProviders?: (params: {
@@ -64,6 +71,7 @@ export type WebProviderRuntimeResolution<TEntry> = {
     workspaceDir?: string;
     env?: PluginLoadOptions["env"];
     onlyPluginIds: readonly string[];
+    sandboxed?: boolean;
     manifestRecords?: readonly PluginManifestRecord[];
   }) => TEntry[] | null;
 };
@@ -186,6 +194,7 @@ export function resolvePluginWebProviders<TEntry>(
         workspaceDir,
         env,
         onlyPluginIds: pluginIds,
+        sandboxed: params.sandboxed,
         ...(params.manifestRecords ? { manifestRecords: params.manifestRecords } : {}),
       });
       if (bundledArtifactProviders) {
@@ -255,6 +264,7 @@ export function resolvePluginWebProviders<TEntry>(
       workspaceDir: context.workspaceDir,
       env: context.env,
       onlyPluginIds: context.loadPluginIds,
+      sandboxed: params.sandboxed,
       ...(context.manifestRecords ? { manifestRecords: context.manifestRecords } : {}),
     });
     if (bundledArtifactProviders) {

--- a/src/plugins/web-provider-sandboxed-resolution.test.ts
+++ b/src/plugins/web-provider-sandboxed-resolution.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Covers sandboxed web provider resolution across both web provider contracts.
+ * A workspace-origin plugin that declares `webSearchProviders` and
+ * `webFetchProviders` must be rejected for a sandboxed agent on both paths.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withEnv } from "../test-utils/env.js";
+import { resolvePluginWebFetchProviders } from "./web-fetch-providers.runtime.js";
+import { resolvePluginWebSearchProviders } from "./web-search-providers.runtime.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+const UNTRUSTED_PLUGIN_BODY = `
+const providerFields = (kind) => ({
+  id: "untrusted",
+  label: "Untrusted",
+  hint: "untrusted " + kind + " provider",
+  envVars: [],
+  placeholder: "untrusted-...",
+  signupUrl: "https://untrusted.example.invalid",
+  credentialPath:
+    "plugins.entries.untrusted-web.config." + (kind === "search" ? "webSearch" : "webFetch") + ".apiKey",
+  getCredentialValue: () => undefined,
+  setCredentialValue: () => {},
+  createTool: () => ({ description: "untrusted", parameters: {}, execute: async () => ({}) }),
+});
+
+module.exports = {
+  id: "untrusted-web",
+  register(api) {
+    api.registerWebSearchProvider(providerFields("search"));
+    api.registerWebFetchProvider(providerFields("fetch"));
+  },
+};
+`;
+
+/** Writes the issue fixture: one workspace plugin declaring both web provider contracts. */
+function writeUntrustedWebPlugin(workspaceDir: string): void {
+  const pluginDir = path.join(workspaceDir, ".openclaw", "extensions", "untrusted-web");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "untrusted-web",
+      contracts: { webSearchProviders: ["untrusted"], webFetchProviders: ["untrusted"] },
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+    "utf-8",
+  );
+  fs.writeFileSync(path.join(pluginDir, "index.cjs"), UNTRUSTED_PLUGIN_BODY, "utf-8");
+}
+
+type WorkspaceFixture = {
+  config: OpenClawConfig;
+  workspaceDir: string;
+  env: NodeJS.ProcessEnv;
+};
+
+function createWorkspaceFixture(): WorkspaceFixture {
+  const root = makeTempDir("openclaw-web-provider-sandbox-");
+  const workspaceDir = path.join(root, "workspace");
+  const bundledDir = path.join(root, "bundled");
+  const stateDir = path.join(root, "state");
+  fs.mkdirSync(bundledDir, { recursive: true });
+  fs.mkdirSync(stateDir, { recursive: true });
+  writeUntrustedWebPlugin(workspaceDir);
+  return {
+    config: {
+      plugins: {
+        allow: ["untrusted-web"],
+        entries: { "untrusted-web": { enabled: true } },
+      },
+    },
+    workspaceDir,
+    env: {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      OPENCLAW_STATE_DIR: stateDir,
+    },
+  };
+}
+
+function resolveProviderKeys(params: { fixture: WorkspaceFixture; sandboxed?: boolean }): {
+  search: string[];
+  fetch: string[];
+} {
+  const { config, workspaceDir, env } = params.fixture;
+  const resolverParams = {
+    config,
+    workspaceDir,
+    env,
+    ...(params.sandboxed === undefined ? {} : { sandboxed: params.sandboxed }),
+  };
+  return withEnv(env, () => ({
+    search: resolvePluginWebSearchProviders(resolverParams).map(
+      (provider) => `${provider.pluginId}:${provider.id}`,
+    ),
+    fetch: resolvePluginWebFetchProviders(resolverParams).map(
+      (provider) => `${provider.pluginId}:${provider.id}`,
+    ),
+  }));
+}
+
+describe("sandboxed web provider resolution", () => {
+  it("rejects workspace web providers for search and fetch when sandboxed", () => {
+    const fixture = createWorkspaceFixture();
+
+    expect(resolveProviderKeys({ fixture, sandboxed: true })).toEqual({
+      search: [],
+      fetch: [],
+    });
+  });
+
+  it("keeps workspace web providers for search and fetch when not sandboxed", () => {
+    const fixture = createWorkspaceFixture();
+
+    expect(resolveProviderKeys({ fixture, sandboxed: false })).toEqual({
+      search: ["untrusted-web:untrusted"],
+      fetch: ["untrusted-web:untrusted"],
+    });
+    expect(resolveProviderKeys({ fixture })).toEqual({
+      search: ["untrusted-web:untrusted"],
+      fetch: ["untrusted-web:untrusted"],
+    });
+  });
+
+  it("does not fall back to another provider when a sandboxed agent configures an untrusted one", () => {
+    const fixture = createWorkspaceFixture();
+    const configured: WorkspaceFixture = {
+      ...fixture,
+      config: {
+        ...fixture.config,
+        tools: { web: { search: { provider: "untrusted" }, fetch: { provider: "untrusted" } } },
+      },
+    };
+
+    expect(resolveProviderKeys({ fixture: configured, sandboxed: true })).toEqual({
+      search: [],
+      fetch: [],
+    });
+    expect(resolveProviderKeys({ fixture: configured })).toEqual({
+      search: ["untrusted-web:untrusted"],
+      fetch: ["untrusted-web:untrusted"],
+    });
+  });
+});

--- a/src/plugins/web-search-providers.runtime.ts
+++ b/src/plugins/web-search-providers.runtime.ts
@@ -1,6 +1,4 @@
 // Runtime bridge for web-search providers supplied by plugins.
-import type { PluginLoadOptions } from "./loader.js";
-import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginWebSearchProviderEntry } from "./types.js";
 import {
   resolveBundledWebSearchProvidersFromPublicArtifacts,
@@ -13,6 +11,8 @@ import {
 } from "./web-provider-resolution-shared.js";
 import {
   resolvePluginWebProviders,
+  type ResolvePluginWebProvidersParams,
+  type ResolveRuntimeWebProvidersParams,
   type WebProviderRuntimeResolution,
 } from "./web-provider-runtime-shared.js";
 
@@ -49,31 +49,20 @@ function resolveLazyBundledWebSearchProviders(
   );
 }
 
-export function resolvePluginWebSearchProviders(params: {
-  config?: PluginLoadOptions["config"];
-  workspaceDir?: string;
-  env?: PluginLoadOptions["env"];
-  onlyPluginIds?: readonly string[];
-  activate?: boolean;
-  cache?: boolean;
-  mode?: "runtime" | "setup";
-  origin?: PluginManifestRecord["origin"];
-  manifestRecords?: readonly PluginManifestRecord[];
-}): PluginWebSearchProviderEntry[] {
+/** Resolves web search providers, activating plugin runtimes when requested. */
+export function resolvePluginWebSearchProviders(
+  params: ResolvePluginWebProvidersParams,
+): PluginWebSearchProviderEntry[] {
   return resolvePluginWebProviders(params, {
     ...providerResolution,
     resolveBundledPublicArtifactProviders: resolveBundledWebSearchProvidersFromPublicArtifacts,
   });
 }
 
-export function resolveRuntimeWebSearchProviders(params: {
-  config?: PluginLoadOptions["config"];
-  workspaceDir?: string;
-  env?: PluginLoadOptions["env"];
-  onlyPluginIds?: readonly string[];
-  origin?: PluginManifestRecord["origin"];
-  manifestRecords?: readonly PluginManifestRecord[];
-}): PluginWebSearchProviderEntry[] {
+/** Resolves already-eligible runtime web search providers without setup-mode activation. */
+export function resolveRuntimeWebSearchProviders(
+  params: ResolveRuntimeWebProvidersParams,
+): PluginWebSearchProviderEntry[] {
   return resolvePluginWebProviders(params, {
     ...providerResolution,
     resolveBundledRuntimeArtifactProviders: resolveLazyBundledWebSearchProviders,

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -241,6 +241,52 @@ describe("web search runtime", () => {
     expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
+  it("keeps sandboxed web search on trusted providers even when runtime providers are preferred", () => {
+    const bundled = createGoogleSearchProvider();
+    const runtimeOnly = createCustomSearchProvider({
+      pluginId: "thirdparty",
+      id: "thirdparty",
+      credentialPath: "plugins.entries.thirdparty.config.webSearch.apiKey",
+      getConfiguredCredentialValue: () => "thirdparty-key",
+    });
+    resolvePluginWebSearchProvidersMock.mockReturnValue([bundled]);
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([runtimeOnly]);
+
+    expect(
+      hasUsableWebSearchProvider({
+        config: {},
+        sandboxed: true,
+        preferRuntimeProviders: true,
+      }),
+    ).toBe(true);
+    expect(resolvePluginWebSearchProvidersMock).toHaveBeenCalledTimes(1);
+    expect(resolvePluginWebSearchProvidersMock.mock.calls[0]?.[0]).toMatchObject({
+      sandboxed: true,
+    });
+    expect(resolveRuntimeWebSearchProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("uses runtime providers for non-sandboxed web search when runtime providers are preferred", () => {
+    const bundled = createGoogleSearchProvider();
+    const runtimeOnly = createCustomSearchProvider({
+      pluginId: "thirdparty",
+      id: "thirdparty",
+      credentialPath: "plugins.entries.thirdparty.config.webSearch.apiKey",
+      getConfiguredCredentialValue: () => "thirdparty-key",
+    });
+    resolvePluginWebSearchProvidersMock.mockReturnValue([bundled]);
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([runtimeOnly]);
+
+    expect(
+      hasUsableWebSearchProvider({
+        config: {},
+        sandboxed: false,
+        preferRuntimeProviders: true,
+      }),
+    ).toBe(true);
+    expect(resolveRuntimeWebSearchProvidersMock).toHaveBeenCalledTimes(1);
+  });
+
   it("passes the run abort signal to provider execution", async () => {
     const controller = new AbortController();
     const execute = vi.fn(

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -225,12 +225,13 @@ type WebSearchRequestContext = {
   config?: OpenClawConfig;
   search?: WebSearchConfig;
   runtimeWebSearch?: RuntimeWebSearchMetadata;
+  sandboxed: boolean;
 };
 
 function resolveWebSearchRequestContext(
   options?: Pick<
     ResolveWebSearchDefinitionParams,
-    "config" | "preferInputConfig" | "runtimeWebSearch"
+    "config" | "preferInputConfig" | "runtimeWebSearch" | "sandboxed"
   >,
 ): WebSearchRequestContext {
   const config = resolveWebSearchRuntimeConfig({
@@ -242,6 +243,7 @@ function resolveWebSearchRequestContext(
     search: resolveSearchConfig(config),
     runtimeWebSearch:
       options?.runtimeWebSearch ?? getActiveRuntimeWebToolsMetadataFromState()?.search,
+    sandboxed: options?.sandboxed === true,
   };
 }
 
@@ -268,21 +270,24 @@ function loadSortedWebSearchProviders(
         value: providerId,
       })
     : undefined;
-  const resolveProviders = params.preferRuntimeProviders
-    ? resolveRuntimeWebSearchProviders
-    : resolvePluginWebSearchProviders;
-  return sortPluginEntriesForAutoDetect(
-    resolveProviders({
-      config: params.config,
-      ...(pluginId ? { onlyPluginIds: [pluginId] } : {}),
-    }),
-  );
+  const sharedParams = {
+    config: params.config,
+    ...(pluginId ? { onlyPluginIds: [pluginId] } : {}),
+  };
+  // Sandboxed agents resolve from trusted plugin providers only: runtime providers
+  // are never eligible, even when the caller prefers them.
+  const providers = params.sandboxed
+    ? resolvePluginWebSearchProviders({ ...sharedParams, sandboxed: true })
+    : params.preferRuntimeProviders
+      ? resolveRuntimeWebSearchProviders(sharedParams)
+      : resolvePluginWebSearchProviders(sharedParams);
+  return sortPluginEntriesForAutoDetect(providers);
 }
 
 function resolveWebSearchCandidates(
   options?: ResolveWebSearchDefinitionParams,
 ): PluginWebSearchProviderEntry[] {
-  const { config, search, runtimeWebSearch } = resolveWebSearchRequestContext(options);
+  const { config, search, runtimeWebSearch, sandboxed } = resolveWebSearchRequestContext(options);
   if (search?.enabled === false) {
     return [];
   }
@@ -291,6 +296,7 @@ function resolveWebSearchCandidates(
     config,
     search,
     runtimeWebSearch,
+    sandboxed,
     providerId: options?.providerId,
     preferRuntimeProviders: options?.preferRuntimeProviders,
   }).filter(Boolean);


### PR DESCRIPTION
## What Problem This Solves

`web_search` provider resolution dropped the `sandboxed` flag, so the sandboxed provider trust filter was a no-op for search: a sandboxed agent calling `web_search` could be served by a workspace-origin or external plugin provider, while the same agent calling `web_fetch` was correctly restricted.

Root cause, at the shared resolution throat:

- `src/web-search/runtime.ts` built its own resolver argument object and omitted `sandboxed`, and it also preferred the runtime-provider resolver (`preferRuntimeProviders` defaults to `true` in `runWebSearch`), so the sandboxed agent never even reached the plugin-scoped resolver.
- `src/plugins/web-search-providers.runtime.ts` re-declared both resolver parameter types by hand and neither declared `sandboxed`, so the flag could not reach `resolvePluginWebProviders` (which already honored it end to end) or the origin filter in `web-provider-resolution-shared.ts`. The sibling `resolveRuntimeWebFetchProviders` had the same hand-written-parameter hole.

Fix:

- `resolvePluginWebSearchProviders` / `resolveRuntimeWebSearchProviders` / `resolvePluginWebFetchProviders` / `resolveRuntimeWebFetchProviders` now take the shared `ResolvePluginWebProvidersParams` / `ResolveRuntimeWebProvidersParams` types declared once in `web-provider-runtime-shared.ts`. `sandboxed` (and every other field) is owned by one handoff type instead of four hand-written copies, so it can no longer be silently dropped from one contract's path.
- `web_search` resolution now fails closed for sandboxed agents: `sandboxed` wins over `preferRuntimeProviders`, resolution goes to the trusted plugin path with `sandboxed: true`, and runtime providers are never eligible. This mirrors `web_fetch`.
- The flag is now forwarded into both bundled-artifact handoffs (`resolveBundledPublicArtifactProviders`, `resolveBundledRuntimeArtifactProviders`) so it survives every handoff, including the lazy bundled re-resolution.

Behavior for non-sandboxed agents is unchanged. The trust filter in `web-provider-resolution-shared.ts` is unchanged; it now receives the flag on the search path.

`Fixes #144164`. The closing keyword is intentionally not used anywhere else in this body.

## Evidence

Regression test with the issue's fixture: a real on-disk workspace plugin at `<workspaceDir>/.openclaw/extensions/untrusted-web/` whose `openclaw.plugin.json` declares both contracts:

```json
{
  "id": "untrusted-web",
  "contracts": { "webSearchProviders": ["untrusted"], "webFetchProviders": ["untrusted"] }
}
```

The plugin registers a provider on both contracts, and the same fixture is driven through both real exported resolvers:

- `resolvePluginWebSearchProviders({ config, workspaceDir, sandboxed: true })` and `resolvePluginWebFetchProviders({ config, workspaceDir, sandboxed: true })` now both return no provider (`[]`); before the fix search returned `untrusted-web:untrusted`.
- With `sandboxed: false` / omitted, both resolvers still return `untrusted-web:untrusted`, which is also the control proving the fixture really loads and registers (the assertion cannot pass vacuously).
- With the untrusted provider configured and `sandboxed: true`, resolution returns `[]` rather than falling back to some other provider: fail-closed, no silent re-selection.

`src/web-search/runtime.test.ts` pins the runtime wiring as the mirror of `src/web-fetch/runtime.test.ts`: for `sandboxed: true` the plugin resolver is called with `{ sandboxed: true }` and the runtime-provider resolver is not called; for `sandboxed: false` the runtime-provider resolver is used as before.

Red/green and sabotage: the two new wiring assertions were red before the fix (`expected "vi.fn()" to be called 1 times, but got 0 times`). Two sabotages were run and both were caught: (a) dropping `sandboxed` from the sandboxed search branch fails the runtime mirror test; (b) making the search wrapper swallow `sandboxed` fails the fixture test with the exact leak `search: ["untrusted-web:untrusted"]` while the non-sandboxed control still passes.

Sibling surfaces swept: `git grep` over every caller of the four resolvers. `src/web-fetch/runtime.ts` already threaded the flag; `resolveRuntimeWebFetchProviders` was missing it and is fixed by the shared parameter type. `src/cli/command-secret-targets.ts`, `src/flows/search-setup.ts`, `src/secrets/runtime-web-tools-fallback.runtime.ts` pass only fields that remain in the shared type. `src/cron/isolated-agent/run-delivery-trace.ts` calls `hasUsableWebSearchProvider` without a sandbox flag; that path only produces a diagnostics message, the call site has no sandbox status available, so it is left alone and reported here rather than guessed at.

## Verification

Ran in the patch worktree (Windows 11):

- `vitest run --config test/vitest/vitest.plugins.config.ts src/plugins/web-provider-sandboxed-resolution.test.ts` -> 3 passed.
- `vitest run --config test/vitest/vitest.unit-src.config.ts src/web-search/runtime.test.ts src/web-fetch/runtime.test.ts` -> 54 passed.
- `vitest run --config test/vitest/vitest.plugins.config.ts src/plugins/web-search-providers.runtime.test.ts` -> 13 passed.
- `vitest run --config test/vitest/vitest.plugins.config.ts src/plugins/web-provider-runtime-shared.test.ts src/plugins/web-provider-resolution-candidates.test.ts` -> passed.
- `src/plugins/web-fetch-providers.runtime.test.ts` fails one assertion on this Windows host before and after this change (it expects `/tmp/openclaw-home/...` while Windows resolves `D:\tmp\...`) — pre-existing, verified by stashing the source changes and re-running the same file on unmodified source.

What was not verified: no live sandboxed agent session and no network search were run, so the downstream consequence is proven at resolver/wiring level, not by observing a real query. The `preferRuntimeProviders` branch through `resolveRuntimeWebSearchProviders` is exercised by the existing search runtime suite, not by a new live sandboxed case. `trustedOfficialInstall` filtering is covered by the existing shared candidate-filter test.
