### PR TITLE
improve: focus worker generation borrowing tests

### DIFF
--- a/test/scripts/vitest-worker-artifacts.test-support.ts
+++ b/test/scripts/vitest-worker-artifacts.test-support.ts
@@ -167,6 +167,43 @@ export function writeFixture(directory: string, name: string, source: string) {
   return filename;
 }
 
+export function workerBorrowingProbe(directory: string) {
+  const value = writeFixture(directory, "value.ts", 'export const value: string = "first";');
+  const test = writeFixture(
+    directory,
+    "child.test.ts",
+    `
+    import fs from 'node:fs';
+    import path from 'node:path';
+    import {it,expect,inject} from 'vitest';
+    import {value} from '#fixture-value';
+    import {runtimeProcessEntrypoints} from ${JSON.stringify(path.join(root, "src/infra/runtime-process-entrypoints.ts"))};
+    import {resolveRuntimeWorkerUrl} from ${JSON.stringify(path.join(root, "src/infra/runtime-worker-url.ts"))};
+    const generation = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteReadOnly);
+    const preparedAtCollection = fs.existsSync(generation);
+    it('borrows the compiled generation through its runtime declaration',()=>{
+      const launcherArgv = inject('launcherArgv');
+      expect(path.isAbsolute(launcherArgv[1])).toBe(true);
+      expect(path.basename(launcherArgv[1])).toBe('vitest.mjs');
+      expect(generation.pathname.endsWith('/dist/infra/sqlite-readonly-location.worker.js')).toBe(true);
+      expect(preparedAtCollection).toBe(true);
+      expect(value).toBe('first');
+      fs.appendFileSync(${JSON.stringify(path.join(directory, "generations.jsonl"))},JSON.stringify(generation.href)+'\\n');
+    });
+  `,
+  );
+  const config = writeFixture(
+    directory,
+    "vitest.config.mts",
+    `
+    import {sharedVitestConfig as shared} from ${JSON.stringify(pathToFileURL(path.join(root, "test/vitest/vitest.shared.config.ts")).href)};
+    const project = name => ({extends:false,plugins:shared.plugins,resolve:{...shared.resolve,alias:[{find:'#fixture-value',replacement:${JSON.stringify(value)}},...shared.resolve.alias]},test:{name,include:[${JSON.stringify(convertPathToPattern(test))}],pool:'forks',maxWorkers:1,testTimeout:shared.test.testTimeout,provide:{launcherArgv:process.argv}}});
+    export default async () => ({root:${JSON.stringify(root)},plugins:shared.plugins,test:{projects:[project('first'),project('second')]}});
+  `,
+  );
+  return { config };
+}
+
 export function workerProbe(
   directory: string,
   holdSecond = false,

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -24,6 +24,7 @@ import { copyFsSafePackageFixture } from "./fs-safe-package.test-support.js";
 import {
   createWorkerArtifactTest,
   preparationClient,
+  workerBorrowingProbe,
   workerProbe,
   writeFixture,
 } from "./vitest-worker-artifacts.test-support.js";
@@ -791,7 +792,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
         ["separate", "equals"].map((configForm) =>
           workerArtifacts.fixtureLifetime.run(async () => {
             const directory = workerArtifacts.fixtureDirectory();
-            const { config } = workerProbe(directory);
+            const { config } = workerBorrowingProbe(directory);
             const budgetReceipt = path.join(directory, "compiler-budget.json");
             const preload = writeFixture(
               directory,
@@ -1078,7 +1079,7 @@ if (process.argv[1]?.endsWith("vitest-worker-compiler.mts")) {
     workerArtifacts.fixtureLifetime.run(async () => {
       const { node } = workerArtifacts.createFixtureCommands();
       const directory = workerArtifacts.fixtureDirectory();
-      const { config } = workerProbe(directory);
+      const { config } = workerBorrowingProbe(directory);
       const reporter = writeFixture(
         directory,
         "tamper-reporter.mjs",


### PR DESCRIPTION
Related: #144359

## What Problem This Solves

Two worker-artifact tests repeat SQLite snapshot, archive-worker, and runtime integration work while checking generation sharing and failure reporting. That extra work makes the tooling suite more expensive.

## Why This Change Was Made

Use a smaller real borrowing fixture for the lazy-build/config-form and failed-trailer cases. It preserves actual compilation, declaration acquisition, IPC ownership, two projects, alias resolution, compiler budget assertions, distinct invocation generations, artifact verification, and cleanup. Existing full runtime integration cases remain unchanged. The tradeoff is 38 additional test/support lines; production code is unchanged.

## User Impact

No product behavior change. Developers get more focused test fixtures. This does not establish a fix for the Windows timeouts observed in #144359; their cause remains unresolved.

## Evidence

- Full existing file on Node 24.19.0 before and after: identical 34 ordered cases, all passing, no skipped cases.
- One matched local pair with separate fresh caches: whole wrapper 73.71s → 70.62s (4.18%); lazy-build/config forms 7.97s → 5.59s; failed trailer 7.65s → 5.65s. These are local observations, not a general performance guarantee.
- Mapped changed checks passed, including root-test typechecking, formatting, lint, dependency guards, and dead-export checks.
- Fresh independent review found no actionable P0–P2 findings. Existing tests and relevant compiler/lifecycle owners were unchanged on current main at review.
