### PR TITLE
fix(talk): suggest accepted spoken confirmation replies

### DIFF
--- a/src/talk/client-voice-confirmation.test.ts
+++ b/src/talk/client-voice-confirmation.test.ts
@@ -72,6 +72,30 @@ describe("client voice confirmation", () => {
     vi.useRealTimers();
   });
 
+  it.each(["yes", "yes do it"])("guides users to an accepted spoken reply: %s", (text) => {
+    const blocked = checkClientVoiceToolConfirmationPolicy({
+      voiceSessionId: "voice-1",
+      runId: "voice-run",
+      toolName: "message",
+      toolParams: { action: "send", message: "hello" },
+      now: 100,
+    });
+    if (blocked.allowed) {
+      throw new Error("expected a confirmation request");
+    }
+    expect(blocked.reason).toContain(`"${text}"`);
+    const confirmationId = confirmationIdFrom(blocked.reason);
+    noteClientVoiceConfirmationUtterance({
+      voiceSessionId: "voice-1",
+      text,
+      timestamp: 101,
+    });
+    expect(
+      authorizeClientVoiceConfirmation({ voiceSessionId: "voice-1", confirmationId, now: 102 })
+        .confirmationId,
+    ).toBe(confirmationId);
+  });
+
   it("does not pause a concurrent non-voice run sharing the session key", () => {
     block({ voiceSessionId: "voice-1", runId: "voice-run" });
 

--- a/src/talk/client-voice-confirmation.ts
+++ b/src/talk/client-voice-confirmation.ts
@@ -4,6 +4,18 @@ import { buildToolMutationState } from "../agents/tool-mutation.js";
 import { AUTOMATIONS_TOOL_NAME } from "../agents/tools/automations-tool-name.js";
 
 const CONFIRMATION_TTL_MS = 2 * 60_000;
+const AFFIRMATION_PHRASES: readonly string[] = [
+  "yes",
+  "yes do it",
+  "do it",
+  "confirm",
+  "confirmed",
+  "go ahead",
+  "proceed",
+  "send it",
+  "make the change",
+  "restart it",
+];
 
 type PendingVoiceConfirmation = {
   confirmationId: string;
@@ -301,7 +313,9 @@ function resolveClientVoiceToolConfirmationPolicy(
     reason:
       `VOICE_CONFIRMATION_REQUIRED:${confirmation.confirmationId} ` +
       `The high-impact voice action "${params.toolName}" was not executed. ` +
-      "Ask the user for explicit spoken confirmation, then call openclaw_agent_consult again with this confirmationId.",
+      `Ask the user for explicit spoken confirmation, such as ${AFFIRMATION_PHRASES.slice(0, 2)
+        .map((phrase) => `"${phrase}"`)
+        .join(" or ")}, then call openclaw_agent_consult again with this confirmationId.`,
   };
 }
 
@@ -340,9 +354,7 @@ function isExplicitAffirmation(text: string): boolean {
     return false;
   }
   // English-only phrases are an accepted first version; localized matching is follow-up work.
-  return /^(yes|yes do it|do it|confirm|confirmed|go ahead|proceed|send it|make the change|restart it)$/.test(
-    normalized,
-  );
+  return AFFIRMATION_PHRASES.includes(normalized);
 }
 
 /** Bind a later affirmative utterance to one exact paused action. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users confirming a paused Talk action receive no guidance about which spoken replies the confirmation parser accepts. A natural-language confirmation outside its exact phrase set can leave the action paused.

## Why This Change Was Made

The confirmation request now suggests "yes" or "yes do it", drawing both examples from the same phrase list used by the parser. The existing accepted vocabulary, normalization, refusals, action/run binding, expiry, and one-shot execution semantics remain unchanged.

## User Impact

Talk can tell users two short responses that the existing confirmation gate accepts.

## Evidence

- `node scripts/run-vitest.mjs run src/talk/client-voice-confirmation.test.ts src/talk/client-voice-confirmation-lifecycle.test.ts` — 2 files, 39 tests passed, including refusals, expiry, exact-action/run binding, and one-shot execution.
- Fix-only revert: `node scripts/run-vitest.mjs run src/talk/client-voice-confirmation.test.ts -t 'guides users to an accepted spoken reply'` — both new cases fail on the original production file because its guidance omits the accepted examples; both pass with the fix restored.
- `node_modules/.bin/oxfmt --check src/talk/client-voice-confirmation.ts src/talk/client-voice-confirmation.test.ts` — passed without rewriting files.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed.
- `node scripts/run-tsgo-core-test-shards.mjs --changed-paths-json '["src/talk/client-voice-confirmation.test.ts"]'` — selected canonical `other` test graph passed.
- `git diff --check` — passed.
- Independent autoreview — scoped-clean through P2, no actionable findings.

Validation used Node 26.8.1 and an independent frozen dependency installation with pnpm 12.3.4. This is a confirmation-guidance change; it does not exempt callers or alter authorization policy.
