### PR TITLE
fix(agents): honor provider backoff during stale recovery

### DIFF
--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -362,6 +362,7 @@ describe("agentCommand compaction transcript rotation", () => {
           activeWriterRunId: params.runId,
         }));
         params.deferredLifecycle?.adopt({
+          beginRetryWait: () => undefined,
           discard: () => {},
           complete: async () => {
             expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -3598,6 +3598,7 @@ describe("CLI attempt execution", () => {
     const handoffToCli = vi.fn();
     const deferredLifecycle: NonNullable<RunAgentAttemptParams["deferredLifecycle"]> = {
       signal: controller.signal,
+      beginRetryWait: () => undefined,
       abort: vi.fn(),
       adopt: vi.fn(),
       handoffToCli,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1401,6 +1401,7 @@ export function runAgentAttempt(params: {
     deferTerminalLifecycle: params.deferTerminalLifecycle,
     onDeferredLifecycleOwner: params.deferredLifecycle?.adopt,
     onDeferredLifecycleAbort: params.deferredLifecycle?.abort,
+    onRetryWait: params.deferredLifecycle?.beginRetryWait,
     suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
     userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
     assistantErrorTranscript: params.assistantErrorTranscript,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { runWithOwnedSessionTranscriptWrite } from "../../../config/sessions/transcript-write-context.js";
 import { captureAgentRunLifecycleGeneration } from "../../../infra/agent-events.js";
+import { validateAgentRunDelegatedAuthority } from "../../../infra/agent-run-registry.js";
 import {
   freezeDiagnosticTraceContext,
   type DiagnosticTraceContext,
@@ -688,6 +689,13 @@ export function prepareEmbeddedAttemptStream(input: {
     deferredLifecycleOwner = createEmbeddedAttemptDeferredLifecycleOwner({
       runId: attempt.runId,
       sessionId: attempt.sessionId,
+      diagnosticOwner: input.diagnosticOwner,
+      onRetryWaitCompleted: () => attempt.replyOperation?.recordActivity(),
+      isCurrent: () =>
+        registration?.delegatedAuthority !== undefined &&
+        validateAgentRunDelegatedAuthority(registration.delegatedAuthority) &&
+        ACTIVE_EMBEDDED_RUN_REGISTRATIONS.get(queueHandle) === registration &&
+        ACTIVE_EMBEDDED_RUNS.get(attempt.sessionId) === queueHandle,
       trajectoryRecorder: input.trajectoryRecorder ?? null,
       clearActiveRun: () =>
         clearActiveEmbeddedRun(

--- a/src/agents/embedded-agent-runner/run/deferred-lifecycle-owner.test.ts
+++ b/src/agents/embedded-agent-runner/run/deferred-lifecycle-owner.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveReplyOperationAbortReason } from "../../../auto-reply/reply/reply-operation-abort.js";
 import {
+  createDiagnosticEmbeddedRunOwner,
+  getDiagnosticSessionActivitySnapshot,
+  markDiagnosticEmbeddedRunStarted,
+  closeDiagnosticEmbeddedRunOwner,
+} from "../../../logging/diagnostic-run-activity.js";
+import {
   isAgentRunRestartAbortReason,
   isAgentRunSupersededAbortReason,
   resolveAgentRunErrorLifecycleFields,
@@ -109,7 +115,11 @@ describe("deferred logical-turn lifecycle", () => {
       sessionId,
       sessionKey,
     });
-    manager.adopt({ complete: async () => clearEmbedded(), discard: clearEmbedded });
+    manager.adopt({
+      beginRetryWait: () => undefined,
+      complete: async () => clearEmbedded(),
+      discard: clearEmbedded,
+    });
 
     manager.handoffToCli();
 
@@ -129,6 +139,9 @@ describe("deferred logical-turn lifecycle", () => {
     const discarded = createEmbeddedAttemptDeferredLifecycleOwner({
       runId: "logical-run",
       sessionId,
+      diagnosticOwner: createDiagnosticEmbeddedRunOwner({ runId: "logical-run", sessionId }),
+      isCurrent: () => true,
+      onRetryWaitCompleted: () => {},
       trajectoryRecorder: { recordEvent, flush, describeFlushState: () => undefined },
       clearActiveRun,
     });
@@ -139,6 +152,9 @@ describe("deferred logical-turn lifecycle", () => {
     const accepted = createEmbeddedAttemptDeferredLifecycleOwner({
       runId: "logical-run",
       sessionId,
+      diagnosticOwner: createDiagnosticEmbeddedRunOwner({ runId: "logical-run", sessionId }),
+      isCurrent: () => true,
+      onRetryWaitCompleted: () => {},
       trajectoryRecorder: { recordEvent, flush, describeFlushState: () => undefined },
       clearActiveRun,
     });
@@ -149,5 +165,89 @@ describe("deferred logical-turn lifecycle", () => {
     expect(recordEvent).toHaveBeenCalledWith("session.ended", { status: "success" });
     expect(flush).toHaveBeenCalledOnce();
     expect(clearActiveRun).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["abort", "timeout", "complete", "replace", "close", "authority"] as const)(
+    "releases a retry wait when its owner loses authority through %s",
+    async (reason) => {
+      const ref = { runId: "waiting-run", sessionId, sessionKey };
+      const diagnosticOwner = createDiagnosticEmbeddedRunOwner(ref);
+      markDiagnosticEmbeddedRunStarted({ ...ref, owner: diagnosticOwner });
+      let current = true;
+      const onRetryWaitCompleted = vi.fn();
+      const manager = createDeferredEmbeddedRunLifecycleManager(ref);
+      manager.adopt(
+        createEmbeddedAttemptDeferredLifecycleOwner({
+          ...ref,
+          diagnosticOwner,
+          isCurrent: () => current,
+          onRetryWaitCompleted,
+          trajectoryRecorder: null,
+          clearActiveRun: () => closeDiagnosticEmbeddedRunOwner(diagnosticOwner),
+        }),
+      );
+      const timeout = new AbortController();
+      const deadlineAtMs = Date.now() + 660_000;
+      const release = manager.beginRetryWait(deadlineAtMs, timeout.signal);
+      try {
+        expect(getDiagnosticSessionActivitySnapshot(ref).activeRetryWaitDeadlineAtMs).toBe(
+          deadlineAtMs,
+        );
+        if (reason === "abort") {
+          manager.abort();
+        } else if (reason === "timeout") {
+          timeout.abort(new DOMException("Execution deadline reached", "TimeoutError"));
+        } else if (reason === "complete") {
+          await manager.complete();
+        } else if (reason === "replace") {
+          manager.adopt({
+            beginRetryWait: () => undefined,
+            complete: async () => {},
+            discard: () => {},
+          });
+        } else if (reason === "close") {
+          closeDiagnosticEmbeddedRunOwner(diagnosticOwner);
+        } else {
+          current = false;
+        }
+        expect(
+          getDiagnosticSessionActivitySnapshot(ref).activeRetryWaitDeadlineAtMs,
+        ).toBeUndefined();
+      } finally {
+        expect(onRetryWaitCompleted).not.toHaveBeenCalled();
+        release?.();
+        await manager.complete();
+      }
+    },
+  );
+
+  it("does not let a completed wait release its owner's next wait", async () => {
+    const ref = { runId: "reused-wait-owner", sessionId, sessionKey };
+    const diagnosticOwner = createDiagnosticEmbeddedRunOwner(ref);
+    markDiagnosticEmbeddedRunStarted({ ...ref, owner: diagnosticOwner });
+    const manager = createDeferredEmbeddedRunLifecycleManager(ref);
+    manager.adopt(
+      createEmbeddedAttemptDeferredLifecycleOwner({
+        ...ref,
+        diagnosticOwner,
+        isCurrent: () => true,
+        onRetryWaitCompleted: () => {},
+        trajectoryRecorder: null,
+        clearActiveRun: () => closeDiagnosticEmbeddedRunOwner(diagnosticOwner),
+      }),
+    );
+    try {
+      const releaseFirst = manager.beginRetryWait(Date.now() + 660_000);
+      const nextDeadline = Date.now() + 900_000;
+      const releaseNext = manager.beginRetryWait(nextDeadline);
+      releaseFirst?.();
+      expect(getDiagnosticSessionActivitySnapshot(ref).activeRetryWaitDeadlineAtMs).toBe(
+        nextDeadline,
+      );
+      releaseNext?.();
+      expect(getDiagnosticSessionActivitySnapshot(ref).activeRetryWaitDeadlineAtMs).toBeUndefined();
+    } finally {
+      await manager.complete();
+    }
   });
 });

--- a/src/agents/embedded-agent-runner/run/deferred-lifecycle-owner.ts
+++ b/src/agents/embedded-agent-runner/run/deferred-lifecycle-owner.ts
@@ -1,5 +1,6 @@
 import { formatErrorMessage } from "../../../infra/errors.js";
 import {
+  beginDiagnosticRetryWait,
   closeDiagnosticEmbeddedRunOwner,
   createDiagnosticEmbeddedRunOwner,
   type DiagnosticEmbeddedRunOwner,
@@ -21,6 +22,10 @@ type DeferredTrajectoryRecorder = {
 };
 
 export type DeferredEmbeddedRunLifecycleOwner = {
+  beginRetryWait: (
+    deadlineAtMs: number,
+    signal: AbortSignal,
+  ) => ((completed?: boolean) => void) | undefined;
   complete: () => Promise<void>;
   discard: () => void;
 };
@@ -32,11 +37,19 @@ export type EmbeddedAttemptDeferredLifecycleOwner = DeferredEmbeddedRunLifecycle
 export function createEmbeddedAttemptDeferredLifecycleOwner(params: {
   runId: string;
   sessionId: string;
+  diagnosticOwner: DiagnosticEmbeddedRunOwner;
+  isCurrent: () => boolean;
+  onRetryWaitCompleted: () => void;
   trajectoryRecorder: DeferredTrajectoryRecorder | null;
   clearActiveRun: () => void;
 }): EmbeddedAttemptDeferredLifecycleOwner {
   let state: "pending" | "completed" | "discarded" = "pending";
   let sessionEndData: Record<string, unknown> | undefined;
+  let closeRetryWait: (() => void) | undefined;
+  const releaseRetryWait = () => {
+    closeRetryWait?.();
+    closeRetryWait = undefined;
+  };
   const releaseActiveRun = () => {
     try {
       params.clearActiveRun();
@@ -48,6 +61,31 @@ export function createEmbeddedAttemptDeferredLifecycleOwner(params: {
     }
   };
   return {
+    beginRetryWait: (deadlineAtMs, signal) => {
+      if (state !== "pending") {
+        return undefined;
+      }
+      releaseRetryWait();
+      const close = beginDiagnosticRetryWait({
+        owner: params.diagnosticOwner,
+        deadlineAtMs,
+        signal,
+        assertCurrent: () => {
+          if (!params.isCurrent()) {
+            throw createAgentRunSupersededAbortError();
+          }
+        },
+      });
+      closeRetryWait = close;
+      return (completed) => {
+        if (close(completed)) {
+          params.onRetryWaitCompleted();
+        }
+        if (closeRetryWait === close) {
+          closeRetryWait = undefined;
+        }
+      };
+    },
     recordSessionEnd: (data) => {
       if (state === "pending") {
         sessionEndData = data;
@@ -58,6 +96,7 @@ export function createEmbeddedAttemptDeferredLifecycleOwner(params: {
         return;
       }
       state = "discarded";
+      releaseRetryWait();
       releaseActiveRun();
     },
     complete: async () => {
@@ -65,6 +104,7 @@ export function createEmbeddedAttemptDeferredLifecycleOwner(params: {
         return;
       }
       state = "completed";
+      releaseRetryWait();
       try {
         if (params.trajectoryRecorder && sessionEndData) {
           params.trajectoryRecorder.recordEvent("session.ended", sessionEndData);
@@ -86,6 +126,10 @@ export type DeferredEmbeddedRunLifecycleManager = {
   signal: AbortSignal;
   abort: (reason?: "user_abort" | "restart" | "superseded") => void;
   adopt: (owner: DeferredEmbeddedRunLifecycleOwner) => void;
+  beginRetryWait: (
+    deadlineAtMs: number,
+    signal?: AbortSignal,
+  ) => ((completed?: boolean) => void) | undefined;
   handoffToCli: () => DiagnosticEmbeddedRunOwner;
   complete: () => Promise<void>;
 };
@@ -129,6 +173,11 @@ export function createDeferredEmbeddedRunLifecycleManager(params: {
       current = owner;
       previous?.discard();
     },
+    beginRetryWait: (deadlineAtMs, retrySignal) =>
+      current?.beginRetryWait(
+        deadlineAtMs,
+        retrySignal ? AbortSignal.any([signal, retrySignal]) : signal,
+      ),
     handoffToCli: () => {
       const diagnosticOwner = createDiagnosticEmbeddedRunOwner(params);
       // Each handoff gets a fresh owner; retained callbacks from a prior CLI

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
@@ -1,7 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { projectProviderError } from "../../../../packages/ai/src/utils/provider-error.js";
+import {
+  createReplyOperation,
+  isReplyRunEvidenceStale,
+} from "../../../auto-reply/reply/reply-run-registry.js";
+import {
+  closeDiagnosticEmbeddedRunOwner,
+  createDiagnosticEmbeddedRunOwner,
+  getDiagnosticSessionActivitySnapshot,
+  markDiagnosticEmbeddedRunStarted,
+  resolveRunStaleThresholdMs,
+} from "../../../logging/diagnostic-run-activity.js";
 import { FailoverError } from "../../failover-error.js";
 import { resolveRetryAfterMs } from "../../failover/retry-evidence.js";
+import {
+  createDeferredEmbeddedRunLifecycleManager,
+  createEmbeddedAttemptDeferredLifecycleOwner,
+} from "./deferred-lifecycle-owner.js";
 
 const mocks = vi.hoisted(() => ({
   sleepWithAbort: vi.fn(async (_ms: number, _abortSignal?: AbortSignal): Promise<void> => {}),
@@ -28,11 +43,13 @@ function createController(
   advanceAuthProfile: ControllerInput["advanceAuthProfile"],
   fallbackConfigured = false,
   abortSignal?: AbortSignal,
+  onRetryWait?: ControllerInput["runParams"]["onRetryWait"],
 ) {
   return createEmbeddedRunFailoverRetryController({
     runParams: {
       runId: "run:failover-retry-controller-test",
       abortSignal,
+      onRetryWait,
     } as ControllerInput["runParams"],
     provider: "openai",
     modelId: "gpt-5.6-luna",
@@ -190,11 +207,36 @@ describe("createEmbeddedRunFailoverRetryController", () => {
       const cancellation = new AbortController();
       const dayMs = 24 * 60 * 60 * 1000;
       const retryAfterMs = 30 * dayMs;
+      const ref = {
+        sessionId: "retry-wait-session",
+        runId: "retry-wait-run",
+        sessionKey: "agent:main:retry-wait",
+      };
+      const operation = createReplyOperation({
+        ...ref,
+        turnKind: "visible",
+        resetTriggered: false,
+      });
+      const diagnosticOwner = createDiagnosticEmbeddedRunOwner(ref);
+      markDiagnosticEmbeddedRunStarted({ ...ref, owner: diagnosticOwner });
+      const lifecycle = createDeferredEmbeddedRunLifecycleManager(ref);
+      lifecycle.adopt(
+        createEmbeddedAttemptDeferredLifecycleOwner({
+          ...ref,
+          diagnosticOwner,
+          isCurrent: () => true,
+          onRetryWaitCompleted: () => operation.recordActivity(),
+          trajectoryRecorder: null,
+          clearActiveRun: () => closeDiagnosticEmbeddedRunOwner(diagnosticOwner),
+        }),
+      );
+      const deadlineAtMs = Date.now() + retryAfterMs;
       try {
         const controller = createController(
           vi.fn(async () => false),
           false,
           cancellation.signal,
+          lifecycle.beginRetryWait,
         );
         let retried = false;
         const retry = controller
@@ -203,21 +245,40 @@ describe("createEmbeddedRunFailoverRetryController", () => {
             retried = result;
             return result;
           });
+        await vi.advanceTimersByTimeAsync(dayMs + 1);
+        const activity = getDiagnosticSessionActivitySnapshot(ref);
+        expect(activity.activeWorkKind).toBe("embedded_run");
+        expect(activity.activeRetryWaitDeadlineAtMs).toBe(deadlineAtMs);
+        expect(activity.lastProgressAgeMs).toBe(dayMs + 1);
+        expect(resolveRunStaleThresholdMs(activity)).toBe(retryAfterMs);
+        expect(isReplyRunEvidenceStale(operation)).toBe(false);
         if (abort) {
           const rejected = expect(retry).rejects.toMatchObject({ name: "AbortError" });
-          await vi.advanceTimersByTimeAsync(dayMs + 1);
           cancellation.abort();
+          expect(
+            getDiagnosticSessionActivitySnapshot(ref).activeRetryWaitDeadlineAtMs,
+          ).toBeUndefined();
           await rejected;
           expect(controller.transientRetryCount).toBe(0);
           expect(vi.getTimerCount()).toBe(0);
         } else {
-          await vi.advanceTimersByTimeAsync(retryAfterMs - 1);
+          await vi.advanceTimersByTimeAsync(retryAfterMs - dayMs - 2);
           expect(retried).toBe(false);
           await vi.advanceTimersByTimeAsync(1);
           await expect(retry).resolves.toBe(true);
           expect(controller.transientRetryCount).toBe(1);
+          expect(
+            getDiagnosticSessionActivitySnapshot(ref).activeRetryWaitDeadlineAtMs,
+          ).toBeUndefined();
+          expect(getDiagnosticSessionActivitySnapshot(ref).lastProgressAgeMs).toBe(0);
+          expect(getDiagnosticSessionActivitySnapshot(ref).lastProgressReason).toBe(
+            "retry_wait:ended",
+          );
+          expect(isReplyRunEvidenceStale(operation)).toBe(false);
         }
       } finally {
+        await lifecycle.complete();
+        operation.complete();
         vi.useRealTimers();
         mocks.sleepWithAbort.mockImplementation(async () => {});
       }

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
@@ -266,12 +266,19 @@ export function createEmbeddedRunFailoverRetryController(input: {
         delayMs,
         reason: retry.reason,
       });
-      // Provider floors can exceed one native timer; the shared helper owns abort errors.
-      let remainingMs = delayMs;
-      while (remainingMs > 0) {
-        const chunkMs = Math.min(remainingMs, RETRY_SLEEP_CHUNK_MS);
-        await sleepWithAbort(chunkMs, params.abortSignal);
-        remainingMs -= chunkMs;
+      const closeRetryWait = params.onRetryWait?.(Date.now() + delayMs, params.abortSignal);
+      let completed = false;
+      try {
+        // Provider floors can exceed one native timer; protect the whole wait.
+        let remainingMs = delayMs;
+        while (remainingMs > 0) {
+          const chunkMs = Math.min(remainingMs, RETRY_SLEEP_CHUNK_MS);
+          await sleepWithAbort(chunkMs, params.abortSignal);
+          remainingMs -= chunkMs;
+        }
+        completed = true;
+      } finally {
+        closeRetryWait?.(completed);
       }
       transientRetryCount += 1;
       return true;

--- a/src/agents/embedded-agent-runner/run/internal-params.ts
+++ b/src/agents/embedded-agent-runner/run/internal-params.ts
@@ -56,6 +56,11 @@ export type RunEmbeddedAgentInternalParams = RunEmbeddedAgentParams & {
   onDeferredLifecycleOwner?: (owner: DeferredEmbeddedRunLifecycleOwner) => void;
   /** Aborts the logical turn when its retained embedded handle is cancelled. */
   onDeferredLifecycleAbort?: (reason?: "user_abort" | "restart" | "superseded") => void;
+  /** Protects an admitted provider wait through the retained logical-turn owner. */
+  onRetryWait?: (
+    deadlineAtMs: number,
+    signal?: AbortSignal,
+  ) => ((completed?: boolean) => void) | undefined;
 };
 
 export type EmbeddedRunAttemptInternalParams = EmbeddedRunAttemptParams &

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -241,6 +241,7 @@ export async function runEmbeddedFallbackCandidate(
         },
         onDeferredLifecycleOwner: params.deferredLifecycle.adopt,
         onDeferredLifecycleAbort: params.deferredLifecycle.abort,
+        onRetryWait: params.deferredLifecycle.beginRetryWait,
         onExecutionStarted: (info) => {
           if (info?.lifecycleGeneration) {
             params.onLifecycleGeneration(info.lifecycleGeneration);

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -111,6 +111,7 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
       setActiveEmbeddedRun(sessionId, handle, sessionKey);
       state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
         params.onDeferredLifecycleOwner?.({
+          beginRetryWait: () => undefined,
           complete: async () => clearActiveEmbeddedRun(sessionId, handle, sessionKey),
           discard: () => clearActiveEmbeddedRun(sessionId, handle, sessionKey),
         });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1751,6 +1751,7 @@ export async function runMemoryFlushIfNeeded(params: {
           abortSignal: deferredLifecycle.signal,
           onDeferredLifecycleOwner: deferredLifecycle.adopt,
           onDeferredLifecycleAbort: deferredLifecycle.abort,
+          onRetryWait: deferredLifecycle.beginRetryWait,
           assistantErrorTranscript: runOptions.assistantErrorTranscript,
           contextEngineLogicalTurnLease: runOptions.contextEngineLogicalTurnLease,
           onContextEngineTurnCandidate: runOptions.onContextEngineTurnCandidate,

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -842,6 +842,7 @@ describe("agentCommand", () => {
         vi.mocked(attemptExecutionRuntime.runAgentAttempt).mockImplementationOnce(
           async (params) => {
             params.deferredLifecycle?.adopt({
+              beginRetryWait: () => undefined,
               complete: async () => {
                 if (fault === "rejection") {
                   throw failure;

--- a/src/logging/diagnostic-owned-activity.ts
+++ b/src/logging/diagnostic-owned-activity.ts
@@ -1,0 +1,126 @@
+import type { DiagnosticEmbeddedRunOwner } from "../infra/diagnostic-model-request-provenance.js";
+import { BLOCKED_TOOL_CALL_ABORT_FLOOR_MS } from "./diagnostic-run-activity-snapshot.js";
+import {
+  activeDiagnosticOwners,
+  touchSessionActivity,
+  type DiagnosticBackendActivity,
+  type DiagnosticOwnerRegistration,
+} from "./diagnostic-run-activity-state.js";
+
+export function resolveCurrentDiagnosticOwner(
+  owner: DiagnosticEmbeddedRunOwner,
+  assertCurrent?: () => void,
+): DiagnosticOwnerRegistration | undefined {
+  const registration = activeDiagnosticOwners.get(owner.generation);
+  if (registration?.owner !== owner) {
+    return undefined;
+  }
+  try {
+    assertCurrent?.();
+  } catch {
+    return undefined;
+  }
+  // The caller assertion may synchronously retire or replace the registration.
+  return activeDiagnosticOwners.get(owner.generation) === registration &&
+    registration.activity.activeEmbeddedRuns.get(owner.workKey)?.generation === owner.generation
+    ? registration
+    : undefined;
+}
+
+/** Retains a provider wait only while its logical run still owns this attempt. */
+export function beginDiagnosticRetryWait(params: {
+  owner: DiagnosticEmbeddedRunOwner;
+  deadlineAtMs: number;
+  signal: AbortSignal;
+  assertCurrent: () => void;
+}): (completed?: boolean) => boolean {
+  const assertCurrent = () => {
+    params.signal.throwIfAborted();
+    params.assertCurrent();
+  };
+  const registration = resolveCurrentDiagnosticOwner(params.owner, assertCurrent);
+  if (!registration) {
+    return () => false;
+  }
+  registration.retryWait?.close();
+  const close = (completed = false) => {
+    const resumed =
+      completed &&
+      registration.retryWait === wait &&
+      resolveCurrentDiagnosticOwner(params.owner, assertCurrent) === registration;
+    if (registration.retryWait === wait) {
+      registration.retryWait = undefined;
+    }
+    params.signal.removeEventListener("abort", onAbort);
+    if (resumed) {
+      touchSessionActivity(registration.activity, "retry_wait:ended");
+    }
+    return resumed;
+  };
+  const onAbort = () => {
+    close();
+  };
+  const wait = { deadlineAtMs: params.deadlineAtMs, assertCurrent, close };
+  registration.retryWait = wait;
+  params.signal.addEventListener("abort", onAbort, { once: true });
+  return close;
+}
+
+/** Binds one backend attempt's quiet allowance to its exact live core owner. */
+export function beginDiagnosticBackendActivity(params: {
+  owner: DiagnosticEmbeddedRunOwner;
+  noOutputTimeoutMs: number;
+  assertCurrent: () => void;
+}): {
+  observeOutput: (modelProgress: boolean) => boolean;
+  setOutstandingWork: (active: boolean) => void;
+  close: () => void;
+} {
+  const { owner, noOutputTimeoutMs, assertCurrent } = params;
+  let quietAllowanceMs = noOutputTimeoutMs;
+  const registration = resolveCurrentDiagnosticOwner(owner, assertCurrent);
+  const backendActivity: DiagnosticBackendActivity = {
+    deadlineAtMs: Date.now() + noOutputTimeoutMs,
+    assertCurrent,
+  };
+  if (registration) {
+    registration.backendActivity = backendActivity;
+  }
+  const currentActivity = () => {
+    const current = resolveCurrentDiagnosticOwner(owner, assertCurrent);
+    return current?.backendActivity === backendActivity ? current.activity : undefined;
+  };
+  return {
+    observeOutput: (modelProgress) => {
+      const activity = currentActivity();
+      if (!activity) {
+        return false;
+      }
+      const now = Date.now();
+      backendActivity.deadlineAtMs = now + quietAllowanceMs;
+      if (!modelProgress || activity.activeTools.size > 0) {
+        return false;
+      }
+      touchSessionActivity(activity, "model_call:stream_progress", now);
+      return true;
+    },
+    setOutstandingWork: (active) => {
+      if (!currentActivity()) {
+        return;
+      }
+      const allowanceMs = active
+        ? Math.max(noOutputTimeoutMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
+        : noOutputTimeoutMs;
+      // Work-state changes preserve the last output's origin, not a new progress clock.
+      backendActivity.deadlineAtMs += allowanceMs - quietAllowanceMs;
+      quietAllowanceMs = allowanceMs;
+    },
+    close: () => {
+      // Compare-release remains valid after abort and cannot retire a later attempt.
+      const current = activeDiagnosticOwners.get(owner.generation);
+      if (current?.owner === owner && current.backendActivity === backendActivity) {
+        delete current.backendActivity;
+      }
+    },
+  };
+}

--- a/src/logging/diagnostic-run-activity-snapshot.ts
+++ b/src/logging/diagnostic-run-activity-snapshot.ts
@@ -22,6 +22,8 @@ export type DiagnosticSessionActivitySnapshot = {
   activeModelCallRequestTimeoutMs?: number;
   /** Absolute quiet deadline validated against the exact executing backend owner. */
   activeBackendLivenessDeadlineAtMs?: number;
+  /** Absolute provider retry deadline validated against the live logical run. */
+  activeRetryWaitDeadlineAtMs?: number;
 };
 
 type SnapshotTool = {
@@ -111,17 +113,26 @@ export function resolveRunStaleThresholdMs(
     | "lastProgressAgeMs"
     | "activeModelCallRequestTimeoutMs"
     | "activeBackendLivenessDeadlineAtMs"
+    | "activeRetryWaitDeadlineAtMs"
   >,
   evidenceAgeMs = activity.lastProgressAgeMs ?? 0,
   minimumMs = RUN_STALE_TAKEOVER_MS,
 ): number {
+  const retryWaitThresholdMs =
+    activity.activeRetryWaitDeadlineAtMs === undefined
+      ? 0
+      : evidenceAgeMs + activity.activeRetryWaitDeadlineAtMs - Date.now();
   if (activity.activeToolDeadlineAtMs !== undefined) {
     // Use the same age the caller compares: subtracting it leaves only the
     // absolute deadline, even when reply activity and tool progress differ.
-    return Math.max(0, evidenceAgeMs + activity.activeToolDeadlineAtMs - Date.now());
+    return Math.max(
+      0,
+      evidenceAgeMs + activity.activeToolDeadlineAtMs - Date.now(),
+      retryWaitThresholdMs,
+    );
   }
   if (activity.activeWorkKind === "tool_call") {
-    return Math.max(minimumMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS);
+    return Math.max(minimumMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS, retryWaitThresholdMs);
   }
   // The backend starts its quiet allowance at execution, not session admission.
   // Translate its absolute deadline into the same evidence age the caller compares.
@@ -129,5 +140,10 @@ export function resolveRunStaleThresholdMs(
     activity.activeBackendLivenessDeadlineAtMs === undefined
       ? 0
       : evidenceAgeMs + activity.activeBackendLivenessDeadlineAtMs - Date.now();
-  return Math.max(minimumMs, activity.activeModelCallRequestTimeoutMs ?? 0, backendThresholdMs);
+  return Math.max(
+    minimumMs,
+    activity.activeModelCallRequestTimeoutMs ?? 0,
+    backendThresholdMs,
+    retryWaitThresholdMs,
+  );
 }

--- a/src/logging/diagnostic-run-activity-state.ts
+++ b/src/logging/diagnostic-run-activity-state.ts
@@ -43,6 +43,11 @@ export type DiagnosticOwnerRegistration = {
   activity: SessionActivity;
   owner: DiagnosticEmbeddedRunOwner;
   backendActivity?: DiagnosticBackendActivity;
+  retryWait?: {
+    deadlineAtMs: number;
+    assertCurrent: () => void;
+    close: () => void;
+  };
 };
 
 export const activityByRef = new Map<string, SessionActivity>();

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -17,6 +17,7 @@ import {
   clearArgumentChurnPolicyWaits,
   type DiagnosticArgumentChurnObservationParams,
 } from "./diagnostic-argument-churn-activity.js";
+import { resolveCurrentDiagnosticOwner } from "./diagnostic-owned-activity.js";
 import {
   clearRepeatedRequestActivity,
   recordRepeatedRequestObservation,
@@ -35,7 +36,6 @@ import {
   shouldIgnoreRecoveredOwnerStartEvent,
 } from "./diagnostic-run-activity-recovery.js";
 import {
-  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   buildDiagnosticSessionActivitySnapshot,
   type DiagnosticSessionActivitySnapshot,
 } from "./diagnostic-run-activity-snapshot.js";
@@ -48,11 +48,13 @@ import {
   resolveSessionActivity,
   sessionRefs,
   touchSessionActivity,
-  type DiagnosticBackendActivity,
-  type DiagnosticOwnerRegistration,
   type SessionActivity,
 } from "./diagnostic-run-activity-state.js";
 
+export {
+  beginDiagnosticBackendActivity,
+  beginDiagnosticRetryWait,
+} from "./diagnostic-owned-activity.js";
 export {
   BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   RUN_STALE_TAKEOVER_MS,
@@ -169,85 +171,6 @@ function hasDiagnosticOwnerForRefs(params: {
     (params.runId && hasDiagnosticActivityOwner(activityByRunId.get(params.runId))) ||
     sessionRefs(params).some((ref) => hasDiagnosticActivityOwner(activityByRef.get(ref)))
   );
-}
-
-function resolveCurrentDiagnosticOwner(
-  owner: DiagnosticEmbeddedRunOwner,
-  assertCurrent?: () => void,
-): DiagnosticOwnerRegistration | undefined {
-  const registration = activeDiagnosticOwners.get(owner.generation);
-  if (registration?.owner !== owner) {
-    return undefined;
-  }
-  try {
-    assertCurrent?.();
-  } catch {
-    return undefined;
-  }
-  // The caller assertion may synchronously retire or replace the registration.
-  return activeDiagnosticOwners.get(owner.generation) === registration &&
-    registration.activity.activeEmbeddedRuns.get(owner.workKey)?.generation === owner.generation
-    ? registration
-    : undefined;
-}
-
-/** Binds one backend attempt's quiet allowance to its exact live core owner. */
-export function beginDiagnosticBackendActivity(params: {
-  owner: DiagnosticEmbeddedRunOwner;
-  noOutputTimeoutMs: number;
-  assertCurrent: () => void;
-}): {
-  observeOutput: (modelProgress: boolean) => boolean;
-  setOutstandingWork: (active: boolean) => void;
-  close: () => void;
-} {
-  const { owner, noOutputTimeoutMs, assertCurrent } = params;
-  let quietAllowanceMs = noOutputTimeoutMs;
-  const registration = resolveCurrentDiagnosticOwner(owner, assertCurrent);
-  const backendActivity: DiagnosticBackendActivity = {
-    deadlineAtMs: Date.now() + noOutputTimeoutMs,
-    assertCurrent,
-  };
-  if (registration) {
-    registration.backendActivity = backendActivity;
-  }
-  const currentActivity = () => {
-    const current = resolveCurrentDiagnosticOwner(owner, assertCurrent);
-    return current?.backendActivity === backendActivity ? current.activity : undefined;
-  };
-  return {
-    observeOutput: (modelProgress) => {
-      const activity = currentActivity();
-      if (!activity) {
-        return false;
-      }
-      const now = Date.now();
-      backendActivity.deadlineAtMs = now + quietAllowanceMs;
-      if (!modelProgress || activity.activeTools.size > 0) {
-        return false;
-      }
-      touchSessionActivity(activity, "model_call:stream_progress", now);
-      return true;
-    },
-    setOutstandingWork: (active) => {
-      if (!currentActivity()) {
-        return;
-      }
-      const allowanceMs = active
-        ? Math.max(noOutputTimeoutMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
-        : noOutputTimeoutMs;
-      // Work-state changes preserve the last output's origin, not a new progress clock.
-      backendActivity.deadlineAtMs += allowanceMs - quietAllowanceMs;
-      quietAllowanceMs = allowanceMs;
-    },
-    close: () => {
-      // Compare-release remains valid after abort and cannot retire a later attempt.
-      const current = activeDiagnosticOwners.get(owner.generation);
-      if (current?.owner === owner && current.backendActivity === backendActivity) {
-        delete current.backendActivity;
-      }
-    },
-  };
 }
 
 function recordModelStarted(
@@ -448,6 +371,7 @@ export function closeDiagnosticEmbeddedRunOwner(owner: DiagnosticEmbeddedRunOwne
     return;
   }
   const { activity } = registration;
+  registration.retryWait?.close();
   activeDiagnosticOwners.delete(owner.generation);
   closedDiagnosticOwnerGenerations.add(owner.generation);
   activity.activeCoreModelCalls.delete(owner.generation);
@@ -603,10 +527,24 @@ export function getDiagnosticSessionActivitySnapshot(
   }
 
   let activeBackendLivenessDeadlineAtMs: number | undefined;
+  let activeRetryWaitDeadlineAtMs: number | undefined;
   for (const embeddedRun of activity.activeEmbeddedRuns.values()) {
     const registration = embeddedRun.generation
       ? activeDiagnosticOwners.get(embeddedRun.generation)
       : undefined;
+    const retryWait = registration?.retryWait;
+    if (
+      registration &&
+      retryWait &&
+      resolveCurrentDiagnosticOwner(registration.owner, retryWait.assertCurrent) === registration &&
+      registration.activity === activity &&
+      registration.retryWait === retryWait
+    ) {
+      activeRetryWaitDeadlineAtMs = Math.max(
+        activeRetryWaitDeadlineAtMs ?? retryWait.deadlineAtMs,
+        retryWait.deadlineAtMs,
+      );
+    }
     const backendActivity = registration?.backendActivity;
     if (
       !registration ||
@@ -628,6 +566,7 @@ export function getDiagnosticSessionActivitySnapshot(
     ...(activeBackendLivenessDeadlineAtMs !== undefined
       ? { activeBackendLivenessDeadlineAtMs }
       : {}),
+    ...(activeRetryWaitDeadlineAtMs !== undefined ? { activeRetryWaitDeadlineAtMs } : {}),
   };
 }
 

--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -3,6 +3,35 @@ import { describe, expect, it } from "vitest";
 import { classifySessionAttention } from "./diagnostic-session-attention.js";
 
 describe("classifySessionAttention", () => {
+  it.each([false, true])(
+    "classifies provider retry waiting until its deadline (expired=%s)",
+    (expired) => {
+      const classification = classifySessionAttention({
+        state: "processing",
+        queueDepth: 1,
+        activity: {
+          activeWorkKind: "embedded_run",
+          hasActiveEmbeddedRun: true,
+          lastProgressAgeMs: 660_000,
+          activeRetryWaitDeadlineAtMs: Date.now() + (expired ? -1000 : 60_000),
+        },
+        staleMs: 120_000,
+        stuckSessionAbortMs: 360_000,
+      });
+      expect(classification).toMatchObject(
+        expired
+          ? {
+              eventType: "session.stalled",
+              reason: "active_work_without_progress",
+            }
+          : {
+              eventType: "session.long_running",
+              reason: "provider_retry_wait",
+              recoveryEligible: false,
+            },
+      );
+    },
+  );
   it.each([
     {
       name: "stale state without queued work",

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -33,6 +33,18 @@ export function classifySessionAttention(params: {
   stuckSessionAbortMs?: number;
   runtimeOwnsLiveness?: boolean;
 }): SessionAttentionClassification {
+  if (
+    params.activity.activeRetryWaitDeadlineAtMs !== undefined &&
+    Date.now() < params.activity.activeRetryWaitDeadlineAtMs
+  ) {
+    return {
+      eventType: "session.long_running",
+      reason: "provider_retry_wait",
+      classification: "long_running",
+      activeWorkKind: params.activity.activeWorkKind,
+      recoveryEligible: false,
+    };
+  }
   if (params.runtimeOwnsLiveness) {
     return {
       eventType: "session.long_running",

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.core.test-utils.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.core.test-utils.ts
@@ -98,6 +98,28 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
+  it.each([false, true])(
+    "rechecks an admitted retry wait before a queued recovery abort (expired=%s)",
+    async (expired) => {
+      mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("waiting-session");
+      mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+        activeWorkKind: "embedded_run",
+        lastProgressAgeMs: 720_000,
+        activeRetryWaitDeadlineAtMs: Date.now() + (expired ? -1000 : 60_000),
+      });
+      mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+      mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+      await recoverStuckDiagnosticSession({
+        sessionId: "waiting-session",
+        sessionKey: "agent:main:waiting",
+        ageMs: 720_000,
+        allowActiveAbort: true,
+      });
+      expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledTimes(expired ? 1 : 0);
+      expect(mocks.waitForEmbeddedAgentRunEnd).toHaveBeenCalledTimes(expired ? 1 : 0);
+    },
+  );
+
   it("returns an abort outcome for a stale tool call on an active embedded run", async () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-tool");
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -86,6 +86,14 @@ function isActiveRunProgressStale(params: {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
   });
+  // A retry can start after recovery was queued. Recheck its current owner and
+  // deadline here before an earlier classification is allowed to abort it.
+  if (
+    activity.activeRetryWaitDeadlineAtMs !== undefined &&
+    Date.now() < activity.activeRetryWaitDeadlineAtMs
+  ) {
+    return false;
+  }
   if (params.allowActiveAbort) {
     // Recovery may have queued before a fresh byte arrived. Revalidate the
     // backend allowance here; active tools retain their separate recovery policy.

--- a/src/plugins/runtime/runtime-embedded-agent.runtime.test.ts
+++ b/src/plugins/runtime/runtime-embedded-agent.runtime.test.ts
@@ -263,6 +263,7 @@ describe("plugin embedded-agent runtime admission", () => {
     "preparedRunAdmission",
     "onDeferredLifecycleOwner",
     "onDeferredLifecycleAbort",
+    "onRetryWait",
     "compactionCountOwner",
     "onCompactionAccounting",
     "onContextAccountingEvent",

--- a/src/plugins/runtime/runtime-embedded-agent.runtime.ts
+++ b/src/plugins/runtime/runtime-embedded-agent.runtime.ts
@@ -26,7 +26,8 @@ export const runPluginEmbeddedAgent: PluginRuntime["agent"]["runEmbeddedAgent"] 
     "onCompactionAccounting" in params ||
     "onContextAccountingEvent" in params ||
     "onDeferredLifecycleOwner" in params ||
-    "onDeferredLifecycleAbort" in params
+    "onDeferredLifecycleAbort" in params ||
+    "onRetryWait" in params
   ) {
     throw new Error("Plugin embedded-agent execution cannot supply host run authority.");
   }


### PR DESCRIPTION
Closes #144424.

## What Problem This Solves

Fixes an issue where heartbeats waiting through a provider's retry minimum were cancelled as stale. A new run could then contact the provider too early and repeat the failure.

## Why This Change Was Made

Keep the bounded retry wait with its current run owner and recheck that deadline before stale recovery or takeover. Release it on cancellation or completion, and record actual resumed activity before preparing the next attempt. Normal retry budgets, timeout rules and shutdown behavior stay intact.

## User Impact

Long provider backoff can finish under the original run. Manual cancellation, a new visible turn, shutdown and execution deadlines can still stop it. Genuine stalled work still recovers.

## Evidence

Public `system event` → enabled heartbeat → real HTTP 429 with `Retry-After: 660`, using an isolated Gateway and a synthetic compatible endpoint:

| Observation | Baseline | Repaired |
| --- | --- | --- |
| Next provider request after the 429 | 387.742 seconds | 660.126 seconds |
| Original run | Cancelled as stale | Retried and completed once |
| Separately queued heartbeat | Ran after premature cancellation | Ran once after original completion |

- Independent behavior acceptance covers the public run, clean transcripts, one transient retry indicator, manual abort, visible replacement, normal shutdown and the configured timeout backstop.
- Real elapsed-time controls preserve genuine stalled-run recovery and ordinary ten-minute takeover. A matched baseline comparison preserves deferred sibling heartbeat delivery without changing scheduling policy.
- Successful configured model fallback, retry budgets, profile rotation and jitter boundaries are covered. Native validation passed 270 focused tests, lint, both ratchets and the normal commit hook.
- The long-wait fixture uses a 20-minute heartbeat timeout to isolate stale recovery. Existing execution deadlines and shutdown grace still apply. No real provider account or channel credential was used.

Thanks @corvid-reads for the report and source trace.
