### PR TITLE
refactor(tests): simplify keyed FIFO fixture bookkeeping

### DIFF
--- a/src/shared/keyed-fifo-lease.test.ts
+++ b/src/shared/keyed-fifo-lease.test.ts
@@ -3,25 +3,16 @@ import { afterEach, describe, expect, it } from "vitest";
 import { drainGlobalSingletonLifecycleState } from "./global-singleton.js";
 import { createKeyedFifoLeaseRegistry } from "./keyed-fifo-lease.js";
 
-const keysToDelete = new Set<symbol>();
 const TEST_KEY = Symbol.for("openclaw.test.keyedFifoLease");
-
-function createRegistry() {
-  keysToDelete.add(TEST_KEY);
-  return createKeyedFifoLeaseRegistry(TEST_KEY);
-}
 
 afterEach(async () => {
   await drainGlobalSingletonLifecycleState("close");
-  for (const key of keysToDelete) {
-    delete (globalThis as Record<PropertyKey, unknown>)[key];
-  }
-  keysToDelete.clear();
+  delete (globalThis as Record<PropertyKey, unknown>)[TEST_KEY];
 });
 
 describe("keyed FIFO leases", () => {
   it("reserves order before reverse-completing work reaches wait", async () => {
-    const registry = createRegistry();
+    const registry = createKeyedFifoLeaseRegistry(TEST_KEY);
     const older = registry.reserve(["target"])!;
     const newer = registry.reserve(["target"])!;
     let newerReady = false;
@@ -39,7 +30,7 @@ describe("keyed FIFO leases", () => {
   });
 
   it("does not release an aborted waiter's reserved slot", async () => {
-    const registry = createRegistry();
+    const registry = createKeyedFifoLeaseRegistry(TEST_KEY);
     const older = registry.reserve(["target"])!;
     const aborted = registry.reserve(["target"])!;
     const newer = registry.reserve(["target"])!;
@@ -64,7 +55,7 @@ describe("keyed FIFO leases", () => {
   });
 
   it("reserves sorted unique multi-key leases without deadlock", async () => {
-    const registry = createRegistry();
+    const registry = createKeyedFifoLeaseRegistry(TEST_KEY);
     const first = registry.reserve(["b", "a", "b"])!;
     const second = registry.reserve(["a", "b"])!;
     let secondReady = false;
@@ -82,7 +73,7 @@ describe("keyed FIFO leases", () => {
   });
 
   it("keeps a newer tail when an older tail cleans up", async () => {
-    const registry = createRegistry();
+    const registry = createKeyedFifoLeaseRegistry(TEST_KEY);
     const first = registry.reserve(["target"])!;
     first.release();
     const second = registry.reserve(["target"])!;
@@ -101,7 +92,7 @@ describe("keyed FIFO leases", () => {
   });
 
   it("releases an idle key independently when a mixed lease exits before its predecessor", async () => {
-    const registry = createRegistry();
+    const registry = createKeyedFifoLeaseRegistry(TEST_KEY);
     const older = registry.reserve(["busy"])!;
     const mixed = registry.reserve(["idle", "busy"])!;
     const idle = registry.reserve(["idle"])!;
@@ -123,8 +114,6 @@ describe("keyed FIFO leases", () => {
   });
 
   it("shares reservations across duplicate runtime chunks", async () => {
-    const key = TEST_KEY;
-    keysToDelete.add(key);
     const moduleA = await importFreshModule<typeof import("./keyed-fifo-lease.js")>(
       import.meta.url,
       "./keyed-fifo-lease.js?scope=duplicate-a",
@@ -133,8 +122,8 @@ describe("keyed FIFO leases", () => {
       import.meta.url,
       "./keyed-fifo-lease.js?scope=duplicate-b",
     );
-    const firstRegistry = moduleA.createKeyedFifoLeaseRegistry(key);
-    const secondRegistry = moduleB.createKeyedFifoLeaseRegistry(key);
+    const firstRegistry = moduleA.createKeyedFifoLeaseRegistry(TEST_KEY);
+    const secondRegistry = moduleB.createKeyedFifoLeaseRegistry(TEST_KEY);
     const first = firstRegistry.reserve(["target"])!;
     const second = secondRegistry.reserve(["target"])!;
     let secondReady = false;
@@ -150,7 +139,7 @@ describe("keyed FIFO leases", () => {
   });
 
   it("releases live gates on full close but not restart", async () => {
-    const registry = createRegistry();
+    const registry = createKeyedFifoLeaseRegistry(TEST_KEY);
     registry.reserve(["target"]);
     registry.reserve(["target"]);
     const last = registry.reserve(["target"])!;


### PR DESCRIPTION
## What Problem This Solves

The keyed-FIFO tests use one fixed global registry key but track it in a Set through a forwarding factory.

## Why This Change Was Made

Call the existing registry factory directly with that key and remove the redundant tracker and same-symbol alias. Teardown still awaits the full-close drain before deleting the owned key.

## User Impact

No runtime or public API change. All seven keyed-FIFO cases and 19 assertions remain unchanged. Production LOC: 0; tests: +9/-20 (net -11). This does not add stronger failure cleanup.

## Evidence

- Fresh baseline and candidate: 18/18 passed, with 11 singleton cases followed by seven keyed-FIFO cases in both runs.
- All 59 frozen source/context pins verified; exact assertion text and order retained.
- Independent review found no actionable findings through P2; all 20 required local changed checks passed.
