### PR TITLE
fix: managed Linux updates fail during service activation

### DIFF
--- a/src/cli/update-cli/update-command-service-maintenance.test.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.test.ts
@@ -285,7 +285,7 @@ it.each([
   }),
 );
 
-it.runIf(process.platform === "linux" || process.platform === "darwin").each([
+const servingAncestorMaintenanceCases = [
   { platform: "linux", identity: "current updater", phase: "inspect", authorized: true },
   { platform: "linux", identity: "current updater", phase: "prepare", authorized: true },
   { platform: "darwin", identity: "current updater", phase: "inspect", authorized: true },
@@ -298,7 +298,15 @@ it.runIf(process.platform === "linux" || process.platform === "darwin").each([
   { platform: "linux", identity: "different run", phase: "prepare", authorized: false },
   { platform: "linux", identity: "stale start identity", phase: "prepare", authorized: false },
   { platform: "linux", identity: "parent lease", phase: "prepare", authorized: false },
-] as const)(
+] as const;
+
+it.runIf(process.platform === "linux" || process.platform === "darwin").each(
+  servingAncestorMaintenanceCases.filter(
+    // Binding a foreign PID reads native process identity, so only exercise that
+    // fixture where the simulated Linux policy matches the actual host.
+    ({ identity }) => identity !== "parent lease" || process.platform === "linux",
+  ),
+)(
   "keeps $platform serving-ancestor maintenance bound to the current updater: $identity $phase",
   ({ platform, identity, phase, authorized }) =>
     withServiceHome(async (home) => {

--- a/src/cli/update-cli/update-command-service-maintenance.test.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.test.ts
@@ -285,105 +285,179 @@ it.each([
   }),
 );
 
-it
-  .runIf(process.platform === "linux" || process.platform === "darwin")
-  .each([
-    "current updater",
-    "missing marker",
-    "missing metadata",
-    "missing lease",
-    "replaced owner",
-    "different root",
-    "different run",
-    "stale start identity",
-    "parent lease",
-    "native preparation",
-  ])("keeps serving-ancestor inspection bound to the current updater: %s", (scenario) =>
-  withServiceHome(async (home) => {
-    const root = await fs.realpath(process.cwd());
-    const metaPath = path.join(home, "handoff-meta.json");
-    vi.spyOn(openClawTmp, "resolvePreferredOpenClawTmpDir").mockReturnValue(home);
-    await fs.writeFile(
-      metaPath,
-      JSON.stringify({
-        version: 1,
-        meta: {
-          root: scenario === "different root" ? home : root,
-          runId: scenario === "different run" ? "other-run" : "update-run",
-          handoffId: "owned-handoff",
-        },
-      }),
-    );
-    const store = createManagedHandoffLeaseStore();
-    if (scenario !== "missing lease") {
-      const claim = store.acquire(
-        root,
-        scenario === "replaced owner" ? "replacement-handoff" : "owned-handoff",
-        { kind: "update" },
+it.runIf(process.platform === "linux" || process.platform === "darwin").each([
+  { platform: "linux", identity: "current updater", phase: "inspect", authorized: true },
+  { platform: "linux", identity: "current updater", phase: "prepare", authorized: true },
+  { platform: "darwin", identity: "current updater", phase: "inspect", authorized: true },
+  { platform: "darwin", identity: "current updater", phase: "prepare", authorized: false },
+  { platform: "linux", identity: "missing marker", phase: "prepare", authorized: false },
+  { platform: "linux", identity: "missing metadata", phase: "prepare", authorized: false },
+  { platform: "linux", identity: "missing lease", phase: "prepare", authorized: false },
+  { platform: "linux", identity: "replaced owner", phase: "prepare", authorized: false },
+  { platform: "linux", identity: "different root", phase: "prepare", authorized: false },
+  { platform: "linux", identity: "different run", phase: "prepare", authorized: false },
+  { platform: "linux", identity: "stale start identity", phase: "prepare", authorized: false },
+  { platform: "linux", identity: "parent lease", phase: "prepare", authorized: false },
+] as const)(
+  "keeps $platform serving-ancestor maintenance bound to the current updater: $identity $phase",
+  ({ platform, identity, phase, authorized }) =>
+    withServiceHome(async (home) => {
+      mockProcessPlatform(platform);
+      const root = await fs.realpath(process.cwd());
+      const metaPath = path.join(home, "handoff-meta.json");
+      const runId = randomUUID();
+      vi.spyOn(openClawTmp, "resolvePreferredOpenClawTmpDir").mockReturnValue(home);
+      createUpdateRun({ runId, trigger: "cli" }, { env: process.env });
+      await fs.writeFile(
+        metaPath,
+        JSON.stringify({
+          version: 1,
+          meta: {
+            root: identity === "different root" ? home : root,
+            runId: identity === "different run" ? randomUUID() : runId,
+            handoffId: "owned-handoff",
+          },
+        }),
       );
+      const store = createManagedHandoffLeaseStore();
+      if (identity !== "missing lease") {
+        const claim = store.acquire(
+          root,
+          identity === "replaced owner" ? "replacement-handoff" : "owned-handoff",
+          { kind: "update" },
+        );
+        if (claim.kind !== "acquired") {
+          throw new Error("fixture could not acquire its installation lease");
+        }
+        if (identity === "parent lease") {
+          expect(store.bind(claim.lease, process.ppid)).not.toBeNull();
+        } else if (identity === "stale start identity") {
+          const db = openNodeSqliteDatabase(path.join(home, "managed-update-handoffs.sqlite"));
+          try {
+            db.prepare(
+              "UPDATE managed_update_handoffs SET payload_json = json_set(payload_json, '$.executor.startIdentity', 'stale') WHERE install_root = ?",
+            ).run(root);
+          } finally {
+            db.close();
+          }
+        }
+      }
+      await withEnvAsync(
+        {
+          OPENCLAW_UPDATE_RUN_HANDOFF: identity === "missing marker" ? undefined : "1",
+          [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]:
+            identity === "missing metadata" ? undefined : metaPath,
+        },
+        async () => {
+          const service = createMockGatewayService({
+            readCommand: async () => ({
+              programArguments: [process.execPath, path.join(root, "openclaw.mjs"), "gateway"],
+              environment: { HOME: home },
+            }),
+            readRuntime: async () => ({
+              status: "running",
+              pid: process.ppid,
+              systemd: { managerUid: 2001 },
+            }),
+            isLoaded: async () => true,
+          });
+          mocks.service.mockReturnValue(service);
+          const inspected = await maybeStopManagedServiceBeforeMutableUpdate({
+            root,
+            updateInstallKind: "package",
+            shouldRestart: true,
+            jsonMode: true,
+            phase,
+            updateRun: { runId, env: process.env },
+            handoffFromGateway: async () => false,
+          });
+          expect(inspected.serviceUpdateVerdict?.kind).toBe("owned");
+          if (authorized) {
+            expect(inspected.blockMessage).toBeUndefined();
+          } else {
+            expect(inspected.blockMessage).toContain("inside the gateway process tree");
+          }
+          expect(service.stop).toHaveBeenCalledTimes(authorized && phase === "prepare" ? 1 : 0);
+          expect(service.start).not.toHaveBeenCalled();
+          expect(service.restart).not.toHaveBeenCalled();
+          expect(service.stage).not.toHaveBeenCalled();
+          expect(service.install).not.toHaveBeenCalled();
+        },
+      );
+    }),
+);
+
+it.runIf(process.platform === "linux")(
+  "rechecks the managed handoff identity immediately before stopping the Gateway",
+  () =>
+    withServiceHome(async (home) => {
+      const root = await fs.realpath(process.cwd());
+      const metaPath = path.join(home, "handoff-meta.json");
+      const runId = randomUUID();
+      createUpdateRun({ runId, trigger: "cli" }, { env: process.env });
+      await fs.writeFile(
+        metaPath,
+        JSON.stringify({
+          version: 1,
+          meta: { root, runId, handoffId: "owned-handoff" },
+        }),
+      );
+      const store = createManagedHandoffLeaseStore();
+      const claim = store.acquire(root, "owned-handoff", { kind: "update" });
       if (claim.kind !== "acquired") {
         throw new Error("fixture could not acquire its installation lease");
       }
-      if (scenario === "parent lease") {
-        expect(store.bind(claim.lease, process.ppid)).not.toBeNull();
-      } else if (scenario === "stale start identity") {
-        const db = openNodeSqliteDatabase(path.join(home, "managed-update-handoffs.sqlite"));
-        try {
-          db.prepare(
-            "UPDATE managed_update_handoffs SET payload_json = json_set(payload_json, '$.executor.startIdentity', 'stale') WHERE install_root = ?",
-          ).run(root);
-        } finally {
-          db.close();
-        }
-      }
-    }
-    await withEnvAsync(
-      {
-        OPENCLAW_UPDATE_RUN_HANDOFF: scenario === "missing marker" ? undefined : "1",
-        [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]:
-          scenario === "missing metadata" ? undefined : metaPath,
-      },
-      async () => {
-        const service = createMockGatewayService({
+      let runtimeReads = 0;
+      const stop = vi.fn(async () => undefined);
+      mocks.service.mockReturnValue(
+        createMockGatewayService({
           readCommand: async () => ({
             programArguments: [process.execPath, path.join(root, "openclaw.mjs"), "gateway"],
             environment: { HOME: home },
           }),
-          readRuntime: async () => ({
-            status: "running",
-            pid: process.ppid,
-            systemd: { managerUid: 2001 },
-          }),
+          readRuntime: async () => {
+            runtimeReads += 1;
+            if (runtimeReads === 2) {
+              const db = openNodeSqliteDatabase(path.join(home, "managed-update-handoffs.sqlite"));
+              try {
+                db.prepare(
+                  "UPDATE managed_update_handoffs SET payload_json = json_set(payload_json, '$.executor.startIdentity', 'replaced') WHERE install_root = ?",
+                ).run(root);
+              } finally {
+                db.close();
+              }
+            }
+            return {
+              status: "running",
+              pid: process.ppid,
+              systemd: { managerUid: 2001 },
+            };
+          },
           isLoaded: async () => true,
-        });
-        mocks.service.mockReturnValue(service);
-        const inspected = await maybeStopManagedServiceBeforeMutableUpdate({
-          root,
-          updateInstallKind: "package",
-          shouldRestart: true,
-          jsonMode: true,
-          phase: scenario === "native preparation" ? "prepare" : "inspect",
-          updateRun: { runId: "update-run", env: process.env },
-          handoffFromGateway: async () => false,
-        });
-        expect(inspected.serviceUpdateVerdict?.kind).toBe("owned");
-        if (scenario === "current updater") {
-          expect(inspected.blockMessage).toBeUndefined();
-        } else {
-          expect(inspected.blockMessage).toContain("inside the gateway process tree");
-        }
-        for (const mutate of [
-          service.stop,
-          service.start,
-          service.restart,
-          service.stage,
-          service.install,
-        ]) {
-          expect(mutate).not.toHaveBeenCalled();
-        }
-      },
-    );
-  }),
+          stop,
+        }),
+      );
+      await withEnvAsync(
+        {
+          OPENCLAW_UPDATE_RUN_HANDOFF: "1",
+          [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]: metaPath,
+        },
+        async () => {
+          await expect(
+            maybeStopManagedServiceBeforeMutableUpdate({
+              root,
+              updateInstallKind: "package",
+              shouldRestart: true,
+              jsonMode: true,
+              phase: "prepare",
+              updateRun: { runId, env: process.env },
+            }),
+          ).rejects.toThrow(/inside the gateway process tree/);
+        },
+      );
+      expect(runtimeReads).toBe(2);
+      expect(stop).not.toHaveBeenCalled();
+    }),
 );
 
 it.each([

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -370,6 +370,22 @@ async function stopManagedServiceBeforeMutableUpdate(
     assertNative?.();
     assertExecutor();
   };
+  // A Linux systemd scope changes cgroup ownership, not Unix ancestry. Reprove
+  // the exact current handoff lease at each boundary that can stop its ancestor.
+  const resolveAncestryBlock = async (state: GatewayServiceState) => {
+    const blockMessage = gatewayMaintenanceBlockMessage(state, params.root);
+    if (
+      !blockMessage ||
+      ((params.phase === "inspect" || process.platform === "linux") &&
+        (await isCurrentManagedServiceUpdateHandoffProcess({
+          root: params.root,
+          runId: params.updateRun?.runId,
+        })))
+    ) {
+      return undefined;
+    }
+    return blockMessage;
+  };
   assertCurrent();
   const uninspected = { stopped: false, inspected: false, runtimeInspected: false, running: false };
   const markInspectionUnavailable = (
@@ -490,17 +506,8 @@ async function stopManagedServiceBeforeMutableUpdate(
   }
   if (params.phase === "inspect") {
     const blockMessage = params.handoffFromGateway
-      ? gatewayMaintenanceBlockMessage(serviceState, params.root)
+      ? await resolveAncestryBlock(serviceState)
       : undefined;
-    if (
-      blockMessage &&
-      (await isCurrentManagedServiceUpdateHandoffProcess({
-        root: params.root,
-        runId: params.updateRun?.runId,
-      }))
-    ) {
-      return inspected;
-    }
     return blockMessage ? { ...inspected, blockMessage } : inspected;
   }
   const suspendTask = async () => {
@@ -545,7 +552,7 @@ async function stopManagedServiceBeforeMutableUpdate(
       ...(windowsTaskAutoStartRecovery ? { windowsTaskAutoStartRecovery } : {}),
     };
   }
-  const blockMessage = gatewayMaintenanceBlockMessage(serviceState, params.root);
+  const blockMessage = await resolveAncestryBlock(serviceState);
   if (blockMessage) {
     return { ...inspected, blockMessage };
   }
@@ -579,7 +586,7 @@ async function stopManagedServiceBeforeMutableUpdate(
       },
     });
     assertCurrent();
-    const currentBlockMessage = gatewayMaintenanceBlockMessage(currentState, params.root);
+    const currentBlockMessage = await resolveAncestryBlock(currentState);
     if (currentBlockMessage) {
       throw new UpdatePreMutationError("managed-service-preflight", currentBlockMessage);
     }


### PR DESCRIPTION
Related: #135655

## What Problem This Solves

Fixes an issue where Linux operators running an agent-initiated managed update could pass handoff inspection but have activation refused because the updater still appeared beneath the Gateway in the Unix process tree.

## Why This Change Was Made

Linux `systemd-run --user --scope` transfers cgroup ownership without changing Unix ancestry. This change consistently accepts only the existing, fully validated managed-handoff identity at every ancestry-sensitive stop boundary, including the final pre-stop revalidation; ordinary, stale, or mismatched callers remain blocked, and non-Linux behavior is unchanged.

## User Impact

Managed Linux updates can proceed from the authorized handoff into service activation instead of stopping at a false ancestry refusal. Existing Gateway self-stop protections remain in place for every caller that cannot prove the current handoff lease and process identity.

## Evidence

- `src/cli/update-cli/update-command-service-maintenance.test.ts`: 45/45 tests passed.
- Focused Linux lifecycle, PID identity, and cgroup selection: 6 tests passed (197 filtered).
- Isolated user-systemd proof confirmed that a helper remains in its separate scope when the parent `KillMode=control-group` service stops, retains the same PID/start identity, and terminates when its own scope stops.
- `oxfmt`, `oxlint`, core typecheck, and core-test typecheck passed on the committed head.
- `node scripts/check-changed.mjs -- <changed files>` passed before the final Linux-only refinement; final exact-head formatting, lint, and type checks passed afterward.
- Autoreview completed; its platform-widening finding was resolved by limiting activation authorization to Linux and adding regression coverage.
- ClawSweeper’s macOS portability finding was resolved on head `a457dd052847`: the foreign-PID lease fixture now runs only on a native Linux host while Linux activation and macOS refusal policy cases remain covered. The focused Linux suite passes 45/45; macOS CI is pending.

A real self-update and live Gateway activation were intentionally not run; validation used isolated service fixtures and a disposable user-systemd lifecycle proof.

