### PR TITLE
fix(macos): keep dashboard controls visible in full screen

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -29,6 +29,7 @@ private final class DashboardWindowContentView: NSView {
 /// Toolbar` (and ⌥⌘T) would collapse the titlebar while the web inset stays
 /// pinned at `--openclaw-native-titlebar-height`, resurrecting the traffic-light
 /// misalignment. Refusing the toggle keeps the two heights in lockstep.
+/// Full screen hides this sizing toolbar so it cannot cover the web controls.
 private final class DashboardWindow: NSWindow {
     /// User intent belongs to the native window, not the privileged document it hosts.
     var userIntentGeneration: UInt64 = 0
@@ -261,6 +262,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             self.requestBrowserProfileImportOfferIfNeeded()
         }
         self.window?.delegate = self
+        self.updateToolbarVisibility(isFullScreen: window.styleMask.contains(.fullScreen))
         self.installHistoryStateBridge()
         if restoreKeyboardFocus {
             window.makeFirstResponder(self.webView)
@@ -1098,6 +1100,20 @@ extension DashboardWindowController {
     /// loads and SPA history do not mutate it, so native fallbacks stay rooted.
     var dashboardBaseURL: URL {
         self.currentURL
+    }
+
+    func windowDidEnterFullScreen(_: Notification) {
+        self.updateToolbarVisibility(isFullScreen: true)
+    }
+
+    func windowDidExitFullScreen(_: Notification) {
+        self.updateToolbarVisibility(isFullScreen: false)
+    }
+
+    private func updateToolbarVisibility(isFullScreen: Bool) {
+        // Apply completed transitions; failed transitions keep their previous chrome.
+        // Reused windows also pass through this owner during initialization.
+        self.window?.toolbar?.isVisible = !isFullScreen
     }
 
     func windowWillClose(_: Notification) {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardFullScreenTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardFullScreenTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Testing
+import WebKit
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct DashboardFullScreenTests {
+    @Test func `completed full screen transitions preserve the windowed toolbar`() throws {
+        let controller = try Self.makeController()
+        defer { controller.closeDashboard() }
+        let window = try #require(controller.window)
+        let toolbar = try #require(window.toolbar)
+        #expect(toolbar.isVisible)
+
+        for _ in 0..<2 {
+            NotificationCenter.default.post(name: NSWindow.willEnterFullScreenNotification, object: window)
+            #expect(toolbar.isVisible)
+
+            NotificationCenter.default.post(name: NSWindow.didEnterFullScreenNotification, object: window)
+            #expect(!toolbar.isVisible)
+            #expect(window.toolbar === toolbar)
+
+            NotificationCenter.default.post(name: NSWindow.willExitFullScreenNotification, object: window)
+            #expect(!toolbar.isVisible)
+
+            NotificationCenter.default.post(name: NSWindow.didExitFullScreenNotification, object: window)
+            #expect(toolbar.isVisible)
+            #expect(window.toolbar === toolbar)
+            #expect(window.toolbarStyle == .unified)
+            window.toggleToolbarShown(nil)
+            #expect(toolbar.isVisible)
+        }
+    }
+
+    @Test func `replacement reconciles toolbar visibility without showing the window`() throws {
+        let controller = try Self.makeController()
+        defer { controller.closeDashboard() }
+        let window = try #require(controller.window)
+        let previousToolbar = try #require(window.toolbar)
+        NotificationCenter.default.post(name: NSWindow.didEnterFullScreenNotification, object: window)
+        #expect(!previousToolbar.isVisible)
+
+        // Notifications exercise delegate routing without an interactive Space transition.
+        // The actual style remains windowed, so replacement must restore windowed chrome.
+        #expect(!window.styleMask.contains(.fullScreen))
+        let transferredWindow = try #require(controller.detachWindowForReplacement())
+        defer { transferredWindow.close() }
+        let replacement = try Self.makeController(reusing: transferredWindow)
+        defer { replacement.closeDashboard() }
+
+        #expect(replacement.window === window)
+        #expect(window.toolbar !== previousToolbar)
+        #expect(window.toolbar?.isVisible == true)
+    }
+
+    @Test func `full screen notifications only affect their own dashboard`() throws {
+        let first = try Self.makeController()
+        defer { first.closeDashboard() }
+        let second = try Self.makeController()
+        defer { second.closeDashboard() }
+        let firstWindow = try #require(first.window)
+        let secondWindow = try #require(second.window)
+
+        NotificationCenter.default.post(name: NSWindow.didEnterFullScreenNotification, object: firstWindow)
+        #expect(firstWindow.toolbar?.isVisible == false)
+        #expect(secondWindow.toolbar?.isVisible == true)
+
+        NotificationCenter.default.post(name: NSWindow.didEnterFullScreenNotification, object: secondWindow)
+        NotificationCenter.default.post(name: NSWindow.didExitFullScreenNotification, object: firstWindow)
+        #expect(firstWindow.toolbar?.isVisible == true)
+        #expect(secondWindow.toolbar?.isVisible == false)
+
+        NotificationCenter.default.post(name: NSWindow.didExitFullScreenNotification, object: secondWindow)
+        #expect(secondWindow.toolbar?.isVisible == true)
+    }
+
+    private static func makeController(reusing window: NSWindow? = nil) throws -> DashboardWindowController {
+        try DashboardWindowController(
+            url: #require(URL(string: "about:blank")),
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            reusingWindow: window,
+            requestBrowserProfileImportOffer: { _ in false })
+    }
+}

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -13,6 +13,10 @@ and Mac-hosted node tools such as `system.run`.
 
 Use **Quick Chat** for a Spotlight-style main-session composer without opening a full window. Press Option-Space (⌥Space) by default, choose it from the menu bar menu, or record another shortcut in **Dashboard → Settings → This Mac → App**.
 
+Use the green window button to enter native full screen. The Dashboard's sidebar
+and chat controls remain available at the top of the window. Leaving full screen
+restores the normal titlebar and window controls.
+
 The full native chat accepts image attachments through its picker, paste, and
 drag and drop. Assistant-generated images render inline through short-lived
 Gateway artifact URLs and open in a larger preview; iOS and macOS share the same


### PR DESCRIPTION
Related: #136131, #138787

## What Problem This Solves

Fixes an issue where users entering native macOS full screen would see a blank band across the Dashboard and lose access to its sidebar, search, and chat header controls. AppKit keeps the window's empty sizing toolbar above those controls.

## Why This Change Was Made

The Dashboard hides its sizing toolbar after entering full screen and restores it after leaving. Initialization applies the same rule when a reconnect replaces the controller of an already open window. Completed-transition callbacks preserve the previous layout if a transition fails, and the hosted web content keeps its existing responsive layout. Toolbar visibility follows full-screen state, with no fixed monitor dimensions.

This overlaps with the earlier proposal in #138787 by Sho Jikumaru. This separate PR carries the same repair on current main, a focused lifecycle test file, and native macOS 27 proof of physical clicks, window reuse, and return from full screen.

## User Impact

The sidebar, search, and chat header buttons remain visible and clickable in full screen, including after reconnecting. Returning to a normal window restores its traffic-light alignment and existing toolbar-toggle behavior.

## Evidence

[Before video](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publish-pr-evidence/20260911-014715-623149000/before.mp4?X-Amz-Expires=604800&X-Amz-Date=20260911T014715Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=2368c0284eced4884192c5a57419f1fa8cc408d845dfee32d4985abce5dede11) · [After video](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publish-pr-evidence/20260911-014715-623149000/after.mp4?X-Amz-Expires=604800&X-Amz-Date=20260911T014715Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=ffb07fb0e22adc5e060ab15c4a5b57c7e089e242f9e10c9834ae1c367508fdc9) · [Proof manifest](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publish-pr-evidence/20260911-014715-623149000/proof.json?X-Amz-Expires=604800&X-Amz-Date=20260911T014715Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=dc08a46e7b668186280ed7af182e1419369b3bddd286d6f733b2f2cd437a4c3c) · [Artifact manifest](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publish-pr-evidence/20260911-014715-623149000/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260911T014727Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=b349c157dbc81d7a9e3f6e35ed5c8bb9a51d054ac528556d818cd8a8cf77ac00) · [Independent evidence review](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publish-pr-evidence/20260911-014715-623149000/behavior-validation.md?X-Amz-Expires=604800&X-Amz-Date=20260911T014715Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=29f897ce3b45807f52412f1575909e0b3dd99ce241bb47b607016ed34d762e56)

| Before, full screen | After, full screen |
| --- | --- |
| ![Empty toolbar covers the controls](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publish-pr-evidence/20260911-014715-623149000/before.png?X-Amz-Expires=604800&X-Amz-Date=20260911T014715Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=04a9b229b15d31480ff94e10e4d39c07426106fbaac251f8ffa933dbc4a7704a) | ![Controls remain visible](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publish-pr-evidence/20260911-014715-623149000/after.png?X-Amz-Expires=604800&X-Amz-Date=20260911T014715Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=7bc66a6d77bfe8a06001a780b3dfe0a2c2f3a15973b1b8e0d146243f7631dc58) |

Artifact links expire September 18, 2026.

- Base: real native full screen creates a separate 66-point toolbar window. Five header controls stop receiving screen-coordinate clicks; the lower content control still works.
- Head: all six controls receive physical clicks in normal mode, full screen, after top-edge pointer reveal/dismiss, after same-window replacement, on return to normal, and in a repeated full-screen cycle. Toolbar visibility and traffic-light placement return to their original windowed state.
- Native app build: passed
- Native test-bundle compilation: passed. Full native test execution remains with disposable macOS CI.
- Swift lint/formatting and localization verification: passed
- Repository changed-file checks: passed, 1,147 tests in 21 files plus repository guards
- Independent source-blind review of saved evidence: all six scoped clauses pass. The reviewer did not run the app.
- Autoreview: one bounded pass, no P0 findings.

The recordings use the exact extracted native window/chrome source with a synthetic nonpersistent web document. Full-screen transitions and physical input routing are real; web callback counters verify delivery. They do not exercise a live Gateway, authentication, or whole-app startup. No installed app, Gateway, or operator settings were changed.

Capture limits: image and geometry snapshots are asynchronous. The last exit has a blank transition frame and one unavailable-window sample. First-return images show restored controls; final restoration is recorded in JSON. The manifests retain these gaps.
