### PR TITLE
fix(reef): park capacity-failed inbound delivery instead of unwinding the shared inbox

### DIFF
--- a/extensions/reef/src/flow.test-helpers.ts
+++ b/extensions/reef/src/flow.test-helpers.ts
@@ -45,6 +45,7 @@ export function flowStores(deliveredMaxEntries?: number) {
     });
   return {
     runtime,
+    stateDir,
     reviews: new ReviewApprovalStore(runtime),
     delivered:
       deliveredMaxEntries === undefined

--- a/extensions/reef/src/flow.test-helpers.ts
+++ b/extensions/reef/src/flow.test-helpers.ts
@@ -34,7 +34,7 @@ export function resetFlowStoresForTests(): void {
   }
 }
 
-export function flowStores() {
+export function flowStores(deliveredMaxEntries?: number) {
   const stateDir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "reef-flow-"));
   stateDirs.push(stateDir);
   const runtime = createPluginRuntimeMock();
@@ -45,7 +45,10 @@ export function flowStores() {
     });
   return {
     reviews: new ReviewApprovalStore(runtime),
-    delivered: new ReefDeliveredStore(runtime),
+    delivered:
+      deliveredMaxEntries === undefined
+        ? new ReefDeliveredStore(runtime)
+        : new ReefDeliveredStore(runtime, deliveredMaxEntries),
   };
 }
 

--- a/extensions/reef/src/flow.test-helpers.ts
+++ b/extensions/reef/src/flow.test-helpers.ts
@@ -44,6 +44,7 @@ export function flowStores(deliveredMaxEntries?: number) {
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
   return {
+    runtime,
     reviews: new ReviewApprovalStore(runtime),
     delivered:
       deliveredMaxEntries === undefined

--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -790,12 +790,13 @@ describe("ReefMessageFlow delivery-store capacity", () => {
     };
 
     await expect(flow.processEntries([entry])).rejects.toBeInstanceOf(ReefInboxEntryParkedError);
-    // Ingress ran (reservation succeeded); the confirmed marker could not be
-    // persisted, so the entry parks and the reservation stays pending for the
-    // re-poll instead of unwinding the shared inbox.
+    // Ingress ran (reservation succeeded); the capacity-neutral confirm frees
+    // the reservation before the delivered insert, so the failed confirm leaves
+    // no stuck record: the entry parks and the re-poll re-ingresses from a
+    // clean reservation instead of unwinding the shared inbox.
     expect(onIngress).toHaveBeenCalledTimes(1);
     expect(relay.acknowledge).not.toHaveBeenCalled();
-    await expect(stores.delivered.status(id)).resolves.toBe("pending");
+    await expect(stores.delivered.status(id)).resolves.toBeUndefined();
   });
 
   it("parks an inbound message before ingress when replay state is at capacity", async () => {

--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -724,42 +724,6 @@ describe("ReefMessageFlow delivery-store capacity", () => {
     resetFlowStoresForTests();
   });
 
-  it("parks a new inbound message before ingress when the delivered reservation store is at capacity", async () => {
-    const alice = generateIdentity();
-    const bob = reefKeys();
-    const id = "01JZ0000000000000000000201";
-    const stores = flowStores(1);
-    await stores.delivered.reserve("occupied");
-    const onIngress = vi.fn(async () => {});
-    const relay = transport();
-    const flow = new ReefMessageFlow({
-      config: config(),
-      trust: trust({ alice: peerTrust(alice) }).store,
-      keys: bob,
-      transport: relay as unknown as ReefTransportClient, // SAFETY: test transport mock satisfies the client contract
-      guard: guard(allow),
-      audit: new MemoryAuditStore(new Uint8Array(32).fill(20)),
-      replay: new MemoryReplayStore(),
-      ...stores,
-      onIngress,
-      onOwnerNotice: async () => {},
-    });
-    const entry: InboxEntry = {
-      seq: 1,
-      peer: "alice",
-      id,
-      kind: "message",
-      envelope: await envelope(alice, bob, id, "should park, not re-enter"),
-      ts: Math.floor(Date.now() / 1_000),
-    };
-
-    await expect(flow.processEntries([entry])).rejects.toBeInstanceOf(ReefInboxEntryParkedError);
-    // Capacity failure must park BEFORE inbound handling: no dispatch, no ack.
-    expect(onIngress).not.toHaveBeenCalled();
-    expect(relay.acknowledge).not.toHaveBeenCalled();
-    await expect(stores.delivered.status(id)).resolves.toBeUndefined();
-  });
-
   it("parks after ingress with the reservation kept pending when the delivered store fills before confirm", async () => {
     const alice = generateIdentity();
     const bob = reefKeys();
@@ -790,13 +754,12 @@ describe("ReefMessageFlow delivery-store capacity", () => {
     };
 
     await expect(flow.processEntries([entry])).rejects.toBeInstanceOf(ReefInboxEntryParkedError);
-    // Ingress ran (reservation succeeded); the capacity-neutral confirm frees
-    // the reservation before the delivered insert, so the failed confirm leaves
-    // no stuck record: the entry parks and the re-poll re-ingresses from a
-    // clean reservation instead of unwinding the shared inbox.
+    // Ingress ran; the in-memory reservation stays pending across the failed
+    // confirm, so the entry parks and each re-poll re-ingresses and retries
+    // the confirmed marker instead of unwinding the shared inbox.
     expect(onIngress).toHaveBeenCalledTimes(1);
     expect(relay.acknowledge).not.toHaveBeenCalled();
-    await expect(stores.delivered.status(id)).resolves.toBeUndefined();
+    await expect(stores.delivered.status(id)).resolves.toBe("pending");
   });
 
   it("parks an inbound message before ingress when replay state is at capacity", async () => {

--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -724,7 +724,7 @@ describe("ReefMessageFlow delivery-store capacity", () => {
     resetFlowStoresForTests();
   });
 
-  it("parks after ingress with the reservation kept pending when the delivered store fills before confirm", async () => {
+  it("parks after ingress without retaining bookkeeping when the delivered store fills before confirm", async () => {
     const alice = generateIdentity();
     const bob = reefKeys();
     const id = "01JZ0000000000000000000204";
@@ -754,12 +754,11 @@ describe("ReefMessageFlow delivery-store capacity", () => {
     };
 
     await expect(flow.processEntries([entry])).rejects.toBeInstanceOf(ReefInboxEntryParkedError);
-    // Ingress ran; the in-memory reservation stays pending across the failed
-    // confirm, so the entry parks and each re-poll re-ingresses and retries
-    // the confirmed marker instead of unwinding the shared inbox.
+    // Ingress ran, but no delivered marker was retained after confirm failed.
+    // Each re-poll re-ingests instead of unwinding the shared inbox.
     expect(onIngress).toHaveBeenCalledTimes(1);
     expect(relay.acknowledge).not.toHaveBeenCalled();
-    await expect(stores.delivered.status(id)).resolves.toBe("pending");
+    await expect(stores.delivered.status(id)).resolves.toBeUndefined();
   });
 
   it("parks an inbound message before ingress when replay state is at capacity", async () => {
@@ -802,12 +801,12 @@ describe("ReefMessageFlow delivery-store capacity", () => {
     expect(relay.acknowledge).not.toHaveBeenCalled();
   });
 
-  it("reserves the delivery marker before ingress and confirms after, so retried entries never re-enter ingress", async () => {
+  it("confirms the delivery marker after ingress, so delivered entries do not re-enter ingress", async () => {
     const alice = generateIdentity();
     const bob = reefKeys();
     const id = "01JZ0000000000000000000203";
     const stores = flowStores();
-    let statusDuringIngress: "delivered" | "pending" | undefined;
+    let statusDuringIngress: "delivered" | undefined;
     const onIngress = vi.fn(async () => {
       statusDuringIngress = await stores.delivered.status(id);
     });
@@ -834,8 +833,8 @@ describe("ReefMessageFlow delivery-store capacity", () => {
     };
 
     await flow.processEntries([entry]);
-    // The marker is durably reserved before inbound handling runs.
-    expect(statusDuringIngress).toBe("pending");
+    // The marker is written only after inbound handling succeeds.
+    expect(statusDuringIngress).toBeUndefined();
     await expect(stores.delivered.status(id)).resolves.toBe("delivered");
 
     await flow.processEntries([{ ...entry, seq: 2 }]);

--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -724,12 +724,12 @@ describe("ReefMessageFlow delivery-store capacity", () => {
     resetFlowStoresForTests();
   });
 
-  it("parks a new inbound message before ingress when the delivered-marker store is at capacity", async () => {
+  it("parks a new inbound message before ingress when the delivered reservation store is at capacity", async () => {
     const alice = generateIdentity();
     const bob = reefKeys();
     const id = "01JZ0000000000000000000201";
     const stores = flowStores(1);
-    await stores.delivered.add("occupied");
+    await stores.delivered.reserve("occupied");
     const onIngress = vi.fn(async () => {});
     const relay = transport();
     const flow = new ReefMessageFlow({
@@ -758,6 +758,44 @@ describe("ReefMessageFlow delivery-store capacity", () => {
     expect(onIngress).not.toHaveBeenCalled();
     expect(relay.acknowledge).not.toHaveBeenCalled();
     await expect(stores.delivered.status(id)).resolves.toBeUndefined();
+  });
+
+  it("parks after ingress with the reservation kept pending when the delivered store fills before confirm", async () => {
+    const alice = generateIdentity();
+    const bob = reefKeys();
+    const id = "01JZ0000000000000000000204";
+    const stores = flowStores(1);
+    await stores.delivered.add("occupied"); // delivered namespace full
+    const onIngress = vi.fn(async () => {});
+    const relay = transport();
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient, // SAFETY: test transport mock satisfies the client contract
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(23)),
+      replay: new MemoryReplayStore(),
+      ...stores,
+      onIngress,
+      onOwnerNotice: async () => {},
+    });
+    const entry: InboxEntry = {
+      seq: 1,
+      peer: "alice",
+      id,
+      kind: "message",
+      envelope: await envelope(alice, bob, id, "confirm hits full store"),
+      ts: Math.floor(Date.now() / 1_000),
+    };
+
+    await expect(flow.processEntries([entry])).rejects.toBeInstanceOf(ReefInboxEntryParkedError);
+    // Ingress ran (reservation succeeded); the confirmed marker could not be
+    // persisted, so the entry parks and the reservation stays pending for the
+    // re-poll instead of unwinding the shared inbox.
+    expect(onIngress).toHaveBeenCalledTimes(1);
+    expect(relay.acknowledge).not.toHaveBeenCalled();
+    await expect(stores.delivered.status(id)).resolves.toBe("pending");
   });
 
   it("parks an inbound message before ingress when replay state is at capacity", async () => {

--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -9,6 +9,7 @@ import {
   open,
   sha256Hex,
   verifyReceipt,
+  type ReplayStore,
   type Verdict,
 } from "../protocol/index.js";
 import { ReefChannelConfigSchema } from "./config-schema.js";
@@ -27,7 +28,7 @@ import {
 } from "./flow.test-helpers.js";
 import { createConfiguredGuard } from "./guard.js";
 import { setReefRuntime } from "./runtime.js";
-import type { ReefTransportClient } from "./transport.js";
+import { ReefInboxEntryParkedError, type ReefTransportClient } from "./transport.js";
 import type { InboxEntry } from "./types.js";
 
 const oauthGuardModel = "gpt-5.6-terra";
@@ -711,5 +712,131 @@ describe("ReefMessageFlow outbound", () => {
     });
     expect(onPlatformSendDispatch).not.toHaveBeenCalled();
     expect(relay.sendEnvelope).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReefMessageFlow delivery-store capacity", () => {
+  beforeEach(() => {
+    resetFlowStoresForTests();
+  });
+
+  afterEach(() => {
+    resetFlowStoresForTests();
+  });
+
+  it("parks a new inbound message before ingress when the delivered-marker store is at capacity", async () => {
+    const alice = generateIdentity();
+    const bob = reefKeys();
+    const id = "01JZ0000000000000000000201";
+    const stores = flowStores(1);
+    await stores.delivered.add("occupied");
+    const onIngress = vi.fn(async () => {});
+    const relay = transport();
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(20)),
+      replay: new MemoryReplayStore(),
+      ...stores,
+      onIngress,
+      onOwnerNotice: async () => {},
+    });
+    const entry: InboxEntry = {
+      seq: 1,
+      peer: "alice",
+      id,
+      kind: "message",
+      envelope: await envelope(alice, bob, id, "should park, not re-enter"),
+      ts: Math.floor(Date.now() / 1_000),
+    };
+
+    await expect(flow.processEntries([entry])).rejects.toBeInstanceOf(ReefInboxEntryParkedError);
+    // Capacity failure must park BEFORE inbound handling: no dispatch, no ack.
+    expect(onIngress).not.toHaveBeenCalled();
+    expect(relay.acknowledge).not.toHaveBeenCalled();
+    await expect(stores.delivered.status(id)).resolves.toBeUndefined();
+  });
+
+  it("parks an inbound message before ingress when replay state is at capacity", async () => {
+    const alice = generateIdentity();
+    const bob = reefKeys();
+    const id = "01JZ0000000000000000000202";
+    const stores = flowStores();
+    const onIngress = vi.fn(async () => {});
+    const relay = transport();
+    const fullReplay = {
+      claim: async () => {
+        throw Object.assign(new Error("plugin state limit exceeded"), {
+          code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+        });
+      },
+    } as unknown as ReplayStore;
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(21)),
+      replay: fullReplay,
+      ...stores,
+      onIngress,
+      onOwnerNotice: async () => {},
+    });
+    const entry: InboxEntry = {
+      seq: 1,
+      peer: "alice",
+      id,
+      kind: "message",
+      envelope: await envelope(alice, bob, id, "replay store is full"),
+      ts: Math.floor(Date.now() / 1_000),
+    };
+
+    await expect(flow.processEntries([entry])).rejects.toBeInstanceOf(ReefInboxEntryParkedError);
+    expect(onIngress).not.toHaveBeenCalled();
+    expect(relay.acknowledge).not.toHaveBeenCalled();
+  });
+
+  it("reserves the delivery marker before ingress and confirms after, so retried entries never re-enter ingress", async () => {
+    const alice = generateIdentity();
+    const bob = reefKeys();
+    const id = "01JZ0000000000000000000203";
+    const stores = flowStores();
+    let statusDuringIngress: "delivered" | "pending" | undefined;
+    const onIngress = vi.fn(async () => {
+      statusDuringIngress = await stores.delivered.status(id);
+    });
+    const relay = transport();
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(22)),
+      replay: new MemoryReplayStore(),
+      ...stores,
+      onIngress,
+      onOwnerNotice: async () => {},
+    });
+    const entry: InboxEntry = {
+      seq: 1,
+      peer: "alice",
+      id,
+      kind: "message",
+      envelope: await envelope(alice, bob, id, "durable outcome first"),
+      ts: Math.floor(Date.now() / 1_000),
+    };
+
+    await flow.processEntries([entry]);
+    // The marker is durably reserved before inbound handling runs.
+    expect(statusDuringIngress).toBe("pending");
+    await expect(stores.delivered.status(id)).resolves.toBe("delivered");
+
+    await flow.processEntries([{ ...entry, seq: 2 }]);
+    expect(onIngress).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -736,7 +736,7 @@ describe("ReefMessageFlow delivery-store capacity", () => {
       config: config(),
       trust: trust({ alice: peerTrust(alice) }).store,
       keys: bob,
-      transport: relay as unknown as ReefTransportClient,
+      transport: relay as unknown as ReefTransportClient, // SAFETY: test transport mock satisfies the client contract
       guard: guard(allow),
       audit: new MemoryAuditStore(new Uint8Array(32).fill(20)),
       replay: new MemoryReplayStore(),
@@ -773,12 +773,12 @@ describe("ReefMessageFlow delivery-store capacity", () => {
           code: "PLUGIN_STATE_LIMIT_EXCEEDED",
         });
       },
-    } as unknown as ReplayStore;
+    } as unknown as ReplayStore; // SAFETY: capacity stub only implements claim
     const flow = new ReefMessageFlow({
       config: config(),
       trust: trust({ alice: peerTrust(alice) }).store,
       keys: bob,
-      transport: relay as unknown as ReefTransportClient,
+      transport: relay as unknown as ReefTransportClient, // SAFETY: test transport mock satisfies the client contract
       guard: guard(allow),
       audit: new MemoryAuditStore(new Uint8Array(32).fill(21)),
       replay: fullReplay,
@@ -814,7 +814,7 @@ describe("ReefMessageFlow delivery-store capacity", () => {
       config: config(),
       trust: trust({ alice: peerTrust(alice) }).store,
       keys: bob,
-      transport: relay as unknown as ReefTransportClient,
+      transport: relay as unknown as ReefTransportClient, // SAFETY: test transport mock satisfies the client contract
       guard: guard(allow),
       audit: new MemoryAuditStore(new Uint8Array(32).fill(22)),
       replay: new MemoryReplayStore(),

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -432,15 +432,40 @@ export class ReefMessageFlow {
       if (error instanceof PipelineError && isParkedInboundPipelineError(error)) {
         throw new ReefInboxEntryParkedError(error.message);
       }
+      if (isPluginStateCapacityError(error)) {
+        // Shared replay state is at capacity. Park instead of tearing down the
+        // shared inbox: the entry stays un-acked at the relay and re-polls
+        // without head-of-line blocking entries from other peers.
+        throw new ReefInboxEntryParkedError(
+          "Reef replay state is at capacity; entry parked for retry",
+        );
+      }
       throw error;
     }
     if (!result.body) {
       await this.options.transport.acknowledge(relayPeer, envelope.id, result.receipt);
       return;
     }
-    if (await this.options.delivered.has(envelope.id)) {
+    const markerState = await this.options.delivered.status(envelope.id);
+    if (markerState === "delivered") {
       await this.options.transport.acknowledge(relayPeer, envelope.id, result.receipt);
       return;
+    }
+    if (markerState === undefined) {
+      // Durable delivery outcome before inbound handling: reserve the marker
+      // first so a capacity failure parks the entry before ingress can fire,
+      // and a retried already-handled entry is classified by marker state
+      // instead of re-entering inbound handling without a durable outcome.
+      try {
+        await this.options.delivered.reserve(envelope.id);
+      } catch (error) {
+        if (isPluginStateCapacityError(error)) {
+          throw new ReefInboxEntryParkedError(
+            "Reef delivered-marker store is at capacity; entry parked for retry",
+          );
+        }
+        throw error;
+      }
     }
     const budget = autonomyBudget(friend.autonomy);
     if (budget.notifyOnly) {
@@ -458,7 +483,7 @@ export class ReefMessageFlow {
         autonomy: friend.autonomy,
       });
     }
-    await this.options.delivered.add(envelope.id);
+    await this.options.delivered.confirm(envelope.id);
     await this.options.transport.acknowledge(relayPeer, envelope.id, result.receipt);
   }
 
@@ -497,5 +522,13 @@ function isParkedInboundPipelineError(error: PipelineError): boolean {
     error.stage === "guard" &&
     error.verdict?.decision === "deny" &&
     error.verdict.category === "guard_failure"
+  );
+}
+
+// PluginStateStoreError is not part of the plugin SDK import surface; its
+// stable error code identifies bounded-store capacity exhaustion (reject-new).
+function isPluginStateCapacityError(error: unknown): boolean {
+  return (
+    error instanceof Error && (error as { code?: unknown }).code === "PLUGIN_STATE_LIMIT_EXCEEDED"
   );
 }

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -529,6 +529,8 @@ function isParkedInboundPipelineError(error: PipelineError): boolean {
 // stable error code identifies bounded-store capacity exhaustion (reject-new).
 function isPluginStateCapacityError(error: unknown): boolean {
   return (
-    error instanceof Error && (error as { code?: unknown }).code === "PLUGIN_STATE_LIMIT_EXCEEDED"
+    error instanceof Error &&
+    // SAFETY: PluginStateStoreError carries a stable string code; the class is not on the plugin-SDK import surface.
+    (error as { code?: unknown }).code === "PLUGIN_STATE_LIMIT_EXCEEDED"
   );
 }

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -452,10 +452,11 @@ export class ReefMessageFlow {
       return;
     }
     if (markerState === undefined) {
-      // Durable delivery outcome before inbound handling: reserve the marker
-      // first so a capacity failure parks the entry before ingress can fire,
-      // and a retried already-handled entry is classified by marker state
-      // instead of re-entering inbound handling without a durable outcome.
+      // Reserve the marker before inbound handling so a retried
+      // already-handled entry is classified by marker state instead of
+      // re-entering inbound handling. In-flight reservations never consume
+      // store capacity, but any capacity error still parks the entry as a
+      // retry-safe domain state.
       try {
         await this.options.delivered.reserve(envelope.id);
       } catch (error) {

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -446,27 +446,9 @@ export class ReefMessageFlow {
       await this.options.transport.acknowledge(relayPeer, envelope.id, result.receipt);
       return;
     }
-    const markerState = await this.options.delivered.status(envelope.id);
-    if (markerState === "delivered") {
+    if ((await this.options.delivered.status(envelope.id)) === "delivered") {
       await this.options.transport.acknowledge(relayPeer, envelope.id, result.receipt);
       return;
-    }
-    if (markerState === undefined) {
-      // Reserve the marker before inbound handling so a retried
-      // already-handled entry is classified by marker state instead of
-      // re-entering inbound handling. In-flight reservations never consume
-      // store capacity, but any capacity error still parks the entry as a
-      // retry-safe domain state.
-      try {
-        await this.options.delivered.reserve(envelope.id);
-      } catch (error) {
-        if (isPluginStateCapacityError(error)) {
-          throw new ReefInboxEntryParkedError(
-            "Reef delivered-marker store is at capacity; entry parked for retry",
-          );
-        }
-        throw error;
-      }
     }
     const budget = autonomyBudget(friend.autonomy);
     if (budget.notifyOnly) {
@@ -488,8 +470,8 @@ export class ReefMessageFlow {
       await this.options.delivered.confirm(envelope.id);
     } catch (error) {
       if (isPluginStateCapacityError(error)) {
-        // The reservation remains pending, so the re-poll re-ingresses and
-        // retries the confirmed marker instead of unwinding the shared inbox.
+        // Failed confirm means no delivered marker persisted, so the re-poll
+        // re-ingests the entry instead of unwinding the shared inbox.
         throw new ReefInboxEntryParkedError(
           "Reef delivered-marker store is at capacity; entry parked for retry",
         );

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -483,7 +483,18 @@ export class ReefMessageFlow {
         autonomy: friend.autonomy,
       });
     }
-    await this.options.delivered.confirm(envelope.id);
+    try {
+      await this.options.delivered.confirm(envelope.id);
+    } catch (error) {
+      if (isPluginStateCapacityError(error)) {
+        // The reservation remains pending, so the re-poll re-ingresses and
+        // retries the confirmed marker instead of unwinding the shared inbox.
+        throw new ReefInboxEntryParkedError(
+          "Reef delivered-marker store is at capacity; entry parked for retry",
+        );
+      }
+      throw error;
+    }
     await this.options.transport.acknowledge(relayPeer, envelope.id, result.receipt);
   }
 

--- a/extensions/reef/src/state.test.ts
+++ b/extensions/reef/src/state.test.ts
@@ -640,7 +640,7 @@ describe("Reef SQLite state", () => {
   });
 });
 
-describe("Reef delivered marker two-phase delivery", () => {
+describe("Reef delivered markers", () => {
   let stateDir = "";
 
   beforeEach(() => {
@@ -659,17 +659,14 @@ describe("Reef delivered marker two-phase delivery", () => {
     return { ...identity, auditKey, replayKey, keyEpoch: 1 };
   }
 
-  it("reserves before delivery and confirms after, keeping states distinct", async () => {
+  it("confirms delivered markers idempotently", async () => {
     const stores = openStores(createRuntime(stateDir), testKeys());
-    await stores.delivered.reserve("m1");
-    await expect(stores.delivered.status("m1")).resolves.toBe("pending");
-    // A reservation is not a delivery: older readers must not suppress it.
+    await expect(stores.delivered.status("m1")).resolves.toBeUndefined();
     await expect(stores.delivered.has("m1")).resolves.toBe(false);
     await stores.delivered.confirm("m1");
     await expect(stores.delivered.status("m1")).resolves.toBe("delivered");
     await expect(stores.delivered.has("m1")).resolves.toBe(true);
-    // Idempotent reserve keeps a confirmed marker delivered.
-    await stores.delivered.reserve("m1");
+    await stores.delivered.confirm("m1");
     await expect(stores.delivered.status("m1")).resolves.toBe("delivered");
     await stores.delivered.add("m2");
     await expect(stores.delivered.status("m2")).resolves.toBe("delivered");
@@ -680,28 +677,22 @@ describe("Reef delivered marker two-phase delivery", () => {
       deliveredMaxEntries: 1,
     });
     await stores.delivered.add("first"); // delivered namespace full
-    // Reservations are in-memory, so they never consume store capacity and
-    // reserve cannot fail; capacity surfaces from confirm.
-    await stores.delivered.reserve("second");
-    await expect(stores.delivered.status("second")).resolves.toBe("pending");
-    // Confirming into a full delivered namespace fails closed. The in-memory
-    // reservation stays pending, so the re-poll re-ingresses and retries the
-    // confirmed marker instead of unwinding the shared inbox.
+    // Confirming into a full delivered namespace fails closed. No marker is
+    // retained, so the re-poll re-ingresses before retrying confirmation.
     await expect(stores.delivered.confirm("second")).rejects.toMatchObject({
       code: "PLUGIN_STATE_LIMIT_EXCEEDED",
     });
-    await expect(stores.delivered.status("second")).resolves.toBe("pending");
+    await expect(stores.delivered.status("second")).resolves.toBeUndefined();
     await expect(stores.delivered.status("first")).resolves.toBe("delivered");
     await expect(stores.delivered.status("third")).resolves.toBeUndefined();
   });
 
-  it("parks confirm at the plugin-wide aggregate limit with the reservation retained", async () => {
+  it("parks confirm at the plugin-wide aggregate limit without retaining bookkeeping", async () => {
     const stores = openStores(createRuntime(stateDir), testKeys(), {
       deliveredMaxEntries: REEF_DELIVERED_MAX_ENTRIES,
     });
-    // Fill the plugin-wide aggregate limit from another namespace's row:
-    // reservations never occupy store rows, so confirm is the only step that
-    // needs one and the parked entry retries bounded, at-least-once.
+    // Fill the plugin-wide aggregate limit from another namespace's row. The
+    // parked entry keeps no separate bookkeeping and retries at-least-once.
     setMaxPluginStateEntriesPerPluginForTests(1);
     try {
       const other = createRuntime(stateDir).state.openSyncKeyedStore<{ id: string }>({
@@ -710,12 +701,11 @@ describe("Reef delivered marker two-phase delivery", () => {
         overflowPolicy: "reject-new",
       });
       other.registerIfAbsent("row-1", { id: "row-1" });
-      await stores.delivered.reserve("aggregate-1");
-      await expect(stores.delivered.status("aggregate-1")).resolves.toBe("pending");
+      await expect(stores.delivered.status("aggregate-1")).resolves.toBeUndefined();
       await expect(stores.delivered.confirm("aggregate-1")).rejects.toMatchObject({
         code: "PLUGIN_STATE_LIMIT_EXCEEDED",
       });
-      await expect(stores.delivered.status("aggregate-1")).resolves.toBe("pending");
+      await expect(stores.delivered.status("aggregate-1")).resolves.toBeUndefined();
     } finally {
       setMaxPluginStateEntriesPerPluginForTests();
     }

--- a/extensions/reef/src/state.test.ts
+++ b/extensions/reef/src/state.test.ts
@@ -675,44 +675,47 @@ describe("Reef delivered marker two-phase delivery", () => {
     await expect(stores.delivered.status("m2")).resolves.toBe("delivered");
   });
 
-  it("surfaces capacity as PLUGIN_STATE_LIMIT_EXCEEDED from reserve and confirm without touching existing markers", async () => {
+  it("surfaces capacity as PLUGIN_STATE_LIMIT_EXCEEDED from confirm without touching existing markers", async () => {
     const stores = openStores(createRuntime(stateDir), testKeys(), {
       deliveredMaxEntries: 1,
     });
     await stores.delivered.add("first"); // delivered namespace full
-    // Reservations have their own capacity: one fits, the next fails closed.
+    // Reservations are in-memory, so they never consume store capacity and
+    // reserve cannot fail; capacity surfaces from confirm.
     await stores.delivered.reserve("second");
     await expect(stores.delivered.status("second")).resolves.toBe("pending");
-    await expect(stores.delivered.reserve("third")).rejects.toMatchObject({
-      code: "PLUGIN_STATE_LIMIT_EXCEEDED",
-    });
-    // Confirming into a full delivered namespace fails closed. The
-    // capacity-neutral transition frees the reservation first, so nothing stays
-    // stuck: the re-poll re-ingresses from a clean reservation.
+    // Confirming into a full delivered namespace fails closed. The in-memory
+    // reservation stays pending, so the re-poll re-ingresses and retries the
+    // confirmed marker instead of unwinding the shared inbox.
     await expect(stores.delivered.confirm("second")).rejects.toMatchObject({
       code: "PLUGIN_STATE_LIMIT_EXCEEDED",
     });
-    await expect(stores.delivered.status("second")).resolves.toBeUndefined();
+    await expect(stores.delivered.status("second")).resolves.toBe("pending");
     await expect(stores.delivered.status("first")).resolves.toBe("delivered");
     await expect(stores.delivered.status("third")).resolves.toBeUndefined();
   });
 
-  it("confirms a reservation at the plugin-wide aggregate limit by reusing its row", async () => {
+  it("parks confirm at the plugin-wide aggregate limit with the reservation retained", async () => {
     const stores = openStores(createRuntime(stateDir), testKeys(), {
       deliveredMaxEntries: REEF_DELIVERED_MAX_ENTRIES,
     });
-    // Squeeze the plugin-wide aggregate limit down to the reservation itself:
-    // the pending row occupies the last available live row.
+    // Fill the plugin-wide aggregate limit from another namespace's row:
+    // reservations never occupy store rows, so confirm is the only step that
+    // needs one and the parked entry retries bounded, at-least-once.
     setMaxPluginStateEntriesPerPluginForTests(1);
     try {
+      const other = createRuntime(stateDir).state.openSyncKeyedStore<{ id: string }>({
+        namespace: "reef-test-other",
+        maxEntries: REEF_DELIVERED_MAX_ENTRIES,
+        overflowPolicy: "reject-new",
+      });
+      other.registerIfAbsent("row-1", { id: "row-1" });
       await stores.delivered.reserve("aggregate-1");
       await expect(stores.delivered.status("aggregate-1")).resolves.toBe("pending");
-      // The transition is capacity-neutral: freeing the reservation makes room
-      // for the delivered marker, so confirmation cannot be blocked by the
-      // aggregate limit once ingress has run.
-      await stores.delivered.confirm("aggregate-1");
-      await expect(stores.delivered.status("aggregate-1")).resolves.toBe("delivered");
-      await expect(stores.delivered.has("aggregate-1")).resolves.toBe(true);
+      await expect(stores.delivered.confirm("aggregate-1")).rejects.toMatchObject({
+        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+      });
+      await expect(stores.delivered.status("aggregate-1")).resolves.toBe("pending");
     } finally {
       setMaxPluginStateEntriesPerPluginForTests();
     }

--- a/extensions/reef/src/state.test.ts
+++ b/extensions/reef/src/state.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
+  setMaxPluginStateEntriesPerPluginForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -685,14 +686,36 @@ describe("Reef delivered marker two-phase delivery", () => {
     await expect(stores.delivered.reserve("third")).rejects.toMatchObject({
       code: "PLUGIN_STATE_LIMIT_EXCEEDED",
     });
-    // Confirming into a full delivered namespace fails closed and keeps the
-    // reservation pending for retry.
+    // Confirming into a full delivered namespace fails closed. The
+    // capacity-neutral transition frees the reservation first, so nothing stays
+    // stuck: the re-poll re-ingresses from a clean reservation.
     await expect(stores.delivered.confirm("second")).rejects.toMatchObject({
       code: "PLUGIN_STATE_LIMIT_EXCEEDED",
     });
-    await expect(stores.delivered.status("second")).resolves.toBe("pending");
+    await expect(stores.delivered.status("second")).resolves.toBeUndefined();
     await expect(stores.delivered.status("first")).resolves.toBe("delivered");
     await expect(stores.delivered.status("third")).resolves.toBeUndefined();
+  });
+
+  it("confirms a reservation at the plugin-wide aggregate limit by reusing its row", async () => {
+    const stores = openStores(createRuntime(stateDir), testKeys(), {
+      deliveredMaxEntries: REEF_DELIVERED_MAX_ENTRIES,
+    });
+    // Squeeze the plugin-wide aggregate limit down to the reservation itself:
+    // the pending row occupies the last available live row.
+    setMaxPluginStateEntriesPerPluginForTests(1);
+    try {
+      await stores.delivered.reserve("aggregate-1");
+      await expect(stores.delivered.status("aggregate-1")).resolves.toBe("pending");
+      // The transition is capacity-neutral: freeing the reservation makes room
+      // for the delivered marker, so confirmation cannot be blocked by the
+      // aggregate limit once ingress has run.
+      await stores.delivered.confirm("aggregate-1");
+      await expect(stores.delivered.status("aggregate-1")).resolves.toBe("delivered");
+      await expect(stores.delivered.has("aggregate-1")).resolves.toBe(true);
+    } finally {
+      setMaxPluginStateEntriesPerPluginForTests();
+    }
   });
 
   it("reads legacy delivered markers without a state as delivered", async () => {

--- a/extensions/reef/src/state.test.ts
+++ b/extensions/reef/src/state.test.ts
@@ -662,9 +662,11 @@ describe("Reef delivered marker two-phase delivery", () => {
     const stores = openStores(createRuntime(stateDir), testKeys());
     await stores.delivered.reserve("m1");
     await expect(stores.delivered.status("m1")).resolves.toBe("pending");
-    await expect(stores.delivered.has("m1")).resolves.toBe(true);
+    // A reservation is not a delivery: older readers must not suppress it.
+    await expect(stores.delivered.has("m1")).resolves.toBe(false);
     await stores.delivered.confirm("m1");
     await expect(stores.delivered.status("m1")).resolves.toBe("delivered");
+    await expect(stores.delivered.has("m1")).resolves.toBe(true);
     // Idempotent reserve keeps a confirmed marker delivered.
     await stores.delivered.reserve("m1");
     await expect(stores.delivered.status("m1")).resolves.toBe("delivered");
@@ -672,16 +674,25 @@ describe("Reef delivered marker two-phase delivery", () => {
     await expect(stores.delivered.status("m2")).resolves.toBe("delivered");
   });
 
-  it("surfaces capacity as PLUGIN_STATE_LIMIT_EXCEEDED from reserve without touching existing markers", async () => {
+  it("surfaces capacity as PLUGIN_STATE_LIMIT_EXCEEDED from reserve and confirm without touching existing markers", async () => {
     const stores = openStores(createRuntime(stateDir), testKeys(), {
       deliveredMaxEntries: 1,
     });
-    await stores.delivered.add("first");
-    await expect(stores.delivered.reserve("second")).rejects.toMatchObject({
+    await stores.delivered.add("first"); // delivered namespace full
+    // Reservations have their own capacity: one fits, the next fails closed.
+    await stores.delivered.reserve("second");
+    await expect(stores.delivered.status("second")).resolves.toBe("pending");
+    await expect(stores.delivered.reserve("third")).rejects.toMatchObject({
       code: "PLUGIN_STATE_LIMIT_EXCEEDED",
     });
+    // Confirming into a full delivered namespace fails closed and keeps the
+    // reservation pending for retry.
+    await expect(stores.delivered.confirm("second")).rejects.toMatchObject({
+      code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+    });
+    await expect(stores.delivered.status("second")).resolves.toBe("pending");
     await expect(stores.delivered.status("first")).resolves.toBe("delivered");
-    await expect(stores.delivered.status("second")).resolves.toBeUndefined();
+    await expect(stores.delivered.status("third")).resolves.toBeUndefined();
   });
 
   it("reads legacy delivered markers without a state as delivered", async () => {

--- a/extensions/reef/src/state.test.ts
+++ b/extensions/reef/src/state.test.ts
@@ -28,9 +28,11 @@ import {
   loadReefSetupSession,
   openStores,
   finalizeReefIdentityBinding,
+  REEF_DELIVERED_MAX_ENTRIES,
   REEF_DELIVERED_NAMESPACE,
   ReefInboxCursorStore,
   REEF_REPLAY_TTL_MS,
+  REEF_DELIVERED_TTL_MS,
   REEF_REVIEWS_NAMESPACE,
   releaseReefIdentityReservation,
   reserveReefIdentityBinding,
@@ -634,5 +636,65 @@ describe("Reef SQLite state", () => {
     await store.request(third);
 
     await expect(store.list()).resolves.toEqual([second, third]);
+  });
+});
+
+describe("Reef delivered marker two-phase delivery", () => {
+  let stateDir = "";
+
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reef-state-"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetPluginStateStoreForTests();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  function testKeys() {
+    const identity = generateIdentity();
+    return { ...identity, auditKey, replayKey, keyEpoch: 1 };
+  }
+
+  it("reserves before delivery and confirms after, keeping states distinct", async () => {
+    const stores = openStores(createRuntime(stateDir), testKeys());
+    await stores.delivered.reserve("m1");
+    await expect(stores.delivered.status("m1")).resolves.toBe("pending");
+    await expect(stores.delivered.has("m1")).resolves.toBe(true);
+    await stores.delivered.confirm("m1");
+    await expect(stores.delivered.status("m1")).resolves.toBe("delivered");
+    // Idempotent reserve keeps a confirmed marker delivered.
+    await stores.delivered.reserve("m1");
+    await expect(stores.delivered.status("m1")).resolves.toBe("delivered");
+    await stores.delivered.add("m2");
+    await expect(stores.delivered.status("m2")).resolves.toBe("delivered");
+  });
+
+  it("surfaces capacity as PLUGIN_STATE_LIMIT_EXCEEDED from reserve without touching existing markers", async () => {
+    const stores = openStores(createRuntime(stateDir), testKeys(), {
+      deliveredMaxEntries: 1,
+    });
+    await stores.delivered.add("first");
+    await expect(stores.delivered.reserve("second")).rejects.toMatchObject({
+      code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+    });
+    await expect(stores.delivered.status("first")).resolves.toBe("delivered");
+    await expect(stores.delivered.status("second")).resolves.toBeUndefined();
+  });
+
+  it("reads legacy delivered markers without a state as delivered", async () => {
+    const runtime = createRuntime(stateDir);
+    const stores = openStores(runtime, testKeys());
+    const legacy = runtime.state.openSyncKeyedStore<{ id: string }>({
+      namespace: REEF_DELIVERED_NAMESPACE,
+      maxEntries: REEF_DELIVERED_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+      defaultTtlMs: REEF_DELIVERED_TTL_MS,
+    });
+    await legacy.registerIfAbsent("legacy-1", { id: "legacy-1" });
+    await expect(stores.delivered.status("legacy-1")).resolves.toBe("delivered");
+    await expect(stores.delivered.has("legacy-1")).resolves.toBe(true);
   });
 });

--- a/extensions/reef/src/state.test.ts
+++ b/extensions/reef/src/state.test.ts
@@ -693,7 +693,7 @@ describe("Reef delivered marker two-phase delivery", () => {
       overflowPolicy: "reject-new",
       defaultTtlMs: REEF_DELIVERED_TTL_MS,
     });
-    await legacy.registerIfAbsent("legacy-1", { id: "legacy-1" });
+    legacy.registerIfAbsent("legacy-1", { id: "legacy-1" });
     await expect(stores.delivered.status("legacy-1")).resolves.toBe("delivered");
     await expect(stores.delivered.has("legacy-1")).resolves.toBe(true);
   });

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -547,15 +547,19 @@ export class ReefDeliveredStore {
   }
 
   async confirm(id: string): Promise<void> {
-    const inserted = this.#delivered.registerIfAbsent(id, { id });
-    if (!inserted && this.#delivered.lookup(id)?.id !== id) {
-      throw new Error("Failed persisting Reef delivered marker");
-    }
+    // Free the reservation row FIRST so the delivered insertion is
+    // capacity-neutral at the plugin-wide aggregate limit: the reservation and
+    // the marker never occupy two rows at once. A crash between the two steps
+    // leaves neither record; the re-poll re-ingresses at-least-once.
     const deleteIf = this.#pending.deleteIf;
     if (!deleteIf) {
       throw new Error("Reef delivered state requires atomic plugin-state updates");
     }
     deleteIf(id, () => true);
+    const inserted = this.#delivered.registerIfAbsent(id, { id });
+    if (!inserted && this.#delivered.lookup(id)?.id !== id) {
+      throw new Error("Failed persisting Reef delivered marker");
+    }
   }
 
   async add(id: string): Promise<void> {

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -495,11 +495,13 @@ export class ReviewApprovalStore {
   }
 }
 
+type ReefDeliveredMarker = { id: string; state?: "pending" | "delivered" };
+
 export class ReefDeliveredStore {
-  readonly #store: PluginStateSyncKeyedStore<{ id: string }>;
+  readonly #store: PluginStateSyncKeyedStore<ReefDeliveredMarker>;
 
   constructor(runtime: PluginRuntime, maxEntries = REEF_DELIVERED_MAX_ENTRIES) {
-    this.#store = runtime.state.openSyncKeyedStore<{ id: string }>({
+    this.#store = runtime.state.openSyncKeyedStore<ReefDeliveredMarker>({
       namespace: REEF_DELIVERED_NAMESPACE,
       maxEntries,
       overflowPolicy: "reject-new",
@@ -513,11 +515,47 @@ export class ReefDeliveredStore {
     return this.#store.lookup(id)?.id === id;
   }
 
-  async add(id: string): Promise<void> {
+  // Markers persisted before two-phase delivery (doctor legacy import, earlier
+  // releases) carry no state and mean the message was fully delivered.
+  async status(id: string): Promise<"delivered" | "pending" | undefined> {
+    const record = this.#store.lookup(id);
+    if (record?.id !== id) {
+      return undefined;
+    }
+    return record.state ?? "delivered";
+  }
+
+  // Reserve the delivery marker BEFORE inbound handling. Capacity failures
+  // propagate so the caller can park the entry as a retry-safe domain state
+  // instead of unwinding the shared inbox after ingress already ran.
+  async reserve(id: string): Promise<void> {
     if (this.#store.lookup(id)?.id === id) {
       return;
     }
-    if (!this.#store.registerIfAbsent(id, { id }) && this.#store.lookup(id)?.id !== id) {
+    const inserted = this.#store.registerIfAbsent(id, { id, state: "pending" });
+    if (!inserted && this.#store.lookup(id)?.id !== id) {
+      throw new Error("Failed persisting Reef delivered marker");
+    }
+  }
+
+  async confirm(id: string): Promise<void> {
+    const update = this.#store.update;
+    if (!update) {
+      throw new Error("Reef delivered state requires atomic plugin-state updates");
+    }
+    update(id, (current) => (current?.id === id ? { id, state: "delivered" } : current));
+  }
+
+  async add(id: string): Promise<void> {
+    const existing = this.#store.lookup(id);
+    if (existing?.id === id) {
+      if (existing.state === "pending") {
+        await this.confirm(id);
+      }
+      return;
+    }
+    this.#store.registerIfAbsent(id, { id, state: "delivered" });
+    if (this.#store.lookup(id)?.id !== id) {
       throw new Error("Failed persisting Reef delivered marker");
     }
   }

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -40,10 +40,6 @@ export const REEF_REPLAY_TTL_MS = (REEF_ENVELOPE_MAX_AGE_SECONDS + 24 * 60 * 60)
 export const REEF_REVIEWS_NAMESPACE = "reviews";
 export const REEF_REVIEWS_MAX_ENTRIES = 2_000;
 export const REEF_DELIVERED_NAMESPACE = "delivered";
-// Reservations live in their own namespace so the delivered namespace keeps its
-// exact historical record shape: older readers that treat any stored id as a
-// completed delivery can never mistake an unconfirmed reservation for one.
-const REEF_DELIVERED_PENDING_NAMESPACE = "delivered-pending";
 export const REEF_DELIVERED_MAX_ENTRIES = 5_000;
 export const REEF_DELIVERED_TTL_MS = REEF_REPLAY_TTL_MS;
 const REEF_INBOX_CURSOR_NAMESPACE = "inbox-cursor";
@@ -501,23 +497,20 @@ export class ReviewApprovalStore {
 
 export class ReefDeliveredStore {
   readonly #delivered: PluginStateSyncKeyedStore<{ id: string }>;
-  readonly #pending: PluginStateSyncKeyedStore<{ id: string }>;
+  // In-flight reservations are process-local: they classify entries within a
+  // single run while the persisted delivered markers and replay store carry
+  // the shipped cross-restart durability contract. A crash in the
+  // dispatch-confirm window re-dispatches once on restart — the same bounded
+  // at-least-once behavior the shipped store already exhibits.
+  readonly #reservations = new Set<string>();
 
   constructor(runtime: PluginRuntime, maxEntries = REEF_DELIVERED_MAX_ENTRIES) {
-    // The delivered namespace keeps the exact historical record shape so older
-    // readers can never mistake an unconfirmed reservation for a delivery.
     this.#delivered = runtime.state.openSyncKeyedStore<{ id: string }>({
       namespace: REEF_DELIVERED_NAMESPACE,
       maxEntries,
       overflowPolicy: "reject-new",
       // Relay redelivery is bounded by the same envelope-age contract as replay.
       // Keep markers longer than that window and fail closed at live capacity.
-      defaultTtlMs: REEF_DELIVERED_TTL_MS,
-    });
-    this.#pending = runtime.state.openSyncKeyedStore<{ id: string }>({
-      namespace: REEF_DELIVERED_PENDING_NAMESPACE,
-      maxEntries,
-      overflowPolicy: "reject-new",
       defaultTtlMs: REEF_DELIVERED_TTL_MS,
     });
   }
@@ -530,36 +523,26 @@ export class ReefDeliveredStore {
     if (this.#delivered.lookup(id)?.id === id) {
       return "delivered";
     }
-    return this.#pending.lookup(id)?.id === id ? "pending" : undefined;
+    return this.#reservations.has(id) ? "pending" : undefined;
   }
 
-  // Reserve the delivery marker BEFORE inbound handling. Capacity failures
-  // propagate so the caller can park the entry as a retry-safe domain state
+  // Reserve the delivery marker BEFORE inbound handling. Reservations are
+  // in-memory, so they never consume store capacity; capacity failures surface
+  // from confirm, and the caller parks the entry as a retry-safe domain state
   // instead of unwinding the shared inbox after ingress already ran.
   async reserve(id: string): Promise<void> {
-    if (this.#pending.lookup(id)?.id === id || this.#delivered.lookup(id)?.id === id) {
+    if (this.#reservations.has(id) || this.#delivered.lookup(id)?.id === id) {
       return;
     }
-    const inserted = this.#pending.registerIfAbsent(id, { id });
-    if (!inserted && this.#pending.lookup(id)?.id !== id) {
-      throw new Error("Failed persisting Reef delivered reservation");
-    }
+    this.#reservations.add(id);
   }
 
   async confirm(id: string): Promise<void> {
-    // Free the reservation row FIRST so the delivered insertion is
-    // capacity-neutral at the plugin-wide aggregate limit: the reservation and
-    // the marker never occupy two rows at once. A crash between the two steps
-    // leaves neither record; the re-poll re-ingresses at-least-once.
-    const deleteIf = this.#pending.deleteIf;
-    if (!deleteIf) {
-      throw new Error("Reef delivered state requires atomic plugin-state updates");
-    }
-    deleteIf(id, () => true);
     const inserted = this.#delivered.registerIfAbsent(id, { id });
     if (!inserted && this.#delivered.lookup(id)?.id !== id) {
       throw new Error("Failed persisting Reef delivered marker");
     }
+    this.#reservations.delete(id);
   }
 
   async add(id: string): Promise<void> {

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -40,6 +40,10 @@ export const REEF_REPLAY_TTL_MS = (REEF_ENVELOPE_MAX_AGE_SECONDS + 24 * 60 * 60)
 export const REEF_REVIEWS_NAMESPACE = "reviews";
 export const REEF_REVIEWS_MAX_ENTRIES = 2_000;
 export const REEF_DELIVERED_NAMESPACE = "delivered";
+// Reservations live in their own namespace so the delivered namespace keeps its
+// exact historical record shape: older readers that treat any stored id as a
+// completed delivery can never mistake an unconfirmed reservation for one.
+export const REEF_DELIVERED_PENDING_NAMESPACE = "delivered-pending";
 export const REEF_DELIVERED_MAX_ENTRIES = 5_000;
 export const REEF_DELIVERED_TTL_MS = REEF_REPLAY_TTL_MS;
 const REEF_INBOX_CURSOR_NAMESPACE = "inbox-cursor";
@@ -495,13 +499,14 @@ export class ReviewApprovalStore {
   }
 }
 
-type ReefDeliveredMarker = { id: string; state?: "pending" | "delivered" };
-
 export class ReefDeliveredStore {
-  readonly #store: PluginStateSyncKeyedStore<ReefDeliveredMarker>;
+  readonly #delivered: PluginStateSyncKeyedStore<{ id: string }>;
+  readonly #pending: PluginStateSyncKeyedStore<{ id: string }>;
 
   constructor(runtime: PluginRuntime, maxEntries = REEF_DELIVERED_MAX_ENTRIES) {
-    this.#store = runtime.state.openSyncKeyedStore<ReefDeliveredMarker>({
+    // The delivered namespace keeps the exact historical record shape so older
+    // readers can never mistake an unconfirmed reservation for a delivery.
+    this.#delivered = runtime.state.openSyncKeyedStore<{ id: string }>({
       namespace: REEF_DELIVERED_NAMESPACE,
       maxEntries,
       overflowPolicy: "reject-new",
@@ -509,55 +514,52 @@ export class ReefDeliveredStore {
       // Keep markers longer than that window and fail closed at live capacity.
       defaultTtlMs: REEF_DELIVERED_TTL_MS,
     });
+    this.#pending = runtime.state.openSyncKeyedStore<{ id: string }>({
+      namespace: REEF_DELIVERED_PENDING_NAMESPACE,
+      maxEntries,
+      overflowPolicy: "reject-new",
+      defaultTtlMs: REEF_DELIVERED_TTL_MS,
+    });
   }
 
   async has(id: string): Promise<boolean> {
-    return this.#store.lookup(id)?.id === id;
+    return this.#delivered.lookup(id)?.id === id;
   }
 
-  // Markers persisted before two-phase delivery (doctor legacy import, earlier
-  // releases) carry no state and mean the message was fully delivered.
   async status(id: string): Promise<"delivered" | "pending" | undefined> {
-    const record = this.#store.lookup(id);
-    if (record?.id !== id) {
-      return undefined;
+    if (this.#delivered.lookup(id)?.id === id) {
+      return "delivered";
     }
-    return record.state ?? "delivered";
+    return this.#pending.lookup(id)?.id === id ? "pending" : undefined;
   }
 
   // Reserve the delivery marker BEFORE inbound handling. Capacity failures
   // propagate so the caller can park the entry as a retry-safe domain state
   // instead of unwinding the shared inbox after ingress already ran.
   async reserve(id: string): Promise<void> {
-    if (this.#store.lookup(id)?.id === id) {
+    if (this.#pending.lookup(id)?.id === id || this.#delivered.lookup(id)?.id === id) {
       return;
     }
-    const inserted = this.#store.registerIfAbsent(id, { id, state: "pending" });
-    if (!inserted && this.#store.lookup(id)?.id !== id) {
-      throw new Error("Failed persisting Reef delivered marker");
+    const inserted = this.#pending.registerIfAbsent(id, { id });
+    if (!inserted && this.#pending.lookup(id)?.id !== id) {
+      throw new Error("Failed persisting Reef delivered reservation");
     }
   }
 
   async confirm(id: string): Promise<void> {
-    const update = this.#store.update;
-    if (!update) {
+    const inserted = this.#delivered.registerIfAbsent(id, { id });
+    if (!inserted && this.#delivered.lookup(id)?.id !== id) {
+      throw new Error("Failed persisting Reef delivered marker");
+    }
+    const deleteIf = this.#pending.deleteIf;
+    if (!deleteIf) {
       throw new Error("Reef delivered state requires atomic plugin-state updates");
     }
-    update(id, (current) => (current?.id === id ? { id, state: "delivered" } : current));
+    deleteIf(id, () => true);
   }
 
   async add(id: string): Promise<void> {
-    const existing = this.#store.lookup(id);
-    if (existing?.id === id) {
-      if (existing.state === "pending") {
-        await this.confirm(id);
-      }
-      return;
-    }
-    this.#store.registerIfAbsent(id, { id, state: "delivered" });
-    if (this.#store.lookup(id)?.id !== id) {
-      throw new Error("Failed persisting Reef delivered marker");
-    }
+    await this.confirm(id);
   }
 }
 

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -497,12 +497,6 @@ export class ReviewApprovalStore {
 
 export class ReefDeliveredStore {
   readonly #delivered: PluginStateSyncKeyedStore<{ id: string }>;
-  // In-flight reservations are process-local: they classify entries within a
-  // single run while the persisted delivered markers and replay store carry
-  // the shipped cross-restart durability contract. A crash in the
-  // dispatch-confirm window re-dispatches once on restart — the same bounded
-  // at-least-once behavior the shipped store already exhibits.
-  readonly #reservations = new Set<string>();
 
   constructor(runtime: PluginRuntime, maxEntries = REEF_DELIVERED_MAX_ENTRIES) {
     this.#delivered = runtime.state.openSyncKeyedStore<{ id: string }>({
@@ -519,22 +513,8 @@ export class ReefDeliveredStore {
     return this.#delivered.lookup(id)?.id === id;
   }
 
-  async status(id: string): Promise<"delivered" | "pending" | undefined> {
-    if (this.#delivered.lookup(id)?.id === id) {
-      return "delivered";
-    }
-    return this.#reservations.has(id) ? "pending" : undefined;
-  }
-
-  // Reserve the delivery marker BEFORE inbound handling. Reservations are
-  // in-memory, so they never consume store capacity; capacity failures surface
-  // from confirm, and the caller parks the entry as a retry-safe domain state
-  // instead of unwinding the shared inbox after ingress already ran.
-  async reserve(id: string): Promise<void> {
-    if (this.#reservations.has(id) || this.#delivered.lookup(id)?.id === id) {
-      return;
-    }
-    this.#reservations.add(id);
+  async status(id: string): Promise<"delivered" | undefined> {
+    return this.#delivered.lookup(id)?.id === id ? "delivered" : undefined;
   }
 
   async confirm(id: string): Promise<void> {
@@ -542,7 +522,6 @@ export class ReefDeliveredStore {
     if (!inserted && this.#delivered.lookup(id)?.id !== id) {
       throw new Error("Failed persisting Reef delivered marker");
     }
-    this.#reservations.delete(id);
   }
 
   async add(id: string): Promise<void> {

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -43,7 +43,7 @@ export const REEF_DELIVERED_NAMESPACE = "delivered";
 // Reservations live in their own namespace so the delivered namespace keeps its
 // exact historical record shape: older readers that treat any stored id as a
 // completed delivery can never mistake an unconfirmed reservation for one.
-export const REEF_DELIVERED_PENDING_NAMESPACE = "delivered-pending";
+const REEF_DELIVERED_PENDING_NAMESPACE = "delivered-pending";
 export const REEF_DELIVERED_MAX_ENTRIES = 5_000;
 export const REEF_DELIVERED_TTL_MS = REEF_REPLAY_TTL_MS;
 const REEF_INBOX_CURSOR_NAMESPACE = "inbox-cursor";

--- a/extensions/reef/src/transport-capacity-recovery.test.ts
+++ b/extensions/reef/src/transport-capacity-recovery.test.ts
@@ -142,8 +142,8 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
     );
 
     // Delivered namespace full: both entries park AFTER ingress as retry-safe
-    // domain states (reservations are in-memory, so capacity surfaces at
-    // confirm). The shared connection survives, later entries are still
+    // domain states when confirmation reaches capacity. The shared connection
+    // survives without retaining per-entry reservation bookkeeping, later entries are still
     // attempted, nothing is acknowledged, and the cursor is held.
     await inbox.drain();
     expect(onIngress).toHaveBeenCalledTimes(2);

--- a/extensions/reef/src/transport-capacity-recovery.test.ts
+++ b/extensions/reef/src/transport-capacity-recovery.test.ts
@@ -1,0 +1,267 @@
+// Real-behavior proof for capacity-parked inbound delivery: the production
+// ReefInboxConnection drives the production ReefMessageFlow over production
+// SQLite delivered/replay stores, with only the relay and the platform send
+// mocked out. Covers shared-inbox survival, later-entry processing, recovery
+// once capacity frees, interrupted-delivery restart, and legacy marker
+// interpretation.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  composeOutbound,
+  generateIdentity,
+  MemoryAuditStore,
+  MemoryReplayStore,
+} from "../protocol/index.js";
+import { ReefMessageFlow } from "./flow.js";
+import {
+  allow,
+  config,
+  flowStores,
+  guard,
+  peerTrust,
+  reefKeys,
+  resetFlowStoresForTests,
+  transport,
+  trust,
+} from "./flow.test-helpers.js";
+import {
+  REEF_DELIVERED_MAX_ENTRIES,
+  REEF_DELIVERED_NAMESPACE,
+  REEF_DELIVERED_TTL_MS,
+} from "./state.js";
+import { ReefInboxConnection, type ReefTransportClient } from "./transport.js";
+import { createClient, parseRequestUrl } from "./transport.test-helpers.js";
+import type { InboxEntry, ReefKeys } from "./types.js";
+
+const ts = Math.floor(Date.now() / 1_000);
+
+async function envelopeFrom(
+  sender: ReturnType<typeof generateIdentity>,
+  senderHandle: string,
+  recipient: ReefKeys,
+  id: string,
+  text: string,
+) {
+  return (
+    await composeOutbound({
+      id,
+      from: `${senderHandle}#1`,
+      to: "bob#1",
+      body: { text },
+      senderSigningSecretKey: sender.signing.secretKey,
+      recipientEncryptionPublicKey: recipient.encryption.publicKey,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(3)),
+      policyVersion: "v1",
+    })
+  ).envelope;
+}
+
+function messageEntry(seq: number, peer: string, envelope: unknown, id: string): InboxEntry {
+  return {
+    seq,
+    peer,
+    id,
+    kind: "message",
+    envelope: envelope as InboxEntry["envelope"],
+    ts,
+  };
+}
+
+function relayRetaining(entries: Map<number, InboxEntry>) {
+  const requestedAfter: number[] = [];
+  const fetcher = vi.fn<typeof fetch>(async (input) => {
+    const after = Number(parseRequestUrl(input).searchParams.get("after"));
+    requestedAfter.push(after);
+    const page = [...entries.values()]
+      .filter((entry) => entry.seq > after)
+      .toSorted((left, right) => left.seq - right.seq);
+    return Response.json({ entries: page, cursor: page.at(-1)?.seq ?? after });
+  });
+  return { fetcher, requestedAfter };
+}
+
+describe("Reef capacity-parked delivery recovery (production connection path)", () => {
+  beforeEach(() => {
+    resetFlowStoresForTests();
+  });
+
+  afterEach(() => {
+    resetFlowStoresForTests();
+  });
+
+  it("survives capacity parks from two peers, keeps later entries attemptable, and completes both once capacity frees", async () => {
+    const alice = generateIdentity();
+    const carol = generateIdentity();
+    const bob = reefKeys();
+    const idA = "01JZ00000000000000000002A1";
+    const idC = "01JZ00000000000000000002C1";
+    const stores = flowStores(2);
+    await stores.delivered.add("occupied-1");
+    await stores.delivered.add("occupied-2");
+
+    const entries = new Map<number, InboxEntry>([
+      [1, messageEntry(1, "alice", await envelopeFrom(alice, "alice", bob, idA, "first"), idA)],
+      [2, messageEntry(2, "carol", await envelopeFrom(carol, "carol", bob, idC, "second"), idC)],
+    ]);
+    const { fetcher } = relayRetaining(entries);
+    const relay = transport();
+    const onIngress = vi.fn(async () => {});
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice), carol: peerTrust(carol) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient, // SAFETY: ack-recording mock satisfies the client contract
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(30)),
+      replay: new MemoryReplayStore(),
+      ...stores,
+      onIngress,
+      onOwnerNotice: async () => {},
+    });
+    const persisted: number[] = [];
+    const inbox = new ReefInboxConnection(
+      createClient(fetcher),
+      async (batch) => {
+        await flow.processEntries(batch);
+      },
+      () => {
+        throw new Error("REST-only proof: no live socket expected");
+      },
+      { initialCursor: 0, persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    // Full store: both entries park as retry-safe domain states. The shared
+    // connection survives and later entries are still attempted.
+    await inbox.drain();
+    expect(onIngress).not.toHaveBeenCalled();
+    expect(relay.acknowledge).not.toHaveBeenCalled();
+    expect(persisted).toEqual([]);
+
+    // Capacity frees (marker TTL expiry in production; explicit free here).
+    // Reopen with the same options the flow's delivered store uses (cap 2).
+    const raw = stores.runtime.state.openSyncKeyedStore<{ id: string }>({
+      namespace: REEF_DELIVERED_NAMESPACE,
+      maxEntries: 2,
+      overflowPolicy: "reject-new",
+      defaultTtlMs: REEF_DELIVERED_TTL_MS,
+    });
+    raw.delete("occupied-1");
+    raw.delete("occupied-2");
+
+    // Re-poll: both parked entries complete in order, with ingress, confirmed
+    // markers, acknowledgments, and a persisted cursor past both.
+    await inbox.drain();
+    expect(onIngress).toHaveBeenCalledTimes(2);
+    expect(relay.acknowledge).toHaveBeenCalledTimes(2);
+    await expect(stores.delivered.status(idA)).resolves.toBe("delivered");
+    await expect(stores.delivered.status(idC)).resolves.toBe("delivered");
+    expect(persisted.at(-1)).toBe(2);
+
+    // A third poll is fully drained: nothing re-dispatches.
+    await inbox.drain();
+    expect(onIngress).toHaveBeenCalledTimes(2);
+    expect(relay.acknowledge).toHaveBeenCalledTimes(2);
+  });
+
+  it("an interrupted delivery with a reserved marker re-ingresses exactly once and confirms on restart", async () => {
+    const alice = generateIdentity();
+    const bob = reefKeys();
+    const id = "01JZ00000000000000000002D1";
+    const stores = flowStores();
+    // Crash window: the marker was reserved before inbound handling ran.
+    await stores.delivered.reserve(id);
+    const entries = new Map<number, InboxEntry>([
+      [1, messageEntry(1, "alice", await envelopeFrom(alice, "alice", bob, id, "resumed"), id)],
+    ]);
+    const { fetcher } = relayRetaining(entries);
+    const relay = transport();
+    const onIngress = vi.fn(async () => {});
+    // Restart: a fresh flow over the same persisted stores.
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient, // SAFETY: ack-recording mock satisfies the client contract
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(31)),
+      replay: new MemoryReplayStore(),
+      ...stores,
+      onIngress,
+      onOwnerNotice: async () => {},
+    });
+    const persisted: number[] = [];
+    const inbox = new ReefInboxConnection(
+      createClient(fetcher),
+      async (batch) => {
+        await flow.processEntries(batch);
+      },
+      () => {
+        throw new Error("REST-only proof: no live socket expected");
+      },
+      { initialCursor: 0, persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    await inbox.drain();
+    expect(onIngress).toHaveBeenCalledTimes(1);
+    await expect(stores.delivered.status(id)).resolves.toBe("delivered");
+    expect(relay.acknowledge).toHaveBeenCalledTimes(1);
+    expect(persisted.at(-1)).toBe(1);
+
+    // The relay re-sends the same envelope id under a new sequence (retained
+    // backlog redelivery): the delivered marker suppresses re-ingress, ack only.
+    entries.set(2, messageEntry(2, "alice", entries.get(1)!.envelope, id));
+    await inbox.drain();
+    expect(onIngress).toHaveBeenCalledTimes(1);
+    expect(relay.acknowledge).toHaveBeenCalledTimes(2);
+    expect(persisted.at(-1)).toBe(2);
+  });
+
+  it("legacy stateless delivered markers suppress re-ingress and acknowledge on the next poll", async () => {
+    const alice = generateIdentity();
+    const bob = reefKeys();
+    const id = "01JZ00000000000000000002E1";
+    const stores = flowStores();
+    const raw = stores.runtime.state.openSyncKeyedStore<{ id: string }>({
+      namespace: REEF_DELIVERED_NAMESPACE,
+      maxEntries: REEF_DELIVERED_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+      defaultTtlMs: REEF_DELIVERED_TTL_MS,
+    });
+    raw.registerIfAbsent(id, { id });
+    const entries = new Map<number, InboxEntry>([
+      [1, messageEntry(1, "alice", await envelopeFrom(alice, "alice", bob, id, "legacy"), id)],
+    ]);
+    const { fetcher } = relayRetaining(entries);
+    const relay = transport();
+    const onIngress = vi.fn(async () => {});
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient, // SAFETY: ack-recording mock satisfies the client contract
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(32)),
+      replay: new MemoryReplayStore(),
+      ...stores,
+      onIngress,
+      onOwnerNotice: async () => {},
+    });
+    const persisted: number[] = [];
+    const inbox = new ReefInboxConnection(
+      createClient(fetcher),
+      async (batch) => {
+        await flow.processEntries(batch);
+      },
+      () => {
+        throw new Error("REST-only proof: no live socket expected");
+      },
+      { initialCursor: 0, persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    await inbox.drain();
+    expect(onIngress).not.toHaveBeenCalled();
+    expect(relay.acknowledge).toHaveBeenCalledTimes(1);
+    await expect(stores.delivered.status(id)).resolves.toBe("delivered");
+    expect(persisted.at(-1)).toBe(1);
+  });
+});

--- a/extensions/reef/src/transport-capacity-recovery.test.ts
+++ b/extensions/reef/src/transport-capacity-recovery.test.ts
@@ -24,7 +24,6 @@ import {
 import {
   REEF_DELIVERED_MAX_ENTRIES,
   REEF_DELIVERED_NAMESPACE,
-  REEF_DELIVERED_PENDING_NAMESPACE,
   REEF_DELIVERED_TTL_MS,
   openStores,
 } from "./state.js";
@@ -151,8 +150,9 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
 
     // Capacity frees (marker TTL expiry in production; explicit free here).
     // Reopen with the same options the flow's reservation store uses (cap 2).
+    // Namespace literal mirrors the internal REEF_DELIVERED_PENDING_NAMESPACE.
     const raw = stores.runtime.state.openSyncKeyedStore<{ id: string }>({
-      namespace: REEF_DELIVERED_PENDING_NAMESPACE,
+      namespace: "delivered-pending",
       maxEntries: 2,
       overflowPolicy: "reject-new",
       defaultTtlMs: REEF_DELIVERED_TTL_MS,

--- a/extensions/reef/src/transport-capacity-recovery.test.ts
+++ b/extensions/reef/src/transport-capacity-recovery.test.ts
@@ -4,13 +4,11 @@
 // mocked out. Covers shared-inbox survival, later-entry processing, recovery
 // once capacity frees, interrupted-delivery restart, and legacy marker
 // interpretation.
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { createPluginStateSyncKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  composeOutbound,
-  generateIdentity,
-  MemoryAuditStore,
-  MemoryReplayStore,
-} from "../protocol/index.js";
+import { composeOutbound, generateIdentity, MemoryAuditStore } from "../protocol/index.js";
 import { ReefMessageFlow } from "./flow.js";
 import {
   allow,
@@ -28,12 +26,25 @@ import {
   REEF_DELIVERED_NAMESPACE,
   REEF_DELIVERED_PENDING_NAMESPACE,
   REEF_DELIVERED_TTL_MS,
+  openStores,
 } from "./state.js";
 import { ReefInboxConnection, type ReefTransportClient } from "./transport.js";
 import { createClient, parseRequestUrl } from "./transport.test-helpers.js";
 import type { InboxEntry, ReefKeys } from "./types.js";
 
 const ts = Math.floor(Date.now() / 1_000);
+
+// A fresh runtime over the same persisted state directory: new store handles,
+// same SQLite database — the production restart shape.
+function reopenRuntime(stateDir: string) {
+  const runtime = createPluginRuntimeMock();
+  runtime.state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateSyncKeyedStoreForTests<T>("reef", {
+      ...options,
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+  return runtime;
+}
 
 async function envelopeFrom(
   sender: ReturnType<typeof generateIdentity>,
@@ -114,7 +125,7 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
       transport: relay as unknown as ReefTransportClient, // SAFETY: ack-recording mock satisfies the client contract
       guard: guard(allow),
       audit: new MemoryAuditStore(new Uint8Array(32).fill(30)),
-      replay: new MemoryReplayStore(),
+      replay: openStores(stores.runtime, reefKeys(), { deliveredMaxEntries: 2 }).replay,
       ...stores,
       onIngress,
       onOwnerNotice: async () => {},
@@ -177,7 +188,9 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
     const { fetcher } = relayRetaining(entries);
     const relay = transport();
     const onIngress = vi.fn(async () => {});
-    // Restart: a fresh flow over the same persisted stores.
+    // Restart: a fresh flow over freshly opened store handles for the same
+    // persisted state directory (production SQLite replay and delivered stores).
+    const reopened = openStores(reopenRuntime(stores.stateDir), reefKeys());
     const flow = new ReefMessageFlow({
       config: config(),
       trust: trust({ alice: peerTrust(alice) }).store,
@@ -185,8 +198,9 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
       transport: relay as unknown as ReefTransportClient, // SAFETY: ack-recording mock satisfies the client contract
       guard: guard(allow),
       audit: new MemoryAuditStore(new Uint8Array(32).fill(31)),
-      replay: new MemoryReplayStore(),
-      ...stores,
+      replay: reopened.replay,
+      reviews: reopened.reviews,
+      delivered: reopened.delivered,
       onIngress,
       onOwnerNotice: async () => {},
     });
@@ -242,7 +256,7 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
       transport: relay as unknown as ReefTransportClient, // SAFETY: ack-recording mock satisfies the client contract
       guard: guard(allow),
       audit: new MemoryAuditStore(new Uint8Array(32).fill(32)),
-      replay: new MemoryReplayStore(),
+      replay: openStores(stores.runtime, reefKeys()).replay,
       ...stores,
       onIngress,
       onOwnerNotice: async () => {},

--- a/extensions/reef/src/transport-capacity-recovery.test.ts
+++ b/extensions/reef/src/transport-capacity-recovery.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   REEF_DELIVERED_MAX_ENTRIES,
   REEF_DELIVERED_NAMESPACE,
+  REEF_DELIVERED_PENDING_NAMESPACE,
   REEF_DELIVERED_TTL_MS,
 } from "./state.js";
 import { ReefInboxConnection, type ReefTransportClient } from "./transport.js";
@@ -96,8 +97,8 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
     const idA = "01JZ00000000000000000002A1";
     const idC = "01JZ00000000000000000002C1";
     const stores = flowStores(2);
-    await stores.delivered.add("occupied-1");
-    await stores.delivered.add("occupied-2");
+    await stores.delivered.reserve("occupied-1");
+    await stores.delivered.reserve("occupied-2");
 
     const entries = new Map<number, InboxEntry>([
       [1, messageEntry(1, "alice", await envelopeFrom(alice, "alice", bob, idA, "first"), idA)],
@@ -138,9 +139,9 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
     expect(persisted).toEqual([]);
 
     // Capacity frees (marker TTL expiry in production; explicit free here).
-    // Reopen with the same options the flow's delivered store uses (cap 2).
+    // Reopen with the same options the flow's reservation store uses (cap 2).
     const raw = stores.runtime.state.openSyncKeyedStore<{ id: string }>({
-      namespace: REEF_DELIVERED_NAMESPACE,
+      namespace: REEF_DELIVERED_PENDING_NAMESPACE,
       maxEntries: 2,
       overflowPolicy: "reject-new",
       defaultTtlMs: REEF_DELIVERED_TTL_MS,

--- a/extensions/reef/src/transport-capacity-recovery.test.ts
+++ b/extensions/reef/src/transport-capacity-recovery.test.ts
@@ -100,15 +100,15 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
     resetFlowStoresForTests();
   });
 
-  it("survives capacity parks from two peers, keeps later entries attemptable, and completes both once capacity frees", async () => {
+  it("survives delivered-capacity parks from two peers, keeps later entries attemptable, and completes both once capacity frees", async () => {
     const alice = generateIdentity();
     const carol = generateIdentity();
     const bob = reefKeys();
     const idA = "01JZ00000000000000000002A1";
     const idC = "01JZ00000000000000000002C1";
     const stores = flowStores(2);
-    await stores.delivered.reserve("occupied-1");
-    await stores.delivered.reserve("occupied-2");
+    await stores.delivered.add("occupied-1");
+    await stores.delivered.add("occupied-2");
 
     const entries = new Map<number, InboxEntry>([
       [1, messageEntry(1, "alice", await envelopeFrom(alice, "alice", bob, idA, "first"), idA)],
@@ -141,18 +141,18 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
       { initialCursor: 0, persistCursor: (cursor) => persisted.push(cursor) },
     );
 
-    // Full store: both entries park as retry-safe domain states. The shared
-    // connection survives and later entries are still attempted.
+    // Delivered namespace full: both entries park AFTER ingress as retry-safe
+    // domain states (reservations are in-memory, so capacity surfaces at
+    // confirm). The shared connection survives, later entries are still
+    // attempted, nothing is acknowledged, and the cursor is held.
     await inbox.drain();
-    expect(onIngress).not.toHaveBeenCalled();
+    expect(onIngress).toHaveBeenCalledTimes(2);
     expect(relay.acknowledge).not.toHaveBeenCalled();
     expect(persisted).toEqual([]);
 
     // Capacity frees (marker TTL expiry in production; explicit free here).
-    // Reopen with the same options the flow's reservation store uses (cap 2).
-    // Namespace literal mirrors the internal REEF_DELIVERED_PENDING_NAMESPACE.
     const raw = stores.runtime.state.openSyncKeyedStore<{ id: string }>({
-      namespace: "delivered-pending",
+      namespace: REEF_DELIVERED_NAMESPACE,
       maxEntries: 2,
       overflowPolicy: "reject-new",
       defaultTtlMs: REEF_DELIVERED_TTL_MS,
@@ -160,10 +160,11 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
     raw.delete("occupied-1");
     raw.delete("occupied-2");
 
-    // Re-poll: both parked entries complete in order, with ingress, confirmed
-    // markers, acknowledgments, and a persisted cursor past both.
+    // Re-poll: both parked entries complete in order, re-ingressing once more
+    // (bounded at-least-once), confirming markers, acknowledging, and
+    // persisting a cursor past both.
     await inbox.drain();
-    expect(onIngress).toHaveBeenCalledTimes(2);
+    expect(onIngress).toHaveBeenCalledTimes(4);
     expect(relay.acknowledge).toHaveBeenCalledTimes(2);
     await expect(stores.delivered.status(idA)).resolves.toBe("delivered");
     await expect(stores.delivered.status(idC)).resolves.toBe("delivered");
@@ -171,17 +172,18 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
 
     // A third poll is fully drained: nothing re-dispatches.
     await inbox.drain();
-    expect(onIngress).toHaveBeenCalledTimes(2);
+    expect(onIngress).toHaveBeenCalledTimes(4);
     expect(relay.acknowledge).toHaveBeenCalledTimes(2);
   });
 
-  it("an interrupted delivery with a reserved marker re-ingresses exactly once and confirms on restart", async () => {
+  it("an interrupted delivery before ingress re-ingresses exactly once and confirms on restart", async () => {
     const alice = generateIdentity();
     const bob = reefKeys();
     const id = "01JZ00000000000000000002D1";
     const stores = flowStores();
-    // Crash window: the marker was reserved before inbound handling ran.
-    await stores.delivered.reserve(id);
+    // Crash window: inbound handling had not run, so no in-flight record
+    // exists; the restart re-classifies the entry from persisted markers and
+    // re-ingresses exactly once.
     const entries = new Map<number, InboxEntry>([
       [1, messageEntry(1, "alice", await envelopeFrom(alice, "alice", bob, id, "resumed"), id)],
     ]);
@@ -229,6 +231,93 @@ describe("Reef capacity-parked delivery recovery (production connection path)", 
     expect(onIngress).toHaveBeenCalledTimes(1);
     expect(relay.acknowledge).toHaveBeenCalledTimes(2);
     expect(persisted.at(-1)).toBe(2);
+  });
+
+  it("a crash after ingress re-dispatches once on restart when capacity had blocked confirm", async () => {
+    const alice = generateIdentity();
+    const bob = reefKeys();
+    const id = "01JZ00000000000000000002E1";
+    const stores = flowStores(1);
+    await stores.delivered.add("occupied"); // delivered namespace full
+    const entries = new Map<number, InboxEntry>([
+      [1, messageEntry(1, "alice", await envelopeFrom(alice, "alice", bob, id, "crashed"), id)],
+    ]);
+    const { fetcher } = relayRetaining(entries);
+    const relay = transport();
+    const onIngress = vi.fn(async () => {});
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient, // SAFETY: ack-recording mock satisfies the client contract
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(33)),
+      replay: openStores(stores.runtime, reefKeys(), { deliveredMaxEntries: 1 }).replay,
+      ...stores,
+      onIngress,
+      onOwnerNotice: async () => {},
+    });
+    const persisted: number[] = [];
+    const inbox = new ReefInboxConnection(
+      createClient(fetcher),
+      async (batch) => {
+        await flow.processEntries(batch);
+      },
+      () => {
+        throw new Error("REST-only proof: no live socket expected");
+      },
+      { initialCursor: 0, persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    // Capacity blocks confirm after ingress: the entry parks, un-acked.
+    await inbox.drain();
+    expect(onIngress).toHaveBeenCalledTimes(1);
+    expect(relay.acknowledge).not.toHaveBeenCalled();
+    expect(persisted).toEqual([]);
+
+    // Restart: fresh flow over freshly opened handles for the same persisted
+    // state directory. Capacity frees (marker TTL expiry in production;
+    // explicit free here); the restart re-classifies the entry and
+    // re-dispatches once — the documented bounded at-least-once trade.
+    const raw = stores.runtime.state.openSyncKeyedStore<{ id: string }>({
+      namespace: REEF_DELIVERED_NAMESPACE,
+      maxEntries: 1,
+      overflowPolicy: "reject-new",
+      defaultTtlMs: REEF_DELIVERED_TTL_MS,
+    });
+    raw.delete("occupied");
+    const reopened = openStores(reopenRuntime(stores.stateDir), reefKeys(), {
+      deliveredMaxEntries: 1,
+    });
+    const restartedFlow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient, // SAFETY: ack-recording mock satisfies the client contract
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(34)),
+      replay: reopened.replay,
+      reviews: reopened.reviews,
+      delivered: reopened.delivered,
+      onIngress,
+      onOwnerNotice: async () => {},
+    });
+    const restartedInbox = new ReefInboxConnection(
+      createClient(fetcher),
+      async (batch) => {
+        await restartedFlow.processEntries(batch);
+      },
+      () => {
+        throw new Error("REST-only proof: no live socket expected");
+      },
+      { initialCursor: 0, persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    await restartedInbox.drain();
+    expect(onIngress).toHaveBeenCalledTimes(2);
+    await expect(stores.delivered.status(id)).resolves.toBe("delivered");
+    expect(relay.acknowledge).toHaveBeenCalledTimes(1);
+    expect(persisted.at(-1)).toBe(1);
   });
 
   it("legacy stateless delivered markers suppress re-ingress and acknowledge on the next poll", async () => {


### PR DESCRIPTION
## Summary

Reef's bounded inbound-delivery stores fail closed on capacity (`reject-new`), but those capacity errors surfaced as ordinary inbox failures: the shared inbox connection treated them as transport faults, tore itself down, and re-polled from the unchanged cursor — head-of-line blocking every other peer's entries and re-entering inbound handling for an entry that already had its content dispatched. This PR makes delivery capacity a parked, retry-safe domain state: capacity errors park the affected entry instead of unwinding the shared inbox, no extra in-flight bookkeeping is retained, and the shipped persisted durability contract is untouched.

## What was wrong

1. **Post-ingress capacity throw with handler re-entry.** `ReefMessageFlow.processEnvelope` dispatched inbound content (`onIngress`/owner notice) before persisting the delivered marker, and `ReefDeliveredStore.add` threw on a full store (`extensions/reef/src/flow.ts`, `extensions/reef/src/state.ts`). The throw escaped `ReefInboxConnection.processEntries` as a transport failure, so the relay entry was never acknowledged, the cursor never advanced, and each re-poll re-entered inbound handling without a durable outcome.
2. **Pre-ingress replay capacity throw with connection teardown.** When the shared account-wide replay store (3,000 entries) was full, `ReefSqliteReplayStore.claim` threw a raw store error that propagated through `flow.processEntries` and `transport.processEntries` uncaught (only `ReefInboxEntryParkedError` is absorbed), tearing down the socket and head-of-line blocking all later entries from all peers for as long as the store stayed full.
3. **Shared-capacity coupling.** Both stores are account-wide, so one friendship's message volume could consume all delivery-marker capacity and stall other friends' delivery.

Net effect: valid traffic from one trusted peer could stall inbound delivery for every peer, with repeated inbound re-dispatch, until store capacity freed.

## Why this design

- Classify capacity at the owning boundary using the existing parked-outcome machinery (`ReefInboxEntryParkedError`): parked entries stay un-acked at the relay, are re-polled at reconcile cadence, and do not block later entries — the same bounded behavior pending owner reviews already use.
- Keep delivery bookkeeping single-owned: persisted `delivered` markers are the only delivery state. No process-local or persisted reservation is retained, so abandoned relay entries cannot leak IDs for the channel lifetime.
- Keep at-least-once ingress: when confirmation cannot persist because capacity is full, the entry parks and re-enters ingress on retry; persisted `delivered` markers remain ack-only. Duplicate suppression and ack/cursor semantics are unchanged.
- Honor the shipped cross-restart durability contract unchanged: persisted `delivered` markers and the replay store keep their exact historical record shape — no migration, no config surface, no default changes. A crash in the dispatch-confirm window re-dispatches once on restart — the same bounded at-least-once behavior the shipped store already exhibits.

## Why this does not conflict with #132420 or #110151/#110177

| PR | Governed layer | Relation to this PR |
|---|---|---|
| #132420 | Owner-review parking and guard classification for inbound entries | This PR reuses the parked-outcome transport semantics #132420 established; it adds capacity as a parked classification and does not alter review/guard flow |
| #110151 / #110177 | Accepted-receipt audit persistence and inbox reconnect/stall behavior | Receipt-audit state only; this PR's sink is the delivered/replay marker stores, and both branches' bases already include the current audit layer |

Shared files (`extensions/reef/src/flow.ts`, `transport.ts`) change only in the capacity-classification and marker-ordering paths; the base of this branch includes both related PRs.

## Evidence

Behavior is exercised through the production path — the real `ReefInboxConnection` REST drain drives the real `ReefMessageFlow` over the production SQLite delivered-marker and replay stores, with only the relay responses and the platform send mocked (`extensions/reef/src/transport-capacity-recovery.test.ts`). Restart cases reopen freshly opened store handles over the same persisted state directory (the production restart shape):

| Path | Mode | Outcome |
|---|---|---|
| Delivered namespace full, new verified entries from two peers | Production `ReefInboxConnection.drain()` → flow → SQLite stores | Before: ingress fired, then raw capacity error escaped, entry un-acked, connection torn down, re-poll re-entered ingress. After: ingress runs, confirm fails closed, both entries park as retry-safe domain states; no ack, cursor held, connection survives |
| Later-entry processing while a peer's entry is parked | Same production path | Later entries remain attemptable while earlier entries are parked; no head-of-line blocking of other peers |
| Recovery after capacity frees | Same production path, capacity freed between polls | Both parked entries complete in order: bounded re-ingress, markers persisted `delivered`, acknowledgments ×2, persisted cursor advances past both; a third poll re-dispatches nothing |
| Interrupted delivery (crash before ingress) | Restart: fresh flow over freshly opened SQLite store handles for the same persisted state directory, production connection path | Re-poll re-ingresses exactly once, confirms the marker, acknowledges, advances the cursor; a relay re-send of the same envelope under a new sequence is suppressed (ack only, no re-ingress) |
| Crash after ingress when capacity had blocked confirm | Same restart path | On restart with capacity freed, the entry re-classifies from persisted markers and re-dispatches once — the documented bounded at-least-once trade; then acks and advances the cursor |
| Upgraded store: legacy stateless delivered marker | Same production path | Marker reads as `delivered`; re-poll acknowledges without re-ingress |
| Full replay store, new verified entry | Flow-level regression test | Entry parks pre-ingress instead of the raw store error escaping into connection teardown |
| Delivered namespace full at confirm, new verified entry | Flow-level park test on the production path | Ingress fires once, confirm fails closed without retaining extra bookkeeping; the entry parks with the cursor held and the connection intact; each re-poll re-runs ingress until the delivered namespace frees — bounded, at-least-once, pre-existing behavior |
| Marker lifecycle | `ReefDeliveredStore` unit tests | `confirm` writes the persisted `delivered` marker idempotently; capacity failure leaves no marker or reservation behind; legacy stateless markers read as `delivered` |
| Existing suites | `node scripts/run-vitest.mjs run extensions/reef/` | 26 files, 374 tests passed; `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` exit 0; oxlint clean; assertion-safety ratchet OK |

Sink-level observations: a full store now produces a bounded, retry-safe per-entry outcome instead of an escaped error; one peer's exhausted capacity can no longer unwind the shared inbox or block later entries from other peers. One pre-existing limitation remains: when the delivered namespace itself stays full, a parked entry re-runs ingress on each re-poll until capacity frees (bounded, at-least-once, unchanged by this PR).

## Persistence boundary

The persisted `delivered` markers and replay store retain their shipped namespaces and exact record shapes. This PR adds no process-local or persisted reservation state, migration, config surface, or default change.

## Testing

- New: transport-level recovery proof through the production connection path (delivered-capacity parks from two peers with shared-inbox survival, later-entry processing, recovery after capacity frees, interrupted-before-ingress restart, crash-after-ingress re-dispatch, legacy-marker suppression), flow-level tests (full replay store parks pre-ingress; delivered-full parks post-ingress without retaining bookkeeping; confirmed-marker suppression on retry), and store-level marker/capacity tests.
- Unchanged-green: full reef extension suite (374 tests), extension typechecks, oxlint, assertion-safety ratchet.

Per-peer occupancy quotas (isolating one friendship's share of the shared store) are deliberately deferred as follow-up hardening: parking already removes the teardown and head-of-line blocking, and a quota introduces sizing and migration decisions that deserve their own change.

