### PR TITLE
fix(state): report database verify snapshot cleanup failures

### DIFF
--- a/src/state/openclaw-database-verify.process.test.ts
+++ b/src/state/openclaw-database-verify.process.test.ts
@@ -474,4 +474,60 @@ describe("database verifier bounded diagnostics", () => {
       }
     }
   });
+
+  // A failed snapshot cleanup must not be swallowed: it leaves a private
+  // read-only copy on disk with no signal. The failure surfaces as a
+  // non-terminal verification error (the database itself was not proven
+  // corrupt), but an existing read/close failure is preserved because it
+  // carries the more important diagnostic.
+  it.each([
+    { name: "cleanup failure after a healthy scan", errcode: undefined, expected: null },
+    { name: "cleanup failure preserves an I/O scan failure", errcode: 10, expected: null },
+    { name: "cleanup failure preserves a corruption scan failure", errcode: 779, expected: null },
+    {
+      name: "cleanup failure preserves a close failure",
+      errcode: undefined,
+      expected: "Error: close failed (code=EIO, errcode=10)",
+    },
+  ])("$name", async ({ errcode, expected }) => {
+    const database = nodeSqlite.openNodeSqliteDatabase(":memory:");
+    const cleanup = vi.fn(() => false);
+    vi.spyOn(sqliteLocation, "prepareSqliteReadOnlyLocationInProcess").mockResolvedValueOnce({
+      location: ":memory:",
+      cleanup,
+    });
+    vi.spyOn(nodeSqlite, "openNodeSqliteDatabase").mockReturnValueOnce(database);
+    if (errcode !== undefined) {
+      vi.spyOn(database, "prepare").mockImplementationOnce(() => {
+        throw Object.assign(new Error("scan failed"), { code: "ERR_SQLITE_ERROR", errcode });
+      });
+    }
+    const close = database.close.bind(database);
+    if (expected === "Error: close failed (code=EIO, errcode=10)") {
+      vi.spyOn(database, "close").mockImplementationOnce(() => {
+        close();
+        throw Object.assign(new Error("close failed"), { code: "EIO", errcode: 10 });
+      });
+    }
+    try {
+      await expect(verifyOpenClawDatabases([target])).resolves.toEqual([
+        {
+          path: target.path,
+          ok: false,
+          terminal: errcode === 779,
+          error:
+            expected ??
+            (errcode === undefined
+              ? `Database verification snapshot cleanup failed: :memory:. Check directory permissions and available storage before retrying.`
+              : `SqliteIntegrityError: SQLite integrity_check failed for synthetic database: scan failed (code=ERR_SQLITE_ERROR, errcode=${errcode})`),
+        },
+      ]);
+      expect(database.isOpen).toBe(false);
+      expect(cleanup).toHaveBeenCalledOnce();
+    } finally {
+      if (database.isOpen) {
+        close();
+      }
+    }
+  });
 });

--- a/src/state/openclaw-database-verify.worker.ts
+++ b/src/state/openclaw-database-verify.worker.ts
@@ -42,11 +42,13 @@ async function verifyOpenClawDatabase(
     import("../infra/sqlite-readonly-location.js"),
   ]);
   let cleanup: (() => boolean) | undefined;
+  let snapshotLocation: string | undefined;
   let database: import("node:sqlite").DatabaseSync | undefined;
   let result = await (async (): Promise<OpenClawDatabaseVerifyResult> => {
     try {
       const prepared = await location.prepareSqliteReadOnlyLocationInProcess(target.path);
       cleanup = prepared.cleanup;
+      snapshotLocation = prepared.location;
       database = sqlite.openNodeSqliteDatabase(prepared.location, {
         readOnly: true,
       });
@@ -75,7 +77,19 @@ async function verifyOpenClawDatabase(
       };
     }
   } finally {
-    cleanup?.();
+    // A failed cleanup leaves the private read-only snapshot on disk with no
+    // signal. Surface it as a non-terminal verification failure (the database
+    // itself was not proven corrupt) so the operator sees the storage problem
+    // instead of a silently healthy result. Preserves an existing read/close
+    // failure, which carries the more important diagnostic.
+    if (cleanup && !cleanup() && result.ok) {
+      result = {
+        path: target.path,
+        ok: false,
+        error: `Database verification snapshot cleanup failed: ${snapshotLocation}. Check directory permissions and available storage before retrying.`,
+        terminal: false,
+      };
+    }
   }
   return result;
 }


### PR DESCRIPTION
## What Problem This Solves

The database integrity verifier creates a temporary read-only snapshot of each database, then deletes it after checking; when deletion failed, the verifier reported a healthy result and left the private copy on disk with no signal. This fix checks the cleanup result and surfaces a non-terminal diagnostic failure instead of silently succeeding.

- Problem: `verifyOpenClawDatabase` in `src/state/openclaw-database-verify.worker.ts` called `cleanup?.()` in a `finally` block without checking its boolean return value. When `removeTempDirectory` fails (disk full, permission denied, file-handle contention), `cleanup()` returns `false` but the caller ignores it, leaving the temporary SQLite copy behind with no error signal.
- Solution: Check the cleanup return value in the `finally` block; on failure, rewrite the result to `ok: false` with a diagnostic error naming the staging location and actionable guidance. An existing read/close failure is preserved because it carries the more important diagnostic.
- What changed: `src/state/openclaw-database-verify.worker.ts` — captured `prepared.location` into a `snapshotLocation` binding and replaced the bare `cleanup?.()` with a guarded `if (cleanup && !cleanup() && result.ok)` that rewrites the result to a non-terminal verification failure on cleanup failure. Added 4 table-driven regression cases in `src/state/openclaw-database-verify.process.test.ts` covering cleanup failure across healthy read, I/O scan failure, corruption scan failure, and close-failure result states.
- What did NOT change: The read logic, integrity assertion, terminal classification of real corruption, and the worker's IPC protocol are unchanged. Normal-path behavior (cleanup succeeds) is identical to before. The `terminal: false` classification means a cleanup failure does not quarantine the database — the database itself was not proven corrupt.

## Why This Change Was Made

This is the same anti-pattern that #143844 fixed in `update-candidate-state.ts`: a `prepareSqliteReadOnlyLocation*` call site that ignores the `cleanup()` return value. Sibling call sites (`cron/store.ts`, `doctor-lint.ts`, and the rest of the BUG-069~074 series) already check the return value, confirming this is the project's expected pattern. This call site was missed.

The fix follows the #143844 template with one adaptation specific to this call site: `verifyOpenClawDatabase` is designed to never throw — every error becomes an `ok: false` result that the worker sends back to the parent over IPC. The worker's outer `try { ... } catch { process.exitCode = 1 }` would swallow a plain `throw` (the #143844 pattern) into a signal-less exit 1, so the parent would receive "worker exited with code 1" instead of a structured result — strictly worse than the pre-fix behavior (the same trap BUG-073 hit with a tolerating catch). Mirroring the existing `database?.close()` failure handling in the same function (`if (result.ok) result = { ok: false, ... }`) surfaces the cleanup failure as a structured result while preserving the worker's no-throw contract.

- Best fix: Yes — minimal, directly aligned with the same function's close-failure handling, with the necessary adaptation for this call site's result-return semantics.
- Alternative: Making `adoptPreparedLocation` default `requireCleanup = true` would fix all call sites at once, but changes the shared primitive's contract and risks unintended throws in call sites that intentionally tolerate cleanup failure. Per-site fixes are safer and match how #143844 and the rest of the series were merged.
- Risk: Low. Normal-path behavior is unchanged. The only new behavior is a diagnostic `ok: false` result when cleanup fails, which was previously silent. `terminal: false` ensures the parent (`applyOpenClawDatabaseVerificationResults`) only logs a warning rather than quarantining a healthy database. Not tested: a real `ENOSPC` (disk-full) condition on this host (cleanup failure is exercised via `fs.rmSync` fault injection); the worker fork path end-to-end (the contract under test is that the cleanup failure is visible in the result, verified by calling `verifyOpenClawDatabases` directly in-process).

## User Impact

Operators will now see a non-terminal verification warning naming the staging directory and suggesting a permissions/storage check when a temporary snapshot cannot be removed during database verification, instead of silent temporary-file accumulation. Healthy databases are not quarantined by a cleanup failure — the warning is about the storage problem, not the database's integrity.

## Evidence

Live command verification using `node --import tsx` driving the real `verifyOpenClawDatabases` against a real SQLite fixture with an `fs.rmSync` fault-injection preload. The fault denies removal only for `openclaw-sqlite-readonly-*` staging directories (the snapshot cleanup target), leaving the fixture's own cleanup untouched.

```console
$ node /home/code/github/contributions/BUG/BUG-075-evidence/proof.mjs

=== Test 1: cleanup failure with healthy read → diagnostic error ===
{"ok":true,"results":[{"path":"/tmp/claude-1000/bug075-OocVAv/healthy/db.sqlite","ok":false,"error":"Database verification snapshot cleanup failed: /home/0668000539/.cache/openclaw/openclaw-sqlite-readonly-192441-QOXPsn/database.sqlite. Check directory permissions and available storage before retrying.","terminal":false}]}
✅ PASS: cleanup failure surfaces as ok:false + diagnostic error + terminal:false

=== Test 2: cleanup failure with corrupt read → preserves read error ===
{"ok":true,"results":[{"path":"/tmp/claude-1000/bug075-OocVAv/corrupt/db.sqlite","ok":false,"error":"SqliteIntegrityError: SQLite integrity_check failed for bug075 fixture: database disk image is malformed (code=ERR_SQLITE_ERROR, errcode=11)","terminal":true}]}
✅ PASS: cleanup failure preserves read error (not overwritten by cleanup error)

=== Test 3: normal path (no fault) → ok:true unchanged ===
{"ok":true,"results":[{"path":"/tmp/claude-1000/bug075-OocVAv/healthy/db.sqlite","ok":true}]}
✅ PASS: normal path returns ok:true (cleanup succeeds, no false alarm)

=== Summary ===
All scenarios produced structured results (no crash/exit-1)
```

Pre-fix verification (source reverted to `origin/main` via `git stash`, same proof): Test 1 returned `ok: true` — the cleanup failure was swallowed and the verifier reported a healthy result, confirming the bug exists on canonical main.

```console
$ node /home/code/github/contributions/BUG/BUG-075-evidence/proof.mjs 2>&1 | grep -E "Test 1|ok.:true|ok.:false|PASS|FAIL"
=== Test 1: cleanup failure with healthy read → diagnostic error ===
{"ok":true,"results":[{"path":"/tmp/claude-1000/bug075-LcL3VA/healthy/db.sqlite","ok":true}]}
❌ FAIL: expected ok:false + diagnostic error, got {"ok":true,"results":[{"path":"/tmp/claude-1000/bug075-LcL3VA/healthy/db.sqlite","ok":true}]}
```

Behavior matrix:

```text
scenario                              => pre-fix result      => post-fix result
cleanup fails, read succeeds          => ok:true (silent)    => ok:false + diagnostic error, terminal:false
cleanup fails, read fails (I/O)       => read error (ok)     => read error preserved (cleanup does not overwrite)
cleanup fails, read fails (corrupt)   => read error (ok)     => read error preserved, terminal:true
cleanup succeeds, read ok             => ok:true             => ok:true (unchanged)
```

Regression tests: `node scripts/run-vitest.mjs src/state/openclaw-database-verify.process.test.ts --run` — 31 passed (including the 4 new cleanup-failure cases). Pre-fix, the "cleanup failure after a healthy scan" case fails for the expected reason (`expected ok:false ... received ok:true`).

What was not tested: a real `ENOSPC` (disk-full) filesystem condition was not produced on this host; cleanup failure is exercised via `fs.rmSync` fault injection (EACCES) only. The worker fork path (`runDatabaseVerifyWorker`) is not driven end-to-end through a real child process — the contract under test is the cleanup-failure visibility in the result, traced directly through `verifyOpenClawDatabases`; the worker simply forwards results over IPC. One pre-existing test (`preserves live WAL ownership while snapshotting an open database`) fails on this host due to a Node.js SQLite `ExperimentalWarning` on stderr — unrelated to this change (fails identically on `origin/main` with the fix stashed).

Open PR collision check: searched open PRs for `database-verify` and scanned changed-file lists; no open PR touched `src/state/openclaw-database-verify.worker.ts`. The file's last commit was #141610 (artifact plugin validation, unrelated to cleanup). This is part of a series applying the #143844 pattern to missed `prepareSqliteReadOnlyLocation*` call sites (BUG-069~075), each in its own PR: #144071 (sqlite-snapshot-source), #144099 (state-db-readonly), #144199 (doctor-schema-guard), #144081 (ownership inspection), #144074 (auth legacy), #144071 (managed recovery) — all different files, no overlap.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude Code (Claude Sonnet 4.6)
- Prompts / session excerpts: local-code-analysis fix workflow — bug discovered via the `removeTempDirectory` anchor reverse-grep over `prepareSqliteReadOnlyLocation*` call sites (BUG-069~075 series); fix pattern derived from #143844 with a result-return adaptation for this call site's no-throw semantics (mirrors the same function's close-failure handling); proof uses a real SQLite fixture + `fs.rmSync` fault injection
- Confirmed understanding of code changes: Yes — can explain every line; the `if (cleanup && !cleanup() && result.ok)` guard mirrors the existing `database?.close()` failure handling, `result.ok` preserves a prior read/close failure whose diagnostic matters more, and `terminal: false` prevents quarantining a healthy database on a storage-only failure
- autoreview: N/A (worktree environment; oxlint + oxfmt + single-file tsgo passed; `core tsgo graph boundary` check passed via `node scripts/check-changed.mjs`)
