### PR TITLE
refactor(test): remove unused temp-directory counter

### DIFF
--- a/src/test-utils/tracked-temp-dirs.ts
+++ b/src/test-utils/tracked-temp-dirs.ts
@@ -6,8 +6,8 @@ import { expectDefined } from "@openclaw/normalization-core";
 
 /** Allocates temp directories under reusable roots with explicit cleanup control. */
 export function createTrackedTempDirs() {
-  const prefixRoots = new Map<string, { root: string; nextIndex: number }>();
-  const pendingPrefixRoots = new Map<string, Promise<{ root: string; nextIndex: number }>>();
+  const prefixRoots = new Map<string, { root: string }>();
+  const pendingPrefixRoots = new Map<string, Promise<{ root: string }>>();
   const cleanupRoots = new Set<string>();
   let globalDirIndex = 0;
 
@@ -22,7 +22,7 @@ export function createTrackedTempDirs() {
     }
     const create = (async () => {
       const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-      const state = { root, nextIndex: 0 };
+      const state = { root };
       prefixRoots.set(prefix, state);
       cleanupRoots.add(root);
       return state;
@@ -39,7 +39,6 @@ export function createTrackedTempDirs() {
     async make(prefix: string): Promise<string> {
       const state = await ensurePrefixRoot(prefix);
       const dir = path.join(state.root, `dir-${String(globalDirIndex)}`);
-      state.nextIndex += 1;
       globalDirIndex += 1;
       await fs.mkdir(dir, { recursive: true });
       return dir;
@@ -64,13 +63,6 @@ export function createTrackedTempDirs() {
           ),
         ),
       );
-      for (const dir of roots) {
-        for (const state of prefixRoots.values()) {
-          if (state.root === dir) {
-            state.nextIndex = 0;
-          }
-        }
-      }
     },
   };
 }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The tracked temporary-directory test helper maintains a per-prefix counter that never affects directory names or cleanup. That unused state obscures the counter that actually owns naming.

## Why This Change Was Made

Remove only the unused `nextIndex` fields, initialization, increment, and reset loop. Keep `globalDirIndex`, cached roots, pending creation, filesystem operations, and error handling unchanged.

## User Impact

No user-visible or production change. Eight net test-support lines are removed; all test cases and callers remain.

## Evidence

- Normal infra run of `archive-helpers.test.ts` and `fs-safe-remove.test.ts`: 27 passes across both suites, plus the existing Windows-only skip on Linux.
- Exact-base changed checks: 15 passed before core-test typechecking failed because the local install lacks a declared UI dependency link. The 12 remaining checks passed in a reviewed continuation; the original failure is retained and no dependencies were changed locally.
- Hosted CI run 34559010308, attempt1 passed. Its three typecheck jobs covered all 17 canonical core-test graphs after successful frozen-lockfile validation of restored dependency caches. The actual synthetic merge checkout was source-bound to this change; this is not a full-local-gate or whole-repository equality claim.
- Required CI gate and Workflow Sanity passed; skipped jobs are not proof.
- Targeted formatting and whitespace checks passed. Scoped independent and completed hosted reviews found no actionable findings.

This is scoped Linux proof, not Windows execution, a full consumer-suite run, or a performance claim.
