### PR TITLE
fix(memory): recover missing full-text index rows

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-schema-fts-reconcile.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts-reconcile.test.ts
@@ -4,6 +4,44 @@ import { describe, expect, it } from "vitest";
 import { ensureMemoryIndexSchema } from "./memory-schema.js";
 
 describe("memory FTS schema reconciliation", () => {
+  it("rebuilds a populated body index when its row count diverges", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      db.exec(`
+        INSERT INTO memory_index_chunks
+          (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+        VALUES
+          ('kept', 'memory/kept.md', 'memory', 1, 1, 'kept-hash', 'model', 'kept body', '[]', 1),
+          ('missing', 'memory/missing.md', 'memory', 1, 1, 'missing-hash', 'model', 'missing body', '[]', 1);
+      `);
+      expect(
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true }).ftsAvailable,
+      ).toBe(true);
+      db.exec("DELETE FROM memory_index_chunks_fts WHERE id = 'missing'");
+
+      expect(
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true }).ftsAvailable,
+      ).toBe(true);
+
+      expect(db.prepare("SELECT id FROM memory_index_chunks_fts ORDER BY id").all()).toEqual([
+        { id: "kept" },
+        { id: "missing" },
+      ]);
+      expect(
+        db
+          .prepare("SELECT id FROM memory_index_chunks_fts WHERE memory_index_chunks_fts MATCH ?")
+          .all("missing"),
+      ).toEqual([{ id: "missing" }]);
+      expect(db.prepare("SELECT id FROM memory_index_chunks ORDER BY id").all()).toEqual([
+        { id: "kept" },
+        { id: "missing" },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
   it("rebuilds body and path indexes when their tokenizer changes", () => {
     const db = new DatabaseSync(":memory:");
     try {

--- a/packages/memory-host-sdk/src/host/memory-schema-fts.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts.ts
@@ -175,16 +175,19 @@ export function ensureMemoryChunkFtsSchema(params: {
         `  end_line UNINDEXED\n` +
         `${params.tokenizeClause});`,
     );
-    // Empty derived tables are rebuilt from canonical chunks; populated,
-    // matching indexes stay untouched on ordinary schema ensures.
-    params.db.exec(`
-      INSERT INTO ${params.ftsTable} (
-        text, id, path, source, model, start_line, end_line
+    const rowCounts = params.db
+      .prepare(
+        `SELECT
+           (SELECT COUNT(*) FROM ${MEMORY_INDEX_CHUNKS_TABLE}) AS canonical_count,
+           (SELECT COUNT(*) FROM ${params.ftsTable}) AS derived_count`,
       )
-      SELECT text, id, path, source, model, start_line, end_line
-      FROM ${MEMORY_INDEX_CHUNKS_TABLE}
-      WHERE NOT EXISTS (SELECT 1 FROM ${params.ftsTable} LIMIT 1);
-    `);
+      // SAFETY: both scalar aggregate subqueries always return their named numeric columns.
+      .get() as { canonical_count: number; derived_count: number };
+    // FTS is fully derived. A cardinality mismatch proves that an ordinary
+    // schema ensure cannot leave the populated index untouched.
+    if (rowCounts.canonical_count !== rowCounts.derived_count) {
+      rebuildMemoryChunkFts(params.db, params.ftsTable);
+    }
     params.db.exec("RELEASE ensure_memory_index_chunks_fts");
   } catch (err) {
     params.db.exec("ROLLBACK TO ensure_memory_index_chunks_fts");

--- a/packages/memory-host-sdk/src/host/memory-schema.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.test.ts
@@ -206,6 +206,7 @@ describe("memory index schema", () => {
       ).toEqual({ origin_class: "untrusted", session_kind: "unknown", observed_at: 50 });
       expect(db.prepare("SELECT id, text FROM memory_index_chunks_fts").all()).toEqual([
         { id: "chunk-1", text: "remember this" },
+        { id: "chunk-2", text: "next" },
       ]);
       expect(db.prepare("SELECT provider, hash FROM memory_embedding_cache").all()).toEqual([
         { provider: "openai", hash: "chunk-hash" },


### PR DESCRIPTION
Related: #115775

## What Problem This Solves

Fixes an issue where users with a populated but incomplete memory full-text index could receive silently missing search results. Ordinary schema reconciliation only rebuilt a completely empty index, so one or more missing derived rows survived startup.

## Why This Change Was Made

The existing Memory Host SDK FTS owner now compares canonical and derived row counts inside its existing savepoint and invokes the existing canonical rebuild operation only when they diverge. This is routine maintenance of the derived-index contract accepted in #115775; it adds no schema, version, configuration, migration, or public API.

## User Impact

Memory search recovers missing FTS rows during normal schema reconciliation while leaving complete indexes and canonical memory rows unchanged.

## Evidence

- Regression proof before the fix: after deleting one row from a populated FTS table, schema reconciliation left only `kept` and failed to restore/search `missing`.
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/memory-schema-fts-reconcile.test.ts packages/memory-host-sdk/src/host/memory-schema.test.ts --maxWorkers=1` (33 passed across both selected projects)
- Changed-path core gates passed: formatting, assertion ratchet, package/plugin boundaries, core and core-test typechecks, dead-export scan, lint, database-first guards, and runtime import-cycle checks.
- Initial fresh local autoreview: scoped clean, confidence 0.94. Follow-up review after the CI-driven sibling assertion update: scoped clean, confidence 0.98.
- CI's first revision exposed one attributable stale assertion in `memory-schema.test.ts`: it expected a newly canonical `chunk-2` to remain absent from FTS. The assertion now requires both canonical chunks after reconciliation, and the full sibling test file passes.

### Isolated real CLI proof

Used a fresh temporary state/config/workspace with two synthetic memory files and the normal supported CLI. `pnpm openclaw memory index --agent main --force` indexed both files. I then removed only the derived FTS row for `memory/beta.md`, producing this persisted precondition:

```json
{
  "canonical": { "n": 2 },
  "derived": { "n": 1 },
  "missingMatch": []
}
```

Running normal initialization through `pnpm openclaw memory search --agent main --query cobalt --json` returned `memory/beta.md` with its synthetic `cobalt-lantern-482` snippet. Read-only inspection after the command showed:

```json
{
  "canonical": { "n": 2 },
  "derived": { "n": 2 },
  "match": [{ "path": "memory/beta.md" }]
}
```

### Data-model and upgrade compatibility

The proof starts from an already persisted current-format agent database, removes a reconstructible derived row to model the affected existing state, and reopens it through the patched normal CLI path. The repair changes no table definition, columns, schema version, canonical rows, configuration, migration, downgrade behavior, or public API. It only rebuilds the existing derived FTS table from the existing canonical chunks when their cardinalities prove divergence. Equal-count databases retain their existing index.
