### PR TITLE
feat(doctor): report a runtime built from a different commit than HEAD

### DIFF
--- a/src/commands/doctor-stale-runtime-build.test.ts
+++ b/src/commands/doctor-stale-runtime-build.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { collectStaleRuntimeBuildFindings } from "./doctor-stale-runtime-build.js";
+
+const BUILT = "1623683f478b1e4a2e3d5632585f006ea142e08c";
+const HEAD = "5034f2ab174b5c76b0f2a7703ddb332572916e02";
+const roots: string[] = [];
+
+async function makeCheckout(options: { built?: string; head?: string }): Promise<string> {
+  // macOS reports /var while prod resolvers return /private/var; canonicalize first.
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-build-")));
+  roots.push(root);
+  if (options.built) {
+    await fs.mkdir(path.join(root, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "dist", "build-info.json"),
+      JSON.stringify({ version: "2026.8.1", commit: options.built }),
+    );
+  }
+  if (options.head) {
+    await fs.mkdir(path.join(root, ".git"), { recursive: true });
+    await fs.writeFile(path.join(root, ".git", "HEAD"), `${options.head}\n`);
+  }
+  return root;
+}
+
+afterEach(async () => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (root) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("collectStaleRuntimeBuildFindings", () => {
+  it("warns when the built commit differs from the checkout commit", async () => {
+    const root = await makeCheckout({ built: BUILT, head: HEAD });
+
+    const findings = await collectStaleRuntimeBuildFindings({ root, env: {} });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.checkId).toBe("core/doctor/stale-runtime-build");
+    // Doctor exits non-zero only for refused config fixes and update advisories,
+    // so this must stay a warning or it starts failing runs it only describes.
+    expect(findings[0]?.severity).toBe("warning");
+    expect(findings[0]?.message).toContain(BUILT.slice(0, 7));
+    expect(findings[0]?.message).toContain(HEAD.slice(0, 7));
+  });
+
+  it("stays silent while an update is in progress", async () => {
+    const root = await makeCheckout({ built: BUILT, head: HEAD });
+
+    // An update pulls source before rebuilding dist, so the drift this check
+    // reports is the update's own expected intermediate state.
+    await expect(
+      collectStaleRuntimeBuildFindings({ root, env: { OPENCLAW_UPDATE_IN_PROGRESS: "1" } }),
+    ).resolves.toEqual([]);
+  });
+
+  it("stays silent for a checkout with no build provenance", async () => {
+    const root = await makeCheckout({ head: HEAD });
+
+    await expect(collectStaleRuntimeBuildFindings({ root, env: {} })).resolves.toEqual([]);
+  });
+
+  it("stays silent when the built commit matches the checkout", async () => {
+    const root = await makeCheckout({ built: BUILT, head: BUILT });
+
+    await expect(collectStaleRuntimeBuildFindings({ root, env: {} })).resolves.toEqual([]);
+  });
+
+  it("stays silent when the checkout commit cannot be read", async () => {
+    const root = await makeCheckout({ built: BUILT });
+
+    await expect(collectStaleRuntimeBuildFindings({ root, env: {} })).resolves.toEqual([]);
+  });
+});

--- a/src/commands/doctor-stale-runtime-build.test.ts
+++ b/src/commands/doctor-stale-runtime-build.test.ts
@@ -1,17 +1,15 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { collectStaleRuntimeBuildFindings } from "./doctor-stale-runtime-build.js";
 
 const BUILT = "1623683f478b1e4a2e3d5632585f006ea142e08c";
 const HEAD = "5034f2ab174b5c76b0f2a7703ddb332572916e02";
-const roots: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function makeCheckout(options: { built?: string; head?: string }): Promise<string> {
-  // macOS reports /var while prod resolvers return /private/var; canonicalize first.
-  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-build-")));
-  roots.push(root);
+  const root = tempDirs.make("openclaw-stale-build-");
   if (options.built) {
     await fs.mkdir(path.join(root, "dist"), { recursive: true });
     await fs.writeFile(
@@ -25,15 +23,6 @@ async function makeCheckout(options: { built?: string; head?: string }): Promise
   }
   return root;
 }
-
-afterEach(async () => {
-  while (roots.length > 0) {
-    const root = roots.pop();
-    if (root) {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  }
-});
 
 describe("collectStaleRuntimeBuildFindings", () => {
   it("warns when the built commit differs from the checkout commit", async () => {

--- a/src/commands/doctor-stale-runtime-build.test.ts
+++ b/src/commands/doctor-stale-runtime-build.test.ts
@@ -72,6 +72,32 @@ describe("collectStaleRuntimeBuildFindings", () => {
     await expect(collectStaleRuntimeBuildFindings({ root, env: {} })).resolves.toEqual([]);
   });
 
+  it("ignores a GIT_COMMIT override that still names the built commit", async () => {
+    const root = await makeCheckout({ built: BUILT, head: HEAD });
+
+    // GIT_COMMIT declares the built identity for packaged installs. Honouring it
+    // here would compare the build against itself and hide the real drift.
+    const findings = await collectStaleRuntimeBuildFindings({
+      root,
+      env: { GIT_COMMIT: BUILT },
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.message).toContain(HEAD.slice(0, 7));
+  });
+
+  it("ignores an unrelated GIT_SHA override on a current build", async () => {
+    const root = await makeCheckout({ built: BUILT, head: BUILT });
+
+    // An unrelated override must not invent drift for a build that matches.
+    await expect(
+      collectStaleRuntimeBuildFindings({
+        root,
+        env: { GIT_SHA: "9999999999999999999999999999999999999999" },
+      }),
+    ).resolves.toEqual([]);
+  });
+
   it("stays silent when the checkout commit cannot be read", async () => {
     const root = await makeCheckout({ built: BUILT });
 

--- a/src/commands/doctor-stale-runtime-build.ts
+++ b/src/commands/doctor-stale-runtime-build.ts
@@ -1,0 +1,45 @@
+import type { HealthFinding } from "../flows/health-checks.js";
+// Reports a checkout whose dist was built from a different commit than HEAD.
+import { isTruthyEnvValue } from "../infra/env.js";
+import { gitCommitPrefixesMatch, resolveCommitHash } from "../infra/git-commit.js";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { readBuiltRuntimeCommit } from "../infra/update-git-runtime.js";
+
+const STALE_RUNTIME_BUILD_CHECK_ID = "core/doctor/stale-runtime-build";
+
+export async function collectStaleRuntimeBuildFindings(
+  params: { env?: NodeJS.ProcessEnv; root?: string } = {},
+): Promise<readonly HealthFinding[]> {
+  const env = params.env ?? process.env;
+  // An update is stale by construction between pulling source and rebuilding
+  // dist, so reporting there would flag the update against its own intermediate
+  // state. Doctor runs inside update recovery; stay silent for that caller.
+  if (isTruthyEnvValue(env.OPENCLAW_UPDATE_IN_PROGRESS)) {
+    return [];
+  }
+  const root = params.root ?? resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url });
+  if (!root) {
+    return [];
+  }
+  const builtCommit = await readBuiltRuntimeCommit(root);
+  // Source runs carry no build provenance, so only a real build can be stale.
+  // Packaged installs ship provenance whose commit the checkout read falls back
+  // to, which keeps them matching instead of reporting a phantom drift.
+  if (!builtCommit) {
+    return [];
+  }
+  const checkoutCommit = resolveCommitHash({ cwd: root, env });
+  if (!checkoutCommit || gitCommitPrefixesMatch(builtCommit, checkoutCommit)) {
+    return [];
+  }
+  return [
+    {
+      checkId: STALE_RUNTIME_BUILD_CHECK_ID,
+      severity: "warning",
+      message: `Running build came from commit ${builtCommit.slice(0, 7)}, but the checkout is at ${checkoutCommit.slice(0, 7)}; the loaded runtime is older than its source.`,
+      path: root,
+      fixHint:
+        "Rebuild with `pnpm build` so the running runtime matches the checkout, then restart the Gateway.",
+    },
+  ];
+}

--- a/src/commands/doctor-stale-runtime-build.ts
+++ b/src/commands/doctor-stale-runtime-build.ts
@@ -28,7 +28,12 @@ export async function collectStaleRuntimeBuildFindings(
   if (!builtCommit) {
     return [];
   }
-  const checkoutCommit = resolveCommitHash({ cwd: root, env });
+  // resolveCommitHash prefers GIT_COMMIT/GIT_SHA, which declare the *built*
+  // identity for packaged installs. Honouring them here would compare the build
+  // against itself (hiding real drift) or against an unrelated commit (inventing
+  // it), so the checkout identity must come from the checkout alone.
+  const { GIT_COMMIT: _gitCommit, GIT_SHA: _gitSha, ...checkoutEnv } = env;
+  const checkoutCommit = resolveCommitHash({ cwd: root, env: checkoutEnv });
   if (!checkoutCommit || gitCommitPrefixesMatch(builtCommit, checkoutCommit)) {
     return [];
   }

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -976,6 +976,18 @@ const legacyCronStoreCheck: DoctorHealthCheck = {
   },
 };
 
+const staleRuntimeBuildCheck: DoctorHealthCheck = {
+  id: "core/doctor/stale-runtime-build",
+  kind: "core",
+  description: "The loaded runtime was built from the checkout's current commit.",
+  source: "doctor",
+  async detect() {
+    const { collectStaleRuntimeBuildFindings } =
+      await import("../commands/doctor-stale-runtime-build.js");
+    return collectStaleRuntimeBuildFindings();
+  },
+};
+
 const codexSessionRoutesCheck: HealthCheck = {
   id: CODEX_SESSION_ROUTES_CHECK_ID,
   kind: "core",
@@ -1460,6 +1472,7 @@ function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly Doct
     removedWorkspacesStateCheck,
     legacyWhatsAppCrontabCheck,
     legacyCronStoreCheck,
+    staleRuntimeBuildCheck,
     codexSessionRoutesCheck,
     telegramGeneralTopicConversationsCheck,
     shellCompletionCheck,

--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -307,6 +307,12 @@ export function resolveInitialDoctorHealthContributions(params: {
       run: async () => {},
     }),
     createDoctorHealthContribution({
+      id: "doctor:stale-runtime-build",
+      label: "Stale runtime build",
+      healthCheckIds: ["core/doctor/stale-runtime-build"],
+      run: async () => {},
+    }),
+    createDoctorHealthContribution({
       id: "doctor:disk-space",
       label: "Disk space",
       healthChecks: {

--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -41,6 +41,11 @@ function legacyOwnedRepair(
   };
 }
 
+async function runStaleRuntimeBuildHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const { runCoreContributionHealth } = await import("./doctor-health-contribution-core.js");
+  await runCoreContributionHealth(ctx, ["core/doctor/stale-runtime-build"]);
+}
+
 async function runTelegramGeneralTopicConversationHealth(
   ctx: DoctorHealthFlowContext,
 ): Promise<void> {
@@ -310,7 +315,9 @@ export function resolveInitialDoctorHealthContributions(params: {
       id: "doctor:stale-runtime-build",
       label: "Stale runtime build",
       healthCheckIds: ["core/doctor/stale-runtime-build"],
-      run: async () => {},
+      // healthCheckIds only claims the check for structured selection, which runs
+      // under --lint/--fix; a plain `openclaw doctor` needs this runner to report.
+      run: runStaleRuntimeBuildHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:disk-space",

--- a/src/flows/doctor-stale-runtime-build-contribution.test.ts
+++ b/src/flows/doctor-stale-runtime-build-contribution.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
+import { resolveDoctorHealthContributions } from "./doctor-health-contributions.test-support.js";
+
+const runCoreContributionHealth = vi.fn(
+  async (_ctx: DoctorHealthFlowContext, _checkIds: readonly string[]) => {},
+);
+
+vi.mock("./doctor-health-contribution-core.js", async (importActual) => ({
+  ...(await importActual<typeof import("./doctor-health-contribution-core.js")>()),
+  runCoreContributionHealth: (ctx: DoctorHealthFlowContext, checkIds: readonly string[]) =>
+    runCoreContributionHealth(ctx, checkIds),
+}));
+
+describe("stale runtime build contribution", () => {
+  it("runs the core check when doctor is not repairing", async () => {
+    const contribution = resolveDoctorHealthContributions().find(
+      (entry) => entry.id === "doctor:stale-runtime-build",
+    );
+    expect(contribution).toBeDefined();
+    runCoreContributionHealth.mockClear();
+
+    // A plain `openclaw doctor` never enters structured repair, so the
+    // contribution itself has to execute the check or it reports nothing.
+    await contribution?.run({ prompter: { shouldRepair: false } } as DoctorHealthFlowContext);
+
+    expect(runCoreContributionHealth).toHaveBeenCalledTimes(1);
+    expect(runCoreContributionHealth.mock.calls[0]?.[1]).toEqual([
+      "core/doctor/stale-runtime-build",
+    ]);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor` did not report when a source checkout and its built `dist/` came from different commits. That is exactly the state behind stale-runtime failures after source moves without a matching rebuild/restart.

## Why This Change Was Made

The check is deliberately advisory and conservative:

1. it is silent while `OPENCLAW_UPDATE_IN_PROGRESS` is set
2. it emits a warning, so it cannot change Doctor's exit code
3. it is silent without both checkout and build provenance
4. packaged installs and current builds do not produce phantom drift

It reads `.git/HEAD` and `dist/build-info.json` only. There is no database, config, schema, migration, repair, or persistent-data write; the ClawSweeper data-model compatibility prompt is therefore not applicable.

## User Impact

Doctor reports that the loaded runtime is older than its source and recommends rebuilding/restarting. This improves diagnosis; it does not prevent a live Gateway from retaining an old module graph.

## Evidence

- `src/commands/doctor-stale-runtime-build.test.ts`: 7 passed
- `src/flows/doctor-stale-runtime-build-contribution.test.ts`: 1 passed
- `node scripts/check-changed.mjs`: passed on the rebased patch
- migrated test fixtures to the repository temp-directory tracker; no new cleanup warnings
- rebased cleanly onto current main

AI-assisted with Claude Code and Codex.
