### PR TITLE
fix(memory): keep lexical recall available during failed upgrades

### DIFF
--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -217,8 +217,19 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
           providerKeyKnown: this.providerInitialized,
         });
       }
-      if (repairedIndexIdentity.status !== "valid") {
+      const pendingChunkingUpgradeKeywordOnly =
+        repairedIndexIdentity.status === "mismatched" &&
+        repairedIndexIdentity.owner === "openclaw" &&
+        repairedIndexIdentity.code === "chunking_version" &&
+        this.fts.enabled &&
+        this.fts.available;
+      if (repairedIndexIdentity.status !== "valid" && !pendingChunkingUpgradeKeywordOnly) {
         return [];
+      }
+      if (pendingChunkingUpgradeKeywordOnly) {
+        log.warn(
+          "memory search: chunking upgrade rebuild is pending; using the existing keyword-only index",
+        );
       }
       // No watcher can observe later edits after kernel capacity exhaustion.
       // Record a fresh generation at the search boundary so detached maintenance
@@ -245,7 +256,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
           this.settings.store.databasePath,
           opts?.signal,
         );
-        if (embeddingBootstrapKeywordOnly) {
+        if (embeddingBootstrapKeywordOnly || pendingChunkingUpgradeKeywordOnly) {
           break;
         }
         const leasedIdentity = this.refreshIndexIdentityDirty({
@@ -295,7 +306,11 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
           activeProjectKeys: opts?.activeProjectKeys,
         });
 
-      const keywordOnly = embeddingBootstrapKeywordOnly || !this.provider || opts?.lexicalOnly;
+      const keywordOnly =
+        embeddingBootstrapKeywordOnly ||
+        pendingChunkingUpgradeKeywordOnly ||
+        !this.provider ||
+        opts?.lexicalOnly;
       const loadKeywordResults = async () => {
         const results =
           (keywordOnly || hybrid.enabled) && this.fts.enabled && this.fts.available

--- a/extensions/memory-core/src/memory/manager-search-upgrade.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-upgrade.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { DatabaseSync } from "node:sqlite";
 import { MEMORY_CHUNKING_VERSION } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
@@ -77,6 +78,59 @@ describe("memory search after a chunking upgrade", () => {
       expect(withDatabase(dbPath, readMeta).chunkingVersion).toBe(MEMORY_CHUNKING_VERSION);
     },
   );
+
+  it("uses the existing lexical index when an upgrade rebuild cannot embed", async () => {
+    const cfg = createConfig();
+    await seedIndex(cfg);
+    await fs.writeFile(
+      `${fixture.paths.memory}/2026-01-12.md`,
+      "# Log\nAlpha memory line changed after the prior index was published.",
+    );
+    const manager = await fixture.getFreshManager(cfg);
+    const quotaError = Object.assign(new Error("Embeddings quota exhausted"), {
+      status: 429,
+      code: "insufficient_quota",
+    });
+    let embedBatchCalls = 0;
+    const fields = manager as unknown as {
+      providerInitialized: boolean;
+      providerKey: string;
+      computeProviderKey: () => string;
+      provider: {
+        id: string;
+        model: string;
+        embed: () => Promise<number[]>;
+        embedBatch: () => Promise<number[][]>;
+        close: () => Promise<void>;
+      };
+    };
+    fields.providerInitialized = true;
+    fields.provider = {
+      id: "mock",
+      model: "mock-embed",
+      embed: async () => {
+        throw quotaError;
+      },
+      embedBatch: async () => {
+        embedBatchCalls += 1;
+        throw quotaError;
+      },
+      close: async () => {},
+    };
+    fields.providerKey = fields.computeProviderKey();
+
+    const results = await manager.search("alpha");
+
+    expect(manager.status().custom?.indexIdentity).toMatchObject({
+      status: "mismatched",
+      code: "chunking_version",
+      owner: "openclaw",
+    });
+    expect(results).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: "memory/2026-01-12.md" })]),
+    );
+    expect(embedBatchCalls).toBe(1);
+  });
 
   it("keeps status inspection read-only during an upgrade", async () => {
     const cfg = createConfig();


### PR DESCRIPTION
Closes #144493

## What Problem This Solves

Fixes an issue where users searching memory would receive no results when an automatic OpenClaw chunking upgrade could not rebuild, even though the last published lexical index remained available.

## Why This Change Was Made

Search now permits keyword-only reads from the existing published generation only when the mismatch is an OpenClaw-owned `chunking_version` upgrade and SQLite FTS is available. The index status remains mismatched, configuration-owned mismatches still fail closed, and the normal read-generation lease continues to protect publication races.

## User Impact

Memory recall remains partially available during a failed re-embedding upgrade. Results can reflect the last successfully published index until rebuilding succeeds; the warning and status preserve that staleness boundary.

## Evidence

- Regression test returned `[]` before the production change and returns the prior lexical hit afterward.
- `pnpm test extensions/memory-core/src/memory/manager-search-upgrade.test.ts` — 6 tests passed, including a one-rebuild-attempt assertion.
- `pnpm check:changed` — passed at exact head, including formatting, extension/test type checks, lint, boundary checks, dead-code scans, and import-cycle checks.

## Operational Notes

- Changed service: bundled `memory-core` extension only.
- Migration risk: none; no schema, index, or configuration migration.
- User-visible behavior: lexical results may remain available from the last published generation while an automatic chunking upgrade is pending.
- Security findings: configuration-owned identity mismatches remain fail-closed; fallback is restricted to OpenClaw-owned chunking-version mismatches and requires available FTS.
- Rollback: revert commit `4a803f8ac2`.
- Release impact: patch-level resilience fix; no deployment performed.
- Independent review: the configured read-only reviewer could not inspect this newly cloned repository because it is outside its fixed allowlist. Repository tests and changed-file gates are green; maintainer review remains required before merge.
