### PR TITLE
refactor: remove redundant provider stream smoke test

### DIFF
--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -615,16 +615,6 @@ describe("buildProviderStreamFamilyHooks", () => {
     expectDefaultThinkingBudget(toolStreamDisabledPayload);
     expect(toolStreamDisabledPayload).not.toHaveProperty("tool_stream");
   });
-
-  it("exposes canonical stream hook constants for reused families", () => {
-    expect(GOOGLE_THINKING_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
-    expect(KILOCODE_THINKING_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
-    expect(MINIMAX_FAST_MODE_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
-    expect(MOONSHOT_THINKING_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
-    expect(OPENAI_RESPONSES_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
-    expect(OPENROUTER_THINKING_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
-    expect(TOOL_STREAM_DEFAULT_ON_HOOKS.wrapStreamFn).toBeTypeOf("function");
-  });
 });
 
 describe("createPlainTextToolCallCompatWrapper", () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

A provider-stream smoke test only checks that seven exported hooks are functions, duplicating checks already performed by the preceding behavior test using those same imports.

## Why This Change Was Made

Remove that single redundant case. The retained stream-family matrix still checks each hook's type, invokes it, and verifies payload, model, and header behavior. Separate shipped-subpath alias-identity tests remain unchanged.

## User Impact

No production change. Ten test lines and one redundant invocation are removed without removing an independently tested contract.

## Evidence

Both complete suites passed before and after: 26 cases before, 25 after, with exactly the approved smoke case removed and every remaining ordered case/status unchanged. No failures or skips. No runtime improvement is claimed.

The mapped changed-file gate passed, including SDK surface checks, typechecking, lint and guards. Fresh independent review found no actionable P0–P2 findings.
