### PR TITLE
docs(web-search): explain Perplexity time filter limits

### DIFF
--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -117,15 +117,15 @@ ISO 639-1 language code (e.g. `en`, `de`, `fr`).
 </ParamField>
 
 <ParamField path="freshness" type="'day' | 'week' | 'month' | 'year'">
-Time filter - `day` is 24 hours.
+Time filter - `day` is 24 hours. Cannot be combined with `date_after` or `date_before`.
 </ParamField>
 
 <ParamField path="date_after" type="string">
-Only results published after this date (`YYYY-MM-DD`).
+Only results published after this date (`YYYY-MM-DD`). Use a date range instead of `freshness`.
 </ParamField>
 
 <ParamField path="date_before" type="string">
-Only results published before this date (`YYYY-MM-DD`).
+Only results published before this date (`YYYY-MM-DD`). Use a date range instead of `freshness`.
 </ParamField>
 
 <ParamField path="domain_filter" type="string[]">

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -471,20 +471,20 @@ provider, OpenClaw does not show the `x_search` prompt.
 
 ## Tool parameters
 
-| Parameter             | Description                                                        |
-| --------------------- | ------------------------------------------------------------------ |
-| `query`               | Search query (required)                                            |
-| `count`               | Results to return (1-10, default: 5)                               |
-| `country`             | 2-letter ISO country code (e.g. "US", "DE")                        |
-| `language`            | ISO 639-1 language code (e.g. "en", "de")                          |
-| `search_lang`         | Search-language code (Brave only)                                  |
-| `freshness`           | Time filter: `day`, `week`, `month`, or `year`                     |
-| `date_after`          | Results after this date (YYYY-MM-DD)                               |
-| `date_before`         | Results before this date (YYYY-MM-DD)                              |
-| `ui_lang`             | UI language code (Brave only)                                      |
-| `domain_filter`       | Domain allowlist/denylist array (Perplexity only)                  |
-| `max_tokens`          | Total content token budget, native Perplexity Search API only      |
-| `max_tokens_per_page` | Per-page extraction token limit, native Perplexity Search API only |
+| Parameter             | Description                                                                                                    |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `query`               | Search query (required)                                                                                        |
+| `count`               | Results to return (1-10, default: 5)                                                                           |
+| `country`             | 2-letter ISO country code (e.g. "US", "DE")                                                                    |
+| `language`            | ISO 639-1 language code (e.g. "en", "de")                                                                      |
+| `search_lang`         | Search-language code (Brave only)                                                                              |
+| `freshness`           | Time filter: `day`, `week`, `month`, or `year`; Perplexity cannot combine this with `date_after`/`date_before` |
+| `date_after`          | Results after this date (YYYY-MM-DD); for Perplexity, use instead of `freshness`                               |
+| `date_before`         | Results before this date (YYYY-MM-DD); for Perplexity, use instead of `freshness`                              |
+| `ui_lang`             | UI language code (Brave only)                                                                                  |
+| `domain_filter`       | Domain allowlist/denylist array (Perplexity only)                                                              |
+| `max_tokens`          | Total content token budget, native Perplexity Search API only                                                  |
+| `max_tokens_per_page` | Per-page extraction token limit, native Perplexity Search API only                                             |
 
 <Warning>
   Not all parameters work with all providers. Brave `llm-context` mode

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -28,7 +28,8 @@ function createPerplexityParameters(transport?: string): Record<string, unknown>
     },
     freshness: {
       type: "string",
-      description: "Filter by time: 'day' (24h), 'week', 'month', or 'year'.",
+      description:
+        "Filter by time: 'day' (24h), 'week', 'month', or 'year'. Cannot be combined with date_after/date_before.",
     },
   };
 
@@ -44,12 +45,12 @@ function createPerplexityParameters(transport?: string): Record<string, unknown>
     properties.date_after = {
       type: "string",
       description:
-        "Native Perplexity Search API only. Only results published after this date (YYYY-MM-DD).",
+        "Native Perplexity Search API only. Only results published after this date (YYYY-MM-DD); use instead of freshness.",
     };
     properties.date_before = {
       type: "string",
       description:
-        "Native Perplexity Search API only. Only results published before this date (YYYY-MM-DD).",
+        "Native Perplexity Search API only. Only results published before this date (YYYY-MM-DD); use instead of freshness.",
     };
     properties.domain_filter = {
       type: "array",

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -29,7 +29,7 @@ function createPerplexityParameters(transport?: string): Record<string, unknown>
     freshness: {
       type: "string",
       description:
-        "Filter by time: 'day' (24h), 'week', 'month', or 'year'. Cannot be combined with date_after/date_before.",
+        "Filter by time: 'day' (24h), 'week', 'month', or 'year'; choose this or a date range.",
     },
   };
 
@@ -45,12 +45,12 @@ function createPerplexityParameters(transport?: string): Record<string, unknown>
     properties.date_after = {
       type: "string",
       description:
-        "Native Perplexity Search API only. Only results published after this date (YYYY-MM-DD); use instead of freshness.",
+        "Native Perplexity Search API only. Only results published after this date (YYYY-MM-DD).",
     };
     properties.date_before = {
       type: "string",
       description:
-        "Native Perplexity Search API only. Only results published before this date (YYYY-MM-DD); use instead of freshness.",
+        "Native Perplexity Search API only. Only results published before this date (YYYY-MM-DD).",
     };
     properties.domain_filter = {
       type: "array",

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -39,18 +39,15 @@ const WebSearchSchema = {
     },
     freshness: {
       type: "string",
-      description:
-        "Time filter: day/week/month/year. For Perplexity, cannot be combined with date_after/date_before.",
+      description: "Time filter: day/week/month/year (Perplexity: choose this or a date range).",
     },
     date_after: {
       type: "string",
-      description:
-        "Published after YYYY-MM-DD. For Perplexity, use this date range instead of freshness.",
+      description: "Published after YYYY-MM-DD.",
     },
     date_before: {
       type: "string",
-      description:
-        "Published before YYYY-MM-DD. For Perplexity, use this date range instead of freshness.",
+      description: "Published before YYYY-MM-DD.",
     },
     search_lang: {
       type: "string",
@@ -102,7 +99,7 @@ export function createWebSearchTool(options?: {
     name: "web_search",
     resultContentSource: "network",
     description:
-      "Search current web; normalized provider results. Supports freshness or date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter). Perplexity cannot combine freshness with date_after/date_before.",
+      "Search current web; normalized provider results. Supports freshness and date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter). Perplexity time filters are mutually exclusive.",
     parameters: WebSearchSchema,
     outputSchema: WebSearchOutputSchema,
     execute: async (_toolCallId, args, signal) => {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -39,15 +39,18 @@ const WebSearchSchema = {
     },
     freshness: {
       type: "string",
-      description: "Time filter: day/week/month/year.",
+      description:
+        "Time filter: day/week/month/year. For Perplexity, cannot be combined with date_after/date_before.",
     },
     date_after: {
       type: "string",
-      description: "Published after YYYY-MM-DD.",
+      description:
+        "Published after YYYY-MM-DD. For Perplexity, use this date range instead of freshness.",
     },
     date_before: {
       type: "string",
-      description: "Published before YYYY-MM-DD.",
+      description:
+        "Published before YYYY-MM-DD. For Perplexity, use this date range instead of freshness.",
     },
     search_lang: {
       type: "string",
@@ -99,7 +102,7 @@ export function createWebSearchTool(options?: {
     name: "web_search",
     resultContentSource: "network",
     description:
-      "Search current web; normalized provider results. Supports freshness and date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter).",
+      "Search current web; normalized provider results. Supports freshness or date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter). Perplexity cannot combine freshness with date_after/date_before.",
     parameters: WebSearchSchema,
     outputSchema: WebSearchOutputSchema,
     execute: async (_toolCallId, args, signal) => {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1307,7 +1307,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search current web; normalized provider results. Supports freshness or date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter). Perplexity cannot combine freshness with date_after/date_before.",
+        "description": "Search current web; normalized provider results. Supports freshness and date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter). Perplexity time filters are mutually exclusive.",
         "inputSchema": {
           "properties": {
             "count": {
@@ -1321,11 +1321,11 @@
               "type": "string"
             },
             "date_after": {
-              "description": "Published after YYYY-MM-DD. For Perplexity, use this date range instead of freshness.",
+              "description": "Published after YYYY-MM-DD.",
               "type": "string"
             },
             "date_before": {
-              "description": "Published before YYYY-MM-DD. For Perplexity, use this date range instead of freshness.",
+              "description": "Published before YYYY-MM-DD.",
               "type": "string"
             },
             "domain_filter": {
@@ -1336,7 +1336,7 @@
               "type": "array"
             },
             "freshness": {
-              "description": "Time filter: day/week/month/year. For Perplexity, cannot be combined with date_after/date_before.",
+              "description": "Time filter: day/week/month/year (Perplexity: choose this or a date range).",
               "type": "string"
             },
             "language": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1307,7 +1307,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search current web; normalized provider results. Supports freshness and date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter).",
+        "description": "Search current web; normalized provider results. Supports freshness or date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter). Perplexity cannot combine freshness with date_after/date_before.",
         "inputSchema": {
           "properties": {
             "count": {
@@ -1321,11 +1321,11 @@
               "type": "string"
             },
             "date_after": {
-              "description": "Published after YYYY-MM-DD.",
+              "description": "Published after YYYY-MM-DD. For Perplexity, use this date range instead of freshness.",
               "type": "string"
             },
             "date_before": {
-              "description": "Published before YYYY-MM-DD.",
+              "description": "Published before YYYY-MM-DD. For Perplexity, use this date range instead of freshness.",
               "type": "string"
             },
             "domain_filter": {
@@ -1336,7 +1336,7 @@
               "type": "array"
             },
             "freshness": {
-              "description": "Time filter: day/week/month/year.",
+              "description": "Time filter: day/week/month/year. For Perplexity, cannot be combined with date_after/date_before.",
               "type": "string"
             },
             "language": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=8f511ca8979aecb9ae5d8990e97aba5a0a61aff814691ea08dda61b40acaa9e9
-+++ discord-group-codex-message-tool.md	sha256=1d7da0fb9a64fa0ce65cfd6434efcb2da67e73387ab3990884ce2d2dc6236efa
+--- telegram-direct-codex-message-tool.md	sha256=1dac85caaf39adce663794bba6c8cdf75f41b7e2505471eb4cf991c201eeee1a
++++ discord-group-codex-message-tool.md	sha256=eef5f28a310c5fb7cfee1c00c6c52b32b8522b254d789b8139c42b5c0edf403d
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -32,10 +32,10 @@
 -    "chars": 882,
 +    "chars": 881,
 @@ -255,2 +255,2 @@
--    "chars": 58556,
--    "roughTokens": 14639
-+    "chars": 59112,
-+    "roughTokens": 14778
+-    "chars": 58402,
+-    "roughTokens": 14601
++    "chars": 58958,
++    "roughTokens": 14740
 @@ -259,2 +259,2 @@
 -    "chars": 2629,
 -    "roughTokens": 658
@@ -47,10 +47,10 @@
 +    "chars": 27781,
 +    "roughTokens": 6946
 @@ -271,2 +271,2 @@
--    "chars": 85021,
--    "roughTokens": 21256
-+    "chars": 86895,
-+    "roughTokens": 21724
+-    "chars": 84867,
+-    "roughTokens": 21217
++    "chars": 86741,
++    "roughTokens": 21686
 @@ -275,2 +275,2 @@
 -    "chars": 793,
 -    "roughTokens": 199

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=0f66cb93e3f9d3181dc10620a601a89904c8a54dc7c334df753e7625ec5f5b08
-+++ discord-group-codex-message-tool.md	sha256=d36e513baae102afa42ee17b8066382974b595bb24dc42d45e9447c20591bc3d
+--- telegram-direct-codex-message-tool.md	sha256=8f511ca8979aecb9ae5d8990e97aba5a0a61aff814691ea08dda61b40acaa9e9
++++ discord-group-codex-message-tool.md	sha256=1d7da0fb9a64fa0ce65cfd6434efcb2da67e73387ab3990884ce2d2dc6236efa
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -32,10 +32,10 @@
 -    "chars": 882,
 +    "chars": 881,
 @@ -255,2 +255,2 @@
--    "chars": 58312,
--    "roughTokens": 14578
-+    "chars": 58868,
-+    "roughTokens": 14717
+-    "chars": 58556,
+-    "roughTokens": 14639
++    "chars": 59112,
++    "roughTokens": 14778
 @@ -259,2 +259,2 @@
 -    "chars": 2629,
 -    "roughTokens": 658
@@ -47,10 +47,10 @@
 +    "chars": 27781,
 +    "roughTokens": 6946
 @@ -271,2 +271,2 @@
--    "chars": 84777,
--    "roughTokens": 21195
-+    "chars": 86651,
-+    "roughTokens": 21663
+-    "chars": 85021,
+-    "roughTokens": 21256
++    "chars": 86895,
++    "roughTokens": 21724
 @@ -275,2 +275,2 @@
 -    "chars": 793,
 -    "roughTokens": 199

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -252,8 +252,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 58556,
-    "roughTokens": 14639
+    "chars": 58402,
+    "roughTokens": 14601
   },
   "openClawDeveloperInstructions": {
     "chars": 2629,
@@ -268,8 +268,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6616
   },
   "totalWithDynamicToolsJson": {
-    "chars": 85021,
-    "roughTokens": 21256
+    "chars": 84867,
+    "roughTokens": 21217
   },
   "userInputText": {
     "chars": 793,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -252,8 +252,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 58312,
-    "roughTokens": 14578
+    "chars": 58556,
+    "roughTokens": 14639
   },
   "openClawDeveloperInstructions": {
     "chars": 2629,
@@ -268,8 +268,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6616
   },
   "totalWithDynamicToolsJson": {
-    "chars": 84777,
-    "roughTokens": 21195
+    "chars": 85021,
+    "roughTokens": 21256
   },
   "userInputText": {
     "chars": 793,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=8f511ca8979aecb9ae5d8990e97aba5a0a61aff814691ea08dda61b40acaa9e9
-+++ telegram-heartbeat-codex-tool.md	sha256=5af58fdd83d4c5a5dc5f81d35639aa9e3be1e612ff3d329d45ac9909bfce3ed7
+--- telegram-direct-codex-message-tool.md	sha256=1dac85caaf39adce663794bba6c8cdf75f41b7e2505471eb4cf991c201eeee1a
++++ telegram-heartbeat-codex-tool.md	sha256=22373cb5c3166e0954c9669a9a4e273de783ee2daeee5ec3983e155bcb195873
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -35,20 +35,20 @@
 +    "chars": 752,
 +    "roughTokens": 188
 @@ -255,2 +252,2 @@
--    "chars": 58556,
--    "roughTokens": 14639
-+    "chars": 60049,
-+    "roughTokens": 15013
+-    "chars": 58402,
+-    "roughTokens": 14601
++    "chars": 59895,
++    "roughTokens": 14974
 @@ -267,2 +264,2 @@
 -    "chars": 26463,
 -    "roughTokens": 6616
 +    "chars": 26675,
 +    "roughTokens": 6669
 @@ -271,2 +268,2 @@
--    "chars": 85021,
--    "roughTokens": 21256
-+    "chars": 86726,
-+    "roughTokens": 21682
+-    "chars": 84867,
+-    "roughTokens": 21217
++    "chars": 86572,
++    "roughTokens": 21643
 @@ -275,2 +272,2 @@
 -    "chars": 793,
 -    "roughTokens": 199

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=0f66cb93e3f9d3181dc10620a601a89904c8a54dc7c334df753e7625ec5f5b08
-+++ telegram-heartbeat-codex-tool.md	sha256=9fb32da8ea040d2c4b35c092cb0514a75d56f1aed05ff75d0da703abbd828794
+--- telegram-direct-codex-message-tool.md	sha256=8f511ca8979aecb9ae5d8990e97aba5a0a61aff814691ea08dda61b40acaa9e9
++++ telegram-heartbeat-codex-tool.md	sha256=5af58fdd83d4c5a5dc5f81d35639aa9e3be1e612ff3d329d45ac9909bfce3ed7
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -35,20 +35,20 @@
 +    "chars": 752,
 +    "roughTokens": 188
 @@ -255,2 +252,2 @@
--    "chars": 58312,
--    "roughTokens": 14578
-+    "chars": 59805,
-+    "roughTokens": 14952
+-    "chars": 58556,
+-    "roughTokens": 14639
++    "chars": 60049,
++    "roughTokens": 15013
 @@ -267,2 +264,2 @@
 -    "chars": 26463,
 -    "roughTokens": 6616
 +    "chars": 26675,
 +    "roughTokens": 6669
 @@ -271,2 +268,2 @@
--    "chars": 84777,
--    "roughTokens": 21195
-+    "chars": 86482,
-+    "roughTokens": 21621
+-    "chars": 85021,
+-    "roughTokens": 21256
++    "chars": 86726,
++    "roughTokens": 21682
 @@ -275,2 +272,2 @@
 -    "chars": 793,
 -    "roughTokens": 199


### PR DESCRIPTION
Closes #144500

## What Problem This Solves

Resolves a documentation and tool-guidance gap where `web_search` users cannot see that Perplexity rejects `freshness` together with `date_after` or `date_before`.

## Why This Change Was Made

The existing Perplexity validator already returns an actionable conflict error before any network request. This change documents that mutual exclusion in the shared tool schema, the Perplexity provider schema, and both public web-search references so callers can choose either a relative freshness filter or an explicit date range.

## User Impact

Agents and operators receive clear parameter guidance before making a rejected Perplexity search request. Existing validation, error behavior, and provider support remain unchanged.

## Evidence

- `extensions/perplexity/src/perplexity-web-search-provider.runtime.ts` and `src/agents/tools/web-search-provider-common.ts` were inspected: the existing `conflicting_time_filters` validation rejects the combination before transport execution.
- `node scripts/run-vitest.mjs extensions/perplexity/src/perplexity-web-search-provider.test.ts src/agents/tools/web-search.test.ts` passed: 48 Perplexity tests and 55 shared web-search tests.
- `pnpm docs:check-mdx` passed (1,294 files).
- `pnpm docs:check-links` passed (`broken_links=0`, 13,297 internal links checked).
- `oxfmt --check` and `git diff --check` passed.

The exact-head production tool constructors were executed without mocks via `node --import ./scripts/tsx.mjs proof-144500.ts`. The captured output showed the shared tool description says `Perplexity time filters are mutually exclusive`, its freshness field says to choose freshness or a date range, and the native Perplexity freshness field says to choose it or a date range. The date fields remain their existing published-date descriptions.

Prompt snapshots were regenerated and `pnpm prompt:snapshots:check` passed. This change does not alter validation, transport, or any external API contract, so no external search service call is required.
