### PR TITLE
refactor(heartbeat): await outcome persistence and claims

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -775,7 +775,7 @@ describe("prepareCliRunContext", () => {
       };
       try {
         const before = await fixture.prepare(input);
-        persistHeartbeatOutcome({
+        await persistHeartbeatOutcome({
           ...sessionTarget,
           runSessionKey: "agent:main:main:heartbeat",
           occurredAt: 1,
@@ -829,7 +829,7 @@ describe("prepareCliRunContext", () => {
     "does not consume silent heartbeat context for %s CLI preparation",
     async (kind) => {
       const { sessionTarget, dir } = fixture.session;
-      persistHeartbeatOutcome({
+      await persistHeartbeatOutcome({
         ...sessionTarget,
         runSessionKey: "agent:main:main:heartbeat",
         occurredAt: 1,
@@ -857,9 +857,9 @@ describe("prepareCliRunContext", () => {
             "Retained CLI outcome",
           );
         }
-        expect(claimHeartbeatOutcomeForRun({ ...sessionTarget, runId: "next-user" })?.summary).toBe(
-          "Retained CLI outcome",
-        );
+        expect(
+          (await claimHeartbeatOutcomeForRun({ ...sessionTarget, runId: "next-user" }))?.summary,
+        ).toBe("Retained CLI outcome");
       } finally {
         admission.close();
       }
@@ -868,7 +868,7 @@ describe("prepareCliRunContext", () => {
 
   it("does not renew an explicitly revoked CLI owner to claim silent heartbeat context", async () => {
     const { sessionTarget } = fixture.session;
-    persistHeartbeatOutcome({
+    await persistHeartbeatOutcome({
       ...sessionTarget,
       runSessionKey: "agent:main:main:heartbeat",
       occurredAt: 1,
@@ -890,9 +890,9 @@ describe("prepareCliRunContext", () => {
         sessionKey: sessionTarget.sessionKey,
       }),
     ).rejects.toThrow("authority");
-    expect(claimHeartbeatOutcomeForRun({ ...sessionTarget, runId: "next-user" })?.summary).toBe(
-      "Keep revoked-owner outcome",
-    );
+    expect(
+      (await claimHeartbeatOutcomeForRun({ ...sessionTarget, runId: "next-user" }))?.summary,
+    ).toBe("Keep revoked-owner outcome");
   });
 
   it("carries the session-key-derived workspace owner into prepared params", async () => {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -2321,7 +2321,7 @@ async function prepareCliRunContextWithinReadFence(
       fallbackReason: params.modelRoutingProvenance?.fallbackReason,
     });
 
-    const note = claimHeartbeatContextForUserRun({
+    const note = await claimHeartbeatContextForUserRun({
       ...preparedParams,
       agentId: sessionAgentId,
       storePath: params.sessionTarget?.storePath ?? params.storePath,

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -591,7 +591,7 @@ describe("runAgentHarnessAttempt", () => {
         storePath: path.join(root, "agent.sqlite"),
       };
       await replaceSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
-      persistHeartbeatOutcome({
+      await persistHeartbeatOutcome({
         ...target,
         runSessionKey: "agent:main:main:heartbeat",
         occurredAt: 1,
@@ -649,7 +649,9 @@ describe("runAgentHarnessAttempt", () => {
       expect(JSON.stringify(await loadTranscriptEvents(target))).not.toContain(
         "ISOLATED_OUTCOME_731",
       );
-      expect(claimHeartbeatOutcomeForRun({ ...target, runId: "later-user-run" })).toBeUndefined();
+      expect(
+        await claimHeartbeatOutcomeForRun({ ...target, runId: "later-user-run" }),
+      ).toBeUndefined();
     },
   );
 
@@ -665,7 +667,7 @@ describe("runAgentHarnessAttempt", () => {
         storePath: path.join(root, "agent.sqlite"),
       };
       await replaceSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
-      persistHeartbeatOutcome({
+      await persistHeartbeatOutcome({
         ...target,
         runSessionKey: "agent:main:main:heartbeat",
         occurredAt: 1,
@@ -685,7 +687,7 @@ describe("runAgentHarnessAttempt", () => {
         await runAgentHarnessAttempt(params);
         expect(agentRunAttempt.mock.calls.at(-1)?.[0].currentInboundContext).toBeUndefined();
       }
-      expect(claimHeartbeatOutcomeForRun({ ...target, runId: "next-user" })?.summary).toBe(
+      expect((await claimHeartbeatOutcomeForRun({ ...target, runId: "next-user" }))?.summary).toBe(
         "Retained outcome",
       );
     },

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -537,11 +537,11 @@ export async function runAgentHarnessAttempt(
                       : input;
                   },
               (prepared) =>
-                pluginAttempt.runWithHostScope(() => {
+                pluginAttempt.runWithHostScope(async () => {
                   if (prepared.trigger !== "user" || !prepared.sessionKey) {
                     return runAgentHarnessLifecycleAttempt(harness, prepared);
                   }
-                  const note = claimHeartbeatContextForUserRun({
+                  const note = await claimHeartbeatContextForUserRun({
                     ...prepared,
                     agentId: resolveSessionAgentIds(prepared).sessionAgentId,
                     storePath: prepared.sessionTarget?.storePath,

--- a/src/infra/heartbeat-dispatch.ts
+++ b/src/infra/heartbeat-dispatch.ts
@@ -294,12 +294,12 @@ async function prepareHeartbeatDispatchReply(
       wakeReason: opts.reason,
       occurredAt: startedAt,
     });
-  const unconfirmed = (reason: string) => {
+  const unconfirmed = async (reason: string) => {
     if (outcome.kind !== "delivery" || !outcome.response) {
       return;
     }
     const value = outcome.response;
-    record({
+    await record({
       ...value,
       outcome: "blocked",
       notify: false,
@@ -312,7 +312,7 @@ async function prepareHeartbeatDispatchReply(
   const suppressSelected = () => suppressPendingFinalDelivery(selected, { preserveActivity: true });
   if (outcome.kind === "ack") {
     if ("response" in outcome && outcome.response) {
-      record(outcome.response);
+      await record(outcome.response);
     }
     await restoreActivity();
     await suppressSelected();
@@ -419,7 +419,9 @@ async function prepareHeartbeatDispatchReply(
   }
   if (!channel || !delivery.to || !visibility.showAlerts || (failed && outcome.shouldSkipMain)) {
     if (!failed) {
-      unconfirmed(!channel || !delivery.to ? (delivery.reason ?? "no-target") : "alerts-disabled");
+      await unconfirmed(
+        !channel || !delivery.to ? (delivery.reason ?? "no-target") : "alerts-disabled",
+      );
       if (!visibility.showAlerts) {
         await restoreActivity();
       }
@@ -446,7 +448,7 @@ async function prepareHeartbeatDispatchReply(
     ?.heartbeat?.checkReady?.({ cfg, accountId: delivery.accountId, deps: opts.deps })
     .catch((error: unknown) => ({ ok: false, reason: formatErrorMessage(error) }));
   if (readiness && !readiness.ok) {
-    unconfirmed(readiness.reason ?? HEARTBEAT_SKIP_CHANNEL_NOT_READY);
+    await unconfirmed(readiness.reason ?? HEARTBEAT_SKIP_CHANNEL_NOT_READY);
     await restoreActivity();
     finish(
       {
@@ -484,7 +486,7 @@ async function prepareHeartbeatDispatchReply(
     settle: async (result) => {
       const sent = result === "delivered";
       if (!sent) {
-        unconfirmed(policy.deliveryError ?? policy.deliveryReason ?? result);
+        await unconfirmed(policy.deliveryError ?? policy.deliveryReason ?? result);
       }
       if (sent && !failed && deliveryText.trim()) {
         await patchSessionEntryCore(

--- a/src/infra/heartbeat-outcome-store.test.ts
+++ b/src/infra/heartbeat-outcome-store.test.ts
@@ -40,9 +40,45 @@ afterEach(() => {
 });
 
 describe("heartbeat outcome store", () => {
+  it("keeps a committed claim but withholds context after its admitted run retires", async () => {
+    const env = await createEnv();
+    const target = { agentId: "main", sessionKey: "agent:main:main", env };
+    await persistHeartbeatOutcome({
+      ...target,
+      runSessionKey: "agent:main:main:heartbeat",
+      response: { outcome: "progress", notify: false, summary: "Saved outcome" },
+      occurredAt: 100,
+    });
+    const admission = prepareSystemAgentRunAdmission(
+      {},
+      "retired-run",
+      "main",
+      "heartbeat-outcome-test",
+    );
+    try {
+      const admitted = await admission.admit("embedded");
+      const pending = claimHeartbeatContextForUserRun({
+        ...target,
+        runId: "retired-run",
+        trigger: "user",
+        assertCurrent: resolveAdmittedRunActiveAssertion(admitted),
+      });
+      admission.close();
+      await expect(pending).rejects.toThrow();
+      expect(await claimHeartbeatOutcomeForRun({ ...target, runId: "retired-run" })).toMatchObject({
+        summary: "Saved outcome",
+      });
+      expect(
+        await claimHeartbeatOutcomeForRun({ ...target, runId: "another-run" }),
+      ).toBeUndefined();
+    } finally {
+      admission.close();
+    }
+  });
+
   it("keeps one bounded typed outcome per base session with provenance", async () => {
     const env = await createEnv();
-    persistHeartbeatOutcome({
+    await persistHeartbeatOutcome({
       agentId: "main",
       sessionKey: "agent:main:main",
       runSessionKey: "agent:main:main:heartbeat",
@@ -61,7 +97,7 @@ describe("heartbeat outcome store", () => {
       env,
     });
 
-    const stored = claimHeartbeatOutcomeForRun({
+    const stored = await claimHeartbeatOutcomeForRun({
       agentId: "main",
       sessionKey: "agent:main:main",
       runId: "user-run-1",
@@ -88,7 +124,7 @@ describe("heartbeat outcome store", () => {
     );
     try {
       const admitted = await admission.admit("embedded");
-      const context = claimHeartbeatContextForUserRun({
+      const context = await claimHeartbeatContextForUserRun({
         agentId: "main",
         sessionKey: "agent:main:main",
         runId: "user-run-1",
@@ -115,28 +151,28 @@ describe("heartbeat outcome store", () => {
       occurredAt: 100,
       env,
     };
-    persistHeartbeatOutcome({
+    await persistHeartbeatOutcome({
       ...base,
       response: { outcome: "done", notify: false, summary: "Finished first task" },
     });
-    persistHeartbeatOutcome({
+    await persistHeartbeatOutcome({
       ...base,
       occurredAt: 200,
       response: { outcome: "blocked", notify: false, summary: "Waiting for build" },
     });
-    persistHeartbeatOutcome({
+    await persistHeartbeatOutcome({
       ...base,
       occurredAt: 300,
       response: { outcome: "needs_attention", notify: true, summary: "Visible alert" },
     });
-    persistHeartbeatOutcome({
+    await persistHeartbeatOutcome({
       ...base,
       occurredAt: 400,
       response: { outcome: "no_change", notify: false, summary: "Nothing changed" },
     });
 
     expect(
-      claimHeartbeatOutcomeForRun({
+      await claimHeartbeatOutcomeForRun({
         agentId: "main",
         sessionKey: "agent:main:main",
         runId: "user-run-1",
@@ -166,16 +202,14 @@ describe("heartbeat outcome store", () => {
       db.prepare("SELECT session_key FROM session_nodes WHERE session_key = ?").get(runSessionKey),
     ).toEqual({ session_key: runSessionKey });
 
-    expect(() =>
-      persistHeartbeatOutcome({
-        agentId: "main",
-        sessionKey,
-        runSessionKey,
-        response: { outcome: "progress", notify: false, summary: "Transient heartbeat" },
-        occurredAt: 500,
-        env,
-      }),
-    ).not.toThrow();
+    await persistHeartbeatOutcome({
+      agentId: "main",
+      sessionKey,
+      runSessionKey,
+      response: { outcome: "progress", notify: false, summary: "Transient heartbeat" },
+      occurredAt: 500,
+      env,
+    });
 
     expect(db.prepare("SELECT COUNT(*) AS count FROM heartbeat_outcomes").get()).toEqual({
       count: 0,
@@ -192,13 +226,13 @@ describe("heartbeat outcome store", () => {
       occurredAt: 100,
       env,
     };
-    persistHeartbeatOutcome({
+    await persistHeartbeatOutcome({
       ...base,
       response: { outcome: "progress", notify: false, summary: "First outcome" },
     });
 
     expect(
-      claimHeartbeatOutcomeForRun({
+      await claimHeartbeatOutcomeForRun({
         agentId: "main",
         sessionKey: "agent:main:main",
         runId: "user-run-1",
@@ -206,7 +240,7 @@ describe("heartbeat outcome store", () => {
       }),
     ).toMatchObject({ summary: "First outcome" });
     expect(
-      claimHeartbeatOutcomeForRun({
+      await claimHeartbeatOutcomeForRun({
         agentId: "main",
         sessionKey: "agent:main:main",
         runId: "user-run-1",
@@ -214,7 +248,7 @@ describe("heartbeat outcome store", () => {
       }),
     ).toMatchObject({ summary: "First outcome" });
     expect(
-      claimHeartbeatOutcomeForRun({
+      await claimHeartbeatOutcomeForRun({
         agentId: "main",
         sessionKey: "agent:main:main",
         runId: "user-run-2",
@@ -222,13 +256,13 @@ describe("heartbeat outcome store", () => {
       }),
     ).toBeUndefined();
 
-    persistHeartbeatOutcome({
+    await persistHeartbeatOutcome({
       ...base,
       occurredAt: 200,
       response: { outcome: "done", notify: false, summary: "Second outcome" },
     });
     expect(
-      claimHeartbeatOutcomeForRun({
+      await claimHeartbeatOutcomeForRun({
         agentId: "main",
         sessionKey: "agent:main:main",
         runId: "user-run-2",

--- a/src/infra/heartbeat-outcome-store.ts
+++ b/src/infra/heartbeat-outcome-store.ts
@@ -97,7 +97,7 @@ function rowToOutcome(row: HeartbeatOutcomeRow): PersistedHeartbeatOutcome | und
 }
 
 /** Replaces the previous silent heartbeat outcome for one base session. */
-export function persistHeartbeatOutcome(params: {
+export async function persistHeartbeatOutcome(params: {
   agentId: string;
   sessionKey: string;
   storePath?: string;
@@ -108,7 +108,7 @@ export function persistHeartbeatOutcome(params: {
   wakeReason?: string;
   occurredAt: number;
   env?: NodeJS.ProcessEnv;
-}): void {
+}): Promise<void> {
   if (params.response.notify || params.response.outcome === "no_change") {
     return;
   }
@@ -178,15 +178,17 @@ export function persistHeartbeatOutcome(params: {
 }
 
 /** Claims the latest outcome for one user run while allowing that run's retries. */
-export function claimHeartbeatOutcomeForRun(params: {
+export async function claimHeartbeatOutcomeForRun(params: {
   agentId: string;
   sessionKey: string;
   storePath?: string;
   runId: string;
   env?: NodeJS.ProcessEnv;
-}): PersistedHeartbeatOutcome | undefined {
+  assertCurrent?: () => void;
+}): Promise<PersistedHeartbeatOutcome | undefined> {
   return runOpenClawAgentWriteTransaction(
     ({ db }) => {
+      params.assertCurrent?.();
       const agentDb = getNodeSqliteKysely<HeartbeatOutcomeDatabase>(db);
       const row = executeSqliteQuerySync(
         db,
@@ -246,14 +248,14 @@ function buildHeartbeatOutcomeContext(
 }
 
 /** Claim bounded next-user context only after the runtime owner has admitted the turn. */
-export function claimHeartbeatContextForUserRun(
+export async function claimHeartbeatContextForUserRun(
   params: Omit<Parameters<typeof claimHeartbeatOutcomeForRun>[0], "sessionKey"> & {
     sessionKey?: string;
     trigger?: EmbeddedRunTrigger;
     detached?: boolean;
     assertCurrent: (() => void) | undefined;
   },
-): string | undefined {
+): Promise<string | undefined> {
   if (params.trigger !== "user" || params.detached || !params.sessionKey) {
     return undefined;
   }
@@ -261,7 +263,7 @@ export function claimHeartbeatContextForUserRun(
     throw new Error("Heartbeat outcome context requires an active admitted run");
   }
   params.assertCurrent();
-  return buildHeartbeatOutcomeContext(
-    claimHeartbeatOutcomeForRun({ ...params, sessionKey: params.sessionKey }),
-  );
+  const outcome = await claimHeartbeatOutcomeForRun({ ...params, sessionKey: params.sessionKey });
+  params.assertCurrent();
+  return buildHeartbeatOutcomeContext(outcome);
 }

--- a/src/infra/heartbeat-runner.first-isolated-outcome.test.ts
+++ b/src/infra/heartbeat-runner.first-isolated-outcome.test.ts
@@ -253,14 +253,14 @@ it.each(
           expect(store[sessionKey]?.sessionId).toBe("existing-user-session");
         }
         const params = { ...scope, runId: "first-user-run" };
-        expect(claimHeartbeatOutcomeForRun(params)).toMatchObject({
+        expect(await claimHeartbeatOutcomeForRun(params)).toMatchObject({
           sessionKey,
           runSessionKey: runKey,
           summary,
         });
-        expect(claimHeartbeatOutcomeForRun(params)).toBeDefined();
+        expect(await claimHeartbeatOutcomeForRun(params)).toBeDefined();
         expect(
-          claimHeartbeatOutcomeForRun({ ...params, runId: "second-user-run" }),
+          await claimHeartbeatOutcomeForRun({ ...params, runId: "second-user-run" }),
         ).toBeUndefined();
         if (agentId === "ops") {
           const physicalPath =

--- a/src/infra/heartbeat-runner.structured-delivery.test.ts
+++ b/src/infra/heartbeat-runner.structured-delivery.test.ts
@@ -19,10 +19,11 @@ import {
 } from "../plugins/hook-runner-global.js";
 import { addTestHook } from "../plugins/hooks.test-helpers.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { getLastHeartbeatEvent, resetHeartbeatEventsForTest } from "./heartbeat-events.js";
-import { claimHeartbeatOutcomeForRun } from "./heartbeat-outcome-store.js";
+import * as heartbeatOutcomeStore from "./heartbeat-outcome-store.js";
 import { runHeartbeatOnce, type HeartbeatDeps } from "./heartbeat-runner.js";
 import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
 import {
@@ -96,6 +97,54 @@ describe("runHeartbeatOnce structured heartbeat delivery", () => {
       },
     });
   }
+
+  it.each([false, true])("awaits outcome persistence failures (notify=%s)", async (notify) => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig(tmpDir, storePath);
+      cfg.agents!.defaults!.heartbeat!.target = "none";
+      const sessionKey = await seedTelegramSession(storePath, cfg);
+      replySpy.mockResolvedValue(
+        createHeartbeatToolResponsePayload({
+          outcome: notify ? "needs_attention" : "progress",
+          notify,
+          summary: "Synthetic outcome awaiting persistence",
+        }),
+      );
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      const persist = vi
+        .spyOn(heartbeatOutcomeStore, "persistHeartbeatOutcome")
+        .mockImplementationOnce(async () => {
+          entered.resolve();
+          await release.promise;
+        });
+      const sendTelegram = vi.fn();
+      const pending = runHeartbeat(cfg, replySpy, sendTelegram);
+      try {
+        await Promise.race([
+          entered.promise,
+          pending.then(() => {
+            throw new Error("heartbeat completed without awaiting persistence");
+          }),
+        ]);
+        release.reject(new Error("outcome storage unavailable"));
+        expect(await pending).toMatchObject({ status: "failed" });
+        expect(sendTelegram).not.toHaveBeenCalled();
+        expect(
+          await heartbeatOutcomeStore.claimHeartbeatOutcomeForRun({
+            agentId: "main",
+            sessionKey,
+            storePath,
+            runId: "next-user",
+          }),
+        ).toBeUndefined();
+      } finally {
+        release.resolve();
+        await pending;
+        persist.mockRestore();
+      }
+    });
+  });
 
   it.each(["none", "new-id", "same-id"] as const)(
     "records the first non-isolated delivery only for its initialized session (replacement: %s)",
@@ -240,7 +289,7 @@ describe("runHeartbeatOnce structured heartbeat delivery", () => {
           expect.soft(isRetryableHeartbeatSkipReason("channel-not-ready")).toBe(true);
         }
         closeOpenClawAgentDatabasesForTest();
-        const stored = claimHeartbeatOutcomeForRun({
+        const stored = await heartbeatOutcomeStore.claimHeartbeatOutcomeForRun({
           agentId: "main",
           sessionKey,
           storePath,

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -447,7 +447,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       });
 
       expect(
-        claimHeartbeatOutcomeForRun({
+        await claimHeartbeatOutcomeForRun({
           agentId: "main",
           sessionKey,
           storePath,


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Heartbeat outcome storage still exposes synchronous persistence and claim operations. Dispatch and agent prompt preparation depend on immediate completion, preventing a delayed backend from preserving failure handling and owner retirement checks.

## Why This Change Was Made

Make outcome persistence and claims Promise-returning and await them in heartbeat dispatch, CLI preparation, and harness selection. The existing admitted-run assertion reaches the SQLite claim transaction and is rechecked after the awaited claim before context publication. SQLite transactions and outcome/retry semantics stay unchanged.

## User Impact

Heartbeat dispatch waits for durable outcome recording; rejected asynchronous writes cannot silently finish as successful heartbeats. A retired run does not receive claimed context, while an already committed claim remains available to that run's retry.

## Evidence

- The 406-case heartbeat/agent cohort passed, plus 24 focused tests including two additional deferred persistence-failure cases.
- Removing the new waits and post-claim authority check makes all three targeted regression cases fail for ignored persistence rejection or retired context publication.
- Full `check:changed` and independent Codex review through P2 passed.
- Standalone actual SQLite smoke covered persist/claim/retry/second-owner refusal, ignoring visible/no-change results, committed claim before real admitted-owner retirement, and fresh-process reopen. Writer/reopen took 4.36/3.23 seconds including imports; no speedup claim.
- Smoke used isolated synthetic state and no model, provider, channel, or credentials. All owned database processes closed cleanly.
