### PR TITLE
docs: align model catalog and provider login guides

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -335,6 +335,10 @@ The CLI reports saved model access separately from confirmed Gateway application
 
 Without `--set-default`, login preserves the current default, including an unset default, and keeps unrelated configuration edits made while login is running. If credentials are saved but provider settings cannot be applied, the error reports the saved credentials separately. Auth changes request a refresh from the running local Gateway; a refresh failure does not undo the saved change, and the command reports how to apply it.
 
+With an older Gateway, the CLI tries its legacy auth-status refresh. This cannot
+confirm that the saved change is active; follow the restart guidance. This
+fallback applies to auth changes, not to `models list`.
+
 For the shared-main agent, `--force` clears the provider's shared credentials and main-agent local overrides, including their order and health state. For another agent it clears only that agent's local profiles, leaving shared credentials unchanged. A busy auth store stops the command before login starts; close other OpenClaw commands using the same state directory and retry. SQLite lock diagnostics can name either the shared state database or an agent database, so checking only the legacy auth file for open handles does not rule out contention.
 
 `models auth logout <profileId>` removes one saved auth profile from the selected agent auth store. Use the profile id shown by `models auth list`. It also drops that profile from `auth.profiles` and from every `auth.order` list in your config, so no stale reference is left behind, and it deletes an `auth.order.<provider>` entry that would otherwise be emptied (an authored empty order means "select no profiles" and would disable the provider). It prompts for confirmation on a TTY; pass `--yes` for scripts and agents. Provider key references are cleared before the credential is removed. Model defaults and connection settings stay unchanged. Logout refuses when the profile is not in the store.

--- a/docs/concepts/model-providers/control-ui-and-keys.md
+++ b/docs/concepts/model-providers/control-ui-and-keys.md
@@ -9,7 +9,16 @@ title: "Control UI and API keys"
 
 ## Configure providers in the Control UI
 
-Open **Settings → Models** in the Control UI to add, replace, or remove provider API keys stored in `models.providers.<id>.apiKey`. The page identifies whether each API key comes from OpenClaw config or an environment variable without displaying the credential. Environment-provided keys remain managed by the gateway process environment.
+Open **Settings → Models** in the Control UI to add, replace, or remove provider
+API keys. The page and `openclaw models auth paste-api-key` use the same credential
+writer: key material stays in the auth store, and configured providers reference
+the saved profile. Environment-provided keys remain managed by the Gateway
+process environment. The page shows credential sources without revealing keys.
+
+Saving a key and refreshing the catalog are separate outcomes. If refresh fails,
+the saved key remains; follow the reported recovery step. Removing a stored key
+keeps model defaults and provider connection settings. See
+[Auth profiles](/cli/models#auth-profiles) for the matching CLI commands.
 
 Provider controls appear as soon as credentials, the model catalog, and configuration are ready. Usage and local costs load independently afterward, so a slow usage response does not block provider settings.
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -85,50 +85,36 @@ Other selection rules:
 
 - Changing `agents.defaults.model.primary` does not rewrite existing session pins. If status reports `This session is pinned to X; config primary Y will apply to new/unpinned sessions.`, run `/model default` to clear the pin.
 - CLI default-model and allowlist pickers respect `models.mode: "replace"` by listing only `models.providers.*.models` instead of the full built-in catalog.
-- The Control UI starts from the Gateway's prepared configured model view, so opening chat does not start provider discovery. Opening a model picker reads published rows, including rows matched by a trailing `provider/*` policy entry. Use its explicit Refresh action to discover provider models. Default and configured picker views hide catalog rows marked `deprecated` or `disabled`. There is one exception: a row stays visible when that exact model is configured as a primary, fallback, utility or tool model, alias or settings key, or exact policy entry. Hidden rows remain selectable by exact `provider/model` ref. The full built-in catalog, including hidden rows, is reserved for explicit browse views (`models.list` with `view: "all"`, or `openclaw models list --all`).
+- The Control UI starts from the Gateway's prepared configured model view, so opening chat does not start provider discovery. Opening the chat model picker reads published rows, including rows matched by a trailing `provider/*` policy entry. Use its explicit Refresh action to discover provider models. Default and configured picker views hide catalog rows marked `deprecated` or `disabled`. There is one exception: a row stays visible when that exact model is configured as a primary, fallback, utility or tool model, alias or settings key, or exact policy entry. Hidden rows remain selectable by exact `provider/model` ref. The full built-in catalog, including hidden rows, is reserved for explicit browse views (`models.list` with `view: "all"`, or `openclaw models list --all`).
 - Provider inventory UIs use `models.list` with `view: "provider-config"` to show source-authored `models.providers.*.models` rows without applying picker allowlists.
 
-Ordinary `models.list` and `/models` browsing use the Gateway's published
-configured or completed catalog. They do not start provider discovery, including
-after a restart. If the owner is not yet published, the request reports that the
-catalog is not ready. Retry after startup or an in-progress refresh finishes.
-Use an explicit Refresh action or `openclaw models list --refresh` to acquire
-provider inventory. Model selection, subagent capability checks, and hook-model
-validation also use the published inventory. Missing capability facts do not
-start another provider discovery. Without a published owner, turn-path thinking
-and input checks leave catalog facts absent instead of loading provider plugins.
-Native runtime observations keep their separate owner and authentication requirements.
-
-Internal catalog loads default to passive reads. Without a published owner they
-use existing read-only facts. The public SDK's `loadPreparedModelCatalog` and legacy
-`loadModelCatalog` keep their writable default for compatibility and can acquire
-provider inventory. Pass `readOnly: true` for a passive SDK read. Explicit full
-refreshes keep inventory acquisition. Explicit read-only requests keep their
-narrower refresh scope.
+The Gateway prepares one model catalog for the CLI, `/models`, the Control UI,
+and native apps. Ordinary CLI and chat browsing do not start provider discovery,
+including after a restart. Use **Refresh** in Models or
+`openclaw models list --refresh` to discover provider models. The Models page also
+requests discovery the first time you open a default-model picker for its current
+page data; later opens read the published catalog. If the catalog is not ready,
+retry after Gateway startup or the current refresh finishes.
 
 For models configured to use a CLI runtime, channel picker availability follows that
 runtime's prepared authentication. A provider API key does not substitute for its
 native login.
 
-Once the Gateway has discovered a provider inventory, model-selection hot reloads
-retain it without running discovery again. Aliases, policy, and runtime capabilities
-use the new configuration. A successful catalog refresh replaces that inventory,
-including a successful empty account list. Metadata alone cannot refill that list.
-Explicitly configured models and independent native runtime catalogs remain.
-When a provider reports failed discovery, the Gateway retains its last compatible
-inventory and reports the failed outcome while healthy providers update. Without
-compatible inventory, the Gateway publishes the provider's prepared starter rows
-with the failed outcome, even when strict discovery returns no rows.
-They cannot widen a retained successful list, including an empty list. Changes to
-provider, plugin, auth, environment, or workspace identity invalidate incompatible inventory.
+If discovery fails, OpenClaw reports the failure and keeps the last compatible
+model list. Without one, it shows prepared starter models with the failure.
+Other providers can still update. A successful empty response clears that
+provider's discovered models; it does not restore old choices. Explicitly
+configured models and independent native runtime catalogs remain.
+
+Changes to aliases or model restrictions reuse compatible inventory. Changes to
+the provider, plugin, credentials, environment, or workspace can invalidate it.
 
 Automations and command-palette model search show a warning when a provider refresh
 fails, while keeping the models returned by the Gateway. Open Models to retry the
 refresh. A successful empty result clears the discovered choices and warning.
 
 A successful provider result takes precedence over retained rows, even when
-another credential reports failure. Catalog results describe one provider's model
-list. OpenClaw does not guess which old models belonged to each credential.
+another credential reports failure.
 
 Full mechanics: [Model failover](/concepts/model-failover).
 
@@ -223,6 +209,10 @@ openclaw config set agents.defaults.modelPolicy.allow '["openai/gpt-5.4","anthro
 </Accordion>
 
 ## Choose a model for a session
+
+In the Control UI chat model menu, search by model or provider name. Use the
+arrow keys to move through results and Enter to select one. Escape clears the
+search. Typing alone does not change the selected model.
 
 Gateway `sessions.create` and `sessions.patch` resolve model aliases and
 `modelPolicy.allow` in the target session's agent scope. An explicit per-agent

--- a/docs/plugins/manifest/setup-and-auth.md
+++ b/docs/plugins/manifest/setup-and-auth.md
@@ -85,11 +85,33 @@ When a manifest choice is selected, setup resolves its `provider` and `method` i
 When `appGuidedDiscovery` is true, the matching provider auth method must expose
 `appGuidedSetup.detect` and `appGuidedSetup.prepare`. Detection must be
 read-only: no login, model pull, download, or config write. Preparation rechecks
-the exact selected model and returns a config proposal; OpenClaw live-tests that
-proposal in isolation and commits it only after success. A provider can also
+the exact selected model and returns a config proposal. OpenClaw saves any
+returned credential, runs one confirmation turn without tools, and activates
+the proposal only after success. Failed activation retains the saved credential
+for retry; a replacement remains inactive until the user accepts activation.
+A provider can also
 expose `appGuidedSetup.detectAvailability` to mark its setup choice as detected
 when the local service is reachable but no model qualifies for automatic setup.
 The availability probe is also read-only.
+
+### Login choices
+
+**Connect** in Models requires `credentialOnly: true` plus `appGuidedAuth` or
+`appGuidedSecret`. Choices marked `appGuidedDiscovery`, `manual-only`, or outside
+text-inference onboarding do not become credential-only actions. Descriptor-only
+`setup.providers[].authMethods` entries do not create executable login choices.
+
+Bare `/login` groups visible browser and device-code choices into provider
+buttons without starting sign-in. A provider with several methods opens a second
+choice. Channels without command buttons show commands to copy. Core builds
+this menu from the manifest; channels do not keep separate provider lists.
+
+`channelLogin` opts a credential-only browser or device-code method into private
+chat. Use `{}` when no alias is needed. The method must complete without asking
+chat for a secret, endpoint, or other free-text input. Methods that need such
+input hand off to the matching Control UI login or setup flow. The host owns any
+model-access consent after saving credentials; the plugin cannot grant it through
+its configuration patch.
 
 Browser-based `channelLogin` methods use `ctx.oauth.authorize` when the host
 supplies it. Pass the provider-generated `state`, a `timeoutMs` deadline, and

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -20,6 +20,12 @@ Choose **Sign in with OpenRouter**, approve access in your browser, and return
 to chat. OpenClaw receives the browser callback and saves the credential before
 reporting success. Use `/login cancel` to cancel a pending sign-in.
 
+Login saves access without choosing a starter model. If current model restrictions
+hide OpenRouter models, choose **Show all OpenRouter models** or **Keep current
+restrictions**. The credential stays saved either way. In the Control UI, use
+**Settings → Models → Connect** for the same credential-only flow, then use the
+model menu to choose a model from the Gateway's catalog.
+
 Chat browser sign-in uses the Gateway's managed [Tailscale HTTPS address](/gateway/tailscale).
 With Tailscale Serve, your browser must have access to the same tailnet. If no
 managed HTTPS address is available, enable Serve and retry, or use the CLI flow

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -97,7 +97,8 @@ tool-capable model with at least 16K of measured effective context already
 loaded in a reachable LM Studio or Ollama server. Detection runs on the
 Gateway host, including when the macOS app connects to a Linux Gateway. Detection
 only presents choices: it does not test, activate, install, or save any candidate.
-Select the connection you want before OpenClaw runs a real completion and saves it.
+Select the connection you want before OpenClaw saves any returned credential and runs one
+confirmation turn without tools. It activates the connection only after success.
 In particular, an existing Codex subscription is never selected automatically.
 If setup fails, the app keeps the detailed reason visible so you can retry or
 choose another connection. Local discovery never pulls or downloads a model.
@@ -112,9 +113,9 @@ staged package's source and capabilities, with integrity when available before i
 enabling it, including verified first-party packages. Review the details, then
 explicitly confirm acceptance to continue.
 Declining or confirmed cancellation stops that attempt without selecting another
-inference route. When the Gateway confirms that the live AI test failed before
-saving the connection, the app shows the failure and lets you retry or choose a
-different connection. Runtime plugins installed for that attempt are kept.
+inference route. If the confirmation turn fails, the app shows the failure and
+keeps the saved credential. Choose the saved sign-in in **Model Setup** to retry
+without signing in again. Runtime plugins installed for that attempt are kept.
 
 Fresh installs also ask whether existing native provider conversations should
 appear in the sidebar. This is discovery in place, not transcript copying, and is
@@ -167,8 +168,12 @@ so another provider can opt in without adding provider-specific macOS code.
 The manual key/token picker uses the same provider registry. In every route,
 the provider supplies its starter model and configuration. If the starter is an
 alias, OpenClaw tests and saves the provider's canonical model name while
-preserving existing model settings that the starter does not replace. The credential is stored only after
-that live test succeeds.
+preserving existing model settings that the starter does not replace.
+A replacement credential stays inactive until you accept **Activate this saved
+sign-in?** after verification. Declining keeps your current connection and the
+saved replacement. Setup preserves unrelated configuration edits made during
+verification. If the same connection settings change, review them and retry the
+saved sign-in instead of overwriting the newer settings.
 Continuing remains locked until one backend has passed, so the first agent
 chat cannot start without working inference.
 </Step>

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -584,6 +584,8 @@ See [BTW side questions](/tools/btw) for the full behavior.
     - **Native Slack commands:** `agent:<agentId>:slack:slash:<userId>` (prefix configurable via `channels.slack.slashCommand.sessionPrefix`)
     - **Native Telegram commands:** `telegram:slash:<userId>` (targets the chat session via `CommandTargetSessionKey`)
     - **`/login`** requires a private chat or Control UI session. It shows provider buttons without starting sign-in. API keys and local setup use the Control UI handoff. `/login codex` still selects OpenAI device pairing. Retry messages name the exact connection command.
+    - **`/login openrouter`** sends a browser sign-in action through the Gateway's managed HTTPS address. Approve access in your browser, then return to chat for the saved result. See [OpenRouter](/providers/openrouter#getting-started) for address requirements. Use `/login cancel` to cancel a pending sign-in.
+    - After login, model restrictions can prompt **Show all provider models** or **Keep current restrictions**. Credentials stay saved either way. A catalog refresh failure is reported separately from saving the credential.
     - **`/stop`** targets the active chat session to abort the current run.
 
   </Accordion>

--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -14,7 +14,7 @@ Use **Search settings** to find pages and configuration fields. Add `tag:storage
 
 Model menus with more than eight choices include search. Filter by model name or provider/model reference, then choose a result to apply it. Typing or dismissing the menu leaves the current selection unchanged. Short menus stay compact, and custom model entry remains available where the setting supports it.
 
-In **Models**, **Connect** offers the credential-only sign-in methods declared by installed provider plugins. Connecting saves the credential and makes the provider available without selecting its starter model or changing model restrictions. **Configure Models** keeps the separate setup and activation flow. If saving has already started, cancellation keeps the dialog open until the saved result arrives. Leaving the page closes pending sign-in input and lets an active save finish, so a later sign-in can start without losing saved credentials.
+In **Models**, **Connect** offers the credential-only sign-in methods declared by installed provider plugins. Connecting saves the credential without selecting its starter model. If model restrictions hide the provider, choose **Show all provider models** or **Keep current restrictions**; saving a credential alone does not widen access. **Configure Models** keeps the separate [setup and activation flow](/start/onboarding). If saving has already started, cancellation keeps the dialog open until the saved result arrives. Leaving the page closes pending sign-in input and lets an active save finish, so a later sign-in can start without losing saved credentials.
 
 ## Environment identity
 


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

Setup and Models documentation described credential saving and API-key storage that no longer matched the product. Catalog guidance also mixed user tasks with internal loader details.

## Why This Change Was Made

The guides now explain the shared catalog, explicit refresh, retained results, session model search, credential-only login, model-access consent, shared key management, and recovery of saved credentials. They preserve the documented first-picker discovery request and distinguish authentication refresh from model-list fallback.

## User Impact

Users can distinguish connecting from activating a model and understand when credentials are saved but not yet applied. Plugin authors can describe supported login choices. Runtime behavior is unchanged.

## Evidence

All eight pages were checked against source. Documentation and whitespace checks passed; optional anchor checking found the same 53 existing failures on both versions. Seventy-three focused tests passed without test changes. Live command-line checks covered model listing and refresh, provider filtering, key save/list/remove, and a disabled catalog result. Telegram checks covered login buttons, the model menu, and missing-secure-address recovery with zero model requests. Browser authorization was source-checked rather than executed.
