### PR TITLE
fix(agents): keep silent heartbeat turns from re-delivering the previous final reply

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts
@@ -1,0 +1,38 @@
+// Heartbeat turns that captured no assistant output of their own must be a true
+// no-op: no reply payload may be built from an older assistant message, which
+// would re-commit and re-deliver the previous final reply (#143787).
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { buildPayloads } from "./payloads.test-helpers.js";
+
+const previousFinalReply = {
+  role: "assistant",
+  stopReason: "stop",
+  content: [{ type: "text", text: "Ship it: the release notes are ready." }],
+} as unknown as AssistantMessage;
+
+describe("buildEmbeddedRunPayloads heartbeat silence", () => {
+  it("does not resurrect the previous final reply for a yielded heartbeat attempt", () => {
+    const payloads = buildPayloads({
+      isHeartbeatTrigger: true,
+      // A yielded attempt ends before message_end: no assistant message of its
+      // own was captured for this turn.
+      currentAssistant: null,
+      // The session snapshot's newest assistant is the previous turn's final.
+      lastAssistant: previousFinalReply,
+    });
+
+    expect(payloads).toEqual([]);
+  });
+
+  it("keeps a captured heartbeat reply deliverable", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Build needs credentials."],
+      isHeartbeatTrigger: true,
+      currentAssistant: null,
+      lastAssistant: previousFinalReply,
+    });
+
+    expect(payloads.map((payload) => payload.text)).toEqual(["Build needs credentials."]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -199,8 +199,16 @@ export function buildEmbeddedRunPayloads(params: {
     .map((text) => sanitizeAssistantVisibleStreamText(text))
     .filter((text) => text.trim().length > 0);
   const currentAssistant = params.currentAssistant ?? undefined;
+  // `lastAssistant` is the session snapshot's newest assistant, which after a
+  // turn that produced no assistant message of its own is the previous final
+  // reply. An internal heartbeat turn must never adopt it: the previous reply
+  // would be re-committed to history and re-delivered as this turn's answer,
+  // so NO_REPLY has to stay a true no-op (#143787).
   const assistantForPayload =
-    currentAssistant ?? (nonEmptyAssistantTexts.length === 1 ? undefined : params.lastAssistant);
+    currentAssistant ??
+    (params.isHeartbeatTrigger === true || nonEmptyAssistantTexts.length === 1
+      ? undefined
+      : params.lastAssistant);
   // Pre-upgrade recovered messages have no stored facts, and recovery intentionally does not
   // reparse text; one in-flight reply can lose delivery or speech intent across this boundary.
   const storedDelivery = assistantForPayload?.openclawDelivery;


### PR DESCRIPTION
## What Problem This Solves

`buildEmbeddedRunPayloads` owns the reply payload for every embedded attempt. When an attempt captured no assistant message of its own, the builder falls back to `params.lastAssistant`. At the production call site (`terminal-preparation.ts`) that fallback is reached by an attempt that ended *before* `message_end` - the `yieldDetected` branch, the only branch that passes the **session snapshot's newest assistant** as `lastAssistant` and forces `currentAssistant: null`. For such a turn that assistant *is* the previous turn's final reply, so the builder emits the previous final as this turn's payload and the commit/deliver layers re-commit and re-deliver it.

Every other attempt - including a heartbeat poll whose answer is the silent token - hands the builder its own completed assistant message, which the silent-token filter drops, so a `NO_REPLY` heartbeat is already silent at this boundary with or without this change (measured: identical before/after runtime traces).

Fix: heartbeat turns keep their silence contract at the payload boundary - a heartbeat turn never adopts a session-level assistant message as its own reply. The turn's own captured assistant message (`currentAssistant`) and its own streamed texts stay untouched, so real heartbeat alerts (including alerts that arrive with no structured tool response) still deliver.
## Evidence

Reproduced without Telegram and without a model, at the payload boundary:

```
$ pnpm exec vitest run --config test/vitest/vitest.unit-fast-root.config.ts \
    src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts
# before the fix (red):
FAIL  > buildEmbeddedRunPayloads heartbeat silence > does not resurrect the previous final reply for a yielded heartbeat attempt
   → expected [ { …(2) } ] to deeply equal []
# the emitted payload is the previous turn's final answer:
[{"text":"Ship it: the release notes are ready.","replyToTag":false}]
```

Call shape (identical to what `prepareEmbeddedRunTerminal` builds for an
attempt that ended before `message_end`, `trigger: "heartbeat"`):

```ts
buildPayloads({ isHeartbeatTrigger: true, currentAssistant: null, lastAssistant: previousFinalReply })
// before: [{ text: "Ship it: the release notes are ready." }]
// after:  []
```

## Verification

```
$ pnpm exec vitest run --config test/vitest/vitest.unit-fast-root.config.ts \
    src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts \
    src/agents/embedded-agent-runner/run/payloads.test.ts
 Test Files  2 passed (2)
      Tests  53 passed (53)

$ pnpm exec vitest run --config test/vitest/vitest.agents-embedded-agent-run.config.ts \
    src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
 Test Files  1 passed (1)
      Tests  39 passed (39)

$ pnpm exec vitest run --config test/vitest/vitest.unit-fast-root.config.ts \
    src/agents/embedded-agent-runner/run/payloads.errors.test.ts \
    src/agents/embedded-agent-runner/run/payloads.delivery-recovery.test.ts
 Test Files  2 passed (2)
      Tests  7 passed (7)
```

The new test was red before the change and green after. Two independent
sabotages of the guard (scoping it to the cron trigger, and inverting the
heartbeat condition) each turn it red again.

Lint/format on the touched files:

```
$ npx oxlint src/agents/embedded-agent-runner/run/payloads.ts \
    src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts   # exit 0
$ npx oxfmt --check src/agents/embedded-agent-runner/run/payloads.ts \
    src/agents/embedded-agent-runner/run/payloads.heartbeat-silence.test.ts
All matched files use the correct format.
```

## Scope

Narrow fix at the payload boundary plus regression coverage. The reported Telegram reproduction is not reproduced by a `NO_REPLY` heartbeat in this environment (runtime before/after traces are identical), and the issue's separate "system-message replay" variant - an undelivered final reply recovered and re-sent by a later turn through the pending-final-delivery path (`src/auto-reply/reply/pending-final-delivery*.ts`), which this change does not touch - remains out of scope for this PR. What this change guarantees is that a heartbeat turn can never adopt a session-level assistant message as its own reply.

### v1 evidence block (constructed snapshot; superseded by the real-heartbeat v2 below)

## 1. Reproduce

```
cd D:/code/wt-oc-143787
node --import ./scripts/tsx.mjs "$LOCALAPPDATA/Temp/ocproof-144519.mjs" after          # HEAD
git checkout HEAD~1 -- src/agents/embedded-agent-runner/run/payloads.ts                # revert ONLY the PR's source file
node --import ./scripts/tsx.mjs "$LOCALAPPDATA/Temp/ocproof-144519.mjs" before
git checkout HEAD -- src/agents/embedded-agent-runner/run/payloads.ts                  # restore
git status --porcelain                                                                 # empty (verified)
```

Script: `%LOCALAPPDATA%/Temp/ocproof-144519.mjs` (deliberately outside the repo). Nothing was committed or pushed; `git status --porcelain` is empty and HEAD is still `64ad6e02642c`. For the `before` run only the PR's *source* file is moved to `HEAD~1`; the PR's new test file stays and is not involved.

## 2. What each layer is (real vs. stub — no ambiguity)

| Layer | Module actually executed | Fidelity |
|---|---|---|
| L1 terminal preparation | `src/agents/embedded-agent-runner/run/terminal-preparation.ts` -> `prepareEmbeddedRunTerminal(...)` with `runParams.trigger = "heartbeat"` — the production call site that maps the trigger to `isHeartbeatTrigger` (line 206) and then calls `buildEmbeddedRunPayloads` | REAL module, real heartbeat trigger, real payload boundary (`payloads.ts`) |
| L2 transcript handling | `src/config/sessions/transcript.ts` -> `appendAssistantMessageToSessionTranscript` (identified delivery mirror: `deliveryMirror: { kind: "channel-final" }` + idempotency key — the same shape the dispatch pipeline passes), read back with the real `loadTranscriptEvents` (`src/config/sessions/session-accessor.ts`) against the real SQLite agent store | REAL writer, REAL store, REAL read-back |
| L3 channel delivery | `src/auto-reply/reply/reply-dispatcher.ts` -> `createReplyDispatcher` + `settleReplyDispatcher` (`src/auto-reply/dispatch-dispatcher.ts`), fed with the payloads from L1 | REAL dispatcher; the only **STUB** is its `deliver` callback = the process-external platform send (network). The stub records every send and answers `{ visibleReplySent: true }`. The dispatcher receipt (`delivered` counts, `anyVisibleDelivered`) is the real dispatcher's own accounting. |

**Stated plainly:** the model/LLM attempt is *not* exercised — there is no model or network in this environment. The attempt snapshot (a yielded heartbeat that captured no assistant message of its own, while the session snapshot's newest assistant is the previous turn's final reply) is constructed in the script, copying the real attempt-result shape from the repo's own fixture `src/agents/embedded-agent-runner/run/terminal-preparation.test.ts`. The heartbeat scheduler and `heartbeat-dispatch.ts` visibility policy are likewise not exercised. Everything between the attempt snapshot and the channel is unmodified repo code.

## 3. Scenario A — silent heartbeat (attempt yields, captures no assistant output of its own)

### AFTER (HEAD, fix present)

```
[meta] label=after repo=D:/code/wt-oc-143787
[meta] payloads.ts fingerprint: const assistantForPayload = currentAssistant ?? (params.isHeartbeatTrigger === true || nonEmptyAssistantTexts.length === 1 ? undefined
[meta] terminal-preparation.ts module: file:///D:/code/wt-oc-143787/src/agents/embedded-agent-runner/run/terminal-preparation.ts

=== scenario: silent-heartbeat (session agent:main:ocproof-after-silent-heartbeat) ===
[L1] input: trigger=heartbeat yieldDetected=true assistantTexts=[]
[L1] input: snapshot newest assistant (previous final reply) = "Ship it: the release notes are ready."
[L1] input: assistant completed by this heartbeat turn = <none>
[L1] -> payloads built by terminal preparation: 0
[L1] finalAssistantVisibleText = null
[L3] channel sends (stubbed transport): 0
[L3] dispatcher receipt: {"counts":{"tool":{"delivered":0,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0},"block":{"delivered":0,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0},"final":{"delivered":0,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0}},"anyVisibleDelivered":false}
[L2] commits appended by this heartbeat turn: 0
[L2] transcript events readable after the heartbeat turn: 2
[L2]    event null: ""
[L2]    event assistant: "Ship it: the release notes are ready."
[L2] transcript events containing the previous final reply: 1 (1 = seeded history only)
[verdict] previous final reply re-emitted/re-delivered by this silent-heartbeat turn: false
[verdict] heartbeat alert delivered to the channel: false

=== scenario: genuine-alert (session agent:main:ocproof-after-genuine-alert) ===
[L1] input: trigger=heartbeat yieldDetected=true assistantTexts=["Build needs credentials before it can continue."]
[L1] input: snapshot newest assistant (previous final reply) = "Ship it: the release notes are ready."
[L1] input: assistant completed by this heartbeat turn = <none>
[L1] -> payloads built by terminal preparation: 1
[L1]    payload.text = "Build needs credentials before it can continue." isError=false
[L1] finalAssistantVisibleText = "Build needs credentials before it can continue."
[L3] channel sends (stubbed transport): 1
[L3]    send {"text":"Build needs credentials before it can continue.","isError":false,"kind":"final"}
[L3] dispatcher receipt: {"counts":{"tool":{"delivered":0,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0},"block":{"delivered":0,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0},"final":{"delivered":1,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0}},"anyVisibleDelivered":true}
[L2] append result: {"ok":true,"target":{"agentId":"main","sessionId":"ocproof-after-genuine-alert","sessionKey":"agent:main:ocproof-after-genuine-alert","storePath":"C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-after-GMaJoi\\agents\\main\\sessions\\sessions.json"},"messageId":"9430254f-f5fd-45d8-9926-37ae4540a2ea","anchor":{"agentId":"main","sessionId":"ocproof-after-genuine-alert","sessionKey":"agent:main:ocproof-after-genuine-alert","storePath":"C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-after-GMaJoi\\agents\\main\\agent\\openclaw-agent.sqlite","generation":"74a97bb208244d7fbcafdd996123ec05","entryId":"9430254f-f5fd-45d8-9926-37ae4540a2ea","rawSeq":2,"effectiveParentId":"663f745f-c980-4a94-bf5d-7537e860e642","activeMessagePosition":1,"idempotencyKey":"run-after-genuine-alert:final-1"}}
[L2] commits appended by this heartbeat turn: 1
[L2] transcript events readable after the heartbeat turn: 3
[L2]    event null: ""
[L2]    event assistant: "Ship it: the release notes are ready."
[L2]    event assistant: "Build needs credentials before it can continue."
[L2] transcript events containing the previous final reply: 1 (1 = seeded history only)
[verdict] previous final reply re-emitted/re-delivered by this genuine-alert turn: false
[verdict] heartbeat alert delivered to the channel: true

=== summary (machine readable) ===
{
  "label": "after",
  "results": [
    {
      "scenario": "silent-heartbeat",
      "payloadCount": 0,
      "payloadTexts": [],
      "channelSends": 0,
      "channelSendTexts": [],
      "transcriptCommits": 0,
      "previousReplyEvents": 1,
      "transcriptEventCount": 2,
      "previousReplyReEmittedOrDelivered": false,
      "alertDelivered": false,
      "stateDir": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-after-GMaJoi"
    },
    {
      "scenario": "genuine-alert",
      "payloadCount": 1,
      "payloadTexts": [
        "Build needs credentials before it can continue."
      ],
      "channelSends": 1,
      "channelSendTexts": [
        "Build needs credentials before it can continue."
      ],
      "transcriptCommits": 1,
      "previousReplyEvents": 1,
      "transcriptEventCount": 3,
      "previousReplyReEmittedOrDelivered": false,
      "alertDelivered": true,
      "stateDir": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-after-GMaJoi"
    }
  ]
}
```

### BEFORE (`payloads.ts` at HEAD~1)

```
[meta] label=before repo=D:/code/wt-oc-143787
[meta] payloads.ts fingerprint: const assistantForPayload = currentAssistant ?? (nonEmptyAssistantTexts.length === 1 ? undefined : params.lastAssistant); // Pre-upgrade recovered messages have no stored facts, and recovery intentionally does not // reparse text; one in-flight reply can lose delivery or speech intent across this boundary.
[meta] terminal-preparation.ts module: file:///D:/code/wt-oc-143787/src/agents/embedded-agent-runner/run/terminal-preparation.ts

=== scenario: silent-heartbeat (session agent:main:ocproof-before-silent-heartbeat) ===
[L1] input: trigger=heartbeat yieldDetected=true assistantTexts=[]
[L1] input: snapshot newest assistant (previous final reply) = "Ship it: the release notes are ready."
[L1] input: assistant completed by this heartbeat turn = <none>
[L1] -> payloads built by terminal preparation: 1
[L1]    payload.text = "Ship it: the release notes are ready." isError=false
[L1] finalAssistantVisibleText = null
[L3] channel sends (stubbed transport): 1
[L3]    send {"text":"Ship it: the release notes are ready.","isError":false,"kind":"final"}
[L3] dispatcher receipt: {"counts":{"tool":{"delivered":0,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0},"block":{"delivered":0,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0},"final":{"delivered":1,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0}},"anyVisibleDelivered":true}
[L2] append result: {"ok":true,"target":{"agentId":"main","sessionId":"ocproof-before-silent-heartbeat","sessionKey":"agent:main:ocproof-before-silent-heartbeat","storePath":"C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-before-kt5Cez\\agents\\main\\sessions\\sessions.json"},"messageId":"fb0696cc-4c09-4169-9519-646dbc6427c5","anchor":{"agentId":"main","sessionId":"ocproof-before-silent-heartbeat","sessionKey":"agent:main:ocproof-before-silent-heartbeat","storePath":"C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-before-kt5Cez\\agents\\main\\agent\\openclaw-agent.sqlite","generation":"3d7ab51d30c2403eabd4f65cd6dd266d","entryId":"fb0696cc-4c09-4169-9519-646dbc6427c5","rawSeq":2,"effectiveParentId":"32cc8c2f-ec63-44ee-b2bc-0b621199ed13","activeMessagePosition":1,"idempotencyKey":"run-before-silent-heartbeat:final-1"}}
[L2] commits appended by this heartbeat turn: 1
[L2] transcript events readable after the heartbeat turn: 3
[L2]    event null: ""
[L2]    event assistant: "Ship it: the release notes are ready."
[L2]    event assistant: "Ship it: the release notes are ready."
[L2] transcript events containing the previous final reply: 2 (1 = seeded history only)
[verdict] previous final reply re-emitted/re-delivered by this silent-heartbeat turn: true
[verdict] heartbeat alert delivered to the channel: false

=== scenario: genuine-alert (session agent:main:ocproof-before-genuine-alert) ===
[L1] input: trigger=heartbeat yieldDetected=true assistantTexts=["Build needs credentials before it can continue."]
[L1] input: snapshot newest assistant (previous final reply) = "Ship it: the release notes are ready."
[L1] input: assistant completed by this heartbeat turn = <none>
[L1] -> payloads built by terminal preparation: 1
[L1]    payload.text = "Build needs credentials before it can continue." isError=false
[L1] finalAssistantVisibleText = "Build needs credentials before it can continue."
[L3] channel sends (stubbed transport): 1
[L3]    send {"text":"Build needs credentials before it can continue.","isError":false,"kind":"final"}
[L3] dispatcher receipt: {"counts":{"tool":{"delivered":0,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0},"block":{"delivered":0,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0},"final":{"delivered":1,"deliveredNotVisible":0,"cancelled":0,"failedBeforeSend":0,"failedAfterSend":0}},"anyVisibleDelivered":true}
[L2] append result: {"ok":true,"target":{"agentId":"main","sessionId":"ocproof-before-genuine-alert","sessionKey":"agent:main:ocproof-before-genuine-alert","storePath":"C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-before-kt5Cez\\agents\\main\\sessions\\sessions.json"},"messageId":"471db46c-889a-490a-9c64-eb1a9454804a","anchor":{"agentId":"main","sessionId":"ocproof-before-genuine-alert","sessionKey":"agent:main:ocproof-before-genuine-alert","storePath":"C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-before-kt5Cez\\agents\\main\\agent\\openclaw-agent.sqlite","generation":"0e945fcd8be74c81bcc84222486d9bae","entryId":"471db46c-889a-490a-9c64-eb1a9454804a","rawSeq":2,"effectiveParentId":"4d1ff8aa-c0c2-40ca-abf6-5653c8c5b9cc","activeMessagePosition":1,"idempotencyKey":"run-before-genuine-alert:final-1"}}
[L2] commits appended by this heartbeat turn: 1
[L2] transcript events readable after the heartbeat turn: 3
[L2]    event null: ""
[L2]    event assistant: "Ship it: the release notes are ready."
[L2]    event assistant: "Build needs credentials before it can continue."
[L2] transcript events containing the previous final reply: 1 (1 = seeded history only)
[verdict] previous final reply re-emitted/re-delivered by this genuine-alert turn: false
[verdict] heartbeat alert delivered to the channel: true

=== summary (machine readable) ===
{
  "label": "before",
  "results": [
    {
      "scenario": "silent-heartbeat",
      "payloadCount": 1,
      "payloadTexts": [
        "Ship it: the release notes are ready."
      ],
      "channelSends": 1,
      "channelSendTexts": [
        "Ship it: the release notes are ready."
      ],
      "transcriptCommits": 1,
      "previousReplyEvents": 2,
      "transcriptEventCount": 3,
      "previousReplyReEmittedOrDelivered": true,
      "alertDelivered": false,
      "stateDir": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-before-kt5Cez"
    },
    {
      "scenario": "genuine-alert",
      "payloadCount": 1,
      "payloadTexts": [
        "Build needs credentials before it can continue."
      ],
      "channelSends": 1,
      "channelSendTexts": [
        "Build needs credentials before it can continue."
      ],
      "transcriptCommits": 1,
      "previousReplyEvents": 1,
      "transcriptEventCount": 3,
      "previousReplyReEmittedOrDelivered": false,
      "alertDelivered": true,
      "stateDir": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\ocproof-144519-before-kt5Cez"
    }
  ]
}
```

## 4. Discriminating lines side by side

| Observation (silent-heartbeat scenario) | AFTER (HEAD) | BEFORE (HEAD~1) |
|---|---|---|
| `[L1] payloads built by terminal preparation` | `0` | `1` -> `"Ship it: the release notes are ready."` (the previous final reply) |
| `[L3] channel sends (stubbed transport)` / dispatcher `final.delivered` | `0` / `0` | `1` / `1` — the previous reply is sent to the channel again |
| `[L2] commits appended by this heartbeat turn` | `0` | `1` |
| `[L2] transcript events containing the previous final reply` | `1` (seeded history only) | `2` — re-committed to the session store |
| `[verdict] previous final reply re-emitted/re-delivered` | `false` | `true` |

Genuine-alert scenario (`assistantTexts: ["Build needs credentials before it can continue."]`): identical in both runs — 1 payload, 1 channel send, 1 transcript commit, `alertDelivered: true`. The fix does not silence real alerts.

Version fingerprint printed by the script itself (second line of each run), so the two runs cannot be confused:

* AFTER: `const assistantForPayload = currentAssistant ?? (params.isHeartbeatTrigger === true || nonEmptyAssistantTexts.length === 1 ? undefined`
* BEFORE: `const assistantForPayload = currentAssistant ?? (nonEmptyAssistantTexts.length === 1 ? undefined : params.lastAssistant);`

## 5. Conclusion

A heartbeat run that produced no assistant message of its own is a true no-op after the fix — no payload, no channel send, no transcript re-commit — while a heartbeat that did produce an alert still delivers; at HEAD~1 the same silent run rebuilt a payload from the session snapshot's newest assistant and re-delivered the previous final reply to the channel and into session history.

### Re-ran by the author

The both-legs run was repeated by hand on this branch (`64ad6e02642c`):

```
silent heartbeat    : payloads=0  transcriptCommits=0  previousReplyReEmittedOrDelivered=false  alertDelivered=false
genuine alert       : payloads=1  transcriptCommits=1  alertDelivered=true   previousReplyReEmittedOrDelivered=false

# with src/agents/embedded-agent-runner/run/payloads.ts at HEAD~1 and the test kept:
silent heartbeat    : previousReplyReEmittedOrDelivered=TRUE   (the reported defect)
genuine alert       : alertDelivered=true
```

---

### Real-heartbeat evidence v2 (owner re-run, 2026-09-14)

The previous evidence block exercised the fallback through a constructed attempt. This revision of the evidence drives the **real heartbeat entry** instead:

`runHeartbeatOnce(...)` (the entry the Gateway cron monitor calls) -> real `getReplyFromConfig` -> embedded agent run -> `terminal-preparation.ts` -> `payloads.ts` -> real dispatcher -> the **real bundled `qa-channel` plugin** (loaded by the real plugin loader) -> HTTP -> the real `qa-lab` bus. Four real turns in one session; the scripted model answers via a loopback SSE endpoint.

| turn | AFTER (HEAD `64ad6e02642c`) | BEFORE (`payloads.ts` at HEAD~1, test kept) |
|---|---|---|
| 1. real final reply becomes the session's newest assistant | delivered + committed | delivered + committed |
| 2. silent heartbeat (`NO_REPLY`) | **0 channel sends**, no re-commit, no re-delivery | **0 channel sends**, no re-commit, no re-delivery |
| 3. genuine alert | **delivered** (real bus POST) | **delivered** |
| 4. heartbeat whose model answer calls `sessions_yield` | tool refuses: `No pending child completion is owned by this turn...`; no re-delivery | identical |

Findings, stated plainly:

- The **silence contract and genuine-alert delivery are now proven on the real heartbeat path**, and both revisions behave identically there.
- The **yielded trigger does not arise from a heartbeat** on this build (yield requires a child-completion claim that a heartbeat turn does not own) - consistent with the earlier P1 concern. The guard's demonstrable effect is therefore scoped to the payload-boundary guarantee stated above; its only executing coverage is the unit-level regression (green at HEAD, red at HEAD~1 with the source reverted).
- The opening diagnosis above has been rewritten to match this result, and the pending-final-delivery / system-message-replay variant is marked out of scope.
- Fidelity notes: wake trigger invoked directly (not the monitor timer); platform is the in-repo synthetic QA channel; model is a loopback SSE endpoint. On this host the in-process Gateway stalls at `channels.qa-channel.is-configured` (documented with logs), which is why the chain is driven layer-direct.
- Owner re-ran both legs (`ocproof-v2-{after,before}-mine.*`): identical numbers, different `payloads.ts` fingerprints per revision.


