### PR TITLE
refactor: reuse empty task summaries in status fixtures

### DIFF
--- a/src/commands/status.scan.test-helpers.ts
+++ b/src/commands/status.scan.test-helpers.ts
@@ -2,6 +2,7 @@
 import type { Mock } from "vitest";
 import { vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
+import { createEmptyTaskRegistrySummary } from "../tasks/task-registry.summary.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
@@ -321,27 +322,7 @@ export function createStatusSummary(
 ) {
   return {
     linkChannel: options.linkChannel,
-    tasks: {
-      total: 0,
-      active: 0,
-      terminal: 0,
-      failures: 0,
-      byStatus: {
-        queued: 0,
-        running: 0,
-        succeeded: 0,
-        failed: 0,
-        timed_out: 0,
-        cancelled: 0,
-        lost: 0,
-      },
-      byRuntime: {
-        subagent: 0,
-        acp: 0,
-        cli: 0,
-        cron: 0,
-      },
-    },
+    tasks: createEmptyTaskRegistrySummary(),
     sessions: {
       count: 0,
       paths: [],

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -3,6 +3,7 @@ import type { Mock } from "vitest";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
 import { createCompatibilityNotice } from "../plugins/status.test-fixtures.js";
+import { createEmptyTaskRegistrySummary } from "../tasks/task-registry.summary.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import type { StatusScanResult } from "./status.scan-result.js";
 
@@ -948,27 +949,7 @@ describe("statusCommand", () => {
     mocks.buildPluginCompatibilityNotices.mockReset();
     mocks.buildPluginCompatibilityNotices.mockReturnValue([]);
     mocks.getInspectableTaskRegistrySummary.mockReset();
-    mocks.getInspectableTaskRegistrySummary.mockReturnValue({
-      total: 0,
-      active: 0,
-      terminal: 0,
-      failures: 0,
-      byStatus: {
-        queued: 0,
-        running: 0,
-        succeeded: 0,
-        failed: 0,
-        timed_out: 0,
-        cancelled: 0,
-        lost: 0,
-      },
-      byRuntime: {
-        subagent: 0,
-        acp: 0,
-        cli: 0,
-        cron: 0,
-      },
-    });
+    mocks.getInspectableTaskRegistrySummary.mockReturnValue(createEmptyTaskRegistrySummary());
     mocks.getInspectableTaskAuditSummary.mockReset();
     mocks.getInspectableTaskAuditSummary.mockReturnValue({
       total: 0,


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Status and scan tests duplicate the complete empty task-summary input, making fixture maintenance more repetitive.

## Why This Change Was Made

Reuse the existing pure empty-summary constructor at two runtime-evaluated fixture sites. Keep both hoisted literals and all independent expected values unchanged; each call still creates fresh counters.

## User Impact

No user-visible behavior change. This removes 38 test lines without changing production code or assertions.

## Evidence

All four status, scan, fast-JSON and summary suites passed the same 87 cases before and after, with identical full names and per-file order. Parser expansion matches the original fixtures; runtime checks confirm identical ordered keys, values, descriptors and three independently mutable fresh objects. Formatting, the required changed gate and fresh independent review passed.
