### PR TITLE
refactor: await progress-card storage operations

### DIFF
--- a/src/gateway/board-store.test.ts
+++ b/src/gateway/board-store.test.ts
@@ -111,7 +111,7 @@ it("keeps global boards and progress under each owner's canonical row across reo
     );
   }
   await invoke("progressCard.put", { sessionKey: "agent:work:main", expectedRevision: 2 });
-  expect(progressCardStore.get("global", "work")?.revision).toBe(1);
+  expect((await progressCardStore.get("global", "work"))?.revision).toBe(1);
   const cleared = await invoke("progressCard.put", {
     sessionKey: "global",
     agentId: "work",
@@ -126,7 +126,7 @@ it("keeps global boards and progress under each owner's canonical row across reo
     },
     { sessionKeys: ["global"], agentId: "work" },
   );
-  expect(progressCardStore.get("global", "main")?.revision).toBe(1);
+  expect((await progressCardStore.get("global", "main"))?.revision).toBe(1);
 });
 
 it("keeps retained global progress separate from an ordinary qualified global row in per-sender mode", async () => {
@@ -202,14 +202,14 @@ it("keeps retained global progress separate from an ordinary qualified global ro
     expectedRevision: 1,
   });
   expect(cleared).toHaveBeenCalledWith(true, { card: null }, undefined);
-  expect(progressCardStore.get("global", "work")).toBeNull();
-  expect(progressCardStore.get("global", "main")?.markdown).toBe("main/global");
-  expect(progressCardStore.get("agent:work:global", "work")?.markdown).toBe(
+  expect(await progressCardStore.get("global", "work")).toBeNull();
+  expect((await progressCardStore.get("global", "main"))?.markdown).toBe("main/global");
+  expect((await progressCardStore.get("agent:work:global", "work"))?.markdown).toBe(
     "work/agent:work:global",
   );
 });
 
-it("reopens separate boards and progress cards in a shared database owned by another agent", () => {
+it("reopens separate boards and progress cards in a shared database owned by another agent", async () => {
   const stateDir = tempDirs.make("openclaw-gateway-shared-boards-");
   const storePath = path.join(stateDir, "shared.sqlite");
   vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
@@ -233,7 +233,7 @@ it("reopens separate boards and progress cards in a shared database owned by ano
       name: agentId,
       content: { kind: "html", html: `<p>${agentId}</p>` },
     });
-    progressCardStore.put(sessionKey, { markdown: `${agentId} progress` });
+    await progressCardStore.put(sessionKey, { markdown: `${agentId} progress` });
   }
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
@@ -243,7 +243,7 @@ it("reopens separate boards and progress cards in a shared database owned by ano
     expect(boardStore.getSnapshot({ sessionKey }).widgets).toEqual([
       expect.objectContaining({ name: agentId, revision: 1 }),
     ]);
-    expect(progressCardStore.get(sessionKey)).toMatchObject({
+    expect(await progressCardStore.get(sessionKey)).toMatchObject({
       sessionKey,
       markdown: `${agentId} progress`,
       revision: 1,

--- a/src/gateway/progress-card-store.ts
+++ b/src/gateway/progress-card-store.ts
@@ -8,21 +8,22 @@ import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js"
 import { resolveGatewaySessionDatabase } from "./board-store.js";
 
 export type ProgressCardStore = {
-  get(sessionKey: string, agentId?: string): ProgressCard | null;
+  get(sessionKey: string, agentId?: string): Promise<ProgressCard | null>;
   put(
     sessionKey: string,
     input: {
       markdown?: string;
       steps?: ProgressCardStep[];
       expectedRevision?: number;
+      // The storage owner checks authority inside its write transaction.
       assertCurrent?: () => void;
     },
     agentId?: string,
-  ): { card: ProgressCard | null };
+  ): Promise<{ card: ProgressCard | null }>;
 };
 
 export const progressCardStore: ProgressCardStore = {
-  get(sessionKey, agentId) {
+  async get(sessionKey, agentId) {
     const resolved = resolveGatewaySessionDatabase(sessionKey, agentId);
     const result = withOpenClawAgentDatabaseReadOnly(
       (database) => readSessionProgressCard(database.db, resolved.sessionKey),
@@ -30,7 +31,7 @@ export const progressCardStore: ProgressCardStore = {
     );
     return result.found ? result.value : null;
   },
-  put(sessionKey, input, agentId) {
+  async put(sessionKey, input, agentId) {
     const resolved = resolveGatewaySessionDatabase(sessionKey, agentId);
     const result = runOpenClawAgentWriteTransaction(
       (transactionDatabase) => {

--- a/src/gateway/server-broadcast.board.test.ts
+++ b/src/gateway/server-broadcast.board.test.ts
@@ -288,8 +288,8 @@ describe("board and progress event session ownership", () => {
             sessionKey: "agent:work:global",
             markdown: "Ordinary session",
           });
-          expect(progressCardStore.get("global", "work")).toBeNull();
-          expect(progressCardStore.get("agent:work:global", "work")?.markdown).toBe(
+          expect(await progressCardStore.get("global", "work")).toBeNull();
+          expect((await progressCardStore.get("agent:work:global", "work"))?.markdown).toBe(
             "Ordinary session",
           );
           const changed = (revision: number | null) => ({

--- a/src/gateway/server-methods/progress-card.authorization.test.ts
+++ b/src/gateway/server-methods/progress-card.authorization.test.ts
@@ -9,7 +9,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import { progressCardStore } from "../progress-card-store.js";
+import { progressCardStore, type ProgressCardStore } from "../progress-card-store.js";
 import { handleGatewayRequest } from "../server-methods.js";
 import {
   resolveSessionMutationAuthorization,
@@ -22,6 +22,119 @@ import { createProgressCardHandlers } from "./progress-card.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 describe("progress card request authorization", () => {
+  it.each([
+    { method: "progressCard.get", beforeCommit: false },
+    { method: "progressCard.put", beforeCommit: true },
+    { method: "progressCard.put", beforeCommit: false },
+  ] as const)(
+    "revalidates $method after delayed storage (beforeCommit=$beforeCommit)",
+    async ({ method, beforeCommit }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const cfg: OpenClawConfig = {
+          ...rolePolicyConfig(),
+          agents: { ownership: "explicit", entries: { main: {}, work: {} } },
+        };
+        setRuntimeConfigSnapshot(cfg, cfg);
+        const target = { sessionKey: "global", agentId: "work" };
+        const client = { ...roleClient("view", "card-owner"), connId: "card-owner" };
+        const entry = {
+          sessionId: "admitted-generation",
+          updatedAt: 1,
+          visibility: "draft" as const,
+          createdActor: {
+            type: "human" as const,
+            source: "profile" as const,
+            id: client.authenticatedUserProfile!.profileId,
+          },
+        };
+        await upsertSessionEntryCore(target, entry);
+        await progressCardStore.put(
+          target.sessionKey,
+          { markdown: "original card" },
+          target.agentId,
+        );
+        const entered = createDeferredCore();
+        const release = createDeferredCore();
+        const store: ProgressCardStore = {
+          async get(...args) {
+            const card = await progressCardStore.get(...args);
+            entered.resolve();
+            await release.promise;
+            return card;
+          },
+          async put(...args) {
+            if (beforeCommit) {
+              entered.resolve();
+              await release.promise;
+            }
+            const result = await progressCardStore.put(...args);
+            if (!beforeCommit) {
+              entered.resolve();
+              await release.promise;
+            }
+            return result;
+          },
+        };
+        const broadcast = vi.fn();
+        const respond = vi.fn<RespondFn>();
+        const context = {
+          getRuntimeConfig: () => cfg,
+          broadcast,
+          logGateway: { warn: vi.fn() },
+          resolveGatewayContext: (): GatewayRequestContext => context,
+        } as unknown as GatewayRequestContext;
+        const pending = handleGatewayRequest({
+          req: {
+            type: "req",
+            id: "delayed-card",
+            method,
+            params: {
+              ...target,
+              ...(method === "progressCard.put" ? { markdown: "committed card" } : {}),
+            },
+          },
+          client,
+          context,
+          respond,
+          isWebchatConnect: () => false,
+          extraHandlers: createProgressCardHandlers(store),
+        });
+        try {
+          await Promise.race([
+            entered.promise,
+            pending.then(() => {
+              throw new Error("request finished before storage settled");
+            }),
+          ]);
+          expect(respond).not.toHaveBeenCalled();
+          expect(broadcast).not.toHaveBeenCalled();
+          await upsertSessionEntryCore(target, {
+            ...entry,
+            sessionId: "successor-generation",
+            updatedAt: 2,
+          });
+        } finally {
+          release.resolve();
+          await pending;
+        }
+        expect(respond).toHaveBeenCalledExactlyOnceWith(
+          false,
+          undefined,
+          expect.objectContaining({
+            code: "INVALID_REQUEST",
+            details: expect.objectContaining({ code: "SESSION_MUTATION_AUTHORIZATION_CHANGED" }),
+          }),
+        );
+        expect(broadcast).not.toHaveBeenCalled();
+        expect(await progressCardStore.get(target.sessionKey, target.agentId)).toMatchObject({
+          markdown:
+            method === "progressCard.put" && !beforeCommit ? "committed card" : "original card",
+          revision: method === "progressCard.put" && !beforeCommit ? 2 : 1,
+        });
+      });
+    },
+  );
+
   it.each(
     (["global", "agent:work:progress-authorization"] as const).flatMap((sessionKey) =>
       (["progressCard.get", "progressCard.put"] as const).flatMap((method) =>
@@ -49,7 +162,11 @@ describe("progress card request authorization", () => {
           visibility: "draft",
           createdActor: { type: "human", source: "profile", id: ownerId },
         });
-        progressCardStore.put(target.sessionKey, { markdown: "original card" }, target.agentId);
+        await progressCardStore.put(
+          target.sessionKey,
+          { markdown: "original card" },
+          target.agentId,
+        );
         const broadcast = vi.fn();
         const context = {
           getRuntimeConfig: () => cfg,
@@ -121,7 +238,7 @@ describe("progress card request authorization", () => {
               visibility: "draft",
               createdActor: { type: "human", source: "profile", id: successorId },
             });
-            progressCardStore.put(
+            await progressCardStore.put(
               target.sessionKey,
               { markdown: "successor card" },
               target.agentId,
@@ -147,7 +264,7 @@ describe("progress card request authorization", () => {
           } else {
             authorization.assertCurrent();
           }
-          const before = progressCardStore.get(target.sessionKey, target.agentId);
+          const before = await progressCardStore.get(target.sessionKey, target.agentId);
           const get = vi.spyOn(progressCardStore, "get");
           const put = vi.spyOn(progressCardStore, "put");
           let storeCalls;
@@ -159,7 +276,7 @@ describe("progress card request authorization", () => {
             get.mockRestore();
             put.mockRestore();
           }
-          const after = progressCardStore.get(target.sessionKey, target.agentId);
+          const after = await progressCardStore.get(target.sessionKey, target.agentId);
           if (testCase.replace) {
             expect({
               responses: respond.mock.calls,
@@ -232,7 +349,7 @@ it.each([false, true])(
           id: client.authenticatedUserProfile!.profileId,
         },
       });
-      progressCardStore.put(target.sessionKey, { markdown: "previous card" }, target.agentId);
+      await progressCardStore.put(target.sessionKey, { markdown: "previous card" }, target.agentId);
       const broadcast = vi.fn();
       const context = {
         getRuntimeConfig: () => cfg,
@@ -283,7 +400,7 @@ it.each([false, true])(
             updatedAt: 2,
           }),
         });
-        progressCardStore.put(target.sessionKey, { markdown: "fresh card" }, target.agentId);
+        await progressCardStore.put(target.sessionKey, { markdown: "fresh card" }, target.agentId);
         release.resolve();
         await pending;
         expect(respond).toHaveBeenCalledWith(
@@ -293,7 +410,7 @@ it.each([false, true])(
             details: expect.objectContaining({ code: "SESSION_MUTATION_AUTHORIZATION_CHANGED" }),
           }),
         );
-        expect(progressCardStore.get(target.sessionKey, target.agentId)?.markdown).toBe(
+        expect((await progressCardStore.get(target.sessionKey, target.agentId))?.markdown).toBe(
           "fresh card",
         );
         expect(broadcast).not.toHaveBeenCalled();

--- a/src/gateway/server-methods/progress-card.test.ts
+++ b/src/gateway/server-methods/progress-card.test.ts
@@ -6,6 +6,7 @@ import {
   type ProgressCard,
   type ProgressCardStep,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { resolveCoreOperatorGatewayMethodScope } from "../methods/core-descriptors.js";
 import type { ProgressCardStore } from "../progress-card-store.js";
 import { createProgressCardHandlers } from "./progress-card.js";
@@ -13,8 +14,8 @@ import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 function createHarness() {
   const cards = new Map<string, ProgressCard>();
-  const get = vi.fn<ProgressCardStore["get"]>((sessionKey) => cards.get(sessionKey) ?? null);
-  const put = vi.fn<ProgressCardStore["put"]>((sessionKey, input) => {
+  const get = vi.fn<ProgressCardStore["get"]>(async (sessionKey) => cards.get(sessionKey) ?? null);
+  const put = vi.fn<ProgressCardStore["put"]>(async (sessionKey, input) => {
     const current = cards.get(sessionKey);
     if (!input.markdown && !input.steps?.length) {
       if (input.expectedRevision !== undefined && current?.revision !== input.expectedRevision) {
@@ -35,8 +36,11 @@ function createHarness() {
   });
   const handlers = createProgressCardHandlers({ get, put });
   const broadcast = vi.fn();
-  const invoke = async (method: "progressCard.get" | "progressCard.put", params: unknown) => {
-    const respond = vi.fn<RespondFn>();
+  const invoke = async (
+    method: "progressCard.get" | "progressCard.put",
+    params: unknown,
+    respond = vi.fn<RespondFn>(),
+  ) => {
     await handlers[method]!({
       params,
       respond,
@@ -51,6 +55,88 @@ function createHarness() {
 }
 
 describe("progress card gateway methods", () => {
+  it.each(["get", "put"] as const)(
+    "waits for %s before responding or broadcasting",
+    async (operation) => {
+      const harness = createHarness();
+      const card: ProgressCard = {
+        sessionKey: "agent:main:main",
+        markdown: "Saved",
+        revision: 3,
+        updatedAt: 1,
+      };
+      const release = createDeferredCore();
+      harness.get.mockImplementationOnce(async () => {
+        await release.promise;
+        return card;
+      });
+      harness.put.mockImplementationOnce(async () => {
+        await release.promise;
+        return { card };
+      });
+      const respond = vi.fn<RespondFn>();
+      const pending = harness.invoke(
+        `progressCard.${operation}`,
+        {
+          sessionKey: card.sessionKey,
+          ...(operation === "put" ? { markdown: card.markdown } : {}),
+        },
+        respond,
+      );
+      try {
+        expect(harness[operation]).toHaveBeenCalledOnce();
+        expect(respond).not.toHaveBeenCalled();
+        expect(harness.broadcast).not.toHaveBeenCalled();
+      } finally {
+        release.resolve();
+        await pending;
+      }
+      expect(respond).toHaveBeenCalledExactlyOnceWith(true, { card }, undefined);
+      expect(harness.broadcast).toHaveBeenCalledTimes(operation === "put" ? 1 : 0);
+      if (operation === "put") {
+        expect(harness.broadcast).toHaveBeenCalledWith(
+          "progressCard.changed",
+          { sessionKey: card.sessionKey, revision: 3 },
+          { sessionKeys: [card.sessionKey], agentId: "main" },
+        );
+      }
+    },
+  );
+
+  it.each(["get", "put"] as const)(
+    "reports rejected %s without publishing or retrying",
+    async (operation) => {
+      const harness = createHarness();
+      const release = createDeferredCore();
+      harness.get.mockImplementationOnce(async () => {
+        await release.promise;
+        return null;
+      });
+      harness.put.mockImplementationOnce(async () => {
+        await release.promise;
+        return { card: null };
+      });
+      const respond = vi.fn<RespondFn>();
+      const pending = harness.invoke(
+        `progressCard.${operation}`,
+        { sessionKey: "agent:main:main" },
+        respond,
+      );
+      release.reject(new Error("storage unavailable"));
+      await pending;
+      expect(respond).toHaveBeenCalledExactlyOnceWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: "UNAVAILABLE",
+          message: expect.stringContaining("storage unavailable"),
+        }),
+      );
+      expect(harness.broadcast).not.toHaveBeenCalled();
+      expect(harness[operation]).toHaveBeenCalledOnce();
+    },
+  );
+
   it("registers read and write scopes", () => {
     expect(resolveCoreOperatorGatewayMethodScope("progressCard.get")).toBe("operator.read");
     expect(resolveCoreOperatorGatewayMethodScope("progressCard.put")).toBe("operator.write");

--- a/src/gateway/server-methods/progress-card.ts
+++ b/src/gateway/server-methods/progress-card.ts
@@ -11,6 +11,7 @@ import {
   ProgressCardInputError,
 } from "../../session-cards/progress-card-input.js";
 import { progressCardStore, type ProgressCardStore } from "../progress-card-store.js";
+import { SessionMutationAuthorizationChangedError } from "../session-mutation-authorization-error.js";
 import { sessionObserverScopeKey } from "../session-observer-model.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveSessionStoreKey } from "../session-store-key.js";
@@ -49,7 +50,7 @@ export function createProgressCardHandlers(
   store: ProgressCardStore = progressCardStore,
 ): GatewayRequestHandlers {
   return {
-    "progressCard.get": ({ params, respond, context, sessionMutationAuthorization }) => {
+    "progressCard.get": async ({ params, respond, context, sessionMutationAuthorization }) => {
       if (!assertValidParams(params, validateProgressCardGetParams, "progressCard.get", respond)) {
         return;
       }
@@ -60,13 +61,17 @@ export function createProgressCardHandlers(
       // Lazy handler preparation can outlive the session authorized by the router.
       sessionMutationAuthorization?.assertCurrent();
       try {
-        const card = store.get(session.sessionKey, session.agentId);
+        const card = await store.get(session.sessionKey, session.agentId);
+        sessionMutationAuthorization?.assertCurrent();
         respond(true, { card: projectProgressCard(card, session.scopeKey) }, undefined);
       } catch (error) {
+        if (error instanceof SessionMutationAuthorizationChangedError) {
+          throw error;
+        }
         respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(error)));
       }
     },
-    "progressCard.put": ({ params, respond, context, sessionMutationAuthorization }) => {
+    "progressCard.put": async ({ params, respond, context, sessionMutationAuthorization }) => {
       if (!assertValidParams(params, validateProgressCardPutParams, "progressCard.put", respond)) {
         return;
       }
@@ -97,7 +102,7 @@ export function createProgressCardHandlers(
       }
       sessionMutationAuthorization?.assertCurrent();
       try {
-        const result = store.put(
+        const result = await store.put(
           session.sessionKey,
           {
             ...input,
@@ -108,6 +113,7 @@ export function createProgressCardHandlers(
           },
           session.agentId,
         );
+        sessionMutationAuthorization?.assertCurrent();
         if (params.expectedRevision === undefined || result.card === null) {
           context.broadcast(
             "progressCard.changed",
@@ -120,6 +126,9 @@ export function createProgressCardHandlers(
         }
         respond(true, { card: projectProgressCard(result.card, session.scopeKey) }, undefined);
       } catch (error) {
+        if (error instanceof SessionMutationAuthorizationChangedError) {
+          throw error;
+        }
         respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(error)));
       }
     },


### PR DESCRIPTION
Closes #144526

## What Problem This Solves

The Gateway progress-card handlers assume their store completes synchronously. That prevents an asynchronous database implementation and would publish responses or change notifications before a delayed operation settles.

## Why This Change Was Made

Make the existing internal store contract return promises and await it in both handlers. SQLite remains the sole implementation, with unchanged synchronous transactions, SQL, schema, revisions, and conditional clears. Preserve the transaction's current-authority assertion, recheck authority before returning or broadcasting after an await, and let structured authorization failures reach the request router.

This is the SQLite-only preparation discussed in #144526. Public synchronous plugin APIs and atomic task/flow persistence are outside this change.

## User Impact

Normal progress-card behavior is unchanged. Callers no longer depend on immediate storage completion; failed or stale requests do not publish a successful result. A write that committed before authority changed remains committed and is not retried.

## Evidence

- All 56 focused Gateway tests pass on rebased head `9931bffee7a025a0e9efd09adc5fbbcc9506ee60`. Coverage includes delayed reads/writes, rejected storage, authority changes before commit and after completion, reopen, agent isolation, and revision handling. Both new response-ordering tests fail against the original handler for premature response.
- `node scripts/check-changed.mjs` passed before the patch-identical rebase; a fresh `pnpm build` passed afterward. Git range-diff confirms the reviewed patch is unchanged.
- Live proof was repeated on the rebuilt candidate using real loopback WebSocket RPC and fresh synthetic SQLite state: public session creation, Unicode roundtrip, agent isolation, stale/matching conditional clear, revision tombstone 1 → cleared → 3, and persistence after restart all passed. Both owned Gateway processes shut down cleanly; their port has no listener.
- Across 25 warmed synthetic loopback requests per operation, read median/p95 was 0.285/0.526 ms; write was 1.977/3.070 ms. These are absolute timings, not a speedup claim.
- Independent Codex review through P2 found no actionable issues. The inherited main UI budget failure was repaired separately in merged #144538 without changing budgets; this PR is rebased onto that repair. [Refreshed exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34550744398). Native prepare/merge completed, and the merged source was verified.
