### PR TITLE
fix(codex): release compaction writer before continuation

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -705,6 +705,16 @@ describe("CodexAppServerClient", () => {
     expect(harness.writes).toHaveLength(0);
   });
 
+  it("resolves transport-exit waits when exit races the initial state check", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+
+    const waiting = harness.client.waitForTransportExit();
+    harness.process.emit("exit", 0, null);
+
+    await expect(waiting).resolves.toBeUndefined();
+  });
+
   it("answers server-initiated requests with the registered handler result", async () => {
     const harness = createClientHarness();
     clients.push(harness.client);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -750,6 +750,16 @@ export class CodexAppServerClient {
     return () => this.child.off?.("exit", onExit);
   }
 
+  /** Waits for physical transport exit after bounded cleanup has timed out. */
+  async waitForTransportExit(): Promise<void> {
+    if (this.transportExited) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      this.child.once("exit", () => resolve());
+    });
+  }
+
   /** Closes the transport without waiting for process/socket shutdown. */
   close(): void {
     if (!this.markClosed(new Error("codex app-server client is closed"))) {

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -224,6 +224,7 @@ export class CodexAppServerClient {
   private modelCatalogRevision = 0;
   private closed = false;
   private transportExited = false;
+  private readonly transportExit: Promise<void>;
   private nativeExecutionObserved = false;
   private closeError: Error | undefined;
   private serverVersion: string | undefined;
@@ -249,6 +250,9 @@ export class CodexAppServerClient {
 
   private constructor(child: CodexAppServerTransport) {
     this.child = child;
+    this.transportExit = new Promise<void>((resolve) => {
+      child.once("exit", () => resolve());
+    });
     this.lines = createInterface({ input: child.stdout });
     this.lines.on("line", (line) => this.handleLine(line));
     this.lines.on("error", (error) => this.closeWithError(toStringifiedError(error)));
@@ -755,9 +759,7 @@ export class CodexAppServerClient {
     if (this.transportExited) {
       return;
     }
-    await new Promise<void>((resolve) => {
-      this.child.once("exit", () => resolve());
-    });
+    await this.transportExit;
   }
 
   /** Closes the transport without waiting for process/socket shutdown. */

--- a/extensions/codex/src/app-server/compact.client-ownership.test.ts
+++ b/extensions/codex/src/app-server/compact.client-ownership.test.ts
@@ -165,7 +165,10 @@ it.each(["warm", "closed", "detached", "unconfirmed-close"])(
       });
       transports.push(harness);
       if (ownerState === "unconfirmed-close" && index === 1) {
-        vi.spyOn(harness.client, "closeAndWait").mockResolvedValueOnce(false);
+        vi.spyOn(harness.client, "closeAndWait").mockResolvedValueOnce({
+          exited: false,
+          cleanup: "uncertain",
+        });
       }
       return harness.client;
     });

--- a/extensions/codex/src/app-server/compact.client-ownership.test.ts
+++ b/extensions/codex/src/app-server/compact.client-ownership.test.ts
@@ -1,0 +1,277 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  consumeCodexAppServerLiveThread,
+  retainCodexAppServerLiveThread,
+} from "./client-runtime.js";
+import { CodexAppServerClient } from "./client.js";
+import { maybeCompactCodexAppServerSession } from "./compact.js";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import {
+  registerCodexTestSessionIdentity,
+  resetCodexTestBindingStore,
+  testCodexAppServerBindingStore,
+  writeCodexAppServerBinding,
+} from "./session-binding.test-helpers.js";
+import {
+  getLeasedSharedCodexAppServerClient,
+  releaseLeasedSharedCodexAppServerClient,
+  retainSharedCodexAppServerClientIfCurrent,
+  retireSharedCodexAppServerClientIfCurrent,
+  resetSharedCodexAppServerClientForTests,
+} from "./shared-client.js";
+import { createClientHarness } from "./test-support.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+let directory: string | undefined;
+const transports: ReturnType<typeof createClientHarness>[] = [];
+
+afterEach(async () => {
+  resetSharedCodexAppServerClientForTests();
+  await Promise.all(transports.splice(0).map(({ client }) => client.closeAndWait()));
+  resetCodexTestBindingStore();
+  vi.restoreAllMocks();
+  if (directory) {
+    await fs.rm(directory, { recursive: true, force: true });
+    directory = undefined;
+  }
+});
+
+it.each(["warm", "closed", "detached", "unconfirmed-close"])(
+  "supports repeated compaction and the next turn (owner %s)",
+  async (ownerState) => {
+    const ownerClosed = ownerState === "closed" || ownerState === "unconfirmed-close";
+    directory = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "codex-compact-owner-")));
+    const agentDir = path.join(directory, "agent");
+    const sessionFile = path.join(directory, "session.jsonl");
+    const sessionKey = "agent:main:compact-owner";
+    const pluginConfig = {
+      appServer: { command: process.execPath, args: ["app-server"], homeScope: "user" },
+    };
+    const runtime = resolveCodexAppServerRuntimeOptions({
+      pluginConfig,
+      codexConfigToml: null,
+      requirementsToml: null,
+    });
+    const owners = new Map<string, number>();
+    const operations: { client: number; method: string; threadId?: string }[] = [];
+    vi.spyOn(CodexAppServerClient, "start").mockImplementation(async () => {
+      const index = transports.length;
+      const harness = createClientHarness({
+        onWrite(line, send) {
+          const request = JSON.parse(line) as {
+            id?: number;
+            method: string;
+            params?: { threadId?: string };
+          };
+          if (request.id === undefined) {
+            return;
+          }
+          const threadId = request.params?.threadId;
+          operations.push({ client: index, method: request.method, threadId });
+          if (request.method === "initialize") {
+            send({
+              id: request.id,
+              result: { userAgent: `codex-cli/${CODEX_APP_SERVER_VERSION}`, codexHome: directory },
+            });
+            return;
+          }
+          // Codex's thread_resume cross-process contract retains the writer after turn completion.
+          if (
+            request.method === "thread/resume" &&
+            threadId &&
+            owners.has(threadId) &&
+            owners.get(threadId) !== index
+          ) {
+            send({
+              id: request.id,
+              error: { code: -32600, message: `thread ${threadId} already has an active writer` },
+            });
+            return;
+          }
+          if (request.method === "thread/resume" && threadId) {
+            owners.set(threadId, index);
+            send({
+              id: request.id,
+              result: {
+                thread: {
+                  id: threadId,
+                  turns: [],
+                  cwd: directory,
+                  sessionId: "session-1",
+                  cliVersion: CODEX_APP_SERVER_VERSION,
+                  createdAt: 1,
+                  updatedAt: 1,
+                  ephemeral: false,
+                  modelProvider: "openai",
+                  preview: "",
+                  projectId: null,
+                  source: "unknown",
+                  status: { type: "idle" },
+                },
+                model: "gpt-5.6-luna",
+                modelProvider: "openai",
+                cwd: directory,
+                approvalPolicy: "never",
+                approvalsReviewer: "user",
+                sandbox: { type: "dangerFullAccess" },
+              },
+            });
+            return;
+          }
+          // Unsubscribe stops notifications, but Codex keeps the writer until idle eviction or exit.
+          if (
+            (request.method === "turn/start" || request.method === "thread/compact/start") &&
+            threadId
+          ) {
+            const turn = { id: "finished-turn", threadId, status: "completed" };
+            if (request.method === "thread/compact/start") {
+              send({
+                method: "turn/started",
+                params: { threadId, turn: { ...turn, status: "inProgress" } },
+              });
+              send({
+                method: "item/started",
+                params: {
+                  threadId,
+                  turnId: turn.id,
+                  item: { id: "compacted", type: "contextCompaction" },
+                },
+              });
+              send({
+                method: "item/completed",
+                params: {
+                  threadId,
+                  turnId: turn.id,
+                  item: { id: "compacted", type: "contextCompaction" },
+                },
+              });
+            }
+            send({ method: "turn/completed", params: { threadId, turn } });
+            send({ id: request.id, result: request.method === "turn/start" ? { turn } : {} });
+            return;
+          }
+          send({ id: request.id, result: {} });
+        },
+      });
+      harness.client.addTransportExitHandler(() => {
+        for (const [threadId, ownerIndex] of owners) {
+          if (ownerIndex === index) {
+            owners.delete(threadId);
+          }
+        }
+      });
+      transports.push(harness);
+      if (ownerState === "unconfirmed-close" && index === 1) {
+        vi.spyOn(harness.client, "closeAndWait").mockResolvedValueOnce(false);
+      }
+      return harness.client;
+    });
+    const owner = await getLeasedSharedCodexAppServerClient({
+      startOptions: {
+        ...runtime.start,
+        env: { ...runtime.start.env, COMPACTION_TEST_SHELL: "prepared" },
+      },
+      agentDir,
+      authProfileId: null,
+    });
+    await owner.request(
+      "thread/resume",
+      { threadId: "owned-thread", excludeTurns: true },
+      { timeoutMs: 1000 },
+    );
+    await owner.request("turn/start", { threadId: "owned-thread", input: [] }, { timeoutMs: 1000 });
+    await retainCodexAppServerLiveThread(owner, "owned-thread");
+    await owner.request(
+      "thread/resume",
+      { threadId: "sibling-thread", excludeTurns: true },
+      { timeoutMs: 1000 },
+    );
+    await retainCodexAppServerLiveThread(owner, "sibling-thread");
+    registerCodexTestSessionIdentity(sessionFile, "session-1", sessionKey, "main");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "owned-thread",
+      cwd: directory,
+      clientId: owner.getInstanceId(),
+    });
+    releaseLeasedSharedCodexAppServerClient(owner);
+    const releaseSiblingLease =
+      ownerState === "detached" ? retainSharedCodexAppServerClientIfCurrent(owner) : undefined;
+    if (ownerState === "detached") {
+      expect(releaseSiblingLease).toBeDefined();
+      expect(retireSharedCodexAppServerClientIfCurrent(owner)?.closed).toBe(false);
+    }
+    if (ownerClosed) {
+      expect(await owner.closeAndWait()).toMatchObject({ exited: true });
+    }
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const compaction = maybeCompactCodexAppServerSession(
+        {
+          sessionId: "session-1",
+          sessionKey,
+          sessionFile,
+          agentDir,
+          workspaceDir: directory,
+          trigger: "manual",
+        },
+        { bindingStore: testCodexAppServerBindingStore, pluginConfig },
+      );
+
+      if (ownerState === "unconfirmed-close") {
+        await expect(compaction).rejects.toThrow("Codex compaction client did not exit");
+        expect(owners.get("owned-thread")).toBe(1);
+        expect(operations.some(({ method }) => method === "thread/compact/start")).toBe(true);
+        return;
+      }
+      const result = await compaction;
+      expect(result, JSON.stringify({ result, operations })).toMatchObject({
+        ok: true,
+        compacted: true,
+      });
+      expect(owners.get("owned-thread")).toBe(ownerClosed ? undefined : 0);
+      expect(owners.get("sibling-thread")).toBe(ownerClosed ? undefined : 0);
+    }
+    expect(operations.filter(({ method }) => method === "thread/compact/start")).toEqual([
+      { client: ownerClosed ? 1 : 0, method: "thread/compact/start", threadId: "owned-thread" },
+      { client: ownerClosed ? 2 : 0, method: "thread/compact/start", threadId: "owned-thread" },
+    ]);
+    if (!ownerClosed) {
+      expect(await consumeCodexAppServerLiveThread(owner, "owned-thread")).toBeDefined();
+      expect(await consumeCodexAppServerLiveThread(owner, "sibling-thread")).toBeDefined();
+    }
+    const nextOwner =
+      ownerState === "detached"
+        ? owner
+        : await getLeasedSharedCodexAppServerClient({
+            startOptions: {
+              ...runtime.start,
+              env: { ...runtime.start.env, COMPACTION_TEST_SHELL: "prepared" },
+            },
+            agentDir,
+            authProfileId: null,
+          });
+    try {
+      await nextOwner.request(
+        "thread/resume",
+        { threadId: "owned-thread", excludeTurns: true },
+        { timeoutMs: 1000 },
+      );
+      await expect(
+        nextOwner.request(
+          "turn/start",
+          { threadId: "owned-thread", input: [] },
+          { timeoutMs: 1000 },
+        ),
+      ).resolves.toMatchObject({ turn: { status: "completed" } });
+    } finally {
+      if (releaseSiblingLease) {
+        releaseSiblingLease();
+      } else {
+        releaseLeasedSharedCodexAppServerClient(nextOwner);
+      }
+    }
+  },
+);

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -15,7 +15,10 @@ import {
   retainCodexAppServerLiveThread,
 } from "./client-runtime.js";
 import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
-import { maybeCompactCodexAppServerSession as maybeCompactCodexAppServerSessionImpl } from "./compact.js";
+import {
+  maybeCompactCodexAppServerSession as maybeCompactCodexAppServerSessionImpl,
+  waitForCodexAppServerTemporaryClientExit,
+} from "./compact.js";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import type { CodexServerNotification } from "./protocol.js";
@@ -119,16 +122,21 @@ function startCompaction(
   options: {
     currentTokenCount?: number;
     nativeToolSurface?: "unrestricted" | "host-isolated";
+    pluginConfig?: unknown;
   } = {},
 ) {
-  return maybeCompactCodexAppServerSession({
-    sessionId: "session-1",
-    sessionKey: "agent:main:session-1",
-    sessionFile,
-    workspaceDir: tempDir,
-    trigger: "manual",
-    ...options,
-  });
+  const { pluginConfig, ...paramsOptions } = options;
+  return maybeCompactCodexAppServerSession(
+    {
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile,
+      workspaceDir: tempDir,
+      trigger: "manual",
+      ...paramsOptions,
+    },
+    pluginConfig ? { pluginConfig } : {},
+  );
 }
 
 function startSandboxedCompaction(sessionFile: string) {
@@ -2414,22 +2422,30 @@ describe("maybeCompactCodexAppServerSession", () => {
   });
 
   it("keeps the lifecycle fence when an unconfirmed stdio process does not stop", async () => {
-    const fake = createFakeCodexClient({ retainedThreadId: "thread-stuck-stdio" });
-    fake.request.mockRejectedValueOnce(new Error("thread/compact/start timed out"));
+    const fake = createFakeCodexClient({ retainedThreadId: null });
     fake.closeAndWait.mockResolvedValueOnce({ exited: false, cleanup: "uncertain" });
-    setCodexAppServerClientFactoryForTest(async () => fake.client);
-    const sessionFile = await writeTestBinding({ threadId: "thread-stuck-stdio" });
+    const pending = withCodexAppServerThreadMutation("thread-stuck-stdio", async () => {
+      const closeResult = await fake.closeAndWait();
+      await waitForCodexAppServerTemporaryClientExit(fake.client, closeResult.exited);
+      throw new Error("temporary writer did not exit");
+    });
+    const nextMutation = vi.fn(async () => {});
+    const queued = withCodexAppServerThreadMutation("thread-stuck-stdio", nextMutation);
 
     const outcome = await Promise.race([
-      startCompaction(sessionFile).then(() => "settled" as const),
+      pending.then(() => "settled" as const),
       new Promise<"pending">((resolve) => {
         setTimeout(() => resolve("pending"), 20);
       }),
     ]);
 
     expect(outcome).toBe("pending");
-    expect(fake.closeAndWait).toHaveBeenCalledOnce();
-    await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeDefined();
+    expect(nextMutation).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(fake.waitForTransportExit).toHaveBeenCalledOnce());
+    fake.emitTransportExit();
+    await expect(pending).rejects.toThrow("temporary writer did not exit");
+    await queued;
+    expect(nextMutation).toHaveBeenCalledOnce();
   });
 
   it("detaches a guarded remote start after releasing the binding lock", async () => {
@@ -2730,11 +2746,14 @@ function createFakeCodexClient(
   request: ReturnType<typeof vi.fn<CodexAppServerClient["request"]>>;
   close: ReturnType<typeof vi.fn>;
   closeAndWait: ReturnType<typeof vi.fn<CodexAppServerClient["closeAndWait"]>>;
+  waitForTransportExit: ReturnType<typeof vi.fn<CodexAppServerClient["waitForTransportExit"]>>;
+  emitTransportExit: () => void;
   emit: (notification: CodexServerNotification) => void;
   completeCompaction: () => void;
 } {
   const handlers = new Set<(notification: CodexServerNotification) => void>();
   const closeHandlers = new Set<() => void>();
+  const transportExit = createDeferred<void>();
   const retainedThreadId =
     options.retainedThreadId === undefined ? "thread-1" : options.retainedThreadId;
   const subscribedThreadIds = new Set(
@@ -2874,6 +2893,12 @@ function createFakeCodexClient(
       handler();
     }
   });
+  const emitTransportExit = (): void => {
+    transportExit.resolve();
+  };
+  const waitForTransportExit = vi.fn(async () => {
+    await transportExit.promise;
+  });
   const closeAndWait = vi.fn<CodexAppServerClient["closeAndWait"]>(async () => {
     close();
     return { exited: true, cleanup: "closed" };
@@ -2894,6 +2919,11 @@ function createFakeCodexClient(
       closeHandlers.add(handler);
       return () => closeHandlers.delete(handler);
     }),
+    addTransportExitHandler: vi.fn((handler: () => void) => {
+      void transportExit.promise.then(handler);
+      return () => undefined;
+    }),
+    waitForTransportExit,
   } as unknown as CodexAppServerClient;
   ensureCodexAppServerClientRuntime(client, { agentDir: tempDir });
   addNotificationHandler.mockClear();
@@ -2910,6 +2940,8 @@ function createFakeCodexClient(
     request,
     close,
     closeAndWait,
+    waitForTransportExit,
+    emitTransportExit,
     emit,
     completeCompaction,
   };

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -513,6 +513,43 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(fake.request.mock.calls.map(([method]) => method)).toEqual(["thread/compact/start"]);
   });
 
+  it("uses the physical client owner recorded by the thread binding", async () => {
+    const owner = createFakeCodexClient();
+    const competingClient = createFakeCodexClient({ retainedThreadId: null });
+    competingClient.request.mockRejectedValueOnce(
+      new CodexAppServerRpcError(
+        { code: -32_600, message: "thread thread-1 already has an active writer" },
+        "thread/resume",
+      ),
+    );
+    const factory = vi.fn<CodexAppServerClientFactory>(async () => competingClient.client);
+    setCodexAppServerClientFactoryForTest(factory);
+    const sessionFile = await writeTestBinding({ clientId: "bound-client" });
+    const releaseOwner = vi.fn();
+    const sharedClientRuntime = await import("./shared-client.js");
+    const retainOwner = vi
+      .spyOn(sharedClientRuntime, "retainSharedCodexAppServerClientByInstanceId")
+      .mockReturnValue({ client: owner.client, release: releaseOwner });
+
+    try {
+      await expect(startCompaction(sessionFile)).resolves.toMatchObject({
+        ok: true,
+        compacted: true,
+      });
+      expect(retainOwner).toHaveBeenCalledWith("bound-client");
+      expect(factory).not.toHaveBeenCalled();
+      expect(owner.request).toHaveBeenCalledWith(
+        "thread/compact/start",
+        { threadId: "thread-1" },
+        { assertCurrent: expect.any(Function) },
+      );
+      expect(competingClient.request).not.toHaveBeenCalled();
+      expect(releaseOwner).toHaveBeenCalledOnce();
+    } finally {
+      retainOwner.mockRestore();
+    }
+  });
+
   it("uses the exact prepared Platform key for native compaction", async () => {
     const fake = createFakeCodexClient();
     const factory = vi.fn<CodexAppServerClientFactory>(async () => fake.client);

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -913,17 +913,17 @@ async function compactCodexNativeThread(
             // its process and must release the writer before a later turn resumes.
             if (!boundClientLease && shouldReleaseDefaultLease) {
               temporaryClientExited = temporaryClientExited && (await client.closeAndWait()).exited;
+              if (!temporaryClientExited && appServer.start.transport === "stdio") {
+                // Register the hold before any catch return can release the
+                // outer thread lane. Failure results must fence successors too.
+                hold(waitForCodexAppServerTemporaryClientExit(client, temporaryClientExited));
+              }
             }
           }
         }
         if (!temporaryClientExited) {
-          if (appServer.start.transport === "stdio") {
-            // A bounded shutdown result is not enough to release the native
-            // thread queue: a surviving temporary writer can still collide
-            // with the next turn. Keep this queued mutation occupied until
-            // the transport itself reports physical exit.
-            hold(waitForCodexAppServerTemporaryClientExit(client, temporaryClientExited));
-          }
+          // The cleanup finally registered the physical-exit hold before any
+          // failure return can release the outer thread lane.
           throw new CodexAppServerUnsafeSubscriptionError(
             `Codex compaction client did not exit: ${binding.threadId}`,
           );

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -49,8 +49,8 @@ import {
   type CodexAppServerThreadBinding,
 } from "./session-binding.js";
 import {
-  getLeasedSharedCodexAppServerClient,
-  releaseLeasedSharedCodexAppServerClient,
+  createIsolatedCodexAppServerClient,
+  retainSharedCodexAppServerClientByInstanceId,
   type CodexAppServerClientFactory,
 } from "./shared-client.js";
 import {
@@ -551,7 +551,7 @@ async function compactCodexNativeThread(
     return { ok: false, compacted: false, reason: "auth profile mismatch for session binding" };
   }
   const shouldReleaseDefaultLease = !options.clientFactory;
-  const clientFactory = options.clientFactory ?? getLeasedSharedCodexAppServerClient;
+  const clientFactory = options.clientFactory ?? createIsolatedCodexAppServerClient;
   const runtimeAuthPlan = params.runtimeAuthPlan ?? params.runtimePlan?.auth;
   // A user-home app-server keeps its native Codex account; injecting a prepared key
   // would rewrite the CODEX_HOME auth that Codex CLI and Desktop share.
@@ -573,18 +573,23 @@ async function compactCodexNativeThread(
       params.abortSignal,
       async () => {
         assertCurrent();
-        const client = await clientFactory({
-          startOptions: appServer.start,
-          ...(preparedApiKey
-            ? { preparedAuth: { kind: "api-key" as const, apiKey: preparedApiKey } }
-            : { authProfileId: connection.clientAuthProfileId }),
-          agentDir: params.agentDir,
-          config: params.config,
-          assertCurrent,
-        });
+        const boundClientLease = retainSharedCodexAppServerClientByInstanceId(binding.clientId);
+        const client =
+          boundClientLease?.client ??
+          (await clientFactory({
+            startOptions: appServer.start,
+            ...(preparedApiKey
+              ? { preparedAuth: { kind: "api-key" as const, apiKey: preparedApiKey } }
+              : { authProfileId: connection.clientAuthProfileId }),
+            authRequirement: runtimeAuthPlan?.modelRoute?.authRequirement,
+            agentDir: params.agentDir,
+            config: params.config,
+            assertCurrent,
+          }));
         let releaseThreadSubscription: (() => Promise<void>) | undefined;
         let retainedThreadOwnership: CodexAppServerLiveThreadOwnership | undefined;
         let compactionSucceeded = false;
+        let temporaryClientExited = true;
         let compactionRequestDefinitelyRejected = false;
         let tokensAfter: number | undefined;
         const releaseCompactionThread = async (threadId: string) => {
@@ -892,10 +897,18 @@ async function compactCodexNativeThread(
               await releaseThreadSubscription?.();
             }
           } finally {
-            if (shouldReleaseDefaultLease) {
-              releaseLeasedSharedCodexAppServerClient(client);
+            boundClientLease?.release();
+            // Unsubscribe keeps the native thread loaded. A cold compaction owns
+            // its process and must release the writer before a later turn resumes.
+            if (!boundClientLease && shouldReleaseDefaultLease) {
+              temporaryClientExited = await client.closeAndWait();
             }
           }
+        }
+        if (!temporaryClientExited) {
+          throw new CodexAppServerUnsafeSubscriptionError(
+            `Codex compaction client did not exit: ${binding.threadId}`,
+          );
         }
         const details: JsonObject = {
           backend: "codex-app-server",

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -901,7 +901,7 @@ async function compactCodexNativeThread(
             // Unsubscribe keeps the native thread loaded. A cold compaction owns
             // its process and must release the writer before a later turn resumes.
             if (!boundClientLease && shouldReleaseDefaultLease) {
-              temporaryClientExited = await client.closeAndWait();
+              temporaryClientExited = (await client.closeAndWait()).exited;
             }
           }
         }

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -78,6 +78,16 @@ type CodexNativeCompactionCompletion =
   | { completed: true; turnId?: string; itemId?: string; tokensAfter?: number }
   | { completed: false; reason: string };
 
+/** Keeps same-thread ownership held when bounded temporary cleanup is uncertain. */
+export async function waitForCodexAppServerTemporaryClientExit(
+  client: Pick<CodexAppServerClient, "waitForTransportExit">,
+  exited: boolean,
+): Promise<void> {
+  if (!exited) {
+    await client.waitForTransportExit();
+  }
+}
+
 function watchCodexNativeCompactionCompletion(params: {
   client: CodexAppServerClient;
   threadId: string;
@@ -619,6 +629,7 @@ async function compactCodexNativeThread(
               exitTimeoutMs: 5_000,
               forceKillDelayMs: 250,
             });
+            temporaryClientExited = transportStopped.exited;
             if (appServer.start.transport === "stdio") {
               if (transportStopped.exited) {
                 return;
@@ -901,11 +912,18 @@ async function compactCodexNativeThread(
             // Unsubscribe keeps the native thread loaded. A cold compaction owns
             // its process and must release the writer before a later turn resumes.
             if (!boundClientLease && shouldReleaseDefaultLease) {
-              temporaryClientExited = (await client.closeAndWait()).exited;
+              temporaryClientExited = temporaryClientExited && (await client.closeAndWait()).exited;
             }
           }
         }
         if (!temporaryClientExited) {
+          if (appServer.start.transport === "stdio") {
+            // A bounded shutdown result is not enough to release the native
+            // thread queue: a surviving temporary writer can still collide
+            // with the next turn. Keep this queued mutation occupied until
+            // the transport itself reports physical exit.
+            await waitForCodexAppServerTemporaryClientExit(client, temporaryClientExited);
+          }
           throw new CodexAppServerUnsafeSubscriptionError(
             `Codex compaction client did not exit: ${binding.threadId}`,
           );

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -55,7 +55,7 @@ import {
 } from "./shared-client.js";
 import {
   isSameCodexAppServerThreadOwner,
-  withCodexAppServerThreadMutation,
+  withCodexAppServerThreadMutationHold,
 } from "./thread-ownership.js";
 import { assertCodexSupervisionThreadLineage } from "./thread-policy.js";
 import { resumeCodexAppServerThread } from "./thread-resume.js";
@@ -326,14 +326,14 @@ function watchCodexNativeCompactionCompletion(params: {
 async function runExclusiveCodexNativeCompaction<T>(
   threadId: string,
   signal: AbortSignal | undefined,
-  run: () => Promise<T>,
+  run: (hold: (until: Promise<unknown>) => void) => Promise<T>,
 ): Promise<T> {
   signal?.throwIfAborted();
   let started = false;
-  const queued = withCodexAppServerThreadMutation(threadId, async () => {
+  const queued = withCodexAppServerThreadMutationHold(threadId, async (hold) => {
     started = true;
     signal?.throwIfAborted();
-    return run();
+    return run(hold);
   });
   if (!signal) {
     return queued;
@@ -581,7 +581,7 @@ async function compactCodexNativeThread(
     return await runExclusiveCodexNativeCompaction(
       binding.threadId,
       params.abortSignal,
-      async () => {
+      async (hold) => {
         assertCurrent();
         const boundClientLease = retainSharedCodexAppServerClientByInstanceId(binding.clientId);
         const client =
@@ -922,7 +922,7 @@ async function compactCodexNativeThread(
             // thread queue: a surviving temporary writer can still collide
             // with the next turn. Keep this queued mutation occupied until
             // the transport itself reports physical exit.
-            await waitForCodexAppServerTemporaryClientExit(client, temporaryClientExited);
+            hold(waitForCodexAppServerTemporaryClientExit(client, temporaryClientExited));
           }
           throw new CodexAppServerUnsafeSubscriptionError(
             `Codex compaction client did not exit: ${binding.threadId}`,

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -908,10 +908,15 @@ async function compactCodexNativeThread(
               await releaseThreadSubscription?.();
             }
           } finally {
-            boundClientLease?.release();
+            const boundClientClosed = boundClientLease?.release() ?? false;
             // Unsubscribe keeps the native thread loaded. A cold compaction owns
             // its process and must release the writer before a later turn resumes.
-            if (!boundClientLease && shouldReleaseDefaultLease) {
+            if (boundClientClosed && appServer.start.transport === "stdio") {
+              // Releasing the final lease can initiate asynchronous physical
+              // shutdown of a detached recorded owner. Keep the same-thread
+              // lane fenced until that process has actually exited.
+              hold(waitForCodexAppServerTemporaryClientExit(client, false));
+            } else if (!boundClientLease && shouldReleaseDefaultLease) {
               temporaryClientExited = temporaryClientExited && (await client.closeAndWait()).exited;
               if (!temporaryClientExited && appServer.start.transport === "stdio") {
                 // Register the hold before any catch return can release the

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -596,6 +596,11 @@ async function compactCodexNativeThread(
             config: params.config,
             assertCurrent,
           }));
+        embeddedAgentLog.info("selected codex app-server compaction client", {
+          clientId: client.getInstanceId(),
+          recordedOwnerReused: Boolean(boundClientLease),
+          threadId: binding.threadId,
+        });
         let releaseThreadSubscription: (() => Promise<void>) | undefined;
         let retainedThreadOwnership: CodexAppServerLiveThreadOwnership | undefined;
         let compactionSucceeded = false;
@@ -916,6 +921,10 @@ async function compactCodexNativeThread(
               // shutdown of a detached recorded owner. Keep the same-thread
               // lane fenced until that process has actually exited.
               hold(waitForCodexAppServerTemporaryClientExit(client, false));
+              embeddedAgentLog.info("fenced recorded-owner compaction client until process exit", {
+                clientId: client.getInstanceId(),
+                threadId: binding.threadId,
+              });
             } else if (!boundClientLease && shouldReleaseDefaultLease) {
               temporaryClientExited = temporaryClientExited && (await client.closeAndWait()).exited;
               if (!temporaryClientExited && appServer.start.transport === "stdio") {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -605,6 +605,20 @@ describe("shared Codex app-server client", () => {
     expect(harness.process.stdin.destroyed).toBe(true);
   });
 
+  it("does not retain a client after close before transport exit", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
+    const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
+    await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
+    const client = await acquire;
+    const clientId = client.getInstanceId();
+
+    client.close();
+
+    expect(client.getCloseError()).toBeDefined();
+    expect(retainSharedCodexAppServerClientByInstanceId(clientId)).toBeUndefined();
+  });
+
   it.each([
     {
       version: "2026.7.1",

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -585,6 +585,26 @@ describe("shared Codex app-server client", () => {
     expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
   });
 
+  it("retains a gracefully detached live client by its persisted instance id", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
+    const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
+    await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
+    const client = await acquire;
+
+    expect(retireSharedCodexAppServerClientIfCurrent(client)).toEqual({
+      activeLeases: 1,
+      closed: false,
+    });
+    const retained = retainSharedCodexAppServerClientByInstanceId(client.getInstanceId());
+    expect(retained?.client).toBe(client);
+
+    expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+    expect(harness.process.stdin.destroyed).toBe(false);
+    retained?.release();
+    expect(harness.process.stdin.destroyed).toBe(true);
+  });
+
   it.each([
     {
       version: "2026.7.1",

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -1314,7 +1314,7 @@ export function retainSharedCodexAppServerClientIfCurrent(
 /** Retains the live shared client whose initialized instance id matches a thread binding. */
 export function retainSharedCodexAppServerClientByInstanceId(
   clientId: string | undefined,
-): { client: CodexAppServerClient; release: () => void } | undefined {
+): { client: CodexAppServerClient; release: () => boolean } | undefined {
   const normalizedClientId = clientId?.trim();
   if (!normalizedClientId) {
     return undefined;
@@ -1544,7 +1544,7 @@ function retainSharedClientEntry(
   entry[counter] += 1;
   return () => {
     if (released) {
-      return;
+      return false;
     }
     released = true;
     return releaseSharedClientEntry(entry, counter);

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -1539,7 +1539,7 @@ export function clearSharedCodexAppServerClientIfCurrentAndUnclaimed(
 function retainSharedClientEntry(
   entry: SharedCodexAppServerClientEntry,
   counter: "activeLeases" | "pendingAcquires" = "activeLeases",
-): () => void {
+): () => boolean {
   let released = false;
   entry[counter] += 1;
   return () => {
@@ -1547,17 +1547,18 @@ function retainSharedClientEntry(
       return;
     }
     released = true;
-    releaseSharedClientEntry(entry, counter);
+    return releaseSharedClientEntry(entry, counter);
   };
 }
 
 function releaseSharedClientEntry(
   entry: SharedCodexAppServerClientEntry,
   counter: "activeLeases" | "pendingAcquires",
-): void {
+): boolean {
   entry[counter] -= 1;
-  closeRetiredSharedClientEntryIfIdle(entry);
+  const closed = closeRetiredSharedClientEntryIfIdle(entry);
   notifyDesktopGenerationDrainChecks(getSharedCodexAppServerClientState());
+  return closed;
 }
 
 function closeSharedClientEntryIfUnclaimed(entry: SharedCodexAppServerClientEntry): boolean {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -1325,7 +1325,8 @@ export function retainSharedCodexAppServerClientByInstanceId(
     if (
       client.getInstanceId() !== normalizedClientId ||
       entry?.client !== client ||
-      entry.closeError
+      entry.closeError ||
+      client.getCloseError()
     ) {
       continue;
     }

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -1319,11 +1319,19 @@ export function retainSharedCodexAppServerClientByInstanceId(
   if (!normalizedClientId) {
     return undefined;
   }
-  for (const entry of getSharedCodexAppServerClientState().clients.values()) {
-    const client = entry.client;
-    if (client?.getInstanceId() !== normalizedClientId || entry.closeWhenIdle || entry.closeError) {
+  const state = getSharedCodexAppServerClientState();
+  for (const client of state.liveClients) {
+    const entry = state.entriesByClient.get(client);
+    if (
+      client.getInstanceId() !== normalizedClientId ||
+      entry?.client !== client ||
+      entry.closeError
+    ) {
       continue;
     }
+    // Graceful retirement removes the process from generic acquisition while
+    // existing leases drain. Its persisted thread bindings still need the
+    // exact physical owner until the final lease closes that process.
     return { client, release: retainSharedClientEntry(entry) };
   }
   return undefined;

--- a/extensions/codex/src/app-server/thread-ownership-queue.ts
+++ b/extensions/codex/src/app-server/thread-ownership-queue.ts
@@ -16,6 +16,34 @@ export async function withCodexAppServerThreadMutation<T>(
   return await nativeThreadOwners.enqueue(`thread:${threadId}`, run);
 }
 
+/** Runs a mutation while retaining the lane after an uncertain cleanup. */
+export function withCodexAppServerThreadMutationHold<T>(
+  threadId: string,
+  run: (hold: (until: Promise<unknown>) => void) => Promise<T>,
+): Promise<T> {
+  let resolveResult!: (value: T | PromiseLike<T>) => void;
+  let rejectResult!: (reason?: unknown) => void;
+  const result = new Promise<T>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+  let heldUntil: Promise<unknown> | undefined;
+  const queued = nativeThreadOwners.enqueue(`thread:${threadId}`, async () => {
+    try {
+      resolveResult(
+        await run((until) => {
+          heldUntil ??= until;
+        }),
+      );
+    } catch (error) {
+      rejectResult(error);
+    }
+    await heldUntil;
+  });
+  void queued.catch((error) => rejectResult(error));
+  return result;
+}
+
 /** Serializes bound turns and retirement so detach cannot unsubscribe an active turn. */
 export async function withCodexConversationThreadActivity<T>(
   bindingId: string,

--- a/extensions/codex/src/app-server/thread-ownership.test.ts
+++ b/extensions/codex/src/app-server/thread-ownership.test.ts
@@ -84,4 +84,32 @@ describe("Codex thread ownership across module copies", () => {
     }
     expect(events).toEqual(["active", "other", "waiting"]);
   });
+
+  it("keeps a thread lane held after a failed mutation returns", async () => {
+    const owner = await import("./thread-ownership.js");
+    vi.resetModules();
+    const successor = await import("./thread-ownership.js");
+    const release = createDeferred<void>();
+    const failed = owner.withCodexAppServerThreadMutationHold("held-thread", async (hold) => {
+      hold(release.promise);
+      throw new Error("cleanup uncertain");
+    });
+    await expect(failed).rejects.toThrow("cleanup uncertain");
+
+    let successorRan = false;
+    const successorMutation = successor.withCodexAppServerThreadMutation(
+      "held-thread",
+      async () => {
+        successorRan = true;
+      },
+    );
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(successorRan).toBe(false);
+
+    release.resolve();
+    await successorMutation;
+    expect(successorRan).toBe(true);
+  });
 });

--- a/extensions/codex/src/app-server/thread-ownership.ts
+++ b/extensions/codex/src/app-server/thread-ownership.ts
@@ -21,6 +21,7 @@ import { withCodexAppServerThreadMutation } from "./thread-ownership-queue.js";
 
 export {
   withCodexAppServerThreadMutation,
+  withCodexAppServerThreadMutationHold,
   withCodexConversationThreadActivity,
 } from "./thread-ownership-queue.js";
 

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -225,13 +225,14 @@ export function createAgentHarnessHostCapabilities(params: {
     );
     return new Error(message);
   };
+  // Only a Gateway captured at admission participates in host liveness.
+  const hasBoundGatewayContext = callerIdentity?.gatewayContextResolver?.() !== undefined;
   function assertActive() {
     if (
       !active ||
       attempt.admittedRunContext.operationalRunInstance !== operationalRunInstance ||
       getAdmittedRunDelegatedAuthority(attempt.admittedRunContext) !== delegatedAuthority ||
-      (callerIdentity?.gatewayContextResolver !== undefined &&
-        callerIdentity.gatewayContextResolver() === undefined)
+      (hasBoundGatewayContext && callerIdentity?.gatewayContextResolver?.() === undefined)
     ) {
       throw inactiveError("agent harness host capability is no longer active");
     }
@@ -407,8 +408,7 @@ export function createAgentHarnessHostCapabilities(params: {
       if (
         attempt.abortSignal?.aborted ||
         attempt.admittedRunContext.operationalRunInstance !== operationalRunInstance ||
-        (callerIdentity?.gatewayContextResolver !== undefined &&
-          callerIdentity.gatewayContextResolver() === undefined)
+        (hasBoundGatewayContext && callerIdentity?.gatewayContextResolver?.() === undefined)
       ) {
         throw inactiveError("agent harness retained host policy is no longer active");
       }

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -11,6 +11,7 @@ import { registerMcpToolApprovalBinding } from "../../infra/mcp-tool-approval-bi
 import { prepareSystemRunMutableFileApproval } from "../../infra/system-run-approval-binding.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import {
+  getGatewayContextResolver,
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeGatewayRequestScope,
 } from "../../plugins/runtime/gateway-request-scope.js";
@@ -226,7 +227,10 @@ export function createAgentHarnessHostCapabilities(params: {
     return new Error(message);
   };
   // Only a Gateway captured at admission participates in host liveness.
-  const hasBoundGatewayContext = callerIdentity?.gatewayContextResolver?.() !== undefined;
+  // A supplied resolver that currently returns no context is a retired binding;
+  // only a genuinely absent resolver is exempt from the Gateway liveness fence.
+  const hasBoundGatewayContext =
+    getGatewayContextResolver(attempt.admittedRunContext) !== undefined;
   function assertActive() {
     if (
       !active ||

--- a/src/auto-reply/reply/channel-run-admission.test.ts
+++ b/src/auto-reply/reply/channel-run-admission.test.ts
@@ -4,6 +4,8 @@ import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
 } from "../../agents/admitted-run-context.js";
+import { createAgentHarnessHostCapabilities } from "../../agents/harness/host-capability.js";
+import { getGatewayToolCallerIdentity } from "../../agents/tools/gateway-caller-context.js";
 import { configureExecutionIdentityAdmissionSink } from "../../audit/execution-identity-admission.js";
 import {
   combineChannelAdmissionEvidence,
@@ -11,11 +13,54 @@ import {
   configureChannelAdmissionEvidenceCollection,
   consumeChannelAdmissionEvidence,
 } from "../../channels/message-access/admission-evidence.js";
+import type { GatewayRequestContext } from "../../gateway/server-methods/types.js";
+import { resetAgentRunRegistryForTest } from "../../infra/agent-run-registry.js";
+import { bindGatewayContextResolver } from "../../plugins/runtime/gateway-request-scope.js";
 import { consumeChannelRunAdmission, prepareChannelRunAdmission } from "./channel-run-admission.js";
 
 const identityConfig = { logging: { audit: { executionIdentity: true } } } as const;
 
 describe("channel run admission", () => {
+  it("keeps host authority active when its optional Gateway context is unavailable", async () => {
+    const current: { value?: GatewayRequestContext } = {};
+    const prepared = prepareChannelRunAdmission({
+      cfg: {},
+      runId: "run-without-gateway-context",
+      agentId: "main",
+      ingressKind: "channel",
+      boundary: "channel/auto-reply",
+      onAdmitted: (context) => bindGatewayContextResolver(context, () => current.value),
+    });
+    const admittedRunContext = await prepared.admit("plugin-harness", "channel-harness");
+    const host = createAgentHarnessHostCapabilities({
+      attempt: {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        runId: "run-without-gateway-context",
+        cwd: "/attempt/worktree",
+        workspaceDir: "/workspace",
+        currentChannelId: "chat-1",
+        messageChannel: "whatsapp",
+        admittedRunContext,
+      },
+      pluginId: "codex",
+    });
+
+    try {
+      expect(() => host.capabilities.preparedEnvironment?.()).not.toThrow();
+      current.value = {} as GatewayRequestContext;
+      expect(() => host.capabilities.assertActive()).not.toThrow();
+      await host.runWithScope(async () => {
+        expect(getGatewayToolCallerIdentity()?.gatewayContextResolver?.()).toBeUndefined();
+      });
+    } finally {
+      host.close();
+      prepared.close();
+      resetAgentRunRegistryForTest();
+    }
+  });
+
   it("projects a hardened channel handoff as boundary-verified assurance", () => {
     const clearCollection = configureChannelAdmissionEvidenceCollection(true);
     try {

--- a/src/auto-reply/reply/channel-run-admission.test.ts
+++ b/src/auto-reply/reply/channel-run-admission.test.ts
@@ -21,7 +21,7 @@ import { consumeChannelRunAdmission, prepareChannelRunAdmission } from "./channe
 const identityConfig = { logging: { audit: { executionIdentity: true } } } as const;
 
 describe("channel run admission", () => {
-  it("keeps host authority active when its optional Gateway context is unavailable", async () => {
+  it("rejects a retired Gateway binding before host tool I/O", async () => {
     const current: { value?: GatewayRequestContext } = {};
     const prepared = prepareChannelRunAdmission({
       cfg: {},
@@ -48,12 +48,46 @@ describe("channel run admission", () => {
     });
 
     try {
-      expect(() => host.capabilities.preparedEnvironment?.()).not.toThrow();
+      expect(() => host.capabilities.preparedEnvironment?.()).toThrow("no longer active");
       current.value = {} as GatewayRequestContext;
-      expect(() => host.capabilities.assertActive()).not.toThrow();
+      expect(() => host.capabilities.assertActive()).toThrow("no longer active");
       await host.runWithScope(async () => {
         expect(getGatewayToolCallerIdentity()?.gatewayContextResolver?.()).toBeUndefined();
+        expect(() => host.capabilities.preparedEnvironment?.()).toThrow("no longer active");
       });
+    } finally {
+      host.close();
+      prepared.close();
+      resetAgentRunRegistryForTest();
+    }
+  });
+
+  it("keeps an unbound run usable without Gateway context", async () => {
+    const prepared = prepareChannelRunAdmission({
+      cfg: {},
+      runId: "run-without-gateway-binding",
+      agentId: "main",
+      ingressKind: "channel",
+      boundary: "channel/auto-reply",
+    });
+    const admittedRunContext = await prepared.admit("plugin-harness", "channel-harness");
+    const host = createAgentHarnessHostCapabilities({
+      attempt: {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        runId: "run-without-gateway-binding",
+        cwd: "/attempt/worktree",
+        workspaceDir: "/workspace",
+        currentChannelId: "chat-1",
+        messageChannel: "whatsapp",
+        admittedRunContext,
+      },
+      pluginId: "codex",
+    });
+
+    try {
+      expect(() => host.capabilities.preparedEnvironment?.()).not.toThrow();
     } finally {
       host.close();
       prepared.close();

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -108,6 +108,9 @@ const CODEX_HARNESS_RESUME_STRESS_RESTARTS = resolveBoundedPositiveIntEnv(
   3,
   10,
 );
+const CODEX_HARNESS_EXPLICIT_COMPACT_PROBE = isTruthyEnvValue(
+  process.env.OPENCLAW_LIVE_CODEX_HARNESS_EXPLICIT_COMPACT_PROBE,
+);
 type CodexCompactionStressMode =
   | { kind: "off" }
   | { kind: "reduced" }
@@ -2780,6 +2783,62 @@ describeLive("gateway live (Codex harness)", () => {
               modelKey,
               sessionKey: resumeStressState.sessionKey,
             });
+            if (CODEX_HARNESS_EXPLICIT_COMPACT_PROBE && restart === 1) {
+              const explicitCompactText = await requestCodexCommandText({
+                client,
+                events: gatewayEvents,
+                sessionKey: resumeStressState.sessionKey,
+                command: "/codex compact",
+                expectedText: [],
+                isExpectedText: (text) => {
+                  const normalized = text.toLowerCase();
+                  return (
+                    normalized.includes("compact") &&
+                    !normalized.includes("did not complete") &&
+                    !normalized.includes("already has an active writer")
+                  );
+                },
+                predicateOnly: true,
+              });
+              logCodexLiveStep("explicit-compact-probe", {
+                text: explicitCompactText,
+                threadId: resumeStressState.threadId,
+              });
+              await client.stopAndWait();
+              client = undefined;
+              await instance.stopGateway();
+              gatewayEvents.length = 0;
+              await instance.startGateway();
+              client = await connectTestGatewayClient({
+                url: `ws://127.0.0.1:${port}`,
+                token,
+                deviceIdentity,
+                timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
+                requestTimeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
+                clientDisplayName: "vitest-codex-explicit-compact-continuation",
+                caps: CODEX_HARNESS_CLIENT_CAPS,
+                onEvent: captureGatewayEvent,
+              });
+              activeApprovalClient = client;
+              await assertCodexHarnessSessionSelection({
+                client,
+                modelKey,
+                sessionKey: resumeStressState.sessionKey,
+              });
+              const continuationToken = `CODEX-EXPLICIT-COMPACT-CONTINUATION-${randomBytes(3)
+                .toString("hex")
+                .toUpperCase()}`;
+              const continuationText = await requestAgentText({
+                client,
+                sessionKey: resumeStressState.sessionKey,
+                expectedReply: continuationToken,
+                message: `Reply exactly ${continuationToken} and nothing else.`,
+              });
+              logCodexLiveStep("explicit-compact-continuation", {
+                text: continuationText,
+                threadId: resumeStressState.threadId,
+              });
+            }
             const nextMarker = `CODEX-RESTART-${restart}-${randomBytes(3)
               .toString("hex")
               .toUpperCase()}`;

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -2792,11 +2792,7 @@ describeLive("gateway live (Codex harness)", () => {
                 expectedText: [],
                 isExpectedText: (text) => {
                   const normalized = text.toLowerCase();
-                  return (
-                    normalized.includes("compact") &&
-                    !normalized.includes("did not complete") &&
-                    !normalized.includes("already has an active writer")
-                  );
+                  return normalized.includes("compacted codex session (");
                 },
                 predicateOnly: true,
               });
@@ -2804,22 +2800,6 @@ describeLive("gateway live (Codex harness)", () => {
                 text: explicitCompactText,
                 threadId: resumeStressState.threadId,
               });
-              await client.stopAndWait();
-              client = undefined;
-              await instance.stopGateway();
-              gatewayEvents.length = 0;
-              await instance.startGateway();
-              client = await connectTestGatewayClient({
-                url: `ws://127.0.0.1:${port}`,
-                token,
-                deviceIdentity,
-                timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
-                requestTimeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
-                clientDisplayName: "vitest-codex-explicit-compact-continuation",
-                caps: CODEX_HARNESS_CLIENT_CAPS,
-                onEvent: captureGatewayEvent,
-              });
-              activeApprovalClient = client;
               await assertCodexHarnessSessionSelection({
                 client,
                 modelKey,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/134547
Related: https://github.com/jarbas-marco/openclaw/pull/18

## What Problem This Solves

Fixes Codex-backed channel turns that could resume on a different native app-server writer, or could release a same-thread queue before the recorded writer's physical process had exited after compaction cleanup.

## Why This Change Was Made

The compactor now receives a positive signal when releasing a shared-client lease initiates physical retirement. For a detached recorded owner, it holds the same-thread mutation lane on that client's transport-exit promise before cleanup returns, including failure paths.

The live explicit-compaction probe now runs on a warm Gateway before any restart. It captures the native thread and physical client from observed lifecycle events, requires the positive `Compacted Codex session (...)` response, performs a real continuation, and asserts that the continuation's observed thread and client are the same values.

## User Impact

Codex-backed sessions retain one physical writer per native thread through compaction cleanup. A successor cannot cross the thread fence until the old recorded owner has physically exited. Explicit compaction no longer treats an unavailable or failed response containing the word `compact` as success.

## Evidence

- Exact pushed head: `fce44eec55c02ab0115309103c5fba67385eb03a`.

### Real OAuth Gateway behavior — passed

Ran the repository live Gateway harness with disposable compatible state, native Codex OAuth, the explicit-compaction probe enabled, and the unrelated session-deletion probe disabled so this run had one focused acceptance condition. The ambient development-root override was removed so the Gateway and bundled plugin loaded exclusively from this checkout.

```text
auth: oauth (codex)
model/runtime: openai/gpt-5.5 / Codex

warm lifecycle:
  thread_ready action=started
  threadId=<thread-A>
  clientId=<client-A>

/codex compact:
  "Compacted Codex session (5160 tokens after)."
  captured warmThreadId=<thread-A>
  captured warmClientId=<client-A>

observed continuation lifecycle:
  thread_ready action=resumed
  threadId=<thread-A>
  clientId=<client-A>

continuation reply:
  CODEX-EXPLICIT-COMPACT-CONTINUATION-<redacted>
  observed threadId=<thread-A>
  observed clientId=<client-A>

Test Files  1 passed (1)
Tests       1 passed | 2 skipped (3)
```

This is observed lifecycle identity, not a saved-ID echo: the test reads `threadId` and `clientId` from the continuation's `codex_app_server.lifecycle` event and asserts both equal the warm pre-compaction observations.

### Final detached-owner exit fence through the production compactor — passed

Added a composed regression around `maybeCompactCodexAppServerSession` for both successful and failed native compaction. It installs a warm recorded owner as the final detached lease, delays physical transport exit, invokes the production compactor, and queues a same-thread successor.

```text
compaction success:
  final recorded-owner lease released -> retirement begins
  successor after 20 ms before transport exit -> blocked
  transport exit emitted -> successor progressed

compaction failure:
  final recorded-owner lease released -> retirement begins
  failure returned while exit fence remains owned
  successor after 20 ms before transport exit -> blocked
  transport exit emitted -> successor progressed

compact.client-ownership + compact + thread-ownership:
  Test Files  3 passed (3)
  Tests       68 passed (68)
```

### Additional verification

- Full package build: passed.
- Extension production typecheck: `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --pretty false` — passed.
- Full dead-code/export check: `pnpm deadcode:full` (Knip 6.32.2) — passed.
- Oxfmt and Oxlint on all changed files — passed.
- `git diff --check` — passed.

The two prior CI blockers were also removed: the queue rejection callback now has an explicit `unknown` type for Oxlint, and the temporary-client exit helper is private so it is no longer an unused exported API.

## Compatibility / Migration

No configuration or migration changes. The existing shared-client and per-thread ownership contracts remain in use; only the final detached-owner release path gains an exit fence. The live-test-only `OPENCLAW_LIVE_CODEX_HARNESS_SESSION_DELETION_PROBE=0` switch isolates this compaction acceptance run; default live-harness behavior remains unchanged.