### PR TITLE
fix(setup): preserve config edits made during provider preparation

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -178,6 +178,24 @@ vi.mock("./shared.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../../plugins/install-record-commit.js", () => ({
+  transformConfigWithPendingPluginInstalls: async (params: {
+    transform: (
+      current: OpenClawConfig,
+      context: { snapshot: { valid: boolean } },
+    ) => { nextConfig: OpenClawConfig };
+    writeOptions?: { beforeCommit?: () => void };
+  }) => {
+    const next = await mocks.updateConfig(
+      (current: OpenClawConfig) =>
+        params.transform(current, { snapshot: { valid: true } }).nextConfig,
+      undefined,
+      params.writeOptions?.beforeCommit,
+    );
+    return { nextConfig: next, result: next };
+  },
+}));
+
 vi.mock("../../config/logging.js", () => ({
   logConfigUpdated: mocks.logConfigUpdated,
 }));

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -30,11 +30,6 @@ import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import { logConfigUpdated } from "../../config/logging.js";
-import {
-  applyMergePatch,
-  createMergePatch,
-  mergePatchConflicts,
-} from "../../config/merge-patch.js";
 import { normalizeAgentModelRefForConfig } from "../../config/model-input.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -44,6 +39,10 @@ import {
   restorePriorAgentsDefaultsModelUnlessOptIn,
   resolveProviderMatch,
 } from "../../plugins/provider-auth-choice-helpers.js";
+import {
+  createProviderAuthConfigPatch,
+  writeProviderAuthConfig,
+} from "../../plugins/provider-auth-config.js";
 import { applyAuthProfileConfig } from "../../plugins/provider-auth-helpers.js";
 import { runProviderPluginAuthMethodUnpersisted } from "../../plugins/provider-auth-method.js";
 import { persistProviderAuthProfilesAfterLogin } from "../../plugins/provider-auth-persistence.js";
@@ -413,13 +412,10 @@ async function persistProviderAuthResult(params: {
     : undefined;
   const profiles = params.profiles ?? params.result.profiles;
   const persistedProfiles: ProviderAuthResult["profiles"] = [];
-  const patchOptions = { mergeObjectArraysById: true };
   // Match source and runtime rows using the config owner's canonical model identities.
   const loginConfig = applyProviderAuthConfigPatch(params.config, {});
-  const sourceConfig = applyProviderAuthConfigPatch(params.configSnapshot.sourceConfig, {});
-  const runtimeConfig = applyProviderAuthConfigPatch(params.configSnapshot.runtimeConfig, {});
   const configPatch = params.result.configPatch
-    ? createMergePatch(
+    ? createProviderAuthConfigPatch(
         loginConfig,
         restorePriorAgentsDefaultsModelUnlessOptIn({
           cfg: applyProviderAuthConfigPatch(
@@ -434,7 +430,6 @@ async function persistProviderAuthResult(params: {
           priorAgentsDefaultsModel: loginConfig.agents?.defaults?.model,
           setDefault: params.setDefault,
         }),
-        patchOptions,
       )
     : undefined;
   const shouldUpdateConfig =
@@ -467,44 +462,26 @@ async function persistProviderAuthResult(params: {
 
     // Replay only the login's changes; the writer may have newer unrelated settings.
     if (shouldUpdateConfig) {
-      const updated = await updateConfig(
-        (cfg) => {
-          params.assertCurrent?.();
+      const updated = await writeProviderAuthConfig({
+        config: params.config,
+        configSnapshot: params.configSnapshot,
+        configPatch,
+        credentialsSaved: persistedProfiles.length > 0,
+        beforeCommit: params.assertCurrent,
+        finalizeConfig: (replayed, cfg) => {
           const priorAgentsDefaultsModel = cfg.agents?.defaults?.model;
-          let next = applyProviderAuthConfigPatch(cfg, {});
-          if (configPatch) {
-            if (
-              (mergePatchConflicts(loginConfig, runtimeConfig, configPatch, patchOptions) &&
-                mergePatchConflicts(loginConfig, sourceConfig, configPatch, patchOptions)) ||
-              mergePatchConflicts(sourceConfig, next, configPatch, patchOptions)
-            ) {
-              throw new Error(
-                "Provider settings changed during sign-in. Review the current settings and retry.",
-              );
-            }
-            // SAFETY: The patch derives from typed config; updateConfig validates the merged value before writing.
-            next = applyMergePatch(next, configPatch, patchOptions) as OpenClawConfig;
-          }
-          next = restorePriorAgentsDefaultsModelUnlessOptIn({
-            cfg: next,
+          const next = restorePriorAgentsDefaultsModelUnlessOptIn({
+            cfg: replayed,
             priorAgentsDefaultsModel,
             setDefault: params.setDefault,
           });
           if (params.setDefault && defaultModel) {
-            next =
-              profiles.length > 0
-                ? applyProviderLoginDefaultModel(next, defaultModel)
-                : applyDefaultModel(next, defaultModel);
+            return profiles.length > 0
+              ? applyProviderLoginDefaultModel(next, defaultModel)
+              : applyDefaultModel(next, defaultModel);
           }
           return next;
         },
-        undefined,
-        params.assertCurrent,
-      ).catch((error: unknown) => {
-        if (persistedProfiles.length === 0) {
-          throw error;
-        }
-        throw new ProviderAuthConfigApplyError(error);
       });
       if (defaultModel) {
         const repaired = await repairCodexRuntimePluginInstallForModelSelection({

--- a/src/gateway/server-methods/system-agent-setup-concurrent.test.ts
+++ b/src/gateway/server-methods/system-agent-setup-concurrent.test.ts
@@ -1,0 +1,206 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { Compile } from "typebox/compile";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  WizardNextResultSchema,
+  WizardStartResultSchema,
+} from "../../../packages/gateway-protocol/src/schema/wizard.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../../config/io.js";
+import type { ModelDefinitionConfig } from "../../config/types.models.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { WizardSession } from "../../wizard/session.js";
+import { readSetupConfigFileSnapshot } from "../../wizard/setup.shared.js";
+import { createWizardSessionTracker } from "../server-wizard-sessions.js";
+import { whenAdmittedWizardSessionSettled } from "./setup-admission.js";
+import { systemAgentHandlers } from "./system-agent.js";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
+import { wizardHandlers } from "./wizard.js";
+
+const provider = vi.hoisted(() => ({
+  prepare:
+    vi.fn<
+      typeof import("../../plugins/provider-auth-choice.js").prepareAuthChoiceLoadedPluginProvider
+    >(),
+}));
+vi.mock("../../plugins/provider-auth-choice.js", () => ({
+  prepareAuthChoiceLoadedPluginProvider: provider.prepare,
+}));
+
+const sessions = new Set<WizardSession>();
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(async () => {
+    for (const session of sessions) {
+      session.cancel();
+      await whenAdmittedWizardSessionSettled(session);
+    }
+    sessions.clear();
+    vi.resetAllMocks();
+    resetCommandQueueStateForTest();
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+    cleanup();
+  });
+});
+const validateResult = Compile(WizardNextResultSchema);
+const validateStart = Compile(WizardStartResultSchema);
+const model = (id: string): ModelDefinitionConfig => ({
+  id,
+  name: id,
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  maxTokens: 1024,
+});
+const connection = { baseUrl: "http://127.0.0.1:11434", models: [model("existing")] };
+let configPath: string;
+const writeConfig = (config: OpenClawConfig) =>
+  fs.writeFileSync(configPath, JSON.stringify(config));
+const readConfig = async () => (await readSetupConfigFileSnapshot()).sourceConfig;
+
+beforeEach(() => {
+  const root = tempDirs.make("openclaw-setup-concurrent-");
+  configPath = path.join(root, "openclaw.json");
+  vi.stubEnv("OPENCLAW_STATE_DIR", root);
+  vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+  vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  writeConfig({
+    plugins: { allow: [] },
+    messages: { ackReaction: "before" },
+    models: { providers: { fixture: connection } },
+  });
+});
+
+async function startPrepare(change: (config: OpenClawConfig) => void = () => {}) {
+  let credentialsSaved = false;
+  provider.prepare.mockImplementationOnce(async ({ config, prompter }) => {
+    const prepared = structuredClone(config);
+    prepared.auth = { profiles: { "fixture:default": { provider: "fixture", mode: "api_key" } } };
+    change(prepared);
+    await prompter.text({ message: "Enter provider key", sensitive: true });
+    return {
+      config: prepared,
+      authProfiles: [
+        {
+          profileId: "fixture:default",
+          credential: { type: "api_key", provider: "fixture", key: "synthetic-key" },
+        },
+      ],
+      persistAuthProfiles: async () => {
+        credentialsSaved = true;
+      },
+    };
+  });
+  const tracker = createWizardSessionTracker();
+  const context = tracker as GatewayRequestContext;
+  const sessionId = "prepare-concurrent";
+  const invoke = async (method: string, params: Record<string, unknown>) => {
+    const respond = vi.fn<RespondFn>();
+    await expectDefined(
+      systemAgentHandlers[method] ?? wizardHandlers[method],
+      method,
+    )({
+      req: { type: "req", id: "request", method, params },
+      params,
+      respond,
+      context,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+    expect(respond).toHaveBeenCalledOnce();
+    const [ok, payload] = expectDefined(respond.mock.calls[0], "Gateway response");
+    expect(ok).toBe(true);
+    if (!validateResult.Check(payload) && !validateStart.Check(payload)) {
+      throw new Error("Invalid wizard response");
+    }
+    return payload;
+  };
+  await invoke("openclaw.setup.prepare.start", { sessionId, authChoice: "fixture" });
+  sessions.add(expectDefined(tracker.wizardSessions.get(sessionId), "prepared session"));
+  const prompt = await invoke("wizard.next", { sessionId });
+  expect(prompt.step).toMatchObject({ type: "text", message: "Enter provider key" });
+  const stepId = expectDefined(prompt.step, "provider prompt").id;
+  return {
+    credentialsSaved: () => credentialsSaved,
+    complete: () =>
+      invoke("wizard.next", { sessionId, answer: { stepId, value: "synthetic-key" } }),
+  };
+}
+
+describe("setup prepare concurrent config writes", () => {
+  it("preserves invalid concurrent edits and reports that credentials were saved", async () => {
+    const setup = await startPrepare();
+    const edited = '{ "messages":';
+    fs.writeFileSync(configPath, edited);
+
+    const result = await setup.complete();
+    expect(setup.credentialsSaved()).toBe(true);
+    expect(result).toMatchObject({ done: true, status: "error" });
+    expect(result.error).toContain("Credentials saved, but provider settings could not be applied");
+    expect(fs.readFileSync(configPath, "utf8")).toBe(edited);
+  });
+
+  it("keeps an unrelated edit made while provider login is pending", async () => {
+    const setup = await startPrepare();
+    const concurrent = await readConfig();
+    concurrent.messages = { ackReaction: "concurrent-edit" };
+    writeConfig(concurrent);
+
+    expect(await setup.complete()).toMatchObject({ done: true, status: "done" });
+    expect(setup.credentialsSaved()).toBe(true);
+    expect(await readConfig()).toMatchObject({
+      messages: { ackReaction: "concurrent-edit" },
+      auth: { profiles: { "fixture:default": { provider: "fixture", mode: "api_key" } } },
+    });
+  });
+
+  it("keeps distinct model rows added by setup and a concurrent editor", async () => {
+    const setup = await startPrepare((config) => {
+      config.models = {
+        providers: {
+          fixture: { ...connection, models: [...connection.models, model("prepared")] },
+        },
+      };
+    });
+    const concurrent = await readConfig();
+    concurrent.models = {
+      providers: {
+        fixture: { ...connection, models: [...connection.models, model("concurrent")] },
+      },
+    };
+    writeConfig(concurrent);
+
+    expect(await setup.complete()).toMatchObject({ done: true, status: "done" });
+    expect((await readConfig()).models?.providers?.fixture?.models).toEqual([
+      model("existing"),
+      model("concurrent"),
+      model("prepared"),
+    ]);
+  });
+
+  it("reports saved credentials when the same provider setting changed during login", async () => {
+    const setup = await startPrepare((config) => {
+      config.models = {
+        providers: { fixture: { ...connection, baseUrl: "http://127.0.0.1:11435" } },
+      };
+    });
+    const concurrent = await readConfig();
+    concurrent.models = {
+      providers: { fixture: { ...connection, baseUrl: "http://127.0.0.1:11436" } },
+    };
+    writeConfig(concurrent);
+
+    const result = await setup.complete();
+    expect(setup.credentialsSaved()).toBe(true);
+    expect(result).toMatchObject({ done: true, status: "error" });
+    expect(result.error).toContain("Credentials saved, but provider settings could not be applied");
+    expect(result.error).toContain("Review the current settings and retry");
+    expect((await readConfig()).models?.providers?.fixture?.baseUrl).toBe("http://127.0.0.1:11436");
+  });
+});

--- a/src/gateway/server-methods/system-agent-setup-prepare.test.ts
+++ b/src/gateway/server-methods/system-agent-setup-prepare.test.ts
@@ -20,7 +20,9 @@ const providerAuthChoiceMocks = vi.hoisted(() => ({
 }));
 const setupSharedMocks = vi.hoisted(() => ({
   readSetupConfigFileSnapshot: vi.fn(),
-  writeWizardConfigFile: vi.fn(),
+}));
+const authConfigMocks = vi.hoisted(() => ({
+  writeProviderAuthConfig: vi.fn(),
 }));
 
 vi.mock("../../plugins/provider-auth-choice.js", () => ({
@@ -29,7 +31,10 @@ vi.mock("../../plugins/provider-auth-choice.js", () => ({
 }));
 vi.mock("../../wizard/setup.shared.js", () => ({
   readSetupConfigFileSnapshot: setupSharedMocks.readSetupConfigFileSnapshot,
-  writeWizardConfigFile: setupSharedMocks.writeWizardConfigFile,
+}));
+vi.mock("../../plugins/provider-auth-config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/provider-auth-config.js")>()),
+  writeProviderAuthConfig: authConfigMocks.writeProviderAuthConfig,
 }));
 
 const config: OpenClawConfig = {
@@ -96,8 +101,8 @@ describe("openclaw.setup provider preparation", () => {
       config,
       issues: [],
     });
-    setupSharedMocks.writeWizardConfigFile.mockImplementation(
-      async (writtenConfig) => writtenConfig,
+    authConfigMocks.writeProviderAuthConfig.mockImplementation(
+      async ({ config: writtenConfig }) => writtenConfig,
     );
   });
 
@@ -180,7 +185,7 @@ describe("openclaw.setup provider preparation", () => {
           } as never);
           expect(calls[0]?.payload).toMatchObject({ status: "running" });
           expect(session.signal.aborted).toBe(false);
-          expect(setupSharedMocks.writeWizardConfigFile).not.toHaveBeenCalled();
+          expect(authConfigMocks.writeProviderAuthConfig).not.toHaveBeenCalled();
           finishCredentialWrite.resolve();
         }
         const done = await terminal;
@@ -191,13 +196,10 @@ describe("openclaw.setup provider preparation", () => {
           status: beforeCredentials ? "cancelled" : "done",
         });
         if (beforeCredentials) {
-          expect(setupSharedMocks.writeWizardConfigFile).not.toHaveBeenCalled();
+          expect(authConfigMocks.writeProviderAuthConfig).not.toHaveBeenCalled();
           expect(done).not.toHaveProperty("preparedModelRef");
         } else {
-          expect(setupSharedMocks.writeWizardConfigFile).toHaveBeenCalledWith(
-            preparedConfig,
-            expect.objectContaining({ baseHash: "setup-resolution-config" }),
-          );
+          expect(authConfigMocks.writeProviderAuthConfig).toHaveBeenCalledOnce();
           expect(done.preparedModelRef).toBe("fixture/demo-model");
         }
         expect(wizardSessions.has(sessionId)).toBe(false);
@@ -283,11 +285,7 @@ describe("openclaw.setup provider preparation", () => {
         preparedModelRef: "ollama/qwen3:0.6b",
       });
       expect(persistAuthProfiles).toHaveBeenCalledOnce();
-      expect(setupSharedMocks.writeWizardConfigFile).toHaveBeenCalledWith(preparedConfig, {
-        allowConfigSizeDrop: false,
-        baseSnapshot: expect.objectContaining({ hash: "setup-resolution-config" }),
-        baseHash: "setup-resolution-config",
-      });
+      expect(authConfigMocks.writeProviderAuthConfig).toHaveBeenCalledOnce();
     },
   );
 });

--- a/src/gateway/server-methods/system-agent-setup-resolution.test.ts
+++ b/src/gateway/server-methods/system-agent-setup-resolution.test.ts
@@ -27,7 +27,9 @@ const providerAuthChoiceMocks = vi.hoisted(() => ({
 }));
 const setupSharedMocks = vi.hoisted(() => ({
   readSetupConfigFileSnapshot: vi.fn(),
-  writeWizardConfigFile: vi.fn(),
+}));
+const authConfigMocks = vi.hoisted(() => ({
+  writeProviderAuthConfig: vi.fn(),
 }));
 
 vi.mock("../../system-agent/setup-inference.js", () => ({
@@ -39,7 +41,10 @@ vi.mock("../../plugins/provider-auth-choice.js", () => ({
 }));
 vi.mock("../../wizard/setup.shared.js", () => ({
   readSetupConfigFileSnapshot: setupSharedMocks.readSetupConfigFileSnapshot,
-  writeWizardConfigFile: setupSharedMocks.writeWizardConfigFile,
+}));
+vi.mock("../../plugins/provider-auth-config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/provider-auth-config.js")>()),
+  writeProviderAuthConfig: authConfigMocks.writeProviderAuthConfig,
 }));
 
 const config: OpenClawConfig = {
@@ -106,8 +111,8 @@ describe("openclaw.setup provider resolution", () => {
       config,
       issues: [],
     });
-    setupSharedMocks.writeWizardConfigFile.mockImplementation(
-      async (writtenConfig) => writtenConfig,
+    authConfigMocks.writeProviderAuthConfig.mockImplementation(
+      async ({ config: writtenConfig }) => writtenConfig,
     );
   });
 
@@ -416,7 +421,7 @@ describe("openclaw.setup provider resolution", () => {
     }
     expect(installed).toBe(true);
     expect(submittedBeforeCleanup).toBe(false);
-    expect(setupSharedMocks.writeWizardConfigFile).not.toHaveBeenCalled();
+    expect(authConfigMocks.writeProviderAuthConfig).not.toHaveBeenCalled();
     expect(offeredStepType).toBe(expiresDuringInstall ? undefined : "text");
     expect(promoteModel).not.toHaveBeenCalled();
     expect(statusAtCheckpoint).toBe(finalCommit ? "running" : "cancelled");
@@ -517,7 +522,7 @@ describe("openclaw.setup provider resolution", () => {
         'Error: Provider setup resolution failed for "ollama". Run `openclaw doctor --fix`, restart the Gateway, and try again.',
     });
     await whenAdmittedWizardSessionSettled(session);
-    expect(setupSharedMocks.writeWizardConfigFile).not.toHaveBeenCalled();
+    expect(authConfigMocks.writeProviderAuthConfig).not.toHaveBeenCalled();
   });
   it.each([false, true])(
     "returns verified provider auth through wizard transport (restart %s)",

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -250,10 +250,12 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
         new WizardSession(
           async (prompter, signal, runnerSession) => {
             await runSystemAgentGatewayTask(async () => {
-              const [{ prepareAuthChoiceLoadedPluginProvider }, setupShared] = await Promise.all([
-                import("../../plugins/provider-auth-choice.js"),
-                import("../../wizard/setup.shared.js"),
-              ]);
+              const [{ prepareAuthChoiceLoadedPluginProvider }, setupShared, authConfig] =
+                await Promise.all([
+                  import("../../plugins/provider-auth-choice.js"),
+                  import("../../wizard/setup.shared.js"),
+                  import("../../plugins/provider-auth-config.js"),
+                ]);
               const snapshot = await setupShared.readSetupConfigFileSnapshot();
               if (!snapshot.valid) {
                 throw new Error(
@@ -295,10 +297,12 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
               signal.throwIfAborted();
               runnerSession.lockCancellation();
               await prepared.persistAuthProfiles();
-              await setupShared.writeWizardConfigFile(prepared.config, {
-                allowConfigSizeDrop: false,
-                baseSnapshot: snapshot,
-                ...(snapshot.hash ? { baseHash: snapshot.hash } : {}),
+              await authConfig.writeProviderAuthConfig({
+                config: baseConfig,
+                configSnapshot: snapshot,
+                configPatch: authConfig.createProviderAuthConfigPatch(baseConfig, prepared.config),
+                credentialsSaved: prepared.authProfiles.length > 0,
+                writeOptions: { allowConfigSizeDrop: false },
               });
               if (prepared.agentModelOverride) {
                 runnerSession.setPreparedModelRef(prepared.agentModelOverride);

--- a/src/plugins/provider-auth-config.ts
+++ b/src/plugins/provider-auth-config.ts
@@ -1,0 +1,73 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import {
+  createInvalidConfigError,
+  formatInvalidConfigDetails,
+} from "../config/io.invalid-config.js";
+import type { ConfigWriteOptions } from "../config/io.js";
+import { applyMergePatch, createMergePatch, mergePatchConflicts } from "../config/merge-patch.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
+import { ProviderAuthConfigApplyError } from "../shared/provider-auth-result.js";
+import { transformConfigWithPendingPluginInstalls } from "./install-record-commit.js";
+import { applyProviderAuthConfigPatch } from "./provider-auth-choice-helpers.js";
+
+const patchOptions = { mergeObjectArraysById: true };
+
+export function createProviderAuthConfigPatch(base: OpenClawConfig, next: OpenClawConfig) {
+  return createMergePatch(
+    applyProviderAuthConfigPatch(base, {}),
+    applyProviderAuthConfigPatch(next, {}),
+    patchOptions,
+  );
+}
+
+/** Replay completed provider setup against current authored settings, without replaying login. */
+export async function writeProviderAuthConfig(params: {
+  config: OpenClawConfig;
+  configSnapshot: ConfigFileSnapshot;
+  configPatch: unknown;
+  credentialsSaved: boolean;
+  finalizeConfig?: (next: OpenClawConfig, current: OpenClawConfig) => OpenClawConfig;
+  beforeCommit?: () => void;
+  writeOptions?: ConfigWriteOptions;
+}): Promise<OpenClawConfig> {
+  const loginConfig = applyProviderAuthConfigPatch(params.config, {});
+  const sourceConfig = applyProviderAuthConfigPatch(params.configSnapshot.sourceConfig, {});
+  const runtimeConfig = applyProviderAuthConfigPatch(params.configSnapshot.runtimeConfig, {});
+  try {
+    const written = await transformConfigWithPendingPluginInstalls({
+      base: "source",
+      writeOptions: { ...params.writeOptions, beforeCommit: params.beforeCommit },
+      transform: (current, { snapshot }) => {
+        if (!snapshot.valid) {
+          throw createInvalidConfigError(
+            snapshot.path,
+            formatInvalidConfigDetails(snapshot.issues),
+          );
+        }
+        params.beforeCommit?.();
+        let next = applyProviderAuthConfigPatch(current, {});
+        if (params.configPatch) {
+          if (
+            (mergePatchConflicts(loginConfig, runtimeConfig, params.configPatch, patchOptions) &&
+              mergePatchConflicts(loginConfig, sourceConfig, params.configPatch, patchOptions)) ||
+            mergePatchConflicts(sourceConfig, next, params.configPatch, patchOptions)
+          ) {
+            throw new Error(
+              "Provider settings changed during sign-in. Review the current settings and retry.",
+            );
+          }
+          // SAFETY: The patch derives from typed config; the config owner validates it before writing.
+          next = applyMergePatch(next, params.configPatch, patchOptions) as OpenClawConfig;
+        }
+        next = params.finalizeConfig ? params.finalizeConfig(next, current) : next;
+        return { nextConfig: next, result: next };
+      },
+    });
+    return expectDefined(written.result, "provider config mutation result");
+  } catch (error) {
+    if (!params.credentialsSaved) {
+      throw error;
+    }
+    throw new ProviderAuthConfigApplyError(error);
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users preparing a provider through Gateway setup received a raw config-changed error after saving credentials if another config edit occurred during login. The unrelated edit survived, but the provider settings were not applied and the error did not explain that the credential was already saved.

## Why This Change Was Made

CLI login and Gateway preparation now share one config writer. It applies only the provider's changes to the latest authored config, merges model rows by ID, rejects conflicting or invalid edits, and uses the existing saved-credential/settings-failure error. Pending plugin-install records remain with their existing commit owner.

The setup path no longer binds publication to the snapshot taken before login. Strict snapshot checks remain for migration promotion and verified setup operations that require them. Credential persistence, cancellation, and default-model policy retain their existing owners.

## User Impact

Unrelated edits made while provider setup waits for input survive, and setup can complete. If settings cannot be applied, setup explains that credentials were saved and retains the config owner's recovery guidance.

## Evidence

- Reproduced on main `a321595f496e5a95d2bd0ffe81f7a080b4fcdfc8` through the shipped Gateway client: start preparation, edit an unrelated setting while the provider key prompt waits, then complete. Before: raw config-changed error with credential saved. After: setup completes with the edit and credential retained.
- Real config-directory permission failure: before, config-only error despite a saved credential; after, explicit saved-credential/settings-failure message. Used isolated state and synthetic credentials.
- 45 targeted Gateway setup tests and 55 CLI auth tests pass. The three original new regressions fail on main. Added protection for a config that becomes invalid during login.
- Focused lint, formatting, line-count and assertion checks pass. Full type checks run in GitHub CI.

Related: #144181, #144436. No changes to the credential replacement paths under #144524.
