### PR TITLE
fix(gateway): report admitted channel accounts as started

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2676,8 +2676,6 @@ src/gateway/board-host-tools.ts	1
 src/gateway/board-view-ticket.ts	1
 src/gateway/boot.ts	1
 src/gateway/call.ts	6
-src/gateway/channel-health-monitor.ts	6
-src/gateway/channel-thaw-restart.ts	1
 src/gateway/chat-attachments.ts	4
 src/gateway/chat-display-projection.canvas.ts	13
 src/gateway/chat-display-projection.core.ts	5

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -225,6 +225,8 @@ Use the same `accountId` in both calls. Omit it from both to select the default 
 
 `channels.stop` returns `{ channel, accountId, stopped }`; `channels.start` returns `{ channel, accountId, started, outcome }`. These booleans reflect the account's runtime snapshot after the operation: `started` is true only when `running` is true, and `stopped` is true when `running` is not true. A `started: false` response does not by itself establish that the account is stopped, and `started: true` does not establish that the provider connection is healthy. Check channel status and logs after recovery.
 
+An explicitly started account appears in runtime status while the Gateway owns its lifecycle, even if the plugin's static account list does not yet include it. After a successful stop, that unlisted account disappears from status. Default-account selection and automatic health-monitor and host-thaw recovery continue to use the plugin's static account list.
+
 `outcome` explains the lifecycle owner's decision for the requested account:
 
 - `{ status: "handed-off" }`: startup was handed to the account runtime. Check status for provider connectivity.

--- a/src/channels/account-summary.ts
+++ b/src/channels/account-summary.ts
@@ -18,6 +18,20 @@ import type { ChannelAccountSnapshot } from "./plugins/types.core.js";
 import type { ChannelPlugin } from "./plugins/types.plugin.js";
 import { applyChannelAccountState, resolveChannelAccountState } from "./status/account-state.js";
 
+/** Projects an admitted lifetime without resolving its potentially stale account configuration. */
+export function buildChannelAccountSnapshotFromRuntime(
+  runtime: ChannelAccountSnapshot,
+): ChannelAccountSnapshot {
+  return {
+    ...buildRuntimeAccountStatusSnapshot({ runtime }),
+    ...projectSafeChannelAccountSnapshotFields(runtime),
+    accountId: runtime.accountId,
+    enabled: runtime.enabled,
+    configured: runtime.configured,
+    stateReason: runtime.stateReason,
+  };
+}
+
 /** Projects diagnostic inspection metadata without treating it as a runtime account. */
 export function buildChannelAccountSnapshotFromInspection(params: {
   account: unknown;

--- a/src/gateway/channel-health-monitor.clock-rollback.test.ts
+++ b/src/gateway/channel-health-monitor.clock-rollback.test.ts
@@ -32,6 +32,7 @@ function createChannelManager(running: boolean) {
     isAmbientAutostartSuppressed: vi.fn(() => false),
     markChannelLoggedOut: vi.fn(),
     isHealthMonitorEnabled: vi.fn(() => true),
+    isAccountListed: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
     isAutoRestartScheduled: vi.fn(() => false),
     resetRestartAttempts: vi.fn(),

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -23,6 +23,7 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     isAmbientAutostartSuppressed: vi.fn(() => false),
     markChannelLoggedOut: vi.fn(),
     isHealthMonitorEnabled: vi.fn(() => true),
+    isAccountListed: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
     isAutoRestartScheduled: vi.fn(() => false),
     resetRestartAttempts: vi.fn(),

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -4,7 +4,6 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 // Gateway channel health monitor.
 // Periodically evaluates channel account health and restarts stale runtimes.
-import type { ChannelId } from "../channels/plugins/types.public.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
@@ -130,10 +129,14 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (!status) {
             continue;
           }
-          if (!channelManager.isHealthMonitorEnabled(channelId as ChannelId, accountId)) {
+          // Status also exposes unlisted lifetimes; automatic recovery keeps its configured scope.
+          if (!channelManager.isAccountListed(channelId, accountId)) {
             continue;
           }
-          if (channelManager.isManuallyStopped(channelId as ChannelId, accountId)) {
+          if (!channelManager.isHealthMonitorEnabled(channelId, accountId)) {
+            continue;
+          }
+          if (channelManager.isManuallyStopped(channelId, accountId)) {
             continue;
           }
           const key = rKey(channelId, accountId);
@@ -179,7 +182,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           // is in flight. Restarting here cannot start anything (the supervisor
           // still holds the account task) and only resets the attempt ladder, so
           // a crash-looping channel would never reach its give-up terminal state.
-          if (channelManager.isAutoRestartScheduled(channelId as ChannelId, accountId)) {
+          if (channelManager.isAutoRestartScheduled(channelId, accountId)) {
             continue;
           }
 
@@ -226,7 +229,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
           try {
             if (status.running) {
-              await channelManager.stopChannel(channelId as ChannelId, accountId, {
+              await channelManager.stopChannel(channelId, accountId, {
                 manual: false,
               });
             }
@@ -235,8 +238,11 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             if (abandonInFlightRestart) {
               return;
             }
-            channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
-            await channelManager.startChannel(channelId as ChannelId, accountId);
+            if (!channelManager.isAccountListed(channelId, accountId)) {
+              continue;
+            }
+            channelManager.resetRestartAttempts(channelId, accountId);
+            await channelManager.startChannel(channelId, accountId);
           } catch (err) {
             log.error?.(
               `[${channelId}:${accountId}] health-monitor: restart failed: ${String(err)}`,

--- a/src/gateway/channel-thaw-restart.ts
+++ b/src/gateway/channel-thaw-restart.ts
@@ -4,7 +4,7 @@ import type { ChannelManager } from "./server-channels.js";
 
 type ThawRestartManager = Pick<
   ChannelManager,
-  "getRuntimeSnapshot" | "isManuallyStopped" | "stopChannel" | "startChannel"
+  "getRuntimeSnapshot" | "isManuallyStopped" | "isAccountListed" | "stopChannel" | "startChannel"
 >;
 
 export type ThawRestartTarget = { channelId: ChannelId; accountId: string };
@@ -17,8 +17,11 @@ function snapshotRunningTargets(manager: ThawRestartManager): ThawRestartTarget[
   return Object.entries(manager.getRuntimeSnapshot().channelAccounts).flatMap(
     ([channelId, accounts]) =>
       Object.entries(accounts ?? {})
-        .filter(([, status]) => status?.running === true)
-        .map(([accountId]) => ({ channelId: channelId as ChannelId, accountId })),
+        .filter(
+          ([accountId, status]) =>
+            status?.running === true && manager.isAccountListed(channelId, accountId),
+        )
+        .map(([accountId]) => ({ channelId, accountId })),
   );
 }
 
@@ -35,7 +38,7 @@ function dedupeTargets(targets: readonly ThawRestartTarget[]): ThawRestartTarget
 }
 
 /**
- * Restarts every running, non-manually-stopped channel account after a host
+ * Restarts running listed, non-manually-stopped channel accounts after a host
  * thaw. Dead sockets from a freeze otherwise wait for the slow health sweep.
  */
 export async function restartRunningChannelAccounts(
@@ -60,7 +63,7 @@ export async function restartRunningChannelAccounts(
     }
     try {
       let current = manager.getRuntimeSnapshot().channelAccounts[channelId]?.[accountId];
-      if (!current) {
+      if (!current || !manager.isAccountListed(channelId, accountId)) {
         continue;
       }
       await manager.stopChannel(channelId, accountId, { manual: false });
@@ -68,7 +71,7 @@ export async function restartRunningChannelAccounts(
         return [...failedTargets, target, ...targets.slice(index + 1)];
       }
       current = manager.getRuntimeSnapshot().channelAccounts[channelId]?.[accountId];
-      if (!current) {
+      if (!current || !manager.isAccountListed(channelId, accountId)) {
         continue;
       }
       let startOutcomes = await manager.startChannel(channelId, accountId, {
@@ -76,7 +79,11 @@ export async function restartRunningChannelAccounts(
       });
       let startOutcome = startOutcomes.get(accountId);
       let restarted = manager.getRuntimeSnapshot().channelAccounts[channelId]?.[accountId];
-      if (startOutcome?.status === "retry" && restarted?.restartPending === true) {
+      if (
+        startOutcome?.status === "retry" &&
+        restarted?.restartPending === true &&
+        manager.isAccountListed(channelId, accountId)
+      ) {
         // A timed-out stop uses a two-call recovery contract: the first call
         // requests replacement and the second discards the stale task.
         startOutcomes = await manager.startChannel(channelId, accountId, {

--- a/src/gateway/health/collector.channel-discovery.test.ts
+++ b/src/gateway/health/collector.channel-discovery.test.ts
@@ -1,5 +1,7 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as persistedAuth from "../../channels/plugins/persisted-auth-state.js";
+import type { ChannelAccountSnapshot, ChannelPlugin } from "../../channels/plugins/types.public.js";
 import * as configRuntime from "../../config/config.js";
 import {
   createPluginMetadataSnapshot,
@@ -31,6 +33,177 @@ afterEach(async () => {
 });
 
 describe("Gateway health channel discovery", () => {
+  it.each(["public", "admin"] as const)(
+    "includes admitted accounts without operational hooks in %s health",
+    async (audience) => {
+      state = await createOpenClawTestState({ label: "health-admitted-accounts" });
+      const config: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { main: {} } },
+        bindings: [{ agentId: "main", match: { channel: "admitted-chat", accountId: "bound" } }],
+      };
+      vi.spyOn(configRuntime, "getRuntimeConfig").mockReturnValue(config);
+      const resolveAccount = vi.fn((_cfg: OpenClawConfig, accountId?: string | null) => {
+        if (accountId !== "primary" && accountId !== "bound") {
+          throw new Error("admitted account has no current operational configuration");
+        }
+        return { accountId, enabled: true, configured: true };
+      });
+      const inspectAccount = vi.fn(resolveAccount);
+      const probeAccount = vi.fn(async () => ({ ok: true, credential: "private-live-probe" }));
+      const buildChannelSummary = vi.fn(({ account }: { account: { accountId: string } }) => ({
+        name: `Resolved ${account.accountId}`,
+      }));
+      const plugin: ChannelPlugin<ReturnType<typeof resolveAccount>> = {
+        ...createChannelTestPluginBase({ id: "admitted-chat" }),
+        config: {
+          listAccountIds: () => ["primary"],
+          resolveAccount,
+          inspectAccount,
+          isEnabled: (account) => account.enabled,
+          isConfigured: (account) => account.configured,
+        },
+        status: { probeAccount, buildChannelSummary },
+      };
+      setActivePluginRegistry(
+        createTestRegistry([{ pluginId: "admitted-owner", plugin, source: "fixture" }]),
+      );
+      const recovered: ChannelAccountSnapshot = {
+        accountId: "recovered",
+        enabled: true,
+        configured: true,
+        running: true,
+        lifecycle: "starting",
+        stateReason: "admitted before configuration changed",
+        lastStartAt: 1200,
+        tokenSource: "config",
+        tokenStatus: "available",
+        baseUrl: "https://runtime-user:runtime-password@chat.example.test/?token=runtime-token",
+        audience:
+          "https://audience-user:audience-password@audience.example.test/?token=audience-token",
+        channelSecret: "private-channel-secret",
+        channelAccessToken: "private-channel-token",
+        webhookUrl: "https://private-webhook.example.test/secret",
+        publicKey: "private-provider-key",
+        probe: { credential: "private-runtime-probe" },
+        audit: { credential: "private-runtime-audit" },
+        application: { credential: "private-application" },
+        bot: { credential: "private-bot" },
+        profile: { credential: "private-profile" },
+      };
+      const snapshot = await collectGatewayHealthSnapshot({
+        audience,
+        probe: true,
+        runtimeSnapshot: {
+          channels: { "admitted-chat": { accountId: "primary", running: false } },
+          channelAccounts: {
+            "admitted-chat": {
+              recovered,
+              retrying: {
+                accountId: "retrying",
+                enabled: true,
+                configured: true,
+                running: false,
+                connected: false,
+                lifecycle: "recovering",
+                restartPending: true,
+                reconnectAttempts: 4,
+                terminalDisconnect: false,
+                lastStopAt: 2300,
+                lastError: "waiting for restart",
+              },
+              terminal: {
+                accountId: "terminal",
+                enabled: true,
+                configured: true,
+                running: false,
+                lifecycle: "blocked",
+                terminalDisconnect: true,
+                lastError: "account requires login",
+              },
+            },
+          },
+        },
+      });
+
+      const channel = expectDefined(snapshot.channels["admitted-chat"], "admitted channel health");
+      expect(channel).toMatchObject({ accountId: "bound", name: "Resolved bound" });
+      const accounts = expectDefined(channel.accounts, "admitted account health records");
+      expect(Object.keys(accounts).toSorted()).toEqual([
+        "bound",
+        "primary",
+        "recovered",
+        "retrying",
+        "terminal",
+      ]);
+      expect(accounts.primary).toMatchObject({
+        accountId: "primary",
+        configured: true,
+        running: false,
+        name: "Resolved primary",
+      });
+      const admitted = expectDefined(accounts.recovered, "admitted runtime health");
+      expect(admitted).toMatchObject({
+        accountId: "recovered",
+        enabled: true,
+        configured: true,
+        running: true,
+        lifecycle: "starting",
+        stateReason: "admitted before configuration changed",
+        lastStartAt: 1200,
+        tokenSource: "config",
+        tokenStatus: "available",
+        baseUrl: "https://chat.example.test/?token=***",
+        audience: "https://audience.example.test/?token=***",
+      });
+      expect(admitted.connected).toBeUndefined();
+      for (const field of [
+        "channelSecret",
+        "channelAccessToken",
+        "webhookUrl",
+        "publicKey",
+        "probe",
+        "audit",
+        "application",
+        "bot",
+        "profile",
+      ]) {
+        expect(admitted[field], field).toBeUndefined();
+      }
+      expect(accounts.retrying).toMatchObject({
+        configured: true,
+        running: false,
+        connected: false,
+        lifecycle: "recovering",
+        restartPending: true,
+        reconnectAttempts: 4,
+        terminalDisconnect: false,
+        lastStopAt: 2300,
+        lastError: "waiting for restart",
+      });
+      expect(accounts.terminal).toMatchObject({
+        running: false,
+        lifecycle: "blocked",
+        terminalDisconnect: true,
+        healthState: "terminal-disconnect",
+        lastError: "account requires login",
+      });
+      expect(new Set(resolveAccount.mock.calls.map((call) => call[1]))).toEqual(
+        new Set(["primary", "bound"]),
+      );
+      expect(new Set(inspectAccount.mock.calls.map((call) => call[1]))).toEqual(
+        new Set(["primary", "bound"]),
+      );
+      expect(probeAccount).toHaveBeenCalledTimes(2);
+      expect(buildChannelSummary).toHaveBeenCalledTimes(2);
+      if (audience === "admin") {
+        expect(accounts.primary?.probe).toEqual({ ok: true, credential: "private-live-probe" });
+      } else {
+        expect(accounts.primary?.probe).toBeUndefined();
+        expect(JSON.stringify(snapshot)).not.toContain("private-live-probe");
+      }
+    },
+  );
+
   it.each(["missing", "empty"] as const)(
     "uses admitted channels and configured failures without credential discovery (%s runtime snapshot)",
     async (runtime) => {

--- a/src/gateway/health/collector.channel-discovery.test.ts
+++ b/src/gateway/health/collector.channel-discovery.test.ts
@@ -67,6 +67,12 @@ describe("Gateway health channel discovery", () => {
       setActivePluginRegistry(
         createTestRegistry([{ pluginId: "admitted-owner", plugin, source: "fixture" }]),
       );
+      const baseUrl = new URL("https://chat.example.test/?token=runtime-token");
+      baseUrl.username = "runtime-user";
+      baseUrl.password = "runtime-password";
+      const audienceUrl = new URL("https://audience.example.test/?token=audience-token");
+      audienceUrl.username = "audience-user";
+      audienceUrl.password = "audience-password";
       const recovered: ChannelAccountSnapshot = {
         accountId: "recovered",
         enabled: true,
@@ -77,9 +83,8 @@ describe("Gateway health channel discovery", () => {
         lastStartAt: 1200,
         tokenSource: "config",
         tokenStatus: "available",
-        baseUrl: "https://runtime-user:runtime-password@chat.example.test/?token=runtime-token",
-        audience:
-          "https://audience-user:audience-password@audience.example.test/?token=audience-token",
+        baseUrl: baseUrl.href,
+        audience: audienceUrl.href,
         channelSecret: "private-channel-secret",
         channelAccessToken: "private-channel-token",
         webhookUrl: "https://private-webhook.example.test/secret",

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -4,7 +4,10 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { listAgentEntries } from "../../agents/agent-scope.js";
 import { redactChannelStatusSummaryBaseUrl } from "../../channels/account-snapshot-fields.js";
-import { buildChannelAccountSnapshotFromInspection } from "../../channels/account-summary.js";
+import {
+  buildChannelAccountSnapshotFromInspection,
+  buildChannelAccountSnapshotFromRuntime,
+} from "../../channels/account-summary.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import { listReadOnlyChannelPluginsForConfig } from "../../channels/plugins/read-only.js";
 import { buildChannelAccountSnapshotFromAccount } from "../../channels/plugins/status.js";
@@ -240,6 +243,7 @@ type HealthChannelPlan = {
   defaultAccountId: string;
   preferredAccountId: string;
   accountIds: string[];
+  configuredAccountIds: ReadonlySet<string>;
   accountSummaries: Record<string, ChannelAccountHealthSummary>;
 };
 
@@ -273,13 +277,34 @@ async function buildHealthAccountRecord(params: {
   deadlineAtMs: number;
   timeoutMs: number;
   runtimeSnapshot?: ChannelRuntimeSnapshot;
+  runtimeOnly: boolean;
 }): Promise<ChannelAccountHealthSummary> {
   const timedOut = () => buildHealthTimeoutRecord(params.accountId, params.timeoutMs);
+  const runtimeAccount =
+    params.runtimeSnapshot?.channelAccounts[params.plugin.id]?.[params.accountId];
   const runtimeSnapshot =
-    params.runtimeSnapshot?.channelAccounts[params.plugin.id]?.[params.accountId] ??
+    runtimeAccount ??
     (params.accountId === params.defaultAccountId
       ? params.runtimeSnapshot?.channels[params.plugin.id]
       : undefined);
+  if (params.runtimeOnly && runtimeAccount) {
+    const snapshot = buildChannelAccountSnapshotFromRuntime(runtimeAccount);
+    const unavailable = resolveUnavailableChannelAccountSnapshot(params.cfg, {
+      channelId: params.plugin.id,
+      accountId: params.accountId,
+      runtime: snapshot,
+    });
+    if (unavailable) {
+      return unavailable;
+    }
+    const healthState = resolveChannelHealthState(snapshot, {
+      channelId: params.plugin.id,
+      now: Date.now(),
+      staleEventThresholdMs: DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
+      channelConnectGraceMs: DEFAULT_CHANNEL_CONNECT_GRACE_MS,
+    });
+    return { ...snapshot, ...(healthState !== undefined ? { healthState } : {}) };
+  }
   const unavailable = resolveUnavailableChannelAccountSnapshot(params.cfg, {
     channelId: params.plugin.id,
     accountId: params.accountId,
@@ -518,9 +543,13 @@ export async function collectGatewayHealthSnapshot(params: {
     );
     const accountIdsToProbe = Array.from(
       new Set(
-        [preferredAccountId, defaultAccountId, ...accountIds, ...boundAccountIdsAll].filter(
-          (value) => value && value.trim(),
-        ),
+        [
+          preferredAccountId,
+          defaultAccountId,
+          ...accountIds,
+          ...boundAccountIdsAll,
+          ...Object.keys(params.runtimeSnapshot?.channelAccounts[plugin.id] ?? {}),
+        ].filter((value) => value && value.trim()),
       ),
     );
     // Probe preferred/default/bound accounts first, but include all configured
@@ -538,6 +567,7 @@ export async function collectGatewayHealthSnapshot(params: {
       defaultAccountId,
       preferredAccountId,
       accountIds: accountIdsToProbe,
+      configuredAccountIds: new Set(accountIds),
       accountSummaries: {},
     };
   });
@@ -558,6 +588,7 @@ export async function collectGatewayHealthSnapshot(params: {
         deadlineAtMs,
         timeoutMs,
         runtimeSnapshot: params.runtimeSnapshot,
+        runtimeOnly: !plan.configuredAccountIds.has(accountId),
       }),
     })),
     limit: params.probe ? HEALTH_PROBE_CONCURRENCY : 1,

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -407,6 +407,8 @@ describe("server-channels auto restart", () => {
       const snapshotChannels = Object.keys(
         managerA.getRuntimeSnapshot().channelAccounts,
       ).toSorted();
+      expect(managerA.isAccountListed("slack", DEFAULT_ACCOUNT_ID)).toBe(false);
+      expect(managerB.isAccountListed("slack", DEFAULT_ACCOUNT_ID)).toBe(true);
 
       await managerA.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
       const stopped = {
@@ -1303,6 +1305,144 @@ describe("server-channels auto restart", () => {
     expect(manager.isManuallyStopped("discord", "manual")).toBe(true);
   });
 
+  it.each(["thaw", "health-monitor"] as const)(
+    "keeps %s recovery limited to listed accounts while an unlisted sibling stays active",
+    async (recovery) => {
+      const admitted = new Map<string, ChannelGatewayContext<TestAccount>>();
+      const starts: string[] = [];
+      const stops: string[] = [];
+      installTestRegistry(
+        createTestPlugin({
+          listAccountIds: () => ["listed"],
+          startAccount: async (context) => {
+            admitted.set(context.accountId, context);
+            starts.push(context.accountId);
+            context.setStatus({
+              accountId: context.accountId,
+              connected: true,
+              lastTransportActivityAt: Date.now(),
+            });
+            await new Promise<void>((resolve) => {
+              context.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+            });
+          },
+          stopAccount: async (context) => {
+            stops.push(context.accountId);
+          },
+        }),
+      );
+      const manager = createManager();
+      await manager.startChannels();
+      await manager.startChannel("discord", "recovered");
+      const listedSignal = admitted.get("listed")?.abortSignal;
+      const recoveredSignal = admitted.get("recovered")?.abortSignal;
+
+      if (recovery === "thaw") {
+        const errors: string[] = [];
+        expect(
+          await restartRunningChannelAccounts(manager, {
+            shouldContinue: () => true,
+            onError: (message) => errors.push(message),
+          }),
+        ).toEqual([]);
+        expect(errors).toEqual([]);
+      } else {
+        const monitor = startChannelHealthMonitor({
+          channelManager: manager,
+          timing: { monitorStartupGraceMs: 2, channelConnectGraceMs: 0, staleEventThresholdMs: 1 },
+        });
+        try {
+          await vi.advanceTimersByTimeAsync(2);
+          await monitor.waitForIdle();
+        } finally {
+          monitor.shutdown();
+        }
+      }
+
+      expect(starts).toEqual(["listed", "recovered", "listed"]);
+      expect(stops).toEqual(["listed"]);
+      expect(listedSignal?.aborted).toBe(true);
+      expect(admitted.get("listed")?.abortSignal.aborted).toBe(false);
+      expect(recoveredSignal?.aborted).toBe(false);
+      expect(manager.getRuntimeSnapshot().channelAccounts.discord).toMatchObject({
+        listed: { running: true },
+        recovered: { running: true },
+      });
+    },
+  );
+
+  it.each(["thaw", "health-monitor"] as const)(
+    "does not recreate an account removed while %s awaits its stop",
+    async (recovery) => {
+      let accountIds = ["removed"];
+      const stopStarted = createDeferred();
+      const releaseStop = createDeferred();
+      const startAccount = vi.fn(async (context: ChannelGatewayContext<TestAccount>) => {
+        context.setStatus({
+          accountId: context.accountId,
+          connected: true,
+          lastTransportActivityAt: Date.now(),
+        });
+        await new Promise<void>((resolve) => {
+          context.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      });
+      installTestRegistry(
+        createTestPlugin({
+          listAccountIds: () => accountIds,
+          resolveAccount: () => ({ enabled: true, configured: true }),
+          startAccount,
+          stopAccount: async () => {
+            stopStarted.resolve();
+            await releaseStop.promise;
+          },
+        }),
+      );
+      const manager = createManager();
+      await manager.startChannels();
+      const errors: string[] = [];
+      const monitor =
+        recovery === "health-monitor"
+          ? startChannelHealthMonitor({
+              channelManager: manager,
+              timing: {
+                monitorStartupGraceMs: 2,
+                channelConnectGraceMs: 0,
+                staleEventThresholdMs: 1,
+              },
+            })
+          : undefined;
+      const thaw =
+        recovery === "thaw"
+          ? restartRunningChannelAccounts(manager, {
+              shouldContinue: () => true,
+              onError: (message) => errors.push(message),
+            })
+          : undefined;
+      try {
+        if (monitor) {
+          await vi.advanceTimersByTimeAsync(2);
+        }
+        await stopStarted.promise;
+        accountIds = [];
+        releaseStop.resolve();
+        if (thaw) {
+          expect(await thaw).toEqual([]);
+        }
+        await monitor?.waitForIdle();
+
+        expect(errors).toEqual([]);
+        expect(startAccount).toHaveBeenCalledOnce();
+        expect(firstStartAccountContext(startAccount).abortSignal.aborted).toBe(true);
+        expect(manager.getRuntimeSnapshot().channelAccounts.discord?.removed).toBeUndefined();
+      } finally {
+        releaseStop.resolve();
+        monitor?.shutdown();
+        await thaw;
+      }
+    },
+  );
+
   it("retries only the failed account after a partial host-thaw restart", async () => {
     let failStop = true;
     const errors: string[] = [];
@@ -1549,6 +1689,52 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(2);
     expect(account?.running).toBe(true);
     expect(account?.restartPending).toBe(false);
+  });
+
+  it("does not repeat a thaw recovery start after the pending account is removed", async () => {
+    let accountIds = [DEFAULT_ACCOUNT_ID];
+    const releaseTask = createDeferred();
+    const startAccount = vi.fn(async () => await releaseTask.promise);
+    installTestRegistry(
+      createTestPlugin({
+        listAccountIds: () => accountIds,
+        resolveAccount: () => ({ enabled: true, configured: true }),
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+    await manager.startChannels();
+    const startChannel = manager.startChannel;
+    const recoveryStart = vi.spyOn(manager, "startChannel").mockImplementation(async (...args) => {
+      const outcome = await startChannel(...args);
+      accountIds = [];
+      return outcome;
+    });
+    const errors: string[] = [];
+    try {
+      const restartTask = restartRunningChannelAccounts(manager, {
+        shouldContinue: () => true,
+        onError: (message) => errors.push(message),
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      const pendingTargets = await restartTask;
+      expect(pendingTargets).toEqual([{ channelId: "discord", accountId: DEFAULT_ACCOUNT_ID }]);
+      expect(recoveryStart).toHaveBeenCalledOnce();
+      expect(startAccount).toHaveBeenCalledOnce();
+      expect(
+        await restartRunningChannelAccounts(
+          manager,
+          { shouldContinue: () => true, onError: (message) => errors.push(message) },
+          { kind: "deferred-retry", targets: pendingTargets },
+        ),
+      ).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(recoveryStart).toHaveBeenCalledOnce();
+    } finally {
+      releaseTask.resolve();
+      await flushMicrotasks();
+    }
   });
 
   it("sanitizes late writes from an abandoned stopAccount racing a replacement", async () => {
@@ -3989,6 +4175,56 @@ describe("server-channels auto restart", () => {
     await manager.startChannels();
 
     expect(manager.getRuntimeSnapshot().channelAccounts.discord?.default).toMatchObject(recorded);
+  });
+
+  it("keeps an explicitly admitted account visible when plugin enumeration omits it", async () => {
+    const admitted = new Map<string, ChannelGatewayContext<TestAccount>>();
+    const describeAccount = vi.fn(() => ({
+      accountId: "recovered",
+      enabled: true,
+      configured: false,
+    }));
+    const startAccount = vi.fn(async (context: ChannelGatewayContext<TestAccount>) => {
+      admitted.set(context.accountId, context);
+      await new Promise<void>((resolve) => {
+        context.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    const plugin = createTestPlugin({
+      listAccountIds: () => [],
+      resolveAccount: () => ({ enabled: true, configured: true }),
+      describeAccount,
+      startAccount,
+    });
+    installTestRegistry(plugin);
+    const manager = createManager();
+
+    await expect(manager.startChannel("discord", "recovered")).resolves.toEqual(
+      new Map([["recovered", { status: "handed-off" }]]),
+    );
+    expect(describeAccount).toHaveBeenCalledOnce();
+    describeAccount.mockClear();
+
+    expect(manager.getRuntimeSnapshot().channelAccounts.discord?.recovered).toMatchObject({
+      accountId: "recovered",
+      enabled: true,
+      configured: true,
+      running: true,
+      lifecycle: "starting",
+    });
+    expect(describeAccount).not.toHaveBeenCalled();
+    expect(manager.getRuntimeSnapshot().channels.discord?.accountId).toBe(DEFAULT_ACCOUNT_ID);
+
+    await manager.startChannel("discord", "sibling");
+    await manager.stopChannel("discord", "recovered");
+
+    expect(admitted.get("recovered")?.abortSignal.aborted).toBe(true);
+    expect(admitted.get("sibling")?.abortSignal.aborted).toBe(false);
+    expect(manager.getRuntimeSnapshot().channelAccounts.discord).toMatchObject({
+      sibling: { accountId: "sibling", enabled: true, configured: true, running: true },
+    });
+    expect(manager.getRuntimeSnapshot().channelAccounts.discord).not.toHaveProperty("recovered");
+    expect(manager.getRuntimeSnapshot().channels.discord?.accountId).toBe(DEFAULT_ACCOUNT_ID);
   });
 
   it("starts enabled accounts without requiring diagnostic inspection", async () => {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -3991,6 +3991,43 @@ describe("server-channels auto restart", () => {
     expect(manager.getRuntimeSnapshot().channelAccounts.discord?.default).toMatchObject(recorded);
   });
 
+  it("keeps an explicitly admitted account visible when plugin enumeration omits it", async () => {
+    const describeAccount = vi.fn(() => ({
+      accountId: "recovered",
+      enabled: true,
+      configured: false,
+    }));
+    const startAccount = vi.fn(
+      async ({ abortSignal }: ChannelGatewayContext<TestAccount>) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+    );
+    const plugin = createTestPlugin({
+      listAccountIds: () => [],
+      resolveAccount: () => ({ enabled: true, configured: true }),
+      describeAccount,
+      startAccount,
+    });
+    installTestRegistry(plugin);
+    const manager = createManager();
+
+    await expect(manager.startChannel("discord", "recovered")).resolves.toEqual(
+      new Map([["recovered", { status: "handed-off" }]]),
+    );
+    expect(describeAccount).toHaveBeenCalledOnce();
+    describeAccount.mockClear();
+
+    expect(manager.getRuntimeSnapshot().channelAccounts.discord?.recovered).toMatchObject({
+      accountId: "recovered",
+      enabled: true,
+      configured: true,
+      running: true,
+      lifecycle: "starting",
+    });
+    expect(describeAccount).not.toHaveBeenCalled();
+  });
+
   it("starts enabled accounts without requiring diagnostic inspection", async () => {
     const startAccount = vi.fn(async () => {});
     const plugin = createTestPlugin({ startAccount });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -3,7 +3,10 @@
 import { RetrySupervisor } from "../../packages/retry/src/index.js";
 import { isChannelAccountExplicitlyDisabled } from "../channels/account-config-enabled.js";
 import { getCredentialUnavailableDiagnostics } from "../channels/account-snapshot-fields.js";
-import { buildChannelAccountSnapshotFromInspection } from "../channels/account-summary.js";
+import {
+  buildChannelAccountSnapshotFromInspection,
+  buildChannelAccountSnapshotFromRuntime,
+} from "../channels/account-summary.js";
 import { isChannelIngressUnavailableError } from "../channels/message/ingress-unavailable.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import {
@@ -294,6 +297,7 @@ export type ChannelManager = {
   isAmbientAutostartSuppressed: (channelId: string) => boolean;
   markChannelLoggedOut: (channelId: ChannelId, cleared: boolean, accountId?: string) => void;
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
+  isAccountListed: (channelId: ChannelId, accountId: string) => boolean;
   isAutoRestartScheduled: (channelId: ChannelId, accountId: string) => boolean;
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
   isHealthMonitorEnabled: (channelId: ChannelId, accountId: string) => boolean;
@@ -1508,15 +1512,20 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     const channelAccounts: ChannelRuntimeSnapshot["channelAccounts"] = {};
     for (const plugin of listLoadedChannelPluginsForRegistry(registry)) {
       const store = getStore(plugin.id);
-      const accountIds = plugin.config.listAccountIds(cfg);
+      const configuredAccountIds = plugin.config.listAccountIds(cfg);
+      const configuredAccountIdSet = new Set(configuredAccountIds);
+      const accountIds = [...new Set([...configuredAccountIds, ...store.lifetimes.keys()])];
       const defaultAccountId = resolveChannelDefaultAccountId({
         plugin,
         cfg,
-        accountIds,
+        accountIds: configuredAccountIds,
       });
       const accounts: Record<string, ChannelAccountSnapshot> = {};
       for (const id of accountIds) {
-        const current = store.runtimes.get(id) ?? cloneDefaultRuntime(plugin.id, id);
+        const recorded = store.runtimes.get(id) ?? cloneDefaultRuntime(plugin.id, id);
+        const current = configuredAccountIdSet.has(id)
+          ? recorded
+          : buildChannelAccountSnapshotFromRuntime(recorded);
         const unavailable = resolveUnavailableChannelAccountSnapshot(cfg, {
           registry,
           channelId: plugin.id,
@@ -1525,6 +1534,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         });
         if (unavailable) {
           accounts[id] = unavailable;
+          continue;
+        }
+        if (!configuredAccountIdSet.has(id)) {
+          // An admitted lifetime owns its state while static account discovery catches up.
+          accounts[id] = current;
           continue;
         }
         const inspected = plugin.config.inspectAccount?.(cfg, id);
@@ -1612,6 +1626,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       ambientAutostartSuppressedChannelIds.has(channelId),
     markChannelLoggedOut,
     isManuallyStopped: isManuallyStoppedFlag,
+    isAccountListed: (channelId, accountId) =>
+      withRegistry(
+        (registry) =>
+          getLoadedChannelPluginEntryById(channelId, registry)
+            ?.plugin.config.listAccountIds(getRuntimeConfig())
+            .includes(accountId) ?? false,
+      ),
     resolveRuntimeAccountId: (channelId, accountId) => {
       const matches = [...(channelStores.get(channelId)?.runtimes.keys() ?? [])].filter(
         (id) => normalizeAccountId(id) === accountId,

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -1508,7 +1508,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     const channelAccounts: ChannelRuntimeSnapshot["channelAccounts"] = {};
     for (const plugin of listLoadedChannelPluginsForRegistry(registry)) {
       const store = getStore(plugin.id);
-      const accountIds = plugin.config.listAccountIds(cfg);
+      const configuredAccountIds = plugin.config.listAccountIds(cfg);
+      const configuredAccountIdSet = new Set(configuredAccountIds);
+      const accountIds = [...new Set([...configuredAccountIds, ...store.lifetimes.keys()])];
       const defaultAccountId = resolveChannelDefaultAccountId({
         plugin,
         cfg,
@@ -1517,6 +1519,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       const accounts: Record<string, ChannelAccountSnapshot> = {};
       for (const id of accountIds) {
         const current = store.runtimes.get(id) ?? cloneDefaultRuntime(plugin.id, id);
+        if (!configuredAccountIdSet.has(id)) {
+          // The manager owns admitted lifetimes even when a plugin's static
+          // account inventory temporarily lags credential recovery or config publication.
+          accounts[id] = { ...current, accountId: id };
+          continue;
+        }
         const unavailable = resolveUnavailableChannelAccountSnapshot(cfg, {
           registry,
           channelId: plugin.id,

--- a/src/gateway/server-methods/channels-account.ts
+++ b/src/gateway/server-methods/channels-account.ts
@@ -1,0 +1,36 @@
+// Account selection and runtime lookup shared by channel lifecycle and status RPCs.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
+import type { ChannelAccountSnapshot, ChannelId } from "../../channels/plugins/types.public.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
+import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
+
+export function resolveRuntimeAccountSnapshot(params: {
+  runtime: ChannelRuntimeSnapshot;
+  channelId: ChannelId;
+  accountId: string;
+}): ChannelAccountSnapshot | undefined {
+  const accounts = params.runtime.channelAccounts[params.channelId];
+  const direct = accounts?.[params.accountId];
+  if (direct) {
+    return direct;
+  }
+  const fallback = params.runtime.channels[params.channelId];
+  return fallback?.accountId === params.accountId ? fallback : undefined;
+}
+
+export function resolveChannelGatewayAccountId(params: {
+  plugin: ChannelPlugin;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string {
+  // Runtime operations use the same account precedence as channel setup:
+  // explicit request, plugin default, first configured account, then fallback.
+  return (
+    normalizeOptionalString(params.accountId) ||
+    params.plugin.config.defaultAccountId?.(params.cfg) ||
+    params.plugin.config.listAccountIds(params.cfg)[0] ||
+    DEFAULT_ACCOUNT_ID
+  );
+}

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -280,6 +280,9 @@ describe("channelsHandlers channels.status", () => {
       mocks.buildChannelAccountSnapshotFromAccount.mockImplementation(
         status.buildChannelAccountSnapshotFromAccount,
       );
+      const baseUrl = new URL("https://chat.example.test/?token=runtime-token");
+      baseUrl.username = "runtime-user";
+      baseUrl.password = "runtime-password";
       const recovered: ChannelAccountSnapshot = {
         accountId: "recovered",
         enabled: true,
@@ -291,7 +294,7 @@ describe("channelsHandlers channels.status", () => {
         stateReason: "admitted before configuration changed",
         lastStartAt: 1200,
         lastError: null,
-        baseUrl: "https://runtime-user:runtime-password@chat.example.test/?token=runtime-token",
+        baseUrl: baseUrl.href,
         channelSecret: "private-channel-secret",
         channelAccessToken: "private-channel-token",
         webhookUrl: "https://private-webhook.example.test/secret",

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -4,11 +4,19 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChannelStatusIssue } from "../../channels/plugins/types.public.js";
+import type {
+  ChannelAccountSnapshot,
+  ChannelPlugin,
+  ChannelStatusIssue,
+} from "../../channels/plugins/types.public.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createPluginRecord } from "../../plugins/status.test-fixtures.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { requireGatewayRecord } from "../test-helpers.assertions.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
@@ -235,6 +243,147 @@ describe("channelsHandlers channels.status", () => {
     const whatsapp = requireGatewayRecord(channels.whatsapp, "whatsapp channel");
     expect(whatsapp.configured).toBe(true);
   });
+
+  it.each([
+    { listed: false, probe: false },
+    { listed: false, probe: true },
+    { listed: true, probe: false },
+    { listed: true, probe: true },
+  ])(
+    "reports admitted accounts safely without resolving removed configuration (listed=$listed, probe=$probe)",
+    async ({ listed, probe }) => {
+      const configured = { accountId: "primary", enabled: true, configured: true };
+      const resolveAccount = vi.fn((_cfg: OpenClawConfig, accountId?: string | null) => {
+        if (accountId !== "primary") {
+          throw new Error("admitted account has no current operational configuration");
+        }
+        return configured;
+      });
+      const probeAccount = vi.fn(async () => ({ ok: true, identity: "configured-provider" }));
+      const auditAccount = vi.fn(async () => ({ ok: true }));
+      const buildChannelSummary = vi.fn(() => ({ configured: true, name: "Configured summary" }));
+      const plugin: ChannelPlugin<typeof configured> = {
+        ...createChannelTestPluginBase({ id: "whatsapp" }),
+        config: {
+          listAccountIds: () => (listed ? ["primary"] : []),
+          resolveAccount,
+          inspectAccount: resolveAccount,
+          isEnabled: (account) => account.enabled,
+          isConfigured: (account) => account.configured,
+        },
+        status: { probeAccount, auditAccount, buildChannelSummary },
+      };
+      mocks.listChannelPlugins.mockReturnValue([plugin]);
+      const status = await vi.importActual<typeof import("../../channels/plugins/status.js")>(
+        "../../channels/plugins/status.js",
+      );
+      mocks.buildChannelAccountSnapshotFromAccount.mockImplementation(
+        status.buildChannelAccountSnapshotFromAccount,
+      );
+      const recovered: ChannelAccountSnapshot = {
+        accountId: "recovered",
+        enabled: true,
+        configured: true,
+        running: true,
+        lifecycle: "starting",
+        tokenSource: "config",
+        tokenStatus: "available",
+        stateReason: "admitted before configuration changed",
+        lastStartAt: 1200,
+        lastError: null,
+        baseUrl: "https://runtime-user:runtime-password@chat.example.test/?token=runtime-token",
+        channelSecret: "private-channel-secret",
+        channelAccessToken: "private-channel-token",
+        webhookUrl: "https://private-webhook.example.test/secret",
+        publicKey: "private-provider-key",
+        probe: { credential: "private-probe" },
+        audit: { credential: "private-audit" },
+        application: { credential: "private-application" },
+        bot: { credential: "private-bot" },
+        profile: { credential: "private-profile" },
+      };
+      const retrying: ChannelAccountSnapshot = {
+        accountId: "retrying",
+        enabled: true,
+        configured: true,
+        running: false,
+        connected: false,
+        lifecycle: "recovering",
+        restartPending: true,
+        reconnectAttempts: 3,
+        terminalDisconnect: false,
+        lastStopAt: 2300,
+        lastDisconnect: { at: 2200, error: "transport closed" },
+        lastError: "waiting for restart",
+      };
+      const options = createOptions({});
+      options.context.getRuntimeSnapshot = () => ({
+        channels: { whatsapp: { accountId: listed ? "primary" : "default" } },
+        channelAccounts: { whatsapp: { recovered, retrying } },
+      });
+
+      const payload = await runChannelsStatus({ probe }, { context: options.context });
+
+      expect(payload.partial).toBeUndefined();
+      expect(payload.channelDefaultAccountId).toEqual({ whatsapp: listed ? "primary" : "default" });
+      const accounts = channelAccounts(payload, "whatsapp");
+      expect(accounts.map((account) => account.accountId)).toEqual(
+        listed ? ["primary", "recovered", "retrying"] : ["recovered", "retrying"],
+      );
+      const admitted = expectDefined(
+        accounts.find((account) => account.accountId === "recovered"),
+        "admitted account status",
+      );
+      expect(admitted).toMatchObject({
+        accountId: "recovered",
+        enabled: true,
+        configured: true,
+        running: true,
+        lifecycle: "starting",
+        tokenSource: "config",
+        tokenStatus: "available",
+        stateReason: "admitted before configuration changed",
+        lastStartAt: 1200,
+        baseUrl: "https://chat.example.test/?token=***",
+      });
+      expect(admitted.connected).toBeUndefined();
+      for (const field of [
+        "channelSecret",
+        "channelAccessToken",
+        "webhookUrl",
+        "publicKey",
+        "probe",
+        "audit",
+        "application",
+        "bot",
+        "profile",
+      ]) {
+        expect(admitted[field], field).toBeUndefined();
+      }
+      expect(accounts.find((account) => account.accountId === "retrying")).toMatchObject({
+        running: false,
+        connected: false,
+        lifecycle: "recovering",
+        restartPending: true,
+        reconnectAttempts: 3,
+        terminalDisconnect: false,
+        lastStopAt: 2300,
+        lastDisconnect: { at: 2200, error: "transport closed" },
+        lastError: "waiting for restart",
+      });
+      expect(resolveAccount.mock.calls.map((call) => call[1])).not.toContain("recovered");
+      expect(resolveAccount.mock.calls.map((call) => call[1])).not.toContain("retrying");
+      expect(probeAccount).toHaveBeenCalledTimes(listed && probe ? 1 : 0);
+      expect(auditAccount).toHaveBeenCalledTimes(listed && probe ? 1 : 0);
+      expect(buildChannelSummary).toHaveBeenCalledTimes(listed ? 1 : 0);
+      if (listed) {
+        expect(accounts[0]).toMatchObject({ accountId: "primary", configured: true });
+        expect(requireGatewayRecord(payload.channels, "channel summaries").whatsapp).toMatchObject({
+          name: "Configured summary",
+        });
+      }
+    },
+  );
 
   it("reports policy and deferred publication without changing healthy transport status", async () => {
     const policyIssue: ChannelStatusIssue = {

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -9,6 +9,7 @@ import {
   validateChannelsStatusParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { redactChannelStatusSummaryBaseUrl } from "../../channels/account-snapshot-fields.js";
+import { buildChannelAccountSnapshotFromRuntime } from "../../channels/account-summary.js";
 import { buildChannelUiCatalog } from "../../channels/plugins/catalog.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import {
@@ -27,7 +28,6 @@ import { resolveUnavailableChannelAccountSnapshot } from "../../channels/status/
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getChannelActivity } from "../../infra/channel-activity.js";
-import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { isAccountEnabled } from "../../shared/account-enabled.js";
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
@@ -37,11 +37,12 @@ import {
   resolveChannelHealthState,
 } from "../channel-health-policy.js";
 import { resolveGatewayPluginConfig } from "../runtime-plugin-config.js";
-import type {
-  ChannelAccountStartOutcome,
-  ChannelRuntimeSnapshot,
-} from "../server-channel-runtime.types.js";
+import type { ChannelAccountStartOutcome } from "../server-channel-runtime.types.js";
 import { formatForLog } from "../ws-log.js";
+import {
+  resolveChannelGatewayAccountId,
+  resolveRuntimeAccountSnapshot,
+} from "./channels-account.js";
 import {
   collectGatewayChannelStatusIssues,
   resolveDeferredChannelReloadIssue,
@@ -229,35 +230,6 @@ function resolveChannelsStatusTimeoutMs(params: { probe: boolean; timeoutMsRaw: 
   return Math.min(Math.max(1000, params.timeoutMsRaw), CHANNEL_STATUS_MAX_TIMEOUT_MS);
 }
 
-function resolveRuntimeAccountSnapshot(params: {
-  runtime: ChannelRuntimeSnapshot;
-  channelId: ChannelId;
-  accountId: string;
-}): ChannelAccountSnapshot | undefined {
-  const accounts = params.runtime.channelAccounts[params.channelId];
-  const direct = accounts?.[params.accountId];
-  if (direct) {
-    return direct;
-  }
-  const fallback = params.runtime.channels[params.channelId];
-  return fallback?.accountId === params.accountId ? fallback : undefined;
-}
-
-function resolveChannelGatewayAccountId(params: {
-  plugin: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-}): string {
-  // Runtime operations use the same account precedence as channel setup:
-  // explicit request, plugin default, first configured account, then fallback.
-  return (
-    normalizeOptionalString(params.accountId) ||
-    params.plugin.config.defaultAccountId?.(params.cfg) ||
-    params.plugin.config.listAccountIds(params.cfg)[0] ||
-    DEFAULT_ACCOUNT_ID
-  );
-}
-
 /** Log out one channel account through its owning channel plugin. */
 async function logoutChannelAccount(params: {
   channelId: ChannelId;
@@ -401,8 +373,21 @@ export const channelsHandlers: GatewayRequestHandlers = {
       channelId: ChannelId,
       plugin: ChannelPlugin,
       accountId: string,
+      listed: boolean,
     ) => {
       const runtimeSnapshot = resolveRuntimeAccountSnapshot({ runtime, channelId, accountId });
+      if (!listed && runtimeSnapshot) {
+        const snapshot = buildChannelAccountSnapshotFromRuntime(runtimeSnapshot);
+        return {
+          accountId,
+          snapshot:
+            resolveUnavailableChannelAccountSnapshot(cfg, {
+              channelId,
+              accountId,
+              runtime: snapshot,
+            }) ?? snapshot,
+        };
+      }
       const unavailable = resolveUnavailableChannelAccountSnapshot(cfg, {
         channelId,
         accountId,
@@ -505,16 +490,29 @@ export const channelsHandlers: GatewayRequestHandlers = {
 
     const buildChannelAccounts = async (plugin: ChannelPlugin) => {
       const channelId = plugin.id;
-      const accountIds = plugin.config.listAccountIds(cfg);
+      const configuredAccountIds = plugin.config.listAccountIds(cfg);
+      const configuredAccountIdSet = new Set(configuredAccountIds);
+      const accountIds = [
+        ...new Set([
+          ...configuredAccountIds,
+          ...Object.keys(runtime.channelAccounts[channelId] ?? {}),
+        ]),
+      ];
       const defaultAccountId = resolveChannelDefaultAccountId({
         plugin,
         cfg,
-        accountIds,
+        accountIds: configuredAccountIds,
       });
       const resolvedAccounts: Record<string, unknown> = {};
       const { results } = await runTasksWithConcurrency({
         tasks: accountIds.map(
-          (accountId) => async () => await buildAccountSnapshot(channelId, plugin, accountId),
+          (accountId) => async () =>
+            await buildAccountSnapshot(
+              channelId,
+              plugin,
+              accountId,
+              configuredAccountIdSet.has(accountId),
+            ),
         ),
         limit: probe ? CHANNEL_STATUS_PROBE_CONCURRENCY : accountIds.length || 1,
         onTaskError: (error, index) => {
@@ -532,7 +530,8 @@ export const channelsHandlers: GatewayRequestHandlers = {
         }
       }
       const defaultAccount =
-        accounts.find((entry) => entry.accountId === defaultAccountId) ?? accounts[0];
+        accounts.find((entry) => entry.accountId === defaultAccountId) ??
+        accounts.find((entry) => configuredAccountIdSet.has(entry.accountId));
       return { accounts, defaultAccountId, defaultAccount, resolvedAccounts };
     };
 

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -58,6 +58,7 @@ describe("server-runtime-services", () => {
       channelManager: {
         getRuntimeSnapshot: vi.fn(),
         isHealthMonitorEnabled: vi.fn(),
+        isAccountListed: vi.fn(() => true),
         isManuallyStopped: vi.fn(),
       } as never,
     });

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -42,6 +42,7 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     isAmbientAutostartSuppressed: vi.fn(() => false),
     markChannelLoggedOut: vi.fn(),
     isHealthMonitorEnabled: vi.fn(() => true),
+    isAccountListed: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
     isAutoRestartScheduled: vi.fn(() => false),
     resetRestartAttempts: vi.fn(),

--- a/test/e2e/qa-lab/runtime/channel-health-monitor-lifecycle-runtime.ts
+++ b/test/e2e/qa-lab/runtime/channel-health-monitor-lifecycle-runtime.ts
@@ -202,6 +202,7 @@ export async function runChannelHealthMonitorLifecycleProof(): Promise<MonitorPr
       recoverAutostartSuppression: async () => false,
       isAmbientAutostartSuppressed: () => false,
       isHealthMonitorEnabled: () => true,
+      isAccountListed: () => true,
       isManuallyStopped: () => false,
       isAutoRestartScheduled: () => false,
     } as unknown as ChannelManager;


### PR DESCRIPTION
Closes #144494

Related: #138947 remains a separate Doctor/replacement-lifecycle issue and is not closed or claimed fixed here.

## What Problem This Solves

Fixes an issue where operators explicitly start a valid channel account and receive `started: false` while its runtime is already active, when the plugin's static account list does not yet include that account. Public channel status also omitted the account.

## Why This Change Was Made

The existing lifecycle manager now includes admitted account lifetimes in runtime snapshots. Public status and health consume those recorded accounts without re-resolving stale configuration or exposing raw credential/provider payloads. Configured-account inspection, default selection, and automatic recovery eligibility retain their existing owners.

The repair preserves the contributor's lifecycle-based approach and completes its public consumers. Automatic host-thaw and health-monitor recovery keep their configured-account scope, including checks after awaited teardown; explicit unlisted accounts retain their existing task-owned crash/backoff behavior. No new dynamic-account automatic recovery policy, public fields, storage, login behavior, or provider-connectivity claim is added. Existing account-selection helpers moved into a small shared module to keep the handler within its normal size limit. Seven redundant type assertions were removed with an exact shrink of their existing allowance.

## User Impact

Operators can see an explicitly admitted account in status and health while its lifecycle is owned, even if static account discovery lags. Successful stop removes an unlisted account after teardown and preserves its credentials and unrelated accounts. Duplicate start can correctly report `started: true` with `retry/task-owned`; the boolean still describes the resulting runtime snapshot.

## Evidence

Independent source-blind acceptance drove the compiled CLI over the real Gateway WebSocket connection with a task-owned external plugin and synthetic isolated state. Static inventory stayed empty in the reproduction profile; a second profile covered configured accounts and the nonliteral plugin default `primary`.

| Public flow | Pinned main | Repaired runtime |
| --- | --- | --- |
| Explicit `recovered` start with empty inventory | `handed-off`, `started: false`, status omits active account | `handed-off`, `started: true`, status reports `running: true` |
| Duplicate active start | `retry/task-owned` with false snapshot result | `retry/task-owned`, `started: true`, no duplicate lifetime |
| Stop recovered beside active siblings | Lifecycle stops but status never showed it | Matching generation aborts/settles, recovered disappears, siblings remain active |
| Disabled or unconfigured start | False with the corresponding skipped reason | Preserved |
| Default account, configured stop/restart, repeated health reads | Existing configured behavior | Preserved alongside newly visible admitted accounts |

- Baseline: `d841e35101d5c727fff71b359758008a16345613`; actual built Gateway red preceded repair edits.
- Tested runtime: `62a169b0e0dd197456347718dd67a229f948b0ea`, build ID `2026.9.3-62a169b0e0dd-2026-09-11T01-29-39.441Z`.
- Final head: `67cbce7e286e6d3cc68c476b06ca44ad3799d1aa`. Changes after the tested build are limited to three test files: one existing QA fixture supplies the inventory query, and two privacy tests construct the same synthetic credential URLs with the standard URL API. All privacy assertions remain unchanged and both affected suites passed again. The exercised Gateway/CLI production code is unchanged; the actual runtime identity is retained.
- **62 independent public RPC calls and two version calls** completed without command failure or retry. Both complete config/auth snapshots were preserved. Every fixture lifetime settled and both Gateways shut down cleanly.
- **323 focused tests across nine existing suites passed**, plus the existing finite QA lifecycle producer. The original manager suite passed 146 tests; seven new manager/status/health cases failed on baseline for omitted records, and the contributor version failed the default-selection control.
- Native hooks, formatting, 230-rule syntax lint, size/assertion guards, conflict scan, and the changed docs page check passed. Original failed checks and their corrections remain retained. Hosted full CI/typechecking and exact-head review remain required gates.

This proves isolated lifecycle/status behavior, not provider connectivity. Runtime-only status uses recorded fields rather than full operational probing. Existing synthetic default/bound cache edge cases are not claimed generally fixed. Intricate secret, reload, backoff, and queued-stop behavior is covered by focused owner tests, not represented as live provider proof. Complete raw evidence and independent judgments are retained privately.
