### PR TITLE
fix: honor trusted-network opt-in for OpenAI OAuth voice transcription

### DIFF
--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -70,7 +70,15 @@ selected API-key or ChatGPT/Codex OAuth profile. An OAuth login can transcribe
 when the account permits it; access, quota, and billing remain account-specific.
 The default model is `gpt-4o-transcribe`; configured models, prompts, and language
 hints are sent through the same multipart request for either credential class.
-Custom endpoints and request overrides require an API-key profile.
+Custom endpoints and headers, auth, proxy, or TLS overrides require an API-key
+profile. The existing trusted provider setting
+`models.providers.openai.request.allowPrivateNetwork` also applies to OAuth
+transcription. Enable it only when your trusted network resolves the official
+OpenAI hostname to a private or special-use address (for example, VPN fake DNS).
+It relaxes the IP-address guard for that provider; HTTPS certificate verification
+and the official OAuth endpoint requirement remain in place. Leave it unset on
+ordinary public DNS. This setting belongs to model-provider configuration, not
+`tools.media.audio.request`.
 
 Automatic selection can try another provider or local backend when the OpenAI
 plugin rejects authentication or configuration before uploading audio. The

--- a/extensions/openai/audio-transcription.test.ts
+++ b/extensions/openai/audio-transcription.test.ts
@@ -1,0 +1,118 @@
+import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { transcribeOpenAiAudioWithContext } from "./audio-transcription.js";
+
+const { lookupMock, resolveAuthMock } = vi.hoisted(() => ({
+  lookupMock: vi.fn(),
+  resolveAuthMock: vi.fn(),
+}));
+
+vi.mock("node:dns/promises", () => ({ lookup: lookupMock }));
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth-runtime")>()),
+  resolveApiKeyForProvider: resolveAuthMock,
+}));
+
+type AudioContext = Parameters<
+  NonNullable<MediaUnderstandingProvider["transcribeAudioWithContext"]>
+>[0];
+
+function createContext(overrides: Partial<AudioContext> = {}): AudioContext {
+  return {
+    cfg: {},
+    buffer: Buffer.from("synthetic audio"),
+    fileName: "voice.ogg",
+    mime: "audio/ogg",
+    timeoutMs: 1000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  for (const name of [
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+  ]) {
+    vi.stubEnv(name, "");
+  }
+  lookupMock.mockResolvedValue([{ address: "240.0.0.37", family: 4 }]);
+  resolveAuthMock.mockResolvedValue({
+    apiKey: "test-oauth-token",
+    source: "profile:openai:test",
+    mode: "oauth",
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("OpenAI OAuth audio network policy", () => {
+  it("honors the trusted private-network opt-in through the real transcription transport", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify({ text: "One two three" }), { status: 200 }));
+    const result = await transcribeOpenAiAudioWithContext(
+      createContext({
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        request: { allowPrivateNetwork: true },
+        fetchFn,
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      value: { text: "One two three", model: "gpt-4o-transcribe" },
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0]!;
+    const requestUrl = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+    expect(requestUrl).toBe("https://api.openai.com/v1/audio/transcriptions");
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer test-oauth-token");
+    expect(init?.body).toBeInstanceOf(FormData);
+  });
+
+  it.each([undefined, {}, { allowPrivateNetwork: false }])(
+    "keeps special-use DNS blocked without opt-in (%j)",
+    async (request) => {
+      const fetchFn = vi.fn<typeof fetch>();
+      await expect(
+        transcribeOpenAiAudioWithContext(createContext({ request, fetchFn })),
+      ).rejects.toThrow(/private|special.use|blocked/i);
+      expect(fetchFn).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each<Partial<AudioContext>>([
+    { baseUrl: "https://proxy.example/v1" },
+    { baseUrl: "http://api.openai.com/v1" },
+    { baseUrl: "https://api.openai.com:8443/v1" },
+    { headers: { "X-Custom": "value" } },
+    { request: { allowPrivateNetwork: true, headers: { "X-Custom": "value" } } },
+    { request: { allowPrivateNetwork: true, auth: { mode: "provider-default" } } },
+    { request: { allowPrivateNetwork: true, proxy: { mode: "env-proxy" } } },
+    { request: { allowPrivateNetwork: true, tls: { insecureSkipVerify: true } } },
+  ])(
+    "rejects endpoint and credential transport overrides before uploading (%j)",
+    async (overrides) => {
+      const fetchFn = vi.fn<typeof fetch>();
+      const result = await transcribeOpenAiAudioWithContext(
+        createContext({
+          request: { allowPrivateNetwork: true },
+          ...overrides,
+          fetchFn,
+        }),
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(String(result.error)).toContain("official endpoint");
+      }
+      expect(fetchFn).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/extensions/openai/audio-transcription.ts
+++ b/extensions/openai/audio-transcription.ts
@@ -90,9 +90,14 @@ export const transcribeOpenAiAudioWithContext: NonNullable<
       if (auth.mode !== "oauth" && auth.mode !== "token") {
         throw new Error("OpenAI audio transcription requires an API key or OAuth profile.");
       }
-      if (!nativeEndpoint || context.headers || context.request) {
+      // The trusted provider-level network opt-in changes DNS policy, not the
+      // endpoint or credential. Other overrides still require API-key auth.
+      const hasRequestOverrides = Object.keys(context.request ?? {}).some(
+        (key) => key !== "allowPrivateNetwork",
+      );
+      if (!nativeEndpoint || context.headers || hasRequestOverrides) {
         throw new Error(
-          "OpenAI OAuth audio transcription requires the official endpoint without custom request overrides. Remove the overrides or select an OpenAI API-key profile.",
+          "OpenAI OAuth audio transcription requires the official endpoint without custom headers, auth, proxy, or TLS overrides. Remove the overrides or select an OpenAI API-key profile.",
         );
       }
     }


### PR DESCRIPTION
Closes #144557.

## What Problem This Solves

Fixes an issue where users sending voice messages on a trusted fake-DNS network could not transcribe them through OpenAI OAuth, even after the operator configured the existing private-network opt-in.

## Why This Change Was Made

Allow only the existing provider-level `request.allowPrivateNetwork` option through the OAuth transcription gate. Continue rejecting custom endpoints, headers, authentication, proxy and TLS overrides. The default special-use address guard remains active unless the operator opts in.

## User Impact

Operators can use `models.providers.openai.request.allowPrivateNetwork` for their trusted network. No new configuration key or unconditional hostname bypass is introduced. The documented setting is provider-wide, not a media-only request option.

## Evidence

- `pnpm check:changed` passed on the combined source checkout: production/test typechecks, changed-file formatting and lint, SDK surface guards, dead-export scans and runtime import-cycle checks. Each PR contains only its own concern.

- 12 OAuth adapter tests and 11 sibling audio/request-policy tests passed on Node 24.19.0.
- Adapter tests exercise the real shared request/SSRF transport with mocked DNS, credentials and network response: a synthetic 240.0.0.37 resolution succeeds only with explicit opt-in; unset/false policy remains blocked; unsafe endpoint and transport overrides remain rejected.
- A temporary installed-build workaround transcribed a received Ogg file during diagnosis. That supports the diagnosis but is not live proof of this source implementation.
- Independent review found no blocking issue. The Python-based autoreview launcher was not run because this contribution's workflow explicitly excludes Python; independent agent review was used instead.
- Full release build and live deployment verification of the source implementation were not performed.
