### PR TITLE
fix(agents): recover tasks when Responses streams end mid-tool-call

### DIFF
--- a/docs/concepts/retry.md
+++ b/docs/concepts/retry.md
@@ -37,6 +37,8 @@ Agent runs automatically recover from temporary rate limits, overloads, and prov
 
 Recovery continues the existing transcript with an instruction to preserve completed work and inspect interrupted actions before deciding whether to repeat them. It can recover a throttle after tool activity or partial output without resubmitting the original user request. The run shows one transient retry indicator while waiting and remains cancellable. Recovered attempts do not leave persisted assistant errors; only terminal failure retains one error. Billing failures, authentication errors, and provider refusals do not use this transient retry budget.
 
+A Responses stream that ends before its terminal event also qualifies for transient recovery, including when a tool call is still unfinished. Partial tool arguments are never executed. A completed response with inconsistent tool-call identities does not qualify as a disconnected stream.
+
 Exhausted subscription, daily, weekly, or monthly usage windows go directly to eligible auth-profile or model fallback. A long `Retry-After` value alone does not establish usage-window exhaustion: temporary throttles still honor the provider's minimum wait.
 
 The [model failover controller](/concepts/model-failover#model-fallback) owns this recovery budget. Once it is exhausted, OpenClaw follows eligible auth-profile or model fallback paths, or surfaces the final failure. Native harnesses may retry individual requests internally before returning a terminal failure to OpenClaw; those internal retries are separate from OpenClaw's continuation budget.

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
@@ -418,13 +418,16 @@ describe("recoverEmbeddedRunAttempt", () => {
     expect(failover.advanceAuthProfile).toHaveBeenCalledOnce();
   });
 
-  it("continues from the transcript after a transient transport drop on a settled exec batch", async () => {
+  it.each([
+    { errorMessage: "WebSocket error" },
+    { errorMessage: "Responses stream ended with unresolved tool calls", diagnostics: [] },
+  ])("continues a settled exec batch after $errorMessage", async (scenario) => {
     const {
       recovery,
       markOwnedTranscriptRetry,
       continueFromCurrentTranscript,
       failoverRetryController,
-    } = await recoverAfterTransportDrop();
+    } = await recoverAfterTransportDrop(scenario);
 
     expect(recovery).toMatchObject({ action: "retry" });
     expect(failoverRetryController.transientRetryCount).toBe(1);

--- a/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
@@ -78,6 +78,11 @@ describe("settled post-tool turn finalization context", () => {
       captures: true,
     },
     {
+      kind: "responses-eof-with-unresolved-tools",
+      error: new Error("Responses stream ended with unresolved tool calls"),
+      captures: true,
+    },
+    {
       kind: "terminated-word-variant",
       error: new Error("the request was terminated by the server"),
       captures: false,

--- a/src/agents/failover/failover-classification.overflow-server-misc.cases.ts
+++ b/src/agents/failover/failover-classification.overflow-server-misc.cases.ts
@@ -67,6 +67,21 @@ export const overflowServerMiscCases = [
     signal: { message: "Proxy stream ended before terminal event" },
     expected: reason("timeout"),
   },
+  {
+    id: "openai-responses-eof-with-unresolved-tools",
+    source: "packages/ai/src/transports/openai-responses-stream-internal.ts",
+    signal: { provider: "openai", message: "Responses stream ended with unresolved tool calls" },
+    expected: reason("timeout"),
+  },
+  {
+    id: "openai-responses-completed-with-unresolved-tools",
+    source: "packages/ai/src/transports/openai-responses-stream-internal.ts",
+    signal: {
+      provider: "openai",
+      message: "Responses stream completed with unresolved tool calls",
+    },
+    expected: null,
+  },
   ...failoverSignalRows(billingSource, reason("timeout"), [
     ["billing-deadline-exceeded", { message: "deadline exceeded" }],
     ["billing-no-stream-chunks", { message: "request ended without sending any chunks" }],

--- a/src/agents/failover/failover-retry.expected.test-support.ts
+++ b/src/agents/failover/failover-retry.expected.test-support.ts
@@ -6,6 +6,8 @@ export const failoverRetryExpectations = {
   "mistral-incomplete-terminal-stream": true,
   "openai-completions-incomplete-terminal-stream": true,
   "openai-responses-incomplete-terminal-stream": true,
+  "openai-responses-eof-with-unresolved-tools": true,
+  "openai-responses-completed-with-unresolved-tools": false,
   "proxy-incomplete-terminal-stream": true,
   "billing-context-input-length-model-limit": false,
   "retry-go-usage-limit": false,

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -39,8 +39,10 @@ export function isProviderRequestSizeCeilingError(errorMessage?: string): boolea
 // "terminal" wording); Mistral/Google keep the longer form. Plugin lifecycle
 // strings such as `opencode-go stream ended without a terminal event` must not
 // match — those are not assistant-stream contracts.
+// Responses EOF can leave a tool call open; a completed response with unresolved
+// calls instead indicates an inconsistent terminal payload, not a disconnect.
 export const INCOMPLETE_ASSISTANT_STREAM_RE =
-  /^[\w -]*stream ended (?:before (?:message_?stop|(?:a )?terminal (?:finish reason|response event|event))|without (?:a terminal )?finish[_ ]reason)[.!]?$/i;
+  /^(?:[\w -]*stream ended (?:before (?:message_?stop|(?:a )?terminal (?:finish reason|response event|event))|without (?:a terminal )?finish[_ ]reason)|Responses stream ended with unresolved tool calls)[.!]?$/i;
 // Undici ends a stream body with this exact bare transport message. Keep it
 // anchored so unrelated failures that merely contain the word do not match.
 export const TERMINATED_TRANSPORT_MESSAGE_RE = /^terminated$/i;

--- a/src/agents/sessions/agent-session-responses-eof.test.ts
+++ b/src/agents/sessions/agent-session-responses-eof.test.ts
@@ -1,0 +1,105 @@
+import {
+  createAssistantMessageEventStream,
+  type Context,
+  type Model,
+} from "openclaw/plugin-sdk/llm";
+import { Type } from "typebox";
+import { expect, it, vi } from "vitest";
+import { processResponsesStream } from "../../../packages/ai/src/transports/openai-responses-stream-internal.js";
+import { failTransportStream } from "../../../packages/ai/src/transports/transport-stream-shared.js";
+import {
+  createAssistant,
+  createAssistantResultStream,
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  streamMocks,
+} from "./agent-session-loop-correctness.test-support.js";
+import { SettingsManager } from "./settings-manager.js";
+
+registerAgentSessionLoopTestLifecycle();
+
+it("recovers Responses EOF after tools without replaying settled or executing unfinished calls", async () => {
+  const execute = vi.fn(async () => ({
+    content: [{ type: "text" as const, text: "saved result" }],
+    details: {},
+  }));
+  const requests: Context[] = [];
+  const transportEvents: string[] = [];
+  streamMocks.streamSimple.mockImplementation((model: Model, context: Context) => {
+    requests.push({ ...context, messages: [...context.messages] });
+    if (requests.length === 1) {
+      return createAssistantResultStream(
+        createAssistant(
+          model,
+          [{ type: "toolCall", id: "settled", name: "record", arguments: {} }],
+          "toolUse",
+        ),
+      );
+    }
+    if (requests.length === 2) {
+      const stream = createAssistantMessageEventStream();
+      const output = createAssistant(model, []);
+      const events = (async function* () {
+        yield {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_unfinished",
+            call_id: "unfinished",
+            name: "record",
+            arguments: "",
+            status: "in_progress",
+          },
+        };
+        yield {
+          type: "response.function_call_arguments.delta",
+          output_index: 0,
+          item_id: "fc_unfinished",
+          delta: '{"value":',
+        };
+      })();
+      void processResponsesStream(
+        events,
+        output,
+        {
+          push: (event) => {
+            transportEvents.push(event.type);
+            stream.push(event);
+          },
+        },
+        model,
+      ).catch((error: unknown) => failTransportStream({ stream, output, error }));
+      return stream;
+    }
+    return createAssistantResultStream(
+      createAssistant(model, [{ type: "text", text: "Recovered using saved result." }]),
+    );
+  });
+  const { session } = await createTestSession({
+    settingsManager: SettingsManager.inMemory({
+      compaction: { enabled: false },
+      retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 },
+    }),
+    customTools: [
+      {
+        name: "record",
+        label: "Record",
+        description: "Records a fixture action",
+        parameters: Type.Object({}),
+        execute,
+      },
+    ],
+  });
+
+  await session.prompt("Record once and report the result.");
+
+  expect(transportEvents).toContain("toolcall_start");
+  expect(transportEvents).not.toContain("toolcall_end");
+  expect(execute).toHaveBeenCalledOnce();
+  expect(session.getLastAssistantText()).toBe("Recovered using saved result.");
+  expect(requests).toHaveLength(3);
+  expect(requests[2]?.messages.filter((message) => message.role === "toolResult")).toMatchObject([
+    { toolCallId: "settled", content: [{ type: "text", text: "saved result" }] },
+  ]);
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running agent tasks would see a generic "Agent run failed" error when an OpenAI Responses stream ended while a tool call was still unfinished, even though the task could continue from its saved transcript.

## Why This Change Was Made

Recognize the transport's exact premature-end error in the shared incomplete-stream matcher, so existing transient continuation and settled-result finalization can handle it. Completed responses with inconsistent tool calls remain excluded; partial tool arguments are never admitted for execution.

## User Impact

Tasks can recover from this interrupted stream without resubmitting the original request or automatically repeating completed tool actions. The existing retry budget and cancellation rules continue to apply.

## Evidence

- The synthetic regression feeds an unfinished call through the real Responses stream parser and AgentSession. Before the fix the session ended without an answer; afterward it recovers, the earlier tool executes exactly once, its result survives, and the unfinished call never executes.
- Embedded-runner coverage verifies continuation from the existing transcript and preservation of settled-result finalization context. Classification coverage distinguishes premature EOF from an inconsistent completed response.
- 1,342 focused tests passed across the session regression, retry/classification corpus, embedded recovery, and finalization-context suites.
- The complete changed-file check passed, including core and test typechecking, lint, formatting, and repository guards. Independent blocking-issue review passed.
- The original stream cutoff was observed in runtime logs, but its upstream cause remains unknown because raw SSE events were not recorded. No live deployment is claimed by this PR.
