### PR TITLE
fix(mac): discard late MLX speech after cancellation

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
+++ b/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
@@ -130,12 +130,7 @@ actor TalkMLXSpeechSynthesizer {
                         })
                 }
             } catch let error as SynthesizeError {
-                let requiresFallback = self.fallbackRequiredIDs.contains(id)
-                self.finishRequest(id: id)
-                if requiresFallback {
-                    throw SynthesizeError.audioGenerationFailed
-                }
-                throw error
+                throw self.finishRequestFailure(id: id, error: error)
             } catch is CancellationError {
                 if self.activeID == id {
                     try? await self.transport?.send(.cancel(id: id))
@@ -148,27 +143,19 @@ actor TalkMLXSpeechSynthesizer {
                     "talk mlx helper stream failed attempt=\(attempt + 1, privacy: .public): " +
                         "\(error.localizedDescription, privacy: .public)")
                 await self.discardTransport(forRequest: id)
-                if self.fallbackRequiredIDs.contains(id) {
-                    self.finishRequest(id: id)
-                    throw SynthesizeError.audioGenerationFailed
-                }
-                if self.cancelRequestedID == id {
-                    self.finishRequest(id: id)
-                    throw SynthesizeError.canceled
-                }
-                guard self.activeID == id else {
-                    throw SynthesizeError.canceled
+                if self.fallbackRequiredIDs.contains(id) || self.cancelRequestedID == id || self.activeID != id {
+                    throw self.finishRequestFailure(id: id, error: error)
                 }
                 if attempt == 0 {
                     continue
                 }
-                self.finishRequest(id: id)
-                throw SynthesizeError.modelLoadFailed(Self.helperInvocation().displayName)
+                throw self.finishRequestFailure(
+                    id: id,
+                    error: SynthesizeError.modelLoadFailed(Self.helperInvocation().displayName))
             }
         }
 
-        self.finishRequest(id: id)
-        throw SynthesizeError.audioGenerationFailed
+        throw self.finishRequestFailure(id: id, error: SynthesizeError.audioGenerationFailed)
         #endif
     }
 
@@ -339,14 +326,11 @@ actor TalkMLXSpeechSynthesizer {
                     continue
                 }
             }
-        } catch SynthesizeError.timedOut {
-            await self.discardTransport(forRequest: id)
-            self.finishRequest(id: id)
-            continuation.finish(throwing: SynthesizeError.timedOut)
         } catch {
-            let requiresFallback = self.fallbackRequiredIDs.contains(id)
-            self.finishRequest(id: id)
-            continuation.finish(throwing: requiresFallback ? SynthesizeError.audioGenerationFailed : error)
+            if case SynthesizeError.timedOut = error {
+                await self.discardTransport(forRequest: id)
+            }
+            continuation.finish(throwing: self.finishRequestFailure(id: id, error: error))
         }
     }
 
@@ -359,6 +343,19 @@ actor TalkMLXSpeechSynthesizer {
         case .busy, .generationFailed, .invalidRequest, .protocolError:
             .audioGenerationFailed
         }
+    }
+
+    private func finishRequestFailure(id: String, error: Error) -> Error {
+        // Capture provider failure intent before finishing clears the request's state.
+        let failure: Error = if self.fallbackRequiredIDs.contains(id) {
+            SynthesizeError.audioGenerationFailed
+        } else if self.cancelRequestedID == id || self.activeID != id {
+            SynthesizeError.canceled
+        } else {
+            error
+        }
+        self.finishRequest(id: id)
+        return failure
     }
 
     private func finishRequest(id: String) {

--- a/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
+++ b/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
@@ -38,7 +38,7 @@ actor TalkMLXSpeechSynthesizer {
     private var transport: (any MLXTTSTransport)?
     private var activeID: String?
     private var cancelRequestedID: String?
-    private var fallbackRequiredID: String?
+    private var fallbackRequiredIDs: Set<String> = []
     private var cancelEscalationTask: Task<Void, Never>?
     private var idleTask: Task<Void, Never>?
     private var memoryPressureMonitor: MLXMemoryPressureMonitor?
@@ -62,94 +62,6 @@ actor TalkMLXSpeechSynthesizer {
         self.idleDuration = idleDuration
         self.cancelGraceDuration = cancelGraceDuration
         self.observesMemoryPressure = observesMemoryPressure
-    }
-
-    func synthesize(
-        text: String,
-        modelRepo: String?,
-        language: String?,
-        voicePreset: String?,
-        referenceAudioPath: String? = nil,
-        referenceText: String? = nil) async throws -> Data
-    {
-        #if !arch(arm64)
-        throw SynthesizeError.modelLoadFailed("MLX TTS requires Apple silicon")
-        #else
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return Data() }
-        guard self.activeID == nil else {
-            throw SynthesizeError.audioGenerationFailed
-        }
-
-        self.ensureMemoryPressureMonitor()
-        self.idleTask?.cancel()
-        self.idleTask = nil
-
-        let id = UUID().uuidString
-        self.activeID = id
-        let request = MLXTTSRequest.synthesize(MLXTTSSynthesizeRequest(
-            id: id,
-            text: trimmed,
-            modelRepo: Self.resolvedModelRepo(modelRepo),
-            language: language?.nilIfBlank,
-            voice: voicePreset?.nilIfBlank,
-            referenceAudioPath: referenceAudioPath?.nilIfBlank,
-            referenceText: referenceText?.nilIfBlank))
-
-        for attempt in 0...1 {
-            do {
-                let transport = try await ensureTransport()
-                guard self.activeID == id, self.cancelRequestedID != id else {
-                    await self.discardTransport(forRequest: id)
-                    throw SynthesizeError.canceled
-                }
-                try await transport.send(request)
-                let audio = try await waitForAudio(id: id, transport: transport)
-                self.finishRequest(id: id)
-                return try Self.makeWAV(audio: audio)
-            } catch let error as SynthesizeError {
-                let requiresFallback = self.fallbackRequiredID == id
-                self.finishRequest(id: id)
-                if requiresFallback {
-                    throw SynthesizeError.audioGenerationFailed
-                }
-                throw error
-            } catch is CancellationError {
-                if self.activeID == id {
-                    try? await self.transport?.send(.cancel(id: id))
-                }
-                await self.discardTransport(forRequest: id)
-                self.finishRequest(id: id)
-                throw SynthesizeError.canceled
-            } catch {
-                self.logger.error(
-                    """
-                    talk mlx helper transport failed attempt=\(attempt + 1, privacy: .public): \
-                    \(error.localizedDescription, privacy: .public)
-                    """)
-                await self.discardTransport(forRequest: id)
-                if self.fallbackRequiredID == id {
-                    self.finishRequest(id: id)
-                    throw SynthesizeError.audioGenerationFailed
-                }
-                if self.cancelRequestedID == id {
-                    self.finishRequest(id: id)
-                    throw SynthesizeError.canceled
-                }
-                guard self.activeID == id else {
-                    throw SynthesizeError.canceled
-                }
-                if attempt == 0 {
-                    continue
-                }
-                self.finishRequest(id: id)
-                throw SynthesizeError.modelLoadFailed(Self.helperInvocation().displayName)
-            }
-        }
-
-        self.finishRequest(id: id)
-        throw SynthesizeError.audioGenerationFailed
-        #endif
     }
 
     func synthesizeStream(
@@ -192,13 +104,14 @@ actor TalkMLXSpeechSynthesizer {
 
         for attempt in 0...1 {
             do {
-                let transport = try await ensureTransport()
+                let transport = try await ensureTransport(forRequest: id)
                 guard self.activeID == id, self.cancelRequestedID != id else {
                     await self.discardTransport(forRequest: id)
                     throw SynthesizeError.canceled
                 }
                 try await transport.send(request)
                 let start = try await waitForStreamStart(id: id, transport: transport)
+                try self.requireCurrentRequest(id)
                 switch start {
                 case let .stream(info):
                     return MLXTTSPlaybackStream(
@@ -217,7 +130,7 @@ actor TalkMLXSpeechSynthesizer {
                         })
                 }
             } catch let error as SynthesizeError {
-                let requiresFallback = self.fallbackRequiredID == id
+                let requiresFallback = self.fallbackRequiredIDs.contains(id)
                 self.finishRequest(id: id)
                 if requiresFallback {
                     throw SynthesizeError.audioGenerationFailed
@@ -235,7 +148,7 @@ actor TalkMLXSpeechSynthesizer {
                     "talk mlx helper stream failed attempt=\(attempt + 1, privacy: .public): " +
                         "\(error.localizedDescription, privacy: .public)")
                 await self.discardTransport(forRequest: id)
-                if self.fallbackRequiredID == id {
+                if self.fallbackRequiredIDs.contains(id) {
                     self.finishRequest(id: id)
                     throw SynthesizeError.audioGenerationFailed
                 }
@@ -275,21 +188,30 @@ actor TalkMLXSpeechSynthesizer {
         self.cancelEscalationTask = nil
         self.idleTask?.cancel()
         self.idleTask = nil
-        if let activeID {
-            try? await self.transport?.send(.cancel(id: activeID))
-        }
-        try? await self.transport?.send(.shutdown)
-        activeID = nil
+        // Revoke ownership before sends suspend; retire only the captured helper.
+        let transport = self.transport
+        let activeID = self.activeID
+        self.transport = nil
+        self.activeID = nil
         self.cancelRequestedID = nil
-        await self.discardTransport()
+        if let activeID {
+            try? await transport?.send(.cancel(id: activeID))
+        }
+        try? await transport?.send(.shutdown)
+        await transport?.close()
     }
 
-    private func ensureTransport() async throws -> any MLXTTSTransport {
+    private func ensureTransport(forRequest id: String) async throws -> any MLXTTSTransport {
         if let transport = self.transport {
             return transport
         }
 
         let transport = try await transportFactory()
+        // A factory can complete after shutdown has admitted another request.
+        guard self.activeID == id, self.cancelRequestedID != id else {
+            await transport.close()
+            throw SynthesizeError.canceled
+        }
         // Publish the starting transport before waiting for `ready` so talk
         // cancellation and app shutdown can still terminate a wedged startup.
         self.transport = transport
@@ -310,34 +232,15 @@ actor TalkMLXSpeechSynthesizer {
         }
     }
 
-    private func waitForAudio(id: String, transport: any MLXTTSTransport) async throws -> MLXTTSAudio {
-        while true {
-            switch try await transport.nextEvent() {
-            case let .audio(audio) where audio.id == id:
-                guard self.cancelRequestedID != id else {
-                    throw SynthesizeError.canceled
-                }
-                return audio
-            case let .canceled(canceledID) where canceledID == id:
-                throw SynthesizeError.canceled
-            case let .error(error) where error.id == nil || error.id == id:
-                switch error.code {
-                case .canceled:
-                    throw SynthesizeError.canceled
-                case .modelLoadFailed:
-                    throw SynthesizeError.modelLoadFailed(error.message)
-                case .busy, .generationFailed, .invalidRequest, .protocolError:
-                    throw SynthesizeError.audioGenerationFailed
-                }
-            case .ready, .audio, .streamStarted, .audioChunk, .completed, .error, .canceled:
-                continue
-            }
-        }
-    }
-
     private enum StreamStart {
         case stream(MLXTTSStreamStart)
         case legacy(MLXTTSAudio)
+    }
+
+    private func requireCurrentRequest(_ id: String) throws {
+        guard self.activeID == id, self.cancelRequestedID != id else {
+            throw SynthesizeError.canceled
+        }
     }
 
     private func waitForStreamStart(
@@ -415,15 +318,15 @@ actor TalkMLXSpeechSynthesizer {
                     operation: { try await transport.nextEvent() })
                 switch event {
                 case let .audioChunk(chunk) where chunk.id == id:
-                    guard self.cancelRequestedID != id else {
-                        throw SynthesizeError.canceled
-                    }
+                    try self.requireCurrentRequest(id)
                     continuation.yield(chunk.pcm)
                 case let .completed(completedID) where completedID == id:
+                    try self.requireCurrentRequest(id)
                     self.finishRequest(id: id)
                     continuation.finish()
                     return
                 case let .audio(audio) where audio.id == id:
+                    try self.requireCurrentRequest(id)
                     continuation.yield(audio.pcm)
                     self.finishRequest(id: id)
                     continuation.finish()
@@ -441,7 +344,7 @@ actor TalkMLXSpeechSynthesizer {
             self.finishRequest(id: id)
             continuation.finish(throwing: SynthesizeError.timedOut)
         } catch {
-            let requiresFallback = self.fallbackRequiredID == id
+            let requiresFallback = self.fallbackRequiredIDs.contains(id)
             self.finishRequest(id: id)
             continuation.finish(throwing: requiresFallback ? SynthesizeError.audioGenerationFailed : error)
         }
@@ -459,9 +362,7 @@ actor TalkMLXSpeechSynthesizer {
     }
 
     private func finishRequest(id: String) {
-        if self.fallbackRequiredID == id {
-            self.fallbackRequiredID = nil
-        }
+        self.fallbackRequiredIDs.remove(id)
         guard self.activeID == id else { return }
         self.activeID = nil
         self.cancelRequestedID = nil
@@ -471,6 +372,7 @@ actor TalkMLXSpeechSynthesizer {
     }
 
     private func scheduleCancelEscalation(id: String) {
+        guard self.activeID == id, self.cancelRequestedID == id else { return }
         self.cancelEscalationTask?.cancel()
         let duration = self.cancelGraceDuration
         self.cancelEscalationTask = Task { [weak self] in
@@ -519,7 +421,10 @@ actor TalkMLXSpeechSynthesizer {
 
     func handleMemoryPressure() async {
         self.logger.info("talk mlx helper memory-pressure shutdown")
-        self.fallbackRequiredID = self.activeID
+        // A later pressure callback must not erase an earlier request's pending fallback.
+        if let activeID {
+            self.fallbackRequiredIDs.insert(activeID)
+        }
         await self.shutdown()
     }
 
@@ -568,43 +473,6 @@ actor TalkMLXSpeechSynthesizer {
 
     private static func resolvedModelRepo(_ modelRepo: String?) -> String {
         modelRepo?.nilIfBlank ?? self.defaultModelRepo
-    }
-
-    static func makeWAV(audio: MLXTTSAudio) throws -> Data {
-        guard audio.format == .pcmS16LE,
-              audio.sampleRate > 0,
-              audio.sampleRate <= Int(UInt32.max),
-              audio.channels > 0,
-              audio.channels <= Int(UInt16.max),
-              audio.pcm.count <= Int(UInt32.max) - 36,
-              audio.pcm.count.isMultiple(of: MemoryLayout<Int16>.size * audio.channels)
-        else {
-            throw SynthesizeError.audioGenerationFailed
-        }
-
-        let channels = UInt16(audio.channels)
-        let sampleRate = UInt32(audio.sampleRate)
-        let bitsPerSample: UInt16 = 16
-        let blockAlign = channels * (bitsPerSample / 8)
-        let byteRate = sampleRate * UInt32(blockAlign)
-        let dataSize = UInt32(audio.pcm.count)
-
-        var data = Data(capacity: 44 + audio.pcm.count)
-        data.append(contentsOf: [0x52, 0x49, 0x46, 0x46])
-        data.appendLEUInt32(36 + dataSize)
-        data.append(contentsOf: [0x57, 0x41, 0x56, 0x45])
-        data.append(contentsOf: [0x66, 0x6D, 0x74, 0x20])
-        data.appendLEUInt32(16)
-        data.appendLEUInt16(1)
-        data.appendLEUInt16(channels)
-        data.appendLEUInt32(sampleRate)
-        data.appendLEUInt32(byteRate)
-        data.appendLEUInt16(blockAlign)
-        data.appendLEUInt16(bitsPerSample)
-        data.append(contentsOf: [0x64, 0x61, 0x74, 0x61])
-        data.appendLEUInt32(dataSize)
-        data.append(audio.pcm)
-        return data
     }
 }
 
@@ -748,17 +616,5 @@ extension String {
     fileprivate var nilIfBlank: String? {
         let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
-    }
-}
-
-extension Data {
-    fileprivate mutating func appendLEUInt16(_ value: UInt16) {
-        var littleEndian = value.littleEndian
-        Swift.withUnsafeBytes(of: &littleEndian) { self.append(contentsOf: $0) }
-    }
-
-    fileprivate mutating func appendLEUInt32(_ value: UInt32) {
-        var littleEndian = value.littleEndian
-        Swift.withUnsafeBytes(of: &littleEndian) { self.append(contentsOf: $0) }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
@@ -35,7 +35,8 @@ struct TalkMLXSpeechSynthesizerTests {
             let synthesizer = TalkMLXSpeechSynthesizer.shared
             await synthesizer.shutdown()
             let synthesis = Task {
-                try await synthesizer.synthesize(
+                try await self.collectSynthesis(
+                    synthesizer,
                     text: "hold transport open",
                     modelRepo: nil,
                     language: nil,
@@ -61,13 +62,14 @@ struct TalkMLXSpeechSynthesizerTests {
     @Test
     func `stale startup exit cannot discard the replacement helper`() async throws {
         let stale = TestMLXTransport(mode: .staleStartupClose)
-        let replacement = TestMLXTransport(mode: .audio)
+        let replacement = TestMLXTransport(mode: .stream)
         let factory = TestMLXTransportFactory([stale, replacement])
         let synthesizer = TalkMLXSpeechSynthesizer(
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
         let staleSynthesis = Task {
-            try await synthesizer.synthesize(
+            try await self.collectSynthesis(
+                synthesizer,
                 text: "stale startup",
                 modelRepo: nil,
                 language: nil,
@@ -76,14 +78,16 @@ struct TalkMLXSpeechSynthesizerTests {
         await factory.waitForCall()
         await synthesizer.shutdown()
 
-        _ = try await synthesizer.synthesize(
+        _ = try await self.collectSynthesis(
+            synthesizer,
             text: "replacement",
             modelRepo: nil,
             language: nil,
             voicePreset: nil)
         await stale.finishStaleClose()
         _ = try? await staleSynthesis.value
-        _ = try await synthesizer.synthesize(
+        _ = try await self.collectSynthesis(
+            synthesizer,
             text: "reuse replacement",
             modelRepo: nil,
             language: nil,
@@ -96,13 +100,14 @@ struct TalkMLXSpeechSynthesizerTests {
     @Test
     func `stale startup ready cannot discard the replacement helper`() async throws {
         let stale = TestMLXTransport(mode: .staleStartupReady)
-        let replacement = TestMLXTransport(mode: .audio)
+        let replacement = TestMLXTransport(mode: .stream)
         let factory = TestMLXTransportFactory([stale, replacement])
         let synthesizer = TalkMLXSpeechSynthesizer(
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
         let staleSynthesis = Task {
-            try await synthesizer.synthesize(
+            try await self.collectSynthesis(
+                synthesizer,
                 text: "stale startup",
                 modelRepo: nil,
                 language: nil,
@@ -111,14 +116,16 @@ struct TalkMLXSpeechSynthesizerTests {
         await factory.waitForCall()
         await synthesizer.shutdown()
 
-        _ = try await synthesizer.synthesize(
+        _ = try await self.collectSynthesis(
+            synthesizer,
             text: "replacement",
             modelRepo: nil,
             language: nil,
             voicePreset: nil)
         await stale.finishStaleReady()
         _ = try? await staleSynthesis.value
-        _ = try await synthesizer.synthesize(
+        _ = try await self.collectSynthesis(
+            synthesizer,
             text: "reuse replacement",
             modelRepo: nil,
             language: nil,
@@ -131,7 +138,7 @@ struct TalkMLXSpeechSynthesizerTests {
     @Test
     func `stale stream timeout cannot discard the replacement helper`() async throws {
         let stale = TestMLXTransport(mode: .staleStreamTimeout)
-        let replacement = TestMLXTransport(mode: .audio)
+        let replacement = TestMLXTransport(mode: .stream)
         let factory = TestMLXTransportFactory([stale, replacement])
         let synthesizer = TalkMLXSpeechSynthesizer(
             transportFactory: { try await factory.make() },
@@ -150,13 +157,15 @@ struct TalkMLXSpeechSynthesizerTests {
         await stale.waitForBlockedEvent()
         await synthesizer.shutdown()
 
-        _ = try await synthesizer.synthesize(
+        _ = try await self.collectSynthesis(
+            synthesizer,
             text: "replacement",
             modelRepo: nil,
             language: nil,
             voicePreset: nil)
         _ = try? await staleConsumption.value
-        _ = try await synthesizer.synthesize(
+        _ = try await self.collectSynthesis(
+            synthesizer,
             text: "reuse replacement",
             modelRepo: nil,
             language: nil,
@@ -166,27 +175,72 @@ struct TalkMLXSpeechSynthesizerTests {
         await synthesizer.shutdown()
     }
 
+    @Test(arguments: [false, true])
+    func `stale stream audio cannot survive shutdown or discard replacement`(_ legacyFrame: Bool) async throws {
+        let stale = TestMLXTransport(mode: legacyFrame ? .staleStreamLateAudio : .staleStreamLateChunk)
+        let replacement = TestMLXTransport(mode: .stream)
+        let factory = TestMLXTransportFactory([stale, replacement])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let staleSynthesis = Task {
+            try await self.collectSynthesis(
+                synthesizer,
+                text: "stale stream",
+                modelRepo: nil,
+                language: nil,
+                voicePreset: nil)
+        }
+        await stale.waitForPendingEventRead()
+        await synthesizer.shutdown()
+        _ = try await self.collectSynthesis(
+            synthesizer,
+            text: "replacement",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil)
+        await stale.deliverLateOutput()
+        do {
+            _ = try await staleSynthesis.value
+            Issue.record("expected stale stream cancellation")
+        } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {
+            #expect(await stale.closeCount == 1)
+        }
+        _ = try await self.collectSynthesis(
+            synthesizer,
+            text: "reuse replacement",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil)
+        #expect(await factory.callCount == 2)
+        await synthesizer.shutdown()
+    }
+
     @Test
     func `reuses resident helper across utterances`() async throws {
-        let transport = TestMLXTransport(mode: .audio)
+        let transport = TestMLXTransport(mode: .stream)
         let factory = TestMLXTransportFactory([transport])
         let synthesizer = TalkMLXSpeechSynthesizer(
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
 
-        let first = try await synthesizer.synthesize(
+        let first = try await self.collectSynthesis(
+            synthesizer,
             text: "first",
             modelRepo: nil,
             language: nil,
             voicePreset: nil)
-        let second = try await synthesizer.synthesize(
+        let second = try await self.collectSynthesis(
+            synthesizer,
             text: "second",
             modelRepo: "repo-a",
             language: "en",
             voicePreset: "voice-a")
 
-        #expect(first.starts(with: Data("RIFF".utf8)))
-        #expect(second.starts(with: Data("RIFF".utf8)))
+        #expect(first.sampleRate == 32000)
+        #expect(first.pcm == Data([0x00, 0x00, 0xFF, 0x7F]))
+        #expect(second.sampleRate == 32000)
+        #expect(second.pcm == Data([0x00, 0x00, 0xFF, 0x7F]))
         #expect(await factory.callCount == 1)
         let requests = await transport.sent
         #expect(requests.count == 2)
@@ -287,19 +341,21 @@ struct TalkMLXSpeechSynthesizerTests {
     @Test
     func `retries once after helper crash`() async throws {
         let crashed = TestMLXTransport(mode: .crash)
-        let restarted = TestMLXTransport(mode: .audio)
+        let restarted = TestMLXTransport(mode: .stream)
         let factory = TestMLXTransportFactory([crashed, restarted])
         let synthesizer = TalkMLXSpeechSynthesizer(
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
 
-        let data = try await synthesizer.synthesize(
+        let data = try await self.collectSynthesis(
+            synthesizer,
             text: "retry me",
             modelRepo: nil,
             language: nil,
             voicePreset: nil)
 
-        #expect(data.starts(with: Data("RIFF".utf8)))
+        #expect(data.sampleRate == 32000)
+        #expect(data.pcm == Data([0x00, 0x00, 0xFF, 0x7F]))
         #expect(await factory.callCount == 2)
         #expect(await crashed.closeCount == 1)
         #expect(await restarted.sent.count == 1)
@@ -314,7 +370,8 @@ struct TalkMLXSpeechSynthesizerTests {
             idleDuration: .seconds(60))
 
         let synthesis = Task {
-            try await synthesizer.synthesize(
+            try await self.collectSynthesis(
+                synthesizer,
                 text: "cancel me",
                 modelRepo: nil,
                 language: nil,
@@ -337,22 +394,26 @@ struct TalkMLXSpeechSynthesizerTests {
         }
     }
 
-    @Test
-    func `late audio after cancel is discarded`() async throws {
-        let transport = TestMLXTransport(mode: .audioAfterCancel)
+    @Test(arguments: [false, true])
+    func `late audio after cancel is discarded`(_ afterStreamStart: Bool) async throws {
+        let transport = TestMLXTransport(mode: afterStreamStart ? .streamAudioAfterCancel : .audioAfterCancel)
         let factory = TestMLXTransportFactory([transport])
         let synthesizer = TalkMLXSpeechSynthesizer(
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
 
         let synthesis = Task {
-            try await synthesizer.synthesize(
+            try await self.collectSynthesis(
+                synthesizer,
                 text: "discard me",
                 modelRepo: nil,
                 language: nil,
                 voicePreset: nil)
         }
         await transport.waitForSynthesisRequest()
+        if afterStreamStart {
+            await transport.waitForPendingEventRead()
+        }
         await synthesizer.cancelCurrent()
 
         do {
@@ -373,7 +434,8 @@ struct TalkMLXSpeechSynthesizerTests {
             cancelGraceDuration: .milliseconds(10))
 
         let synthesis = Task {
-            try await synthesizer.synthesize(
+            try await self.collectSynthesis(
+                synthesizer,
                 text: "cancel me hard",
                 modelRepo: nil,
                 language: nil,
@@ -400,7 +462,8 @@ struct TalkMLXSpeechSynthesizerTests {
             idleDuration: .seconds(60))
 
         let synthesis = Task {
-            try await synthesizer.synthesize(
+            try await self.collectSynthesis(
+                synthesizer,
                 text: "stop during shutdown",
                 modelRepo: nil,
                 language: nil,
@@ -427,7 +490,8 @@ struct TalkMLXSpeechSynthesizerTests {
             idleDuration: .seconds(60))
 
         let synthesis = Task {
-            try await synthesizer.synthesize(
+            try await self.collectSynthesis(
+                synthesizer,
                 text: "fall back after pressure",
                 modelRepo: nil,
                 language: nil,
@@ -455,7 +519,8 @@ struct TalkMLXSpeechSynthesizerTests {
             cancelGraceDuration: .milliseconds(10))
 
         let synthesis = Task {
-            try await synthesizer.synthesize(
+            try await self.collectSynthesis(
+                synthesizer,
                 text: "never ready",
                 modelRepo: nil,
                 language: nil,
@@ -475,13 +540,14 @@ struct TalkMLXSpeechSynthesizerTests {
 
     @Test
     func `idle timeout shuts down resident helper`() async throws {
-        let transport = TestMLXTransport(mode: .audio)
+        let transport = TestMLXTransport(mode: .stream)
         let factory = TestMLXTransportFactory([transport])
         let synthesizer = TalkMLXSpeechSynthesizer(
             transportFactory: { try await factory.make() },
             idleDuration: .milliseconds(10))
 
-        _ = try await synthesizer.synthesize(
+        _ = try await self.collectSynthesis(
+            synthesizer,
             text: "brief",
             modelRepo: nil,
             language: nil,
@@ -492,16 +558,43 @@ struct TalkMLXSpeechSynthesizerTests {
     }
 
     @Test
-    func `pcm response becomes playable WAV`() throws {
-        let wav = try TalkMLXSpeechSynthesizer.makeWAV(audio: MLXTTSAudio(
-            id: "one",
-            sampleRate: 32000,
-            pcm: Data([0x00, 0x00, 0xFF, 0x7F])))
+    func `legacy audio response is delivered as PCM`() async throws {
+        let transport = TestMLXTransport(mode: .audio)
+        let factory = TestMLXTransportFactory([transport])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let audio = try await self.collectSynthesis(
+            synthesizer,
+            text: "legacy helper",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil)
 
-        #expect(wav.count == 48)
-        #expect(wav.prefix(4) == Data("RIFF".utf8))
-        #expect(wav.subdata(in: 8..<12) == Data("WAVE".utf8))
-        #expect(wav.suffix(4) == Data([0x00, 0x00, 0xFF, 0x7F]))
+        #expect(audio.sampleRate == 32000)
+        #expect(audio.pcm == Data([0x00, 0x00, 0xFF, 0x7F]))
+        await synthesizer.shutdown()
+    }
+
+    private func collectSynthesis(
+        _ synthesizer: TalkMLXSpeechSynthesizer,
+        text: String,
+        modelRepo: String?,
+        language: String?,
+        voicePreset: String?) async throws -> (sampleRate: Double, pcm: Data)
+    {
+        let playback = try await synthesizer.synthesizeStream(
+            text: text,
+            modelRepo: modelRepo,
+            language: language,
+            voicePreset: voicePreset,
+            referenceAudioPath: nil,
+            referenceText: nil)
+        var pcm = Data()
+        for try await chunk in playback.chunks {
+            pcm.append(chunk)
+        }
+        return (playback.sampleRate, pcm)
     }
 }
 
@@ -518,6 +611,9 @@ private actor TestMLXTransport: MLXTTSTransport {
         case staleStartupClose
         case staleStartupReady
         case staleStreamTimeout
+        case staleStreamLateAudio
+        case staleStreamLateChunk
+        case streamAudioAfterCancel
         case startupHang
         case stream
         case streamWaitForCancel
@@ -529,6 +625,7 @@ private actor TestMLXTransport: MLXTTSTransport {
     private(set) var closeCount = 0
     private var events: [MLXTTSEvent] = [.ready]
     private var closed = false
+    private var pendingEventRead = false
 
     init(mode: Mode) {
         self.mode = mode
@@ -555,7 +652,8 @@ private actor TestMLXTransport: MLXTTSTransport {
                     id: synthesize.id,
                     pcm: Data([0x00, 0x00, 0xFF, 0x7F]))))
                 self.events.append(.completed(id: synthesize.id))
-            case .staleStreamTimeout, .streamWaitForCancel:
+            case .staleStreamTimeout, .streamWaitForCancel, .streamAudioAfterCancel,
+                 .staleStreamLateAudio, .staleStreamLateChunk:
                 self.events.append(.streamStarted(MLXTTSStreamStart(
                     id: synthesize.id,
                     sampleRate: 32000)))
@@ -566,7 +664,7 @@ private actor TestMLXTransport: MLXTTSTransport {
                 break
             }
         case let .cancel(id):
-            if self.mode == .audioAfterCancel {
+            if self.mode == .audioAfterCancel || self.mode == .streamAudioAfterCancel {
                 self.events.append(.audio(MLXTTSAudio(
                     id: id,
                     sampleRate: 32000,
@@ -574,6 +672,8 @@ private actor TestMLXTransport: MLXTTSTransport {
             } else if self.mode != .ignoreCancel,
                       self.mode != .staleStartupReady,
                       self.mode != .staleStreamTimeout,
+                      self.mode != .staleStreamLateAudio,
+                      self.mode != .staleStreamLateChunk,
                       self.mode != .startupHang
             {
                 self.events.append(.canceled(id: id))
@@ -581,7 +681,9 @@ private actor TestMLXTransport: MLXTTSTransport {
         case .shutdown:
             if self.mode != .staleStartupClose,
                self.mode != .staleStartupReady,
-               self.mode != .staleStreamTimeout
+               self.mode != .staleStreamTimeout,
+               self.mode != .staleStreamLateAudio,
+               self.mode != .staleStreamLateChunk
             {
                 self.closed = true
             }
@@ -589,6 +691,9 @@ private actor TestMLXTransport: MLXTTSTransport {
     }
 
     func nextEvent() async throws -> MLXTTSEvent {
+        if self.events.isEmpty {
+            self.pendingEventRead = true
+        }
         while self.events.isEmpty {
             if self.closed {
                 throw TestMLXTransportError.closed
@@ -602,7 +707,9 @@ private actor TestMLXTransport: MLXTTSTransport {
         self.closeCount += 1
         if self.mode != .staleStartupClose,
            self.mode != .staleStartupReady,
-           self.mode != .staleStreamTimeout
+           self.mode != .staleStreamTimeout,
+           self.mode != .staleStreamLateAudio,
+           self.mode != .staleStreamLateChunk
         {
             self.closed = true
         }
@@ -614,6 +721,26 @@ private actor TestMLXTransport: MLXTTSTransport {
 
     func finishStaleReady() {
         self.events.append(.ready)
+    }
+
+    func waitForPendingEventRead() async {
+        while !self.pendingEventRead {
+            await Task.yield()
+        }
+    }
+
+    func deliverLateOutput() {
+        guard let request = self.sent.first, case let .synthesize(synthesize) = request else {
+            Issue.record("expected a synthesis request before late output")
+            return
+        }
+        let pcm = Data([0x00, 0x00, 0xFF, 0x7F])
+        if self.mode == .staleStreamLateAudio {
+            self.events.append(.audio(MLXTTSAudio(id: synthesize.id, sampleRate: 32000, pcm: pcm)))
+        } else {
+            self.events.append(.audioChunk(MLXTTSAudioChunk(id: synthesize.id, pcm: pcm)))
+            self.events.append(.completed(id: synthesize.id))
+        }
     }
 
     func waitForBlockedEvent() async {

--- a/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
@@ -217,6 +217,132 @@ struct TalkMLXSpeechSynthesizerTests {
     }
 
     @Test
+    func `stale factory completion closes only its unpublished helper`() async throws {
+        let stale = TestMLXTransport(mode: .stream)
+        let replacement = TestMLXTransport(mode: .stream)
+        let factory = TestMLXTransportFactory([stale, replacement], holdsFirstCall: true)
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let staleSynthesis = Task {
+            try await self.collectSynthesis(synthesizer, text: "unpublished helper")
+        }
+        await factory.waitForCall()
+        await synthesizer.shutdown()
+        let replacementResult = await Task {
+            try await self.collectSynthesis(synthesizer, text: "replacement")
+        }.result
+        await factory.releaseFirstCall()
+        do {
+            _ = try await staleSynthesis.value
+            Issue.record("expected unpublished request cancellation")
+        } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {}
+        _ = try replacementResult.get()
+        #expect(await stale.closeCount == 1)
+        _ = try await self.collectSynthesis(synthesizer, text: "reuse replacement")
+        #expect(await factory.callCount == 2)
+        #expect(await stale.sent.isEmpty)
+        await synthesizer.shutdown()
+        #expect(await replacement.closeCount == 1)
+    }
+
+    @Test(arguments: [false, true])
+    func `shutdown revokes ownership while cancel send is suspended`(_ legacyFrame: Bool) async throws {
+        let stale = TestMLXTransport(
+            mode: legacyFrame ? .staleStreamLateAudio : .staleStreamLateChunk,
+            holdsFirstCancelSend: true)
+        let replacement = TestMLXTransport(mode: .stream)
+        let factory = TestMLXTransportFactory([stale, replacement])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let staleSynthesis = Task {
+            try await self.collectSynthesis(synthesizer, text: "retiring stream")
+        }
+        await stale.waitForPendingEventRead()
+        let shutdown = Task { await synthesizer.shutdown() }
+        await stale.waitForCancelRequest()
+        await stale.deliverLateOutput()
+        let staleResult = await staleSynthesis.result
+        let playbackResult = await Task {
+            try await synthesizer.synthesizeStream(
+                text: "replacement during shutdown",
+                modelRepo: nil,
+                language: nil,
+                voicePreset: nil,
+                referenceAudioPath: nil,
+                referenceText: nil)
+        }.result
+        #expect(await factory.callCount == 2)
+        await stale.releaseCancelSend()
+        await shutdown.value
+        do {
+            _ = try staleResult.get()
+            Issue.record("expected cancellation before shutdown sends resume")
+        } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {}
+        let playback = try playbackResult.get()
+        var pcm = Data()
+        for try await chunk in playback.chunks {
+            pcm.append(chunk)
+        }
+        #expect(pcm == Data([0x00, 0x00, 0xFF, 0x7F]))
+        #expect(await replacement.closeCount == 0)
+        _ = try await self.collectSynthesis(synthesizer, text: "reuse replacement")
+        #expect(await factory.callCount == 2)
+        await synthesizer.shutdown()
+    }
+
+    @Test
+    func `stale cancel completion preserves replacement cancel escalation`() async throws {
+        let transport = TestMLXTransport(mode: .staleStreamLateChunk, holdsFirstCancelSend: true)
+        let factory = TestMLXTransportFactory([transport])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let first = try await synthesizer.synthesizeStream(
+            text: "first",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil,
+            referenceAudioPath: nil,
+            referenceText: nil)
+        await transport.waitForPendingEventRead()
+        let staleCancellation = Task { await synthesizer.cancelCurrent() }
+        await transport.waitForCancelRequest()
+        await transport.cancelFirstSynthesis()
+        let firstResult = await Task {
+            for try await _ in first.chunks {}
+        }.result
+        let replacementResult = await Task {
+            try await synthesizer.synthesizeStream(
+                text: "replacement",
+                modelRepo: nil,
+                language: nil,
+                voicePreset: nil,
+                referenceAudioPath: nil,
+                referenceText: nil,
+                stallTimeoutSeconds: 4)
+        }.result
+        await synthesizer.cancelCurrent()
+        await transport.releaseCancelSend()
+        await staleCancellation.value
+        do {
+            try firstResult.get()
+            Issue.record("expected first request cancellation")
+        } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {}
+        let replacement = try replacementResult.get()
+        do {
+            for try await _ in replacement.chunks {}
+            Issue.record("expected unresponsive replacement cancellation to close the helper")
+        } catch TestMLXTransportError.closed {
+            #expect(await transport.closeCount == 1)
+        } catch {
+            Issue.record("expected cancellation grace to close the helper before the stream stalls: \(error)")
+        }
+        await synthesizer.shutdown()
+    }
+
+    @Test
     func `reuses resident helper across utterances`() async throws {
         let transport = TestMLXTransport(mode: .stream)
         let factory = TestMLXTransportFactory([transport])
@@ -579,9 +705,9 @@ struct TalkMLXSpeechSynthesizerTests {
     private func collectSynthesis(
         _ synthesizer: TalkMLXSpeechSynthesizer,
         text: String,
-        modelRepo: String?,
-        language: String?,
-        voicePreset: String?) async throws -> (sampleRate: Double, pcm: Data)
+        modelRepo: String? = nil,
+        language: String? = nil,
+        voicePreset: String? = nil) async throws -> (sampleRate: Double, pcm: Data)
     {
         let playback = try await synthesizer.synthesizeStream(
             text: text,
@@ -626,16 +752,26 @@ private actor TestMLXTransport: MLXTTSTransport {
     private var events: [MLXTTSEvent] = [.ready]
     private var closed = false
     private var pendingEventRead = false
+    private let holdsFirstCancelSend: Bool
+    private var heldCancelID: String?
+    private var cancelSendReleased = false
 
-    init(mode: Mode) {
+    init(mode: Mode, holdsFirstCancelSend: Bool = false) {
         self.mode = mode
+        self.holdsFirstCancelSend = holdsFirstCancelSend
         if mode == .startupHang || mode == .staleStartupClose || mode == .staleStartupReady {
             self.events = []
         }
     }
 
-    func send(_ request: MLXTTSRequest) {
+    func send(_ request: MLXTTSRequest) async {
         self.sent.append(request)
+        if case let .cancel(id) = request, self.holdsFirstCancelSend, self.heldCancelID == nil {
+            self.heldCancelID = id
+            while !self.cancelSendReleased {
+                await Task.yield()
+            }
+        }
         switch request {
         case let .synthesize(synthesize):
             switch self.mode {
@@ -705,6 +841,10 @@ private actor TestMLXTransport: MLXTTSTransport {
 
     func close() {
         self.closeCount += 1
+        if self.holdsFirstCancelSend {
+            self.closed = true
+            return
+        }
         if self.mode != .staleStartupClose,
            self.mode != .staleStartupReady,
            self.mode != .staleStreamTimeout,
@@ -727,6 +867,18 @@ private actor TestMLXTransport: MLXTTSTransport {
         while !self.pendingEventRead {
             await Task.yield()
         }
+    }
+
+    func releaseCancelSend() {
+        self.cancelSendReleased = true
+    }
+
+    func cancelFirstSynthesis() {
+        guard let request = self.sent.first, case let .synthesize(synthesize) = request else {
+            Issue.record("expected a synthesis request before cancellation")
+            return
+        }
+        self.events.append(.canceled(id: synthesize.id))
     }
 
     func deliverLateOutput() {
@@ -781,17 +933,30 @@ private actor TestMLXTransport: MLXTTSTransport {
 private actor TestMLXTransportFactory {
     private var transports: [TestMLXTransport]
     private(set) var callCount = 0
+    private let holdsFirstCall: Bool
+    private var firstCallReleased = false
 
-    init(_ transports: [TestMLXTransport]) {
+    init(_ transports: [TestMLXTransport], holdsFirstCall: Bool = false) {
         self.transports = transports
+        self.holdsFirstCall = holdsFirstCall
     }
 
-    func make() throws -> any MLXTTSTransport {
+    func make() async throws -> any MLXTTSTransport {
         self.callCount += 1
         guard !self.transports.isEmpty else {
             throw TestMLXTransportError.closed
         }
-        return self.transports.removeFirst()
+        let transport = self.transports.removeFirst()
+        if self.holdsFirstCall, self.callCount == 1 {
+            while !self.firstCallReleased {
+                await Task.yield()
+            }
+        }
+        return transport
+    }
+
+    func releaseFirstCall() {
+        self.firstCallReleased = true
     }
 
     func waitForCall() async {

--- a/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
@@ -635,6 +635,50 @@ struct TalkMLXSpeechSynthesizerTests {
         }
     }
 
+    @Test(arguments: [false, true])
+    func `repeated memory pressure preserves every pending fallback`(_ pressureOnReplacement: Bool) async throws {
+        let first = TestMLXTransport(mode: .staleStreamLateChunk)
+        let replacement = TestMLXTransport(mode: .staleStreamLateChunk)
+        let factory = TestMLXTransportFactory([first, replacement])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let firstSynthesis = Task {
+            try await self.collectSynthesis(synthesizer, text: "first pressure fallback")
+        }
+        await first.waitForPendingEventRead()
+        await synthesizer.handleMemoryPressure()
+        let replacementSynthesis: Task<(sampleRate: Double, pcm: Data), Error>?
+        if pressureOnReplacement {
+            replacementSynthesis = Task {
+                try await self.collectSynthesis(synthesizer, text: "replacement pressure fallback")
+            }
+            await replacement.waitForPendingEventRead()
+        } else {
+            replacementSynthesis = nil
+        }
+        await synthesizer.handleMemoryPressure()
+        await first.cancelFirstSynthesis()
+        do {
+            _ = try await firstSynthesis.value
+            Issue.record("expected first request to require fallback")
+        } catch TalkMLXSpeechSynthesizer.SynthesizeError.audioGenerationFailed {} catch {
+            Issue.record("repeated pressure lost the first request's fallback: \(error)")
+        }
+        if let replacementSynthesis {
+            await replacement.cancelFirstSynthesis()
+            do {
+                _ = try await replacementSynthesis.value
+                Issue.record("expected replacement request to require fallback")
+            } catch TalkMLXSpeechSynthesizer.SynthesizeError.audioGenerationFailed {} catch {
+                Issue.record("earlier request completion lost the replacement's fallback: \(error)")
+            }
+            #expect(await replacement.closeCount == 1)
+        }
+        #expect(await first.closeCount == 1)
+        await synthesizer.shutdown()
+    }
+
     @Test
     func `cancel can terminate helper before ready`() async throws {
         let transport = TestMLXTransport(mode: .startupHang)

--- a/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
@@ -286,7 +286,7 @@ struct TalkMLXSpeechSynthesizerTests {
         } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {
             #expect(await transport.closeCount == 1)
         } catch {
-            Issue.record("expected cancellation without system-voice fallback: \(error)")
+            Issue.record("expected a canceled terminal outcome after helper closure: \(error)")
         }
         await synthesizer.shutdown()
     }
@@ -495,7 +495,7 @@ struct TalkMLXSpeechSynthesizerTests {
             _ = try await synthesis.value
             Issue.record("expected canceled helper failure")
         } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {} catch {
-            Issue.record("late helper failure requested system-voice fallback: \(error)")
+            Issue.record("late helper failure returned a non-cancellation outcome: \(error)")
         }
         #expect(await factory.callCount == 1)
         await synthesizer.shutdown()
@@ -546,7 +546,7 @@ struct TalkMLXSpeechSynthesizerTests {
             _ = try await synthesis.value
             Issue.record("expected stopped stream cancellation")
         } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {} catch {
-            Issue.record("stopped stream requested system-voice fallback: \(error)")
+            Issue.record("stopped stream returned a non-cancellation outcome: \(error)")
         }
         #expect(await transport.closeCount == 1)
         #expect(await factory.callCount == 1)

--- a/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import OpenClawKit
 import OpenClawMLXTTSProtocol
 import Testing
 @testable import OpenClaw
@@ -35,12 +36,7 @@ struct TalkMLXSpeechSynthesizerTests {
             let synthesizer = TalkMLXSpeechSynthesizer.shared
             await synthesizer.shutdown()
             let synthesis = Task {
-                try await self.collectSynthesis(
-                    synthesizer,
-                    text: "hold transport open",
-                    modelRepo: nil,
-                    language: nil,
-                    voicePreset: nil)
+                try await self.collectSynthesis(synthesizer, text: "hold transport open")
             }
             let pid = try await TestProcessSupport.waitForPID(in: pidFile)
 
@@ -68,30 +64,15 @@ struct TalkMLXSpeechSynthesizerTests {
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
         let staleSynthesis = Task {
-            try await self.collectSynthesis(
-                synthesizer,
-                text: "stale startup",
-                modelRepo: nil,
-                language: nil,
-                voicePreset: nil)
+            try await self.collectSynthesis(synthesizer, text: "stale startup")
         }
         await factory.waitForCall()
         await synthesizer.shutdown()
 
-        _ = try await self.collectSynthesis(
-            synthesizer,
-            text: "replacement",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        _ = try await self.collectSynthesis(synthesizer, text: "replacement")
         await stale.finishStaleClose()
         _ = try? await staleSynthesis.value
-        _ = try await self.collectSynthesis(
-            synthesizer,
-            text: "reuse replacement",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        _ = try await self.collectSynthesis(synthesizer, text: "reuse replacement")
 
         #expect(await factory.callCount == 2)
         await synthesizer.shutdown()
@@ -106,30 +87,15 @@ struct TalkMLXSpeechSynthesizerTests {
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
         let staleSynthesis = Task {
-            try await self.collectSynthesis(
-                synthesizer,
-                text: "stale startup",
-                modelRepo: nil,
-                language: nil,
-                voicePreset: nil)
+            try await self.collectSynthesis(synthesizer, text: "stale startup")
         }
         await factory.waitForCall()
         await synthesizer.shutdown()
 
-        _ = try await self.collectSynthesis(
-            synthesizer,
-            text: "replacement",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        _ = try await self.collectSynthesis(synthesizer, text: "replacement")
         await stale.finishStaleReady()
         _ = try? await staleSynthesis.value
-        _ = try await self.collectSynthesis(
-            synthesizer,
-            text: "reuse replacement",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        _ = try await self.collectSynthesis(synthesizer, text: "reuse replacement")
 
         #expect(await factory.callCount == 2)
         await synthesizer.shutdown()
@@ -157,19 +123,9 @@ struct TalkMLXSpeechSynthesizerTests {
         await stale.waitForBlockedEvent()
         await synthesizer.shutdown()
 
-        _ = try await self.collectSynthesis(
-            synthesizer,
-            text: "replacement",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        _ = try await self.collectSynthesis(synthesizer, text: "replacement")
         _ = try? await staleConsumption.value
-        _ = try await self.collectSynthesis(
-            synthesizer,
-            text: "reuse replacement",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        _ = try await self.collectSynthesis(synthesizer, text: "reuse replacement")
 
         #expect(await factory.callCount == 2)
         await synthesizer.shutdown()
@@ -184,21 +140,11 @@ struct TalkMLXSpeechSynthesizerTests {
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
         let staleSynthesis = Task {
-            try await self.collectSynthesis(
-                synthesizer,
-                text: "stale stream",
-                modelRepo: nil,
-                language: nil,
-                voicePreset: nil)
+            try await self.collectSynthesis(synthesizer, text: "stale stream")
         }
         await stale.waitForPendingEventRead()
         await synthesizer.shutdown()
-        _ = try await self.collectSynthesis(
-            synthesizer,
-            text: "replacement",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        _ = try await self.collectSynthesis(synthesizer, text: "replacement")
         await stale.deliverLateOutput()
         do {
             _ = try await staleSynthesis.value
@@ -206,12 +152,7 @@ struct TalkMLXSpeechSynthesizerTests {
         } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {
             #expect(await stale.closeCount == 1)
         }
-        _ = try await self.collectSynthesis(
-            synthesizer,
-            text: "reuse replacement",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        _ = try await self.collectSynthesis(synthesizer, text: "reuse replacement")
         #expect(await factory.callCount == 2)
         await synthesizer.shutdown()
     }
@@ -320,8 +261,7 @@ struct TalkMLXSpeechSynthesizerTests {
                 language: nil,
                 voicePreset: nil,
                 referenceAudioPath: nil,
-                referenceText: nil,
-                stallTimeoutSeconds: 4)
+                referenceText: nil)
         }.result
         await synthesizer.cancelCurrent()
         await transport.releaseCancelSend()
@@ -332,12 +272,21 @@ struct TalkMLXSpeechSynthesizerTests {
         } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {}
         let replacement = try replacementResult.get()
         do {
+            try await AsyncTimeout.withTimeout(
+                seconds: 4,
+                onTimeout: { TestMLXTransportError.cancelGraceTimedOut },
+                operation: { try await transport.waitForClose() })
+        } catch {
+            Issue.record("replacement cancellation grace did not close the helper: \(error)")
+            await synthesizer.shutdown()
+        }
+        do {
             for try await _ in replacement.chunks {}
             Issue.record("expected unresponsive replacement cancellation to close the helper")
-        } catch TestMLXTransportError.closed {
+        } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {
             #expect(await transport.closeCount == 1)
         } catch {
-            Issue.record("expected cancellation grace to close the helper before the stream stalls: \(error)")
+            Issue.record("expected cancellation without system-voice fallback: \(error)")
         }
         await synthesizer.shutdown()
     }
@@ -350,12 +299,7 @@ struct TalkMLXSpeechSynthesizerTests {
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
 
-        let first = try await self.collectSynthesis(
-            synthesizer,
-            text: "first",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        let first = try await self.collectSynthesis(synthesizer, text: "first")
         let second = try await self.collectSynthesis(
             synthesizer,
             text: "second",
@@ -473,12 +417,7 @@ struct TalkMLXSpeechSynthesizerTests {
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
 
-        let data = try await self.collectSynthesis(
-            synthesizer,
-            text: "retry me",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        let data = try await self.collectSynthesis(synthesizer, text: "retry me")
 
         #expect(data.sampleRate == 32000)
         #expect(data.pcm == Data([0x00, 0x00, 0xFF, 0x7F]))
@@ -496,12 +435,7 @@ struct TalkMLXSpeechSynthesizerTests {
             idleDuration: .seconds(60))
 
         let synthesis = Task {
-            try await self.collectSynthesis(
-                synthesizer,
-                text: "cancel me",
-                modelRepo: nil,
-                language: nil,
-                voicePreset: nil)
+            try await self.collectSynthesis(synthesizer, text: "cancel me")
         }
         await transport.waitForSynthesisRequest()
         await synthesizer.cancelCurrent()
@@ -529,12 +463,7 @@ struct TalkMLXSpeechSynthesizerTests {
             idleDuration: .seconds(60))
 
         let synthesis = Task {
-            try await self.collectSynthesis(
-                synthesizer,
-                text: "discard me",
-                modelRepo: nil,
-                language: nil,
-                voicePreset: nil)
+            try await self.collectSynthesis(synthesizer, text: "discard me")
         }
         await transport.waitForSynthesisRequest()
         if afterStreamStart {
@@ -551,6 +480,28 @@ struct TalkMLXSpeechSynthesizerTests {
     }
 
     @Test
+    func `late helper failure before stream start stays canceled`() async throws {
+        let transport = TestMLXTransport(mode: .errorAfterCancel)
+        let factory = TestMLXTransportFactory([transport])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let synthesis = Task {
+            try await self.collectSynthesis(synthesizer, text: "cancel before helper failure")
+        }
+        await transport.waitForSynthesisRequest()
+        await synthesizer.cancelCurrent()
+        do {
+            _ = try await synthesis.value
+            Issue.record("expected canceled helper failure")
+        } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {} catch {
+            Issue.record("late helper failure requested system-voice fallback: \(error)")
+        }
+        #expect(await factory.callCount == 1)
+        await synthesizer.shutdown()
+    }
+
+    @Test
     func `unresponsive cancel terminates helper without retry`() async throws {
         let transport = TestMLXTransport(mode: .ignoreCancel)
         let factory = TestMLXTransportFactory([transport])
@@ -560,12 +511,7 @@ struct TalkMLXSpeechSynthesizerTests {
             cancelGraceDuration: .milliseconds(10))
 
         let synthesis = Task {
-            try await self.collectSynthesis(
-                synthesizer,
-                text: "cancel me hard",
-                modelRepo: nil,
-                language: nil,
-                voicePreset: nil)
+            try await self.collectSynthesis(synthesizer, text: "cancel me hard")
         }
         await transport.waitForSynthesisRequest()
         await synthesizer.cancelCurrent()
@@ -579,6 +525,34 @@ struct TalkMLXSpeechSynthesizerTests {
         }
     }
 
+    @Test(arguments: [false, true])
+    func `stopping an unresponsive active stream stays canceled`(_ shutdown: Bool) async throws {
+        let transport = TestMLXTransport(mode: .streamIgnoreCancel)
+        let factory = TestMLXTransportFactory([transport])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60),
+            cancelGraceDuration: .milliseconds(10))
+        let synthesis = Task {
+            try await self.collectSynthesis(synthesizer, text: "user-stopped stream")
+        }
+        await transport.waitForPendingEventRead()
+        if shutdown {
+            await synthesizer.shutdown()
+        } else {
+            await synthesizer.cancelCurrent()
+        }
+        do {
+            _ = try await synthesis.value
+            Issue.record("expected stopped stream cancellation")
+        } catch TalkMLXSpeechSynthesizer.SynthesizeError.canceled {} catch {
+            Issue.record("stopped stream requested system-voice fallback: \(error)")
+        }
+        #expect(await transport.closeCount == 1)
+        #expect(await factory.callCount == 1)
+        await synthesizer.shutdown()
+    }
+
     @Test
     func `shutdown terminates unresponsive in-flight helper`() async throws {
         let transport = TestMLXTransport(mode: .ignoreCancel)
@@ -588,12 +562,7 @@ struct TalkMLXSpeechSynthesizerTests {
             idleDuration: .seconds(60))
 
         let synthesis = Task {
-            try await self.collectSynthesis(
-                synthesizer,
-                text: "stop during shutdown",
-                modelRepo: nil,
-                language: nil,
-                voicePreset: nil)
+            try await self.collectSynthesis(synthesizer, text: "stop during shutdown")
         }
         await transport.waitForSynthesisRequest()
         await synthesizer.shutdown()
@@ -616,12 +585,7 @@ struct TalkMLXSpeechSynthesizerTests {
             idleDuration: .seconds(60))
 
         let synthesis = Task {
-            try await self.collectSynthesis(
-                synthesizer,
-                text: "fall back after pressure",
-                modelRepo: nil,
-                language: nil,
-                voicePreset: nil)
+            try await self.collectSynthesis(synthesizer, text: "fall back after pressure")
         }
         await transport.waitForSynthesisRequest()
         await synthesizer.handleMemoryPressure()
@@ -689,12 +653,7 @@ struct TalkMLXSpeechSynthesizerTests {
             cancelGraceDuration: .milliseconds(10))
 
         let synthesis = Task {
-            try await self.collectSynthesis(
-                synthesizer,
-                text: "never ready",
-                modelRepo: nil,
-                language: nil,
-                voicePreset: nil)
+            try await self.collectSynthesis(synthesizer, text: "never ready")
         }
         await factory.waitForCall()
         await synthesizer.cancelCurrent()
@@ -716,12 +675,7 @@ struct TalkMLXSpeechSynthesizerTests {
             transportFactory: { try await factory.make() },
             idleDuration: .milliseconds(10))
 
-        _ = try await self.collectSynthesis(
-            synthesizer,
-            text: "brief",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        _ = try await self.collectSynthesis(synthesizer, text: "brief")
         await transport.waitForShutdown()
 
         #expect(await transport.closeCount == 1)
@@ -734,12 +688,7 @@ struct TalkMLXSpeechSynthesizerTests {
         let synthesizer = TalkMLXSpeechSynthesizer(
             transportFactory: { try await factory.make() },
             idleDuration: .seconds(60))
-        let audio = try await self.collectSynthesis(
-            synthesizer,
-            text: "legacy helper",
-            modelRepo: nil,
-            language: nil,
-            voicePreset: nil)
+        let audio = try await self.collectSynthesis(synthesizer, text: "legacy helper")
 
         #expect(audio.sampleRate == 32000)
         #expect(audio.pcm == Data([0x00, 0x00, 0xFF, 0x7F]))
@@ -769,6 +718,7 @@ struct TalkMLXSpeechSynthesizerTests {
 }
 
 private enum TestMLXTransportError: Error {
+    case cancelGraceTimedOut
     case closed
 }
 
@@ -777,6 +727,7 @@ private actor TestMLXTransport: MLXTTSTransport {
         case audio
         case audioAfterCancel
         case crash
+        case errorAfterCancel
         case ignoreCancel
         case staleStartupClose
         case staleStartupReady
@@ -786,6 +737,7 @@ private actor TestMLXTransport: MLXTTSTransport {
         case streamAudioAfterCancel
         case startupHang
         case stream
+        case streamIgnoreCancel
         case streamWaitForCancel
         case waitForCancel
     }
@@ -832,14 +784,14 @@ private actor TestMLXTransport: MLXTTSTransport {
                     id: synthesize.id,
                     pcm: Data([0x00, 0x00, 0xFF, 0x7F]))))
                 self.events.append(.completed(id: synthesize.id))
-            case .staleStreamTimeout, .streamWaitForCancel, .streamAudioAfterCancel,
+            case .staleStreamTimeout, .streamWaitForCancel, .streamIgnoreCancel, .streamAudioAfterCancel,
                  .staleStreamLateAudio, .staleStreamLateChunk:
                 self.events.append(.streamStarted(MLXTTSStreamStart(
                     id: synthesize.id,
                     sampleRate: 32000)))
             case .crash:
                 self.closed = true
-            case .audioAfterCancel, .ignoreCancel, .staleStartupClose, .staleStartupReady,
+            case .audioAfterCancel, .errorAfterCancel, .ignoreCancel, .staleStartupClose, .staleStartupReady,
                  .startupHang, .waitForCancel:
                 break
             }
@@ -849,7 +801,13 @@ private actor TestMLXTransport: MLXTTSTransport {
                     id: id,
                     sampleRate: 32000,
                     pcm: Data([0x00, 0x00, 0xFF, 0x7F]))))
+            } else if self.mode == .errorAfterCancel {
+                self.events.append(.error(MLXTTSErrorEvent(
+                    id: id,
+                    code: .generationFailed,
+                    message: "helper failed after cancellation")))
             } else if self.mode != .ignoreCancel,
+                      self.mode != .streamIgnoreCancel,
                       self.mode != .staleStartupReady,
                       self.mode != .staleStreamTimeout,
                       self.mode != .staleStreamLateAudio,
@@ -915,6 +873,13 @@ private actor TestMLXTransport: MLXTTSTransport {
 
     func releaseCancelSend() {
         self.cancelSendReleased = true
+    }
+
+    func waitForClose() async throws {
+        while self.closeCount == 0 {
+            try Task.checkCancellation()
+            await Task.yield()
+        }
     }
 
     func cancelFirstSynthesis() {


### PR DESCRIPTION
## What Problem This Solves

Canceled or shut-down MLX speech could still produce late audio. Retired asynchronous work could also overwrite or close a replacement helper, replace its cancellation timer, or erase pending memory-pressure fallback. Before stream startup, a late helper failure after cancellation could trigger system-voice fallback instead of remaining canceled.

## Why This Change Was Made

The streaming owner now validates request ownership before accepting success, publishing a newly created helper, or replacing cancellation escalation. Shutdown revokes ownership before suspension and retires only the captured helper. Pressure fallback is retained per pending request until that request finishes.

One failure finisher resolves provider and stream errors before request state is cleared: pressure fallback first, then cancellation or retired ownership, otherwise the original error. Timeout cleanup finishes before that policy is evaluated. Ordinary helper retries and genuine current-request stalls remain intact, and the separate pre-stream caller-task cancellation branch is unchanged.

Mac Talk already uses streaming synthesis. This change removes the unused internal buffered entry point, wait loop, and WAV writer, while moving retained lifecycle coverage onto the production streaming path. Public framing, the default streaming flag, and legacy PCM responses remain supported.

## User Impact

Late MLX output is discarded, replacement requests retain their helper and timer ownership, and canceled requests keep a canceled terminal outcome. The pre-stream failure fix prevents a late helper error after cancellation from triggering fallback. Repeated pressure callbacks preserve fallback for every affected request.

Post-start playback error/stop information is still lost in the pinned PCM consumer; that separate follow-up is recorded and is outside this owner repair. This PR makes no claim to repair post-start playback fallback.

Production shrinks by 147 lines. The expanded regression suite adds 301 test lines after removing 110 lines of redundant fixture arguments/wrapping, for a net increase of 154 lines.

## Evidence

- [Initial ownership red proof](https://github.com/openclaw/openclaw/actions/runs/34557004371/job/103131868703): all 26 MLX invocations executed on the verified pre-fix merge source, with 16 passing and 10 intended failures. Their 16 issues were the only issues in that default native run.
- [Terminal-policy red proof](https://github.com/openclaw/openclaw/actions/runs/34560291029/job/103141552845): the intermediate owner repair compiled on arm64 and executed all 24 MLX functions / 29 invocations. The prior ownership fixes and the independent cancellation-close deadline passed. Exactly four classification probes failed (25 passing): the stale-cancel terminal result, both active-stream stop cases, and the pre-stream late helper error. The merged production/test hashes matched the reviewed intermediate source. The full default run had 2,146 tests across 239 suites and one additional DashboardReconnect test failure, which is being investigated separately. The named AppState partition was not reached on the failing heads.
- Current Swift lint, formatting, and whitespace checks pass. Earlier apps changed-file checks passed. Fresh managed P0–P2 review of the complete final staged candidate passed with no actionable findings; all 29 test predicates remain unchanged since the terminal-policy red probe.
- [Final native green proof](https://github.com/openclaw/openclaw/actions/runs/34565322472/job/103156256268): all 24 MLX functions / 29 invocations passed, including all four terminal-classification probes. The full default native run passed 2,146 tests across 239 suites, the separate named AppState partition passed both tests, and the Talk speech siblings passed. Shared OpenClawKit tests also passed (1,676 tests / 130 suites). The normal native launcher ran on arm64 against merge commit `4a7772d5a63efa69c8928339132209f4d5317087`, containing final PR head `b4b3aadccd6558b2e80c9fd3751faf84631c6621`; merged production/test hashes matched the reviewed source. The exact CI run and required gate succeeded. Native execution used disposable macOS CI; the canceled local cold compile is not counted as proof.
