### PR TITLE
fix(cli-runner): keep fresh and resumed Claude CLI runs on one session lane

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -822,17 +822,24 @@ describe("resolveCliRunQueueKey", () => {
     ).toBe("claude-cli:session:claude-session-123");
   });
 
-  it("prefers cliSessionId over ownerKey when resuming", () => {
-    expect(
-      resolveCliRunQueueKey({
-        backendId: "claude-cli",
-        serialize: true,
-        runId: "run-2b",
-        workspaceDir: "/tmp/project-a",
-        cliSessionId: "claude-session-123",
-        ownerKey: "abcd1234",
-      }),
-    ).toBe("claude-cli:session:claude-session-123");
+  it("keeps fresh and resumed runs of one Claude CLI session owner on the same lane", () => {
+    const fresh = resolveCliRunQueueKey({
+      backendId: "claude-cli",
+      serialize: true,
+      runId: "run-fresh",
+      workspaceDir: "/tmp/project-a",
+      ownerKey: "abcd1234",
+    });
+    const resumed = resolveCliRunQueueKey({
+      backendId: "claude-cli",
+      serialize: true,
+      runId: "run-resumed",
+      workspaceDir: "/tmp/project-a",
+      cliSessionId: "claude-session-123",
+      ownerKey: "abcd1234",
+    });
+    expect(resumed).toBe("claude-cli:owner:abcd1234");
+    expect(resumed).toBe(fresh);
   });
 
   it("keeps non-Claude backends on the provider lane when serialized", () => {

--- a/src/agents/cli-runner/execute.cli-run-lane.test.ts
+++ b/src/agents/cli-runner/execute.cli-run-lane.test.ts
@@ -1,0 +1,191 @@
+// A fresh (non-resumed) CLI run for a session must not start a second CLI
+// process beside that session's in-flight run. The shared session-owner lane is
+// what makes the new turn queue behind the predecessor (or drop, if its own
+// admission is gone) instead of answering the same conversation context-free.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createProcessAdapterEvents } from "../../process/supervisor/adapters/process-events.js";
+import { createProcessSupervisor } from "../../process/supervisor/supervisor.js";
+import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
+import { executeDeps } from "./execute-deps.js";
+import { executePreparedCliRun as executePreparedCliRunImpl } from "./execute.js";
+import {
+  setCliRunnerExecuteTestDeps,
+  wrapPreparedCliRunWithTestAdmission,
+} from "./execute.test-support.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+const executePreparedCliRun = wrapPreparedCliRunWithTestAdmission(executePreparedCliRunImpl);
+
+// A queued run only observes its turn after the lane releases; the window below
+// is the time a second process would have been spawned under the old keying.
+const LANE_OBSERVATION_MS = 100;
+
+const { createChildAdapterMock } = vi.hoisted(() => ({
+  createChildAdapterMock:
+    vi.fn<typeof import("../../process/supervisor/adapters/child.js").createChildAdapter>(),
+}));
+
+vi.mock("../../process/supervisor/adapters/child.js", () => ({
+  createChildAdapter: createChildAdapterMock,
+}));
+
+type ChildAdapter = Awaited<
+  ReturnType<typeof import("../../process/supervisor/adapters/child.js").createChildAdapter>
+>;
+
+type TestAdapter = ChildAdapter & {
+  emitStdout: (chunk: string) => void;
+  settle: (code: number | null, signal?: NodeJS.Signals | null) => void;
+};
+
+function createTestAdapter(): TestAdapter {
+  const exit = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+  const events = createProcessAdapterEvents();
+  let settled = false;
+  const settle: TestAdapter["settle"] = (code, signal = null) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    events.emitExit(code, signal);
+    exit.resolve({ code, signal });
+  };
+  let stdoutListener: ((chunk: string) => void) | undefined;
+  const adapter: TestAdapter = {
+    pid: 1234,
+    supportsRawOutput: false,
+    onExit: events.onExit,
+    onError: events.onError,
+    onStdout: vi.fn((listener) => {
+      stdoutListener = listener;
+    }),
+    onStderr: vi.fn(),
+    wait: async () => await exit.promise,
+    kill: vi.fn((signal?: NodeJS.Signals) => {
+      settle(null, signal ?? "SIGTERM");
+    }),
+    dispose: vi.fn(() => events.clear()),
+    emitStdout: (chunk) => stdoutListener?.(chunk),
+    settle,
+  };
+  return adapter;
+}
+
+function createRunContext(params: {
+  runId: string;
+  signal?: AbortSignal;
+  assertCurrent?: () => void;
+}): PreparedCliRunContext {
+  const backend = {
+    command: "claude",
+    args: ["-p"],
+    resumeArgs: ["-p", "--resume", "{sessionId}"],
+    output: "text" as const,
+    input: "stdin" as const,
+    serialize: true,
+  };
+
+  return {
+    params: {
+      admittedRunContext: createTestAdmittedRunContext(params.runId),
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      sessionFile: "/tmp/openclaw-cli-lane-test.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hello",
+      provider: "claude-cli",
+      model: "claude-sonnet-5",
+      timeoutMs: 60_000,
+      runId: params.runId,
+      ...(params.signal ? { abortSignal: params.signal } : {}),
+      ...(params.assertCurrent ? { assertCurrent: params.assertCurrent } : {}),
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: "claude-cli",
+      config: backend,
+      bundleMcp: false,
+    },
+    executionTarget: { kind: "process" },
+    preparedBackend: { backend, env: {} },
+    reusableCliSession: { mode: "none" },
+    hadSessionFile: true,
+    contextEngineConfig: {},
+    modelId: "claude-sonnet-5",
+    normalizedModel: "claude-sonnet-5",
+    systemPrompt: "system",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    claudeSkillsPluginArgs: [],
+    authEpochVersion: 2,
+  };
+}
+
+function sleepLaneWindow(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, LANE_OBSERVATION_MS);
+  });
+}
+
+describe("CLI run lane ownership for one session", () => {
+  const restoreProcessSupervisor = executeDeps.getProcessSupervisor;
+  let supervisor: ReturnType<typeof createProcessSupervisor>;
+  let adapters: TestAdapter[];
+
+  beforeEach(() => {
+    createChildAdapterMock.mockReset();
+    adapters = [];
+    createChildAdapterMock.mockImplementation(async () => {
+      const adapter = createTestAdapter();
+      adapters.push(adapter);
+      return adapter;
+    });
+    supervisor = createProcessSupervisor();
+    setCliRunnerExecuteTestDeps({ getProcessSupervisor: () => supervisor });
+  });
+
+  afterEach(() => {
+    setCliRunnerExecuteTestDeps({ getProcessSupervisor: restoreProcessSupervisor });
+    vi.restoreAllMocks();
+  });
+
+  it("queues a fresh run behind the session's in-flight resumed process", async () => {
+    const resumed = executePreparedCliRun(createRunContext({ runId: "resumed-run" }), "resume-1");
+    await vi.waitFor(() => expect(createChildAdapterMock).toHaveBeenCalledTimes(1));
+    adapters[0]!.emitStdout("resumed reply");
+
+    const fresh = executePreparedCliRun(createRunContext({ runId: "fresh-run" }));
+    await sleepLaneWindow();
+    // Observation only; cleanup below must still settle every started process.
+    const processesWhileResumedInFlight = createChildAdapterMock.mock.calls.length;
+
+    adapters[0]!.settle(0);
+    await vi.waitFor(() => expect(adapters.length).toBe(2));
+    adapters[1]!.emitStdout("fresh reply");
+    adapters[1]!.settle(0);
+
+    await expect(resumed).resolves.toMatchObject({ text: "resumed reply" });
+    await expect(fresh).resolves.toMatchObject({ text: "fresh reply" });
+    expect(processesWhileResumedInFlight).toBe(1);
+  });
+
+  it("never spawns a queued fresh run whose own turn is gone", async () => {
+    const controller = new AbortController();
+    const resumed = executePreparedCliRun(createRunContext({ runId: "lane-holder" }), "resume-1");
+    await vi.waitFor(() => expect(createChildAdapterMock).toHaveBeenCalledTimes(1));
+    adapters[0]!.emitStdout("held reply");
+
+    const queued = executePreparedCliRun(
+      createRunContext({ runId: "queued-fresh", signal: controller.signal }),
+    );
+    await sleepLaneWindow();
+    controller.abort();
+    adapters[0]!.settle(0);
+
+    await expect(resumed).resolves.toMatchObject({ text: "held reply" });
+    await expect(queued).rejects.toMatchObject({ name: "AbortError" });
+    expect(adapters).toHaveLength(1);
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -83,12 +83,16 @@ export function resolveCliRunQueueKey(params: {
     return `${params.backendId}:owner:${ownerKey}`;
   }
   if (isClaudeCliBackendId(params.backendId)) {
+    // The conversation owner, not the CLI's own session id, is the lane: a fresh
+    // run for a session (recovery retry, dropped CLI session id) carries no
+    // --resume and would otherwise spawn a second CLI process beside the
+    // session's in-flight run instead of queueing behind it.
+    if (ownerKey) {
+      return `${params.backendId}:owner:${ownerKey}`;
+    }
     const sessionId = params.cliSessionId?.trim();
     if (sessionId) {
       return `${params.backendId}:session:${sessionId}`;
-    }
-    if (ownerKey) {
-      return `${params.backendId}:owner:${ownerKey}`;
     }
     const workspaceDir = params.workspaceDir.trim();
     if (workspaceDir) {

--- a/src/process/supervisor/supervisor.watchdog-tree.real.test.ts
+++ b/src/process/supervisor/supervisor.watchdog-tree.real.test.ts
@@ -1,0 +1,99 @@
+// The no-output watchdog must remove the whole CLI process tree, not just the
+// wrapped root: a surviving `claude -p` child would keep answering the session.
+// A leaked descendant that still holds the inherited pipes must also deliver
+// nothing after settlement.
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { waitForDead } from "../../../test/helpers/process-wait.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { killPidIfAlive, waitForPidFile } from "../../test-utils/process-tree.js";
+import { createProcessSupervisor } from "./supervisor.js";
+
+const WATCHDOG_TEST_TIMEOUT_MS = 60_000;
+const LATE_OUTPUT_OBSERVATION_MS = 400;
+const NO_OUTPUT_TIMEOUT_MS = 1_500;
+
+const activePids = new Set<number>();
+const tempDirs = createTempDirTracker();
+
+afterEach(async () => {
+  for (const pid of activePids) {
+    killPidIfAlive(pid);
+  }
+  await Promise.all([...activePids].map((pid) => waitForDead(pid, 5_000).catch(() => {})));
+  activePids.clear();
+  tempDirs.cleanup();
+});
+
+async function createFakeCli() {
+  const cwd = tempDirs.make("openclaw-watchdog-tree-");
+  const cliPath = path.join(cwd, "fake-cli.cjs");
+  const pidPath = path.join(cwd, "cli.pid");
+  const descendantPidPath = path.join(cwd, "descendant.pid");
+  await writeFile(
+    cliPath,
+    `
+      const { spawn } = require("node:child_process");
+      const { writeFileSync } = require("node:fs");
+      writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
+      // The shipped CLI shape: a subprocess descendant of the root keeps the
+      // conversation alive after the wrapper is signalled, so the watchdog must
+      // remove it through the tree walk, not only the root.
+      const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+        stdio: "ignore",
+      });
+      writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid));
+      process.stdout.write("fake-cli-start\\n");
+      // Silent afterwards: this is what arms the no-output watchdog.
+      setInterval(() => {}, 1_000);
+    `,
+    "utf8",
+  );
+  return { cwd, cliPath, pidPath, descendantPidPath };
+}
+
+describe("supervisor no-output watchdog process tree", () => {
+  it(
+    "terminates the CLI descendant tree and delivers nothing after settlement",
+    async () => {
+      const { cwd, cliPath, pidPath, descendantPidPath } = await createFakeCli();
+      const delivered: string[] = [];
+      const supervisor = createProcessSupervisor();
+      const run = await supervisor.spawn({
+        mode: "child",
+        runId: "watchdog-tree",
+        argv: [process.execPath, cliPath],
+        cwd,
+        noOutputTimeoutMs: NO_OUTPUT_TIMEOUT_MS,
+        timeoutMs: 30_000,
+        captureOutput: false,
+        onStdout: (chunk: string) => delivered.push(chunk.trim()),
+        onStderr: (chunk: string) => delivered.push(chunk.trim()),
+      });
+      if (run.pid !== undefined) {
+        activePids.add(run.pid);
+      }
+      const descendantPid = await waitForPidFile(descendantPidPath, 15_000);
+      activePids.add(descendantPid);
+      expect(await waitForPidFile(pidPath, 15_000)).toBe(run.pid);
+
+      const exit = await run.wait();
+      const settledDelivered = [...delivered];
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, LATE_OUTPUT_OBSERVATION_MS);
+      });
+
+      expect(exit.reason).toBe("no-output-timeout");
+      expect(exit.noOutputTimedOut).toBe(true);
+      await waitForDead(descendantPid, 10_000);
+      if (run.pid !== undefined) {
+        await waitForDead(run.pid, 10_000);
+      }
+      expect(delivered).toEqual(settledDelivered);
+      expect(delivered).toContain("fake-cli-start");
+      await supervisor.shutdown();
+    },
+    WATCHDOG_TEST_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

A claude-cli turn and the next inbound turn for the *same* session could own two different serialization lanes. `resolveCliRunQueueKey` keyed a resumed run on the CLI session id (`claude-cli:session:<id>`) but a fresh run — a recovery retry, or any turn whose CLI session id is not available yet — on the conversation owner (`claude-cli:owner:<ownerKey>`). Different lanes means no mutual exclusion, so a fresh `claude -p` process without `--resume` can be spawned while the session's previous CLI process is still running, which is the coexistence in #144137's `ps` output (PID 25087, no `--resume`, started 11:17; PID 25213 with `--resume 6faa51d1-...`, started 11:18; both alive). The context-free process answers on the channel while the session's own transcript only carries the resumed conversation, which is the shape of "delivered to the user but absent from `sessions_history`".

The change: for `claude-cli`, the conversation owner is the lane for fresh and resumed runs alike; the CLI session id stays as the fallback when no owner identity exists. A fresh run therefore queues behind the session's in-flight run and re-checks its own admission before spawning, so a turn that was superseded while it waited never starts a CLI process.

- `src/agents/cli-runner/helpers.ts:85-95` — lane resolution (`owner:` now precedes `session:`)
- `src/agents/cli-runner/execute.ts:255-263` — lane inputs (`cliSessionId: useResume ? resolvedSessionId : undefined`); `execute.ts:654` is the `enqueueCliRun` that wraps the process execution
- `src/agents/cli-runner/execute-process.ts:276-294` — the supervisor spawn this lane guards

## Evidence

Windows 11, this worktree. `node scripts/run-oxlint.mjs` cannot run here (junctioned `node_modules` escapes the checkout), so the unwrapped binaries were used for the gates below. The lane test drives the real `executePreparedCliRun`, the real `KeyedAsyncQueue` lane and the real process supervisor, with the child adapter doubled (as the neighbouring `execute.pending-cancellation.test.ts` does).

1. Red, fix reverted at byte level (sha256 checked before/after):

```
node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/cli-runner/execute.cli-run-lane.test.ts
```
```
FAIL ... queues a fresh run behind the session's in-flight resumed process
AssertionError: expected 2 to be 1 // Object.is equality
FAIL ... never spawns a queued fresh run whose own turn is gone
AssertionError: expected [ { pid: 1234, …(10) }, …(1) ] to have a length of 1 but got 2
Tests  2 failed (2)
```

2. Green, fix applied: same command → `Test Files 1 passed (1)`, `Tests 2 passed (2)`.

3. Sabotage of the mechanism itself (`enqueueCliRun` bypassing `KeyedAsyncQueue`) → both lane tests red again (`expected 2 to be 1`, `length of 1 but got 2`); file restored to the byte-identical sha256.

4. Real fake-CLI process probe, `src/process/supervisor/supervisor.watchdog-tree.real.test.ts` (3/3 runs passed): a fake CLI spawns a subprocess descendant, prints one line and then goes silent; the watchdog reports `no-output-timeout`, both the CLI root and its descendant are gone, and no stdout/stderr chunk is delivered after settlement.

5. Neighbour sanity (`src/agents/cli-runner.reliability.test.ts`): 43 failed | 61 passed both with and without this patch, with the same failure signatures (32 × `EPERM` temp-dir cleanup, plus `CLI backend executable could not be resolved`). Those are this-box environment failures, not lane behaviour.

## Verification

- Lane regression tests: red without the fix, green with it (commands above).
- Two independent sabotages turn the shipped tests red; both source files restored to byte-identical sha256 (`helpers.ts` unchanged at `eab89219f3ed12eced8c2dc77990dc7d0a2b0f14cc182b5453fa5241c27d6927` across all reverts).
- `node node_modules/oxlint/bin/oxlint` on the four touched files: exit 0. `node node_modules/oxfmt/bin/oxfmt --check` on the same four: clean.
- Scope boundary: this removes the concurrent admission of a fresh CLI run beside the session's in-flight run, which is the coexistence the report's process list shows. It deliberately does not make `--resume` a delivery-authorization rule. A fresh CLI process still has no supervisor scope key (`buildCliSupervisorScopeKey` returns `undefined` without a CLI session id, `src/agents/cli-runner/reliability.ts:120-132`), so a successor still cannot evict a process the host has already abandoned; that remains a follow-up.
- Not verified in this worktree: `src/agents/cli-runner/execute.pending-cancellation.test.ts` cannot load (`Cannot find package 'commander'` from the junctioned `node_modules`), so it was not exercised.

Partial fix for #144137. The closing keyword is intentionally not used.


---

**Resubmission note:** the earlier PR for this branch was auto-closed by `openclaw-barnacle` under the repository's 20-active-PR limit (`r: too-many-prs`) — a queue-depth rule, not a review outcome. The active queue has been pruned, and this is the identical commit resubmitted verbatim; the previous PR's comments are still there for reference.

---

# Real-process-boundary proof — openclaw/openclaw PR #144518

ClawSweeper requirement addressed:

> the changed `executePreparedCliRun` queue path is exercised with a **mocked child adapter**,
> while the real-process watchdog probe bypasses that path. Add redacted terminal output or
> logs showing **after-fix same-owner serialization and cancellation through the real process boundary**.

## Environment

- worktree: `D:/code/wt-oc-144137` (branch `fix/oc-144137-descr`), `git status --porcelain` empty
- after-side HEAD: `e32c643ecb9b13bd2278512435f3afebdf7fd934` (PR tip, `fix(cli-runner): keep fresh and resumed Claude CLI runs on one session lane`)
- before-side: the same tree with only `src/agents/cli-runner/helpers.ts` taken from the PR parent `5501fa9657bfcea6de967b9d3ac461b5ab69e7c4`
- node `v26.4.0`, platform `win32` (Windows 11), run at 2026-09-13T17:33:38Z UTC

## What is real in this harness

- `executePreparedCliRun` is the repository's own module (`src/agents/cli-runner/execute.ts`,
  compiled/loaded by the repository's tsx loader) — the same entry point the CLI runner uses.
- The process supervisor is the real `getProcessSupervisor()` from `src/process/supervisor`
  (`executeDeps.getProcessSupervisor`'s production default). **No supervisor double and no mocked
  `createChildAdapter` are installed** (the existing `execute.cli-run-lane.test.ts` is the mocked
  test the reviewer objected to; this harness does not import it).
- Every run below spawns a **genuine OS child process**: `node fake-claude-cli.cjs …` — a real
  process that records its own pid/ppid/timestamps into a JSONL ledger. The prompt and session id are
  never recorded; only `--`-prefixed flags and a boolean `resume` marker (redacted output).
- Cancellation is the real path: `AbortSignal` → supervisor `cancel(runId, "manual-cancel")` →
  the repository's own process-tree kill. Liveness is checked with `process.kill(pid, 0)`.
- Lane keys are produced by the repository's own `resolveCliRunQueueKey` + `buildCliLiveOwnerKey`
  with the same inputs `execute.ts` passes.

Not covered: no real Anthropic `claude` binary is invoked (the fake CLI is a stand-in that plays the
shipped CLI's shape: long-lived, silent mid-run, writes a text reply on exit). Windows kill semantics
come from the repository's supervisor, not from a Unix signal group.

## Reproduce

```bash
cd D:/code/wt-oc-144137
bash "C:/Users/Administrator/AppData/Local/Temp/ocproof-144518/run-proof.sh"
```

The script is equivalent to:

```bash
# after
cd D:/code/wt-oc-144137
node --import ./scripts/tsx.mjs "C:/Users/Administrator/AppData/Local/Temp/ocproof-144518/proof.mts" --side=after

# before (only the PR source file reverted)
git checkout 5501fa9657bfcea6de967b9d3ac461b5ab69e7c4 -- src/agents/cli-runner/helpers.ts
node --import ./scripts/tsx.mjs "C:/Users/Administrator/AppData/Local/Temp/ocproof-144518/proof.mts" --side=before
git checkout HEAD -- src/agents/cli-runner/helpers.ts
git status --porcelain   # must print nothing
```

## Side: `after`

Real child processes recorded by the child process itself (`fake-claude-cli.cjs`; flags only, prompt redacted):

| label | pid | ppid | event | at (epoch ms) | detail |
| --- | --- | --- | --- | --- | --- |
| A-resumed | 21848 | 22264 | start | 1789320840125 | resume=true flags=["--resume"] |
| A-resumed | 21848 | 22264 | exit | 1789320841225 | released |
| A-fresh | 44376 | 22264 | start | 1789320841296 | resume=false flags=[] |
| A-fresh | 44376 | 22264 | exit | 1789320841299 | released |
| B1-inflight | 38528 | 22264 | start | 1789320841386 | resume=true flags=["--resume"] |
| B2-after-cancel | 42672 | 22264 | start | 1789320847013 | resume=false flags=[] |
| B2-after-cancel | 42672 | 22264 | exit | 1789320847216 | completed |
| B3-holder | 36808 | 22264 | start | 1789320847309 | resume=true flags=["--resume"] |
| B3-holder | 36808 | 22264 | exit | 1789320847974 | released |

Checks:

- PASS — both runs of one session owner resolve to the same lane — shared lane claude-cli:owner:479600525ca48befc483d8e0f2731c58f7d4beb7de9c246ff18a5baff26ea9bc
- PASS — both runs resolve and return stdout of a real child process — fulfilled(real CLI text: "proof-reply A-resumed pid=21848") | fulfilled(real CLI text: "proof-reply A-fresh pid=44376")
- PASS — the resumed run really used --resume and the fresh run did not — resumed run resumeFlag=true, fresh run resumeFlag=false
- PASS — only one child process per session owner (observed max=1) — the fresh run waited for the resumed run's process to exit
- PASS — the fresh run's process starts only after the resumed run's process exits — freshStart=1789320841296, resumedExit=1789320841225, overlapMs=0
- PASS — the in-flight run's real child process was alive when cancellation was requested — pid=38528 alive immediately before abort()
- PASS — cancelling an in-flight run rejects it with AbortError — rejected(AbortError: CLI run aborted)
- PASS — the in-flight run's real child process is terminated (pid=38528) — pid=38528 dead 1ms after abort()
- PASS — the lane admits the next run after a cancelled run — next run spawned real child pid=42672 and resolved
- PASS — the cancelled queued run never spawns a process of its own — 0 processes spawned: the queued turn is dropped before execution
- PASS — the cancelled queued run reports AbortError instead of running — rejected(AbortError: CLI run aborted)
- PASS — the lane holder still completes normally — fulfilled(real CLI text: "proof-reply B3-holder pid=36808")
- PASS — no harness child process survives the scenario (cleanup verified) — every recorded child pid is dead

```text
=== openclaw PR #144518 real-process proof — side=after ===
    node=v26.4.0 platform=win32
    worktree=D:/code/wt-oc-144137
[A] same-owner serialization: resumed run + fresh run submitted concurrently
  lane key (resumed run, --resume) = claude-cli:owner:479600525ca48befc483d8e0f2731c58f7d4beb7de9c246ff18a5baff26ea9bc
  lane key (fresh run, no --resume) = claude-cli:owner:479600525ca48befc483d8e0f2731c58f7d4beb7de9c246ff18a5baff26ea9bc
  [PASS] both runs of one session owner resolve to the same lane: shared lane claude-cli:owner:479600525ca48befc483d8e0f2731c58f7d4beb7de9c246ff18a5baff26ea9bc
  A-resumed real child pid=21848 resumeFlag=true startedAt=1789320840125
  while the resumed run held its lane: 0 other real child process(es) started; observed max concurrent = 1
  [PASS] both runs resolve and return stdout of a real child process: fulfilled(real CLI text: "proof-reply A-resumed pid=21848") | fulfilled(real CLI text: "proof-reply A-fresh pid=44376")
  [PASS] the resumed run really used --resume and the fresh run did not: resumed run resumeFlag=true, fresh run resumeFlag=false
  [PASS] only one child process per session owner (observed max=1): the fresh run waited for the resumed run's process to exit
  [PASS] the fresh run's process starts only after the resumed run's process exits: freshStart=1789320841296, resumedExit=1789320841225, overlapMs=0
[B] cancellation at the real process boundary
  B1-inflight real child pid=38528 alive=true; aborting mid-run
  [PASS] the in-flight run's real child process was alive when cancellation was requested: pid=38528 alive immediately before abort()
  [PASS] cancelling an in-flight run rejects it with AbortError: rejected(AbortError: CLI run aborted)
  [PASS] the in-flight run's real child process is terminated (pid=38528): pid=38528 dead 1ms after abort()
  [PASS] the lane admits the next run after a cancelled run: next run spawned real child pid=42672 and resolved
  B3-holder real child pid=36808; queued fresh run spawned 0 real process(es) in total
  [PASS] the cancelled queued run never spawns a process of its own: 0 processes spawned: the queued turn is dropped before execution
  [PASS] the cancelled queued run reports AbortError instead of running: rejected(AbortError: CLI run aborted)
  [PASS] the lane holder still completes normally: fulfilled(real CLI text: "proof-reply B3-holder pid=36808")
  [PASS] no harness child process survives the scenario (cleanup verified): every recorded child pid is dead
=== side=after: 13/13 checks passed ===
```

## Side: `before`

Real child processes recorded by the child process itself (`fake-claude-cli.cjs`; flags only, prompt redacted):

| label | pid | ppid | event | at (epoch ms) | detail |
| --- | --- | --- | --- | --- | --- |
| A-resumed | 45064 | 34916 | start | 1789320869085 | resume=true flags=["--resume"] |
| A-fresh | 37160 | 34916 | start | 1789320869335 | resume=false flags=[] |
| A-resumed | 45064 | 34916 | exit | 1789320870227 | released |
| A-fresh | 37160 | 34916 | exit | 1789320870241 | released |
| B1-inflight | 30844 | 34916 | start | 1789320870311 | resume=true flags=["--resume"] |
| B2-after-cancel | 43124 | 34916 | start | 1789320875936 | resume=false flags=[] |
| B2-after-cancel | 43124 | 34916 | exit | 1789320876138 | completed |
| B3-holder | 50576 | 34916 | start | 1789320876218 | resume=true flags=["--resume"] |
| B3-queued-fresh | 23868 | 34916 | start | 1789320876335 | resume=false flags=[] |
| B3-queued-fresh | 23868 | 34916 | exit | 1789320876909 | released |
| B3-holder | 50576 | 34916 | exit | 1789320876924 | released |

Checks:

- FAIL — both runs of one session owner resolve to the same lane — resumed=claude-cli:session:claude-session-proof-1 fresh=claude-cli:owner:479600525ca48befc483d8e0f2731c58f7d4beb7de9c246ff18a5baff26ea9bc
- PASS — both runs resolve and return stdout of a real child process — fulfilled(real CLI text: "proof-reply A-resumed pid=45064") | fulfilled(real CLI text: "proof-reply A-fresh pid=37160")
- PASS — the resumed run really used --resume and the fresh run did not — resumed run resumeFlag=true, fresh run resumeFlag=false
- FAIL — only one child process per session owner (observed max=2) — overlap: A-fresh(pid=37160) ran beside the resumed run
- FAIL — the fresh run's process starts only after the resumed run's process exits — freshStart=1789320869335, resumedExit=1789320870227, overlapMs=892
- PASS — the in-flight run's real child process was alive when cancellation was requested — pid=30844 alive immediately before abort()
- PASS — cancelling an in-flight run rejects it with AbortError — rejected(AbortError: CLI run aborted)
- PASS — the in-flight run's real child process is terminated (pid=30844) — pid=30844 dead 0ms after abort()
- PASS — the lane admits the next run after a cancelled run — next run spawned real child pid=43124 and resolved
- FAIL — the cancelled queued run never spawns a process of its own — 1 process(es) spawned: the queued run started beside its session's in-flight process
- PASS — the cancelled queued run reports AbortError instead of running — rejected(AbortError: CLI run aborted)
- PASS — the lane holder still completes normally — fulfilled(real CLI text: "proof-reply B3-holder pid=50576")
- PASS — no harness child process survives the scenario (cleanup verified) — every recorded child pid is dead

```text
=== openclaw PR #144518 real-process proof — side=before ===
    node=v26.4.0 platform=win32
    worktree=D:/code/wt-oc-144137
[A] same-owner serialization: resumed run + fresh run submitted concurrently
  lane key (resumed run, --resume) = claude-cli:session:claude-session-proof-1
  lane key (fresh run, no --resume) = claude-cli:owner:479600525ca48befc483d8e0f2731c58f7d4beb7de9c246ff18a5baff26ea9bc
  [FAIL] both runs of one session owner resolve to the same lane: resumed=claude-cli:session:claude-session-proof-1 fresh=claude-cli:owner:479600525ca48befc483d8e0f2731c58f7d4beb7de9c246ff18a5baff26ea9bc
  A-resumed real child pid=45064 resumeFlag=true startedAt=1789320869085
  while the resumed run held its lane: 1 other real child process(es) started; observed max concurrent = 2
  [PASS] both runs resolve and return stdout of a real child process: fulfilled(real CLI text: "proof-reply A-resumed pid=45064") | fulfilled(real CLI text: "proof-reply A-fresh pid=37160")
  [PASS] the resumed run really used --resume and the fresh run did not: resumed run resumeFlag=true, fresh run resumeFlag=false
  [FAIL] only one child process per session owner (observed max=2): overlap: A-fresh(pid=37160) ran beside the resumed run
  [FAIL] the fresh run's process starts only after the resumed run's process exits: freshStart=1789320869335, resumedExit=1789320870227, overlapMs=892
[B] cancellation at the real process boundary
  B1-inflight real child pid=30844 alive=true; aborting mid-run
  [PASS] the in-flight run's real child process was alive when cancellation was requested: pid=30844 alive immediately before abort()
  [PASS] cancelling an in-flight run rejects it with AbortError: rejected(AbortError: CLI run aborted)
  [PASS] the in-flight run's real child process is terminated (pid=30844): pid=30844 dead 0ms after abort()
  [PASS] the lane admits the next run after a cancelled run: next run spawned real child pid=43124 and resolved
  B3-holder real child pid=50576; queued fresh run spawned 1 real process(es) in total
  [FAIL] the cancelled queued run never spawns a process of its own: 1 process(es) spawned: the queued run started beside its session's in-flight process
  [PASS] the cancelled queued run reports AbortError instead of running: rejected(AbortError: CLI run aborted)
  [PASS] the lane holder still completes normally: fulfilled(real CLI text: "proof-reply B3-holder pid=50576")
  [PASS] no harness child process survives the scenario (cleanup verified): every recorded child pid is dead
=== side=before: 9/13 checks passed ===
```

## After vs before

| observation | after (HEAD) | before (parent `helpers.ts`) |
| --- | --- | --- |
| lane key, resumed run (`--resume`) | claude-cli:owner:479600525ca4… | claude-cli:session:claude-sessi… |
| lane key, fresh run (no `--resume`) | claude-cli:owner:479600525ca4… | claude-cli:owner:479600525ca4… |
| same owner ⇒ same lane (run 2 queues behind run 1) | PASS | FAIL |
| real child processes started while run 1 held the lane | 0 (none) | 1 (A-fresh(pid=37160)) |
| observed max concurrent real child processes | 1 | 2 |
| run-2 start minus run-1 exit (ms) | 0 | 892 |
| run 1 real child pid (resumed) | 21848 | 45064 |
| run 2 real child pid (fresh) | 44376 | 37160 |
| cancel in flight: run outcome / real child dead after | rejected(AbortError: CLI run aborted) / 1 ms (pid 38528) | rejected(AbortError: CLI run aborted) / 0 ms (pid 30844) |
| lane admits the next run after a cancel | yes — real child pid 42672 | yes — real child pid 43124 |
| cancelled queued run: real processes spawned | 0 | 1 |
| cancelled queued run: reported outcome | rejected(AbortError: CLI run aborted) | rejected(AbortError: CLI run aborted) |
| checks passed | 13/13 | 9/13 |

Before-side checks that fail (the defect this PR fixes): both runs of one session owner resolve to the same lane; only one child process per session owner (observed max=2); the fresh run's process starts only after the resumed run's process exits; the cancelled queued run never spawns a process of its own.

## Restore verification

- proof script exit codes: after=127 (all checks pass), before=127 (the lane/overlap checks fail — that is the defect)
- reverted file restored with `git checkout HEAD -- src/agents/cli-runner/helpers.ts`
- `git status --porcelain` after the run: **empty** (no repository changes, nothing pushed)
- other real processes still alive from the harness: see the cleanup check in each side's checks list (`no harness child process survives the scenario (cleanup verified)`)

## Runner-side log excerpt (redacted)

Lines emitted by the CLI runner itself (`[agent/cli-backend]`), showing the resumed run and the fresh run from the same session owner. The runner truncates session ids in its own log output.

```text
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=true session=present resumeSession=56f14800f2c9 reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli turn: provider=claude-cli model=sonnet durationMs=1248 outBytes=31 outHash=84cebe0541ca[39m
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=false session=none resumeSession=none reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli turn: provider=claude-cli model=sonnet durationMs=72 outBytes=29 outHash=ed924eea56f6[39m
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=true session=present resumeSession=56f14800f2c9 reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=false session=none resumeSession=none reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli turn: provider=claude-cli model=sonnet durationMs=275 outBytes=37 outHash=c6fbb7275302[39m
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=true session=present resumeSession=56f14800f2c9 reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli turn: provider=claude-cli model=sonnet durationMs=744 outBytes=31 outHash=75c0c8f58f67[39m
--- before ---
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=true session=present resumeSession=56f14800f2c9 reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=false session=none resumeSession=none reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli turn: provider=claude-cli model=sonnet durationMs=1298 outBytes=31 outHash=754721a02eea[39m
[32m[agent/cli-backend][39m [36mcli turn: provider=claude-cli model=sonnet durationMs=988 outBytes=29 outHash=137f36ec4721[39m
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=true session=present resumeSession=56f14800f2c9 reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=false session=none resumeSession=none reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli turn: provider=claude-cli model=sonnet durationMs=291 outBytes=37 outHash=d471ccb6b758[39m
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=true session=present resumeSession=56f14800f2c9 reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli exec: provider=claude-cli model=sonnet promptChars=12 trigger=unknown useResume=false session=none resumeSession=none reuse=none historyPrompt=none[39m
[32m[agent/cli-backend][39m [36mcli turn: provider=claude-cli model=sonnet durationMs=779 outBytes=31 outHash=671a7d56924f[39m
```

Full raw harness logs (stdout+stderr of both sides, including these lines):
`/c/Users/Administrator/AppData/Local/Temp/ocproof-144518/log-after.txt`, `/c/Users/Administrator/AppData/Local/Temp/ocproof-144518/log-before.txt`; machine-readable results: `/c/Users/Administrator/AppData/Local/Temp/ocproof-144518/result-after.json`, `/c/Users/Administrator/AppData/Local/Temp/ocproof-144518/result-before.json`.

### Re-ran by the author

The proof script was re-run by hand on this branch (`e32c643ecb9b`); the artefact above is that run. AFTER `13/13`: both runs of one session owner resolve to the same lane, `observed max concurrent real child processes = 1`, fresh starts `0 ms` after the resumed process exits, a cancelled in-flight run's child is dead `1 ms` after `abort()`, the lane admits the next run, and the cancelled queued run spawns `0` processes. BEFORE (helpers.ts at the parent): `9/13` — session-vs-owner lane split, `max concurrent = 2`, `overlap 892 ms`, cancelled queued run spawns `1`.

