### PR TITLE
fix: preserve embedding quota errors beyond display previews

### DIFF
--- a/src/plugins/openai-compatible-embedding-provider.http-error.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.http-error.test.ts
@@ -19,53 +19,94 @@ afterEach(async () => {
 });
 
 describe("OpenAI-compatible embedding HTTP errors", () => {
-  it("preserves retry metadata while redacting reflected request credentials", async () => {
-    const token = "secret-reflected-token";
-    const server = createServer((request, response) => {
-      request.resume();
-      request.once("end", () => {
-        expect(request.headers.authorization).toBe(`Bearer ${token}`);
-        response.writeHead(429, {
-          "content-type": "application/json",
-          "retry-after": "4",
-        });
-        response.end(
-          JSON.stringify({
-            error: {
-              message: `Quota exhausted for ${token}`,
-              type: "rate_limit_error",
-              code: "rate_limit_exceeded",
-            },
-          }),
-        );
-      });
-    });
-    servers.add(server);
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const address = server.address() as AddressInfo;
-
-    const result = await openAICompatibleEmbeddingProviderAdapter.create({
-      config: {},
-      provider: "openai-compatible",
-      model: "text-embedding-bge-m3",
-      remote: { baseUrl: `http://127.0.0.1:${address.port}/v1`, apiKey: token },
-    });
-    if (!result.provider) {
-      throw new Error("expected OpenAI-compatible embedding provider");
-    }
-
-    const error = await result.provider.embed("hello").catch((cause: unknown) => cause);
-
-    expect(error).toBeInstanceOf(ProviderHttpError);
-    expect(error).toMatchObject({
-      status: 429,
+  it.each([
+    {
+      label: "short rate-limit",
+      padding: 0,
+      credentialPadding: 0,
       code: "rate_limit_exceeded",
       errorType: "rate_limit_error",
+      retryAfter: "4",
       retryAfterMs: 4_000,
-    });
-    expect((error as Error).message).toContain("openai-compatible embeddings failed: HTTP 429");
-    expect((error as Error).message).not.toContain(token);
-    expect((error as ProviderHttpError).errorBody).not.toContain(token);
-  });
+    },
+    {
+      label: "complete long quota",
+      padding: 1_200,
+      credentialPadding: 0,
+      code: "insufficient_quota",
+      errorType: "insufficient_quota",
+      retryAfter: undefined,
+      retryAfterMs: undefined,
+    },
+    {
+      label: "byte-limited error",
+      padding: 0,
+      credentialPadding: 9 * 1024,
+      code: undefined,
+      errorType: undefined,
+      retryAfter: undefined,
+      retryAfterMs: undefined,
+    },
+  ])(
+    "preserves $label metadata while redacting reflected request credentials",
+    async ({ padding, credentialPadding, code, errorType, retryAfter, retryAfterMs }) => {
+      const tokenPrefix = "secret-reflected-token";
+      const token = `${tokenPrefix}${"q".repeat(credentialPadding)}`;
+      const body = JSON.stringify({
+        error: {
+          message: `${padding || credentialPadding ? "Request rejected" : "Quota exhausted"} for ${token}${"x".repeat(padding)}`,
+          type: errorType,
+          code,
+        },
+      });
+      if (credentialPadding) {
+        expect(Buffer.byteLength(body)).toBeGreaterThan(8 * 1024);
+      } else if (padding) {
+        expect(body.length).toBeGreaterThan(1_000);
+        expect(Buffer.byteLength(body)).toBeLessThan(8 * 1024);
+      }
+      const server = createServer((request, response) => {
+        request.resume();
+        request.once("end", () => {
+          expect(request.headers.authorization).toBe(`Bearer ${token}`);
+          response.writeHead(429, {
+            "content-type": "application/json",
+            ...(retryAfter ? { "retry-after": retryAfter } : {}),
+          });
+          response.end(body);
+        });
+      });
+      servers.add(server);
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address() as AddressInfo;
+
+      const result = await openAICompatibleEmbeddingProviderAdapter.create({
+        config: {},
+        provider: "openai-compatible",
+        model: "text-embedding-bge-m3",
+        remote: { baseUrl: `http://127.0.0.1:${address.port}/v1`, apiKey: token },
+      });
+      if (!result.provider) {
+        throw new Error("expected OpenAI-compatible embedding provider");
+      }
+
+      const error = await result.provider.embed("hello").catch((cause: unknown) => cause);
+
+      expect(error).toBeInstanceOf(ProviderHttpError);
+      expect(error).toMatchObject({
+        status: 429,
+        code,
+        errorType,
+        retryAfterMs,
+      });
+      expect((error as Error).message).toContain("openai-compatible embeddings failed: HTTP 429");
+      expect((error as Error).message).not.toContain(tokenPrefix);
+      expect((error as ProviderHttpError).errorBody).not.toContain(tokenPrefix);
+      if (credentialPadding) {
+        expect((error as Error).message).toContain("Request rejected for ***... [truncated]");
+        expect((error as ProviderHttpError).errorBody).toContain("Request rejected for ***");
+      }
+    },
+  );
 });

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -292,30 +292,23 @@ function malformedEmbeddingResponse(): Error {
   return new Error("openai-compatible embeddings failed: malformed JSON response");
 }
 
-async function readEmbeddingErrorBodySnippet(response: Response): Promise<string | undefined> {
-  if (!response.body || response.bodyUsed) {
-    return undefined;
-  }
-  const prefix = await readResponseTextPrefix(response, EMBEDDING_ERROR_BODY_MAX_BYTES).catch(
-    () => undefined,
-  );
-  if (!prefix?.text) {
-    return undefined;
-  }
-  const { text, truncated } = prefix;
-  if (text.length > EMBEDDING_ERROR_BODY_MAX_CHARS) {
-    return `${truncateUtf16Safe(text, EMBEDDING_ERROR_BODY_MAX_CHARS)}${EMBEDDING_ERROR_TRUNCATED_SUFFIX}`;
-  }
-  return truncated ? `${text}${EMBEDDING_ERROR_TRUNCATED_SUFFIX}` : text;
-}
-
 async function createEmbeddingHttpError(
   response: Response,
   requestHeaders: HeadersInit,
 ): Promise<Error> {
-  const snippet = await readEmbeddingErrorBodySnippet(response);
+  const prefix =
+    response.body && !response.bodyUsed
+      ? await readResponseTextPrefix(response, EMBEDDING_ERROR_BODY_MAX_BYTES).catch(
+          () => undefined,
+        )
+      : undefined;
+  const safeBody = prefix?.text
+    ? redactProviderResponseErrorText(prefix.text, requestHeaders, {
+        sourceTruncated: prefix.truncated,
+      })
+    : undefined;
   const error = await createProviderHttpError(
-    new Response(snippet, {
+    new Response(safeBody, {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
@@ -323,12 +316,13 @@ async function createEmbeddingHttpError(
     "openai-compatible embeddings failed",
     { requestHeaders },
   );
-  const safeSnippet = snippet
-    ? redactProviderResponseErrorText(snippet, requestHeaders, {
-        sourceTruncated: snippet.endsWith(EMBEDDING_ERROR_TRUNCATED_SUFFIX),
-      })
-    : undefined;
-  error.message = `openai-compatible embeddings failed: HTTP ${response.status}${safeSnippet ? `: ${safeSnippet}` : ""}`;
+  let snippet = safeBody;
+  if (snippet && snippet.length > EMBEDDING_ERROR_BODY_MAX_CHARS) {
+    snippet = `${truncateUtf16Safe(snippet, EMBEDDING_ERROR_BODY_MAX_CHARS)}${EMBEDDING_ERROR_TRUNCATED_SUFFIX}`;
+  } else if (snippet && prefix?.truncated) {
+    snippet = `${snippet}${EMBEDDING_ERROR_TRUNCATED_SUFFIX}`;
+  }
+  error.message = `openai-compatible embeddings failed: HTTP ${response.status}${snippet ? `: ${snippet}` : ""}`;
   return error;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where memory indexing could treat a permanent embedding quota error as a temporary rate limit when an OpenAI-compatible provider returned a long JSON error message. The adapter shortened the body for display before extracting structured error fields, losing the quota code even when the complete response fit within its bounded read.

## Why This Change Was Made

The adapter now redacts the bounded response using its original truncation information, passes that body to the existing HTTP error parser, and shortens only the displayed message afterward. Structured quota metadata reaches the existing retry policy. This removes the one-use snippet reader and keeps body capture, redaction, and display limits distinct within the same error owner.

## User Impact

Long quota errors retain their error code and type, allowing the existing retry policy to stop when quota is exhausted. Displayed errors remain bounded and reflected request credentials remain redacted. Retry-After and transient rate-limit behavior are preserved.

## Evidence

- The original adapter failed the long-quota HTTP regression while its short rate-limit control passed.
- Final validation passed 110 selected cases: 3 loopback HTTP cases, 103 adapter/parser/redaction sibling cases, and 4 quota-policy cases (41 unrelated policy cases filtered).
- All 29 checks selected by the changed-file gate passed, including core and test type checks, lint, formatting, and boundary checks. Independent review found no remaining actionable findings through P2.
- Review caught a lost truncation fact in an intermediate version; the final version preserves it and checks bounded-body redaction. That added case was verified after repair.

The HTTP proof uses a synthetic local server; the retry policy is tested separately. No live provider or complete memory-indexing campaign was run.
