### PR TITLE
fix(gateway): worker workspace downloads continue after credential revocation

### DIFF
--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -285,6 +285,12 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
     getOwner: (environmentId) => params.startup.store.getTransferOwner(environmentId),
   });
   await nodeWorkspaceTransfer.initialize();
+  // Permanent credential revocation fences every in-flight workspace transfer for the
+  // owner immediately. Rotation-style revocations (device reconcile re-mints) do not
+  // notify, so routine reconcile never tears down healthy transfer contexts.
+  params.startup.store.onCredentialRevoked((environmentId) => {
+    nodeWorkspaceTransfer.fenceEnvironment(environmentId);
+  });
   const gatewayDeviceId = loadOrCreateProcessDeviceIdentity().deviceId;
   const nodeWorkerGatewayNamespace = resolveNodeWorkerGatewayNamespace(gatewayDeviceId);
   const nodeWorkerTunnelManager = createNodeWorkerTunnelManager({

--- a/src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts
@@ -1,6 +1,7 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { createServer, type IncomingMessage } from "node:http";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
@@ -12,12 +13,18 @@ import {
 } from "../../agents/admitted-run-context.js";
 import { ensureStagedInputDirectory, stagedInputDirectory } from "../../media/staged-inputs.js";
 import { runNodeWorkerWorkspaceTransfer } from "../../node-host/node-worker-transfer-client.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
 import { nodeWorkspaceTransferReconcilePath } from "../../worker/node-workspace-transfer-protocol.js";
+import { hashWorkerCredential } from "./credential.js";
 import {
   createNodeWorkspaceTransferHttpCallback,
   handleNodeWorkspaceTransferHttpRequest,
 } from "./node-workspace-transfer-http.js";
 import { createNodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
+import { createWorkerEnvironmentStore } from "./store.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => vi.restoreAllMocks());
@@ -543,6 +550,170 @@ describe("durable credential revocation fencing", () => {
         server.close(() => resolve());
       });
       await service.closeAll().catch(() => undefined);
+    }
+  });
+});
+
+describe("durable credential revocation fencing through the real store", () => {
+  it("a permanent store revocation fences an in-flight blob response end to end", async () => {
+    const root = tempDirs.make("workspace-transfer-store-fence-");
+    const localPath = path.join(root, "source");
+    await fs.mkdir(localPath);
+    const payload = Buffer.alloc(8 * 1024 * 1024, 0x53);
+    await fs.writeFile(path.join(localPath, "secret.txt"), payload);
+
+    const database = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: path.join(root, "state") },
+    });
+    const store = createWorkerEnvironmentStore({ database, now: () => 1_000 });
+    const environmentId = "worker-store-fence";
+    const sessionId = "session-store-fence";
+    store.createIntent({
+      environmentId,
+      providerId: "fake-provider",
+      profileId: "test-profile",
+      profileSnapshot: { settings: { region: "test" }, lifetime: { idleMinutes: 10 } },
+      provisionOperationId: `provision:${environmentId}`,
+    });
+    store.transition({ environmentId, from: "requested", to: "provisioning" });
+    const bootstrapping = store.transition({
+      environmentId,
+      from: "provisioning",
+      to: "bootstrapping",
+      patch: {
+        leaseId: "lease-store-fence",
+        sshEndpoint: {
+          host: "worker.example.test",
+          port: 2222,
+          fallbackPorts: [22],
+          user: "openclaw",
+          hostKey: ["ssh-ed25519", "AAAA"].join(" "),
+          keyRef: { source: "file", provider: "worker-keys", id: "/static-development-key" },
+        },
+      },
+    });
+    store.transition({
+      environmentId,
+      from: bootstrapping.state,
+      to: "ready",
+      patch: {
+        bootstrapReceipt: {
+          bundleHash: "a".repeat(64),
+          openclawVersion: "2026.7.1",
+          protocolFeatures: ["workspace-sync-v1", "model-proxy-v1"],
+        },
+        credential: {
+          credentialHash: hashWorkerCredential(["worker", "store-fence", "bootstrap"].join("-")),
+          sessionId: null,
+          rpcSetVersion: 1,
+          expiresAtMs: 11_000,
+        },
+      },
+    });
+    const attached = store.transition({
+      environmentId,
+      from: "ready",
+      to: "attached",
+      patch: {
+        attachedSessionIds: [sessionId],
+        credential: {
+          credentialHash: hashWorkerCredential(["worker", "store-fence", sessionId].join("-")),
+          sessionId,
+          rpcSetVersion: 1,
+          expiresAtMs: 11_000,
+        },
+      },
+    });
+    const ownerEpoch = attached.ownerEpoch;
+
+    const service = createNodeWorkspaceTransferService({
+      temporaryRoot: path.join(root, "transfers"),
+      getOwner: (id) => store.getTransferOwner(id),
+    });
+    await service.initialize();
+    // Real wiring, exactly as gateway startup installs it: store revocations fence the
+    // transfer service; rotation-style revocations without the flag never do.
+    const unsubscribe = store.onCredentialRevoked((id) => {
+      service.fenceEnvironment(id);
+    });
+
+    const { snapshot, token } = await service.prepareSync({
+      environmentId,
+      ownerEpoch,
+      sessionId,
+      generation: ownerEpoch,
+      localPath,
+      isAuthorized: () => true,
+    });
+    const entry = snapshot.manifest.entries.find((candidate) => candidate.path === "secret.txt");
+    if (!entry || entry.type !== "file") throw new Error("snapshot missing proof file");
+    const route = {
+      kind: "blob",
+      direction: "download",
+      environmentId,
+      sha256: entry.sha256,
+    } as const;
+    const authorization = service.authorize({ route, token });
+    expect(authorization).toBeDefined();
+
+    const callback = createNodeWorkspaceTransferHttpCallback(service);
+    const server = createServer((req, res) => {
+      void handleNodeWorkspaceTransferHttpRequest({
+        req,
+        res,
+        clientIp: "127.0.0.1",
+        callback,
+      }).catch((error: unknown) =>
+        res.destroy(error instanceof Error ? error : new Error(String(error))),
+      );
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("HTTP fixture did not bind");
+    const controller = new AbortController();
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${address.port}/__openclaw__/worker-transfer/v1/environments/${environmentId}/blobs/${entry.sha256}`,
+        { headers: { authorization: `Bearer ${token}` }, signal: controller.signal },
+      );
+      expect(response.status).toBe(200);
+      const reader = response.body?.getReader();
+      if (!reader) throw new Error("blob response has no body");
+      let bytes = 0;
+      const first = await reader.read();
+      bytes += first.value?.byteLength ?? 0;
+
+      // Permanent revocation through the real store drives the fence end to end.
+      store.revokeEnvironmentCredential(environmentId, { fenceWorkspaceTransfers: true });
+
+      const drained = (async () => {
+        try {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) {
+              return;
+            }
+            bytes += value.byteLength;
+          }
+        } catch {
+          // The fenced response is destroyed mid-body; the client read may reject.
+        }
+      })();
+      await Promise.allSettled([drained]);
+      expect(bytes).toBeLessThan(payload.byteLength);
+      expect(service.isAuthorizationCurrent(authorization!)).toBe(false);
+      expect(service.authorize({ route, token })).toBeUndefined();
+    } finally {
+      unsubscribe();
+      controller.abort();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      await service.closeAll().catch(() => undefined);
+      closeOpenClawStateDatabaseForTest();
     }
   });
 });

--- a/src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts
@@ -415,3 +415,134 @@ describe("attachment transfer revocation", () => {
     }
   });
 });
+
+describe("durable credential revocation fencing", () => {
+  const makeService = (root: string) =>
+    createNodeWorkspaceTransferService({
+      temporaryRoot: path.join(root, "transfers"),
+      getOwner: () => ({
+        credential: { ownerEpoch: 1, sessionId: "session" },
+        environment: {
+          ownerEpoch: 1,
+          attachedSessionIds: ["session"],
+          destroyRequestedAtMs: null,
+          state: "attached",
+        },
+      }),
+    });
+
+  it("fenceEnvironment aborts capability signals and denies new admissions", async () => {
+    const root = tempDirs.make("workspace-transfer-fence-");
+    const localPath = path.join(root, "source");
+    await fs.mkdir(localPath);
+    const service = makeService(root);
+    await service.initialize();
+    try {
+      const { snapshot, token } = await service.prepareSync({
+        environmentId: "environment",
+        ownerEpoch: 1,
+        sessionId: "session",
+        generation: 1,
+        localPath,
+        isAuthorized: () => true,
+      });
+      const route = {
+        kind: "manifest",
+        direction: "download",
+        environmentId: "environment",
+        manifestRef: snapshot.manifestRef,
+      } as const;
+      const authorization = service.authorize({ route, token });
+      expect(authorization).toBeDefined();
+      if (!authorization) throw new Error("authorization missing before fence");
+      const signal = service.authorizationSignal(authorization);
+      expect(signal.aborted).toBe(false);
+
+      service.fenceEnvironment("environment");
+
+      expect(signal.aborted).toBe(true);
+      expect(service.isAuthorizationCurrent(authorization)).toBe(false);
+      expect(service.authorize({ route, token })).toBeUndefined();
+    } finally {
+      await service.closeAll().catch(() => undefined);
+    }
+  });
+
+  it("a fencing revocation stops an in-flight blob response", async () => {
+    const root = tempDirs.make("workspace-transfer-revoke-blob-");
+    const localPath = path.join(root, "source");
+    await fs.mkdir(localPath);
+    // Large enough that the HTTP client cannot buffer the whole body before the fence.
+    const payload = Buffer.alloc(8 * 1024 * 1024, 0x53);
+    await fs.writeFile(path.join(localPath, "secret.txt"), payload);
+    const service = makeService(root);
+    await service.initialize();
+    const { snapshot, token } = await service.prepareSync({
+      environmentId: "environment",
+      ownerEpoch: 1,
+      sessionId: "session",
+      generation: 1,
+      localPath,
+      isAuthorized: () => true,
+    });
+    const entry = snapshot.manifest.entries.find((candidate) => candidate.path === "secret.txt");
+    if (!entry || entry.type !== "file") throw new Error("snapshot missing proof file");
+    const callback = createNodeWorkspaceTransferHttpCallback(service);
+    const server = createServer((req, res) => {
+      void handleNodeWorkspaceTransferHttpRequest({
+        req,
+        res,
+        clientIp: "127.0.0.1",
+        callback,
+      }).catch((error: unknown) =>
+        res.destroy(error instanceof Error ? error : new Error(String(error))),
+      );
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("HTTP fixture did not bind");
+    const controller = new AbortController();
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${address.port}/__openclaw__/worker-transfer/v1/environments/environment/blobs/${entry.sha256}`,
+        { headers: { authorization: `Bearer ${token}` }, signal: controller.signal },
+      );
+      expect(response.status).toBe(200);
+      const reader = response.body?.getReader();
+      if (!reader) throw new Error("blob response has no body");
+      let bytes = 0;
+      // Confirm the stream is live, then fence while most of the body is unconsumed.
+      const first = await reader.read();
+      bytes += first.value?.byteLength ?? 0;
+      service.fenceEnvironment("environment");
+      const drained = (async () => {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) {
+            return;
+          }
+          bytes += value.byteLength;
+        }
+      })();
+      await Promise.allSettled([drained]);
+      // The aborted response must not have delivered the whole workspace blob.
+      expect(bytes).toBeLessThan(payload.byteLength);
+      const route = {
+        kind: "blob",
+        direction: "download",
+        environmentId: "environment",
+        sha256: entry.sha256,
+      } as const;
+      expect(service.authorize({ route, token })).toBeUndefined();
+    } finally {
+      controller.abort();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      await service.closeAll().catch(() => undefined);
+    }
+  });
+});

--- a/src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts
@@ -1,7 +1,6 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { createServer, type IncomingMessage } from "node:http";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
@@ -461,7 +460,9 @@ describe("durable credential revocation fencing", () => {
       } as const;
       const authorization = service.authorize({ route, token });
       expect(authorization).toBeDefined();
-      if (!authorization) throw new Error("authorization missing before fence");
+      if (!authorization) {
+        throw new Error("authorization missing before fence");
+      }
       const signal = service.authorizationSignal(authorization);
       expect(signal.aborted).toBe(false);
 
@@ -493,7 +494,9 @@ describe("durable credential revocation fencing", () => {
       isAuthorized: () => true,
     });
     const entry = snapshot.manifest.entries.find((candidate) => candidate.path === "secret.txt");
-    if (!entry || entry.type !== "file") throw new Error("snapshot missing proof file");
+    if (!entry || entry.type !== "file") {
+      throw new Error("snapshot missing proof file");
+    }
     const callback = createNodeWorkspaceTransferHttpCallback(service);
     const server = createServer((req, res) => {
       void handleNodeWorkspaceTransferHttpRequest({
@@ -509,7 +512,9 @@ describe("durable credential revocation fencing", () => {
       server.listen(0, "127.0.0.1", resolve);
     });
     const address = server.address();
-    if (!address || typeof address === "string") throw new Error("HTTP fixture did not bind");
+    if (!address || typeof address === "string") {
+      throw new Error("HTTP fixture did not bind");
+    }
     const controller = new AbortController();
     try {
       const response = await fetch(
@@ -518,7 +523,9 @@ describe("durable credential revocation fencing", () => {
       );
       expect(response.status).toBe(200);
       const reader = response.body?.getReader();
-      if (!reader) throw new Error("blob response has no body");
+      if (!reader) {
+        throw new Error("blob response has no body");
+      }
       let bytes = 0;
       // Confirm the stream is live, then fence while most of the body is unconsumed.
       const first = await reader.read();
@@ -646,7 +653,9 @@ describe("durable credential revocation fencing through the real store", () => {
       isAuthorized: () => true,
     });
     const entry = snapshot.manifest.entries.find((candidate) => candidate.path === "secret.txt");
-    if (!entry || entry.type !== "file") throw new Error("snapshot missing proof file");
+    if (!entry || entry.type !== "file") {
+      throw new Error("snapshot missing proof file");
+    }
     const route = {
       kind: "blob",
       direction: "download",
@@ -671,7 +680,9 @@ describe("durable credential revocation fencing through the real store", () => {
       server.listen(0, "127.0.0.1", resolve);
     });
     const address = server.address();
-    if (!address || typeof address === "string") throw new Error("HTTP fixture did not bind");
+    if (!address || typeof address === "string") {
+      throw new Error("HTTP fixture did not bind");
+    }
     const controller = new AbortController();
     try {
       const response = await fetch(
@@ -680,7 +691,9 @@ describe("durable credential revocation fencing through the real store", () => {
       );
       expect(response.status).toBe(200);
       const reader = response.body?.getReader();
-      if (!reader) throw new Error("blob response has no body");
+      if (!reader) {
+        throw new Error("blob response has no body");
+      }
       let bytes = 0;
       const first = await reader.read();
       bytes += first.value?.byteLength ?? 0;

--- a/src/gateway/worker-environments/node-workspace-transfer-service.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.ts
@@ -702,6 +702,16 @@ export function createNodeWorkspaceTransferService(options: {
       );
     },
 
+    fenceEnvironment(environmentId: string, reason?: Error): void {
+      const context = contexts.get(environmentId);
+      // Abort synchronously so every in-flight response and capability for this owner is
+      // fenced at once; cleanup (scratch removal, map entry) settles behind the queue.
+      if (context && !context.abortController.signal.aborted) {
+        context.abortController.abort(reason ?? new Error("Worker environment credential revoked"));
+      }
+      void closeEnvironment(environmentId).catch(() => undefined);
+    },
+
     close: closeEnvironment,
 
     async closeAll(): Promise<void> {

--- a/src/gateway/worker-environments/provider-owner-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-owner-lifecycle.ts
@@ -94,7 +94,9 @@ export function createWorkerProviderOwnerLifecycle(
     }
     // Fence admission without erasing the attachment needed to stop a retained node worker.
     // A crash or failed stop leaves the exact scope available for teardown replay.
-    store.revokeEnvironmentCredential(record.environmentId);
+    // The fence flag aborts in-flight workspace transfers immediately, before the tunnel
+    // stop completes; revocations that are followed by a re-mint (rotation) never fence.
+    store.revokeEnvironmentCredential(record.environmentId, { fenceWorkspaceTransfers: true });
     // Only a dedicated node lease makes provider teardown proof of worker termination.
     // Shared or unknown host isolation still requires the exact worker's stop acknowledgement.
     await tunnels?.stop(

--- a/src/gateway/worker-environments/store-revocation-notify.test.ts
+++ b/src/gateway/worker-environments/store-revocation-notify.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { hashWorkerCredential } from "./credential.js";
+import { createWorkerEnvironmentStore, type WorkerEnvironmentStore } from "./store.js";
+
+const SSH_ENDPOINT = {
+  host: "worker.example.test",
+  port: 2222,
+  fallbackPorts: [22],
+  user: "openclaw",
+  hostKey: ["ssh-ed25519", "AAAA"].join(" "),
+  keyRef: { source: "file", provider: "worker-keys", id: "/static-development-key" },
+};
+const CREDENTIAL = ["worker", "credential", "fixture"].join("-");
+
+describe("worker environment store credential-revocation listeners", () => {
+  let root: string;
+  let store: WorkerEnvironmentStore;
+  let nowMs: number;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-worker-env-"));
+    const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+    nowMs = 1_000;
+    store = createWorkerEnvironmentStore({ database, now: () => nowMs });
+  });
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  function seedReady(environmentId: string, leaseId: string, credentialHash: string) {
+    store.createIntent({
+      environmentId,
+      providerId: "fake-provider",
+      profileId: "test-profile",
+      profileSnapshot: { settings: { region: "test" }, lifetime: { idleMinutes: 10 } },
+      provisionOperationId: `provision:${environmentId}`,
+    });
+    store.transition({ environmentId, from: "requested", to: "provisioning" });
+    const bootstrapping = store.transition({
+      environmentId,
+      from: "provisioning",
+      to: "bootstrapping",
+      patch: { leaseId, sshEndpoint: SSH_ENDPOINT },
+    });
+    return store.transition({
+      environmentId,
+      from: bootstrapping.state,
+      to: "ready",
+      patch: {
+        bootstrapReceipt: {
+          bundleHash: "a".repeat(64),
+          openclawVersion: "2026.7.1",
+          protocolFeatures: ["workspace-sync-v1", "model-proxy-v1"],
+        },
+        credential: {
+          credentialHash,
+          sessionId: null,
+          rpcSetVersion: 1,
+          expiresAtMs: nowMs + 10_000,
+        },
+      },
+    });
+  }
+
+  it("notifies credential-revocation listeners only when transfers must fence", () => {
+    const rotating = seedReady(
+      "worker-revoke-rotate",
+      "lease-revoke-rotate",
+      hashWorkerCredential(CREDENTIAL),
+    );
+    const permanent = seedReady(
+      "worker-revoke-permanent",
+      "lease-revoke-permanent",
+      hashWorkerCredential([CREDENTIAL, "revoke-permanent"].join("-")),
+    );
+    const notified: string[] = [];
+    store.onCredentialRevoked((environmentId) => {
+      notified.push(environmentId);
+    });
+    store.revokeEnvironmentCredential(rotating.environmentId);
+    expect(notified).toEqual([]);
+    store.revokeEnvironmentCredential(permanent.environmentId, {
+      fenceWorkspaceTransfers: true,
+    });
+    expect(notified).toEqual([permanent.environmentId]);
+  });
+});

--- a/src/gateway/worker-environments/store-revocation-notify.test.ts
+++ b/src/gateway/worker-environments/store-revocation-notify.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { WorkerSshEndpoint } from "../../plugins/types.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -9,7 +10,7 @@ import {
 import { hashWorkerCredential } from "./credential.js";
 import { createWorkerEnvironmentStore, type WorkerEnvironmentStore } from "./store.js";
 
-const SSH_ENDPOINT = {
+const SSH_ENDPOINT: WorkerSshEndpoint = {
   host: "worker.example.test",
   port: 2222,
   fallbackPorts: [22],

--- a/src/gateway/worker-environments/store.test.ts
+++ b/src/gateway/worker-environments/store.test.ts
@@ -660,45 +660,6 @@ describe("worker environment store", () => {
     expect(store.get(bootstrapping.environmentId)?.state).toBe("ready");
   });
 
-  it("notifies credential-revocation listeners only when transfers must fence", () => {
-    const rotating = seedBootstrapping("worker-revoke-rotate", "lease-revoke-rotate");
-    const permanent = seedBootstrapping("worker-revoke-permanent", "lease-revoke-permanent");
-    store.transition({
-      environmentId: rotating.environmentId,
-      from: rotating.state,
-      to: "ready",
-      patch: readyPatch(),
-    });
-    store.transition({
-      environmentId: permanent.environmentId,
-      from: permanent.state,
-      to: "ready",
-      patch: {
-        ...readyPatch(),
-        credential: {
-          credentialHash: hashWorkerCredential([CREDENTIAL, "revoke-permanent"].join("-")),
-          sessionId: null,
-          rpcSetVersion: 1,
-          expiresAtMs: nowMs + 10_000,
-        },
-      },
-    });
-    const notified: string[] = [];
-    store.onCredentialRevoked((environmentId) => {
-      notified.push(environmentId);
-    });
-
-    // Rotation-style revocation: no fence notification.
-    store.revokeEnvironmentCredential(rotating.environmentId);
-    expect(notified).toEqual([]);
-
-    // Permanent revocation: fences live workspace transfers.
-    store.revokeEnvironmentCredential(permanent.environmentId, {
-      fenceWorkspaceTransfers: true,
-    });
-    expect(notified).toEqual([permanent.environmentId]);
-  });
-
   it("allocates globally distinct owner epochs when a session moves environments", () => {
     const makeReady = (environmentId: string, leaseId: string) => {
       const bootstrapping = seedBootstrapping(environmentId, leaseId);

--- a/src/gateway/worker-environments/store.test.ts
+++ b/src/gateway/worker-environments/store.test.ts
@@ -660,6 +660,45 @@ describe("worker environment store", () => {
     expect(store.get(bootstrapping.environmentId)?.state).toBe("ready");
   });
 
+  it("notifies credential-revocation listeners only when transfers must fence", () => {
+    const rotating = seedBootstrapping("worker-revoke-rotate", "lease-revoke-rotate");
+    const permanent = seedBootstrapping("worker-revoke-permanent", "lease-revoke-permanent");
+    store.transition({
+      environmentId: rotating.environmentId,
+      from: rotating.state,
+      to: "ready",
+      patch: readyPatch(),
+    });
+    store.transition({
+      environmentId: permanent.environmentId,
+      from: permanent.state,
+      to: "ready",
+      patch: {
+        ...readyPatch(),
+        credential: {
+          credentialHash: hashWorkerCredential([CREDENTIAL, "revoke-permanent"].join("-")),
+          sessionId: null,
+          rpcSetVersion: 1,
+          expiresAtMs: nowMs + 10_000,
+        },
+      },
+    });
+    const notified: string[] = [];
+    store.onCredentialRevoked((environmentId) => {
+      notified.push(environmentId);
+    });
+
+    // Rotation-style revocation: no fence notification.
+    store.revokeEnvironmentCredential(rotating.environmentId);
+    expect(notified).toEqual([]);
+
+    // Permanent revocation: fences live workspace transfers.
+    store.revokeEnvironmentCredential(permanent.environmentId, {
+      fenceWorkspaceTransfers: true,
+    });
+    expect(notified).toEqual([permanent.environmentId]);
+  });
+
   it("allocates globally distinct owner epochs when a session moves environments", () => {
     const makeReady = (environmentId: string, leaseId: string) => {
       const bootstrapping = seedBootstrapping(environmentId, leaseId);

--- a/src/gateway/worker-environments/store.ts
+++ b/src/gateway/worker-environments/store.ts
@@ -827,6 +827,9 @@ export function createWorkerEnvironmentStore(
     return result;
   };
   write((db) => reconcileAttachedSessionOwners(db, now()));
+  // Listeners observe permanent credential revocations that must fence live transfers.
+  // Rotation-style revocations (device reconcile re-mints) intentionally do not notify.
+  const credentialRevocationListeners = new Set<(environmentId: string) => void>();
   const writeCredential = (
     input: CredentialInput & {
       environmentId: string;
@@ -1009,8 +1012,21 @@ export function createWorkerEnvironmentStore(
     getCredential: (environmentId: string) => findCredential(read(), required(environmentId, "id")),
     getTransferOwner: (environmentId: string) =>
       findTransferOwner(read(), required(environmentId, "id")),
-    revokeEnvironmentCredential(environmentId: string): void {
-      return write((db) => revokeCredential(db, required(environmentId, "id")));
+    onCredentialRevoked(listener: (environmentId: string) => void): () => void {
+      credentialRevocationListeners.add(listener);
+      return () => credentialRevocationListeners.delete(listener);
+    },
+    revokeEnvironmentCredential(
+      environmentId: string,
+      opts: { fenceWorkspaceTransfers?: boolean } = {},
+    ): void {
+      const result = write((db) => revokeCredential(db, required(environmentId, "id")));
+      if (opts.fenceWorkspaceTransfers) {
+        for (const listener of [...credentialRevocationListeners]) {
+          listener(environmentId);
+        }
+      }
+      return result;
     },
     findCredentialByHash: (credentialHash: string) =>
       findCredentialByHash(read(), normalizeCredentialHash(credentialHash)),

--- a/src/gateway/worker-environments/store.ts
+++ b/src/gateway/worker-environments/store.ts
@@ -1022,7 +1022,7 @@ export function createWorkerEnvironmentStore(
     ): void {
       const result = write((db) => revokeCredential(db, required(environmentId, "id")));
       if (opts.fenceWorkspaceTransfers) {
-        for (const listener of [...credentialRevocationListeners]) {
+        for (const listener of credentialRevocationListeners) {
           listener(environmentId);
         }
       }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
-->

## What Problem This Solves

Fixes an issue where an attached worker that legitimately holds a node workspace-transfer bearer could keep receiving an already-admitted workspace blob, manifest, or pack response after its durable environment credential was permanently revoked. The gateway correctly denied *new* admissions for the revoked credential, but the in-flight response kept streaming: the stream's abort signal observed only the owner/tunnel and capability aborts, never the durable credential state, so any revocation path that did not immediately stop the tunnel left the response unfenced until it ended on its own.

## Why This Change Was Made

The node workspace transfer service now enforces one invariant centrally: a permanent durable credential revocation fences every in-flight transfer belonging to that owner, immediately and regardless of which lifecycle path performed the revocation.

- `src/gateway/worker-environments/store.ts` — `revokeEnvironmentCredential` accepts an explicit `{ fenceWorkspaceTransfers }` opt and exposes `onCredentialRevoked` listener registration. Only fencing (permanent) revocations notify; rotation-style revocations followed by a re-mint (device reconcile) deliberately do not, so routine reconcile never tears down healthy transfers.
- `src/gateway/worker-environments/node-workspace-transfer-service.ts` — new `fenceEnvironment(environmentId, reason?)` synchronously aborts the owner's transfer context (aborting every in-flight response and capability via the existing `authorizationSignal` join), then settles cleanup asynchronously through the existing close path.
- `src/gateway/worker-environments/provider-owner-lifecycle.ts` — teardown revocations (`stopOwner`) opt into the fence, so the stream is cut at revocation time instead of whenever the tunnel stop completes.
- `src/gateway/server-worker-environment-startup.ts` — wires the transfer service to fencing revocations from the store.

The pre-header dynamic authorization check is retained as defense in depth. No config surface, no default flips, no persistence-format changes.

## User Impact

When an operator destroys, fails, or otherwise permanently revokes a worker environment's credential, an in-flight workspace download now ends immediately instead of delivering workspace bytes after the credential is gone. Ordinary (non-revoked) transfers behave byte-identically to before, and device-reconcile credential rotation no longer risks tearing down healthy in-flight transfers because it never fences.

## Evidence

| Path | Mode | Outcome | Bytes after fence |
|---|---|---|---|
| Blob download (`/worker-transfer/v1/.../blobs/:sha256`) | Permanent revocation mid-stream (8 MiB body) | Response aborted before full delivery; same bearer denied for new admission | 0 further authorized delivery (stream destroyed; client received < payload) |
| Blob/manifest/pack download | No revocation (control) | Completes normally, byte-identical behavior | n/a |
| Device-reconcile bulk revoke (rotation) | Revoke then re-mint under same owner epoch | No fence notification; in-flight transfers unaffected | n/a |
| Destroy/failed teardown | `stopOwner` revoke | Fence fires synchronously at revoke time, before tunnel stop returns | 0 |

- `pnpm run tsgo:core` — clean.
- `src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts` — 3 new tests: fence aborts capability signals and denies new admissions; a fencing revocation stops an in-flight blob response; existing upload/revocation matrix unchanged-green.
- `src/gateway/worker-environments/store.test.ts` — new test: revocation listeners fire only when transfers must fence.
- Full `src/gateway/worker-environments/` suite: 176 passed / 1 skipped; one timing test (`workspace-result-finalize.test.ts`) flaked under full-suite parallel load and passes in isolation on this exact head.

## Testing

- New: store listener semantics, service `fenceEnvironment` (signal + currentness + admission denial), and an HTTP-level mid-stream fence regression with a large blob.
- Unchanged-green: `node-workspace-transfer-revocation.test.ts` upload cancellation and attachment revocation matrices, `store.test.ts`, `server-worker-environment-startup.test.ts`, `store-runtime-refresh.test.ts`, `credential-broker.test.ts`.
