### PR TITLE
fix(backup): preserve committed data in SQLite hardlink aliases

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -342,6 +342,17 @@ SQLite capabilities also fails closed rather than falling back to a direct file
 copy. Other workspace SQLite files outside configured agent roots remain raw
 workspace files and do not receive the SQLite snapshot or compaction guarantee.
 
+Hardlinks to a generic SQLite database share one captured image, stored as a
+separate regular archive entry for each name. Every hardlink must be an included
+`.sqlite` file under the state directory or a configured agent root. If exactly
+one name has a nonempty write-ahead log (WAL), that
+name supplies the committed data. Closed databases without a nonempty WAL remain
+supported. Multiple nonempty WALs, a nonempty rollback journal, or hardlinks
+outside the backup inventory cause an explicit refusal with no archive. Close
+the database writers cleanly and include every hardlink in those roots before retrying.
+Canonical OpenClaw database aliases retain their existing owner validation and
+sanitization.
+
 Installed plugin source and manifest files under the state directory's `extensions/` tree are included, but their nested `node_modules/` dependency trees are skipped as rebuildable install artifacts. After restoring an archive, use `openclaw plugins update <id>` or reinstall with `openclaw plugins install <spec> --force` if a restored plugin reports missing dependencies.
 
 The state directory's `plugin-skills/` root is a generated, OpenClaw-owned symlink index, not authoritative state. Backup creation reports and omits that root because its absolute targets are specific to the source installation. After activating restored state, run `openclaw skills list` or start an agent session to rebuild the links from current plugin metadata.

--- a/src/infra/backup-create.sqlite-hardlinks.test.ts
+++ b/src/infra/backup-create.sqlite-hardlinks.test.ts
@@ -1,0 +1,396 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import * as tar from "tar";
+import { describe, expect, it, vi } from "vitest";
+import { verifyBackupArchive } from "../commands/backup-verify.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  type OpenClawTestState,
+  withOpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { createBackupArchive, type BackupCreateResult } from "./backup-create.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import * as sqliteSnapshot from "./sqlite-snapshot.js";
+
+type HardlinkedDatabase = {
+  state: OpenClawTestState;
+  database: DatabaseSync;
+  ownerPath: string;
+  aliasPath: string;
+};
+
+async function withHardlinkedDatabase(
+  ownerName: "alpha.sqlite" | "zeta.sqlite",
+  run: (fixture: HardlinkedDatabase) => Promise<void>,
+): Promise<void> {
+  await withOpenClawTestState(
+    { layout: "split", prefix: "backup-generic-hardlinks-", scenario: "minimal" },
+    async (state) => {
+      const ownerPath = state.statePath("plugins", "hardlinks", ownerName);
+      const aliasPath = state.statePath(
+        "plugins",
+        "hardlinks",
+        ownerName === "alpha.sqlite" ? "zeta.sqlite" : "alpha.sqlite",
+      );
+      await fs.mkdir(path.dirname(ownerPath), { recursive: true });
+      const sqlite = requireNodeSqlite();
+      const database = new sqlite.DatabaseSync(ownerPath);
+      try {
+        database.exec(`
+          PRAGMA journal_mode = WAL;
+          PRAGMA wal_autocheckpoint = 0;
+          CREATE TABLE hardlink_records (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+          INSERT INTO hardlink_records (id, value) VALUES (7, 'committed-in-wal');
+        `);
+        await fs.link(ownerPath, aliasPath);
+        const owner = await fs.stat(ownerPath);
+        const alias = await fs.stat(aliasPath);
+        expect({ dev: alias.dev, ino: alias.ino, nlink: alias.nlink }).toEqual({
+          dev: owner.dev,
+          ino: owner.ino,
+          nlink: 2,
+        });
+        expect(owner.nlink).toBe(2);
+        expect((await fs.stat(`${ownerPath}-wal`)).size).toBeGreaterThan(0);
+        await expect(fs.stat(`${aliasPath}-wal`)).rejects.toMatchObject({ code: "ENOENT" });
+        await run({ state, database, ownerPath, aliasPath });
+      } finally {
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+    },
+  );
+}
+
+async function readArchivedRecords(state: OpenClawTestState, archive: BackupCreateResult) {
+  const entries: Array<{ path: string; type: string | undefined; linkpath: string | undefined }> =
+    [];
+  await tar.t({
+    file: archive.archivePath,
+    gzip: true,
+    onentry: (entry) => {
+      if (entry.path.includes("/state/plugins/hardlinks/") && entry.type !== "Directory") {
+        entries.push({ path: entry.path, type: entry.type, linkpath: entry.linkpath });
+      }
+      entry.resume();
+    },
+  });
+  entries.sort((left, right) => left.path.localeCompare(right.path));
+  expect(
+    entries.map((entry) => ({
+      name: path.basename(entry.path),
+      type: entry.type,
+      linkpath: entry.linkpath,
+    })),
+  ).toEqual([
+    { name: "alpha.sqlite", type: "File", linkpath: undefined },
+    { name: "zeta.sqlite", type: "File", linkpath: undefined },
+  ]);
+  const extractDir = state.path("extract");
+  await fs.mkdir(extractDir);
+  await tar.x({ file: archive.archivePath, gzip: true, cwd: extractDir });
+  const sqlite = requireNodeSqlite();
+  return entries.map((entry) => {
+    const database = new sqlite.DatabaseSync(path.join(extractDir, entry.path), { readOnly: true });
+    try {
+      expect(database.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+      return {
+        name: path.basename(entry.path),
+        rows: database.prepare("SELECT id, value FROM hardlink_records ORDER BY id").all(),
+      };
+    } finally {
+      database.close();
+    }
+  });
+}
+
+async function expectBackupRefused(state: OpenClawTestState, message: RegExp): Promise<void> {
+  const output = state.path("rejected.tar.gz");
+  await expect(createBackupArchive({ output, includeWorkspace: false })).rejects.toThrow(message);
+  await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+}
+
+describe.skipIf(process.platform === "win32")("backup generic SQLite hardlinks", () => {
+  it.each(["alpha.sqlite", "zeta.sqlite"] as const)(
+    "preserves WAL-only schema and rows in both regular entries when %s owns the WAL",
+    async (ownerName) => {
+      await withHardlinkedDatabase(ownerName, async ({ state }) => {
+        const archive = await createBackupArchive({
+          output: state.path("backup.tar.gz"),
+          includeWorkspace: false,
+        });
+        await expect(verifyBackupArchive(archive.archivePath)).resolves.toMatchObject({ ok: true });
+        expect(await readArchivedRecords(state, archive)).toEqual([
+          { name: "alpha.sqlite", rows: [{ id: 7, value: "committed-in-wal" }] },
+          { name: "zeta.sqlite", rows: [{ id: 7, value: "committed-in-wal" }] },
+        ]);
+      });
+    },
+  );
+
+  it("refuses competing nonempty WAL names even when their contents are identical", async () => {
+    await withHardlinkedDatabase("alpha.sqlite", async ({ state, ownerPath, aliasPath }) => {
+      await fs.copyFile(`${ownerPath}-wal`, `${aliasPath}-wal`);
+      await expectBackupRefused(state, /ambiguous.*multiple non-empty WAL/iu);
+    });
+  });
+
+  it.each([
+    {
+      name: "refuses a canonical symlink retargeted after an earlier generic snapshot completes",
+      change: "symlink retarget",
+    },
+    {
+      name: "refuses a canonical-bound hardlink alias replaced after an earlier generic snapshot completes",
+      change: "hardlink replacement",
+    },
+  ])("$name", async ({ change }) => {
+    await withHardlinkedDatabase("alpha.sqlite", async ({ state, ownerPath }) => {
+      const canonicalPath = resolveOpenClawStateSqlitePath(state.env);
+      const firstPath = state.statePath("state", "first-global.sqlite");
+      const secondPath = state.statePath("state", "second-global.sqlite");
+      const canonicalAliasPath = state.statePath("state", "zeta-global-alias.sqlite");
+      await fs.mkdir(path.dirname(canonicalPath), { recursive: true });
+      const sqlite = requireNodeSqlite();
+      for (const databasePath of [firstPath, secondPath]) {
+        const database = new sqlite.DatabaseSync(databasePath);
+        try {
+          database.exec(`
+            CREATE TABLE schema_meta (
+              meta_key TEXT NOT NULL PRIMARY KEY,
+              role TEXT NOT NULL,
+              schema_version INTEGER NOT NULL,
+              agent_id TEXT,
+              app_version TEXT,
+              created_at INTEGER NOT NULL,
+              updated_at INTEGER NOT NULL
+            );
+            PRAGMA user_version = 1;
+            INSERT INTO schema_meta
+              (meta_key, role, schema_version, agent_id, app_version, created_at, updated_at)
+            VALUES ('primary', 'global', 1, NULL, NULL, 1, 1);
+          `);
+        } finally {
+          database.close();
+        }
+      }
+      await fs.symlink(firstPath, canonicalPath);
+      await fs.link(firstPath, canonicalAliasPath);
+      const originalIdentity = await fs.stat(firstPath);
+      expect((await fs.stat(canonicalAliasPath)).ino).toBe(originalIdentity.ino);
+      const originalSnapshot = sqliteSnapshot.createVerifiedSqliteSnapshot;
+      let changed = false;
+      const snapshot = vi
+        .spyOn(sqliteSnapshot, "createVerifiedSqliteSnapshot")
+        .mockImplementation(async (options) => {
+          const result = await originalSnapshot(options);
+          if (!changed && options.sourcePath === ownerPath) {
+            if (change === "symlink retarget") {
+              await fs.unlink(canonicalPath);
+              await fs.symlink(secondPath, canonicalPath);
+            } else {
+              await fs.unlink(canonicalAliasPath);
+              await fs.copyFile(secondPath, canonicalAliasPath);
+            }
+            changed = true;
+          }
+          return result;
+        });
+      try {
+        await expectBackupRefused(state, /Canonical SQLite path changed after discovery/iu);
+        expect(changed).toBe(true);
+        if (change === "symlink retarget") {
+          expect(await fs.realpath(canonicalPath)).toBe(secondPath);
+        } else {
+          expect(await fs.realpath(canonicalPath)).toBe(firstPath);
+          expect((await fs.stat(canonicalPath)).ino).toBe(originalIdentity.ino);
+          expect((await fs.stat(canonicalAliasPath)).ino).not.toBe(originalIdentity.ino);
+        }
+      } finally {
+        snapshot.mockRestore();
+      }
+    });
+  });
+
+  it.each([
+    { admitted: 1, total: 2 },
+    { admitted: 2, total: 3 },
+  ])(
+    "refuses $admitted admitted names for an inode with $total links",
+    async ({ admitted, total }) => {
+      await withHardlinkedDatabase("alpha.sqlite", async ({ state, ownerPath, aliasPath }) => {
+        if (admitted === 1) {
+          await fs.rename(aliasPath, state.path("outside.sqlite"));
+        } else {
+          await fs.link(ownerPath, state.path("outside.sqlite"));
+        }
+        expect((await fs.stat(ownerPath)).nlink).toBe(total);
+        await expectBackupRefused(state, /journal owner may be outside the backup inventory/iu);
+      });
+    },
+  );
+
+  it.each(["absent", "empty"] as const)(
+    "preserves closed checkpointed hardlinks with %s WAL sidecars",
+    async (sidecars) => {
+      await withHardlinkedDatabase(
+        "alpha.sqlite",
+        async ({ state, database, ownerPath, aliasPath }) => {
+          database.close();
+          await expect(fs.stat(`${ownerPath}-wal`)).rejects.toMatchObject({ code: "ENOENT" });
+          if (sidecars === "empty") {
+            await fs.writeFile(`${ownerPath}-wal`, "");
+            await fs.writeFile(`${aliasPath}-wal`, "");
+            await fs.writeFile(`${aliasPath}-journal`, "");
+          }
+          const archive = await createBackupArchive({
+            output: state.path("backup.tar.gz"),
+            includeWorkspace: false,
+          });
+          expect(await readArchivedRecords(state, archive)).toEqual([
+            { name: "alpha.sqlite", rows: [{ id: 7, value: "committed-in-wal" }] },
+            { name: "zeta.sqlite", rows: [{ id: 7, value: "committed-in-wal" }] },
+          ]);
+        },
+      );
+    },
+  );
+
+  it("refuses a hardlink group with a live rollback journal", async () => {
+    await withHardlinkedDatabase("alpha.sqlite", async ({ state, database, ownerPath }) => {
+      database.exec(`
+        PRAGMA wal_checkpoint(TRUNCATE);
+        PRAGMA journal_mode = DELETE;
+        BEGIN IMMEDIATE;
+        UPDATE hardlink_records SET value = 'uncommitted' WHERE id = 7;
+      `);
+      try {
+        expect((await fs.stat(`${ownerPath}-journal`)).size).toBeGreaterThan(0);
+        await expectBackupRefused(state, /journal ownership.*rollback journal is present/iu);
+      } finally {
+        database.exec("ROLLBACK");
+      }
+    });
+  });
+
+  it.each([
+    { change: "a competing WAL appears", error: /ambiguous.*multiple non-empty WAL/iu },
+    {
+      change: "an alias is replaced",
+      error: /source identity changed|outside the backup inventory/iu,
+    },
+    { change: "an outside link is added", error: /outside the backup inventory/iu },
+    { change: "the selected WAL is replaced", error: /journal ownership changed/iu },
+  ])("publishes no archive when $change during capture", async ({ change, error }) => {
+    await withHardlinkedDatabase("alpha.sqlite", async ({ state, ownerPath, aliasPath }) => {
+      const originalSnapshot = sqliteSnapshot.createVerifiedSqliteSnapshot;
+      const movedWal = state.path("selected-wal.saved");
+      let changed = false;
+      let walMoved = false;
+      const snapshot = vi
+        .spyOn(sqliteSnapshot, "createVerifiedSqliteSnapshot")
+        .mockImplementation(async (options) => {
+          const result = await originalSnapshot(options);
+          if (!changed && options.sourcePath === ownerPath) {
+            changed = true;
+            if (change === "a competing WAL appears") {
+              await fs.copyFile(`${ownerPath}-wal`, `${aliasPath}-wal`);
+            } else if (change === "an alias is replaced") {
+              await fs.unlink(aliasPath);
+              await fs.copyFile(ownerPath, aliasPath);
+            } else if (change === "an outside link is added") {
+              await fs.link(ownerPath, state.path("outside.sqlite"));
+            } else {
+              await fs.rename(`${ownerPath}-wal`, movedWal);
+              walMoved = true;
+              await fs.copyFile(movedWal, `${ownerPath}-wal`);
+            }
+          }
+          return result;
+        });
+      try {
+        await expectBackupRefused(state, error);
+        expect(changed).toBe(true);
+      } finally {
+        snapshot.mockRestore();
+        if (walMoved) {
+          await fs.rename(movedWal, `${ownerPath}-wal`);
+        }
+      }
+    });
+  });
+
+  it("refuses a closed hardlink group that acquires its first WAL during capture", async () => {
+    await withHardlinkedDatabase(
+      "alpha.sqlite",
+      async ({ state, database, ownerPath, aliasPath }) => {
+        database.close();
+        await expect(fs.stat(`${ownerPath}-wal`)).rejects.toMatchObject({ code: "ENOENT" });
+        const sqlite = requireNodeSqlite();
+        const originalSnapshot = sqliteSnapshot.createVerifiedSqliteSnapshot;
+        let writer: DatabaseSync | undefined;
+        const snapshot = vi
+          .spyOn(sqliteSnapshot, "createVerifiedSqliteSnapshot")
+          .mockImplementation(async (options) => {
+            const result = await originalSnapshot(options);
+            if (!writer && (options.sourcePath === ownerPath || options.sourcePath === aliasPath)) {
+              writer = new sqlite.DatabaseSync(ownerPath);
+              writer.exec(`
+              PRAGMA journal_mode = WAL;
+              PRAGMA wal_autocheckpoint = 0;
+              INSERT INTO hardlink_records (id, value) VALUES (9, 'new-wal-owner');
+            `);
+            }
+            return result;
+          });
+        try {
+          await expectBackupRefused(state, /journal ownership changed/iu);
+          expect((await fs.stat(`${ownerPath}-wal`)).size).toBeGreaterThan(0);
+        } finally {
+          snapshot.mockRestore();
+          writer?.close();
+        }
+      },
+    );
+  });
+
+  it("keeps one captured image for both aliases while the selected WAL grows", async () => {
+    await withHardlinkedDatabase("alpha.sqlite", async ({ state, database, ownerPath }) => {
+      const originalSnapshot = sqliteSnapshot.createVerifiedSqliteSnapshot;
+      const walBefore = await fs.stat(`${ownerPath}-wal`);
+      let appended = false;
+      const snapshot = vi
+        .spyOn(sqliteSnapshot, "createVerifiedSqliteSnapshot")
+        .mockImplementation(async (options) => {
+          const result = await originalSnapshot(options);
+          if (!appended && options.sourcePath === ownerPath) {
+            appended = true;
+            database.exec("INSERT INTO hardlink_records (id, value) VALUES (9, 'committed-later')");
+          }
+          return result;
+        });
+      try {
+        const archive = await createBackupArchive({
+          output: state.path("backup.tar.gz"),
+          includeWorkspace: false,
+        });
+        expect(appended).toBe(true);
+        expect((await fs.stat(`${ownerPath}-wal`)).size).toBeGreaterThan(walBefore.size);
+        expect(
+          database.prepare("SELECT id, value FROM hardlink_records ORDER BY id").all(),
+        ).toEqual([
+          { id: 7, value: "committed-in-wal" },
+          { id: 9, value: "committed-later" },
+        ]);
+        expect(await readArchivedRecords(state, archive)).toEqual([
+          { name: "alpha.sqlite", rows: [{ id: 7, value: "committed-in-wal" }] },
+          { name: "zeta.sqlite", rows: [{ id: 7, value: "committed-in-wal" }] },
+        ]);
+      } finally {
+        snapshot.mockRestore();
+      }
+    });
+  });
+});

--- a/src/infra/backup-create.sqlite-hardlinks.test.ts
+++ b/src/infra/backup-create.sqlite-hardlinks.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../test-utils/openclaw-test-state.js";
 import { createBackupArchive, type BackupCreateResult } from "./backup-create.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
+import { readMainDatabasePosixLocks } from "./sqlite-posix-locks.test-support.js";
 import * as sqliteSnapshot from "./sqlite-snapshot.js";
 
 type HardlinkedDatabase = {
@@ -113,6 +114,29 @@ async function expectBackupRefused(state: OpenClawTestState, message: RegExp): P
 }
 
 describe.skipIf(process.platform === "win32")("backup generic SQLite hardlinks", () => {
+  it.runIf(process.platform === "linux").each(["singleton", "hardlink pair"] as const)(
+    "preserves a live writer's main-file POSIX lock when backing up a generic %s",
+    async (layout) => {
+      await withHardlinkedDatabase("alpha.sqlite", async ({ state, ownerPath, aliasPath }) => {
+        if (layout === "singleton") {
+          await fs.unlink(aliasPath);
+        }
+        const locksBefore = readMainDatabasePosixLocks(ownerPath);
+        expect(locksBefore).toEqual([
+          { length: 510, pid: process.pid, start: 1073741826, type: "read" },
+        ]);
+
+        const archive = await createBackupArchive({
+          output: state.path("backup.tar.gz"),
+          includeWorkspace: false,
+        });
+
+        expect(readMainDatabasePosixLocks(ownerPath)).toEqual(locksBefore);
+        expect((await fs.stat(archive.archivePath)).size).toBeGreaterThan(0);
+      });
+    },
+  );
+
   it.each(["alpha.sqlite", "zeta.sqlite"] as const)(
     "preserves WAL-only schema and rows in both regular entries when %s owns the WAL",
     async (ownerName) => {

--- a/src/infra/backup-sqlite-snapshot.ts
+++ b/src/infra/backup-sqlite-snapshot.ts
@@ -13,6 +13,11 @@ import {
   sanitizeOpenClawGlobalStateSnapshot,
   sanitizeOpenClawStateLeaseRows,
 } from "../state/openclaw-state-snapshot-sanitizer.js";
+import {
+  captureBackupSqliteSourceGroup,
+  planBackupSqliteSourceGroups,
+  type BackupSqliteSourceGroup,
+} from "./backup-sqlite-source-groups.js";
 import { isTransientSqliteBackupPath } from "./backup-volatile-filter.js";
 import { hasErrnoCode } from "./errno.js";
 import { collectErrorGraphCandidates, formatErrorMessage } from "./errors.js";
@@ -299,7 +304,11 @@ export async function createBackupSqliteSnapshotPlan(params: {
     });
   }
 
-  const snapshots: SqliteBackupAsset[] = [];
+  const sources: Array<{
+    archiveSourcePath: string;
+    identity: Stats;
+    canonicalSource: CanonicalSqliteSource | undefined;
+  }> = [];
   for (const archiveSourcePath of discovery.snapshotPaths) {
     const archiveSourceIdentity = await fs.stat(archiveSourcePath);
     const exactCanonicalSource = canonicalSources.find(
@@ -325,41 +334,71 @@ export async function createBackupSqliteSnapshotPlan(params: {
       );
     }
     const canonicalSource = matchingCanonicalSources[0];
-    const sourceDatabasePath = canonicalSource?.sourcePath ?? archiveSourcePath;
+    sources.push({ archiveSourcePath, identity: archiveSourceIdentity, canonicalSource });
+  }
+  const genericGroups = await planBackupSqliteSourceGroups(
+    sources
+      .filter((source) => !source.canonicalSource)
+      .map((source) => ({ path: source.archiveSourcePath, identity: source.identity })),
+  );
+  const capturedGroups = new Map<BackupSqliteSourceGroup, string>();
+  const snapshots: SqliteBackupAsset[] = [];
+  for (const { archiveSourcePath, canonicalSource } of sources) {
+    if (
+      canonicalSource &&
+      !sameFileIdentity(canonicalSource.identity, await fs.stat(archiveSourcePath))
+    ) {
+      throw new Error(`Canonical SQLite path changed after discovery: ${archiveSourcePath}`);
+    }
+    const genericGroup = genericGroups.get(archiveSourcePath);
+    const sourceDatabasePath =
+      canonicalSource?.sourcePath ?? genericGroup?.sourcePath ?? archiveSourcePath;
     const sourcePath = path.join(params.tempDir, `openclaw-state-db-${snapshots.length}.sqlite`);
     try {
-      await createVerifiedSqliteSnapshot({
-        sourcePath: sourceDatabasePath,
-        targetPath: sourcePath,
-        requireNonEmptySource: Boolean(canonicalSource),
-        validate:
-          canonicalSource?.role === "global"
-            ? (database, pathname) => assertOpenClawStateDatabaseOwner(database, { pathname })
-            : canonicalSource?.role === "agent"
-              ? (database, pathname) =>
-                  assertOpenClawAgentDatabaseOwner(database, {
-                    agentId: canonicalSource.agentId,
-                    pathname,
-                  })
-              : undefined,
-        transform:
-          canonicalSource?.role === "global"
-            ? (database) => {
-                if (
-                  params.legacyAuditDatabaseWitness !== undefined &&
-                  createLegacyAuditDatabaseWitness(database) !== params.legacyAuditDatabaseWitness
-                ) {
-                  throw new LegacyAuditBackupStateChangedError(
-                    "Legacy audit database rows changed during SQLite backup",
-                  );
+      const capture = () =>
+        createVerifiedSqliteSnapshot({
+          sourcePath: sourceDatabasePath,
+          targetPath: sourcePath,
+          requireNonEmptySource: Boolean(canonicalSource),
+          validate:
+            canonicalSource?.role === "global"
+              ? (database, pathname) => assertOpenClawStateDatabaseOwner(database, { pathname })
+              : canonicalSource?.role === "agent"
+                ? (database, pathname) =>
+                    assertOpenClawAgentDatabaseOwner(database, {
+                      agentId: canonicalSource.agentId,
+                      pathname,
+                    })
+                : undefined,
+          transform:
+            canonicalSource?.role === "global"
+              ? (database) => {
+                  if (
+                    params.legacyAuditDatabaseWitness !== undefined &&
+                    createLegacyAuditDatabaseWitness(database) !== params.legacyAuditDatabaseWitness
+                  ) {
+                    throw new LegacyAuditBackupStateChangedError(
+                      "Legacy audit database rows changed during SQLite backup",
+                    );
+                  }
+                  sanitizeOpenClawGlobalStateSnapshot(database);
+                  rewriteLegacyAuditBackupCheckpoints(database, params.legacyAuditSnapshots);
                 }
-                sanitizeOpenClawGlobalStateSnapshot(database);
-                rewriteLegacyAuditBackupCheckpoints(database, params.legacyAuditSnapshots);
-              }
-            : canonicalSource?.role === "agent"
-              ? sanitizeOpenClawStateLeaseRows
-              : undefined,
-      });
+              : canonicalSource?.role === "agent"
+                ? sanitizeOpenClawStateLeaseRows
+                : undefined,
+        });
+      const capturedPath = genericGroup && capturedGroups.get(genericGroup);
+      if (capturedPath) {
+        // Each archive name needs its own staged path; the remap owner keys by
+        // staged path. Copy only the already verified, compacted private image.
+        await fs.copyFile(capturedPath, sourcePath, fs.constants.COPYFILE_EXCL);
+      } else if (genericGroup) {
+        await captureBackupSqliteSourceGroup(genericGroup, capture);
+        capturedGroups.set(genericGroup, sourcePath);
+      } else {
+        await capture();
+      }
     } catch (error) {
       const stateChange = findLegacyAuditBackupStateChange(error);
       if (stateChange) {

--- a/src/infra/backup-sqlite-source-groups.ts
+++ b/src/infra/backup-sqlite-source-groups.ts
@@ -1,4 +1,4 @@
-import { constants, type Stats } from "node:fs";
+import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
 import { hasErrnoCode } from "./errno.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
@@ -137,21 +137,9 @@ export async function captureBackupSqliteSourceGroup(
   group: BackupSqliteSourceGroup,
   capture: () => Promise<unknown>,
 ): Promise<void> {
-  const handle = await fs.open(
-    group.sourcePath,
-    constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
-  );
-  try {
-    const opened = await handle.stat();
-    if (!opened.isFile() || !sameFileIdentity(group.sources[0].identity, opened)) {
-      throw new Error(`SQLite backup source identity changed: ${group.sourcePath}`);
-    }
-    await assertGroupBinding(group);
-    // SQLite owns the committed read view. WAL appends are allowed; changing
-    // pathname ownership is not. The descriptor pins the shared main inode.
-    await capture();
-    await assertGroupBinding(group);
-  } finally {
-    await handle.close();
-  }
+  await assertGroupBinding(group);
+  // SQLite owns source descriptors: closing a raw fs descriptor can release
+  // another connection's POSIX locks in this process. WAL appends remain valid.
+  await capture();
+  await assertGroupBinding(group);
 }

--- a/src/infra/backup-sqlite-source-groups.ts
+++ b/src/infra/backup-sqlite-source-groups.ts
@@ -1,0 +1,157 @@
+import { constants, type Stats } from "node:fs";
+import fs from "node:fs/promises";
+import { hasErrnoCode } from "./errno.js";
+import { sameFileIdentity } from "./fs-safe-advanced.js";
+
+export type BackupSqliteSource = {
+  path: string;
+  identity: Stats;
+};
+
+export type BackupSqliteSourceGroup = {
+  sources: [BackupSqliteSource, ...BackupSqliteSource[]];
+  sourcePath: string;
+  walIdentity: Stats | null;
+};
+
+function hasKnownIdentity(identity: Stats): boolean {
+  return process.platform !== "win32" || (identity.dev !== 0 && identity.ino !== 0);
+}
+
+async function readRegularSidecar(pathname: string): Promise<Stats | null> {
+  let identity: Stats;
+  try {
+    identity = await fs.lstat(pathname);
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return null;
+    }
+    throw error;
+  }
+  if (!identity.isFile()) {
+    throw new Error(`SQLite hardlink sidecar must be a regular file: ${pathname}`);
+  }
+  return identity;
+}
+
+async function assertGroupPaths(group: BackupSqliteSourceGroup): Promise<void> {
+  for (const source of group.sources) {
+    const current = await fs.lstat(source.path);
+    if (
+      !current.isFile() ||
+      !sameFileIdentity(source.identity, current) ||
+      (group.sources.length > 1 && !hasKnownIdentity(current)) ||
+      (await fs.realpath(source.path)) !== source.path
+    ) {
+      throw new Error(`SQLite backup source identity changed: ${source.path}`);
+    }
+    if (current.nlink !== group.sources.length) {
+      throw new Error(
+        `SQLite hardlink journal owner may be outside the backup inventory: ${source.path} has ${current.nlink} links, but ${group.sources.length} paths were admitted. Include every database hardlink before retrying.`,
+      );
+    }
+  }
+}
+
+async function readGroupWalOwners(
+  group: BackupSqliteSourceGroup,
+): Promise<Array<{ path: string; identity: Stats }>> {
+  const owners: Array<{ path: string; identity: Stats }> = [];
+  for (const source of group.sources) {
+    const wal = await readRegularSidecar(`${source.path}-wal`);
+    const journal = await readRegularSidecar(`${source.path}-journal`);
+    await readRegularSidecar(`${source.path}-shm`);
+    if (journal && journal.size > 0) {
+      throw new Error(
+        `SQLite hardlink journal ownership cannot be established safely while a rollback journal is present: ${source.path}. Close the database cleanly before retrying.`,
+      );
+    }
+    if (wal && wal.size > 0) {
+      if (!hasKnownIdentity(wal)) {
+        throw new Error(`SQLite hardlink WAL identity cannot be verified: ${source.path}-wal`);
+      }
+      owners.push({ path: source.path, identity: wal });
+    }
+  }
+  if (owners.length > 1) {
+    throw new Error(
+      `Ambiguous SQLite hardlink journal ownership: multiple non-empty WAL files for ${group.sources.map((source) => source.path).join(", ")}. Close the database writers before retrying.`,
+    );
+  }
+  return owners;
+}
+
+async function assertGroupBinding(group: BackupSqliteSourceGroup): Promise<void> {
+  await assertGroupPaths(group);
+  if (group.sources.length === 1) {
+    return;
+  }
+  const [owner] = await readGroupWalOwners(group);
+  if (
+    group.walIdentity
+      ? !owner ||
+        owner.path !== group.sourcePath ||
+        !sameFileIdentity(group.walIdentity, owner.identity)
+      : owner !== undefined
+  ) {
+    throw new Error(`SQLite hardlink journal ownership changed during backup: ${group.sourcePath}`);
+  }
+}
+
+/** Canonical database owners are resolved before generic pathname journal ownership. */
+export async function planBackupSqliteSourceGroups(
+  sources: readonly BackupSqliteSource[],
+): Promise<Map<string, BackupSqliteSourceGroup>> {
+  const groups = new Map<string, BackupSqliteSourceGroup>();
+  for (const source of sources) {
+    const knownIdentity = hasKnownIdentity(source.identity);
+    if (!knownIdentity && source.identity.nlink > 1) {
+      throw new Error(`SQLite hardlink identity cannot be verified: ${source.path}`);
+    }
+    const key = knownIdentity ? `${source.identity.dev}:${source.identity.ino}` : source.path;
+    const group = groups.get(key);
+    if (group) {
+      group.sources.push(source);
+    } else {
+      groups.set(key, { sources: [source], sourcePath: source.path, walIdentity: null });
+    }
+  }
+  const byPath = new Map<string, BackupSqliteSourceGroup>();
+  for (const group of groups.values()) {
+    await assertGroupPaths(group);
+    if (group.sources.length > 1) {
+      const [owner] = await readGroupWalOwners(group);
+      if (owner) {
+        group.sourcePath = owner.path;
+        group.walIdentity = owner.identity;
+      }
+    }
+    for (const source of group.sources) {
+      byPath.set(source.path, group);
+    }
+  }
+  return byPath;
+}
+
+export async function captureBackupSqliteSourceGroup(
+  group: BackupSqliteSourceGroup,
+  capture: () => Promise<unknown>,
+): Promise<void> {
+  const handle = await fs.open(
+    group.sourcePath,
+    constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+  );
+  try {
+    const opened = await handle.stat();
+    if (!opened.isFile() || !sameFileIdentity(group.sources[0].identity, opened)) {
+      throw new Error(`SQLite backup source identity changed: ${group.sourcePath}`);
+    }
+    await assertGroupBinding(group);
+    // SQLite owns the committed read view. WAL appends are allowed; changing
+    // pathname ownership is not. The descriptor pins the shared main inode.
+    await capture();
+    await assertGroupBinding(group);
+  } finally {
+    await handle.close();
+  }
+}


### PR DESCRIPTION
Closes #144585. Related: #140989.

## What Problem This Solves

A verified backup of a live database with hardlink aliases could omit committed write-ahead-log data from the alias entries.

## Why This Change Was Made

Generic database aliases now share one verified snapshot from the unambiguous journal-owning name, with a separate regular archive entry for each name. Capture preserves live writer locks and refuses competing journals, incomplete hardlink coverage, active rollback journals, and changed source identities.

## User Impact

Both names retain the same committed content. Every hardlink must be included as a database file under the state directory or a configured agent root, including aliases of closed databases. Uncertain ownership fails explicitly without publishing an archive. Canonical database sanitization remains intact.

## Evidence

Before the fix, backup creation and verification succeeded but an extracted alias lacked the committed table. Corrected public commands preserved the data in both filename orders, and each extracted database passed integrity checks. Eighteen new regressions and 25 existing backup cases passed. Nine public scenarios and ten combined backup scenarios passed with synthetic Linux files, including refusal controls and canonical database sanitization. Writer-lock regressions rejected the earlier capture implementation.
