### PR TITLE
refactor(docs-i18n): remove unused test translator

### DIFF
--- a/scripts/docs-i18n/doc_mode_test.go
+++ b/scripts/docs-i18n/doc_mode_test.go
@@ -248,18 +248,6 @@ func (t *singletonFenceRetryTranslator) TranslateRaw(_ context.Context, text, _,
 
 func (t *singletonFenceRetryTranslator) Close() {}
 
-type splitProtocolMarkerTranslator struct{}
-
-func (splitProtocolMarkerTranslator) Translate(_ context.Context, text, _, _ string) (string, error) {
-	return text, nil
-}
-
-func (splitProtocolMarkerTranslator) TranslateRaw(_ context.Context, text, _, _ string) (string, error) {
-	return strings.ReplaceAll(text, "[Notice kind=system]", "[Aviso kind=system]"), nil
-}
-
-func (splitProtocolMarkerTranslator) Close() {}
-
 type fencedLiteralMaskingTranslator struct {
 	rawInputs []string
 }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The docs translation tests retained an unused translator after marker-preservation coverage moved to the fenced-literal masking helper. Its declaration and methods were the only remaining references.

## Why This Change Was Made

Remove only that dead test helper. Keep every test, import, fixture and production file unchanged, including split-marker preservation, fenced-literal masking and duplicate-placeholder retry coverage.

## User Impact

No runtime behavior change. This removes 12 lines of obsolete test support without removing a test case.

## Evidence

- Three focused Go marker/fence tests passed, with no skips, using the installed Go toolchain and `GOTOOLCHAIN=local`.
- The normal `test/scripts/docs-i18n.test.ts` bridge executed all four Go-test partitions successfully, with no skips.
- `gofmt -d` and `git diff --check` were empty.
- All 12 selected changed-file checks completed successfully. The oxfmt step matched no Go files; Go formatting is covered separately by `gofmt`.
- One fresh scoped P2 review found no actionable issues.
- Required CI is green after separately reviewed, job-only diagnostic retries of small-15 and small-19 on the unchanged head. Both previously failing case groups, resource-cleanup assertions and the workflow-owned gate passed. The original failures remain recorded; this recovery does not establish a flake or root-cause fix.
- CI tested the bound GitHub synthetic merge of this head. Its patch and selected source inputs were verified, without claiming whole-repository equality.

The local module/bridge and hosted checks are not live translation-service or external Codex runtime proof. No performance improvement is claimed.
