### PR TITLE
fix(agents): dir_fetch attachments are dropped while the tool says they were sent

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
@@ -526,6 +526,34 @@ describe("prepareEmbeddedAttemptClientTools", () => {
     expect(result.clientToolDefs.map((tool) => tool.name)).toEqual(["client_probe"]);
   });
 
+  it("exposes the run's trusted local-media tool names from contract metadata", () => {
+    const catalogRef = seedCatalog("tool-search", TOOL_SEARCH_CONFIG);
+    const dirFetch = createStubTool("dir_fetch");
+    setPluginToolMeta(dirFetch as never, {
+      pluginId: "file-transfer",
+      optional: false,
+      trustedLocalMedia: true,
+    });
+    const unmarked = createStubTool("some_mcp_tool");
+    setPluginToolMeta(unmarked as never, {
+      pluginId: "some-mcp",
+      optional: false,
+    });
+    const exec = createStubTool("exec");
+
+    const result = prepare({
+      codeModeControlsEnabledForRun: false,
+      attemptConfig: CATALOGS_DISABLED_CONFIG,
+      toolSearchRuntimeConfig: CATALOGS_DISABLED_CONFIG,
+      catalogRef,
+      uncompactedEffectiveTools: [dirFetch, unmarked, exec],
+    });
+
+    // dir_fetch earns it from the bundled contract, exec from the core
+    // allowlist; an unmarked plugin tool earns nothing.
+    expect(result.trustedLocalMediaToolNames).toEqual(new Set(["dir_fetch", "exec"]));
+  });
+
   it("binds side-effect metadata to the concrete plugin tool owner", () => {
     const catalogRef = seedCatalog("tool-search", TOOL_SEARCH_CONFIG);
     const memoryStore = createStubTool("memory_store");

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
@@ -11,6 +11,7 @@ import { wrapToolWithAbortSignal } from "../../agent-tools.abort.js";
 import { resolveToolLoopDetectionConfig } from "../../agent-tools.js";
 import { isCodeModeExecTool } from "../../code-mode-control-tools.js";
 import { addClientToolsToCodeModeCatalog } from "../../code-mode.js";
+import { collectTrustedLocalMediaToolNames } from "../../embedded-agent-tool-media.js";
 import type { AgentTool } from "../../runtime/index.js";
 import {
   createToolDefinitionFromAgentTool,
@@ -121,6 +122,15 @@ export function prepareEmbeddedAttemptClientTools(params: {
       isPluginTool: (tool) =>
         Boolean(getPluginToolMeta(tool as Parameters<typeof getPluginToolMeta>[0])),
     });
+    // Derived from exact tool metadata, never from the whole builtin set: a
+    // registered name earns local-media trust only by being core-trusted
+    // already or by carrying the bundled contract's trustedLocalMedia mark.
+    const trustedLocalMediaToolNames = collectTrustedLocalMediaToolNames(
+      params.uncompactedEffectiveTools,
+      (tool) =>
+        getPluginToolMeta(tool as Parameters<typeof getPluginToolMeta>[0])?.trustedLocalMedia ===
+        true,
+    );
     const isReplaySafeTool = (tool: { name?: string }) =>
       isAgentToolReplaySafe(tool, params.replaySafetyOptions);
     const replaySafeTools = new Set(params.uncompactedEffectiveTools.filter(isReplaySafeTool));
@@ -198,6 +208,7 @@ export function prepareEmbeddedAttemptClientTools(params: {
       allCustomTools,
       builtinToolNames,
       coreBuiltinToolNames,
+      trustedLocalMediaToolNames,
       clientToolCallSlots,
       clientToolDefs,
       replaySafeToolNames,
@@ -222,6 +233,7 @@ export function prepareEmbeddedAttemptClientTools(params: {
       for (const key of [
         "builtinToolNames",
         "coreBuiltinToolNames",
+        "trustedLocalMediaToolNames",
         "replaySafeToolNames",
         "codeModeExecToolNames",
       ] as const) {

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
@@ -164,6 +164,7 @@ export async function runEmbeddedAttemptExecutionPhase(
     sandboxSessionKey: input.setup.sandboxSessionKey,
     builtinToolNames: sessionRuntime.agentSession.builtinToolNames,
     coreBuiltinToolNames: sessionRuntime.agentSession.coreBuiltinToolNames,
+    trustedLocalMediaToolNames: sessionRuntime.agentSession.trustedLocalMediaToolNames,
     replaySafeToolNames: sessionRuntime.agentSession.replaySafeToolNames,
     codeModeExecToolNames: sessionRuntime.agentSession.codeModeExecToolNames,
     sideEffectToolOwners: sessionRuntime.agentSession.sideEffectToolOwners,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -122,6 +122,7 @@ export function prepareEmbeddedAttemptStream(input: {
   sandboxSessionKey: string;
   builtinToolNames: ReadonlySet<string>;
   coreBuiltinToolNames?: ReadonlySet<string>;
+  trustedLocalMediaToolNames?: ReadonlySet<string>;
   replaySafeToolNames: ReadonlySet<string>;
   codeModeExecToolNames?: ReadonlySet<string>;
   sideEffectToolOwners?: ReadonlyMap<string, string>;
@@ -371,6 +372,9 @@ export function prepareEmbeddedAttemptStream(input: {
     agentId: input.hookAgentId,
     builtinToolNames: input.builtinToolNames,
     coreBuiltinToolNames: input.coreBuiltinToolNames,
+    ...(input.trustedLocalMediaToolNames
+      ? { trustedLocalMediaToolNames: input.trustedLocalMediaToolNames }
+      : {}),
     replaySafeToolNames: input.replaySafeToolNames,
     ...(input.codeModeExecToolNames ? { codeModeExecToolNames: input.codeModeExecToolNames } : {}),
     ...(input.sideEffectToolOwners ? { sideEffectToolOwners: input.sideEffectToolOwners } : {}),

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -629,6 +629,51 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.emitToolOutput).toHaveBeenCalledTimes(1);
     expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/meeting.wav"]);
   });
+  it("queues dir_fetch local paths once the run supplies its trusted set", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: true,
+      toolResultFormat: "plain",
+      trustedLocalMediaToolNames: new Set(["dir_fetch"]),
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "dir_fetch",
+      toolCallId: "tc-dir-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Fetched 40 files (channel attaches first 25)" }],
+        details: { media: { mediaUrls: ["/tmp/run/a.png", "/tmp/run/b.png"] } },
+      },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/run/a.png", "/tmp/run/b.png"]);
+  });
+
+  it("drops dir_fetch local paths when the run supplies no trusted set", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: true,
+      toolResultFormat: "plain",
+      trustedLocalMediaToolNames: new Set(),
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "dir_fetch",
+      toolCallId: "tc-dir-2",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Fetched 40 files (channel attaches first 25)" }],
+        details: { media: { mediaUrls: ["/tmp/run/a.png", "/tmp/run/b.png"] } },
+      },
+    });
+
+    // The reported defect: the summary text still says the channel attached
+    // them while nothing is queued.
+    expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+    expect(ctx.emitToolOutput).toHaveBeenCalledTimes(1);
+  });
+
   it("queues structured media once for markdown verbose output", async () => {
     const ctx = await handleVerboseGeneratedImage("markdown");
 

--- a/src/agents/embedded-agent-subscribe.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.media.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import { isToolResultMediaTrusted } from "./embedded-agent-subscribe.tools.test-support.js";
 import {
+  collectTrustedLocalMediaToolNames,
   extractToolResultMediaArtifact,
   filterToolResultMediaUrls,
 } from "./embedded-agent-tool-media.js";
@@ -519,5 +520,68 @@ describe("extractToolResultMediaArtifact", () => {
         },
       }),
     ).toEqual(["https://example.com/screenshot.png"]);
+  });
+});
+
+describe("collectTrustedLocalMediaToolNames", () => {
+  const marked = new Set(["dir_fetch", "file_fetch"]);
+  const hasMark = (tool: { name?: string }) => marked.has(tool.name ?? "");
+
+  it("collects bundled contract tools alongside the core-trusted names", () => {
+    expect(
+      collectTrustedLocalMediaToolNames(
+        [{ name: "exec" }, { name: "dir_fetch" }, { name: "some_mcp_tool" }],
+        hasMark,
+      ),
+    ).toEqual(new Set(["exec", "dir_fetch"]));
+  });
+
+  it("excludes plugin tools that carry no trustedLocalMedia mark", () => {
+    expect(collectTrustedLocalMediaToolNames([{ name: "some_mcp_tool" }], hasMark)).toEqual(
+      new Set(),
+    );
+    expect(collectTrustedLocalMediaToolNames([{ name: "dir_list" }], hasMark)).toEqual(new Set());
+  });
+
+  it("ignores tools with no usable name", () => {
+    expect(collectTrustedLocalMediaToolNames([{ name: "  " }, {}], hasMark)).toEqual(new Set());
+  });
+
+  it("keeps dir_fetch local paths that the run-local set now covers", () => {
+    const names = collectTrustedLocalMediaToolNames(
+      [{ name: "exec" }, { name: "dir_fetch" }, { name: "some_mcp_tool" }],
+      hasMark,
+    );
+    // The defect: without the set, dir_fetch local paths are filtered to nothing
+    // while its summary text tells the model the channel attached them.
+    expect(
+      filterToolResultMediaUrls("dir_fetch", ["/tmp/run/report.png"], undefined, undefined),
+    ).toStrictEqual([]);
+    expect(
+      filterToolResultMediaUrls("dir_fetch", ["/tmp/run/report.png"], undefined, names),
+    ).toEqual(["/tmp/run/report.png"]);
+  });
+
+  it("does not widen local-media trust to unmarked tools in the same run", () => {
+    const names = collectTrustedLocalMediaToolNames(
+      [{ name: "exec" }, { name: "dir_fetch" }, { name: "some_mcp_tool" }],
+      hasMark,
+    );
+    expect(
+      filterToolResultMediaUrls("some_mcp_tool", ["/tmp/run/report.png"], undefined, names),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps core tools trusted once the run supplies its exact set", () => {
+    const names = collectTrustedLocalMediaToolNames(
+      [{ name: "exec" }, { name: "read" }, { name: "dir_fetch" }],
+      hasMark,
+    );
+    expect(filterToolResultMediaUrls("exec", ["/tmp/out.png"], undefined, names)).toEqual([
+      "/tmp/out.png",
+    ]);
+    expect(filterToolResultMediaUrls("read", ["/tmp/out.png"], undefined, names)).toEqual([
+      "/tmp/out.png",
+    ]);
   });
 });

--- a/src/agents/embedded-agent-tool-media.ts
+++ b/src/agents/embedded-agent-tool-media.ts
@@ -147,6 +147,35 @@ function isExternalToolResult(result: unknown): boolean {
   return typeof details.mcpServer === "string" || typeof details.mcpTool === "string";
 }
 
+/**
+ * Exact raw tool names for this run that may carry local-media paths.
+ *
+ * Two sources, and only two. The core allowlist above, matched through the
+ * same normalization `isCoreToolResultMediaTrustedName` uses, so every tool
+ * trusted today stays trusted and this is not a widening for them. Plus
+ * bundled manifest tools whose contract marks them `trustedLocalMedia`, which
+ * is the seam that exists for exactly this and which nothing was reading.
+ *
+ * Raw names, because `filterToolResultMediaUrls` matches the name the tool
+ * emitted rather than its normalized policy name.
+ */
+export function collectTrustedLocalMediaToolNames(
+  tools: readonly { name?: string }[],
+  hasTrustedLocalMediaMeta: (tool: { name?: string }) => boolean,
+): Set<string> {
+  const names = new Set<string>();
+  for (const tool of tools) {
+    const name = (tool.name ?? "").trim();
+    if (!name) {
+      continue;
+    }
+    if (isCoreToolResultMediaTrustedName(name) || hasTrustedLocalMediaMeta(tool)) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
 function isToolResultMediaTrusted(
   toolName?: string,
   result?: unknown,


### PR DESCRIPTION
Fixes #138383.

## What Problem This Solves

`dir_fetch` builds `details.media.mediaUrls` from local gateway paths, caps the list at 25, and returns a summary saying the channel attaches the first 25. Nothing attaches them.

`filterToolResultMediaUrls` reduces an untrusted tool's media to `http(s)` entries. `dir_fetch` emits filesystem paths, so the list empties on every call and `embedded-agent-subscribe.handlers.tools.results.ts` returns before `queuePendingToolMedia`. The tool text has already been emitted by then, so the model is handed a false statement and relays it. No warning, nothing logged, attachment count 0.

## Why This Change Was Made

The mechanism for this already exists on both ends, and nothing connects them.

- `setManifestPluginToolMeta` (`src/plugins/tools.ts`) marks a bundled plugin tool `trustedLocalMedia` when the manifest's `contracts.tools` declares it. `extensions/file-transfer/openclaw.plugin.json` declares `dir_fetch`.
- `filterToolResultMediaUrls` already accepts a run-local `trustedLocalMediaToolNames` set, and a name in it is trusted for local media.

No production caller populates that set — only `embedded-agent-subscribe.e2e-harness.ts` does. The metadata is computed, the consumer is wired, and the value in between is permanently `undefined`.

This collects the set where the run's tool surface is already assembled (`attempt-client-tools.ts`, next to `coreBuiltinToolNames`) and threads it through `attempt-execution-phase` → `attempt-stream-prepare` → the subscription, which already forwards `params.trustedLocalMediaToolNames`.

**`collectTrustedLocalMediaToolNames` takes names from two sources and no others:**

1. The core allowlist, matched exactly as `isCoreToolResultMediaTrustedName` matches it today — so every tool trusted before this change is still trusted, and this half is not a widening.
2. Tools whose plugin metadata carries the bundled contract's `trustedLocalMedia` mark.

Forwarding the whole builtin set — what the e2e harness does as its fallback — would have granted local-media trust to every registered tool including MCP tools, which is the boundary the set exists to hold.

**`TRUSTED_TOOL_RESULT_MEDIA` is untouched.** #101434 moved this project away from widening that Set, and #120718 ruled on the delivery mechanism. Neither is reopened here, and the issue explicitly asked for neither.

**Alias behaviour is deliberately unchanged.** Supplying a defined set activates `filterToolResultMediaUrls`'s exact-raw-name branch, and the set is built so every name trusted today passes it. Tightening that gate for core names would change behaviour for `bash`, `cron` and `apply-patch` — a separate decision that does not belong in a delivery fix.

## User Impact

An agent that runs `dir_fetch` to bring back a directory of images, logs or exported reports for a person to look at now has those files attached, which is what the tool already told the model would happen. `file_fetch`, `dir_list` and `file_write` are declared in the same manifest contract and are covered by the same collection.

Nothing changes for any other tool: unmarked plugin tools and MCP tools keep being filtered to `http(s)`, and core tools behave exactly as before.

## Evidence

The defect and the fix are both pinned at the two boundaries the report names.

**At the filter** (`embedded-agent-subscribe.tools.media.test.ts`) — this is repro A from the issue, which needs neither node pairing nor a policy grant:

```
filterToolResultMediaUrls("dir_fetch", ["/tmp/run/report.png"], undefined, undefined) -> []
filterToolResultMediaUrls("dir_fetch", ["/tmp/run/report.png"], undefined, collected)  -> ["/tmp/run/report.png"]
```

**At the delivery boundary** (`embedded-agent-subscribe.handlers.tools.media.test.ts`), driving `handleToolExecutionEnd` with a `dir_fetch` result carrying two local paths:

| run's trusted set | `state.pendingToolMediaUrls` | tool text emitted |
|---|---|---|
| absent | `[]` | yes — including the "channel attaches first 25" claim |
| `{dir_fetch}` | `["/tmp/run/a.png", "/tmp/run/b.png"]` | yes |

The second row is the contradiction closing: the summary and the attachments finally agree.

**The collector** is covered directly: both sources included, unmarked plugin tools excluded, `dir_list` without the mark excluded, unnamed tools ignored, and core tools (`exec`, `read`) still trusted once a run supplies its exact set — that last one is the regression guard for turning the set on at all.

**The wiring** is pinned in `attempt-client-tools.test.ts`: a run holding a marked `dir_fetch`, an unmarked MCP tool and `exec` exposes exactly `{dir_fetch, exec}`, so dropping the call site fails a test rather than silently restoring the bug.

### Checks

- branched from `d331583bbf0`
- the four suites named as acceptance criteria on the issue: `attempt-client-tools` 16, `attempt-stream-prepare` + `dir-fetch-tool` 43, `handlers.tools.media` 32, `tools.media` 46 — all passing
- `tsgo -p tsconfig.json`: no errors in `src/agents`; the pre-existing `scripts/**` and `extensions/qa-lab/**` errors on that project are untouched by this branch
- `oxlint` and `oxfmt --check`: clean on all seven changed files

## Open questions

- The issue offered three consistent end states and I took a fourth, the one ClawSweeper's review pointed at: thread the metadata that already exists rather than reword the string or add a direct send. If you would rather have option (i) — make the summary say only what is true and drop the dead `MEDIA_URL_CAP` slicing — that is a much smaller diff and I am happy to send it instead.
- `mediaNote` is only appended when the directory holds more than 25 files, but `details.media.mediaUrls` is populated regardless. This fix covers both; the false sentence and the dropped attachments had different trigger conditions.
