### PR TITLE
refactor(ui): share Markdown disclosure decisions

### DIFF
--- a/ui/src/components/markdown-details.test.ts
+++ b/ui/src/components/markdown-details.test.ts
@@ -52,6 +52,27 @@ describe("model-authored details blocks", () => {
     expect(fragment.querySelector("details")?.textContent).toContain("<script>nope</script>");
   });
 
+  it.each([false, true])("consumes summary labels before nesting (streaming=%s)", (streaming) => {
+    const source =
+      "<details><summary>Outer </details><details> label</summary>" +
+      "<details><summary>Inner</summary>body</details>tail</details>\n\noutside";
+    const fragment = htmlFragment(
+      streaming ? toStreamingMarkdownParts(source).join("") : toSanitizedMarkdownHtml(source),
+    );
+    const details = fragment.querySelectorAll("details");
+
+    expect(details).toHaveLength(2);
+    expect([...details].map((entry) => entry.querySelector("summary")?.textContent)).toEqual([
+      "Outer </details><details> label",
+      "Inner",
+    ]);
+    expect(details[1]?.querySelector("p")?.textContent).toBe("body");
+    expect(details[1]?.textContent).not.toContain("tail");
+    expect(details[0]?.textContent).toContain("tail");
+    expect(details[0]?.textContent).not.toContain("outside");
+    expect(fragment.lastElementChild?.textContent).toBe("outside");
+  });
+
   it("keeps large runs of disclosure tags literal inside fenced code", () => {
     const count = 2_000;
     const literals = Array.from({ length: count }, () => "</details>").join("\n");
@@ -132,12 +153,22 @@ describe("model-authored details blocks", () => {
     expect(details?.textContent).not.toContain("</details>");
   });
 
-  it("repairs an unterminated summary while streaming", () => {
-    const html = toStreamingMarkdownParts("<details>\n<summary>Still arriving").join("");
-    const fragment = htmlFragment(html);
+  it.each([
+    ["<details>\n<summary>Still arriving", ["Still arriving"], null],
+    ["<details><summary>Outer</summary>\n<details><summary>Inner", ["Outer", "Inner"], null],
+    ["<summary>Orphan", [], "<summary>Orphan"],
+    ["<details><summary>First</summary>\n<summary>Second", ["First"], "<summary>Second"],
+    ["<details>\n<summary>Earlier\nbody", [], "<summary>Earlier"],
+  ] as const)("repairs only an eligible final summary: %s", (source, summaries, literal) => {
+    const fragment = htmlFragment(toStreamingMarkdownParts(source).join(""));
 
-    expect(fragment.querySelector("details summary")?.textContent).toBe("Still arriving");
-    expect(html).not.toContain("&lt;summary");
+    expect([...fragment.querySelectorAll("summary")].map((entry) => entry.textContent)).toEqual(
+      summaries,
+    );
+    expect(fragment.textContent).not.toContain("</summary>");
+    if (literal) {
+      expect(fragment.textContent).toContain(literal);
+    }
   });
 
   it("keeps completed code fences inside an open details streaming tail", () => {

--- a/ui/src/components/markdown-details.ts
+++ b/ui/src/components/markdown-details.ts
@@ -1,7 +1,7 @@
 import type { MarkdownIt, StateBlock } from "markdown-it";
 import { findMarkdownCodeSpans } from "../../../packages/markdown-core/src/reasoning-tags.js";
 
-export const MAX_MARKDOWN_DETAILS_DEPTH = 32;
+const MAX_MARKDOWN_DETAILS_DEPTH = 32;
 const DISCLOSURE_TAG_RE = /<\/?(?:details|summary)(?=[\s>])[^>]*>/gi;
 const DETAILS_OPEN_RE = /^<details( open)?>$/i;
 const DETAILS_CLOSE_RE = /^<\/details>$/i;
@@ -9,8 +9,8 @@ const SUMMARY_OPEN_RE = /^<summary>$/i;
 const SUMMARY_CLOSE_RE = /^<\/summary>$/i;
 const DETAILS_STACK = Symbol("markdownDetailsStack");
 
-type DetailsFrame = { hasSummary: boolean };
-type DetailsBlockState = StateBlock & { [DETAILS_STACK]?: DetailsFrame[] };
+export type MarkdownDetailsFrame = { hasSummary: boolean };
+type DetailsBlockState = StateBlock & { [DETAILS_STACK]?: MarkdownDetailsFrame[] };
 type DetailsToken = ReturnType<StateBlock["push"]>;
 type DetailsTokenSink = {
   push(type: string, tag: string, nesting: -1 | 0 | 1): DetailsToken;
@@ -50,7 +50,7 @@ function isInsideMarkdownCode(
   return codeSpans.some(([start, end]) => index >= start && index < end);
 }
 
-export function markdownDisclosureTagKind(raw: string): MarkdownDisclosureTagKind | null {
+function markdownDisclosureTagKind(raw: string): MarkdownDisclosureTagKind | null {
   const detailsOpen = DETAILS_OPEN_RE.exec(raw);
   if (detailsOpen) {
     return detailsOpen[1] ? "details_open_expanded" : "details_open";
@@ -111,16 +111,17 @@ function pushSummary(state: DetailsTokenSink, label: string, line: number): void
   state.push("summary_close", "summary", -1);
 }
 
-function pushDisclosureLine(
-  state: DetailsTokenSink,
-  line: string,
-  lineNumber: number,
-  stack: DetailsFrame[],
+/** Share nesting decisions between rendered blocks and streaming-tail repair. */
+export function walkMarkdownDisclosureTags(
+  tags: readonly MarkdownDisclosureTag[],
+  stack: MarkdownDetailsFrame[],
+  options: {
+    allowPendingSummary?: boolean;
+    onOpen?: (tag: MarkdownDisclosureTag, expanded: boolean) => void;
+    onClose?: (tag: MarkdownDisclosureTag) => void;
+    onSummary?: (open: MarkdownDisclosureTag, close: MarkdownDisclosureTag) => void;
+  } = {},
 ): boolean {
-  const tags = scanMarkdownDisclosureLine(line);
-  if (!tags) {
-    return false;
-  }
   const kinds = tags.map((tag) => markdownDisclosureTagKind(tag.raw));
   const nextSummaryClose = Array.from({ length: tags.length }, () => -1);
   let nearestSummaryClose = -1;
@@ -130,55 +131,74 @@ function pushDisclosureLine(
       nearestSummaryClose = index;
     }
   }
-  let cursor = 0;
-  let pendingText = "";
-  const flushText = () => {
-    pushInlineParagraph(state, pendingText, lineNumber);
-    pendingText = "";
-  };
-
   for (let index = 0; index < tags.length; index += 1) {
     const tag = tags[index];
     if (!tag) {
       continue;
     }
-    pendingText += line.slice(cursor, tag.start);
-
     const kind = kinds[index];
     if (
       (kind === "details_open" || kind === "details_open_expanded") &&
       stack.length < MAX_MARKDOWN_DETAILS_DEPTH
     ) {
-      flushText();
-      const token = state.push("details_open", "details", 1);
-      if (kind === "details_open_expanded") {
-        token.attrSet("open", "");
-      }
+      options.onOpen?.(tag, kind === "details_open_expanded");
       stack.push({ hasSummary: false });
     } else if (kind === "details_close" && stack.length > 0) {
-      flushText();
-      state.push("details_close", "details", -1);
+      options.onClose?.(tag);
       stack.pop();
     } else if (kind === "summary_open") {
       const frame = stack.at(-1);
-      const closeIndex = nextSummaryClose[index] ?? -1;
-      const close = closeIndex >= 0 ? tags[closeIndex] : undefined;
-      if (frame && !frame.hasSummary && close) {
-        flushText();
-        pushSummary(state, line.slice(tag.end, close.start), lineNumber);
-        frame.hasSummary = true;
-        cursor = close.end;
-        index = closeIndex;
+      if (!frame || frame.hasSummary) {
         continue;
       }
-      pendingText += tag.raw;
-    } else {
-      pendingText += tag.raw;
+      const closeIndex = nextSummaryClose[index] ?? -1;
+      const close = closeIndex >= 0 ? tags[closeIndex] : undefined;
+      if (close) {
+        options.onSummary?.(tag, close);
+        frame.hasSummary = true;
+        index = closeIndex;
+      } else if (options.allowPendingSummary) {
+        return true;
+      }
     }
-    cursor = tag.end;
   }
-  pendingText += line.slice(cursor);
-  flushText();
+  return false;
+}
+
+function pushDisclosureLine(
+  state: DetailsTokenSink,
+  line: string,
+  lineNumber: number,
+  stack: MarkdownDetailsFrame[],
+): boolean {
+  const tags = scanMarkdownDisclosureLine(line);
+  if (!tags) {
+    return false;
+  }
+  let cursor = 0;
+  const flushText = (tag: MarkdownDisclosureTag, end = tag.end) => {
+    // Unaccepted tags stay in the literal span between structural events.
+    pushInlineParagraph(state, line.slice(cursor, tag.start), lineNumber);
+    cursor = end;
+  };
+  walkMarkdownDisclosureTags(tags, stack, {
+    onOpen(tag, expanded) {
+      flushText(tag);
+      const token = state.push("details_open", "details", 1);
+      if (expanded) {
+        token.attrSet("open", "");
+      }
+    },
+    onClose(tag) {
+      flushText(tag);
+      state.push("details_close", "details", -1);
+    },
+    onSummary(open, close) {
+      flushText(open, close.end);
+      pushSummary(state, line.slice(open.end, close.start), lineNumber);
+    },
+  });
+  pushInlineParagraph(state, line.slice(cursor), lineNumber);
   return true;
 }
 
@@ -250,7 +270,7 @@ export function installMarkdownDetails(markdownParser: MarkdownIt): void {
   // open, but leave raw HTML block types 1-5 entirely literal.
   markdownParser.core.ruler.after("block", "details_balance", (state) => {
     const output: DetailsToken[] = [];
-    const stack: DetailsFrame[] = [];
+    const stack: MarkdownDetailsFrame[] = [];
 
     for (const token of state.tokens) {
       if (token.type === "details_open") {

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -4,8 +4,8 @@ import {
   findMarkdownCodeRegions,
 } from "../../../packages/markdown-core/src/reasoning-tags.js";
 import {
-  markdownDisclosureTagKind,
-  MAX_MARKDOWN_DETAILS_DEPTH,
+  walkMarkdownDisclosureTags,
+  type MarkdownDetailsFrame,
   scanMarkdownDisclosureLine,
 } from "./markdown-details.ts";
 
@@ -16,7 +16,6 @@ const LINK_REFERENCE_CANDIDATE_RE = /^[ \t]*\[/u;
 const DISCLOSURE_LINE_CANDIDATE_RE = /^[ \t]*<\/?(?:details|summary)(?=[\s>])/iu;
 const STREAMING_SPLIT_CACHE_LIMIT = 8;
 
-type DetailsFrame = { hasSummary: boolean };
 type FenceMarker = { length: number; marker: "`" | "~" };
 type StrippedMarkdownLine = { content: string; offset: number };
 
@@ -55,7 +54,7 @@ function isFenceClose(line: string, fence: FenceMarker): boolean {
 
 function updateDetailsStack(
   line: string,
-  stack: DetailsFrame[],
+  stack: MarkdownDetailsFrame[],
   allowPendingSummary: boolean,
   codeSpans: ReadonlyArray<readonly [number, number]>,
   lineOffset: number,
@@ -66,42 +65,7 @@ function updateDetailsStack(
     codeSpans,
     lineOffset + stripped.offset,
   );
-  if (!tags) {
-    return false;
-  }
-  const kinds = tags.map((tag) => markdownDisclosureTagKind(tag.raw));
-  const nextSummaryClose = Array.from({ length: tags.length }, () => -1);
-  let nearestSummaryClose = -1;
-  for (let index = tags.length - 1; index >= 0; index -= 1) {
-    nextSummaryClose[index] = nearestSummaryClose;
-    if (kinds[index] === "summary_close") {
-      nearestSummaryClose = index;
-    }
-  }
-  for (let index = 0; index < tags.length; index += 1) {
-    const kind = kinds[index];
-    if (
-      (kind === "details_open" || kind === "details_open_expanded") &&
-      stack.length < MAX_MARKDOWN_DETAILS_DEPTH
-    ) {
-      stack.push({ hasSummary: false });
-    } else if (kind === "details_close" && stack.length > 0) {
-      stack.pop();
-    } else if (kind === "summary_open") {
-      const frame = stack.at(-1);
-      if (!frame || frame.hasSummary) {
-        continue;
-      }
-      const closeIndex = nextSummaryClose[index] ?? -1;
-      if (closeIndex >= 0) {
-        frame.hasSummary = true;
-        index = closeIndex;
-      } else if (allowPendingSummary) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return tags ? walkMarkdownDisclosureTags(tags, stack, { allowPendingSummary }) : false;
 }
 
 type StreamingMarkdownSplit = {
@@ -152,7 +116,7 @@ function scanStableStreamingMarkdown(
   let { boundary, firstListOffset, hasLinkReferenceDefinition, index, lastFenceOffset } = cursor;
   let lineMode = cursor.lineMode;
   let openFence = cursor.openFence;
-  const detailsStack: DetailsFrame[] = [];
+  const detailsStack: MarkdownDetailsFrame[] = [];
   // Completed fences cannot gain indentation ownership from later prose. Keep
   // list containers and unfinished fences intact when parsing the retained suffix.
   const codeStart = cursor.openFence
@@ -328,7 +292,7 @@ export function repairStreamingMarkdownTail(tail: string, repairStart = 0): stri
   if (!repaired.includes("<")) {
     return repaired;
   }
-  const detailsStack: DetailsFrame[] = [];
+  const detailsStack: MarkdownDetailsFrame[] = [];
   const codeSpans = findMarkdownCodeSpans(repaired);
   let openFence: FenceMarker | null = null;
   let pendingSummary = false;


### PR DESCRIPTION
## What Problem This Solves

Completed and streaming chat Markdown maintain separate decisions for disclosure depth, matching summary closers, and each disclosure's first summary. Future syntax changes could make the same content behave differently while streaming and after completion. This maintainer-requested refactor gives those decisions one owner.

## Why This Change Was Made

The existing disclosure owner now handles structural tag traversal and nesting. Rendering emits the existing tokens from accepted structural events and preserves the literal spans between them. Streaming uses the same traversal while retaining final-line-only completion of an eligible unfinished summary.

The change retains parser ordering, invalid and escaped literal tags, code and raw-HTML exclusions, the depth limit, and per-disclosure summary ownership. Including the added preservation tests, the complete maintained cost is +12 code lines / +15 physical lines.

## User Impact

No intended behavior or appearance change. Nested disclosures, summary labels, and partially streamed content retain their existing rendering.

## Evidence

- 278 tests passed across the disclosure, streaming, links, session-links, and streaming-highlight suites through `node scripts/run-vitest.mjs`.
- The new disclosure preservation cases also passed against the original production owners before the refactor.
- The full changed-file gate passed against base `a305cafee671bf85c29c2e68e7b0afe0f0e4d09f`, including core-test/UI typechecks, formatting, lint, i18n, dependency/coercion guards, and dead-export scans.
- Managed Codex P2 review was scoped-clean with no actionable findings, using the actual parser, render/stream entry points, code-region scanner, and streaming/highlighting test context.
- Parsed-output and DOM assertions verify literal summary content, nested ownership, orphan/repeated/non-final summary handling, and the existing streaming boundaries. Current main was rechecked; these source and caller contracts are unchanged.

The integration refresh is based on main `57674ef82592b712a17507539b6f89609d8547c2` at head `463d867ebe3521a683c21dc4b33a4f91fe1571c4`. The full-index disclosure patch remains `9ecbdfd05553845d912969c0223c5ea0bb917e50b8ff1bbca192ccda5d118122`.

The integration refresh includes the separately landed plugin-status reconnect repair in #144605 and plugin-tab intent repair in #144647, while preserving later main changes. The disclosure patch and all three changed-file blobs remain identical to the reviewed version, so the existing focused tests, changed-file gate, and managed P2 evidence are retained.

The previous [UI E2E run](https://github.com/openclaw/openclaw/actions/runs/34558481730/job/103136278903) used the old base without #144647 and failed while locating the plugin configuration field. That failure and its original logs remain preserved. The fresh [CI run 34666346236](https://github.com/openclaw/openclaw/actions/runs/34666346236) passed for head `463d867ebe3521a683c21dc4b33a4f91fe1571c4`. The authenticated ClawSweeper review completed at revision 3 with no findings. The old failed run was not rerun or described as green.


The complete refreshed three-file diff and hosted revision 3 review were checked with no remaining actionable findings. The retained 278-test, changed-file, and managed P2 evidence still applies to the identical source patch.

### Before and after: actual Control UI

The same synthetic chat fixture was captured through the existing Control UI E2E source server and mock Gateway at base `57674ef82592b712a17507539b6f89609d8547c2` and head `463d867ebe3521a683c21dc4b33a4f91fe1571c4`. Both captures show the completed expanded/nested/collapsed disclosures alongside an active streamed disclosure whose summary has not yet received its closing tag. The fixture also opens and closes the nested disclosure through the UI, observes the cold-start transcript subscription and one `chat.send` request, and delivers the streaming delta through the Gateway boundary.

Rendered disclosure state is identical. Browser source-map contents match the exact archived production files at each revision. These are inspected synthetic-only captures of the running UI, using Chromium 151.0.7922.34 at 1380 × 1000; no live provider or real-user data was used.

**Before — original disclosure owners**

![Before: completed nested and collapsed disclosures with an unfinished streaming summary](https://github.com/user-attachments/assets/6d6e1605-4c61-49b0-942f-c74547b35ca5)

**After — shared disclosure owner**

![After: matching completed nested and collapsed disclosures with an unfinished streaming summary](https://github.com/user-attachments/assets/b05ea3c7-cfce-4fa9-bdad-99010af289f0)
