### PR TITLE
chore(release): update appcast for 2026.9.4

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -3,6 +3,1266 @@
     <channel>
         <title>OpenClaw</title>
         <item>
+            <title>2026.9.4</title>
+            <pubDate>Fri, 11 Sep 2026 00:20:37 +0000</pubDate>
+            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
+            <sparkle:version>2609000490</sparkle:version>
+            <sparkle:shortVersionString>2026.9.4</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+            <description><![CDATA[<h2>OpenClaw 2026.9.4</h2>
+<h3>Highlights</h3>
+<ul>
+<li><strong>Recover from compatible failed updates:</strong> retain the previous package and restore it with the previous configuration and service when schema and configuration checks prove rollback is safe; database migrations still require a verified pre-update backup. (#140339) Thanks @fuller-stack-dev.</li>
+<li><strong>Plugins in one place:</strong> discover bundled and ClawHub plugins, install them from the Control UI, and manage their setup, settings, and access in a unified Plugins workspace. (#135839, #135840, #139042, #137659, #137886, #138755, #142624, #142782) Thanks @Patrick-Erichsen.</li>
+<li><strong>Prepared cloud sessions:</strong> start eligible Linux sessions from prepared local projects or public GitHub repositories, and build reusable snapshots from the Control UI before starting a conversation. (#143227, #143372, #143410, #143838, #143929)</li>
+<li><strong>Answer questions in the terminal:</strong> use keyboard-driven choices, free-text answers, and multi-question prompts in both Gateway-connected and local TUI sessions. (#143273)</li>
+<li><strong>GPT Image 2.5:</strong> select the new Flare and Sunburst variants for image generation and editing through OpenAI or fal without changing your existing default model. Related #143007. (#143068, #143069) Thanks @vincentkoc.</li>
+<li><strong>More dependable conversation history:</strong> recover final replies after interrupted streams, retain timeout notices after reload, and prevent duplicate final answers when live chat hands off to saved history. Related #141839. (#142168, #142135, #142422) Thanks @LiuwqGit, @obviyus, @chelsealong, @von8794, and @jalehman.</li>
+<li><strong>Voice that finishes delegated work:</strong> return subagent results to Talk and deliver the final answer even after repeated rounds of delegation. (#129535, #142830) Thanks @vincentkoc.</li>
+<li><strong>Externally managed configuration:</strong> set <code>OPENCLAW_CONFIG_READONLY=1</code> to keep OpenClaw from rewriting deployment-managed configuration while preserving read-only diagnostics and ordinary runtime state. Related #140706. (#140719) Thanks @sallyom.</li>
+</ul>
+<h3>Changes</h3>
+<ul>
+<li><strong>Rollback and recovery:</strong> eligible schema-neutral update failures restore the retained package, command shim, service, and pre-activation configuration, then verify the previous Gateway again. Changed database schemas, incompatible new databases, or intervening operator configuration edits block automatic rollback; a recovered update remains a failed update with a recorded rollback outcome. Use a <a href="https://docs.openclaw.ai/install/updating/rollback-and-recovery">verified backup</a> before migration-bearing upgrades. (#140339) Thanks @fuller-stack-dev.</li>
+<li><strong>Plugin organization:</strong> browse installed plugins by category, keep detail tabs together, use short plugin-page URLs such as <code>/reports</code>, and discover installed and ClawHub skills through one search. (#142710, #142711, #142712, #142713, #143183, #143758) Thanks @Patrick-Erichsen.</li>
+<li><strong>Cloud ready workers:</strong> eligible local Git projects and public GitHub repository sessions can reuse prepared workers without repeating setup; private repository-only sessions and paired devices remain outside this preparation flow. The default reserve target is one per project/profile, capped at four Gateway-wide. Ready workers incur provider running-machine charges until deleted. Set <code>cloudWorkers.profiles.<id>.readyWorkers</code> or <code>cloudWorkers.preparedPool.maxTotal</code> to zero to disable the corresponding reserves. See <a href="https://docs.openclaw.ai/gateway/cloud-workers/warm-images#ready-workers">warm images and ready workers</a>. (#143227, #143372, #143410)</li>
+<li><strong>Terminal question controls:</strong> navigate choices with arrows or numbers, type an Other answer, toggle multi-select choices, and reopen a pending prompt with <code>/question</code>; local-mode questions last only for the running TUI process. (#143273)</li>
+<li><strong>Chat navigation and composition:</strong> use a compact left-side conversation rail with sender identities in shared-chat previews, add selected text to the main composer, and preview attached videos before sending. Related #142207, #142592, #143473. (#142227, #143486, #142543, #142623) Thanks @vyctorbrzezowski and @Patrick-Erichsen.</li>
+<li><strong>Skill learning:</strong> open learning from past work in a normal session that you can inspect and continue. (#142909) Thanks @obviyus.</li>
+<li><strong>Command review:</strong> let the automatic command reviewer allow, deny, or escalate a command using bounded conversation context while retaining the execution policy's authority. (#141987, #142279)</li>
+<li><strong>Node runtime recovery:</strong> offer a Node.js update when the CLI runtime is incompatible and keep diagnostics and update commands available to help repair the installation. (#142742, #143344) Thanks @jason-allen-oneal and @morrow-bluedot.</li>
+<li><strong>Read-only deployments:</strong> honor host-owned <code>OPENCLAW_CONFIG_READONLY=1</code> across configuration writes, setup, Doctor repairs, plugin changes, and updates; read-only configuration commands continue to work, and this mode does not make runtime state read-only. Related #140706. (#140719) Thanks @sallyom.</li>
+<li><strong>Upcoming SDK deprecation:</strong> <code>agent-harness-credential-prompt-string-argument</code> entered deprecation on September 9, 2026; the legacy string argument to <code>buildCredentialSafetyPrompt</code> remains supported through November 30, 2026; plugin authors should pass <code>{ controlToolsAvailable }</code>. See <a href="https://docs.openclaw.ai/plugins/sdk-migration/removed-surfaces#credential-prompt-builder">credential prompt migration</a>. Related #128076. (#143238) Thanks @ejc3.</li>
+<li><strong>SDK context compatibility:</strong> <code>sdk-untrusted-context-identifier-aliases</code> reached its September 8, 2026 removal date but remains <code>removal-pending</code>; retain the deprecated untrusted-named context aliases while published plugin readers migrate to the channel-named replacements; removal remains pending migration verification and explicit breaking-release acceptance. See <a href="https://docs.openclaw.ai/plugins/compatibility">plugin compatibility</a>. (#142708)</li>
+<li><strong>Cloud snapshot controls:</strong> build, rebuild, inspect, pin, delete, and roll back supported cloud-worker snapshots from Settings → Connections → Cloud workers → Snapshots. Active builds can be canceled with confirmation; held or pinned images remain protected. Snapshot storage and ready-worker charges still apply. (#143814, #143838, #143893, #143929)</li>
+<li><strong>Cloud placement and diagnostics:</strong> edit advanced worker profiles and repository defaults, inspect cloud-session machine specifications, and select native Windows workers when the backend supports them. Warm images and desktops remain Linux-only. (#143801, #143864, #143769, #143798)</li>
+<li><strong>Deepgram voice notes:</strong> transcribe voice notes with <code>flux-general-en</code> or <code>flux-general-multi</code> through Deepgram Flux; these models require <code>ffmpeg</code>. See <a href="https://docs.openclaw.ai/providers/deepgram#flux-models">Flux configuration</a>. Related #129452. (#141836) Thanks @obviyus and @safzanpirani.</li>
+<li><strong>Slow session diagnostics:</strong> identify the work holding a session lifecycle queue and see which artifact-cleanup preparation stage is taking time. Related #143885, #143939. (#143886, #143942)</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li><strong>Access and content boundaries:</strong> preserve existing WhatsApp group allowlists during security repairs, continue blocking cloud-metadata addresses when private IPv6 exceptions are enabled, bound Slack HTTP request bodies, and restrict Tlon citation retrieval to the cited post. Reject stale signed Feishu webhook callbacks, prevent attachment reads from sibling agent sandboxes, and stop pipelined MCP calls after a rejected upload. Related #107972. (#142589, #137684, #136508, #142041, #143484, #143521, #143724) Thanks @eleqtrizit, @drobison00, @pgondhi987, and @yetval.</li>
+<li><strong>Workspace and backup safety:</strong> preserve concurrent workspace edits, include required external configuration files in full backups, keep private update captures out of ordinary exports even after they move, and tolerate a disappearing live SQLite sidecar after its database is snapshotted. Related #141042, #143678. (#135865, #141161, #143693, #143799, #143899) Thanks @yetval, @obviyus, @LiuwqGit, @Cobblestone-Digital1, and @fuller-stack-dev.</li>
+<li><strong>Migration recovery:</strong> recover markerless multi-agent configurations, leave ambiguous Skill Workshop migrations available for review, explain hard-linked session migration refusals, and preserve normalized media when republishing migrated archives. Retain legacy Codex assistant messages during session SQLite import and repair the dangling Workshop review index. Related #142582, #142585, #143094, #142584, #143593, #140100. (#143202, #143141, #143195, #143595, #140296, #142522) Thanks @GitHoubi, @fahrenhe1t, @fuller-stack-dev, @ylcn91, @ikenraf, @jjjhenriksen, @RomneyDa, and @pash-openai.</li>
+<li><strong>Doctor and authentication:</strong> preserve source state during full lint, keep saved authentication profiles aligned during migration, scope legacy auth-profile refusals to affected providers, recover legacy node tokens with invalid scopes, and prevent stale shared OAuth refresh generations from overwriting newer credentials. Restore Zalo User policy promotion and stop Moonshot China setup from repeatedly reinstalling its provider. Related #143173, #143263, #143865, #143630. (#142839, #143310, #143599, #141477, #143429, #143860, #143742) Thanks @thien-ngn, @obviyus, @tskerpnext, @matthewmoroz, @vincentkoc, @wangmiao0668000666, and @zwyhmcn.</li>
+<li><strong>Reply delivery and history:</strong> recover final replies from terminated streams and earlier tool errors, retain partial failed-turn text and timeout outcomes, preserve paragraph and code-block boundaries, and report truncated Responses replies as incomplete. Preserve long transcript history across <code>sessions_yield</code>, avoid duplicate final replies during history hydration and duplicate user turns after Claude CLI resume, and retain final ChatGPT Responses frames at stream end. Related #141839, #132762, #143641. (#142168, #142135, #140833, #142778, #137381, #142422, #143598, #125977, #143722, #143960, #120902) Thanks @LiuwqGit, @obviyus, @chelsealong, @von8794, @leapdragon, @zhangguiping-xydt, @jalehman, @harjothkhara, @CK-XYZ, @ayaangazali, @rgregg, @Marvinthebored, @Peetiegonzalez, and @zenglingbiao.</li>
+<li><strong>Chat continuity:</strong> keep submitted images visible during history handoff, prevent cold-session switching flashes, and reconcile concurrent session updates consistently. (#143407, #134868, #143049) Thanks @jesse-merhi.</li>
+<li><strong>Claude CLI session reuse:</strong> keep warm sessions alive when skills-watcher readiness changes but prepared skill content is unchanged, while invalidating reuse after real skill-content changes. Related #144368. (#144402) Thanks @vincentkoc.</li>
+<li><strong>Voice conversations:</strong> deliver yielded and repeatedly delegated results, permit independent voice consultations from model-locked requester sessions, and truncate interrupted realtime audio at the amount actually played. Related #142483, #138592. (#129535, #142830, #142736, #138619) Thanks @vincentkoc, @RileyJJY, @jai-assistant, @LiuwqGit, @obviyus, and @fabiolr.</li>
+<li><strong>Telegram:</strong> retain replies when an HTTP proxy rejects its tunnel, recognize bot-ID mentions in text and photo captions, preserve code-example spacing, and stop late stall reactions after preparation is canceled. Related #140265, #141078. (#140388, #140266, #142504, #141079) Thanks @Hekzory, @obviyus, @cai-ops, and @ooiuuii.</li>
+<li><strong>Discord:</strong> restore delegation from guild messages, preserve ambient voice-note transcripts, show member presence immediately after reconnect, and retain repeated component captions and link emoji. Related #142832, #141054. (#143006, #142860, #141218, #142342) Thanks @Marvinthebored, @Peetiegonzalez, @obviyus, @ericcaiwx-star, @aatreya, @harshitgupta31415, @vincentkoc, and @nissl24.</li>
+<li><strong>Slack:</strong> resolve Enterprise workspace ownership for heartbeat DMs, keep acknowledgement reactions independent of status reactions, and avoid formatting ordinary prose as code after Windows root paths. Related #142489. (#138689, #142595, #142288) Thanks @Kimiyu-186, @sunlit-deng, and @alexjpanagis.</li>
+<li><strong>Mattermost and Signal:</strong> keep sibling Mattermost accounts connected during secret-reference reloads, preserve replacement previews while retracting earlier messages, and retain Signal reply quotes when streamed delivery fails. (#142193, #143621, #142600) Thanks @ceckert and @obviyus.</li>
+<li><strong>Channel text fidelity:</strong> preserve unknown Matrix message text and escaped mentions, decode HTML-only Teams messages correctly, retain Feishu rich-text styles and unrelated tools, and keep outbound WhatsApp response prefixes out of inbound messages. Related #140971, #138779. (#135359, #142369, #142496, #142627, #141984, #138819) Thanks @teddytennant, @obviyus, @SunnyShu0925, @hayden-cc, @sunlit-deng, @vincentkoc, and @Jackten.</li>
+<li><strong>Android chat and folding screens:</strong> wait for picked attachments before sending their captions, restore completed tool activity, distinguish connection state from chat readiness, and keep thinking controls, background tasks, and the branch picker inside their fold panes. Related #142805. (#143162, #142810, #143128, #141860, #141899, #142418) Thanks @ansxor, @IWhatsskill, and @vincentkoc.</li>
+<li><strong>Mobile connection feedback:</strong> show failures and recovery for unreachable Gateways and report battery fractions as the intended percentage. Related #141066. (#142651, #141069) Thanks @vincentkoc, @NullArbitrage, and @obviyus.</li>
+<li><strong>Provider and model selection:</strong> preserve authored catalog rows, exact model identities, metadata, and credentials when aliases coexist or catalogs refresh. Keep model overrides, context limits, thinking choices, vision, compaction, and tool inventories tied to the selected model and provider; hide unsupported thinking or Fast choices and preserve session lists after fallback. (#142302, #142898, #142751, #142790, #142646, #142682, #143337, #143643, #143686, #143708, #143777, #143780, #143822, #143848, #143872, #143954, #143967, #143975, #143994, #143999, #144009, #144010, #144034, #144060, #144107, #142822) Thanks @obviyus.</li>
+<li><strong>Provider requests:</strong> preserve Anthropic prompt-cache reuse across transient runtime context, treat Kimi quota exhaustion as a rate limit rather than an authentication failure, preserve managed Responses session affinity, and recover supported malformed streamed tool arguments and silent tool rejections. Related #140607, #142524, #140918, #135111. (#140621, #142656, #141107, #141323, #142176) Thanks @LightningWareLLC, @RileyJJY, @obviyus, @rico007, @louisfy, @alexph-dev, @lraesly, and @1Vision365-PeterTijsma.</li>
+<li><strong>Memory:</strong> use the selected fallback provider’s embedding model and index status, observe external LanceDB writes, and retain recall through trigger timeouts. Keep top search results stable as result limits change, give managed local embedding startup its own readiness budget, honor bounded provider cooldowns, require real query diversity for promotion, and skip unnecessary recall for inter-session deliveries. Preserve first-run setup after empty dreaming and bound pre-compaction flush context while recording when no memory-write tool exists. Related #137805, #142479, #141787, #143188, #134604, #143169, #108893, #143821. (#142364, #142609, #137806, #142567, #141808, #143193, #127031, #136984, #143590, #134959, #119624, #143903) Thanks @Yigtwxx, @obviyus, @azuretek, @ylcn91, @BsnizND, @SunnyShu0925, @dh-js, @KirDE, @ayaangazali, @linhongyu510, @scottcha, @wangmiao0668000666, @PeterHodl, @shojikumaru, @developercrocodiles, @pcpilot-dev, @LiuwqGit, and @kiagentkronos-cell.</li>
+<li><strong>Update handoff and restart:</strong> keep older updaters and Git installs upgrading from 2026.9.1 able to restart the Gateway; accept shipped 2026.9.2/2026.9.3 service handoffs without weakening current service-owner checks. Preserve pnpm-generation handoff and schema-upgrade restart intent, prepare managed helper schemas before readiness, replace unsupported service Node runtimes, retain restored-version verification, and prevent systemd restart hangs. Related #143204, #140821, #143543. (#142195, #142631, #143137, #143159, #142817, #140914, #143859, #143738, #144031) Thanks @jason-allen-oneal, @wangmiao0668000666, @NianJiuZst, @obviyus, @rboy1, @RomneyDa, and @IWhatsskill.</li>
+<li><strong>Plugin updates:</strong> converge the plugin cohort when core is already current without turning unchanged installations into needless updates, retain bundled aliases during rehearsal, avoid false Memory Core migration refusals, and explain retained official plugin pins. (#143174, #143462, #143190, #143138, #142457) Thanks @RomneyDa, @PollyBot13, and @obviyus.</li>
+<li><strong>CLI update and transcript reliability:</strong> allow updates when native inspection confirms no installed Gateway service, while retaining strict service-owner checks; keep transcript plaintext and JSON output free of unrelated startup warnings. Related #144356, #144357. (#144402) Thanks @vincentkoc.</li>
+<li><strong>Update recovery feedback:</strong> allow long Doctor finalization to finish, clear orphaned update runs instead of showing permanent progress, retain cleanup outcomes and recoverable warnings, and avoid linking unavailable reports. Preserve diagnostics when history is unavailable and require confirmation before automatic triage launches a coding agent; verified rollback follow-up actions remain opt-in. Related #139714. (#143321, #143557, #143139, #143774, #143767, #143844, #143921, #143965, #143748, #143657) Thanks @fuller-stack-dev and @Colton-Harris.</li>
+<li><strong>Gateway responsiveness:</strong> move cold history planning, integrity checks, and archive pruning off the main thread; keep prepared updates and post-eviction maintenance responsive; reduce memory spikes when inspecting long sessions. Reduce unused plugin and model catalog preparation, bound parallel remote workspace hashing, avoid unnecessary diagnostic copies, and keep automation delivery previews responsive. (#143332, #143226, #143379, #143434, #143602, #143175, #143783, #143846, #144095, #144017, #144109, #144014)</li>
+<li><strong>Session retention:</strong> stop excess cleanup once disk pressure clears, preserve history that becomes protected during cleanup, and avoid premature daily resets around daylight-saving gaps. (#143285, #142505, #142482)</li>
+<li><strong>Browser actions:</strong> keep existing browser sessions from timing out prematurely, preserve newer pending dialogs when older actions settle, report blocked or interrupted CLI actions, and leave browser focus intact during passive following. (#143365, #142608, #142480, #134480) Thanks @scotthuang and @obviyus.</li>
+<li><strong>Settings and sign-in:</strong> preserve settings drafts after deleting array rows, make agent automations editable from Settings, and request the Gateway token when a remembered device token is stale. Related #139781. (#142564, #139782, #143156) Thanks @jjjhenriksen and @vyctorbrzezowski.</li>
+<li><strong>Plugin and skill installation:</strong> prevent installed-plugin matches across different ClawHub registries, report newer releases for pinned installs, recover capability-consent dead ends, and retain bundled trust for development-path installs. Preserve plugin selection and restart progress, rank official catalog results consistently, refresh skill snapshots on Gateway restart, and avoid cutting off skill installation after two minutes. Related #137624, #143111, #122107. (#143644, #137892, #143125, #143516, #143000, #143671, #143730, #143731, #122110) Thanks @pfrederiksen, @vincentkoc, @LiuwqGit, @obviyus, @yxloveql, @RomneyDa, @gozu, @Patrick-Erichsen, and @sappkevin.</li>
+<li><strong>Paired devices and Linux:</strong> expose window discovery on the first computer action, preserve activation and observation results, open chat desktops on their assigned machines, and identify who took desktop control. Honor SSH alias ports, retain remote credential references on reconnect, and keep background-update results actionable. Related #121934. (#141277, #142900, #142907, #121938, #143736, #143953, #143831, #143828) Thanks @oywino, @obviyus, and @vincentkoc.</li>
+<li><strong>Plugin schema typing:</strong> preserve catchall input and output types, including transformations, in multi-account channel schemas. Related #144358. (#144402) Thanks @vincentkoc.</li>
+<li><strong>Doctor update finalization:</strong> allow implicit Codex preferences when the plugin is absent while retaining errors for explicitly required runtimes; finish configuration-less updates without creating a configuration file; close only Doctor’s private snapshot database before cleanup, leaving the source database open. Related #143786, #143797, #138260. Thanks @osipovia.</li>
+<li><strong>Delegation and reset:</strong> keep background completion wakes alive after a foreground reply, preserve subagent history when a parent thread changes, show full subagent transcripts in the task sidebar, and keep session resets responsive while stopping yielded child work. Canceled automations release their pending result waits. Related #143389. (#143866, #143869, #143747, #143916, #143832) Thanks @obviyus, @aleps001, and @pash-openai.</li>
+<li><strong>Provider routing and search:</strong> preserve stable routing identities for standalone OpenCode and OpenCode Go turns, retain provider turn headers for explicit sessions, preserve local-model request prefixes, and keep Gemini web search available with new API keys. Global web-search disable remains effective in session controls. Related #137257, #96974, #121401. (#143659, #143558, #143890, #137371, #111964, #121557) Thanks @HAPPYFAPTAIN, @obviyus, @RomneyDa, @vincentkoc, @gwiltschek, @dillona, @anguslogan01, @zyw02, and @cursoragent.</li>
+<li><strong>Update ownership and cloud continuity:</strong> stop plugin persistence and rollback actions after updater authority is lost, reject unverified Gateway replacements, preserve cloud machines across Gateway updates, and continue submitted turns across worker-runtime updates. Related #143750, #143841. (#144130, #143791, #143863, #143858, #143910) Thanks @fuller-stack-dev and @vincentkoc.</li>
+<li><strong>Runtime and state diagnostics:</strong> re-execute the CLI under an available supported Node runtime before refusing to start, preserve the selected Bun SQLite library in managed services, retain macOS launchd error logs, restore Linux Bun CPU diagnostics, and tolerate transient locks during read-only state access. Schema-drift failures name the repair path. Related #90711, #143800. (#143464, #143651, #142186, #143519, #143805, #143908, #143531) Thanks @RomneyDa, @Enominera, and @pash-openai.</li>
+<li><strong>Control UI recovery:</strong> restore Send when Stop finds an already-finished run, retain terminal sessions after interrupted restoration, report failed Review file opens, stop stale task reads after Review changes, and keep session files and embedded reports from being squeezed into nested scrolling regions. Related #143356, #143971. (#143437, #144015, #143958, #144073, #143854, #143765) Thanks @ylcn91, @obviyus, @YanHE1169, @vincentkoc, @Marvinthebored, and @Peetiegonzalez.</li>
+<li><strong>Tool and export fidelity:</strong> preserve flat tool arguments beside empty search wrappers, keep native image-generation hooks available, retain paginated read evidence in trajectory exports, and report the actual filesystem error when workspace writes fail. Related #143830, #115920. (#143729, #143717, #143930, #116378) Thanks @xydigitLybnnnn, @obviyus, @linhongyu510, @cp1369, @sloptop-the-terrible, and @609NFT.</li>
+</ul>
+<h3>Complete contribution record</h3>
+This audited record covers the complete 58fcf69cadd0be59ecee41b21b655f195ccda7b2..0b7ddbd9c5e97a82b6bd7a36daa8dcff984d338d history: 1,174 in-range PRs + 0 retained seed-only PRs = 1,174 unique PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
+Shipped baseline exclusions: v2026.9.3 (19 PRs: #111451, #120728, #121140, #129636, #131475, #132740, #133652, #134290, #134400, #135043, #139089, #139196, #139393, #139722, #140263, #140274, #140672, #140803, #141055).
+<h4>Pull requests</h4>
+<ul>
+<li><strong>PR #142314</strong></li>
+<li><strong>PR #137684</strong> Thanks @eleqtrizit.</li>
+<li><strong>PR #142311</strong></li>
+<li><strong>PR #142288</strong></li>
+<li><strong>PR #142230</strong></li>
+<li><strong>PR #142290</strong></li>
+<li><strong>PR #111899</strong> Related #111407. Thanks @xialonglee and @obviyus and @MrNozz.</li>
+<li><strong>PR #142302</strong> Thanks @obviyus.</li>
+<li><strong>PR #142318</strong> Related #142244.</li>
+<li><strong>PR #142346</strong></li>
+<li><strong>PR #142339</strong> Related #142330. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142305</strong></li>
+<li><strong>PR #142360</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142291</strong></li>
+<li><strong>PR #142365</strong></li>
+<li><strong>PR #142187</strong></li>
+<li><strong>PR #142361</strong></li>
+<li><strong>PR #141266</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142359</strong> Related #142351.</li>
+<li><strong>PR #142334</strong></li>
+<li><strong>PR #142342</strong></li>
+<li><strong>PR #142324</strong></li>
+<li><strong>PR #142363</strong> Related #142362.</li>
+<li><strong>PR #142366</strong></li>
+<li><strong>PR #142195</strong></li>
+<li><strong>PR #137565</strong> Thanks @jalehman.</li>
+<li><strong>PR #135411</strong></li>
+<li><strong>PR #142274</strong> Related #142211. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #129186</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #137686</strong> Thanks @ly85206559 and @obviyus.</li>
+<li><strong>PR #141689</strong> Thanks @vincentkoc and @RomneyDa.</li>
+<li><strong>PR #142378</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142354</strong></li>
+<li><strong>PR #142042</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #138350</strong> Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142376</strong></li>
+<li><strong>PR #142385</strong></li>
+<li><strong>PR #142327</strong></li>
+<li><strong>PR #142353</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142114</strong></li>
+<li><strong>PR #142369</strong></li>
+<li><strong>PR #141477</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142381</strong></li>
+<li><strong>PR #142205</strong> Related #142204.</li>
+<li><strong>PR #142344</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #136508</strong> Thanks @drobison00.</li>
+<li><strong>PR #142246</strong> Related #142222. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142348</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #138689</strong> Thanks @Kimiyu-186.</li>
+<li><strong>PR #142379</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141221</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142345</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142388</strong></li>
+<li><strong>PR #142332</strong> Related #142212. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142384</strong> Thanks @obviyus.</li>
+<li><strong>PR #142367</strong> Thanks @obviyus.</li>
+<li><strong>PR #142411</strong></li>
+<li><strong>PR #137668</strong> Related #137665. Thanks @elbourne12345 and @obviyus.</li>
+<li><strong>PR #127254</strong></li>
+<li><strong>PR #142213</strong> Related #142209. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142396</strong></li>
+<li><strong>PR #142400</strong> Related #142598. Thanks @hannesrudolph.</li>
+<li><strong>PR #142374</strong> Related #142373.</li>
+<li><strong>PR #142402</strong> Related #142397.</li>
+<li><strong>PR #142420</strong></li>
+<li><strong>PR #141224</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141860</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142350</strong></li>
+<li><strong>PR #142437</strong> Related #142598. Thanks @hannesrudolph.</li>
+<li><strong>PR #142135</strong> Related #141839. Thanks @chelsealong and @obviyus and @von8794.</li>
+<li><strong>PR #142227</strong> Related #142207. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142425</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142138</strong> Thanks @fabiolr and @obviyus.</li>
+<li><strong>PR #142415</strong></li>
+<li><strong>PR #141987</strong></li>
+<li><strong>PR #142431</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142407</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142410</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142409</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142084</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142083</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142082</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142408</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142081</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142387</strong> Related #142386.</li>
+<li><strong>PR #138211</strong> Related #138176.</li>
+<li><strong>PR #142432</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #136462</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142406</strong></li>
+<li><strong>PR #142371</strong></li>
+<li><strong>PR #142391</strong> Related #142390.</li>
+<li><strong>PR #137877</strong> Thanks @teddytennant and @obviyus.</li>
+<li><strong>PR #142451</strong></li>
+<li><strong>PR #142448</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142405</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142455</strong> Related #142454.</li>
+<li><strong>PR #117631</strong></li>
+<li><strong>PR #142404</strong> Related #142403.</li>
+<li><strong>PR #142413</strong> Related #142412.</li>
+<li><strong>PR #142458</strong></li>
+<li><strong>PR #137869</strong> Related #128928. Thanks @teddytennant and @obviyus and @aniruddhaadak80.</li>
+<li><strong>PR #142466</strong></li>
+<li><strong>PR #142279</strong></li>
+<li><strong>PR #142436</strong></li>
+<li><strong>PR #141162</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142460</strong></li>
+<li><strong>PR #142375</strong> Thanks @obviyus.</li>
+<li><strong>PR #142440</strong></li>
+<li><strong>PR #142467</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142447</strong> Related #142446.</li>
+<li><strong>PR #141725</strong> Related #141694. Thanks @leilei3167 and @obviyus and @markthebest12.</li>
+<li><strong>PR #142469</strong> Related #142468.</li>
+<li><strong>PR #142423</strong></li>
+<li><strong>PR #140719</strong> Related #140706. Thanks @sallyom.</li>
+<li><strong>PR #137974</strong> Related #137959. Thanks @SunnyShu0925 and @obviyus and @Hawk5150.</li>
+<li><strong>PR #142465</strong></li>
+<li><strong>PR #142428</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142441</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142472</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141896</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141899</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142474</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #137806</strong> Related #137805. Thanks @azuretek and @obviyus.</li>
+<li><strong>PR #142450</strong> Related #142449.</li>
+<li><strong>PR #142495</strong> Related #142493.</li>
+<li><strong>PR #142503</strong></li>
+<li><strong>PR #142480</strong></li>
+<li><strong>PR #142364</strong> Thanks @Yigtwxx and @obviyus.</li>
+<li><strong>PR #142507</strong></li>
+<li><strong>PR #142426</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142494</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142456</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142065</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142475</strong> Related #142598. Thanks @hannesrudolph.</li>
+<li><strong>PR #142444</strong> Related #142443.</li>
+<li><strong>PR #142275</strong> Related #142216. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #137664</strong> Thanks @ly85206559 and @obviyus.</li>
+<li><strong>PR #142499</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142482</strong></li>
+<li><strong>PR #129610</strong> Thanks @jalehman.</li>
+<li><strong>PR #142419</strong> Related #142392. Thanks @jalehman.</li>
+<li><strong>PR #142541</strong> Related #142598. Thanks @hannesrudolph.</li>
+<li><strong>PR #142249</strong> Related #142247.</li>
+<li><strong>PR #142525</strong></li>
+<li><strong>PR #142498</strong> Thanks @obviyus.</li>
+<li><strong>PR #142543</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142544</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142508</strong></li>
+<li><strong>PR #142519</strong></li>
+<li><strong>PR #142542</strong></li>
+<li><strong>PR #142505</strong></li>
+<li><strong>PR #142442</strong> Thanks @jalehman.</li>
+<li><strong>PR #142143</strong> Thanks @IWhatsskill and @vyctorbrzezowski.</li>
+<li><strong>PR #142551</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142316</strong> Related #142254. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142057</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #137679</strong> Thanks @teddytennant and @obviyus.</li>
+<li><strong>PR #142496</strong></li>
+<li><strong>PR #142546</strong> Related #142539.</li>
+<li><strong>PR #142478</strong> Related #142477.</li>
+<li><strong>PR #142485</strong> Thanks @eleqtrizit.</li>
+<li><strong>PR #137678</strong> Thanks @teddytennant and @obviyus.</li>
+<li><strong>PR #142576</strong></li>
+<li><strong>PR #142560</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #138303</strong> Related #138301. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142578</strong> Thanks @jalehman.</li>
+<li><strong>PR #142438</strong> Related #126455. Thanks @jalehman and @vyctorbrzezowski.</li>
+<li><strong>PR #142488</strong> Related #142487.</li>
+<li><strong>PR #142537</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142561</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142491</strong> Related #142490.</li>
+<li><strong>PR #142557</strong> Thanks @obviyus.</li>
+<li><strong>PR #142538</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142520</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142563</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142562</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142513</strong> Related #142512.</li>
+<li><strong>PR #142587</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142372</strong> Thanks @obviyus.</li>
+<li><strong>PR #142338</strong> Related #142337.</li>
+<li><strong>PR #142570</strong> Related #142569.</li>
+<li><strong>PR #142568</strong></li>
+<li><strong>PR #130494</strong> Related #130456. Thanks @jalehman.</li>
+<li><strong>PR #142602</strong></li>
+<li><strong>PR #142605</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140680</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142604</strong></li>
+<li><strong>PR #142504</strong></li>
+<li><strong>PR #142518</strong></li>
+<li><strong>PR #142614</strong></li>
+<li><strong>PR #142335</strong> Related #142287. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142607</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142527</strong></li>
+<li><strong>PR #142418</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142601</strong> Related #142594.</li>
+<li><strong>PR #138667</strong> Thanks @Szqub and @obviyus.</li>
+<li><strong>PR #142599</strong></li>
+<li><strong>PR #142630</strong></li>
+<li><strong>PR #142573</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142066</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142278</strong> Related #141838. Thanks @MoerAI and @obviyus and @von8794.</li>
+<li><strong>PR #142609</strong> Thanks @Yigtwxx and @obviyus.</li>
+<li><strong>PR #137485</strong> Related #125360. Thanks @shojikumaru and @obviyus and @noelillinger.</li>
+<li><strong>PR #142632</strong></li>
+<li><strong>PR #136545</strong> Related #136544. Thanks @TheAngryPit and @obviyus.</li>
+<li><strong>PR #142618</strong></li>
+<li><strong>PR #142612</strong></li>
+<li><strong>PR #142641</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142276</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142625</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142643</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142622</strong> Thanks @obviyus.</li>
+<li><strong>PR #142535</strong></li>
+<li><strong>PR #142629</strong></li>
+<li><strong>PR #142554</strong></li>
+<li><strong>PR #142648</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142652</strong> Thanks @jalehman.</li>
+<li><strong>PR #142564</strong></li>
+<li><strong>PR #142589</strong> Thanks @eleqtrizit.</li>
+<li><strong>PR #142620</strong> Thanks @obviyus.</li>
+<li><strong>PR #142666</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142550</strong> Related #142510. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142577</strong></li>
+<li><strong>PR #142536</strong> Related #142517. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142667</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142636</strong></li>
+<li><strong>PR #142600</strong></li>
+<li><strong>PR #141851</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142684</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #141705</strong> Thanks @fabiolr.</li>
+<li><strong>PR #141268</strong> Related #141264. Thanks @ooiuuii and @obviyus.</li>
+<li><strong>PR #142555</strong> Related #142514. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142422</strong> Thanks @jalehman.</li>
+<li><strong>PR #142669</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #142665</strong> Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142500</strong></li>
+<li><strong>PR #142679</strong></li>
+<li><strong>PR #142041</strong> Thanks @pgondhi987.</li>
+<li><strong>PR #142675</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #142677</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142540</strong> Related #142511. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142672</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #142608</strong></li>
+<li><strong>PR #142690</strong></li>
+<li><strong>PR #142674</strong> Thanks @jalehman.</li>
+<li><strong>PR #142691</strong> Related #142689.</li>
+<li><strong>PR #142659</strong></li>
+<li><strong>PR #142523</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142686</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #131805</strong> Related #86174. Thanks @jalehman and @rqlangley.</li>
+<li><strong>PR #142627</strong></li>
+<li><strong>PR #142457</strong> Thanks @PollyBot13 and @obviyus.</li>
+<li><strong>PR #142634</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142687</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142685</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142646</strong> Thanks @obviyus.</li>
+<li><strong>PR #142509</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142635</strong></li>
+<li><strong>PR #142683</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142703</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142382</strong> Related #142380. Thanks @sercada and @obviyus.</li>
+<li><strong>PR #142696</strong> Related #142680. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142645</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142613</strong> Related #142596. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142637</strong> Related #142615. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142658</strong> Related #142650. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142248</strong> Thanks @TheAngryPit and @obviyus.</li>
+<li><strong>PR #142682</strong> Thanks @obviyus.</li>
+<li><strong>PR #141852</strong> Thanks @obviyus.</li>
+<li><strong>PR #142708</strong></li>
+<li><strong>PR #141373</strong> Thanks @nocodet888-arch and @obviyus.</li>
+<li><strong>PR #142730</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142728</strong></li>
+<li><strong>PR #142731</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142732</strong></li>
+<li><strong>PR #142733</strong></li>
+<li><strong>PR #142725</strong></li>
+<li><strong>PR #142727</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #142720</strong> Related #142716. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142623</strong> Related #142592. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #137192</strong> Related #137190. Thanks @husodrn46 and @obviyus.</li>
+<li><strong>PR #141315</strong> Thanks @hugenshen and @obviyus.</li>
+<li><strong>PR #142735</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142729</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142567</strong> Related #142479. Thanks @ylcn91 and @obviyus and @BsnizND.</li>
+<li><strong>PR #142763</strong></li>
+<li><strong>PR #142714</strong></li>
+<li><strong>PR #142752</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142762</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142775</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #138285</strong> Related #138277. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142774</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142777</strong></li>
+<li><strong>PR #142705</strong> Related #100537. Thanks @MasterSwords1 and @obviyus and @guarismo.</li>
+<li><strong>PR #142628</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142757</strong></li>
+<li><strong>PR #142707</strong></li>
+<li><strong>PR #142785</strong></li>
+<li><strong>PR #142779</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142656</strong> Related #142524. Thanks @RileyJJY and @obviyus and @rico007.</li>
+<li><strong>PR #142651</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139782</strong> Related #139781. Thanks @jjjhenriksen and @vyctorbrzezowski.</li>
+<li><strong>PR #142780</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #129535</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142787</strong></li>
+<li><strong>PR #142786</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142790</strong> Thanks @obviyus.</li>
+<li><strong>PR #142766</strong> Thanks @obviyus.</li>
+<li><strong>PR #142795</strong></li>
+<li><strong>PR #142176</strong> Related #135111. Thanks @lraesly and @obviyus and @1Vision365-PeterTijsma.</li>
+<li><strong>PR #142797</strong></li>
+<li><strong>PR #137311</strong> Thanks @Alix-007 and @obviyus.</li>
+<li><strong>PR #142796</strong></li>
+<li><strong>PR #142639</strong> Related #142593. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142806</strong></li>
+<li><strong>PR #142801</strong></li>
+<li><strong>PR #142807</strong></li>
+<li><strong>PR #142778</strong> Thanks @zhangguiping-xydt and @obviyus.</li>
+<li><strong>PR #142368</strong> Thanks @Glucksberg and @obviyus.</li>
+<li><strong>PR #142738</strong></li>
+<li><strong>PR #142809</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142671</strong> Related #142662. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142816</strong></li>
+<li><strong>PR #142811</strong></li>
+<li><strong>PR #142803</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #131968</strong> Related #131944. Thanks @vyctorbrzezowski and @obviyus.</li>
+<li><strong>PR #142818</strong></li>
+<li><strong>PR #142819</strong></li>
+<li><strong>PR #142823</strong> Thanks @jalehman.</li>
+<li><strong>PR #142694</strong> Related #142688. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #142827</strong> Thanks @obviyus and @ly85206559.</li>
+<li><strong>PR #142814</strong></li>
+<li><strong>PR #142824</strong></li>
+<li><strong>PR #142804</strong></li>
+<li><strong>PR #142833</strong></li>
+<li><strong>PR #137376</strong> Thanks @Yigtwxx and @obviyus.</li>
+<li><strong>PR #136266</strong> Thanks @yetval and @obviyus.</li>
+<li><strong>PR #142830</strong></li>
+<li><strong>PR #142835</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142837</strong> Thanks @jalehman.</li>
+<li><strong>PR #142834</strong></li>
+<li><strong>PR #137381</strong> Thanks @jalehman.</li>
+<li><strong>PR #142836</strong></li>
+<li><strong>PR #142845</strong></li>
+<li><strong>PR #134868</strong> Thanks @jesse-merhi.</li>
+<li><strong>PR #142595</strong> Related #142489. Thanks @sunlit-deng and @alexjpanagis.</li>
+<li><strong>PR #142843</strong></li>
+<li><strong>PR #135964</strong> Thanks @qingminglong and @obviyus.</li>
+<li><strong>PR #142840</strong> Thanks @obviyus.</li>
+<li><strong>PR #142855</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142751</strong></li>
+<li><strong>PR #136268</strong> Thanks @yetval and @obviyus.</li>
+<li><strong>PR #142865</strong></li>
+<li><strong>PR #135865</strong> Thanks @yetval and @obviyus.</li>
+<li><strong>PR #142581</strong> Thanks @aim9sour.</li>
+<li><strong>PR #142873</strong> Thanks @obviyus.</li>
+<li><strong>PR #142858</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142846</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142709</strong> Related #142704. Thanks @vincentkoc.</li>
+<li><strong>PR #141161</strong> Related #141042. Thanks @LiuwqGit and @Cobblestone-Digital1.</li>
+<li><strong>PR #142849</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142889</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142887</strong></li>
+<li><strong>PR #142886</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142812</strong> Related #142794. Thanks @fanyangCS and @obviyus.</li>
+<li><strong>PR #142640</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142899</strong></li>
+<li><strong>PR #142838</strong></li>
+<li><strong>PR #142856</strong></li>
+<li><strong>PR #142903</strong></li>
+<li><strong>PR #136181</strong></li>
+<li><strong>PR #142882</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #127746</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142910</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142904</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142876</strong></li>
+<li><strong>PR #142919</strong></li>
+<li><strong>PR #142900</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142891</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142909</strong> Thanks @obviyus.</li>
+<li><strong>PR #142912</strong></li>
+<li><strong>PR #142907</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142928</strong></li>
+<li><strong>PR #142906</strong> Related #142905. Thanks @vincentkoc.</li>
+<li><strong>PR #137576</strong> Related #137539. Thanks @jalehman.</li>
+<li><strong>PR #142908</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142913</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142934</strong></li>
+<li><strong>PR #142917</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142894</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142926</strong> Related #142921. Thanks @vincentkoc.</li>
+<li><strong>PR #142944</strong> Related #142881. Thanks @jalehman.</li>
+<li><strong>PR #142925</strong> Related #142923. Thanks @vincentkoc.</li>
+<li><strong>PR #121938</strong> Related #121934.</li>
+<li><strong>PR #142951</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142911</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142884</strong> Related #142883. Thanks @jalehman.</li>
+<li><strong>PR #142955</strong> Thanks @jalehman.</li>
+<li><strong>PR #142960</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142962</strong></li>
+<li><strong>PR #142839</strong> Thanks @thien-ngn and @obviyus.</li>
+<li><strong>PR #142930</strong> Related #142929. Thanks @vincentkoc.</li>
+<li><strong>PR #142958</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142946</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #137334</strong> Thanks @Alix-007 and @obviyus.</li>
+<li><strong>PR #142961</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142896</strong></li>
+<li><strong>PR #142978</strong></li>
+<li><strong>PR #142975</strong></li>
+<li><strong>PR #142808</strong> Thanks @SunnyShu0925 and @obviyus.</li>
+<li><strong>PR #142985</strong></li>
+<li><strong>PR #127205</strong></li>
+<li><strong>PR #134480</strong> Thanks @scotthuang and @obviyus.</li>
+<li><strong>PR #142986</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142963</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142980</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141218</strong> Related #141054. Thanks @harshitgupta31415 and @vincentkoc and @nissl24.</li>
+<li><strong>PR #142982</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143005</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142999</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142984</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #135318</strong> Related #135282. Thanks @LiuwqGit and @obviyus and @youens.</li>
+<li><strong>PR #143014</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142989</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142995</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143013</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143004</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143022</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #127031</strong> Thanks @ayaangazali.</li>
+<li><strong>PR #143009</strong></li>
+<li><strong>PR #143025</strong></li>
+<li><strong>PR #135359</strong> Thanks @teddytennant and @obviyus.</li>
+<li><strong>PR #142898</strong> Thanks @obviyus.</li>
+<li><strong>PR #143027</strong></li>
+<li><strong>PR #142996</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143020</strong></li>
+<li><strong>PR #142864</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142991</strong></li>
+<li><strong>PR #143029</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143042</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141323</strong> Thanks @lraesly.</li>
+<li><strong>PR #142859</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143035</strong></li>
+<li><strong>PR #142993</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143021</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143038</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143041</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143040</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143002</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143016</strong> Related #143011. Thanks @vincentkoc.</li>
+<li><strong>PR #143045</strong></li>
+<li><strong>PR #143046</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143047</strong></li>
+<li><strong>PR #143039</strong></li>
+<li><strong>PR #141107</strong> Related #140918. Thanks @louisfy and @obviyus and @alexph-dev.</li>
+<li><strong>PR #143048</strong></li>
+<li><strong>PR #143057</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143058</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #133269</strong> Thanks @xydt-juyaohui and @obviyus.</li>
+<li><strong>PR #143055</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142992</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143062</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143059</strong></li>
+<li><strong>PR #143063</strong></li>
+<li><strong>PR #143034</strong></li>
+<li><strong>PR #142933</strong> Thanks @obviyus.</li>
+<li><strong>PR #143071</strong></li>
+<li><strong>PR #143072</strong></li>
+<li><strong>PR #143068</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143075</strong></li>
+<li><strong>PR #143076</strong></li>
+<li><strong>PR #143006</strong> Thanks @Marvinthebored and @Peetiegonzalez and @obviyus.</li>
+<li><strong>PR #143082</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143085</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143079</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143084</strong></li>
+<li><strong>PR #143087</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143051</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142168</strong> Thanks @LiuwqGit and @obviyus.</li>
+<li><strong>PR #142322</strong> Related #142208. Thanks @SunnyShu0925 and @guarismo.</li>
+<li><strong>PR #143000</strong> Thanks @gozu and @obviyus.</li>
+<li><strong>PR #143091</strong></li>
+<li><strong>PR #143053</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142093</strong> Thanks @pgondhi987.</li>
+<li><strong>PR #142927</strong> Related #142924. Thanks @vincentkoc.</li>
+<li><strong>PR #143060</strong></li>
+<li><strong>PR #142997</strong> Related #142901. Thanks @ylcn91 and @obviyus and @Conan-Scott.</li>
+<li><strong>PR #143052</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #143104</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142193</strong> Thanks @ceckert and @obviyus.</li>
+<li><strong>PR #143096</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143105</strong></li>
+<li><strong>PR #143103</strong></li>
+<li><strong>PR #141289</strong> Thanks @hugenshen and @obviyus.</li>
+<li><strong>PR #142473</strong></li>
+<li><strong>PR #143116</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143102</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143122</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143124</strong> Related #143118.</li>
+<li><strong>PR #141808</strong> Related #141787. Thanks @SunnyShu0925 and @obviyus and @dh-js.</li>
+<li><strong>PR #143130</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143129</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143108</strong></li>
+<li><strong>PR #141756</strong> Thanks @chelsealong and @obviyus.</li>
+<li><strong>PR #136277</strong> Thanks @yetval and @obviyus.</li>
+<li><strong>PR #142631</strong> Thanks @jason-allen-oneal.</li>
+<li><strong>PR #143112</strong></li>
+<li><strong>PR #143133</strong></li>
+<li><strong>PR #141303</strong> Thanks @hugenshen and @obviyus.</li>
+<li><strong>PR #142237</strong></li>
+<li><strong>PR #142860</strong> Related #142832. Thanks @ericcaiwx-star and @aatreya.</li>
+<li><strong>PR #142869</strong> Related #142868. Thanks @Marvinthebored and @obviyus.</li>
+<li><strong>PR #143149</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143148</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142719</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141771</strong> Related #141701. Thanks @chelsealong and @tomdailey55.</li>
+<li><strong>PR #143138</strong></li>
+<li><strong>PR #143152</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143160</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142932</strong> Related #142878. Thanks @ashawwal and @obviyus.</li>
+<li><strong>PR #143151</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143117</strong></li>
+<li><strong>PR #143137</strong></li>
+<li><strong>PR #143154</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143161</strong></li>
+<li><strong>PR #143156</strong></li>
+<li><strong>PR #143139</strong></li>
+<li><strong>PR #141307</strong> Thanks @hugenshen and @obviyus.</li>
+<li><strong>PR #143163</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143168</strong></li>
+<li><strong>PR #143158</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143140</strong></li>
+<li><strong>PR #143166</strong> Related #143165.</li>
+<li><strong>PR #143128</strong></li>
+<li><strong>PR #143164</strong></li>
+<li><strong>PR #143150</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143167</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #143182</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142284</strong> Thanks @obviyus.</li>
+<li><strong>PR #143172</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143179</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143194</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143171</strong> Related #143170. Thanks @vincentkoc.</li>
+<li><strong>PR #142968</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143181</strong></li>
+<li><strong>PR #143191</strong></li>
+<li><strong>PR #143134</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143192</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143197</strong></li>
+<li><strong>PR #143136</strong> Related #141617. Thanks @yncubys.</li>
+<li><strong>PR #143088</strong> Thanks @ly85206559 and @obviyus.</li>
+<li><strong>PR #143125</strong> Related #143111. Thanks @LiuwqGit and @obviyus and @yxloveql.</li>
+<li><strong>PR #143049</strong></li>
+<li><strong>PR #143203</strong></li>
+<li><strong>PR #143159</strong></li>
+<li><strong>PR #120843</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143147</strong> Thanks @LiuwqGit and @obviyus.</li>
+<li><strong>PR #143209</strong></li>
+<li><strong>PR #143213</strong></li>
+<li><strong>PR #143221</strong></li>
+<li><strong>PR #137892</strong> Related #137624. Thanks @pfrederiksen and @vincentkoc.</li>
+<li><strong>PR #143109</strong></li>
+<li><strong>PR #128738</strong> Thanks @Leon-SK668 and @obviyus.</li>
+<li><strong>PR #143202</strong> Related #142582, #142585. Thanks @GitHoubi.</li>
+<li><strong>PR #143222</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142259</strong></li>
+<li><strong>PR #143069</strong> Related #143007. Thanks @vincentkoc.</li>
+<li><strong>PR #143219</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143205</strong></li>
+<li><strong>PR #143107</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143175</strong></li>
+<li><strong>PR #143240</strong></li>
+<li><strong>PR #138819</strong> Related #138779. Thanks @sunlit-deng and @vincentkoc and @Jackten.</li>
+<li><strong>PR #143247</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142661</strong> Thanks @eleqtrizit.</li>
+<li><strong>PR #143249</strong></li>
+<li><strong>PR #142221</strong></li>
+<li><strong>PR #143195</strong> Related #142584. Thanks @GitHoubi.</li>
+<li><strong>PR #143258</strong></li>
+<li><strong>PR #143226</strong></li>
+<li><strong>PR #143031</strong></li>
+<li><strong>PR #143153</strong> Related #143001. Thanks @syfvb.</li>
+<li><strong>PR #143253</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143261</strong></li>
+<li><strong>PR #142990</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #142979</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143237</strong></li>
+<li><strong>PR #143251</strong></li>
+<li><strong>PR #143254</strong></li>
+<li><strong>PR #143223</strong></li>
+<li><strong>PR #143141</strong> Related #143094. Thanks @fahrenhe1t.</li>
+<li><strong>PR #143243</strong></li>
+<li><strong>PR #143065</strong></li>
+<li><strong>PR #143268</strong></li>
+<li><strong>PR #142817</strong> Related #143204. Thanks @wangmiao0668000666.</li>
+<li><strong>PR #143272</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140621</strong> Related #140607. Thanks @LightningWareLLC.</li>
+<li><strong>PR #143207</strong></li>
+<li><strong>PR #143281</strong> Related #143252.</li>
+<li><strong>PR #142242</strong></li>
+<li><strong>PR #143174</strong></li>
+<li><strong>PR #142749</strong> Related #141279. Thanks @pengzh1 and @aevgeniou.</li>
+<li><strong>PR #143198</strong> Related #142868. Thanks @Marvinthebored.</li>
+<li><strong>PR #143273</strong></li>
+<li><strong>PR #143298</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140914</strong> Related #140821. Thanks @NianJiuZst and @obviyus and @rboy1.</li>
+<li><strong>PR #142742</strong> Thanks @jason-allen-oneal and @morrow-bluedot.</li>
+<li><strong>PR #143097</strong></li>
+<li><strong>PR #143235</strong> Thanks @obviyus.</li>
+<li><strong>PR #143271</strong></li>
+<li><strong>PR #143300</strong></li>
+<li><strong>PR #143292</strong> Related #143210. Thanks @fanyuantaier.</li>
+<li><strong>PR #143183</strong></li>
+<li><strong>PR #143302</strong></li>
+<li><strong>PR #143190</strong></li>
+<li><strong>PR #143287</strong></li>
+<li><strong>PR #143307</strong></li>
+<li><strong>PR #143288</strong></li>
+<li><strong>PR #142935</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143238</strong> Related #128076. Thanks @ejc3.</li>
+<li><strong>PR #143189</strong> Related #143186.</li>
+<li><strong>PR #143285</strong></li>
+<li><strong>PR #143269</strong></li>
+<li><strong>PR #143309</strong></li>
+<li><strong>PR #143308</strong></li>
+<li><strong>PR #141163</strong> Related #141123. Thanks @ly85206559 and @orangejon.</li>
+<li><strong>PR #143260</strong></li>
+<li><strong>PR #143317</strong></li>
+<li><strong>PR #143316</strong></li>
+<li><strong>PR #143297</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143320</strong></li>
+<li><strong>PR #143321</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #142453</strong> Thanks @VACInc.</li>
+<li><strong>PR #143313</strong></li>
+<li><strong>PR #143291</strong> Related #124555. Thanks @sallyom and @sercada.</li>
+<li><strong>PR #143299</strong> Thanks @qingminglong and @obviyus.</li>
+<li><strong>PR #143326</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143324</strong></li>
+<li><strong>PR #143318</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143336</strong></li>
+<li><strong>PR #143325</strong></li>
+<li><strong>PR #143330</strong></li>
+<li><strong>PR #143266</strong></li>
+<li><strong>PR #143337</strong></li>
+<li><strong>PR #143305</strong></li>
+<li><strong>PR #143332</strong></li>
+<li><strong>PR #143339</strong></li>
+<li><strong>PR #143338</strong></li>
+<li><strong>PR #143340</strong></li>
+<li><strong>PR #137255</strong> Thanks @sunlit-deng and @obviyus.</li>
+<li><strong>PR #142810</strong> Related #142805. Thanks @ansxor and @IWhatsskill.</li>
+<li><strong>PR #143162</strong></li>
+<li><strong>PR #143346</strong></li>
+<li><strong>PR #142699</strong></li>
+<li><strong>PR #143270</strong></li>
+<li><strong>PR #143345</strong></li>
+<li><strong>PR #143349</strong></li>
+<li><strong>PR #140266</strong> Related #140265. Thanks @cai-ops and @obviyus.</li>
+<li><strong>PR #141984</strong> Related #140971. Thanks @SunnyShu0925 and @hayden-cc.</li>
+<li><strong>PR #143360</strong></li>
+<li><strong>PR #143333</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141600</strong> Thanks @DonnieFi and @IWhatsskill.</li>
+<li><strong>PR #143358</strong></li>
+<li><strong>PR #143362</strong></li>
+<li><strong>PR #143352</strong> Related #143348.</li>
+<li><strong>PR #143319</strong> Thanks @qingminglong and @obviyus.</li>
+<li><strong>PR #143354</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143282</strong> Related #143267. Thanks @LiuwqGit and @obviyus and @jlapenna.</li>
+<li><strong>PR #143301</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143365</strong></li>
+<li><strong>PR #143347</strong> Thanks @obviyus.</li>
+<li><strong>PR #143312</strong></li>
+<li><strong>PR #143146</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143370</strong></li>
+<li><strong>PR #143369</strong></li>
+<li><strong>PR #142915</strong> Related #142848. Thanks @sunlit-deng and @obviyus and @igs-rogenlo.</li>
+<li><strong>PR #133693</strong> Related #133692. Thanks @ekinnee.</li>
+<li><strong>PR #143366</strong></li>
+<li><strong>PR #143379</strong></li>
+<li><strong>PR #143378</strong></li>
+<li><strong>PR #143380</strong></li>
+<li><strong>PR #143377</strong></li>
+<li><strong>PR #140388</strong> Thanks @Hekzory and @obviyus.</li>
+<li><strong>PR #143392</strong></li>
+<li><strong>PR #143384</strong></li>
+<li><strong>PR #143393</strong></li>
+<li><strong>PR #143361</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143398</strong></li>
+<li><strong>PR #143373</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143401</strong></li>
+<li><strong>PR #143394</strong></li>
+<li><strong>PR #143397</strong></li>
+<li><strong>PR #143402</strong></li>
+<li><strong>PR #143395</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143400</strong></li>
+<li><strong>PR #141841</strong> Related #141807. Thanks @glenn-agent and @obviyus and @dh-js.</li>
+<li><strong>PR #142736</strong> Related #142483. Thanks @RileyJJY and @jai-assistant.</li>
+<li><strong>PR #143409</strong></li>
+<li><strong>PR #143081</strong> Related #143077. Thanks @barbarhan and @obviyus.</li>
+<li><strong>PR #143411</strong></li>
+<li><strong>PR #143403</strong></li>
+<li><strong>PR #143404</strong></li>
+<li><strong>PR #143412</strong></li>
+<li><strong>PR #143408</strong> Related #143388.</li>
+<li><strong>PR #143421</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143418</strong></li>
+<li><strong>PR #143407</strong></li>
+<li><strong>PR #143227</strong></li>
+<li><strong>PR #143415</strong></li>
+<li><strong>PR #143425</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #143405</strong></li>
+<li><strong>PR #143344</strong></li>
+<li><strong>PR #143436</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143430</strong> Related #143428.</li>
+<li><strong>PR #143424</strong> Related #142429. Thanks @obviyus and @schjonhaug.</li>
+<li><strong>PR #143310</strong> Related #143173. Thanks @tskerpnext.</li>
+<li><strong>PR #143157</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143427</strong></li>
+<li><strong>PR #143439</strong> Related #143438.</li>
+<li><strong>PR #143443</strong></li>
+<li><strong>PR #143416</strong></li>
+<li><strong>PR #143444</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143445</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143447</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #140864</strong> Thanks @LiuwqGit and @obviyus.</li>
+<li><strong>PR #143456</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143440</strong></li>
+<li><strong>PR #142802</strong> Thanks @keshavbotagent and @obviyus.</li>
+<li><strong>PR #141069</strong> Related #141066. Thanks @NullArbitrage and @obviyus.</li>
+<li><strong>PR #143459</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143452</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143450</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143453</strong></li>
+<li><strong>PR #143458</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143462</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143469</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143451</strong></li>
+<li><strong>PR #143472</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143414</strong></li>
+<li><strong>PR #141277</strong> Thanks @oywino and @obviyus.</li>
+<li><strong>PR #143426</strong></li>
+<li><strong>PR #143446</strong> Thanks @jalehman.</li>
+<li><strong>PR #143470</strong></li>
+<li><strong>PR #143487</strong></li>
+<li><strong>PR #143460</strong></li>
+<li><strong>PR #143477</strong></li>
+<li><strong>PR #143463</strong></li>
+<li><strong>PR #143457</strong></li>
+<li><strong>PR #143481</strong></li>
+<li><strong>PR #143449</strong></li>
+<li><strong>PR #143490</strong></li>
+<li><strong>PR #139548</strong> Thanks @srikolagani and @obviyus.</li>
+<li><strong>PR #143497</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143517</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143515</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143513</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143514</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143492</strong></li>
+<li><strong>PR #143507</strong></li>
+<li><strong>PR #143510</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143520</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143527</strong></li>
+<li><strong>PR #143522</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143493</strong></li>
+<li><strong>PR #143529</strong></li>
+<li><strong>PR #142741</strong> Related #142737. Thanks @galiniliev.</li>
+<li><strong>PR #143434</strong></li>
+<li><strong>PR #143455</strong></li>
+<li><strong>PR #143482</strong></li>
+<li><strong>PR #142844</strong> Related #140246. Thanks @Finn763 and @obviyus and @jmissig.</li>
+<li><strong>PR #143532</strong></li>
+<li><strong>PR #143537</strong></li>
+<li><strong>PR #143485</strong></li>
+<li><strong>PR #143193</strong> Related #143188. Thanks @KirDE and @obviyus.</li>
+<li><strong>PR #143544</strong></li>
+<li><strong>PR #143342</strong> Related #143177. Thanks @sunlit-deng and @obviyus and @bricelb.</li>
+<li><strong>PR #143516</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143508</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143465</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143435</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143574</strong></li>
+<li><strong>PR #143585</strong></li>
+<li><strong>PR #143559</strong></li>
+<li><strong>PR #143486</strong> Related #143473. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #143547</strong></li>
+<li><strong>PR #143599</strong> Related #143263. Thanks @obviyus and @matthewmoroz.</li>
+<li><strong>PR #143530</strong></li>
+<li><strong>PR #143491</strong></li>
+<li><strong>PR #143568</strong></li>
+<li><strong>PR #143557</strong></li>
+<li><strong>PR #135839</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #135840</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #139042</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #137659</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #137846</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #137856</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #137886</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #138755</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142624</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142710</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142711</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142712</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142713</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #142782</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #143606</strong></li>
+<li><strong>PR #143613</strong></li>
+<li><strong>PR #143605</strong></li>
+<li><strong>PR #143600</strong></li>
+<li><strong>PR #143595</strong> Related #143593. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143586</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143602</strong></li>
+<li><strong>PR #143601</strong></li>
+<li><strong>PR #140833</strong> Thanks @leapdragon and @obviyus.</li>
+<li><strong>PR #143542</strong></li>
+<li><strong>PR #143603</strong></li>
+<li><strong>PR #143592</strong></li>
+<li><strong>PR #143579</strong> Related #143575. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143561</strong> Related #143560. Thanks @masatohoshino and @obviyus.</li>
+<li><strong>PR #143626</strong></li>
+<li><strong>PR #143372</strong></li>
+<li><strong>PR #143627</strong></li>
+<li><strong>PR #143629</strong></li>
+<li><strong>PR #132158</strong> Thanks @stevenlee-oai.</li>
+<li><strong>PR #143628</strong></li>
+<li><strong>PR #143633</strong></li>
+<li><strong>PR #143636</strong></li>
+<li><strong>PR #141079</strong> Related #141078. Thanks @ooiuuii and @obviyus.</li>
+<li><strong>PR #143634</strong></li>
+<li><strong>PR #143637</strong></li>
+<li><strong>PR #143639</strong></li>
+<li><strong>PR #143368</strong></li>
+<li><strong>PR #143642</strong></li>
+<li><strong>PR #143621</strong></li>
+<li><strong>PR #143371</strong></li>
+<li><strong>PR #143374</strong></li>
+<li><strong>PR #143644</strong></li>
+<li><strong>PR #143382</strong></li>
+<li><strong>PR #140339</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143383</strong></li>
+<li><strong>PR #114662</strong> Related #114602. Thanks @synthalorian and @obviyus and @jackatagenticforce.</li>
+<li><strong>PR #138619</strong> Related #138592. Thanks @LiuwqGit and @obviyus and @fabiolr.</li>
+<li><strong>PR #143652</strong></li>
+<li><strong>PR #143655</strong></li>
+<li><strong>PR #143429</strong> Thanks @obviyus.</li>
+<li><strong>PR #125977</strong> Thanks @ayaangazali and @obviyus.</li>
+<li><strong>PR #143653</strong></li>
+<li><strong>PR #143598</strong> Related #132762. Thanks @harjothkhara and @obviyus and @CK-XYZ.</li>
+<li><strong>PR #143660</strong></li>
+<li><strong>PR #141836</strong> Related #129452. Thanks @obviyus and @safzanpirani.</li>
+<li><strong>PR #143663</strong></li>
+<li><strong>PR #143651</strong></li>
+<li><strong>PR #142186</strong></li>
+<li><strong>PR #143657</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143662</strong></li>
+<li><strong>PR #143376</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143680</strong></li>
+<li><strong>PR #143667</strong> Related #143654.</li>
+<li><strong>PR #143666</strong></li>
+<li><strong>PR #92288</strong> Thanks @ai-hpc and @obviyus.</li>
+<li><strong>PR #143690</strong></li>
+<li><strong>PR #137303</strong> Thanks @qingminglong and @obviyus.</li>
+<li><strong>PR #143684</strong></li>
+<li><strong>PR #136466</strong> Related #136392. Thanks @vincentkoc.</li>
+<li><strong>PR #143697</strong></li>
+<li><strong>PR #143676</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #143698</strong></li>
+<li><strong>PR #143705</strong></li>
+<li><strong>PR #142522</strong> Thanks @jjjhenriksen and @RomneyDa and @pash-openai.</li>
+<li><strong>PR #143687</strong></li>
+<li><strong>PR #143658</strong></li>
+<li><strong>PR #143709</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143710</strong></li>
+<li><strong>PR #143706</strong></li>
+<li><strong>PR #143682</strong> Related #143656. Thanks @vincentkoc.</li>
+<li><strong>PR #143674</strong></li>
+<li><strong>PR #143622</strong></li>
+<li><strong>PR #143675</strong></li>
+<li><strong>PR #143723</strong></li>
+<li><strong>PR #143506</strong> Related #143385. Thanks @sunlit-deng and @obviyus and @dbarbatti.</li>
+<li><strong>PR #143720</strong></li>
+<li><strong>PR #143721</strong></li>
+<li><strong>PR #143695</strong></li>
+<li><strong>PR #143531</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143567</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143590</strong> Related #143169. Thanks @wangmiao0668000666 and @obviyus and @PeterHodl.</li>
+<li><strong>PR #119624</strong> Thanks @pcpilot-dev.</li>
+<li><strong>PR #143519</strong> Related #90711. Thanks @RomneyDa and @Enominera.</li>
+<li><strong>PR #109092</strong> Thanks @Pick-cat and @obviyus.</li>
+<li><strong>PR #143724</strong></li>
+<li><strong>PR #143726</strong></li>
+<li><strong>PR #143643</strong> Thanks @obviyus.</li>
+<li><strong>PR #143708</strong></li>
+<li><strong>PR #143722</strong> Related #143641. Thanks @obviyus and @rgregg.</li>
+<li><strong>PR #143734</strong></li>
+<li><strong>PR #143725</strong></li>
+<li><strong>PR #143671</strong></li>
+<li><strong>PR #143741</strong></li>
+<li><strong>PR #143749</strong></li>
+<li><strong>PR #143736</strong></li>
+<li><strong>PR #143693</strong> Related #143678. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143737</strong></li>
+<li><strong>PR #143716</strong></li>
+<li><strong>PR #143746</strong></li>
+<li><strong>PR #143681</strong></li>
+<li><strong>PR #143699</strong></li>
+<li><strong>PR #143712</strong></li>
+<li><strong>PR #143748</strong></li>
+<li><strong>PR #143742</strong> Related #143630. Thanks @zwyhmcn.</li>
+<li><strong>PR #143715</strong></li>
+<li><strong>PR #143763</strong></li>
+<li><strong>PR #143686</strong></li>
+<li><strong>PR #143773</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143765</strong></li>
+<li><strong>PR #143762</strong></li>
+<li><strong>PR #143669</strong></li>
+<li><strong>PR #143775</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143717</strong></li>
+<li><strong>PR #137147</strong> Thanks @qingminglong and @obviyus.</li>
+<li><strong>PR #143766</strong></li>
+<li><strong>PR #143770</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #116378</strong> Related #115920. Thanks @sloptop-the-terrible and @obviyus and @609NFT.</li>
+<li><strong>PR #143738</strong> Related #143543. Thanks @RomneyDa.</li>
+<li><strong>PR #143704</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143751</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143729</strong> Thanks @xydigitLybnnnn and @obviyus.</li>
+<li><strong>PR #143758</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #143760</strong></li>
+<li><strong>PR #143769</strong></li>
+<li><strong>PR #143747</strong></li>
+<li><strong>PR #143696</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143692</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143689</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143582</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143576</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143474</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143570</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143793</strong></li>
+<li><strong>PR #125413</strong></li>
+<li><strong>PR #143782</strong></li>
+<li><strong>PR #143783</strong></li>
+<li><strong>PR #143780</strong></li>
+<li><strong>PR #143754</strong></li>
+<li><strong>PR #122110</strong> Related #122107. Thanks @sappkevin and @obviyus.</li>
+<li><strong>PR #143558</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143795</strong></li>
+<li><strong>PR #143796</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143805</strong> Related #143800.</li>
+<li><strong>PR #143815</strong></li>
+<li><strong>PR #143807</strong></li>
+<li><strong>PR #120902</strong> Thanks @zenglingbiao and @obviyus.</li>
+<li><strong>PR #143798</strong></li>
+<li><strong>PR #143659</strong> Thanks @HAPPYFAPTAIN and @obviyus.</li>
+<li><strong>PR #143730</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #143731</strong> Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #143801</strong></li>
+<li><strong>PR #121557</strong> Related #121401. Thanks @zyw02 and @cursoragent and @obviyus.</li>
+<li><strong>PR #143808</strong></li>
+<li><strong>PR #143828</strong></li>
+<li><strong>PR #143806</strong></li>
+<li><strong>PR #143845</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143855</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143844</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143856</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143835</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143824</strong></li>
+<li><strong>PR #143776</strong></li>
+<li><strong>PR #143846</strong></li>
+<li><strong>PR #143813</strong></li>
+<li><strong>PR #143862</strong></li>
+<li><strong>PR #143789</strong></li>
+<li><strong>PR #143867</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143464</strong></li>
+<li><strong>PR #143816</strong></li>
+<li><strong>PR #143859</strong></li>
+<li><strong>PR #143831</strong></li>
+<li><strong>PR #143664</strong> Thanks @obviyus.</li>
+<li><strong>PR #143848</strong></li>
+<li><strong>PR #143799</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143868</strong></li>
+<li><strong>PR #143863</strong> Related #143841. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143791</strong> Related #143750. Thanks @vincentkoc and @fuller-stack-dev.</li>
+<li><strong>PR #143877</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143812</strong></li>
+<li><strong>PR #143875</strong></li>
+<li><strong>PR #143849</strong></li>
+<li><strong>PR #143850</strong></li>
+<li><strong>PR #143857</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143853</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143870</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143871</strong></li>
+<li><strong>PR #143869</strong></li>
+<li><strong>PR #137371</strong> Related #137257. Thanks @gwiltschek and @obviyus.</li>
+<li><strong>PR #143814</strong></li>
+<li><strong>PR #143811</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143573</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143810</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143768</strong></li>
+<li><strong>PR #143553</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143552</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143551</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143572</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143565</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143562</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143564</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143874</strong></li>
+<li><strong>PR #143785</strong> Thanks @obviyus.</li>
+<li><strong>PR #143767</strong></li>
+<li><strong>PR #143889</strong></li>
+<li><strong>PR #143838</strong></li>
+<li><strong>PR #136984</strong> Related #134604. Thanks @linhongyu510 and @obviyus and @scottcha.</li>
+<li><strong>PR #143533</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143534</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143536</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143535</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143914</strong></li>
+<li><strong>PR #143861</strong></li>
+<li><strong>PR #143887</strong></li>
+<li><strong>PR #143554</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #143854</strong></li>
+<li><strong>PR #143858</strong></li>
+<li><strong>PR #137422</strong> Thanks @qingminglong and @obviyus.</li>
+<li><strong>PR #143913</strong></li>
+<li><strong>PR #143895</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143563</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #138160</strong> Thanks @SunnyShu0925 and @obviyus.</li>
+<li><strong>PR #143919</strong></li>
+<li><strong>PR #143866</strong></li>
+<li><strong>PR #143886</strong> Related #143885.</li>
+<li><strong>PR #134959</strong> Related #108893. Thanks @shojikumaru and @obviyus and @developercrocodiles.</li>
+<li><strong>PR #143916</strong> Related #143389. Thanks @obviyus and @aleps001.</li>
+<li><strong>PR #143851</strong></li>
+<li><strong>PR #111964</strong> Related #96974. Thanks @dillona and @vincentkoc and @anguslogan01.</li>
+<li><strong>PR #143912</strong></li>
+<li><strong>PR #143901</strong></li>
+<li><strong>PR #142132</strong> Thanks @mgabor3141 and @obviyus.</li>
+<li><strong>PR #143904</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143926</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143873</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143872</strong></li>
+<li><strong>PR #143925</strong></li>
+<li><strong>PR #139071</strong> Thanks @qingminglong and @obviyus.</li>
+<li><strong>PR #143777</strong></li>
+<li><strong>PR #143893</strong></li>
+<li><strong>PR #143923</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143792</strong></li>
+<li><strong>PR #143774</strong> Related #139714. Thanks @Colton-Harris.</li>
+<li><strong>PR #143927</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143945</strong></li>
+<li><strong>PR #143928</strong></li>
+<li><strong>PR #143864</strong></li>
+<li><strong>PR #143899</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143931</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143922</strong></li>
+<li><strong>PR #143942</strong> Related #143939.</li>
+<li><strong>PR #141762</strong> Thanks @xiaoguomeiyitian and @obviyus.</li>
+<li><strong>PR #143950</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143920</strong></li>
+<li><strong>PR #143822</strong></li>
+<li><strong>PR #143954</strong></li>
+<li><strong>PR #135539</strong> Thanks @kvnloo and @obviyus.</li>
+<li><strong>PR #143962</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143910</strong></li>
+<li><strong>PR #143949</strong> Related #143947.</li>
+<li><strong>PR #143964</strong></li>
+<li><strong>PR #143921</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #143965</strong></li>
+<li><strong>PR #143974</strong></li>
+<li><strong>PR #143977</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143979</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143759</strong> Related #143756.</li>
+<li><strong>PR #143969</strong></li>
+<li><strong>PR #143982</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141283</strong> Thanks @north-echo and @obviyus.</li>
+<li><strong>PR #143978</strong></li>
+<li><strong>PR #143924</strong></li>
+<li><strong>PR #143888</strong></li>
+<li><strong>PR #143967</strong></li>
+<li><strong>PR #111706</strong> Thanks @xydt-tanshanshan and @obviyus.</li>
+<li><strong>PR #143803</strong></li>
+<li><strong>PR #143975</strong></li>
+<li><strong>PR #143908</strong> Thanks @pash-openai.</li>
+<li><strong>PR #143832</strong> Thanks @pash-openai.</li>
+<li><strong>PR #143953</strong></li>
+<li><strong>PR #139562</strong> Thanks @TheCrazyLex and @obviyus.</li>
+<li><strong>PR #140296</strong> Related #140100. Thanks @ylcn91 and @ikenraf.</li>
+<li><strong>PR #143983</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143410</strong></li>
+<li><strong>PR #144004</strong></li>
+<li><strong>PR #143996</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143997</strong></li>
+<li><strong>PR #144018</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144002</strong></li>
+<li><strong>PR #144021</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144030</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144028</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144033</strong></li>
+<li><strong>PR #144039</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143958</strong> Related #143971. Thanks @Marvinthebored and @Peetiegonzalez and @obviyus.</li>
+<li><strong>PR #144037</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #144051</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144049</strong></li>
+<li><strong>PR #144050</strong></li>
+<li><strong>PR #142822</strong> Thanks @obviyus.</li>
+<li><strong>PR #144058</strong></li>
+<li><strong>PR #144032</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144067</strong></li>
+<li><strong>PR #143929</strong></li>
+<li><strong>PR #144017</strong></li>
+<li><strong>PR #144007</strong></li>
+<li><strong>PR #144060</strong></li>
+<li><strong>PR #144014</strong></li>
+<li><strong>PR #144010</strong></li>
+<li><strong>PR #144012</strong></li>
+<li><strong>PR #144029</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143930</strong> Related #143830. Thanks @linhongyu510 and @obviyus and @cp1369.</li>
+<li><strong>PR #144009</strong></li>
+<li><strong>PR #144072</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144036</strong></li>
+<li><strong>PR #143993</strong></li>
+<li><strong>PR #143772</strong></li>
+<li><strong>PR #144076</strong></li>
+<li><strong>PR #144038</strong> Related #144035.</li>
+<li><strong>PR #144083</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144080</strong></li>
+<li><strong>PR #144073</strong></li>
+<li><strong>PR #144087</strong></li>
+<li><strong>PR #144034</strong></li>
+<li><strong>PR #144022</strong></li>
+<li><strong>PR #144015</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144054</strong></li>
+<li><strong>PR #141071</strong> Related #141000. Thanks @ooiuuii and @obviyus.</li>
+<li><strong>PR #144011</strong></li>
+<li><strong>PR #144092</strong></li>
+<li><strong>PR #144091</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143903</strong> Related #143821. Thanks @LiuwqGit and @obviyus and @kiagentkronos-cell.</li>
+<li><strong>PR #144075</strong></li>
+<li><strong>PR #143994</strong></li>
+<li><strong>PR #143521</strong> Related #107972. Thanks @eleqtrizit and @yetval.</li>
+<li><strong>PR #144090</strong></li>
+<li><strong>PR #144089</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144086</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144024</strong></li>
+<li><strong>PR #144077</strong></li>
+<li><strong>PR #144096</strong></li>
+<li><strong>PR #143999</strong></li>
+<li><strong>PR #144095</strong></li>
+<li><strong>PR #143484</strong> Thanks @eleqtrizit.</li>
+<li><strong>PR #144097</strong></li>
+<li><strong>PR #143437</strong> Related #143356. Thanks @ylcn91 and @obviyus and @YanHE1169.</li>
+<li><strong>PR #144023</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144108</strong></li>
+<li><strong>PR #144085</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144105</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143960</strong> Thanks @Marvinthebored and @Peetiegonzalez and @obviyus.</li>
+<li><strong>PR #144116</strong></li>
+<li><strong>PR #144109</strong></li>
+<li><strong>PR #144031</strong> Thanks @IWhatsskill.</li>
+<li><strong>PR #144107</strong></li>
+<li><strong>PR #144117</strong></li>
+<li><strong>PR #144115</strong> Related #144114.</li>
+<li><strong>PR #144110</strong></li>
+<li><strong>PR #144122</strong></li>
+<li><strong>PR #144120</strong></li>
+<li><strong>PR #144126</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #144088</strong></li>
+<li><strong>PR #144130</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #144129</strong> Related #144123. Thanks @vincentkoc.</li>
+<li><strong>PR #143890</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143311</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #143745</strong> Related #143743. Thanks @vincentkoc.</li>
+<li><strong>PR #144135</strong></li>
+<li><strong>PR #143860</strong> Related #143865. Thanks @wangmiao0668000666 and @obviyus.</li>
+<li><strong>PR #144121</strong></li>
+<li><strong>PR #144402</strong> Thanks @vincentkoc.</li>
+</ul>
+<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
+]]></description>
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.9.4/OpenClaw-2026.9.4.zip" length="613988830" type="application/octet-stream" sparkle:edSignature="A4u8pAnqmSWz7I65g+kPSvkenMUTEZEYzZJKvR9QRv51/799vT1FMeRcv57oLqjmH/sNNoGzKBeCbvgQGlJaCw=="/>
+        </item>
+        <item>
             <title>2026.9.3</title>
             <pubDate>Tue, 08 Sep 2026 04:35:03 +0000</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
@@ -3423,1305 +4683,6 @@ Shipped baseline exclusions: v2026.9.1 (1223 PRs: #64490, #70002, #93842, #98236
 <p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
             <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.9.2/OpenClaw-2026.9.2.zip" length="581596294" type="application/octet-stream" sparkle:edSignature="5xtZX7gmjDnBJ0rju7wlVHbcqMhSnt/dgz+JiRb6j5wIxGisuM59wrpiLXNIijTHXbcGn6hoyLGH516FO2gzBw=="/>
-        </item>
-        <item>
-            <title>2026.9.1</title>
-            <pubDate>Thu, 03 Sep 2026 22:28:34 +0000</pubDate>
-            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>2609000190</sparkle:version>
-            <sparkle:shortVersionString>2026.9.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <description><![CDATA[<h2>OpenClaw 2026.9.1</h2>
-<h3>Highlights</h3>
-<ul>
-<li><strong>Diagrams in every chat:</strong> Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and Android apps, with enlarge previews and a retry when a diagram fails to render on mobile. (#134913, #135746, #135470, #135342)</li>
-<li><strong>From install to chat in one prompt:</strong> fresh installs (including <code>npx openclaw@latest</code>) get a quick-start lane that detects existing Claude Code or Codex logins and API keys, verifies them live, and opens the web dashboard from a foreground Gateway; the full wizard stays available as Custom setup. (#134221) Thanks @fuller-stack-dev.</li>
-<li><strong>Personal skill libraries on shared Gateways:</strong> keep your own skills beside the workspace set with <code>openclaw skills library</code>, import them from ZIP archives, and share or publish them per identity on team Gateways. Related #133602. (#134068)</li>
-<li><strong>Updates that leave you working:</strong> <code>openclaw update</code> now rolls back the npm candidate when the post-update Doctor fails, preserves your configuration and secret references across a failed upgrade, hands failures to a built-in triage agent, waits for plugin readiness before restarting, accepts npm 12 local archives, lets agent-launched updates finish outside the Gateway process tree, and proceeds without a Gateway service instead of refusing when no service manager exists (users on 2026.8.2 without a service manager should run <code>openclaw update --no-restart</code> once). Related #134204, #135655. (#135462, #134490, #134865, #134699, #134663, #136316, #135701) Thanks @fuller-stack-dev, @Patrick-Erichsen, @vyctorbrzezowski, @jalehman, @devzeroLL, and @obviyus.</li>
-<li><strong>A Gateway that stays up:</strong> startup recovers under load and with large agent rosters, malformed legacy cron rows are quarantined instead of blocking boot, migration warnings degrade the Gateway instead of refusing to start, local model servers become the preferred OOM victims, and Windows Gateways stay online after an agent restart. Related #135743, #134458, #135150, #136275, #120134, #134851. (#132186, #135773, #134704, #135713, #136276, #134549, #134853) Thanks @galiniliev, @LiuwqGit, @obviyus, @609NFT, @Nielsh82, @Zak-Finance, @vincentkoc, @nerclid, @w1130150306, and @cmanrav.</li>
-<li><strong>Codex approvals that stick:</strong> "Allow Always" is durable for MCP tools on OpenClaw-configured servers, tool approvals follow the session's posture, and approvals granted to an active Codex placement are reused instead of asked again. Related #132369. (#136019, #135812, #132370) Thanks @jalehman.</li>
-<li><strong>Approvals reach your chat:</strong> when a delegated system agent proposes a config change or Gateway restart, the approval card is delivered to the originating channel (Telegram topics included) with the requester's title, instead of stalling silently. Related #136083. (#134670, #136091) Thanks @obviyus.</li>
-<li><strong>Android catches up with the web UI:</strong> the chat screen, sidebar navigation, and appearance settings match the Control UI, the composer grows to six lines, and recording is offered when dictation is unavailable. Related #125322. (#134939, #135923, #135794) Thanks @IWhatsskill, @obviyus, @BennyAI2, and @RaviTharuma.</li>
-</ul>
-<h3>Changes</h3>
-<ul>
-<li><strong>Personal GitHub accounts:</strong> connect "My GitHub" beside the system account in your profile, publish pull requests under an explicit personal identity, and switch sessions without re-verifying credentials every time. (#133799, #136223)</li>
-<li><strong>Model setup that shows how you are signed in:</strong> Model Setup lists account versus API-key access with the runtime-reported email for Codex and Claude candidates, the catalog "+" opens the native Codex or Claude CLI in a terminal, and the provider defaults page autosaves with a simpler model picker footer. Related #136068. (#136521, #136230, #134813, #136160) Thanks @Patrick-Erichsen.</li>
-<li><strong>New models and usage:</strong> support Anthropic Fable 5.1 from shared model metadata, show SuperGrok usage in <code>openclaw models</code> and the usage panel, keep GPT-5.6 Ultra selected across runtime boundaries and configured native accounts, and keep Sonnet 5 pricing current on Vertex. Related #135623, #135991, #135664. (#135638, #135766, #135397, #136061, #135761)</li>
-<li><strong>Local and configured providers:</strong> discover llama.cpp models behind web-app endpoints, keep local Ollama routes selectable, auto-enable the Google provider plugin when it is configured, retain externally authenticated providers in the model menu, and refresh model catalogs after auth or config changes without a restart. Related #135361, #134731, #135221, #134516. (#135445, #135095, #135239, #135046, #134361, #135063, #135353) Thanks @gaoanze888, @Bloodis94, @obviyus, @BoatAngle, @Solvely-Colin, and @goslingmanagment.</li>
-<li><strong>Agent working directories and worktrees:</strong> set <code>agents.defaults.cwd</code> or a per-agent <code>cwd</code> and describe directory roles in the prompt, configure a global <code>worktreeRoot</code>, and run up to 100 managed checkouts without sessions being rejected at the limit. Related #134848, #135852. (#135080, #134872, #135885, #135989)</li>
-<li><strong>Configuration controls:</strong> <code>cron.skipMissedJobs</code> skips missed recurring jobs at startup, <code>blockedHostnames</code> on the SSRF policy blocks configured hosts for browser, web fetch, and webhooks, <code>config set</code> accepts <code>--expect-current-json</code>, <code>--expect-current-absent</code>, <code>--dry-run</code>, and <code>--strict-json</code>, and <code>channels.<id>.enabled: false</code> no longer loads that channel plugin. (#135071, #135097, #136137, #136211) Thanks @vincentkoc.</li>
-<li><strong>Memory maintenance:</strong> <code>openclaw memory reset</code> rebuilds derived indexes without deleting sessions, and recall outcomes from active memory are surfaced to the model. Related #135086. (#135653, #135193) Thanks @Alix-007, @obviyus, and @wave-workflow.</li>
-<li><strong>Codex plugin:</strong> preserve native history in supervised message forks, let idle chats resume while other chats run, stop interrupting long quiet native turns, keep configured MCP tools on native fallback, honor the user's time zone, keep replies working after sub-plugin config changes, keep inbound audio for automatic voice replies, hide saved reasoning unless enabled, hide node exec when no capable node is connected, keep Codex streams connected under load, and move managed installs to Codex 0.152.1. Related #134552, #136143, #99272, #122233, #136015, #135618, #135571, #135978, #135966, #135338. (#134660, #136196, #134755, #134941, #136172, #135863, #135884, #136008, #136000, #135577, #136184, #136705) Thanks @obviyus, @ernestrolfson-design, @itsuzef, @NianJiuZst, @davidcittadini, @vyctorbrzezowski, @hyper-sdn, and @tzlwn1.</li>
-<li><strong>Session naming and switching:</strong> new-session names are prepared after idle typing, switching sessions in large lists is faster with lighter sidebar work and payloads, sidebar catalog groups are capped at five sessions, and New Session and Chat do less startup work. Related #133702. (#133724, #135021, #135332, #135574, #136362, #136021, #136040) Thanks @fuller-stack-dev.</li>
-<li><strong>Control UI layout:</strong> sidebar controls move into the agent header, session context menus are regrouped, the accent color lives with the theme, dashboard widgets fill mobile width, the shared Agent picker and settings pages are streamlined with loading skeletons, hovercards show participants, and Gateway suspension appears in account footers. Related #135506, #135535, #132147. (#134365, #135526, #135547, #133814, #134680, #134684, #134659, #134636, #136542, #136220, #134478, #134764) Thanks @vyctorbrzezowski, @MoerAI, and @Patrick-Erichsen.</li>
-<li><strong>Chat polish:</strong> compaction gets a folding shimmer, the composer has a stable accessible name and accepts the next prompt right after send, Escape closes the visible session popover, dropdowns reopened stay dismissible, keyboard navigation survives submenu switches, and chat errors can be copied without expanding them. Related #136441, #134997, #135613, #136070. (#135988, #133829, #135345, #136445, #135006, #135629, #136085) Thanks @aniruddhaadak80 and @Takhoffman.</li>
-<li><strong>macOS app:</strong> a streamlined native chat composer, a browser sidebar that can expand past half width, lower idle menu-bar CPU, notifications when background sessions finish, a Talk overlay that survives quick toggles, and speech recognizers reused between voice captures. Related #136157, #136562, #127645. (#135608, #136168, #136572, #136519, #135731, #135401) Thanks @HuzaifaChaudary and @Colton-Harris.</li>
-<li><strong>iOS and watchOS:</strong> open session dashboards without nested Control UI, disclose model targets and enforce availability, show the latest output when reopening chats, keep Watch and realtime voice replies with their own turn, and explain when a spoken reply times out. Related #134306, #135251, #135693. (#132983, #135044, #135429, #135697, #135795, #135765) Thanks @fuller-stack-dev and @goslingmanagment.</li>
-<li><strong>Linux desktop:</strong> first-run Gateway choices work without the CLI installed. Related #135565. (#135650)</li>
-<li><strong>Channel controls:</strong> Feishu and Matrix deliver the buttons an agent reply offers, and LINE tells the agent which buttons it renders, keeps the words a quick-reply prompt leaves behind, lets a group mention reach the turn that answers it, and gives up a card LINE would refuse instead of losing the reply. Related #132739, #134975, #135187, #135228. (#135255, #133268, #134915, #134976, #135195, #135229) Thanks @edenfunf and @ml12580.</li>
-<li><strong>CLI:</strong> <code>channels add/login/logout/remove/resolve</code> accept <code>--agent</code>, <code>mcp --json</code> emits a JSON failure envelope, zsh and Bash completions escape descriptions and option values correctly, heartbeat status shows Gateway ages, <code>sessions tail</code> reports recorded trajectory outcomes, secrets JSON failures stay machine-readable, device approval hints keep their profile context, and TUI picker cancellation routes through shared input. Related #132347, #46932, #136089, #136406, #136632, #136556, #135089, #133128. (#135505, #132379, #64490, #135114, #136557, #136093, #136407, #136142, #136633, #133151) Thanks @wangmiao0668000666, @EdenKangdw, @walker1211, @jeffrey4341, @qingminglong, @obviyus, and @aniruddhaadak80.</li>
-<li><strong>Plugins and skills:</strong> renamed official plugins migrate by their legacy npm package name, plugin updates require capability consent when prior acceptance is stale while verified first-party plugins are exempt, plugin uninstalls persist across a Gateway restart and keep channel settings, and skill Workshop content, read-only diagnosis, and channel setup are corrected. Related #134076, #135726, #136591. (#130894, #134172, #134933, #135460, #135729, #134759, #134871, #136600, #136615) Thanks @cxyhhhhh, @RileyJJY, @beastyrabbit, @devzeroLL, @obviyus, and @Patrick-Erichsen.</li>
-<li><strong>Uninstall and backups:</strong> <code>openclaw uninstall</code> defaults to removing only the service and keeps user data, Claude migration backups preserve overwritten generated skills, and backups exclude disabled workspaces, tolerate ACPX-generated symlinks, find managed schedules by identity, keep Git failure diagnostics, and retain the active config through volatile filtering. Related #125694, #127403, #135218, #136159, #136118, #136665. (#134299, #134302, #135830, #136215, #136133, #135455, #136666) Thanks @PollyBot13, @kodi, @obviyus, @ericcaiwx-star, @jarvismazz, @LiuwqGit, @wave-workflow, @ly85206559, and @devzeroLL.</li>
-</ul>
-<h3>Fixes</h3>
-<ul>
-<li><strong>Ingress and token safety:</strong> bound concurrent pre-auth reads on SMS webhooks, stop delivering commands to a Watch node after its device is revoked, require the per-process nonce on the Copilot Azure BYOK proxy, isolate webhook rate limits by client, let authorized scoped node tokens be managed by their owner, and reject oversized A2A JSON-RPC batches and responses. (#136504, #135904, #134781, #134622, #135617, #134603) Thanks @drobison00 and @eleqtrizit.</li>
-<li><strong>Secrets stay redacted:</strong> <code>config.get</code> no longer returns unredacted pre-migration snapshots, blank sensitive fields stay editable without being treated as secrets, systemd unit backups no longer leak Gateway tokens, and iOS omits deep-link URLs from logs. Related #135649, #131781. (#134940, #135798, #131786, #134738) Thanks @SunnyShu0925, @markhaines, @vyctorbrzezowski, and @eleqtrizit.</li>
-<li><strong>Browser and filesystem boundaries:</strong> Chrome MCP <code>--browserUrl</code> endpoints obey the CDP reachability policy, unreviewed Chrome MCP upgrades are blocked, unsupported fill field keys are rejected, sanitized temp file names reject dot segments, and memory sync skips symlinked or non-regular workspace files instead of aborting. Related #135845, #131231, #134967. (#135857, #136121, #131400, #135803, #135042) Thanks @LiuwqGit, @obviyus, @srb11e, @teddytennant, @ruel225, and @kiranvk-2011.</li>
-<li><strong>Authority boundaries:</strong> agent creation stops after delegated authority closes, system-agent setup stops writing after its run closes, unauthorized native <code>/compact</code> returns no response, clients are paused when a role requires a verified identity, guest coding works again in private sandboxes, and dashboard GitHub Actions reads use the agent identity. Related #136081, #136219, #133955, #37634, #135515. (#136090, #136247, #131408, #136420, #135702, #135740) Thanks @igs-rogenlo, @obviyus, @aoclaw-glitch, and @whyuds.</li>
-<li><strong>Upgrade data safety:</strong> identical session event replays migrate cleanly, nested session writes keep their order, schema-17 session repair is atomic, legacy cron rows keep their enabled state and delivery intent, credentials replaced during cleanup are preserved, workspaces survive legacy agent-list upgrades, and per-agent memory search survives Doctor. Related #134455, #131113, #135634, #135635, #135637, #135656, #134256. (#134568, #131456, #134272, #132868, #135736, #134892, #134760) Thanks @shakkernerd, @gaoanze888, @Grynn, @RileyJJY, @obviyus, @CanReader, and @vdruts.</li>
-<li><strong>Doctor converges:</strong> <code>doctor --fix</code> finishes on empty workspace attestations, stale workspace setup loops resolve, incomplete exec-approvals migrations fail loudly and empty stubs retire, contaminated device-pairing records no longer crash migration, Windows Doctor and retained workspace recovery are unblocked, and legacy transcript checks are left to migration. Related #134445, #134331, #135437, #135968, #134340, #131770. (#134641, #135755, #135454, #135981, #134483, #136578, #134765) Thanks @leilei3167, @obviyus, @rosssaunders, @jjjhenriksen, @Deregtx, @qdivan, @samson1357924, @LiuwqGit, and @sblindt.</li>
-<li><strong>Doctor keeps your config:</strong> authored values and agents survive repair, official plugin config is preserved before install, external plugin payloads are kept, keyed multi-agent rosters and explicit agent rosters are repaired and persisted, and stale npm plugins are recovered during update repair. Related #134407, #134353, #135450. (#135671, #134717, #135791, #134706, #134758, #135451) Thanks @fuller-stack-dev, @obviyus, @abacha, and @xiaomijituan.</li>
-<li><strong>Shared credential migration:</strong> interrupted migrations recover, stranded credentials are restored, redundant relocation subsets converge, relocation conflicts are diagnosed with forced-login owners cleared, relogin repairs stale profile order, custom provider SecretRefs survive Doctor, the durable auth order is published on a running Gateway, and shared auth health reports without a default agent. Related #132605, #132979, #135385, #135140, #135079, #135734. (#134952, #135346, #135096, #134808, #135739, #135355, #135357, #135847, #135443, #134902, #133978) Thanks @jodok, @fuller-stack-dev, @Deregtx, @obviyus, @mattcbianco, @dannevang, @yetval, @josephbergvinson, and @lzhan011.</li>
-<li><strong>Credential writes and state directories:</strong> CLI and Gateway state-directory split-brain is detected before credential writes, Model Setup no longer leaves a stale claude-cli key after Claude CLI activation, retained device-auth files and unconfigured agent databases are explained, and stale OpenAI doctor route pins are repaired. Related #134379, #101672. (#134403, #134779, #135295, #102180) Thanks @obviyus, @leilei3167, @aaajiao, @PollyBot13, @849261680, and @cpwilhelmi.</li>
-<li><strong>Subagent completions arrive:</strong> completions are delivered after busy parent turns, background completion rejections are caught, empty completions are recorded, unsent completions are no longer reported as delivered, rejected requester wakes settle, model reroutes are shown in the completion including rerouted siblings in batched requester wakes, and Swarm completion guidance matches delivery. Related #134186, #131734, #135633, #135692, #133517. (#136423, #131735, #135846, #136524, #136033, #135531, #133660) Thanks @svdwalt007, @ruel225, @louisfy, @obviyus, @jakestenger, @Grynn, and @MertBasar0.</li>
-<li><strong>Compaction and context accounting:</strong> native compaction is serialized with session writers and kept in one persistent transcript marker, cached usage is no longer overcounted, context usage survives Anthropic proxies that omit usage or cache fields, and status keeps context usage after tool-only turns. Related #99843, #126436, #135530. (#135441, #136169, #99864, #126473, #135467, #134634, #135580) Thanks @jjjhenriksen, @obviyus, @LZY3538, @ayaangazali, @jrex-jooni, @Oliverbot26, @Yigtwxx, @goslingmanagment, @dmsrg399, and @VACInc.</li>
-<li><strong>Fallback and retries:</strong> Anthropic refusals are terminal instead of resending, model fallback no longer cycles every provider when the session already holds a turn claim, transient LLM retries have one failover owner that surfaces a persistent outage sooner, and failover counters appear in console logs. Related #134968, #134187. (#134980, #134219, #134281, #135844) Thanks @Marvinthebored, @obviyus, @tzlwn1, and @svdwalt007.</li>
-<li><strong>Replies that reach the conversation:</strong> stale session dispatches are refreshed so a message after a reset is not dropped, deliveries mirrored into another session are no longer silently lost, an interrupted user message stays in context after restart recovery, fenced code survives duplicate-block collapse byte for byte, commentary progress shows before final validation with unique segment identities, and requester sessions recover after a settle-wake timeout. Related #135149, #132766, #135881, #135882, #135949, #134971, #135231. (#135154, #134083, #136023, #135945, #135954, #135081, #135854) Thanks @brettdaman, @obviyus, @edenfunf, @VACInc, @abacha, @leilei3167, @yetval, @ruel225, @JosephNatsu, @akagifreeez, @tomroberts78, and @nikolascostello.</li>
-<li><strong>Cron and heartbeat:</strong> cancelled runs settle without ending cron retries early, <code>NO_REPLY</code> is preserved after tool calls, proven-not-sent announce deliveries retry, failure-alert outcomes persist, one-shot retries survive startup recovery, immediate main-session wakes are admitted with heartbeat disabled, the first-alert preamble shows once for isolated routes, the configured watchdog timeout is honored, scheduled replies bind to the published runtime, and ISO dates honor time zones. Related #133743, #133785, #135658, #135836, #134500, #135205, #135435, #136225. (#133747, #135919, #135985, #135516, #135083, #134648, #135849, #135925, #136256, #135973, #135155) Thanks @shakkernerd, @leilei3167, @obviyus, @Frank683456, @gaoanze888, @yetval, @RayWangyangMa, @rwinkelman, @sunlit-deng, @LowCode191, @virtexvirtuoso, @xialonglee, @jaxonparrott, @Famyoff, and @brettdaman.</li>
-<li><strong>Cron configuration:</strong> kind changes work without an env object, isolated <code>cron add</code> no longer hides a fail-closed announce route, jobs are created with configured Codex app-server auth, legacy shorthand schedules validate their payload, history pages after visibility filtering, Doctor refuses store rewrites another process committed after its snapshot, and account identities are no longer suggested as recipients. Related #134895, #136042. (#134639, #135003, #134525, #135829, #136043, #127999, #134368) Thanks @solomonneas, @ericcaiwx-star, @obviyus, @sjf-oa, @sjf, @teddytennant, @yetval, and @BryanTegomoh.</li>
-<li><strong>Sessions and runs:</strong> a cyclic session parent chain no longer hangs context building, the Gateway survives late CLI output after a timeout, restart drain counts as ingress idle, stale CLI recovery cannot replace newer sessions, yielded CLI spawns settle, BOOT.md runs when a previous boot session exists, oversized transcript archives stream instead of loading whole, queued cold turns keep CLI continuity, and worktree restore capacity advice is correct. Related #132581, #124343, #134748. (#131567, #132582, #133871, #135168, #134974, #134831, #136171, #136283, #136644, #136717) Thanks @igs-rogenlo, @TARSDrakon, @SebTardif, @obviyus, @mushuiyu886, @VACInc, @aoclaw-glitch, @miguelarios, @efe-arv, @liri-ha, and @anyech.</li>
-<li><strong>Tool results and edits:</strong> <code>oc-path</code> patches preserve exact edit bytes, PDF and image analysis survive Code Mode, plugin tools are kept for namespaced allowlist entries, exec selects capable nodes and reports its target, failed <code>/bash</code> commands show their real exit status, <code>sessions_spawn</code> declares its completion-message expectation, and failed-exec warnings are preserved on silent turns. Related #136530, #132750, #131765, #133385, #75848, #135068. (#136531, #135037, #132753, #131767, #133414, #136570, #135119, #132756) Thanks @tommyjoseph, @vyctorbrzezowski, @MoerAI, @alfredjbclaw, and @sashankh.</li>
-<li><strong>Markdown, links, and media:</strong> task lists survive chunk boundaries, literal Markdown and balanced image URLs are preserved, complete markdown links are parsed and link preprocessing is cancelled with the reply, UTF-8 attachments are recognized across sniff boundaries and keep their types when chunks are reused, inferred text is preserved while downloads are rejected promptly, fractional storage limits are reported accurately, and attachment failure cards stay out of durable model history. Related #127637, #135921, #135922, #136397, #135061, #136139, #136140. (#135200, #136228, #135341, #132883, #135227, #135232, #135928, #136402, #135185, #136685) Thanks @teddytennant, @obviyus, @SunnyShu0925, @ly85206559, @gaoanze888, and @snls1994.</li>
-<li><strong>Slack:</strong> replies to existing threads send again, Agent View DMs keep their per-root sessions after a Gateway restart in HTTP mode and collapse correctly when Slack rejects the prompts probe, short replies arrive before progress finalization, quiet previews stay on the latest preamble, socket and relay accounts start without an unused signing secret, pre-dispatch rejections are surfaced, agent RPC messages use the configured identity, and Enterprise thread lookups are not duplicated. Related #126872. (#136566, #136559, #136510, #136460, #134716, #136092, #134827, #132723, #122078, #121598) Thanks @danielduerr, @pash-openai, @zhangguiping-xydt, @Iskam31, and @mikasa0818.</li>
-<li><strong>Discord:</strong> webhook reply limits and delivery outcomes are preserved, missing response IDs no longer falsely confirm delivery, model picker choices apply without false failures, session-busy notices honor reply visibility, error replies stop after a voice consult is cancelled, and voice capture is bound to one lifecycle owner. Related #135946, #135947, #133550, #135442, #135340. (#135963, #136620, #135382, #135444, #135380, #135870) Thanks @Call44 and @LZY3538.</li>
-<li><strong>Telegram and WhatsApp:</strong> durably queued Telegram callbacks are acknowledged promptly, WhatsApp replies are sent unquoted when the quote cache misses so bubbles never render blank, and Doctor reports shadowed ack emoji and lossy acknowledgement scope migrations. Related #133294, #127948, #119317, #112796. (#133379, #127959, #119501, #129825) Thanks @zhangguiping-xydt, @Paeddy87, @Finn763, @markswitch83, @harjothkhara, @obviyus, @abacha, and @yetval.</li>
-<li><strong>iMessage, Signal, Google Chat, Teams, Matrix, Feishu, Twitch, Tlon:</strong> iMessage sends fail fast after the private-API bridge dies and remote attachments survive materialization, Signal publishes terminal status on permanent SSE rejection and rejects invalid UTF-8, Google Chat labeled links keep labels with spaces, Teams keeps thread context without a replyToId and Doctor can load its state checker after a source build, Matrix keeps code out of spoiler collisions and persists its sync cache after schema upgrades, Feishu validates document API outcomes, Twitch names the <code>accessToken</code> key in setup errors, and Tlon preserves parser progress. Related #135860, #136104, #129344, #136499, #134741. (#134572, #136301, #136178, #121569, #136151, #129345, #136509, #128453, #134742, #135106, #135421, #135181) Thanks @omarshahine, @zhangguiping-xydt, @obviyus, @zqchris, @masatohoshino, @sunlit-deng, @ericcaiwx-star, @KimOckHyun, @amalysh, @ruel225, @w9n, and @ly85206559.</li>
-<li><strong>Channel accounts and delivery:</strong> HTTP routes are scoped to account lifetimes, rejected webhook connections are released after answering, failed plugin accounts appear in status and health, explicitly disabled manifest accounts are omitted, explicit channels resolve through the scoped plugin registry, capability timeout reports stay alive, message plugin cleanup runs before the CLI exits, and the selected agent is preserved during plugin discovery. Related #132886, #126808, #135573, #136538, #136563. (#133297, #126818, #135082, #135417, #135831, #136539, #136564, #135505) Thanks @zhangguiping-xydt, @goffern, @edenfunf, @obviyus, @ly85206559, @ruel225, and @TailsProwerWorks.</li>
-<li><strong>Voice, Talk, and TTS:</strong> voice-call setup reports missing agent ownership, diagnostic logs stream with backpressure, host cancellation is not reported as a tool failure, Talk consults keep their owner across clients and internal prompts out of later context, narration requests are cancelled when their turn ends, terminal command replies stay text-only, local CLI synthesis inherits request timeouts, OpenAI OAuth audio transcription works again, and Volcengine TTS rejects invalid UTF-8. Related #132619, #134883, #126730, #82582, #96135. (#134739, #134838, #134924, #135031, #135423, #134839, #134802, #135222, #135855, #134010) Thanks @felixboenkost-droid, @sunlit-deng, @astra-openclaw, @najef1979-code, @yungchentang, @kAIborg24, and @ZengWen-DT.</li>
-<li><strong>Web chat and Control UI recovery:</strong> replies to attachment-only assistant messages are restored, replies appear above queued prompts and hydrated replies reconcile by identity during recovery, WebChat reset denials show without admin scope, Ask OpenClaw connections and conversation recovery are restored, and cloud sessions can be restored from Chat or kept stopped with cleanup failures surfaced. Related #135507, #135533, #134679, #134727, #134506. (#135393, #135568, #135715, #134696, #134776, #135024, #135583) Thanks @starship863, @jalehman, @rwinkelman, and @obviyus.</li>
-<li><strong>Control UI chat:</strong> new-session sends show immediately under load, sent images stay visible during history handoff and stable on hover, loaded images survive Gateway outages, late dictation transcripts are kept after Stop, the selected agent stays on native progress cards and dashboards, interrupted runs retire from history, commentary reconciles by run and item identity, and speaker names survive conversation exports. Related #135026, #135156, #136437. (#136069, #136072, #136440, #136446, #135109, #135426, #134714, #134457, #134888, #136439) Thanks @obviyus, @jadabreu, @rwinkelman, @Synthetic2802, and @RomneyDa.</li>
-<li><strong>Control UI details:</strong> wildcard tool policies display correctly, compact output token counts return, tool-only model auth rows are ignored, the model picker discloses its write scope, unavailable agent harnesses and trusted-proxy login failures are explained, OAuth errors are concise, heartbeat scratch loads read-only, automation links open beyond the loaded page, equivalent Usage filters clear from their menus, format-constrained settings stay editable, the chat face switch gets icons and embedded visibility with standardized menu options, sharing member lists load with skeletons, model provider refresh status is aligned, Inbox stays out of Settings, and the macOS composer shows the Default permission icon. Related #134306, #134304, #135556, #134916, #135457, #135948, #136568, #135720, #134409. (#135786, #135951, #134218, #134473, #135118, #135584, #135112, #135508, #136012, #136569, #136603, #136602, #136646, #136647, #136648, #136649, #136650, #136609, #135722, #134413) Thanks @wantosure, @fuller-stack-dev, @goslingmanagment, @shakkernerd, @gaoanze888, @obviyus, @itsuzef, @Patrick-Erichsen, and @vyctorbrzezowski.</li>
-<li><strong>Control UI sessions and boards:</strong> pinned sessions show a filled neutral pin without repeating titles, group titles stay on one marquee line, question sessions stay on one line, rewind hides while the agent works, task reviews fill the side panel, tall task progress scrolls, board widgets replace on put and Remove matches its menu, Workboard task links recover after cursor rejection, and free-text questions are separated from optionless ones. Related #134647, #135705, #134477. (#134775, #134651, #135523, #136606, #135521, #135926, #134517, #135748, #136637, #136619, #134598, #135524, #136607, #136614, #136527, #136668, #134631, #134732, #134860, #134791, #134653, #134833, #135008, #135681, #135957, #134686, #135724, #136002) Thanks @Patrick-Erichsen, @obviyus, @asgeirtj, @VACInc, @teddytennant, @shakkernerd, @goslingmanagment, and @Grynn.</li>
-<li><strong>Pull request tooling in the Control UI:</strong> an explicitly approved replacement head is recovered, merge receipts finish when main advances, merges invoked from another checkout are recovered, ignored files are preserved, quota failures are distinguished from authentication errors, and GitHub sign-in works when anonymous API quota is exhausted with the CLI preflighted before device authorization. Related #135496, #135335, #134701, #135872, #135028. (#135622, #135396, #134778, #135500, #135657, #135873, #134724, #135301) Thanks @mushuiyu886, @obviyus, and @jadabreu.</li>
-<li><strong>macOS app fixes:</strong> confirmed setup cancellation and onboarding failures are shown clearly with retry actions, misleading AI setup progress is replaced, computer input works after execution, bounded native pipe reads and final drains are centralized, native notifications are cancelled before side effects, and completions are delivered before notification status arrives. Related #134573, #134800, #134621, #136206, #136207, #136208. (#134654, #134756, #135041, #134689, #136214, #135796, #136683) Thanks @gaoanze888 and @wbstrbt.</li>
-<li><strong>iOS fixes:</strong> assistant text selection survives long press, duplicate replies after a history refresh are gone, and dependency resolution works with WebRTC 152. Related #135217, #135249. (#135430, #135789, #134942) Thanks @Solvely-Colin and @nikolaihack.</li>
-<li><strong>Android fixes:</strong> sends are prevented with auth-unavailable models, credentials are masked with correct secret input behavior, reconnect cleanup stays scoped to its connection, reconnected and queued messages no longer get stuck or reappear after deletion, health is rechecked when Refresh races a queued send, chat choices and live appearance updates are preserved, narrow composers stay readable, the settings conversation keeps its position, and refresh results and progress stay current. Related #135874, #136047, #128926, #136638. (#134884, #136352, #135878, #135961, #136161, #136413, #136173, #135432, #136550, #136643) Thanks @fuller-stack-dev and @aniruddhaadak80.</li>
-<li><strong>Installers:</strong> Windows installs tolerate npm stderr warnings, use basic parsing for MinGit downloads, and keep the portable Node extraction fallback; the installer no longer points at a log that does not exist; Docker images install <code>libgomp1</code> for managed llama.cpp and build the explicitly selected WhatsApp plugin; and source installs use isolated linking to reduce filesystem churn. Related #134638, #134439, #120659. (#134385, #134412, #135410, #134655, #134532, #120660, #135728) Thanks @ly85206559, @mohamedelrefaiy, @chelsealong, @henrique-simoes, and @fr-meyer.</li>
-<li><strong>Plugins:</strong> orphan installs recover without weakening ownership, ambiguous copied plugin paths are rejected, build stamps are ignored in registry freshness, plugin load errors survive retries, complete config errors are reported, the Weixin package compatible with the current SDK is selected, scoped ClawHub specs match in uninstall warnings, optional hook-pack dependencies install, inspection diagnostics and configured policy are preserved, lifecycle-less prepared channel turns run, packaged setup and TSX build artifacts resolve, the persisted registry refreshes when source mounts change, and plugin updates rediscover restored payloads instead of reusing stale cached facts after a reinstall. Related #134321, #136357, #134657, #136046, #136594, #136595, #114020, #135990, #136455, #136456, #136516. (#134590, #136373, #134780, #134874, #93842, #134854, #135749, #136050, #136596, #135179, #135993, #135245, #135820, #134719, #136458, #136517) Thanks @MoerAI, @obviyus, @abacha, @LiuwqGit, @Dresch63, @RayWangyangMa, @axiom-ncis, @bladin, @teddytennant, @nissl24, @fridaylans2000-art, @jooey, and @ssaade01.</li>
-<li><strong>Memory:</strong> automatic reindex recovers after concurrent writes, orphaned workspace locks recover after PID reuse, deep consolidation works with explicit ownership, clean transient CLI searches stay off the reindex path, index identity mismatches are attributed, unnecessary full rebuilds are avoided, replies stay responsive during legacy index repair, cache overflow is prevented during forced reindex, embeddings honor the environment proxy and resolve profile auth, and embedded session recall returns the newest history. Related #134332, #134999, #134687, #135459, #135641, #134337, #135414, #136656. (#134333, #135051, #135166, #135520, #135864, #136064, #135062, #135373, #134858, #134744, #135415, #136657, #131329) Thanks @TheAngryPit, @obviyus, @pengzh1, @gru-10k, @zhangguiping-xydt, @giangthb, @gaoanze888, @LifeViwer, @yetval, @CjTruHeart, @ThatGuySizemore, @Artemeey, @0x-Parzival, and @hartmark.</li>
-<li><strong>Model harness selection:</strong> model selections without an activatable harness are rejected with the reason explained, utility completions route through the selected runtime, scheduled model aliases stay scoped to the selected agent, <code>models status</code> skips refresh with a matching agent directory override, harness policy reasons are preserved, and the Claude subprocess keeps its failure diagnostics. Related #134305, #134304, #135566, #134690. (#134837, #135118, #135711, #135069, #134862, #135206, #134794) Thanks @fuller-stack-dev and @goslingmanagment.</li>
-<li><strong>Providers and CLIs on PATH:</strong> claude-cli connects through PATH shims, Windows bare commands resolve through PATHEXT with empty entries dropped, native Claude login is preserved for blank node-host credentials, the CLI-backend run honors the fallback delegation gate, Responses continuations survive admitted tool arguments and exclude tools from the request-equality check, zai honors <code>thinkingLevelMap</code>, DeepInfra refreshes estimates from native pricing, Model Studio cache defaults are honored, Bedrock rejects malformed embedding encodings, and OpenCode Go sends the required User-Agent. Related #135013, #134960, #134709, #135538. (#135124, #135138, #135807, #134932, #115405, #134423, #132951, #132697, #134893, #135093, #133716, #135588) Thanks @zhangguiping-xydt, @obviyus, @masatokawano, @gaoanze888, @Vasanthdev2004, @teddytennant, @MertBasar0, @hartmark, @wangjx-xydt, @RileyJJY, and @VACInc.</li>
-<li><strong>Local models:</strong> llama.cpp context-size-exceeded is treated as overflow, managed release archives extract safely, managed server inspection responses are bounded, and local providers are stopped before Gateway shutdown. Related #133860, #134649. (#133888, #129035, #132490, #134890) Thanks @gokay-ai, @cursoragent, @Areson, @pgondhi987, @RileyJJY, @MoerAI, @obviyus, and @Deregtx.</li>
-<li><strong>MCP and tools:</strong> OAuth-authenticated MCP requests carry a Content-Length, MCP runtimes are not evicted during requester resolution, MCP lint finishes when SQLite is busy, <code>agents_wait</code> deadlines stay monotonic, approval grant lifetimes are validated, terminal summaries release after nested calls settle, and tool-loop warnings are bucketed. Related #136204, #134605. (#136234, #134819, #134698, #135292, #133806, #135398, #135103) Thanks @LiuwqGit, @obviyus, @Volevanius, @qingminglong, and @pfrederiksen.</li>
-<li><strong>Browser tool:</strong> tab enumeration has its own budget separate from the CDP handshake timeout, messages are no longer interrupted during startup recovery, standalone routing errors and cropped screenshots are avoided, native action cancellation is isolated by page, and stale group updates no longer revoke valid commands. Related #132452, #136464, #135176. (#135219, #135016, #135315, #136465, #135186) Thanks @SunnyShu0925, @obviyus, @alexph-dev, @jesse-merhi, and @rwinkelman.</li>
-<li><strong>Nodes and devices:</strong> the <code>openclaw node</code> worker exits after a stop even with stdin held open, same-install CLI nodes are classified correctly, ambiguity between current node clients is preserved, recently connected nodes stay in list age filters, remote exec hides without an executable node, node wakes retry after clock rollback, presence expires after rollback and stays bounded, and the rejected setup-code warning is clarified. Related #135661, #136593, #136635, #135914. (#135665, #136604, #136636, #135936, #136067, #133354, #134737, #134740, #134795, #136654) Thanks @Colton-Harris, @obviyus, @qingminglong, @lzhan011, @0x-Parzival, and @eleqtrizit.</li>
-<li><strong>Gateway networking:</strong> SSH tunnel stop awaits process reaping, probe tunnels are abortable and handle SIGINT/SIGTERM, listener timeouts ignore clock skew, long temp paths no longer break desktop tunnels, socat forwards that name OpenClaw are distinguished, the tailscale sudo fallback names the operator fix, Accept media-range precedence is honored, invalid <code>utcOffset</code> values are rejected, and usage peak hours survive daylight saving. Related #127457, #127591, #135706, #124567. (#133847, #135182, #135281, #135456, #133381, #135825, #118197, #124568, #135153, #125378) Thanks @aniruddhaadak80, @obviyus, @xialonglee, @ly85206559, @ericcaiwx-star, @cursoragent, @pengzh1, @ezimerman, @peterolkhov, @zyw02, @qdivan, and @tzlwn1.</li>
-<li><strong>Gateway serving and status:</strong> encoded and symlinked Control UI assets load, stale 304 responses are avoided, retained asset memory is bounded, APNG icons go through the shared image policy, small hosts no longer get false RSS critical alerts, delivery queue warnings appear in detailed status, active probes are reported when the preferred account is unconfigured, wait deadlines are not reported as draining, terminal timeout reasons stay in the sidebar, session-observer failures show their real cause, and method discovery no longer loads session storage. Related #136442, #136443, #135606, #136106, #136415, #136640, #136598, #135305. (#136444, #135619, #136108, #136417, #136641, #134889, #136599, #135797, #135466, #135337, #135102, #135105, #136676) Thanks @vincentkoc, @LiuwqGit, and @Cobblestone-Digital1.</li>
-<li><strong>Sessions store and CLI selectors:</strong> strict transcript appends work without a storePath, configured transcript stores are honored, incognito sessions stay in their explicit environment, ACP metadata comes from the selected agent, blank <code>--session-id</code>, <code>--session-key</code>, <code>--store</code>, <code>--every</code>, suspend wait, dead-letter, and agent selectors are rejected instead of silently defaulted, <code>--target-file</code> reads are bounded, and deeply nested config mutations are stack-safe. Related #136198, #136217, #136224, #136662, #129734. (#136201, #136221, #136227, #136280, #134797, #134799, #135742, #135270, #135848, #136664, #134957, #129918, #135273, #136574) Thanks @marmar9615-cloud, @obviyus, @qingminglong, @masatohoshino, @xialonglee, @SunnyShu0925, @hpyhandsome, and @SebTardif.</li>
-<li><strong>Skills and worktrees:</strong> one profile cannot exhaust pending ZIP imports, Doctor reports plugin version drift after upgrades and blocked workspace migration cleanup, tailscale-managed ingress recovers after upgrades, concurrent session starts avoid duplicate Git work, canonical skill names survive discovery and the Workshop, and ordinary replies no longer trigger eager skill discovery. Related #135587, #136493. (#135593, #134719, #134751, #135394, #134912, #136495, #136716) Thanks @jjjhenriksen.</li>
-<li><strong>Config and terminal output:</strong> the CLI suggests <code>config patch --file</code> when a shell strips JSON quotes, <code>openclaw config</code> shows approval allowlist no-op snapshots, tabbed table columns stay aligned, authored hyperlink destinations survive in the TUI, duration quantities are preserved across locales, and console trace stacks are kept without duplicate errors. Related #135164, #136573, #136468. (#135203, #136574, #136312, #136469, #133224, #136066, #135932) Thanks @SunnyShu0925 and @wojtek76.</li>
-<li><strong>Lower memory:</strong> reduce memory spikes in catalogs, resets, and chat, release retained Gateway and Activity memory, cut memory held by transcript scans and chat views, decode and capture large command output with less memory, drop repeated JSON copies of Code Mode results, release completed log payloads and evicted queue entries, and reduce memory used by HTTP response bodies and CodeMode between tool calls. (#134722, #134891, #135326, #135189, #135894, #135898, #135918, #136030, #136416, #134954, #135040, #135183, #136567, #136340)</li>
-<li><strong>Faster replies and streaming:</strong> less overhead for concurrent and long streaming replies, faster concurrent final-answer streaming, pending streamed replies kept current, reduced work during streaming event delivery, faster CodeMode and session lookup, reduced turn preparation, cheaper session metadata reads, lower approval tracking across concurrent runs, and faster fence-aware message chunking. Related #135750. (#136350, #135751, #136180, #136041, #136249, #136296, #134935, #134673, #136391, #136205, #135208, #135220, #135204, #135034, #135014, #134930, #135626, #135607, #136428, #136425, #136099, #135464, #135390, #135504, #135514) Thanks @quangtran88.</li>
-<li><strong>Faster startup and plugins:</strong> faster Doctor bootstrap and cold Doctor in built checkouts, CLI-only code no longer loads at startup, plugin catalogs and known contribution owners avoid full scans, catalog worker imports are scoped, verified metadata is reused during startup, unused discovery is skipped for read-only catalog queries, the Claude Code catalog refresh no longer re-scans the projects tree on every poll, and shell commands have shorter cold starts. Related #136385, #135893, #134864. (#136500, #136399, #133105, #135260, #135953, #135486, #136141, #136020, #136222, #136124, #134581, #134807, #134812, #134814, #135169, #135172, #135091, #135073, #135121, #136063, #136080, #136162, #136398, #136401, #136403, #136381, #135998, #135986, #135942, #135931, #135077, #135048, #135007) Thanks @ly85206559, @zeroaltitude, @obviyus, @LiuwqGit, and @rwinkelman.</li>
-<li><strong>Faster UI, terminal, and logging:</strong> cheaper Control UI history and config processing, side panel and Workboard styles load with their owners, Settings English is deferred, attributed Markdown and reply formatting allocate less, terminal tables and SGR handling avoid character arrays, and log formatting, payload counting, and tail trimming do less work. (#135851, #136186, #135131, #135950, #135725, #136014, #136389, #135473, #136451, #136479, #136380, #135602, #135625, #136435, #134979, #135974, #136028, #136393, #136404, #135476, #135477, #135475, #135597, #136450, #136457, #136418, #135094, #135107, #135116, #135162, #134978, #134988, #134998, #136377, #135135, #134746) Thanks @arpe1618 and @vincentkoc.</li>
-<li><strong>Compaction, updates, and diagnostics:</strong> update recovery modules load only when an update starts, the Docker upgrade survivor stops before the package update, diagnostics keep explicit fleet ownership and read-only work off the SQLite writer lifecycle, maintenance leases renew during synchronous work, and worker state closes before its runtime directory is removed. Related #135684. (#135942, #135561, #135447, #136010, #134880, #134911) Thanks @fuller-stack-dev, @obviyus, @Grynn, and @rwinkelman.</li>
-</ul>
-<h3>Complete contribution record</h3>
-This audited record covers the complete 999239d745d9cf73b0bf5c8791944565ecd3fcf2..c0433bc59efc6a6ccde0363dd6f5dabbbbc950f3 history: 1,195 in-range PRs + 0 retained seed-only PRs = 1,195 unique PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
-Shipped baseline exclusions: v2026.8.1 (14 PRs: #109622, #111527, #112678, #112967, #117561, #119051, #121394, #128548, #129174, #130030, #131220, #131228, #131717, #131811); v2026.8.2 (8 PRs: #133773, #133963, #134103, #134111, #134207, #134208, #134428, #134870).
-<h4>Pull requests</h4>
-<ul>
-<li><strong>PR #134568</strong> Related #134455. Thanks @shakkernerd.</li>
-<li><strong>PR #134083</strong> Related #132766. Thanks @edenfunf and @VACInc and @abacha.</li>
-<li><strong>PR #134478</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134637</strong></li>
-<li><strong>PR #134642</strong></li>
-<li><strong>PR #134645</strong></li>
-<li><strong>PR #134646</strong></li>
-<li><strong>PR #134652</strong></li>
-<li><strong>PR #134643</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134630</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134656</strong></li>
-<li><strong>PR #134661</strong></li>
-<li><strong>PR #134672</strong></li>
-<li><strong>PR #134671</strong></li>
-<li><strong>PR #134537</strong></li>
-<li><strong>PR #134627</strong></li>
-<li><strong>PR #134675</strong></li>
-<li><strong>PR #134676</strong></li>
-<li><strong>PR #134669</strong></li>
-<li><strong>PR #134590</strong> Related #134321. Thanks @MoerAI and @obviyus and @abacha.</li>
-<li><strong>PR #134593</strong></li>
-<li><strong>PR #134272</strong> Thanks @RileyJJY and @obviyus.</li>
-<li><strong>PR #134654</strong> Related #134573.</li>
-<li><strong>PR #134673</strong></li>
-<li><strong>PR #134677</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134694</strong></li>
-<li><strong>PR #134634</strong> Thanks @goslingmanagment and @dmsrg399.</li>
-<li><strong>PR #134698</strong> Related #134605. Thanks @obviyus and @pfrederiksen.</li>
-<li><strong>PR #134631</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134707</strong></li>
-<li><strong>PR #134641</strong> Related #134445. Thanks @leilei3167 and @obviyus and @rosssaunders.</li>
-<li><strong>PR #134536</strong></li>
-<li><strong>PR #134717</strong> Related #134407. Thanks @obviyus and @abacha.</li>
-<li><strong>PR #134702</strong></li>
-<li><strong>PR #134651</strong> Related #134647. Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134691</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134650</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134720</strong></li>
-<li><strong>PR #134704</strong> Related #134458. Thanks @obviyus and @Nielsh82.</li>
-<li><strong>PR #134693</strong></li>
-<li><strong>PR #134695</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134706</strong></li>
-<li><strong>PR #134728</strong></li>
-<li><strong>PR #134483</strong> Related #134340. Thanks @qdivan and @obviyus and @samson1357924.</li>
-<li><strong>PR #134733</strong></li>
-<li><strong>PR #134732</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134653</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134684</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134722</strong></li>
-<li><strong>PR #134716</strong> Thanks @pash-openai.</li>
-<li><strong>PR #134747</strong></li>
-<li><strong>PR #134581</strong></li>
-<li><strong>PR #134688</strong></li>
-<li><strong>PR #134754</strong></li>
-<li><strong>PR #134751</strong></li>
-<li><strong>PR #134668</strong></li>
-<li><strong>PR #132917</strong> Related #132862. Thanks @xydt-juyaohui and @obviyus and @lakemike.</li>
-<li><strong>PR #132199</strong> Thanks @africoding.</li>
-<li><strong>PR #134686</strong></li>
-<li><strong>PR #134626</strong></li>
-<li><strong>PR #134699</strong> Related #134204. Thanks @Patrick-Erichsen and @vyctorbrzezowski.</li>
-<li><strong>PR #134760</strong> Related #134256. Thanks @obviyus and @vdruts.</li>
-<li><strong>PR #134763</strong></li>
-<li><strong>PR #134765</strong> Related #131770. Thanks @obviyus and @LiuwqGit and @sblindt.</li>
-<li><strong>PR #134745</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #131619</strong> Thanks @MertBasar0.</li>
-<li><strong>PR #134746</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134517</strong> Thanks @VACInc.</li>
-<li><strong>PR #134724</strong></li>
-<li><strong>PR #134764</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134782</strong></li>
-<li><strong>PR #134473</strong> Related #134306. Thanks @fuller-stack-dev and @goslingmanagment.</li>
-<li><strong>PR #132727</strong> Thanks @qingminglong.</li>
-<li><strong>PR #134752</strong></li>
-<li><strong>PR #132868</strong> Thanks @CanReader and @obviyus.</li>
-<li><strong>PR #134172</strong> Related #134076. Thanks @RileyJJY and @beastyrabbit.</li>
-<li><strong>PR #134793</strong></li>
-<li><strong>PR #134659</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134792</strong></li>
-<li><strong>PR #134762</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134791</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #115405</strong> Thanks @MertBasar0.</li>
-<li><strong>PR #122726</strong> Related #122372. Thanks @191612731-cloud and @vincentkoc.</li>
-<li><strong>PR #134598</strong> Related #134477. Thanks @Patrick-Erichsen and @goslingmanagment.</li>
-<li><strong>PR #134632</strong></li>
-<li><strong>PR #134696</strong> Related #134679.</li>
-<li><strong>PR #129825</strong> Related #112796. Thanks @zhangguiping-xydt and @obviyus and @yetval.</li>
-<li><strong>PR #131567</strong> Thanks @igs-rogenlo.</li>
-<li><strong>PR #134351</strong> Related #134323.</li>
-<li><strong>PR #134739</strong> Related #132619. Thanks @felixboenkost-droid.</li>
-<li><strong>PR #134712</strong></li>
-<li><strong>PR #134758</strong></li>
-<li><strong>PR #124672</strong> Thanks @qingminglong.</li>
-<li><strong>PR #134778</strong> Related #134701.</li>
-<li><strong>PR #134708</strong> Related #134692.</li>
-<li><strong>PR #134775</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134636</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134825</strong></li>
-<li><strong>PR #122628</strong> Thanks @sunlit-deng and @obviyus.</li>
-<li><strong>PR #134719</strong></li>
-<li><strong>PR #134820</strong></li>
-<li><strong>PR #134811</strong></li>
-<li><strong>PR #134822</strong></li>
-<li><strong>PR #134808</strong> Related #132979. Thanks @fuller-stack-dev.</li>
-<li><strong>PR #127999</strong> Thanks @yetval and @obviyus.</li>
-<li><strong>PR #134759</strong></li>
-<li><strong>PR #134412</strong> Thanks @ly85206559.</li>
-<li><strong>PR #133354</strong> Thanks @qingminglong.</li>
-<li><strong>PR #134832</strong></li>
-<li><strong>PR #134814</strong></li>
-<li><strong>PR #134548</strong></li>
-<li><strong>PR #134844</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134833</strong></li>
-<li><strong>PR #133220</strong> Related #133171. Thanks @SunnyShu0925 and @ruel225.</li>
-<li><strong>PR #134836</strong></li>
-<li><strong>PR #134840</strong></li>
-<li><strong>PR #133414</strong> Related #133385. Thanks @MoerAI.</li>
-<li><strong>PR #134776</strong> Related #134727.</li>
-<li><strong>PR #134299</strong> Related #125694. Thanks @PollyBot13 and @kodi.</li>
-<li><strong>PR #134804</strong></li>
-<li><strong>PR #134847</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134845</strong></li>
-<li><strong>PR #134809</strong></li>
-<li><strong>PR #134805</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #133105</strong> Thanks @ly85206559.</li>
-<li><strong>PR #134838</strong> Thanks @sunlit-deng.</li>
-<li><strong>PR #134861</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134856</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134361</strong> Thanks @obviyus.</li>
-<li><strong>PR #134852</strong></li>
-<li><strong>PR #134877</strong></li>
-<li><strong>PR #134863</strong></li>
-<li><strong>PR #134821</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #114678</strong> Thanks @harjothkhara and @obviyus.</li>
-<li><strong>PR #134802</strong> Related #82582. Thanks @najef1979-code.</li>
-<li><strong>PR #132723</strong> Thanks @zhangguiping-xydt.</li>
-<li><strong>PR #134885</strong></li>
-<li><strong>PR #134660</strong> Related #134552.</li>
-<li><strong>PR #134874</strong></li>
-<li><strong>PR #134882</strong></li>
-<li><strong>PR #134674</strong></li>
-<li><strong>PR #134857</strong></li>
-<li><strong>PR #134894</strong></li>
-<li><strong>PR #132186</strong> Thanks @galiniliev.</li>
-<li><strong>PR #119501</strong> Related #119317. Thanks @harjothkhara and @obviyus and @abacha.</li>
-<li><strong>PR #134842</strong></li>
-<li><strong>PR #134879</strong></li>
-<li><strong>PR #134909</strong></li>
-<li><strong>PR #134824</strong></li>
-<li><strong>PR #134281</strong> Thanks @obviyus.</li>
-<li><strong>PR #132883</strong> Related #127637. Thanks @SunnyShu0925.</li>
-<li><strong>PR #134928</strong></li>
-<li><strong>PR #132756</strong> Thanks @sashankh.</li>
-<li><strong>PR #134923</strong></li>
-<li><strong>PR #134889</strong></li>
-<li><strong>PR #134927</strong> Related #134919.</li>
-<li><strong>PR #134828</strong> Related #134823.</li>
-<li><strong>PR #134860</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134936</strong></li>
-<li><strong>PR #134921</strong></li>
-<li><strong>PR #134932</strong></li>
-<li><strong>PR #134908</strong></li>
-<li><strong>PR #134933</strong></li>
-<li><strong>PR #134812</strong></li>
-<li><strong>PR #134813</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134930</strong></li>
-<li><strong>PR #102180</strong> Related #101672. Thanks @849261680 and @obviyus and @cpwilhelmi.</li>
-<li><strong>PR #132477</strong></li>
-<li><strong>PR #134837</strong> Related #134305. Thanks @fuller-stack-dev and @goslingmanagment.</li>
-<li><strong>PR #134827</strong></li>
-<li><strong>PR #134872</strong> Related #134848.</li>
-<li><strong>PR #134949</strong></li>
-<li><strong>PR #134742</strong> Related #134741. Thanks @w9n and @obviyus.</li>
-<li><strong>PR #134940</strong></li>
-<li><strong>PR #134935</strong></li>
-<li><strong>PR #134907</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #134950</strong></li>
-<li><strong>PR #134961</strong></li>
-<li><strong>PR #134912</strong></li>
-<li><strong>PR #134585</strong></li>
-<li><strong>PR #134905</strong></li>
-<li><strong>PR #134954</strong></li>
-<li><strong>PR #134973</strong></li>
-<li><strong>PR #134946</strong></li>
-<li><strong>PR #134881</strong></li>
-<li><strong>PR #134981</strong></li>
-<li><strong>PR #134942</strong></li>
-<li><strong>PR #134978</strong></li>
-<li><strong>PR #134601</strong></li>
-<li><strong>PR #131691</strong> Related #131491. Thanks @LiuwqGit and @meircohen.</li>
-<li><strong>PR #134711</strong> Thanks @qingminglong.</li>
-<li><strong>PR #134983</strong></li>
-<li><strong>PR #134926</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134979</strong></li>
-<li><strong>PR #134876</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134947</strong></li>
-<li><strong>PR #134904</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134934</strong></li>
-<li><strong>PR #134734</strong></li>
-<li><strong>PR #134884</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #134917</strong> Thanks @qingminglong.</li>
-<li><strong>PR #134958</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134962</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134948</strong></li>
-<li><strong>PR #134302</strong> Related #127403. Thanks @PollyBot13.</li>
-<li><strong>PR #134977</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134991</strong></li>
-<li><strong>PR #134893</strong> Related #134709.</li>
-<li><strong>PR #134986</strong></li>
-<li><strong>PR #134888</strong></li>
-<li><strong>PR #135011</strong></li>
-<li><strong>PR #134850</strong> Related #134841.</li>
-<li><strong>PR #134984</strong></li>
-<li><strong>PR #135001</strong></li>
-<li><strong>PR #134952</strong></li>
-<li><strong>PR #134607</strong> Thanks @vincentkoc and @obviyus.</li>
-<li><strong>PR #134725</strong> Related #134718.</li>
-<li><strong>PR #120105</strong> Thanks @qingminglong and @vincentkoc.</li>
-<li><strong>PR #135004</strong></li>
-<li><strong>PR #134964</strong></li>
-<li><strong>PR #135015</strong></li>
-<li><strong>PR #134913</strong></li>
-<li><strong>PR #135020</strong></li>
-<li><strong>PR #134998</strong></li>
-<li><strong>PR #134988</strong></li>
-<li><strong>PR #135021</strong></li>
-<li><strong>PR #134519</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135007</strong></li>
-<li><strong>PR #135008</strong></li>
-<li><strong>PR #134965</strong></li>
-<li><strong>PR #134466</strong></li>
-<li><strong>PR #134854</strong></li>
-<li><strong>PR #134966</strong></li>
-<li><strong>PR #135025</strong></li>
-<li><strong>PR #135040</strong></li>
-<li><strong>PR #135005</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134891</strong></li>
-<li><strong>PR #134839</strong></li>
-<li><strong>PR #135014</strong></li>
-<li><strong>PR #132627</strong> Thanks @Alix-007.</li>
-<li><strong>PR #134944</strong></li>
-<li><strong>PR #135012</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134992</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #135037</strong></li>
-<li><strong>PR #134807</strong></li>
-<li><strong>PR #134670</strong> Thanks @obviyus.</li>
-<li><strong>PR #134799</strong> Thanks @marmar9615-cloud.</li>
-<li><strong>PR #135050</strong></li>
-<li><strong>PR #135048</strong></li>
-<li><strong>PR #135027</strong></li>
-<li><strong>PR #134714</strong></li>
-<li><strong>PR #122730</strong> Related #121083. Thanks @191612731-cloud and @fujixm5.</li>
-<li><strong>PR #134875</strong> Related #134867.</li>
-<li><strong>PR #133778</strong> Thanks @qingminglong.</li>
-<li><strong>PR #120645</strong> Thanks @firepinn.</li>
-<li><strong>PR #135039</strong></li>
-<li><strong>PR #135046</strong> Related #134516. Thanks @goslingmanagment.</li>
-<li><strong>PR #134423</strong> Thanks @hartmark.</li>
-<li><strong>PR #135034</strong></li>
-<li><strong>PR #125791</strong> Thanks @santhiprakash.</li>
-<li><strong>PR #135029</strong></li>
-<li><strong>PR #135030</strong></li>
-<li><strong>PR #134862</strong></li>
-<li><strong>PR #120913</strong> Thanks @qingminglong.</li>
-<li><strong>PR #135033</strong></li>
-<li><strong>PR #135043</strong></li>
-<li><strong>PR #125378</strong> Thanks @qdivan.</li>
-<li><strong>PR #135047</strong></li>
-<li><strong>PR #135076</strong></li>
-<li><strong>PR #134740</strong> Thanks @lzhan011 and @0x-Parzival.</li>
-<li><strong>PR #134880</strong></li>
-<li><strong>PR #134385</strong> Thanks @ly85206559.</li>
-<li><strong>PR #135064</strong></li>
-<li><strong>PR #134831</strong> Related #134748. Thanks @miguelarios.</li>
-<li><strong>PR #134797</strong> Thanks @marmar9615-cloud.</li>
-<li><strong>PR #135065</strong></li>
-<li><strong>PR #134915</strong> Thanks @edenfunf.</li>
-<li><strong>PR #134902</strong></li>
-<li><strong>PR #135074</strong></li>
-<li><strong>PR #135066</strong></li>
-<li><strong>PR #135069</strong></li>
-<li><strong>PR #121569</strong> Thanks @sunlit-deng.</li>
-<li><strong>PR #135095</strong> Related #134731. Thanks @obviyus and @BoatAngle.</li>
-<li><strong>PR #133806</strong> Thanks @qingminglong.</li>
-<li><strong>PR #135072</strong></li>
-<li><strong>PR #135073</strong></li>
-<li><strong>PR #134010</strong> Thanks @ZengWen-DT.</li>
-<li><strong>PR #135078</strong></li>
-<li><strong>PR #134362</strong></li>
-<li><strong>PR #135094</strong></li>
-<li><strong>PR #133814</strong> Related #132147. Thanks @MoerAI and @vyctorbrzezowski.</li>
-<li><strong>PR #135070</strong></li>
-<li><strong>PR #135096</strong> Related #132605. Thanks @jodok.</li>
-<li><strong>PR #133297</strong> Related #132886. Thanks @zhangguiping-xydt and @goffern.</li>
-<li><strong>PR #135075</strong></li>
-<li><strong>PR #135101</strong></li>
-<li><strong>PR #135019</strong> Thanks @xialonglee and @obviyus.</li>
-<li><strong>PR #135062</strong></li>
-<li><strong>PR #132623</strong> Thanks @sunlit-deng.</li>
-<li><strong>PR #135031</strong> Related #126730. Thanks @astra-openclaw.</li>
-<li><strong>PR #135090</strong></li>
-<li><strong>PR #120161</strong> Thanks @qingminglong.</li>
-<li><strong>PR #134924</strong> Related #134883.</li>
-<li><strong>PR #135091</strong></li>
-<li><strong>PR #128453</strong> Thanks @ruel225.</li>
-<li><strong>PR #134892</strong></li>
-<li><strong>PR #135105</strong></li>
-<li><strong>PR #134835</strong> Related #134834.</li>
-<li><strong>PR #133716</strong> Thanks @RileyJJY.</li>
-<li><strong>PR #135107</strong></li>
-<li><strong>PR #135110</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #135103</strong></li>
-<li><strong>PR #121598</strong> Thanks @mikasa0818.</li>
-<li><strong>PR #135082</strong></li>
-<li><strong>PR #135120</strong></li>
-<li><strong>PR #135051</strong> Related #134999. Thanks @pengzh1 and @obviyus and @gru-10k.</li>
-<li><strong>PR #135098</strong></li>
-<li><strong>PR #135099</strong></li>
-<li><strong>PR #135116</strong></li>
-<li><strong>PR #135113</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #129035</strong> Thanks @pgondhi987.</li>
-<li><strong>PR #135108</strong></li>
-<li><strong>PR #135102</strong></li>
-<li><strong>PR #134221</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #135123</strong> Related #135104.</li>
-<li><strong>PR #134794</strong> Related #134690.</li>
-<li><strong>PR #135114</strong> Related #135089. Thanks @walker1211.</li>
-<li><strong>PR #64490</strong> Thanks @EdenKangdw and @walker1211.</li>
-<li><strong>PR #135121</strong></li>
-<li><strong>PR #135122</strong></li>
-<li><strong>PR #135119</strong> Related #135068.</li>
-<li><strong>PR #135128</strong></li>
-<li><strong>PR #135100</strong></li>
-<li><strong>PR #135141</strong></li>
-<li><strong>PR #134969</strong></li>
-<li><strong>PR #118197</strong> Thanks @peterolkhov.</li>
-<li><strong>PR #135042</strong> Related #134967. Thanks @ruel225 and @obviyus and @kiranvk-2011.</li>
-<li><strong>PR #120660</strong> Related #120659. Thanks @fr-meyer.</li>
-<li><strong>PR #135136</strong></li>
-<li><strong>PR #123220</strong> Thanks @wanyongstar.</li>
-<li><strong>PR #122078</strong> Thanks @Iskam31.</li>
-<li><strong>PR #123893</strong></li>
-<li><strong>PR #135003</strong> Related #134895. Thanks @ericcaiwx-star and @obviyus.</li>
-<li><strong>PR #135157</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #135006</strong> Related #134997.</li>
-<li><strong>PR #135109</strong> Related #135026. Thanks @obviyus and @jadabreu.</li>
-<li><strong>PR #135165</strong></li>
-<li><strong>PR #134890</strong> Related #134649. Thanks @MoerAI and @obviyus and @Deregtx.</li>
-<li><strong>PR #135161</strong></li>
-<li><strong>PR #135126</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #135063</strong></li>
-<li><strong>PR #134655</strong> Related #134638. Thanks @mohamedelrefaiy.</li>
-<li><strong>PR #135118</strong> Related #134304. Thanks @fuller-stack-dev and @goslingmanagment.</li>
-<li><strong>PR #135059</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134744</strong> Thanks @0x-Parzival.</li>
-<li><strong>PR #135162</strong></li>
-<li><strong>PR #134957</strong> Thanks @xialonglee and @obviyus.</li>
-<li><strong>PR #135172</strong></li>
-<li><strong>PR #135131</strong></li>
-<li><strong>PR #134490</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #135146</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #135125</strong></li>
-<li><strong>PR #135170</strong></li>
-<li><strong>PR #135169</strong></li>
-<li><strong>PR #135183</strong></li>
-<li><strong>PR #132951</strong> Thanks @hartmark.</li>
-<li><strong>PR #135158</strong></li>
-<li><strong>PR #134937</strong></li>
-<li><strong>PR #135201</strong></li>
-<li><strong>PR #133224</strong></li>
-<li><strong>PR #135159</strong></li>
-<li><strong>PR #135160</strong></li>
-<li><strong>PR #133268</strong> Related #132739. Thanks @edenfunf and @ml12580.</li>
-<li><strong>PR #135106</strong></li>
-<li><strong>PR #135204</strong></li>
-<li><strong>PR #135189</strong></li>
-<li><strong>PR #135181</strong></li>
-<li><strong>PR #135186</strong> Related #135176.</li>
-<li><strong>PR #135081</strong> Related #134971. Thanks @akagifreeez and @obviyus and @tomroberts78.</li>
-<li><strong>PR #135207</strong></li>
-<li><strong>PR #134780</strong> Related #134657. Thanks @RayWangyangMa and @obviyus and @axiom-ncis.</li>
-<li><strong>PR #134910</strong></li>
-<li><strong>PR #135153</strong></li>
-<li><strong>PR #135246</strong></li>
-<li><strong>PR #135257</strong></li>
-<li><strong>PR #135206</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #135259</strong></li>
-<li><strong>PR #134403</strong> Thanks @obviyus.</li>
-<li><strong>PR #135232</strong></li>
-<li><strong>PR #135220</strong></li>
-<li><strong>PR #135208</strong></li>
-<li><strong>PR #135258</strong></li>
-<li><strong>PR #132582</strong> Related #132581. Thanks @TARSDrakon.</li>
-<li><strong>PR #135145</strong></li>
-<li><strong>PR #135235</strong></li>
-<li><strong>PR #135222</strong></li>
-<li><strong>PR #135226</strong></li>
-<li><strong>PR #135265</strong></li>
-<li><strong>PR #135269</strong></li>
-<li><strong>PR #135271</strong></li>
-<li><strong>PR #135260</strong></li>
-<li><strong>PR #134738</strong> Thanks @eleqtrizit.</li>
-<li><strong>PR #135289</strong></li>
-<li><strong>PR #135275</strong></li>
-<li><strong>PR #135274</strong></li>
-<li><strong>PR #135245</strong> Thanks @ssaade01.</li>
-<li><strong>PR #135254</strong></li>
-<li><strong>PR #135285</strong></li>
-<li><strong>PR #135294</strong></li>
-<li><strong>PR #134903</strong></li>
-<li><strong>PR #134911</strong></li>
-<li><strong>PR #134779</strong> Related #134379. Thanks @leilei3167 and @obviyus and @aaajiao.</li>
-<li><strong>PR #135288</strong></li>
-<li><strong>PR #133799</strong></li>
-<li><strong>PR #135306</strong></li>
-<li><strong>PR #133379</strong> Related #133294. Thanks @zhangguiping-xydt and @Paeddy87.</li>
-<li><strong>PR #135124</strong> Related #135013. Thanks @zhangguiping-xydt and @obviyus and @masatokawano.</li>
-<li><strong>PR #135155</strong> Thanks @brettdaman and @obviyus.</li>
-<li><strong>PR #131456</strong> Related #131113. Thanks @gaoanze888 and @Grynn.</li>
-<li><strong>PR #135317</strong></li>
-<li><strong>PR #135319</strong></li>
-<li><strong>PR #135325</strong></li>
-<li><strong>PR #135148</strong></li>
-<li><strong>PR #135323</strong></li>
-<li><strong>PR #135326</strong></li>
-<li><strong>PR #131017</strong> Related #130918. Thanks @Alix-007 and @emes.</li>
-<li><strong>PR #135077</strong> Related #134864.</li>
-<li><strong>PR #132571</strong> Thanks @edenfunf.</li>
-<li><strong>PR #134980</strong> Related #134968. Thanks @Marvinthebored and @obviyus.</li>
-<li><strong>PR #135227</strong></li>
-<li><strong>PR #135312</strong></li>
-<li><strong>PR #135360</strong></li>
-<li><strong>PR #135322</strong></li>
-<li><strong>PR #135332</strong></li>
-<li><strong>PR #135321</strong></li>
-<li><strong>PR #135304</strong></li>
-<li><strong>PR #135313</strong></li>
-<li><strong>PR #134781</strong> Thanks @eleqtrizit.</li>
-<li><strong>PR #135138</strong> Related #134960. Thanks @gaoanze888 and @Vasanthdev2004.</li>
-<li><strong>PR #135346</strong></li>
-<li><strong>PR #135345</strong> Thanks @Takhoffman.</li>
-<li><strong>PR #135355</strong> Related #135140. Thanks @obviyus and @mattcbianco.</li>
-<li><strong>PR #135363</strong></li>
-<li><strong>PR #135287</strong></li>
-<li><strong>PR #134865</strong></li>
-<li><strong>PR #131329</strong> Thanks @hartmark.</li>
-<li><strong>PR #135369</strong></li>
-<li><strong>PR #135368</strong></li>
-<li><strong>PR #135353</strong></li>
-<li><strong>PR #135357</strong> Related #135079. Thanks @obviyus and @dannevang.</li>
-<li><strong>PR #135374</strong></li>
-<li><strong>PR #134974</strong> Related #124343. Thanks @VACInc and @aoclaw-glitch.</li>
-<li><strong>PR #135302</strong></li>
-<li><strong>PR #135382</strong> Related #133550. Thanks @Call44.</li>
-<li><strong>PR #135407</strong> Thanks @itsuzef.</li>
-<li><strong>PR #135279</strong> Thanks @qingminglong.</li>
-<li><strong>PR #135185</strong> Related #135061. Thanks @gaoanze888 and @obviyus and @snls1994.</li>
-<li><strong>PR #135373</strong></li>
-<li><strong>PR #135426</strong> Related #135156. Thanks @obviyus and @rwinkelman and @Synthetic2802.</li>
-<li><strong>PR #135303</strong></li>
-<li><strong>PR #134680</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #135444</strong> Related #135442.</li>
-<li><strong>PR #135390</strong></li>
-<li><strong>PR #135474</strong></li>
-<li><strong>PR #135336</strong></li>
-<li><strong>PR #118045</strong> Thanks @AAliKKhan.</li>
-<li><strong>PR #132370</strong> Related #132369. Thanks @jalehman.</li>
-<li><strong>PR #135454</strong> Related #135437.</li>
-<li><strong>PR #135380</strong> Related #135340.</li>
-<li><strong>PR #135393</strong></li>
-<li><strong>PR #135264</strong></li>
-<li><strong>PR #135367</strong></li>
-<li><strong>PR #135044</strong> Related #134306. Thanks @fuller-stack-dev and @goslingmanagment.</li>
-<li><strong>PR #135386</strong></li>
-<li><strong>PR #131767</strong> Related #131765. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #135428</strong></li>
-<li><strong>PR #135024</strong> Related #134506. Thanks @jalehman.</li>
-<li><strong>PR #134664</strong> Thanks @jalehman.</li>
-<li><strong>PR #135154</strong> Related #135149. Thanks @brettdaman and @obviyus.</li>
-<li><strong>PR #134068</strong> Related #133602.</li>
-<li><strong>PR #135497</strong></li>
-<li><strong>PR #135529</strong></li>
-<li><strong>PR #135239</strong> Related #135221. Thanks @Solvely-Colin.</li>
-<li><strong>PR #134365</strong> Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #135397</strong></li>
-<li><strong>PR #135112</strong> Related #134916. Thanks @shakkernerd.</li>
-<li><strong>PR #135431</strong></li>
-<li><strong>PR #135440</strong></li>
-<li><strong>PR #135432</strong></li>
-<li><strong>PR #135425</strong></li>
-<li><strong>PR #135543</strong></li>
-<li><strong>PR #135401</strong> Thanks @Colton-Harris.</li>
-<li><strong>PR #135495</strong> Thanks @lzhan011.</li>
-<li><strong>PR #135445</strong> Related #135361. Thanks @gaoanze888 and @Bloodis94.</li>
-<li><strong>PR #135391</strong> Thanks @Peetiegonzalez and @obviyus.</li>
-<li><strong>PR #134929</strong> Thanks @hannesrudolph.</li>
-<li><strong>PR #135392</strong></li>
-<li><strong>PR #135447</strong></li>
-<li><strong>PR #135460</strong></li>
-<li><strong>PR #134756</strong></li>
-<li><strong>PR #135464</strong></li>
-<li><strong>PR #135505</strong></li>
-<li><strong>PR #135342</strong></li>
-<li><strong>PR #135560</strong></li>
-<li><strong>PR #135500</strong></li>
-<li><strong>PR #135071</strong></li>
-<li><strong>PR #135423</strong></li>
-<li><strong>PR #135200</strong></li>
-<li><strong>PR #135568</strong> Related #135507.</li>
-<li><strong>PR #135572</strong></li>
-<li><strong>PR #135375</strong></li>
-<li><strong>PR #135195</strong> Related #135187. Thanks @edenfunf.</li>
-<li><strong>PR #135579</strong></li>
-<li><strong>PR #135405</strong></li>
-<li><strong>PR #135586</strong></li>
-<li><strong>PR #135523</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #135524</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #135595</strong> Thanks @hannesrudolph.</li>
-<li><strong>PR #134532</strong> Related #134439. Thanks @chelsealong and @henrique-simoes.</li>
-<li><strong>PR #135594</strong></li>
-<li><strong>PR #135412</strong></li>
-<li><strong>PR #135284</strong></li>
-<li><strong>PR #135557</strong></li>
-<li><strong>PR #134976</strong> Related #134975. Thanks @edenfunf.</li>
-<li><strong>PR #135559</strong></li>
-<li><strong>PR #134945</strong></li>
-<li><strong>PR #134572</strong> Thanks @omarshahine.</li>
-<li><strong>PR #135093</strong></li>
-<li><strong>PR #135600</strong></li>
-<li><strong>PR #127284</strong> Thanks @RomneyDa and @karkarl.</li>
-<li><strong>PR #135605</strong></li>
-<li><strong>PR #135598</strong></li>
-<li><strong>PR #135415</strong> Related #135414.</li>
-<li><strong>PR #124568</strong> Related #124567. Thanks @zyw02.</li>
-<li><strong>PR #135521</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #135514</strong></li>
-<li><strong>PR #135473</strong></li>
-<li><strong>PR #135574</strong></li>
-<li><strong>PR #135593</strong> Related #135587.</li>
-<li><strong>PR #135475</strong></li>
-<li><strong>PR #135504</strong></li>
-<li><strong>PR #135602</strong></li>
-<li><strong>PR #135477</strong></li>
-<li><strong>PR #135563</strong></li>
-<li><strong>PR #135624</strong></li>
-<li><strong>PR #135597</strong></li>
-<li><strong>PR #135577</strong> Related #135338.</li>
-<li><strong>PR #135644</strong></li>
-<li><strong>PR #135592</strong></li>
-<li><strong>PR #135651</strong></li>
-<li><strong>PR #135421</strong> Thanks @ly85206559.</li>
-<li><strong>PR #135601</strong></li>
-<li><strong>PR #135640</strong></li>
-<li><strong>PR #135638</strong> Related #135623.</li>
-<li><strong>PR #135669</strong></li>
-<li><strong>PR #135611</strong></li>
-<li><strong>PR #135476</strong></li>
-<li><strong>PR #135210</strong></li>
-<li><strong>PR #135643</strong></li>
-<li><strong>PR #135398</strong></li>
-<li><strong>PR #133897</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #122586</strong> Related #68170. Thanks @vincentkoc and @lidge-jun and @richard-scott.</li>
-<li><strong>PR #135273</strong> Thanks @SebTardif.</li>
-<li><strong>PR #134443</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135625</strong></li>
-<li><strong>PR #135585</strong></li>
-<li><strong>PR #135626</strong></li>
-<li><strong>PR #135607</strong></li>
-<li><strong>PR #135616</strong></li>
-<li><strong>PR #135667</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #134457</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135662</strong></li>
-<li><strong>PR #126887</strong> Thanks @vincentkoc and @RomneyDa.</li>
-<li><strong>PR #134613</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #134614</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #134615</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135622</strong> Related #135496.</li>
-<li><strong>PR #135177</strong></li>
-<li><strong>PR #135619</strong> Related #135606.</li>
-<li><strong>PR #135650</strong> Related #135565.</li>
-<li><strong>PR #135674</strong></li>
-<li><strong>PR #126473</strong> Related #126436. Thanks @ayaangazali and @Oliverbot26.</li>
-<li><strong>PR #99864</strong> Related #99843. Thanks @LZY3538 and @ayaangazali and @jrex-jooni.</li>
-<li><strong>PR #135672</strong></li>
-<li><strong>PR #135629</strong> Related #135613.</li>
-<li><strong>PR #135547</strong> Related #135535. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #135501</strong></li>
-<li><strong>PR #135681</strong> Related #135575.</li>
-<li><strong>PR #135617</strong></li>
-<li><strong>PR #135680</strong></li>
-<li><strong>PR #135608</strong></li>
-<li><strong>PR #135685</strong></li>
-<li><strong>PR #135687</strong></li>
-<li><strong>PR #133091</strong> Related #127333. Thanks @SunnyShu0925.</li>
-<li><strong>PR #135174</strong></li>
-<li><strong>PR #135470</strong></li>
-<li><strong>PR #135609</strong> Related #135352.</li>
-<li><strong>PR #135698</strong></li>
-<li><strong>PR #135719</strong></li>
-<li><strong>PR #135703</strong></li>
-<li><strong>PR #135718</strong> Related #135233. Thanks @boramyleng.</li>
-<li><strong>PR #135725</strong></li>
-<li><strong>PR #134549</strong> Related #120134. Thanks @nerclid and @w1130150306.</li>
-<li><strong>PR #135723</strong></li>
-<li><strong>PR #135526</strong> Related #135506. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #129402</strong> Related #129401. Thanks @ashawwal.</li>
-<li><strong>PR #135712</strong></li>
-<li><strong>PR #135337</strong> Related #135305. Thanks @LiuwqGit and @Cobblestone-Digital1.</li>
-<li><strong>PR #135702</strong> Related #37634. Thanks @whyuds.</li>
-<li><strong>PR #135670</strong></li>
-<li><strong>PR #135721</strong></li>
-<li><strong>PR #135735</strong></li>
-<li><strong>PR #135741</strong></li>
-<li><strong>PR #135451</strong> Related #135450.</li>
-<li><strong>PR #135315</strong></li>
-<li><strong>PR #129345</strong> Related #129344. Thanks @amalysh.</li>
-<li><strong>PR #121618</strong> Thanks @fr-meyer.</li>
-<li><strong>PR #135697</strong> Related #135693.</li>
-<li><strong>PR #135752</strong></li>
-<li><strong>PR #135739</strong> Related #135385. Thanks @Deregtx.</li>
-<li><strong>PR #135724</strong> Related #135691.</li>
-<li><strong>PR #135653</strong></li>
-<li><strong>PR #135394</strong> Thanks @jjjhenriksen.</li>
-<li><strong>PR #135080</strong></li>
-<li><strong>PR #135711</strong> Related #135566. Thanks @goslingmanagment.</li>
-<li><strong>PR #135733</strong></li>
-<li><strong>PR #132379</strong> Related #132347. Thanks @wangmiao0668000666.</li>
-<li><strong>PR #135755</strong> Related #134331. Thanks @jjjhenriksen and @Deregtx.</li>
-<li><strong>PR #134939</strong> Thanks @IWhatsskill and @obviyus.</li>
-<li><strong>PR #135639</strong></li>
-<li><strong>PR #135763</strong></li>
-<li><strong>PR #133847</strong> Related #127457. Thanks @aniruddhaadak80 and @obviyus.</li>
-<li><strong>PR #135715</strong> Related #135533. Thanks @starship863.</li>
-<li><strong>PR #135229</strong> Related #135228. Thanks @edenfunf.</li>
-<li><strong>PR #135713</strong> Related #135150. Thanks @Zak-Finance.</li>
-<li><strong>PR #135701</strong> Related #135655.</li>
-<li><strong>PR #135396</strong> Related #135335.</li>
-<li><strong>PR #135736</strong> Related #135634, #135635, #135637, #135656.</li>
-<li><strong>PR #135580</strong> Related #135530. Thanks @VACInc.</li>
-<li><strong>PR #135097</strong></li>
-<li><strong>PR #135781</strong></li>
-<li><strong>PR #135203</strong> Related #135164. Thanks @SunnyShu0925 and @wojtek76.</li>
-<li><strong>PR #135772</strong></li>
-<li><strong>PR #135647</strong> Related #135630.</li>
-<li><strong>PR #135270</strong> Thanks @qingminglong.</li>
-<li><strong>PR #135292</strong> Thanks @qingminglong.</li>
-<li><strong>PR #135564</strong> Related #135562. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #135753</strong></li>
-<li><strong>PR #135787</strong></li>
-<li><strong>PR #135792</strong></li>
-<li><strong>PR #135790</strong> Related #135785.</li>
-<li><strong>PR #135799</strong></li>
-<li><strong>PR #135769</strong></li>
-<li><strong>PR #135456</strong> Thanks @ly85206559.</li>
-<li><strong>PR #135804</strong></li>
-<li><strong>PR #135806</strong></li>
-<li><strong>PR #129930</strong> Thanks @ralphptorres.</li>
-<li><strong>PR #135766</strong></li>
-<li><strong>PR #134218</strong> Thanks @wantosure.</li>
-<li><strong>PR #135584</strong> Related #135556.</li>
-<li><strong>PR #135805</strong> Thanks @hannesrudolph.</li>
-<li><strong>PR #135810</strong></li>
-<li><strong>PR #135417</strong> Thanks @ly85206559.</li>
-<li><strong>PR #135583</strong></li>
-<li><strong>PR #135817</strong></li>
-<li><strong>PR #126818</strong> Related #126808. Thanks @edenfunf and @obviyus.</li>
-<li><strong>PR #135561</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #131400</strong> Related #131231. Thanks @LiuwqGit and @obviyus and @srb11e.</li>
-<li><strong>PR #135791</strong> Related #134353. Thanks @xiaomijituan.</li>
-<li><strong>PR #135439</strong> Related #135365.</li>
-<li><strong>PR #135797</strong></li>
-<li><strong>PR #135182</strong> Related #127591. Thanks @aniruddhaadak80 and @obviyus.</li>
-<li><strong>PR #135823</strong></li>
-<li><strong>PR #133888</strong> Related #133860. Thanks @gokay-ai and @cursoragent and @Areson.</li>
-<li><strong>PR #135728</strong></li>
-<li><strong>PR #132697</strong> Thanks @wangjx-xydt.</li>
-<li><strong>PR #135820</strong> Related #135819.</li>
-<li><strong>PR #135756</strong></li>
-<li><strong>PR #134639</strong> Thanks @solomonneas.</li>
-<li><strong>PR #135818</strong></li>
-<li><strong>PR #135784</strong></li>
-<li><strong>PR #70002</strong> Thanks @xudaiyanzi.</li>
-<li><strong>PR #135738</strong></li>
-<li><strong>PR #135822</strong> Thanks @hannesrudolph.</li>
-<li><strong>PR #135761</strong> Related #135664.</li>
-<li><strong>PR #134755</strong> Related #99272, #122233. Thanks @obviyus and @ernestrolfson-design.</li>
-<li><strong>PR #135179</strong> Related #114020. Thanks @nissl24 and @fridaylans2000-art and @obviyus and @jooey.</li>
-<li><strong>PR #135833</strong></li>
-<li><strong>PR #135657</strong></li>
-<li><strong>PR #135135</strong> Thanks @arpe1618.</li>
-<li><strong>PR #135834</strong></li>
-<li><strong>PR #135849</strong> Related #135205. Thanks @obviyus and @virtexvirtuoso.</li>
-<li><strong>PR #135765</strong></li>
-<li><strong>PR #135816</strong></li>
-<li><strong>PR #135830</strong> Related #135218. Thanks @obviyus and @ericcaiwx-star and @jarvismazz.</li>
-<li><strong>PR #135751</strong> Related #135750.</li>
-<li><strong>PR #135832</strong></li>
-<li><strong>PR #135850</strong></li>
-<li><strong>PR #135854</strong> Related #135231. Thanks @obviyus and @nikolascostello.</li>
-<li><strong>PR #135168</strong> Thanks @mushuiyu886 and @obviyus.</li>
-<li><strong>PR #135740</strong> Related #135515.</li>
-<li><strong>PR #135166</strong> Related #134687. Thanks @zhangguiping-xydt and @obviyus and @giangthb.</li>
-<li><strong>PR #135466</strong></li>
-<li><strong>PR #135844</strong></li>
-<li><strong>PR #135812</strong></li>
-<li><strong>PR #135041</strong> Related #134800.</li>
-<li><strong>PR #135875</strong></li>
-<li><strong>PR #135885</strong> Related #135852.</li>
-<li><strong>PR #135193</strong> Related #135086. Thanks @Alix-007 and @obviyus and @wave-workflow.</li>
-<li><strong>PR #135902</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135870</strong> Thanks @LZY3538.</li>
-<li><strong>PR #135795</strong></li>
-<li><strong>PR #135894</strong></li>
-<li><strong>PR #135891</strong></li>
-<li><strong>PR #135869</strong></li>
-<li><strong>PR #135903</strong> Related #135896.</li>
-<li><strong>PR #135904</strong></li>
-<li><strong>PR #135898</strong></li>
-<li><strong>PR #135901</strong> Related #135899.</li>
-<li><strong>PR #135873</strong> Related #135872.</li>
-<li><strong>PR #135915</strong></li>
-<li><strong>PR #135926</strong> Related #135705. Thanks @obviyus and @asgeirtj.</li>
-<li><strong>PR #135825</strong> Related #135706. Thanks @pengzh1 and @obviyus and @ezimerman.</li>
-<li><strong>PR #135911</strong></li>
-<li><strong>PR #130894</strong> Thanks @cxyhhhhh.</li>
-<li><strong>PR #135916</strong></li>
-<li><strong>PR #135877</strong></li>
-<li><strong>PR #135918</strong></li>
-<li><strong>PR #135255</strong> Thanks @edenfunf.</li>
-<li><strong>PR #135760</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135759</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135928</strong> Related #135921, #135922.</li>
-<li><strong>PR #135932</strong></li>
-<li><strong>PR #135786</strong></li>
-<li><strong>PR #135883</strong></li>
-<li><strong>PR #135940</strong></li>
-<li><strong>PR #135773</strong> Related #135743. Thanks @LiuwqGit and @obviyus and @609NFT.</li>
-<li><strong>PR #135936</strong> Related #135914.</li>
-<li><strong>PR #135942</strong></li>
-<li><strong>PR #135888</strong></li>
-<li><strong>PR #135511</strong> Related #135487.</li>
-<li><strong>PR #135931</strong></li>
-<li><strong>PR #135952</strong></li>
-<li><strong>PR #135939</strong></li>
-<li><strong>PR #135956</strong></li>
-<li><strong>PR #135953</strong></li>
-<li><strong>PR #135957</strong> Related #135682. Thanks @obviyus and @Grynn.</li>
-<li><strong>PR #135951</strong></li>
-<li><strong>PR #134689</strong> Related #134621. Thanks @gaoanze888 and @wbstrbt.</li>
-<li><strong>PR #135919</strong> Related #135658. Thanks @leilei3167 and @obviyus and @Frank683456.</li>
-<li><strong>PR #135884</strong> Related #135571. Thanks @hyper-sdn.</li>
-<li><strong>PR #135582</strong></li>
-<li><strong>PR #135665</strong> Related #135661. Thanks @Colton-Harris and @obviyus.</li>
-<li><strong>PR #135938</strong> Related #135920, #135930.</li>
-<li><strong>PR #133829</strong> Thanks @aniruddhaadak80.</li>
-<li><strong>PR #135878</strong> Related #135874.</li>
-<li><strong>PR #135971</strong></li>
-<li><strong>PR #135758</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135967</strong></li>
-<li><strong>PR #135973</strong></li>
-<li><strong>PR #135963</strong> Related #135946, #135947.</li>
-<li><strong>PR #135950</strong></li>
-<li><strong>PR #135972</strong></li>
-<li><strong>PR #135974</strong></li>
-<li><strong>PR #135989</strong></li>
-<li><strong>PR #135993</strong> Related #135990.</li>
-<li><strong>PR #135965</strong></li>
-<li><strong>PR #135960</strong></li>
-<li><strong>PR #135995</strong> Related #135975, #135977.</li>
-<li><strong>PR #136004</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #135986</strong></li>
-<li><strong>PR #135994</strong></li>
-<li><strong>PR #135983</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136000</strong> Related #135966.</li>
-<li><strong>PR #136003</strong></li>
-<li><strong>PR #136017</strong></li>
-<li><strong>PR #135789</strong></li>
-<li><strong>PR #136020</strong> Related #135893. Thanks @LiuwqGit.</li>
-<li><strong>PR #135794</strong> Related #125322. Thanks @RaviTharuma.</li>
-<li><strong>PR #135998</strong></li>
-<li><strong>PR #135746</strong></li>
-<li><strong>PR #135981</strong> Related #135968.</li>
-<li><strong>PR #136001</strong> Related #135999.</li>
-<li><strong>PR #136027</strong></li>
-<li><strong>PR #135962</strong></li>
-<li><strong>PR #136024</strong></li>
-<li><strong>PR #136040</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #136006</strong></li>
-<li><strong>PR #135729</strong> Related #135726. Thanks @devzeroLL and @obviyus.</li>
-<li><strong>PR #135988</strong></li>
-<li><strong>PR #136028</strong></li>
-<li><strong>PR #136044</strong></li>
-<li><strong>PR #135731</strong> Related #127645. Thanks @HuzaifaChaudary.</li>
-<li><strong>PR #135857</strong> Related #135845.</li>
-<li><strong>PR #136012</strong> Related #135948.</li>
-<li><strong>PR #136007</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #135943</strong></li>
-<li><strong>PR #136055</strong></li>
-<li><strong>PR #136054</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136008</strong> Related #135978.</li>
-<li><strong>PR #136031</strong></li>
-<li><strong>PR #135864</strong> Related #135641. Thanks @yetval and @obviyus and @CjTruHeart.</li>
-<li><strong>PR #135961</strong></li>
-<li><strong>PR #136050</strong> Related #136046.</li>
-<li><strong>PR #135976</strong></li>
-<li><strong>PR #135847</strong> Related #135734. Thanks @yetval and @obviyus and @josephbergvinson.</li>
-<li><strong>PR #136030</strong></li>
-<li><strong>PR #136002</strong></li>
-<li><strong>PR #136061</strong> Related #135991.</li>
-<li><strong>PR #136041</strong></li>
-<li><strong>PR #136014</strong></li>
-<li><strong>PR #136053</strong> Related #136051, #136052.</li>
-<li><strong>PR #136057</strong></li>
-<li><strong>PR #135478</strong></li>
-<li><strong>PR #136043</strong> Related #136042.</li>
-<li><strong>PR #136021</strong></li>
-<li><strong>PR #135829</strong> Thanks @teddytennant and @obviyus.</li>
-<li><strong>PR #136063</strong></li>
-<li><strong>PR #135803</strong> Thanks @teddytennant.</li>
-<li><strong>PR #136066</strong></li>
-<li><strong>PR #136010</strong> Related #135684. Thanks @obviyus and @Grynn.</li>
-<li><strong>PR #136062</strong> Related #136058, #136060.</li>
-<li><strong>PR #136064</strong> Related #134337. Thanks @ThatGuySizemore.</li>
-<li><strong>PR #135848</strong> Thanks @masatohoshino and @obviyus.</li>
-<li><strong>PR #136019</strong></li>
-<li><strong>PR #136086</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136101</strong></li>
-<li><strong>PR #135749</strong> Thanks @teddytennant and @obviyus.</li>
-<li><strong>PR #135831</strong> Related #135573. Thanks @ruel225 and @obviyus and @TailsProwerWorks.</li>
-<li><strong>PR #136033</strong> Related #135692. Thanks @obviyus and @Grynn.</li>
-<li><strong>PR #136065</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #136056</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #136077</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #136075</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135954</strong> Related #135949. Thanks @JosephNatsu.</li>
-<li><strong>PR #136080</strong></li>
-<li><strong>PR #136124</strong></li>
-<li><strong>PR #136108</strong> Related #136106. Thanks @vincentkoc.</li>
-<li><strong>PR #135517</strong> Thanks @jmewing and @obviyus.</li>
-<li><strong>PR #136112</strong></li>
-<li><strong>PR #135742</strong> Thanks @marmar9615-cloud and @obviyus.</li>
-<li><strong>PR #135520</strong> Related #135459. Thanks @gaoanze888 and @obviyus and @LifeViwer.</li>
-<li><strong>PR #136093</strong> Related #46932, #136089. Thanks @jeffrey4341.</li>
-<li><strong>PR #136078</strong></li>
-<li><strong>PR #135748</strong> Thanks @teddytennant and @obviyus.</li>
-<li><strong>PR #136121</strong></li>
-<li><strong>PR #136067</strong></li>
-<li><strong>PR #136114</strong></li>
-<li><strong>PR #136109</strong> Related #136087.</li>
-<li><strong>PR #136119</strong></li>
-<li><strong>PR #136141</strong></li>
-<li><strong>PR #136091</strong> Related #136083.</li>
-<li><strong>PR #135351</strong> Thanks @teddytennant and @obviyus.</li>
-<li><strong>PR #136136</strong></li>
-<li><strong>PR #136152</strong> Related #136128.</li>
-<li><strong>PR #136090</strong> Related #136081.</li>
-<li><strong>PR #136023</strong> Related #135881. Thanks @leilei3167 and @obviyus and @yetval.</li>
-<li><strong>PR #136092</strong> Thanks @pash-openai.</li>
-<li><strong>PR #136125</strong></li>
-<li><strong>PR #136099</strong></li>
-<li><strong>PR #136133</strong> Related #136118.</li>
-<li><strong>PR #135807</strong> Thanks @teddytennant.</li>
-<li><strong>PR #136069</strong></li>
-<li><strong>PR #136164</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136162</strong></li>
-<li><strong>PR #136160</strong></li>
-<li><strong>PR #136132</strong> Related #136117.</li>
-<li><strong>PR #136166</strong></li>
-<li><strong>PR #135516</strong> Thanks @RayWangyangMa and @obviyus.</li>
-<li><strong>PR #136111</strong> Related #136102.</li>
-<li><strong>PR #134648</strong> Related #134500. Thanks @sunlit-deng and @obviyus and @LowCode191.</li>
-<li><strong>PR #136191</strong></li>
-<li><strong>PR #136153</strong></li>
-<li><strong>PR #93842</strong> Thanks @bladin.</li>
-<li><strong>PR #136167</strong> Related #136163.</li>
-<li><strong>PR #134333</strong> Related #134332. Thanks @TheAngryPit and @obviyus.</li>
-<li><strong>PR #134219</strong> Related #134187. Thanks @tzlwn1 and @obviyus and @svdwalt007.</li>
-<li><strong>PR #136195</strong></li>
-<li><strong>PR #136193</strong></li>
-<li><strong>PR #136169</strong></li>
-<li><strong>PR #135467</strong> Thanks @Yigtwxx.</li>
-<li><strong>PR #134737</strong> Thanks @lzhan011 and @obviyus.</li>
-<li><strong>PR #136137</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136186</strong></li>
-<li><strong>PR #136201</strong> Related #136198.</li>
-<li><strong>PR #136150</strong></li>
-<li><strong>PR #136209</strong></li>
-<li><strong>PR #136072</strong></li>
-<li><strong>PR #136127</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136187</strong></li>
-<li><strong>PR #135083</strong> Thanks @rwinkelman and @obviyus.</li>
-<li><strong>PR #136180</strong></li>
-<li><strong>PR #136227</strong> Related #136224.</li>
-<li><strong>PR #135281</strong> Thanks @xialonglee.</li>
-<li><strong>PR #135341</strong> Thanks @teddytennant and @obviyus.</li>
-<li><strong>PR #136228</strong> Related #136139, #136140.</li>
-<li><strong>PR #136134</strong></li>
-<li><strong>PR #134525</strong> Thanks @sjf-oa and @sjf.</li>
-<li><strong>PR #136222</strong></li>
-<li><strong>PR #136214</strong> Related #136206, #136207, #136208.</li>
-<li><strong>PR #135855</strong> Related #96135. Thanks @yungchentang and @kAIborg24.</li>
-<li><strong>PR #135671</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #132492</strong> Thanks @RileyJJY.</li>
-<li><strong>PR #132490</strong> Thanks @RileyJJY.</li>
-<li><strong>PR #135851</strong></li>
-<li><strong>PR #136142</strong> Thanks @qingminglong and @obviyus.</li>
-<li><strong>PR #136182</strong></li>
-<li><strong>PR #136243</strong></li>
-<li><strong>PR #136232</strong></li>
-<li><strong>PR #136161</strong></li>
-<li><strong>PR #135846</strong> Related #135633. Thanks @louisfy and @obviyus and @jakestenger.</li>
-<li><strong>PR #136192</strong></li>
-<li><strong>PR #135455</strong> Thanks @ly85206559 and @obviyus.</li>
-<li><strong>PR #136241</strong> Related #136237.</li>
-<li><strong>PR #136245</strong></li>
-<li><strong>PR #136223</strong></li>
-<li><strong>PR #136254</strong></li>
-<li><strong>PR #131408</strong> Thanks @igs-rogenlo.</li>
-<li><strong>PR #136216</strong></li>
-<li><strong>PR #136196</strong> Related #136143.</li>
-<li><strong>PR #136151</strong> Related #136104. Thanks @ericcaiwx-star and @obviyus and @KimOckHyun.</li>
-<li><strong>PR #136234</strong> Related #136204. Thanks @LiuwqGit and @obviyus and @Volevanius.</li>
-<li><strong>PR #135925</strong> Related #135435. Thanks @xialonglee and @obviyus and @jaxonparrott.</li>
-<li><strong>PR #136256</strong> Related #136225. Thanks @obviyus and @Famyoff.</li>
-<li><strong>PR #136184</strong></li>
-<li><strong>PR #136221</strong> Related #136217.</li>
-<li><strong>PR #136205</strong> Thanks @quangtran88.</li>
-<li><strong>PR #133871</strong> Thanks @SebTardif and @obviyus.</li>
-<li><strong>PR #136272</strong></li>
-<li><strong>PR #135985</strong> Related #135836. Thanks @gaoanze888 and @obviyus and @yetval.</li>
-<li><strong>PR #136105</strong></li>
-<li><strong>PR #132753</strong> Related #132750. Thanks @tommyjoseph.</li>
-<li><strong>PR #136265</strong></li>
-<li><strong>PR #136215</strong> Related #136159. Thanks @LiuwqGit and @obviyus and @wave-workflow.</li>
-<li><strong>PR #136171</strong> Thanks @efe-arv and @liri-ha and @obviyus.</li>
-<li><strong>PR #136229</strong></li>
-<li><strong>PR #136172</strong> Related #136015. Thanks @NianJiuZst and @obviyus and @davidcittadini.</li>
-<li><strong>PR #135462</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #136278</strong> Thanks @jodok.</li>
-<li><strong>PR #136173</strong> Related #128926. Thanks @aniruddhaadak80.</li>
-<li><strong>PR #136085</strong> Related #136070.</li>
-<li><strong>PR #136036</strong> Related #136032.</li>
-<li><strong>PR #135824</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #135793</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136280</strong></li>
-<li><strong>PR #135443</strong> Thanks @lzhan011 and @obviyus.</li>
-<li><strong>PR #136287</strong></li>
-<li><strong>PR #133747</strong> Related #133743, #133785. Thanks @shakkernerd.</li>
-<li><strong>PR #136291</strong></li>
-<li><strong>PR #133978</strong> Thanks @yetval.</li>
-<li><strong>PR #136263</strong></li>
-<li><strong>PR #135828</strong> Thanks @griswomw2 and @obviyus.</li>
-<li><strong>PR #136298</strong></li>
-<li><strong>PR #136211</strong></li>
-<li><strong>PR #135016</strong> Thanks @jesse-merhi.</li>
-<li><strong>PR #136296</strong></li>
-<li><strong>PR #136138</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #136305</strong></li>
-<li><strong>PR #136249</strong></li>
-<li><strong>PR #136247</strong> Related #136219.</li>
-<li><strong>PR #131786</strong> Related #131781. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #136283</strong> Related #135905. Thanks @obviyus and @anyech.</li>
-<li><strong>PR #136018</strong></li>
-<li><strong>PR #136304</strong></li>
-<li><strong>PR #136312</strong></li>
-<li><strong>PR #136315</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136233</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #136307</strong></li>
-<li><strong>PR #136316</strong></li>
-<li><strong>PR #135508</strong> Related #135457. Thanks @gaoanze888 and @obviyus and @itsuzef.</li>
-<li><strong>PR #136107</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136323</strong></li>
-<li><strong>PR #136308</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #133724</strong> Related #133702.</li>
-<li><strong>PR #136269</strong> Thanks @yetval and @obviyus.</li>
-<li><strong>PR #136347</strong></li>
-<li><strong>PR #136351</strong></li>
-<li><strong>PR #136344</strong></li>
-<li><strong>PR #136336</strong></li>
-<li><strong>PR #136353</strong></li>
-<li><strong>PR #136185</strong></li>
-<li><strong>PR #136335</strong></li>
-<li><strong>PR #136352</strong></li>
-<li><strong>PR #136168</strong> Related #136157.</li>
-<li><strong>PR #135441</strong> Thanks @jjjhenriksen and @obviyus.</li>
-<li><strong>PR #135796</strong></li>
-<li><strong>PR #136273</strong></li>
-<li><strong>PR #136276</strong> Related #136275. Thanks @vincentkoc.</li>
-<li><strong>PR #135486</strong> Thanks @zeroaltitude and @obviyus.</li>
-<li><strong>PR #136354</strong></li>
-<li><strong>PR #136380</strong></li>
-<li><strong>PR #136377</strong></li>
-<li><strong>PR #136381</strong></li>
-<li><strong>PR #135301</strong> Related #135028. Thanks @mushuiyu886 and @obviyus and @jadabreu.</li>
-<li><strong>PR #136359</strong></li>
-<li><strong>PR #134853</strong> Related #134851. Thanks @cmanrav and @obviyus.</li>
-<li><strong>PR #132983</strong> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #136407</strong> Related #136406.</li>
-<li><strong>PR #136340</strong></li>
-<li><strong>PR #136389</strong></li>
-<li><strong>PR #136416</strong></li>
-<li><strong>PR #136417</strong> Related #136415.</li>
-<li><strong>PR #136309</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136418</strong></li>
-<li><strong>PR #136398</strong></li>
-<li><strong>PR #136404</strong></li>
-<li><strong>PR #136319</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136403</strong></li>
-<li><strong>PR #133381</strong> Thanks @ericcaiwx-star and @cursoragent and @obviyus.</li>
-<li><strong>PR #136391</strong></li>
-<li><strong>PR #136362</strong></li>
-<li><strong>PR #136425</strong></li>
-<li><strong>PR #134663</strong> Thanks @jalehman.</li>
-<li><strong>PR #135863</strong> Related #135618. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #127959</strong> Related #127948. Thanks @Finn763 and @markswitch83.</li>
-<li><strong>PR #136178</strong> Thanks @masatohoshino and @obviyus.</li>
-<li><strong>PR #136301</strong> Related #135860. Thanks @zhangguiping-xydt and @obviyus and @zqchris.</li>
-<li><strong>PR #136438</strong></li>
-<li><strong>PR #136448</strong></li>
-<li><strong>PR #136473</strong></li>
-<li><strong>PR #136450</strong></li>
-<li><strong>PR #134795</strong> Thanks @eleqtrizit.</li>
-<li><strong>PR #136402</strong> Related #136397. Thanks @ly85206559.</li>
-<li><strong>PR #136481</strong></li>
-<li><strong>PR #135219</strong> Related #132452. Thanks @SunnyShu0925 and @obviyus and @alexph-dev.</li>
-<li><strong>PR #135798</strong> Related #135649. Thanks @SunnyShu0925 and @markhaines.</li>
-<li><strong>PR #136393</strong></li>
-<li><strong>PR #134941</strong> Thanks @itsuzef and @obviyus.</li>
-<li><strong>PR #136444</strong> Related #136442, #136443.</li>
-<li><strong>PR #136483</strong></li>
-<li><strong>PR #136446</strong></li>
-<li><strong>PR #136479</strong></li>
-<li><strong>PR #129918</strong> Related #129734. Thanks @SunnyShu0925 and @obviyus and @hpyhandsome.</li>
-<li><strong>PR #136522</strong></li>
-<li><strong>PR #135430</strong> Related #135217, #135249. Thanks @Solvely-Colin and @nikolaihack.</li>
-<li><strong>PR #135429</strong> Related #135251.</li>
-<li><strong>PR #135295</strong> Thanks @PollyBot13 and @obviyus.</li>
-<li><strong>PR #136534</strong></li>
-<li><strong>PR #136419</strong></li>
-<li><strong>PR #136388</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136460</strong></li>
-<li><strong>PR #136463</strong></li>
-<li><strong>PR #134819</strong> Thanks @qingminglong and @obviyus.</li>
-<li><strong>PR #136423</strong> Related #134186. Thanks @svdwalt007.</li>
-<li><strong>PR #136500</strong></li>
-<li><strong>PR #136440</strong></li>
-<li><strong>PR #134858</strong> Thanks @Artemeey and @obviyus.</li>
-<li><strong>PR #136434</strong> Thanks @masatohoshino and @obviyus.</li>
-<li><strong>PR #136461</strong></li>
-<li><strong>PR #136541</strong></li>
-<li><strong>PR #136445</strong> Related #136441.</li>
-<li><strong>PR #136470</strong></li>
-<li><strong>PR #136413</strong> Related #136047.</li>
-<li><strong>PR #136428</strong></li>
-<li><strong>PR #136510</strong> Related #126872. Thanks @danielduerr.</li>
-<li><strong>PR #136401</strong></li>
-<li><strong>PR #136550</strong></li>
-<li><strong>PR #136435</strong></li>
-<li><strong>PR #136567</strong></li>
-<li><strong>PR #136451</strong></li>
-<li><strong>PR #136420</strong> Related #133955. Thanks @obviyus and @aoclaw-glitch.</li>
-<li><strong>PR #136511</strong></li>
-<li><strong>PR #136539</strong> Related #136538.</li>
-<li><strong>PR #136570</strong> Related #75848. Thanks @alfredjbclaw.</li>
-<li><strong>PR #136501</strong></li>
-<li><strong>PR #136457</strong></li>
-<li><strong>PR #136540</strong></li>
-<li><strong>PR #136478</strong></li>
-<li><strong>PR #136399</strong> Related #136385.</li>
-<li><strong>PR #136220</strong></li>
-<li><strong>PR #135945</strong> Related #135882. Thanks @ruel225 and @obviyus and @yetval.</li>
-<li><strong>PR #136580</strong></li>
-<li><strong>PR #136439</strong> Related #136437.</li>
-<li><strong>PR #136469</strong> Related #136468.</li>
-<li><strong>PR #136366</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136574</strong> Related #136573.</li>
-<li><strong>PR #131735</strong> Related #131734. Thanks @ruel225.</li>
-<li><strong>PR #136577</strong></li>
-<li><strong>PR #136527</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136373</strong> Related #136357. Thanks @LiuwqGit and @obviyus and @Dresch63.</li>
-<li><strong>PR #136094</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #133445</strong> Thanks @edenfunf.</li>
-<li><strong>PR #135588</strong> Related #135538. Thanks @VACInc.</li>
-<li><strong>PR #136230</strong> Related #136068.</li>
-<li><strong>PR #136572</strong> Related #136562.</li>
-<li><strong>PR #136559</strong></li>
-<li><strong>PR #135410</strong> Thanks @ly85206559.</li>
-<li><strong>PR #136566</strong></li>
-<li><strong>PR #136571</strong></li>
-<li><strong>PR #136601</strong></li>
-<li><strong>PR #136590</strong></li>
-<li><strong>PR #136542</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #135923</strong> Thanks @BennyAI2.</li>
-<li><strong>PR #136532</strong></li>
-<li><strong>PR #136465</strong> Related #136464.</li>
-<li><strong>PR #136569</strong> Related #136568.</li>
-<li><strong>PR #136603</strong></li>
-<li><strong>PR #136615</strong></li>
-<li><strong>PR #136604</strong> Related #136593.</li>
-<li><strong>PR #136521</strong></li>
-<li><strong>PR #136602</strong></li>
-<li><strong>PR #136430</strong></li>
-<li><strong>PR #136616</strong></li>
-<li><strong>PR #136607</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136620</strong></li>
-<li><strong>PR #136597</strong></li>
-<li><strong>PR #136624</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #136531</strong> Related #136530.</li>
-<li><strong>PR #136537</strong> Related #136536.</li>
-<li><strong>PR #136628</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #136614</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136504</strong> Thanks @drobison00.</li>
-<li><strong>PR #126419</strong> Thanks @drobison00.</li>
-<li><strong>PR #136505</strong> Thanks @drobison00.</li>
-<li><strong>PR #136564</strong> Related #136563.</li>
-<li><strong>PR #136286</strong></li>
-<li><strong>PR #136596</strong> Related #136594, #136595.</li>
-<li><strong>PR #136509</strong> Related #136499.</li>
-<li><strong>PR #136599</strong> Related #136598.</li>
-<li><strong>PR #136600</strong> Related #136591.</li>
-<li><strong>PR #132266</strong> Thanks @MonkeyLeeT.</li>
-<li><strong>PR #136637</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136520</strong></li>
-<li><strong>PR #136621</strong></li>
-<li><strong>PR #136557</strong> Related #136556.</li>
-<li><strong>PR #135531</strong> Thanks @MertBasar0 and @obviyus.</li>
-<li><strong>PR #136626</strong></li>
-<li><strong>PR #136176</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136633</strong> Related #136632.</li>
-<li><strong>PR #136519</strong></li>
-<li><strong>PR #136636</strong> Related #136635.</li>
-<li><strong>PR #136578</strong> Thanks @LiuwqGit.</li>
-<li><strong>PR #136325</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136619</strong> Thanks @shakkernerd.</li>
-<li><strong>PR #136641</strong> Related #136640. Thanks @vincentkoc.</li>
-<li><strong>PR #134622</strong> Thanks @eleqtrizit.</li>
-<li><strong>PR #136654</strong></li>
-<li><strong>PR #136606</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136627</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #135744</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136657</strong> Related #136656.</li>
-<li><strong>PR #136524</strong></li>
-<li><strong>PR #136664</strong> Related #136662.</li>
-<li><strong>PR #136668</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136658</strong></li>
-<li><strong>PR #133660</strong> Related #133517.</li>
-<li><strong>PR #134603</strong> Thanks @eleqtrizit.</li>
-<li><strong>PR #134368</strong> Thanks @BryanTegomoh.</li>
-<li><strong>PR #136037</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #136038</strong> Thanks @RomneyDa.</li>
-<li><strong>PR #136666</strong> Related #136665.</li>
-<li><strong>PR #134413</strong> Related #134409. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #133151</strong> Related #133128. Thanks @aniruddhaadak80.</li>
-<li><strong>PR #136672</strong></li>
-<li><strong>PR #136605</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136676</strong></li>
-<li><strong>PR #136646</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136647</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136648</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136649</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136650</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136681</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136644</strong></li>
-<li><strong>PR #136495</strong> Related #136493.</li>
-<li><strong>PR #135802</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136643</strong> Related #136638.</li>
-<li><strong>PR #135722</strong> Related #135720. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #136517</strong> Related #136516.</li>
-<li><strong>PR #136670</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136685</strong></li>
-<li><strong>PR #136683</strong></li>
-<li><strong>PR #136688</strong></li>
-<li><strong>PR #136700</strong></li>
-<li><strong>PR #136667</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136659</strong></li>
-<li><strong>PR #136295</strong></li>
-<li><strong>PR #136698</strong></li>
-<li><strong>PR #136695</strong></li>
-<li><strong>PR #135859</strong> Thanks @vincentkoc.</li>
-<li><strong>PR #136704</strong></li>
-<li><strong>PR #136678</strong></li>
-<li><strong>PR #136705</strong></li>
-<li><strong>PR #136716</strong></li>
-<li><strong>PR #136717</strong></li>
-<li><strong>PR #136675</strong></li>
-<li><strong>PR #136458</strong> Related #136455, #136456.</li>
-<li><strong>PR #136084</strong></li>
-<li><strong>PR #136350</strong></li>
-<li><strong>PR #136609</strong> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #136770</strong></li>
-<li><strong>PR #136771</strong></li>
-<li><strong>PR #136798</strong></li>
-<li><strong>PR #136968</strong></li>
-<li><strong>PR #136395</strong> Thanks @fuller-stack-dev and @vincentkoc.</li>
-<li><strong>PR #137012</strong> Related #136881. Thanks @leilei3167 and @obviyus and @anordick.</li>
-</ul>
-<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
-]]></description>
-            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.9.1/OpenClaw-2026.9.1.zip" length="534673086" type="application/octet-stream" sparkle:edSignature="dfwVKJGzi3OivvXVNxNMvqvyEOEQt1SNLPbUFDfFIWl7Wedb3E3fMSsmDQwpN9CV5P9r/HppP/oRt+ne7chnDw=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Updates the stable Sparkle appcast generated by macOS publish for v2026.9.4.