### PR TITLE
fix(memory): fail promptly when API credits are exhausted

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-policy.integration.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.integration.test.ts
@@ -26,9 +26,8 @@ describe("memory embedding retry policy with remote transport", () => {
     const server = createServer((request, response) => {
       void (async () => {
         try {
-          for await (const _chunk of request) {
-            // Drain the request before responding so the real transport completes normally.
-          }
+          request.resume();
+          await once(request, "end");
           requestCount += 1;
           response.writeHead(429, { "content-type": "application/json" });
           response.end(

--- a/extensions/memory-core/src/memory/manager-embedding-policy.integration.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.integration.test.ts
@@ -1,0 +1,79 @@
+import { once } from "node:events";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createRemoteEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runMemoryEmbeddingRetryLoop } from "./manager-embedding-policy.js";
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  const activeServers = servers.splice(0);
+  await Promise.all(
+    activeServers.map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+          server.closeAllConnections();
+        }),
+    ),
+  );
+});
+
+describe("memory embedding retry policy with remote transport", () => {
+  it("fails after one request when the provider reports exhausted credits", async () => {
+    let requestCount = 0;
+    const server = createServer((request, response) => {
+      void (async () => {
+        try {
+          for await (const _chunk of request) {
+            // Drain the request before responding so the real transport completes normally.
+          }
+          requestCount += 1;
+          response.writeHead(429, { "content-type": "application/json" });
+          response.end(
+            JSON.stringify({
+              error: {
+                message: "Credit balance exhausted",
+                type: "rate_limit_error",
+                code: "credit_balance_exhausted",
+              },
+            }),
+          );
+        } catch (error) {
+          response.writeHead(500, { "content-type": "text/plain" });
+          response.end(error instanceof Error ? error.message : String(error));
+        }
+      })();
+    });
+    servers.push(server);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address() as AddressInfo;
+    const provider = createRemoteEmbeddingProvider({
+      id: "openai",
+      client: {
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        headers: { authorization: "Bearer fixture-token" },
+        model: "text-embedding-3-small",
+        ssrfPolicy: { allowedHostnames: ["127.0.0.1"] },
+      },
+      errorPrefix: "openai embeddings failed",
+    });
+    const waitForRetry = vi.fn(async () => {});
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        profile: "index",
+        run: async () => await provider.embedBatch(["alpha"], { inputType: "document" }),
+        waitForRetry,
+      }),
+    ).rejects.toMatchObject({
+      status: 429,
+      code: "credit_balance_exhausted",
+    });
+
+    expect(requestCount).toBe(1);
+    expect(waitForRetry).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -213,6 +213,7 @@ describe("memory embedding policy", () => {
     { code: "insufficient_quota" },
     { errorType: "insufficient_quota" },
     { errorCode: "insufficient_quota", errorType: "rate_limit_error" },
+    { code: "credit_balance_exhausted" },
   ])("fails fast for structured permanent quota without a cooldown: %j", async (fields) => {
     const quotaError = Object.assign(new Error("Too many tokens per day"), {
       status: 429,

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -110,7 +110,11 @@ function resolveMemoryEmbeddingRetryBudget(
   );
   const permanentQuota = [fields?.errorCode, fields?.code, fields?.errorType].some((value) => {
     const code = normalizeOptionalString(value)?.toLowerCase();
-    return code === "quota_exceeded" || code === "insufficient_quota";
+    return (
+      code === "quota_exceeded" ||
+      code === "insufficient_quota" ||
+      code === "credit_balance_exhausted"
+    );
   });
   if (permanentQuota && retryAfterMs === undefined) {
     return undefined;


### PR DESCRIPTION
Closes #144487

## What Problem This Solves

Fixes an issue where users indexing memory with an exhausted OpenAI API credit balance would wait through repeated requests even though the structured provider response cannot succeed until billing state changes.

## Why This Change Was Made

The memory retry policy now classifies `credit_balance_exhausted` alongside the existing permanent quota codes. It still honors a provider-supplied cooldown and preserves the existing retry budgets for ordinary HTTP 429 responses.

## User Impact

Memory indexing fails promptly when OpenAI reports an exhausted credit balance, reducing avoidable latency and request noise. No configuration or data format changes are required.

## Evidence

- Regression test failed before the production change with five provider calls instead of one.
- A loopback HTTP integration test exercises the shared OpenAI remote embedding transport with a structured 429 response and verifies exactly one request, preserved `credit_balance_exhausted` metadata, and no retry wait.
- `pnpm test extensions/memory-core/src/memory/manager-embedding-policy.integration.test.ts extensions/memory-core/src/memory/manager-embedding-policy.test.ts` — 47 tests passed.
- `pnpm check:changed` — all lanes passed except one lint finding in the new transport fixture; the lint finding was corrected, then the focused suite and direct `oxlint` check passed at exact head. Formatting, extension/test type checks, boundary checks, dead-code scans, and import-cycle checks passed.

## Operational Notes

- Changed service: bundled `memory-core` extension only.
- Migration risk: none; no schema, index, or configuration migration.
- Security findings: none introduced or addressed; error classification uses an existing structured provider field.
- Rollback: revert commits `4efc961dc8`, `ab2e04ad6a`, and `eb54e23196`.
- Release impact: patch-level behavior fix; no deployment performed.
- Independent review: ClawSweeper found no actionable code defect at `eb54e23196` and requested transport-level proof. That proof is now included at `4efc961dc8`; a fresh upstream review is pending. The local configured reviewer could not inspect this new checkout because it is outside its fixed allowlist.
