### PR TITLE
refactor(codex): normalize account rate-limit responses once

### DIFF
--- a/extensions/codex/src/app-server/rate-limits.ts
+++ b/extensions/codex/src/app-server/rate-limits.ts
@@ -14,11 +14,10 @@ import {
   type UsageWindow,
 } from "openclaw/plugin-sdk/provider-usage";
 import {
-  asBoolean,
-  asFiniteNumber,
   normalizeOptionalString,
   parseStrictFiniteNumber,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { z } from "zod";
 import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
 
 const CODEX_LIMIT_ID = "codex";
@@ -34,13 +33,77 @@ const CODEX_USAGE_LIMIT_MESSAGE_PREFIX = "You've reached your Codex subscription
 const CODEX_USAGE_LIMIT_STATE_MISMATCH_MESSAGE =
   "Codex rejected the request with a usage-limit error, but its current account usage does not report an exhausted limit.";
 
+// Sparse updates may omit fields; an invalid optional value must not discard
+// the other window or account metadata. Normalize both wire spellings once.
+const optionalNumber = z.number().optional().catch(undefined);
+const optionalBoolean = z.boolean().optional().catch(undefined);
+const rateLimitWindowSchema = z
+  .object({
+    usedPercent: optionalNumber,
+    used_percent: optionalNumber,
+    resetsAt: optionalNumber,
+    resets_at: optionalNumber,
+    windowDurationMins: optionalNumber,
+    window_duration_mins: optionalNumber,
+    windowMinutes: optionalNumber,
+    window_minutes: optionalNumber,
+  })
+  .transform((window) => {
+    const resetsAt = window.resetsAt ?? window.resets_at;
+    return {
+      usedPercent: window.usedPercent ?? window.used_percent,
+      // Deduplication uses wire seconds, before reset-date validation/truncation.
+      resetsAt,
+      resetsAtMs:
+        resolveExpiresAtMsFromEpochSeconds(resetsAt, { maxMs: MAX_DATE_TIMESTAMP_MS }) ?? 0,
+      windowDurationMins:
+        window.windowDurationMins ??
+        window.window_duration_mins ??
+        window.windowMinutes ??
+        window.window_minutes,
+    };
+  })
+  .optional()
+  .catch(undefined);
+const creditsSchema = z
+  .object({
+    hasCredits: optionalBoolean,
+    has_credits: optionalBoolean,
+    unlimited: optionalBoolean,
+    balance: z.preprocess(parseStrictFiniteNumber, optionalNumber),
+  })
+  .transform((credits) => ({
+    hasCredits: credits.hasCredits ?? credits.has_credits,
+    unlimited: credits.unlimited,
+    balance: credits.balance,
+  }))
+  .optional()
+  .catch(undefined);
+const rateLimitSnapshotSchema = z
+  .looseObject({
+    primary: rateLimitWindowSchema,
+    secondary: rateLimitWindowSchema,
+    credits: creditsSchema,
+  })
+  .transform((snapshot) => ({
+    primary: snapshot.primary,
+    secondary: snapshot.secondary,
+    credits: snapshot.credits,
+    limitId:
+      normalizeOptionalString(snapshot.limitId) ?? normalizeOptionalString(snapshot.limit_id),
+    limitName:
+      normalizeOptionalString(snapshot.limitName) ?? normalizeOptionalString(snapshot.limit_name),
+    planType:
+      normalizeOptionalString(snapshot.planType) ?? normalizeOptionalString(snapshot.plan_type),
+    rateLimitReachedType:
+      normalizeOptionalString(snapshot.rateLimitReachedType) ??
+      normalizeOptionalString(snapshot.rate_limit_reached_type),
+  }));
+type RateLimitSnapshot = z.infer<typeof rateLimitSnapshotSchema>;
+
 type LimitWindowKey = (typeof LIMIT_WINDOW_KEYS)[number];
 
-type RateLimitReset = {
-  resetsAtMs: number;
-  usedPercent?: number;
-  windowDurationMins?: number;
-};
+type RateLimitReset = NonNullable<z.infer<typeof rateLimitWindowSchema>>;
 
 type RateLimitWindowEntry = {
   key: LimitWindowKey;
@@ -220,7 +283,8 @@ export function buildCodexAppServerUsageSnapshot(
   value: unknown,
   options: { accountDetails?: boolean } = {},
 ): ProviderUsageSnapshot {
-  const snapshot = selectCodexProviderUsageSnapshot(value);
+  const snapshots = collectCodexRateLimitSnapshots(value);
+  const snapshot = snapshots.find(isCodexLimitSnapshot) ?? snapshots[0];
   const entries = snapshot ? readWindowEntries(snapshot) : [];
   const windows = entries
     .map((entry) => readProviderUsageWindow(entry, entries))
@@ -232,9 +296,8 @@ export function buildCodexAppServerUsageSnapshot(
     ...(snapshot ? { plan: resolveCodexProviderUsagePlan(snapshot) } : {}),
   };
   if (options.accountDetails && snapshot) {
-    result.plan =
-      normalizeOptionalString(snapshot.planType) ?? normalizeOptionalString(snapshot.plan_type);
-    for (const extra of collectCodexRateLimitSnapshots(value)) {
+    result.plan = snapshot.planType;
+    for (const extra of snapshots) {
       if (extra === snapshot) {
         continue;
       }
@@ -246,11 +309,8 @@ export function buildCodexAppServerUsageSnapshot(
         }
       }
     }
-    const credits = isJsonObject(snapshot.credits) ? snapshot.credits : undefined;
-    const balance =
-      typeof credits?.balance === "string"
-        ? parseStrictFiniteNumber(credits.balance)
-        : asFiniteNumber(credits?.balance);
+    const credits = snapshot.credits;
+    const balance = credits?.balance;
     if (balance !== undefined && balance >= 0 && credits?.unlimited !== true) {
       result.billing = [{ type: "balance", amount: balance, unit: "credits" }];
     }
@@ -276,7 +336,7 @@ function selectNextRateLimitReset(
   nowMs: number,
 ): RateLimitReset | undefined {
   const windows = collectCodexRateLimitSnapshots(value).flatMap((snapshot) =>
-    LIMIT_WINDOW_KEYS.flatMap((key) => readRateLimitWindow(snapshot, key) ?? []),
+    LIMIT_WINDOW_KEYS.flatMap((key) => snapshot[key] ?? []),
   );
   const futureWindows = windows.filter((window) => window.resetsAtMs > nowMs);
   if (futureWindows.length === 0) {
@@ -300,15 +360,16 @@ function selectBlockingRateLimitReset(
   return blockingSnapshot ? selectSnapshotBlockingReset(blockingSnapshot, nowMs) : undefined;
 }
 
-function summarizeRateLimitSnapshot(snapshot: JsonObject, nowMs: number): string | undefined {
+function summarizeRateLimitSnapshot(
+  snapshot: RateLimitSnapshot,
+  nowMs: number,
+): string | undefined {
   const label = formatLimitLabel(snapshot);
   const windows = LIMIT_WINDOW_KEYS.flatMap((key) => {
-    const window = readRateLimitWindow(snapshot, key);
+    const window = snapshot[key];
     return window ? [formatRateLimitWindow(key, window, nowMs)] : [];
   });
-  const reachedType =
-    normalizeOptionalString(snapshot.rateLimitReachedType) ??
-    normalizeOptionalString(snapshot.rate_limit_reached_type);
+  const reachedType = snapshot.rateLimitReachedType;
   const suffix = reachedType ? ` (${formatReachedType(reachedType)})` : "";
   if (windows.length > 0) {
     return `${label}: ${windows.join(" · ")}${suffix}`;
@@ -319,8 +380,8 @@ function summarizeRateLimitSnapshot(snapshot: JsonObject, nowMs: number): string
   return undefined;
 }
 
-function collectCodexRateLimitSnapshots(value: unknown): JsonObject[] {
-  const snapshots: JsonObject[] = [];
+function collectCodexRateLimitSnapshots(value: unknown): RateLimitSnapshot[] {
+  const snapshots: RateLimitSnapshot[] = [];
   const seen = new Set<string>();
   collectRateLimitSnapshots(value, snapshots, seen);
   return snapshots;
@@ -328,7 +389,7 @@ function collectCodexRateLimitSnapshots(value: unknown): JsonObject[] {
 
 function collectRateLimitSnapshots(
   value: unknown,
-  snapshots: JsonObject[],
+  snapshots: RateLimitSnapshot[],
   seen: Set<string>,
 ): void {
   if (Array.isArray(value)) {
@@ -341,7 +402,7 @@ function collectRateLimitSnapshots(
     return;
   }
   if (isRateLimitSnapshot(value)) {
-    addRateLimitSnapshot(value, snapshots, seen);
+    addRateLimitSnapshot(rateLimitSnapshotSchema.parse(value), snapshots, seen);
     return;
   }
   const byLimitId = value.rateLimitsByLimitId;
@@ -375,15 +436,13 @@ function sortedRateLimitKeys(keys: string[]): string[] {
 }
 
 function addRateLimitSnapshot(
-  snapshot: JsonObject,
-  snapshots: JsonObject[],
+  snapshot: RateLimitSnapshot,
+  snapshots: RateLimitSnapshot[],
   seen: Set<string>,
 ): void {
   const signature = [
-    normalizeOptionalString(snapshot.limitId) ?? normalizeOptionalString(snapshot.limit_id) ?? "",
-    normalizeOptionalString(snapshot.limitName) ??
-      normalizeOptionalString(snapshot.limit_name) ??
-      "",
+    snapshot.limitId ?? "",
+    snapshot.limitName ?? "",
     formatWindowSignature(snapshot.primary),
     formatWindowSignature(snapshot.secondary),
   ].join("|");
@@ -407,53 +466,13 @@ function isRateLimitSnapshot(value: JsonObject): boolean {
   );
 }
 
-function readRateLimitWindow(
-  snapshot: JsonObject,
-  key: LimitWindowKey,
-): RateLimitReset | undefined {
-  const window = snapshot[key];
-  if (!isJsonObject(window)) {
-    return undefined;
-  }
-  const resetsAt = asFiniteNumber(window.resetsAt) ?? asFiniteNumber(window.resets_at);
-  const resetsAtMs =
-    resolveExpiresAtMsFromEpochSeconds(resetsAt, { maxMs: MAX_DATE_TIMESTAMP_MS }) ?? 0;
-  return {
-    resetsAtMs,
-    ...readOptionalNumberField(window, "usedPercent", "used_percent"),
-    ...readOptionalNumberField(
-      window,
-      "windowDurationMins",
-      "window_duration_mins",
-      "windowMinutes",
-      "window_minutes",
-    ),
-  };
-}
-
-function snapshotHasDisplayableData(snapshot: JsonObject): boolean {
-  if (
-    normalizeOptionalString(snapshot.rateLimitReachedType) ??
-    normalizeOptionalString(snapshot.rate_limit_reached_type)
-  ) {
-    return true;
-  }
-  return readWindowEntries(snapshot).some(
-    (entry) => entry.window.usedPercent !== undefined || entry.window.resetsAtMs > 0,
+function snapshotHasDisplayableData(snapshot: RateLimitSnapshot): boolean {
+  return (
+    Boolean(snapshot.rateLimitReachedType) ||
+    readWindowEntries(snapshot).some(
+      (entry) => entry.window.usedPercent !== undefined || entry.window.resetsAtMs > 0,
+    )
   );
-}
-
-function readOptionalNumberField(
-  record: JsonObject,
-  ...keys: string[]
-): { usedPercent?: number; windowDurationMins?: number } {
-  const value = keys.map((key) => asFiniteNumber(record[key])).find((entry) => entry !== undefined);
-  if (value === undefined) {
-    return {};
-  }
-  return keys.some((key) => key.toLowerCase().includes("window"))
-    ? { windowDurationMins: value }
-    : { usedPercent: value };
 }
 
 function formatRateLimitWindow(key: LimitWindowKey, window: RateLimitReset, nowMs: number): string {
@@ -470,12 +489,8 @@ function formatRateLimitWindowDetails(window: RateLimitReset, nowMs: number): st
   return `${remainingPercent}${reset}`;
 }
 
-function formatLimitLabel(snapshot: JsonObject): string {
-  const label =
-    normalizeOptionalString(snapshot.limitName) ??
-    normalizeOptionalString(snapshot.limit_name) ??
-    normalizeOptionalString(snapshot.limitId) ??
-    normalizeOptionalString(snapshot.limit_id);
+function formatLimitLabel(snapshot: RateLimitSnapshot): string {
+  const label = snapshot.limitName ?? snapshot.limitId;
   if (!label || label === CODEX_LIMIT_ID) {
     return "Codex";
   }
@@ -499,25 +514,17 @@ function formatAccountResetTime(resetsAtMs: number, nowMs: number): string {
   )})`;
 }
 
-function snapshotHasLimitBlock(snapshot: JsonObject): boolean {
+function snapshotHasLimitBlock(snapshot: RateLimitSnapshot): boolean {
   return Boolean(
-    normalizeOptionalString(snapshot.rateLimitReachedType) ??
-    normalizeOptionalString(snapshot.rate_limit_reached_type) ??
+    snapshot.rateLimitReachedType ??
     readWindowEntries(snapshot).some(
       (entry) => entry.window.usedPercent !== undefined && entry.window.usedPercent >= 100,
     ),
   );
 }
 
-function isCodexLimitSnapshot(snapshot: JsonObject): boolean {
-  const id =
-    normalizeOptionalString(snapshot.limitId) ?? normalizeOptionalString(snapshot.limit_id);
-  return !id || id === CODEX_LIMIT_ID;
-}
-
-function selectCodexProviderUsageSnapshot(value: unknown): JsonObject | undefined {
-  const snapshots = collectCodexRateLimitSnapshots(value);
-  return snapshots.find(isCodexLimitSnapshot) ?? snapshots[0];
+function isCodexLimitSnapshot(snapshot: RateLimitSnapshot): boolean {
+  return !snapshot.limitId || snapshot.limitId === CODEX_LIMIT_ID;
 }
 
 function readProviderUsageWindow(
@@ -558,32 +565,23 @@ function formatProviderUsageWindowLabel(
   return entry.key === "primary" ? "Short" : "Long";
 }
 
-function resolveCodexProviderUsagePlan(snapshot: JsonObject): string | undefined {
-  const plan =
-    normalizeOptionalString(snapshot.planType) ?? normalizeOptionalString(snapshot.plan_type);
-  const credits = isJsonObject(snapshot.credits) ? snapshot.credits : undefined;
-  const creditSummary = formatCodexCreditSummary(credits);
+function resolveCodexProviderUsagePlan(snapshot: RateLimitSnapshot): string | undefined {
+  const plan = snapshot.planType;
+  const creditSummary = formatCodexCreditSummary(snapshot.credits);
   if (!creditSummary) {
     return plan;
   }
   return plan ? `${plan} (${creditSummary})` : creditSummary;
 }
 
-function formatCodexCreditSummary(credits: JsonObject | undefined): string | undefined {
-  if (!credits) {
+function formatCodexCreditSummary(credits: RateLimitSnapshot["credits"]): string | undefined {
+  if (!credits || credits.hasCredits === false) {
     return undefined;
   }
-  const hasCredits = asBoolean(credits.hasCredits) ?? asBoolean(credits.has_credits);
-  if (hasCredits === false) {
-    return undefined;
-  }
-  if (asBoolean(credits.unlimited)) {
+  if (credits.unlimited) {
     return "Unlimited credits";
   }
-  const balance =
-    typeof credits.balance === "string"
-      ? parseStrictFiniteNumber(credits.balance)
-      : asFiniteNumber(credits.balance);
+  const balance = credits.balance;
   if (balance === undefined || balance <= 0) {
     return undefined;
   }
@@ -592,7 +590,7 @@ function formatCodexCreditSummary(credits: JsonObject | undefined): string | und
 }
 
 function selectSnapshotBlockingReset(
-  snapshot: JsonObject,
+  snapshot: RateLimitSnapshot,
   nowMs: number,
 ): RateLimitReset | undefined {
   const futureWindows = readWindowEntries(snapshot)
@@ -636,9 +634,9 @@ function selectBlockingWindowEntry(
   )[0];
 }
 
-function readWindowEntries(snapshot: JsonObject): RateLimitWindowEntry[] {
+function readWindowEntries(snapshot: RateLimitSnapshot): RateLimitWindowEntry[] {
   return LIMIT_WINDOW_KEYS.flatMap((key) => {
-    const window = readRateLimitWindow(snapshot, key);
+    const window = snapshot[key];
     return window ? [{ key, window }] : [];
   });
 }
@@ -663,7 +661,7 @@ function formatBlockingLimitPeriod(
   return undefined;
 }
 
-function formatUsageLine(snapshot: JsonObject): string | undefined {
+function formatUsageLine(snapshot: RateLimitSnapshot): string | undefined {
   const entries = readWindowEntries(snapshot);
   const windows = entries
     .filter((entry) => entry.window.usedPercent !== undefined)
@@ -779,13 +777,8 @@ function formatResetDuration(resetsAtMs: number, nowMs: number): string {
   return `${seconds}s`;
 }
 
-function formatWindowSignature(value: JsonValue | undefined): string {
-  if (!isJsonObject(value)) {
-    return "";
-  }
-  return `${asFiniteNumber(value.usedPercent) ?? asFiniteNumber(value.used_percent) ?? ""}:${
-    asFiniteNumber(value.resetsAt) ?? asFiniteNumber(value.resets_at) ?? ""
-  }`;
+function formatWindowSignature(window: RateLimitSnapshot["primary"]): string {
+  return window ? `${window.usedPercent ?? ""}:${window.resetsAt ?? ""}` : "";
 }
 
 function extractCodexRetryHint(message: string | undefined): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Codex account usage, status summaries, and usage-limit errors repeatedly interpret the same response fields. This maintainer-requested cleanup gives those consumers one normalized snapshot while preserving their existing output.

Related: #132453 (saved-account usage backend), #132454 (account usage UI).

## Why This Change Was Made

Use the plugin's existing Zod 4.4.3 dependency to normalize windows and credits once. Keep the existing envelope recognition, bucket ordering, first-wins deduplication, camelCase/snake_case support, and partial-value handling. Remove three parsing helpers and reuse the parsed snapshot array when selecting additional account quota groups.

## User Impact

No intended user-visible change. Default provider summaries retain rounded credit wording; account rows retain precise balances and extra quota groups. The approved UI, Codex-only account selection, lazy registration boundary, reset selection, and error guidance remain unchanged.

## Evidence

Representative input: plan `pro`, balance `"12.75"`, a Codex window at 10% used, and an extra quota group at 75% used.

| Observed output | Before | After |
| --- | --- | --- |
| Default plan summary | `pro (13 credits)` | `pro (13 credits)` |
| Account plan | `pro` | `pro` |
| Account balance | `12.75 credits` | `12.75 credits` |
| Account quota groups | Codex once, Extra quota once | Codex once, Extra quota once |

- 42 focused parser/provider/account-RPC/import-boundary tests passed, plus three selected command-output tests.
- A temporary differential probe compared 777 payloads across nine public output projections (6,993 comparisons); all matched the baseline. It covered supported envelopes, partial windows, both naming styles, precise/zero/invalid balances, additional buckets, deduplication, summaries, resets, and error guidance.
- Selected repository checks passed, including production/test types, changed-file lint/format, plugin/dependency guards, dead-export checks, and import-cycle checks.
- Proof ran on Blacksmith Testbox prepared by [run 34553540712](https://github.com/openclaw/openclaw/actions/runs/34553540712). Candidate and relevant caller/test files were verified by SHA-256 before the successful candidate runs. This is focused proof in the prepared environment, not exact-base full CI. Exact published-head CI is tracked separately below.
- No authenticated live quota request or new browser proof was performed. UI files are untouched.

Inspected upstream Codex revision `c73296a0f095e72dbb646909c613ae09c9459c3a`: `codex-rs/app-server-protocol/src/protocol/v2/account.rs:264,410,492,513`, the generated `GetAccountRateLimitsResponse` JSON/TypeScript schemas, and `codex-rs/protocol/src/protocol.rs:2090,2130,2140`. Installed `@openai/codex` is 0.153.4 and exports its binary, not an importable response schema.

## Review and CI

- Native Astra medium review: two consecutive clean passes on `72eb3f59113673bf232c07d4fa59cd37254c8011`.
- Independent Astra medium review: general and focused TypeScript/schema reviewers found no supported defects on the same head. These were source reviews; runtime proof is reported above. No review fixes were needed.
- Exact-head [CI run 34557962614](https://github.com/openclaw/openclaw/actions/runs/34557962614): the first attempt passed 190 jobs and failed the board browser job plus its dependent aggregate gate (six jobs skipped). The [board failure](https://github.com/openclaw/openclaw/actions/runs/34557962614/job/103134772830) received no frameless-iframe size message before its wait expired (`board-view.browser.test.ts:458`). That local `about:blank`/`srcdoc` fixture does not enter the Codex parser flow. [Nearby main UI proof](https://github.com/openclaw/openclaw/actions/runs/34557873998/job/103134444867) passed the same test in 284 ms with identical relevant source, test configuration, and dependencies. After inspecting both logs, one targeted debug retry was requested; the CI run link shows its result. The exact missing-message cause is unproven, and no unrelated source repair or rebase was made.

## Change Breakdown

Compared `e62272f04a3ed701ae1a2f13d5ae29beb85f9224` to `72eb3f59113673bf232c07d4fa59cd37254c8011`.

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Implementation | 1 | +116 | -123 |
| **Total** | **1** | **+116** | **-123** |

The parser decreases from 805 to 798 lines. Explicit `if`/ternary branches decrease from 108 to 99; these are source counts, not a performance claim.
