### PR TITLE
fix(tests): release singleton fixtures after assertion failures

### DIFF
--- a/src/shared/global-singleton.test.ts
+++ b/src/shared/global-singleton.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   drainGlobalSingletonLifecycleState,
   resolveGlobalMap,
@@ -107,10 +108,7 @@ describe("global singleton lifecycle resets", () => {
   it("awaits asynchronous resets while starting sibling owners", async () => {
     const asyncKey = Symbol("global-singleton:async-reset");
     const siblingKey = Symbol("global-singleton:async-sibling");
-    let release!: () => void;
-    const held = new Promise<void>((resolve) => {
-      release = resolve;
-    });
+    const { promise: held, resolve: release } = createDeferred();
     const siblingReset = vi.fn();
     resolveGlobalSingleton(
       asyncKey,
@@ -120,12 +118,17 @@ describe("global singleton lifecycle resets", () => {
     resolveGlobalSingleton(siblingKey, () => ({}), siblingReset);
 
     const drain = drainGlobalSingletonLifecycleState();
-    expect(siblingReset).toHaveBeenCalledOnce();
-    release();
-    await drain;
-
-    delete (globalThis as Record<PropertyKey, unknown>)[asyncKey];
-    delete (globalThis as Record<PropertyKey, unknown>)[siblingKey];
+    try {
+      expect(siblingReset).toHaveBeenCalledOnce();
+    } finally {
+      release();
+      try {
+        await drain;
+      } finally {
+        delete (globalThis as Record<PropertyKey, unknown>)[asyncKey];
+        delete (globalThis as Record<PropertyKey, unknown>)[siblingKey];
+      }
+    }
   });
 
   it("runs every registered reset before reporting failures", async () => {
@@ -144,12 +147,14 @@ describe("global singleton lifecycle resets", () => {
     );
     resolveGlobalSingleton(succeedingKey, () => ({}), succeedingReset);
 
-    await expect(drainGlobalSingletonLifecycleState()).rejects.toThrow(AggregateError);
-    shouldThrow = false;
-    expect(succeedingReset).toHaveBeenCalledOnce();
-
-    delete (globalThis as Record<PropertyKey, unknown>)[failingKey];
-    delete (globalThis as Record<PropertyKey, unknown>)[succeedingKey];
+    try {
+      await expect(drainGlobalSingletonLifecycleState()).rejects.toThrow(AggregateError);
+      expect(succeedingReset).toHaveBeenCalledOnce();
+    } finally {
+      shouldThrow = false;
+      delete (globalThis as Record<PropertyKey, unknown>)[failingKey];
+      delete (globalThis as Record<PropertyKey, unknown>)[succeedingKey];
+    }
   });
 
   it("preserves close-only state across restart drains", async () => {


### PR DESCRIPTION
## What Problem This Solves

An assertion failure in the singleton lifecycle tests could leave their reset fixture pending or still configured to throw, interfering with later test cleanup.

## Why This Change Was Made

Release and await the asynchronous reset in `finally`, and always disarm the throwing reset and remove each test’s owned keys. Reuse the existing deferred helper. All 11 cases and 22 assertions remain; production code and public APIs are unchanged.

## User Impact

No user-visible behavior change. The test fixtures clean up after assertion failures. Production LOC: 0; tests: +21/-16 (net +5).

## Evidence

- Original and final suites: 11/11 passed on the same runtime.
- Four deliberate assertion-failure controls: original fixtures left a pending/rejected reset and present keys; candidate fixtures had fulfilled drains and absent keys before rescue. Each control intentionally failed its selected test.
- The original async control’s recorder also reported a raw Git index mismatch after source restoration. Its failure is preserved; separate reconciliation verified current staged semantics. The rewrite cause remains unknown.
- Independent source review found no actionable findings through P2. All 20 required local changed checks passed.
