### PR TITLE
refactor(gateway): derive probe config summary type

### DIFF
--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -30,30 +30,7 @@ export type GatewayStatusTarget = {
 };
 
 /** Sanitized config subset rendered by the deep gateway status view. */
-export type GatewayConfigSummary = {
-  path: string | null;
-  exists: boolean;
-  valid: boolean;
-  issues: Array<{ path: string; message: string }>;
-  legacyIssues: Array<{ path: string; message: string }>;
-  gateway: {
-    mode: string | null;
-    bind: string | null;
-    port: number | null;
-    controlUiEnabled: boolean | null;
-    controlUiBasePath: string | null;
-    authMode: string | null;
-    authTokenConfigured: boolean;
-    authPasswordConfigured: boolean;
-    remoteUrl: string | null;
-    remoteTokenConfigured: boolean;
-    remotePasswordConfigured: boolean;
-    tailscaleMode: string | null;
-  };
-  discovery: {
-    wideAreaEnabled: boolean | null;
-  };
-};
+export type GatewayConfigSummary = ReturnType<typeof extractConfigSummary>;
 
 function parseIntOrNull(value: unknown): number | null {
   const s =
@@ -192,7 +169,7 @@ export async function resolveAuthForTarget(
 }
 
 /** Extracts the config fields displayed by `openclaw gateway status --deep`. */
-export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSummary {
+export function extractConfigSummary(snapshotUnknown: unknown) {
   const snap = snapshotUnknown as Partial<ConfigFileSnapshot> | null;
   const path = typeof snap?.path === "string" ? snap.path : null;
   const exists = Boolean(snap?.exists);


### PR DESCRIPTION
## What Problem This Solves

The Gateway probe config-summary type duplicates the complete shape of its sole producer. Derive the existing `GatewayConfigSummary` name from `ReturnType<typeof extractConfigSummary>` and remove the producer's explicit return annotation to avoid a circular type.

This removes 23 net production lines (+2/-25) in one file. No runtime expressions, imports or tests change. Configuration, authentication, storage, protocol and plugin SDK contracts are unchanged. The existing extractor comment that names `gateway status --deep` rather than the registered `gateway probe` route is retained, not corrected by this patch.

## Failure-justified base refresh

The original head `e91364d` failed the startup JavaScript budget by 10 bytes in CI. This refresh rebases the identical one-file patch onto canonical [492d32a](https://github.com/openclaw/openclaw/commit/492d32a05f4b0a1e8c11c0368435d0637c18e3f5) from #144538; it adds no duplicate UI repair and changes no budget.

An isolated same-runtime before/after comparison retained the Summary helper in both roles. The ordinary sidebar and persistence suites passed 27 and 5 cases in each role. The canonical performance comparator failed before and passed after: startup gzip 353,117 → 353,099 bytes against the unchanged 353,107-byte limit. This is not an all-assets compression improvement: total JavaScript gzip increased 312 bytes and startup Brotli increased 1 byte. Local Node 26.8.1 is not the failed CI's Node 24.20.0.

## Refreshed Summary evidence

Fresh helper/output/command verification on `1d61bc1` passed the same 70 cases (21/9/40), with full test names, per-file order and statuses checked. Four fresh TypeScript 6 programs compared original and candidate roles in both exact-optional-property modes, including shape, requiredness, mutability, NoAny/NotNever, producer and export witnesses. All witnesses passed and exported records matched. The earlier 20 structural negative controls remain explicitly historical, not 20 newly rerun programs.

The complete 11,923-byte emitted helper module is byte-identical; a runtime-expression polarity control changes it. This remains bounded type/transpilation proof, not a clean whole-program claim: the fresh alternate compiler graphs retain matched 1/16,810 source diagnostics (`fullProgramGreen=false`). Shifted owner diagnostic positions were compared without waiving diagnostics.

The ordinary configured 28-check gate passed against the verified exact `1d61bc1` tree on Linux Node 24.19.0/pnpm 12.3.4, including core/source-test typing, all three unused-code scopes, lint and remaining guards. [Configured gate carrier](https://github.com/openclaw/openclaw/actions/runs/34577740182). The candidate binding comes from the retained native source/tree and result records, not from the carrier's workflow head or final Actions appearance. The one-shot lease stopped/completed and its local capsule/processes were cleared. Native full-sync fallback and a post-success runner-portal synchronization warning are retained.

Fresh complete-branch and separate exact-commit Codex reviews each completed both evidence passes with no P0–P2 findings, using the repository helper. Both explicitly omit one unchanged dependency file under the helper's sensitive-filename policy; its contents were not renamed or copied into another input. The isolated passes did not each receive the other batch. These limitations are preserved; exact contract sufficiency relies on the separately inspected dependency and compiler proof, not the review's absence of findings alone.

## CI recovery and remaining limits

The old CI run also failed the Parallels escaped-descendant fixture while waiting for its PID marker. That test and its production owner are unchanged here. The unchanged local full file passed 111 cases; an external controlled startup-barrier diagnostic demonstrated a reachable setup dependency, but did not establish the exact hosted failure cause. The proposed test redesign remains unimplemented and the follow-up issue draft remains unposted. Both originally failing CI contexts passed on the refreshed head; this does not establish that the unchanged Parallels fixture was repaired.

[Exact-head CI run 34583080813](https://github.com/openclaw/openclaw/actions/runs/34583080813), attempt 2, completed successfully on unchanged `1d61bc1`. Attempt 1 passed the prior UI-performance and Parallels contexts but failed before large-shard tests when GitHub's Vitest cache-key `hashFiles` expression exceeded 120 seconds. One qualified failed-only rerun request, with no source/cache/action/timeout/environment changes, obtained the missing hosted proof. All 127 jobs are successful or skipped; the large shard's setup, build and test steps and the required CI gate passed. The exact cause of the earlier hashing slowdown remains unknown; no transient, host-load or cache-owner repair claim is made. A watcher pagination error after completion was reconciled by independent attempt-specific and normal run metadata, not by another rerun.

Existing report-replay warnings and incomplete sampling of short-lived worker PIDs remain documented. No live Gateway, provider/auth-policy, development-wrapper or full-build claim is made.

