### PR TITLE
test(auth): share catalog fixture provider runtime

### DIFF
--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -40,15 +40,61 @@ vi.mock("../src/plugins/provider-discovery.runtime.js", () => ({
   resolvePluginDiscoveryProvidersRuntime: () => discovery.providers,
 }));
 
-function withCatalogProviders<T>(run: () => T): T {
+vi.mock("../src/plugins/provider-hook-runtime.js", async () => {
+  const { createProviderHookRuntime } =
+    await import("../src/plugins/provider-hook-runtime-core.js");
+  const { matchesProviderPluginRef } = await import("../src/plugins/provider-registry-shared.js");
+  const selectProviders = (params: {
+    onlyPluginIds?: string[];
+    providerRefs?: readonly string[];
+  }) =>
+    discovery.providers.filter(
+      (provider) =>
+        (!params.onlyPluginIds || params.onlyPluginIds.includes(provider.id)) &&
+        (!params.providerRefs?.length ||
+          params.providerRefs.some((ref) => matchesProviderPluginRef(provider, ref))),
+    );
+  // Discovery and runtime hooks use the same fixture providers; no plugin loading is under test.
+  return createProviderHookRuntime({
+    isPluginProvidersLoadInFlight: () => false,
+    resolvePluginProviderRegistryCore: (params) => {
+      const providers = selectProviders(params);
+      if (providers.length === 0) {
+        return undefined;
+      }
+      return {
+        registry: createCatalogProviderRegistry(providers),
+        workspaceDir: params.workspaceDir,
+        onlyPluginIds: params.onlyPluginIds,
+        isProviderOwnerEligible: (pluginId, providerRef) =>
+          providers.some(
+            (provider) =>
+              provider.id === pluginId && matchesProviderPluginRef(provider, providerRef),
+          ),
+      };
+    },
+    resolvePluginProvidersCore: (params, onSelectedRegistry) => {
+      const providers = selectProviders(params);
+      if (providers.length) {
+        onSelectedRegistry?.(createCatalogProviderRegistry(providers));
+      }
+      return providers.map((provider) => Object.assign({}, provider, { pluginId: provider.id }));
+    },
+  });
+});
+
+function createCatalogProviderRegistry(providers = discovery.providers) {
   const registry = createEmptyPluginRegistry();
-  registry.providers = discovery.providers.map((provider) => ({
+  registry.providers = providers.map((provider) => ({
     pluginId: provider.id,
     provider,
     source: "test",
   }));
-  // Exhausted auth must consult the same providers as discovery, without loading a second runtime.
-  return withPluginRuntimeRegistryScope(registry, run);
+  return registry;
+}
+
+function withCatalogProviders<T>(run: () => T): T {
+  return withPluginRuntimeRegistryScope(createCatalogProviderRegistry(), run);
 }
 
 describe("Provider model discovery auth preparation", () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Model-discovery auth tests supplied synthetic providers to discovery while runtime hooks could still load a separate plugin registry. That mismatch made the Chutes case take over a minute and hit its existing timeout under full-suite load; stubbing individual hooks merely moved the cost into another case.

## Why This Change Was Made

Use the same fixture provider collection for discovery and the existing real hook-runtime constructor. The fixture adapter filters registered providers and preserves owner eligibility; capability checks, formatting, failure-policy dispatch, OAuth fencing, persistence, and catalog behavior remain real. No prepared-runtime ownership is manufactured, and all existing test bodies and hooks remain unchanged.

## User Impact

No production behavior changes. This makes the auth-order fixture consistent and adds 46 test lines while retaining all 24 cases, including synthetic providers without refresh capability and late catalog finalization.

## Evidence

- A controlled local full-file comparison on Node 24.19.0 passed the same 24 ordered cases: 75.80 seconds before and 18.85 seconds after, with no shifted slow case. This is a file-level observation, not a full-suite speedup claim.
- Temporary identity guards confirmed the intended synthetic OAuth/fetch callbacks, with no denials. Those guards were removed and production source restored exactly.
- Normal guard-free validation passed 124 cases: the auth-order file, provider-runtime integration suite, and Chutes implicit-provider suite.
- The final mapped changed-file gate and fresh independent review passed. Lint-required braces and a fresh Object.assign copy were applied before those final checks.
