### PR TITLE
fix: reuse the bound Codex thread when compacting chats

### DIFF
--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -14,9 +14,12 @@ import {
   ensureCodexAppServerClientRuntime,
   retainCodexAppServerLiveThread,
 } from "./client-runtime.js";
-import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
+import { CodexAppServerClient, CodexAppServerRpcError } from "./client.js";
 import { maybeCompactCodexAppServerSession as maybeCompactCodexAppServerSessionImpl } from "./compact.js";
-import { resolveCodexSupervisionAppServerRuntimeOptions } from "./config.js";
+import {
+  resolveCodexAppServerRuntimeOptions,
+  resolveCodexSupervisionAppServerRuntimeOptions,
+} from "./config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import type { CodexServerNotification } from "./protocol.js";
 import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
@@ -31,7 +34,11 @@ import {
   testCodexAppServerBindingStore,
   writeCodexAppServerBinding,
 } from "./session-binding.test-helpers.js";
-import type { CodexAppServerClientFactory } from "./shared-client.js";
+import {
+  getLeasedSharedCodexAppServerClient,
+  releaseLeasedSharedCodexAppServerClient,
+  type CodexAppServerClientFactory,
+} from "./shared-client.js";
 import { createClientHarness } from "./test-support.js";
 import { withCodexAppServerThreadMutation } from "./thread-ownership.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
@@ -214,6 +221,125 @@ describe("maybeCompactCodexAppServerSession", () => {
   afterEach(async () => {
     resetCodexAppServerClientFactoryForTest();
     await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("compacts through the bound shared client despite a different startup cache key", async () => {
+    vi.stubEnv("CODEX_HOME", tempDir);
+    const harnesses: ReturnType<typeof createClientHarness>[] = [];
+    const start = vi.spyOn(CodexAppServerClient, "start").mockImplementation(async () => {
+      const harness = createClientHarness({
+        onWrite: (line, send) => {
+          const request = JSON.parse(line) as { id?: number; method: string };
+          if (request.id === undefined) {
+            return;
+          }
+          if (request.method === "initialize") {
+            send({
+              id: request.id,
+              result: { userAgent: `codex-cli/${CODEX_APP_SERVER_VERSION}`, codexHome: tempDir },
+            });
+          } else if (request.method === "account/read") {
+            send({ id: request.id, result: { account: null, requiresOpenaiAuth: false } });
+          } else if (request.method === "thread/start") {
+            send({
+              id: request.id,
+              result: {
+                thread: { id: "thread-1", cwd: tempDir, status: { type: "idle" }, turns: [] },
+              },
+            });
+          } else if (request.method === "thread/resume") {
+            send({
+              id: request.id,
+              error: { code: -32600, message: "thread thread-1 already has an active writer" },
+            });
+          } else {
+            send({ id: request.id, result: {} });
+            if (request.method === "thread/compact/start") {
+              for (const method of ["item/started", "item/completed"]) {
+                send({
+                  method,
+                  params: {
+                    threadId: "thread-1",
+                    turnId: "compact-turn",
+                    item: { type: "contextCompaction", id: "compact-item" },
+                  },
+                });
+              }
+              send({
+                method: "turn/completed",
+                params: { threadId: "thread-1", turn: { id: "compact-turn", status: "completed" } },
+              });
+            }
+          }
+        },
+      });
+      harnesses.push(harness);
+      return harness.client;
+    });
+    const pluginConfig = {
+      appServer: {
+        command: process.execPath,
+        args: ["app-server"],
+        homeScope: "user",
+      },
+    };
+    let owner: CodexAppServerClient | undefined;
+    try {
+      owner = await getLeasedSharedCodexAppServerClient({
+        startOptions: resolveCodexAppServerRuntimeOptions({ pluginConfig }).start,
+        agentDir: tempDir,
+        authProfileId: null,
+        authBindingFingerprint: "ordinary-turn-binding",
+      });
+      await owner.request("thread/start", { cwd: tempDir }, { timeoutMs: 5_000 });
+      expect(await retainCodexAppServerLiveThread(owner, "thread-1")).toBe(true);
+      const sessionFile = await writeTestBinding({ clientId: owner.getInstanceId() });
+      const params = {
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        sessionFile,
+        agentDir: tempDir,
+        workspaceDir: tempDir,
+        trigger: "manual" as const,
+      };
+      const options = {
+        pluginConfig,
+        nativeCompletionTimeoutMs: 1_000,
+        nativeInterruptGraceMs: 100,
+      };
+      const explicitFactory = vi.fn(async () => owner!);
+      await expect(
+        maybeCompactCodexAppServerSession(params, { ...options, clientFactory: explicitFactory }),
+      ).resolves.toMatchObject({ ok: true, compacted: true });
+      expect(explicitFactory).toHaveBeenCalledOnce();
+
+      const result = await maybeCompactCodexAppServerSession(params, options);
+      expect(result, result?.reason).toMatchObject({ ok: true, compacted: true });
+      await expect(maybeCompactCodexAppServerSession(params, options)).resolves.toMatchObject({
+        ok: true,
+        compacted: true,
+      });
+      expect(start).toHaveBeenCalledOnce();
+      expect(
+        harnesses[0]?.writes
+          .map((line) => JSON.parse(line).method)
+          .filter((method) => method.startsWith("thread/")),
+      ).toEqual([
+        "thread/start",
+        "thread/compact/start",
+        "thread/compact/start",
+        "thread/compact/start",
+      ]);
+      expect(releaseLeasedSharedCodexAppServerClient(owner)).toBe(true);
+      expect(releaseLeasedSharedCodexAppServerClient(owner)).toBe(false);
+    } finally {
+      if (owner) {
+        releaseLeasedSharedCodexAppServerClient(owner);
+      }
+      start.mockRestore();
+      await Promise.all(harnesses.map(({ client }) => client.closeAndWait()));
+      vi.unstubAllEnvs();
+    }
   });
 
   it("rejects a host-only rotation after recovering the predecessor during compaction startup", async () => {

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -51,6 +51,7 @@ import {
 import {
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
+  retainSharedCodexAppServerClientByInstanceId,
   type CodexAppServerClientFactory,
 } from "./shared-client.js";
 import {
@@ -573,15 +574,20 @@ async function compactCodexNativeThread(
       params.abortSignal,
       async () => {
         assertCurrent();
-        const client = await clientFactory({
-          startOptions: appServer.start,
-          ...(preparedApiKey
-            ? { preparedAuth: { kind: "api-key" as const, apiKey: preparedApiKey } }
-            : { authProfileId: connection.clientAuthProfileId }),
-          agentDir: params.agentDir,
-          config: params.config,
-          assertCurrent,
-        });
+        const boundClient = options.clientFactory
+          ? undefined
+          : retainSharedCodexAppServerClientByInstanceId(binding.clientId);
+        const client =
+          boundClient?.client ??
+          (await clientFactory({
+            startOptions: appServer.start,
+            ...(preparedApiKey
+              ? { preparedAuth: { kind: "api-key" as const, apiKey: preparedApiKey } }
+              : { authProfileId: connection.clientAuthProfileId }),
+            agentDir: params.agentDir,
+            config: params.config,
+            assertCurrent,
+          }));
         let releaseThreadSubscription: (() => Promise<void>) | undefined;
         let retainedThreadOwnership: CodexAppServerLiveThreadOwnership | undefined;
         let compactionSucceeded = false;
@@ -892,7 +898,9 @@ async function compactCodexNativeThread(
               await releaseThreadSubscription?.();
             }
           } finally {
-            if (shouldReleaseDefaultLease) {
+            if (boundClient) {
+              boundClient.release();
+            } else if (shouldReleaseDefaultLease) {
               releaseLeasedSharedCodexAppServerClient(client);
             }
           }


### PR DESCRIPTION
Closes #144612

## What Problem This Solves

Fixes an issue where users running `/compact` on a Codex-backed chat could receive “thread already has an active writer” even though the chat's existing app-server was still available. Compaction could select a second app-server when its startup cache key differed from the one used by the ordinary turn.

## Why This Change Was Made

Default compaction now retains the live app-server identified by the private thread binding, using the existing instance-ID lease lookup. Its own lease is released afterward. Explicit client factories retain precedence, and the existing startup path remains available when the recorded client is unavailable. Binding, sandbox, and account checks remain in place.

## User Impact

`/compact` can complete on the already-loaded native thread, including repeated requests, without opening a competing writer or consuming another caller's lease.

## Evidence

- The regression uses the real app-server client, shared registry, binding store, thread leases, and compactor with an in-memory native transport. An explicit-owner control succeeds before the fix; default compaction fails with the active-writer error.
- `pnpm test extensions/codex/src/app-server/compact.test.ts extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/thread-ownership.test.ts`: all 180 tests pass.
- Reverting only the production fix reproduces the active-writer failure. Restoring it passes all 60 compaction tests. The regression also verifies repeated compaction, explicit-factory precedence, no duplicate startup/resume, and preservation of the original caller's lease.
- Exact native dependency inspected: `openai/codex` tag `rust-v0.153.4`, commit `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`. Its [compaction processor](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/app-server/src/request_processors/thread_processor.rs#L2350) loads the existing thread; its [resume regression](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/app-server/tests/suite/v2/thread_resume.rs#L375) checks rejection of a competing writer.
- Production and test extension TypeScript checks, focused oxlint, formatter checks, and `git diff --check` pass.
- Independent upstream autoreview: scoped-clean at P1, with the shared-client lease implementation and pinned native contract supplied.
- Validation ran on Node 26.8.1 and pnpm 12.3.4. No live model/API compaction or full repository build/test run was performed.
