### PR TITLE
improve: speed up long Slack message chunking

### DIFF
--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -98,6 +98,7 @@ describe("normalizeSlackOutboundText", () => {
 
     expect(normalizeSlackOutboundText(input)).toBe(expected);
     expect(markdownToSlackMrkdwnChunks(input, 4000)).toEqual([expected]);
+    expect(markdownToSlackMrkdwnChunks(input, Number.POSITIVE_INFINITY)).toEqual([expected]);
     expect(normalizeSlackOutboundText(expected)).toBe(expected);
     expect(normalizeSlackOutboundText(`intro\n${input}`)).toBe(`\`Assistant:\` intro\n${input}`);
     expect(normalizeSlackOutboundText("<!date^0^user[Thu 2026-07-02]|safe> authorize")).toBe(
@@ -243,6 +244,28 @@ describe("normalizeSlackOutboundText", () => {
         .filter((chunk) => chunk.length > 8),
     ).toStrictEqual([]);
   });
+
+  it("includes transcript protection when a native token exactly fills the chunk budget", () => {
+    expect(markdownToSlackMrkdwnChunks("<@U|user[t]>", 12)).toEqual(["&lt;@U|user[", "t]&gt;"]);
+  });
+
+  it.each(["<@U|user[t]>", "<!date^0^user[t]|safe>", "<!date^0^safe|user[t]>"])(
+    "protects %s when an oversized link prevents any fitting split",
+    (header) => {
+      const href = `https://example.com/${"a".repeat(100)}`;
+      expect(markdownToSlackMrkdwnChunks(`[x](${href})\n${header}`, 32)).toEqual([
+        `\`Assistant:\` <${href}|x>\n${header}`,
+      ]);
+    },
+  );
+
+  it.each([1, 1.9, 0, -1, Number.NaN, Number.NEGATIVE_INFINITY])(
+    "preserves complete code points with normalized chunk limit %s",
+    (limit) => {
+      expect(markdownToSlackMrkdwnChunks("😀x", limit)).toEqual(["😀", "x"]);
+      expect(markdownToSlackMrkdwnChunks("", limit)).toEqual([]);
+    },
+  );
 
   it("keeps unsafe emphasis boundaries plain when chunking", () => {
     expect(markdownToSlackMrkdwnChunks("これは*重要*です。", 100)).toEqual(["これは重要です。"]);

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -1,6 +1,7 @@
 // Slack helper module supports format behavior.
 import { eastAsianWidthType } from "get-east-asian-width";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
+import { resolveIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import {
   chunkTextForOutbound,
   FormatCapabilityProfile,
@@ -529,13 +530,23 @@ export function markdownToSlackMrkdwnChunks(
     }),
   );
   const renderOptions = buildSlackRenderOptions();
+  const normalizedLimit =
+    limit === Number.POSITIVE_INFINITY ? limit : resolveIntegerOption(limit, 1, { min: 1 });
   return renderMarkdownIRChunksWithinLimit({
     ir,
-    limit,
-    renderChunk: (chunk) =>
-      protectSlackAssistantTranscriptRoleHeaders(
-        renderMarkdownWithMarkers(chunk, renderOptions, SLACK_FORMAT_PROFILE),
-      ),
+    limit: normalizedLimit,
+    renderChunk: (chunk) => {
+      const rendered = renderMarkdownWithMarkers(chunk, renderOptions, SLACK_FORMAT_PROFILE);
+      // Protection only adds a prefix, so an oversized probe cannot become a fit.
+      return rendered.length > normalizedLimit
+        ? rendered
+        : protectSlackAssistantTranscriptRoleHeaders(rendered);
+    },
     measureRendered: (rendered) => rendered.length,
-  }).map(({ rendered }) => rendered);
+  }).map(({ rendered }) =>
+    // Unsplittable safety fallbacks still need protection before leaving Slack.
+    rendered.length > normalizedLimit
+      ? protectSlackAssistantTranscriptRoleHeaders(rendered)
+      : rendered,
+  );
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Long Slack replies with expanded links or many annotations can spend hundreds of milliseconds in local text chunking before delivery. The chunk search repeatedly projects and reparses candidate text that is already too large to send.

## Why This Change Was Made

Skip transcript-header protection while measuring an already-oversized rendered candidate: protection can only leave text unchanged or add a fixed prefix, so it cannot make that candidate fit. Keep protection in every potentially fitting measurement and apply it to any oversized fallback before returning the final chunks. The shared chunk search, output protection policy, and caller behavior stay unchanged; the existing numeric helper keeps limit normalization aligned.

## User Impact

Expensive long-message chunking uses substantially less CPU while preserving complete Slack output, chunk boundaries, Unicode handling, and uncapped limits. Short messages are not uniformly faster. This is a local formatting improvement, not a measured Slack network or model-response speedup.

## Evidence

A fixed synthetic corpus exercised both actual formatter exports in four separate processes, ordered baseline/candidate/candidate/baseline, on Linux x64 with Node 24.19.0. All **600 full returned strings/arrays and input snapshots** matched. Each row had one initial call, two warmups, and twelve warm observations; the table uses the median of those twelve observations.

| Chunking workload | Forward baseline → candidate | Reverse baseline → candidate |
| --- | --- | --- |
| Mixed long message | 348.388 → 115.111 ms (−66.96%) | 343.273 → 99.331 ms (−71.06%) |
| 256 annotations | 96.582 → 29.459 ms (−69.50%) | 107.046 → 31.174 ms (−70.88%) |

The corresponding CPU medians improved 66.43%/71.16% and 67.35%/70.12%. The complete results retain unfavorable outcomes: across all ten formatter/workload rows and both orders, 9/20 warm wall medians, 8/20 means, and 11/20 maxima were higher; 94/240 paired warm wall observations and 96/240 CPU observations were higher. Small and unchanged control paths show order/JIT/GC noise; this single fixed-order cohort does not establish a universal improvement. Process maximum RSS was 24.22%/23.53% lower, an observation rather than an allocation claim.

Validation completed:

- The whole Slack formatting test file passed with both baseline and candidate source: 37 tests each, including exact-budget protection, oversized fallbacks, Unicode, and Infinity. Six whole Markdown parser/rendering/chunking files passed 85 tests. Those unchanged tests and successful targeted formatting/lint were reused only after a fresh frozen install matched the selected installed inputs.
- Normal `pnpm build` passed; emitted Slack code and the actual runtime-only SDK JavaScript export were checked. The existing isolated Slack entrypoint profiler passed: 109.375 MiB peak RSS versus 45.750 MiB for empty Node. It imports the built index only and does not measure full channel registration or startup.
- Independent Codex source review found no actionable P0–P2 findings. `git diff --check` passed. All eleven managed stages joined and released; the isolated container and Testbox lease were cleaned up.

[Completed Testbox run](https://github.com/openclaw/openclaw/actions/runs/34507287520). The delegated wrapper returned zero; the backing Actions job may appear cancelled after normal lease cleanup. The frozen comparison uses base `b81c01a6bff0fc2e0b98fc797aac9199e3759b9f`; exact-head required CI and native landing checks remain pending. Current main retains the same formatter, callers, and Markdown/numeric owners.

Earlier apparatus failures are preserved: one incorrectly treated legitimate lint declarations as stale output, another enumerated a file as a directory, and another demanded a packaged declaration that the runtime-only SDK contract intentionally excludes. The normal build passed before that last binder failure. Recovery corrected those premises, did not change product source or increase limits, and produced no numerical samples until the completed run above. No live Slack API or Gateway inference was exercised by this formatter proof.
