### PR TITLE
test(config): retain operator startup configuration corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3063,6 +3063,7 @@ jobs:
               pnpm check:assertion-safety --base "$base_ref"
               pnpm config:docs:check
               pnpm plugins:inventory:check
+              node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/config-startup-corpus.test.ts
               ;;
             release-lint-core-*)
               stripe="${TASK#release-lint-core-}"

--- a/src/config/config-startup-corpus.test.ts
+++ b/src/config/config-startup-corpus.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { listAgentIds } from "../agents/agent-scope-config.js";
+import { acquireReadOnlyPreparedModelRuntime } from "../agents/prepared-model-runtime.js";
+import { applyLegacyCompatibilityStep } from "../commands/doctor/shared/config-flow-steps.js";
+import { normalizeCompatibilityConfigValues } from "../commands/doctor/shared/legacy-config-core-migrate.js";
+import { loadGatewayStartupConfigSnapshot } from "../gateway/server-startup-config-helpers.js";
+import { resolveProviderChannelLoginChoice } from "../plugins/provider-login-options.js";
+import { createConfigIO } from "./io.js";
+
+const corpusDir = fileURLToPath(new URL("../../test/fixtures/config-corpus/", import.meta.url));
+const fixtureNames = fs
+  .readdirSync(corpusDir)
+  .filter((name) => name.endsWith(".json"))
+  .toSorted();
+const expectations: Record<string, { providers: string[]; model?: string }> = {
+  "agent-override.json": { providers: ["openai", "fixture-provider"] },
+  "api-key-no-models.json": { providers: ["openai"] },
+  "custom-models.json": { providers: ["openai"], model: "fixture-model" },
+  "empty-providers.json": { providers: ["openai"] },
+  "enabled-only.json": { providers: ["openai"] },
+  "legacy-roster.json": { providers: ["openai"] },
+  "models-allow.json": { providers: ["fixture-provider"], model: "fixture-model" },
+  "oauth-only.json": { providers: ["openai"] },
+  "operator-container.json": { providers: ["xai"], model: "grok-4.3" },
+  "operator-host.json": { providers: ["xai"], model: "grok-4.3" },
+};
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.unstubAllEnvs());
+
+describe("operator config startup corpus", () => {
+  it("covers every retained config with an explicit catalog expectation", () => {
+    expect(fixtureNames).toEqual(Object.keys(expectations).toSorted());
+  });
+
+  it.each(fixtureNames)(
+    "%s loads, prepares model rows, and offers provider login",
+    async (name) => {
+      const home = tempDirs.make("openclaw-config-corpus-");
+      const stateDir = path.join(home, ".openclaw");
+      const configPath = path.join(stateDir, "openclaw.json");
+      for (const [key, value] of Object.entries({
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_TEST_HOME: home,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: fileURLToPath(new URL("../../extensions/", import.meta.url)),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "0",
+      })) {
+        vi.stubEnv(key, value);
+      }
+      fs.mkdirSync(stateDir, { recursive: true });
+      const pluginDir = path.join(home, "external-plugin");
+      fs.mkdirSync(pluginDir);
+      fs.writeFileSync(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: "fixture-extension",
+          configSchema: { type: "object", additionalProperties: false, properties: {} },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(pluginDir, "index.ts"),
+        'export default { id: "fixture-extension", register() {} };\n',
+      );
+
+      // Relocate sanitized operator paths without removing their config contracts.
+      const raw: unknown = JSON.parse(
+        fs.readFileSync(path.join(corpusDir, name), "utf8"),
+        (_key, value: unknown) =>
+          typeof value === "string" && value.startsWith("/home/fixture/")
+            ? path.join(home, value.slice("/home/fixture/".length))
+            : value,
+      );
+      fs.writeFileSync(configPath, JSON.stringify(raw));
+      const env = { ...process.env };
+      const io = createConfigIO({
+        configPath,
+        env,
+        homedir: () => home,
+        observe: false,
+      });
+      const snapshot = await io.readConfigFileSnapshot();
+      const migrated = applyLegacyCompatibilityStep({
+        snapshot,
+        state: {
+          cfg: snapshot.sourceConfig,
+          candidate: snapshot.sourceConfig,
+          pendingChanges: false,
+          fixHints: [],
+        },
+        shouldRepair: true,
+        doctorFixCommand: "openclaw doctor --fix",
+      });
+      const normalized = normalizeCompatibilityConfigValues(migrated.state.candidate, {
+        sourceRaw: snapshot.parsed,
+        sourceConfigBeforeMigrations: snapshot.sourceConfigBeforeMigrations,
+      });
+      fs.writeFileSync(configPath, JSON.stringify(normalized.config));
+      const startup = await loadGatewayStartupConfigSnapshot({
+        initialSnapshotRead: await io.readConfigFileSnapshotWithPluginMetadata(),
+        minimalTestGateway: false,
+        log: console,
+      });
+      const config = startup.snapshot.config;
+      if (["enabled-only.json", "api-key-no-models.json", "oauth-only.json"].includes(name)) {
+        expect(startup.snapshot.sourceConfig.models?.providers?.openai).not.toHaveProperty(
+          "models",
+        );
+      }
+      const expected = expectations[name]!;
+      const agentIds = listAgentIds(config);
+      expect(agentIds.length).toBeGreaterThan(0);
+      if (name === "legacy-roster.json") {
+        expect([...migrated.changeLines, ...normalized.changes].length).toBeGreaterThan(0);
+        expect(config.agents?.entries?.main).toBeDefined();
+      }
+
+      for (const agentId of agentIds) {
+        const workspaceDir = path.join(home, "workspaces", agentId);
+        const lease = await acquireReadOnlyPreparedModelRuntime(
+          {
+            config,
+            agentId,
+            agentDir: path.join(stateDir, "agents", agentId, "agent"),
+            workspaceDir,
+            env,
+            readOnly: true,
+            skipCredentials: true,
+          },
+          { catalogMode: "static" },
+        );
+        try {
+          const catalog = lease.snapshot.modelCatalog;
+          for (const provider of expected.providers) {
+            expect(catalog.entries, `${name}: ${agentId} must expose ${provider}`).toContainEqual(
+              expect.objectContaining({ provider }),
+            );
+          }
+          if (expected.model) {
+            expect(catalog.entries).toContainEqual(expect.objectContaining({ id: expected.model }));
+          }
+          const login = resolveProviderChannelLoginChoice(undefined, { config, env, workspaceDir });
+          expect(login.status).toBe("providers");
+          if (login.status === "providers") {
+            expect(login.providers.length).toBeGreaterThan(0);
+          }
+        } finally {
+          lease.release();
+        }
+      }
+    },
+  );
+});

--- a/test/fixtures/config-corpus/agent-override.json
+++ b/test/fixtures/config-corpus/agent-override.json
@@ -1,0 +1,66 @@
+{
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "openai/gpt-5.5",
+      "systemAgent": {
+        "agentId": "main"
+      },
+      "heartbeat": {
+        "agentId": "main"
+      }
+    },
+    "entries": {
+      "main": {},
+      "secondary": {
+        "model": "fixture-provider/fixture-model",
+        "models": {
+          "fixture-provider/fixture-model": {
+            "alias": "fixture-local"
+          }
+        }
+      }
+    },
+    "ownership": "explicit"
+  },
+  "plugins": {
+    "entries": {
+      "openai": {
+        "enabled": true
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "openai": {},
+      "fixture-provider": {
+        "baseUrl": "https://fixture-provider.invalid/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "fixture-model",
+            "name": "Fixture Model",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 8192,
+            "maxTokens": 1024
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/config-corpus/api-key-no-models.json
+++ b/test/fixtures/config-corpus/api-key-no-models.json
@@ -1,0 +1,31 @@
+{
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "openai/gpt-5.5"
+    },
+    "entries": {
+      "main": {}
+    }
+  },
+  "plugins": {
+    "entries": {
+      "openai": {
+        "enabled": true
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "openai": {
+        "apiKey": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+      }
+    }
+  }
+}

--- a/test/fixtures/config-corpus/custom-models.json
+++ b/test/fixtures/config-corpus/custom-models.json
@@ -1,0 +1,49 @@
+{
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "openai/fixture-model"
+    },
+    "entries": {
+      "main": {}
+    }
+  },
+  "plugins": {
+    "entries": {
+      "openai": {
+        "enabled": true
+      }
+    }
+  },
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "openai": {
+        "models": [
+          {
+            "id": "fixture-model",
+            "name": "Fixture Model",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 8192,
+            "maxTokens": 1024
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/config-corpus/empty-providers.json
+++ b/test/fixtures/config-corpus/empty-providers.json
@@ -1,0 +1,27 @@
+{
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "openai/gpt-5.5"
+    },
+    "entries": {
+      "main": {}
+    }
+  },
+  "plugins": {
+    "entries": {
+      "openai": {
+        "enabled": true
+      }
+    }
+  },
+  "models": {
+    "providers": {}
+  }
+}

--- a/test/fixtures/config-corpus/enabled-only.json
+++ b/test/fixtures/config-corpus/enabled-only.json
@@ -1,0 +1,29 @@
+{
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "openai/gpt-5.5"
+    },
+    "entries": {
+      "main": {}
+    }
+  },
+  "plugins": {
+    "entries": {
+      "openai": {
+        "enabled": true
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "openai": {}
+    }
+  }
+}

--- a/test/fixtures/config-corpus/legacy-roster.json
+++ b/test/fixtures/config-corpus/legacy-roster.json
@@ -1,0 +1,35 @@
+{
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "openai/gpt-4.1"
+    },
+    "list": [
+      {
+        "id": "main",
+        "default": true,
+        "model": "openai/gpt-4.1"
+      }
+    ]
+  },
+  "plugins": {
+    "entries": {
+      "openai": {
+        "enabled": true
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "openai": {
+        "api": "openai"
+      }
+    }
+  }
+}

--- a/test/fixtures/config-corpus/models-allow.json
+++ b/test/fixtures/config-corpus/models-allow.json
@@ -1,0 +1,48 @@
+{
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "fixture-provider/fixture-model",
+      "modelPolicy": {
+        "allow": [
+          "fixture-provider/fixture-model"
+        ]
+      }
+    },
+    "entries": {
+      "main": {}
+    }
+  },
+  "plugins": {
+    "entries": {
+      "openai": {
+        "enabled": true
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "fixture-provider": {
+        "baseUrl": "https://fixture-provider.invalid/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "fixture-model",
+            "name": "Fixture Model",
+            "reasoning": false,
+            "input": ["text"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 8192,
+            "maxTokens": 1024
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/config-corpus/oauth-only.json
+++ b/test/fixtures/config-corpus/oauth-only.json
@@ -1,0 +1,31 @@
+{
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "openai/gpt-5.5"
+    },
+    "entries": {
+      "main": {}
+    }
+  },
+  "plugins": {
+    "entries": {
+      "openai": {
+        "enabled": true
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "openai": {
+        "auth": "oauth"
+      }
+    }
+  }
+}

--- a/test/fixtures/config-corpus/operator-container.json
+++ b/test/fixtures/config-corpus/operator-container.json
@@ -1,0 +1,611 @@
+{
+  "meta": {
+    "lastTouchedVersion": "2026.9.2",
+    "migrations": {
+      "modelPolicyAllowlist": true
+    }
+  },
+  "env": {
+    "vars": {
+      "MINIMAX_API_KEY": "FAKE_CONFIG_CORPUS_CREDENTIAL",
+      "OPENROUTER_API_KEY": "FAKE_CONFIG_CORPUS_CREDENTIAL",
+      "BH_CONFIG_DIR": "/home/fixture/path-1"
+    }
+  },
+  "wizard": {
+    "lastRunAt": "2026-01-01T00:00:00.000Z",
+    "lastRunVersion": "2026.9.2",
+    "lastRunCommand": "doctor",
+    "lastRunMode": "local"
+  },
+  "browser": {
+    "enabled": true,
+    "noSandbox": true
+  },
+  "auth": {
+    "profiles": {
+      "openrouter:default": {
+        "provider": "openrouter",
+        "mode": "api_key"
+      },
+      "xai:fixture2@example.invalid": {
+        "provider": "xai",
+        "mode": "oauth"
+      },
+      "openai:fixture3@example.invalid": {
+        "provider": "openai",
+        "mode": "oauth"
+      },
+      "openai:fixture4@example.invalid": {
+        "provider": "openai",
+        "mode": "oauth"
+      }
+    }
+  },
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "xai": {
+        "baseUrl": "https://fixture-5.invalid/v1",
+        "api": "openai-responses",
+        "models": [
+          {
+            "id": "grok-4.3",
+            "name": "Grok 4.3",
+            "api": "openai-responses",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-4.20-beta-latest-reasoning",
+            "name": "Grok 4.20 Beta Latest (Reasoning)",
+            "api": "openai-responses",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          },
+          {
+            "id": "grok-4.20-beta-latest-non-reasoning",
+            "name": "Grok 4.20 Beta Latest (Non-Reasoning)",
+            "api": "openai-responses",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          },
+          {
+            "id": "grok-build-0.1",
+            "name": "Grok Build 0.1",
+            "api": "openai-responses",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1,
+              "output": 2,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 256000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-4.5",
+            "name": "Grok 4.5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 2,
+              "output": 6,
+              "cacheRead": 0.5,
+              "cacheWrite": 0
+            },
+            "contextWindow": 500000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-4.20-0309-reasoning",
+            "name": "Grok 4.20 0309 (Reasoning)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          },
+          {
+            "id": "grok-4.20-0309-non-reasoning",
+            "name": "Grok 4.20 0309 (Non-Reasoning)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "openai/fixture-model-6"
+      },
+      "models": {
+        "openai/fixture-model-7": {
+          "agentRuntime": {
+            "id": "openclaw"
+          }
+        },
+        "openai/fixture-model-8": {
+          "alias": "fixture-alias-9",
+          "agentRuntime": {
+            "id": "openclaw"
+          }
+        },
+        "openai/fixture-model-10": {
+          "alias": "fixture-alias-11",
+          "agentRuntime": {
+            "id": "openclaw"
+          }
+        },
+        "openai/fixture-model-6": {
+          "alias": "fixture-alias-12",
+          "params": {
+            "responsesServerCompaction": true,
+            "responsesCompactEndpoint": true
+          }
+        },
+        "xai/grok-4.3": {
+          "alias": "fixture-alias-13"
+        },
+        "anthropic/claude-opus-4-8": {
+          "alias": "fixture-alias-14",
+          "agentRuntime": {
+            "id": "claude-cli"
+          }
+        },
+        "anthropic/claude-sonnet-4-6": {
+          "alias": "fixture-alias-15",
+          "agentRuntime": {
+            "id": "claude-cli"
+          }
+        },
+        "anthropic/claude-opus-4-7": {
+          "agentRuntime": {
+            "id": "claude-cli"
+          }
+        },
+        "anthropic/claude-opus-4-6": {
+          "agentRuntime": {
+            "id": "claude-cli"
+          }
+        },
+        "xai/auto": {
+          "alias": "fixture-alias-16"
+        }
+      },
+      "modelPolicy": {
+        "allow": [
+          "openai/*"
+        ]
+      },
+      "thinkingDefault": "medium",
+      "reasoningDefault": "stream",
+      "typingMode": "instant",
+      "maxConcurrent": 4,
+      "subagents": {
+        "maxConcurrent": 8,
+        "archiveAfterMinutes": 60
+      },
+      "heartbeat": {
+        "target": "telegram",
+        "to": "900000017"
+      }
+    },
+    "entries": {
+      "main": {
+        "models": {
+          "openai/fixture-model-6": {}
+        },
+        "model": "openai/fixture-model-6"
+      }
+    }
+  },
+  "tools": {
+    "web": {
+      "search": {
+        "enabled": true,
+        "provider": "grok",
+        "openaiCodex": {}
+      },
+      "fetch": {
+        "enabled": true
+      }
+    },
+    "toolSearch": false,
+    "exec": {
+      "mode": "full"
+    }
+  },
+  "messages": {
+    "visibleReplies": "automatic",
+    "groupChat": {
+      "unmentionedInbound": "room_event"
+    },
+    "ackReactionScope": "group-mentions"
+  },
+  "commands": {
+    "native": "auto",
+    "nativeSkills": "auto",
+    "restart": true,
+    "ownerAllowFrom": [
+      "telegram:900000018"
+    ]
+  },
+  "cron": {
+    "triggers": {
+      "enabled": true
+    }
+  },
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "richMessages": true,
+      "dmPolicy": "allowlist",
+      "groupPolicy": "allowlist",
+      "groupAllowFrom": [
+        "*"
+      ],
+      "allowFrom": [
+        "900000017"
+      ],
+      "groups": {
+        "-9000000000019": {
+          "requireMention": false
+        },
+        "-9000000020": {
+          "requireMention": false
+        },
+        "-9000000021": {
+          "requireMention": false
+        },
+        "-9000000000022": {
+          "requireMention": false
+        }
+      },
+      "botToken": "9000000000:FAKE_TOKEN_FOR_CONFIG_CORPUS_ONLY",
+      "streaming": {
+        "mode": "progress",
+        "progress": {
+          "commentary": true
+        }
+      },
+      "replyToMode": "first",
+      "ackReaction": "👀"
+    }
+  },
+  "discovery": {
+    "mdns": {
+      "mode": "off"
+    }
+  },
+  "talk": {
+    "interruptOnSpeech": true,
+    "providers": {
+      "microsoft": {
+        "voiceId": "en-US-AvaMultilingualNeural"
+      }
+    },
+    "provider": "microsoft"
+  },
+  "gateway": {
+    "port": 18789,
+    "mode": "local",
+    "bind": "loopback",
+    "controlUi": {
+      "allowedOrigins": [
+        "http://fixture-23.invalid:18789/",
+        "http://fixture-24.invalid:18789/",
+        "http://fixture-25.invalid:18789/",
+        "http://fixture-26.invalid:18789/",
+        "http://fixture-27.invalid:18789/",
+        "https://fixture-28.invalid/"
+      ]
+    },
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    },
+    "tailscale": {
+      "mode": "off"
+    }
+  },
+  "memory": {
+    "search": {
+      "provider": "none"
+    }
+  },
+  "skills": {
+    "entries": {
+      "1password": {
+        "enabled": false
+      },
+      "apple-notes": {
+        "enabled": false
+      },
+      "apple-reminders": {
+        "enabled": false
+      },
+      "bear-notes": {
+        "enabled": false
+      },
+      "blogwatcher": {
+        "enabled": false
+      },
+      "blucli": {
+        "enabled": false
+      },
+      "bluebubbles": {
+        "enabled": false
+      },
+      "camsnap": {
+        "enabled": false
+      },
+      "clawhub": {
+        "enabled": false
+      },
+      "coding-agent": {
+        "enabled": false
+      },
+      "discord": {
+        "enabled": false
+      },
+      "eightctl": {
+        "enabled": false
+      },
+      "gemini": {
+        "enabled": false
+      },
+      "gifgrep": {
+        "enabled": false
+      },
+      "gog": {
+        "enabled": false
+      },
+      "goplaces": {
+        "enabled": false
+      },
+      "himalaya": {
+        "enabled": false
+      },
+      "imsg": {
+        "enabled": false
+      },
+      "mcporter": {
+        "enabled": false
+      },
+      "model-usage": {
+        "enabled": false
+      },
+      "nano-pdf": {
+        "enabled": false
+      },
+      "notion": {
+        "enabled": false
+      },
+      "obsidian": {
+        "enabled": false
+      },
+      "openai-whisper": {
+        "enabled": false
+      },
+      "openai-whisper-api": {
+        "enabled": false
+      },
+      "openhue": {
+        "enabled": false
+      },
+      "oracle": {
+        "enabled": false
+      },
+      "ordercli": {
+        "enabled": false
+      },
+      "peekaboo": {
+        "enabled": false
+      },
+      "sag": {
+        "enabled": false
+      },
+      "session-logs": {
+        "enabled": false
+      },
+      "sherpa-onnx-tts": {
+        "enabled": false
+      },
+      "slack": {
+        "enabled": false
+      },
+      "songsee": {
+        "enabled": false
+      },
+      "sonoscli": {
+        "enabled": false
+      },
+      "spotify-player": {
+        "enabled": false
+      },
+      "things-mac": {
+        "enabled": false
+      },
+      "trello": {
+        "enabled": false
+      },
+      "video-frames": {
+        "enabled": false
+      },
+      "voice-call": {
+        "enabled": false
+      },
+      "wacli": {
+        "enabled": false
+      },
+      "xurl": {
+        "enabled": false
+      },
+      "gh-issues": {
+        "enabled": false
+      },
+      "github": {
+        "enabled": false
+      },
+      "summarize": {
+        "enabled": false
+      },
+      "tmux": {
+        "enabled": false
+      }
+    }
+  },
+  "plugins": {
+    "load": {
+      "paths": [
+        "/home/fixture/external-plugin"
+      ]
+    },
+    "entries": {
+      "telegram": {
+        "enabled": true,
+        "config": {}
+      },
+      "memory-core": {
+        "enabled": true,
+        "config": {
+          "dreaming": {
+            "enabled": true,
+            "frequency": "0 3 * * *",
+            "phases": {
+              "deep": {
+                "minScore": 0.7,
+                "minRecallCount": 0,
+                "minUniqueQueries": 1
+              }
+            }
+          }
+        }
+      },
+      "browser": {
+        "enabled": true,
+        "config": {}
+      },
+      "anthropic": {
+        "enabled": true,
+        "config": {}
+      },
+      "openai": {
+        "enabled": true,
+        "config": {
+          "personality": "friendly"
+        }
+      },
+      "codex": {
+        "enabled": true,
+        "config": {
+          "codexDynamicToolsLoading": "searchable",
+          "codexDynamicToolsExclude": [],
+          "appServer": {
+            "transport": "stdio",
+            "homeScope": "agent",
+            "codeModeOnly": false,
+            "requestTimeoutMs": 60000
+          }
+        }
+      },
+      "fixture-extension": {
+        "enabled": true,
+        "hooks": {
+          "allowPromptInjection": true,
+          "allowConversationAccess": true
+        },
+        "config": {}
+      },
+      "xai": {
+        "enabled": true,
+        "config": {}
+      },
+      "diagnostics-otel": {
+        "enabled": true
+      },
+      "microsoft": {
+        "enabled": true
+      }
+    }
+  },
+  "diagnostics": {
+    "enabled": true,
+    "otel": {
+      "enabled": true,
+      "endpoint": "http://fixture-30.invalid:4318/",
+      "protocol": "http/protobuf",
+      "serviceName": "fixture-gateway",
+      "traces": true,
+      "metrics": false,
+      "logs": false,
+      "logsExporter": "otlp",
+      "sampleRate": 1,
+      "flushIntervalMs": 60000,
+      "captureContent": false
+    }
+  }
+}

--- a/test/fixtures/config-corpus/operator-host.json
+++ b/test/fixtures/config-corpus/operator-host.json
@@ -1,0 +1,336 @@
+{
+  "meta": {
+    "lastTouchedVersion": "2026.8.1",
+    "migrations": {
+      "modelPolicyAllowlist": true
+    }
+  },
+  "auth": {
+    "profiles": {
+      "xai:fixture1@example.invalid": {
+        "provider": "xai",
+        "mode": "oauth"
+      },
+      "xai:fixture2@example.invalid": {
+        "provider": "xai",
+        "mode": "oauth"
+      }
+    }
+  },
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "xai": {
+        "baseUrl": "https://fixture-3.invalid/v1",
+        "api": "openai-responses",
+        "models": [
+          {
+            "id": "grok-4.3",
+            "name": "Grok 4.3",
+            "api": "openai-responses",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-4.20-beta-latest-reasoning",
+            "name": "Grok 4.20 Beta Latest (Reasoning)",
+            "api": "openai-responses",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          },
+          {
+            "id": "grok-4.20-beta-latest-non-reasoning",
+            "name": "Grok 4.20 Beta Latest (Non-Reasoning)",
+            "api": "openai-responses",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          },
+          {
+            "id": "grok-4.6",
+            "name": "Grok 4.6",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 2,
+              "output": 6,
+              "cacheRead": 0.5,
+              "cacheWrite": 0
+            },
+            "contextWindow": 500000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-4.5",
+            "name": "Grok 4.5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 2,
+              "output": 6,
+              "cacheRead": 0.3,
+              "cacheWrite": 0
+            },
+            "contextWindow": 500000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-build-0.1",
+            "name": "Grok Build 0.1",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1,
+              "output": 2,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 256000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-4.20-0309-reasoning",
+            "name": "Grok 4.20 0309 (Reasoning)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          },
+          {
+            "id": "grok-4.20-0309-non-reasoning",
+            "name": "Grok 4.20 0309 (Non-Reasoning)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "xai/grok-4.3"
+      },
+      "models": {
+        "xai/grok-4.3": {
+          "alias": "fixture-alias-4"
+        },
+        "openai/fixture-model-5": {},
+        "xai/auto": {
+          "alias": "fixture-alias-6"
+        }
+      },
+      "modelPolicy": {
+        "allow": [
+          "xai/grok-4.3"
+        ]
+      },
+      "maxConcurrent": 16,
+      "subagents": {
+        "maxConcurrent": 8,
+        "archiveAfterMinutes": 60
+      }
+    },
+    "entries": {
+      "main": {}
+    }
+  },
+  "commands": {
+    "native": "auto",
+    "nativeSkills": "auto",
+    "restart": true
+  },
+  "messages": {
+    "ackReactionScope": "group-mentions"
+  },
+  "plugins": {
+    "entries": {
+      "xai": {
+        "enabled": true
+      },
+      "openai": {
+        "enabled": true
+      },
+      "codex": {
+        "enabled": true
+      }
+    }
+  },
+  "wizard": {
+    "lastRunAt": "2026-01-01T00:00:00.000Z",
+    "lastRunVersion": "2026.8.1",
+    "lastRunCommand": "doctor",
+    "lastRunMode": "local"
+  },
+  "skills": {
+    "entries": {
+      "1password": {
+        "enabled": false
+      },
+      "blogwatcher": {
+        "enabled": false
+      },
+      "blucli": {
+        "enabled": false
+      },
+      "camsnap": {
+        "enabled": false
+      },
+      "coding-agent": {
+        "enabled": false
+      },
+      "eightctl": {
+        "enabled": false
+      },
+      "gemini": {
+        "enabled": false
+      },
+      "gifgrep": {
+        "enabled": false
+      },
+      "gog": {
+        "enabled": false
+      },
+      "goplaces": {
+        "enabled": false
+      },
+      "himalaya": {
+        "enabled": false
+      },
+      "mcporter": {
+        "enabled": false
+      },
+      "model-usage": {
+        "enabled": false
+      },
+      "nano-pdf": {
+        "enabled": false
+      },
+      "obsidian": {
+        "enabled": false
+      },
+      "openai-whisper": {
+        "enabled": false
+      },
+      "openai-whisper-api": {
+        "enabled": false
+      },
+      "openhue": {
+        "enabled": false
+      },
+      "oracle": {
+        "enabled": false
+      },
+      "ordercli": {
+        "enabled": false
+      },
+      "qqbot-channel": {
+        "enabled": false
+      },
+      "qqbot-media": {
+        "enabled": false
+      },
+      "qqbot-remind": {
+        "enabled": false
+      },
+      "sag": {
+        "enabled": false
+      },
+      "sherpa-onnx-tts": {
+        "enabled": false
+      },
+      "songsee": {
+        "enabled": false
+      },
+      "sonoscli": {
+        "enabled": false
+      },
+      "spotify-player": {
+        "enabled": false
+      },
+      "summarize": {
+        "enabled": false
+      },
+      "trello": {
+        "enabled": false
+      },
+      "xurl": {
+        "enabled": false
+      }
+    }
+  },
+  "tools": {
+    "web": {
+      "search": {
+        "provider": "grok"
+      }
+    }
+  },
+  "gateway": {
+    "auth": {
+      "mode": "token",
+      "token": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

A provider entry without custom model rows passed synthetic coverage and then crashed a Gateway. This maintainer-requested corpus makes real operator configuration shapes part of pull-request validation.

Related: #144599

## Why This Change Was Made

The suite loads two sanitized operator configurations and eight canonical shapes through shared Doctor normalization, the Gateway startup snapshot owner, prepared static catalog construction, and provider login-choice resolution. It preserves absent optional model lists so normalization cannot hide the startup regression. The existing core CI checks run this corpus on core changes.

## User Impact

No production behavior changes. New startup regressions in retained operator config shapes fail CI before landing.

## Evidence

- The missing-list cases fail on the baseline at the same registry call as a real Gateway startup.
- Final rebased head: 13 focused tests pass, including the corpus and a legacy-provider sibling. The same command used by CI passes.
- All ten fixtures pass real Gateway startup, CLI listing, full-inventory RPC, webchat command responses, and browser rendering. The multi-agent fixture also exercises both agents.
- Telegram Test Server proof covers the provider picker, owner login choices, and non-owner rejection with zero model requests.
- Corpus runs use synthetic credentials and loopback-only network namespaces. Private plugin configuration uses an inert fixture plugin.
- Legacy API aliases require `doctor --fix` before direct startup; recovery is covered.
- The requested local source config was absent. Both available remote operator sources are retained, with structure-preserving sanitization.
