### PR TITLE
fix(usage): clear timeline ranges after session replacement

### DIFF
--- a/docs/web/control-ui/feature-reference.md
+++ b/docs/web/control-ui/feature-reference.md
@@ -93,7 +93,7 @@ Control UI capabilities grouped by area, each with the Gateway RPC methods behin
     - A provider usage failure does not block the session/cost dashboard; unavailable provider cards show their own error state.
     - Incomplete session/cost totals stay readable while the visible, focused page checks for updates. Automatic checks are bounded; if they pause, select **Refresh** to check again.
     - **Refresh** also reloads the selected session's timeline, conversation, and system-prompt breakdown.
-    - If a selected session is deleted and recreated, its new details replace the old ones without clearing your selection. Context details from a different session instance show an error and can be retried with **Refresh**.
+    - If a selected session is deleted and recreated, its new details replace the old ones and clear the previous timeline interval without clearing your session selection. An unfinished drag on the old timeline cannot change the new interval. Refreshing the same instance retains its selected interval. Context details from a different session instance show an error and can be retried with **Refresh**.
     - The overview loads session summaries first. Full system-prompt breakdowns load when you select a session; the `has:context` filter still works before opening details.
     - JSON exports keep the displayed usage snapshot and load prompt details for the same session instance. If that session has been replaced, refresh Usage and export again.
 

--- a/ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
+++ b/ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
@@ -47,6 +47,24 @@ async function prepareUsageProofPage(page: Page) {
   }, COMMUNITY_INVITE_KEY);
 }
 
+async function dragTimelineRange(page: Page, fraction: number) {
+  const panel = page.locator(".session-detail-panel");
+  const handle = panel.locator(".chart-handle-right");
+  await handle.scrollIntoViewIfNeeded();
+  const handleBox = await handle.boundingBox();
+  const chartBox = await panel.locator(".timeseries-svg").boundingBox();
+  if (!handleBox || !chartBox) {
+    throw new Error("Timeline drag handles did not render");
+  }
+  const y = handleBox.y + handleBox.height / 2;
+  const x = chartBox.x + (chartBox.width * (30 + 366 * fraction)) / 400;
+  await page.mouse.move(handleBox.x + handleBox.width / 2, y);
+  await page.mouse.down();
+  const move = () => page.mouse.move(x, y, { steps: 8 });
+  await move();
+  return move;
+}
+
 async function requestGateway<T>(
   page: Page,
   methodName: string,
@@ -243,304 +261,356 @@ suite.define(() => {
     },
   );
 
-  it("replaces selected details when the same agent recreates a deleted session key", async (context) => {
-    let fixture: OpenClawTestState | undefined;
-    let gateway: Promise<GatewayServer> | undefined;
-    let restoreClock: (() => void) | undefined;
-    await suite.runScenario(context, {
-      retainedState: () => fixture?.root,
-      close: async () => {
-        await (await gateway)?.close({ reason: "usage detail instance e2e cleanup" });
-      },
-      release: async () => {
-        restoreClock?.();
-        await fixture?.cleanup();
-        resetLogger();
-      },
-      run: async (signal) => {
-        const port = await getFreePort();
-        signal.throwIfAborted();
-        const state = await createOpenClawTestState({
-          label: "usage-detail-instance",
-          env: {
-            OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
-            OPENCLAW_SKIP_CANVAS_HOST: "1",
-            OPENCLAW_SKIP_CHANNELS: "1",
-            OPENCLAW_SKIP_CRON: "1",
-            OPENCLAW_SKIP_GMAIL_WATCHER: "1",
-            OPENCLAW_SKIP_PROVIDERS: "1",
-            OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
-            VITEST: "1",
-          },
-        });
-        fixture = state;
-        setLoggerOverride({
-          file: state.path("gateway.log"),
-          level: "silent",
-          consoleLevel: "silent",
-        });
-        signal.throwIfAborted();
-        await state.writeConfig({
-          agents: {
-            ownership: "explicit",
-            defaults: { workspace: state.workspaceDir },
-            entries: { main: {}, opus: {} },
-          },
-          gateway: {
-            mode: "local",
-            port,
-            bind: "loopback",
+  it.for([1, 2])(
+    "clears ranges after session recreation (%s points)",
+    async (pointCount, context) => {
+      let fixture: OpenClawTestState | undefined;
+      let gateway: Promise<GatewayServer> | undefined;
+      let restoreClock: (() => void) | undefined;
+      await suite.runScenario(context, {
+        retainedState: () => fixture?.root,
+        close: async () => {
+          await (await gateway)?.close({ reason: "usage detail instance e2e cleanup" });
+        },
+        release: async () => {
+          restoreClock?.();
+          await fixture?.cleanup();
+          resetLogger();
+        },
+        run: async (signal) => {
+          const port = await getFreePort();
+          signal.throwIfAborted();
+          const state = await createOpenClawTestState({
+            label: "usage-detail-instance",
+            env: {
+              OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+              OPENCLAW_SKIP_CANVAS_HOST: "1",
+              OPENCLAW_SKIP_CHANNELS: "1",
+              OPENCLAW_SKIP_CRON: "1",
+              OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+              OPENCLAW_SKIP_PROVIDERS: "1",
+              OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+              VITEST: "1",
+            },
+          });
+          fixture = state;
+          setLoggerOverride({
+            file: state.path("gateway.log"),
+            level: "silent",
+            consoleLevel: "silent",
+          });
+          signal.throwIfAborted();
+          await state.writeConfig({
+            agents: {
+              ownership: "explicit",
+              defaults: { workspace: state.workspaceDir },
+              entries: { main: {}, opus: {} },
+            },
+            gateway: {
+              mode: "local",
+              port,
+              bind: "loopback",
+              auth: { mode: "none" },
+              controlUi: { enabled: false },
+            },
+            plugins: { enabled: false },
+          });
+          const { startGatewayServer } = await import("../../../src/gateway/server.js");
+          const { persistSessionTranscriptTurn } =
+            await import("../../../src/config/sessions/session-accessor.js");
+          const { ensureGatewayOwnerProfile } = await import("../../../src/state/user-profiles.js");
+          ensureGatewayOwnerProfile("Usage Proof", { env: state.env });
+          signal.throwIfAborted();
+          gateway = startGatewayServer(port, {
             auth: { mode: "none" },
-            controlUi: { enabled: false },
-          },
-          plugins: { enabled: false },
-        });
-        const { startGatewayServer } = await import("../../../src/gateway/server.js");
-        const { persistSessionTranscriptTurn } =
-          await import("../../../src/config/sessions/session-accessor.js");
-        const { ensureGatewayOwnerProfile } = await import("../../../src/state/user-profiles.js");
-        ensureGatewayOwnerProfile("Usage Proof", { env: state.env });
-        signal.throwIfAborted();
-        gateway = startGatewayServer(port, {
-          auth: { mode: "none" },
-          bind: "loopback",
-          controlUiEnabled: false,
-          sidecarStartup: "defer",
-        });
-        await gateway;
-        signal.throwIfAborted();
+            bind: "loopback",
+            controlUiEnabled: false,
+            sidecarStartup: "defer",
+          });
+          await gateway;
+          signal.throwIfAborted();
 
-        await suite.withPage(
-          { locale: "en-US", timezoneId: "UTC", serviceWorkers: "block", viewport },
-          async ({ page }) => {
-            await prepareUsageProofPage(page);
-            const key = "agent:opus:usage-instance-proof";
-            const gatewayUrl = new URL(`ws://127.0.0.1:${port}`).href;
-            const pageErrors: string[] = [];
-            const overviewRequests = new Map<string, Record<string, unknown>>();
-            const observedOverviews: Array<{
-              requestId: string;
-              params: Record<string, unknown>;
-              session?: { key: string; agentId?: string; sessionId?: string; tokens?: number };
-            }> = [];
-            let connections = 0;
-            page.on("pageerror", (error) => pageErrors.push(String(error)));
-            page.on("websocket", (socket) => {
-              if (socket.url() !== gatewayUrl) {
-                return;
-              }
-              connections++;
-              socket.on("framesent", ({ payload }) => {
-                const frame: {
-                  type: string;
-                  id: string;
-                  method?: string;
-                  params?: Record<string, unknown>;
-                } = JSON.parse(payload.toString());
-                if (
-                  frame.type === "req" &&
-                  frame.method === "sessions.usage" &&
-                  frame.params &&
-                  frame.params.key === undefined
-                ) {
-                  overviewRequests.set(frame.id, frame.params);
-                }
-              });
-              socket.on("framereceived", ({ payload }) => {
-                const frame: {
-                  type: string;
-                  id: string;
-                  ok?: boolean;
-                  payload?: SessionsUsageResult;
-                } = JSON.parse(payload.toString());
-                const params = overviewRequests.get(frame.id);
-                if (frame.type !== "res" || !frame.ok || !params || !frame.payload) {
+          await suite.withPage(
+            { locale: "en-US", timezoneId: "UTC", serviceWorkers: "block", viewport },
+            async ({ page }) => {
+              await prepareUsageProofPage(page);
+              const key = "agent:opus:usage-instance-proof";
+              const gatewayUrl = new URL(`ws://127.0.0.1:${port}`).href;
+              const pageErrors: string[] = [];
+              const overviewRequests = new Map<string, Record<string, unknown>>();
+              const observedOverviews: Array<{
+                requestId: string;
+                params: Record<string, unknown>;
+                session?: { key: string; agentId?: string; sessionId?: string; tokens?: number };
+              }> = [];
+              let connections = 0;
+              page.on("pageerror", (error) => pageErrors.push(String(error)));
+              page.on("websocket", (socket) => {
+                if (socket.url() !== gatewayUrl) {
                   return;
                 }
-                const session = frame.payload.sessions.find((entry) => entry.key === key);
-                observedOverviews.push({
-                  requestId: frame.id,
-                  params,
-                  ...(session
-                    ? {
-                        session: {
-                          key: session.key,
-                          agentId: session.agentId,
-                          sessionId: session.sessionId,
-                          tokens: session.usage?.totalTokens,
-                        },
-                      }
-                    : {}),
+                connections++;
+                socket.on("framesent", ({ payload }) => {
+                  const frame: {
+                    type: string;
+                    id: string;
+                    method?: string;
+                    params?: Record<string, unknown>;
+                  } = JSON.parse(payload.toString());
+                  if (
+                    frame.type === "req" &&
+                    frame.method === "sessions.usage" &&
+                    frame.params &&
+                    frame.params.key === undefined
+                  ) {
+                    overviewRequests.set(frame.id, frame.params);
+                  }
+                });
+                socket.on("framereceived", ({ payload }) => {
+                  const frame: {
+                    type: string;
+                    id: string;
+                    ok?: boolean;
+                    payload?: SessionsUsageResult;
+                  } = JSON.parse(payload.toString());
+                  const params = overviewRequests.get(frame.id);
+                  if (frame.type !== "res" || !frame.ok || !params || !frame.payload) {
+                    return;
+                  }
+                  const session = frame.payload.sessions.find((entry) => entry.key === key);
+                  observedOverviews.push({
+                    requestId: frame.id,
+                    params,
+                    ...(session
+                      ? {
+                          session: {
+                            key: session.key,
+                            agentId: session.agentId,
+                            sessionId: session.sessionId,
+                            tokens: session.usage?.totalTokens,
+                          },
+                        }
+                      : {}),
+                  });
                 });
               });
-            });
-            const url = new URL("settings/general", suite.server.baseUrl);
-            url.searchParams.set("gatewayUrl", gatewayUrl);
-            await page.goto(url.toString());
-            await page
-              .locator("openclaw-gateway-url-confirmation")
-              .getByRole("button", { name: `Switch to 127.0.0.1:${port}`, exact: true })
-              .click();
-            await waitForControlUiGatewayReady(page);
+              const url = new URL("settings/general", suite.server.baseUrl);
+              url.searchParams.set("gatewayUrl", gatewayUrl);
+              await page.goto(url.toString());
+              await page
+                .locator("openclaw-gateway-url-confirmation")
+                .getByRole("button", { name: `Switch to 127.0.0.1:${port}`, exact: true })
+                .click();
+              await waitForControlUiGatewayReady(page);
 
-            const date = new Date().toISOString().slice(0, 10);
-            const timestamp = Date.parse(`${date}T12:00:00Z`);
-            const createSession = async (label: string, tokens: number) => {
-              const created = await requestGateway<{ ok: boolean; key: string; sessionId: string }>(
-                page,
-                "sessions.create",
-                { key, agentId: "opus", label: `${label} usage session` },
-              );
-              expect(created.ok).toBe(true);
-              expect(created.key).toBe(key);
-              expect(created.sessionId).toBeTruthy();
-              signal.throwIfAborted();
-              await persistSessionTranscriptTurn(
-                { agentId: "opus", sessionKey: key, sessionId: created.sessionId, env: state.env },
-                {
-                  cwd: state.workspaceDir,
-                  updateMode: "none",
-                  messages: [0, 1].map((index) => ({
-                    now: timestamp + index * 1_000,
-                    message: {
-                      role: "assistant",
-                      content: [{ type: "text", text: `${label} reply ${index + 1}` }],
-                      api: "openai-responses",
-                      provider: "fixture",
-                      model: "usage-proof",
-                      stopReason: "stop",
-                      timestamp: timestamp + index * 1_000,
-                      usage: {
-                        input: tokens,
-                        output: 0,
-                        cacheRead: 0,
-                        cacheWrite: 0,
-                        totalTokens: tokens,
-                        cost: { input: 0.01, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.01 },
-                      },
-                    },
-                  })),
-                },
-              );
-              return created.sessionId;
-            };
-            const originalId = await createSession("Original", 100);
-            await page.goto(new URL("usage", suite.server.baseUrl).toString());
-            await waitForControlUiGatewayReady(page);
-            const selected = page.locator(
-              `.session-bar-row[title="${key}"] .session-bar-selection`,
-            );
-            await selected.click();
-            const panel = page.locator(".session-detail-panel");
-            const readDetails = async () => ({
-              timeline: await panel.locator(".timeseries-summary").textContent(),
-              conversation: await panel.locator(".session-log-content").allTextContents(),
-            });
-            await expect.poll(readDetails).toEqual({
-              timeline: expect.stringContaining("200"),
-              conversation: ["Original reply 1", "Original reply 2"],
-            });
-            const initialOverview = observedOverviews.findLast(
-              (overview) => overview.session?.sessionId === originalId,
-            );
-            if (!initialOverview) {
-              throw new Error("The Usage page did not receive its original session overview");
-            }
-            await capture(page, "01-original-instance-details.png");
-            const selectedConnections = connections;
-
-            const deleted = await requestGateway<{ deleted: boolean }>(page, "sessions.delete", {
-              key,
-              agentId: "opus",
-              expectedSessionId: originalId,
-              deleteTranscript: true,
-            });
-            expect(deleted.deleted).toBe(true);
-            const replacementId = await createSession("Replacement", 300);
-            expect(replacementId).not.toBe(originalId);
-
-            // Age the real cache without replacing its loader or advancing asynchronous timers.
-            const realNow = Date.now.bind(Date);
-            const clock = vi.spyOn(Date, "now").mockImplementation(() => realNow() + 31_000);
-            restoreClock = () => clock.mockRestore();
-            const overviewParams = initialOverview.params;
-            // The first stale-while-refresh read may still return the retired instance.
-            await expect
-              .poll(async () => {
-                const overview = await requestGateway<SessionsUsageResult>(
-                  page,
-                  "sessions.usage",
-                  overviewParams,
-                );
-                const current = overview.sessions.find((session) => session.key === key);
-                return { sessionId: current?.sessionId, tokens: current?.usage?.totalTokens };
-              })
-              .toEqual({ sessionId: replacementId, tokens: 600 });
-            const focusOverviewStart = observedOverviews.length;
-
-            // Keep the real connection active while aging the browser's five-minute focus TTL.
-            const browserNow = await page.evaluate(() => Date.now());
-            for (let step = 1; step <= 31; step++) {
-              await page.clock.setFixedTime(new Date(browserNow + step * 10_000));
-              await requestGateway(page, "health", {});
-            }
-            await page.bringToFront();
-            await page.evaluate(() => window.dispatchEvent(new Event("focus")));
-            await expect
-              .poll(() => panel.locator(".session-detail-title").textContent())
-              .toContain("Replacement usage session");
-            await expect
-              .poll(() => panel.locator(".session-detail-stats").textContent())
-              .toContain("600");
-            const selectedReplacement = page.locator(
-              ".session-bar-row.selected .session-bar-selection",
-            );
-            expect(await selectedReplacement.count()).toBe(1);
-            expect(await selectedReplacement.getAttribute("aria-pressed")).toBe("true");
-            expect(await selectedReplacement.getAttribute("aria-label")).toBe(
-              "Replacement usage session",
-            );
-            expect(
-              observedOverviews
-                .slice(focusOverviewStart)
-                .some((overview) => overview.session?.sessionId === replacementId),
-            ).toBe(true);
-            expect(connections).toBe(selectedConnections);
-            try {
-              await expect.poll(readDetails).toEqual({
-                timeline: expect.stringContaining("600"),
-                conversation: ["Replacement reply 1", "Replacement reply 2"],
-              });
-            } finally {
-              await capture(page, "02-replacement-instance-details.png");
-              await panel.locator(".session-log-content").last().scrollIntoViewIfNeeded();
-              await capture(page, "03-replacement-instance-conversation.png");
-              if (captureUiProof) {
-                await writeFile(
-                  path.join(suite.artifactDir, "instance-replacement.json"),
-                  JSON.stringify({
-                    key,
+              const date = new Date().toISOString().slice(0, 10);
+              const timestamp = Date.parse(`${date}T12:00:00Z`);
+              const createSession = async (label: string, tokens: number, timestamps: number[]) => {
+                const created = await requestGateway<{
+                  ok: boolean;
+                  key: string;
+                  sessionId: string;
+                }>(page, "sessions.create", {
+                  key,
+                  agentId: "opus",
+                  label: `${label} usage session`,
+                });
+                expect(created.ok).toBe(true);
+                expect(created.key).toBe(key);
+                expect(created.sessionId).toBeTruthy();
+                signal.throwIfAborted();
+                await persistSessionTranscriptTurn(
+                  {
                     agentId: "opus",
-                    originalId,
-                    replacementId,
-                    selection: {
-                      pressed: await selectedReplacement.getAttribute("aria-pressed"),
-                      label: await selectedReplacement.getAttribute("aria-label"),
-                    },
-                    initialOverview,
-                    focusOverviews: observedOverviews.slice(focusOverviewStart),
-                    selectedConnections,
-                    connections,
-                    ...(await readDetails()),
-                  }),
+                    sessionKey: key,
+                    sessionId: created.sessionId,
+                    env: state.env,
+                  },
+                  {
+                    cwd: state.workspaceDir,
+                    updateMode: "none",
+                    messages: timestamps.map((turnTimestamp, index) => ({
+                      now: turnTimestamp,
+                      message: {
+                        role: "assistant",
+                        content: [{ type: "text", text: `${label} reply ${index + 1}` }],
+                        api: "openai-responses",
+                        provider: "fixture",
+                        model: "usage-proof",
+                        stopReason: "stop",
+                        timestamp: turnTimestamp,
+                        usage: {
+                          input: tokens,
+                          output: 0,
+                          cacheRead: 0,
+                          cacheWrite: 0,
+                          totalTokens: tokens,
+                          cost: {
+                            input: 0.01,
+                            output: 0,
+                            cacheRead: 0,
+                            cacheWrite: 0,
+                            total: 0.01,
+                          },
+                        },
+                      },
+                    })),
+                  },
                 );
+                return created.sessionId;
+              };
+              const originalId = await createSession("Original", 100, [
+                timestamp,
+                timestamp + 1_000,
+              ]);
+              await page.goto(new URL("usage", suite.server.baseUrl).toString());
+              await waitForControlUiGatewayReady(page);
+              const selected = page.locator(
+                `.session-bar-row[title="${key}"] .session-bar-selection`,
+              );
+              await selected.click();
+              const panel = page.locator(".session-detail-panel");
+              const readDetails = async () => ({
+                timeline: (await panel.locator(".timeseries-summary").allTextContents()).join("\n"),
+                conversation: await panel.locator(".session-log-content").allTextContents(),
+              });
+              await expect.poll(readDetails).toEqual({
+                timeline: expect.stringContaining("200"),
+                conversation: ["Original reply 1", "Original reply 2"],
+              });
+              const initialOverview = observedOverviews.findLast(
+                (overview) => overview.session?.sessionId === originalId,
+              );
+              if (!initialOverview) {
+                throw new Error("The Usage page did not receive its original session overview");
               }
-            }
-            expect(connections).toBe(selectedConnections);
-            expect(pageErrors).toEqual([]);
-          },
-        );
-      },
-    });
-  });
+              const moveOriginalRange = await dragTimelineRange(page, 0.5);
+              await panel.locator(".session-detail-indicator").waitFor({ state: "visible" });
+              if (pointCount === 1) {
+                await page.mouse.up();
+              }
+              await capture(page, "01-original-instance-details.png");
+              const selectedConnections = connections;
+
+              const deleted = await requestGateway<{ deleted: boolean }>(page, "sessions.delete", {
+                key,
+                agentId: "opus",
+                expectedSessionId: originalId,
+                deleteTranscript: true,
+              });
+              expect(deleted.deleted).toBe(true);
+              const replacementId = await createSession(
+                "Replacement",
+                300,
+                Array.from(
+                  { length: pointCount },
+                  (_, index) => timestamp + 60_000 + index * 1_000,
+                ),
+              );
+              expect(replacementId).not.toBe(originalId);
+
+              // Age the real cache without replacing its loader or advancing asynchronous timers.
+              const realNow = Date.now.bind(Date);
+              const clock = vi.spyOn(Date, "now").mockImplementation(() => realNow() + 31_000);
+              restoreClock = () => clock.mockRestore();
+              const overviewParams = initialOverview.params;
+              // The first stale-while-refresh read may still return the retired instance.
+              await expect
+                .poll(async () => {
+                  const overview = await requestGateway<SessionsUsageResult>(
+                    page,
+                    "sessions.usage",
+                    overviewParams,
+                  );
+                  const current = overview.sessions.find((session) => session.key === key);
+                  return { sessionId: current?.sessionId, tokens: current?.usage?.totalTokens };
+                })
+                .toEqual({ sessionId: replacementId, tokens: pointCount * 300 });
+              const focusOverviewStart = observedOverviews.length;
+
+              // Keep the real connection active while aging the browser's five-minute focus TTL.
+              const browserNow = await page.evaluate(() => Date.now());
+              for (let step = 1; step <= 31; step++) {
+                await page.clock.setFixedTime(new Date(browserNow + step * 10_000));
+                await requestGateway(page, "health", {});
+              }
+              await page.bringToFront();
+              await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+              await expect
+                .poll(() => panel.locator(".session-detail-title").textContent())
+                .toContain("Replacement usage session");
+              await expect
+                .poll(() => panel.locator(".session-detail-stats").textContent())
+                .toContain(String(pointCount * 300));
+              const selectedReplacement = page.locator(
+                ".session-bar-row.selected .session-bar-selection",
+              );
+              expect(await selectedReplacement.count()).toBe(1);
+              expect(await selectedReplacement.getAttribute("aria-pressed")).toBe("true");
+              expect(await selectedReplacement.getAttribute("aria-label")).toBe(
+                "Replacement usage session",
+              );
+              expect(
+                observedOverviews
+                  .slice(focusOverviewStart)
+                  .some((overview) => overview.session?.sessionId === replacementId),
+              ).toBe(true);
+              expect(connections).toBe(selectedConnections);
+              if (pointCount === 2) {
+                await moveOriginalRange();
+                await page.mouse.up();
+              }
+              try {
+                await expect.poll(readDetails).toEqual({
+                  timeline: pointCount === 1 ? "" : expect.stringContaining("600"),
+                  conversation: Array.from(
+                    { length: pointCount },
+                    (_, index) => `Replacement reply ${index + 1}`,
+                  ),
+                });
+                expect(await panel.locator(".timeseries-summary__range").count()).toBe(0);
+              } finally {
+                await page.mouse.up();
+                await capture(page, "02-replacement-instance-details.png");
+                await panel.locator(".session-logs-compact").scrollIntoViewIfNeeded();
+                await capture(page, "03-replacement-instance-conversation.png");
+                if (captureUiProof) {
+                  await writeFile(
+                    path.join(suite.artifactDir, "instance-replacement.json"),
+                    JSON.stringify({
+                      key,
+                      agentId: "opus",
+                      originalId,
+                      replacementId,
+                      pointCount,
+                      selection: {
+                        pressed: await selectedReplacement.getAttribute("aria-pressed"),
+                        label: await selectedReplacement.getAttribute("aria-label"),
+                      },
+                      initialOverview,
+                      focusOverviews: observedOverviews.slice(focusOverviewStart),
+                      selectedConnections,
+                      connections,
+                      ...(await readDetails()),
+                    }),
+                  );
+                }
+              }
+              if (pointCount === 2) {
+                await dragTimelineRange(page, 0.25);
+                await page.mouse.up();
+                await expect
+                  .poll(() => panel.locator(".session-log-content").allTextContents())
+                  .toEqual(["Replacement reply 1"]);
+                await panel.getByRole("button", { name: "Reset", exact: true }).click();
+                await expect.poll(() => panel.locator(".session-log-content").count()).toBe(2);
+              }
+              expect(connections).toBe(selectedConnections);
+              expect(pageErrors).toEqual([]);
+            },
+          );
+        },
+      });
+    },
+  );
 });

--- a/ui/src/pages/usage/detail-controller.ts
+++ b/ui/src/pages/usage/detail-controller.ts
@@ -38,6 +38,7 @@ function createUsageDetailRequest<T>(
   ) => Promise<T>,
   resolveTarget: (key: string) => UsageDetailTarget,
   canLoad?: (key: string) => boolean,
+  onClear?: () => void,
 ) {
   let value: { target: UsageDetailTarget; data?: T } | null = null;
   let status = createPanelRefreshStatus();
@@ -86,6 +87,11 @@ function createUsageDetailRequest<T>(
     generation += 1;
     task.cancel();
   };
+  const reset = (target?: UsageDetailTarget) => {
+    value = target ? { target } : null;
+    status = createPanelRefreshStatus();
+    onClear?.();
+  };
   return {
     get data() {
       return value?.data ?? null;
@@ -119,8 +125,7 @@ function createUsageDetailRequest<T>(
       const target = resolveTarget(sessionKey);
       const sameTarget = sameUsageTarget(value?.target, target);
       if (!sameTarget || !enabled) {
-        value = enabled ? { target } : null;
-        status = createPanelRefreshStatus();
+        reset(enabled ? target : undefined);
       }
       if (!enabled) {
         cancel();
@@ -136,8 +141,7 @@ function createUsageDetailRequest<T>(
     },
     cancel,
     clear() {
-      value = null;
-      status = createPanelRefreshStatus();
+      reset();
       cancel();
     },
   };
@@ -153,6 +157,7 @@ export class UsageDetailsController {
     gateway: GatewayPageController,
     query: () => SessionUsageQuery,
     sessions: () => UsageSessionEntry[],
+    clearTimeSeriesRange: () => void,
   ) {
     const resolveTarget = (key: string): UsageDetailTarget => {
       const session = sessions().find((entry) => entry.key === key);
@@ -164,6 +169,8 @@ export class UsageDetailsController {
       gateway,
       requestSessionUsageTimeSeries,
       resolveTarget,
+      undefined,
+      clearTimeSeriesRange,
     );
     this.sessionLogs = createUsageDetailRequest(
       host,

--- a/ui/src/pages/usage/usage-page-detail-identity.test.ts
+++ b/ui/src/pages/usage/usage-page-detail-identity.test.ts
@@ -16,7 +16,110 @@ import {
 
 afterEach(cleanupUsagePageTest);
 
+function usagePoints(timestamp: number, count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    timestamp: timestamp + index * 1_000,
+    input: 100,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 100,
+    cost: 0,
+    cumulativeTokens: (index + 1) * 100,
+    cumulativeCost: 0,
+  }));
+}
+
+function dragTimelineRange(page: HTMLElement) {
+  const svg = page.querySelector<SVGSVGElement>(".timeseries-svg")!;
+  const handle = page.querySelector<HTMLElement>(".chart-handle-right")!;
+  vi.spyOn(svg, "getBoundingClientRect").mockReturnValue(new DOMRect(0, 0, 400, 118));
+  handle.dispatchEvent(
+    new MouseEvent("mousedown", {
+      bubbles: true,
+      clientX: Number.parseFloat(handle.style.left) * 4,
+    }),
+  );
+  const move = () => document.dispatchEvent(new MouseEvent("mousemove", { clientX: 213 }));
+  move();
+  return { move, end: () => document.dispatchEvent(new MouseEvent("mouseup")) };
+}
+
 describe("UsagePage detail identity", () => {
+  it.each([
+    { refresh: "automatic", points: 1, activeDrag: false },
+    { refresh: "manual", points: 2, activeDrag: false },
+    { refresh: "automatic", points: 1, activeDrag: true },
+    { refresh: "manual", points: 2, activeDrag: true },
+  ])(
+    "retires a selected range during $refresh instance replacement with $points points (active drag: $activeDrag)",
+    async ({ refresh, points, activeDrag }) => {
+      const snapshot = cacheSnapshot("sessions", "fresh");
+      const timestamp = new Date().setHours(12, 0, 0, 0);
+      let sessionId = "original-instance";
+      let series = usagePoints(timestamp, 3);
+      const request = vi.fn(async (method: string) => {
+        if (method === "sessions.usage") {
+          return {
+            ...snapshot.result,
+            sessions: [
+              { key: "global", agentId: "main", sessionId, usage: snapshot.result.totals },
+            ],
+          };
+        }
+        if (method === "sessions.usage.timeseries") {
+          return { sessionId, points: series };
+        }
+        if (method === "sessions.usage.logs") {
+          return {
+            logs: series.map((point, index) => ({
+              timestamp: point.timestamp,
+              role: "assistant",
+              content: `${sessionId} reply ${index + 1}`,
+            })),
+          };
+        }
+        return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
+      });
+      const page = await createPage({ request } as unknown as GatewayBrowserClient, true);
+      await preloadUsage(page);
+      page.querySelector<HTMLButtonElement>(".session-bar-selection")!.click();
+      await vi.waitFor(() => expect(page.querySelectorAll(".session-log-entry")).toHaveLength(3));
+      const drag = dragTimelineRange(page);
+      try {
+        await page.updateComplete;
+        expect(page.querySelectorAll(".session-log-entry")).toHaveLength(2);
+        if (!activeDrag) {
+          drag.end();
+        }
+        sessionId = "replacement-instance";
+        series = usagePoints(timestamp + 60_000, points);
+        if (refresh === "manual") {
+          refreshButton(page).click();
+        } else {
+          await page.loadUsage();
+        }
+        await vi.waitFor(() => expect(page.details.timeSeries.data?.sessionId).toBe(sessionId));
+        if (activeDrag) {
+          drag.move();
+        }
+        await page.updateComplete;
+        expect.soft(page.usageSelectedSessions).toEqual(["global"]);
+        expect
+          .soft(
+            [...page.querySelectorAll(".session-log-content")].map((entry) => entry.textContent),
+          )
+          .toEqual(series.map((_, index) => `${sessionId} reply ${index + 1}`));
+        expect.soft(page.querySelector(".timeseries-summary__range")).toBeNull();
+        expect
+          .soft(page.querySelector(".session-logs-header-count")?.textContent)
+          .not.toContain("timeline filtered");
+      } finally {
+        drag.end();
+      }
+    },
+  );
+
   it.each([
     { replacement: "owner", refresh: "manual" },
     { replacement: "owner", refresh: "automatic" },
@@ -115,10 +218,16 @@ describe("UsagePage detail identity", () => {
     },
   );
 
-  it.each([undefined, "stable-instance"])(
-    "retains healthy details during automatic refresh of the same optional instance %s",
-    async (sessionId) => {
+  it.each([
+    { sessionId: undefined, refresh: "automatic" },
+    { sessionId: "stable-instance", refresh: "automatic" },
+    { sessionId: undefined, refresh: "manual" },
+    { sessionId: "stable-instance", refresh: "manual" },
+  ])(
+    "retains healthy details and range during $refresh refresh of optional instance $sessionId",
+    async ({ sessionId, refresh }) => {
       const snapshot = cacheSnapshot("sessions", "fresh");
+      const points = usagePoints(new Date().setHours(12, 0, 0, 0), 3);
       let label = "Original summary";
       const request = vi.fn(async (method: string) => {
         if (method === "sessions.usage") {
@@ -130,10 +239,16 @@ describe("UsagePage detail identity", () => {
           };
         }
         if (method === "sessions.usage.logs") {
-          return { logs: [{ timestamp: 1, role: "user", content: "Retained turn" }] };
+          return {
+            logs: points.map((point) => ({
+              timestamp: point.timestamp,
+              role: "user",
+              content: "Retained turn",
+            })),
+          };
         }
         if (method === "sessions.usage.timeseries") {
-          return { sessionId, points: [] };
+          return { sessionId, points };
         }
         return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
       });
@@ -141,20 +256,34 @@ describe("UsagePage detail identity", () => {
       await preloadUsage(page);
       page.querySelector<HTMLButtonElement>(".session-bar-selection")!.click();
       await vi.waitFor(() => expect(page.textContent).toContain("Retained turn"));
+      dragTimelineRange(page).end();
+      await page.updateComplete;
+      expect(page.querySelectorAll(".session-log-entry")).toHaveLength(2);
+      const range = page.querySelector(".timeseries-summary__range")?.textContent;
       const timeSeries = page.details.timeSeries.data;
       const logs = page.details.sessionLogs.data;
       label = "Refreshed summary";
-      await page.loadUsage();
+      if (refresh === "manual") {
+        refreshButton(page).click();
+      } else {
+        await page.loadUsage();
+      }
+      await vi.waitFor(() =>
+        expect(page.querySelector(".session-bar-selection")?.textContent).toContain(label),
+      );
+      await vi.waitFor(() => expect(page.details.timeSeries.loading).toBe(false));
       await page.updateComplete;
       expect(page.querySelector(".session-bar-selection")?.textContent).toContain(label);
       expect(page.usageSelectedSessions).toEqual(["global"]);
       expect(page.details.timeSeries.data).toEqual(timeSeries);
       expect(page.details.sessionLogs.data).toEqual(logs);
+      expect(page.querySelectorAll(".session-log-entry")).toHaveLength(2);
+      expect(page.querySelector(".timeseries-summary__range")?.textContent).toBe(range);
       for (const method of ["sessions.usage.timeseries", "sessions.usage.logs"]) {
         expect(
           request.mock.calls.filter(([name]) => name === method),
           method,
-        ).toHaveLength(1);
+        ).toHaveLength(refresh === "manual" ? 2 : 1);
       }
     },
   );

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -203,6 +203,10 @@ class UsagePage extends OpenClawLightDomElement {
       agentId: this.usageAgentId ?? undefined,
     }),
     () => this.usageResult?.sessions ?? [],
+    () => {
+      this.usageTimeSeriesCursorStart = null;
+      this.usageTimeSeriesCursorEnd = null;
+    },
   );
   private readonly subscriptions = new SubscriptionsController(this)
     .effect(
@@ -369,16 +373,10 @@ class UsagePage extends OpenClawLightDomElement {
     this.usageSelectedSessions = [];
   }
 
-  private clearDetails() {
-    this.details.clear();
-    this.usageTimeSeriesCursorStart = null;
-    this.usageTimeSeriesCursorEnd = null;
-  }
-
   private clearSelectionsAndDetails() {
     this.usageExportRequest.cancel();
     this.clearSelections();
-    this.clearDetails();
+    this.details.clear();
   }
 
   private clearDateDebounce() {
@@ -431,7 +429,7 @@ class UsagePage extends OpenClawLightDomElement {
   }
 
   private selectSession(key: string, shiftKey: boolean, orderedKeys: string[]) {
-    this.clearDetails();
+    this.details.clear();
     this.usageRecentSessions = [
       key,
       ...this.usageRecentSessions.filter((entry) => entry !== key),
@@ -453,6 +451,7 @@ class UsagePage extends OpenClawLightDomElement {
   }
 
   override render() {
+    const timeSeries = this.details.timeSeries.data;
     const props: UsageProps = {
       data: {
         loading: this.usageLoading,
@@ -506,7 +505,7 @@ class UsagePage extends OpenClawLightDomElement {
         },
         timeSeriesMode: this.usageTimeSeriesMode,
         timeSeriesBreakdownMode: this.usageTimeSeriesBreakdownMode,
-        timeSeries: this.details.timeSeries.data,
+        timeSeries,
         timeSeriesLoading: this.details.timeSeries.loading,
         timeSeriesStatus: this.details.timeSeries.status,
         timeSeriesCursorStart: this.usageTimeSeriesCursorStart,
@@ -588,7 +587,7 @@ class UsagePage extends OpenClawLightDomElement {
           onClearHours: () => (this.usageSelectedHours = []),
           onClearSessions: () => {
             this.usageSelectedSessions = [];
-            this.clearDetails();
+            this.details.clear();
           },
           onClearFilters: () => this.clearSelectionsAndDetails(),
         },
@@ -638,8 +637,10 @@ class UsagePage extends OpenClawLightDomElement {
             this.usageTimeSeriesBreakdownMode = mode;
           },
           onTimeSeriesCursorRangeChange: (start, end) => {
-            this.usageTimeSeriesCursorStart = start;
-            this.usageTimeSeriesCursorEnd = end;
+            if (this.details.timeSeries.data === timeSeries) {
+              this.usageTimeSeriesCursorStart = start;
+              this.usageTimeSeriesCursorEnd = end;
+            }
           },
         },
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Usage hid a recreated session's messages when the previous session had a selected timeline range. The old timestamps continued filtering the replacement's later replies. A one-point timeline offered no Reset button; a two-point timeline could show “Turns 1–0.” An unfinished old drag could also restore those bounds after replacement.

## Why This Change Was Made

Clear the range through the existing timeline detail owner's invalidation and reject range writes tied to superseded rendered data. Explicit clearing uses that same owner, removing the redundant page wrapper. Logical session selection, other filters and same-instance range retention remain intact.

## User Impact

Replacement messages stay visible, and users can select a fresh range without closing and reopening the session. Refreshing the same session keeps its selected range. The Usage guide describes the behavior.

## Evidence

Before the fix, four mounted cases and two real Gateway/browser cases fail for the intended stale-range behavior. Afterward, all 86 owner/sibling tests and four complete browser cases pass, along with 20 selected changed-file checks and both independent review passes.

The browser flow completes an actual drag before a one-point replacement and keeps a drag active across a two-point replacement. It creates later replacement timestamps through the existing transcript writer, waits for the real overview to adopt that instance, and verifies the current conversation without reconnecting or clearing session selection. The two-point case also selects and resets a new range successfully. Mounted controls retain ranges through manual/automatic refresh with stable or absent session IDs.

The four inspected synthetic captures below show before/after for the one-point session (300 tokens, one reply), then the two-point session (600 tokens, two replies). The before images show empty filtered conversations; the after images show the replacement replies. This uses a task-owned loopback Gateway with isolated state and silent private logging. Other captures and diagnostics are excluded, and the final complete browser run disables capture of unrelated legacy scenarios. Fixture dates/version labels are not release-version proof. No live provider or operator Gateway was used.

![Before one point: the replacement is selected but its only message is hidden by the old range](https://github.com/user-attachments/assets/22fdae3a-6754-49be-8da5-c233d99487ac)

![After one point: the old range is cleared and the replacement message is visible](https://github.com/user-attachments/assets/bb5fe80b-b820-416d-ab10-eef0d5dee669)

![Before two points: an old drag leaves an empty turn range and hides both replacement messages](https://github.com/user-attachments/assets/60f06339-c60a-441c-9675-42f779b6946f)

![After two points: old drag writes are rejected and both replacement messages are visible](https://github.com/user-attachments/assets/fe771603-3f59-47ed-aaeb-88d4a7503c6d)