### PR TITLE
fix(skills): preserve full verification reports

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -172,8 +172,8 @@ Notes:
 | `curator status --json`          | Reports live Workshop skill usage recorded from trusted `skill.used` events, collection review outcomes per agent, and experience review outcomes per agent and workspace.                                                                                                                                                        |
 | `curator pin`/`unpin`/`restore`  | Retired commands remain registered but return an error explaining that weekly collection review manages the skill collection.                                                                                                                                                                                                     |
 
-Verification JSON includes `scannerReports.aig` (the full upstream SARIF report)
-and `scannerReports.skillspector` (the full upstream JSON report) when ClawHub
+Verification JSON includes `security.scannerReports.aig` (the full upstream SARIF report)
+and `security.scannerReports.skillspector` (the full upstream JSON report) when ClawHub
 has retained them. Nested scanner fields pass through unchanged, including
 coverage and incomplete-analysis details. A report is `null` when unavailable,
 including older scans whose full output was not retained; summaries are not

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -172,6 +172,13 @@ Notes:
 | `curator status --json`          | Reports live Workshop skill usage recorded from trusted `skill.used` events, collection review outcomes per agent, and experience review outcomes per agent and workspace.                                                                                                                                                        |
 | `curator pin`/`unpin`/`restore`  | Retired commands remain registered but return an error explaining that weekly collection review manages the skill collection.                                                                                                                                                                                                     |
 
+Verification JSON includes `scannerReports.aig` (the full upstream SARIF report)
+and `scannerReports.skillspector` (the full upstream JSON report) when ClawHub
+has retained them. Nested scanner fields pass through unchanged, including
+coverage and incomplete-analysis details. A report is `null` when unavailable,
+including older scans whose full output was not retained; summaries are not
+substituted. `verify` reads the stored scan and does not start another scan.
+
 ## Release trust
 
 Community ClawHub skill installs and updates check trust before downloading.

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -172,12 +172,15 @@ Notes:
 | `curator status --json`          | Reports live Workshop skill usage recorded from trusted `skill.used` events, collection review outcomes per agent, and experience review outcomes per agent and workspace.                                                                                                                                                        |
 | `curator pin`/`unpin`/`restore`  | Retired commands remain registered but return an error explaining that weekly collection review manages the skill collection.                                                                                                                                                                                                     |
 
-Verification JSON includes `security.scannerReports.aig` (the full upstream SARIF report)
+On servers supporting full scanner reports, verification JSON includes `security.scannerReports.aig` (the full upstream SARIF report)
 and `security.scannerReports.skillspector` (the full upstream JSON report) when ClawHub
 has retained them. Nested scanner fields pass through unchanged, including
 coverage and incomplete-analysis details. A report is `null` when unavailable,
 including older scans whose full output was not retained; summaries are not
-substituted. `verify` reads the stored scan and does not start another scan.
+substituted. Older servers may omit `security.scannerReports` entirely. `verify`
+reads the stored scan and does not start another scan. Verification responses
+can be up to 64 MiB; larger responses fail explicitly without printing partial
+reports. Other ClawHub JSON requests retain their 16 MiB limit.
 
 ## Release trust
 

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -263,6 +263,11 @@ vi.mock("../runtime.js", async (importOriginal) => ({
   defaultRuntime: mocks.defaultRuntime,
 }));
 
+vi.mock("./one-shot-exit.js", () => ({
+  exitCliAfterOutput: (runtime: typeof mocks.defaultRuntime, exitCode: number) =>
+    runtime.exit(exitCode),
+}));
+
 vi.mock("../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => mocks.callGatewayMock(...args),
   isGatewayClientRequestError: (error: unknown) =>

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -72,6 +72,7 @@ import { inheritOptionFromParent } from "./command-options.js";
 import { formatCliJsonFailure } from "./failure-output.js";
 import { canFallbackToImplicitLocalGateway } from "./gateway-rpc.js";
 import { resolveInstallPolicyWarningAcknowledgementCliOptions } from "./install-policy-warning-acknowledgement.js";
+import { exitCliAfterOutput } from "./one-shot-exit.js";
 import { parseStrictPositiveIntOption } from "./program/helpers.js";
 import { setCommandJsonMode } from "./program/json-mode.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
@@ -921,11 +922,10 @@ export function registerSkillsCli(program: Command) {
           }
         } catch (err) {
           reportError(formatErrorMessage(err));
-          defaultRuntime.exit(1);
-          return;
+          exitCode = 1;
         }
         if (exitCode) {
-          defaultRuntime.exit(exitCode);
+          exitCliAfterOutput(defaultRuntime, exitCode);
         }
       },
     );

--- a/src/cli/skills-cli.verify.process.test.ts
+++ b/src/cli/skills-cli.verify.process.test.ts
@@ -34,7 +34,7 @@ describe("skills verify process output", () => {
               analysis_completeness: { is_complete: pass, coverage_percent: pass ? 100 : 99.1 },
               components: Array.from({ length: 235 }, (_, index) => ({
                 path: `references/service-${index}.md`,
-                upstreamDetails: { context: "  report detail\n".repeat(160) },
+                upstreamDetails: { context: "  report detail\n".repeat(5500) },
               })),
             }
           : null,
@@ -52,7 +52,7 @@ describe("skills verify process output", () => {
       };
       const body = JSON.stringify(verification);
       if (reportsAvailable) {
-        expect(Buffer.byteLength(body)).toBeGreaterThan(520 * 1024);
+        expect(Buffer.byteLength(body)).toBeGreaterThan(18 * 1024 * 1024);
       }
       const requests: string[] = [];
       const server = createServer((request, response) => {
@@ -94,7 +94,9 @@ describe("skills verify process output", () => {
 
         expect(result.signal, result.stderr).toBeNull();
         expect(result.code, result.stderr).toBe(pass ? 0 : 1);
-        expect(JSON.parse(result.stdout)).toEqual({
+        const output = JSON.parse(result.stdout);
+        expect(output.security).toBeDefined();
+        expect(output).toEqual({
           ...verification,
           openclaw: expect.any(Object),
         });

--- a/src/cli/skills-cli.verify.process.test.ts
+++ b/src/cli/skills-cli.verify.process.test.ts
@@ -1,0 +1,113 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { cliRecoveryEntrypoints } from "./cli-entrypoint.test-support.js";
+import { runCliProcessChild } from "./cli-process-child.test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("skills verify process output", () => {
+  it.each([
+    { label: "failed default JSON", pass: false, json: false, reportsAvailable: true },
+    { label: "passed explicit JSON", pass: true, json: true, reportsAvailable: true },
+    { label: "unavailable reports", pass: false, json: false, reportsAvailable: false },
+  ])(
+    "preserves complete scanner reports through $label",
+    async ({ pass, json, reportsAvailable }) => {
+      const root = tempDirs.make("openclaw-verify-output-");
+      const configPath = path.join(root, "openclaw.json");
+      await fs.writeFile(configPath, JSON.stringify({ agents: { defaults: { workspace: root } } }));
+      const scannerReports = {
+        aig: reportsAvailable
+          ? {
+              version: "2.1.0",
+              runs: [{ results: [], properties: { upstreamDetails: { checks: ["completed"] } } }],
+            }
+          : null,
+        skillspector: reportsAvailable
+          ? {
+              risk_assessment: { score: 0, recommendation: pass ? "SAFE" : "CAUTION" },
+              analysis_completeness: { is_complete: pass, coverage_percent: pass ? 100 : 99.1 },
+              components: Array.from({ length: 235 }, (_, index) => ({
+                path: `references/service-${index}.md`,
+                upstreamDetails: { context: "  report detail\n".repeat(160) },
+              })),
+            }
+          : null,
+      };
+      const verification = {
+        schema: "clawhub.skill.verify.v1",
+        ok: pass,
+        decision: pass ? "pass" : "fail",
+        reasons: pass ? [] : ["security.status_not_clean"],
+        slug: "weather",
+        publisherHandle: "demo-owner",
+        version: "2.0.0",
+        security: { status: pass ? "clean" : "suspicious" },
+        provenance: null,
+        scannerReports,
+      };
+      const body = JSON.stringify(verification);
+      if (reportsAvailable) {
+        expect(Buffer.byteLength(body)).toBeGreaterThan(520 * 1024);
+      }
+      const requests: string[] = [];
+      const server = createServer((request, response) => {
+        requests.push(request.url ?? "");
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(body);
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("HTTP fixture did not bind a TCP port");
+        }
+        const result = await runCliProcessChild({
+          nodeArgs: [
+            ...resolveRuntimeWorkerArgv(resolveRuntimeWorkerUrl(cliRecoveryEntrypoints.cli)),
+            "skills",
+            "verify",
+            "@demo-owner/weather",
+            "--version",
+            "2.0.0",
+            ...(json ? ["--json"] : []),
+          ],
+          env: {
+            PATH: process.env.PATH,
+            ESBUILD_WORKER_THREADS: process.env.ESBUILD_WORKER_THREADS,
+            HOME: root,
+            USERPROFILE: root,
+            NODE_DISABLE_COMPILE_CACHE: "1",
+            OPENCLAW_NO_RESPAWN: "1",
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_STATE_DIR: path.join(root, "state"),
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+            OPENCLAW_CLAWHUB_URL: `http://127.0.0.1:${address.port}`,
+            NO_COLOR: "1",
+          },
+        });
+
+        expect(result.signal, result.stderr).toBeNull();
+        expect(result.code, result.stderr).toBe(pass ? 0 : 1);
+        expect(JSON.parse(result.stdout)).toEqual({
+          ...verification,
+          openclaw: expect.any(Object),
+        });
+        expect(requests).toEqual([
+          "/api/v1/skills/weather/verify?version=2.0.0&ownerHandle=demo-owner",
+        ]);
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+});

--- a/src/cli/skills-cli.verify.process.test.ts
+++ b/src/cli/skills-cli.verify.process.test.ts
@@ -47,9 +47,8 @@ describe("skills verify process output", () => {
         slug: "weather",
         publisherHandle: "demo-owner",
         version: "2.0.0",
-        security: { status: pass ? "clean" : "suspicious" },
+        security: { status: pass ? "clean" : "suspicious", scannerReports },
         provenance: null,
-        scannerReports,
       };
       const body = JSON.stringify(verification);
       if (reportsAvailable) {

--- a/src/cli/skills-cli.verify.test.ts
+++ b/src/cli/skills-cli.verify.test.ts
@@ -47,6 +47,11 @@ vi.mock("../runtime.js", () => ({
   defaultRuntime: mocks.defaultRuntime,
 }));
 
+vi.mock("./one-shot-exit.js", () => ({
+  exitCliAfterOutput: (runtime: typeof mocks.defaultRuntime, exitCode: number) =>
+    runtime.exit(exitCode),
+}));
+
 vi.mock("../utils.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../utils.js")>()),
   CONFIG_DIR: "/tmp/openclaw-config",

--- a/src/infra/clawhub-client.test.ts
+++ b/src/infra/clawhub-client.test.ts
@@ -8,6 +8,7 @@ import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/e
 import {
   fetchClawHubSkillInstallResolution,
   fetchClawHubSkillSecurityVerdicts,
+  fetchClawHubSkillVerification,
   searchClawHubSkills,
 } from "./clawhub-skills.js";
 
@@ -477,39 +478,42 @@ describe("clawhub client", () => {
     expect(finalResponse?.cancel.mock.calls[0]?.[0]).toBeInstanceOf(Error);
   });
 
-  it("bounds oversized successful ClawHub JSON responses and cancels the stream", async () => {
-    const cancel = vi.fn();
-    const chunk = new Uint8Array(512 * 1024).fill("x".charCodeAt(0));
-    const overshootChunks = 34; // 34 * 512 KiB = 17 MiB > 16 MiB cap
-    let emitted = 0;
-    const body = new ReadableStream<Uint8Array>({
-      pull(controller) {
-        if (emitted >= overshootChunks) {
-          controller.close();
-          return;
-        }
-        emitted += 1;
-        controller.enqueue(chunk);
-      },
-      cancel() {
-        cancel();
-      },
-    });
+  it.each([
+    { kind: "metadata", maxMiB: 16, requestPath: "/api/v1/search" },
+    { kind: "verification", maxMiB: 64, requestPath: "/api/v1/skills/weather/verify" },
+  ])(
+    "bounds oversized $kind JSON and cancels the stream",
+    async ({ kind, maxMiB, requestPath }) => {
+      const cancel = vi.fn();
+      const chunk = new Uint8Array(512 * 1024).fill("x".charCodeAt(0));
+      let emitted = 0;
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (emitted >= (maxMiB + 1) * 2) {
+            controller.close();
+            return;
+          }
+          emitted += 1;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          cancel();
+        },
+      });
+      const fetchImpl = async () =>
+        new Response(body, { status: 200, headers: { "content-type": "application/json" } });
+      const result =
+        kind === "verification"
+          ? fetchClawHubSkillVerification({ slug: "weather", fetchImpl })
+          : searchClawHubSkills({ query: "calendar", fetchImpl });
 
-    await expect(
-      searchClawHubSkills({
-        query: "calendar",
-        fetchImpl: async () =>
-          new Response(body, {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-      }),
-    ).rejects.toThrow(/ClawHub \/api\/v1\/search response exceeded 16777216 bytes/);
-    // The reader is cancelled at the cap so the oversized stream releases its
-    // socket/buffer instead of being drained into memory.
-    expect(cancel).toHaveBeenCalledTimes(1);
-  });
+      await expect(result).rejects.toThrow(
+        `ClawHub ${requestPath} response exceeded ${maxMiB * 1024 * 1024} bytes`,
+      );
+      // Cancel at the cap before allocating a contiguous copy of the oversized body.
+      expect(cancel).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("bounds oversized ClawHub error bodies to a short collapsed snippet", async () => {
     const oversized = "boom ".repeat(64 * 1024); // ~320 KiB error body

--- a/src/infra/clawhub-client.ts
+++ b/src/infra/clawhub-client.ts
@@ -342,12 +342,14 @@ export function decodeClawHubResponseBody(buffer: Uint8Array): string {
   return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
 }
 
-export async function fetchClawHubJson<T>(params: ClawHubRequestParams): Promise<T> {
+export async function fetchClawHubJson<T>(
+  params: ClawHubRequestParams & { maxResponseBytes?: number },
+): Promise<T> {
   return await withClawHubResponse(params, async ({ response, url, hasToken }) => {
     if (!response.ok) {
       throw await createClawHubError(response, url, hasToken, params.timeoutMs);
     }
-    return parseClawHubJsonBody<T>(response, url, params.timeoutMs);
+    return parseClawHubJsonBody<T>(response, url, params.timeoutMs, params.maxResponseBytes);
   });
 }
 
@@ -355,8 +357,9 @@ export async function parseClawHubJsonBody<T>(
   response: Response,
   url: URL,
   timeoutMs?: number,
+  maxResponseBytes = CLAWHUB_JSON_MAX_BYTES,
 ): Promise<T> {
-  const buffer = await readResponseWithLimit(response, CLAWHUB_JSON_MAX_BYTES, {
+  const buffer = await readResponseWithLimit(response, maxResponseBytes, {
     chunkTimeoutMs: resolveClawHubRequestTimeoutMs(timeoutMs),
     onOverflow: ({ size, maxBytes }) =>
       new Error(

--- a/src/infra/clawhub-skills.ts
+++ b/src/infra/clawhub-skills.ts
@@ -16,6 +16,8 @@ import {
 } from "./clawhub-client.js";
 
 const SKILL_CARD_MAX_BYTES = 256 * 1024;
+// Full scanner evidence can exceed the metadata reader's 16 MiB cap.
+const SKILL_VERIFICATION_MAX_BYTES = 64 * 1024 * 1024;
 
 export const CLAWHUB_SKILLS_SH_TRUST_STATE = "not-scanned-by-clawhub" as const;
 export const CLAWHUB_SKILLS_SH_TRUST_LABEL = "Not scanned by ClawHub" as const;
@@ -367,6 +369,7 @@ export async function fetchClawHubSkillVerification(params: {
   return await fetchClawHubJson<ClawHubSkillVerificationResponse>({
     baseUrl: params.baseUrl,
     path: `/api/v1/skills/${encodeURIComponent(params.slug)}/verify`,
+    maxResponseBytes: SKILL_VERIFICATION_MAX_BYTES,
     token: params.token,
     skipAuth: params.skipAuth,
     timeoutMs: params.timeoutMs,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users piping `openclaw skills verify` to CI would receive truncated, invalid JSON when verification failed and the response contained a large scanner report. The command could exit before stdout finished writing. Full scanner reports over 16 MiB also hit the metadata response cap before the CLI could inspect their verdict.

## Why This Change Was Made

Use the existing `exitCliAfterOutput` helper for failed verification and error responses. Successful verification still exits 0; rejected verification still exits 1. Document complete upstream AIG and SkillSpector JSON under `security.scannerReports`, including older servers that may omit reports. Give verification a finite 64 MiB response budget while keeping the shared metadata budget at 16 MiB. Responses over the limit fail explicitly; no report is silently truncated.

Companion: https://github.com/openclaw/clawhub/pull/3663. This accompanies ClawHub's full scanner-report output. ClawHub still owns the verdict and response shape; the CLI passes the response through.

## User Impact

CI can parse the complete JSON for both passing and failing verification. Coverage, limitations and findings remain available for large skills.

## Evidence

Same synthetic 235-component HTTP fixture through the installed CLI before and the built candidate CLI after, with stdout captured through a pipe:

| Case | Before | After |
| --- | --- | --- |
| Failed verification | 65,536 bytes; invalid JSON; exit 1 | 675,306 bytes; valid JSON; exit 1 |
| Passing verification | Valid JSON; exit 0 | Valid JSON; exit 0 |
| Full native reports preserved | No on failure | Yes on both paths, checked by deep equality |

The fixture uses the final `security.scannerReports` layout. These are synthetic transport cases, not published skill verdicts. Separately, a fresh real `bro` scan passed through a local ClawHub backend and this built CLI: complete AIG and SkillSpector reports, 18,152-byte JSON, exit 0.

A second captured HTTP-to-built-CLI fixture exercises the reviewed response-cap failure (21,990,670 bytes for pass / 21,990,708 bytes for fail). Before the follow-up, both returned a 183-byte size-limit error and exit 1. After the fix, passing verification emits 22,008,560 bytes of valid JSON and exit 0; failing verification emits 22,008,606 bytes and exit 1. Both native reports match the original fixture exactly, with no stderr. Unit coverage separately verifies cancellation above 64 MiB and retention of the 16 MiB metadata cap.

Validation:
- 229 targeted CLI/HTTP tests passed, including real subprocess coverage for failed/default JSON, successful/explicit JSON and unavailable reports, plus cancellation at both response caps.
- `node scripts/check-changed.mjs` passed on the final changes; `pnpm docs:check-links` reports 13,417 checked links and zero broken links.
- Full build passed. After two lint-only binding renames, all 68 HTTP tests passed again.
- Structured autoreview: clean, no actionable findings.
