### PR TITLE
fix(ui): reserve space for the Android soft keyboard in the terminal

### DIFF
--- a/ui/src/components/terminal/terminal-keyboard-reserve.test.ts
+++ b/ui/src/components/terminal/terminal-keyboard-reserve.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { observeTerminalKeyboardReserve } from "./terminal-keyboard-reserve.ts";
+
+/**
+ * Stubs window.visualViewport with controllable height, offsetTop, and scale.
+ * vitest's vi.stubGlobal replaces the property on the window object; we use
+ * Object.defineProperty so the stub is configurable and restorable.
+ */
+function stubVisualViewport(opts: { height: number; offsetTop?: number; scale?: number }): {
+  trigger: (event: "resize" | "scroll") => void;
+} {
+  const listeners: Record<string, Array<() => void>> = {};
+  const vv = {
+    height: opts.height,
+    offsetTop: opts.offsetTop ?? 0,
+    scale: opts.scale ?? 1,
+    addEventListener(type: string, fn: () => void) {
+      (listeners[type] ??= []).push(fn);
+    },
+    removeEventListener(type: string, fn: () => void) {
+      listeners[type] = (listeners[type] ?? []).filter((f) => f !== fn);
+    },
+  };
+  vi.stubGlobal("visualViewport", vv);
+  return {
+    trigger(event: "resize" | "scroll") {
+      for (const fn of listeners[event] ?? []) {
+        fn();
+      }
+    },
+  };
+}
+
+/**
+ * Stubs window.innerHeight (read-only in browsers, configurable in jsdom).
+ */
+function stubInnerHeight(value: number): void {
+  Object.defineProperty(window, "innerHeight", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("observeTerminalKeyboardReserve", () => {
+  let container: HTMLDivElement;
+  let cleanupReserve: (() => void) | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    cleanupReserve = undefined;
+  });
+
+  afterEach(() => {
+    cleanupReserve?.();
+    cleanupReserve = undefined;
+    container.remove();
+    vi.unstubAllGlobals();
+    // Reset configurable properties.
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      value: 768,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  function setupCoarseDevice(): void {
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 5,
+      configurable: true,
+      writable: true,
+    });
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: true }) as MediaQueryList),
+    );
+  }
+
+  function setupNonTouchDevice(): void {
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: false }) as MediaQueryList),
+    );
+  }
+
+  it("at scale 1 with keyboard open (innerHeight 676, vv.height 363, offsetTop 0): applies 313 px padding", async () => {
+    setupCoarseDevice();
+    stubInnerHeight(676);
+    const vv = stubVisualViewport({ height: 363, offsetTop: 0, scale: 1 });
+
+    cleanupReserve = observeTerminalKeyboardReserve(container);
+
+    // scheduleUpdate uses requestAnimationFrame; flush it.
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(container.style.paddingBottom).toBe("313px");
+
+    // Verify it also responds to a viewport resize event.
+    // Simulate keyboard closing.
+    stubInnerHeight(676);
+    // Update vv height to match innerHeight (keyboard gone).
+    vi.stubGlobal("visualViewport", {
+      ...window.visualViewport,
+      height: 676,
+      offsetTop: 0,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vv.trigger("resize");
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(container.style.paddingBottom).toBe("");
+  });
+
+  it("at scale 1 with keyboard closed (vv.height = innerHeight): applies no padding", async () => {
+    setupCoarseDevice();
+    stubInnerHeight(800);
+    stubVisualViewport({ height: 800, offsetTop: 0, scale: 1 });
+
+    cleanupReserve = observeTerminalKeyboardReserve(container);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(container.style.paddingBottom).toBe("");
+  });
+
+  it("at scale 2 (pinch-zoom) with open-looking gap: applies no padding (zoom guard)", async () => {
+    setupCoarseDevice();
+    // At scale 2, innerHeight 915 vs vv.height 457.5 looks like a 457.5 px gap
+    // but it is actually the zoom factor, not a keyboard.
+    stubInnerHeight(915);
+    stubVisualViewport({ height: 457.5, offsetTop: 0, scale: 2 });
+
+    cleanupReserve = observeTerminalKeyboardReserve(container);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(container.style.paddingBottom).toBe("");
+  });
+
+  it("on non-touch device: no padding applied even with a large gap", async () => {
+    setupNonTouchDevice();
+    stubInnerHeight(676);
+    stubVisualViewport({ height: 363, offsetTop: 0, scale: 1 });
+
+    cleanupReserve = observeTerminalKeyboardReserve(container);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(container.style.paddingBottom).toBe("");
+  });
+
+  it("cleanup removes listeners so subsequent viewport resize has no effect", async () => {
+    setupCoarseDevice();
+    stubInnerHeight(676);
+    const vv = stubVisualViewport({ height: 363, offsetTop: 0, scale: 1 });
+
+    const cleanup = observeTerminalKeyboardReserve(container);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    // Confirm padding was applied.
+    expect(container.style.paddingBottom).toBe("313px");
+
+    // Cleanup resets padding and removes listeners.
+    cleanup();
+    expect(container.style.paddingBottom).toBe("");
+
+    // Trigger a resize; padding must not come back.
+    vv.trigger("resize");
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(container.style.paddingBottom).toBe("");
+  });
+});

--- a/ui/src/components/terminal/terminal-keyboard-reserve.ts
+++ b/ui/src/components/terminal/terminal-keyboard-reserve.ts
@@ -1,0 +1,117 @@
+/**
+ * Soft-keyboard viewport reserve for the ghostty terminal on Android.
+ *
+ * On a Galaxy Z Fold6 (Chrome, Android) with the soft keyboard open:
+ *   innerHeight = 676, visualViewport.height = 363, offsetTop = 0
+ *   => gap = 313 px
+ *
+ * The page declares `interactive-widget=resizes-content`, which by spec
+ * should make this gap zero, but Chrome on the Fold6 does not resize the
+ * layout viewport when the keyboard is shown. The 313 px gap is real and
+ * covers the terminal canvas. ghostty's FitAddon computes row count from
+ * `container.clientHeight - paddingTop - paddingBottom`, so setting
+ * `padding-bottom` on the ghostty container is enough to prevent the canvas
+ * from being painted behind the keyboard -- no synthetic resize events needed.
+ *
+ * Pinch-zoom guard: at page scale 2 with no keyboard, innerHeight 915 vs
+ * visualViewport.height 457.5 yields a false ~458 px reserve that would
+ * collapse the terminal. The scale check (`Math.abs(scale - 1) <= 0.01`)
+ * suppresses the reserve at non-unit zoom.
+ *
+ * Remove this workaround when Chrome on Android respects
+ * `interactive-widget=resizes-content` for `innerHeight`, or when ghostty
+ * provides a direct API to account for the keyboard inset.
+ */
+
+/**
+ * Computes the current soft-keyboard inset in pixels.
+ *
+ * Returns 0 when:
+ * - `window.visualViewport` is unavailable.
+ * - The page scale is not approximately 1 (pinch-zoom guard).
+ * - The computed gap is 1 px or less (rounding noise tolerance).
+ */
+function keyboardInset(): number {
+  const vv = window.visualViewport;
+  if (!vv) {
+    return 0;
+  }
+  // Pinch-zoom guard: at non-unit scale the innerHeight / vv.height ratio
+  // reflects zoom, not the keyboard. Suppress the reserve entirely.
+  const scale = vv.scale;
+  if (Math.abs(scale - 1) > 0.01) {
+    return 0;
+  }
+  // gap = space between the visual viewport top edge (accounting for scrolled
+  // offset) and the bottom of the layout viewport. When the soft keyboard is
+  // open this equals the keyboard height on Chrome/Android despite the page
+  // declaring interactive-widget=resizes-content.
+  //
+  // This reads window.innerHeight rather than the
+  // `documentElement.clientHeight || innerHeight` pairing used elsewhere in the
+  // app (see chat-composer-dom.ts). That pairing prefers the layout viewport
+  // excluding classic scrollbars, which is right when positioning against
+  // document flow. The quantity needed here is specifically the one the
+  // keyboard does not move: innerHeight held at 676 across the keyboard
+  // opening while visualViewport.height dropped to 363. Substituting
+  // clientHeight would reintroduce a dependency on the layout-viewport resize
+  // whose absence this workaround exists to handle.
+  const gap = window.innerHeight - (vv.height + vv.offsetTop);
+  return gap > 1 ? Math.round(gap) : 0;
+}
+
+/**
+ * Observes soft-keyboard visibility and applies a matching `padding-bottom`
+ * to `container` to reserve space so the ghostty canvas is not painted
+ * behind the keyboard on Android.
+ *
+ * Only installed on coarse-pointer touch devices. Returns a cleanup function
+ * that removes all listeners and clears the reserved padding.
+ *
+ * @param container - The ghostty container element (`options.parent` from
+ *   `createIsolatedGhosttyTerminal`).
+ * @returns A cleanup function.
+ */
+export function observeTerminalKeyboardReserve(container: HTMLElement): () => void {
+  // Guard: coarse-pointer touch devices only.
+  if (
+    !(navigator.maxTouchPoints > 0) ||
+    !(typeof window.matchMedia === "function" && window.matchMedia("(pointer: coarse)").matches)
+  ) {
+    return () => {};
+  }
+
+  let rafHandle: number | null = null;
+  const vv = window.visualViewport;
+
+  function applyReserve(): void {
+    rafHandle = null;
+    const inset = keyboardInset();
+    container.style.paddingBottom = inset > 0 ? `${inset}px` : "";
+  }
+
+  function scheduleUpdate(): void {
+    if (rafHandle !== null) {
+      return;
+    }
+    rafHandle = requestAnimationFrame(applyReserve);
+  }
+
+  window.addEventListener("resize", scheduleUpdate, { passive: true });
+  vv?.addEventListener("resize", scheduleUpdate);
+  vv?.addEventListener("scroll", scheduleUpdate);
+
+  // Apply immediately so the reserve is correct before the first RAF.
+  scheduleUpdate();
+
+  return () => {
+    window.removeEventListener("resize", scheduleUpdate);
+    vv?.removeEventListener("resize", scheduleUpdate);
+    vv?.removeEventListener("scroll", scheduleUpdate);
+    if (rafHandle !== null) {
+      cancelAnimationFrame(rafHandle);
+      rafHandle = null;
+    }
+    container.style.paddingBottom = "";
+  };
+}

--- a/ui/src/components/terminal/terminal-runtime.ts
+++ b/ui/src/components/terminal/terminal-runtime.ts
@@ -1,5 +1,6 @@
 import type { CreateGhosttyTerminalOptions } from "@openclaw/libterminal/browser";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { observeTerminalKeyboardReserve } from "./terminal-keyboard-reserve.ts";
 
 function isEventListener(value: unknown): value is EventListener {
   return typeof value === "function";
@@ -26,6 +27,9 @@ export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTermin
   const mouseUpCandidate = asOptionalRecord(terminal)?.handleMouseUp;
   let handleMouseUp = isEventListener(mouseUpCandidate) ? mouseUpCandidate : undefined;
   let disposed = false;
+  // Soft-keyboard viewport reserve for Android Chrome. See
+  // observeTerminalKeyboardReserve for the full explanation.
+  const cleanupKeyboardReserve = observeTerminalKeyboardReserve(options.parent);
   // Ghostty 0.4.0 drops resize notifications during its 50ms fit lock. Measure
   // through its public addon, but let one owner apply every final layout size.
   controller.fit = () => {
@@ -44,6 +48,7 @@ export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTermin
     disposed = true;
     observer?.disconnect();
     measurement.dispose();
+    cleanupKeyboardReserve();
     // ghostty-web 0.4.0 clears isOpen before cleanup, skipping this listener removal.
     if (handleMouseUp) {
       document.removeEventListener("mouseup", handleMouseUp);


### PR DESCRIPTION
## What Problem This Solves

On Android, opening the soft keyboard in the terminal paints the canvas behind the keyboard. The prompt and the cursor end up underneath it, so you cannot see what you are typing.

Ghostty's `FitAddon` derives its row count from its container's `clientHeight` minus padding, and registers no window resize listener of its own. Nothing in the current code informs it that the usable area shrank.

## Anticipating the first objection

The Control UI declares:

```
interactive-widget=resizes-content
```

Under that policy the layout viewport is supposed to shrink with the keyboard, which would make `innerHeight - visualViewport.height` approximately zero and this entire change pointless. That was my own first conclusion, and it was wrong.

Measured on a physical Galaxy Z Fold6 in Chrome:

| State | innerHeight | visualViewport.height | gap | applied | canvas height |
|---|---|---|---|---|---|
| Idle, no keyboard | 676 | 676 | 0 | 0 | 611 |
| **Keyboard open** | **676** | **363** | **313** | **313px** | **247** |

`innerHeight` does not move. The layout viewport is not resized despite the declared policy, the gap is a real 313px, and the reserve is load-bearing.

This is one handset, and I would not want that overstated. Ruled out on the way: both routes serve a byte-identical document with the same viewport meta, and the bundle contains no `navigator.virtualKeyboard.overlaysContent` override, which is the one API that can legitimately shadow the meta policy. That leaves a Chrome, device, or browsing-mode discrepancy. The comment in the source records the measurement explicitly so the next reader does not delete the code on the strength of the declared policy, which is what I nearly did.

## Approach

Apply `padding-bottom` matching the keyboard inset to the ghostty container. Because `FitAddon` already subtracts padding from `clientHeight`, this is sufficient on its own and needs no synthetic resize events.

**A pinch-zoom guard is required, not optional.** At page scale 2 with no keyboard, the naive expression returns a false reserve of roughly 458px, which collapses the terminal. Keyboard avoidance is therefore suppressed at any non-unit scale. That is a deliberate trade: a scale-corrected estimate risks recreating the very collapse the guard prevents, so the conservative behavior is to do nothing while zoomed.

The implementation follows the `visualViewport` observation pattern already used in `chat-composer-dom.ts`, with one documented divergence. It reads `window.innerHeight` rather than that file's `documentElement.clientHeight || innerHeight` pairing, because the quantity needed here is specifically the one the keyboard does not move. Substituting `clientHeight` would reintroduce a dependency on the layout-viewport resize whose absence this workaround exists to handle. The reasoning is in the source comment.

Scoped to coarse-pointer devices, and fully reverted by the returned cleanup function, which is wired into the existing dispose path.

## Evidence

New unit test, `ui/src/components/terminal/terminal-keyboard-reserve.ts` covered by `terminal-keyboard-reserve.test.ts`, using the measured device numbers as fixtures rather than invented ones:

```
✓ at scale 1 with keyboard open (innerHeight 676, vv.height 363, offsetTop 0): applies 313 px padding
✓ at scale 1 with keyboard closed (vv.height = innerHeight): applies no padding
✓ at scale 2 (pinch-zoom) with open-looking gap: applies no padding (zoom guard)
✓ on non-touch device: no padding applied even with a large gap
✓ cleanup removes listeners so subsequent viewport resize has no effect

Test Files  1 passed (1)
     Tests  5 passed (5)
```

Typecheck passes on the changed files.

## Open question for reviewers

This sets `container.style.paddingBottom` directly. If a CSS custom property applied through `terminal-panel-styles.ts` is the preferred layer for this project, say so and I will move it.
