### PR TITLE
fix(memory-core): keep lexical recall readable during a pending chunking upgrade

### DIFF
--- a/extensions/memory-core/src/chunking-upgrade-real-transport.test.ts
+++ b/extensions/memory-core/src/chunking-upgrade-real-transport.test.ts
@@ -1,0 +1,390 @@
+// Memory Core tests prove the chunking upgrade fallback against a real HTTP
+// embedding server: the outage reaches the wire through the real
+// openai-compatible provider, the real embedding retry policy, and the real
+// SQLite store instead of a test-double provider.
+import { mkdirSync, rmSync } from "node:fs";
+import fs from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { MEMORY_CHUNKING_VERSION } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  closeOpenClawStateDatabaseForTest,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MemoryIndexManager } from "./memory/manager.js";
+import { isolateMemoryManagerTestConfig } from "./memory/test-config-helpers.js";
+import "./memory/test-runtime-mocks.js";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+} from "./test-helpers.js";
+import { createMemorySearchTool, testing } from "./tools.js";
+
+const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./memory/index.js");
+
+type ServerMode = "ok" | "unauthorized" | "quota";
+
+type CapturedRequest = {
+  method: string | undefined;
+  url: string | undefined;
+  status: number;
+  body: Record<string, unknown>;
+};
+
+type EmbeddingServer = {
+  baseUrl: string;
+  requests: CapturedRequest[];
+  setMode: (mode: ServerMode) => void;
+  close: () => Promise<void>;
+};
+
+const servers: EmbeddingServer[] = [];
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+}
+
+function errorBody(mode: Exclude<ServerMode, "ok">): Record<string, unknown> {
+  return mode === "quota"
+    ? {
+        error: {
+          message: "You exceeded your current quota, please check your plan and billing details.",
+          type: "insufficient_quota",
+          code: "insufficient_quota",
+        },
+      }
+    : {
+        error: {
+          message: "Invalid API key provided.",
+          type: "invalid_request_error",
+          code: "invalid_api_key",
+        },
+      };
+}
+
+async function startEmbeddingServer(): Promise<EmbeddingServer> {
+  const requests: CapturedRequest[] = [];
+  let mode: ServerMode = "ok";
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    void (async () => {
+      try {
+        const body = await readJsonBody(req);
+        if (mode !== "ok") {
+          const status = mode === "quota" ? 429 : 401;
+          requests.push({ method: req.method, url: req.url, status, body });
+          res.writeHead(status, { "content-type": "application/json" });
+          res.end(JSON.stringify(errorBody(mode)));
+          return;
+        }
+        requests.push({ method: req.method, url: req.url, status: 200, body });
+        const input = body.input;
+        const texts = Array.isArray(input) ? input : [input];
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            object: "list",
+            data: texts.map((text, index) => ({
+              object: "embedding",
+              embedding: [String(text).length, index + 0.5, 3],
+              index,
+            })),
+            model: body.model,
+          }),
+        );
+      } catch (error) {
+        requests.push({ method: req.method, url: req.url, status: 500, body: {} });
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { message: String(error) } }));
+      }
+    })();
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  servers.push({
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    requests,
+    setMode: (next) => {
+      mode = next;
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  });
+  return servers[servers.length - 1] as EmbeddingServer;
+}
+
+vi.setConfig({ testTimeout: 240_000 });
+
+afterAll(() => {
+  vi.resetConfig();
+});
+
+describe("memory chunking upgrade fallback over a real embedding transport", () => {
+  let root = "";
+  let workspace = "";
+  let memory = "";
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+
+  const setStateDir = (stateDir: string): void => {
+    Reflect.set(process.env, "OPENCLAW_STATE_DIR", stateDir);
+  };
+
+  function requireManager(
+    result: Awaited<ReturnType<typeof getMemorySearchManager>>,
+  ): MemoryIndexManager {
+    if (!result.manager) {
+      throw new Error("memory search manager missing");
+    }
+    return result.manager as unknown as MemoryIndexManager;
+  }
+
+  function createConfig(params: { baseUrl: string; extraPaths?: string[] }): OpenClawConfig {
+    return isolateMemoryManagerTestConfig({
+      memory: {
+        search: {
+          provider: "openai-compatible",
+          model: "text-embedding-bge-m3",
+          remote: { baseUrl: params.baseUrl, apiKey: "fixture-token" },
+          outputDimensionality: 3,
+          store: { vector: { enabled: true } },
+          query: { minScore: 0 },
+          ...(params.extraPaths ? { extraPaths: params.extraPaths } : {}),
+        },
+      },
+      agents: { defaults: { workspace }, list: [{ id: "main", default: true }] },
+    } as OpenClawConfig);
+  }
+
+  // Seeds a published index, then reopens its metadata as an older runtime's
+  // index so the next search sees a pending OpenClaw chunking upgrade.
+  async function seedPriorChunkingVersionIndex(cfg: OpenClawConfig): Promise<string> {
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    await manager.sync({ reason: "test", force: true });
+    const dbPath = manager.status().dbPath;
+    if (!dbPath) {
+      throw new Error("memory search manager database path missing");
+    }
+    await manager.close();
+    await closeAllMemorySearchManagers();
+    closeOpenClawAgentDatabasesForTest();
+    const db = new DatabaseSync(dbPath);
+    try {
+      const row = db
+        .prepare("SELECT value FROM memory_index_meta WHERE key = 'memory_index_meta_v1'")
+        .get();
+      if (typeof row?.value !== "string") {
+        throw new Error("fixture index metadata is missing");
+      }
+      const meta = JSON.parse(row.value) as Record<string, unknown>;
+      db.prepare("UPDATE memory_index_meta SET value = ? WHERE key = 'memory_index_meta_v1'").run(
+        JSON.stringify({ ...meta, chunkingVersion: MEMORY_CHUNKING_VERSION - 1 }),
+      );
+    } finally {
+      db.close();
+    }
+    return dbPath;
+  }
+
+  function createMemorySearchToolFor(cfg: OpenClawConfig) {
+    const tool = createMemorySearchTool({ config: cfg, agentId: "main", oneShotCliRun: true });
+    if (!tool) {
+      throw new Error("memory_search tool missing");
+    }
+    return tool;
+  }
+
+  beforeAll(async () => {
+    const rawRoot = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-mem-real-transport-"),
+    );
+    root = await fs.realpath(rawRoot);
+    workspace = path.join(root, "workspace");
+    memory = path.join(workspace, "memory");
+  });
+
+  afterAll(async () => {
+    if (root) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(async () => {
+    testing.resetMemorySearchToolCooldowns();
+    rmSync(workspace, { recursive: true, force: true });
+    mkdirSync(memory, { recursive: true });
+    setStateDir(path.join(workspace, ".state-memory-index"));
+    await configureMemoryCoreDreamingStateForTests();
+    await fs.writeFile(
+      path.join(memory, "2026-01-12.md"),
+      "# Log\nAlpha memory line.\nZebra memory line.",
+    );
+  });
+
+  afterEach(async () => {
+    const pendingServers = servers.splice(0);
+    await Promise.all(pendingServers.map((server) => server.close()));
+    await closeAllMemorySearchManagers();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    resetMemoryCoreDreamingStateForTests();
+    if (originalStateDir === undefined) {
+      Reflect.deleteProperty(process.env, "OPENCLAW_STATE_DIR");
+    } else {
+      Reflect.set(process.env, "OPENCLAW_STATE_DIR", originalStateDir);
+    }
+  });
+
+  it("serves keyword results through memory_search when a real server rejects the upgrade rebuild", async () => {
+    const server = await startEmbeddingServer();
+    const cfg = createConfig({ baseUrl: server.baseUrl });
+    const filePath = path.join(memory, "upgrade-fallback.md");
+    await fs.writeFile(filePath, "UpgradeKeywordFallback()\nfinish()");
+    await seedPriorChunkingVersionIndex(cfg);
+    // The changed file forces the upgrade rebuild to request a fresh embedding
+    // instead of republishing from the embedding cache.
+    await fs.writeFile(
+      filePath,
+      "UpgradeKeywordFallback() changed after the prior index was published.",
+    );
+    server.setMode("unauthorized");
+
+    const tool = createMemorySearchToolFor(cfg);
+    try {
+      const result = await tool.execute("upgrade-keyword-fallback", {
+        query: "UpgradeKeywordFallback",
+        corpus: "memory",
+      });
+      expect(result.details).toMatchObject({
+        results: [expect.objectContaining({ path: "memory/upgrade-fallback.md" })],
+      });
+      expect(result.details).not.toHaveProperty("unavailable");
+    } finally {
+      await closeAllMemorySearchManagers();
+      closeOpenClawAgentDatabasesForTest();
+    }
+    // The rejection must have reached the real server for the rebuild's fresh
+    // embedding; the seed phase answered 200 beforehand.
+    expect(server.requests.some((request) => request.status === 401)).toBe(true);
+    expect(server.requests.some((request) => request.status === 200)).toBe(true);
+  });
+
+  it("keeps memory_search paused when a real outage rebuild has no usable FTS index", async () => {
+    const server = await startEmbeddingServer();
+    const cfg = createConfig({ baseUrl: server.baseUrl });
+    const filePath = path.join(memory, "upgrade-fts-paused.md");
+    await fs.writeFile(filePath, "UpgradeFtsPaused()\nfinish()");
+    const dbPath = await seedPriorChunkingVersionIndex(cfg);
+    await fs.writeFile(filePath, "UpgradeFtsPaused() changed after the prior index was published.");
+    // Occupy the FTS table name with a view so every schema ensure — including
+    // the upgrade rebuild's republish — fails to restore a usable keyword index.
+    const sabotaged = new DatabaseSync(dbPath);
+    try {
+      sabotaged.exec("DROP TABLE IF EXISTS memory_index_chunks_fts");
+      sabotaged.exec("CREATE VIEW memory_index_chunks_fts AS SELECT 1 AS text");
+    } finally {
+      sabotaged.close();
+    }
+    server.setMode("unauthorized");
+
+    const tool = createMemorySearchToolFor(cfg);
+    try {
+      const result = await tool.execute("upgrade-fts-paused", {
+        query: "UpgradeFtsPaused",
+        corpus: "memory",
+      });
+      expect(result.details).toMatchObject({
+        unavailable: true,
+        error: expect.stringContaining("chunking"),
+      });
+    } finally {
+      await closeAllMemorySearchManagers();
+      closeOpenClawAgentDatabasesForTest();
+    }
+    expect(server.requests.some((request) => request.status === 401)).toBe(true);
+  });
+
+  it("pauses memory_search when a real outage rebuild coincides with a changed scope", async () => {
+    const server = await startEmbeddingServer();
+    const wikiPath = path.join(root, "wiki");
+    await fs.mkdir(wikiPath, { recursive: true });
+    await fs.writeFile(path.join(wikiPath, "note.md"), "UpgradeScopeWiki alpha note.");
+    const cfgWithWiki = createConfig({ baseUrl: server.baseUrl, extraPaths: [wikiPath] });
+    const cfgWithoutWiki = createConfig({ baseUrl: server.baseUrl });
+    const filePath = path.join(memory, "upgrade-scope.md");
+    await fs.writeFile(filePath, "UpgradeScopeMemory alpha note.");
+    await seedPriorChunkingVersionIndex(cfgWithWiki);
+    await fs.writeFile(filePath, "UpgradeScopeMemory note changed after the prior index.");
+    server.setMode("unauthorized");
+
+    const tool = createMemorySearchToolFor(cfgWithoutWiki);
+    try {
+      const result = await tool.execute("upgrade-changed-scope", {
+        query: "UpgradeScopeMemory",
+        corpus: "memory",
+      });
+      expect(result.details).toMatchObject({
+        unavailable: true,
+        error: expect.stringContaining("chunking"),
+      });
+    } finally {
+      await closeAllMemorySearchManagers();
+      closeOpenClawAgentDatabasesForTest();
+    }
+    expect(server.requests.some((request) => request.status === 401)).toBe(true);
+  });
+
+  it("keeps keyword results readable when a real quota-exhausted server rate-limits the rebuild", async () => {
+    const server = await startEmbeddingServer();
+    const cfg = createConfig({ baseUrl: server.baseUrl });
+    const filePath = path.join(memory, "upgrade-quota.md");
+    await fs.writeFile(filePath, "UpgradeQuotaFallback()\nfinish()");
+    await seedPriorChunkingVersionIndex(cfg);
+    await fs.writeFile(
+      filePath,
+      "UpgradeQuotaFallback() changed after the prior index was published.",
+    );
+    server.setMode("quota");
+
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    try {
+      // The search outwaits the real index retry budget: the OpenAI-style
+      // quota response is rate-limited retried before the rebuild gives up.
+      const results = await manager.search("UpgradeQuotaFallback");
+      expect(results).toEqual(
+        expect.arrayContaining([expect.objectContaining({ path: "memory/upgrade-quota.md" })]),
+      );
+      expect(manager.status().custom?.indexIdentity).toMatchObject({
+        status: "mismatched",
+        code: "chunking_version",
+        owner: "openclaw",
+        chunkingVersionOnly: true,
+      });
+    } finally {
+      await manager.close();
+      await closeAllMemorySearchManagers();
+      closeOpenClawAgentDatabasesForTest();
+    }
+    // Every index retry attempt reached the real server before the fallback;
+    // both the identity-repair rebuild and the follow-up background search sync
+    // exhaust the full five-attempt rate-limit budget over the wire.
+    expect(
+      server.requests.filter((request) => request.status === 429).length,
+    ).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/extensions/memory-core/src/chunking-upgrade-real-transport.test.ts
+++ b/extensions/memory-core/src/chunking-upgrade-real-transport.test.ts
@@ -363,8 +363,8 @@ describe("memory chunking upgrade fallback over a real embedding transport", () 
 
     const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
     try {
-      // The search outwaits the real index retry budget: the OpenAI-style
-      // quota response is rate-limited retried before the rebuild gives up.
+      // A real quota rejection rate-limits the rebuild over the wire while the
+      // published keyword index stays readable.
       const results = await manager.search("UpgradeQuotaFallback");
       expect(results).toEqual(
         expect.arrayContaining([expect.objectContaining({ path: "memory/upgrade-quota.md" })]),
@@ -380,11 +380,11 @@ describe("memory chunking upgrade fallback over a real embedding transport", () 
       await closeAllMemorySearchManagers();
       closeOpenClawAgentDatabasesForTest();
     }
-    // Every index retry attempt reached the real server before the fallback;
-    // both the identity-repair rebuild and the follow-up background search sync
-    // exhaust the full five-attempt rate-limit budget over the wire.
-    expect(
-      server.requests.filter((request) => request.status === 429).length,
-    ).toBeGreaterThanOrEqual(5);
+    // The quota rejection reached the real server over the wire. How many
+    // retries fit into the run is clock-dependent — the rate-limit budget
+    // drains through backoff sleeps and the search fallback races it — so the
+    // run only promises at least one wire-visible 429; the exact budget is
+    // owned by the embedding-policy unit tests.
+    expect(server.requests.some((request) => request.status === 429)).toBe(true);
   });
 });

--- a/extensions/memory-core/src/memory-search-tool-query.ts
+++ b/extensions/memory-core/src/memory-search-tool-query.ts
@@ -200,12 +200,16 @@ async function finalizeMemorySearchToolQuery(params: {
   const pausedIndexIdentity = resolveMemoryIndexIdentityDiagnostic(status);
   // A pending chunking upgrade on an otherwise matching index degrades to
   // keyword-only results instead of pausing memory search; every other
-  // mismatch still withholds all candidates.
+  // mismatch still withholds all candidates. Keyword results still need a
+  // usable FTS index — the manager's fallback requires the same, so without
+  // it there is no retrieval path and the tool must keep the paused
+  // diagnostic instead of reporting a successful empty search.
   const chunkingUpgradeKeywordOnly =
     pausedIndexIdentity?.status === "mismatched" &&
     pausedIndexIdentity.owner === "openclaw" &&
     pausedIndexIdentity.code === "chunking_version" &&
-    pausedIndexIdentity.chunkingVersionOnly === true;
+    pausedIndexIdentity.chunkingVersionOnly === true &&
+    Boolean(status.fts?.enabled && status.fts?.available);
   if (pausedIndexIdentity && !chunkingUpgradeKeywordOnly) {
     return {
       searchStartedAt: startedAt,

--- a/extensions/memory-core/src/memory-search-tool-query.ts
+++ b/extensions/memory-core/src/memory-search-tool-query.ts
@@ -198,7 +198,15 @@ async function finalizeMemorySearchToolQuery(params: {
   const { active, searched, query, visibility, searchSources, runtimeDebug, startedAt } = params;
   const status = params.status ?? active.manager.status();
   const pausedIndexIdentity = resolveMemoryIndexIdentityDiagnostic(status);
-  if (pausedIndexIdentity) {
+  // A pending chunking upgrade on an otherwise matching index degrades to
+  // keyword-only results instead of pausing memory search; every other
+  // mismatch still withholds all candidates.
+  const chunkingUpgradeKeywordOnly =
+    pausedIndexIdentity?.status === "mismatched" &&
+    pausedIndexIdentity.owner === "openclaw" &&
+    pausedIndexIdentity.code === "chunking_version" &&
+    pausedIndexIdentity.chunkingVersionOnly === true;
+  if (pausedIndexIdentity && !chunkingUpgradeKeywordOnly) {
     return {
       searchStartedAt: startedAt,
       status,

--- a/extensions/memory-core/src/memory/manager-index.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-index.test-support.ts
@@ -62,6 +62,7 @@ type ProviderControls = {
   embeddedQueryTexts: string[];
   embedBatchCalls: number;
   embeddedBatchTexts: string[];
+  embedBatchPermanentFailure: Error | null;
   embedBatchInputCalls: number;
   embeddedBatchInputs: EmbeddingInput[][];
   providerRuntimeBatchCalls: string[][];
@@ -126,6 +127,7 @@ const providerState = vi.hoisted(() => ({
   embeddedQueryTexts: [] as string[],
   embedBatchCalls: 0,
   embeddedBatchTexts: [] as string[],
+  embedBatchPermanentFailure: null as Error | null,
   embedBatchInputCalls: 0,
   embeddedBatchInputs: [] as EmbeddingInput[][],
   providerRuntimeBatchCalls: [] as string[][],
@@ -300,6 +302,9 @@ vi.mock("./embeddings.js", async (importOriginal) => {
                   return embedText(input.text);
                 });
               }
+            }
+            if (providerState.embedBatchPermanentFailure !== null) {
+              throw providerState.embedBatchPermanentFailure;
             }
             const texts = inputs.map((input) => (typeof input === "string" ? input : input.text));
             providerState.embedBatchCalls += 1;
@@ -571,6 +576,7 @@ export function createManagerIndexFixture(deps: {
     providerState.embeddedQueryTexts = [];
     providerState.embedBatchCalls = 0;
     providerState.embeddedBatchTexts = [];
+    providerState.embedBatchPermanentFailure = null;
     providerState.embedBatchInputCalls = 0;
     providerState.embeddedBatchInputs = [];
     providerState.providerRuntimeBatchCalls = [];

--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -73,23 +73,32 @@ describe("memory reindex state", () => {
       meta: { provenanceVersion: undefined },
       reason: "index provenance classifier changed",
       code: "provenance_version",
+      chunkingVersionOnly: false,
     },
     {
       name: "missing chunking version",
       meta: { chunkingVersion: undefined },
       reason: "index chunking implementation changed",
       code: "chunking_version",
+      chunkingVersionOnly: true,
     },
-  ])("invalidates indexes with $name as OpenClaw-owned", ({ meta, reason, code }) => {
-    expect(
-      resolveMemoryIndexIdentityState(createIdentityParams({ meta: createMeta(meta) })),
-    ).toEqual({
-      status: "mismatched",
-      reason,
-      code,
-      owner: "openclaw",
-    });
-  });
+  ])(
+    "invalidates indexes with $name as OpenClaw-owned",
+    ({ meta, reason, code, chunkingVersionOnly }) => {
+      expect(
+        resolveMemoryIndexIdentityState(createIdentityParams({ meta: createMeta(meta) })),
+      ).toEqual({
+        status: "mismatched",
+        reason,
+        code,
+        owner: "openclaw",
+        // Strict equality in both directions: the keyword-only fallback marker
+        // appears exactly when the stored content still matches the configured
+        // corpus, and never rides along on other OpenClaw-owned mismatches.
+        ...(chunkingVersionOnly ? { chunkingVersionOnly: true } : {}),
+      });
+    },
+  );
 
   it("invalidates indexes built by a previous chunking implementation", () => {
     expect(
@@ -99,6 +108,25 @@ describe("memory reindex state", () => {
         }),
       ),
     ).toMatchObject({
+      status: "mismatched",
+      reason: "index chunking implementation changed",
+      code: "chunking_version",
+      owner: "openclaw",
+    });
+  });
+
+  it("withholds the keyword-only fallback when the indexed scope no longer matches", () => {
+    expect(
+      resolveMemoryIndexIdentityState(
+        createIdentityParams({
+          meta: createMeta({
+            chunkingVersion: MEMORY_CHUNKING_VERSION - 1,
+            scopeHash: "scope-prior",
+          }),
+          configuredScopeHash: "scope-current",
+        }),
+      ),
+    ).toEqual({
       status: "mismatched",
       reason: "index chunking implementation changed",
       code: "chunking_version",

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -145,7 +145,7 @@ export function resolveConfiguredScopeHash(params: {
   );
 }
 
-export function resolveMemoryIndexIdentityState(params: {
+type MemoryIndexIdentityParams = {
   meta: MemoryIndexMeta | null;
   provider: { id: string; model?: string } | null;
   providerKey?: string;
@@ -158,7 +158,11 @@ export function resolveMemoryIndexIdentityState(params: {
   vectorReady: boolean;
   hasIndexedChunks?: boolean;
   ftsTokenizer: string;
-}): MemoryIndexIdentityState {
+};
+
+function resolveConfigurationIndexIdentityState(
+  params: MemoryIndexIdentityParams,
+): MemoryIndexIdentityState {
   const { meta } = params;
   if (!meta) {
     return {
@@ -167,12 +171,6 @@ export function resolveMemoryIndexIdentityState(params: {
       code: "metadata_missing",
       owner: "openclaw",
     };
-  }
-  if (meta.provenanceVersion !== MEMORY_INDEX_PROVENANCE_VERSION) {
-    return openClawIndexMismatch("provenance_version", "index provenance classifier changed");
-  }
-  if (meta.chunkingVersion !== MEMORY_CHUNKING_VERSION) {
-    return openClawIndexMismatch("chunking_version", "index chunking implementation changed");
   }
   const expectedModel =
     params.provider && params.provider.model === undefined
@@ -223,4 +221,70 @@ export function resolveMemoryIndexIdentityState(params: {
     return configuredIndexMismatch("fts_tokenizer", "index FTS tokenizer changed");
   }
   return { status: "valid" };
+}
+
+// The constraints that decide whether stored keyword rows still describe the
+// configured corpus. Embedding identity is deliberately absent: keyword reads
+// never consume embeddings, so a changed model or an unavailable provider must
+// not lock the last published keyword index away.
+function resolveContentScopeIdentityState(
+  params: MemoryIndexIdentityParams,
+): MemoryIndexIdentityState {
+  const { meta } = params;
+  if (!meta) {
+    return {
+      status: "missing",
+      reason: "index metadata is missing",
+      code: "metadata_missing",
+      owner: "openclaw",
+    };
+  }
+  if (configuredMetaSourcesDiffer({ meta, configuredSources: params.configuredSources })) {
+    return configuredIndexMismatch("sources", "index sources changed");
+  }
+  if (meta.scopeHash !== params.configuredScopeHash) {
+    return configuredIndexMismatch("scope", "index scope changed");
+  }
+  if (meta.chunkTokens !== params.chunkTokens || meta.chunkOverlap !== params.chunkOverlap) {
+    return configuredIndexMismatch("chunking", "index chunking changed");
+  }
+  if ((meta.ftsTokenizer ?? "unicode61") !== params.ftsTokenizer) {
+    return configuredIndexMismatch("fts_tokenizer", "index FTS tokenizer changed");
+  }
+  return { status: "valid" };
+}
+
+export function resolveMemoryIndexIdentityState(
+  params: MemoryIndexIdentityParams,
+): MemoryIndexIdentityState {
+  const { meta } = params;
+  if (!meta) {
+    return {
+      status: "missing",
+      reason: "index metadata is missing",
+      code: "metadata_missing",
+      owner: "openclaw",
+    };
+  }
+  if (meta.provenanceVersion !== MEMORY_INDEX_PROVENANCE_VERSION) {
+    return openClawIndexMismatch("provenance_version", "index provenance classifier changed");
+  }
+  if (meta.chunkingVersion !== MEMORY_CHUNKING_VERSION) {
+    // The version diagnostic normally shadows the configuration checks, so run
+    // the content-scope constraints explicitly: stored keyword rows may stay
+    // readable during a pending upgrade only when the indexed corpus still
+    // matches the configured sources and scope. A narrowed scope must keep
+    // failing closed even while the version diagnostic shadows it. Embedding
+    // identity (model/provider/settings/vector dims) does not block this
+    // keyword-only fallback: those constraints gate vector retrieval, which the
+    // fallback never touches, and a provider that just failed its rebuild would
+    // otherwise keep keyword results locked out forever.
+    return {
+      ...openClawIndexMismatch("chunking_version", "index chunking implementation changed"),
+      ...(resolveContentScopeIdentityState(params).status === "valid"
+        ? { chunkingVersionOnly: true }
+        : {}),
+    };
+  }
+  return resolveConfigurationIndexIdentityState(params);
 }

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -8,6 +8,7 @@ import {
   MEMORY_INDEX_FTS_TABLE,
   MEMORY_INDEX_VECTOR_TABLE,
   MEMORY_SEARCH_DEADLINE_CONTROL,
+  type MemoryIndexIdentityState,
   type MemorySearchManager,
   type MemorySearchResult,
   type MemorySource,
@@ -217,8 +218,24 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
           providerKeyKnown: this.providerInitialized,
         });
       }
+      // A pending OpenClaw chunking upgrade keeps the stored keyword rows
+      // readable: the resolver only marks chunkingVersionOnly when every
+      // configuration-owned constraint still matches, so scope or model changes
+      // still fail closed here.
+      const chunkingUpgradePendingKeywordOnly = (state: MemoryIndexIdentityState): boolean =>
+        state.status === "mismatched" &&
+        state.owner === "openclaw" &&
+        state.code === "chunking_version" &&
+        state.chunkingVersionOnly === true &&
+        this.fts.enabled &&
+        this.fts.available;
       if (repairedIndexIdentity.status !== "valid") {
-        return [];
+        if (!chunkingUpgradePendingKeywordOnly(repairedIndexIdentity)) {
+          return [];
+        }
+        log.warn(
+          "memory search: chunking upgrade rebuild is pending; serving the existing keyword index",
+        );
       }
       // No watcher can observe later edits after kernel capacity exhaustion.
       // Record a fresh generation at the search boundary so detached maintenance
@@ -240,6 +257,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       }
       // Bootstrap and identity repair may publish a new generation. Acquire the
       // read lease only after those writers finish so first search cannot wait on itself.
+      let effectiveIdentity: MemoryIndexIdentityState = repairedIndexIdentity;
       for (let identityAttempt = 0; identityAttempt < 2; identityAttempt += 1) {
         releaseGeneration = await acquireMemoryIndexReadGeneration(
           this.settings.store.databasePath,
@@ -248,10 +266,16 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         if (embeddingBootstrapKeywordOnly) {
           break;
         }
+        // Recompute under the lease: a publisher that queued ahead of this read
+        // may have replaced the generation the earlier eligibility was based on.
         const leasedIdentity = this.refreshIndexIdentityDirty({
           providerKeyKnown: this.providerInitialized,
         });
-        if (leasedIdentity.status === "valid") {
+        effectiveIdentity = leasedIdentity;
+        if (
+          leasedIdentity.status === "valid" ||
+          chunkingUpgradePendingKeywordOnly(leasedIdentity)
+        ) {
           break;
         }
         releaseGeneration();
@@ -295,7 +319,11 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
           activeProjectKeys: opts?.activeProjectKeys,
         });
 
-      const keywordOnly = embeddingBootstrapKeywordOnly || !this.provider || opts?.lexicalOnly;
+      const keywordOnly =
+        embeddingBootstrapKeywordOnly ||
+        chunkingUpgradePendingKeywordOnly(effectiveIdentity) ||
+        !this.provider ||
+        opts?.lexicalOnly;
       const loadKeywordResults = async () => {
         const results =
           (keywordOnly || hybrid.enabled) && this.fts.enabled && this.fts.available

--- a/extensions/memory-core/src/memory/manager-search-upgrade.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-upgrade.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { MEMORY_CHUNKING_VERSION } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
@@ -101,6 +103,75 @@ describe("memory search after a chunking upgrade", () => {
       code: "model",
       owner: "configuration",
     });
+  });
+
+  it("keeps keyword results readable while an upgrade rebuild cannot embed", async () => {
+    const cfg = fixture.createConfig({});
+    await seedIndex(cfg);
+    // The changed file forces the upgrade rebuild to request a fresh embedding.
+    await fs.writeFile(
+      path.join(fixture.paths.memory, "2026-01-12.md"),
+      "# Log\nAlpha memory line changed after the prior index was published.",
+    );
+    fixture.provider.embedBatchPermanentFailure = Object.assign(
+      new Error("openai embeddings failed: 429 insufficient_quota"),
+      { status: 429, code: "insufficient_quota" },
+    );
+    const manager = await fixture.getFreshManager(cfg);
+    try {
+      const results = await manager.search("alpha");
+      expect(results).toEqual(
+        expect.arrayContaining([expect.objectContaining({ path: "memory/2026-01-12.md" })]),
+      );
+      expect(manager.status().custom?.indexIdentity).toMatchObject({
+        status: "mismatched",
+        code: "chunking_version",
+        owner: "openclaw",
+        chunkingVersionOnly: true,
+      });
+    } finally {
+      await manager.close();
+      await closeAllMemorySearchManagers();
+      closeOpenClawAgentDatabasesForTest();
+    }
+  });
+
+  it("fails closed when a pending upgrade coincides with a changed scope", async () => {
+    const wikiPath = path.join(fixture.paths.root, "wiki");
+    await fs.mkdir(wikiPath, { recursive: true });
+    await fs.writeFile(path.join(wikiPath, "note.md"), "# Wiki\nWiki alpha note.");
+    const cfgWithWiki = fixture.createConfig({ extraPaths: [wikiPath] });
+    const cfgWithoutWiki = fixture.createConfig({});
+    await seedIndex(cfgWithWiki);
+    // The changed file forces the upgrade rebuild to request a fresh embedding.
+    // Without it the embedding cache satisfies the whole rebuild, which then
+    // republishes a valid index under the narrowed scope and never reaches the
+    // fail-closed path under test.
+    await fs.writeFile(
+      path.join(fixture.paths.memory, "2026-01-12.md"),
+      "# Log\nAlpha memory line changed after the prior index was published.",
+    );
+    fixture.provider.embedBatchPermanentFailure = Object.assign(
+      new Error("openai embeddings failed: 429 insufficient_quota"),
+      { status: 429, code: "insufficient_quota" },
+    );
+    const manager = await fixture.getFreshManager(cfgWithoutWiki);
+    try {
+      await expect(manager.search("alpha", { lexicalOnly: true })).resolves.toEqual([]);
+      expect(manager.status().custom?.indexIdentity).toMatchObject({
+        status: "mismatched",
+        code: "chunking_version",
+        owner: "openclaw",
+      });
+      expect(manager.status().custom?.indexIdentity).not.toHaveProperty(
+        "chunkingVersionOnly",
+        true,
+      );
+    } finally {
+      await manager.close();
+      await closeAllMemorySearchManagers();
+      closeOpenClawAgentDatabasesForTest();
+    }
   });
 
   it("uses current configured settings when an eligible upgrade rebuild runs", async () => {

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import { MEMORY_SEARCH_DEADLINE_CONTROL } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  MEMORY_CHUNKING_VERSION,
+  MEMORY_SEARCH_DEADLINE_CONTROL,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 // Memory Core integration tests exercise the real SQLite search manager through tools.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import {
@@ -740,6 +744,117 @@ describe("memory_search real manager", () => {
       await execution.catch(() => undefined);
       await cleanupFinished.promise;
       getSpy.mockRestore();
+    }
+  });
+
+  // Seeds a published index, then reopens its metadata as an older runtime's
+  // index so the next search sees a pending OpenClaw chunking upgrade.
+  async function seedPriorChunkingVersionIndex(
+    cfg: Parameters<typeof fixture.getFreshManager>[0],
+  ): Promise<string> {
+    const manager = await fixture.getFreshManager(cfg);
+    await manager.sync({ reason: "test", force: true });
+    const dbPath = manager.status().dbPath;
+    if (!dbPath) {
+      throw new Error("memory search manager database path missing");
+    }
+    await manager.close();
+    await closeAllMemorySearchManagers();
+    closeOpenClawAgentDatabasesForTest();
+    const db = new DatabaseSync(dbPath);
+    try {
+      const row = db
+        .prepare("SELECT value FROM memory_index_meta WHERE key = 'memory_index_meta_v1'")
+        .get();
+      if (typeof row?.value !== "string") {
+        throw new Error("fixture index metadata is missing");
+      }
+      const meta = JSON.parse(row.value) as Record<string, unknown>;
+      db.prepare("UPDATE memory_index_meta SET value = ? WHERE key = 'memory_index_meta_v1'").run(
+        JSON.stringify({ ...meta, chunkingVersion: MEMORY_CHUNKING_VERSION - 1 }),
+      );
+    } finally {
+      db.close();
+    }
+    return dbPath;
+  }
+
+  it("serves keyword results through memory_search while an upgrade rebuild cannot embed", async () => {
+    const cfg = fixture.createConfig({ minScore: 0 });
+    const filePath = path.join(fixture.paths.memory, "upgrade-fallback.md");
+    await fs.writeFile(filePath, "UpgradeKeywordFallback()\nfinish()");
+    await seedPriorChunkingVersionIndex(cfg);
+    // The changed file forces the upgrade rebuild to request a fresh embedding
+    // instead of republishing from the embedding cache.
+    await fs.writeFile(
+      filePath,
+      "UpgradeKeywordFallback() changed after the prior index was published.",
+    );
+    fixture.provider.embedBatchPermanentFailure = Object.assign(
+      new Error("openai embeddings failed: 429 insufficient_quota"),
+      { status: 429, code: "insufficient_quota" },
+    );
+
+    const tool = createMemorySearchTool({
+      config: cfg,
+      agentId: "main",
+      oneShotCliRun: true,
+    });
+    if (!tool) {
+      throw new Error("memory_search tool missing");
+    }
+    try {
+      const result = await tool.execute("upgrade-keyword-fallback", {
+        query: "UpgradeKeywordFallback",
+        corpus: "memory",
+      });
+      expect(result.details).toMatchObject({
+        results: [expect.objectContaining({ path: "memory/upgrade-fallback.md" })],
+      });
+    } finally {
+      await closeAllMemorySearchManagers();
+      closeOpenClawAgentDatabasesForTest();
+    }
+  });
+
+  it("pauses memory_search when a pending upgrade coincides with a changed scope", async () => {
+    const wikiPath = path.join(fixture.paths.root, "wiki");
+    await fs.mkdir(wikiPath, { recursive: true });
+    await fs.writeFile(path.join(wikiPath, "note.md"), "UpgradeScopeWiki alpha note.");
+    const cfgWithWiki = fixture.createConfig({ extraPaths: [wikiPath], minScore: 0 });
+    const cfgWithoutWiki = fixture.createConfig({ minScore: 0 });
+    const filePath = path.join(fixture.paths.memory, "upgrade-scope.md");
+    await fs.writeFile(filePath, "UpgradeScopeMemory alpha note.");
+    await seedPriorChunkingVersionIndex(cfgWithWiki);
+    // The changed file forces the upgrade rebuild to request a fresh embedding;
+    // without it the embedding cache satisfies the whole rebuild, which then
+    // republishes a valid index under the narrowed scope.
+    await fs.writeFile(filePath, "UpgradeScopeMemory note changed after the prior index.");
+    fixture.provider.embedBatchPermanentFailure = Object.assign(
+      new Error("openai embeddings failed: 429 insufficient_quota"),
+      { status: 429, code: "insufficient_quota" },
+    );
+
+    const tool = createMemorySearchTool({
+      config: cfgWithoutWiki,
+      agentId: "main",
+      oneShotCliRun: true,
+    });
+    if (!tool) {
+      throw new Error("memory_search tool missing");
+    }
+    try {
+      const result = await tool.execute("upgrade-changed-scope", {
+        query: "UpgradeScopeMemory",
+        corpus: "memory",
+      });
+      expect(result.details).toMatchObject({
+        unavailable: true,
+        error: expect.stringContaining("chunking"),
+      });
+    } finally {
+      await closeAllMemorySearchManagers();
+      closeOpenClawAgentDatabasesForTest();
     }
   });
 });

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -817,6 +817,51 @@ describe("memory_search real manager", () => {
     }
   });
 
+  it("keeps memory_search paused when a pending upgrade has no usable FTS index", async () => {
+    const cfg = fixture.createConfig({ minScore: 0 });
+    const filePath = path.join(fixture.paths.memory, "upgrade-fts-paused.md");
+    await fs.writeFile(filePath, "UpgradeFtsPaused()\nfinish()");
+    const dbPath = await seedPriorChunkingVersionIndex(cfg);
+    // The changed file forces the upgrade rebuild to request a fresh embedding
+    // instead of republishing from the embedding cache.
+    await fs.writeFile(filePath, "UpgradeFtsPaused() changed after the prior index was published.");
+    // Occupy the FTS table name with a view so every schema ensure — including
+    // the upgrade rebuild's republish — fails to restore a usable keyword index.
+    const sabotaged = new DatabaseSync(dbPath);
+    try {
+      sabotaged.exec("DROP TABLE IF EXISTS memory_index_chunks_fts");
+      sabotaged.exec("CREATE VIEW memory_index_chunks_fts AS SELECT 1 AS text");
+    } finally {
+      sabotaged.close();
+    }
+    fixture.provider.embedBatchPermanentFailure = Object.assign(
+      new Error("openai embeddings failed: 429 insufficient_quota"),
+      { status: 429, code: "insufficient_quota" },
+    );
+
+    const tool = createMemorySearchTool({
+      config: cfg,
+      agentId: "main",
+      oneShotCliRun: true,
+    });
+    if (!tool) {
+      throw new Error("memory_search tool missing");
+    }
+    try {
+      const result = await tool.execute("upgrade-fts-paused", {
+        query: "UpgradeFtsPaused",
+        corpus: "memory",
+      });
+      expect(result.details).toMatchObject({
+        unavailable: true,
+        error: expect.stringContaining("chunking"),
+      });
+    } finally {
+      await closeAllMemorySearchManagers();
+      closeOpenClawAgentDatabasesForTest();
+    }
+  });
+
   it("pauses memory_search when a pending upgrade coincides with a changed scope", async () => {
     const wikiPath = path.join(fixture.paths.root, "wiki");
     await fs.mkdir(wikiPath, { recursive: true });

--- a/packages/memory-host-sdk/src/host/types.test.ts
+++ b/packages/memory-host-sdk/src/host/types.test.ts
@@ -71,6 +71,29 @@ describe("memory search staleness", () => {
     });
   });
 
+  it("preserves the keyword-only marker only when a pending upgrade carries it", () => {
+    const base = {
+      status: "mismatched",
+      reason: "index chunking implementation changed",
+      code: "chunking_version",
+      owner: "openclaw",
+    } as const;
+    expect(
+      resolveMemoryIndexIdentityDiagnostic({
+        backend: "builtin",
+        provider: "openai",
+        custom: { indexIdentity: { ...base, chunkingVersionOnly: true } },
+      }),
+    ).toEqual({ ...base, chunkingVersionOnly: true });
+    expect(
+      resolveMemoryIndexIdentityDiagnostic({
+        backend: "builtin",
+        provider: "openai",
+        custom: { indexIdentity: { ...base } },
+      }),
+    ).toEqual({ ...base });
+  });
+
   it("does not claim provider cost for a keyword-only index", () => {
     expect(
       resolveMemorySearchStaleness(

--- a/packages/memory-host-sdk/src/host/types.test.ts
+++ b/packages/memory-host-sdk/src/host/types.test.ts
@@ -80,15 +80,11 @@ describe("memory search staleness", () => {
     } as const;
     expect(
       resolveMemoryIndexIdentityDiagnostic({
-        backend: "builtin",
-        provider: "openai",
         custom: { indexIdentity: { ...base, chunkingVersionOnly: true } },
       }),
     ).toEqual({ ...base, chunkingVersionOnly: true });
     expect(
       resolveMemoryIndexIdentityDiagnostic({
-        backend: "builtin",
-        provider: "openai",
         custom: { indexIdentity: { ...base } },
       }),
     ).toEqual({ ...base });

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -211,8 +211,13 @@ export type MemoryIndexIdentityState =
       | {
           code: "provenance_version" | "chunking_version";
           owner: "openclaw";
-          // Set only when every configuration-owned constraint still matches, so
-          // a pending OpenClaw chunking upgrade cannot mask a narrowed scope.
+          // Corpus-compatibility marker: set only when every configuration-owned
+          // constraint (sources, scope hash, chunk settings, FTS tokenizer) still
+          // matches, so a pending OpenClaw chunking upgrade cannot mask a narrowed
+          // scope. It excludes embedding identity — provider, model, provider
+          // settings, and vector dims may differ — and does not establish keyword
+          // retrieval availability; consumers must still check usable FTS before
+          // treating the index as servable.
           chunkingVersionOnly?: boolean;
         }
       | {

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -211,6 +211,9 @@ export type MemoryIndexIdentityState =
       | {
           code: "provenance_version" | "chunking_version";
           owner: "openclaw";
+          // Set only when every configuration-owned constraint still matches, so
+          // a pending OpenClaw chunking upgrade cannot mask a narrowed scope.
+          chunkingVersionOnly?: boolean;
         }
       | {
           code:
@@ -261,7 +264,15 @@ export function resolveMemoryIndexIdentityDiagnostic(
     identity.owner === "openclaw" &&
     (identity.code === "provenance_version" || identity.code === "chunking_version")
   ) {
-    return { status: "mismatched", reason, code: identity.code, owner: "openclaw" };
+    return {
+      status: "mismatched",
+      reason,
+      code: identity.code,
+      owner: "openclaw",
+      ...(identity.code === "chunking_version" && identity.chunkingVersionOnly === true
+        ? { chunkingVersionOnly: true }
+        : {}),
+    };
   }
   if (
     identity.owner === "configuration" &&


### PR DESCRIPTION
## What Problem This Solves

Fixes lost lexical memory after an OpenClaw software upgrade when rebuilding an older chunking-version index cannot obtain embeddings.

Closes #144493.

## User Impact

Users can still search compatible, already-indexed memory by keyword while the upgrade rebuild is pending. Results remain marked stale with the repair failure and provider-cost guidance. Newer-than-runtime indexes and incompatible corpora remain unreadable; this does not expand recovery for ordinary current-version embedding outages.

## Why This Change Was Made

The existing index identity owner now distinguishes an older chunker with matching provenance, sources, scope, chunk settings, and tokenizer. Search permits lexical retrieval only with usable FTS, revalidates eligibility after acquiring the read-generation lease, and preserves asynchronous release. Embedding identity is not used to authorize keyword reads because no stored vectors are consumed.

There is no stored schema or version change. Automatic upgrade repair remains enabled; failed repair does not replace the published index. Original contribution by @ruel225, adapted to current main while retaining contributor ancestry.

## Evidence

- Focused identity, upgrade, real-manager, SDK diagnostics, and asynchronous generation coverage: 96 relevant tests passed across the completed runs. Real local HTTP 401 and 429 cases verify both available keyword recall and fail-closed scope/FTS behavior.
- Genuine prior-producer qualification: the immutable version-4 chunker from `70a949a7dd2949edb366dae0810c999d2e44279a` created an isolated index. Unpatched version-5 search then lost recall after an actual HTTP 401; this candidate returned the cited stored keyword hit against the same corpus and failure. Metadata, chunks, source rows, and FTS rows were unchanged in both consuming runs.
- This qualification uses the historical chunking producer in a compatible isolated test host, not a full published-release installation or a live Gateway. The committed transport regressions use synthetic version metadata and do not claim otherwise.
- All planned changed checks passed, including four typecheck stages, dead-export scans, and core/extension lint. Extension declaration/lint ran on a separate physical copy of the exact candidate tree because the native nested worktree failed the ancestor-install boundary guard.
- Independent API-only review of the exact integrated candidate completed scoped-clean at P0–P2 (three passes, no actionable findings).
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/35439838166) passed on `a06cd91162872d5ecd1415818441af68f7d94577`. The initial run had two timer-cleanup assertions fail in unchanged session-diagnostics tests; the narrow 10-test diagnostic passed locally and one accepted same-head failed-shard retry passed hosted CI. No unrelated source change or gate bypass was used.
