### PR TITLE
fix(cli): keep transcript output free of startup notes

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -120,6 +120,11 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
       networkProxy: "default",
     },
   },
+  {
+    commandPath: ["transcripts"],
+    // Lists, summaries, and artifact paths own stdout; startup notes must not corrupt them.
+    policy: { ownsProtocolStdout: true, hideBanner: true },
+  },
   { commandPath: ["message"], policy: { loadPlugins: "never" } },
   { commandPath: ["docs"], policy: { configGuard: "skip" } },
   // Destructive maintenance owns a validity-aware, non-observing config read.

--- a/src/cli/program/register.transcripts.test.ts
+++ b/src/cli/program/register.transcripts.test.ts
@@ -4,16 +4,31 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as doctorConfigPreflight from "../../commands/doctor-config-preflight.js";
+import { createDoctorConfigSnapshot } from "../../commands/doctor-config-snapshot.test-helpers.js";
+import { noteStaleUpdateRuns } from "../../commands/doctor-update-run.js";
+import { clearRuntimeConfigSnapshot } from "../../config/config.js";
+import { isVerbose, setVerbose } from "../../globals.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import {
+  createUpdateRun,
+  finishUpdateRun,
+  getUpdateRun,
+  recordUpdateRunStep,
+} from "../../infra/update-run-ledger.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import { manualTranscriptSourceProvider } from "../../transcripts/manual-source.js";
 import type { TranscriptSessionDescriptor } from "../../transcripts/provider-types.js";
 import { TranscriptsStore } from "../../transcripts/store.js";
 import { summarizeTranscripts } from "../../transcripts/summary.js";
+import { withConsoleLogsRoutedToStderrForJson } from "../json-output-mode.js";
+import { testApi as configGuardTestApi } from "./config-guard.js";
+import { registerPreActionHooks } from "./preaction.js";
 import { registerTranscriptsCli } from "./register.transcripts.js";
 
 const originalStateDir = process.env.OPENCLAW_STATE_DIR;
@@ -46,7 +61,7 @@ async function writeSession(
   return store.sessionDir(session);
 }
 
-async function runTranscriptsCli(args: string[]): Promise<string> {
+async function captureStdout(run: () => Promise<void>): Promise<string> {
   let output = "";
   const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
     chunk: string | Uint8Array,
@@ -55,14 +70,22 @@ async function runTranscriptsCli(args: string[]): Promise<string> {
     return true;
   }) as typeof process.stdout.write);
   try {
-    const program = new Command();
-    program.name("openclaw");
-    registerTranscriptsCli(program);
-    await program.parseAsync(["transcripts", ...args], { from: "user" });
+    await run();
     return output;
   } finally {
     writeSpy.mockRestore();
   }
+}
+
+async function runTranscriptsCli(args: string[], startup = false): Promise<string> {
+  return captureStdout(async () => {
+    const program = new Command().name("openclaw");
+    registerTranscriptsCli(program);
+    if (startup) {
+      registerPreActionHooks(program, "test");
+    }
+    await program.parseAsync(["transcripts", ...args], { from: "user" });
+  });
 }
 
 describe("transcripts CLI", () => {
@@ -88,6 +111,73 @@ describe("transcripts CLI", () => {
 
     expect(program.commands.map((command) => command.name())).toContain("transcripts");
   });
+
+  it.each(["list", "show", "path"] as const)(
+    "keeps %s output clean after a successful update with warnings",
+    async (command) => {
+      await writeSession(stateDir, "design-review");
+      const args =
+        command === "list"
+          ? [command]
+          : [command, "design-review", ...(command === "path" ? ["--dir"] : [])];
+      const jsonArgs = [...args, "--json"];
+      const expected = await runTranscriptsCli(args);
+      const expectedJson = await runTranscriptsCli(jsonArgs);
+      const run = createUpdateRun({ trigger: "cli" });
+      const warning = "Recorded update warning";
+      const warningStep = {
+        step: "warning:openclaw doctor",
+        status: "completed",
+        detail: warning,
+      } as const;
+      recordUpdateRunStep(run.runId, warningStep);
+      finishUpdateRun(run.runId, { status: "succeeded" });
+      const snapshot = createDoctorConfigSnapshot();
+      // Keep real note emission and guard suppression; state migration is outside this output test.
+      const preflight = vi
+        .spyOn(doctorConfigPreflight, "runDoctorConfigPreflight")
+        .mockImplementation(async () => {
+          await noteStaleUpdateRuns({});
+          return { snapshot, baseConfig: snapshot.config };
+        });
+      const originalArgv = process.argv;
+      const originalTitle = process.title;
+      const originalVerbose = isVerbose();
+      try {
+        await withEnvAsync(
+          { OPENCLAW_SUPPRESS_NOTES: undefined, NODE_NO_WARNINGS: process.env.NODE_NO_WARNINGS },
+          async () => {
+            expect(await captureStdout(() => noteStaleUpdateRuns({}))).toContain(warning);
+            for (const [commandArgs, expectedOutput] of [
+              [args, expected],
+              [jsonArgs, expectedJson],
+            ] as const) {
+              configGuardTestApi.resetConfigGuardStateForTests();
+              process.argv = ["node", "openclaw", "transcripts", ...commandArgs];
+              const output = await withConsoleLogsRoutedToStderrForJson(
+                process.argv,
+                () => runTranscriptsCli([...commandArgs], true),
+                { restoreChanges: true },
+              );
+              expect(output).toBe(expectedOutput);
+            }
+            expect(preflight).toHaveBeenCalledTimes(2);
+            expect(getUpdateRun(run.runId)?.steps).toContainEqual(
+              expect.objectContaining(warningStep),
+            );
+            expect(await captureStdout(() => noteStaleUpdateRuns({}))).toContain(warning);
+          },
+        );
+      } finally {
+        preflight.mockRestore();
+        configGuardTestApi.resetConfigGuardStateForTests();
+        clearRuntimeConfigSnapshot();
+        process.argv = originalArgv;
+        process.title = originalTitle;
+        setVerbose(originalVerbose);
+      }
+    },
+  );
 
   it("lists stored transcript sessions from SQLite", async () => {
     const sessionDir = await writeSession(stateDir, "design-review");


### PR DESCRIPTION
Closes #144357

Related: #144402 carries the release/2026.9.4 repair. This forward-port restores the same output contract on main.

## What Problem This Solves

Fixes an issue where users pipe `transcripts list`, `transcripts show`, or `transcripts path --dir` into another command and receive an update-warning box before the expected rows, summary, or path. Normal CLI startup presents the warning from a completed update record.

## Why This Change Was Made

Declare the transcript family as owning stdout in the existing shared command catalog. This reuses startup-note suppression and banner handling while retaining normal config validation, explicit Doctor/update diagnostics, and durable warning records. The contributor's focused regression covers all three commands in plaintext and JSON modes.

## User Impact

Transcript stdout contains the documented data or artifact path. Operators can still inspect recorded warnings with Doctor and update status. Missing transcripts, missing summaries, and invalid configuration retain their normal errors and exit codes.

## Evidence

The real compiled `openclaw.mjs` CLI ran through normal startup in isolated Linux state. Synthetic transcripts and a completed warning record were created through their normal storage owners. No Doctor preflight or command parser was replaced in this public proof.

| Public flow | Pinned main | Repaired runtime |
| --- | --- | --- |
| Plaintext list, show, and directory path | Update history note precedes transcript data | Only the expected rows, full summary, or path |
| JSON output and artifact exports | Existing structured fields and exports | Preserved |
| Explicit Doctor and update status | Recorded warning remains visible | Preserved, including after transcript commands |
| Missing selector/summary or invalid config | Existing failure diagnostics and mode distinctions | Preserved |

- Baseline: `872cb0a3613d3541d3bb7f4b263a7d49c99efc54`. All three plaintext failures were observed before repair edits.
- Tested candidate and final head: `922a28ff5b0de1d212c200a6e88d159f2c747821`; build ID `2026.9.3-922a28ff5b0d-2026-09-11T03-51-27.220Z`.
- **Independent source-blind acceptance passed:** 60 public CLI calls, seven setup/ledger observations, and one Node version call. The 20 expected error exits and all 27 valid JSON outputs were retained. No command was retried or interrupted.
- **147 focused tests passed** across transcript registration, shared startup policy, config guard, and Doctor preflight. The three new regression cases first failed on unchanged baseline production for the warning-prefix mismatch.
- Native formatting, 230-rule syntax lint, staged-content hook, conflict, size, and assertion checks passed. Exact-head hosted CI and ClawSweeper review remain landing gates.

Expected missing-Gateway-credentials and failed-fetch/dev-registry HTTP 404 diagnostics remain in the evidence. This local transcript proof covers output and warning preservation; it does not establish Gateway health, successful update discovery, or other-platform behavior. The CLI exposes no list-limit or summary-truncation option; existing tool/Gateway limits are unchanged. Complete raw proof, prior failures, and independent validation records are retained privately.
