### PR TITLE
improve: avoid duplicate Bedrock model classification

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -904,9 +904,6 @@ function resolveCacheRetention(
  * whose ARNs don't contain the model name.
  */
 function isAnthropicClaudeModel(model: Model<"bedrock-converse-stream">): boolean {
-  if (usesClaudeFable5BedrockContract(model)) {
-    return true;
-  }
   if (resolveClaudeModelIdentity(model).startsWith("claude-")) {
     return true;
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Preparing Amazon Bedrock requests with long signed reasoning histories incurs avoidable local work before the request is sent. This maintainer-requested performance cleanup reduces that overhead without changing the request or replay behavior.

## Why This Change Was Made

Remove a redundant specialist-family check from the Bedrock Claude classifier: the specialist resolver already delegates to the canonical identity resolver, and every successful specialist match satisfies the immediately following `claude-` prefix check. Canonical metadata precedence, opaque profile ID/name fallbacks, other specialist policies, and signed or redacted reasoning handling remain unchanged. The change removes three production lines and adds no cache, dependency, public API, or test seam.

## User Impact

Bedrock requests keep the same payloads and terminal results while avoiding repeated classification work when replaying reasoning blocks. Synthetic full-stream measurements showed approximately 42–46 microseconds lower warm median time for the long regional-profile fixture. These are local request-preparation and stream-completion measurements, not live AWS, model inference, or Gateway latency claims.

## Evidence

Validated on baseline `a3f3bfe953d48cf550fc2150c7c6e5ab07a8a273`, with only this deletion applied, using Linux x64, Node 24.19.0, and pnpm 12.3.4. Independent Codex review found no actionable P0–P2 issues. The candidate preserves ordinary model descriptor contracts; stateful getters or monkey-patched resolver behavior are not demonstrated production contracts.

- **Behavior:** all 84 tests in the complete Bedrock runtime and accounting/replay suites passed. The unchanged 21-case shared model-contract coverage retains its earlier successful evidence; it was not rerun or described as fresh proof.
- **Changed checks:** all 24 selected checks are covered by composite evidence. The initial run completed the first 19 commands, including both extension typecheck graphs, six doctor contract tests, and all three dead-export scans, then reached its 500-second command limit in extension lint. Recovery ran only that lint stage, the four remaining guards, and final diff check. All passed with the original limits. Lint prepared package declarations and reported zero warnings/errors across 263 rules. No full single-run `check:changed` success is claimed.
- **Measurement:** 832 calls in fixed B0/C0/C1/B1 order, covering direct IDs, regional profiles, foundation ARNs, opaque canonical metadata, name-only profiles, non-Claude models, no-history controls, and normalized canonical metadata. Each row has one first call, five warmups, and 20 steady calls. The real `streamSimpleBedrock(...).result()` path runs through actual SDK client and command construction; only SDK `send` is replaced by a fixed transport response. No AWS credentials or network requests are used.
- **Output parity:** all 832 complete input/request/terminal V8 outcomes match across variants, with input immutability and own-key checks. Raw timestamps are retained and excluded only from terminal semantic equality. Independent audit reproduced all 80 scalar comparisons and 416 individual paired observations.

Warm medians improved in 13 of 16 comparisons. The long regional-profile fixture improved 17.57% and 16.57%; long opaque canonical metadata improved 12.50% and 5.91%. Results are not uniformly favorable: three medians, six first calls, six means, eight p95s, nine maxima, and 125 of 416 individual pairs were slower. The largest candidate outlier was the foundation-ARN fixture at 11.748 ms versus 0.242 ms, increasing that pair's mean by 336.9%. Whole-process user CPU changed −10.43%/+12.62%, system CPU −11.65%/+4.42%, and managed wall −11.39%/+13.42% across orders. Maximum RSS changed −1.74%/−4.23%; this is not an allocation claim.

The recovery's source and installed locks, package versions, selected runtime bytes, and link targets match the initial capture. Only generated install housekeeping metadata differed, with both hashes retained. All 13 recovery process records joined successfully and released claims; the container exited successfully and was removed, and the Testbox lease was stopped. The [initial Testbox run](https://github.com/openclaw/openclaw/actions/runs/34504187796) retains the timeout; the [recovery Testbox run](https://github.com/openclaw/openclaw/actions/runs/34507326597) has wrapper exit 0. Its backing Actions job is cancelled because the successful one-shot Testbox lease was cleaned up, not because a validation command failed.

Complete raw evidence, including adverse observations, is retained in the recovery archive with SHA-256 `4d3b859a8f33ee152dfbe16f2bff3e5c6c017ecaa604061ae14531e6b4913811`. Current-main source inspection through `ae94766f288b54ec7ac840cc4e1479232405949b` finds no change to the Bedrock owner or classifier contract. Recorded timings remain bound to the baseline above. Required PR CI and native landing checks remain pending; no full repository build, full test-suite, or live AWS result is claimed.
