### PR TITLE
fix(talk): log relay lifecycle transitions without payloads

### DIFF
--- a/src/gateway/talk-realtime-relay-state.ts
+++ b/src/gateway/talk-realtime-relay-state.ts
@@ -291,6 +291,16 @@ export function broadcastToOwner(
   connId: string,
   event: TalkRealtimeRelayEvent,
 ): void {
+  if (event.type === "ready" || event.type === "error" || event.type === "close") {
+    const [relaySessionId, ownerConnId] = [event.relaySessionId, connId].map((value) =>
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+        ? value
+        : "unknown",
+    );
+    context.logGateway?.[event.type === "error" ? "warn" : "info"]?.(
+      `[talk-relay] ${event.type} relaySessionId=${relaySessionId} connId=${ownerConnId}`,
+    );
+  }
   // Classify the materialized Talk event so final results cannot be mistaken
   // for transient tool progress by individual provider callback paths.
   const delivery = relayEventDeliveryOptions(event, event.talkEvent);

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -287,6 +287,8 @@ describe("talk realtime gateway relay", () => {
   ])("keeps a relay reusable after each terminal response", async (outcome, terminalType) => {
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
     const close = vi.fn();
+    const logGateway = { info: vi.fn(), warn: vi.fn() };
+    const connId = "00000000-0000-4000-8000-000000000002";
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -298,6 +300,7 @@ describe("talk realtime gateway relay", () => {
     };
     const events: Array<{ payload: unknown; delivery?: { dropIfSlow?: boolean } }> = [];
     const context = {
+      logGateway,
       broadcastToConnIds: (
         _event: string,
         payload: unknown,
@@ -307,7 +310,7 @@ describe("talk realtime gateway relay", () => {
     } as never;
     const session = createTalkRealtimeRelaySession({
       context,
-      connId: "conn-1",
+      connId,
       provider,
       providerConfig: {},
       instructions: "be brief",
@@ -318,9 +321,12 @@ describe("talk realtime gateway relay", () => {
       throw new Error("expected realtime bridge request");
     }
 
+    bridgeRequest.onReady?.();
+    bridgeRequest.onTranscript?.("user", "private transcript", false);
+
     void sendTalkRealtimeRelayAudio({
       relaySessionId: session.relaySessionId,
-      connId: "conn-1",
+      connId,
       audioBase64: Buffer.from("first").toString("base64"),
       timestamp: 1,
     });
@@ -367,7 +373,7 @@ describe("talk realtime gateway relay", () => {
 
     void sendTalkRealtimeRelayAudio({
       relaySessionId: session.relaySessionId,
-      connId: "conn-1",
+      connId,
       audioBase64: Buffer.from("later").toString("base64"),
       timestamp: 2,
     });
@@ -398,6 +404,16 @@ describe("talk realtime gateway relay", () => {
     ).toHaveLength(2);
     expect(relaySessions.has(session.relaySessionId)).toBe(true);
     expect(close).not.toHaveBeenCalled();
+    stopTalkRealtimeRelaySession({ relaySessionId: session.relaySessionId, connId });
+    expect(logGateway.info.mock.calls).toEqual([
+      [`[talk-relay] ready relaySessionId=${session.relaySessionId} connId=${connId}`],
+      [`[talk-relay] close relaySessionId=${session.relaySessionId} connId=${connId}`],
+    ]);
+    expect(logGateway.warn.mock.calls).toEqual(
+      outcome.status === "failed" || outcome.status === "incomplete"
+        ? [[`[talk-relay] error relaySessionId=${session.relaySessionId} connId=${connId}`]]
+        : [],
+    );
   });
 
   it("redacts failed response outcome details from relay broadcasts", async () => {
@@ -604,7 +620,7 @@ describe("talk realtime gateway relay", () => {
       });
     };
     try {
-      const logGateway = { warn: vi.fn() };
+      const logGateway = { info: vi.fn(), warn: vi.fn() };
       const broadcastToConnIds = vi.fn();
       const context = {
         broadcastToConnIds,
@@ -642,6 +658,9 @@ describe("talk realtime gateway relay", () => {
       await Promise.resolve();
       await Promise.resolve();
 
+      expect(logGateway.info).toHaveBeenCalledWith(
+        `[talk-relay] close relaySessionId=${firstOwned.relaySessionId} connId=unknown`,
+      );
       expect(bridgeCloses[0]).toHaveBeenCalledOnce();
       expect(bridgeCloses[1]).toHaveBeenCalledOnce();
       expect(bridgeCloses[2]).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators troubleshooting a Talk gateway relay cannot correlate its ready, error, and close events in Gateway logs after the browser session has ended.

## Why This Change Was Made

The shared owner-delivery path emits one short lifecycle log entry containing the event name and validated relay/connection UUIDs. Errors use warning level; readiness and closure use informational level. Other relay events and payload contents are omitted, and owner delivery remains unchanged.

## User Impact

Operators can correlate relay connection lifecycle events without retaining audio, transcripts, tool arguments, or provider error messages in these new log entries. Unexpected identifier values appear as `unknown`.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/talk-realtime-relay.test.ts`: 131 tests passed.
- Strengthened existing real relay lifecycle tests across completed, failed, incomplete and cancelled responses, plus connection disconnect. Provider callbacks prove readiness/error/closure severity, correlation, omitted payload contents and continued owner delivery.
- Reversing only the production fix makes all five strengthened cases fail; restoring it passes them. Focused command adds `-t 'keeps a relay reusable|closes only realtime relays owned'` to the full-suite command above.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`: passed.
- `node scripts/run-tsgo-core-test-shards.mjs --changed-paths-json '["src/gateway/talk-realtime-relay.test.ts"]'`: passed; selected canonical gateway-root graph.
- Formatting, `git diff --check`, and the max-lines ratchet passed. No new test graph root or raised limit.
- Supplementary direct-source probe confirms arbitrary relay identifiers are sanitized while the original event still reaches its intended owner.

Autoreview: final production and integration-test diff scoped-clean through P2, exit 0. No live voice/provider calls were made.
