### PR TITLE
docs(line): document channels.line.historyLimit

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -275,6 +275,7 @@ as untrusted.
   and rejects group and room ids — so a group reply arrives without one. Heartbeat
   turns also show the loading animation while the reply is generated.
 - Media downloads are capped by `channels.line.mediaMaxMb` (default 10).
+- Group history context uses `channels.line.historyLimit` (or `channels.line.accounts.*.historyLimit`), falling back to `messages.groupChat.historyLimit`. Set `0` to disable (default 50).
 - Inbound media is saved under `~/.openclaw/media/inbound/` before it is passed
   to the agent, matching the shared media store used by other channel plugins.
 - LINE webhooks carry ids but no names, so the sender's display name and the


### PR DESCRIPTION
## What Problem This Solves

The LINE channel reference omitted the `channels.line.historyLimit` option, even though the field is defined in the LINE config schema and consumed at runtime when recording group-chat history context. Users configuring via the docs could not discover this capability.

- Problem: `docs/channels/line.md` had no mention of `historyLimit` in its Message behavior section (or anywhere in the page). The field has existed in the schema since before the recent Simplified Technical English pass (#143979), which refined wording but did not add the missing field.
- Solution: Add a one-line entry to the Message behavior section, matching the sibling channel wording (Signal).
- What changed: `docs/channels/line.md` (+1 line).
- What did NOT change: No code or behavior changes. Documentation only.

## Why This Change Was Made

`channels.line.historyLimit` is defined in `extensions/line/src/config-schema.ts:27` as `z.number().int().min(0).optional()`, part of `LineCommonConfigSchemaBase` (so it applies both at the top level and per account via `LineAccountConfigSchema = LineCommonConfigSchemaBase.extend({...})` at config-schema.ts:48). At runtime, `extensions/line/src/bot.ts:109-111` resolves it as `account.config.historyLimit ?? cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT` and passes the result as `historyLimit` to `handleLineWebhookEvents`. `DEFAULT_GROUP_HISTORY_LIMIT` is `50` (`src/auto-reply/reply/history.ts:6`). The implementation and command contract are unchanged; this is a documentation discoverability fix.

## User Impact

Users can now discover the `historyLimit` group-history context cap (`0` disables; default `50`; falls back to `messages.groupChat.historyLimit`) from the LINE Message behavior section, matching the existing wording in the Signal docs (`docs/channels/signal.md:312`). No runtime behavior changes.

## Evidence

**Schema source** (`extensions/line/src/config-schema.ts:27`)
```typescript
historyLimit: z.number().int().min(0).optional(),
```
Part of `LineCommonConfigSchemaBase`, extended by `LineAccountConfigSchema` at config-schema.ts:48, so `channels.line.historyLimit` and `channels.line.accounts.<id>.historyLimit` are both valid.

**Type** (`extensions/line/src/types.ts:35`)
```typescript
historyLimit?: number;
```

**Runtime default** (`src/auto-reply/reply/history.ts:6`)
```typescript
export const DEFAULT_GROUP_HISTORY_LIMIT = 50;
```

**Runtime consumer** (`extensions/line/src/bot.ts:109-111`)
```typescript
historyLimit:
  account.config.historyLimit ??
  cfg.messages?.groupChat?.historyLimit ??
  DEFAULT_GROUP_HISTORY_LIMIT,
```
Passed as `historyLimit` to `handleLineWebhookEvents`.

**Sibling docs** — already documented for Signal (`docs/channels/signal.md:312`): "Group history context uses `channels.signal.historyLimit` (or `channels.signal.accounts.*.historyLimit`), falling back to `messages.groupChat.historyLimit`. Set `0` to disable (default 50)." and Nextcloud Talk (`docs/channels/nextcloud-talk.md:156`).

**Documentation checks**
- `oxfmt --check docs/channels/line.md` — All matched files use the correct format (1 file).
- `node scripts/docs-list.js` — line page indexed normally, no `[unterminated]`/error.
- `git diff --check` — no whitespace issues.
- `node scripts/check-docs-mdx.mjs` — not run in worktree (missing `node_modules`; `scripts/lib/tsx-cli-shim.mjs` throws "Repository dependencies are missing... Run pnpm install"). Same environment limitation as prior docs PRs; MDX check runs in CI on the exact head.

**Autoreview**: not run; codex engine failed in the local worktree environment (same as #143981). P0 threshold review of a 1-line docs-only change adds no additional signal.

**Proof boundary**: this is a documentation discoverability fix; the LINE implementation is unchanged. No runtime behavior proof applies.

Public documentation: https://docs.openclaw.ai/channels/line

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding**: Yes — verified 5-layer evidence (Schema → Type → Default → Consumer → Sibling docs), confirmed the gap still exists on the latest `origin/main` (a1b4f6f91724, which includes the STE pass #143979), and confirmed LINE has no `dmHistoryLimit` dead-field concern before writing.

