### PR TITLE
fix(memory): retain daily checkpoints across capped sweeps

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1058,7 +1058,7 @@ describe("memory-core dreaming phases", () => {
     expect(after.some((entry) => entry.snippet.includes("Canonical daily note"))).toBe(true);
   });
 
-  it("does not recount unvisited daily files after a capped sweep", async () => {
+  it("retains current unvisited daily checkpoints and prunes notes outside lookback", async () => {
     const workspaceDir = await createDreamingWorkspace();
     const files = [
       "2026-04-05.md",
@@ -1074,14 +1074,27 @@ describe("memory-core dreaming phases", () => {
         "utf-8",
       );
     }
-
-    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+    const oldRelativePath = "memory/2026-03-16.md";
+    const gammaRelativePath = "memory/2026-04-05-gamma.md";
+    await fs.writeFile(
+      path.join(workspaceDir, oldRelativePath),
+      "- Historical kiln inspection records belong in the blue archive.\n",
+      "utf-8",
+    );
+    const initialHarness = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      limit: 1,
+      lookbackDays: 30,
+    });
+    const narrowedHarness = createDefaultStorageLightDreamingHarness(workspaceDir, {
       limit: 1,
       lookbackDays: 2,
     });
 
     await withDreamingTestClock(async () => {
-      await triggerLightDreaming(beforeAgentReply, workspaceDir, 0);
+      await triggerLightDreaming(initialHarness.beforeAgentReply, workspaceDir, 0);
+      const initial = await dreamingTestState.readDailyIngestionState(workspaceDir);
+      expect(initial.files[oldRelativePath]).toBeDefined();
+      expect(initial.files[gammaRelativePath]).toBeDefined();
 
       for (const fileName of files.slice(0, -1)) {
         await fs.writeFile(
@@ -1091,15 +1104,79 @@ describe("memory-core dreaming phases", () => {
         );
       }
 
-      await triggerLightDreaming(beforeAgentReply, workspaceDir, 1);
-      await triggerLightDreaming(beforeAgentReply, workspaceDir, 2);
+      await triggerLightDreaming(narrowedHarness.beforeAgentReply, workspaceDir, 1);
+      const capped = await dreamingTestState.readDailyIngestionState(workspaceDir);
+      expect(capped.files[oldRelativePath]).toBeUndefined();
+      expect(capped.files[gammaRelativePath]).toEqual(initial.files[gammaRelativePath]);
+
+      await triggerLightDreaming(narrowedHarness.beforeAgentReply, workspaceDir, 2);
       const recalls = await shortTermTesting.readRecallStore(
         workspaceDir,
         new Date(DREAMING_TEST_BASE_TIME.getTime() + 2 * 60_000).toISOString(),
       );
       expect(
-        Object.values(recalls.entries).find((entry) => entry.path.endsWith("-gamma.md")),
-      ).toMatchObject({ dailyCount: 1 });
+        Object.values(recalls.entries).find((entry) => entry.path === gammaRelativePath),
+      ).toMatchObject({
+        dailyCount: 1,
+      });
+      expect(
+        Object.values(recalls.entries).find((entry) => entry.path === oldRelativePath),
+      ).toMatchObject({
+        dailyCount: 1,
+      });
+    });
+  });
+
+  it("drops a daily checkpoint when its file disappears before stat", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const removedRelativePath = "memory/2026-04-05-alpha.md";
+    const keptRelativePath = "memory/2026-04-05-beta.md";
+    const removedPath = path.join(workspaceDir, removedRelativePath);
+    await fs.writeFile(removedPath, "- Alpha archive keeps signed delivery receipts.\n", "utf-8");
+    await fs.writeFile(
+      path.join(workspaceDir, keptRelativePath),
+      "- Beta workshop stores the copper gauge in cabinet seven.\n",
+      "utf-8",
+    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      limit: 1,
+      lookbackDays: 2,
+    });
+
+    await withDreamingTestClock(async () => {
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 0);
+      const initial = await dreamingTestState.readDailyIngestionState(workspaceDir);
+      expect(initial.files[removedRelativePath]).toBeDefined();
+      expect(initial.files[keptRelativePath]).toBeDefined();
+
+      const stat = fs.stat.bind(fs);
+      let removed = false;
+      const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
+        if (!removed && args[0] === removedPath) {
+          removed = true;
+          await fs.unlink(removedPath);
+        }
+        return await stat(...args);
+      });
+      try {
+        await triggerLightDreaming(beforeAgentReply, workspaceDir, 1);
+      } finally {
+        statSpy.mockRestore();
+      }
+
+      expect(removed).toBe(true);
+      const after = await dreamingTestState.readDailyIngestionState(workspaceDir);
+      expect(after.files[removedRelativePath]).toBeUndefined();
+      expect(after.files[keptRelativePath]).toEqual(initial.files[keptRelativePath]);
+      const recalls = await shortTermTesting.readRecallStore(
+        workspaceDir,
+        new Date(DREAMING_TEST_BASE_TIME.getTime() + 60_000).toISOString(),
+      );
+      expect(
+        Object.values(recalls.entries).find((entry) => entry.path === keptRelativePath),
+      ).toMatchObject({
+        dailyCount: 1,
+      });
     });
   });
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1058,6 +1058,51 @@ describe("memory-core dreaming phases", () => {
     expect(after.some((entry) => entry.snippet.includes("Canonical daily note"))).toBe(true);
   });
 
+  it("does not recount unvisited daily files after a capped sweep", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const files = [
+      "2026-04-05.md",
+      "2026-04-05-alpha.md",
+      "2026-04-05-beta.md",
+      "2026-04-05-delta.md",
+      "2026-04-05-gamma.md",
+    ];
+    for (const fileName of files) {
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", fileName),
+        `- Initial ${fileName} checkpoint has enough detail to ingest.\n`,
+        "utf-8",
+      );
+    }
+
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      limit: 1,
+      lookbackDays: 2,
+    });
+
+    await withDreamingTestClock(async () => {
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 0);
+
+      for (const fileName of files.slice(0, -1)) {
+        await fs.writeFile(
+          path.join(workspaceDir, "memory", fileName),
+          dailyCapStressLines(`Updated ${fileName}`).join("\n"),
+          "utf-8",
+        );
+      }
+
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 1);
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 2);
+      const recalls = await shortTermTesting.readRecallStore(
+        workspaceDir,
+        new Date(DREAMING_TEST_BASE_TIME.getTime() + 2 * 60_000).toISOString(),
+      );
+      expect(
+        Object.values(recalls.entries).find((entry) => entry.path.endsWith("-gamma.md")),
+      ).toMatchObject({ dailyCount: 1 });
+    });
+  });
+
   it("prioritizes the date-only daily file before same-day slugged files during historical seeding", async () => {
     const workspaceDir = await createDreamingWorkspace();
     const canonicalPath = path.join(workspaceDir, "memory", "2026-04-05.md");

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -846,7 +846,12 @@ async function collectDailyIngestionBatches(params: {
     .toSorted(compareDailyMemoryFilesByNewestDay);
 
   const batches: DailyIngestionBatch[] = [];
-  const nextFiles: Record<string, DailyIngestionFileState> = {};
+  const currentPaths = new Set(files.map((file) => `memory/${file.fileName}`));
+  // A bounded sweep must retain checkpoints for current files it never reaches.
+  // Files absent from the current lookback remain pruned from the next state.
+  const nextFiles: Record<string, DailyIngestionFileState> = Object.fromEntries(
+    Object.entries(params.state.files).filter(([relativePath]) => currentPaths.has(relativePath)),
+  );
   let changed = false;
   const totalCap = Math.max(20, params.limit * 4);
   const perFileCap = Math.max(6, Math.ceil(totalCap / Math.max(1, Math.max(files.length, 1))));
@@ -861,6 +866,7 @@ async function collectDailyIngestionBatches(params: {
       throw err;
     });
     if (!stat) {
+      delete nextFiles[relativePath];
       continue;
     }
     const fingerprint: DailyIngestionFileState = {


### PR DESCRIPTION
Related: #76359

## What Problem This Solves

Fixes an issue where capped dreaming sweeps could count an unchanged daily note again on the same day. Earlier changed notes consumed the sweep budget, so a later untouched note gained duplicate recall evidence.

## Why This Change Was Made

The daily-ingestion owner retains existing checkpoints for discovered notes within the current lookback, including notes a bounded sweep does not reach. It still removes expired or absent paths and handles files that disappear before stat. The existing same-day and cross-day contracts stay intact.

## User Impact

Dreaming no longer amplifies unchanged daily-memory evidence after a capped sweep. Changed notes still ingest, and an unchanged note can contribute once again on a new dreaming day. Promotion thresholds and storage schemas are unchanged.

## Evidence

A real isolated Gateway ran its existing managed dreaming cron against five synthetic daily notes. The first four notes were then expanded to consume the ingestion cap; the last note's bytes and modification time stayed unchanged. Counts came from public `memory promote-explain --json` output.

| Public action | Main baseline | Repaired candidate |
| --- | ---: | ---: |
| Initial western-day job | 1 | 1 |
| Capped job on the same day | 2 | 1 |
| Another unchanged same-day job | 2 | 1 |
| Change only dreaming timezone to the next calendar day; run | 3 | 2 |
| Repeat on that new day | 3 | 2 |

The managed job runs both light and REM ingestion, so the baseline recount appears within the capped job. The new-day increase is intentional behavior from #76359. The host clock and ingestion state were not changed.

- Baseline: `008a95d8059dd7abd4bd12c4f214e47f8a4038ea`. Candidate runtime: `6b0acfbed5d4420ef88ddd7c9584861ca46aa570` plus test-only coverage changes.
- Changed-note readback passed. Deleted and out-of-window note selectors returned explicit no-match. Promotion preview stayed empty with default score/count/query thresholds `0.75 / 3 / 3`.
- A fresh source-blind validator independently exercised a separate synthetic workspace: all five initial facts and all four changed facts were visible; same-day and cross-day counts, deletion, an eligible older note, far-old exclusion, unchanged defaults, and one managed job passed. It also independently inspected the retained baseline public outputs.
- 63 focused dreaming tests passed. The extended capped-sweep test fails on the original implementation at the missing unvisited checkpoint. Separate controls detect omitted deletion cleanup and retention of out-of-lookback checkpoints.
- Combined runtime/UI builds, changed-file formatting and lint, max-lines and assertion-safety checks passed. Full type-aware checks remain with hosted CI.
- Setup history retained: initial cron selection was corrected to distinguish the one dreaming job from other product-managed jobs; assertion comparison was corrected from newer main to the actual PR merge base. Neither setup failure was counted as product behavior.

The discovery/stat race and pruning of a previously stored out-of-lookback checkpoint use focused owner tests and source review. Public deletion and old-file exclusion are separate controls.
