### PR TITLE
refactor(tests): simplify embedding batch JSON fixtures

### DIFF
--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -1,4 +1,3 @@
-// Google tests cover embedding batch bounded JSON response reads.
 import { createServer } from "node:http";
 import * as embeddingSdk from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -39,13 +38,6 @@ function fetchInputUrl(input: RequestInfo | URL): string {
     return input.href;
   }
   return input.url;
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
 }
 
 async function listenLoopbackServer(server: ReturnType<typeof createServer>): Promise<number> {
@@ -132,15 +124,15 @@ function batchStageForUrl(url: string): BatchStage {
 function defaultBatchResponse(stage: BatchStage): Response {
   switch (stage) {
     case "upload":
-      return jsonResponse({ file: { name: "files/f-ok" } });
+      return Response.json({ file: { name: "files/f-ok" } });
     case "create":
-      return jsonResponse({
+      return Response.json({
         name: "batches/b-0",
         done: false,
         metadata: { state: "BATCH_STATE_PENDING" },
       });
     case "status":
-      return jsonResponse({
+      return Response.json({
         name: "batches/b-0",
         done: true,
         metadata: { state: "BATCH_STATE_SUCCEEDED" },
@@ -300,9 +292,9 @@ describe("Google embedding-batch bounded JSON reads", () => {
   });
 
   it("marks create 404 as unavailable while preserving the structured cause", async () => {
-    const response = jsonResponse(
+    const response = Response.json(
       { error: { code: 404, message: "Input file was not found", status: "NOT_FOUND" } },
-      404,
+      { status: 404 },
     );
     stubBatchFetch((stage) => (stage === "create" ? response : undefined));
 
@@ -525,7 +517,7 @@ describe("Google embedding-batch bounded JSON reads", () => {
   it("honors terminal LRO fields when metadata is stale", async () => {
     stubBatchFetch((stage) =>
       stage === "create"
-        ? jsonResponse({
+        ? Response.json({
             name: "batches/b-0",
             done: true,
             metadata: { state: "BATCH_STATE_RUNNING" },
@@ -540,7 +532,7 @@ describe("Google embedding-batch bounded JSON reads", () => {
   it("keeps a terminal Operation error ahead of stale success metadata", async () => {
     stubBatchFetch((stage) =>
       stage === "create"
-        ? jsonResponse({
+        ? Response.json({
             name: "batches/b-0",
             done: true,
             metadata: { state: "BATCH_STATE_SUCCEEDED" },
@@ -597,7 +589,7 @@ describe("Google embedding-batch bounded JSON reads", () => {
   ])("surfaces $state Operation failures", async ({ state, normalized }) => {
     stubBatchFetch((stage) =>
       stage === "create"
-        ? jsonResponse({
+        ? Response.json({
             name: "batches/b-0",
             done: true,
             metadata: { state },
@@ -611,7 +603,7 @@ describe("Google embedding-batch bounded JSON reads", () => {
   it("rejects conflicting output files in one Operation", async () => {
     stubBatchFetch((stage) =>
       stage === "create"
-        ? jsonResponse({
+        ? Response.json({
             name: "batches/b-0",
             done: true,
             metadata: {

--- a/extensions/openai/embedding-batch.test.ts
+++ b/extensions/openai/embedding-batch.test.ts
@@ -1,4 +1,3 @@
-// Openai tests cover embedding batch plugin behavior.
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cancelTrackedTextResponse } from "../test-support/streaming-error-response.js";
@@ -33,13 +32,6 @@ function singleRequestBatchParams(
     pollIntervalMs,
     timeoutMs,
   };
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
 }
 
 function jsonlBytes(value: string): number {
@@ -246,22 +238,22 @@ describe("OpenAI embedding batch output", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = fetchInputUrl(input);
       if (url.endsWith("/files") && init?.method === "POST") {
-        return jsonResponse({ id: "file-0" });
+        return Response.json({ id: "file-0" });
       }
       if (url.endsWith("/batches") && init?.method === "POST") {
-        return jsonResponse({ id: "batch-0", status: "in_progress" });
+        return Response.json({ id: "batch-0", status: "in_progress" });
       }
       if (url.endsWith("/batches/batch-0")) {
         statusCalls += 1;
         statusTimes.push(Date.now());
         const nextStatus = scenario.statusSequence[statusCalls - 1];
         if (nextStatus === "pending") {
-          return jsonResponse({ id: "batch-0", status: "in_progress" });
+          return Response.json({ id: "batch-0", status: "in_progress" });
         }
         if (nextStatus === "retry") {
-          return jsonResponse({ error: { message: "retry status" } }, 503);
+          return Response.json({ error: { message: "retry status" } }, { status: 503 });
         }
-        return jsonResponse({ id: "batch-0", status: "completed", output_file_id: "output-0" });
+        return Response.json({ id: "batch-0", status: "completed", output_file_id: "output-0" });
       }
       if (url.endsWith("/files/output-0/content")) {
         return new Response(
@@ -335,15 +327,15 @@ describe("OpenAI embedding batch output", () => {
       const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = fetchInputUrl(input);
         if (url.endsWith("/files") && init?.method === "POST") {
-          return jsonResponse({ id: "input-0" });
+          return Response.json({ id: "input-0" });
         }
         if (url.endsWith("/batches") && init?.method === "POST") {
-          return jsonResponse(
+          return Response.json(
             completionStage === "create" ? terminal : { id: "batch-0", status: "in_progress" },
           );
         }
         if (url.endsWith("/batches/batch-0")) {
-          return jsonResponse(terminal);
+          return Response.json(terminal);
         }
         if (url.endsWith("/files/error-0/content")) {
           return new Response(
@@ -408,7 +400,7 @@ describe("OpenAI embedding batch output", () => {
           fileId,
           jsonl.split("\n").map((line) => JSON.parse(line) as { custom_id?: string }),
         );
-        return jsonResponse({ id: fileId });
+        return Response.json({ id: fileId });
       }
       if (url.endsWith("/batches") && init?.method === "POST") {
         const body = parseStringBody(init) as { input_file_id?: string };
@@ -430,7 +422,7 @@ describe("OpenAI embedding batch output", () => {
             )
             .join("\n"),
         );
-        return jsonResponse({ id: batchId, status: "completed", output_file_id: outputFileId });
+        return Response.json({ id: batchId, status: "completed", output_file_id: outputFileId });
       }
       const contentMatch = url.match(/\/files\/([^/]+)\/content$/);
       if (contentMatch) {
@@ -497,7 +489,7 @@ describe("OpenAI embedding batch output", () => {
         const customIds = uploadedRequests.map((request) => request.custom_id ?? "");
         uploadedGroups.push(customIds);
         if (uploadedRequests.length > 2) {
-          return jsonResponse(
+          return Response.json(
             {
               error: {
                 message: "Request body too large. Maximum allowed: 10 MB",
@@ -505,13 +497,13 @@ describe("OpenAI embedding batch output", () => {
                 code: "PAYLOAD_TOO_LARGE",
               },
             },
-            413,
+            { status: 413 },
           );
         }
         const fileId = `file-${fileIndex}`;
         fileIndex += 1;
         requestsByFileId.set(fileId, uploadedRequests);
-        return jsonResponse({ id: fileId });
+        return Response.json({ id: fileId });
       }
       if (url.endsWith("/batches") && init?.method === "POST") {
         const body = parseStringBody(init) as { input_file_id?: string };
@@ -533,7 +525,7 @@ describe("OpenAI embedding batch output", () => {
             )
             .join("\n"),
         );
-        return jsonResponse({ id: batchId, status: "completed", output_file_id: outputFileId });
+        return Response.json({ id: batchId, status: "completed", output_file_id: outputFileId });
       }
       const contentMatch = url.match(/\/files\/([^/]+)\/content$/);
       if (contentMatch) {
@@ -603,10 +595,10 @@ describe("OpenAI embedding batch output", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = fetchInputUrl(input);
       if (url.endsWith("/files") && init?.method === "POST") {
-        return jsonResponse({ id: "file-0" });
+        return Response.json({ id: "file-0" });
       }
       if (url.endsWith("/batches") && init?.method === "POST") {
-        return jsonResponse({ id: "batch-0", status: "in_progress" });
+        return Response.json({ id: "batch-0", status: "in_progress" });
       }
       if (url.endsWith("/batches/batch-0") && !batchStatusCalled) {
         batchStatusCalled = true;
@@ -663,10 +655,10 @@ describe("OpenAI embedding batch output", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = fetchInputUrl(input);
       if (url.endsWith("/files") && init?.method === "POST") {
-        return jsonResponse({ id: "file-0" });
+        return Response.json({ id: "file-0" });
       }
       if (url.endsWith("/batches") && init?.method === "POST") {
-        return jsonResponse({ id: "batch-0", status: "completed", output_file_id: "output-0" });
+        return Response.json({ id: "batch-0", status: "completed", output_file_id: "output-0" });
       }
       if (url.endsWith("/files/output-0/content")) {
         return outputResponse;
@@ -734,10 +726,10 @@ describe("OpenAI embedding batch output", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = fetchInputUrl(input);
       if (url.endsWith("/files") && init?.method === "POST") {
-        return jsonResponse({ id: "file-0" });
+        return Response.json({ id: "file-0" });
       }
       if (url.endsWith("/batches") && init?.method === "POST") {
-        return jsonResponse({ id: "batch-0", status: "completed", output_file_id: "output-0" });
+        return Response.json({ id: "batch-0", status: "completed", output_file_id: "output-0" });
       }
       if (url.endsWith("/files/output-0/content")) {
         return outputResponse;
@@ -817,16 +809,16 @@ describe("OpenAI embedding batch output", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = fetchInputUrl(input);
       if (url.endsWith("/files") && init?.method === "POST") {
-        return jsonResponse({ id: "file-0" });
+        return Response.json({ id: "file-0" });
       }
       if (url.endsWith("/batches") && init?.method === "POST") {
-        return jsonResponse({ id: "batch-0", status: "in_progress" });
+        return Response.json({ id: "batch-0", status: "in_progress" });
       }
       if (url.endsWith("/batches/batch-0")) {
         statusCalls += 1;
         return statusCalls === 1
-          ? jsonResponse({ error: { message: "retry status" } }, 503)
-          : jsonResponse({
+          ? Response.json({ error: { message: "retry status" } }, { status: 503 })
+          : Response.json({
               id: "batch-0",
               status: "completed",
               output_file_id: "output-0",
@@ -859,10 +851,10 @@ describe("OpenAI embedding batch output", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = fetchInputUrl(input);
       if (url.endsWith("/files") && init?.method === "POST") {
-        return jsonResponse({ id: "file-0" });
+        return Response.json({ id: "file-0" });
       }
       if (url.endsWith("/batches") && init?.method === "POST") {
-        return jsonResponse({ id: "batch-0", status: "in_progress" });
+        return Response.json({ id: "batch-0", status: "in_progress" });
       }
       if (url.endsWith("/batches/batch-0") && !batchStatusReturned) {
         batchStatusReturned = true;

--- a/extensions/voyage/embedding-batch.test.ts
+++ b/extensions/voyage/embedding-batch.test.ts
@@ -1,4 +1,3 @@
-// Voyage batch tests cover the real HTTP boundary and bounded response reads.
 import { once } from "node:events";
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -7,13 +6,6 @@ import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./emb
 
 type VoyageBatchOptions = Parameters<typeof runVoyageEmbeddingBatches>[0];
 type BatchStage = "upload" | "create" | "status" | "output" | "error";
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
 
 function buildClient(): VoyageEmbeddingClient {
   return {
@@ -45,11 +37,11 @@ function resolveBatchStage(url: string, init?: RequestInit): BatchStage {
 function defaultBatchResponse(stage: BatchStage): Response {
   switch (stage) {
     case "upload":
-      return jsonResponse({ id: "input-0" });
+      return Response.json({ id: "input-0" });
     case "create":
-      return jsonResponse({ id: "batch-0", status: "in_progress" });
+      return Response.json({ id: "batch-0", status: "in_progress" });
     case "status":
-      return jsonResponse({ id: "batch-0", status: "completed", output_file_id: "output-0" });
+      return Response.json({ id: "batch-0", status: "completed", output_file_id: "output-0" });
     case "output":
       return new Response(
         JSON.stringify({
@@ -349,7 +341,7 @@ describe("voyage batch bounded reads", () => {
     const streamed = streamingResponse({ chunkCount: 20, chunkSize: 1024 * 1024 });
     stubBatchFetch((stage) => {
       if (stage === "create") {
-        return jsonResponse({
+        return Response.json({
           id: "batch-0",
           status: "completed",
           output_file_id: "output-0",
@@ -413,7 +405,7 @@ describe("voyage batch bounded reads", () => {
   it("reads a completed error file before downloading successful output", async () => {
     const fetchMock = stubBatchFetch((stage) =>
       stage === "status"
-        ? jsonResponse({
+        ? Response.json({
             id: "batch-0",
             status: "completed",
             output_file_id: "output-0",
@@ -459,7 +451,7 @@ describe("voyage batch bounded reads", () => {
       if (stage !== "create" || ++attempts > 1) {
         return undefined;
       }
-      return jsonResponse({ error: { message: "retry this request" } }, 503);
+      return Response.json({ error: { message: "retry this request" } }, { status: 503 });
     });
 
     await expect(runBatch()).resolves.toEqual(new Map([["req-0", [1, 2]]]));


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

OpenAI, Google and Voyage embedding batch tests repeated the same JSON-response construction in private helpers. The native response factory already expresses that fixture behavior.

## Why This Change Was Made

Use `Response.json` for the 39 ordinary JSON fixtures, retaining all payloads and the five explicit non-200 statuses. Keep JSONL, raw responses, custom streams, transport mocks and existing request builders unchanged.

## User Impact

No production behavior change or runtime bug claim. This removes 24 test lines while retaining all 108 assertion sites and existing cases.

## Evidence

- All three complete embedding batch suites passed before and after: 59/59, with matching ordered case inventories across three native projects.
- All 19 normal changed checks passed; independent source review was scoped clean.
- Existing bounded-read, cancellation, timeout, retry, error-ordering and loopback HTTP cases remain intact.
- Proof uses synthetic responses and local loopback servers; no live provider behavior is claimed.
