### PR TITLE
fix: preserve voice and text senders in reconstructed group history

### DIFF
--- a/src/channels/inbound-event/session-transcript-context.runtime.test.ts
+++ b/src/channels/inbound-event/session-transcript-context.runtime.test.ts
@@ -38,6 +38,45 @@ describe("session transcript inbound context", () => {
     readRecent.mockReset();
   });
 
+  it.each([false, true])(
+    "keeps voice authors in model context (chatWindow=%s)",
+    async (chatWindow) => {
+      readRecent.mockResolvedValue([
+        {
+          id: "voice",
+          role: "user",
+          text: "[Audio] Transcript: It is late",
+          timestamp: 1_000,
+          senderName: "Alice",
+          senderUsername: "@alice",
+          senderId: "42",
+        },
+        {
+          id: "other",
+          role: "user",
+          text: "Who sent that?",
+          timestamp: 2_000,
+          senderName: "Bob",
+          senderUsername: "bob",
+          senderId: "43",
+        },
+      ]);
+      const ctx = context({
+        ChatType: "group",
+        SessionTranscriptContext: { historyLimit: 3, chatWindow },
+      });
+      await mergeSessionTranscriptContext({
+        ctx,
+        sessionKey: ctx.SessionKey!,
+        storePath: "/tmp/sessions.json",
+      });
+      const prompt = buildInboundUserContextPrefix(ctx, { timezone: "UTC" });
+      expect(prompt).toContain("Alice @alice");
+      expect(prompt).toContain("Bob @bob");
+      expect(prompt).toContain("[Audio] Transcript: It is late");
+    },
+  );
+
   it("restores Slack assistant context when the live window is empty after restart", async () => {
     readRecent.mockResolvedValue([
       { id: "u1", role: "user", text: "deploy at noon", timestamp: 1_000 },

--- a/src/channels/inbound-event/session-transcript-context.runtime.ts
+++ b/src/channels/inbound-event/session-transcript-context.runtime.ts
@@ -136,13 +136,20 @@ export async function mergeSessionTranscriptContext(params: {
   });
   const labels = options?.senderLabels ?? { assistant: "Assistant", user: "User" };
   const transcript = turns.map((turn) => {
+    const username = turn.senderUsername?.replace(/^@+/, "");
+    const sender =
+      turn.role === "user"
+        ? [turn.senderName, username ? `@${username}` : undefined].filter(Boolean).join(" ") ||
+          turn.senderId ||
+          labels.user
+        : labels.assistant;
     const item: {
       entry: HistoryEntry;
       role: "assistant" | "user";
       transcriptId?: string;
     } = {
       entry: {
-        sender: `${labels[turn.role]}${turn.sourceChannel ? ` (${turn.sourceChannel})` : ""}`,
+        sender: `${sender}${turn.sourceChannel ? ` (${turn.sourceChannel})` : ""}`,
         body: turn.text,
       },
       role: turn.role,

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -993,6 +993,36 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
+  it("preserves the sender of a stored voice transcript", async () => {
+    await writeTranscriptStore();
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [
+        {
+          message: {
+            role: "user",
+            content: "[Audio] Transcript: It is late, what are you doing?",
+            __openclaw: { senderId: "42", senderName: "Alice", senderUsername: "alice" },
+          },
+        },
+      ],
+    });
+    await expect(
+      readRecentUserAssistantTextForSession({
+        agentId: "main",
+        sessionKey,
+        storePath: fixture.storePath(),
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        text: "[Audio] Transcript: It is late, what are you doing?",
+        senderId: "42",
+        senderName: "Alice",
+        senderUsername: "alice",
+      }),
+    ]);
+  });
+
   it("resolves recent transcript context from session identity", async () => {
     await writeTranscriptStore();
     await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,4 +1,5 @@
 // Session transcript facade resolves transcript files, appends mirror messages, and reads tails.
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { SessionManager } from "../../agents/sessions/session-manager.js";
@@ -123,6 +124,9 @@ export type SessionRecentConversationText = {
   text: string;
   timestamp?: number;
   sourceChannel?: string;
+  senderId?: string;
+  senderName?: string;
+  senderUsername?: string;
 };
 
 type ReadRecentSessionConversationTextOptions = {
@@ -254,7 +258,15 @@ function parseRecentConversationText(
     message.provenance && typeof message.provenance === "object"
       ? (message.provenance as { sourceChannel?: unknown })
       : undefined;
+  const metadata = message.role === "user" ? asOptionalRecord(message["__openclaw"]) : undefined;
+  const sender = Object.fromEntries(
+    ["senderId", "senderName", "senderUsername"].flatMap((key) => {
+      const value = metadata?.[key];
+      return typeof value === "string" && value.trim() ? [[key, value.trim()]] : [];
+    }),
+  );
   return {
+    ...sender,
     ...(typeof parsed.id === "string" && parsed.id ? { id: parsed.id } : {}),
     role: message.role,
     text,


### PR DESCRIPTION
Related to #98229.

## What Problem This Solves

Fixes an issue where users asking who sent an earlier group message would get an unknown-sender answer after OpenClaw reconstructed conversation history. Voice transcripts were particularly confusing: their text survived, but the model received only a generic `User` label.

## Why This Change Was Made

Carry the already-persisted sender ID, name and username through the recent-transcript reader and render the name plus handle in channel history. Keep the existing role fallback, assistant labels, channel suffix, ordering and prompt sanitization. This changes attribution in the model-facing projection, not authentication or stored transcript content.

## User Impact

Follow-up questions can distinguish the authors of earlier text and voice messages when their sender metadata was saved. Records without identity metadata retain the existing fallback.

## Evidence

- `pnpm check:changed` passed on the combined source checkout: production/test typechecks, changed-file formatting and lint, SDK surface guards, dead-export scans and runtime import-cycle checks. Each PR contains only its own concern.

- 67 transcript tests and 10 channel-history tests passed on Node 24.19.0. Tests cover actual SQLite persistence/read of a voice transcript and both final prompt history paths.
- A read-only check of the installed reader → history merger → prompt renderer against an existing voice record confirmed its saved name and handle appear beside the transcription. The gateway then restarted with Telegram connected/ready; no test message was posted to the group.
- Independent review found no blocking issue. The Python-based autoreview launcher was not run because this contribution's workflow explicitly excludes Python; independent agent review was used instead.
- Full release build and full repository test suite were not run. The related issue also describes an older renderer; this PR fixes the current shared channel-history reconstruction path without claiming all other renderers are covered.
