### PR TITLE
fix(ui): let canvas surfaces keep their own horizontal drag

### DIFF
--- a/ui/src/app/nav-drawer-swipe.runtime.test.ts
+++ b/ui/src/app/nav-drawer-swipe.runtime.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NavDrawerSwipeOwner } from "./nav-drawer-swipe.runtime.ts";
+
+type TestHost = HTMLElement & {
+  onboardingMode: boolean;
+  updateComplete: Promise<boolean>;
+  navDrawerOpen: boolean;
+};
+
+function createHost(): TestHost {
+  const host = document.createElement("div") as TestHost;
+  host.onboardingMode = false;
+  host.navDrawerOpen = false;
+  host.updateComplete = Promise.resolve(true);
+  host.innerHTML = `
+    <div class="shell-nav"></div>
+    <div class="shell-nav-backdrop"></div>
+    <div class="content">
+      <div class="plain-region"></div>
+      <div class="terminal-region">
+        <canvas></canvas>
+        <textarea></textarea>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(host);
+  return host;
+}
+
+/**
+ * jsdom ships no TouchEvent constructor, so the touch list is attached to a
+ * plain Event. Dispatching it through the real tree keeps composedPath()
+ * authentic, which is the part of handleStart under test.
+ */
+function dispatchTouch(
+  target: Element,
+  type: "touchstart" | "touchmove" | "touchend",
+  clientX: number,
+): void {
+  const event = new Event(type, { bubbles: true, composed: true, cancelable: true });
+  const touches = [{ identifier: 0, clientX, clientY: 100 }];
+  Object.defineProperties(event, {
+    touches: { value: type === "touchend" ? [] : touches },
+    changedTouches: { value: touches },
+  });
+  target.dispatchEvent(event);
+}
+
+/** Drags left-to-right far enough to clear both the lock and open thresholds. */
+function swipeRight(target: Element): void {
+  dispatchTouch(target, "touchstart", 10);
+  dispatchTouch(target, "touchmove", 80);
+  dispatchTouch(target, "touchend", 80);
+}
+
+describe("NavDrawerSwipeOwner", () => {
+  let host: TestHost;
+  let requestOpen: ReturnType<typeof vi.fn>;
+  let owner: NavDrawerSwipeOwner;
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: true }) as MediaQueryList),
+    );
+    host = createHost();
+    requestOpen = vi.fn();
+    owner = new NavDrawerSwipeOwner(host, requestOpen);
+    owner.connect();
+  });
+
+  afterEach(() => {
+    owner.disconnect();
+    host.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("opens the drawer for a horizontal drag over ordinary content", () => {
+    const plain = host.querySelector(".plain-region");
+    expect(plain).not.toBeNull();
+
+    swipeRight(plain as Element);
+
+    expect(requestOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a horizontal drag over a canvas to the canvas", () => {
+    // A terminal or VNC surface paints its own selection onto a canvas and has
+    // no ancestor matching the other opt-out entries: the textarea it keeps for
+    // IME is a sibling. Without canvas in the selector the drawer claims every
+    // drag-select in the terminal.
+    const canvas = host.querySelector("canvas");
+    expect(canvas).not.toBeNull();
+
+    swipeRight(canvas as Element);
+
+    expect(requestOpen).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/nav-drawer-swipe.runtime.ts
+++ b/ui/src/app/nav-drawer-swipe.runtime.ts
@@ -6,6 +6,14 @@ const LOCK_DISTANCE_PX = 7;
 const DIRECTION_RATIO = 1.25;
 const FOCUSABLE_SELECTOR =
   "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
+// Elements that own their own horizontal drag, so the edge swipe must not claim
+// it. `canvas` covers surfaces that render their own selection instead of using
+// DOM text: the terminal drags to select, and the VNC view drags the remote
+// pointer. Neither has a DOM ancestor that matches any other entry here, since
+// the hidden textarea a terminal keeps for IME is a sibling of the canvas, not a
+// parent of it.
+const SWIPE_OPT_OUT_SELECTOR =
+  "a, button, canvas, input, textarea, select, pre, [role='slider'], [contenteditable]:not([contenteditable='false'])";
 
 type Swipe = {
   identifier: number;
@@ -131,11 +139,7 @@ export class NavDrawerSwipeOwner {
       if (!(target instanceof Element)) {
         return false;
       }
-      if (
-        target.matches(
-          "a, button, input, textarea, select, pre, [role='slider'], [contenteditable]:not([contenteditable='false'])",
-        )
-      ) {
+      if (target.matches(SWIPE_OPT_OUT_SELECTOR)) {
         return true;
       }
       return target instanceof HTMLElement && target.scrollWidth > target.clientWidth + 1;


### PR DESCRIPTION
## What Problem This Solves

On a touch device, dragging left to right inside the terminal opens the navigation drawer instead of selecting text. Selection is effectively unusable there, because the gesture that performs it is intercepted by the app shell.

The edge swipe already opts out of elements that own their own horizontal drag, but that selector lists only form and text elements:

```
a, button, input, textarea, select, pre, [role='slider'], [contenteditable]:not([contenteditable='false'])
```

A `<canvas>` matches none of them. It renders its own selection rather than using DOM text, and critically it has no *ancestor* that matches either. The hidden `<textarea>` a terminal keeps for IME is a sibling of the canvas, not a parent, so walking the composed path finds nothing to block on and the drawer claims the gesture.

The same class of bug affects any canvas-based surface where a horizontal drag is meaningful. The VNC view drags the remote pointer and is hit identically.

## Approach

Add `canvas` to the opt-out selector. The selector moves to a named module constant so it can carry a comment explaining why canvas belongs there, since that is the part a future reader is most likely to question and delete.

This deliberately means an edge swipe started on a canvas will not open the drawer. That is the intended trade: the canvas owns the gesture, and the drawer remains reachable from any other part of the content area as well as from its button.

## Evidence

New unit test, `ui/src/app/nav-drawer-swipe.runtime.test.ts`, covering both directions of the behavior so the fix cannot regress into either failure mode:

```
✓ opens the drawer for a horizontal drag over ordinary content  22ms
✓ leaves a horizontal drag over a canvas to the canvas           3ms

Test Files  1 passed (1)
     Tests  2 passed (2)
```

jsdom provides no `TouchEvent` constructor, so the test attaches the touch list to a plain `Event` and dispatches it through a real DOM tree, which keeps `composedPath()` authentic. That path is the part of `handleStart` under test.

Typecheck and lint pass on the changed files.

Originally diagnosed by reading the deployed `nav-drawer-swipe.runtime` bundle to confirm the opt-out selector was the actual cause, rather than inferring it from the symptom.
