### PR TITLE
fix(sessions): avoid slow rejection of stale deletions

### DIFF
--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -48,6 +48,12 @@ uses the admitted handle. Coalesced callers retain their own guards. History
 eviction also uses this admission when reopening after archive materialization,
 then rereads candidate protection before preparing reclamation.
 
+After archive preparation, session deletion rereads its target before admitting
+the final reclamation worker. A missing or changed target returns the existing
+entry-mismatch result without starting that worker, while preserving archives
+already committed by the deletion. Admitted workers still recheck the target
+and current authority inside their deletion transaction.
+
 Prepared session-store updates, entry replacements, and lifecycle upserts use
 the same admission for cold snapshot reads and actual commits, retaining their
 existing writer position. Warm update callbacks remain direct. Result-only

--- a/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
@@ -611,40 +611,6 @@ describe("SQLite lifecycle cleanup races", () => {
     ).resolves.toEqual([{ ...events[2]!, content: "concurrent transcript" }]);
   });
 
-  it("reports an entry replacement during final transcript materialization", async () => {
-    const sessionKey = "agent:main:entry-materialization-race";
-    const sessionId = "entry-materialization-run";
-    const events = [{ type: "session" as const, id: sessionId, content: "original transcript" }];
-    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 1 });
-    await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, events);
-    const currentEntry = loadSessionEntry({ sessionKey, storePath });
-    if (!currentEntry) {
-      throw new Error("expected current guarded entry");
-    }
-    const replacementEntry = { ...currentEntry, label: "concurrent replacement" };
-    archiveMaterializationHook.afterMaterialize = () => {
-      replaceSessionEntrySync({ sessionKey, storePath }, replacementEntry);
-    };
-
-    const result = await deleteSessionEntryLifecycle({
-      archiveTranscript: true,
-      expectedEntry: currentEntry,
-      expectedTranscript: { eventJson: [JSON.stringify(events[0])], sessionId },
-      storePath,
-      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
-    });
-
-    expect(result).toEqual({
-      archivedTranscripts: [],
-      deleted: false,
-      expectedEntryMismatch: true,
-    });
-    expect(loadSessionEntry({ sessionKey, storePath })).toEqual(replacementEntry);
-    await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toEqual(
-      events,
-    );
-  });
-
   it("releases the store writer while lifecycle cleanup archives a transcript", async () => {
     const now = Date.now();
     const deletedKey = "agent:main:cleanup-race-archived";

--- a/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
@@ -3,17 +3,21 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as logging from "../../logging/logger.js";
+import { runExclusiveSessionLifecycleMutation } from "../../sessions/session-lifecycle-admission.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import {
   cleanupSessionLifecycleArtifactsCore,
+  deleteSessionEntryLifecycle,
   loadSessionEntry,
   loadTranscriptEvents,
   replaceSessionEntry,
+  replaceSessionEntrySync,
 } from "./session-accessor.js";
 import { readArtifactPreparationLogs } from "./session-accessor.sqlite-diagnostics.test-support.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
@@ -88,6 +92,128 @@ describe("SQLite lifecycle cleanup reclamation", () => {
     }
     expect(workersStarted).toBe(0);
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject(entry);
+  });
+
+  it.each(["replace", "delete"] as const)(
+    "rejects a stale entry plan before starting a Worker after an awaited %s",
+    async (mutation) => {
+      const sessionKey = "agent:main:queued-entry-deletion";
+      const sessionId = "queued-entry-deletion";
+      const entry = { sessionId, updatedAt: Date.now() };
+      await replaceSessionEntry({ sessionKey, storePath }, entry);
+      const target = { canonicalKey: sessionKey, storeKeys: [sessionKey] };
+      const entered = createDeferred();
+      const prepared = createDeferred();
+      let workersStarted = 0;
+      let workersBeforeRelease = 0;
+      const onWorker = () => {
+        workersStarted += 1;
+      };
+      const workerChannel = channel("worker_threads");
+      workerChannel.subscribe(onWorker);
+      const previousMutation = runExclusiveSessionLifecycleMutation({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        run: async () => {
+          entered.resolve();
+          await prepared.promise;
+          if (mutation === "replace") {
+            await replaceSessionEntry(
+              { sessionKey, storePath },
+              { ...entry, label: "changed by the preceding owner" },
+            );
+          } else {
+            const result = await deleteSessionEntryLifecycle({
+              archiveTranscript: false,
+              storePath,
+              target,
+            });
+            expect(result.deleted).toBe(true);
+          }
+          workersBeforeRelease = workersStarted;
+        },
+      });
+      let deletion: ReturnType<typeof deleteSessionEntryLifecycle> | undefined;
+      try {
+        await entered.promise;
+        deletion = deleteSessionEntryLifecycle({
+          archiveTranscript: false,
+          commitGuard: () => prepared.resolve(),
+          storePath,
+          target,
+        });
+        // Preparation reads the old row while the prior lifecycle owner is held;
+        // its queued mutation commits before this deletion acquires that hold.
+        await previousMutation;
+        await expect(deletion).resolves.toEqual({
+          archivedTranscripts: [],
+          deleted: false,
+          expectedEntryMismatch: true,
+        });
+        expect(workersStarted).toBe(workersBeforeRelease);
+        const current = loadSessionEntry({ sessionKey, storePath });
+        if (mutation === "replace") {
+          expect(current).toMatchObject({ ...entry, label: "changed by the preceding owner" });
+        } else {
+          expect(current).toBeUndefined();
+        }
+      } finally {
+        prepared.resolve();
+        await Promise.allSettled([previousMutation, ...(deletion ? [deletion] : [])]);
+        workerChannel.unsubscribe(onWorker);
+      }
+    },
+  );
+
+  it("keeps published history when the entry changes during final materialization", async () => {
+    const sessionKey = "agent:main:entry-materialization-race";
+    const historicalSessionId = "entry-materialization-history";
+    const sessionId = "entry-materialization-run";
+    const events = [{ type: "session" as const, id: sessionId, content: "original transcript" }];
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      { sessionId: historicalSessionId, updatedAt: 1 },
+    );
+    await replaceTranscriptEvents({ sessionKey, sessionId: historicalSessionId, storePath }, [
+      { type: "session", id: historicalSessionId, content: "already published history" },
+    ]);
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 1 });
+    await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, events);
+    const currentEntry = loadSessionEntry({ sessionKey, storePath });
+    if (!currentEntry) {
+      throw new Error("expected current guarded entry");
+    }
+    const replacementEntry = { ...currentEntry, label: "concurrent replacement" };
+    let materializations = 0;
+    archiveMaterializationHook.afterMaterialize = () => {
+      if (++materializations === 2) {
+        replaceSessionEntrySync({ sessionKey, storePath }, replacementEntry);
+      }
+    };
+
+    const result = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      expectedEntry: currentEntry,
+      expectedTranscript: { eventJson: [JSON.stringify(events[0])], sessionId },
+      storePath,
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+    });
+
+    expect(result).toMatchObject({
+      deleted: false,
+      expectedEntryMismatch: true,
+    });
+    expect(materializations).toBe(2);
+    expect(result.archivedTranscripts).toEqual([
+      expect.objectContaining({ sessionId: historicalSessionId }),
+    ]);
+    await expect(
+      loadTranscriptEvents({ sessionKey, sessionId: historicalSessionId, storePath }),
+    ).resolves.toEqual([]);
+    expect(loadSessionEntry({ sessionKey, storePath })).toEqual(replacementEntry);
+    await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toEqual(
+      events,
+    );
   });
 
   it.each([false, true])(

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -440,6 +440,13 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         params.commitGuard?.();
         assertCurrent();
       };
+      const matchesPreparedTarget = (database: OpenClawAgentDatabase) => {
+        const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
+        return (
+          sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) &&
+          shouldDeleteSqliteSessionEntryLifecycle(database, targetSnapshot[0]?.entry, params)
+        );
+      };
       const historicalArchivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
       for (const sessionId of prepared.historicalGenerationIds) {
         const plan = await runExclusiveSqliteSessionWrite(
@@ -448,15 +455,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
             withSqliteSessionDatabase(
               databaseOptions,
               (database) => {
-                const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
-                if (
-                  !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
-                  !shouldDeleteSqliteSessionEntryLifecycle(
-                    database,
-                    targetSnapshot[0]?.entry,
-                    params,
-                  )
-                ) {
+                if (!matchesPreparedTarget(database)) {
                   return DELETE_EXPECTED_ENTRY_MISMATCH;
                 }
                 const referencedAfterDelete = readReferencedSessionIdsAfterTargetMutation(
@@ -503,15 +502,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
               withSqliteSessionDatabase(
                 databaseOptions,
                 (database) => {
-                  const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
-                  if (
-                    !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
-                    !shouldDeleteSqliteSessionEntryLifecycle(
-                      database,
-                      targetSnapshot[0]?.entry,
-                      params,
-                    )
-                  ) {
+                  if (!matchesPreparedTarget(database)) {
                     return DELETE_EXPECTED_ENTRY_MISMATCH;
                   }
                   const protectedSessionIds = collectAdmissionProtectedSessionIds({
@@ -579,12 +570,30 @@ async function deleteSqliteSessionEntryLifecycleLocked(
       const result = await runExclusiveSqliteSessionReclamation(async () => {
         const materializedPlans = await materializeSessionStateDeletePlans(prepared.entryPlans);
         const diagnostics: SqliteSessionReclamationDiagnostics = {};
-        const reclamationPlan = createSessionEntryReclamationPlan({
-          databaseOptions: toDatabaseOptions(resolved),
-          deleteParams: params,
-          materializedPlans,
-          preparedTargetSnapshot: prepared.targetSnapshot,
-        });
+        const reclamationPlan = await runExclusiveSqliteSessionWrite(
+          resolved,
+          async () =>
+            withSqliteSessionDatabase(
+              databaseOptions,
+              (database) => {
+                if (!matchesPreparedTarget(database)) {
+                  return DELETE_EXPECTED_ENTRY_MISMATCH;
+                }
+                return createSessionEntryReclamationPlan({
+                  databaseOptions,
+                  deleteParams: params,
+                  materializedPlans,
+                  preparedTargetSnapshot: prepared.targetSnapshot,
+                });
+              },
+              assertDeletionCurrent,
+            ),
+          "session.lifecycle.reclamation-plan",
+          diagnostics,
+        );
+        if (reclamationPlan === DELETE_EXPECTED_ENTRY_MISMATCH) {
+          return expectedEntryMismatchResult([]);
+        }
         const reclaimed = await runSqliteSessionReclamation({
           diagnostics,
           assertCommitAllowed: assertDeletionCurrent,


### PR DESCRIPTION
Related: #112423
Related: #142505

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where a queued session deletion could perform a full database validation even after a preceding lifecycle operation had replaced or deleted its target. The operation eventually returned the correct conflict result, but started an unnecessary reclamation worker first.

## Why This Change Was Made

The final entry plan now uses the same fresh target predicate as historical-generation deletion, under the existing writer and lifecycle owner after archive materialization. Admitted workers retain their final transaction checks and native-exit ownership. Earlier committed history remains published and included in a conflict result.

## User Impact

Stale session deletions return their existing conflict result before starting a reclamation worker. Valid deletions and archive retention keep their existing behavior.

## Evidence

- Regression uses an actual awaited lifecycle hold and a real preceding replacement or deletion. Original code started one extra native worker in each case; the repaired code starts none for the rejected plan.
- All 75 focused lifecycle/reclamation tests passed. After moving the strengthened archive-preservation case into the smaller suite, all 27 tests in the two affected suites passed again.
- Final changed-file checks, normal build, and independent review passed.
- Local public CLI cleanup smoke removed the cap-archived entry, preserved the manual archive and transcript, and repeated with no further entry reclamation. This smoke exercises successful cleanup; the deterministic hold-order test proves stale-plan rejection.
- Linux Testbox [hosting run](https://github.com/openclaw/openclaw/actions/runs/34546126798): clean installation/build and both public CLI cleanup invocations passed. Native setup/proof cgroups closed, pipes reached EOF, and clients joined; controller exit was 0. Artifacts were verified before stopping the lease. The hosting Actions job may show cancellation from that lease cleanup.
