### PR TITLE
refactor(android): reuse reflection test helper

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ClawHubSkillRuntimeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ClawHubSkillRuntimeTest.kt
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import java.lang.reflect.Field
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -315,27 +314,12 @@ class ClawHubSkillRuntimeTest {
     name: String,
     value: Any?,
   ) {
-    field(target, name).set(target, value)
+    findTestField(target, name).set(target, value)
   }
 
   @Suppress("UNCHECKED_CAST")
   private fun <T> readField(
     target: Any,
     name: String,
-  ): T = field(target, name).get(target) as T
-
-  private fun field(
-    target: Any,
-    name: String,
-  ): Field {
-    var type: Class<*>? = target.javaClass
-    while (type != null) {
-      try {
-        return type.getDeclaredField(name).apply { isAccessible = true }
-      } catch (_: NoSuchFieldException) {
-        type = type.superclass
-      }
-    }
-    error("Field $name not found on ${target.javaClass.name}")
-  }
+  ): T = findTestField(target, name).get(target) as T
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/CronRuntimeGuardTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/CronRuntimeGuardTest.kt
@@ -16,7 +16,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import java.lang.reflect.Field
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
@@ -344,7 +343,7 @@ class CronRuntimeGuardTest {
     name: String,
     value: Any?,
   ) {
-    findField(target, name).set(target, value)
+    findTestField(target, name).set(target, value)
   }
 
   private fun <T> readField(
@@ -352,22 +351,7 @@ class CronRuntimeGuardTest {
     name: String,
   ): T {
     @Suppress("UNCHECKED_CAST")
-    return findField(target, name).get(target) as T
-  }
-
-  private fun findField(
-    target: Any,
-    name: String,
-  ): Field {
-    var type: Class<*>? = target.javaClass
-    while (type != null) {
-      try {
-        return type.getDeclaredField(name).apply { isAccessible = true }
-      } catch (_: NoSuchFieldException) {
-        type = type.superclass
-      }
-    }
-    error("Field $name not found on ${target.javaClass.name}")
+    return findTestField(target, name).get(target) as T
   }
 
   private fun invokeStringMethod(


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Two Android runtime test suites duplicate the field-hierarchy lookup already provided by the shared test helper, leaving three implementations to maintain.

## Why This Change Was Made

Reuse `findTestField` at four existing call sites and remove the two identical private walkers and unused `Field` imports. Keep all test cases, assertions, casts, setup, cleanup, and the canonical helper unchanged.

## User Impact

No production or user-visible behavior change. This is test-support cleanup only.

## Evidence

- Fresh PlayDebug and ThirdPartyDebug JVM runs, with `--no-build-cache --rerun-tasks`: 124 passes per flavor across `ClawHubSkillRuntimeTest`, `CronRuntimeGuardTest`, `GatewayBootstrapAuthTest`, and `GatewayExecApprovalRuntimeTest`. All 248 executions passed with zero failures, errors, or skips; eight fresh XML reports were verified.
- All 13 exact-base changed-check commands passed, including executed `ktlintCheck` tasks for app, benchmark, wear, and wear-shared.
- Scoped independent review: no findings. Diff and source bindings retained.
- Hosted CI initially failed a `SettingsScreensContrastTest` visibility assertion. One job-only recovery passed the executed ThirdParty tests, existing ThirdParty lint, and dependent CI gate on the unchanged synthetic merge checkout. The workflow selected its GitHub-hosted retry runner. The original failure is retained; this establishes successful recovery, not a proven flake or root-cause fix.

This is JVM unit-test and static-check evidence, not emulator, device, live Gateway, or release-packaging proof.
