### PR TITLE
fix(ci): await plugin status across reconnects

### DIFF
--- a/ui/src/e2e/plugins-settings-admin.e2e.test.ts
+++ b/ui/src/e2e/plugins-settings-admin.e2e.test.ts
@@ -583,13 +583,15 @@ suite.define(() => {
         const toggle = page.locator("wa-switch").filter({ hasText: "Enable or disable Workboard" });
         await toggle.click();
         await gateway.waitForRequest("plugins.setEnabled");
-        await page.getByRole("status").filter({ hasText: "Disabled Workboard." }).waitFor();
-        expect(
-          await page
-            .locator(".plugins-row-message")
-            .filter({ hasText: "Disabled Workboard." })
-            .count(),
-        ).toBe(1);
+        await expect
+          .poll(() =>
+            page
+              .getByRole("status")
+              .filter({ hasText: "Disabled Workboard." })
+              .and(page.locator(".plugins-row-message:visible"))
+              .count(),
+          )
+          .toBe(1);
 
         await page.getByRole("tab", { name: "Configuration", exact: true }).click();
         const workspace = page.getByLabel("Workspace label", { exact: true });


### PR DESCRIPTION
Related: #144590

## What Problem This Solves

The plugin-settings browser test can fail after a successful enable/disable operation. It first waits for the status message, then separately counts the row. The intentional post-mutation Gateway reconnect can temporarily replace that row with loading content between those observations, producing an expected-one/actual-zero failure.

This occurred in [the plugin-settings E2E job for #144590](https://github.com/openclaw/openclaw/actions/runs/34554762311/job/103125019521) and predates that PR's disclosure refactor.

## Why This Change Was Made

Poll one observation of the same row: accessible `role=status`, the existing “Disabled Workboard.” text, visibility, the `.plugins-row-message` class, and an exact count of one. Keep the existing timeout and mutation behavior.

This is a separate test repair: +2 test lines / +2 bytes, with no production or tooling changes.

## User Impact

No production behavior change. The browser test retains its accessibility, visibility, text, and uniqueness checks while awaiting the expected reconnect/catalog transition.

## Evidence

- A deterministic browser reproduction used the existing deferred Gateway controls to expose the reconnect window. The original assertion observed `[0]` and failed; the repaired assertion observed `[0,1]`, passed, and completed the remaining configuration-save and uninstall flow.
- All six uninstrumented plugin-settings administration E2E scenarios passed.
- The full changed-file gate passed against base `d6997b6bbf2e269887f03bddae6a488d74908af2`, including the UI-E2E test type graph, formatting, lint, i18n, dependency/coercion guards, and dead-export scans.
- Managed Codex P2 review was scoped-clean with no actionable findings, using the actual mutation, reconnect, and rendering owners as context.
- Fresh main was checked; the test and relevant production/harness contracts are unchanged. #144590's source and head were left unchanged.
