### PR TITLE
refactor(workspace): await guarded state operations

### DIFF
--- a/src/agents/agent-create.integration.test.ts
+++ b/src/agents/agent-create.integration.test.ts
@@ -187,7 +187,7 @@ it.each(["workspace", "workspace-write", "config"] as const)(
       expect.soft(await fs.stat(stagedFile).catch(() => null)).toBeNull();
       if (phase !== "config") {
         expect.soft(await fs.readdir(workspace)).toEqual([]);
-        expect.soft(readWorkspaceStateSnapshot(workspace).setupExists).toBe(false);
+        expect.soft((await readWorkspaceStateSnapshot(workspace)).setupExists).toBe(false);
         expect.soft(prepareConfigCommit).not.toHaveBeenCalled();
         expect.soft(await fs.stat(state.sessionsDir("prepared")).catch(() => null)).toBeNull();
       } else {

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -191,7 +191,7 @@ async function createHeartbeatAgentsWorkspace() {
 }
 
 async function writeCompletedWorkspaceState(workspaceDir: string): Promise<void> {
-  mergeWorkspaceSetupState(workspaceDir, {
+  await mergeWorkspaceSetupState(workspaceDir, {
     bootstrapSeededAt: "2026-05-16T00:00:00.000Z",
     setupCompletedAt: "2026-05-16T00:00:01.000Z",
   });

--- a/src/agents/workspace-alias-rebind.test.ts
+++ b/src/agents/workspace-alias-rebind.test.ts
@@ -40,14 +40,14 @@ function repoint(alias: string, target: string) {
   fs.unlinkSync(alias);
   link(target, alias);
 }
-function movedWorkspace(attestationOnly = false) {
+async function movedWorkspace(attestationOnly = false) {
   const original = state.workspaceDir;
   const alias = state.path("workspace-link");
   const moved = state.path("moved-workspace");
   link(original, alias);
   fs.writeFileSync(path.join(original, "project.txt"), "user content");
   if (!attestationOnly) {
-    mergeWorkspaceSetupState(
+    await mergeWorkspaceSetupState(
       alias,
       {
         bootstrapSeededAt: "2026-07-16T01:00:00.000Z",
@@ -56,7 +56,7 @@ function movedWorkspace(attestationOnly = false) {
       1000,
     );
   }
-  replaceWorkspaceAttestation({
+  await replaceWorkspaceAttestation({
     workspaceDir: alias,
     attestedAtMs: 1000,
     generatedHashes: new Map([["AGENTS.md", "a".repeat(64)]]),
@@ -73,13 +73,13 @@ describe("workspace move recovery", () => {
     const alias = state.path("alias-e\u0301");
     const moved = state.path("unicode-alias-moved");
     link(original, alias);
-    mergeWorkspaceSetupState(alias, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
+    await mergeWorkspaceSetupState(alias, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
     fs.renameSync(original, moved);
     repoint(alias, moved);
     const facts = detectRepointedWorkspaceAlias(alias);
     expect(facts).toBeDefined();
     expect(await rebindRepointedWorkspaceAlias(alias, facts!)).toBe("rebound");
-    expect(readWorkspaceStateSnapshot(alias).setup.setupCompletedAt).toBe(
+    expect((await readWorkspaceStateSnapshot(alias)).setup.setupCompletedAt).toBe(
       "2026-07-16T02:00:00.000Z",
     );
   });
@@ -87,13 +87,13 @@ describe("workspace move recovery", () => {
   it("recovers when the original configured directory becomes the moved directory's alias", async () => {
     const original = state.workspaceDir;
     const moved = state.path("direct-move");
-    mergeWorkspaceSetupState(original, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
+    await mergeWorkspaceSetupState(original, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
     fs.renameSync(original, moved);
     link(moved, original);
     expect(
       await rebindRepointedWorkspaceAlias(original, detectRepointedWorkspaceAlias(original)!),
     ).toBe("rebound");
-    expect(readWorkspaceStateSnapshot(original).setup.setupCompletedAt).toBe(
+    expect((await readWorkspaceStateSnapshot(original)).setup.setupCompletedAt).toBe(
       "2026-07-16T02:00:00.000Z",
     );
   });
@@ -107,15 +107,15 @@ describe("workspace move recovery", () => {
       fs.mkdirSync(original, { recursive: true });
       fs.mkdirSync(moved);
       link(original, alias);
-      mergeWorkspaceSetupState(alias, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
+      await mergeWorkspaceSetupState(alias, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
       repoint(alias, moved);
       expect(
         await rebindRepointedWorkspaceAlias(alias, detectRepointedWorkspaceAlias(alias)!),
       ).toBe("original-workspace-exists");
-      expect(readWorkspaceStateSnapshot(original).setup.setupCompletedAt).toBe(
+      expect((await readWorkspaceStateSnapshot(original)).setup.setupCompletedAt).toBe(
         "2026-07-16T02:00:00.000Z",
       );
-      expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+      expect((await readWorkspaceStateSnapshot(moved)).setupExists).toBe(false);
     },
   );
 
@@ -129,7 +129,7 @@ describe("workspace move recovery", () => {
     fs.mkdirSync(original);
     fs.mkdirSync(moved);
     link(original, alias);
-    mergeWorkspaceSetupState(alias, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
+    await mergeWorkspaceSetupState(alias, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
     if (fs.existsSync(normalized)) {
       skip();
     }
@@ -138,16 +138,16 @@ describe("workspace move recovery", () => {
     expect(await rebindRepointedWorkspaceAlias(alias, detectRepointedWorkspaceAlias(alias)!)).toBe(
       "original-workspace-exists",
     );
-    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(moved)).setupExists).toBe(false);
   });
 
   it.each([false, true])(
     "preserves setup and attestation without changing files (attestation only: %s)",
     async (attestationOnly) => {
-      const { alias, moved } = movedWorkspace(attestationOnly);
+      const { alias, moved } = await movedWorkspace(attestationOnly);
       const facts = detectRepointedWorkspaceAlias(alias)!;
       expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("rebound");
-      const snapshot = readWorkspaceStateSnapshot(alias);
+      const snapshot = await readWorkspaceStateSnapshot(alias);
       expect(snapshot.setupExists).toBe(!attestationOnly);
       if (!attestationOnly) {
         expect(snapshot.setup).toMatchObject({
@@ -162,84 +162,84 @@ describe("workspace move recovery", () => {
       expect(fs.readFileSync(path.join(moved, "project.txt"), "utf8")).toBe("user content");
       expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("no-repoint");
       closeOpenClawStateDatabaseForTest();
-      expect(readWorkspaceStateSnapshot(alias)).toEqual(snapshot);
+      expect(await readWorkspaceStateSnapshot(alias)).toEqual(snapshot);
     },
   );
 
   it("refuses a copy while the original folder still exists", async () => {
-    const { original, alias, moved } = movedWorkspace();
+    const { original, alias, moved } = await movedWorkspace();
     fs.mkdirSync(original);
     const before = detectRepointedWorkspaceAlias(alias)!;
     expect(await rebindRepointedWorkspaceAlias(alias, before)).toBe("original-workspace-exists");
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(moved)).setupExists).toBe(false);
   });
 
   it("does not merge an existing destination owner and still reports a typed repair failure", async () => {
-    const { original, alias, moved } = movedWorkspace();
-    mergeWorkspaceSetupState(moved, { bootstrapSeededAt: "2026-07-17T01:00:00.000Z" }, 2000);
+    const { original, alias, moved } = await movedWorkspace();
+    await mergeWorkspaceSetupState(moved, { bootstrapSeededAt: "2026-07-17T01:00:00.000Z" }, 2000);
     const facts = detectRepointedWorkspaceAlias(alias)!;
-    expect(() => readWorkspaceStateSnapshot(alias)).toThrow(WorkspaceAliasRepointedError);
+    await expect(readWorkspaceStateSnapshot(alias)).rejects.toThrow(WorkspaceAliasRepointedError);
     expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("current-target-owns-state");
-    expect(readWorkspaceStateSnapshot(original).setup.setupCompletedAt).toBe(
+    expect((await readWorkspaceStateSnapshot(original)).setup.setupCompletedAt).toBe(
       "2026-07-16T02:00:00.000Z",
     );
-    expect(readWorkspaceStateSnapshot(moved).setup.bootstrapSeededAt).toBe(
+    expect((await readWorkspaceStateSnapshot(moved)).setup.bootstrapSeededAt).toBe(
       "2026-07-17T01:00:00.000Z",
     );
   });
 
   it("rejects changed setup records after confirmation facts were read", async () => {
-    const { original, alias, moved } = movedWorkspace();
+    const { original, alias, moved } = await movedWorkspace();
     const facts = detectRepointedWorkspaceAlias(alias)!;
-    mergeWorkspaceSetupState(original, {}, 3000);
+    await mergeWorkspaceSetupState(original, {}, 3000);
     expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("repoint-changed");
-    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(moved)).setupExists).toBe(false);
   });
 
   it("rejects a replacement directory at the same approved path", async () => {
-    const { alias, moved } = movedWorkspace();
+    const { alias, moved } = await movedWorkspace();
     const facts = detectRepointedWorkspaceAlias(alias)!;
     fs.renameSync(moved, state.path("retained-content"));
     fs.mkdirSync(moved);
     expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("repoint-changed");
-    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(moved)).setupExists).toBe(false);
   });
 
   it("uses actual directory bytes when a moved path has decomposed Unicode", async () => {
-    const { alias, moved } = movedWorkspace();
+    const { alias, moved } = await movedWorkspace();
     const decomposed = state.path("move-e\u0301");
     fs.renameSync(moved, decomposed);
     repoint(alias, decomposed);
     expect(await rebindRepointedWorkspaceAlias(alias, detectRepointedWorkspaceAlias(alias)!)).toBe(
       "rebound",
     );
-    expect(readWorkspaceStateSnapshot(alias).setup.setupCompletedAt).toBe(
+    expect((await readWorkspaceStateSnapshot(alias)).setup.setupCompletedAt).toBe(
       "2026-07-16T02:00:00.000Z",
     );
     expect(fs.readFileSync(path.join(decomposed, "project.txt"), "utf8")).toBe("user content");
   });
 
   it("refuses a configured path that still needs the old owner", async () => {
-    const { original, alias, moved } = movedWorkspace();
+    const { original, alias, moved } = await movedWorkspace();
     const facts = detectRepointedWorkspaceAlias(alias)!;
     expect(await rebindRepointedWorkspaceAlias(alias, facts, {}, [alias, original])).toBe(
       "configured-workspace-conflict",
     );
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(moved)).setupExists).toBe(false);
   });
 
   it("protects a configured alias before its first workspace access", async () => {
-    const { original, alias, moved } = movedWorkspace();
+    const { original, alias, moved } = await movedWorkspace();
     const unused = state.path("unused-link");
     link(original, unused);
     const facts = detectRepointedWorkspaceAlias(alias)!;
     expect(await rebindRepointedWorkspaceAlias(alias, facts, {}, [alias, unused])).toBe(
       "configured-workspace-conflict",
     );
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(moved)).setupExists).toBe(false);
   });
 
   it("keeps verified sibling aliases but removes old paths from the moved owner's cleanup", async () => {
@@ -249,8 +249,8 @@ describe("workspace move recovery", () => {
     const moved = state.path("moved");
     link(original, first);
     link(original, second);
-    mergeWorkspaceSetupState(first, { setupCompletedAt: "2026-07-16T02:00:00.000Z" }, 1000);
-    readWorkspaceStateSnapshot(second);
+    await mergeWorkspaceSetupState(first, { setupCompletedAt: "2026-07-16T02:00:00.000Z" }, 1000);
+    await readWorkspaceStateSnapshot(second);
     fs.renameSync(original, moved);
     repoint(first, moved);
     repoint(second, moved);
@@ -260,20 +260,24 @@ describe("workspace move recovery", () => {
         second,
       ]),
     ).toBe("rebound");
-    const snapshot = readWorkspaceStateSnapshot(second);
-    deleteWorkspaceState(prepareWorkspaceStateDeletion(original));
-    clearExpiredWorkspaceStateForVanishedWorkspace(
+    const snapshot = await readWorkspaceStateSnapshot(second);
+    await deleteWorkspaceState(prepareWorkspaceStateDeletion(original));
+    await clearExpiredWorkspaceStateForVanishedWorkspace(
       original,
       WORKSPACE_ATTESTATION_RECENT_MS + 2000,
     );
-    expect(readWorkspaceStateSnapshot(first)).toEqual(snapshot);
+    expect(await readWorkspaceStateSnapshot(first)).toEqual(snapshot);
     fs.mkdirSync(original);
-    mergeWorkspaceSetupState(original, { bootstrapSeededAt: "2026-07-18T01:00:00.000Z" }, 4000);
-    expect(readWorkspaceStateSnapshot(second)).toEqual(snapshot);
+    await mergeWorkspaceSetupState(
+      original,
+      { bootstrapSeededAt: "2026-07-18T01:00:00.000Z" },
+      4000,
+    );
+    expect(await readWorkspaceStateSnapshot(second)).toEqual(snapshot);
   });
 
-  it("rejects malformed persisted attestation before it can be transferred", () => {
-    const { alias } = movedWorkspace();
+  it("rejects malformed persisted attestation before it can be transferred", async () => {
+    const { alias } = await movedWorkspace();
     openOpenClawStateDatabase()
       .db.prepare("UPDATE workspace_generated_bootstrap_hashes SET filename = '../outside.md'")
       .run();
@@ -283,15 +287,15 @@ describe("workspace move recovery", () => {
   });
 
   it("fails closed after a second repoint following a committed move", async () => {
-    const { alias, moved } = movedWorkspace();
+    const { alias, moved } = await movedWorkspace();
     expect(await rebindRepointedWorkspaceAlias(alias, detectRepointedWorkspaceAlias(alias)!)).toBe(
       "rebound",
     );
     const other = state.path("other");
     fs.mkdirSync(other);
     repoint(alias, other);
-    expect(() => readWorkspaceStateSnapshot(alias)).toThrow(WorkspaceAliasRepointedError);
-    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(other).setupExists).toBe(false);
+    await expect(readWorkspaceStateSnapshot(alias)).rejects.toThrow(WorkspaceAliasRepointedError);
+    expect((await readWorkspaceStateSnapshot(moved)).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(other)).setupExists).toBe(false);
   });
 });

--- a/src/agents/workspace-sqlite-safety.test.ts
+++ b/src/agents/workspace-sqlite-safety.test.ts
@@ -77,7 +77,7 @@ describe("workspace setup-only SQLite safety", () => {
     await expect(
       fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME)),
     ).resolves.toBeUndefined();
-    expect(readWorkspaceStateSnapshot(tempDir).setup.setupCompletedAt).toBeUndefined();
+    expect((await readWorkspaceStateSnapshot(tempDir)).setup.setupCompletedAt).toBeUndefined();
   });
 
   it("clears expired state when only one generated bootstrap file survives", async () => {
@@ -103,12 +103,12 @@ describe("workspace setup-only SQLite safety", () => {
     await expect(
       fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME)),
     ).resolves.toBeUndefined();
-    expect(readWorkspaceStateSnapshot(tempDir).setup.setupCompletedAt).toBeUndefined();
+    expect((await readWorkspaceStateSnapshot(tempDir)).setup.setupCompletedAt).toBeUndefined();
   });
 
   it("refuses an empty recent setup-only workspace when bootstrap creation is disabled", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
-    mergeWorkspaceSetupState(tempDir, {
+    await mergeWorkspaceSetupState(tempDir, {
       bootstrapSeededAt: new Date().toISOString(),
     });
 
@@ -124,7 +124,7 @@ describe("workspace setup-only SQLite safety", () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const identityPath = path.join(tempDir, DEFAULT_IDENTITY_FILENAME);
     await fs.writeFile(identityPath, "# Existing identity\n");
-    mergeWorkspaceSetupState(tempDir, {
+    await mergeWorkspaceSetupState(tempDir, {
       setupCompletedAt: "2026-07-15T10:01:00.000Z",
     });
 
@@ -137,7 +137,7 @@ describe("workspace setup-only SQLite safety", () => {
   it("does not mistake an old generated template for setup-only customization", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await fs.writeFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), "old generated agents\n");
-    mergeWorkspaceSetupState(tempDir, {
+    await mergeWorkspaceSetupState(tempDir, {
       bootstrapSeededAt: "2026-07-15T10:00:00.000Z",
       setupCompletedAt: "2026-07-15T10:01:00.000Z",
     });
@@ -156,7 +156,7 @@ describe("workspace setup-only SQLite safety", () => {
 
   it("refuses to reseed a missing workspace with recent setup-only state", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
-    mergeWorkspaceSetupState(tempDir, {
+    await mergeWorkspaceSetupState(tempDir, {
       bootstrapSeededAt: new Date().toISOString(),
     });
     await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/workspace-state-dirs.ts
+++ b/src/agents/workspace-state-dirs.ts
@@ -83,12 +83,12 @@ export function listWorkspaceStateDirs(params: {
   return [...dirs];
 }
 
-/** Refuse completion before channels accept work that a workspace cannot execute. */
-export function assertConfiguredWorkspaceStateReady(params: {
+type ConfiguredWorkspaceStateParams = {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
-  operation?: "doctor";
-}): void {
+};
+
+function configuredWorkspaceStateScope(params: ConfiguredWorkspaceStateParams) {
   const env = params.env ?? process.env;
   const homedir = os.homedir;
   const workspaceDirs = listWorkspaceStateDirs({
@@ -97,10 +97,20 @@ export function assertConfiguredWorkspaceStateReady(params: {
     homedir,
     stateDir: resolveStateDir(env, homedir),
   });
-  if (params.operation === "doctor") {
-    for (const workspaceDir of workspaceDirs) {
-      readWorkspaceStateSnapshot(workspaceDir, { env, readOnly: true });
-    }
+  return { ...params, workspaceDirs, env, homedir };
+}
+
+/** Refuse completion before channels accept work that a workspace cannot execute. */
+export function assertConfiguredWorkspaceStateReady(params: ConfiguredWorkspaceStateParams): void {
+  assertWorkspaceStateMigrationReady(configuredWorkspaceStateScope(params));
+}
+
+export async function assertConfiguredWorkspaceStateReadyForDoctor(
+  params: ConfiguredWorkspaceStateParams,
+): Promise<void> {
+  const scope = configuredWorkspaceStateScope(params);
+  for (const workspaceDir of scope.workspaceDirs) {
+    await readWorkspaceStateSnapshot(workspaceDir, { env: scope.env, readOnly: true });
   }
-  assertWorkspaceStateMigrationReady({ ...params, workspaceDirs, env, homedir });
+  assertWorkspaceStateMigrationReady({ ...scope, operation: "doctor" });
 }

--- a/src/agents/workspace-state-store.test.ts
+++ b/src/agents/workspace-state-store.test.ts
@@ -7,7 +7,6 @@ import {
   closeOpenClawStateDatabaseForTest,
   openExistingOpenClawStateDatabaseReadOnly,
   openOpenClawStateDatabase,
-  runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
@@ -58,8 +57,8 @@ function workspaceDir(): string {
   return testState.workspaceDir;
 }
 
-function deleteState(targetDir: string): void {
-  deleteWorkspaceState(prepareWorkspaceStateDeletion(targetDir));
+async function deleteState(targetDir: string): Promise<void> {
+  await deleteWorkspaceState(prepareWorkspaceStateDeletion(targetDir));
 }
 
 function insertPersistedAttestationHash(filename: string, sha256: string): void {
@@ -76,12 +75,12 @@ function insertPersistedAttestationHash(filename: string, sha256: string): void 
 }
 
 describe("workspace state store", () => {
-  it("does not create shared state for a read-only snapshot", () => {
+  it("does not create shared state for a read-only snapshot", async () => {
     const statePath = resolveOpenClawStateSqlitePath(testState!.env);
     expect(fs.existsSync(statePath)).toBe(false);
 
     expect(
-      readWorkspaceStateSnapshot(workspaceDir(), {
+      await readWorkspaceStateSnapshot(workspaceDir(), {
         env: testState!.env,
         readOnly: true,
       }),
@@ -89,13 +88,13 @@ describe("workspace state store", () => {
     expect(fs.existsSync(statePath)).toBe(false);
   });
 
-  it("round-trips setup and attestation state after a database restart", () => {
+  it("round-trips setup and attestation state after a database restart", async () => {
     const dir = workspaceDir();
-    mergeWorkspaceSetupState(dir, {
+    await mergeWorkspaceSetupState(dir, {
       bootstrapSeededAt: "2026-07-16T01:00:00.000Z",
       setupCompletedAt: "2026-07-16T02:00:00.000Z",
     });
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 1_752_628_800_000,
       generatedHashes: new Map([
@@ -106,7 +105,7 @@ describe("workspace state store", () => {
 
     closeOpenClawStateDatabaseForTest();
 
-    const snapshot = readWorkspaceStateSnapshot(dir);
+    const snapshot = await readWorkspaceStateSnapshot(dir);
     expect(snapshot.setupExists).toBe(true);
     expect(snapshot.setup).toStrictEqual({
       version: 1,
@@ -122,11 +121,13 @@ describe("workspace state store", () => {
 
   it.each(["HEARTBEAT.md", "RETIRED.md"])(
     "reads a persisted hash for a retired or unknown bootstrap filename: %s",
-    (filename) => {
+    async (filename) => {
       insertPersistedAttestationHash(filename, "a".repeat(64));
 
       expect([
-        ...readWorkspaceStateSnapshot(workspaceDir()).attestation!.generatedHashes.entries(),
+        ...(
+          await readWorkspaceStateSnapshot(workspaceDir())
+        ).attestation!.generatedHashes.entries(),
       ]).toStrictEqual([[filename, "a".repeat(64)]]);
     },
   );
@@ -142,27 +143,77 @@ describe("workspace state store", () => {
     "CONIN$.md",
     "CONOUT$.md",
     ".hidden.md",
-  ])("rejects an unsafe persisted attestation filename: %s", (filename) => {
+  ])("rejects an unsafe persisted attestation filename: %s", async (filename) => {
     insertPersistedAttestationHash(filename, "a".repeat(64));
 
-    expect(() => readWorkspaceStateSnapshot(workspaceDir())).toThrow(
+    await expect(readWorkspaceStateSnapshot(workspaceDir())).rejects.toThrow(
       "workspace attestation hash row is invalid",
     );
   });
 
-  it("rejects a malformed persisted attestation hash", () => {
+  it("rejects a malformed persisted attestation hash", async () => {
     insertPersistedAttestationHash("AGENTS.md", "a".repeat(63));
 
-    expect(() => readWorkspaceStateSnapshot(workspaceDir())).toThrow(
+    await expect(readWorkspaceStateSnapshot(workspaceDir())).rejects.toThrow(
       "workspace attestation hash row is invalid",
     );
   });
 
-  it("never regresses persisted setup milestones", () => {
+  it.each(["merge", "attest", "expire", "delete", "register-alias"] as const)(
+    "checks current ownership inside the %s transaction before changing state",
+    async (operation) => {
+      const dir = workspaceDir();
+      const alias = testState!.path("workspace-link");
+      await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+      await replaceWorkspaceAttestation({
+        workspaceDir: dir,
+        attestedAtMs: 1_000,
+        generatedHashes: new Map([["AGENTS.md", "a".repeat(64)]]),
+        nowMs: 1_000,
+      });
+      const before = await readWorkspaceStateSnapshot(dir);
+      const db = openOpenClawStateDatabase().db;
+      fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
+      const filePath = path.join(dir, "AGENTS.md");
+      writeWorkspaceFileCache({ filePath, content: "cached", identity: "identity" });
+      const retired = new Error("workspace owner retired");
+      const assertCurrent = () => {
+        expect(db.isTransaction).toBe(true);
+        throw retired;
+      };
+      const operations = {
+        merge: () =>
+          mergeWorkspaceSetupState(dir, { setupCompletedAt: "2026-07-16T02:00:00.000Z" }, 2_000, {
+            assertCurrent,
+          }),
+        attest: () =>
+          replaceWorkspaceAttestation({
+            workspaceDir: dir,
+            attestedAtMs: 2_000,
+            generatedHashes: new Map([["AGENTS.md", "b".repeat(64)]]),
+            nowMs: 2_000,
+            assertCurrent,
+          }),
+        expire: () =>
+          clearExpiredWorkspaceStateForVanishedWorkspace(dir, 86_401_001, { assertCurrent }),
+        delete: () => deleteWorkspaceState(prepareWorkspaceStateDeletion(dir), { assertCurrent }),
+        "register-alias": () => readWorkspaceStateSnapshot(alias, { assertCurrent }),
+      };
+
+      await expect(operations[operation]()).rejects.toBe(retired);
+      expect(await readWorkspaceStateSnapshot(dir)).toEqual(before);
+      expect(readWorkspaceFileCache(filePath, "identity")).toBe("cached");
+      expect(
+        db.prepare("SELECT alias_key FROM workspace_path_aliases WHERE alias_path = ?").get(alias),
+      ).toBeUndefined();
+    },
+  );
+
+  it("never regresses persisted setup milestones", async () => {
     const dir = workspaceDir();
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    mergeWorkspaceSetupState(dir, { setupCompletedAt: "2026-07-16T02:00:00.000Z" }, 2_000);
-    const state = mergeWorkspaceSetupState(
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(dir, { setupCompletedAt: "2026-07-16T02:00:00.000Z" }, 2_000);
+    const state = await mergeWorkspaceSetupState(
       dir,
       {
         bootstrapSeededAt: "2026-07-16T03:00:00.000Z",
@@ -176,12 +227,12 @@ describe("workspace state store", () => {
       bootstrapSeededAt: "2026-07-16T01:00:00.000Z",
       setupCompletedAt: "2026-07-16T02:00:00.000Z",
     });
-    expect(readWorkspaceStateSnapshot(dir).setup).toStrictEqual(state);
+    expect((await readWorkspaceStateSnapshot(dir)).setup).toStrictEqual(state);
   });
 
-  it("replaces generated hashes atomically and ignores older attestations", () => {
+  it("replaces generated hashes atomically and ignores older attestations", async () => {
     const dir = workspaceDir();
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 2_000,
       generatedHashes: new Map([
@@ -190,20 +241,20 @@ describe("workspace state store", () => {
       ]),
       nowMs: 2_000,
     });
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 3_000,
       generatedHashes: new Map([["SOUL.md", "c".repeat(64)]]),
       nowMs: 3_000,
     });
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 1_000,
       generatedHashes: new Map([["USER.md", "d".repeat(64)]]),
       nowMs: 4_000,
     });
 
-    const snapshot = readWorkspaceStateSnapshot(dir);
+    const snapshot = await readWorkspaceStateSnapshot(dir);
     // Attestation-only rows carry NULL setup columns: recording hashes before
     // any setup write must not fabricate setup state.
     expect(snapshot.setupExists).toBe(false);
@@ -214,85 +265,85 @@ describe("workspace state store", () => {
     ]);
   });
 
-  it("replaces a future-dated attestation with a live refresh", () => {
+  it("replaces a future-dated attestation with a live refresh", async () => {
     const dir = workspaceDir();
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 100_000,
       generatedHashes: new Map([["AGENTS.md", "a".repeat(64)]]),
       nowMs: 100_000,
     });
 
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 2_000,
       generatedHashes: new Map([["TOOLS.md", "b".repeat(64)]]),
       nowMs: 2_000,
     });
 
-    const attestation = readWorkspaceStateSnapshot(dir).attestation;
+    const attestation = (await readWorkspaceStateSnapshot(dir)).attestation;
     expect(attestation?.attestedAtMs).toBe(2_000);
     expect([...attestation!.generatedHashes.entries()]).toStrictEqual([
       ["TOOLS.md", "b".repeat(64)],
     ]);
   });
 
-  it("preserves future-dated state for a vanished workspace", () => {
+  it("preserves future-dated state for a vanished workspace", async () => {
     const dir = workspaceDir();
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    replaceWorkspaceAttestation({
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 100_000,
       generatedHashes: new Map(),
       nowMs: 100_000,
     });
 
-    expect(clearExpiredWorkspaceStateForVanishedWorkspace(dir, 2_000)).toBe(false);
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(dir).attestation?.attestedAtMs).toBe(100_000);
+    expect(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, 2_000)).toBe(false);
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(dir)).attestation?.attestedAtMs).toBe(100_000);
   });
 
-  it("preserves recent setup-only state and cached content for a vanished workspace", () => {
+  it("preserves recent setup-only state and cached content for a vanished workspace", async () => {
     const dir = workspaceDir();
     const filePath = path.join(dir, "AGENTS.md");
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
     writeWorkspaceFileCache({ filePath, content: "cached", identity: "identity" });
 
-    expect(clearExpiredWorkspaceStateForVanishedWorkspace(dir, 2_000)).toBe(false);
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(true);
+    expect(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, 2_000)).toBe(false);
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(true);
     expect(readWorkspaceFileCache(filePath, "identity")).toBe("cached");
   });
 
-  it("keeps symlink aliases on one identity after the workspace target vanishes", () => {
+  it("keeps symlink aliases on one identity after the workspace target vanishes", async () => {
     const dir = workspaceDir();
     const alias = testState!.path("workspace-link");
     fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
     const identity = resolveWorkspaceStateIdentity(dir);
 
     expect(resolveWorkspaceStateIdentity(alias)).toStrictEqual(identity);
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
     fs.rmSync(dir, { recursive: true, force: true });
 
     expect(resolveWorkspaceStateIdentity(alias)).toStrictEqual(identity);
-    expect(clearExpiredWorkspaceStateForVanishedWorkspace(alias, 2_000)).toBe(false);
-    expect(readWorkspaceStateSnapshot(alias).setupExists).toBe(true);
+    expect(await clearExpiredWorkspaceStateForVanishedWorkspace(alias, 2_000)).toBe(false);
+    expect((await readWorkspaceStateSnapshot(alias)).setupExists).toBe(true);
   });
 
-  it("uses a persisted alias after the configured symlink itself disappears", () => {
+  it("uses a persisted alias after the configured symlink itself disappears", async () => {
     const dir = workspaceDir();
     const alias = testState!.path("workspace-link");
     fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
     const identity = resolveWorkspaceStateIdentity(dir);
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
 
     fs.unlinkSync(alias);
 
     expect(resolveWorkspaceStateIdentity(alias)).not.toStrictEqual(identity);
-    expect(readWorkspaceStateSnapshot(alias).identity).toStrictEqual(identity);
-    expect(clearExpiredWorkspaceStateForVanishedWorkspace(alias, 2_000)).toBe(false);
+    expect((await readWorkspaceStateSnapshot(alias)).identity).toStrictEqual(identity);
+    expect(await clearExpiredWorkspaceStateForVanishedWorkspace(alias, 2_000)).toBe(false);
   });
 
-  it("registers missing aliases in the caller-selected state database", () => {
+  it("registers missing aliases in the caller-selected state database", async () => {
     const dir = workspaceDir();
     const alias = testState!.path("workspace-link");
     const env = {
@@ -301,17 +352,17 @@ describe("workspace state store", () => {
     };
     fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
     const identity = resolveWorkspaceStateIdentity(dir);
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000, {
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000, {
       env,
     });
 
-    expect(readWorkspaceStateSnapshot(alias, { env }).identity).toStrictEqual(identity);
+    expect((await readWorkspaceStateSnapshot(alias, { env })).identity).toStrictEqual(identity);
     fs.unlinkSync(alias);
 
-    expect(readWorkspaceStateSnapshot(alias, { env }).identity).toStrictEqual(identity);
-    expect(readWorkspaceStateSnapshot(alias, { env }).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(alias, { env })).identity).toStrictEqual(identity);
+    expect((await readWorkspaceStateSnapshot(alias, { env })).setupExists).toBe(true);
     expect(resolveOpenClawStateSqlitePath(env)).not.toBe(resolveOpenClawStateSqlitePath());
-    expect(readWorkspaceStateSnapshot(alias).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(alias)).setupExists).toBe(false);
   });
 
   it("does not register missing aliases through a read-only database", async () => {
@@ -321,7 +372,7 @@ describe("workspace state store", () => {
       ...process.env,
       OPENCLAW_STATE_DIR: testState!.path("custom-state"),
     };
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000, {
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000, {
       env,
     });
     closeOpenClawStateDatabaseForTest();
@@ -332,48 +383,52 @@ describe("workspace state store", () => {
     }
 
     try {
-      expect(readWorkspaceStateSnapshot(alias, { database, env, readOnly: true }).setupExists).toBe(
-        true,
-      );
+      expect(
+        (await readWorkspaceStateSnapshot(alias, { database, env, readOnly: true })).setupExists,
+      ).toBe(true);
     } finally {
       database.walMaintenance.close();
     }
     fs.unlinkSync(alias);
 
-    expect(readWorkspaceStateSnapshot(alias, { env }).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(alias, { env })).setupExists).toBe(false);
   });
 
-  it("fails closed when a persisted symlink alias is repointed", () => {
+  it("fails closed when a persisted symlink alias is repointed", async () => {
     const dir = workspaceDir();
     const alias = testState!.path("workspace-link");
     const replacement = testState!.path("replacement-workspace");
     fs.mkdirSync(replacement, { recursive: true });
     fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
     fs.unlinkSync(alias);
     fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
 
-    expect(() => readWorkspaceStateSnapshot(alias)).toThrow(WorkspaceAliasRepointedError);
-    expect(() => readWorkspaceStateSnapshot(alias)).toThrow(/different current target/u);
+    await expect(readWorkspaceStateSnapshot(alias)).rejects.toThrow(WorkspaceAliasRepointedError);
+    await expect(readWorkspaceStateSnapshot(alias)).rejects.toThrow(/different current target/u);
   });
 
-  it("cleans current state and only the stale association for a repointed alias", () => {
+  it("cleans current state and only the stale association for a repointed alias", async () => {
     const dir = workspaceDir();
     const alias = testState!.path("workspace-link");
     const replacement = testState!.path("replacement-workspace");
     fs.mkdirSync(replacement, { recursive: true });
     fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    mergeWorkspaceSetupState(replacement, { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" }, 2_000);
+    await mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(
+      replacement,
+      { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" },
+      2_000,
+    );
     fs.unlinkSync(alias);
     fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
 
     const deletion = prepareWorkspaceStateDeletion(alias);
     fs.unlinkSync(alias);
-    deleteWorkspaceState(deletion);
+    await deleteWorkspaceState(deletion);
 
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(replacement)).setupExists).toBe(false);
     const staleAlias = openOpenClawStateDatabase()
       .db.prepare("SELECT alias_key FROM workspace_path_aliases WHERE alias_path = ?")
       .get(alias);
@@ -385,37 +440,44 @@ describe("workspace state store", () => {
     { cleanup: "delete", name: "cafe\u0301" },
     { cleanup: "expire", name: "plain" },
     { cleanup: "expire", name: "cafe\u0301" },
-  ])("$cleanup retires cached content through a missing alias ($name)", ({ cleanup, name }) => {
-    const dir = path.join(workspaceDir(), name);
-    fs.mkdirSync(dir);
-    const canonicalDir = fs.realpathSync(dir);
-    const alias = testState!.path("workspace-link");
-    const filePath = path.join(canonicalDir, "AGENTS.md");
-    fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    writeWorkspaceFileCache({ filePath, content: "cached", identity: "identity" });
-    fs.unlinkSync(alias);
+  ])(
+    "$cleanup retires cached content through a missing alias ($name)",
+    async ({ cleanup, name }) => {
+      const dir = path.join(workspaceDir(), name);
+      fs.mkdirSync(dir);
+      const canonicalDir = fs.realpathSync(dir);
+      const alias = testState!.path("workspace-link");
+      const filePath = path.join(canonicalDir, "AGENTS.md");
+      fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
+      await mergeWorkspaceSetupState(
+        alias,
+        { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" },
+        1_000,
+      );
+      writeWorkspaceFileCache({ filePath, content: "cached", identity: "identity" });
+      fs.unlinkSync(alias);
 
-    if (cleanup === "delete") {
-      deleteState(alias);
-    } else {
-      expect(clearExpiredWorkspaceStateForVanishedWorkspace(alias, 86_401_001)).toBe(true);
-    }
+      if (cleanup === "delete") {
+        await deleteState(alias);
+      } else {
+        expect(await clearExpiredWorkspaceStateForVanishedWorkspace(alias, 86_401_001)).toBe(true);
+      }
 
-    expect(readWorkspaceFileCache(filePath, "identity")).toBeUndefined();
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(false);
-    const aliases = openOpenClawStateDatabase()
-      .db.prepare("SELECT alias_key FROM workspace_path_aliases")
-      .all();
-    expect(aliases).toEqual([]);
-  });
+      expect(readWorkspaceFileCache(filePath, "identity")).toBeUndefined();
+      expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(false);
+      const aliases = openOpenClawStateDatabase()
+        .db.prepare("SELECT alias_key FROM workspace_path_aliases")
+        .all();
+      expect(aliases).toEqual([]);
+    },
+  );
 
-  it.each(["delete", "expire"])("keeps cached files when %s fails", (cleanup) => {
+  it.each(["delete", "expire"])("keeps cached files when %s fails", async (cleanup) => {
     const dir = workspaceDir();
     const alias = testState!.path("workspace-link");
     const filePath = path.join(dir, "AGENTS.md");
     fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
     writeWorkspaceFileCache({ filePath, content: "cached", identity: "identity" });
     const deletion = prepareWorkspaceStateDeletion(alias);
     openOpenClawStateDatabase()
@@ -423,100 +485,96 @@ describe("workspace state store", () => {
       .run(`${alias}-mismatch`, alias);
 
     try {
-      expect(() => {
-        if (cleanup === "delete") {
-          deleteWorkspaceState(deletion);
-        } else {
-          clearExpiredWorkspaceStateForVanishedWorkspace(alias, 86_401_001);
-        }
-      }).toThrow(/alias key collision/u);
+      await expect(
+        cleanup === "delete"
+          ? deleteWorkspaceState(deletion)
+          : clearExpiredWorkspaceStateForVanishedWorkspace(alias, 86_401_001),
+      ).rejects.toThrow(/alias key collision/u);
       expect(readWorkspaceFileCache(filePath, "identity")).toBe("cached");
     } finally {
       retireWorkspaceFileCache(dir);
     }
   });
 
-  it.each(["delete", "expire"])(
-    "retires %s cache entries only after the outer commit",
-    (cleanup) => {
-      const dir = workspaceDir();
-      const filePath = path.join(dir, "AGENTS.md");
-      mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-      writeWorkspaceFileCache({ filePath, content: "cached", identity: "identity" });
-      const remove = () => {
-        if (cleanup === "delete") {
-          deleteState(dir);
-        } else {
-          expect(clearExpiredWorkspaceStateForVanishedWorkspace(dir, 86_401_001)).toBe(true);
-        }
-      };
+  it.each(["delete", "expire"])("keeps %s cache entries when the commit fails", async (cleanup) => {
+    const dir = workspaceDir();
+    const filePath = path.join(dir, "AGENTS.md");
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    writeWorkspaceFileCache({ filePath, content: "cached", identity: "identity" });
+    const db = openOpenClawStateDatabase().db;
+    db.exec(`CREATE TABLE workspace_commit_guard (
+        workspace_key TEXT REFERENCES workspace_setup_state(workspace_key)
+          DEFERRABLE INITIALLY DEFERRED
+      )`);
+    db.prepare("INSERT INTO workspace_commit_guard VALUES (?)").run(
+      resolveWorkspaceStateIdentity(dir).workspaceKey,
+    );
+    const remove = async () =>
+      cleanup === "delete"
+        ? await deleteState(dir)
+        : await clearExpiredWorkspaceStateForVanishedWorkspace(dir, 86_401_001);
 
-      expect(() =>
-        runOpenClawStateWriteTransaction(() => {
-          remove();
-          expect(readWorkspaceFileCache(filePath, "identity")).toBe("cached");
-          throw new Error("rollback cleanup");
-        }),
-      ).toThrow("rollback cleanup");
-      expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(true);
-      expect(readWorkspaceFileCache(filePath, "identity")).toBe("cached");
+    await expect(remove()).rejects.toThrow(/FOREIGN KEY constraint failed/u);
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(true);
+    expect(readWorkspaceFileCache(filePath, "identity")).toBe("cached");
 
-      runOpenClawStateWriteTransaction(() => {
-        remove();
-        expect(readWorkspaceFileCache(filePath, "identity")).toBe("cached");
-      });
-      expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(false);
-      expect(readWorkspaceFileCache(filePath, "identity")).toBeUndefined();
-    },
-  );
+    db.exec("DELETE FROM workspace_commit_guard");
+    await remove();
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(false);
+    expect(readWorkspaceFileCache(filePath, "identity")).toBeUndefined();
+  });
 
-  it("retires canonical cached files after deleting through an alias", () => {
+  it("retires canonical cached files after deleting through an alias", async () => {
     const dir = workspaceDir();
     const alias = testState!.path("workspace-link");
     const filePath = path.join(dir, "AGENTS.md");
     fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
     writeWorkspaceFileCache({ filePath, content: "cached", identity: "identity" });
     const deletion = prepareWorkspaceStateDeletion(alias);
     fs.unlinkSync(alias);
 
-    deleteWorkspaceState(deletion);
+    await deleteWorkspaceState(deletion);
 
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(false);
     expect(readWorkspaceFileCache(filePath, "identity")).toBeUndefined();
   });
 
-  it("clears expired setup-only state for a vanished workspace", () => {
+  it("clears expired setup-only state for a vanished workspace", async () => {
     const dir = workspaceDir();
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
 
-    expect(clearExpiredWorkspaceStateForVanishedWorkspace(dir, 86_401_001)).toBe(true);
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(false);
+    expect(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, 86_401_001)).toBe(true);
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(false);
   });
 
-  it("does not protect a markerless setup row", () => {
+  it("does not protect a markerless setup row", async () => {
     const dir = workspaceDir();
-    mergeWorkspaceSetupState(dir, {}, 1_000);
+    await mergeWorkspaceSetupState(dir, {}, 1_000);
 
-    expect(clearExpiredWorkspaceStateForVanishedWorkspace(dir, 2_000)).toBe(true);
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(false);
+    expect(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, 2_000)).toBe(true);
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(false);
   });
 
-  it("preserves recent setup state when its attestation is stale", () => {
+  it("preserves recent setup state when its attestation is stale", async () => {
     const dir = workspaceDir();
-    mergeWorkspaceSetupState(dir, { setupCompletedAt: "2026-07-16T01:00:00.000Z" }, 100_000_000);
-    replaceWorkspaceAttestation({
+    await mergeWorkspaceSetupState(
+      dir,
+      { setupCompletedAt: "2026-07-16T01:00:00.000Z" },
+      100_000_000,
+    );
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 1_000,
       generatedHashes: new Map(),
       nowMs: 1_000,
     });
 
-    expect(clearExpiredWorkspaceStateForVanishedWorkspace(dir, 100_001_000)).toBe(false);
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(true);
+    expect(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, 100_001_000)).toBe(false);
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(true);
   });
 
-  it("deletes future-version state without parsing it", () => {
+  it("deletes future-version state without parsing it", async () => {
     const dir = workspaceDir();
     const identity = resolveWorkspaceStateIdentity(dir);
     const db = openOpenClawStateDatabase().db;
@@ -531,17 +589,17 @@ describe("workspace state store", () => {
       ) VALUES (?, ?, 99, NULL, NULL, 1)`,
     ).run(identity.workspaceKey, identity.workspacePath);
 
-    expect(() => readWorkspaceStateSnapshot(dir)).toThrow(
+    await expect(readWorkspaceStateSnapshot(dir)).rejects.toThrow(
       /unsupported workspace setup version 99/u,
     );
-    expect(() => deleteState(dir)).not.toThrow();
+    await expect(deleteState(dir)).resolves.toBeUndefined();
     const row = db
       .prepare("SELECT workspace_key FROM workspace_setup_state WHERE workspace_key = ?")
       .get(identity.workspaceKey);
     expect(row).toBeUndefined();
   });
 
-  it("does not recreate a missing database during delete-only cleanup", () => {
+  it("does not recreate a missing database during delete-only cleanup", async () => {
     const dir = workspaceDir();
     const filePath = path.join(dir, "AGENTS.md");
     writeWorkspaceFileCache({ filePath, content: "cached", identity: "identity" });
@@ -549,18 +607,18 @@ describe("workspace state store", () => {
     closeOpenClawStateDatabaseForTest();
     fs.rmSync(path.dirname(databasePath), { recursive: true, force: true });
 
-    deleteState(dir);
+    await deleteState(dir);
 
     expect(fs.existsSync(databasePath)).toBe(false);
     expect(fs.existsSync(path.dirname(databasePath))).toBe(false);
     expect(readWorkspaceFileCache(filePath, "identity")).toBeUndefined();
   });
 
-  it("deletes migration receipts owned by the workspace", () => {
+  it("deletes migration receipts owned by the workspace", async () => {
     const dir = workspaceDir();
     const identity = resolveWorkspaceStateIdentity(dir);
     const db = openOpenClawStateDatabase().db;
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" });
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" });
     const insertRun = db.prepare(
       "INSERT INTO migration_runs (id, started_at, finished_at, status, report_json) VALUES (?, 1, 1, 'completed', '{}')",
     );
@@ -593,7 +651,7 @@ describe("workspace state store", () => {
       JSON.stringify({ workspaceKey: "other-workspace" }),
     );
 
-    deleteState(dir);
+    await deleteState(dir);
 
     const receipts = db
       .prepare("SELECT source_key FROM migration_sources ORDER BY source_key")
@@ -603,28 +661,32 @@ describe("workspace state store", () => {
     expect(runs).toEqual([{ id: "unrelated-run" }]);
   });
 
-  it("clears expired missing-workspace state but preserves a concurrent refresh", () => {
+  it("clears expired missing-workspace state but preserves a concurrent refresh", async () => {
     const dir = workspaceDir();
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    replaceWorkspaceAttestation({
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 1_000,
       generatedHashes: new Map(),
       nowMs: 1_000,
     });
 
-    expect(clearExpiredWorkspaceStateForVanishedWorkspace(dir, 86_401_001)).toBe(true);
-    expect(readWorkspaceStateSnapshot(dir)).toMatchObject({ setupExists: false });
-    expect(readWorkspaceStateSnapshot(dir).attestation).toBeUndefined();
+    expect(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, 86_401_001)).toBe(true);
+    expect(await readWorkspaceStateSnapshot(dir)).toMatchObject({ setupExists: false });
+    expect((await readWorkspaceStateSnapshot(dir)).attestation).toBeUndefined();
 
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" }, 86_401_000);
-    replaceWorkspaceAttestation({
+    await mergeWorkspaceSetupState(
+      dir,
+      { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" },
+      86_401_000,
+    );
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs: 86_401_000,
       generatedHashes: new Map(),
       nowMs: 86_401_000,
     });
-    expect(clearExpiredWorkspaceStateForVanishedWorkspace(dir, 86_401_001)).toBe(false);
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(true);
+    expect(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, 86_401_001)).toBe(false);
+    expect((await readWorkspaceStateSnapshot(dir)).setupExists).toBe(true);
   });
 });

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -13,6 +13,7 @@ import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
@@ -87,6 +88,8 @@ export type WorkspaceStateSnapshot = {
   attestation?: WorkspaceAttestation;
 };
 
+type WorkspaceStateOperationOptions = { assertCurrent?: () => void };
+
 type WorkspaceStateDeletionPlan = {
   cacheRoot: string;
   lexicalAlias: WorkspaceStateIdentity;
@@ -103,10 +106,7 @@ type WorkspaceStateDatabase = Pick<
   | "migration_sources"
 >;
 
-type WorkspaceStateDatabaseHandle = Pick<
-  ReturnType<typeof openOpenClawStateDatabase>,
-  "db" | "path"
->;
+type WorkspaceStateDatabaseHandle = Pick<OpenClawStateDatabase, "db" | "path">;
 
 function workspacePathEntryExists(workspaceDir: string): boolean {
   try {
@@ -319,10 +319,10 @@ export function readWorkspaceStateSnapshotFromDatabase(params: {
   };
 }
 
-export function readWorkspaceStateSnapshot(
+export async function readWorkspaceStateSnapshot(
   workspaceDir: string,
-  options: OpenClawStateDatabaseOptions = {},
-): WorkspaceStateSnapshot {
+  options: OpenClawStateDatabaseOptions & WorkspaceStateOperationOptions = {},
+): Promise<WorkspaceStateSnapshot> {
   if (options.readOnly) {
     const snapshot = withExistingOpenClawStateDatabaseReadOnly(
       (database) =>
@@ -360,6 +360,7 @@ export function readWorkspaceStateSnapshot(
   // Register a newly observed configured spelling once state proves the target
   // identity. Later disappearance must still find the same safety evidence.
   return runOpenClawStateWriteTransaction((writeDatabase) => {
+    options.assertCurrent?.();
     const currentAliases = resolveWorkspaceStateAliases(workspaceDir);
     const currentCanonicalIdentity = currentAliases.at(-1)!;
     if (
@@ -394,12 +395,12 @@ export function readWorkspaceStateSnapshot(
   }, options);
 }
 
-export function mergeWorkspaceSetupState(
+export async function mergeWorkspaceSetupState(
   workspaceDir: string,
   next: Partial<Omit<WorkspaceSetupState, "version">>,
   nowMs = Date.now(),
-  options: OpenClawStateDatabaseOptions = {},
-): WorkspaceSetupState {
+  options: OpenClawStateDatabaseOptions & WorkspaceStateOperationOptions = {},
+): Promise<WorkspaceSetupState> {
   assertCanonicalIntegerTimestamp(nowMs, "setup update");
   if (next.bootstrapSeededAt) {
     assertCanonicalTimestamp(next.bootstrapSeededAt, "bootstrap seeded");
@@ -408,6 +409,7 @@ export function mergeWorkspaceSetupState(
     assertCanonicalTimestamp(next.setupCompletedAt, "setup completed");
   }
   return runOpenClawStateWriteTransaction((database) => {
+    options.assertCurrent?.();
     const resolution = resolveWorkspaceIdentityFromDatabase({ workspaceDir, database });
     const identity = resolution.identity;
     const snapshot = readWorkspaceStateSnapshotFromDatabase({ identity, database });
@@ -451,12 +453,14 @@ export function mergeWorkspaceSetupState(
   }, options);
 }
 
-export function replaceWorkspaceAttestation(params: {
-  workspaceDir: string;
-  attestedAtMs: number;
-  generatedHashes: ReadonlyMap<string, string>;
-  nowMs?: number;
-}): WorkspaceAttestation {
+export async function replaceWorkspaceAttestation(
+  params: {
+    workspaceDir: string;
+    attestedAtMs: number;
+    generatedHashes: ReadonlyMap<string, string>;
+    nowMs?: number;
+  } & WorkspaceStateOperationOptions,
+): Promise<WorkspaceAttestation> {
   assertCanonicalIntegerTimestamp(params.attestedAtMs, "attestation");
   if (params.nowMs !== undefined) {
     assertCanonicalIntegerTimestamp(params.nowMs, "attestation update");
@@ -470,6 +474,7 @@ export function replaceWorkspaceAttestation(params: {
     left.localeCompare(right),
   );
   return runOpenClawStateWriteTransaction((database) => {
+    params.assertCurrent?.();
     // Capture the comparison clock only after BEGIN IMMEDIATE acquires the
     // writer lock, so a newer committed row cannot look future-dated.
     const updatedAtMs = params.nowMs ?? Date.now();
@@ -634,12 +639,14 @@ export function retireWorkspaceRelocationAttestation(params: {
 }
 
 /** Clear expired state only when no concurrent writer refreshed the vanished workspace. */
-export function clearExpiredWorkspaceStateForVanishedWorkspace(
+export async function clearExpiredWorkspaceStateForVanishedWorkspace(
   workspaceDir: string,
   nowMs = Date.now(),
-): boolean {
+  options: WorkspaceStateOperationOptions = {},
+): Promise<boolean> {
   assertCanonicalIntegerTimestamp(nowMs, "workspace expiry check");
   return runOpenClawStateWriteTransaction((database) => {
+    options.assertCurrent?.();
     const resolution = resolveWorkspaceIdentityFromDatabase({ workspaceDir, database });
     const identity = resolution.identity;
     const snapshot = readWorkspaceStateSnapshotFromDatabase({ identity, database });
@@ -683,14 +690,19 @@ export function prepareWorkspaceStateDeletion(workspaceDir: string): WorkspaceSt
   };
 }
 
-export function deleteWorkspaceState(plan: WorkspaceStateDeletionPlan): void {
+export async function deleteWorkspaceState(
+  plan: WorkspaceStateDeletionPlan,
+  options: WorkspaceStateOperationOptions = {},
+): Promise<void> {
   // Delete-only cleanup must not recreate state after reset/uninstall removed
   // the canonical database successfully or partially.
   if (!existsSync(resolveOpenClawStateSqlitePath())) {
+    options.assertCurrent?.();
     retireWorkspaceFileCache(plan.cacheRoot);
     return;
   }
   runOpenClawStateWriteTransaction((database) => {
+    options.assertCurrent?.();
     const { lexicalAlias, currentCanonicalIdentity } = plan;
     const kysely = getNodeSqliteKysely<WorkspaceStateDatabase>(database.db);
     const storedAlias = executeSqliteQueryTakeFirstSync(

--- a/src/agents/workspace.attestation-survival.test.ts
+++ b/src/agents/workspace.attestation-survival.test.ts
@@ -57,8 +57,8 @@ describe("workspace attestation survival", () => {
     await fs.rm(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
 
-    const snapshot = readWorkspaceStateSnapshot(tempDir);
-    replaceWorkspaceAttestation({
+    const snapshot = await readWorkspaceStateSnapshot(tempDir);
+    await replaceWorkspaceAttestation({
       workspaceDir: tempDir,
       attestedAtMs: Date.now(),
       generatedHashes: new Map([
@@ -76,10 +76,10 @@ describe("workspace attestation survival", () => {
     const tempDir = await makeWorkspace();
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
     await fs.rm(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
-    const snapshot = readWorkspaceStateSnapshot(tempDir);
+    const snapshot = await readWorkspaceStateSnapshot(tempDir);
     const generatedHashes = new Map(snapshot.attestation!.generatedHashes);
     generatedHashes.delete(DEFAULT_AGENTS_FILENAME);
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: tempDir,
       attestedAtMs: Date.now(),
       generatedHashes,
@@ -95,10 +95,10 @@ describe("workspace attestation survival", () => {
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
     await fs.rm(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
     await fs.writeFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), "custom instructions\n");
-    const snapshot = readWorkspaceStateSnapshot(tempDir);
+    const snapshot = await readWorkspaceStateSnapshot(tempDir);
     const generatedHashes = new Map(snapshot.attestation!.generatedHashes);
     generatedHashes.delete(DEFAULT_AGENTS_FILENAME);
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: tempDir,
       attestedAtMs: Date.now(),
       generatedHashes,
@@ -113,10 +113,10 @@ describe("workspace attestation survival", () => {
     const tempDir = await makeWorkspace();
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
     await fs.rm(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
-    const snapshot = readWorkspaceStateSnapshot(tempDir);
+    const snapshot = await readWorkspaceStateSnapshot(tempDir);
     const generatedHashes = new Map(snapshot.attestation!.generatedHashes);
     generatedHashes.set(DEFAULT_AGENTS_FILENAME, "0".repeat(64));
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: tempDir,
       attestedAtMs: Date.now(),
       generatedHashes,

--- a/src/agents/workspace.provisioning.test.ts
+++ b/src/agents/workspace.provisioning.test.ts
@@ -67,7 +67,7 @@ describe("ensureAgentWorkspace runtime-managed-implicit provisioning", () => {
     await expectPathMissing(path.join(targetDir, DEFAULT_AGENTS_FILENAME));
     await expectPathMissing(path.join(targetDir, DEFAULT_BOOTSTRAP_FILENAME));
     await expectPathMissing(path.join(targetDir, ".git"));
-    expect(workspaceState.readWorkspaceStateSnapshot(targetDir).setupExists).toBe(false);
+    expect((await workspaceState.readWorkspaceStateSnapshot(targetDir)).setupExists).toBe(false);
   });
 
   it("runtime-managed-implicit provisioning preserves pre-existing workspace content", async () => {
@@ -86,6 +86,79 @@ describe("ensureAgentWorkspace runtime-managed-implicit provisioning", () => {
     await expectPathMissing(path.join(targetDir, DEFAULT_AGENTS_FILENAME));
     await expectPathMissing(path.join(targetDir, ".git"));
   });
+});
+
+describe("workspace completion persistence", () => {
+  it.each(["committed", "failed", "retired-before-commit", "retired-after-commit"] as const)(
+    "waits for the completion write before bootstrap cleanup: %s",
+    async (outcome) => {
+      const dir = testState!.workspaceDir;
+      await ensureAgentWorkspace({ dir, ensureBootstrapFiles: true });
+      const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
+      await fs.writeFile(path.join(dir, DEFAULT_USER_FILENAME), "A configured user.\n");
+      const entered = createDeferred();
+      const release = createDeferred();
+      const realMerge = workspaceState.mergeWorkspaceSetupState;
+      const write = vi
+        .spyOn(workspaceState, "mergeWorkspaceSetupState")
+        .mockImplementation(async (...args) => {
+          entered.resolve();
+          await release.promise;
+          if (outcome === "failed") {
+            throw new Error("completion write failed");
+          }
+          const result = await realMerge(...args);
+          if (outcome === "retired-after-commit") {
+            current = false;
+          }
+          return result;
+        });
+      let current = true;
+      let settled = false;
+      const pending = ensureAgentWorkspace({
+        dir,
+        ensureBootstrapFiles: true,
+        beforePersistentApply: () => {
+          if (!current) {
+            throw new Error("workspace owner retired");
+          }
+        },
+      });
+      void pending.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      try {
+        await withTestTimeout(entered.promise, 5_000, "Completion write was not reached");
+        await checkpoint();
+        expect(settled).toBe(false);
+        await expect(fs.access(bootstrapPath)).resolves.toBeUndefined();
+        current = outcome !== "retired-before-commit";
+        release.resolve();
+        if (outcome === "committed") {
+          await expect(pending).resolves.toMatchObject({ bootstrapPending: false });
+          await expectPathMissing(bootstrapPath);
+        } else {
+          await expect(pending).rejects.toThrow(
+            outcome === "failed" ? "completion write failed" : "workspace owner retired",
+          );
+          await expect(fs.access(bootstrapPath)).resolves.toBeUndefined();
+        }
+        const snapshot = await workspaceState.readWorkspaceStateSnapshot(dir);
+        expect(Boolean(snapshot.setup.setupCompletedAt)).toBe(
+          outcome === "committed" || outcome === "retired-after-commit",
+        );
+      } finally {
+        release.resolve();
+        await Promise.allSettled([pending]);
+        write.mockRestore();
+      }
+    },
+  );
 });
 
 function startGitProvisioning(directories: string[], retryAfterFailure = false) {
@@ -139,8 +212,8 @@ function startGitProvisioning(directories: string[], retryAfterFailure = false) 
   const realMerge = workspaceState.mergeWorkspaceSetupState;
   const mergeSpy = vi
     .spyOn(workspaceState, "mergeWorkspaceSetupState")
-    .mockImplementation((...args) => {
-      const result = realMerge(...args);
+    .mockImplementation(async (...args) => {
+      const result = await realMerge(...args);
       if (initGates.has(args[0]) && ++setupWrites === dirs.length - Number(retryAfterFailure)) {
         setup.resolve();
       }

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -110,7 +110,7 @@ async function readWorkspaceState(dir: string): Promise<{
   bootstrapSeededAt?: string;
   setupCompletedAt?: string;
 }> {
-  return readWorkspaceStateSnapshot(dir).setup;
+  return (await readWorkspaceStateSnapshot(dir)).setup;
 }
 
 async function writeLegacyWorkspaceState(dir: string, state: unknown): Promise<void> {
@@ -180,9 +180,9 @@ describe("ensureAgentWorkspace", () => {
     const seededAt = "2026-07-31T12:00:00.000Z";
     await fs.mkdir(workspace);
     await fs.symlink(workspace, workspaceAlias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(workspace, { bootstrapSeededAt: seededAt }, Date.now(), options);
+    await mergeWorkspaceSetupState(workspace, { bootstrapSeededAt: seededAt }, Date.now(), options);
 
-    expect(readWorkspaceStateSnapshot(workspaceAlias, options).setup).toEqual({
+    expect((await readWorkspaceStateSnapshot(workspaceAlias, options)).setup).toEqual({
       version: 1,
       bootstrapSeededAt: seededAt,
     });
@@ -196,7 +196,7 @@ describe("ensureAgentWorkspace", () => {
     await expectBootstrapSeeded(tempDir);
     await expectNoLegacyWorkspaceStateWrites(tempDir);
     expect((await readWorkspaceState(tempDir)).setupCompletedAt).toBeUndefined();
-    expect(readWorkspaceStateSnapshot(tempDir).attestation).toBeDefined();
+    expect((await readWorkspaceStateSnapshot(tempDir)).attestation).toBeDefined();
   });
 
   it("does not overwrite a foreign root workspace-state.json file", async () => {
@@ -224,13 +224,13 @@ describe("ensureAgentWorkspace", () => {
     await expect(
       fs.access(path.join(tempDir, ...LEGACY_WORKSPACE_STATE_PATH_SEGMENTS)),
     ).resolves.toBeUndefined();
-    expect(readWorkspaceStateSnapshot(tempDir).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(tempDir)).setupExists).toBe(false);
   });
 
   it("requires Doctor when partial SQLite state coexists with legacy setup state", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const seededAt = "2026-07-15T10:00:00.000Z";
-    mergeWorkspaceSetupState(tempDir, { bootstrapSeededAt: seededAt });
+    await mergeWorkspaceSetupState(tempDir, { bootstrapSeededAt: seededAt });
     await writeLegacyWorkspaceState(tempDir, {
       version: 1,
       setupCompletedAt: "2026-07-15T10:01:00.000Z",
@@ -242,7 +242,7 @@ describe("ensureAgentWorkspace", () => {
     await expect(
       fs.access(path.join(tempDir, ...LEGACY_WORKSPACE_STATE_PATH_SEGMENTS)),
     ).resolves.toBeUndefined();
-    expect(readWorkspaceStateSnapshot(tempDir).setup).toEqual({
+    expect((await readWorkspaceStateSnapshot(tempDir)).setup).toEqual({
       version: 1,
       bootstrapSeededAt: seededAt,
     });
@@ -251,7 +251,7 @@ describe("ensureAgentWorkspace", () => {
   it("refuses to re-seed a recently attested workspace after the directory disappears", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
-    expect(readWorkspaceStateSnapshot(tempDir).attestation).toBeDefined();
+    expect((await readWorkspaceStateSnapshot(tempDir)).attestation).toBeDefined();
 
     await fs.rm(tempDir, { recursive: true, force: true });
 
@@ -272,7 +272,7 @@ describe("ensureAgentWorkspace", () => {
       ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
     );
     await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
-    expect(readWorkspaceStateSnapshot(tempDir).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(tempDir)).setupExists).toBe(true);
   });
 
   it("refuses to re-seed a recently attested workspace after only generated remnants survive", async () => {
@@ -288,15 +288,15 @@ describe("ensureAgentWorkspace", () => {
       ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
     );
     await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
-    expect(readWorkspaceStateSnapshot(tempDir).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(tempDir)).setupExists).toBe(true);
   });
 
   it("refuses to re-seed a future-attested workspace after only generated remnants survive", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
-    const snapshot = readWorkspaceStateSnapshot(tempDir);
+    const snapshot = await readWorkspaceStateSnapshot(tempDir);
     const generatedAgents = await fs.readFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), "utf-8");
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: tempDir,
       attestedAtMs: Date.now() + 60_000,
       generatedHashes: snapshot.attestation!.generatedHashes,
@@ -330,11 +330,11 @@ describe("ensureAgentWorkspace", () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const oldGeneratedAgents = "old generated agents\n";
     await fs.writeFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), oldGeneratedAgents);
-    mergeWorkspaceSetupState(tempDir, {
+    await mergeWorkspaceSetupState(tempDir, {
       bootstrapSeededAt: "2026-07-15T10:00:00.000Z",
       setupCompletedAt: "2026-07-15T10:01:00.000Z",
     });
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: tempDir,
       attestedAtMs: Date.now(),
       generatedHashes: new Map([
@@ -371,7 +371,7 @@ describe("ensureAgentWorkspace", () => {
     await fs.rm(tempDir, { recursive: true, force: true });
     await fs.mkdir(tempDir, { recursive: true });
     await fs.writeFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), generatedAgents);
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: tempDir,
       attestedAtMs: Date.now(),
       generatedHashes: new Map(),
@@ -481,7 +481,7 @@ describe("ensureAgentWorkspace", () => {
   it("allows a brand new workspace when its SQLite attestation is stale", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const expiredAtMs = Date.now() - 25 * 60 * 60 * 1000;
-    mergeWorkspaceSetupState(
+    await mergeWorkspaceSetupState(
       tempDir,
       {
         bootstrapSeededAt: "2026-07-15T10:00:00.000Z",
@@ -489,7 +489,7 @@ describe("ensureAgentWorkspace", () => {
       },
       expiredAtMs,
     );
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: tempDir,
       attestedAtMs: expiredAtMs,
       generatedHashes: new Map(),
@@ -505,7 +505,7 @@ describe("ensureAgentWorkspace", () => {
   it("clears expired setup state when a wiped workspace retains only .git", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const expiredAtMs = Date.now() - 25 * 60 * 60 * 1000;
-    mergeWorkspaceSetupState(
+    await mergeWorkspaceSetupState(
       tempDir,
       {
         bootstrapSeededAt: "2026-07-15T10:00:00.000Z",
@@ -513,7 +513,7 @@ describe("ensureAgentWorkspace", () => {
       },
       expiredAtMs,
     );
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: tempDir,
       attestedAtMs: expiredAtMs,
       generatedHashes: new Map(),
@@ -529,7 +529,7 @@ describe("ensureAgentWorkspace", () => {
 
   it("clears expired setup-only state before reseeding an empty workspace", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
-    mergeWorkspaceSetupState(
+    await mergeWorkspaceSetupState(
       tempDir,
       {
         bootstrapSeededAt: "2026-07-15T10:00:00.000Z",
@@ -555,12 +555,12 @@ describe("ensureAgentWorkspace", () => {
     ).rejects.toThrow(/run openclaw doctor --fix/u);
 
     expect(await fs.readFile(attestationPath, "utf-8")).toBe(marker);
-    expect(readWorkspaceStateSnapshot(tempDir).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(tempDir)).setupExists).toBe(false);
   });
 
   it("requires Doctor when SQLite setup state coexists with a legacy attestation", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
-    mergeWorkspaceSetupState(tempDir, {
+    await mergeWorkspaceSetupState(tempDir, {
       bootstrapSeededAt: "2026-07-15T10:00:00.000Z",
     });
     const attestationPath = `${tempDir}.attested`;
@@ -572,7 +572,7 @@ describe("ensureAgentWorkspace", () => {
     ).rejects.toThrow(/run openclaw doctor --fix/u);
 
     expect(await fs.readFile(attestationPath, "utf-8")).toBe(marker);
-    expect(readWorkspaceStateSnapshot(tempDir).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(tempDir)).setupExists).toBe(true);
   });
 
   it("ignores and preserves a foreign sibling attestation file", async () => {
@@ -920,7 +920,7 @@ describe("ensureAgentWorkspace", () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
     await fs.writeFile(agentsPath, "custom agents instructions\n", "utf8");
-    mergeWorkspaceSetupState(tempDir, {
+    await mergeWorkspaceSetupState(tempDir, {
       bootstrapSeededAt: "2026-07-15T10:00:00.000Z",
     });
     const realAccess = fs.access.bind(fs);
@@ -928,7 +928,7 @@ describe("ensureAgentWorkspace", () => {
     const accessSpy = vi.spyOn(fs, "access").mockImplementation(async (filePath, mode) => {
       if (!completed && filePath === agentsPath) {
         completed = true;
-        mergeWorkspaceSetupState(tempDir, {
+        await mergeWorkspaceSetupState(tempDir, {
           setupCompletedAt: "2026-07-15T10:01:00.000Z",
         });
       }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -573,7 +573,9 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
       setupCompletedAt: new Date().toISOString(),
     };
     params.beforePersistentApply?.();
-    const persistedState = mergeWorkspaceSetupState(params.dir, completedState);
+    const persistedState = await mergeWorkspaceSetupState(params.dir, completedState, undefined, {
+      assertCurrent: params.beforePersistentApply,
+    });
     return { repaired: true, bootstrapExists: false, state: persistedState };
   }
 
@@ -593,7 +595,9 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
     setupCompletedAt: now,
   };
   params.beforePersistentApply?.();
-  const persistedState = mergeWorkspaceSetupState(params.dir, repairedState);
+  const persistedState = await mergeWorkspaceSetupState(params.dir, repairedState, undefined, {
+    assertCurrent: params.beforePersistentApply,
+  });
   params.beforePersistentApply?.();
   try {
     await fs.rm(params.bootstrapPath, { force: true });
@@ -646,15 +650,17 @@ async function maybeWriteWorkspaceAttestation(
   const generatedHashes = await collectGeneratedBootstrapHashes(dir);
   beforePersistentApply?.();
   try {
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: dir,
       attestedAtMs,
       generatedHashes,
+      assertCurrent: beforePersistentApply,
     });
   } catch {
     // Attestation is a lifecycle guard; setup should not fail solely because
     // the auxiliary disappearance evidence could not be refreshed.
   }
+  beforePersistentApply?.();
 }
 
 function hasWorkspaceSetupStateMarker(state: WorkspaceSetupState): boolean {
@@ -700,6 +706,7 @@ async function workspaceSetupStateHasSurvivalEvidence(params: {
   dir: string;
   bootstrapPath: string;
   initialState: WorkspaceStateSnapshot;
+  beforePersistentApply?: () => void;
 }): Promise<boolean> {
   if (await pathExists(params.bootstrapPath)) {
     return true;
@@ -707,7 +714,11 @@ async function workspaceSetupStateHasSurvivalEvidence(params: {
   if (await workspaceProfileLooksConfigured({ dir: params.dir })) {
     return true;
   }
-  const currentState = readCanonicalWorkspaceStateSnapshot(params.dir);
+  const currentState = await readCanonicalWorkspaceStateSnapshot(
+    params.dir,
+    undefined,
+    params.beforePersistentApply,
+  );
   if (
     currentState.setup.bootstrapSeededAt !== params.initialState.setup.bootstrapSeededAt ||
     currentState.setup.setupCompletedAt !== params.initialState.setup.setupCompletedAt
@@ -723,11 +734,12 @@ async function workspaceSetupStateHasSurvivalEvidence(params: {
   ].every((fileName) => generatedHashes.has(fileName));
 }
 
-function readCanonicalWorkspaceStateSnapshot(
+async function readCanonicalWorkspaceStateSnapshot(
   dir: string,
   options: OpenClawStateDatabaseOptions = {},
-): WorkspaceStateSnapshot {
-  const snapshot = readWorkspaceStateSnapshot(dir, options);
+  assertCurrent?: () => void,
+): Promise<WorkspaceStateSnapshot> {
+  const snapshot = await readWorkspaceStateSnapshot(dir, { ...options, assertCurrent });
   assertNoUnmigratedWorkspaceState({
     workspaceDir: dir,
   });
@@ -738,7 +750,7 @@ export async function isWorkspaceSetupCompleted(
   dir: string,
   options: OpenClawStateDatabaseOptions = {},
 ): Promise<boolean> {
-  const state = readCanonicalWorkspaceStateSnapshot(dir, options).setup;
+  const state = (await readCanonicalWorkspaceStateSnapshot(dir, options)).setup;
   return typeof state.setupCompletedAt === "string" && state.setupCompletedAt.trim().length > 0;
 }
 
@@ -747,7 +759,7 @@ export async function resolveWorkspaceBootstrapStatus(
   options: OpenClawStateDatabaseOptions = {},
 ): Promise<"pending" | "complete"> {
   const resolvedDir = resolveUserPath(dir);
-  const state = readCanonicalWorkspaceStateSnapshot(resolvedDir, options).setup;
+  const state = (await readCanonicalWorkspaceStateSnapshot(resolvedDir, options)).setup;
   if (typeof state.setupCompletedAt === "string" && state.setupCompletedAt.trim().length > 0) {
     return "complete";
   }
@@ -789,7 +801,7 @@ export async function seedWorkspaceBootstrap(params: {
 
   const dir = resolveUserPath(params.dir);
   const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
-  const initialState = readCanonicalWorkspaceStateSnapshot(dir, params.stateOptions).setup;
+  const initialState = (await readCanonicalWorkspaceStateSnapshot(dir, params.stateOptions)).setup;
   if (initialState.setupCompletedAt) {
     return "consumed";
   }
@@ -889,7 +901,7 @@ export async function seedWorkspaceBootstrap(params: {
 
   if (!initialState.bootstrapSeededAt) {
     const nowMs = params.nowMs ?? Date.now();
-    mergeWorkspaceSetupState(
+    await mergeWorkspaceSetupState(
       dir,
       {
         bootstrapSeededAt: new Date(nowMs).toISOString(),
@@ -987,7 +999,11 @@ export async function ensureAgentWorkspace(params?: {
     await fs.mkdir(dir, { recursive: true });
     return { dir, bootstrapPending: false };
   }
-  let initialState = readCanonicalWorkspaceStateSnapshot(dir);
+  let initialState = await readCanonicalWorkspaceStateSnapshot(
+    dir,
+    undefined,
+    beforePersistentApply,
+  );
   let reseedingExpiredWorkspaceState = false;
   const recentAttestation = recentWorkspaceAttestation(initialState.attestation);
   const recentSetupState = hasRecentWorkspaceSetupState(initialState);
@@ -1001,7 +1017,11 @@ export async function ensureAgentWorkspace(params?: {
     // Expired SQLite evidence must preserve that reseed contract. The write
     // transaction also catches a concurrent attestation refresh.
     beforePersistentApply?.();
-    if (!clearExpiredWorkspaceStateForVanishedWorkspace(dir)) {
+    if (
+      !(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, undefined, {
+        assertCurrent: beforePersistentApply,
+      }))
+    ) {
       throw new WorkspaceVanishedError({ workspaceDir: dir });
     }
   }
@@ -1022,13 +1042,18 @@ export async function ensureAgentWorkspace(params?: {
         dir,
         bootstrapPath,
         initialState,
+        beforePersistentApply,
       }))
     ) {
       if (recentSetupState) {
         throw new WorkspaceVanishedError({ workspaceDir: dir });
       }
       beforePersistentApply?.();
-      if (!clearExpiredWorkspaceStateForVanishedWorkspace(dir)) {
+      if (
+        !(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, undefined, {
+          assertCurrent: beforePersistentApply,
+        }))
+      ) {
         throw new WorkspaceVanishedError({ workspaceDir: dir });
       }
     }
@@ -1067,7 +1092,11 @@ export async function ensureAgentWorkspace(params?: {
     // A wiped workspace can leave its directory (or only .git) behind. Clear
     // expired SQLite evidence before deciding whether setup already completed.
     beforePersistentApply?.();
-    if (!clearExpiredWorkspaceStateForVanishedWorkspace(dir)) {
+    if (
+      !(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, undefined, {
+        assertCurrent: beforePersistentApply,
+      }))
+    ) {
       throw new WorkspaceVanishedError({ workspaceDir: dir });
     }
   }
@@ -1087,14 +1116,23 @@ export async function ensureAgentWorkspace(params?: {
       // The transaction rejects a concurrent refresh. Only the expired
       // snapshot we just inspected may be cleared before reseeding.
       beforePersistentApply?.();
-      if (!clearExpiredWorkspaceStateForVanishedWorkspace(dir)) {
+      if (
+        !(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, undefined, {
+          assertCurrent: beforePersistentApply,
+        }))
+      ) {
         throw new WorkspaceVanishedError({ workspaceDir: dir });
       }
     }
   } else if (
     hasWorkspaceSetupStateMarker(initialState.setup) &&
     !isBrandNewWorkspace &&
-    !(await workspaceSetupStateHasSurvivalEvidence({ dir, bootstrapPath, initialState }))
+    !(await workspaceSetupStateHasSurvivalEvidence({
+      dir,
+      bootstrapPath,
+      initialState,
+      beforePersistentApply,
+    }))
   ) {
     // Setup can outlive a best-effort attestation write or arrive alone from
     // Doctor. Ambiguous partial remnants must fail closed, not inherit stale
@@ -1104,7 +1142,11 @@ export async function ensureAgentWorkspace(params?: {
     }
     reseedingExpiredWorkspaceState = true;
     beforePersistentApply?.();
-    if (!clearExpiredWorkspaceStateForVanishedWorkspace(dir)) {
+    if (
+      !(await clearExpiredWorkspaceStateForVanishedWorkspace(dir, undefined, {
+        assertCurrent: beforePersistentApply,
+      }))
+    ) {
       throw new WorkspaceVanishedError({ workspaceDir: dir });
     }
   }
@@ -1115,7 +1157,7 @@ export async function ensureAgentWorkspace(params?: {
   const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
   // Template and filesystem checks above are async. Another process may have
   // completed setup while they ran, so optional-file policy needs fresh state.
-  initialState = readCanonicalWorkspaceStateSnapshot(dir);
+  initialState = await readCanonicalWorkspaceStateSnapshot(dir, undefined, beforePersistentApply);
   const skipOptionalBootstrapFiles = new Set(params?.skipOptionalBootstrapFiles ?? []);
   // When the workspace is already configured, skip optional bootstrap files to
   // prevent subagent spawns from recreating root-level SOUL.md, USER.md, or
@@ -1140,7 +1182,8 @@ export async function ensureAgentWorkspace(params?: {
     await publishBootstrapFile(userPath, userTemplate, beforePersistentApply);
   }
 
-  let state = readCanonicalWorkspaceStateSnapshot(dir).setup;
+  let state = (await readCanonicalWorkspaceStateSnapshot(dir, undefined, beforePersistentApply))
+    .setup;
   let stateDirty = false;
   const markState = (next: Partial<WorkspaceSetupState>) => {
     state = { ...state, ...next };
@@ -1206,7 +1249,9 @@ export async function ensureAgentWorkspace(params?: {
 
   if (stateDirty) {
     beforePersistentApply?.();
-    state = mergeWorkspaceSetupState(dir, state);
+    state = await mergeWorkspaceSetupState(dir, state, undefined, {
+      assertCurrent: beforePersistentApply,
+    });
   }
   await ensureGitRepo(dir, isBrandNewWorkspace, beforePersistentApply);
   await maybeWriteWorkspaceAttestation(dir, beforePersistentApply);

--- a/src/claws/bootstrap.test.ts
+++ b/src/claws/bootstrap.test.ts
@@ -125,7 +125,7 @@ describe("package-root BOOTSTRAP.md", () => {
     await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).resolves.toContain(
       "which repositories",
     );
-    expect(readWorkspaceStateSnapshot(workspace, { env }).setup).toMatchObject({
+    expect((await readWorkspaceStateSnapshot(workspace, { env })).setup).toMatchObject({
       bootstrapSeededAt: new Date(1_000).toISOString(),
     });
     await expect(readClawStatus("bootstrap-worker", { env, config })).resolves.toMatchObject({
@@ -214,7 +214,9 @@ describe("package-root BOOTSTRAP.md", () => {
     });
     expect(config).toEqual({});
     expect(readClawInstallRecord("bootstrap-worker", { env })?.status).toBe("workspace_ready");
-    expect(readWorkspaceStateSnapshot(workspace, { env }).setup.bootstrapSeededAt).toBeUndefined();
+    expect(
+      (await readWorkspaceStateSnapshot(workspace, { env })).setup.bootstrapSeededAt,
+    ).toBeUndefined();
     await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).rejects.toThrow();
 
     const resumed = await applyClawAddPlan(plan, {

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -294,7 +294,7 @@ export async function cleanupClawAgentFilesystem(params: {
           params.runtime.log(warning);
         }
         params.assertCurrent();
-        deleteWorkspaceState(statePlan);
+        await deleteWorkspaceState(statePlan, { assertCurrent: params.assertCurrent });
       } catch (error) {
         errors.push(coerceErrorMessage(error));
       }
@@ -397,7 +397,7 @@ export async function inspectClawBootstrap(
   options: OpenClawStateDatabaseOptions,
 ): Promise<ClawBootstrapStatus> {
   const nativeState = await resolveWorkspaceBootstrapStatus(install.workspace, options);
-  const setupState = readWorkspaceStateSnapshot(install.workspace, options).setup;
+  const setupState = (await readWorkspaceStateSnapshot(install.workspace, options)).setup;
   const base = {
     workspace: install.workspace,
     path: DEFAULT_BOOTSTRAP_FILENAME,

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -393,7 +393,7 @@ export async function agentsDeleteCommand(
             quietRuntime.log(warning);
           }
           deletion.assertCurrent();
-          deleteWorkspaceState(statePlan);
+          await deleteWorkspaceState(statePlan, { assertCurrent: deletion.assertCurrent });
         } catch (error) {
           workspaceCleanupError = error instanceof Error ? error : new Error(String(error));
         }

--- a/src/commands/agents.delete.workspace.test.ts
+++ b/src/commands/agents.delete.workspace.test.ts
@@ -168,9 +168,12 @@ describe("agents delete workspace lifecycle", () => {
       });
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
-      expect(workspaceStateMocks.deleteWorkspaceState).toHaveBeenCalledWith({
-        workspaceDir: opsWorkspace,
-      });
+      expect(workspaceStateMocks.deleteWorkspaceState).toHaveBeenCalledWith(
+        {
+          workspaceDir: opsWorkspace,
+        },
+        { assertCurrent: expect.any(Function) },
+      );
       const workspaceTrashOrder = fsSafeMocks.movePathToTrash.mock.invocationCallOrder[0];
       const stateDeleteOrder = workspaceStateMocks.deleteWorkspaceState.mock.invocationCallOrder[0];
       expect(workspaceTrashOrder).toBeLessThan(stateDeleteOrder ?? 0);
@@ -420,9 +423,12 @@ describe("agents delete workspace lifecycle", () => {
       expect(fsSafeMocks.movePathToTrash).toHaveBeenCalledWith(expectedOpsWorkspace, {
         allowedRoots: [path.dirname(expectedOpsWorkspace)],
       });
-      expect(workspaceStateMocks.deleteWorkspaceState).toHaveBeenCalledWith({
-        workspaceDir: opsWorkspace,
-      });
+      expect(workspaceStateMocks.deleteWorkspaceState).toHaveBeenCalledWith(
+        {
+          workspaceDir: opsWorkspace,
+        },
+        { assertCurrent: expect.any(Function) },
+      );
       expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalled();
     });
   });

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -582,9 +582,7 @@ export async function removeWorkspaceDirs(
       }
     }
     if (!opts?.dryRun && statePlan) {
-      await attempt(stateLabel, () => {
-        deleteWorkspaceState(statePlan);
-      });
+      await attempt(stateLabel, () => deleteWorkspaceState(statePlan));
     }
   }
   return [...failures];

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -303,10 +303,10 @@ export async function assertDoctorPreflightMigrationsComplete(params: {
     if (error instanceof DoctorStateMigrationRefusalError) {
       // A refused owner stops all later repairs. Still diagnose canonical
       // workspace state read-only before final completion becomes unreachable.
-      const { assertConfiguredWorkspaceStateReady } =
+      const { assertConfiguredWorkspaceStateReadyForDoctor } =
         await import("../agents/workspace-state-dirs.js");
       try {
-        assertConfiguredWorkspaceStateReady({ cfg: params.cfg, operation: "doctor" });
+        await assertConfiguredWorkspaceStateReadyForDoctor({ cfg: params.cfg });
       } catch (workspaceError) {
         params.report({ changes: [], warnings: [String(workspaceError)] });
       }

--- a/src/commands/doctor-skill-workshop-workspace.test.ts
+++ b/src/commands/doctor-skill-workshop-workspace.test.ts
@@ -84,7 +84,7 @@ async function createLegacyWorkspace(userContent = false, skillsPath = "skills")
     await fs.writeFile(path.join(workspaceDir, "README.md"), "# User project\n");
   }
   await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: false });
-  const before = readWorkspaceStateSnapshot(workspaceDir);
+  const before = await readWorkspaceStateSnapshot(workspaceDir);
   expect(before.attestation).toBeDefined();
   expect(before.attestation?.generatedHashes.size).toBe(0);
   expect(before.setupExists).toBe(false);
@@ -135,7 +135,7 @@ async function interruptPendingWrite(fixture: LegacyWorkspace) {
   await expect(fs.readFile(path.join(fixture.destination, "SKILL.md"), "utf8")).resolves.toBe(
     fixture.content,
   );
-  expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toEqual(
+  expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toEqual(
     fixture.before.attestation,
   );
 }
@@ -163,7 +163,7 @@ describe("Workshop relocation and workspace survival", () => {
       await expect(fs.readFile(path.join(fixture.destination, "SKILL.md"), "utf8")).resolves.toBe(
         fixture.content,
       );
-      expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toBeUndefined();
+      expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toBeUndefined();
       await expectWorkspaceUsable(fixture.workspaceDir);
     },
   );
@@ -172,7 +172,7 @@ describe("Workshop relocation and workspace survival", () => {
     "imports legacy workspace evidence before relocating (Doctor preflight: %s)",
     async (doctorOnlyStateMigrations) => {
       const fixture = await createLegacyWorkspace();
-      deleteWorkspaceState(prepareWorkspaceStateDeletion(fixture.workspaceDir));
+      await deleteWorkspaceState(prepareWorkspaceStateDeletion(fixture.workspaceDir));
       const marker = resolveLegacyWorkspaceSourcePaths(fixture.workspaceDir, {
         env: state.env,
         homedir: () => state.home,
@@ -204,7 +204,7 @@ describe("Workshop relocation and workspace survival", () => {
         });
         await expect(fs.access(marker)).rejects.toMatchObject({ code: "ENOENT" });
       }
-      expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toBeUndefined();
+      expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toBeUndefined();
       const detected = await detectLegacyStateMigrations({
         ...migrationInput,
         mode: "doctor",
@@ -223,15 +223,15 @@ describe("Workshop relocation and workspace survival", () => {
         fixture.content,
       );
       await expectWorkspaceUsable(fixture.workspaceDir);
-      expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toBeUndefined();
+      expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toBeUndefined();
     },
   );
 
   it("captures a new attestation only for remaining filesystem moves", async () => {
     const fixture = await createLegacyWorkspace();
     repairOpenClawStateDatabaseSchemaIfNeeded({ env: state.env });
-    deleteWorkspaceState(prepareWorkspaceStateDeletion(fixture.workspaceDir));
-    const before = readWorkspaceStateSnapshot(fixture.workspaceDir);
+    await deleteWorkspaceState(prepareWorkspaceStateDeletion(fixture.workspaceDir));
+    const before = await readWorkspaceStateSnapshot(fixture.workspaceDir);
     expect(before.attestation).toBeUndefined();
     const name = "remaining-relocation";
     const skillDir = path.join(fixture.workspaceDir, "skills", name);
@@ -277,7 +277,7 @@ describe("Workshop relocation and workspace survival", () => {
       [],
     );
     await ensureAgentWorkspace({ dir: fixture.workspaceDir, ensureBootstrapFiles: false });
-    const attested = readWorkspaceStateSnapshot(fixture.workspaceDir);
+    const attested = await readWorkspaceStateSnapshot(fixture.workspaceDir);
     expect(attested.attestation).toBeDefined();
     expect(attested.attestation?.generatedHashes.size).toBe(0);
 
@@ -287,7 +287,7 @@ describe("Workshop relocation and workspace survival", () => {
     });
 
     expect(resumed.warnings).toEqual([]);
-    expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toBeUndefined();
+    expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toBeUndefined();
     expect(receipts.all(WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND, fixture.workspaceDir)).toEqual(
       [
         {
@@ -332,7 +332,7 @@ describe("Workshop relocation and workspace survival", () => {
     await migrateLegacySkillWorkshopProposals({ config: fixture.config, env: state.env });
 
     await expectWorkspaceUsable(fixture.workspaceDir);
-    expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toBeUndefined();
+    expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toBeUndefined();
   });
 
   it("revokes pending relocation cleanup when the workspace is reset", async () => {
@@ -346,23 +346,23 @@ describe("Workshop relocation and workspace survival", () => {
       [expect.objectContaining({ status: "prepared" })],
     );
 
-    deleteWorkspaceState(prepareWorkspaceStateDeletion(fixture.workspaceDir));
+    await deleteWorkspaceState(prepareWorkspaceStateDeletion(fixture.workspaceDir));
 
     expect(receipts.all(WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND, fixture.workspaceDir)).toEqual(
       [],
     );
-    expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toBeUndefined();
+    expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toBeUndefined();
     const projectFile = path.join(fixture.workspaceDir, "README.md");
     await fs.writeFile(projectFile, "# Project created after reset\n");
     await ensureAgentWorkspace({ dir: fixture.workspaceDir, ensureBootstrapFiles: false });
-    const refreshed = readWorkspaceStateSnapshot(fixture.workspaceDir).attestation;
+    const refreshed = (await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation;
     expect(refreshed).toBeDefined();
     await fs.rm(projectFile);
     closeOpenClawStateDatabaseForTest();
 
     await migrateLegacySkillWorkshopProposals({ config: fixture.config, env: state.env });
 
-    expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toEqual(refreshed);
+    expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toEqual(refreshed);
     await expect(
       ensureAgentWorkspace({ dir: fixture.workspaceDir, ensureBootstrapFiles: false }),
     ).rejects.toMatchObject({ code: WORKSPACE_VANISHED_ERROR_CODE });
@@ -385,7 +385,7 @@ describe("Workshop relocation and workspace survival", () => {
 
       await migrateLegacySkillWorkshopProposals({ config: fixture.config, env: state.env });
 
-      expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toEqual(
+      expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toEqual(
         fixture.before.attestation,
       );
       await expect(
@@ -402,7 +402,7 @@ describe("Workshop relocation and workspace survival", () => {
 
     await migrateLegacySkillWorkshopProposals({ config: fixture.config, env: state.env });
 
-    expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toEqual(
+    expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toEqual(
       fixture.before.attestation,
     );
     await expect(fs.readFile(path.join(fixture.workspaceDir, "README.md"), "utf8")).resolves.toBe(
@@ -418,7 +418,7 @@ describe("Workshop relocation and workspace survival", () => {
       await interruptPendingWrite(fixture);
       const refreshedAtMs =
         Math.max(Date.now(), fixture.before.attestation!.attestedAtMs + 1) + clockOffsetMs;
-      const refreshed = replaceWorkspaceAttestation({
+      const refreshed = await replaceWorkspaceAttestation({
         workspaceDir: fixture.workspaceDir,
         attestedAtMs: refreshedAtMs,
         generatedHashes: new Map(),
@@ -428,7 +428,9 @@ describe("Workshop relocation and workspace survival", () => {
 
       await migrateLegacySkillWorkshopProposals({ config: fixture.config, env: state.env });
 
-      expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toEqual(refreshed);
+      expect((await readWorkspaceStateSnapshot(fixture.workspaceDir)).attestation).toEqual(
+        refreshed,
+      );
       await expect(
         ensureAgentWorkspace({ dir: fixture.workspaceDir, ensureBootstrapFiles: false }),
       ).rejects.toMatchObject({ code: WORKSPACE_VANISHED_ERROR_CODE });

--- a/src/commands/doctor-skill-workshop-workspaces.ts
+++ b/src/commands/doctor-skill-workshop-workspaces.ts
@@ -119,7 +119,7 @@ export async function prepareWorkshopWorkspaceRelocation(
   if (existing?.status === "prepared") {
     return;
   }
-  const snapshot = readWorkspaceStateSnapshot(workspaceDir, { env, readOnly: true });
+  const snapshot = await readWorkspaceStateSnapshot(workspaceDir, { env, readOnly: true });
   const attestation = snapshot.attestation;
   const now = Date.now();
   if (

--- a/src/commands/doctor-workspace-alias.test.ts
+++ b/src/commands/doctor-workspace-alias.test.ts
@@ -65,20 +65,20 @@ async function runWorkspaceRepair(params: { cfg: OpenClawConfig; prompter: Docto
   await repair!(params.cfg);
 }
 
-function repointAlias(params: { seedAttestedFile?: boolean }): {
+async function repointAlias(params: { seedAttestedFile?: boolean }): Promise<{
   alias: string;
   original: string;
   replacement: string;
-} {
+}> {
   const original = testState!.workspaceDir;
   const alias = testState!.path("workspace-link");
   const replacement = testState!.path("replacement-workspace");
   fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
-  mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+  await mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
   if (params.seedAttestedFile) {
     const content = "seeded bootstrap content";
     fs.writeFileSync(path.join(original, "BOOTSTRAP.md"), content);
-    replaceWorkspaceAttestation({
+    await replaceWorkspaceAttestation({
       workspaceDir: alias,
       attestedAtMs: 1_000,
       generatedHashes: new Map([
@@ -95,7 +95,7 @@ function repointAlias(params: { seedAttestedFile?: boolean }): {
 
 describe("doctor workspace alias repair", () => {
   it("leaves state intact when configuration changes during confirmation", async () => {
-    const { alias, original, replacement } = repointAlias({ seedAttestedFile: true });
+    const { alias, original, replacement } = await repointAlias({ seedAttestedFile: true });
     const cfg = buildAliasCfg(alias);
     await testState!.writeConfig(cfg);
     const prompter = buildPrompter({
@@ -107,12 +107,12 @@ describe("doctor workspace alias repair", () => {
       }),
     });
     await expect(runWorkspaceRepair({ cfg, prompter })).rejects.toThrow();
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(replacement)).setupExists).toBe(false);
   });
 
   it("does not adopt a target substituted during confirmation", async () => {
-    const { alias, original } = repointAlias({ seedAttestedFile: true });
+    const { alias, original } = await repointAlias({ seedAttestedFile: true });
     const changed = testState!.path("changed-target");
     fs.mkdirSync(changed);
     const prompter = buildPrompter({
@@ -123,12 +123,12 @@ describe("doctor workspace alias repair", () => {
       }),
     });
     await expect(runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter })).rejects.toThrow();
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(changed).setupExists).toBe(false);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(changed)).setupExists).toBe(false);
   });
 
-  it("reports a repointed alias as a warning finding", () => {
-    const { alias } = repointAlias({ seedAttestedFile: false });
+  it("reports a repointed alias as a warning finding", async () => {
+    const { alias } = await repointAlias({ seedAttestedFile: false });
 
     const findings = collectRepointedWorkspaceAliasFindings(buildAliasCfg(alias));
 
@@ -140,26 +140,26 @@ describe("doctor workspace alias repair", () => {
     });
   });
 
-  it("reports nothing when aliases are intact", () => {
+  it("reports nothing when aliases are intact", async () => {
     const dir = testState!.workspaceDir;
-    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
 
     expect(collectRepointedWorkspaceAliasFindings(buildAliasCfg(dir))).toHaveLength(0);
   });
 
   it("requires explicit confirmation even when generated hashes match", async () => {
-    const { alias, original } = repointAlias({ seedAttestedFile: true });
+    const { alias, original } = await repointAlias({ seedAttestedFile: true });
     const prompter = buildPrompter();
 
     await expect(runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter })).rejects.toThrow();
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
     expect(prompter.confirmRuntimeRepair).toHaveBeenCalledOnce();
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
 
     const approving = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
     await runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter: approving });
-    const snapshot = readWorkspaceStateSnapshot(alias);
+    const snapshot = await readWorkspaceStateSnapshot(alias);
     expect(snapshot.setupExists).toBe(true);
     expect(snapshot.setup.bootstrapSeededAt).toBe("2026-07-16T01:00:00.000Z");
 
@@ -173,7 +173,7 @@ describe("doctor workspace alias repair", () => {
   });
 
   it("requires the explicit operator gate when continuity is unproven", async () => {
-    const { alias, original } = repointAlias({ seedAttestedFile: false });
+    const { alias, original } = await repointAlias({ seedAttestedFile: false });
     const prompter = buildPrompter();
 
     await expect(runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter })).rejects.toThrow();
@@ -181,28 +181,32 @@ describe("doctor workspace alias repair", () => {
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
     expect(prompter.confirmRuntimeRepair).toHaveBeenCalledOnce();
     // Declined: stored state stays with the original canonical target.
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
 
     const approving = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
     await runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter: approving });
-    expect(readWorkspaceStateSnapshot(alias).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(alias)).setupExists).toBe(true);
   });
 
   it("refuses to merge when the current target already owns state", async () => {
-    const { alias, original, replacement } = repointAlias({ seedAttestedFile: false });
-    mergeWorkspaceSetupState(replacement, { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" }, 2_000);
+    const { alias, original, replacement } = await repointAlias({ seedAttestedFile: false });
+    await mergeWorkspaceSetupState(
+      replacement,
+      { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" },
+      2_000,
+    );
     const prompter = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
 
     await expect(runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter })).rejects.toThrow();
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
     expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(replacement)).setupExists).toBe(true);
   });
 
   it("does not move records from diagnostic mode", async () => {
-    const { original } = repointAlias({ seedAttestedFile: true });
+    const { original } = await repointAlias({ seedAttestedFile: true });
     const prompter = buildPrompter({
       shouldRepair: false,
       confirmRuntimeRepair: vi.fn(async () => true),
@@ -219,11 +223,11 @@ describe("doctor workspace alias repair", () => {
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
     expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
   });
 
   it("refuses to transfer state while another configured agent uses the stored target", async () => {
-    const { alias, original } = repointAlias({ seedAttestedFile: false });
+    const { alias, original } = await repointAlias({ seedAttestedFile: false });
     const prompter = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
     const cfg = {
       agents: {
@@ -237,6 +241,6 @@ describe("doctor workspace alias repair", () => {
     await expect(runWorkspaceRepair({ cfg, prompter })).rejects.toThrow();
 
     expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
-    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect((await readWorkspaceStateSnapshot(original)).setupExists).toBe(true);
   });
 });

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -393,9 +393,7 @@ describe("handleReset", () => {
     mocks.removeLegacyWorkspaceStateForReset.mockRejectedValueOnce(
       new Error("retired state unavailable"),
     );
-    mocks.deleteWorkspaceState.mockImplementationOnce(() => {
-      throw new Error("state database unavailable");
-    });
+    mocks.deleteWorkspaceState.mockRejectedValueOnce(new Error("state database unavailable"));
 
     const reset = withEnvAsync(
       {
@@ -420,9 +418,7 @@ describe("handleReset", () => {
     const stateDir = path.join(homeDir, ".openclaw");
     const workspaceDir = path.join(stateDir, "workspace");
     fs.mkdirSync(workspaceDir, { recursive: true });
-    mocks.deleteWorkspaceState.mockImplementationOnce(() => {
-      throw new Error("state database unavailable");
-    });
+    mocks.deleteWorkspaceState.mockRejectedValueOnce(new Error("state database unavailable"));
 
     await withEnvAsync(
       {

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -256,9 +256,9 @@ describe("runDoctorHealthFlow", () => {
           kind.endsWith("loaded-disabled")
         ) {
           await run;
-          expect(readWorkspaceStateSnapshot(state.workspaceDir).setup.setupCompletedAt).toBe(
-            completedAt,
-          );
+          expect(
+            (await readWorkspaceStateSnapshot(state.workspaceDir)).setup.setupCompletedAt,
+          ).toBe(completedAt);
           expect(fs.existsSync(sourcePath)).toBe(false);
           expect(mocks.outro).toHaveBeenCalledWith("Doctor complete.");
           if (kind !== "absent" && kind !== "runtime-only") {
@@ -494,9 +494,9 @@ describe("runDoctorHealthFlow", () => {
               },
             });
             expect(migration.warnings.join("\n")).toContain("legacy cleanup failed");
-            expect(readWorkspaceStateSnapshot(state.workspaceDir).setup.setupCompletedAt).toBe(
-              "2026-07-15T00:00:00.000Z",
-            );
+            expect(
+              (await readWorkspaceStateSnapshot(state.workspaceDir)).setup.setupCompletedAt,
+            ).toBe("2026-07-15T00:00:00.000Z");
           }
         });
         const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
@@ -973,7 +973,7 @@ describe("runDoctorHealthFlow", () => {
           runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true }),
         );
         expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("legacy cleanup failed"));
-        expect(readWorkspaceStateSnapshot(workspaceDir).setup.setupCompletedAt).toBe(
+        expect((await readWorkspaceStateSnapshot(workspaceDir)).setup.setupCompletedAt).toBe(
           "2026-07-15T00:00:00.000Z",
         );
         expect(fs.existsSync(`${sourcePath}.doctor-importing`)).toBe(true);

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -211,9 +211,9 @@ async function runDoctorHealthFlowWithResult(
           env: process.env,
         }),
       });
-      const { assertConfiguredWorkspaceStateReady } =
+      const { assertConfiguredWorkspaceStateReadyForDoctor } =
         await import("../agents/workspace-state-dirs.js");
-      assertConfiguredWorkspaceStateReady({ cfg: ctx.cfg, operation: "doctor" });
+      await assertConfiguredWorkspaceStateReadyForDoctor({ cfg: ctx.cfg });
       const { assertNoPendingLegacyExecApprovals } =
         await import("../infra/exec-approvals-migration-gate.js");
       assertNoPendingLegacyExecApprovals({ operation: "doctor" });

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -5743,7 +5743,7 @@ async function prepareLiveGatewayWorkspace(workspaceDir: string): Promise<void> 
   // retired JSON markers or empty initialized workspaces block the first turn.
   await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: true });
   await fs.rm(path.join(workspaceDir, "BOOTSTRAP.md"), { force: true });
-  mergeWorkspaceSetupState(workspaceDir, { setupCompletedAt: new Date().toISOString() });
+  await mergeWorkspaceSetupState(workspaceDir, { setupCompletedAt: new Date().toISOString() });
 }
 
 async function runGatewayModelSuite(params: GatewayModelSuiteParams) {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1935,7 +1935,10 @@ describe("agents.delete", () => {
       trashedPaths.indexOf("/journal/agent"),
     );
     expect(trashedPaths.indexOf("/journal/agent")).toBeLessThan(trashedPaths.indexOf("/journal"));
-    expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({ workspaceDir: "/journal" });
+    expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith(
+      { workspaceDir: "/journal" },
+      { assertCurrent: mocks.assertAgentDeletionCurrent },
+    );
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -2939,9 +2942,28 @@ describe("agents.delete", () => {
 
     expectRespondOk(respond, { ok: true });
     expectTrashedWithinParent("/workspace/test-agent");
-    expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({
-      workspaceDir: "/workspace/test-agent",
+    expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith(
+      {
+        workspaceDir: "/workspace/test-agent",
+      },
+      { assertCurrent: mocks.assertAgentDeletionCurrent },
+    );
+  });
+
+  it("keeps directory ownership when deletion retires during workspace cleanup", async () => {
+    const retired = new Error("deletion owner retired");
+    mocks.deleteWorkspaceState.mockImplementationOnce(async () => {
+      await Promise.resolve();
+      mocks.assertAgentDeletionCurrent.mockImplementation(() => {
+        throw retired;
+      });
     });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await expect(promise).rejects.toBe(retired);
+    expect(respond).not.toHaveBeenCalled();
+    expect(mocks.unregisterResolvedAgentDir).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
   });
 
   it("trashes a dangling workspace symlink before deleting its state", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1469,11 +1469,12 @@ export const agentsHandlers: GatewayRequestHandlers = {
                   assertCurrent: deletion.assertCurrent,
                 });
                 deletion.assertCurrent();
-                deleteWorkspaceState(statePlan);
+                await deleteWorkspaceState(statePlan, { assertCurrent: deletion.assertCurrent });
               } catch {
                 // Best-effort cleanup. A later explicit reset can remove stale rows.
               }
             }
+            deletion.assertCurrent();
             const agentDirCleanupPaths = cleanupPaths.filter((cleanupPath) =>
               cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath),
             );

--- a/src/infra/heartbeat-runner.live.test.ts
+++ b/src/infra/heartbeat-runner.live.test.ts
@@ -71,7 +71,7 @@ describeLive("session event wake through a live Gateway", () => {
       instance.state.applyEnv();
       await ensureAgentWorkspace({ dir: workspace, ensureBootstrapFiles: true });
       await fs.rm(path.join(workspace, "BOOTSTRAP.md"), { force: true });
-      mergeWorkspaceSetupState(workspace, { setupCompletedAt: new Date().toISOString() });
+      await mergeWorkspaceSetupState(workspace, { setupCompletedAt: new Date().toISOString() });
       await fs.writeFile(
         path.join(workspace, "AGENTS.md"),
         "Follow exact reply instructions. This workspace contains only synthetic live-test data.\n",

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -839,7 +839,7 @@ describe("state migrations", () => {
     expect(repaired.warnings).toEqual([]);
     expect(assertReady).not.toThrow();
     expect(fsSync.existsSync(sourcePath)).toBe(false);
-    expect(readWorkspaceStateSnapshot(workspaceDir, { env }).setup.setupCompletedAt).toBe(
+    expect((await readWorkspaceStateSnapshot(workspaceDir, { env })).setup.setupCompletedAt).toBe(
       completedAt,
     );
   });

--- a/src/infra/state-migrations.workspace-move-order.test.ts
+++ b/src/infra/state-migrations.workspace-move-order.test.ts
@@ -74,7 +74,7 @@ describe("Doctor workspace move ordering", () => {
       expect(fs.existsSync(carriedSource)).toBe(false);
       expect(fs.existsSync(`${carriedSource}.doctor-importing`)).toBe(false);
       const identity = resolveWorkspaceStateIdentity(moved);
-      expect(readWorkspaceStateSnapshot(alias, { env: context.env })).toMatchObject({
+      expect(await readWorkspaceStateSnapshot(alias, { env: context.env })).toMatchObject({
         identity,
         setup: milestones,
       });

--- a/src/infra/state-migrations.workspace-move.test.ts
+++ b/src/infra/state-migrations.workspace-move.test.ts
@@ -103,7 +103,7 @@ describe("workspace move migration recovery", () => {
         expect(fs.readFileSync(receipt!.archivePath!, "utf8")).toBe(raw);
       }
       expect(db.prepare("SELECT * FROM migration_runs ORDER BY id").all()).toEqual(runs);
-      expect(readWorkspaceStateSnapshot(alias).setup).toEqual(milestones);
+      expect((await readWorkspaceStateSnapshot(alias)).setup).toEqual(milestones);
       const row = db
         .prepare("SELECT report_json FROM migration_sources WHERE source_key = ?")
         .get(receipt!.sourceKey)!;
@@ -134,7 +134,7 @@ describe("workspace move migration recovery", () => {
         JSON.stringify({ setupCompletedAt: "2026-07-16T00:00:00.000Z" }),
       );
       expect((await migrate(configured)).warnings).toEqual([]);
-      expect(readWorkspaceStateSnapshot(alias).setup).toEqual(milestones);
+      expect((await readWorkspaceStateSnapshot(alias)).setup).toEqual(milestones);
       expect(readReceipt(movedSource, context.env)?.removedSource).toBe(true);
     },
   );

--- a/src/infra/state-migrations.workspace-setup-sandbox.test.ts
+++ b/src/infra/state-migrations.workspace-setup-sandbox.test.ts
@@ -160,7 +160,7 @@ describe("sandbox workspace Doctor migration", () => {
 
     expect(result.warnings).toEqual([]);
     expect(fs.existsSync(setupPath)).toBe(false);
-    expect(readWorkspaceStateSnapshot(sandboxLayout.sandboxWorkspaceDir)).toMatchObject({
+    expect(await readWorkspaceStateSnapshot(sandboxLayout.sandboxWorkspaceDir)).toMatchObject({
       setup: {
         bootstrapSeededAt: "2026-07-20T00:00:00.000Z",
       },
@@ -231,7 +231,7 @@ describe("sandbox workspace Doctor migration", () => {
 
       expect(result.warnings).toEqual([]);
       expect(fs.existsSync(setupPath)).toBe(false);
-      expect(readWorkspaceStateSnapshot(sandboxLayout.sandboxWorkspaceDir)).toMatchObject({
+      expect(await readWorkspaceStateSnapshot(sandboxLayout.sandboxWorkspaceDir)).toMatchObject({
         setup: { bootstrapSeededAt: "2026-07-20T00:00:00.000Z" },
         setupExists: true,
       });
@@ -296,7 +296,7 @@ describe("sandbox workspace Doctor migration", () => {
 
     expect(result.warnings).toEqual([]);
     expect(fs.existsSync(setupPath)).toBe(false);
-    expect(readWorkspaceStateSnapshot(layout.sandboxWorkspaceDir)).toMatchObject({
+    expect(await readWorkspaceStateSnapshot(layout.sandboxWorkspaceDir)).toMatchObject({
       setup: { bootstrapSeededAt: "2026-07-20T00:00:00.000Z" },
       setupExists: true,
     });
@@ -778,7 +778,7 @@ describe("sandbox workspace Doctor migration", () => {
 
     expect(result.warnings).toEqual([]);
     expect(fs.existsSync(setupPath)).toBe(false);
-    expect(readWorkspaceStateSnapshot(sandboxLayout.sandboxWorkspaceDir)).toMatchObject({
+    expect(await readWorkspaceStateSnapshot(sandboxLayout.sandboxWorkspaceDir)).toMatchObject({
       setup: { bootstrapSeededAt: "2026-07-20T00:00:00.000Z" },
       setupExists: true,
     });
@@ -913,7 +913,7 @@ describe("sandbox workspace Doctor migration", () => {
 
     expect(result.warnings).toEqual([]);
     expect(fs.existsSync(setupPath)).toBe(false);
-    expect(readWorkspaceStateSnapshot(sandboxLayout.sandboxWorkspaceDir)).toMatchObject({
+    expect(await readWorkspaceStateSnapshot(sandboxLayout.sandboxWorkspaceDir)).toMatchObject({
       setup: {
         bootstrapSeededAt: "2026-07-20T00:00:00.000Z",
       },

--- a/src/infra/state-migrations.workspace-setup.multi-agent.test.ts
+++ b/src/infra/state-migrations.workspace-setup.multi-agent.test.ts
@@ -101,7 +101,7 @@ describe("legacy workspace Doctor multi-agent migration", () => {
           )
           .get(identity.workspaceKey),
       ).toEqual({ filename: "AGENTS.md", sha256: HASH });
-      expect(readWorkspaceStateSnapshot(workspace)).toMatchObject({
+      expect(await readWorkspaceStateSnapshot(workspace)).toMatchObject({
         identity,
         setup: { bootstrapSeededAt: seededAt, setupCompletedAt: completedAt },
         attestation: { attestedAtMs: mtime.getTime() },

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -125,7 +125,7 @@ describe("legacy workspace Doctor migration", () => {
     expect(fs.existsSync(canonicalSiblingPath)).toBe(false);
     fs.unlinkSync(workspaceAlias);
 
-    expect(readWorkspaceStateSnapshot(workspaceAlias)).toMatchObject({
+    expect(await readWorkspaceStateSnapshot(workspaceAlias)).toMatchObject({
       identity,
       setup: { setupCompletedAt: completedAt },
     });
@@ -168,7 +168,7 @@ describe("legacy workspace Doctor migration", () => {
     expect((await migrate(aliasContext)).warnings).toEqual([]);
     fs.unlinkSync(workspaceAlias);
 
-    expect(readWorkspaceStateSnapshot(workspaceAlias)).toMatchObject({
+    expect(await readWorkspaceStateSnapshot(workspaceAlias)).toMatchObject({
       identity,
       attestation: { attestedAtMs: attestedAt.getTime() },
     });
@@ -202,7 +202,7 @@ describe("legacy workspace Doctor migration", () => {
 
     fs.unlinkSync(workspaceAlias);
     fs.symlinkSync(targetB, workspaceAlias, process.platform === "win32" ? "junction" : "dir");
-    deleteWorkspaceState(prepareWorkspaceStateDeletion(workspaceAlias));
+    await deleteWorkspaceState(prepareWorkspaceStateDeletion(workspaceAlias));
     const identityB = resolveWorkspaceStateIdentity(targetB);
     await fsp.writeFile(
       sourcePath,
@@ -787,7 +787,7 @@ describe("legacy workspace Doctor migration", () => {
       expect(result.warnings).toEqual([]);
       expect(fs.existsSync(setupPath)).toBe(false);
       expect(fs.existsSync(`${setupPath}.doctor-importing`)).toBe(false);
-      expect(readWorkspaceStateSnapshot(context.workspaceDir).setup).toEqual({
+      expect((await readWorkspaceStateSnapshot(context.workspaceDir)).setup).toEqual({
         version: 1,
         bootstrapSeededAt: seededAt,
         ...(completedAt ? { setupCompletedAt: completedAt } : {}),


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Workspace setup, attestation and cleanup currently expose synchronous database operations. Introducing awaited storage without retaining operation ownership could allow a retired setup or cleanup to delete files or unregister a workspace after authority is lost.

## Why This Change Was Made

Convert the workspace state domain operations and their callers to awaited contracts. Forward existing authority checks to native write transaction admission and recheck after awaited work before deleting bootstrap files or unregistering directories. Cleanup returns its deletion promise to the existing error collector, and Doctor prepares canonical readiness asynchronously.

SQLite transactions remain synchronous and the schema and persisted state meaning are unchanged. Session directory discovery is a separate coordinated session-accessor conversion.

## User Impact

Workspace provisioning, attestation and cleanup retain their existing behavior while supporting asynchronous persistence. Retired work cannot publish completion or continue cleanup across the new waits.

## Evidence

- Focused store, provisioning, Gateway, CLI and workspace test cohorts passed; one platform-specific Unicode test is skipped on this host.
- Negative controls demonstrate that removing the await or authority checks permits premature bootstrap deletion, a retired milestone or stale unregistration.
- Full selected changed checks and fresh independent Codex review passed.
- Standalone production-source SQLite smoke passed across three isolated processes on this commit: setup/completion/attestation, reopen, refused deletion preserving durable rows/cache/files, and authorized cleanup. All database handles and process groups were closed and synthetic state removed.
- Single-run measurements: seed 141.45 ms, completion 3.08 ms, refused delete 0.76 ms. These are observations, not a comparative performance claim.
