### PR TITLE
refactor(ui): avoid discarded sidebar layout indexes

### DIFF
--- a/ui/src/pages/chat/sidebar-layout-normalize.ts
+++ b/ui/src/pages/chat/sidebar-layout-normalize.ts
@@ -59,11 +59,13 @@ export function normalizeSidebarLayout(value: unknown): SidebarLayout {
   if (!isRecord(value) || !Array.isArray(value.columns)) {
     return { columns: [], open: false, expanded: false };
   }
-  const usedColumnIds = new Set<string>();
+  let columnId: string | undefined;
   const usedPanelIds = new Set<string>();
   const usedSlots = new Set<SidebarSlotId>();
   const panels: SidebarPanel[] = [];
-  const panelIdsBySource = new Map<string, string>();
+  const requestedMainId =
+    typeof value.mainPanelId === "string" ? value.mainPanelId.trim() : undefined;
+  let mainPanelId: string | undefined;
   let activePanelId = "";
   let width = DEFAULT_WIDTH;
   let height = DEFAULT_HEIGHT;
@@ -75,9 +77,10 @@ export function normalizeSidebarLayout(value: unknown): SidebarLayout {
     ) {
       continue;
     }
-    uniqueId(rawColumn.id, "column", usedColumnIds);
-    const columnPanels: SidebarPanel[] = [];
-    const panelIds = new Map<string, string>();
+    columnId ??= (typeof rawColumn.id === "string" ? rawColumn.id.trim() : "") || "column";
+    const requestedActiveId =
+      typeof rawColumn.activePanelId === "string" ? rawColumn.activePanelId.trim() : "";
+    let columnActivePanelId: string | undefined;
     for (const rawPanel of rawColumn.panels) {
       if (!isRecord(rawPanel)) {
         continue;
@@ -89,18 +92,16 @@ export function normalizeSidebarLayout(value: unknown): SidebarLayout {
       const rawPanelId = typeof rawPanel.id === "string" ? rawPanel.id.trim() : "";
       const panelId = uniqueId(rawPanel.id, slot, usedPanelIds);
       const sourceId = rawPanelId || (rawPanel.slot === "chat" ? "chat" : slot);
-      if (!panelIds.has(sourceId)) {
-        panelIds.set(sourceId, panelId);
+      if (sourceId === requestedActiveId) {
+        columnActivePanelId ??= panelId;
       }
-      if (!panelIdsBySource.has(sourceId)) {
-        panelIdsBySource.set(sourceId, panelId);
+      if (sourceId === requestedMainId) {
+        mainPanelId ??= panelId;
       }
       usedSlots.add(slot);
-      columnPanels.push({ id: panelId, slot });
+      panels.push({ id: panelId, slot });
     }
-    const requestedActiveId =
-      typeof rawColumn.activePanelId === "string" ? rawColumn.activePanelId.trim() : "";
-    activePanelId = panelIds.get(requestedActiveId) ?? activePanelId;
+    activePanelId = columnActivePanelId ?? activePanelId;
     width =
       typeof rawColumn.width === "number" && Number.isFinite(rawColumn.width)
         ? clampWidth(rawColumn.width)
@@ -109,11 +110,7 @@ export function normalizeSidebarLayout(value: unknown): SidebarLayout {
       typeof rawColumn.height === "number" && Number.isFinite(rawColumn.height)
         ? clampHeight(rawColumn.height)
         : height;
-    panels.push(...columnPanels);
   }
-  const requestedMainId =
-    typeof value.mainPanelId === "string" ? value.mainPanelId.trim() : undefined;
-  let mainPanelId = requestedMainId ? panelIdsBySource.get(requestedMainId) : undefined;
   let conversation = panels.find((panel) => panel.slot === "conversation");
   // Legacy expansion only hid chat while the side panel was open. A minimized
   // panel must not displace chat just because its old expanded flag was retained.
@@ -137,10 +134,10 @@ export function normalizeSidebarLayout(value: unknown): SidebarLayout {
     }
   }
   const columns =
-    usedColumnIds.size > 0 || panels.length > 0 || value.open === true
+    columnId || panels.length > 0 || value.open === true
       ? [
           {
-            id: usedColumnIds.values().next().value ?? "side-panel-column",
+            id: columnId ?? "side-panel-column",
             side: "right" as const,
             panels,
             activePanelId: panels.some(


### PR DESCRIPTION
Related: #144529

## What Problem This Solves

The Control UI startup bundle exceeds its existing size limit on unchanged main, blocking unrelated pull requests. The official Node 24.20.0 comparison reproduces 353,123 B against the 353,107 B limit at `a0c92e8cbd687fb262c92efd6a9e46132d661bd5`.

Sidebar layout normalization also builds indexes it immediately discards: all legacy columns collapse into one column, and the active/main panel indexes each serve a single lookup.

## Why This Change Was Made

Keep the first valid column ID and first matching active/main panel IDs directly, and append accepted panels in traversal order. This removes a Set, two Maps, and a temporary per-column panel array while preserving normalization output. Budget thresholds and build-variance allowances are unchanged.

## User Impact

No rendering, persisted-format, or migration behavior changes. Legacy sidebar layouts retain their selected panels, IDs, dimensions, ordering, and expansion behavior while normalization does less allocation and indexing.

## Evidence

- All 32 existing focused layout tests pass before and after.
- A task-local differential probe compares complete old/new output for 5,630 deterministic persisted JSON layouts, including duplicate, missing, blank, and padded IDs and legacy dashboard/expansion cases; all match.
- Official Node 24.20.0 performance comparison passes: startup gzip 353,123 → 353,087 B; raw startup 1,148,036 → 1,147,955 B. The existing limit stays 353,107 B.
- `node scripts/check-changed.mjs` passes, including core-test/UI typechecks, UI i18n, dead-export scans, and changed-file/style lint.
- Independent Codex review through P2: no actionable findings.
