### PR TITLE
fix: keep streamed code examples from redirecting replies

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
@@ -34,6 +34,7 @@ import { warnIfAssistantEmittedSuspiciousText } from "./embedded-agent-subscribe
 import {
   createThinkingTagStreamState,
   extractAssistantThinking,
+  extractAssistantVisibleText,
   extractEmbeddedAssistantText,
   extractThinkingFromTaggedText,
   promoteThinkingTagsToBlocks,
@@ -122,13 +123,21 @@ export function handleMessageEnd(
     rawThinking: extractAssistantThinking(assistantMessage),
   }));
   warnIfAssistantEmittedSuspiciousText(ctx, assistantMessage);
+  const messageToolText = extractStandaloneMessageToolText(rawVisibleText, {
+    allowRoutedReply: isOpenAiCompletionsAssistantMessage(assistantMessage),
+    allowCurrentSourceReply:
+      ctx.params.sourceReplyDeliveryMode === "message_tool_only" &&
+      ctx.builtinToolNames?.has("message") === true,
+  });
+  // JSON decoding can introduce control syntax after snapshot sanitization.
+  // Retain the selected text phase without requiring another outer <final> envelope.
   const text =
-    extractStandaloneMessageToolText(rawVisibleText, {
-      allowRoutedReply: isOpenAiCompletionsAssistantMessage(assistantMessage),
-      allowCurrentSourceReply:
-        ctx.params.sourceReplyDeliveryMode === "message_tool_only" &&
-        ctx.builtinToolNames?.has("message") === true,
-    }) ?? rawVisibleText;
+    messageToolText === undefined
+      ? rawVisibleText
+      : extractAssistantVisibleText(
+          scopeAssistantMessageToStreamBlock(assistantMessage, snapshot.parts[0]?.index, undefined),
+          () => messageToolText,
+        );
   // Exact NO_REPLY stays silent. The legacy rewrite (silentReplyRewrite) was
   // removed by contract; global messaging-tool send evidence is not a
   // user-route reply and must never be mirrored into the final payload.
@@ -177,7 +186,7 @@ export function handleMessageEnd(
   if (text !== rawVisibleText) {
     // A structured message-tool result is projected before it enters the reply buffer.
     ctx.state.blockState.textIsVisible = true;
-    replaceBlockReplyBuffer(ctx, text);
+    replaceBlockReplyBuffer(ctx, cleanedText);
   } else if (ctx.blockChunker.consumedLength === 0) {
     // Observing a native index does not mean its predecessors were delivered:
     // phase-pending and suppressed streams can leave the whole message unsent.
@@ -188,13 +197,15 @@ export function handleMessageEnd(
             ctx.state.lastAssistantTextItemId,
           )
         : -1;
-    const pendingText =
+    const pendingSnapshot =
       preparedIndex >= 0 && Array.isArray(sourceContent)
         ? extractAssistantStreamSnapshot(ctx, {
             ...sourceMessage,
             content: sourceContent.slice(preparedIndex + 1),
-          }).text
-        : sourceSnapshot.text;
+          })
+        : sourceSnapshot;
+    const pendingText =
+      pendingSnapshot === snapshot ? cleanedText : parseReplyDirectives(pendingSnapshot.text).text;
     ctx.state.blockState = {
       thinking: false,
       final: false,

--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream-replies.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream-replies.test.ts
@@ -94,7 +94,13 @@ describe("resolveStreamingReply", () => {
         appendDelta: delta,
         parsedStreamDirectives: { text: delta, replyToTag: false, isSilent: false },
       }),
-    ).toEqual({ text: delta, delta, replace: false, hasText: true });
+    ).toEqual({
+      text: delta,
+      delta,
+      replace: false,
+      hasText: true,
+      replyDirectives: { text: delta, replyToTag: false, isSilent: false },
+    });
     expect(performance.now() - started).toBeLessThan(1_000);
   });
 });

--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
@@ -358,15 +358,28 @@ export function resolveStreamingReply(params: {
   visibleDelta: string;
   appendDelta: string | null;
   parsedStreamDirectives: ReplyDirectiveParseResult | null;
-}): { text: string; delta: string; replace: boolean; hasText: boolean } {
+}): {
+  text: string;
+  delta: string;
+  replace: boolean;
+  hasText: boolean;
+  replyDirectives: ReplyDirectiveParseResult | null;
+} {
   if (!params.parsedStreamDirectives && params.evtType === "text_delta") {
     const text = params.previousCleaned;
-    return { text, delta: "", replace: false, hasText: Boolean(text.trim()) };
+    return {
+      text,
+      delta: "",
+      replace: false,
+      hasText: Boolean(text.trim()),
+      replyDirectives: null,
+    };
   }
 
   let text: string | undefined;
   let delta: string | undefined;
   let isAppend = false;
+  let replyDirectives = params.parsedStreamDirectives;
   if (
     params.evtType !== "text_end" &&
     params.parsedStreamDirectives &&
@@ -383,9 +396,22 @@ export function resolveStreamingReply(params: {
     isAppend = true;
   }
 
-  text ??= parseReplyDirectives(
-    params.evtType === "text_end" ? params.next : splitTrailingDirective(params.next).text,
-  ).text;
+  if (text === undefined) {
+    const parsed = parseReplyDirectives(
+      params.evtType === "text_end" ? params.next : splitTrailingDirective(params.next).text,
+    );
+    text = parsed.text;
+    if (replyDirectives) {
+      // Reply targeting needs the same code context as visible text. Audio stays
+      // scoped to its streaming chunk rather than replaying earlier voice tags.
+      replyDirectives = {
+        ...replyDirectives,
+        replyToId: parsed.replyToId,
+        replyToCurrent: parsed.replyToCurrent,
+        replyToTag: parsed.replyToTag,
+      };
+    }
+  }
   const replace = Boolean(
     !isAppend && params.previousCleaned && !text.startsWith(params.previousCleaned),
   );
@@ -394,5 +420,6 @@ export function resolveStreamingReply(params: {
     delta: replace ? "" : (delta ?? text.slice(params.previousCleaned.length)),
     replace,
     hasText: Boolean(isAppend ? text : text.trim()),
+    replyDirectives,
   };
 }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -469,15 +469,13 @@ export function handleMessageUpdate(
             ? ctx.consumePartialReplyDirectives("", { final: finalText })
             : null,
         );
-    if (shouldUsePhaseAwareBlockReply || isTerminalSnapshot) {
-      recordPendingAssistantReplyDirectives(ctx.state, parsedStreamDirectives);
-    }
     const previousCleaned = ctx.state.assistantStream?.text ?? "";
     const {
       text: cleanedText,
       delta: replyDelta,
       replace,
       hasText,
+      replyDirectives,
     } = resolveStreamingReply({
       evtType,
       next,
@@ -487,6 +485,9 @@ export function handleMessageUpdate(
       appendDelta,
       parsedStreamDirectives,
     });
+    if (shouldUsePhaseAwareBlockReply || isTerminalSnapshot) {
+      recordPendingAssistantReplyDirectives(ctx.state, replyDirectives);
+    }
     const hasAudio = Boolean(parsedStreamDirectives?.audioAsVoice);
 
     const hasVisibleReply = hasText || hasAudio;

--- a/src/agents/embedded-agent-subscribe.reply-tags.test.ts
+++ b/src/agents/embedded-agent-subscribe.reply-tags.test.ts
@@ -11,7 +11,13 @@ import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
 import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 
 describe("subscribeEmbeddedAgentSession reply tags", () => {
-  type ReplyPayload = { text?: string; replyToCurrent?: boolean; replyToTag?: boolean };
+  type ReplyPayload = {
+    text?: string;
+    replyToId?: string;
+    replyToCurrent?: boolean;
+    replyToTag?: boolean;
+    audioAsVoice?: boolean;
+  };
 
   function replyPayloadAt(mock: ReturnType<typeof vi.fn>, index: number): ReplyPayload {
     const call = mock.mock.calls[index];
@@ -49,6 +55,79 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
 
     return { emit, onBlockReply, subscription };
   }
+
+  it.each([
+    {
+      name: "split inline code",
+      chunks: ["Use `", "[[reply_to:example-id]]` literally.\n\n"],
+      text: "Use `[[reply_to:example-id]]` literally.",
+      replyToId: undefined,
+    },
+    {
+      name: "inline code split by block chunking",
+      chunks: ["Use `" + "x".repeat(60), "[[reply_to:example-id]]` literally.\n\n"],
+      literal: "[[reply_to:example-id]]",
+      replyToId: undefined,
+    },
+    {
+      name: "complete inline code",
+      chunks: ["Use `[[reply_to:example-id]]` literally.\n\n"],
+      text: "Use `[[reply_to:example-id]]` literally.",
+      replyToId: undefined,
+    },
+    {
+      name: "a reply directive outside code",
+      chunks: ["[[reply_to:example-id]]", "Visible reply.\n\n"],
+      text: "Visible reply.",
+      replyToId: "example-id",
+    },
+    {
+      name: "a voice directive followed by ordinary blocks",
+      chunks: [
+        "[[audio_as_voice]]Hello.\n\n",
+        "An ordinary paragraph is long enough to drain the earlier voice block.\n\n",
+      ],
+      text: "Hello.",
+      audioAsVoice: true,
+      replyToId: undefined,
+    },
+  ])("delivers $name before text_end with matching reply metadata", async (scenario) => {
+    const { emit, onBlockReply, subscription } = createBlockReplyHarness();
+    const message = { role: "assistant", phase: "final_answer", content: [] };
+
+    emit({ type: "message_start", message });
+    for (const delta of [
+      ...scenario.chunks,
+      "A second paragraph gives the first completed block enough text to drain.",
+    ]) {
+      emit({
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta },
+      });
+    }
+    await subscription.waitForPendingEvents();
+
+    const payload = replyPayloadAt(onBlockReply, 0);
+    if (scenario.text) {
+      expect(payload.text).toBe(scenario.text);
+    }
+    if (scenario.literal) {
+      expect(replyTexts(onBlockReply).join("")).toContain(scenario.literal);
+    }
+    expect(payload.replyToId).toBe(scenario.replyToId);
+    expect(Boolean(payload.replyToTag)).toBe(Boolean(scenario.replyToId));
+    expect(payload.replyToCurrent).toBeFalsy();
+    expect(Boolean(payload.audioAsVoice)).toBe(Boolean(scenario.audioAsVoice));
+    for (const [later] of onBlockReply.mock.calls.slice(1)) {
+      expect(later.audioAsVoice).toBeFalsy();
+      if (!scenario.replyToId) {
+        expect(later.replyToId).toBeUndefined();
+        expect(later.replyToTag).toBeFalsy();
+        expect(later.replyToCurrent).toBeFalsy();
+      }
+    }
+  });
 
   it("carries reply_to_current across tag-only block chunks", () => {
     const { emit, onBlockReply } = createBlockReplyHarness();
@@ -182,23 +261,48 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     }
   });
 
-  it("strips a malformed reply prefix from the final block reply", async () => {
+  it.each([
+    {
+      name: "a split malformed prefix",
+      chunks: ["[[reply_to_", "current] Visible reply"],
+      source: "[[reply_to_current] Visible reply",
+      text: "Visible reply",
+      replyToId: undefined,
+    },
+    {
+      name: "a genuine tag without streamed deltas",
+      chunks: [],
+      source: "[[reply_to:target]] Visible reply",
+      text: "Visible reply",
+      replyToId: "target",
+    },
+    {
+      name: "a literal tag without streamed deltas",
+      chunks: [],
+      source: "Use `[[reply_to:target]]` literally.",
+      text: "Use `[[reply_to:target]]` literally.",
+      replyToId: undefined,
+    },
+  ])("prepares the final block reply for $name", async (scenario) => {
     const { emit, onBlockReply, subscription } = createBlockReplyHarness();
 
     emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta({ emit, delta: "[[reply_to_" });
-    emitAssistantTextDelta({ emit, delta: "current] Visible reply" });
-    emitAssistantTextEnd({ emit });
+    for (const delta of scenario.chunks) {
+      emitAssistantTextDelta({ emit, delta });
+    }
+    if (scenario.chunks.length > 0) {
+      emitAssistantTextEnd({ emit });
+    }
 
-    const assistantMessage = textAssistant("[[reply_to_current] Visible reply") as AssistantMessage;
+    const assistantMessage = textAssistant(scenario.source) as AssistantMessage;
     emit({ type: "message_end", message: assistantMessage });
     await subscription.waitForPendingEvents();
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
     const payload = replyPayloadAt(onBlockReply, 0);
-    expect(payload.text).toBe("Visible reply");
+    expect(payload.text).toBe(scenario.text);
+    expect(payload.replyToId).toBe(scenario.replyToId);
     expect(payload.replyToCurrent).toBeFalsy();
-    expect(payload.replyToTag).toBeFalsy();
-    expect(payload.text).not.toContain("[[reply_to");
+    expect(Boolean(payload.replyToTag)).toBe(Boolean(scenario.replyToId));
   });
 });

--- a/src/agents/embedded-agent-subscribe.stream-rendering.ts
+++ b/src/agents/embedded-agent-subscribe.stream-rendering.ts
@@ -461,9 +461,13 @@ export function createStreamRendering({
       markBlockReplyTextHandled();
       return;
     }
-    let splitResult = replyDirectiveAccumulator.consume(chunk, {
-      final: options?.finalReply !== undefined,
-    });
+    // Prepared chunks already removed real directives with full source context;
+    // a chunk boundary can separate a remaining literal from its code opener.
+    let splitResult: ReplyDirectiveParseResult | null = state.blockState.textIsVisible
+      ? { text: chunk, replyToTag: false, isSilent: false }
+      : replyDirectiveAccumulator.consume(chunk, {
+          final: options?.finalReply !== undefined,
+        });
     if (options?.finalReply) {
       let pendingText = splitResult?.text ?? "";
       if (pendingText && !options.finalReply.text.endsWith(pendingText)) {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-answer-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-answer-delivery.test.ts
@@ -428,6 +428,109 @@ function expectSingleBlockReplyText(params: {
 }
 
 describe("subscribeEmbeddedAgentSession", () => {
+  it.each([
+    {
+      name: "decoded reasoning and reply controls",
+      body: "<think>hidden [[reply_to:example-id]]</think>Visible reply.",
+      expected: "Visible reply.",
+    },
+    {
+      name: "decoded tool-call controls",
+      body: '<tool_call>{"name":"example","arguments":{}}</tool_call>Visible reply.',
+      expected: "Visible reply.",
+    },
+    {
+      name: "an entirely hidden decoded body",
+      body: "<think>hidden [[reply_to:example-id]]</think>",
+      expected: "",
+    },
+    {
+      name: "decoded inline code",
+      body: "Use `<think>literal</think>` literally.",
+      expected: "Use `<think>literal</think>` literally.",
+    },
+    {
+      name: "decoded fenced code",
+      body: "```text\n<think>literal</think>\n```\n\nVisible reply.",
+      expected: "```text\n<think>literal</think>\n```\n\nVisible reply.",
+    },
+    {
+      name: "decoded final-answer prose",
+      body: "Before <think>literal tag text after",
+      phase: "final_answer",
+      expected: "Before <think>literal tag text after",
+    },
+    {
+      name: "decoded final prose after commentary",
+      body: "Before <think>literal tag text after",
+      mixedPhases: true,
+      expected: "Before <think>literal tag text after",
+    },
+    {
+      name: "an outer final envelope",
+      body: "Visible reply.",
+      enforceFinalTag: true,
+      finalEnvelope: true,
+      expected: "Visible reply.",
+    },
+    {
+      name: "a missing required final envelope",
+      body: "Visible reply.",
+      enforceFinalTag: true,
+      expected: "",
+    },
+  ])("prepares $name from standalone message-tool JSON", async (scenario) => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-decoded-message-tool",
+      onBlockReply,
+      blockReplyBreak: "message_end",
+      enforceFinalTag: scenario.enforceFinalTag,
+    });
+    const encoded = JSON.stringify({
+      name: "message",
+      arguments: { action: "send", target: "test-target", message: scenario.body },
+    }).replaceAll("<", "\\u003c");
+    const message = {
+      ...textAssistant(scenario.finalEnvelope ? `<final>${encoded}</final>` : encoded),
+      api: "openai-completions",
+      phase: scenario.phase,
+      ...(scenario.mixedPhases
+        ? {
+            content: [
+              createOpenAiResponsesTextBlock({
+                text: "Working...",
+                id: "commentary",
+                phase: "commentary",
+              }),
+              createOpenAiResponsesTextBlock({
+                text: encoded,
+                id: "answer",
+                phase: "final_answer",
+              }),
+            ],
+          }
+        : {}),
+    };
+
+    try {
+      emit({ type: "message_start", message });
+      emit({ type: "message_end", message });
+      await subscription.waitForPendingEvents();
+
+      expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual(
+        scenario.expected ? [scenario.expected] : [],
+      );
+      for (const [payload] of onBlockReply.mock.calls) {
+        expect(payload.replyToId).toBeUndefined();
+        expect(payload.replyToCurrent).toBeFalsy();
+        expect(payload.replyToTag).toBeFalsy();
+      }
+    } finally {
+      subscription.unsubscribe();
+    }
+  });
+
   it.each(["text_end", "message_end"] as const)(
     "retains silent terminal evidence with %s block replies",
     async (blockReplyBreak) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a streamed inline-code example containing a reply tag could attach that literal tag as a real reply target before the message finished. A later chunk could also lose the literal marker when the code opener had already been drained. Terminal-only delivery had related inconsistencies between prepared visible text and directive metadata.

## Why This Change Was Made

The subscriber now takes reply-target metadata from the same cumulative parse that owns visible text. Prepared chunks keep their literal bytes instead of parsing them again without the preceding code context. Terminal fallback producers prepare their text before passing it to that path, while final media stays with its existing owner.

Standalone message-tool JSON can introduce control syntax during decoding. Its decoded body now passes through the existing phase-aware visibility extractor before directive parsing, preserving code examples, selected final-answer content, and empty sanitized results.

## User Impact

Reply tags shown in streamed code examples remain literal and do not become reply targets merely because a provider or delivery chunk splits the example. Decoded standalone message text receives the same visibility preparation as other delivered text.

## Evidence

- The original subscriber failed two code-example regressions across provider-delta and physical-block boundaries; unaffected controls passed.
- The decoded-text cases reproduced three failures with five passing controls on both the original main source and an intermediate candidate. This was an existing defect, despite an initial review attributing it to the candidate.
- All 334 selected tests passed across 12 files, with no filtered cases. Coverage includes terminal fallback, literal code, phase selection, chunk boundaries, final media, and nine decoded-body cases.
- All 29 selected changed-file checks passed. Final independent review through P2 found no remaining actionable findings.

Proof uses the registered subscriber with synthetic provider events; no live provider or channel send was run. Per-chunk audio metadata and the separate raw-block accumulator retain their existing behavior and remain separate follow-ups. No transcript, config, persistence, or dependency format changes.
