### PR TITLE
fix(ui): deliver Android IME text to the terminal

### DIFF
--- a/ui/src/components/terminal/terminal-runtime-ime.test.ts
+++ b/ui/src/components/terminal/terminal-runtime-ime.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installTerminalImeWorkaround } from "./terminal-runtime.ts";
+
+/**
+ * Creates a ghostty-like container in the real DOM: a div holding both a
+ * canvas and a textarea (the structure ghostty-web creates inside its
+ * container). The caller provides the container element, so tests can
+ * pre-install the ghostty beforeinput bug simulation before calling
+ * installTerminalImeWorkaround.
+ */
+function createGhosttyContainer(): {
+  container: HTMLDivElement;
+  canvas: HTMLCanvasElement;
+  textarea: HTMLTextAreaElement;
+} {
+  const container = document.createElement("div");
+  const canvas = document.createElement("canvas");
+  const textarea = document.createElement("textarea");
+  container.appendChild(canvas);
+  container.appendChild(textarea);
+  document.body.appendChild(container);
+  return { container, canvas, textarea };
+}
+
+/**
+ * Installs the ghostty beforeinput bug simulation: it calls e.preventDefault()
+ * on all beforeinput events on the container, exactly as ghostty-web 0.4.0 does.
+ * Must be called before installTerminalImeWorkaround so the probe sees the bug.
+ */
+function installGhosttyBugSimulation(container: HTMLElement): void {
+  container.addEventListener("beforeinput", (e) => e.preventDefault());
+}
+
+/**
+ * jsdom has no complete InputEvent API, but the InputEvent constructor does
+ * exist. Dispatching through the real tree keeps composedPath() authentic,
+ * which is the part of findGhosttyContainer under test.
+ *
+ * For beforeinput, we dispatch on a descendant element so the event bubbles
+ * through the container, which is how Android IME actually delivers it.
+ */
+function dispatchBeforeInput(target: Element, inputType: string, data: string | null = null): void {
+  const event = new InputEvent("beforeinput", {
+    bubbles: true,
+    composed: true,
+    cancelable: true,
+    inputType,
+    data: data ?? undefined,
+  });
+  target.dispatchEvent(event);
+}
+
+/**
+ * Activates IME state via keydown with keyCode 229 dispatched on the target,
+ * mirroring what Android Chrome sends when an IME session starts.
+ */
+function dispatchImeKeyDown(target: Element): void {
+  // jsdom does not support keyCode via the KeyboardEvent constructor, so attach
+  // it directly on a plain Event, the same pattern used in nav-drawer tests.
+  const event = new Event("keydown", { bubbles: true, composed: true, cancelable: true });
+  Object.defineProperty(event, "keyCode", { value: 229 });
+  Object.defineProperty(event, "isComposing", { value: true });
+  target.dispatchEvent(event);
+}
+
+describe("installTerminalImeWorkaround", () => {
+  let cleanupWorkaround: (() => void) | undefined;
+
+  beforeEach(() => {
+    cleanupWorkaround = undefined;
+  });
+
+  afterEach(() => {
+    cleanupWorkaround?.();
+    cleanupWorkaround = undefined;
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+    // jsdom keeps navigator properties across tests; reset manually.
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  function setupCoarseDevice(): void {
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 5,
+      configurable: true,
+      writable: true,
+    });
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: true }) as MediaQueryList),
+    );
+  }
+
+  function setupNonTouchDevice(): void {
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: false }) as MediaQueryList),
+    );
+  }
+
+  it("on coarse-pointer device: beforeinput insertText during IME active dispatches compositionend on ghostty container", () => {
+    setupCoarseDevice();
+    const { container, textarea } = createGhosttyContainer();
+    // Simulate the ghostty bug before installing the workaround so the probe
+    // at install time correctly detects it.
+    installGhosttyBugSimulation(container);
+
+    const received: CompositionEvent[] = [];
+    container.addEventListener("compositionend", (e) => received.push(e as CompositionEvent));
+
+    cleanupWorkaround = installTerminalImeWorkaround(container);
+
+    // Activate IME state, then commit text.
+    dispatchImeKeyDown(textarea);
+    dispatchBeforeInput(textarea, "insertText", "あ");
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.data).toBe("あ");
+  });
+
+  it("on coarse-pointer device: beforeinput during non-IME state does nothing", () => {
+    setupCoarseDevice();
+    const { container, textarea } = createGhosttyContainer();
+    installGhosttyBugSimulation(container);
+
+    const received: CompositionEvent[] = [];
+    container.addEventListener("compositionend", (e) => received.push(e as CompositionEvent));
+
+    cleanupWorkaround = installTerminalImeWorkaround(container);
+
+    // No IME keydown -- fire a plain insertText that should not be forwarded.
+    dispatchBeforeInput(textarea, "insertText", "a");
+
+    expect(received).toHaveLength(0);
+  });
+
+  it("on non-touch device: fix is not installed (no compositionend dispatched)", () => {
+    setupNonTouchDevice();
+    const { container, textarea } = createGhosttyContainer();
+    installGhosttyBugSimulation(container);
+
+    const received: CompositionEvent[] = [];
+    container.addEventListener("compositionend", (e) => received.push(e as CompositionEvent));
+
+    cleanupWorkaround = installTerminalImeWorkaround(container);
+
+    dispatchImeKeyDown(textarea);
+    dispatchBeforeInput(textarea, "insertText", "あ");
+
+    expect(received).toHaveLength(0);
+  });
+
+  it("insertLineBreak maps to carriage return", () => {
+    setupCoarseDevice();
+    const { container, textarea } = createGhosttyContainer();
+    installGhosttyBugSimulation(container);
+
+    const received: CompositionEvent[] = [];
+    container.addEventListener("compositionend", (e) => received.push(e as CompositionEvent));
+
+    cleanupWorkaround = installTerminalImeWorkaround(container);
+
+    dispatchImeKeyDown(textarea);
+    dispatchBeforeInput(textarea, "insertLineBreak");
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.data).toBe("\r");
+  });
+
+  it("insertParagraph also maps to carriage return", () => {
+    setupCoarseDevice();
+    const { container, textarea } = createGhosttyContainer();
+    installGhosttyBugSimulation(container);
+
+    const received: CompositionEvent[] = [];
+    container.addEventListener("compositionend", (e) => received.push(e as CompositionEvent));
+
+    cleanupWorkaround = installTerminalImeWorkaround(container);
+
+    dispatchImeKeyDown(textarea);
+    dispatchBeforeInput(textarea, "insertParagraph");
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.data).toBe("\r");
+  });
+
+  it("deleteContentBackward maps to DEL byte (0x7f)", () => {
+    setupCoarseDevice();
+    const { container, textarea } = createGhosttyContainer();
+    installGhosttyBugSimulation(container);
+
+    const received: CompositionEvent[] = [];
+    container.addEventListener("compositionend", (e) => received.push(e as CompositionEvent));
+
+    cleanupWorkaround = installTerminalImeWorkaround(container);
+
+    dispatchImeKeyDown(textarea);
+    dispatchBeforeInput(textarea, "deleteContentBackward");
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.data).toBe("\x7f");
+  });
+
+  it("cleanup removes listeners so subsequent beforeinput no longer forwards", () => {
+    setupCoarseDevice();
+    const { container, textarea } = createGhosttyContainer();
+    installGhosttyBugSimulation(container);
+
+    const received: CompositionEvent[] = [];
+    container.addEventListener("compositionend", (e) => received.push(e as CompositionEvent));
+
+    const cleanup = installTerminalImeWorkaround(container);
+    cleanup();
+    // cleanupWorkaround already cleared to avoid double-cleanup in afterEach.
+
+    dispatchImeKeyDown(textarea);
+    dispatchBeforeInput(textarea, "insertText", "あ");
+
+    expect(received).toHaveLength(0);
+  });
+});

--- a/ui/src/components/terminal/terminal-runtime.ts
+++ b/ui/src/components/terminal/terminal-runtime.ts
@@ -5,6 +5,151 @@ function isEventListener(value: unknown): value is EventListener {
   return typeof value === "function";
 }
 
+// Module-level WeakMap: probe result per container element, cached so each
+// container is interrogated at most once even across multiple install calls.
+const imeWorkaroundBugCache = new WeakMap<Element, boolean>();
+
+/**
+ * Installs an IME forwarding shim on the ghostty container for Android
+ * soft-keyboard input.
+ *
+ * ghostty-web 0.4.0 registers `addEventListener("beforeinput", e => e.preventDefault())`
+ * on its container and skips keyCode 229 events in its keydown handler, so
+ * committed IME text from Android soft keyboards never reaches the PTY write
+ * path (coder/ghostty-web#120, open, unreleased). This shim intercepts
+ * `beforeinput` in capture phase, ahead of ghostty's bubble-phase handler,
+ * and forwards data by dispatching a `compositionend` on the ghostty container,
+ * which ghostty's own listener picks up and passes to `onDataCallback(data)`.
+ *
+ * Scoped to coarse-pointer touch devices only so desktop CJK input, which
+ * has a working native `compositionend`, is not doubled.
+ *
+ * Remove this workaround when coder/ghostty-web#120 is fixed and the minimum
+ * bundled ghostty-web version includes the fix.
+ *
+ * @param parent - The ghostty container element (`options.parent` from
+ *   `createIsolatedGhosttyTerminal`).
+ * @returns A cleanup function that removes all installed listeners.
+ */
+export function installTerminalImeWorkaround(parent: Element): () => void {
+  // Guard: coarse-pointer touch devices only. Desktop CJK composition already
+  // works via native compositionend; applying this shim there would double input.
+  if (
+    !(navigator.maxTouchPoints > 0) ||
+    !(typeof window.matchMedia === "function" && window.matchMedia("(pointer: coarse)").matches)
+  ) {
+    return () => {};
+  }
+
+  // Probe whether ghostty's beforeinput-clobber bug is still present. The probe
+  // is run once at install time, before any of our listeners are registered, to
+  // avoid the probe event re-entering our own handlers. The result is cached in
+  // the module-level WeakMap so repeated calls for the same container are
+  // pure cache lookups (no per-keystroke probe dispatches).
+  if (!imeWorkaroundBugCache.has(parent)) {
+    const probe = new InputEvent("beforeinput", {
+      bubbles: false,
+      cancelable: true,
+      inputType: "insertText",
+      data: "",
+    });
+    parent.dispatchEvent(probe);
+    imeWorkaroundBugCache.set(parent, probe.defaultPrevented);
+  }
+  if (!imeWorkaroundBugCache.get(parent)) {
+    // ghostty-web fixed its beforeinput handling; no workaround needed.
+    return () => {};
+  }
+
+  let imeActive = false;
+
+  function onKeyDown(event: Event): void {
+    const ke = event as KeyboardEvent;
+    if (ke.keyCode === 229 || ke.isComposing) {
+      imeActive = true;
+    }
+  }
+
+  function onCompositionStart(): void {
+    imeActive = true;
+  }
+
+  function onCompositionEnd(): void {
+    // Reset our tracking state. Ghostty's own compositionend listener also
+    // runs for the synthetic event we dispatch in onBeforeInput.
+    imeActive = false;
+  }
+
+  /**
+   * Walk composedPath() to find the ghostty container: the element that owns
+   * both a canvas child (the renderer) and a textarea child (the IME proxy).
+   */
+  function findGhosttyContainer(path: EventTarget[]): Element | null {
+    for (const target of path) {
+      if (!(target instanceof Element)) {
+        continue;
+      }
+      if (target.querySelector("canvas") !== null && target.querySelector("textarea") !== null) {
+        return target;
+      }
+    }
+    return null;
+  }
+
+  function onBeforeInput(event: Event): void {
+    if (!imeActive) {
+      return;
+    }
+    const ie = event as InputEvent;
+
+    let data: string | null = null;
+    if (ie.inputType === "insertText") {
+      data = ie.data ?? "";
+    } else if (ie.inputType === "insertLineBreak" || ie.inputType === "insertParagraph") {
+      data = "\r";
+    } else if (ie.inputType === "deleteContentBackward") {
+      data = "\x7f";
+    }
+    if (data === null) {
+      return;
+    }
+
+    const path = event.composedPath();
+    const container = findGhosttyContainer(path);
+    if (!container) {
+      return;
+    }
+    // Bug was confirmed at install time (cached in imeWorkaroundBugCache); the
+    // check above against the module WeakMap is a pure lookup with no dispatch.
+    if (!imeWorkaroundBugCache.get(container)) {
+      return;
+    }
+
+    // Forward the committed text to ghostty's own compositionend listener.
+    // ghostty's handleCompositionEnd calls onDataCallback(data) for non-empty
+    // data, which is the PTY write path. Use bubbles:false so only listeners
+    // on the container itself (ghostty's own) receive this synthetic event.
+    const compositionEnd = new CompositionEvent("compositionend", {
+      bubbles: false,
+      cancelable: false,
+      data,
+    });
+    container.dispatchEvent(compositionEnd);
+  }
+
+  parent.addEventListener("keydown", onKeyDown, { capture: true });
+  parent.addEventListener("compositionstart", onCompositionStart, { capture: true });
+  parent.addEventListener("compositionend", onCompositionEnd, { capture: true });
+  parent.addEventListener("beforeinput", onBeforeInput, { capture: true });
+
+  return () => {
+    parent.removeEventListener("keydown", onKeyDown, true);
+    parent.removeEventListener("compositionstart", onCompositionStart, true);
+    parent.removeEventListener("compositionend", onCompositionEnd, true);
+    parent.removeEventListener("beforeinput", onBeforeInput, true);
+  };
+}
+
 /** Creates a terminal whose WASM memory is never reused by another tab. */
 export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTerminalOptions) {
   const [{ createGhosttyTerminal, loadGhosttyRuntime }, ghosttyModule] = await Promise.all([
@@ -26,6 +171,9 @@ export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTermin
   const mouseUpCandidate = asOptionalRecord(terminal)?.handleMouseUp;
   let handleMouseUp = isEventListener(mouseUpCandidate) ? mouseUpCandidate : undefined;
   let disposed = false;
+  // Android soft-keyboard IME forwarding for ghostty-web 0.4.0 bug. See
+  // installTerminalImeWorkaround for the full explanation and issue reference.
+  const cleanupIme = installTerminalImeWorkaround(options.parent);
   // Ghostty 0.4.0 drops resize notifications during its 50ms fit lock. Measure
   // through its public addon, but let one owner apply every final layout size.
   controller.fit = () => {
@@ -44,6 +192,7 @@ export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTermin
     disposed = true;
     observer?.disconnect();
     measurement.dispose();
+    cleanupIme();
     // ghostty-web 0.4.0 clears isOpen before cleanup, skipping this listener removal.
     if (handleMouseUp) {
       document.removeEventListener("mouseup", handleMouseUp);


### PR DESCRIPTION
## What Problem This Solves

Typing into the terminal from an Android soft keyboard does nothing. No characters appear, and there is no error. The terminal looks focused and behaves as though the keystrokes were discarded, which is exactly what happens.

`ghostty-web` 0.4.0 installs this listener:

```js
A.addEventListener("beforeinput", (E) => E.preventDefault());
```

and separately returns early for `keyCode === 229`. Android soft keyboards deliver committed text on `beforeinput` with `keyCode 229` on the preceding `keydown`. The listener cancels the browser's own DOM editing but never forwards `event.data` to a PTY write path, and the tested keyboard emitted no later data-bearing composition completion. So the text exists in the event and is then dropped.

Confirmed by live remote debugging on a physical device:

```
keydown     {keyCode: 229, target: "OPENCLAW-TERMINAL-PANEL"}
beforeinput {data: "k", inputType: "insertText", defaultPrevented: false}
composedPath: TEXTAREA > DIV > SLOT > ... > OPENCLAW-TERMINAL-PANEL
```

Upstream bug: [coder/ghostty-web#120](https://github.com/coder/ghostty-web/issues/120), "fix: Korean/CJK IME composition events not captured", open at time of writing.

## Approach

This follows the existing convention in `terminal-runtime.ts`, which already carries workarounds for three other `ghostty-web` 0.4.0 defects, each stating what breaks and when it can be removed. This is a fourth entry in that pattern rather than a new mechanism.

Two choices worth calling out:

**It does not reimplement a write path.** The committed text is handed to ghostty's own `handleCompositionEnd`, which already does `if (data && data.length > 0) onDataCallback(data)`. Ghostty's encoder keeps ownership of the spelling, including live DECCKM state.

**It is scoped to coarse-pointer devices.** On desktop the existing keydown route works and a native `compositionend` still fires, so forwarding unconditionally would deliver CJK input twice. The guard confines the workaround to the path where the defect was observed.

The terminal lives inside an open shadow root, so document-level listeners see events retargeted to the host element. The container is located via `composedPath()`, which does expose the internals, and is identified structurally as the element owning both a canvas and a textarea rather than by any incidental attribute.

Removal is gated on `coder/ghostty-web#120` being fixed and the minimum version moving past it.

## Evidence

New unit test, `ui/src/components/terminal/terminal-runtime-ime.test.ts`:

```
✓ beforeinput insertText during IME active dispatches compositionend on ghostty container
✓ beforeinput during non-IME state does nothing
✓ on non-touch device: fix is not installed
✓ insertLineBreak maps to carriage return
✓ insertParagraph also maps to carriage return
✓ deleteContentBackward maps to DEL byte (0x7f)
✓ cleanup removes listeners so subsequent beforeinput no longer forwards

Test Files  1 passed (1)
     Tests  7 passed (7)
```

The non-touch case is the one that matters most for review: it is the guard against double-delivery of CJK input on desktop, so it is asserted directly rather than assumed.

Typecheck passes on the changed files.
