### PR TITLE
refactor(discord): remove unused classic model picker layout

### DIFF
--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -39,7 +39,6 @@ const PICKER_VIEWS = ["providers", "models", "recents"] as const;
 export type DiscordModelPickerCommandContext = (typeof COMMAND_CONTEXTS)[number];
 type DiscordModelPickerAction = (typeof PICKER_ACTIONS)[number];
 type DiscordModelPickerView = (typeof PICKER_VIEWS)[number];
-export type DiscordModelPickerLayout = "v2" | "classic";
 
 export type DiscordModelPickerState = {
   command: DiscordModelPickerCommandContext;

--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -20,7 +20,6 @@ import {
   renderDiscordModelPickerModelsView,
   renderDiscordModelPickerProvidersView,
   renderDiscordModelPickerRecentsView,
-  toDiscordModelPickerMessagePayload,
 } from "./model-picker.view.js";
 
 const DISCORD_CUSTOM_ID_MAX_CHARS = 100;
@@ -57,6 +56,7 @@ afterEach(() => {
 type SerializedComponent = {
   type: number;
   label?: string;
+  content?: string;
   disabled?: boolean;
   custom_id?: string;
   options?: Array<{ label?: string; value: string; default?: boolean }>;
@@ -84,7 +84,7 @@ function renderModelsViewRows(
   params: Parameters<typeof renderDiscordModelPickerModelsView>[0],
 ): SerializedComponent[] {
   const rendered = renderDiscordModelPickerModelsView(params);
-  const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+  const payload = serializePayload(rendered) as {
     components?: SerializedComponent[];
   };
   return extractContainerRows(payload.components);
@@ -94,7 +94,7 @@ function renderRecentsViewRows(
   params: Parameters<typeof renderDiscordModelPickerRecentsView>[0],
 ): SerializedComponent[] {
   const rendered = renderDiscordModelPickerRecentsView(params);
-  const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+  const payload = serializePayload(rendered) as {
     components?: SerializedComponent[];
   };
   return extractContainerRows(payload.components);
@@ -466,7 +466,7 @@ describe("Discord model picker rendering", () => {
       currentModel: "provider-01/model-1",
     });
 
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+    const payload = serializePayload(rendered) as {
       content?: string;
       components?: SerializedComponent[];
     };
@@ -518,7 +518,7 @@ describe("Discord model picker rendering", () => {
       currentModel: "provider-01/model-1",
     });
 
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+    const payload = serializePayload(rendered) as {
       components?: SerializedComponent[];
     };
 
@@ -547,7 +547,7 @@ describe("Discord model picker rendering", () => {
       userId: "42",
       data,
     });
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+    const payload = serializePayload(rendered) as {
       components?: SerializedComponent[];
     };
     const providerSelect = requireValue(
@@ -610,7 +610,7 @@ describe("Discord model picker rendering", () => {
       modelBucket: "21-30",
     });
 
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+    const payload = serializePayload(rendered) as {
       components?: SerializedComponent[];
     };
     const rows = extractContainerRows(payload.components);
@@ -643,7 +643,7 @@ describe("Discord model picker rendering", () => {
       pendingRuntime: "codex",
     });
 
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+    const payload = serializePayload(rendered) as {
       components?: SerializedComponent[];
     };
     const rows = extractContainerRows(payload.components);
@@ -851,7 +851,7 @@ describe("Discord model picker rendering", () => {
       providerBucket: "p",
     });
 
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+    const payload = serializePayload(rendered) as {
       components?: SerializedComponent[];
     };
     const rows = extractContainerRows(payload.components);
@@ -882,29 +882,6 @@ describe("Discord model picker rendering", () => {
     }
   });
 
-  it("supports classic fallback rendering with content + action rows", () => {
-    const data = createModelsProviderData({ openai: ["gpt-4o"], anthropic: ["claude-sonnet-4-5"] });
-
-    const rendered = renderDiscordModelPickerProvidersView({
-      command: "model",
-      userId: "99",
-      data,
-      layout: "classic",
-    });
-
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
-      content?: string;
-      components?: SerializedComponent[];
-    };
-
-    expect(payload.content).toContain("Model Picker");
-    const firstComponent = requireValue(
-      payload.components?.[0],
-      "classic provider view should render an action row",
-    );
-    expect(firstComponent.type).toBe(ComponentType.ActionRow);
-  });
-
   it("preserves the stored model suffix spacing in Discord current-model text", () => {
     const data = createModelsProviderData({ openai: [" gpt-5", "gpt-4o"] });
 
@@ -913,14 +890,17 @@ describe("Discord model picker rendering", () => {
       userId: "99",
       data,
       currentModel: " OpenAI/ gpt-5 ",
-      layout: "classic",
     });
 
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
-      content?: string;
+    const payload = serializePayload(rendered) as {
+      components?: SerializedComponent[];
     };
+    const text = payload.components
+      ?.flatMap((component) => component.components ?? [])
+      .map((component) => component.content ?? "")
+      .join("\n");
 
-    expect(payload.content).toContain("Current model: openai/ gpt-5");
+    expect(text).toContain("Current model: openai/ gpt-5");
   });
 
   it("keeps provider navigation available when model bucketing drops the provider select", () => {
@@ -992,7 +972,7 @@ describe("Discord model picker rendering", () => {
       pendingModelIndex: 3,
     });
 
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+    const payload = serializePayload(rendered) as {
       components?: SerializedComponent[];
     };
 
@@ -1180,7 +1160,7 @@ describe("Discord model picker rendering", () => {
       providerPage: 3,
     });
 
-    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+    const payload = serializePayload(rendered) as {
       components?: SerializedComponent[];
     };
 

--- a/extensions/discord/src/monitor/model-picker.view.ts
+++ b/extensions/discord/src/monitor/model-picker.view.ts
@@ -14,7 +14,6 @@ import {
   Separator,
   StringSelectMenu,
   TextDisplay,
-  type MessagePayloadObject,
   type TopLevelComponents,
 } from "../internal/discord.js";
 import {
@@ -30,7 +29,6 @@ import {
   normalizeModelPickerPage,
   type DiscordModelPickerBucket,
   type DiscordModelPickerCommandContext,
-  type DiscordModelPickerLayout,
   type DiscordModelPickerModelPage,
   type DiscordModelPickerPage,
   type DiscordModelPickerProviderItem,
@@ -57,7 +55,6 @@ type CompactRuntimeState = {
 };
 
 type DiscordModelPickerRenderShellParams = {
-  layout: DiscordModelPickerLayout;
   title: string;
   detailLines: string[];
   rows: DiscordModelPickerRow[];
@@ -69,8 +66,6 @@ type DiscordModelPickerRenderShellParams = {
 };
 
 type DiscordModelPickerRenderedView = {
-  layout: DiscordModelPickerLayout;
-  content?: string;
   components: TopLevelComponents[];
 };
 
@@ -81,7 +76,6 @@ type DiscordModelPickerProviderViewParams = {
   page?: number;
   providerBucket?: string;
   currentModel?: string;
-  layout?: DiscordModelPickerLayout;
 };
 
 type DiscordModelPickerModelViewParams = {
@@ -99,7 +93,6 @@ type DiscordModelPickerModelViewParams = {
   pendingModelIndex?: number;
   pendingRuntime?: string;
   quickModels?: string[];
-  layout?: DiscordModelPickerLayout;
 };
 
 function parseCurrentModelRef(raw?: string): DiscordModelPickerCurrentModelRef | null {
@@ -269,15 +262,6 @@ function resolveCompactRuntimeState(params: {
 function buildRenderedShell(
   params: DiscordModelPickerRenderShellParams,
 ): DiscordModelPickerRenderedView {
-  if (params.layout === "classic") {
-    const lines = [params.title, ...params.detailLines, "", params.footer].filter(Boolean);
-    return {
-      layout: "classic",
-      content: lines.join("\n"),
-      components: params.rows,
-    };
-  }
-
   const containerComponents: Array<TextDisplay | Separator | DiscordModelPickerRow> = [
     new TextDisplay(`## ${params.title}`),
   ];
@@ -300,7 +284,6 @@ function buildRenderedShell(
 
   const container = new Container(containerComponents);
   return {
-    layout: "v2",
     components: [container],
   };
 }
@@ -709,7 +692,6 @@ export function renderDiscordModelPickerProvidersView(
       ? `Showing page ${page.page}/${page.totalPages} · ${page.totalItems} providers total`
       : `All ${page.totalItems} providers shown`;
   return buildRenderedShell({
-    layout: params.layout ?? "v2",
     title: "Model Picker",
     detailLines,
     rows,
@@ -745,7 +727,6 @@ export function renderDiscordModelPickerModelsView(
     ];
 
     return buildRenderedShell({
-      layout: params.layout ?? "v2",
       title: "Model Picker",
       detailLines: [
         formatCurrentModelLine(params.currentModel),
@@ -826,7 +807,6 @@ export function renderDiscordModelPickerModelsView(
   }
 
   return buildRenderedShell({
-    layout: params.layout ?? "v2",
     title: "Model Picker",
     detailLines,
     preRowText: pendingLine,
@@ -847,7 +827,6 @@ type DiscordModelPickerRecentsViewParams = {
   page?: number;
   providerPage?: number;
   modelBucket?: string;
-  layout?: DiscordModelPickerLayout;
 };
 
 function formatRecentsButtonLabel(modelRef: string, suffix?: string): string {
@@ -920,7 +899,6 @@ export function renderDiscordModelPickerRecentsView(
   ]);
 
   return buildRenderedShell({
-    layout: params.layout ?? "v2",
     title: "Recents",
     detailLines: [
       "Models you've previously selected appear here.",
@@ -930,19 +908,5 @@ export function renderDiscordModelPickerRecentsView(
     rows,
     trailingRows: [backRow],
   });
-}
-
-export function toDiscordModelPickerMessagePayload(
-  view: DiscordModelPickerRenderedView,
-): MessagePayloadObject {
-  if (view.layout === "classic") {
-    return {
-      content: view.content,
-      components: view.components,
-    };
-  }
-  return {
-    components: view.components,
-  };
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -38,7 +38,6 @@ import {
   renderDiscordModelPickerModelsView,
   renderDiscordModelPickerProvidersView,
   renderDiscordModelPickerRecentsView,
-  toDiscordModelPickerMessagePayload,
 } from "./model-picker.view.js";
 import type { DispatchDiscordCommandInteraction } from "./native-command-dispatch.js";
 import { applyDiscordModelPickerSelection } from "./native-command-model-picker-apply.js";
@@ -351,7 +350,7 @@ async function handleDiscordModelPickerInteraction(params: {
       quickModels,
       ...state,
     });
-    return await updatePicker(toDiscordModelPickerMessagePayload(rendered));
+    return await updatePicker(rendered);
   };
 
   if (parsed.action !== "cancel" && pickerData.isCurrent?.() === false) {
@@ -387,7 +386,7 @@ async function handleDiscordModelPickerInteraction(params: {
       providerPage: parsed.providerPage,
       modelBucket: parsed.modelBucket,
     });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
+    await updatePicker(rendered);
     return;
   }
 
@@ -404,7 +403,7 @@ async function handleDiscordModelPickerInteraction(params: {
       providerBucket: selectingBucket ? resolveSelectedBucket(interaction) : parsed.providerBucket,
       currentModel: currentModelRef,
     });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
+    await updatePicker(rendered);
     return;
   }
 

--- a/extensions/discord/src/monitor/native-command-model-picker-ui.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-ui.ts
@@ -32,10 +32,7 @@ import {
   resolveDiscordModelPickerPageForModel,
   type DiscordModelPickerCommandContext,
 } from "./model-picker.state.js";
-import {
-  renderDiscordModelPickerModelsView,
-  toDiscordModelPickerMessagePayload,
-} from "./model-picker.view.js";
+import { renderDiscordModelPickerModelsView } from "./model-picker.view.js";
 import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
 import type { SafeDiscordInteractionCall } from "./native-command-ui.types.js";
 import { resolveDiscordNativeInteractionChannelContext } from "./native-interaction-channel-context.js";
@@ -359,7 +356,7 @@ export async function replyWithDiscordModelPickerProviders(params: {
     quickModels,
   });
   const payload = {
-    ...toDiscordModelPickerMessagePayload(rendered),
+    ...rendered,
     ephemeral: true,
   };
 

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -24,10 +24,7 @@ import {
   createModelsProviderData as createBaseModelsProviderData,
   setFixtureRuntimeChoices,
 } from "./model-picker.test-utils.js";
-import {
-  renderDiscordModelPickerModelsView,
-  toDiscordModelPickerMessagePayload,
-} from "./model-picker.view.js";
+import { renderDiscordModelPickerModelsView } from "./model-picker.view.js";
 import type { DispatchDiscordCommandInteraction } from "./native-command-dispatch.js";
 import { applyDiscordModelPickerSelection } from "./native-command-model-picker-apply.js";
 import {
@@ -1534,7 +1531,7 @@ describe("Discord model picker interactions", () => {
         pendingRuntime: "codex",
       });
       type PickerComponent = { label?: string; custom_id?: string; components?: PickerComponent[] };
-      const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+      const payload = serializePayload(rendered) as {
         components: PickerComponent[];
       };
       const submit = payload.components


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

This maintainer-requested refactor removes the unused classic layout from Discord’s model picker. Every production renderer call already uses Components V2; the classic option is private and is not exposed by the published plugin API.

## Why This Change Was Made

The renderer now returns its components-only payload directly, allowing the classic branch, layout fields and redundant payload projection to be removed together. Existing callback parsing and minimum-host runtime compatibility remain intact.

Only the test dedicated to classic output is removed. The stored-model suffix-spacing regression is retained against actual V2 TextDisplay content, along with all native interaction cases.

## User Impact

No user-visible change. The current picker’s serialized V2 output, appearance and behavior are unchanged.

## Evidence

- Original renderer and native interaction suites: 102 tests passed.
- Candidate product suites: 101 retained tests passed, including all 53 native interaction cases. One additional disposable proof test passed separately from that retained-suite count.
- All 37 complete original/candidate serialized V2 payloads were byte-identical; the suffix-spacing assertion also passed through the original payload boundary.
- Required changed-file gate and full `pnpm build` passed.
- Independent P2 review returned scoped-clean with no findings.
