### PR TITLE
fix(talk): preserve readiness during WebRTC relay startup

### DIFF
--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -40,6 +40,9 @@ describe("GPT-Live gateway relay bridge", () => {
   function createPendingPeerBridge(params?: {
     onClose?: (reason: "completed" | "error") => void;
     onError?: (error: Error) => void;
+    onReady?: () => void;
+    applyAnswer?: () => Promise<void>;
+    webSocketFactory?: OpenAIQuicksilverSocketFactory;
   }) {
     let resolvePeer: ((peer: OpenAIQuicksilverAudioPeerContract) => void) | undefined;
     let rejectPeer: ((error: Error) => void) | undefined;
@@ -48,9 +51,10 @@ describe("GPT-Live gateway relay bridge", () => {
       resolvePeer = resolve;
       rejectPeer = reject;
     });
+    const socket = new FakeSocket("manual");
     const peer = {
       createOffer: vi.fn(async () => "v=offer\r\n"),
-      applyAnswer: vi.fn(async () => undefined),
+      applyAnswer: vi.fn(params?.applyAnswer ?? (async () => undefined)),
       adoptPendingAudio: vi.fn(),
       sendAudio: vi.fn(),
       close: vi.fn(),
@@ -71,6 +75,7 @@ describe("GPT-Live gateway relay bridge", () => {
         onClearAudio: vi.fn(),
         onClose: params?.onClose ?? onClose,
         onError: params?.onError,
+        onReady: params?.onReady,
         runAgentConsult: vi.fn(async () => ({ text: "done" })),
         logger,
         resolveAuth: vi.fn(async () => ({
@@ -80,7 +85,15 @@ describe("GPT-Live gateway relay bridge", () => {
         })),
         createPeer,
         fetchImpl: vi.fn(async () => createCallResponse("v=answer\r\n", "rtc_pending_audio")),
-        webSocketFactory: () => new FakeSocket(),
+        webSocketFactory:
+          params?.webSocketFactory ??
+          (() => {
+            queueMicrotask(() => {
+              socket.readyState = 1;
+              socket.emit("open");
+            });
+            return socket;
+          }),
       },
       openAIRealtimeHost,
     );
@@ -91,6 +104,8 @@ describe("GPT-Live gateway relay bridge", () => {
       onClose,
       logger,
       peer,
+      socket,
+      triggerPeerReady: () => peerCallbacks?.onReady?.(),
       rejectPeer: (error: Error) => rejectPeer?.(error),
       resolvePeer: () => resolvePeer?.(peer),
       triggerPeerError: (error: Error) => peerCallbacks?.onError(error),
@@ -100,6 +115,90 @@ describe("GPT-Live gateway relay bridge", () => {
       },
     };
   }
+
+  it.each(["sideband", "peer"] as const)(
+    "holds %s readiness until the SDP answer is accepted",
+    async (source) => {
+      const onReady = vi.fn();
+      let acceptAnswer!: () => void;
+      const answer = new Promise<void>((resolve) => {
+        acceptAnswer = resolve;
+      });
+      const harness = createPendingPeerBridge({ onReady, applyAnswer: () => answer });
+      try {
+        harness.resolvePeer();
+        await vi.waitFor(() => expect(harness.peer.applyAnswer).toHaveBeenCalledOnce());
+        expect(harness.socket.readyState).toBe(1);
+        expect(harness.socket.listenerCount("message")).toBe(1);
+        if (source === "sideband") {
+          emitSideband(harness.socket, { type: "session.started", session: {} });
+        } else {
+          harness.triggerPeerReady();
+        }
+        expect(onReady).not.toHaveBeenCalled();
+        expect(harness.bridge.isConnected()).toBe(false);
+        acceptAnswer();
+        await harness.connection;
+        expect(onReady).toHaveBeenCalledOnce();
+        expect(harness.bridge.isConnected()).toBe(true);
+        harness.triggerPeerReady();
+        emitSideband(harness.socket, { type: "session.started", session: {} });
+        expect(onReady).toHaveBeenCalledOnce();
+      } finally {
+        harness.bridge.close();
+        acceptAnswer();
+        await harness.connection.catch(() => undefined);
+      }
+    },
+  );
+
+  it.each(["close", "error"] as const)(
+    "rejects buffered startup %s without publishing readiness",
+    async (terminal) => {
+      const onReady = vi.fn();
+      const socket = new FakeSocket("manual");
+      const harness = createPendingPeerBridge({
+        onReady,
+        webSocketFactory: () => {
+          queueMicrotask(() => {
+            socket.readyState = 1;
+            socket.emit("open");
+            emitSideband(socket, { type: "session.started", session: {} });
+            if (terminal === "close") {
+              socket.close(1000, "complete");
+            } else {
+              socket.emit("error", new Error("startup failed"));
+            }
+          });
+          return socket;
+        },
+      });
+      harness.resolvePeer();
+      await expect(harness.connection).rejects.toThrow("OpenAI GPT-Live gateway relay failed");
+      expect(onReady).not.toHaveBeenCalled();
+      expect(harness.bridge.isConnected()).toBe(false);
+      expect(socket.closed).toBe(true);
+      expect(harness.peer.close).toHaveBeenCalledOnce();
+      harness.triggerPeerReady();
+      expect(onReady).not.toHaveBeenCalled();
+    },
+  );
+
+  it("closes both transports when the answer fails after provider readiness", async () => {
+    const onReady = vi.fn();
+    const harness = createPendingPeerBridge({
+      onReady,
+      applyAnswer: async () => {
+        harness.triggerPeerReady();
+        throw new Error("invalid answer");
+      },
+    });
+    harness.resolvePeer();
+    await expect(harness.connection).rejects.toThrow("OpenAI GPT-Live gateway relay failed");
+    expect(onReady).not.toHaveBeenCalled();
+    expect(harness.socket.closed).toBe(true);
+    expect(harness.peer.close).toHaveBeenCalledOnce();
+  });
 
   it("preserves the call on media errors without logging raw error details", async () => {
     const harness = createPendingPeerBridge();

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -116,6 +116,7 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   private peer: OpenAIQuicksilverAudioPeerContract | undefined;
   private pendingAudio = new OpenAIQuicksilverPendingAudio();
   private ready = false;
+  private providerReady = false;
   private sideband: ActiveSideband | undefined;
   private timer: ReturnType<typeof setTimeout> | undefined;
   private transport: OpenAIQuicksilverGatewayTransport | undefined;
@@ -208,6 +209,10 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
         throw connectAbortError(connectSignal);
       }
       this.connected = true;
+      this.notifyReady();
+      if (this.closed || connectSignal.aborted) {
+        throw connectAbortError(connectSignal);
+      }
       if (!this.timer) {
         this.scheduleExpiry(QUICKSILVER_SESSION_TTL_MS);
       }
@@ -264,6 +269,10 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
       });
     const peerPromise = createPeer(
       {
+        onReady: () => {
+          this.providerReady = true;
+          this.notifyReady();
+        },
         onAudio: (audio) => this.config.onAudio(audio),
         onError: (error) => this.fail(error),
         onMediaError: () => this.config.logger.debug?.("GPT-Live WebRTC media packet dropped"),
@@ -312,9 +321,12 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
     if (call.kind !== "gpt-live") {
       throw new Error("GPT-Live gateway relay unexpectedly used the GA realtime call shape");
     }
-    await waitForConnectStep(this.peer.applyAnswer(call.answerSdp), connectSignal);
     const connected = await this.connectSocket(auth, requestIds, call.sidebandUrl, connectSignal);
+    // Applying the answer can start media and emit the only session.started event.
+    // Own the sideband first so startup events cannot fall between transports.
     this.adoptConnectedSocket(connected);
+    connectSignal.throwIfAborted();
+    await waitForConnectStep(this.peer.applyAnswer(call.answerSdp), connectSignal);
   }
 
   private async connectSocket(
@@ -350,15 +362,15 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
     connected: Awaited<ReturnType<typeof connectOpenAIQuicksilverSideband>>,
   ): void {
     const terminalEvent = connected.detachBuffer();
-    for (const frame of connected.bufferedFrames) {
-      this.handleSidebandFrame(frame.data, frame.isBinary);
-    }
     if (terminalEvent?.kind === "error") {
       throw terminalEvent.error;
     }
     if (terminalEvent?.kind === "close") {
       const reason = normalizeSidebandCloseReason(terminalEvent.reason);
       throw new Error(describeSidebandClose(terminalEvent.code, reason));
+    }
+    for (const frame of connected.bufferedFrames) {
+      this.handleSidebandFrame(frame.data, frame.isBinary);
     }
   }
 
@@ -384,12 +396,8 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
               Math.min(QUICKSILVER_SESSION_TTL_MS, Math.max(0, expiresAt * 1000 - Date.now())),
             );
           }
-          if (!this.ready) {
-            this.connected = true;
-            this.ready = true;
-            this.flushPendingDirectAudio();
-            this.config.onReady?.();
-          }
+          this.providerReady = true;
+          this.notifyReady();
           params?.onSessionStarted?.();
         },
         onTranscript: (role, text, done) => this.config.onTranscript?.(role, text, done),
@@ -405,6 +413,15 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
       },
       this.runtime.formatErrorMessage,
     );
+  }
+
+  private notifyReady(): void {
+    if (!this.providerReady || !this.connected || this.closed || this.ready) {
+      return;
+    }
+    this.ready = true;
+    this.flushPendingDirectAudio();
+    this.config.onReady?.();
   }
 
   private flushPendingDirectAudio(): void {
@@ -504,6 +521,7 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
     releaseOpenAIQuicksilverSession(this);
     this.connected = false;
     this.ready = false;
+    this.providerReady = false;
     this.transport = undefined;
     this.pendingAudio.clear();
     if (disposition === "detach") {

--- a/extensions/openai/realtime-quicksilver-peer.runtime.test.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.test.ts
@@ -114,7 +114,7 @@ async function createInboundAudioHarness(params?: {
 }
 
 describe("GPT-Live werift audio peer", () => {
-  it("creates a full-candidate Opus sendrecv offer without a data channel", async () => {
+  it("creates a bundled full-candidate Opus and events offer", async () => {
     const peer = await OpenAIQuicksilverAudioPeer.create({
       callbacks: { onAudio: vi.fn(), onError: vi.fn() },
       iceServers: [],
@@ -126,9 +126,48 @@ describe("GPT-Live werift audio peer", () => {
       expect(offer).toMatch(/^a=sendrecv$/m);
       expect(offer).toMatch(/^a=candidate:/m);
       expect(offer).toMatch(/^a=end-of-candidates$/m);
-      expect(offer).not.toMatch(/^m=application /m);
+      expect(offer).toMatch(/^m=application .*UDP\/DTLS\/SCTP /m);
+      expect(offer).toMatch(/^a=group:BUNDLE 0 1$/m);
     } finally {
       peer.close();
+    }
+  });
+
+  it("reports readiness from the negotiated events channel and closes it with the peer", async () => {
+    const { RTCPeerConnection, useOPUS } = await import("werift");
+    const onReady = vi.fn();
+    const onError = vi.fn();
+    const channels = vi.spyOn(RTCPeerConnection.prototype, "createDataChannel");
+    const peer = await OpenAIQuicksilverAudioPeer.create({
+      callbacks: { onAudio: vi.fn(), onError, onReady },
+      iceServers: [],
+    });
+    const channel = channels.mock.results[0]?.value;
+    channels.mockRestore();
+    const remote = new RTCPeerConnection({
+      bundlePolicy: "max-bundle",
+      iceServers: [],
+      codecs: { audio: [useOPUS({ payloadType: 111 })], video: [] },
+    });
+    try {
+      if (!channel) {
+        throw new Error("expected event channel");
+      }
+      expect(channel.label).toBe("oai-events");
+      expect(onReady).not.toHaveBeenCalled();
+      await remote.setRemoteDescription({ type: "offer", sdp: await peer.createOffer() });
+      await remote.setLocalDescription(await remote.createAnswer());
+      await peer.applyAnswer(remote.localDescription!.sdp);
+      await vi.waitFor(() => expect(onReady).toHaveBeenCalledOnce());
+      expect(channel.readyState).toBe("open");
+      expect(onError).not.toHaveBeenCalled();
+      peer.close();
+      await vi.waitFor(() => expect(channel.readyState).toBe("closed"));
+      channel.stateChanged.execute("open");
+      expect(onReady).toHaveBeenCalledOnce();
+    } finally {
+      peer.close();
+      await remote.close();
     }
   });
 

--- a/extensions/openai/realtime-quicksilver-peer.runtime.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.ts
@@ -43,6 +43,7 @@ type InboundRtpState = {
 };
 
 export type OpenAIQuicksilverAudioPeerCallbacks = {
+  onReady?: () => void;
   onAudio: (audio: Buffer) => void;
   onError: (error: Error) => void;
   // Omission preserves the existing fatal packet-error callback contract.
@@ -106,6 +107,7 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
     const [werift, libopus] = await Promise.all([import("werift"), import("libopus-wasm")]);
     params.signal?.throwIfAborted();
     const peer = new werift.RTCPeerConnection({
+      bundlePolicy: "max-bundle",
       codecs: {
         audio: [werift.useOPUS({ payloadType: 111 })],
         video: [],
@@ -203,6 +205,12 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
       werift: WeriftModule;
     },
   ) {
+    // Negotiate the provider event channel even though the sideband owns event handling.
+    state.peer.createDataChannel("oai-events").stateChanged.subscribe((channelState) => {
+      if (channelState === "open" && !this.closed) {
+        state.callbacks.onReady?.();
+      }
+    });
     state.peer.onTrack.subscribe((track) => this.attachInboundTrack(track));
     state.peer.connectionStateChange.subscribe((connectionState) => {
       if (this.closed) {


### PR DESCRIPTION
Closes #144597

## What Problem This Solves

Fixes an issue where users starting a GPT-Live Gateway voice relay could miss readiness when the provider started during WebRTC negotiation. A startup that subsequently failed could also announce readiness prematurely.

## Why This Change Was Made

Adopt the sideband before applying the SDP answer, reject buffered terminal events before replay, and publish readiness only after startup accepts the transport. Negotiate the provider's `oai-events` data channel with bundled media so its open event can supply readiness when `session.started` is not replayed; the sideband continues to handle provider events. The direct transport retains its existing readiness and audio behavior.

## User Impact

Gateway voice relays retain early provider readiness and notify the host once after successful startup. Failed startup releases both transports without announcing readiness.

## Evidence

- Node 26.8.1, native Vitest 5: six affected bridge, direct, lifecycle, error, audio-pipeline, and peer suites passed (53 tests; existing Bun-only check skipped because Bun is not installed).
- Reversing only the two production-file changes made seven regressions fail. Restoring the fix passed those regressions, including a real local WebRTC event-channel handshake and closure.
- Extension test typechecking passed. Targeted lint and formatting passed.
- Full OpenAI lane: 1,195 tests passed, one existing Bun check skipped, and one transcription client-secret test timed out under the full run. That transcription test passed in isolation with both production changes reversed.
- Independent autoreview found no actionable P0–P2 findings. Subsequent changes added required braces in three test branches only.

These are deterministic startup and local WebRTC proofs; a live provider call was not repeated against this source change. The issue is timing-dependent, not a claim that every unmodified voice startup fails.
