### PR TITLE
fix(gateway): keep the display cap from re-materializing retired live-buffer bytes

### DIFF
--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -104,13 +104,26 @@ export function mergeAssistantText(
   }
   let text: string;
   if (scope) {
+    // The scope's prefix length and separator length are offsets into the shared
+    // live buffer. The display cap retires that buffer's head, so a stale scope
+    // can outlive the bytes it indexed; reading the item text at those offsets
+    // then lands outside this message and re-materializes dropped bytes in the
+    // user-visible tail. Only trust the offsets while the retained buffer still
+    // carries the recorded prefix, otherwise the buffer IS this item's text.
+    const retainedItemText =
+      scope === previous.scope && previous.text.startsWith(scope.prefix)
+        ? previous.text.slice(scope.prefix.length + scope.separatorLength)
+        : undefined;
+    if (scope === previous.scope && retainedItemText === undefined) {
+      scope.prefix = "";
+      scope.boundaryNewlines = 0;
+      scope.separatorLength = 0;
+    }
     // Inserted padding is not provider text. Keep it out of later item deltas
     // so a matching cumulative snapshot cannot retract a streamed newline.
     const itemText =
       input.text ??
-      (scope === previous.scope
-        ? previous.text.slice(scope.prefix.length + scope.separatorLength)
-        : "") + (input.delta ?? "");
+      (retainedItemText ?? (scope === previous.scope ? previous.text : "")) + (input.delta ?? "");
     const leadingNewlines = itemText.startsWith("\n\n") ? 2 : itemText.startsWith("\n") ? 1 : 0;
     if (!scope.prefix) {
       // Once the display cap retires the prior item, only surviving padding

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -37,6 +37,15 @@ export function capLiveAssistantText(snapshot: AssistantTextSnapshot): string {
         : Math.max(0, scope.boundaryNewlines - retiredAfterPrefix);
     scope.separatorLength = Math.max(0, scope.separatorLength - retiredAfterPrefix);
     scope.prefix = sliceUtf16Safe(scope.prefix, retired);
+    // The scope indexes the shared buffer by character offsets. A surrogate-safe
+    // cut can retire one more unit than the recorded lengths account for, so the
+    // retained buffer is the authority: never keep a prefix the cap did not keep,
+    // or a later offset read lands outside this message and emits foreign bytes.
+    if (!capped.startsWith(scope.prefix)) {
+      scope.prefix = "";
+      scope.boundaryNewlines = 0;
+      scope.separatorLength = 0;
+    }
   }
   return capped;
 }

--- a/src/gateway/live-display-cap-boundary.test.ts
+++ b/src/gateway/live-display-cap-boundary.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Display-cap truncation boundary regression tests.
+ *
+ * The live display cap retires the head of the shared assistant buffer while the
+ * snapshot scope keeps character offsets into that buffer. Truncation must stay
+ * on character boundaries and must never re-materialize bytes the retained buffer
+ * no longer carries into a user-visible reply.
+ */
+import { describe, expect, it } from "vitest";
+import { mergeAssistantText } from "./agent-event-assistant-text.js";
+import { truncateChatHistoryText } from "./chat-display-projection.helpers.js";
+import { sanitizeChatHistoryMessage } from "./chat-display-projection.sanitize.js";
+import { capLiveAssistantText } from "./live-chat-projector.js";
+
+const LIVE_CHAT_BUFFER_CHARS = 500_000;
+const CJK = "代码审查报告与修复建议";
+const EMOJI = "🚀🐈‍⬛🧪";
+
+function findLoneSurrogate(value: string): number | null {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return index;
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return index;
+    }
+  }
+  return null;
+}
+
+describe("display-cap truncation boundary", () => {
+  it("does not emit bytes the retained live buffer no longer carries", () => {
+    const firstItem = `${CJK}${EMOJI}`.repeat(LIVE_CHAT_BUFFER_CHARS / 8);
+    const authoredTail = `${CJK}尾巴🙂`;
+    const first = capLiveAssistantText(
+      mergeAssistantText({ text: "" }, { itemId: "first", text: firstItem }, "live"),
+    );
+    // A second item is appended, so the scope records the retired prior item as a
+    // prefix offset into the shared live buffer.
+    const snapshot = mergeAssistantText(
+      { text: first },
+      { itemId: "answer", text: authoredTail, delta: authoredTail },
+      "live",
+    );
+    const capped = capLiveAssistantText(snapshot);
+    expect(capped.endsWith(authoredTail)).toBe(true);
+    expect(snapshot.scope?.prefix.length).toBeGreaterThan(1_000);
+    // A transport-level bound (the second display cap in the pipeline) keeps only
+    // the visible window while the snapshot's recorded offsets stay unchanged.
+    const visibleWindow = capped.slice(capped.indexOf(authoredTail));
+    const merged = mergeAssistantText(
+      { text: visibleWindow, scope: snapshot.scope },
+      { itemId: "answer", delta: "新增结论" },
+      "live",
+    );
+
+    expect(merged.text).toBe(`${visibleWindow}新增结论`);
+    expect(merged.text.startsWith(visibleWindow)).toBe(true);
+    expect(merged.text.length).toBeLessThanOrEqual(visibleWindow.length + 4);
+  });
+
+  it("keeps the retained buffer carrying the prefix its scope records", () => {
+    const shapes = [CJK, EMOJI, "a🚀b", "字🧪字", `${CJK}${EMOJI}${CJK}`];
+    const failures: string[] = [];
+    for (const shape of shapes) {
+      for (let fill = 0; fill <= 4; fill++) {
+        for (const tail of ["", CJK, EMOJI, `\n\n${CJK}`]) {
+          const prefix = `${shape.repeat(Math.ceil(LIVE_CHAT_BUFFER_CHARS / shape.length) + 1)}${"字".repeat(fill)}`;
+          const text = `${prefix}${tail}`;
+          const snapshot = mergeAssistantText(
+            { text: "" },
+            { itemId: "answer", text, delta: text },
+            "live",
+          );
+          const capped = capLiveAssistantText(snapshot);
+          const scopePrefix = snapshot.scope?.prefix ?? "";
+          if (!capped.startsWith(scopePrefix)) {
+            failures.push(
+              `capped head=${JSON.stringify(capped.slice(0, 8))} scope prefix=${JSON.stringify(scopePrefix.slice(0, 8))}`,
+            );
+          }
+          if (capped.length > LIVE_CHAT_BUFFER_CHARS + 1) {
+            failures.push(`cap exceeded: ${capped.length}`);
+          }
+          const lone = findLoneSurrogate(capped);
+          if (lone !== null) {
+            failures.push(`lone surrogate at ${lone}`);
+          }
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it.each([
+    { name: "multi-byte history text", text: `${CJK}${EMOJI}`.repeat(2_000) },
+    { name: "surrogate pair on the cap edge", text: `${CJK.repeat(1_333)}🚀${CJK.repeat(2_000)}` },
+  ])("truncates $name on a character boundary and keeps the display-cap marker", ({ text }) => {
+    const capped = truncateChatHistoryText(text, 8_000);
+    expect(capped.truncated).toBe(true);
+    expect(findLoneSurrogate(capped.text)).toBeNull();
+    expect(capped.text).not.toContain("\uFFFD");
+    expect(text.startsWith(capped.text.replace(/\n\.\.\.\(truncated\)\.\.\.$/u, ""))).toBe(true);
+
+    const projected = sanitizeChatHistoryMessage(
+      { role: "assistant", content: [{ type: "text", text }] },
+      8_000,
+    ).message as Record<string, unknown>;
+    expect(projected["__openclaw"]).toMatchObject({ truncated: true, reason: "display-cap" });
+  });
+
+  it("leaves capped text unchanged when the reported limit is never reached", () => {
+    const text = `${CJK}${EMOJI}`;
+    expect(truncateChatHistoryText(text, 8_000)).toEqual({ text, truncated: false });
+  });
+});


### PR DESCRIPTION
# Keep the display cap from re-materializing retired live-buffer bytes

Fixes #144401

## What Problem This Solves

A long final assistant reply was persisted with unrelated bytes in its tail. The session-history
row carried `truncated: true`, `reason: "display-cap"`, so the report points at the display cap.

The display cap for streamed assistant text owns a *shared* live buffer plus a scope that records
character offsets into it (`prefix` and the inserted paragraph padding). `capLiveAssistantText`
retires the head of that buffer when it exceeds the cap, and `mergeAssistantText` later recovers
the current item's text by slicing the retained buffer at those recorded offsets:

```ts
previous.text.slice(scope.prefix.length + scope.separatorLength)
```

Nothing verified that the retained buffer still carried the recorded prefix. As soon as the buffer
shrinks under a *second* bound in the same pipeline (the transport's own display bound, the history
cap, a terminal read that keeps only the visible window), the recorded offsets outlive the bytes
they index. The slice then lands outside the current message and the merge *prepends the retired
prefix again*, so bytes that are no longer part of the message - and, with multi-byte text, bytes
from the wrong character boundary - are written into the user-visible tail. That is the reported
shape: a tail that does not belong to the message it was appended to.

The same boundary is where a non-character-safe cut shows up: a raw `slice` at the cap produces a
dangling surrogate (rendered as U+FFFD) at the retained head.

Fix, at the two functions that own the truncation boundary:

- `mergeAssistantText` only trusts the scope offsets while the retained buffer still carries the
  recorded prefix; otherwise the retained buffer *is* this item's text and the stale prefix and
  padding are dropped instead of being re-emitted. This is the guard the append-only OpenAI
  stream path already uses before slicing a previously emitted prefix.
- `capLiveAssistantText` treats the retained buffer as the authority for the scope it publishes:
  after retiring the head it never keeps a prefix the returned buffer does not start with.

Both changes stay inside the existing truncation boundary: no message-protocol change, no new
dependency, no signature change, and `truncated: true` plus the `display-cap` reason are unchanged.
Truncation continues to use the surrogate-safe slice, so it still never splits a character.

## Evidence

The incident could not be replayed from a host artifact: the report states the raw streaming buffer
and outbound spool were not retained, and the corrupted row only exists in the reporter's private
session store. What is reproducible is the boundary itself, with locally constructed long
multi-byte (CJK + emoji) text:

- Before the fix, the new regression test shows the corrupted shape directly. The merged live text
  becomes content from the retired region (`审查报告与修复建议🚀🐈‍⬛🧪...`) instead of the retained
  window plus the newest delta (`代码审查报告与修复建议尾巴🙂新增结论`).
- After the fix the same test yields exactly the retained window plus the newest delta, and the
  merged length is bounded by the retained window.

## Verification

- New regression file `src/gateway/live-display-cap-boundary.test.ts` (5 tests):
  - offset read after the display cap retired the head, with CJK + emoji + a split surrogate pair;
  - the retained buffer always carries the prefix its scope records, over a multi-byte boundary
    corpus, with no lone surrogate and no cap overshoot;
  - the history display cap truncates multi-byte text on a character boundary, keeps
    `__openclaw.truncated: true` with `reason: "display-cap"`, and never introduces U+FFFD;
  - an under-limit message is returned untouched.
- Red then green: with the two source files reverted, the offset test fails with the corrupted
  string; with the fix it passes.
- Sabotage checks (applied, observed, reverted):
  1. delete the retained-prefix guard in `mergeAssistantText` -> the offset test fails again with
     the corrupted string;
  2. replace the cap's surrogate-safe slice with a raw unit slice -> the boundary test fails with
     `lone surrogate at 0`.
- Existing suite for the same path still passes: `src/gateway/server-chat.stream-text-merge.test.ts`
  plus the new file = 31 tests passed.
- Run: `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/live-display-cap-boundary.test.ts src/gateway/server-chat.stream-text-merge.test.ts`.
- Lint/format: `scripts/run-oxlint.mjs` cannot run in this checkout because its declaration inputs
  resolve into a sibling worktree's `node_modules` (`Declaration input escapes checkout:
  D:\code\wt-oc-143262\node_modules\.pnpm\...`), so the packed `oxlint`/`oxfmt` binaries were run
  directly against the changed files: no diagnostics, and `oxfmt --check` reports the files already
  formatted.

## Evidence boundary

The exact producer of the reported incident is not proven from here: it requires either a stream
that trims the live buffer behind the recorded offsets, or a cut that is not character-safe in the
same truncation path. Both are closed by this change, and the regression test pins the observable
requirement: truncation stays on character boundaries, no bytes outside the retained message enter
the visible tail, and the `display-cap` metadata is preserved. If private triage produces the raw
native stream, this boundary is the first place to compare against.
