### PR TITLE
refactor(team-reports): await persistence and drain shutdown

### DIFF
--- a/docs/plugins/team-reports.md
+++ b/docs/plugins/team-reports.md
@@ -97,7 +97,7 @@ To request a report immediately, use:
 openclaw team-reports generate --intraday
 ```
 
-Generation returns a run ID before collection and summarization finish. Check
+Generation returns a run ID after recording the run, before collection and summarization finish. Check
 `status` for the result, then open **Reports** in the Control UI.
 
 ## Read reports in the Control UI
@@ -303,7 +303,9 @@ call. Collection is stored before summarization, which may take several minutes.
 Only one run executes at a time. Scheduled work waits for an active run;
 manual generation is rejected while another run is active. Runs have a
 45-minute deadline. Stopping the service cancels its timers and waits up to
-30 seconds for active work before closing storage.
+30 seconds for active work, then cancels remote collection and summarization.
+Any database operation already in progress and the final run outcome finish
+before storage closes.
 
 ## Understand report windows and counts
 

--- a/extensions/team-reports/index.test.ts
+++ b/extensions/team-reports/index.test.ts
@@ -6,6 +6,7 @@ import type {
   OpenClawPluginServiceContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as configRuntime from "./src/config.js";
 import { createTeamReportsStore } from "./src/store.js";
@@ -17,6 +18,8 @@ vi.mock("./src/store.js", () => ({
 }));
 
 import plugin from "./index.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const pluginConfig = {
   basePath: "/team/activity/",
@@ -62,6 +65,55 @@ beforeEach(() => vi.clearAllMocks());
 afterEach(() => vi.restoreAllMocks());
 
 describe("Team Reports registration", () => {
+  it("drains storage that opens after retirement without publishing the service", async () => {
+    const directory = tempDirs.make("team-reports-retired-open-");
+    const { createTeamReportsStore: openStore } =
+      await vi.importActual<typeof import("./src/store.js")>("./src/store.js");
+    const store = await openStore({ stateDir: directory });
+    const opened = createDeferred<void>();
+    const releaseOpen = createDeferred<void>();
+    const releaseClose = createDeferred<void>();
+    const closeStore = store.close.bind(store);
+    const close = vi.spyOn(store, "close").mockImplementation(async () => {
+      await releaseClose.promise;
+      await closeStore();
+    });
+    vi.mocked(createTeamReportsStore).mockImplementationOnce(async () => {
+      opened.resolve();
+      await releaseOpen.promise;
+      return store;
+    });
+    const parsed = configRuntime.parseTeamReportsConfig(pluginConfig);
+    vi.spyOn(configRuntime, "resolveTeamReportsConfig").mockResolvedValue({
+      github: { ...parsed.github, token: "fixture-github-token", ignoreCommentPatterns: [] },
+      people: [],
+    });
+    const { captured, services } = captureReports();
+    const service = services[0]!;
+    const lifecycle = captured.runtimeLifecycles[0]!;
+    const starting = service.start({
+      config,
+      stateDir: directory,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    await opened.promise;
+    const stopped = vi.fn();
+    const cleanup = Promise.resolve(lifecycle.cleanup?.({ reason: "disable" })).then(stopped);
+    try {
+      releaseOpen.resolve();
+      await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+      expect(stopped).not.toHaveBeenCalled();
+    } finally {
+      releaseOpen.resolve();
+      releaseClose.resolve();
+      await Promise.all([starting, cleanup]);
+    }
+    await expect(store.listRuns()).rejects.toThrow("store is closed");
+    await expect(service.start({ config, stateDir: directory, logger: console })).rejects.toThrow(
+      "runtime has been retired",
+    );
+  });
+
   it("exposes reports through the authenticated tab, read methods, and admin generation method", () => {
     const { captured, services, routes, methods } = captureReports();
     expect(captured.controlUiDescriptors).toEqual([

--- a/extensions/team-reports/index.ts
+++ b/extensions/team-reports/index.ts
@@ -23,18 +23,16 @@ export default definePluginEntry({
     let generation = 0;
     let retired = false;
     let stopping: Promise<void> | undefined;
+    let startingStore: Promise<void> | undefined;
     const stop = () => {
       generation++;
       const current = scheduler;
       scheduler = undefined;
-      const currentStore = store;
       store = undefined;
+      const pendingStart = startingStore;
       return (stopping ??= (async () => {
-        try {
-          await current?.stop();
-        } finally {
-          currentStore?.close();
-        }
+        await pendingStart?.catch(() => undefined);
+        await current?.stop();
       })());
     };
     const requireScheduler = () => {
@@ -78,15 +76,33 @@ export default definePluginEntry({
         if (policy?.allowModelOverride !== true) {
           delete summaryOptions.model;
         }
-        store = createTeamReportsStore({ stateDir: ctx.stateDir });
-        scheduler = new TeamReportsScheduler({
-          config: { ...config, summaries: summaryOptions },
-          resolved,
-          store,
-          llm: api.runtime.llm,
-          context: ctx,
-        });
-        scheduler.start();
+        startingStore = (async () => {
+          const nextStore = await createTeamReportsStore({ stateDir: ctx.stateDir });
+          if (retired || currentGeneration !== generation) {
+            await nextStore.close();
+            return;
+          }
+          const nextScheduler = new TeamReportsScheduler({
+            config: { ...config, summaries: summaryOptions },
+            resolved,
+            store: nextStore,
+            llm: api.runtime.llm,
+            context: ctx,
+          });
+          try {
+            await nextScheduler.start();
+            if (retired || currentGeneration !== generation) {
+              await nextScheduler.stop();
+              return;
+            }
+            store = nextStore;
+            scheduler = nextScheduler;
+          } catch (error) {
+            await nextScheduler.stop();
+            throw error;
+          }
+        })();
+        await startingStore;
       },
       stop,
     });

--- a/extensions/team-reports/src/gateway-methods.ts
+++ b/extensions/team-reports/src/gateway-methods.ts
@@ -27,13 +27,13 @@ export function registerTeamReportsGatewayMethods(
   const register = (
     name: string,
     scope: "operator.read" | "operator.admin",
-    run: (params: unknown) => unknown,
+    run: (params: unknown) => Promise<unknown>,
   ) => {
     api.registerGatewayMethod(
       `team-reports.${name}`,
-      ({ params, respond }) => {
+      async ({ params, respond }) => {
         try {
-          respond(true, run(params ?? {}));
+          respond(true, await run(params ?? {}));
         } catch (error) {
           const message = error instanceof Error ? error.message : "Team Reports request failed";
           respond(
@@ -53,13 +53,13 @@ export function registerTeamReportsGatewayMethods(
     z.strictObject({}).parse(params);
     return access.scheduler().status();
   });
-  register("list", "operator.read", (params) => ({
-    periods: access.store().listPeriods(listSchema.parse(params)),
+  register("list", "operator.read", async (params) => ({
+    periods: await access.store().listPeriods(listSchema.parse(params)),
   }));
-  register("get", "operator.read", (params) => {
+  register("get", "operator.read", async (params) => {
     const { period, key, format } = getSchema.parse(params);
     describePeriod(period, key);
-    const stored = access.store().getPeriod(period, key);
+    const stored = await access.store().getPeriod(period, key);
     if (!stored) {
       throw new Error("Report not found; generate the requested UTC day first");
     }
@@ -67,7 +67,7 @@ export function registerTeamReportsGatewayMethods(
       ? { markdown: stored.markdown }
       : { report: stored.report, summary: stored.summary };
   });
-  register("generate", "operator.admin", (params) => ({
-    runId: access.scheduler().generate(generateSchema.parse(params)),
+  register("generate", "operator.admin", async (params) => ({
+    runId: await access.scheduler().generate(generateSchema.parse(params)),
   }));
 }

--- a/extensions/team-reports/src/http.test.ts
+++ b/extensions/team-reports/src/http.test.ts
@@ -117,7 +117,7 @@ function fetchPath(
 
 beforeAll(async () => {
   directory = fs.mkdtempSync(path.join(os.tmpdir(), "team-reports-http-"));
-  store = createTeamReportsStore({ stateDir: directory });
+  store = await createTeamReportsStore({ stateDir: directory });
   const avatarReport = report("day", "2026-08-19");
   avatarReport.members = avatarPeople.map((person) => ({
     login: person.github[0] ?? "",
@@ -139,15 +139,19 @@ beforeAll(async () => {
     report("week", "2026-W34"),
     report("month", "2026-08"),
   ]) {
-    store.upsertPeriod({ report: document, summary, markdown: renderMarkdown(document, summary) });
+    await store.upsertPeriod({
+      report: document,
+      summary,
+      markdown: renderMarkdown(document, summary),
+    });
   }
   const handler = createTeamReportsHttpHandler({
     basePath: "/reports",
     displayTimezone: "UTC",
     assetsDir: fileURLToPath(new URL("../assets", import.meta.url)),
     getStore,
-    status: () => ({ running: false, lastRun: "fixture-run" }),
-    health: () => ({ running: false, warnings: 1 }),
+    status: async () => ({ running: false, lastRun: "fixture-run" }),
+    health: async () => ({ running: false, warnings: 1 }),
     orgs: () => currentOrgs,
     people: () => [
       {
@@ -160,7 +164,11 @@ beforeAll(async () => {
       ...avatarPeople,
     ],
   });
-  server = createServer(handler);
+  server = createServer((req, res) => {
+    void handler(req, res).catch((error: unknown) => {
+      res.destroy(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
   const address = server.address();
@@ -174,7 +182,7 @@ afterAll(async () => {
   await new Promise<void>((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
-  store.close();
+  await store.close();
   fs.rmSync(directory, { recursive: true, force: true });
 });
 
@@ -456,7 +464,7 @@ describe("Team Reports HTTP responses", () => {
   });
 
   it("reads current overview organizations and prefers the displayed report's organizations", async () => {
-    const emptyStore = createTeamReportsStore({ stateDir: path.join(directory, "empty") });
+    const emptyStore = await createTeamReportsStore({ stateDir: path.join(directory, "empty") });
     try {
       for (const name of ["first-organization", "new <organization>"]) {
         currentOrgs = [name];
@@ -471,7 +479,7 @@ describe("Team Reports HTTP responses", () => {
       expect(stored.body).toContain("example · team");
       expect(stored.body).not.toContain("new &lt;organization&gt; · team");
     } finally {
-      emptyStore.close();
+      await emptyStore.close();
     }
   });
 

--- a/extensions/team-reports/src/http.ts
+++ b/extensions/team-reports/src/http.ts
@@ -23,8 +23,8 @@ type TeamReportsHttpOptions = {
   /** The plugin's shipped `assets` directory; the dist bundle flattens `src/`, so callers resolve it from the plugin root. */
   assetsDir: string;
   getStore: () => TeamReportsStore | undefined;
-  status: () => unknown;
-  health: () => TeamReportsHealth;
+  status: () => Promise<unknown>;
+  health: () => Promise<TeamReportsHealth>;
   orgs: () => string[];
   people: () => Person[];
 };
@@ -116,7 +116,7 @@ function visiblePeople(configured: Person[], recentReports: PersonReport[]): Per
 }
 
 export function createTeamReportsHttpHandler(options: TeamReportsHttpOptions) {
-  return (req: IncomingMessage, res: ServerResponse): boolean => {
+  return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
     const nonce = randomBytes(16).toString("base64url");
     const send = (
       status: number,
@@ -177,15 +177,15 @@ export function createTeamReportsHttpHandler(options: TeamReportsHttpOptions) {
     }
     const json = (body: unknown) => send(200, "application/json", JSON.stringify(body));
     if (first === "status" && route.segments.length === 1) {
-      return json(options.status());
+      return json(await options.status());
     }
-    const index = (): PeriodIndex => ({
-      day: store.listPeriods({ period: "day", limit: 400 }),
-      week: store.listPeriods({ period: "week", limit: 60 }),
-      month: store.listPeriods({ period: "month", limit: 60 }),
+    const index = async (): Promise<PeriodIndex> => ({
+      day: await store.listPeriods({ period: "day", limit: 400 }),
+      week: await store.listPeriods({ period: "week", limit: 60 }),
+      month: await store.listPeriods({ period: "month", limit: 60 }),
     });
     if (first === "latest" && route.segments.length === 1) {
-      const closed = store.listPeriods({ period: "day", status: "closed", limit: 1 })[0];
+      const closed = (await store.listPeriods({ period: "day", status: "closed", limit: 1 }))[0];
       if (closed) {
         return send(302, "text/plain", "Redirecting to the latest closed day.\n", {
           Location: `${options.basePath}/day/${closed.key}/`,
@@ -194,7 +194,7 @@ export function createTeamReportsHttpHandler(options: TeamReportsHttpOptions) {
       return notFound();
     }
     if (first === "index.json" && route.segments.length === 1) {
-      const periods = index();
+      const periods = await index();
       return json({
         latest: {
           day: periods.day[0]?.key ?? null,
@@ -216,33 +216,35 @@ export function createTeamReportsHttpHandler(options: TeamReportsHttpOptions) {
     };
     const html = (body: string) => send(200, "text/html", body);
     if (route.segments.length === 0) {
-      const periods = index();
+      const periods = await index();
       const latest = periods.day[0];
-      const stored = latest ? store.getPeriod("day", latest.key) : undefined;
+      const stored = latest ? await store.getPeriod("day", latest.key) : undefined;
       return html(
         renderIndexPage(ctx, periods, {
           orgs: stored?.report.orgs ?? options.orgs(),
           latest: stored,
-          health: options.health(),
+          health: await options.health(),
         }),
       );
     }
     if (first === "people" && route.segments.length <= 2) {
-      const latest = store.listPeriods({ period: "day", limit: 1 })[0];
-      const recent = latest ? (store.getPeriod("day", latest.key)?.report.members ?? []) : [];
+      const latest = (await store.listPeriods({ period: "day", limit: 1 }))[0];
+      const recent = latest
+        ? ((await store.getPeriod("day", latest.key))?.report.members ?? [])
+        : [];
       const people = visiblePeople(options.people(), recent);
       if (!key) {
         const endKey = latest?.key ?? new Date().toISOString().slice(0, 10);
         const since = new Date(Date.parse(`${endKey}T00:00:00Z`) - 27 * DAY_MS)
           .toISOString()
           .slice(0, 10);
-        return html(renderPeoplePage(ctx, people, store.listPersonDaysSince(since), endKey));
+        return html(renderPeoplePage(ctx, people, await store.listPersonDaysSince(since), endKey));
       }
       const person = people.find((candidate) =>
         candidate.github.some((login) => login.toLowerCase() === key.toLowerCase()),
       );
       const login = person?.github[0] ?? key;
-      const days = store.listPersonDays(login, { limit: 400 });
+      const days = await store.listPersonDays(login, { limit: 400 });
       if (!person && days.length === 0) {
         return notFound();
       }
@@ -264,7 +266,7 @@ export function createTeamReportsHttpHandler(options: TeamReportsHttpOptions) {
       } catch {
         return notFound();
       }
-      const stored = store.getPeriod(first, key);
+      const stored = await store.getPeriod(first, key);
       if (!stored) {
         return notFound();
       }
@@ -279,7 +281,9 @@ export function createTeamReportsHttpHandler(options: TeamReportsHttpOptions) {
           ctx,
           stored.report,
           stored.summary,
-          store.listPeriods({ period: first, limit: 400 }).filter((entry) => entry.key <= key),
+          (await store.listPeriods({ period: first, limit: 400 })).filter(
+            (entry) => entry.key <= key,
+          ),
         ),
       );
     }

--- a/extensions/team-reports/src/run.ts
+++ b/extensions/team-reports/src/run.ts
@@ -46,6 +46,24 @@ export function runPeriods(
   return [...periods.values()];
 }
 
+function untilAborted<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const abort = () => {
+      const reason: unknown = signal.reason;
+      reject(
+        reason instanceof Error
+          ? reason
+          : new Error(typeof reason === "string" ? reason : "Team Reports run aborted"),
+      );
+    };
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) {
+      abort();
+    }
+    void work.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+  });
+}
+
 export async function generateReportPeriods(params: {
   config: TeamReportsConfig;
   resolved: ResolvedTeamReportsConfig;
@@ -58,7 +76,7 @@ export async function generateReportPeriods(params: {
 }): Promise<Record<string, SourceStatus>> {
   const { config, resolved, store, runtime } = params;
   const sources = params.sources(runtime);
-  const loaded = await sources.github.loadRoster(resolved.github);
+  const loaded = await untilAborted(sources.github.loadRoster(resolved.github), runtime.signal);
   runtime.signal.throwIfAborted();
   if (!loaded.status.ok) {
     throw new Error("GitHub roster unavailable; check token access and configured teams");
@@ -68,16 +86,23 @@ export async function generateReportPeriods(params: {
   const statuses: Record<string, SourceStatus> = {};
   for (const period of params.periods) {
     runtime.signal.throwIfAborted();
-    const previous = store.getPeriod(period.period, period.key);
+    const previous = await store.getPeriod(period.period, period.key);
+    runtime.signal.throwIfAborted();
     let report;
     if (period.period === "day") {
       const cutoffMs = Date.now();
       const window = { sinceMs: period.sinceMs, untilMs: Math.min(cutoffMs, period.untilMs) };
-      const github = await sources.github.collect(resolved.github, window, roster);
+      const github = await untilAborted(
+        sources.github.collect(resolved.github, window, roster),
+        runtime.signal,
+      );
       runtime.signal.throwIfAborted();
       const discord =
         resolved.discord && sources.discord
-          ? await sources.discord.collect(resolved.discord, window, roster)
+          ? await untilAborted(
+              sources.discord.collect(resolved.discord, window, roster),
+              runtime.signal,
+            )
           : undefined;
       runtime.signal.throwIfAborted();
       const githubStatus: SourceStatus = {
@@ -102,7 +127,7 @@ export async function generateReportPeriods(params: {
       report = aggregateDays({
         period,
         nowMs: Date.now(),
-        days: store.getDayReports(period.sinceMs, period.untilMs),
+        days: await store.getDayReports(period.sinceMs, period.untilMs),
         roster,
         orgs: resolved.github.orgs,
       });
@@ -120,30 +145,35 @@ export async function generateReportPeriods(params: {
     });
     runtime.signal.throwIfAborted();
     const boundedFallback = boundReportDocument(fallback.report);
-    store.upsertPeriod({
+    await store.upsertPeriod({
       report: boundedFallback,
       summary: fallback.summary,
       markdown: renderMarkdown(boundedFallback, fallback.summary),
     });
+    runtime.signal.throwIfAborted();
     if (config.summaries.enabled) {
-      const summarized = await generateSummaries({
-        report,
-        options: config.summaries,
-        llm: params.llm,
-        logger: runtime.logger,
-        previous: previous?.summary
-          ? { report: previous.report, summary: previous.summary }
-          : undefined,
-        signal: runtime.signal,
-      });
+      const summarized = await untilAborted(
+        generateSummaries({
+          report,
+          options: config.summaries,
+          llm: params.llm,
+          logger: runtime.logger,
+          previous: previous?.summary
+            ? { report: previous.report, summary: previous.summary }
+            : undefined,
+          signal: runtime.signal,
+        }),
+        runtime.signal,
+      );
       runtime.signal.throwIfAborted();
       const bounded = boundReportDocument(summarized.report);
-      store.upsertPeriod({
+      await store.upsertPeriod({
         report: bounded,
         summary: summarized.summary,
         markdown: renderMarkdown(bounded, summarized.summary),
       });
     }
+    runtime.signal.throwIfAborted();
   }
   return statuses;
 }

--- a/extensions/team-reports/src/scheduler.test.ts
+++ b/extensions/team-reports/src/scheduler.test.ts
@@ -18,7 +18,7 @@ const resources: Array<{
 }> = [];
 const healthy: SourceStatus = { ok: true, warnings: [], stats: { apiCalls: 1 } };
 
-function setup(
+async function setup(
   options: {
     stateDir?: string;
     schedule?: Partial<TeamReportsConfig["schedule"]>;
@@ -65,16 +65,16 @@ function setup(
   };
   const directory =
     options.stateDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "team-reports-scheduler-"));
-  const store = createTeamReportsStore({ stateDir: directory });
+  const store = await createTeamReportsStore({ stateDir: directory });
   if (options.caughtUp !== false) {
     const yesterday = describePeriod("day", Date.now() - 86_400_000);
-    store.startRun({
+    await store.startRun({
       id: "previous-closed-day",
       kind: options.caughtUp ?? "closed-day",
       startedAtMs: yesterday.untilMs,
       periods: [{ period: "day", key: yesterday.key }],
     });
-    store.finishRun("previous-closed-day", { status: "ok", finishedAtMs: Date.now() });
+    await store.finishRun("previous-closed-day", { status: "ok", finishedAtMs: Date.now() });
   }
   const github = {
     loadRoster: vi
@@ -165,7 +165,7 @@ afterEach(async () => {
   await vi.advanceTimersByTimeAsync(30_001);
   await Promise.all(stopped);
   for (const { store, directory } of owned) {
-    store.close();
+    await store.close();
     fs.rmSync(directory, { recursive: true, force: true });
   }
   vi.restoreAllMocks();
@@ -177,16 +177,16 @@ describe("Team Reports schedule boundaries", () => {
     { random: 0, expected: "2026-08-20T00:05:00Z" },
     { random: 0.5, expected: "2026-08-20T00:07:30Z" },
     { random: 1, expected: "2026-08-20T00:10:00Z" },
-  ])("keeps closed-day jitter in the configured window ($random)", ({ random, expected }) => {
+  ])("keeps closed-day jitter in the configured window ($random)", async ({ random, expected }) => {
     vi.spyOn(Math, "random").mockReturnValue(random);
     for (const [now, expectedDue] of [
       ["2026-08-20T00:00:00Z", Date.parse(expected)],
       ["2026-08-20T00:11:00Z", Date.parse(expected) + 86_400_000],
     ] as const) {
       vi.setSystemTime(new Date(now));
-      const { scheduler } = setup({ schedule: { closedDayUtc: "00:05", jitterMinutes: 5 } });
-      scheduler.start();
-      expect(scheduler.status().nextDue.closedDay).toBe(expectedDue);
+      const { scheduler } = await setup({ schedule: { closedDayUtc: "00:05", jitterMinutes: 5 } });
+      await scheduler.start();
+      expect((await scheduler.status()).nextDue.closedDay).toBe(expectedDue);
     }
   });
 
@@ -196,43 +196,162 @@ describe("Team Reports schedule boundaries", () => {
     { now: "2026-08-20T23:59:59Z", hours: 4, expected: "2026-08-21T00:00:00Z" },
     { now: "2026-08-20T21:00:00Z", hours: 5, expected: "2026-08-21T00:00:00Z" },
     { now: "2026-08-20T02:15:00Z", hours: 0, expected: undefined },
-  ])("aligns intraday refreshes to UTC boundaries ($now, $hours)", ({ now, hours, expected }) => {
-    vi.setSystemTime(new Date(now));
-    const { scheduler } = setup({ schedule: { intradayEveryHours: hours } });
-    scheduler.start();
-    expect(scheduler.status().nextDue.intraday).toBe(expected ? Date.parse(expected) : undefined);
-  });
+  ])(
+    "aligns intraday refreshes to UTC boundaries ($now, $hours)",
+    async ({ now, hours, expected }) => {
+      vi.setSystemTime(new Date(now));
+      const { scheduler } = await setup({ schedule: { intradayEveryHours: hours } });
+      await scheduler.start();
+      expect((await scheduler.status()).nextDue.intraday).toBe(
+        expected ? Date.parse(expected) : undefined,
+      );
+    },
+  );
 
   it("does not schedule another closed-day run today when the next jitter sample is larger", async () => {
     vi.setSystemTime(new Date("2026-08-20T00:04:00Z"));
     vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValue(1);
-    const { scheduler, store } = setup({ schedule: { closedDayUtc: "00:05", jitterMinutes: 5 } });
-    scheduler.start();
+    const { scheduler, store } = await setup({
+      schedule: { closedDayUtc: "00:05", jitterMinutes: 5 },
+    });
+    await scheduler.start();
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(store.listRuns().filter((run) => run.id !== "previous-closed-day")).toHaveLength(1);
-    expect(scheduler.status().nextDue.closedDay).toBe(Date.parse("2026-08-21T00:10:00Z"));
+    expect((await store.listRuns()).filter((run) => run.id !== "previous-closed-day")).toHaveLength(
+      1,
+    );
+    expect((await scheduler.status()).nextDue.closedDay).toBe(Date.parse("2026-08-21T00:10:00Z"));
     await vi.advanceTimersByTimeAsync(5 * 60_000);
-    expect(store.listRuns().filter((run) => run.id !== "previous-closed-day")).toHaveLength(1);
+    expect((await store.listRuns()).filter((run) => run.id !== "previous-closed-day")).toHaveLength(
+      1,
+    );
   });
 });
 
 describe("Team Reports scheduler lifecycle", () => {
+  it("reserves the run while admission is pending and returns its ID only after persistence", async () => {
+    const { scheduler, store, github } = await setup();
+    await scheduler.start();
+    const admission = createDeferred<void>();
+    const startRun = store.startRun.bind(store);
+    vi.spyOn(store, "startRun").mockImplementationOnce(async (run) => {
+      await admission.promise;
+      await startRun(run);
+    });
+    const accepted = vi.fn();
+    const pending = scheduler.generate().then(accepted);
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(accepted).not.toHaveBeenCalled();
+      expect(github.loadRoster).not.toHaveBeenCalled();
+      await expect(scheduler.generate()).rejects.toThrow("already in progress");
+    } finally {
+      admission.resolve();
+      await pending;
+    }
+    const id = accepted.mock.calls[0]?.[0];
+    expect(await store.listRuns()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id })]),
+    );
+  });
+
+  it("rejects failed admission without collecting and releases the run for another request", async () => {
+    const { scheduler, store, github } = await setup();
+    await scheduler.start();
+    vi.spyOn(store, "startRun").mockRejectedValueOnce(new Error("database unavailable"));
+    await expect(scheduler.generate()).rejects.toThrow("database unavailable");
+    expect(github.loadRoster).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(0);
+    const id = await scheduler.generate();
+    await vi.advanceTimersByTimeAsync(0);
+    expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("ok");
+  });
+
+  it("drains an admitted report write after cancellation before closing storage or starting summaries", async () => {
+    const { scheduler, store, directory, complete } = await setup({ summaries: true });
+    await scheduler.start();
+    const write = createDeferred<void>();
+    const entered = createDeferred<void>();
+    const upsertPeriod = store.upsertPeriod.bind(store);
+    vi.spyOn(store, "upsertPeriod").mockImplementationOnce(async (period) => {
+      entered.resolve();
+      await write.promise;
+      await upsertPeriod(period);
+    });
+    const close = vi.spyOn(store, "close");
+    const id = await scheduler.generate();
+    await entered.promise;
+    const stopped = scheduler.stop();
+    try {
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(close).not.toHaveBeenCalled();
+      expect(complete).not.toHaveBeenCalled();
+    } finally {
+      write.resolve();
+      await stopped;
+    }
+    expect(close).toHaveBeenCalledOnce();
+    const reopened = await createTeamReportsStore({ stateDir: directory });
+    try {
+      expect((await reopened.getPeriod("day", "2026-08-19"))?.report.totals.github.total).toBe(1);
+      expect((await reopened.listRuns()).find((run) => run.id === id)).toMatchObject({
+        status: "error",
+        error: expect.stringContaining("30 seconds"),
+      });
+    } finally {
+      await reopened.close();
+    }
+  });
+
+  it("waits for pending startup reads and asynchronous storage disposal during stop", async () => {
+    const { scheduler, store } = await setup();
+    const read = createDeferred<void>();
+    const disposal = createDeferred<void>();
+    const listRuns = store.listRuns.bind(store);
+    vi.spyOn(store, "listRuns").mockImplementationOnce(async (...args) => {
+      await read.promise;
+      return await listRuns(...args);
+    });
+    const closeStore = store.close.bind(store);
+    const close = vi.spyOn(store, "close").mockImplementation(async () => {
+      await disposal.promise;
+      await closeStore();
+    });
+    const started = scheduler.start();
+    const completed = vi.fn();
+    const stopped = scheduler.stop().then(completed);
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(close).not.toHaveBeenCalled();
+      read.resolve();
+      await started;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(close).toHaveBeenCalledOnce();
+      expect(completed).not.toHaveBeenCalled();
+      await expect(scheduler.start()).rejects.toThrow("cannot be started again");
+    } finally {
+      read.resolve();
+      disposal.resolve();
+      await Promise.all([started, stopped]);
+    }
+    await expect(scheduler.generate()).rejects.toThrow("not running");
+  });
+
   it("reports the earliest due time and last completed run while another run is active", async () => {
-    const { scheduler, github } = setup({
+    const { scheduler, github } = await setup({
       caughtUp: false,
       schedule: { intradayEveryHours: 4 },
     });
-    expect(scheduler.health()).toEqual({ running: false, warnings: 0 });
-    scheduler.start();
-    expect(scheduler.health()).toEqual({
+    expect(await scheduler.health()).toEqual({ running: false, warnings: 0 });
+    await scheduler.start();
+    expect(await scheduler.health()).toEqual({
       running: true,
       nextDueMs: Date.parse("2026-08-20T12:01:00Z"),
       warnings: 0,
     });
-    scheduler.generate();
-    expect(scheduler.health().lastRun).toBeUndefined();
+    await scheduler.generate();
+    expect((await scheduler.health()).lastRun).toBeUndefined();
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(scheduler.health()).toEqual({
+    expect(await scheduler.health()).toEqual({
       running: true,
       lastRun: { status: "ok", kind: "manual", finishedAtMs: Date.parse("2026-08-20T12:00:00Z") },
       nextDueMs: Date.parse("2026-08-20T16:00:00Z"),
@@ -240,31 +359,33 @@ describe("Team Reports scheduler lifecycle", () => {
     });
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
     github.collect.mockImplementationOnce(() => blocked.promise);
-    scheduler.generate({ intraday: true });
+    await scheduler.generate({ intraday: true });
     await vi.advanceTimersByTimeAsync(0);
-    expect(scheduler.health().lastRun).toEqual({
+    expect((await scheduler.health()).lastRun).toEqual({
       status: "ok",
       kind: "manual",
       finishedAtMs: Date.parse("2026-08-20T12:00:00Z"),
     });
     blocked.resolve({ items: [], status: healthy });
     await vi.advanceTimersByTimeAsync(0);
-    expect(scheduler.health().lastRun?.finishedAtMs).toBe(Date.parse("2026-08-20T12:01:00Z"));
+    expect((await scheduler.health()).lastRun?.finishedAtMs).toBe(
+      Date.parse("2026-08-20T12:01:00Z"),
+    );
   });
 
   it("catches up yesterday once after the startup delay and also publishes today's partial", async () => {
-    const { scheduler, store, github } = setup({ caughtUp: false });
-    scheduler.start();
-    expect(scheduler.status().nextDue.catchUp).toBe(Date.now() + 60_000);
+    const { scheduler, store, github } = await setup({ caughtUp: false });
+    await scheduler.start();
+    expect((await scheduler.status()).nextDue.catchUp).toBe(Date.now() + 60_000);
     await vi.advanceTimersByTimeAsync(59_999);
     expect(github.collect).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
-    expect(store.listRuns()).toMatchObject([{ kind: "closed-day", status: "ok" }]);
-    expect(store.listPeriods()).toMatchObject([
+    expect(await store.listRuns()).toMatchObject([{ kind: "closed-day", status: "ok" }]);
+    expect(await store.listPeriods()).toMatchObject([
       { period: "day", key: "2026-08-20", status: "partial" },
       { period: "day", key: "2026-08-19", status: "closed" },
     ]);
-    expect(scheduler.status().nextDue.catchUp).toBeUndefined();
+    expect((await scheduler.status()).nextDue.catchUp).toBeUndefined();
     await vi.advanceTimersByTimeAsync(60_000);
     expect(github.collect).toHaveBeenCalledTimes(2);
   });
@@ -272,22 +393,22 @@ describe("Team Reports scheduler lifecycle", () => {
   it.each(["closed-day", "manual"] as const)(
     "skips startup catch-up when yesterday has a successful %s run started at close before newer unrelated runs",
     async (kind) => {
-      const { scheduler, store, github } = setup({ caughtUp: kind });
+      const { scheduler, store, github } = await setup({ caughtUp: kind });
       for (let index = 0; index < 21; index++) {
         const id = `newer-${index}`;
-        store.startRun({
+        await store.startRun({
           id,
           kind: "manual",
           startedAtMs: Date.now() - index,
           periods: [{ period: "day", key: "2026-08-18" }],
         });
-        store.finishRun(id, { status: "ok", finishedAtMs: Date.now() });
+        await store.finishRun(id, { status: "ok", finishedAtMs: Date.now() });
       }
-      scheduler.start();
-      expect(scheduler.status().nextDue.catchUp).toBeUndefined();
+      await scheduler.start();
+      expect((await scheduler.status()).nextDue.catchUp).toBeUndefined();
       await vi.advanceTimersByTimeAsync(60_000);
       expect(github.collect).not.toHaveBeenCalled();
-      expect(store.listRuns(-1)).toHaveLength(22);
+      expect(await store.listRuns(-1)).toHaveLength(22);
     },
   );
 
@@ -295,85 +416,85 @@ describe("Team Reports scheduler lifecycle", () => {
     "catches up after rollover despite a successful %s run covering today's partial window",
     async (kind) => {
       vi.setSystemTime(new Date("2026-08-20T11:59:00Z"));
-      const first = setup({
+      const first = await setup({
         schedule: {
           intradayEveryHours: kind === "intraday" ? 4 : 0,
           closedDayUtc: kind === "closed-day" ? "12:00" : "23:59",
         },
       });
-      first.scheduler.start();
+      await first.scheduler.start();
       if (kind === "manual") {
-        first.scheduler.generate({ intraday: true });
+        await first.scheduler.generate({ intraday: true });
       }
       await vi.advanceTimersByTimeAsync(60_000);
-      expect(first.store.listRuns()[0]).toMatchObject({
+      expect((await first.store.listRuns())[0]).toMatchObject({
         kind,
         status: "ok",
         periods: expect.arrayContaining([{ period: "day", key: "2026-08-20" }]),
       });
-      expect(first.store.getPeriod("day", "2026-08-20")?.report.status).toBe("partial");
+      expect((await first.store.getPeriod("day", "2026-08-20"))?.report.status).toBe("partial");
       await first.scheduler.stop();
 
       vi.setSystemTime(new Date("2026-08-21T12:00:00Z"));
-      const restarted = setup({ stateDir: first.directory, caughtUp: false });
-      restarted.scheduler.start();
-      expect(restarted.scheduler.status().nextDue.catchUp).toBe(Date.now() + 60_000);
+      const restarted = await setup({ stateDir: first.directory, caughtUp: false });
+      await restarted.scheduler.start();
+      expect((await restarted.scheduler.status()).nextDue.catchUp).toBe(Date.now() + 60_000);
       await vi.advanceTimersByTimeAsync(60_000);
       expect(restarted.github.collect).toHaveBeenCalledTimes(2);
       expect(restarted.github.collect.mock.calls[0]?.[1]).toEqual({
         sinceMs: Date.parse("2026-08-20T00:00:00Z"),
         untilMs: Date.parse("2026-08-21T00:00:00Z"),
       });
-      expect(restarted.store.getPeriod("day", "2026-08-20")?.report.status).toBe("closed");
+      expect((await restarted.store.getPeriod("day", "2026-08-20"))?.report.status).toBe("closed");
     },
   );
 
   it("skips deferred catch-up after a manual run completes yesterday", async () => {
-    const { scheduler, store, github } = setup({ caughtUp: false });
+    const { scheduler, store, github } = await setup({ caughtUp: false });
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
     github.collect.mockImplementationOnce(() => blocked.promise);
-    scheduler.start();
-    const id = scheduler.generate({ date: "2026-08-19" });
+    await scheduler.start();
+    const id = await scheduler.generate({ date: "2026-08-19" });
     await vi.advanceTimersByTimeAsync(19 * 60_000);
     expect(github.collect).toHaveBeenCalledOnce();
-    expect(store.listRuns()).toMatchObject([{ id, kind: "manual", status: "running" }]);
+    expect(await store.listRuns()).toMatchObject([{ id, kind: "manual", status: "running" }]);
     blocked.resolve({ items: [], status: healthy });
     await vi.advanceTimersByTimeAsync(0);
-    expect(store.listRuns()).toMatchObject([{ id, kind: "manual", status: "ok" }]);
+    expect(await store.listRuns()).toMatchObject([{ id, kind: "manual", status: "ok" }]);
     await vi.advanceTimersByTimeAsync(60_000);
     expect(github.collect).toHaveBeenCalledOnce();
-    expect(store.listRuns()).toHaveLength(1);
+    expect(await store.listRuns()).toHaveLength(1);
   });
 
   it("rejects a concurrent manual run and defers an intraday tick without overlapping collectors", async () => {
     vi.setSystemTime(new Date("2026-08-20T03:59:00Z"));
-    const { scheduler, store, github } = setup({ schedule: { intradayEveryHours: 4 } });
+    const { scheduler, store, github } = await setup({ schedule: { intradayEveryHours: 4 } });
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
     github.collect.mockImplementationOnce(() => blocked.promise);
-    scheduler.start();
-    const id = scheduler.generate({ intraday: true });
+    await scheduler.start();
+    const id = await scheduler.generate({ intraday: true });
     await vi.advanceTimersByTimeAsync(0);
-    expect(() => scheduler.generate()).toThrow("already in progress");
+    await expect(scheduler.generate()).rejects.toThrow("already in progress");
     await vi.advanceTimersByTimeAsync(60_000);
     expect(github.collect).toHaveBeenCalledOnce();
-    expect(store.listRuns().find((run) => run.id === id)?.status).toBe("running");
+    expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("running");
     blocked.resolve({ items: [], status: healthy });
     await vi.advanceTimersByTimeAsync(0);
-    expect(store.listRuns().find((run) => run.id === id)?.status).toBe("ok");
+    expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("ok");
     await vi.advanceTimersByTimeAsync(60_000);
     expect(github.collect).toHaveBeenCalledTimes(2);
-    expect(store.listRuns().some((run) => run.kind === "intraday" && run.status === "ok")).toBe(
-      true,
-    );
-    expect(scheduler.status().nextDue.intraday).toBe(Date.parse("2026-08-20T08:00:00Z"));
+    expect(
+      (await store.listRuns()).some((run) => run.kind === "intraday" && run.status === "ok"),
+    ).toBe(true);
+    expect((await scheduler.status()).nextDue.intraday).toBe(Date.parse("2026-08-20T08:00:00Z"));
   });
 
   it("waits for an in-flight run during stop and preserves its successful report", async () => {
-    const { scheduler, github, directory } = setup();
+    const { scheduler, github, directory } = await setup();
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
     github.collect.mockImplementationOnce(() => blocked.promise);
-    scheduler.start();
-    const id = scheduler.generate();
+    await scheduler.start();
+    const id = await scheduler.generate();
     await vi.advanceTimersByTimeAsync(0);
     let finished = false;
     const stopped = scheduler.stop().then(() => {
@@ -381,25 +502,25 @@ describe("Team Reports scheduler lifecycle", () => {
     });
     await vi.advanceTimersByTimeAsync(10_000);
     expect(finished).toBe(false);
-    expect(() => scheduler.generate()).toThrow("not running");
+    await expect(scheduler.generate()).rejects.toThrow("not running");
     blocked.resolve({ items: [], status: healthy });
     await stopped;
     expect(finished).toBe(true);
-    const reopened = createTeamReportsStore({ stateDir: directory });
+    const reopened = await createTeamReportsStore({ stateDir: directory });
     try {
-      expect(reopened.listRuns().find((run) => run.id === id)?.status).toBe("ok");
-      expect(reopened.getPeriod("day", "2026-08-19")?.report.status).toBe("closed");
+      expect((await reopened.listRuns()).find((run) => run.id === id)?.status).toBe("ok");
+      expect((await reopened.getPeriod("day", "2026-08-19"))?.report.status).toBe("closed");
     } finally {
-      reopened.close();
+      await reopened.close();
     }
   });
 
   it("aborts after the 30-second stop bound and fences a late collector from the closed store", async () => {
-    const { scheduler, github, directory, runtimes } = setup();
+    const { scheduler, github, directory, runtimes } = await setup();
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
     github.collect.mockImplementationOnce(() => blocked.promise);
-    scheduler.start();
-    const id = scheduler.generate();
+    await scheduler.start();
+    const id = await scheduler.generate();
     await vi.advanceTimersByTimeAsync(0);
     const stopped = scheduler.stop();
     await vi.advanceTimersByTimeAsync(29_999);
@@ -409,109 +530,109 @@ describe("Team Reports scheduler lifecycle", () => {
     expect(runtimes[0]?.signal?.aborted).toBe(true);
     blocked.resolve({ items: [], status: healthy });
     await vi.advanceTimersByTimeAsync(0);
-    const reopened = createTeamReportsStore({ stateDir: directory });
+    const reopened = await createTeamReportsStore({ stateDir: directory });
     try {
-      expect(reopened.listRuns().find((run) => run.id === id)).toMatchObject({
+      expect((await reopened.listRuns()).find((run) => run.id === id)).toMatchObject({
         status: "error",
         error: expect.stringContaining("30 seconds"),
       });
-      expect(reopened.listPeriods()).toEqual([]);
+      expect(await reopened.listPeriods()).toEqual([]);
     } finally {
-      reopened.close();
+      await reopened.close();
     }
   });
 
   it("passes the 45-minute deadline abort to sources and records a failed run without late writes", async () => {
-    const { scheduler, github, runtimes, store, context } = setup();
+    const { scheduler, github, runtimes, store, context } = await setup();
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
     github.collect.mockImplementationOnce(() => blocked.promise);
-    scheduler.start();
-    const id = scheduler.generate();
+    await scheduler.start();
+    const id = await scheduler.generate();
     await vi.advanceTimersByTimeAsync(45 * 60_000 - 1);
     expect(runtimes[0]?.signal?.aborted).toBe(false);
     await vi.advanceTimersByTimeAsync(1);
     expect(runtimes[0]?.signal?.aborted).toBe(true);
-    expect(store.listRuns().find((run) => run.id === id)).toMatchObject({
+    expect((await store.listRuns()).find((run) => run.id === id)).toMatchObject({
       status: "error",
       error: expect.stringContaining("45-minute"),
     });
     expect(context.serviceHealth.reportFailure).toHaveBeenCalledOnce();
     blocked.resolve({ items: [], status: healthy });
     await vi.advanceTimersByTimeAsync(0);
-    expect(store.listPeriods()).toEqual([]);
+    expect(await store.listPeriods()).toEqual([]);
   });
 
   it("makes collected evidence readable while model summaries are still pending", async () => {
-    const { scheduler, store, complete } = setup({ summaries: true });
+    const { scheduler, store, complete } = await setup({ summaries: true });
     const blocked = createDeferred<Awaited<ReturnType<Complete>>>();
     complete.mockImplementation(() => blocked.promise);
-    scheduler.start();
-    const id = scheduler.generate();
+    await scheduler.start();
+    const id = await scheduler.generate();
     await vi.advanceTimersByTimeAsync(0);
-    const before = store.getPeriod("day", "2026-08-19");
+    const before = await store.getPeriod("day", "2026-08-19");
     expect(before?.report.totals.github.total).toBe(1);
     expect(before?.summary?.source).toBe("fallback");
-    expect(store.listRuns().find((run) => run.id === id)?.status).toBe("running");
+    expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("running");
     blocked.resolve(modelResponse());
     await vi.advanceTimersByTimeAsync(0);
-    expect(store.getPeriod("day", "2026-08-19")?.summary?.source).toBe("model");
-    expect(store.listRuns().find((run) => run.id === id)?.status).toBe("ok");
+    expect((await store.getPeriod("day", "2026-08-19"))?.summary?.source).toBe("model");
+    expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("ok");
   });
 
   it("surfaces the latest day's model fallback in status, storage, Markdown, and logs", async () => {
-    const { scheduler, store, context, complete, github } = setup({ summaries: true });
+    const { scheduler, store, context, complete, github } = await setup({ summaries: true });
     github.loadRoster.mockResolvedValue({
       people: [{ github: ["alex"] }],
       status: { ...healthy, warnings: ["Roster coverage warning"] },
     });
     complete.mockRejectedValue(new Error("private-provider-error-marker"));
-    scheduler.start();
-    scheduler.generate();
+    await scheduler.start();
+    await scheduler.generate();
     await vi.advanceTimersByTimeAsync(0);
     const reason = "Model summary unavailable: completion failed";
-    const stored = store.getPeriod("day", "2026-08-19");
+    const stored = await store.getPeriod("day", "2026-08-19");
     expect(stored?.summary?.warnings).toEqual([reason]);
     expect(stored?.markdown).toContain(`> ${reason}`);
-    expect(scheduler.status().sourceWarnings).toEqual(["Roster coverage warning", reason]);
-    expect(scheduler.health().warnings).toBe(2);
+    expect((await scheduler.status()).sourceWarnings).toEqual(["Roster coverage warning", reason]);
+    expect((await scheduler.health()).warnings).toBe(2);
     expect(context.logger.warn.mock.calls).toEqual([[reason]]);
     complete.mockResolvedValue(modelResponse());
-    scheduler.generate({ intraday: true });
+    await scheduler.generate({ intraday: true });
     await vi.advanceTimersByTimeAsync(0);
-    expect(scheduler.status().sourceWarnings).toEqual(["Roster coverage warning"]);
-    expect(scheduler.health().warnings).toBe(1);
+    expect((await scheduler.status()).sourceWarnings).toEqual(["Roster coverage warning"]);
+    expect((await scheduler.health()).warnings).toBe(1);
   });
 
   it("reports source failures with redacted errors and clears health on the next successful run", async () => {
-    const { scheduler, store, github, context } = setup();
+    const { scheduler, store, github, context } = await setup();
     github.collect.mockRejectedValueOnce(new Error("Access failed for fixture-github-token"));
-    scheduler.start();
-    const failed = scheduler.generate();
+    await scheduler.start();
+    const failed = await scheduler.generate();
     await vi.advanceTimersByTimeAsync(0);
-    expect(store.listRuns().find((run) => run.id === failed)).toMatchObject({
+    expect((await store.listRuns()).find((run) => run.id === failed)).toMatchObject({
       status: "error",
       error: "Access failed for [redacted]",
     });
     expect(context.serviceHealth.reportFailure).toHaveBeenCalledOnce();
-    expect(scheduler.health().lastRun).toEqual({
+    expect((await scheduler.health()).lastRun).toEqual({
       status: "error",
       kind: "manual",
       finishedAtMs: Date.now(),
     });
     expect(JSON.stringify(context.logger.error.mock.calls)).not.toContain("fixture-github-token");
-    const succeeded = scheduler.generate();
+    const succeeded = await scheduler.generate();
     await vi.advanceTimersByTimeAsync(0);
-    expect(store.listRuns().find((run) => run.id === succeeded)?.status).toBe("ok");
+    expect((await store.listRuns()).find((run) => run.id === succeeded)?.status).toBe("ok");
     expect(context.serviceHealth.clearFailure).toHaveBeenCalledOnce();
   });
 
   it.each([false, true])("collects Discord only when configured (enabled: %s)", async (enabled) => {
-    const { scheduler, discord, store, complete } = setup({ discord: enabled });
-    scheduler.start();
-    scheduler.generate();
+    const { scheduler, discord, store, complete } = await setup({ discord: enabled });
+    await scheduler.start();
+    await scheduler.generate();
     await vi.advanceTimersByTimeAsync(0);
     expect(discord.collect).toHaveBeenCalledTimes(enabled ? 1 : 0);
-    const generated = store.getPeriod("day", "2026-08-19");
+    const generated = await store.getPeriod("day", "2026-08-19");
     expect(generated?.report.totals.discord.messages).toBe(enabled ? 1 : 0);
     expect(generated?.report.sources.discord?.ok).toBe(enabled ? true : undefined);
     expect(complete).not.toHaveBeenCalled();
@@ -519,14 +640,14 @@ describe("Team Reports scheduler lifecycle", () => {
 
   it("closes the prior week and month while opening the current periods at calendar rollover", async () => {
     vi.setSystemTime(new Date("2026-06-01T00:04:00Z"));
-    const { scheduler, store, github } = setup({
+    const { scheduler, store, github } = await setup({
       caughtUp: "manual",
       schedule: { closedDayUtc: "00:05", weekly: true, monthly: true },
     });
-    scheduler.start();
+    await scheduler.start();
     await vi.advanceTimersByTimeAsync(60_000);
     expect(github.collect).toHaveBeenCalledTimes(2);
-    expect(store.listPeriods()).toEqual(
+    expect(await store.listPeriods()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ period: "day", key: "2026-05-31", status: "closed" }),
         expect.objectContaining({ period: "day", key: "2026-06-01", status: "partial" }),
@@ -536,7 +657,7 @@ describe("Team Reports scheduler lifecycle", () => {
         expect.objectContaining({ period: "month", key: "2026-06", status: "partial" }),
       ]),
     );
-    expect(store.getPeriod("week", "2026-W22")?.report.totals.github.total).toBe(1);
-    expect(store.getPeriod("month", "2026-06")?.report.totals.github.total).toBe(1);
+    expect((await store.getPeriod("week", "2026-W22"))?.report.totals.github.total).toBe(1);
+    expect((await store.getPeriod("month", "2026-06"))?.report.totals.github.total).toBe(1);
   });
 });

--- a/extensions/team-reports/src/scheduler.ts
+++ b/extensions/team-reports/src/scheduler.ts
@@ -44,29 +44,13 @@ function nextIntradayDue(nowMs: number, everyHours: number): number | undefined 
   return today + Math.min(DAY_MS, (Math.floor((nowMs - today) / interval) + 1) * interval);
 }
 
-function untilAborted<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const abort = () => {
-      const reason: unknown = signal.reason;
-      reject(
-        reason instanceof Error
-          ? reason
-          : new Error(typeof reason === "string" ? reason : "Team Reports run aborted"),
-      );
-    };
-    signal.addEventListener("abort", abort, { once: true });
-    if (signal.aborted) {
-      abort();
-    }
-    void work.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
-  });
-}
-
 export class TeamReportsScheduler {
   private accepting = false;
   private closed = false;
   private active?: ActiveRun;
   private stopPromise?: Promise<void>;
+  private startPromise?: Promise<void>;
+  private scheduledWork = new Set<Promise<void>>();
   private timers = new Set<ReturnType<typeof setTimeout>>();
   private due: { closedDay?: number; intraday?: number; catchUp?: number } = {};
   private deferred = new Set<"closed-day" | "intraday">();
@@ -85,20 +69,30 @@ export class TeamReportsScheduler {
     this.roster = options.resolved.people;
   }
 
-  start(): void {
-    if (this.closed || this.accepting) {
+  async start(): Promise<void> {
+    if (this.closed || this.accepting || this.stopPromise) {
       throw new Error("Team Reports scheduler cannot be started again");
     }
     this.accepting = true;
+    return (this.startPromise = this.startOnce().catch((error: unknown) => {
+      this.accepting = false;
+      throw error;
+    }));
+  }
+
+  private async startOnce(): Promise<void> {
+    const yesterday = describePeriod("day", Date.now() - DAY_MS);
+    const completed = await this.closedDayCompleted(yesterday.key);
+    if (!this.accepting) {
+      return;
+    }
     this.armClosedDay();
     this.armIntraday();
-    const yesterday = describePeriod("day", Date.now() - DAY_MS);
-    const completed = this.closedDayCompleted(yesterday.key);
     if (!completed) {
       this.due.catchUp = Date.now() + 60_000;
       this.schedule(this.due.catchUp, () => {
         delete this.due.catchUp;
-        this.tick("closed-day", true);
+        return this.tick("closed-day", true);
       });
     }
   }
@@ -111,21 +105,21 @@ export class TeamReportsScheduler {
     return this.roster;
   }
 
-  status() {
+  async status() {
     return {
       running: this.accepting,
       activeRunId: this.active?.id,
       nextDue: { ...this.due },
-      runs: this.options.store.listRuns(),
-      periods: this.options.store.listPeriods(),
-      sourceWarnings: this.sourceWarnings(),
+      runs: await this.options.store.listRuns(),
+      periods: await this.options.store.listPeriods(),
+      sourceWarnings: await this.sourceWarnings(),
     };
   }
 
-  health(): TeamReportsHealth {
+  async health(): Promise<TeamReportsHealth> {
     const finished = [
-      ...this.options.store.listRuns(1, { status: "ok" }),
-      ...this.options.store.listRuns(1, { status: "error" }),
+      ...(await this.options.store.listRuns(1, { status: "ok" })),
+      ...(await this.options.store.listRuns(1, { status: "error" })),
     ].toSorted(
       (a, b) => (b.finishedAtMs ?? 0) - (a.finishedAtMs ?? 0) || b.startedAtMs - a.startedAtMs,
     )[0];
@@ -142,13 +136,13 @@ export class TeamReportsScheduler {
           }
         : {}),
       ...(due.length ? { nextDueMs: Math.min(...due) } : {}),
-      warnings: this.sourceWarnings().length,
+      warnings: (await this.sourceWarnings()).length,
     };
   }
 
-  private sourceWarnings(): string[] {
-    const latest = this.options.store.listPeriods({ period: "day", limit: 1 })[0];
-    const stored = latest ? this.options.store.getPeriod("day", latest.key) : undefined;
+  private async sourceWarnings(): Promise<string[]> {
+    const latest = (await this.options.store.listPeriods({ period: "day", limit: 1 }))[0];
+    const stored = latest ? await this.options.store.getPeriod("day", latest.key) : undefined;
     return stored
       ? stored.report.sources.github.warnings.concat(
           stored.report.sources.discord?.warnings ?? [],
@@ -157,7 +151,7 @@ export class TeamReportsScheduler {
       : [];
   }
 
-  generate(params: { date?: string; intraday?: boolean } = {}): string {
+  async generate(params: { date?: string; intraday?: boolean } = {}): Promise<string> {
     const now = Date.now();
     const day = describePeriod("day", params.date ?? now - (params.intraday ? 0 : DAY_MS));
     const today = describePeriod("day", now);
@@ -183,30 +177,35 @@ export class TeamReportsScheduler {
     this.timers.clear();
     this.deferred.clear();
     const active = this.active;
-    try {
-      if (active) {
-        const timeout = setTimeout(
+    const timeout = active
+      ? setTimeout(
           () => active.controller.abort(new Error("Team Reports stopped after 30 seconds")),
           STOP_TIMEOUT_MS,
-        );
-        try {
-          await active.done;
-        } finally {
-          clearTimeout(timeout);
-        }
-      }
+        )
+      : undefined;
+    try {
+      await this.startPromise?.catch(() => undefined);
+      await Promise.all(this.scheduledWork);
+      await active?.done;
     } finally {
+      clearTimeout(timeout);
       this.closed = true;
-      this.options.store.close();
+      await this.options.store.close();
     }
   }
 
-  private schedule(atMs: number, callback: () => void): void {
+  private schedule(atMs: number, callback: () => void | Promise<void>): void {
     const timer = setTimeout(
       () => {
         this.timers.delete(timer);
         if (this.accepting) {
-          callback();
+          const work = Promise.resolve()
+            .then(callback)
+            .catch((error: unknown) => {
+              this.options.context.logger.error(`team-reports: ${this.safeError(error)}`);
+            });
+          this.scheduledWork.add(work);
+          void work.finally(() => this.scheduledWork.delete(work));
         }
       },
       Math.max(0, atMs - Date.now()),
@@ -218,8 +217,11 @@ export class TeamReportsScheduler {
   private armClosedDay(afterMs = Date.now()): void {
     const due = nextClosedDayDue(afterMs, this.options.config.schedule);
     this.due.closedDay = due;
-    this.schedule(due, () => {
-      this.tick("closed-day");
+    this.schedule(due, async () => {
+      await this.tick("closed-day");
+      if (!this.accepting) {
+        return;
+      }
       this.armClosedDay(describePeriod("day", due).untilMs - 1);
     });
   }
@@ -230,15 +232,23 @@ export class TeamReportsScheduler {
       this.options.config.schedule.intradayEveryHours,
     );
     if (this.due.intraday !== undefined) {
-      this.schedule(this.due.intraday, () => {
-        this.tick("intraday");
-        this.armIntraday();
+      this.schedule(this.due.intraday, async () => {
+        await this.tick("intraday");
+        if (this.accepting) {
+          this.armIntraday();
+        }
       });
     }
   }
 
-  private tick(kind: "closed-day" | "intraday", catchUp = false): void {
-    if (catchUp && this.closedDayCompleted(describePeriod("day", Date.now() - DAY_MS).key)) {
+  private async tick(kind: "closed-day" | "intraday", catchUp = false): Promise<void> {
+    if (
+      catchUp &&
+      (await this.closedDayCompleted(describePeriod("day", Date.now() - DAY_MS).key))
+    ) {
+      return;
+    }
+    if (!this.accepting) {
       return;
     }
     if (this.active) {
@@ -246,7 +256,7 @@ export class TeamReportsScheduler {
         this.deferred.add(kind);
         this.schedule(Date.now() + 60_000, () => {
           this.deferred.delete(kind);
-          this.tick(kind, catchUp);
+          return this.tick(kind, catchUp);
         });
       }
       return;
@@ -256,22 +266,20 @@ export class TeamReportsScheduler {
       kind === "closed-day"
         ? [describePeriod("day", now - DAY_MS), describePeriod("day", now)]
         : [describePeriod("day", now)];
-    this.begin(kind, days);
+    await this.begin(kind, days);
   }
 
-  private closedDayCompleted(key: string): boolean {
+  private async closedDayCompleted(key: string): Promise<boolean> {
     const untilMs = describePeriod("day", key).untilMs;
     // Include older completions even when newer successful runs cover other days.
-    return this.options.store
-      .listRuns(-1, { status: "ok" })
-      .some(
-        (run) =>
-          run.startedAtMs >= untilMs &&
-          run.periods.some((period) => period.period === "day" && period.key === key),
-      );
+    return (await this.options.store.listRuns(-1, { status: "ok" })).some(
+      (run) =>
+        run.startedAtMs >= untilMs &&
+        run.periods.some((period) => period.period === "day" && period.key === key),
+    );
   }
 
-  private begin(kind: RunKind, days: PeriodDescriptor[]): string {
+  private async begin(kind: RunKind, days: PeriodDescriptor[]): Promise<string> {
     if (!this.accepting) {
       throw new Error("Team Reports service is not running");
     }
@@ -281,7 +289,7 @@ export class TeamReportsScheduler {
     const id = randomUUID();
     const periods = runPeriods(this.options.config, days);
     const controller = new AbortController();
-    this.options.store.startRun({
+    const started = this.options.store.startRun({
       id,
       kind,
       startedAtMs: Date.now(),
@@ -293,24 +301,26 @@ export class TeamReportsScheduler {
     );
     const done = Promise.resolve().then(async () => {
       let stats: Record<string, SourceStatus> | undefined;
+      let recorded = false;
       try {
-        stats = await untilAborted(
-          generateReportPeriods({
-            ...this.options,
-            periods,
-            sources:
-              this.options.sources ??
-              ((runtime) => createReportSources(runtime, Boolean(this.options.resolved.discord))),
-            runtime: { logger: this.options.context.logger, signal: controller.signal },
-            onRoster: (people) => {
-              this.roster = people;
-            },
-          }),
-          controller.signal,
-        );
+        await started;
+        recorded = true;
+        controller.signal.throwIfAborted();
+        stats = await generateReportPeriods({
+          ...this.options,
+          periods,
+          sources:
+            this.options.sources ??
+            ((runtime) => createReportSources(runtime, Boolean(this.options.resolved.discord))),
+          runtime: { logger: this.options.context.logger, signal: controller.signal },
+          onRoster: (people) => {
+            this.roster = people;
+          },
+        });
         controller.signal.throwIfAborted();
         if (kind === "closed-day") {
-          this.options.store.prune(this.options.config.retention.days);
+          await this.options.store.prune(this.options.config.retention.days);
+          controller.signal.throwIfAborted();
         }
         const failed = Object.values(stats).some((source) => !source.ok);
         if (failed) {
@@ -318,17 +328,19 @@ export class TeamReportsScheduler {
             "An activity source failed; inspect report source warnings and check access",
           );
         }
-        this.options.store.finishRun(id, { status: "ok", finishedAtMs: Date.now(), stats });
+        await this.options.store.finishRun(id, { status: "ok", finishedAtMs: Date.now(), stats });
         this.options.context.serviceHealth?.clearFailure();
       } catch (error) {
         const message = this.safeError(error);
         try {
-          this.options.store.finishRun(id, {
-            status: "error",
-            finishedAtMs: Date.now(),
-            error: message,
-            stats,
-          });
+          if (recorded) {
+            await this.options.store.finishRun(id, {
+              status: "error",
+              finishedAtMs: Date.now(),
+              error: message,
+              stats,
+            });
+          }
         } catch {
           this.options.context.logger.error(
             "team-reports: failed to record run outcome; check database access and disk space",
@@ -344,6 +356,7 @@ export class TeamReportsScheduler {
       }
     });
     this.active = { id, controller, done };
+    await started;
     return id;
   }
 

--- a/extensions/team-reports/src/store.test.ts
+++ b/extensions/team-reports/src/store.test.ts
@@ -10,9 +10,9 @@ import type { PeriodDescriptor, ReportDocument, SummaryDocument } from "./types.
 const DAY_MS = 86_400_000;
 const resources: Array<{ store: TeamReportsStore; directory: string }> = [];
 
-function openStore() {
+async function openStore() {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "team-reports-store-"));
-  const store = createTeamReportsStore({ stateDir: directory });
+  const store = await createTeamReportsStore({ stateDir: directory });
   resources.push({ directory, store });
   return { store, dbPath: path.join(directory, "plugins", "team-reports", "team-reports.sqlite") };
 }
@@ -55,17 +55,17 @@ const summary: SummaryDocument = {
   warnings: ["Model summary unavailable: completion failed"],
 };
 
-afterEach(() => {
+afterEach(async () => {
   for (const { store, directory } of resources.splice(0)) {
-    store.close();
+    await store.close();
     fs.rmSync(directory, { force: true, recursive: true });
   }
 });
 
 describe("Team Reports storage", () => {
-  it("creates private STRICT tables and reopens durable reports with summary warnings in WAL mode", () => {
-    const { store, dbPath } = openStore();
-    store.upsertPeriod({ report: report(), summary, markdown: "# Daily report" });
+  it("creates private STRICT tables and reopens durable reports with summary warnings in WAL mode", async () => {
+    const { store, dbPath } = await openStore();
+    await store.upsertPeriod({ report: report(), summary, markdown: "# Daily report" });
     const database = openNodeSqliteDatabase(dbPath);
     try {
       const tables = database
@@ -84,60 +84,62 @@ describe("Team Reports storage", () => {
     } finally {
       database.close();
     }
-    store.close();
-    const reopened = createTeamReportsStore({ dbPath });
+    await store.close();
+    const reopened = await createTeamReportsStore({ dbPath });
     try {
-      expect(reopened.getPeriod("day", "2026-08-20")).toEqual({
+      expect(await reopened.getPeriod("day", "2026-08-20")).toEqual({
         report: report(),
         summary,
         markdown: "# Daily report",
       });
     } finally {
-      reopened.close();
+      await reopened.close();
     }
-    expect(() => store.listPeriods()).toThrow("store is closed");
+    await expect(store.listPeriods()).rejects.toThrow("store is closed");
   });
 
-  it("replaces the document, summary, markdown, and person-day counts as one unit", () => {
-    const { store } = openStore();
-    store.upsertPeriod({ report: report(), summary, markdown: "original" });
-    expect(store.listPersonDays("ALICE")).toMatchObject([
+  it("replaces the document, summary, markdown, and person-day counts as one unit", async () => {
+    const { store } = await openStore();
+    await store.upsertPeriod({ report: report(), summary, markdown: "original" });
+    expect(await store.listPersonDays("ALICE")).toMatchObject([
       { dayKey: "2026-08-20", githubTotal: 1, commits: 1, discordMessages: 2 },
     ]);
-    expect(() =>
+    await expect(
       store.upsertPeriod({
         report: report("2026-08-20", ["alice", "alice"]),
         markdown: "failed refresh",
       }),
-    ).toThrow();
-    expect(store.getPeriod("day", "2026-08-20")?.markdown).toBe("original");
-    expect(store.listPersonDays("bob")).toHaveLength(1);
+    ).rejects.toThrow();
+    expect((await store.getPeriod("day", "2026-08-20"))?.markdown).toBe("original");
+    expect(await store.listPersonDays("bob")).toHaveLength(1);
     const refreshed = report("2026-08-20", ["alice"]);
     refreshed.members[0]!.github.commits = 3;
     refreshed.members[0]!.github.total = 3;
     refreshed.generatedAtMs += 1000;
-    store.upsertPeriod({ report: refreshed, markdown: "refreshed" });
-    expect(store.getPeriod("day", "2026-08-20")).toEqual({
+    await store.upsertPeriod({ report: refreshed, markdown: "refreshed" });
+    expect(await store.getPeriod("day", "2026-08-20")).toEqual({
       report: refreshed,
       summary: null,
       markdown: "refreshed",
     });
-    expect(store.listPersonDays("alice")[0]).toMatchObject({ githubTotal: 3, commits: 3 });
-    expect(store.listPersonDays("bob")).toEqual([]);
+    expect((await store.listPersonDays("alice"))[0]).toMatchObject({ githubTotal: 3, commits: 3 });
+    expect(await store.listPersonDays("bob")).toEqual([]);
   });
 
-  it("rejects a report exceeding the UTF-8 byte limit without replacing existing data", () => {
-    const { store } = openStore();
-    store.upsertPeriod({ report: report(), markdown: "kept" });
+  it("rejects a report exceeding the UTF-8 byte limit without replacing existing data", async () => {
+    const { store } = await openStore();
+    await store.upsertPeriod({ report: report(), markdown: "kept" });
     const oversized = report();
     oversized.period.title = "é".repeat(1024 * 1024);
-    expect(() => store.upsertPeriod({ report: oversized, markdown: "too large" })).toThrow("2 MiB");
-    expect(store.getPeriod("day", "2026-08-20")?.markdown).toBe("kept");
-    expect(store.listPersonDays("alice")).toHaveLength(1);
+    await expect(store.upsertPeriod({ report: oversized, markdown: "too large" })).rejects.toThrow(
+      "2 MiB",
+    );
+    expect((await store.getPeriod("day", "2026-08-20"))?.markdown).toBe("kept");
+    expect(await store.listPersonDays("alice")).toHaveLength(1);
   });
 
-  it("lists stored totals for each period kind and reflects regenerated documents", () => {
-    const { store } = openStore();
+  it("lists stored totals for each period kind and reflects regenerated documents", async () => {
+    const { store } = await openStore();
     for (const [period, key] of [
       ["day", "2026-08-20"],
       ["week", "2026-W34"],
@@ -154,8 +156,8 @@ describe("Team Reports storage", () => {
         securityAdvisories: 6,
       };
       document.totals.discord.messages = 7;
-      store.upsertPeriod({ report: document, markdown: key });
-      expect(store.listPeriods({ period })).toEqual([
+      await store.upsertPeriod({ report: document, markdown: key });
+      expect(await store.listPeriods({ period })).toEqual([
         {
           period,
           key,
@@ -174,8 +176,8 @@ describe("Team Reports storage", () => {
         },
       ]);
     }
-    store.upsertPeriod({ report: report("2026-08-20", []), markdown: "refreshed" });
-    expect(store.listPeriods({ period: "day" })[0]).toMatchObject({
+    await store.upsertPeriod({ report: report("2026-08-20", []), markdown: "refreshed" });
+    expect((await store.listPeriods({ period: "day" }))[0]).toMatchObject({
       activeMembers: 0,
       memberCount: 0,
       githubTotal: 0,
@@ -187,16 +189,16 @@ describe("Team Reports storage", () => {
     });
   });
 
-  it("lists all logins since an inclusive day without the individual timeline limit", () => {
-    const { store } = openStore();
+  it("lists all logins since an inclusive day without the individual timeline limit", async () => {
+    const { store } = await openStore();
     const logins = Array.from(
       { length: 30 },
       (_, index) => `member-${String(index).padStart(2, "0")}`,
     );
-    store.upsertPeriod({ report: report("2026-08-18", ["older"]), markdown: "older" });
-    store.upsertPeriod({ report: report("2026-08-19", logins), markdown: "boundary" });
-    store.upsertPeriod({ report: report("2026-08-20", ["latest"]), markdown: "latest" });
-    const days = store.listPersonDaysSince("2026-08-19");
+    await store.upsertPeriod({ report: report("2026-08-18", ["older"]), markdown: "older" });
+    await store.upsertPeriod({ report: report("2026-08-19", logins), markdown: "boundary" });
+    await store.upsertPeriod({ report: report("2026-08-20", ["latest"]), markdown: "latest" });
+    const days = await store.listPersonDaysSince("2026-08-19");
     expect(days.map(({ dayKey, login }) => [dayKey, login])).toEqual([
       ["2026-08-20", "latest"],
       ...logins.map((login) => ["2026-08-19", login]),
@@ -215,13 +217,13 @@ describe("Team Reports storage", () => {
       reviewComments: 0,
       discordMessages: 2,
     });
-    expect(store.listPersonDaysSince("2026-08-21")).toEqual([]);
+    expect(await store.listPersonDaysSince("2026-08-21")).toEqual([]);
   });
 
-  it("reads half-open day ranges and indexes newest first without projecting week rows onto people", () => {
-    const { store } = openStore();
+  it("reads half-open day ranges and indexes newest first without projecting week rows onto people", async () => {
+    const { store } = await openStore();
     for (const key of ["2026-08-18", "2026-08-19", "2026-08-20"]) {
-      store.upsertPeriod({ report: report(key), markdown: key });
+      await store.upsertPeriod({ report: report(key), markdown: key });
     }
     const week = report();
     week.period = {
@@ -231,40 +233,42 @@ describe("Team Reports storage", () => {
       sinceMs: Date.parse("2026-08-17T00:00:00Z"),
       untilMs: Date.parse("2026-08-24T00:00:00Z"),
     };
-    store.upsertPeriod({ report: week, markdown: "week" });
+    await store.upsertPeriod({ report: week, markdown: "week" });
     expect(
-      store
-        .getDayReports(Date.parse("2026-08-19T00:00:00Z"), Date.parse("2026-08-20T00:00:00Z"))
-        .map((day) => day.period.key),
+      (
+        await store.getDayReports(
+          Date.parse("2026-08-19T00:00:00Z"),
+          Date.parse("2026-08-20T00:00:00Z"),
+        )
+      ).map((day) => day.period.key),
     ).toEqual(["2026-08-19"]);
-    expect(store.listPeriods({ period: "day", limit: 2 }).map((entry) => entry.key)).toEqual([
-      "2026-08-20",
-      "2026-08-19",
-    ]);
     expect(
-      store
-        .listPersonDays("alice", { since: "2026-08-18", until: "2026-08-20" })
-        .map((day) => day.dayKey),
+      (await store.listPeriods({ period: "day", limit: 2 })).map((entry) => entry.key),
+    ).toEqual(["2026-08-20", "2026-08-19"]);
+    expect(
+      (await store.listPersonDays("alice", { since: "2026-08-18", until: "2026-08-20" })).map(
+        (day) => day.dayKey,
+      ),
     ).toEqual(["2026-08-19", "2026-08-18"]);
-    expect(store.getPeriod("month", "2026-08")).toBeUndefined();
+    expect(await store.getPeriod("month", "2026-08")).toBeUndefined();
   });
 
-  it("records run outcomes once, including bounded failures and collector statistics", () => {
-    const { store } = openStore();
-    store.startRun({
+  it("records run outcomes once, including bounded failures and collector statistics", async () => {
+    const { store } = await openStore();
+    await store.startRun({
       id: "first",
       kind: "manual",
       startedAtMs: 1,
       periods: [{ period: "day", key: "2026-08-20" }],
     });
-    store.startRun({ id: "second", kind: "intraday", startedAtMs: 2, periods: [] });
-    store.finishRun("first", {
+    await store.startRun({ id: "second", kind: "intraday", startedAtMs: 2, periods: [] });
+    await store.finishRun("first", {
       finishedAtMs: 3,
       status: "error",
       error: "x".repeat(3000),
       stats: { apiCalls: 2 },
     });
-    expect(store.listRuns()).toMatchObject([
+    expect(await store.listRuns()).toMatchObject([
       { id: "second", status: "running", finishedAtMs: null },
       {
         id: "first",
@@ -274,21 +278,21 @@ describe("Team Reports storage", () => {
         periods: [{ period: "day", key: "2026-08-20" }],
       },
     ]);
-    expect(store.listRuns()[1]?.error).toHaveLength(2000);
-    expect(store.listRuns(1, { kind: "manual", status: "error" }).map((run) => run.id)).toEqual([
-      "first",
-    ]);
-    expect(() => store.finishRun("first", { finishedAtMs: 4, status: "ok" })).toThrow(
+    expect((await store.listRuns())[1]?.error).toHaveLength(2000);
+    expect(
+      (await store.listRuns(1, { kind: "manual", status: "error" })).map((run) => run.id),
+    ).toEqual(["first"]);
+    await expect(store.finishRun("first", { finishedAtMs: 4, status: "ok" })).rejects.toThrow(
       "not running",
     );
-    store.finishRun("second", { finishedAtMs: 4, status: "ok" });
-    expect(store.listRuns(1)).toMatchObject([{ id: "second", status: "ok", periods: [] }]);
+    await store.finishRun("second", { finishedAtMs: 4, status: "ok" });
+    expect(await store.listRuns(1)).toMatchObject([{ id: "second", status: "ok", periods: [] }]);
   });
 
-  it("prunes old complete periods and person days, retaining overlap, active runs, and keep-all state", () => {
-    const { store } = openStore();
+  it("prunes old complete periods and person days, retaining overlap, active runs, and keep-all state", async () => {
+    const { store } = await openStore();
     for (const key of ["2026-08-15", "2026-08-16", "2026-08-17"]) {
-      store.upsertPeriod({ report: report(key, ["alice"]), markdown: key });
+      await store.upsertPeriod({ report: report(key, ["alice"]), markdown: key });
     }
     const periods: PeriodDescriptor[] = [
       {
@@ -307,17 +311,20 @@ describe("Team Reports storage", () => {
       },
     ];
     for (const period of periods) {
-      store.upsertPeriod({ report: { ...report(), period }, markdown: period.title });
+      await store.upsertPeriod({ report: { ...report(), period }, markdown: period.title });
     }
-    store.startRun({ id: "old-complete", kind: "closed-day", startedAtMs: 1, periods: [] });
-    store.finishRun("old-complete", { finishedAtMs: 2, status: "ok" });
-    store.startRun({ id: "running", kind: "manual", startedAtMs: 3, periods: [] });
+    await store.startRun({ id: "old-complete", kind: "closed-day", startedAtMs: 1, periods: [] });
+    await store.finishRun("old-complete", { finishedAtMs: 2, status: "ok" });
+    await store.startRun({ id: "running", kind: "manual", startedAtMs: 3, periods: [] });
     const now = Date.parse("2026-08-20T13:00:00Z");
-    expect(store.prune(0, now)).toEqual({ periods: 0, personDays: 0, runs: 0 });
-    expect(store.listPeriods()).toHaveLength(5);
-    expect(store.prune(3, now)).toEqual({ periods: 3, personDays: 2, runs: 1 });
-    expect(store.listPeriods().map((entry) => entry.key)).toEqual(["2026-08-17", "2026-08"]);
-    expect(store.listPersonDays("alice").map((day) => day.dayKey)).toEqual(["2026-08-17"]);
-    expect(store.listRuns().map((run) => run.id)).toEqual(["running"]);
+    expect(await store.prune(0, now)).toEqual({ periods: 0, personDays: 0, runs: 0 });
+    expect(await store.listPeriods()).toHaveLength(5);
+    expect(await store.prune(3, now)).toEqual({ periods: 3, personDays: 2, runs: 1 });
+    expect((await store.listPeriods()).map((entry) => entry.key)).toEqual([
+      "2026-08-17",
+      "2026-08",
+    ]);
+    expect((await store.listPersonDays("alice")).map((day) => day.dayKey)).toEqual(["2026-08-17"]);
+    expect((await store.listRuns()).map((run) => run.id)).toEqual(["running"]);
   });
 });

--- a/extensions/team-reports/src/store.ts
+++ b/extensions/team-reports/src/store.ts
@@ -149,7 +149,9 @@ export class TeamReportsStore {
     }
   }
 
-  upsertPeriod(value: Omit<StoredPeriod, "summary"> & { summary?: SummaryDocument | null }): void {
+  async upsertPeriod(
+    value: Omit<StoredPeriod, "summary"> & { summary?: SummaryDocument | null },
+  ): Promise<void> {
     this.assertOpen();
     const { report } = value;
     const dataJson = JSON.stringify(report);
@@ -207,7 +209,7 @@ export class TeamReportsStore {
     });
   }
 
-  getPeriod(period: Period, key: string): StoredPeriod | undefined {
+  async getPeriod(period: Period, key: string): Promise<StoredPeriod | undefined> {
     this.assertOpen();
     const row = executeSqliteQueryTakeFirstSync(
       this.db,
@@ -220,13 +222,13 @@ export class TeamReportsStore {
     return row ? readPeriod(row) : undefined;
   }
 
-  listPeriods(
+  async listPeriods(
     options: {
       period?: Period;
       status?: "partial" | "closed";
       limit?: number;
     } = {},
-  ): PeriodListEntry[] {
+  ): Promise<PeriodListEntry[]> {
     this.assertOpen();
     let query = this.query
       .selectFrom("team_reports_periods")
@@ -272,7 +274,7 @@ export class TeamReportsStore {
     return executeSqliteQuerySync(this.db, query.limit(options.limit ?? 180)).rows;
   }
 
-  getDayReports(sinceMs: number, untilMs: number): ReportDocument[] {
+  async getDayReports(sinceMs: number, untilMs: number): Promise<ReportDocument[]> {
     this.assertOpen();
     return executeSqliteQuerySync(
       this.db,
@@ -286,10 +288,10 @@ export class TeamReportsStore {
     ).rows.map((row) => reportDocumentSchema.parse(JSON.parse(row.data_json)));
   }
 
-  listPersonDays(
+  async listPersonDays(
     login: string,
     options: { since?: string; until?: string; limit?: number } = {},
-  ): PersonDay[] {
+  ): Promise<PersonDay[]> {
     this.assertOpen();
     let query = this.selectPersonDays()
       .where("login", "=", login.toLowerCase())
@@ -303,7 +305,7 @@ export class TeamReportsStore {
     return executeSqliteQuerySync(this.db, query.limit(options.limit ?? 28)).rows;
   }
 
-  listPersonDaysSince(since: string): PersonDay[] {
+  async listPersonDaysSince(since: string): Promise<PersonDay[]> {
     this.assertOpen();
     return executeSqliteQuerySync(
       this.db,
@@ -333,12 +335,12 @@ export class TeamReportsStore {
       ]);
   }
 
-  startRun(run: {
+  async startRun(run: {
     id: string;
     kind: ReportRun["kind"];
     startedAtMs: number;
     periods: RunPeriod[];
-  }): void {
+  }): Promise<void> {
     this.assertOpen();
     executeSqliteQuerySync(
       this.db,
@@ -355,7 +357,7 @@ export class TeamReportsStore {
     );
   }
 
-  finishRun(
+  async finishRun(
     id: string,
     result: {
       finishedAtMs: number;
@@ -363,7 +365,7 @@ export class TeamReportsStore {
       stats?: Record<string, unknown>;
       error?: string;
     },
-  ): void {
+  ): Promise<void> {
     this.assertOpen();
     const updated = executeSqliteQuerySync(
       this.db,
@@ -383,10 +385,10 @@ export class TeamReportsStore {
     }
   }
 
-  listRuns(
+  async listRuns(
     limit = 20,
     filter: { kind?: ReportRun["kind"]; status?: ReportRun["status"] } = {},
-  ): ReportRun[] {
+  ): Promise<ReportRun[]> {
     this.assertOpen();
     let query = this.query.selectFrom("team_reports_runs").selectAll();
     if (filter.kind) {
@@ -410,10 +412,10 @@ export class TeamReportsStore {
     }));
   }
 
-  prune(
+  async prune(
     retentionDays: number,
     nowMs = Date.now(),
-  ): { periods: number; personDays: number; runs: number } {
+  ): Promise<{ periods: number; personDays: number; runs: number }> {
     this.assertOpen();
     if (!Number.isSafeInteger(retentionDays) || retentionDays < 0) {
       throw new Error("Team Reports retention days must be a nonnegative integer.");
@@ -449,7 +451,7 @@ export class TeamReportsStore {
     }));
   }
 
-  close(): void {
+  async close(): Promise<void> {
     if (this.closed) {
       return;
     }
@@ -462,9 +464,9 @@ export class TeamReportsStore {
   }
 }
 
-export function createTeamReportsStore(
+export async function createTeamReportsStore(
   options: { stateDir?: string; dbPath?: string } = {},
-): TeamReportsStore {
+): Promise<TeamReportsStore> {
   const dbPath =
     options.dbPath ??
     path.join(


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Team Reports owns synchronous database operations across startup, scheduling, HTTP handlers and shutdown. Awaiting these operations requires shutdown to account for work admitted before it stops, including a run record that is still being created.

## Why This Change Was Made

Convert the store factory, queries, mutations and close operation to asynchronous contracts and migrate all callers. The scheduler reserves a run before awaiting persistence and drains admitted database work before closing the store. Cancellation interrupts external collection and model work; final database outcomes are allowed to settle. Startup publishes one scheduler/store owner only after initialization succeeds and closes an instance retired during startup.

Remove the duplicate store-closing owner. Prepared in-memory organization and people accessors stay synchronous. The SQLite schema, transaction callbacks and retention policy are unchanged.

## User Impact

Reports keep their existing API and scheduling behavior. Startup and shutdown consistently own pending persistence, preventing store closure underneath an admitted report run.

## Evidence

- 238 focused store, scheduler, lifecycle and HTTP tests passed, including delayed startup, cancellation and drainage.
- Full selected changed checks, the full build (348.8 seconds) and fresh independent Codex review passed.
- Standalone production-source smoke exercised synthetic collection, real SQLite persistence and fresh-process reopening, plus four real loopback HTTP routes returning 200.
- Thirty warm samples measured read median 0.102 ms and write median 0.216 ms; no comparative speedup is claimed.
- This proof uses isolated source runtime and synthetic inputs, not a deployed Gateway or external model service.

CI initially timed out in the unchanged managed-update refusal process test. The exact candidate case passed locally in 1.60 seconds with its original 60-second deadline and journal-immutability assertions; the same-head failed-job rerun is green. No Team Reports or test changes were needed.
