### PR TITLE
fix: avoid replaying older Telegram photos in Codex image requests

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -19,6 +19,13 @@ the current turn as untrusted external content, subject to the existing file
 extraction limits. This also applies to adopted and forked Codex sessions with
 locked model selection. Images continue through Codex's native image input.
 
+For Telegram, a new photo or album takes priority over saved photos when OpenClaw
+rebuilds context for Codex. A text-only follow-up includes the most recent saved
+photo or album. Older captions and attachment references remain available; the
+agent can retrieve an older image when you explicitly ask about it. Saved
+documents and mixed document/image messages keep their existing behavior. This
+does not erase images already present in a resumed native Codex thread.
+
 Remote Codex app-servers can run on a different machine from the Gateway. Set
 `remoteWorkspaceRoot` to validate remote workspace attachment paths. OpenClaw
 transfers authoritative attachment bytes over the existing app-server connection

--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -107,6 +107,81 @@ describe("projectContextEngineAssemblyForCodex", () => {
     );
   });
 
+  it.each(["all", "latest-turn", "none"] as const)(
+    "selects photo history without changing transcripts or document pages (%s)",
+    async (imageHistory) => {
+      const image = (data: string) => ({ type: "image" as const, mimeType: "image/png", data });
+      const older = { role: "user" as const, content: [image("old")], timestamp: 1 };
+      const album = {
+        role: "user" as const,
+        content: "New album caption",
+        timestamp: 2,
+        __openclaw: {
+          media: [
+            { kind: "image", path: "/tmp/first.png" },
+            { kind: "image", path: "/tmp/second.png" },
+          ],
+        },
+      };
+      const document = textMessage("user", "Document caption");
+      const messages = [older, album, document];
+      const original = structuredClone(messages);
+      const result = await projectContextEngineAssemblyForCodex({
+        assembledMessages: messages,
+        originalHistoryMessages: messages,
+        prompt: "What is in the latest picture?",
+        imageHistory,
+        maxRenderedContextChars: 4 * IMAGE_BLOCK_TOKENS * 4 + 2_000,
+        prepareFileContext: async (message) => ({
+          imageOnly: message !== document,
+          text:
+            message === older
+              ? "old.png"
+              : message === album
+                ? "first.png second.png"
+                : "Document text",
+          images:
+            message === older
+              ? [image("old")]
+              : message === album
+                ? [image("first"), image("second")]
+                : [image("document-page")],
+        }),
+      });
+      expect(result.images).toEqual([
+        ...(imageHistory === "all" ? [image("old")] : []),
+        ...(imageHistory !== "none" ? [image("first"), image("second")] : []),
+        image("document-page"),
+      ]);
+      expect(result.promptText).toContain("old.png");
+      expect(result.promptText).toContain("New album caption");
+      expect(result.promptText).toContain("Document text");
+      expect(messages).toEqual(original);
+    },
+  );
+
+  it("does not substitute an old image when the latest image cannot be hydrated", async () => {
+    const oldImage = { type: "image" as const, mimeType: "image/png", data: "old" };
+    const older = { role: "user" as const, content: [oldImage], timestamp: 1 };
+    const latest = {
+      role: "user" as const,
+      content: [{ ...oldImage, data: "latest" }],
+      timestamp: 2,
+    };
+    const result = await projectContextEngineAssemblyForCodex({
+      assembledMessages: [older, latest],
+      originalHistoryMessages: [],
+      prompt: "Describe the latest image",
+      imageHistory: "latest-turn",
+      prepareFileContext: async (message) =>
+        message === latest
+          ? { text: "[Attachment could not be read]", images: [], imageOnly: true }
+          : { text: "old.png", images: [oldImage], imageOnly: true },
+    });
+    expect(result.images).toBeUndefined();
+    expect(result.promptText).toContain("Attachment could not be read");
+  });
+
   it("retains document bytes when the saved caption duplicates the current prompt", async () => {
     const result = await projectContextEngineAssemblyForCodex({
       assembledMessages: [textMessage("user", "read this document")],

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -23,7 +23,7 @@ type CodexContextProjection = {
 type PrepareContextFile = (
   message: AgentMessage,
   maxChars: number,
-) => Promise<{ text?: string; images: ImageContent[] }>;
+) => Promise<{ text?: string; images: ImageContent[]; imageOnly?: boolean }>;
 
 /** Attachment preparation must not degrade to a prompt that silently loses the saved input. */
 export class CodexContextAttachmentError extends Error {}
@@ -82,6 +82,8 @@ export async function projectContextEngineAssemblyForCodex(params: {
   toolPayloadMode?: "elide" | "preserve";
   prepareFileContext?: PrepareContextFile;
   currentUserTurnIdempotencyKey?: string;
+  /** Telegram photos should not be replayed as a new multi-image upload. */
+  imageHistory?: "all" | "latest-turn" | "none";
 }): Promise<CodexContextProjection> {
   const prompt = params.prompt.trim();
   const maxRenderedContextChars = normalizeRenderedContextMaxChars(params.maxRenderedContextChars);
@@ -95,6 +97,7 @@ export async function projectContextEngineAssemblyForCodex(params: {
       maxRenderedContextChars,
       prepareFileContext: params.prepareFileContext,
       currentUserTurnIdempotencyKey: params.currentUserTurnIdempotencyKey,
+      imageHistory: params.imageHistory,
     },
   );
   const boundedContext = context.text;
@@ -365,6 +368,7 @@ async function renderMessagesForCodexContext(
     maxRenderedContextChars: number;
     prepareFileContext?: PrepareContextFile;
     currentUserTurnIdempotencyKey?: string;
+    imageHistory?: "all" | "latest-turn" | "none";
   },
 ): Promise<{ text: string; images: ImageContent[] }> {
   const tail: string[] = [];
@@ -372,6 +376,7 @@ async function renderMessagesForCodexContext(
   let retainedImageChars = 0;
   let totalChars = 0;
   let retainedChars = 0;
+  let seenImageTurn = options.imageHistory === "none";
   // Count the discarded prefix for the existing marker, but never materialize the
   // whole history. Sigil neutralization preserves UTF-16 length and cannot span separators.
   for (let index = messages.length - 1; index >= 0; index--) {
@@ -385,10 +390,27 @@ async function renderMessagesForCodexContext(
     }
     const remaining = options.maxRenderedContextChars - retainedChars;
     // Read only retained attachments, then charge their rendered text to this same window.
-    const files =
+    let files =
       remaining > 0 && message.role === "user"
         ? await options.prepareFileContext?.(message, Math.min(remaining, options.maxTextPartChars))
         : undefined;
+    if (options.imageHistory && options.imageHistory !== "all" && files?.imageOnly === true) {
+      // Walk newest first. Keep the entire latest album, never fall back to an
+      // older photo if that album failed hydration or exceeded the image budget.
+      if (seenImageTurn && files?.images.length) {
+        files = {
+          ...files,
+          images: [],
+          text: [
+            files.text,
+            "[Earlier image pixels omitted; retrieve the attachment if requested.]",
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        };
+      }
+      seenImageTurn = true;
+    }
     // Use the shared image estimate; native image payloads consume context too.
     const imageChars =
       (files?.images.length ?? 0) * IMAGE_BLOCK_TOKENS * APPROX_RENDERED_CHARS_PER_TOKEN;

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -82,6 +82,12 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
   } = connection;
   const { toolBridge } = attemptTools;
   let contextImages: ImageContent[] = [];
+  const imageHistory =
+    (params.messageChannel ?? params.messageProvider) === "telegram"
+      ? params.images?.length
+        ? "none"
+        : "latest-turn"
+      : "all";
   const currentUserTurnIdempotencyKey = params.userTurnTranscriptRecorder?.message?.idempotencyKey;
   const assertProjectionCurrent = () => {
     params.hostCapabilities.assertActive();
@@ -127,6 +133,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
       maxRenderedContextChars: codexContinuityProjectionMaxChars,
       prepareFileContext,
       currentUserTurnIdempotencyKey,
+      imageHistory,
     });
     assertProjectionCurrent();
     contextImages = projection.images ?? [];
@@ -191,6 +198,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
       toolPayloadMode: contextEngineProjection ? "preserve" : "elide",
       ...(projectionDecision.project ? { prepareFileContext } : {}),
       currentUserTurnIdempotencyKey,
+      imageHistory,
     });
     assertProjectionCurrent();
     contextImages = projectionDecision.project ? (projection.images ?? []) : [];

--- a/extensions/codex/src/app-server/run-attempt.continuity-media.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.continuity-media.test.ts
@@ -221,150 +221,179 @@ describe("Codex attachment continuity", () => {
       closeHost();
     }
   });
-  it.each(["inline", "offloaded", "current", "closed"] as const)(
-    "restores real image bytes with exact source ownership (%s)",
-    async (mode) => {
-      const sessionId = "session-continuity-images";
-      const sessionFile = `agent:main:${sessionId}`;
-      const storePath = path.join(tempDir, "image-continuity.sqlite");
-      const workspaceDir = path.join(tempDir, "image-workspace");
-      await fs.mkdir(workspaceDir, { recursive: true });
-      const params = createParams(sessionFile, workspaceDir);
-      params.model = { ...params.model, input: ["text", "image"] };
-      await attachSqliteSessionTarget(params, storePath, sessionId);
-      const target = { agentId: "main", sessionId, sessionKey: params.sessionKey!, storePath };
-      const cutoff = Date.now();
-      await writeCodexAppServerBinding(sessionFile, {
-        threadId: "thread-existing",
-        cwd: workspaceDir,
-        model: params.modelId,
-        modelProvider: "openai",
-        historyCoveredThrough: new Date(cutoff).toISOString(),
-        dynamicToolsFingerprint: "[]",
-        webSearchThreadConfigFingerprint: JSON.stringify({
-          "features.standalone_web_search": false,
-          web_search: "disabled",
-        }),
-      });
-      const blue = createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 255 });
-      const green = createSolidPngBuffer(1, 1, { r: 0, g: 255, b: 0 });
-      const image = {
-        type: "image" as const,
-        mimeType: "image/png",
-        data: blue.toString("base64"),
-      };
-      const saved = await saveMediaBuffer(blue, "image/png", "inbound", undefined, "blue.png");
-      const historical = {
-        role: "user" as const,
-        timestamp: cutoff + 1,
-        idempotencyKey: "historical-image:user",
-        content:
-          mode === "inline"
-            ? [{ type: "text" as const, text: "Read this image." }, image]
-            : "Read this image.",
-        __openclaw: {
-          media: [
-            { url: `media://inbound/${saved.id}`, contentType: "image/png", fileName: "blue.png" },
-          ],
-          mediaImageLayout: {
-            slots: [{ kind: mode === "inline" ? "inline" : "offloaded", factIndex: 0 }],
-          },
-          ...(mode === "inline" ? { mediaImageBlockFactIndexes: [0] } : {}),
+  it.each([
+    "inline",
+    "offloaded",
+    "current",
+    "closed",
+    "telegram-current",
+    "telegram-history",
+  ] as const)("restores real image bytes with exact source ownership (%s)", async (mode) => {
+    const sessionId = "session-continuity-images";
+    const sessionFile = `agent:main:${sessionId}`;
+    const storePath = path.join(tempDir, "image-continuity.sqlite");
+    const workspaceDir = path.join(tempDir, "image-workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const params = createParams(sessionFile, workspaceDir);
+    const hasCurrentImage = mode === "current" || mode === "telegram-current";
+    if (mode.startsWith("telegram-")) {
+      params.messageChannel = "telegram";
+    }
+    params.model = { ...params.model, input: ["text", "image"] };
+    await attachSqliteSessionTarget(params, storePath, sessionId);
+    const target = { agentId: "main", sessionId, sessionKey: params.sessionKey!, storePath };
+    const cutoff = Date.now();
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-existing",
+      cwd: workspaceDir,
+      model: params.modelId,
+      modelProvider: "openai",
+      historyCoveredThrough: new Date(cutoff).toISOString(),
+      dynamicToolsFingerprint: "[]",
+      webSearchThreadConfigFingerprint: JSON.stringify({
+        "features.standalone_web_search": false,
+        web_search: "disabled",
+      }),
+    });
+    const blue = createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 255 });
+    const green = createSolidPngBuffer(1, 1, { r: 0, g: 255, b: 0 });
+    const image = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: blue.toString("base64"),
+    };
+    const saved = await saveMediaBuffer(blue, "image/png", "inbound", undefined, "blue.png");
+    const historical = {
+      role: "user" as const,
+      timestamp: cutoff + 1,
+      idempotencyKey: "historical-image:user",
+      content:
+        mode === "inline"
+          ? [{ type: "text" as const, text: "Read this image." }, image]
+          : "Read this image.",
+      __openclaw: {
+        media: [
+          mode === "telegram-current"
+            ? { path: saved.path }
+            : {
+                url: `media://inbound/${saved.id}`,
+                contentType: "image/png",
+                fileName: "blue.png",
+              },
+        ],
+        mediaImageLayout: {
+          slots: [{ kind: mode === "inline" ? "inline" : "offloaded", factIndex: 0 }],
         },
+        ...(mode === "inline" ? { mediaImageBlockFactIndexes: [0] } : {}),
+      },
+    };
+    await appendSessionTranscriptMessageByIdentity({
+      ...target,
+      message: historical,
+      now: cutoff + 1,
+    });
+    params.prompt = "Read this image.";
+    if (mode === "telegram-history") {
+      await appendSessionTranscriptMessageByIdentity({
+        ...target,
+        message: {
+          ...historical,
+          timestamp: cutoff + 2,
+          idempotencyKey: "latest-image:user",
+          content: [{ ...image, data: green.toString("base64") }],
+          __openclaw: {},
+        },
+        now: cutoff + 2,
+      });
+    }
+    if (hasCurrentImage) {
+      const currentImage = { ...image, data: green.toString("base64") };
+      params.images = [currentImage];
+      const current = {
+        role: "user" as const,
+        timestamp: cutoff + 2,
+        idempotencyKey: "current-image:user",
+        content: [{ type: "text" as const, text: params.prompt }, currentImage],
       };
       await appendSessionTranscriptMessageByIdentity({
         ...target,
-        message: historical,
-        now: cutoff + 1,
+        message: current,
+        now: cutoff + 2,
       });
-      params.prompt = "Read this image.";
-      if (mode === "current") {
-        const currentImage = { ...image, data: green.toString("base64") };
-        params.images = [currentImage];
-        const current = {
-          role: "user" as const,
-          timestamp: cutoff + 2,
-          idempotencyKey: "current-image:user",
-          content: [{ type: "text" as const, text: params.prompt }, currentImage],
-        };
-        await appendSessionTranscriptMessageByIdentity({
-          ...target,
-          message: current,
-          now: cutoff + 2,
-        });
-        // Model an already committed current source with no read fence, so both
-        // rows enter projection and only exact current-source identity removes it.
-        params.userTurnTranscriptRecorder = {
-          message: current,
-          resolveMessage: async () => current,
-          getAdmissionReceipt: () => undefined,
-          markRuntimePersistencePending: () => {},
-          markRuntimePersisted: () => {},
-          markBlocked: () => {},
-          hasPersisted: () => true,
-          isBlocked: () => false,
-          hasRuntimePersistencePending: () => false,
-          waitForRuntimePersistence: async () => {},
-          persistApproved: async () => undefined,
-          persistBlocked: async () => undefined,
-          persistFallback: async () => undefined,
-        };
-      }
-      const abort = new AbortController();
-      params.abortSignal = abort.signal;
-      const started = createDeferred<void>();
-      params.onAgentEvent = (event) => {
-        if (event.stream === "lifecycle" && event.data.phase === "start") {
-          started.resolve();
-        }
+      // Model an already committed current source with no read fence, so both
+      // rows enter projection and only exact current-source identity removes it.
+      params.userTurnTranscriptRecorder = {
+        message: current,
+        resolveMessage: async () => current,
+        getAdmissionReceipt: () => undefined,
+        markRuntimePersistencePending: () => {},
+        markRuntimePersisted: () => {},
+        markBlocked: () => {},
+        hasPersisted: () => true,
+        isBlocked: () => false,
+        hasRuntimePersistencePending: () => false,
+        waitForRuntimePersistence: async () => {},
+        persistApproved: async () => undefined,
+        persistBlocked: async () => undefined,
+        persistFallback: async () => undefined,
       };
-      const closeHost = await bindProductionHarnessHostCapabilitiesForTest(params);
+    }
+    const abort = new AbortController();
+    params.abortSignal = abort.signal;
+    const started = createDeferred<void>();
+    params.onAgentEvent = (event) => {
+      if (event.stream === "lifecycle" && event.data.phase === "start") {
+        started.resolve();
+      }
+    };
+    const closeHost = await bindProductionHarnessHostCapabilitiesForTest(params);
+    if (mode === "closed") {
+      const prepare = params.hostCapabilities.prepareContextMedia!;
+      params.hostCapabilities = {
+        ...params.hostCapabilities,
+        prepareContextMedia: async (request) => {
+          const prepared = await prepare(request);
+          expect(prepared.images).toHaveLength(1);
+          closeHost();
+          return prepared;
+        },
+      };
+    }
+    vi.useFakeTimers();
+    const harness = createResumeHarness();
+    const run = runCodexAppServerAttempt(params);
+    try {
       if (mode === "closed") {
-        const prepare = params.hostCapabilities.prepareContextMedia!;
-        params.hostCapabilities = {
-          ...params.hostCapabilities,
-          prepareContextMedia: async (request) => {
-            const prepared = await prepare(request);
-            expect(prepared.images).toHaveLength(1);
-            closeHost();
-            return prepared;
-          },
-        };
+        await expect(run).rejects.toThrow(/active|closed|authority/i);
+        expect(harness.requests.filter((request) => request.method === "turn/start")).toEqual([]);
+      } else {
+        await started.promise;
+        await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+        expect(readAttemptTerminal(await run)).toMatchObject({ aborted: false, timedOut: false });
+        const request = harness.requests.find((entry) => entry.method === "turn/start");
+        const input = asOptionalRecord(request?.params)?.input;
+        expect(Array.isArray(input)).toBe(true);
+        const images = Array.isArray(input)
+          ? input.filter((part) => asOptionalRecord(part)?.type === "image")
+          : [];
+        expect(images).toEqual([
+          ...(!mode.startsWith("telegram-")
+            ? [{ type: "image", url: `data:image/png;base64,${blue.toString("base64")}` }]
+            : []),
+          ...(hasCurrentImage || mode === "telegram-history"
+            ? [{ type: "image", url: `data:image/png;base64,${green.toString("base64")}` }]
+            : []),
+        ]);
       }
-      vi.useFakeTimers();
-      const harness = createResumeHarness();
-      const run = runCodexAppServerAttempt(params);
-      try {
-        if (mode === "closed") {
-          await expect(run).rejects.toThrow(/active|closed|authority/i);
-          expect(harness.requests.filter((request) => request.method === "turn/start")).toEqual([]);
-        } else {
-          await started.promise;
-          await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
-          expect(readAttemptTerminal(await run)).toMatchObject({ aborted: false, timedOut: false });
-          const request = harness.requests.find((entry) => entry.method === "turn/start");
-          const input = asOptionalRecord(request?.params)?.input;
-          expect(Array.isArray(input)).toBe(true);
-          const images = Array.isArray(input)
-            ? input.filter((part) => asOptionalRecord(part)?.type === "image")
-            : [];
-          expect(images).toEqual([
-            { type: "image", url: `data:image/png;base64,${blue.toString("base64")}` },
-            ...(mode === "current"
-              ? [{ type: "image", url: `data:image/png;base64,${green.toString("base64")}` }]
-              : []),
-          ]);
-        }
-        const rows = (await readSessionTranscriptEvents(target)).flatMap((event) => {
-          const message = asOptionalRecord(asOptionalRecord(event)?.message);
-          return message?.idempotencyKey === historical.idempotencyKey ? [message] : [];
-        });
-        expect(rows).toEqual([historical]);
-      } finally {
-        abort.abort("test cleanup");
-        await run.catch(() => undefined);
-        closeHost();
-      }
-    },
-  );
+      const rows = (await readSessionTranscriptEvents(target)).flatMap((event) => {
+        const message = asOptionalRecord(asOptionalRecord(event)?.message);
+        return message?.idempotencyKey === historical.idempotencyKey ? [message] : [];
+      });
+      expect(rows).toEqual([historical]);
+    } finally {
+      abort.abort("test cleanup");
+      await run.catch(() => undefined);
+      closeHost();
+    }
+  });
 });

--- a/src/agents/harness/context-media-runtime.ts
+++ b/src/agents/harness/context-media-runtime.ts
@@ -31,7 +31,7 @@ export async function prepareHarnessContextMedia(params: {
   accountId?: string;
   sandbox?: { root: string; bridge: SandboxFsBridge };
   assertCurrent: () => void;
-}): Promise<{ text?: string; images: ImageContent[] }> {
+}): Promise<{ text?: string; images: ImageContent[]; imageOnly?: boolean }> {
   params.assertCurrent();
   if (params.message.role !== "user" || params.maxChars <= 0) {
     return { images: [] };
@@ -58,6 +58,7 @@ export async function prepareHarnessContextMedia(params: {
   });
   params.assertCurrent();
   const imageFacts = media.filter(isImageMediaFact);
+  const imageOnly = media.length > 0 ? imageFacts.length === media.length : inlineImages.length > 0;
   const text = [files.text];
   if (imageFacts.length || inlineImages.length) {
     text.push(buildInboundMediaNoteProjection({ media: imageFacts }).text ?? "[Image attachment]");
@@ -66,7 +67,7 @@ export async function prepareHarnessContextMedia(params: {
     if (imageFacts.length || inlineImages.length || files.images.length) {
       text.push("[Attachment images omitted: this model does not support image input]");
     }
-    return { text: text.filter(Boolean).join("\n\n"), images: [] };
+    return { text: text.filter(Boolean).join("\n\n"), images: [], imageOnly };
   }
   const limits = { ...resolveImageSanitizationLimits(params.config), maxBytes: MAX_IMAGE_BYTES };
   const workspaceOnly = resolveEffectiveToolFsWorkspaceOnly({
@@ -123,6 +124,7 @@ export async function prepareHarnessContextMedia(params: {
     text.push("[Referenced image contents are not included in this context]");
   }
   return {
+    imageOnly,
     text: text.filter(Boolean).join("\n\n"),
     images: entries
       .toSorted(

--- a/src/agents/harness/host-capability-types.ts
+++ b/src/agents/harness/host-capability-types.ts
@@ -45,7 +45,12 @@ export type AgentHarnessHostCapabilities = Readonly<{
   prepareContextMedia?: (request: {
     message: import("../runtime/index.js").AgentMessage;
     maxChars: number;
-  }) => Promise<{ text?: string; images: import("../../llm/types.js").ImageContent[] }>;
+  }) => Promise<{
+    text?: string;
+    images: import("../../llm/types.js").ImageContent[];
+    /** Whether the source contains only native image attachments, even if loading failed. */
+    imageOnly?: boolean;
+  }>;
   /** Closure-bound event sink backed by the host-owned trajectory recorder. */
   trajectory?: Readonly<{
     recordEvent: (type: string, data?: Record<string, unknown>) => void;


### PR DESCRIPTION
Closes #144556.

## What Problem This Solves

Fixes an issue where users discussing a new Telegram photo would get answers about older photos when the Codex harness reconstructed history. Earlier and current photo pixels could become attachments in the same native user input.

## Why This Change Was Made

For Telegram projections, omit historical photo pixels when the current turn supplies images. For text-only follow-ups, retain the latest photo turn, including a complete album. Use the same canonical media classification as hydration, including path-derived image types and stickers. Retain captions and file references; mixed document/image messages and other channels keep their existing behavior.

## User Impact

New Telegram photos no longer automatically reattach unrelated earlier photos. Older references remain available for explicit retrieval. This does not erase images already present in a resumed native Codex thread, and attachment preparation still occurs before the projection filter.

## Evidence

- `pnpm check:changed` passed on the combined source checkout: production/test typechecks, changed-file formatting and lint, SDK surface guards, dead-export scans and runtime import-cycle checks. Each PR contains only its own concern.

- 57 context projection tests and 13 continuity/media tests passed on Node 24.19.0. Regressions cover albums, path-only image metadata, retained document pages, unchanged transcripts and no fallback to an older photo when the latest cannot be hydrated.
- The continuity test loads real PNG bytes through the production media host and inspects native `turn/start` image input.
- Personally inspected Codex source at commit 9e22e74e8dcab53f8bf1799c0eed1f9834c32f1a: `codex-rs/protocol/src/models.rs` combines supplied inputs into one user message. This is not a claim that Codex generates a literal collage.
- Independent review identified a filename-classification gap; it was corrected by carrying the core media classifier’s image-only fact through the existing preparation capability and covered by a real-host regression test. Final independent review found no blocking issues. The Python-based autoreview launcher was not run because this contribution's workflow excludes Python.
- No full release build or live Telegram end-to-end verification of this source implementation was performed.
