### PR TITLE
refactor(tests): reuse Telegram settled receipt defaults

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -20,33 +20,6 @@ import {
 } from "./bot-message-dispatch.test-harness.js";
 import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness.js";
 
-const visibleFinalReceipt = {
-  counts: {
-    tool: {
-      delivered: 0,
-      deliveredNotVisible: 0,
-      cancelled: 0,
-      failedBeforeSend: 0,
-      failedAfterSend: 0,
-    },
-    block: {
-      delivered: 0,
-      deliveredNotVisible: 0,
-      cancelled: 0,
-      failedBeforeSend: 0,
-      failedAfterSend: 0,
-    },
-    final: {
-      delivered: 1,
-      deliveredNotVisible: 0,
-      cancelled: 0,
-      failedBeforeSend: 0,
-      failedAfterSend: 0,
-    },
-  },
-  anyVisibleDelivered: true,
-} as const;
-
 function createMessageToolOnlyGroupContext(): TelegramMessageContext {
   return createContext({
     chatId: -1001234,
@@ -71,7 +44,6 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
   it("uses resolved DM config for auto-topic-label overrides", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: true,
-      settledReceipt: visibleFinalReceipt,
     });
     loadSessionStore.mockReturnValue({ s1: {} });
     const bot = createBot();
@@ -110,7 +82,6 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
     });
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: true,
-      settledReceipt: visibleFinalReceipt,
     });
     const bot = createBot();
     const base = "a".repeat(499);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Two Telegram topic-label tests explicitly construct the settled receipt already supplied by their shared dispatch harness.

## Why This Change Was Made

Keep the existing queued-final result and let the harness supply its matching settled receipt. Remove the redundant shared receipt object and its two references. Topic configuration, UTF-16 assertions, and every other scenario remain unchanged.

## User Impact

No production behavior changes. This deletes 29 test lines. The receipt changes from a shared object to fresh per-dispatch data; these cases do not observe its identity.

## Evidence

All 16 cases in the complete fallback/topic/media suite passed before and after with identical names, order, and statuses. One-off verification using the actual unchanged harness helper confirms equal normalized data and fresh receipt identity. Changed-file checks and independent P2 review passed. No runtime savings are claimed.
