### PR TITLE
fix(ui): session New window/New tab always fails with "Allow pop-ups" in the macOS app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2855,6 +2855,7 @@ jobs:
             ui/src/e2e/model-picker-search.real-gateway.e2e.test.ts \
             ui/src/e2e/device-alias-rename.real-gateway.e2e.test.ts \
             ui/src/e2e/device-platform-family.real-gateway.e2e.test.ts \
+            ui/src/e2e/session-menu-native-bridge.real-gateway.e2e.test.ts \
             ui/src/e2e/session-progress-hovercard.real-gateway.e2e.test.ts \
             ui/src/e2e/worker-initial-setup.real-gateway.e2e.test.ts \
             extensions/qa-lab/src/control-ui-media-transcript.real-gateway.e2e.test.ts \

--- a/test/vitest-ui-e2e-config.test.ts
+++ b/test/vitest-ui-e2e-config.test.ts
@@ -126,6 +126,7 @@ const realGatewayFiles = [
   "model-api-keys.real-gateway",
   "model-picker-search.real-gateway",
   "profile-page.real-gateway",
+  "session-menu-native-bridge.real-gateway",
   "session-progress-hovercard.real-gateway",
   "usage-sessions-owner-attribution",
   "worker-initial-setup.real-gateway",
@@ -598,6 +599,13 @@ describe("Control UI E2E resource ownership", () => {
         },
         {
           file: "ui/src/e2e/profile-page.real-gateway.e2e.test.ts",
+          project: "ui-e2e-serial",
+          phase: 1,
+          workers: 1,
+          fileParallelism: false,
+        },
+        {
+          file: "ui/src/e2e/session-menu-native-bridge.real-gateway.e2e.test.ts",
           project: "ui-e2e-serial",
           phase: 1,
           workers: 1,

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -45,6 +45,7 @@ export const uiE2eRealGatewayTestFiles = [
   "ui/src/e2e/model-picker-search.real-gateway.e2e.test.ts",
   "ui/src/e2e/profile-page.real-gateway.e2e.test.ts",
   sessionHostCommandStateRealGatewayTest,
+  "ui/src/e2e/session-menu-native-bridge.real-gateway.e2e.test.ts",
   "ui/src/e2e/session-progress-hovercard.real-gateway.e2e.test.ts",
   "ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts",
   mediaTranscriptRealGatewayTest,

--- a/ui/src/e2e/session-menu-native-bridge.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/session-menu-native-bridge.real-gateway.e2e.test.ts
@@ -1,0 +1,205 @@
+import { readFile } from "node:fs/promises";
+import { expect, it } from "vitest";
+import { appendTranscriptMessage } from "../../../src/config/sessions/session-accessor.js";
+import { createOpenClawTestInstance } from "../../../test/helpers/openclaw-test-instance.ts";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { controlUiSessionUrl } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { openSessionMenuSubmenu } from "./session-management.test-support.ts";
+
+type NativeLinkPost = { type: string; url: string; target: string };
+
+declare global {
+  interface Window {
+    nativeLinkProof?: {
+      posts: NativeLinkPost[];
+      windowOpenCalls: string[];
+    };
+  }
+}
+
+const gatewayToken = "session-menu-native-bridge-proof";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI session menu native link bridge with a real Gateway",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed at ${executablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
+suite.define(() => {
+  it(
+    "hands session New window and New tab to the native link bridge instead of a popup",
+    { timeout: 300_000 },
+    async () => {
+      const owner = await createOpenClawTestInstance({
+        name: "session-menu-native-bridge",
+        gatewayToken,
+        config: { gateway: { controlUi: { enabled: false } } },
+      });
+      try {
+        const config = JSON.parse(await readFile(owner.configPath, "utf8")) as Record<
+          string,
+          unknown
+        >;
+        await owner.state.writeConfig({
+          ...config,
+          agents: {
+            defaults: {
+              workspace: owner.state.workspaceDir,
+              model: { primary: "openai/gpt-5.6-luna" },
+            },
+            entries: {
+              main: { identity: { name: "Bridge Proof" } },
+            },
+          },
+        });
+        await owner.startGateway();
+
+        const sessionKey = "agent:main:native-bridge-proof";
+        const label = "Native bridge proof";
+        const created = await owner.cli([
+          "gateway",
+          "call",
+          "sessions.create",
+          "--params",
+          JSON.stringify({ key: sessionKey, agentId: "main", label }),
+          "--json",
+        ]);
+        expect(created.code, created.stderr).toBe(0);
+        const session = JSON.parse(created.stdout) as { ok: boolean; sessionId: string };
+        expect(session.ok).toBe(true);
+        const reply = "The native link bridge opens this session route.";
+        await appendTranscriptMessage(
+          { agentId: "main", sessionKey, sessionId: session.sessionId, env: owner.env },
+          {
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: reply }],
+              timestamp: Date.now(),
+            },
+          },
+        );
+
+        const expectedSessionUrl = controlUiSessionUrl(suite.server.baseUrl, sessionKey, "chat");
+
+        await suite.withPage(
+          { locale: "en-US", viewport: { width: 1440, height: 900 }, serviceWorkers: "block" },
+          async ({ page }) => {
+            // Stand in for the WKWebView host contract the macOS shell installs
+            // before any page script runs: record openclawLink posts and observe
+            // window.open reservations. Like the native receiver, the stub does
+            // not open anything inside this browser; the posted destination is
+            // verified below in an isolated context, the way an external default
+            // browser receives the NSWorkspace.open handoff.
+            await page.addInitScript(() => {
+              const posts: Array<{ type: string; url: string; target: string }> = [];
+              const windowOpenCalls: string[] = [];
+              const open = window.open.bind(window);
+              Object.defineProperty(window, "nativeLinkProof", {
+                value: { posts, windowOpenCalls },
+                configurable: true,
+              });
+              window.open = (...args: Parameters<typeof open>) => {
+                windowOpenCalls.push(String(args[0] ?? ""));
+                return open(...args);
+              };
+              Object.defineProperty(window, "webkit", {
+                value: {
+                  messageHandlers: {
+                    openclawLink: {
+                      postMessage(message: { type: string; url: string; target: string }) {
+                        posts.push(message);
+                      },
+                    },
+                  },
+                },
+                configurable: true,
+              });
+            });
+            const url = new URL(expectedSessionUrl);
+            url.searchParams.set("gatewayUrl", `ws://127.0.0.1:${owner.port}`);
+            url.hash = `token=${encodeURIComponent(gatewayToken)}`;
+            expect((await page.goto(url.toString()))?.status()).toBe(200);
+            const confirmation = page.locator("openclaw-gateway-url-confirmation");
+            await confirmation.waitFor({ timeout: 15_000 });
+            await confirmation
+              .getByRole("button", { name: `Switch to 127.0.0.1:${owner.port}`, exact: true })
+              .click();
+            await waitForControlUiGatewayReady(page);
+            await page.getByText(reply, { exact: true }).waitFor();
+
+            const activePane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+            const menuTrigger = activePane.getByRole("button", { name: `Actions for ${label}` });
+            await expect.poll(() => menuTrigger.getAttribute("aria-expanded")).toBe("false");
+
+            const nativePosts = () => page.evaluate(() => window.nativeLinkProof?.posts ?? []);
+            const windowOpenCalls = () =>
+              page.evaluate(() => window.nativeLinkProof?.windowOpenCalls ?? []);
+
+            const expectedPost = { type: "open-link", url: expectedSessionUrl, target: "external" };
+
+            for (const action of ["New window", "New tab"] as const) {
+              await menuTrigger.click();
+              await openSessionMenuSubmenu(page, "Open in");
+              await page.getByRole("menuitem", { name: action, exact: true }).click();
+
+              // The action posts the final session URL to the native bridge...
+              await expect
+                .poll(async () => (await nativePosts()).at(-1), { timeout: 10_000 })
+                .toEqual(expectedPost);
+              // ...without reserving an about:blank popup or showing the
+              // blocked-popup toast that a WKWebView host cannot satisfy.
+              expect(await windowOpenCalls()).toEqual([]);
+              expect(
+                await page.getByText("Allow pop-ups for this site, then try again.").count(),
+              ).toBe(0);
+            }
+            // Both actions handed the same session destination to the bridge.
+            const posts = await nativePosts();
+            expect(posts).toEqual([expectedPost, expectedPost]);
+
+            // Verify the handoff destination the way an external default browser
+            // receives it after NSWorkspace.open: load the exact posted URL in a
+            // fresh isolated browser context that shares no cookies, storage, or
+            // page state with the source page, and confirm the intended session
+            // route renders there. The gatewayUrl/token parameters stand in for
+            // the default browser already being signed in to this gateway.
+            const postedUrl = posts.at(-1)!.url;
+            const externalContext = await suite.newBrowserContext({
+              locale: "en-US",
+              viewport: { width: 1440, height: 900 },
+              serviceWorkers: "block",
+            });
+            try {
+              const externalPage = await externalContext.newPage();
+              const externalUrl = new URL(postedUrl);
+              externalUrl.searchParams.set("gatewayUrl", `ws://127.0.0.1:${owner.port}`);
+              externalUrl.hash = `token=${encodeURIComponent(gatewayToken)}`;
+              expect((await externalPage.goto(externalUrl.toString()))?.status()).toBe(200);
+              const externalConfirmation = externalPage.locator(
+                "openclaw-gateway-url-confirmation",
+              );
+              await externalConfirmation.waitFor({ timeout: 15_000 });
+              await externalConfirmation
+                .getByRole("button", { name: `Switch to 127.0.0.1:${owner.port}`, exact: true })
+                .click();
+              await waitForControlUiGatewayReady(externalPage);
+              const expectedDestination = new URL(postedUrl).pathname + new URL(postedUrl).search;
+              await expect
+                .poll(
+                  () => new URL(externalPage.url()).pathname + new URL(externalPage.url()).search,
+                )
+                .toBe(expectedDestination);
+              await externalPage.getByText(reply, { exact: true }).waitFor({ timeout: 15_000 });
+            } finally {
+              await suite.closeBrowserContext(externalContext);
+            }
+          },
+        );
+      } finally {
+        await owner.cleanup();
+      }
+    },
+  );
+});

--- a/ui/src/lib/sessions/session-menu-navigation.test.ts
+++ b/ui/src/lib/sessions/session-menu-navigation.test.ts
@@ -58,6 +58,7 @@ afterEach(() => {
   document.body.replaceChildren();
   vi.restoreAllMocks();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("session menu navigation actions", () => {
@@ -151,6 +152,49 @@ describe("session menu navigation actions", () => {
     vi.spyOn(window, "open").mockReturnValue(null);
     await runSessionNavigationAction("open-new-window", fixture().params);
     expect(showToast).toHaveBeenCalledWith({ message: t("sessionsView.openWindowBlocked") });
+  });
+
+  it.each(["open-new-tab", "open-new-window"] as const)(
+    "hands %s to the native shell link bridge instead of a blocked popup",
+    async (kind) => {
+      const postMessage = vi.fn();
+      vi.stubGlobal("webkit", {
+        messageHandlers: { openclawLink: { postMessage } },
+      });
+      const open = vi.spyOn(window, "open");
+      const { params } = fixture();
+      Object.assign(params.context.gateway.snapshot.hello!, {
+        controlUiUrl: "https://gateway.example.test/remote",
+      });
+      await runSessionNavigationAction(kind, params);
+      expect(postMessage).toHaveBeenCalledWith({
+        type: "open-link",
+        url: `${window.location.origin}/control/dashboard/research/dashboard/12345678-90ab-cdef-1234-567890abcdef`,
+        target: "external",
+      });
+      expect(open).not.toHaveBeenCalled();
+      expect(showToast).not.toHaveBeenCalled();
+    },
+  );
+
+  it("falls back to the browser popup when the native link bridge rejects the post", async () => {
+    vi.stubGlobal("webkit", {
+      messageHandlers: {
+        openclawLink: {
+          postMessage: vi.fn(() => {
+            throw new Error("bridge unavailable");
+          }),
+        },
+      },
+    });
+    const opened = { opener: window, location: { replace: vi.fn() } };
+    const open = vi.spyOn(window, "open").mockReturnValue(opened as unknown as Window);
+    await runSessionNavigationAction("open-new-window", fixture().params);
+    expect(open).toHaveBeenCalledWith("about:blank", "_blank", "popup");
+    expect(opened.location.replace).toHaveBeenCalledWith(
+      `${window.location.origin}/control/dashboard/research/dashboard/12345678-90ab-cdef-1234-567890abcdef`,
+    );
+    expect(showToast).not.toHaveBeenCalled();
   });
 
   it("copies every history page chronologically without duplicating replayed records", async () => {

--- a/ui/src/lib/sessions/session-menu-navigation.ts
+++ b/ui/src/lib/sessions/session-menu-navigation.ts
@@ -2,6 +2,7 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import { normalizeBasePath } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
+import { postNativeExternalLink } from "../../app/native-link-routing.ts";
 import { UI_COMMAND_EVENT } from "../../components/panel-toggle-contract.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatHistoryResult } from "../../pages/chat/chat-history-snapshot.ts";
@@ -208,6 +209,12 @@ export async function runSessionNavigationAction<TRouteId extends string>(
     if (copyLink) {
       const copied = await copyToClipboard(href);
       showToast({ message: t(copied ? "common.copied" : "common.copyFailed") });
+      return;
+    }
+    // The native macOS shell rejects synthetic about:blank popups before the
+    // deferred navigation can commit, so hand the final URL to its trusted
+    // link bridge instead; window.open below stays the browser fallback.
+    if (postNativeExternalLink(href)) {
       return;
     }
     // Reserve an inert page so popup blocking remains observable, and detach


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #144582

## What Problem This Solves

Fixes an issue where users of the native macOS app choosing "New window" or "New tab" from the Control UI session tab menu would always see the toast "Allow pop-ups for this site, then try again." There is no way to allow pop-ups for the embedded WKWebView, so both actions were dead ends (the same actions work in a regular browser).

- **Related:** #144582 (labels: clawsweeper:queueable-fix, clawsweeper:fix-shape-clear, clawsweeper:source-repro).

## Why This Change Was Made

The web side reserves an inert `about:blank` popup via `window.open` and later redirects it to the session route. The macOS shell's `createWebViewWith` delegate classifies the `about:blank` request as ignorable and returns nil, so `window.open` returns null and the UI reports a blocked popup. The fix hands the final session URL to the existing native `openclawLink` bridge (already used by the Browser panel's external open) whenever that bridge is present, and keeps the previous `window.open` reservation as the browser fallback.

- **Intended outcome:** inside the macOS app, New window / New tab from the session menu hand the final session URL to the native link bridge instead of failing; no popup-blocked toast.
- **Out of scope:** creating a native dashboard window/tab for the session (the shell has no such API today); browser popup semantics are unchanged.
- **Highest-risk area:** routing the action through the native bridge could change behavior in setups where the bridge exists but an external open is undesirable.
- **How is that risk mitigated?** The native receiver already validates main-frame + trusted same-origin source before opening; without the bridge (regular browsers), or if the post throws, the previous flow including the blocked-popup toast is preserved and covered by tests.

## User Impact

macOS app users can open a session from the session menu's New window / New tab items again: the session route now opens through the native link handoff instead of failing with an impossible "Allow pop-ups" instruction. Regular browser behavior is unchanged.

- **Success criteria:** with the native link bridge present, both menu actions post the final same-origin session URL and never call `window.open`; without the bridge, the previous reservation + toast flow is kept.
- **What should reviewers focus on?** `ui/src/lib/sessions/session-menu-navigation.ts` (bridge handoff placed before the popup reservation); regression fixtures in `session-menu-navigation.test.ts` ("hands … to the native shell link bridge instead of a blocked popup", "falls back to the browser popup when the native link bridge rejects the post"); the real-Gateway E2E in `ui/src/e2e/session-menu-native-bridge.real-gateway.e2e.test.ts` (real Gateway + served Control UI + a page-level `openclawLink` bridge stand-in, covering both actions, plus the posted destination loaded in a **fresh isolated browser context** with no shared cookies/storage — the external-default-browser analog of the native handoff).

## Evidence

- **Real environment tested:** Linux, Node 26, Playwright Chromium, a real Gateway child process built from this branch (`createOpenClawTestInstance`), and the Control UI served from this branch's source. The page-level `window.webkit.messageHandlers.openclawLink` bridge is installed through a browser init script before any page script runs — the same surface the macOS dashboard shell installs — and, like the native receiver, it does not open anything inside the source browser. The posted destination URL is instead loaded in a **fresh isolated browser context** that shares no cookies, storage, or page state with the source page, mirroring how an external default browser receives the `NSWorkspace.open` handoff (addressing the ClawSweeper merge-risk item that a same-browser destination shares state with the source page). The macOS app itself is not runnable in this environment.
- **Exact steps or commands run after this patch:**
  ```bash
  node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-menu-native-bridge.real-gateway.e2e.test.ts
  node scripts/run-vitest.mjs run ui/src/lib/sessions/session-menu-navigation.test.ts ui/src/app/native-link-routing.test.ts
  pnpm exec oxfmt --check ui/src/e2e/session-menu-native-bridge.real-gateway.e2e.test.ts
  pnpm exec oxlint ui/src/e2e/session-menu-native-bridge.real-gateway.e2e.test.ts
  node scripts/run-tsgo.mts -b test/tsconfig/tsconfig.core.test.ui-e2e.json --builders 1
  ```
- **Evidence after fix:** real-Gateway E2E (`session-menu-native-bridge.real-gateway.e2e.test.ts`, head `8d40173`) output:
  ```text
  ✓ hands session New window and New tab to the native link bridge instead of a popup 22418ms
   Test Files  1 passed (1)
        Tests  1 passed (1)
  ```
  Both "New window" and "New tab" from the session menu post to the bridge:
  ```json
  [
    { "type": "open-link", "url": "http://127.0.0.1:<port>/chat/main/native-bridge-proof", "target": "external" },
    { "type": "open-link", "url": "http://127.0.0.1:<port>/chat/main/native-bridge-proof", "target": "external" }
  ]
  ```
  with zero `window.open` reservations from the menu code and no "Allow pop-ups" toast. The exact URL taken from the recorded bridge posts is then loaded in a freshly created isolated browser context (new `BrowserContext`, no shared cookies/storage with the source page): it resolves to the same session route, reaches gateway-ready, and renders the session's transcript message there — establishing that the handed-off URL grants session access with no state carried over from the source page.
- **Observed result after fix:** with the `openclawLink` bridge present, `open-new-window`/`open-new-tab` hand the final same-origin session URL to the bridge and never touch `window.open`; the blocked-popup toast no longer fires; the posted URL opens the intended session in an isolated default-browser-analog context. Without the bridge (regular browser), the previous reservation + fallback flow is preserved (covered by unit tests).
- **Before evidence:** with `session-menu-navigation.ts` restored to its pre-patch state (same worktree, patched E2E), the E2E fails — `AssertionError: expected undefined to deeply equal { type: 'open-link', …(2) }`, `Test Files 1 failed (1)` — the bridge never receives anything because every attempt goes through the `about:blank` popup reservation, matching the report (so the isolated-context destination step is never reached on unpatched code). At unit level the regression tests fail on main with `AssertionError: expected "vi.fn()" to be called … Number of calls: 0`.
- **What was not tested:** live macOS app / WKWebView runtime and the native Swift receiver (no macOS hardware in this environment); the native receiver path is unchanged and covered by existing native tests.
- **Proof tier:** L2 (real Gateway, real served Control UI, real browser; the WKWebView host bridge surface is installed at page level as the shell does, not mocked at module level; the handoff destination is verified in an isolated browser context rather than a state-sharing same-browser tab).
- **Proof limitations:** no macOS environment available; the WKWebView message-handler transport and the Swift-side `NSWorkspace.open` handoff would need a reporter/maintainer repro on macOS. The bridge contract asserted in the E2E matches the existing native `DashboardWindowController.receiveLinkMessage` validation (main frame, trusted same-origin source, http(s) URL). The isolated-context destination check removes the shared-browser-state gap but cannot exercise the macOS platform transport itself.
- **Review state:** Awaiting CI + maintainer review; CI lanes pending on the updated head. Note: `checks-ui-e2e-real-gateway` previously failed on `quota-reset-status.real-gateway.e2e.test.ts` ("expected 'Signed in' to be 'Ready'") — a main-level failure unrelated to this PR's files (the same test fails identically on other current PRs, e.g. #146400) and not chased here.
