### PR TITLE
refactor(tests): share Bedrock AWS SDK config inputs

### DIFF
--- a/src/agents/auth-profiles/config-fixtures.test-support.ts
+++ b/src/agents/auth-profiles/config-fixtures.test-support.ts
@@ -1,0 +1,24 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+export function createBedrockAwsSdkConfig(): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        "amazon-bedrock": {
+          auth: "aws-sdk",
+          baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+          api: "bedrock-converse-stream",
+          models: [],
+        },
+      },
+    },
+    auth: {
+      profiles: {
+        "amazon-bedrock:default": {
+          provider: "amazon-bedrock",
+          mode: "aws-sdk",
+        },
+      },
+    },
+  };
+}

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createBedrockAwsSdkConfig } from "./config-fixtures.test-support.js";
 import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import {
   authStoreMocks,
@@ -112,26 +113,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       const sessionStore = { "agent:main:main": sessionEntry };
 
       const resolved = await resolveSession({
-        cfg: {
-          models: {
-            providers: {
-              "amazon-bedrock": {
-                auth: "aws-sdk",
-                baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-                api: "bedrock-converse-stream",
-                models: [],
-              },
-            },
-          },
-          auth: {
-            profiles: {
-              "amazon-bedrock:default": {
-                provider: "amazon-bedrock",
-                mode: "aws-sdk",
-              },
-            },
-          },
-        } as OpenClawConfig,
+        cfg: createBedrockAwsSdkConfig(),
         provider: "amazon-bedrock",
         agentDir,
         sessionEntry,
@@ -166,26 +148,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       const sessionStore = { "agent:main:main": sessionEntry };
 
       const resolved = await resolveSession({
-        cfg: {
-          models: {
-            providers: {
-              "amazon-bedrock": {
-                auth: "aws-sdk",
-                baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-                api: "bedrock-converse-stream",
-                models: [],
-              },
-            },
-          },
-          auth: {
-            profiles: {
-              "amazon-bedrock:default": {
-                provider: "amazon-bedrock",
-                mode: "aws-sdk",
-              },
-            },
-          },
-        } as OpenClawConfig,
+        cfg: createBedrockAwsSdkConfig(),
         provider: "amazon-bedrock",
         agentDir,
         sessionEntry,

--- a/src/auto-reply/reply/directive-handling.auth.test.ts
+++ b/src/auto-reply/reply/directive-handling.auth.test.ts
@@ -2,6 +2,7 @@ import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coerc
 // Tests auth profile directive handling and provider override selection.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import { createBedrockAwsSdkConfig } from "../../agents/auth-profiles/config-fixtures.test-support.js";
 import type { OpenClawConfig } from "../../config/config.js";
 
 let mockStore: AuthProfileStore;
@@ -166,26 +167,7 @@ describe("resolveAuthLabel ref-aware labels", () => {
     mockOrder = ["amazon-bedrock:default"];
     const result = await resolveAuthLabel(
       "amazon-bedrock",
-      {
-        models: {
-          providers: {
-            "amazon-bedrock": {
-              auth: "aws-sdk",
-              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-              api: "bedrock-converse-stream",
-              models: [],
-            },
-          },
-        },
-        auth: {
-          profiles: {
-            "amazon-bedrock:default": {
-              provider: "amazon-bedrock",
-              mode: "aws-sdk",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      createBedrockAwsSdkConfig(),
       "/tmp/models.json",
       undefined,
       "compact",
@@ -199,26 +181,7 @@ describe("resolveAuthLabel ref-aware labels", () => {
     mockOrder = ["amazon-bedrock:default"];
     const result = await resolveAuthLabel(
       "amazon-bedrock",
-      {
-        models: {
-          providers: {
-            "amazon-bedrock": {
-              auth: "aws-sdk",
-              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-              api: "bedrock-converse-stream",
-              models: [],
-            },
-          },
-        },
-        auth: {
-          profiles: {
-            "amazon-bedrock:default": {
-              provider: "amazon-bedrock",
-              mode: "aws-sdk",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      createBedrockAwsSdkConfig(),
       "/tmp/models.json",
       undefined,
       "verbose",


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Four authentication tests repeat the same Bedrock AWS SDK configuration, obscuring the stored-profile state and label mode that distinguish the cases.

## Why This Change Was Made

Use one pure typed input fixture that returns fresh configuration data. Keep credential-store state, mock ordering, session pins, and compact/verbose expected labels in their original cases. The fixture has no runtime imports and contains configuration metadata, not stored credentials.

## User Impact

No production behavior changes. This removes 50 net test/support lines, including the new 24-line helper.

## Evidence

All 35 cases in the session-override and directive-auth suites passed before and after with identical names, order, and statuses. One-off verification recovered both original test files and confirmed exact input values, fresh independent graphs, and no runtime imports. Changed-file checks and independent P2 review passed. No live AWS calls or runtime savings are claimed.
