### PR TITLE
fix(discord): honor persona text limits and preserve reply receipts

### DIFF
--- a/docs/channels/discord/messaging.md
+++ b/docs/channels/discord/messaging.md
@@ -14,6 +14,7 @@ How inbound and outbound Discord messages are routed, formatted, acknowledged, a
 - Gateway owns the Discord connection.
 - Reply routing is deterministic: Discord inbound replies back to Discord.
 - Bot replies and thread-bound persona replies share Markdown formatting, including CommonMark bold and configured table conversion.
+- Both delivery paths reapply caller-supplied character limits after formatting and mention expansion.
 - Forwarded message snapshots reach the agent together with any accompanying caption. Forwarded text is not treated as a typed command; command classification uses only the sender’s own message text.
 - Discord guild/channel metadata is added to the model prompt as untrusted context, not as a user-visible reply prefix. If a model copies that envelope back, OpenClaw strips the copied metadata from outbound replies and from future replay context.
 - By default (`session.dmScope=main`), direct chats share the agent main session (`agent:main:main`).
@@ -49,6 +50,7 @@ How inbound and outbound Discord messages are routed, formatted, acknowledged, a
     - `batched`: attaches it only when the inbound event was a debounced batch of multiple messages — useful when you want native replies mainly for ambiguous bursty chats, not every single-message turn
 
     Message IDs are surfaced in context/history so agents can target specific messages.
+    Chunked persona delivery receipts retain the reply target selected for each chunk.
 
   </Accordion>
 

--- a/extensions/discord/src/durable-line-limit.test.ts
+++ b/extensions/discord/src/durable-line-limit.test.ts
@@ -31,7 +31,7 @@ async function runDurableLineLimitScenario(params: {
   text?: string;
   replyToIdSource?: "implicit" | "explicit";
   replyToMode?: "first" | "all";
-  formatting?: { maxLinesPerMessage?: number };
+  formatting?: Parameters<typeof sendDurableMessageBatch>[0]["formatting"];
 }) {
   let messageCount = 0;
   const loopback = await createDiscordLoopbackRest({
@@ -172,6 +172,24 @@ describe("durable Discord configured line limits", () => {
 });
 
 describe.each([false, true])("durable Discord transport webhook=%s", (webhook) => {
+  it("reapplies the explicit character limit after expanding mentions", async () => {
+    const userId = "123456789012345678";
+    const { chunks, replies, result } = await runDurableLineLimitScenario({
+      cfg: { channels: { discord: { token: "fixture-token", mentionAliases: { op: userId } } } },
+      webhook,
+      text: Array.from({ length: 30 }, () => "@op").join(" "),
+      replyToMode: "first",
+      formatting: { textLimit: 500 },
+    });
+
+    expect(result.status).toBe("sent");
+    expect(chunks.every((chunk) => chunk.length <= 500)).toBe(true);
+    expect(chunks.join(""), JSON.stringify(chunks)).toBe(
+      Array.from({ length: 30 }, () => `<@${userId}>`).join(" "),
+    );
+    expect(replies).toEqual(chunks.map((_, index) => (index === 0 ? "fixture-reply" : undefined)));
+  });
+
   it.each([
     {
       name: "default 17",

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -96,7 +96,10 @@ async function maybeSendDiscordWebhookText(params: DiscordOutboundMessageContext
     username: truncateUtf16Safe(username, 80) || undefined,
     avatarUrl: normalizeOptionalString(params.identity?.avatarUrl),
     tableMode: params.formatting?.tableMode,
-    chunking: { maxLines: params.formatting?.maxLinesPerMessage },
+    chunking: {
+      maxChars: params.formatting?.textLimit,
+      maxLines: params.formatting?.maxLinesPerMessage,
+    },
     ...resolveDiscordDeliveryOptions(params),
   });
 }

--- a/extensions/discord/src/outbound-text.ts
+++ b/extensions/discord/src/outbound-text.ts
@@ -10,6 +10,7 @@ export function prepareDiscordOutboundText(
     cfg: OpenClawConfig;
     account: Pick<ResolvedDiscordAccount, "accountId" | "config">;
     tableMode?: MarkdownTableMode;
+    textLimit?: number;
   },
 ) {
   const { account } = params;
@@ -20,6 +21,10 @@ export function prepareDiscordOutboundText(
   // Both transports measure chunks after rendering and alias expansion; titles retain display names.
   return {
     renderedText,
+    textLimit:
+      typeof params.textLimit === "number" && Number.isFinite(params.textLimit)
+        ? Math.max(1, Math.min(Math.floor(params.textLimit), 2000))
+        : undefined,
     textWithMentions: rewriteDiscordKnownMentions(renderedText, {
       accountId: account.accountId,
       mentionAliases: account.config.mentionAliases,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -186,18 +186,15 @@ export async function sendMessageDiscord(
     configured: accountInfo.config.suppressEmbeds,
     override: opts.suppressEmbeds,
   });
-  const textLimit =
-    typeof opts.textLimit === "number" && Number.isFinite(opts.textLimit)
-      ? Math.max(1, Math.min(Math.floor(opts.textLimit), 2000))
-      : undefined;
   const mediaMaxBytes =
     typeof accountInfo.config.mediaMaxMb === "number"
       ? accountInfo.config.mediaMaxMb * 1024 * 1024
       : DEFAULT_DISCORD_MEDIA_MAX_MB * 1024 * 1024;
-  const { renderedText, textWithMentions } = prepareDiscordOutboundText(text ?? "", {
+  const { renderedText, textWithMentions, textLimit } = prepareDiscordOutboundText(text ?? "", {
     cfg,
     account: accountInfo,
     tableMode: opts.tableMode,
+    textLimit: opts.textLimit,
   });
   const recipient = await parseAndResolveChannelRecipient(to, cfg, accountInfo.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);

--- a/extensions/discord/src/send.webhook.chunk-limit.test.ts
+++ b/extensions/discord/src/send.webhook.chunk-limit.test.ts
@@ -90,6 +90,43 @@ describe("Discord webhook delivery", () => {
 
   it.each([
     {
+      label: "first",
+      replyTo: { messageId: "fixture-reply", scope: "first" as const },
+      expected: ["fixture-reply", undefined],
+    },
+    {
+      label: "all",
+      replyTo: { messageId: "fixture-reply", scope: "all" as const },
+      expected: ["fixture-reply", "fixture-reply"],
+    },
+    { label: "none", replyTo: undefined, expected: [undefined, undefined] },
+  ])("records physical $label reply references in each receipt", async ({ replyTo, expected }) => {
+    await withWebhookServer(
+      (_content, index) => ({ body: { id: String(index), channel_id: "thread-1" } }),
+      async (contents, references) => {
+        const delivered: Array<Awaited<ReturnType<typeof realWebhookSend>>> = [];
+        const result = await realWebhookSend("first\nsecond", {
+          cfg,
+          webhookId: "fixture",
+          webhookToken: "fixture-token",
+          replyTo,
+          chunking: { maxLines: 1 },
+          onDeliveryResult: (part) => {
+            delivered.push(part);
+          },
+        });
+        expect(contents).toEqual(["first", "second"]);
+        expect(references).toEqual(expected);
+        expect(result.receipt?.parts.map((part) => part.replyToId)).toEqual(expected);
+        expect(
+          delivered.flatMap((part) => part.receipt?.parts.map((entry) => entry.replyToId)),
+        ).toEqual(expected);
+      },
+    );
+  });
+
+  it.each([
+    {
       label: "CommonMark bold",
       text: "`__literal__` __Important__",
       expected: "`__literal__` **Important**",

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -49,7 +49,7 @@ type DiscordWebhookSendOpts = {
   tableMode?: MarkdownTableMode;
   wait?: boolean;
   /** Opt into configured line limits; omission preserves character-only chunking. */
-  chunking?: { maxLines?: number };
+  chunking?: { maxChars?: number; maxLines?: number };
   onPlatformSendDispatch?: () => Promise<void>;
   assertPlatformSendAuthorized?: () => void;
   onDeliveryResult?: (result: DiscordSendResult) => Promise<void> | void;
@@ -120,10 +120,11 @@ export async function sendWebhookMessageDiscord(
     cfg: opts.cfg,
     accountId: opts.accountId,
   });
-  const { textWithMentions } = prepareDiscordOutboundText(text, {
+  const { textWithMentions, textLimit } = prepareDiscordOutboundText(text, {
     cfg: opts.cfg,
     account,
     tableMode: opts.tableMode,
+    textLimit: opts.chunking?.maxChars,
   });
   const flags = resolveDiscordMessageFlags({
     suppressEmbeds: resolveDiscordSuppressEmbeds({ configured: account.config.suppressEmbeds }),
@@ -155,6 +156,7 @@ export async function sendWebhookMessageDiscord(
   // Alias expansion happens after the outer delivery planner. Bound the actual
   // wire text here, retaining each accepted part before another can fail.
   const chunks = chunkDiscordTextWithMode(textWithMentions, {
+    maxChars: textLimit,
     maxLines: opts.chunking
       ? (opts.chunking.maxLines ?? account.config.maxLinesPerMessage)
       : Number.MAX_SAFE_INTEGER,
@@ -222,7 +224,7 @@ export async function sendWebhookMessageDiscord(
         fallbackChannelId: opts.threadId ? String(opts.threadId) : "",
         kind: "text",
         ...(opts.threadId != null ? { threadId: opts.threadId } : {}),
-        ...(replyTo ? { replyToId: replyTo } : {}),
+        reply: createReusableDiscordReplyReference(replyTo),
       });
       const resultConversationId = result.channelId.trim();
       if (result.messageId && resultConversationId) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where thread-bound Discord persona replies could exceed a caller's character limit after mention expansion, even though ordinary bot replies honored that limit. It also fixes missing reply-target metadata in the direct webhook delivery receipts and progress callbacks for chunked replies.

## Why This Change Was Made

Both Discord transports now consume the character limit normalized by their existing shared text-preparation owner. The persona adapter forwards the caller's limit through to final webhook chunking, after formatting and mention expansion.

Webhook results now pass each physical chunk's reply reference to the canonical receipt constructor using its current contract. This replaces an ignored legacy property and preserves first-only, all-chunk, and absent reply scope in returned receipts and progress callbacks.

## User Impact

Persona replies honor the caller's requested character cap after rendering, with the same normalization as bot replies. Their delivery receipts accurately retain the reply target selected for each chunk. Existing defaults, line limits, and requested webhook reply fields are preserved.

## Evidence

- The character-cap regression failed on the original webhook path while the bot control and 19 sibling cases passed. The repaired bot and webhook paths reconstruct the exact expanded message and keep every wire chunk within the 500-character cap.
- Direct webhook receipt tests failed before the receipt repair for first-only and all-chunk replies, then passed with matching aggregate and progress-callback metadata. The no-reply control remains covered.
- All 297 selected tests passed across six files, including durable delivery through the real local HTTP adapters, webhook activity, chunking, and ordinary bot sends.
- All 25 checks selected by the changed-file gate passed, including extension and test type checks, lint, formatting, and plugin boundaries. A later documentation-only wording correction received its own formatting and diff checks.

Independent review completed two clean passes through P2 on the final source.

Transport proof uses synthetic loopback HTTP servers. It verifies requested webhook fields and receipt metadata; it does not establish whether Discord applies the existing webhook reply-reference field. No live Discord or Gateway send was run.
