### PR TITLE
improve: simplify sidebar session tree projection

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -508,6 +508,142 @@ describe("sidebar navigation lineage ownership", () => {
     },
   );
 
+  it("keeps alias cycles path-local and projects shared descendants in postorder", () => {
+    const root: GatewaySessionRow = {
+      key: "root",
+      kind: "direct",
+      childSessions: ["alias", "root", "left", "right"],
+    };
+    const alias = { key: "root", kind: "direct", archived: true } satisfies GatewaySessionRow;
+    const left = {
+      key: "left",
+      kind: "direct",
+      childSessions: ["shared"],
+    } satisfies GatewaySessionRow;
+    const right = { ...left, key: "right" };
+    const shared = { key: "shared", kind: "direct" } satisfies GatewaySessionRow;
+    const rowsByKey = new Map<string, GatewaySessionRow>([
+      ["root", root],
+      ["alias", alias],
+      ["left", left],
+      ["right", right],
+      ["shared", shared],
+    ]);
+    const calls: string[] = [];
+    for (let iteration = 0; iteration < 2; iteration += 1) {
+      calls.length = 0;
+      const trees = projectSessionTree({
+        roots: [root],
+        rowsByKey,
+        loadingChildKeys: new Set(["root"]),
+        knownSessionAttention: [],
+        toSidebarSession: (row, isChild) => {
+          calls.push(`${row.key}:${isChild}`);
+          return { ...projectSidebarSession(row), isChild: isChild === true };
+        },
+      });
+      expect(calls).toEqual([
+        "root:true",
+        "shared:true",
+        "left:true",
+        "shared:true",
+        "right:true",
+        "root:false",
+      ]);
+      expect(
+        trees[0]?.children.map((row) => [
+          row.key,
+          row.children.map((descendant) => descendant.key),
+        ]),
+      ).toStrictEqual([
+        ["root", []],
+        ["left", ["shared"]],
+        ["right", ["shared"]],
+      ]);
+      expect(trees[0]).toHaveProperty("workspaceConflictCount", undefined);
+      expect(trees[0]?.loadingChildren).toBe(true);
+    }
+  });
+
+  it.each([
+    ["unloaded before children", "none", true, "approval", 1, 4_503_599_627_370_497],
+    ["parent before an unloaded tie", "question", true, "question", 1, 4_503_599_627_370_497],
+    [
+      "first child before an equal-priority sibling",
+      "none",
+      false,
+      "question",
+      1,
+      4_503_599_627_370_497,
+    ],
+    [
+      "saturated conflicts",
+      "none",
+      false,
+      "question",
+      Number.MAX_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER,
+    ],
+  ] as const)(
+    "preserves transitive summaries with %s",
+    (_name, own, known, expected, conflicts, expectedConflicts) => {
+      const root = {
+        key: "root",
+        kind: "direct",
+        childSessions: ["first", "second", "missing"],
+      } satisfies GatewaySessionRow;
+      const rows: GatewaySessionRow[] = [
+        root,
+        { key: "first", kind: "direct", status: "failed", childSessions: ["grandchild"] },
+        { key: "second", kind: "direct", status: "timeout" },
+        { key: "grandchild", kind: "direct", status: "running", hasActiveRun: true },
+      ];
+      const trees = projectSessionTree({
+        roots: [root],
+        rowsByKey: collectSidebarSessionRowsByKey({ rows, childRowsByParent: {} }),
+        loadingChildKeys: new Set(),
+        knownSessionAttention: known
+          ? [{ sessionKey: "missing", attention: { kind: "approval" } }]
+          : [],
+        toSidebarSession: (row, isChild) => ({
+          ...projectSidebarSession(row),
+          isChild: isChild === true,
+          visuallyActive: row.key === "grandchild",
+          attention:
+            row.key === "root"
+              ? { kind: own }
+              : row.key === "first"
+                ? { kind: "question" }
+                : row.key === "second"
+                  ? { kind: "approval" }
+                  : { kind: "none" },
+          workspaceConflictCount:
+            row.key === "root"
+              ? conflicts
+              : row.key === "first"
+                ? 4_503_599_627_370_496
+                : row.key === "second"
+                  ? 0.5
+                  : undefined,
+        }),
+      });
+      expect(trees[0]).toMatchObject({
+        attention: { kind: expected },
+        runningChildCount: 1,
+        failedChildCount: 2,
+        containsActiveDescendant: true,
+        workspaceConflictCount: expectedConflicts,
+      });
+      expect(trees[0]?.childSessionKeys).toStrictEqual(["first", "second", "missing"]);
+      expect(
+        trees[0]?.children.map((row) => [row.key, row.runningChildCount, row.failedChildCount]),
+      ).toStrictEqual([
+        ["first", 1, 0],
+        ["second", 0, 0],
+      ]);
+    },
+  );
+
   it("walks a directly opened child through its navigation parent, not its controller", async () => {
     const knownRows = new Map(
       [navigationParent, controlParent, child].map((row) => [row.key, row]),

--- a/ui/src/components/app-sidebar-session-tree.ts
+++ b/ui/src/components/app-sidebar-session-tree.ts
@@ -63,38 +63,20 @@ export function projectSessionTree(params: {
   const build = (
     row: GatewaySessionRow,
     isChild: boolean,
-    ancestors: ReadonlySet<string>,
+    ancestors: Set<string>,
   ): SidebarRecentSession => {
     const childSessionKeys = row.archived === true ? [] : (childKeysByParent.get(row.key) ?? []);
-    const nextAncestors = new Set(ancestors);
-    nextAncestors.add(row.key);
+    const ownsAncestor = !ancestors.has(row.key);
+    ancestors.add(row.key);
     const children = childSessionKeys.flatMap((key) => {
       const child = rowsByKey.get(key);
-      return child && !nextAncestors.has(key) ? [build(child, true, nextAncestors)] : [];
+      return child && !ancestors.has(key) ? [build(child, true, ancestors)] : [];
     });
+    // Aliased map entries can share row.key with an ancestor; only remove our own entry.
+    if (ownsAncestor) {
+      ancestors.delete(row.key);
+    }
     const projected = toSidebarSession(row, isChild);
-    const projectedRunningChildCount = children.reduce(
-      (count, child) => count + (child.hasActiveRun ? 1 : 0) + child.runningChildCount,
-      0,
-    );
-    const runningChildCount = Math.max(
-      projectedRunningChildCount,
-      row.hasActiveSubagentRun ? 1 : 0,
-    );
-    const failedChildCount = children.reduce(
-      (count, child) =>
-        count +
-        (child.status === "failed" || child.status === "timeout" ? 1 : 0) +
-        child.failedChildCount,
-      0,
-    );
-    // Conflict attention is transitive: a collapsed parent must expose staged
-    // cloud results held by descendants or the recovery signal disappears.
-    const workspaceConflictCount = Math.min(
-      Number.MAX_SAFE_INTEGER,
-      (projected.workspaceConflictCount ?? 0) +
-        children.reduce((count, child) => count + (child.workspaceConflictCount ?? 0), 0),
-    );
     const unloadedChildKeys = childSessionKeys.filter((key) => !rowsByKey.has(key));
     // Only direct unloaded children can match: parents carry their keys, but not grandchildren's.
     // Grandchildren join the normal transitive fold after their branch is materialized.
@@ -109,16 +91,37 @@ export function projectSessionTree(params: {
     // Accepted gap: an unloaded failed child needs expansion before its error attention can surface.
     // Child attention is transitive just like live-run counts: a collapsed
     // ancestor remains actionable even when the blocked descendant is hidden.
-    const attention = children.reduce(
-      (current, child) =>
-        rowDemandsVisibility(child, RowVisibilityReason.Attention) &&
-        sidebarSessionAttentionPriority(child.attention) > sidebarSessionAttentionPriority(current)
-          ? child.attention
-          : current,
+    let attention =
       sidebarSessionAttentionPriority(unloadedChildAttention) >
-        sidebarSessionAttentionPriority(projected.attention)
+      sidebarSessionAttentionPriority(projected.attention)
         ? unloadedChildAttention
-        : projected.attention,
+        : projected.attention;
+    let runningChildCount = 0;
+    let failedChildCount = 0;
+    let childWorkspaceConflictCount = 0;
+    let containsActiveDescendant = false;
+    for (const child of children) {
+      runningChildCount =
+        runningChildCount + (child.hasActiveRun ? 1 : 0) + child.runningChildCount;
+      failedChildCount =
+        failedChildCount +
+        (child.status === "failed" || child.status === "timeout" ? 1 : 0) +
+        child.failedChildCount;
+      childWorkspaceConflictCount += child.workspaceConflictCount ?? 0;
+      if (
+        rowDemandsVisibility(child, RowVisibilityReason.Attention) &&
+        sidebarSessionAttentionPriority(child.attention) >
+          sidebarSessionAttentionPriority(attention)
+      ) {
+        attention = child.attention;
+      }
+      containsActiveDescendant ||=
+        child.active || child.visuallyActive || child.containsActiveDescendant;
+    }
+    // Sum descendants before adding the parent's conflicts, then clamp once.
+    const workspaceConflictCount = Math.min(
+      Number.MAX_SAFE_INTEGER,
+      (projected.workspaceConflictCount ?? 0) + childWorkspaceConflictCount,
     );
     return {
       ...projected,
@@ -126,11 +129,9 @@ export function projectSessionTree(params: {
       childSessionKeys,
       children,
       loadingChildren: loadingChildKeys.has(row.key),
-      containsActiveDescendant: children.some(
-        (child) => child.active || child.visuallyActive || child.containsActiveDescendant,
-      ),
+      containsActiveDescendant,
       workspaceConflictCount: workspaceConflictCount || undefined,
-      runningChildCount,
+      runningChildCount: Math.max(runningChildCount, row.hasActiveSubagentRun ? 1 : 0),
       failedChildCount,
     };
   };


### PR DESCRIPTION
## What Problem This Solves

The Control UI rebuilds nested session summaries as its sidebar updates. This is a maintenance cleanup of that work, preserving the existing hierarchy, running indicators, attention and conflict badges. It does not address a reproduced user-visible failure or promise a noticeable speedup.

## Why This Change Was Made

Reuse one path-local ancestor Set per root instead of copying it at every recursive frame, and compute the five child summaries in one traversal. Each frame releases only membership it introduced, preserving cycle handling and shared descendants. Keep callback order, attention tie precedence, archived/category placement, running-subagent fallback and conflict arithmetic unchanged.

The existing projection owner remains responsible for the result. No cache, persistent state, configuration, public API or rendering behavior is added. Production grows by one formatted line; preservation tests add 136 lines.

## User Impact

No intended visible change. The sidebar continues to show the same rows, links and indicators, while the projection has fewer repeated traversals and ancestor copies. Synthetic before/after captures are byte-identical.

## Evidence

- The final navigation suite passed 40 tests on both the original and modified projector, including the same added preservation cases. Three complete candidate UI suites passed 426 tests across navigation, projection and mounted sidebar behavior. That broader run preceded two test-only corrections; the final navigation suite was rerun on both projectors afterward.
- All 20 selected changed checks passed, including core-test and UI typechecks, type-aware lint, formatting, i18n and dead-export checks. The existing Chromium row-identity test passed. Independent Codex review found no actionable P0–P2 issues.
- A fixed baseline/candidate/candidate/baseline Chromium cohort made 364 direct projector calls and 252 mounted publications. Complete DTO/property/reference, callback-order, machine identity, input, root membership, DOM/link/badge/toggle, row reuse and update-completion checks matched between versions. The filtered All-status scenario refreshed its actual managed-list owner before awaiting the UI update; its timing includes that synthetic list request.

The browser clock advanced in 0.1 ms steps, and 159 of 364 direct samples recorded zero. These observations do **not** support a defensible percentage speedup claim. Mounted steady medians were also small and order-sensitive:

| Mounted scenario | First order: baseline → candidate | Reverse order: baseline → candidate |
| --- | --- | --- |
| Empty | 0.3 → 0.4 ms | 0.3 → 0.3 ms |
| Single | 0.3 → 0.3 ms | 0.3 → 0.4 ms |
| Ordinary shallow tree | 0.5 → 0.6 ms | 0.5 → 0.5 ms |
| Broad tree | 0.9 → 0.9 ms | 0.9 → 0.8 ms |
| Bounded deep stress case | 0.8 → 0.8 ms | 0.9 → 0.7 ms |
| Attention and machine facts | 0.4 → 0.3 ms | 0.4 → 0.3 ms |
| Categories and archived rows, including filtered refresh | 0.8 → 0.8 ms | 1.0 → 0.9 ms |

All first-call, warmup and adverse observations were retained: 38 of 98 steady mounted sample pairs and 26 of 140 steady direct pairs were slower. No Gateway, inference, startup or allocation measurement claim follows from this cohort. Numerical mounted cases kept child branches collapsed; the existing mounted tests cover expansion.

Measurements are bound to baseline `4492b7502d1b3d3986e6f606290f694206503c15`. An earlier baseline-only attempt failed because its All-status fixture published to the active-list owner; that failed attempt remains separate and was not pooled with the corrected full cohort. A nonnumerical preflight verified all three expected All-status roots and updated labels before the corrected cohort ran. All owned browser/process families closed and the candidate source was restored.

![Before: synthetic sidebar attention state](https://github.com/user-attachments/assets/1fd9f930-d67a-4450-a6fd-7f74e0e017d6)

![After: identical synthetic sidebar attention state](https://github.com/user-attachments/assets/c95f670f-e6db-4860-bc4b-042344dc4ad0)