### PR TITLE
test(ui): make catalog proof portable and opt-in

### DIFF
--- a/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
@@ -15,6 +15,7 @@ import { pickerValue } from "../test-helpers/select-picker-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const requireRecord = createRequireRecord("record", "expected-object-value");
+const captureEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const models = (id: string) => [
   { id: "anchor", name: "Anchor" },
   { id, name: id },
@@ -187,11 +188,14 @@ suite.define(() => {
           const pickers = settings.locator(".model-providers__defaults openclaw-select-picker");
           const primary = pickers.first();
           const trigger = primary.locator(".picker-select__trigger");
-          const capture = async (name: string) =>
-            fs.writeFile(
-              path.join(suite.artifactDir, name),
-              await takeControlUiViewportScreenshot(page, settings, [primary]),
-            );
+          const capture = async (name: string) => {
+            if (captureEnabled) {
+              await fs.writeFile(
+                path.join(suite.artifactDir, name),
+                await takeControlUiViewportScreenshot(page, settings, [primary]),
+              );
+            }
+          };
           await trigger.waitFor({ state: "visible" });
           await expect.poll(() => pickerValue(primary)).toBe("fixture/anchor");
           await expect
@@ -364,7 +368,7 @@ suite.define(() => {
         );
         expect(JSON.stringify(failed)).not.toContain("private upstream error body");
         await automations.getByText(warning, { exact: true }).waitFor({ state: "visible" });
-        await page.keyboard.press("Control+K");
+        await page.keyboard.press("ControlOrMeta+K");
         await page.locator(".cmd-palette__input").fill("refresh-fixture");
         const model = page.getByRole("option", {
           name: "refresh-fixture:latest ollama",
@@ -376,7 +380,9 @@ suite.define(() => {
           .locator(".cmd-palette")
           .getByText(warning, { exact: true })
           .waitFor({ state: "visible" });
-        await page.screenshot({ path: path.join(suite.artifactDir, "acquisition-failed.png") });
+        if (captureEnabled) {
+          await page.screenshot({ path: path.join(suite.artifactDir, "acquisition-failed.png") });
+        }
 
         providerMode = "empty";
         expect((await refresh()).providerOutcomes).toContainEqual({
@@ -389,7 +395,9 @@ suite.define(() => {
           .locator(".cmd-palette")
           .getByText(warning, { exact: true })
           .waitFor({ state: "hidden" });
-        await page.screenshot({ path: path.join(suite.artifactDir, "acquisition-empty.png") });
+        if (captureEnabled) {
+          await page.screenshot({ path: path.join(suite.artifactDir, "acquisition-empty.png") });
+        }
         console.log(
           "catalog-refresh-consumer-proof",
           JSON.stringify({
@@ -483,7 +491,7 @@ suite.define(() => {
           });
           await page.goto(browserUrl);
           await waitForControlUiGatewayReady(page);
-          await page.keyboard.press("Control+K");
+          await page.keyboard.press("ControlOrMeta+K");
           const input = page.locator(".cmd-palette__input");
           await input.fill("palette-");
           const retiring = page.getByRole("option", {
@@ -495,11 +503,15 @@ suite.define(() => {
             exact: true,
           });
           await retiring.waitFor({ state: "visible" });
-          await page.screenshot({ path: path.join(suite.artifactDir, "initial.png") });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(suite.artifactDir, "initial.png") });
+          }
           await publish("palette-published");
           await expect.poll(() => published.count()).toBe(1);
           expect(await retiring.count()).toBe(0);
-          await page.screenshot({ path: path.join(suite.artifactDir, "published.png") });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(suite.artifactDir, "published.png") });
+          }
 
           rejectCatalogReplies = true;
           await publish("palette-held");
@@ -508,7 +520,9 @@ suite.define(() => {
             .filter({ hasText: "Model search unavailable" });
           await status.waitFor({ state: "visible" });
           expect(await published.count()).toBe(1);
-          await page.screenshot({ path: path.join(suite.artifactDir, "read-failure.png") });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(suite.artifactDir, "read-failure.png") });
+          }
           rejectCatalogReplies = false;
           await input.fill("palette-held");
           const recovered = page.getByRole("option", { name: "palette-held fixture", exact: true });
@@ -516,8 +530,14 @@ suite.define(() => {
           await status.waitFor({ state: "hidden" });
           await input.press("Enter");
           await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-providers");
-          await page.screenshot({ path: path.join(suite.artifactDir, "recovered.png") });
+          // History changes before the new view commits; capture must not supply that wait.
+          const settings = page.locator("openclaw-model-providers-page");
+          await settings.waitFor({ state: "visible" });
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(suite.artifactDir, "recovered.png") });
+          }
           await page.goBack();
+          await settings.waitFor({ state: "hidden" });
           rejectCatalogReplies = true;
           const sidebar = page.locator("openclaw-app-sidebar");
           await sidebar.getByRole("button", { name: /Switch agent/ }).click();
@@ -526,7 +546,7 @@ suite.define(() => {
             .click();
           await expect.poll(() => new URL(page.url()).pathname).toBe("/chat/reviewer");
           const requestsBeforeOpen = catalogParams.length;
-          await page.keyboard.press("Control+K");
+          await page.keyboard.press("ControlOrMeta+K");
           await input.fill("palette");
           await status.waitFor({ state: "visible" });
           expect(catalogParams.length).toBeGreaterThan(requestsBeforeOpen);
@@ -535,9 +555,11 @@ suite.define(() => {
             agentId: "reviewer",
           });
           expect(await recovered.count()).toBe(0);
-          await page.screenshot({
-            path: path.join(suite.artifactDir, "selected-agent-failure.png"),
-          });
+          if (captureEnabled) {
+            await page.screenshot({
+              path: path.join(suite.artifactDir, "selected-agent-failure.png"),
+            });
+          }
           rejectCatalogReplies = false;
           await input.fill("palette-held");
           await recovered.waitFor({ state: "visible" });


### PR DESCRIPTION
## What Problem This Solves

Catalog browser tests used Control+K on macOS, where the command palette uses Command+K. Two cases timed out waiting for a palette that never opened. The same file also produced eleven success screenshots during ordinary CI despite the existing proof-capture setting being disabled.

## Why This Change Was Made

Use Playwright's platform-aware ControlOrMeta modifier and apply the existing capture opt-in to the file's screenshot calls. Wait for the Settings view to appear and disappear around history navigation, so screenshots are no longer supplying that synchronization.

All three cases and their catalog, failure, recovery, selected-agent and publication assertions remain. JSON/log/asset evidence and automatic failure diagnostics retain their existing owners.

## User Impact

Test-only repair and efficiency improvement. macOS executes the intended shortcut, while Linux and Windows retain Control+K. Ordinary runs avoid eleven optional PNGs; explicit capture retains the same stage filenames. CI shard counts and production behavior are unchanged.

## Evidence

- The original two macOS palette timeouts are retained as failing evidence. The corrected full three-case file passed on Node 24.20.0.
- All three cases passed with capture disabled: zero PNGs and all four unconditional JSON/log files.
- All three cases passed with capture enabled: all eleven valid PNGs and the same four JSON/log files.
- Native process cleanup and runtime/dependency seals passed for both runs. No runtime rebuild occurred during the tests.
- Selected changed-file checks and independent P2 review passed after relocating the patch onto current main.

The local runs used the recorded built runtime and are functional proofs, not a whole-CI performance comparison. Exact-head CI will build the current runtime and remains required before landing.
