### PR TITLE
fix: distinguish native preflight in tool policy hooks

### DIFF
--- a/docs/plugins/hooks/tool-policy.md
+++ b/docs/plugins/hooks/tool-policy.md
@@ -31,6 +31,10 @@ contributions, and transcript persistence. Part of the [Plugin hooks](/plugins/h
 - optional `event.toolCallId`
 - context fields such as `ctx.agentId`, `ctx.sessionKey`, `ctx.sessionId`,
   `ctx.runId`, `ctx.toolKind`, `ctx.toolInputKind`, and diagnostic `ctx.trace`
+- optional `ctx.policyPhase: "native-pre-tool-use"`, set by the host for native
+  preflight. These calls support observation and blocking, but reject parameter
+  rewrites. Ordinary host tool execution leaves it absent. This field does not
+  grant authority and is never read from tool arguments.
 - optional `ctx.abortSignal`, which aborts when the owning tool call is
   cancelled; handlers should pass it to cancellable I/O and remove any
   listeners they register

--- a/src/agents/agent-tools.before-tool-call.policy.ts
+++ b/src/agents/agent-tools.before-tool-call.policy.ts
@@ -99,6 +99,7 @@ export function consumeFinalClientVoiceToolConfirmation(args: {
 }
 
 export async function runBeforeToolCallHook(args: {
+  policyPhase?: "native-pre-tool-use";
   toolName: string;
   params: unknown;
   toolKind?: PluginHookToolKind;
@@ -219,6 +220,7 @@ export async function runBeforeToolCallHook(args: {
       ...(args.toolInputKind && { toolInputKind: args.toolInputKind }),
     };
     const buildToolContext = (identity: typeof toolIdentity) => ({
+      ...(args.policyPhase === "native-pre-tool-use" ? { policyPhase: args.policyPhase } : {}),
       toolName,
       ...identity,
       ...(args.ctx?.agentId && { agentId: args.ctx.agentId }),

--- a/src/agents/harness/native-hook-relay-events.ts
+++ b/src/agents/harness/native-hook-relay-events.ts
@@ -128,6 +128,7 @@ async function runNativeHookRelayPreToolUse(params: {
   const originalToolInputFingerprint = stableStringify(toolInput);
   const approvalMode = readNativeHookRelayApprovalMode(params.invocation.rawPayload);
   const policyRequest = {
+    policyPhase: "native-pre-tool-use" as const,
     toolName,
     params: toolInput,
     ...(params.invocation.toolUseId ? { toolCallId: params.invocation.toolUseId } : {}),

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -33,6 +33,7 @@ import {
   closeAdmittedRunDelegatedAuthority,
   getAdmittedRunDelegatedAuthority,
 } from "../admitted-run-context.js";
+import { runBeforeToolCallHook } from "../agent-tools.before-tool-call.js";
 import { createAdmittedHostCapabilityTestFixture } from "./host-capability.test-support.js";
 import * as nativeHookRelayBridge from "./native-hook-relay-bridge.js";
 import { invokeNativeHookRelayBridge } from "./native-hook-relay-client.js";
@@ -3193,6 +3194,64 @@ describe("native hook relay registry", () => {
         expect.objectContaining({ toolName: canonicalToolName }),
         expect.objectContaining({ toolName: canonicalToolName }),
       );
+    },
+  );
+
+  it.each([false, true])(
+    "distinguishes native preflight from execution-time policy (host callback: %s)",
+    async (useHostCallback) => {
+      const beforeToolCall = vi.fn(async (event: unknown, ctx: unknown) =>
+        requireRecord(ctx, "tool context").policyPhase === "native-pre-tool-use"
+          ? undefined
+          : {
+              params: {
+                ...requireRecord(requireRecord(event, "tool event").params, "tool params"),
+                value: "normalized",
+              },
+            },
+      );
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+      );
+      const fixture = useHostCallback
+        ? await createAdmittedHostCapabilityTestFixture({ runId: "run-preflight-phase" })
+        : undefined;
+      const relay = registerNativeHookRelay({
+        provider: "codex",
+        sessionId: "session-preflight-phase",
+        runId: "run-preflight-phase",
+        ...(fixture
+          ? {
+              runBeforeToolCall: fixture.hostCapabilities.runBeforeToolCall,
+              assertActive: fixture.hostCapabilities.assertActive,
+            }
+          : {}),
+      });
+      // A model-provided field cannot establish the host's policy phase.
+      const params = { value: "original", policyPhase: "native-pre-tool-use" };
+      try {
+        const response = await invokeNativeHookRelay({
+          provider: "codex",
+          relayId: relay.relayId,
+          event: "pre_tool_use",
+          rawPayload: { tool_name: "phase_tool", tool_input: params },
+        });
+        expect(JSON.parse(response.stdout || "{}").hookSpecificOutput?.permissionDecision).not.toBe(
+          "deny",
+        );
+        expect(beforeToolCall).toHaveBeenCalledWith(
+          expect.objectContaining({ params }),
+          expect.objectContaining({ policyPhase: "native-pre-tool-use" }),
+        );
+        beforeToolCall.mockClear();
+        const outcome = await runBeforeToolCallHook({ toolName: "phase_tool", params });
+        expect(outcome).toMatchObject({ blocked: false, params: { value: "normalized" } });
+        expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("policyPhase");
+      } finally {
+        relay.unregister();
+        fixture?.closeHost();
+        fixture?.closeAdmission();
+      }
     },
   );
 

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -703,6 +703,8 @@ export type PluginHookToolRequesterContext = {
 };
 
 export type PluginHookToolContext = {
+  /** Host-supplied native preflight, where parameter rewrites are not supported. */
+  policyPhase?: "native-pre-tool-use";
   agentId?: string;
   sessionKey?: string;
   sessionId?: string;


### PR DESCRIPTION
Closes #144608

## What Problem This Solves

Fixes an issue where users of a plugin that normalizes host-tool arguments can see those calls denied during native preflight, because the plugin cannot distinguish preflight from ordinary host execution.

## Why This Change Was Made

The existing plugin hook context gains optional, host-supplied `policyPhase: "native-pre-tool-use"`. Both native relay dispatch paths carry it into the shared policy hook. Ordinary host calls leave it absent, even when tool arguments contain a field with the same name.

OpenClaw's native rewrite rejection remains intact. The phase identifies the invocation context; it does not grant authority, bypass approval, or change admitted-run lifetime checks.

## User Impact

Plugin authors can reserve argument normalization for host execution while continuing to observe or block native preflight. Existing plugins and hook signatures remain compatible. The tool policy hook reference documents the field and its limits.

## Evidence

- New parameterized regression invokes the real native relay both directly and through an admitted host capability callback. Both fail before the fix, pass after it, and fail again with only the production patch reversed.
- The same regression confirms that a model-provided `policyPhase` argument does not establish the host context field, and ordinary execution-time normalization still applies.
- Full native relay suite: 126 tests passed. Plugin before-tool-call suite: 29 tests passed. Broader before-tool-call E2E suite: 103 tests passed after its normal source-build prerequisites.
- Core and agents-other test typechecks, lint, formatting, and max-lines ratchet passed. Autoreview is scoped-clean through P2 (exit 0).
- Inspected pinned Codex source `rust-v0.153.4` / `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`. Codex core supports updated hook inputs; this fix preserves OpenClaw's narrower, documented native relay contract.

Commands:

```sh
node scripts/run-vitest.mjs run src/agents/harness/native-hook-relay.test.ts -t 'distinguishes native preflight'
node scripts/run-vitest.mjs run src/agents/harness/native-hook-relay.test.ts src/plugins/hooks.before-tool-call.test.ts
node scripts/run-vitest.mjs run src/agents/agent-tools.before-tool-call.e2e.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo-core-test-shards.mjs --changed-paths-json '["src/agents/harness/native-hook-relay.test.ts"]'
```

Synthetic tools and isolated test state only; no live provider calls or business data.
