### PR TITLE
fix(telegram): preserve shared contact details in messages

### DIFF
--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -221,6 +221,33 @@ function transcribeCallContext(): Record<string, unknown> {
 
 describe("resolveTelegramInboundBody", () => {
   privateBodyTest(
+    "preserves shared contact details in private inbound bodies",
+    { contact: { first_name: "Alex", phone_number: "+15555550123" } },
+    (result) => expect(result?.rawBody).toBe("[Shared contact] Alex, +15555550123"),
+  );
+
+  it.each([
+    { name: "@bot", patterns: undefined },
+    { name: "Alex", patterns: ["Alex"] },
+    { name: "Alex", patterns: ["15555550123"] },
+  ])("does not activate groups from shared contact fields %j", async ({ name, patterns }) => {
+    const result = await resolveGroup({
+      message: { contact: { first_name: name, phone_number: "+15555550123" } },
+      logger: createLogger(),
+      patterns,
+    });
+    expect(result).toBeNull();
+  });
+
+  it.each(["text", "caption"])("preserves group mentions in original %s", async (field) => {
+    const result = await resolveGroup({
+      message: { [field]: "@bot hello" },
+      logger: createLogger(),
+    });
+    expect(result?.effectiveWasMentioned).toBe(true);
+  });
+
+  privateBodyTest(
     "delivers native poll questions, options, voter totals, and state",
     {
       poll: {

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -328,7 +328,7 @@ export async function resolveTelegramInboundBody(params: {
       (richText ? hasBotMentionInText(richText, botUsername) : false)
     : false;
   const computedWasMentioned = matchesMentionWithExplicit({
-    text: messageTextParts.text || richText || "",
+    text: getTelegramTextParts({ ...msg, contact: undefined }).text || richText || "",
     mentionRegexes,
     explicit: {
       hasAnyMention,

--- a/extensions/telegram/src/bot/body-helpers.inbound.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.inbound.test.ts
@@ -1,7 +1,7 @@
 import type { Message, MessageEntity } from "grammy/types";
 import { markdownToIR } from "openclaw/plugin-sdk/text-chunking";
 import { describe, expect, it } from "vitest";
-import { getTelegramTextParts, joinTelegramTextParts } from "./body-helpers.js";
+import { getTelegramTextParts, hasBotMention, joinTelegramTextParts } from "./body-helpers.js";
 import { renderTelegramTextEntities } from "./inbound-text-entities.js";
 
 function asTelegramMessage(message: unknown): Message {
@@ -9,6 +9,33 @@ function asTelegramMessage(message: unknown): Message {
 }
 
 describe("getTelegramTextParts", () => {
+  it("does not treat shared contact names as bot mentions", () => {
+    expect(
+      hasBotMention(
+        asTelegramMessage({ contact: { first_name: "@examplebot", phone_number: "+15555550123" } }),
+        "examplebot",
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    [
+      { first_name: " Alex ", last_name: " Example ", phone_number: " +15555550123 " },
+      "Alex Example, +15555550123",
+    ],
+    [{ first_name: "Alex", phone_number: "+15555550123" }, "Alex, +15555550123"],
+    [{ first_name: " ", phone_number: " " }, "no details"],
+  ])("preserves shared contact details %j", (contact, details) => {
+    const message = asTelegramMessage({ contact });
+    expect(getTelegramTextParts(message)).toEqual({
+      text: `[Shared contact] ${details}`,
+      entities: [],
+    });
+    expect(joinTelegramTextParts([message, asTelegramMessage({ text: "Thanks" })], "\n").text).toBe(
+      `[Shared contact] ${details}\nThanks`,
+    );
+  });
+
   it("projects native Telegram polls into bounded, accurate inbound text", () => {
     const result = getTelegramTextParts(
       asTelegramMessage({

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -106,7 +106,7 @@ const TELEGRAM_RICH_MESSAGE_PLACEHOLDER = "[unsupported Telegram rich_message re
 
 type TelegramTextMessage = Pick<
   Message,
-  "text" | "caption" | "entities" | "caption_entities" | "poll"
+  "text" | "caption" | "entities" | "caption_entities" | "poll" | "contact"
 > & { rich_message?: Message.RichMessageMessage["rich_message"] };
 
 function compactRichText(value: string): string {
@@ -288,6 +288,17 @@ export function getTelegramTextParts(msg: TelegramTextMessage): {
   if (text) {
     return { text, entities: msg.entities ?? msg.caption_entities ?? [] };
   }
+  if (msg.contact) {
+    const name = [msg.contact.first_name, msg.contact.last_name]
+      .map((value) => normalizeOptionalString(value))
+      .filter(Boolean)
+      .join(" ");
+    const phone = normalizeOptionalString(msg.contact.phone_number);
+    return {
+      text: `[Shared contact] ${[name, phone].filter(Boolean).join(", ") || "no details"}`,
+      entities: [],
+    };
+  }
   return { text: msg.poll ? formatTelegramPollText(msg.poll) : "", entities: [] };
 }
 
@@ -348,7 +359,7 @@ function isBotCommandAddressedToMention(command: string, mention: string): boole
 }
 
 export function hasBotMention(msg: Message, botUsername: string, botId?: number) {
-  const { text, entities } = getTelegramTextParts(msg);
+  const { text, entities } = getTelegramTextParts({ ...msg, contact: undefined });
   const mention = normalizeLowercaseStringOrEmpty(`@${botUsername}`);
   if (hasStandaloneTelegramMention(normalizeLowercaseStringOrEmpty(text), mention)) {
     return true;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users sharing a Telegram contact card would receive no response because the incoming message had no text or media body.

## Why This Change Was Made

Preserve a shared contact's name and phone number in the existing inbound text projection, including joined messages and reply context. Contact details remain message content and do not become sender identity or authorization. Both mention-detection paths exclude the synthesized contact fields, so a contact name or phone number cannot activate a mention-gated group.

## User Impact

The agent can read shared contact details without requiring users to type them again. Existing text, caption and poll handling is preserved.

## Evidence

- Original production code with new contact tests: 3 failed, 28 passed; shared contacts produced empty text.
- A review caught synthesized contact fields activating group mentions. Regression against the initial fix: 3 failed, 34 passed in the inbound body suite.
- Final focused and adjacent Vitest run: **148 passed across 4 files** (inbound body, inbound text, text mentions and helper tests).
- Command: `node scripts/run-vitest.mjs extensions/telegram/src/bot/body-helpers.inbound.test.ts extensions/telegram/src/bot-message-context.body.test.ts extensions/telegram/src/bot/body-helpers.text-mention.test.ts extensions/telegram/src/bot/helpers.test.ts` on Node 24.20.0.
- Synthetic contact data only; no live Telegram transport test performed.
- Independent autoreview: scoped-clean at P0–P2 after addressing the mention finding. Native extension production and test typechecks, formatting, and `git diff --check` pass.
