### PR TITLE
refactor(agents): start GitHub reads within caller authority

### DIFF
--- a/src/agents/github-read-identity.test.ts
+++ b/src/agents/github-read-identity.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveExecutablePath } from "../infra/executable-path.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 
 const mocks = vi.hoisted(() => ({ runCommandBuffered: vi.fn() }));
@@ -295,6 +296,119 @@ describe("prepared GitHub read authority", () => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
   });
+
+  it.each(["refresh", "credential", "probe", "delivery"] as const)(
+    "awaits caller authority before %s during identity preparation",
+    async (stage) => {
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      let phase = "refresh";
+      let allowed = true;
+      const refresh = vi.fn(async () => {
+        phase = "credential";
+      });
+      mocks.runCommandBuffered.mockImplementation(async () => {
+        phase = "probe";
+        return commandResult(`native-authority-${stage}`);
+      });
+      vi.mocked(fetch).mockImplementation(async () => {
+        phase = "delivery";
+        return new Response(JSON.stringify({ id: 101, login: "native-user", avatar_url: null }));
+      });
+      const options = {
+        config: {},
+        agentId: "main",
+        env: {},
+        getCurrentConfig: () => ({}),
+        assertActive: () => {},
+        revalidateActive: async () => {
+          if (phase === stage) {
+            entered.resolve();
+            await release.promise;
+          }
+          if (!allowed) {
+            throw new Error("grant revoked");
+          }
+        },
+        refresh,
+      };
+      const preparing = prepareGitHubReadIdentity(options);
+      const outcome = preparing.then(
+        () => "delivered",
+        () => "refused",
+      );
+      try {
+        expect(await Promise.race([entered.promise.then(() => "checking"), outcome])).toBe(
+          "checking",
+        );
+        expect(refresh).toHaveBeenCalledTimes(stage === "refresh" ? 0 : 1);
+        expect(mocks.runCommandBuffered).toHaveBeenCalledTimes(
+          stage === "refresh" || stage === "credential" ? 0 : 1,
+        );
+        expect(fetch).toHaveBeenCalledTimes(stage === "delivery" ? 1 : 0);
+        allowed = false;
+        release.resolve();
+        await expect(preparing).rejects.toThrow("grant revoked");
+      } finally {
+        release.resolve();
+        await outcome;
+      }
+    },
+  );
+
+  it.each(["before", "after"] as const)(
+    "rechecks live selection after delayed caller authority %s a retained credential read",
+    async (stage) => {
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      let phase = "preparing";
+      let active = true;
+      const config = {};
+      mocks.runCommandBuffered.mockImplementation(async () => {
+        if (phase === "before") {
+          phase = "after";
+        }
+        return commandResult(`native-retained-${stage}`);
+      });
+      const identity = await prepareGitHubReadIdentity({
+        config,
+        agentId: "main",
+        env: {},
+        getCurrentConfig: () => config,
+        assertActive: () => {
+          if (!active) {
+            throw new Error("caller closed");
+          }
+        },
+        revalidateActive: async () => {
+          if (phase === stage) {
+            entered.resolve();
+            await release.promise;
+          }
+        },
+        refresh: async () => {},
+      });
+      mocks.runCommandBuffered.mockClear();
+      phase = "before";
+      const checking = identity.revalidate();
+      const outcome = checking.then(
+        () => "delivered",
+        () => "refused",
+      );
+      try {
+        expect(await Promise.race([entered.promise.then(() => "checking"), outcome])).toBe(
+          "checking",
+        );
+        expect(mocks.runCommandBuffered).toHaveBeenCalledTimes(stage === "before" ? 0 : 1);
+        active = false;
+        release.resolve();
+        await expect(checking).rejects.toThrow("caller closed");
+      } finally {
+        release.resolve();
+        await outcome;
+      }
+    },
+  );
 
   it("refreshes before read credential verification and fences native rotation without changing publication snapshots", async () => {
     const config = { gateway: { controlUi: { github: { token: "resolved-preview-token" } } } };

--- a/src/agents/github-read-identity.test.ts
+++ b/src/agents/github-read-identity.test.ts
@@ -5,6 +5,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveExecutablePath } from "../infra/executable-path.js";
 import { createDeferredCore } from "../shared/deferred.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 
 const mocks = vi.hoisted(() => ({ runCommandBuffered: vi.fn() }));
@@ -321,7 +322,7 @@ describe("prepared GitHub read authority", () => {
         env: {},
         getCurrentConfig: () => ({}),
         assertActive: () => {},
-        revalidateActive: async () => {
+        startActive: async <T>(start: () => T): Promise<Awaited<T>> => {
           if (phase === stage) {
             entered.resolve();
             await release.promise;
@@ -329,6 +330,7 @@ describe("prepared GitHub read authority", () => {
           if (!allowed) {
             throw new Error("grant revoked");
           }
+          return await start();
         },
         refresh,
       };
@@ -380,11 +382,12 @@ describe("prepared GitHub read authority", () => {
             throw new Error("caller closed");
           }
         },
-        revalidateActive: async () => {
+        startActive: async <T>(start: () => T): Promise<Awaited<T>> => {
           if (phase === stage) {
             entered.resolve();
             await release.promise;
           }
+          return await start();
         },
         refresh: async () => {},
       });
@@ -409,6 +412,96 @@ describe("prepared GitHub read authority", () => {
       }
     },
   );
+
+  it("starts credential and network operations inside current caller admission", async () => {
+    let admitted = false;
+    const assertAdmitted = () => expect(admitted).toBe(true);
+    mocks.runCommandBuffered.mockImplementation(async () => {
+      assertAdmitted();
+      return commandResult("native-admitted-start");
+    });
+    vi.mocked(fetch).mockImplementation(async () => {
+      assertAdmitted();
+      return new Response(JSON.stringify({ id: 101, login: "native-user", avatar_url: null }));
+    });
+    const identity = await prepareGitHubReadIdentity({
+      config: {},
+      agentId: "main",
+      env: {},
+      getCurrentConfig: () => ({}),
+      assertActive: () => {},
+      startActive: async <T>(start: () => T): Promise<Awaited<T>> => {
+        await Promise.resolve();
+        admitted = true;
+        let result: T;
+        try {
+          result = start();
+        } finally {
+          admitted = false;
+        }
+        return await result;
+      },
+      refresh: async () => assertAdmitted(),
+    });
+    await identity.start(() => {
+      assertAdmitted();
+      return "read result";
+    });
+    expect(admitted).toBe(false);
+  });
+
+  it("releases admission during shared transport and authorizes each caller's final delivery", async () => {
+    const transport = createDeferredCore<string>();
+    const pending = new Map<string, Promise<string>>();
+    const fetchShared = vi.fn(() => transport.promise);
+    const caller = () => {
+      const state = { active: true, admitted: false };
+      const identity = createGitHubReadIdentity({
+        token: "synthetic-shared-token",
+        selection: { source: "system-detected", accountId: 101 },
+        assertSelected: () => {},
+        readToken: async () => "synthetic-shared-token",
+        startActive: async <T>(start: () => T): Promise<Awaited<T>> => {
+          await Promise.resolve();
+          if (!state.active) {
+            throw new Error("grant revoked");
+          }
+          state.admitted = true;
+          let result: T;
+          try {
+            result = start();
+          } finally {
+            state.admitted = false;
+          }
+          return await result;
+        },
+      });
+      const started = createDeferredCore();
+      const result = identity.start(() => {
+        expect(state.admitted).toBe(true);
+        started.resolve();
+        return getOrCreatePromise(pending, identity.cacheScope, fetchShared);
+      });
+      return { state, identity, started, result };
+    };
+    const leader = caller();
+    const follower = caller();
+    await Promise.all([leader.started.promise, follower.started.promise]);
+    expect(leader.state.admitted || follower.state.admitted).toBe(false);
+    expect(fetchShared).toHaveBeenCalledOnce();
+    leader.state.active = false;
+    transport.resolve("shared result");
+    const [leaderResult, followerResult] = await Promise.all([leader.result, follower.result]);
+    const publish = vi.fn((value: string) => value);
+    await expect(leader.identity.start(() => publish(leaderResult))).rejects.toThrow(
+      "grant revoked",
+    );
+    expect(publish).not.toHaveBeenCalled();
+    await expect(follower.identity.start(() => publish(followerResult))).resolves.toBe(
+      "shared result",
+    );
+    expect(publish).toHaveBeenCalledOnce();
+  });
 
   it("refreshes before read credential verification and fences native rotation without changing publication snapshots", async () => {
     const config = { gateway: { controlUi: { github: { token: "resolved-preview-token" } } } };

--- a/src/agents/github-read-identity.ts
+++ b/src/agents/github-read-identity.ts
@@ -168,6 +168,7 @@ export type GitHubIdentityPreparation = {
 export type GitHubReadIdentityPreparation = GitHubIdentityPreparation & {
   getCurrentConfig: () => OpenClawConfig;
   assertActive: () => void;
+  revalidateActive?: () => Promise<void>;
   refresh: () => Promise<void>;
 };
 
@@ -206,13 +207,14 @@ export type PreparedGitHubSourceReadIdentity =
 export function createGitHubReadIdentity(
   params: {
     assertSelected: () => void;
+    revalidateActive?: () => Promise<void>;
     readToken: () => Promise<string | undefined>;
   } & (
     | { token: string; selection: GitHubReadIdentitySelection }
     | { token: undefined; selection: Readonly<{ source: "anonymous" }> }
   ),
 ): PreparedGitHubSourceReadIdentity {
-  const { token, selection, assertSelected, readToken } = params;
+  const { token, selection, assertSelected, revalidateActive, readToken } = params;
   const authority: GitHubReadAuthority = {
     cacheScope:
       selection.source === "anonymous"
@@ -225,8 +227,16 @@ export function createGitHubReadIdentity(
     assertSelected,
     revalidate: async () => {
       assertSelected();
+      if (revalidateActive) {
+        await revalidateActive();
+        assertSelected();
+      }
       const current = await readToken();
       assertSelected();
+      if (revalidateActive) {
+        await revalidateActive();
+        assertSelected();
+      }
       if (current !== token) {
         throw new GitHubIdentityError("changed");
       }

--- a/src/agents/github-read-identity.ts
+++ b/src/agents/github-read-identity.ts
@@ -165,12 +165,29 @@ export type GitHubIdentityPreparation = {
   agentId: string;
   env?: NodeJS.ProcessEnv;
 };
+/** Release admission after starting the operation, before its asynchronous result settles. */
+export type GitHubReadIdentityStarter = <T>(start: () => T) => Promise<Awaited<T>>;
+
 export type GitHubReadIdentityPreparation = GitHubIdentityPreparation & {
   getCurrentConfig: () => OpenClawConfig;
   assertActive: () => void;
-  revalidateActive?: () => Promise<void>;
+  startActive?: GitHubReadIdentityStarter;
   refresh: () => Promise<void>;
 };
+
+/** The caller's owner admits the operation; selection is checked inside that admission. */
+export function startGitHubIdentityOperation<T>(
+  operation: () => T,
+  authority: { assertCurrent?: () => void; startCurrent?: GitHubReadIdentityStarter },
+): T | Promise<Awaited<T>> {
+  authority.assertCurrent?.();
+  return authority.startCurrent
+    ? authority.startCurrent(() => {
+        authority.assertCurrent?.();
+        return operation();
+      })
+    : operation();
+}
 
 export class GitHubIdentityError extends Error {
   constructor(readonly reason: "unavailable" | "changed" | "rate_limited" | "unverified") {
@@ -195,6 +212,7 @@ type GitHubReadAuthority = {
   cacheScope: string;
   assertSelected: () => void;
   revalidate: () => Promise<void>;
+  start: GitHubReadIdentityStarter;
 };
 export type PreparedGitHubReadIdentity = GitHubReadAuthority & {
   token: string;
@@ -207,14 +225,24 @@ export type PreparedGitHubSourceReadIdentity =
 export function createGitHubReadIdentity(
   params: {
     assertSelected: () => void;
-    revalidateActive?: () => Promise<void>;
+    startActive?: GitHubReadIdentityStarter;
     readToken: () => Promise<string | undefined>;
   } & (
     | { token: string; selection: GitHubReadIdentitySelection }
     | { token: undefined; selection: Readonly<{ source: "anonymous" }> }
   ),
 ): PreparedGitHubSourceReadIdentity {
-  const { token, selection, assertSelected, revalidateActive, readToken } = params;
+  const { token, selection, assertSelected, startActive, readToken } = params;
+  const caller = { assertCurrent: assertSelected, startCurrent: startActive };
+  const start = async <T>(operation: () => T): Promise<Awaited<T>> => {
+    const current = await startGitHubIdentityOperation(readToken, caller);
+    return await startGitHubIdentityOperation(() => {
+      if (current !== token) {
+        throw new GitHubIdentityError("changed");
+      }
+      return operation();
+    }, caller);
+  };
   const authority: GitHubReadAuthority = {
     cacheScope:
       selection.source === "anonymous"
@@ -225,22 +253,8 @@ export function createGitHubReadIdentity(
             )
             .digest("hex"),
     assertSelected,
-    revalidate: async () => {
-      assertSelected();
-      if (revalidateActive) {
-        await revalidateActive();
-        assertSelected();
-      }
-      const current = await readToken();
-      assertSelected();
-      if (revalidateActive) {
-        await revalidateActive();
-        assertSelected();
-      }
-      if (current !== token) {
-        throw new GitHubIdentityError("changed");
-      }
-    },
+    revalidate: () => start(() => undefined),
+    start,
   };
   // Durable selection excludes credentials; the in-process result cache still
   // separates rotations, and later native sign-in closes anonymous authority.

--- a/src/agents/github-tool-identity.ts
+++ b/src/agents/github-tool-identity.ts
@@ -26,8 +26,10 @@ import {
   normalizeGitHubToken as normalizeManagedGitHubToken,
   readNativeGitHubToken,
   runGitHubIdentityCommand as runIdentityCommand,
+  startGitHubIdentityOperation,
   type GitHubIdentityPreparation,
   type GitHubReadIdentityPreparation,
+  type GitHubReadIdentityStarter,
   type PreparedGitHubReadIdentity,
   type PreparedGitHubSourceReadIdentity,
 } from "./github-read-identity.js";
@@ -493,7 +495,7 @@ export function matchesPreparedGitHubPublicationIdentity(params: {
 async function prepareSharedGitHubIdentity(
   params: GitHubIdentityPreparation & {
     assertCurrent?: () => void;
-    revalidateCurrent?: () => Promise<void>;
+    startCurrent?: GitHubReadIdentityStarter;
     allowAnonymous?: boolean;
   },
 ) {
@@ -508,41 +510,30 @@ async function prepareSharedGitHubIdentity(
     managed
       ? readManagedGitHubToken(identity.profileDir)
       : readNativeGitHubToken(currentEnvironment(), params.allowAnonymous === true);
-  params.assertCurrent?.();
-  if (params.revalidateCurrent) {
-    await params.revalidateCurrent();
-    params.assertCurrent?.();
-  }
-  const token = await readToken();
-  params.assertCurrent?.();
-  if (params.revalidateCurrent) {
-    await params.revalidateCurrent();
-    params.assertCurrent?.();
-  }
+  const token = await startGitHubIdentityOperation(readToken, params);
   if (!token) {
-    if (!managed && params.allowAnonymous) {
-      return { prepared: undefined, token: undefined, readToken };
+    return startGitHubIdentityOperation(() => {
+      if (!managed && params.allowAnonymous) {
+        return { prepared: undefined, token: undefined, readToken };
+      }
+      throw new GitHubIdentityError("unavailable");
+    }, params);
+  }
+  const probe = await startGitHubIdentityOperation(() => verifyGitHubCredential(token), params);
+  return startGitHubIdentityOperation(() => {
+    if (probe.status !== "available") {
+      throw new GitHubIdentityError(probe.status);
     }
-    throw new GitHubIdentityError("unavailable");
-  }
-  const probe = await verifyGitHubCredential(token);
-  params.assertCurrent?.();
-  if (params.revalidateCurrent) {
-    await params.revalidateCurrent();
-    params.assertCurrent?.();
-  }
-  if (probe.status !== "available") {
-    throw new GitHubIdentityError(probe.status);
-  }
-  const prepared: PreparedGitHubPublicationIdentity = Object.freeze({
-    source: identity.source,
-    ...(managed ? { profileId: identity.config.profileId } : {}),
-    account: probe.account,
-    // Broker children and worker launches receive this fixed snapshot. Profile
-    // retirement cannot redirect an already-admitted operation.
-    env: Object.freeze({ ...env, GH_TOKEN: token, GITHUB_TOKEN: undefined }),
-  });
-  return { prepared, token, readToken };
+    const prepared: PreparedGitHubPublicationIdentity = Object.freeze({
+      source: identity.source,
+      ...(managed ? { profileId: identity.config.profileId } : {}),
+      account: probe.account,
+      // Broker children and worker launches receive this fixed snapshot. Profile
+      // retirement cannot redirect an already-admitted operation.
+      env: Object.freeze({ ...env, GH_TOKEN: token, GITHUB_TOKEN: undefined }),
+    });
+    return { prepared, token, readToken };
+  }, params);
 }
 
 /** Publication owns a fixed credential snapshot for its already-admitted operation. */
@@ -580,22 +571,17 @@ export async function prepareGitHubReadIdentity(
       throw new GitHubIdentityError("changed");
     }
   };
-  assertSelected();
-  if (params.revalidateActive) {
-    await params.revalidateActive();
-    assertSelected();
-  }
-  await params.refresh();
+  const caller = { assertCurrent: assertSelected, startCurrent: params.startActive };
+  await startGitHubIdentityOperation(params.refresh, caller);
   assertSelected();
   const { token, readToken, prepared } = await prepareSharedGitHubIdentity({
     ...params,
-    assertCurrent: assertSelected,
-    revalidateCurrent: params.revalidateActive,
+    ...caller,
   });
   assertSelected();
   return createGitHubReadIdentity({
     assertSelected,
-    revalidateActive: params.revalidateActive,
+    startActive: params.startActive,
     readToken,
     ...(!prepared || token === undefined
       ? { token: undefined, selection: { source: "anonymous" as const } }

--- a/src/agents/github-tool-identity.ts
+++ b/src/agents/github-tool-identity.ts
@@ -493,6 +493,7 @@ export function matchesPreparedGitHubPublicationIdentity(params: {
 async function prepareSharedGitHubIdentity(
   params: GitHubIdentityPreparation & {
     assertCurrent?: () => void;
+    revalidateCurrent?: () => Promise<void>;
     allowAnonymous?: boolean;
   },
 ) {
@@ -508,8 +509,16 @@ async function prepareSharedGitHubIdentity(
       ? readManagedGitHubToken(identity.profileDir)
       : readNativeGitHubToken(currentEnvironment(), params.allowAnonymous === true);
   params.assertCurrent?.();
+  if (params.revalidateCurrent) {
+    await params.revalidateCurrent();
+    params.assertCurrent?.();
+  }
   const token = await readToken();
   params.assertCurrent?.();
+  if (params.revalidateCurrent) {
+    await params.revalidateCurrent();
+    params.assertCurrent?.();
+  }
   if (!token) {
     if (!managed && params.allowAnonymous) {
       return { prepared: undefined, token: undefined, readToken };
@@ -518,6 +527,10 @@ async function prepareSharedGitHubIdentity(
   }
   const probe = await verifyGitHubCredential(token);
   params.assertCurrent?.();
+  if (params.revalidateCurrent) {
+    await params.revalidateCurrent();
+    params.assertCurrent?.();
+  }
   if (probe.status !== "available") {
     throw new GitHubIdentityError(probe.status);
   }
@@ -568,15 +581,21 @@ export async function prepareGitHubReadIdentity(
     }
   };
   assertSelected();
+  if (params.revalidateActive) {
+    await params.revalidateActive();
+    assertSelected();
+  }
   await params.refresh();
   assertSelected();
   const { token, readToken, prepared } = await prepareSharedGitHubIdentity({
     ...params,
     assertCurrent: assertSelected,
+    revalidateCurrent: params.revalidateActive,
   });
   assertSelected();
   return createGitHubReadIdentity({
     assertSelected,
+    revalidateActive: params.revalidateActive,
     readToken,
     ...(!prepared || token === undefined
       ? { token: undefined, selection: { source: "anonymous" as const } }

--- a/src/gateway/control-ui-github-preview.test.ts
+++ b/src/gateway/control-ui-github-preview.test.ts
@@ -62,6 +62,10 @@ function managedIdentity(cacheScope: string, assertSelected: () => void = vi.fn(
     cacheScope,
     assertSelected,
     revalidate: vi.fn(async () => assertSelected()),
+    start: async <T>(start: () => T): Promise<Awaited<T>> => {
+      assertSelected();
+      return await start();
+    },
   };
 }
 

--- a/src/gateway/server-methods/control-ui.test.ts
+++ b/src/gateway/server-methods/control-ui.test.ts
@@ -49,6 +49,7 @@ describe("controlUi.githubPreview", () => {
   it("uses the selected agent's Settings identity for public metadata", async () => {
     vi.stubEnv("GH_TOKEN", "");
     vi.stubEnv("GITHUB_TOKEN", "");
+    const assertSelected = vi.fn();
     const identity = {
       token: "selected-agent-github-token",
       selection: {
@@ -57,8 +58,12 @@ describe("controlUi.githubPreview", () => {
         accountId: 101,
       },
       cacheScope: "selected-agent-preview",
-      assertSelected: vi.fn(),
+      assertSelected,
       revalidate: vi.fn().mockResolvedValue(undefined),
+      start: async <T>(start: () => T): Promise<Awaited<T>> => {
+        assertSelected();
+        return await start();
+      },
     };
     const prepare = vi
       .spyOn(githubIdentity, "prepareGitHubReadIdentity")


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

GitHub reads backed by database permissions need to start credential and request work while the caller still owns the authorization that permitted it. Returning a checked value across an await leaves another handoff where that authority can retire.

## Why This Change Was Made

Introduce an optional caller-owned operation starter during GitHub read identity preparation and retained identity use. The caller validates its current authority and invokes the operation in the same continuation. Credential refresh, token reads, verification and prepared-result publication use that boundary; existing configuration and runtime selection checks remain at operation admission. Retained identities expose the same start operation and revalidation delegates to it.

This is the shared prerequisite for the asynchronous Board store conversion. Existing callers without the starter retain their current behavior. No database schema, credential selection or endpoint changes.

## User Impact

Database-backed permissions can become asynchronous while preserving the authority boundary around GitHub credential and request work.

## Evidence

- 160 focused and sibling tests passed, including credential admission, delayed authority, shared identity preparation and Gateway callers.
- Final identity fixture cleanup reran all 36 identity tests and lint successfully.
- Full selected changed checks passed.
- Fresh independent Codex review of the final full change found no actionable findings through P2.
- Real Board integration and isolated Gateway proof are tracked in the dependent Board conversion; this prerequisite uses focused boundary tests and does not claim a live external GitHub request.
