### PR TITLE
improve: stop update CLI tests inheriting prior case state

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -51,6 +51,7 @@ import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contra
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 import { getFreePort } from "../test-utils/ports.js";
+import type { TempHomeEnv } from "../test-utils/temp-home.js";
 import { VERSION } from "../version.js";
 import { createCliRuntimeCapture, getMockCallOutput } from "./test-runtime-capture.js";
 
@@ -743,6 +744,7 @@ describe("update-cli", () => {
       profile === "default" ? ".openclaw" : `.openclaw-${profile}`,
     );
   let fixtureCount = 0;
+  let tempHome: TempHomeEnv | undefined;
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   const tempDirsToCleanup = new Set<string>();
 
@@ -1930,6 +1932,9 @@ describe("update-cli", () => {
   };
 
   beforeEach(async () => {
+    // Clear the helper's state selector below so HOME and profile overrides keep their semantics.
+    const { createTempHomeEnv } = await import("../test-utils/temp-home.js");
+    tempHome = await createTempHomeEnv("openclaw-update-cli-home-");
     const executorTmp = tempDirs.make("update-cli-owner-");
     absentServicePort = await getFreePort();
     const gatewayEntrypoint = await import("../daemon/gateway-entrypoint.js");
@@ -2184,6 +2189,8 @@ describe("update-cli", () => {
   afterEach(async () => {
     vi.restoreAllMocks();
     closeOpenClawStateDatabaseForTest();
+    await tempHome?.restore();
+    tempHome = undefined;
     if (tempDirsToCleanup.size === 0) {
       return;
     }


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where the update CLI test suite became much slower after earlier cases wrote update history. Cases inherited a shared default state directory even though teardown closed its database handles, so later cases repeatedly launched subprocesses to read cold database snapshots.

## Why This Change Was Made

Give each case a temporary home through the existing fixture owner, then close database/session state and restore the environment before removing that home. The existing selector reset preserves HOME-derived paths and explicit profile, state-directory, and relocated-home scenarios. Load the helper after mock initialization; a static import was verified to trigger an initialization-order failure.

## User Impact

Faster, independent update CLI tests. No product behavior, storage semantics, test cases, assertions, or deadlines change. The fixture adds seven test lines.

## Evidence

- Complete original and candidate suites both passed all 473 cases, with identical ordered names and outcomes.
- One matched macOS/Node 26.8.1 pair, using the same checkout, private dependencies, normal test wrapper, and separate fresh caches: wrapper wall time fell from 418.8s to 94.2s (77.5%). This is a local file-level result, not an overall test-suite speedup claim. Measurements used commit `8609f24e`; the tested file, fixture/cleanup owners, update owners, and lockfile were unchanged at publication base `6dd21216`.
- A temporary call-through observer retained all six selected outcomes and all 189 lease-handle closes. The previously slow failure case started without inherited state and launched zero snapshot workers, versus 31 before isolation. The observer was removed before both complete-suite runs.
- Mapped changed-file checks, formatting, and independent review passed. The initial static-import collection failure is retained separately from the successful lazy-import proof.
