### PR TITLE
refactor(tasks): separate committed publication from flow persistence

### DIFF
--- a/src/agents/subagents/completion/subagent-completion-admission.store.ts
+++ b/src/agents/subagents/completion/subagent-completion-admission.store.ts
@@ -19,6 +19,7 @@ import {
 import { publishTaskRecordAfterAtomicStore } from "../../../tasks/runtime-internal.js";
 import { resolveRequiredCompletionDeliveryFailureTerminalResult } from "../../../tasks/task-completion-contract.js";
 import { formatTaskBlockedFollowupMessage } from "../../../tasks/task-executor-policy.js";
+import { syncFlowFromTaskAfterTaskMutation } from "../../../tasks/task-registry-mutation.js";
 import {
   bindTaskRecord,
   readTaskRecord,
@@ -66,7 +67,12 @@ export function publishCommittedRecords(subagent: SubagentRunRecord, task: TaskR
   } else {
     subagentRuns.set(subagent.runId, subagent);
   }
-  publishTaskRecordAfterAtomicStore(task);
+  const deferredObserverEvents: Array<() => void> = [];
+  const published = publishTaskRecordAfterAtomicStore(task, { deferredObserverEvents });
+  syncFlowFromTaskAfterTaskMutation(published, "atomic completion admission");
+  for (const emitObserverEvent of deferredObserverEvents) {
+    emitObserverEvent();
+  }
 }
 
 function assertCorrelatedEntry(params: {

--- a/src/agents/subagents/registry/subagent-registry-replacement-store.ts
+++ b/src/agents/subagents/registry/subagent-registry-replacement-store.ts
@@ -122,7 +122,6 @@ export function commitSubagentTaskReplacement(params: {
   const deferredObserverEvents: Array<() => void> = [];
   publishSubagentRunsAfterAtomicStore(params.runs, params.changedRunIds, deferredObserverEvents);
   publishTaskRecordAfterAtomicStore(params.task.next, {
-    syncTaskFlow: false,
     deferredObserverEvents,
   });
   if (flow) {

--- a/src/tasks/task-registry-mutation.ts
+++ b/src/tasks/task-registry-mutation.ts
@@ -232,51 +232,6 @@ export function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskReco
   return cloneTaskRecord(next);
 }
 
-/** Publishes a record already committed by a cross-owner shared-state transaction. */
-export function publishTaskRecordAfterAtomicStore(
-  record: TaskRecord,
-  options?: { syncTaskFlow?: boolean; deferredObserverEvents?: Array<() => void> },
-): TaskRecord {
-  const next = normalizeTaskTimestamps(cloneTaskRecord(record));
-  const current = tasks.get(next.taskId);
-  const becomesTerminal =
-    current !== undefined &&
-    !isTerminalTaskStatus(current.status) &&
-    isTerminalTaskStatus(next.status);
-  if (becomesTerminal) {
-    flushTaskActivity(next.taskId);
-  }
-  if (current) {
-    deleteOwnerKeyIndex(next.taskId, current);
-    deleteParentFlowIdIndex(next.taskId, current);
-    deleteRelatedSessionKeyIndex(next.taskId, current);
-  }
-  tasks.set(next.taskId, next);
-  bumpTaskRegistryRevision();
-  if (becomesTerminal) {
-    clearTaskActivity(next.taskId);
-  }
-  addOwnerKeyIndex(next.taskId, next);
-  addParentFlowIdIndex(next.taskId, next);
-  addRelatedSessionKeyIndex(next.taskId, next);
-  rebuildRunIdIndex();
-  if (options?.syncTaskFlow !== false) {
-    syncFlowFromTaskAfterTaskMutation(next, "atomic completion admission");
-  }
-  const emit = () =>
-    emitTaskRegistryObserverEvent(() => ({
-      kind: "upserted",
-      task: cloneTaskRecordForObserver(next),
-      ...(current ? { previous: cloneTaskRecordForObserver(current) } : {}),
-    }));
-  if (options?.deferredObserverEvents) {
-    options.deferredObserverEvents.push(emit);
-  } else {
-    emit();
-  }
-  return cloneTaskRecord(next);
-}
-
 export function upsertTaskDeliveryState(state: TaskDeliveryState): TaskDeliveryState {
   const current = taskDeliveryStates.get(state.taskId);
   const next: TaskDeliveryState = {

--- a/src/tasks/task-registry-publication.ts
+++ b/src/tasks/task-registry-publication.ts
@@ -1,0 +1,62 @@
+import { isTerminalTaskStatus } from "./task-executor-policy.js";
+import { clearTaskActivity, flushTaskActivity } from "./task-registry-activity.js";
+import {
+  cloneTaskRecord,
+  cloneTaskRecordForObserver,
+  normalizeTaskTimestamps,
+} from "./task-registry-records.js";
+import {
+  addOwnerKeyIndex,
+  addParentFlowIdIndex,
+  addRelatedSessionKeyIndex,
+  bumpTaskRegistryRevision,
+  deleteOwnerKeyIndex,
+  deleteParentFlowIdIndex,
+  deleteRelatedSessionKeyIndex,
+  emitTaskRegistryObserverEvent,
+  rebuildRunIdIndex,
+  tasks,
+} from "./task-registry-state.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+/** Publishes a record already committed by a cross-owner shared-state transaction. */
+export function publishTaskRecordAfterAtomicStore(
+  record: TaskRecord,
+  options?: { deferredObserverEvents?: Array<() => void> },
+): TaskRecord {
+  const next = normalizeTaskTimestamps(cloneTaskRecord(record));
+  const current = tasks.get(next.taskId);
+  const becomesTerminal =
+    current !== undefined &&
+    !isTerminalTaskStatus(current.status) &&
+    isTerminalTaskStatus(next.status);
+  if (becomesTerminal) {
+    flushTaskActivity(next.taskId);
+  }
+  if (current) {
+    deleteOwnerKeyIndex(next.taskId, current);
+    deleteParentFlowIdIndex(next.taskId, current);
+    deleteRelatedSessionKeyIndex(next.taskId, current);
+  }
+  tasks.set(next.taskId, next);
+  bumpTaskRegistryRevision();
+  if (becomesTerminal) {
+    clearTaskActivity(next.taskId);
+  }
+  addOwnerKeyIndex(next.taskId, next);
+  addParentFlowIdIndex(next.taskId, next);
+  addRelatedSessionKeyIndex(next.taskId, next);
+  rebuildRunIdIndex();
+  const emit = () =>
+    emitTaskRegistryObserverEvent(() => ({
+      kind: "upserted",
+      task: cloneTaskRecordForObserver(next),
+      ...(current ? { previous: cloneTaskRecordForObserver(current) } : {}),
+    }));
+  if (options?.deferredObserverEvents) {
+    options.deferredObserverEvents.push(emit);
+  } else {
+    emit();
+  }
+  return cloneTaskRecord(next);
+}

--- a/src/tasks/task-registry-session-index.test.ts
+++ b/src/tasks/task-registry-session-index.test.ts
@@ -4,7 +4,8 @@ import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createNextAcpTaskBackingDetail } from "./task-backing-authority.js";
 import { createAcpTaskBackingDetailForTest } from "./task-backing-authority.test-support.js";
 import { createTaskFlowForTask } from "./task-flow-registry.js";
-import { publishTaskRecordAfterAtomicStore, updateTask } from "./task-registry-mutation.js";
+import { updateTask } from "./task-registry-mutation.js";
+import { publishTaskRecordAfterAtomicStore } from "./task-registry-publication.js";
 import {
   deleteTaskRecordById,
   hasActiveTaskForChildSessionKey,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -39,7 +39,7 @@ export {
   listTasksForRelatedSessionKey,
   resolveTaskForLookupToken,
 } from "./task-registry-query.js";
-export { publishTaskRecordAfterAtomicStore } from "./task-registry-mutation.js";
+export { publishTaskRecordAfterAtomicStore } from "./task-registry-publication.js";
 export { ensureTaskRegistryReady, reloadTaskRegistryFromStore } from "./task-registry-state.js";
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Committed task publication also initiated flow persistence unless callers supplied a suppression option. That hidden write makes the publication boundary unsuitable for the ongoing asynchronous storage conversion and obscures which owner controls persistence.

## Why This Change Was Made

Move committed task mirror/index/observer publication into its own owner. Completion now explicitly preserves the existing sequence: publish the task mirror, synchronize its flow with the existing failure/retry behavior, then emit task observers. Atomic replacement publishes its already-committed flow directly and no longer needs the suppression option. SQLite transaction boundaries and runtime behavior are unchanged.

This is a prerequisite for #144592; task/flow storage and SDK APIs are not yet fully asynchronous.

## User Impact

No user-visible behavior or persisted-format change. Storage ownership is explicit, allowing later async orchestration to keep database work outside synchronous post-commit publication callbacks.

## Evidence

- All 87 focused native-store tests passed before and after; full `check:changed` passed.
- Independent Codex review through P2 found no actionable issues.
- A standalone synthetic SQLite smoke exercised real task creation, atomic subagent replacement, correlated completion admission, deferred task publication, and fresh-process restore. Observers saw matching durable and memory state; pure publication did not rewrite the flow (revision stayed 3). No model or channel service was used.
- The native smoke writer/reopen processes completed in 6.20/4.06 seconds including imports; these are proof timings, not a performance comparison.
