### PR TITLE
fix: inherit the final Codex dynamic-tool surface

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -233,6 +233,21 @@ async function buildDynamicToolsForTest(
 }
 
 describe("Codex app-server dynamic tool build", () => {
+  it("forwards the inherited tool allowlist reference to host tool construction", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    const inheritedToolAllowlistRef: string[] = [];
+    const factory = vi.fn((_options?: OpenClawCodingToolsOptionsForTest) => []);
+    setOpenClawCodingToolsFactoryForTests(factory);
+
+    await buildDynamicToolsForTest(params, workspaceDir, { inheritedToolAllowlistRef });
+
+    expect(factory).toHaveBeenCalledWith(expect.objectContaining({ inheritedToolAllowlistRef }));
+    expect(factory.mock.calls[0]?.[0]?.inheritedToolAllowlistRef).toBe(inheritedToolAllowlistRef);
+  });
+
   it("forwards private yield context and acknowledgment to the lifecycle owner", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -152,6 +152,7 @@ type DynamicToolBuildParams = {
   policyAgentId: string;
   pluginConfig: CodexPluginConfig;
   profilerEnabled?: boolean;
+  inheritedToolAllowlistRef?: OpenClawCodingToolsOptions["inheritedToolAllowlistRef"];
   cronCreatorToolAllowlistRef?: OpenClawCodingToolsOptions["cronCreatorToolAllowlistRef"];
   cronCreatorToolAllowlistCaptureRef?: OpenClawCodingToolsOptions["cronCreatorToolAllowlistCaptureRef"];
   resolveCronCreatorToolAuthority?: Parameters<
@@ -368,6 +369,7 @@ export async function buildDynamicTools(
     onToolOutcome: params.onToolOutcome,
     isTurnTainted: params.isTurnTainted,
     allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
+    inheritedToolAllowlistRef: input.inheritedToolAllowlistRef,
     cronCreatorToolAllowlistRef: input.cronCreatorToolAllowlistRef,
     cronCreatorToolAllowlistCaptureRef: input.cronCreatorToolAllowlistCaptureRef,
     cronCreatorAuthorityUnavailableReason: input.cronCreatorAuthorityUnavailableReason,

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -152,6 +152,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     frameImageIdentity?: string;
   } = { value: 0 };
   const runCleanups: Array<(reason: string) => Promise<void>> = [];
+  const inheritedToolAllowlist: string[] = [];
   const cronCreatorToolAllowlist: Array<string | { name: string; pluginId?: string }> = [];
   const cronCreatorToolAllowlistCaptureRef: {
     value?: { version: 1; source: "final-executable-surface" };
@@ -305,6 +306,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     onMessageToolTargetResolved: (required) => {
       requireExplicitMessageTarget = required;
     },
+    inheritedToolAllowlistRef: inheritedToolAllowlist,
     cronCreatorToolAllowlistRef: cronCreatorToolAllowlist,
     cronCreatorToolAllowlistCaptureRef,
     onPersistentWebSearchPolicyResolved: (allowed) => {
@@ -526,6 +528,15 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
       ),
       hookContext,
     });
+    if (inheritedToolAllowlist.length > 0) {
+      // Only restrictive parent policy populates this spawn-owned reference.
+      // Capture executable tools after Codex filtering and late MCP materialization.
+      inheritedToolAllowlist.splice(
+        0,
+        inheritedToolAllowlist.length,
+        ...new Set(toolBridge.availableTools.map((tool) => tool.name)),
+      );
+    }
     const captureCronCreatorToolAllowlist = async () => {
       await captureFinalCodexCronCreatorToolAllowlist(
         cronCreatorToolAllowlist,

--- a/extensions/codex/src/app-server/run-attempt.tool-inheritance.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.tool-inheritance.test.ts
@@ -1,0 +1,81 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createParams,
+  createCodexRuntimePlanFixture,
+  createStartedThreadHarness,
+  runCodexAppServerAttempt,
+  setCodexTestModelSupportsTools,
+  setupRunAttemptTestHooks,
+  tempDir,
+} from "./run-attempt-test-harness.js";
+
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>();
+  return {
+    ...actual,
+    materializeRequesterScopedMcpToolsForHarnessRun: async () => {
+      const tool = {
+        name: "fake__show",
+        description: "Late requester-scoped tool.",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({ content: [{ type: "text" as const, text: "fixture" }] }),
+      };
+      return { tools: [tool], advertisedTools: [tool], dispose: async () => undefined };
+    },
+  };
+});
+
+setupRunAttemptTestHooks();
+
+describe("runCodexAppServerAttempt tool inheritance", () => {
+  it.each([true, false])(
+    "captures final executable tools only when parent policy is restrictive (%s)",
+    async (restricted) => {
+      const sessionFile = path.join(tempDir, "session-tool-inheritance.jsonl");
+      const params = createParams(sessionFile, path.join(tempDir, "workspace-tool-inheritance"));
+      setCodexTestModelSupportsTools(params, true);
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      params.toolsAllow = ["read", "sessions_spawn", "fake__show"];
+      if (restricted) {
+        params.config = { ...params.config, tools: { allow: params.toolsAllow } };
+      }
+      const host = params.hostCapabilities;
+      const snapshots: Array<{ ref?: string[]; initial: string[] }> = [];
+      params.hostCapabilities = Object.freeze({
+        ...host,
+        createToolSurface: (options, bindingOptions) => {
+          const tools = host.createToolSurface!(options, bindingOptions);
+          snapshots.push({
+            ref: options.inheritedToolAllowlistRef,
+            initial: [...(options.inheritedToolAllowlistRef ?? [])],
+          });
+          return tools;
+        },
+      });
+      const harness = createStartedThreadHarness();
+      const run = runCodexAppServerAttempt(params, {
+        pluginConfig: {
+          appServer: { approvalPolicy: "never", sandbox: "danger-full-access" },
+          codexDynamicToolsExclude: ["read"],
+        },
+      });
+      await harness.waitForMethod("turn/start");
+      // Finish the attempt before assertions so a regression cannot leave a pending run.
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+
+      expect(snapshots).toHaveLength(2);
+      expect(snapshots[1]?.ref).toBeUndefined();
+      expect(snapshots[0]?.ref).toBeDefined();
+      if (restricted) {
+        expect(snapshots[0]?.initial).toEqual(expect.arrayContaining(["read", "sessions_spawn"]));
+        expect(snapshots[0]?.initial).not.toContain("fake__show");
+        expect(snapshots[0]?.ref?.toSorted()).toEqual(["fake__show", "sessions_spawn"]);
+      } else {
+        expect(snapshots[0]?.initial).toEqual([]);
+        expect(snapshots[0]?.ref).toEqual([]);
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #144617

## What Problem This Solves

Fixes an issue where child sessions spawned from a policy-restricted Codex attempt could inherit a tool list captured before Codex filtering and late MCP tool discovery. The list could retain excluded tools and omit requester-scoped tools available to the parent.

## Why This Change Was Made

Forward the existing host-owned allowlist reference through the execution tool build, then refresh that same reference from the final executable dynamic-tool surface. The registration-only catalog does not receive the reference, and unrestricted policy keeps its existing empty-list behavior.

The host remains the policy owner. The inspected native Codex `rust-v0.153.4` source (`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`, `codex-rs/core/src/tools/spec_plan.rs` and `codex-rs/core/src/tools/handlers/dynamic.rs`) registers these as external dynamic tools and waits for host execution results; no native protocol or permission change is needed.

## User Impact

Child sessions receive the parent's final authorized OpenClaw dynamic-tool names, including late requester-scoped MCP tools and excluding tools removed by the Codex adapter.

## Evidence

- Three affected native suites passed all 150 tests. Native Node 26.8.1 / Vitest 5 tests exercise `runCodexAppServerAttempt` and real host tool construction. Only requester-scoped MCP materialization is stubbed.
- With restrictive policy, the initial `read`/`sessions_spawn` list becomes `fake__show`/`sessions_spawn` after `read` is excluded and MCP discovery adds `fake__show`. Unrestricted policy leaves the inheritance reference empty; registration-only construction receives no execution reference.
- Reversing the production fix fails all three new regressions. Reversing only final capture while preserving forwarding fails the restrictive case with the stale list and passes the unrestricted control.
- Extension test typechecking, targeted lint/formatting, extension-test import boundaries, and max-lines ratchet passed. Independent autoreview of the final diff was scoped-clean through P2.

These checks prove the public attempt's inherited policy snapshot; they do not launch a live model or child agent.
