### PR TITLE
test(ci): avoid repeated QA Git grace waits

### DIFF
--- a/test/scripts/ci-linux-git.test.ts
+++ b/test/scripts/ci-linux-git.test.ts
@@ -464,9 +464,10 @@ function runQaGitCase(profile: QaGitCase, fetchResults: FetchResult[]) {
       step: profile.step,
     },
     fetchResults,
-    // Preserve real 120-second/no-deadline calls and real cleanup; readiness,
-    // not a sleep, ensures every successful Git leader leaves two live writers.
+    // Keep real command deadlines and ready descendant cleanup; these boundary
+    // checks do not need the TERM grace covered by the owner lifecycle tests.
     realClock: true,
+    realDrain: false,
     poisonPython: true,
     env: {
       EXPECTED_SHA: candidate,


### PR DESCRIPTION
## What Problem This Solves

QA Git workflow tests repeatedly waited through five seconds of TERM grace even though their fixture descendants deliberately ignore TERM. Eight successful fetches paid this delay while testing checkout, trust, and publication boundaries.

## Why This Change Was Made

Use the existing immediate-escalation fixture option for these cases, as neighboring workflow tests already do. Command deadlines remain real. Native signals, process-tree settlement, unrelated-process sentinels, and failure handling remain exercised; the existing owner lifecycle tests retain real grace periods.

## User Impact

Test-only change. All ten QA cases and their assertions remain, including the four cases that reject further work after failed cleanup. Production behavior and CI shard counts are unchanged.

## Evidence

The same ten POSIX cases, in the same order and with the same command settings, took **50.41 / 9.68 / 50.00 seconds** for original / candidate / restored original. The candidate saved **40.32 seconds** against the restored control, including wrapper preparation and cleanup.

Every arm retained six successful outcomes and four expected cleanup-failure outcomes. All native cleanup receipts passed, unrelated sentinels remained alive, recorded owned processes were gone, and fixture directories returned to their original inventory. Two existing real-grace cancellation cases also passed. Targeted changed-file checks passed, and independent P2 review found no actionable issues.

These local measurements cover the ten shared POSIX cases on macOS; the full Linux file has additional platform-specific cases. Exact-head CI is required before landing. No whole-CI speedup is inferred from the focused comparison.
