### PR TITLE
fix: retain plugin detail tab selections while inspection loads

### DIFF
--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -122,6 +122,7 @@ overview counts. Each row opens a detail view; its overflow (`…`) menu enables
 or disables the plugin and offers **Remove** for externally installed plugins.
 It also lists configured [MCP servers](/cli/mcp) and supports adding, disabling,
 and removing them inline. The same server controls live on **Settings → MCP**.
+Your selected detail tab stays open as additional plugin information loads.
 The **Discover** tab is the store: featured plugins included with OpenClaw,
 official external plugins, and one-click MCP connectors for popular services.
 Typing in the search box queries

--- a/ui/src/components/hub-tabs.test.ts
+++ b/ui/src/components/hub-tabs.test.ts
@@ -57,46 +57,60 @@ describe("renderHubTabs", () => {
     }
   });
 
-  it("selects only enabled tabs from direct user activation", () => {
-    const onSelect = vi.fn();
-    const onActivate = vi.fn();
-    const container = document.createElement("div");
-    render(
-      renderHubTabs({
-        id: "example",
-        active: "first",
-        tabs: [
-          { value: "first", label: "First" },
-          { value: "second", label: "Second" },
-          { value: "disabled", label: "Disabled", disabled: true },
-        ],
-        ariaLabel: "Example sections",
-        panelId: "example-panel",
-        onSelect,
-        onActivate,
-      }),
-      container,
-    );
+  it.each([undefined, "first"] as const)(
+    "selects only enabled tabs from direct activation with requested=%s",
+    (requestedActive) => {
+      const onSelect = vi.fn();
+      const onActivate = vi.fn();
+      const container = document.createElement("div");
+      render(
+        renderHubTabs({
+          id: "example",
+          active: "first",
+          requestedActive,
+          tabs: [
+            { value: "first", label: "First" },
+            { value: "second", label: "Second" },
+            { value: "disabled", label: "Disabled", disabled: true },
+          ],
+          ariaLabel: "Example sections",
+          panelId: "example-panel",
+          onSelect,
+          onActivate,
+        }),
+        container,
+      );
 
-    container
-      .querySelector("#example-tab-second")
-      ?.dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
-    container
-      .querySelector("#example-tab-disabled")
-      ?.dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
-    container.querySelector("wa-tab-group")?.dispatchEvent(
-      new CustomEvent("wa-tab-show", {
-        bubbles: true,
-        composed: true,
-        detail: { name: "disabled" },
-      }),
-    );
+      container
+        .querySelector("#example-tab-second")
+        ?.dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
+      container
+        .querySelector("#example-tab-disabled")
+        ?.dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
+      container.querySelector("wa-tab-group")?.dispatchEvent(
+        new CustomEvent("wa-tab-show", {
+          bubbles: true,
+          composed: true,
+          detail: { name: "disabled" },
+        }),
+      );
 
-    expect(onSelect).toHaveBeenCalledOnce();
-    expect(onSelect).toHaveBeenCalledWith("second");
-    expect(onActivate).toHaveBeenCalledWith(container.querySelector("#example-tab-second"));
-    expect(container.querySelector("wa-tab-group")?.getAttribute("activation")).toBe("manual");
-  });
+      container
+        .querySelector("#example-tab-first")
+        ?.dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
+      for (const key of ["Enter", " "]) {
+        container
+          .querySelector("#example-tab-first")
+          ?.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+      }
+
+      expect(onSelect).toHaveBeenCalledOnce();
+      expect(onActivate).toHaveBeenCalledOnce();
+      expect(onSelect).toHaveBeenCalledWith("second");
+      expect(onActivate).toHaveBeenCalledWith(container.querySelector("#example-tab-second"));
+      expect(container.querySelector("wa-tab-group")?.getAttribute("activation")).toBe("manual");
+    },
+  );
 
   it("preserves an intentional no-selection state", () => {
     const container = document.createElement("div");

--- a/ui/src/components/hub-tabs.ts
+++ b/ui/src/components/hub-tabs.ts
@@ -15,6 +15,8 @@ export type HubTabOption<T extends string> = {
 type HubTabsProps<T extends string> = {
   id: string;
   active: T | null;
+  /** Owning selection when active is a provisional display fallback. */
+  requestedActive?: T;
   tabs: ReadonlyArray<HubTabOption<T>>;
   ariaLabel: string;
   panelId: string;
@@ -66,6 +68,7 @@ function reclaimFocus(hubId: string, tab: string, element: Element | undefined) 
 
 export function renderHubTabs<T extends string>(props: HubTabsProps<T>): TemplateResult {
   const variant = props.variant ?? "primary";
+  const requestedActive = props.requestedActive ?? props.active;
   const className = `hub-tabs hub-tabs--${variant} ${props.id}-hub-tabs${props.carapace ? " oc-segmented" : ""}${props.className ? ` ${props.className}` : ""}`;
   const fallbackFocusValue =
     props.active === null ? props.tabs.find((tab) => !tab.disabled)?.value : null;
@@ -99,7 +102,7 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
               if (
                 !tab.disabled &&
                 (event.detail > 0 || event.isTrusted) &&
-                tab.value !== props.active
+                tab.value !== requestedActive
               ) {
                 props.onSelect(tab.value);
                 props.onActivate?.(activeElement);
@@ -114,7 +117,7 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
                 !tab.disabled &&
                 !event.repeat &&
                 (event.key === "Enter" || event.key === " ") &&
-                tab.value !== props.active
+                tab.value !== requestedActive
               ) {
                 event.preventDefault();
                 pendingFocus = {

--- a/ui/src/e2e/plugins-settings-admin.e2e.test.ts
+++ b/ui/src/e2e/plugins-settings-admin.e2e.test.ts
@@ -630,6 +630,59 @@ suite.define(() => {
     );
   });
 
+  it.each(["click", "Enter", " "] as const)(
+    "retains a fallback tab selected with %j while reconnect inspection finishes",
+    async (activation) => {
+      await suite.withPage(
+        {
+          colorScheme: "dark",
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 1000, width: 1440 },
+        },
+        async ({ page }) => {
+          const gateway = await installMockGateway(page, {
+            featureMethods: pluginMethods,
+            methodResponses: pluginResponses(),
+            operatorScopes: ["operator.read", "operator.admin"],
+          });
+          await openWorkboard(page, suite.server.baseUrl);
+          const readme = page.getByRole("tab", { name: "README", exact: true });
+          await readme.waitFor();
+          const inspections = (await gateway.getRequests("plugins.inspect")).length;
+          await gateway.deferNext("plugins.inspect");
+          await page
+            .locator("wa-switch")
+            .filter({ hasText: "Enable or disable Workboard" })
+            .click();
+          await gateway.waitForRequest("plugins.inspect", { after: inspections });
+          await readme.waitFor({ state: "detached" });
+
+          const configuration = page.getByRole("tab", { name: "Configuration", exact: true });
+          await configuration.waitFor();
+          expect(await configuration.getAttribute("aria-selected")).toBe("true");
+          if (activation === "click") {
+            await configuration.click();
+          } else {
+            await configuration.press(activation);
+          }
+          await gateway.resolveDeferred("plugins.inspect", inspection);
+          await readme.waitFor();
+          if (captureUiProof && activation === "click") {
+            await page.screenshot({
+              animations: "disabled",
+              path: path.join(proofDir, "selected-tab-after-inspection.png"),
+            });
+          }
+
+          await expect.poll(() => new URL(page.url()).hash).toBe("#configuration");
+          expect(await configuration.getAttribute("aria-selected")).toBe("true");
+          await page.getByLabel("Workspace label", { exact: true }).waitFor();
+        },
+      );
+    },
+  );
+
   it("keeps global plugin policy in Advanced and exposes read-only details without mutations", async () => {
     await suite.withPage(
       {

--- a/ui/src/pages/plugins/detail-shell.ts
+++ b/ui/src/pages/plugins/detail-shell.ts
@@ -15,6 +15,7 @@ export function renderPluginDetailShell<T extends string>(props: {
   sidebar?: TemplateResult;
   tabs: ReadonlyArray<HubTabOption<T>>;
   activeTab: T;
+  requestedTab?: T;
   onTabChange: (tab: T) => void;
   panel: TemplateResult;
 }): TemplateResult {
@@ -61,6 +62,7 @@ export function renderPluginDetailShell<T extends string>(props: {
     ${renderHubTabs({
       id: props.id,
       active: props.activeTab,
+      requestedActive: props.requestedTab,
       tabs: props.tabs,
       ariaLabel: t("pluginsPage.detailSections"),
       panelId,

--- a/ui/src/pages/plugins/settings-view.ts
+++ b/ui/src/pages/plugins/settings-view.ts
@@ -666,6 +666,7 @@ export function renderPluginSettingsDetail(props: DetailProps): TemplateResult {
         label: installedTabLabel(tab, plugin.state === "needs-setup"),
       })),
       activeTab,
+      requestedTab: props.tab,
       onTabChange: props.onTabChange,
       panel: html`${props.pageNotice ? renderMessage(props.pageNotice) : nothing}
       ${props.error ? renderRetryError(props.error, props.onRefresh) : nothing}


### PR DESCRIPTION
Related: #144590

<details>
<summary>Additional instructions</summary>

This branch is in openclaw/openclaw, so repository maintainers can edit it.

</details>

## What Problem This Solves

Fixes an issue where users selecting Configuration in an installed plugin's detail view would be sent back to README when inspection finished after a reconnect. The Configuration tab was already displayed as a temporary fallback, so clicking it or pressing Enter or Space did not preserve that selection.

## Why This Change Was Made

The detail view now carries the owning selection separately from the displayed fallback through the detail shell to the shared tabs component. Activation records the requested tab even when it is temporarily displayed; ordinary active-tab activation remains a no-op. ARIA selection, focus behavior, disabled tabs, and synthetic-event guards keep their existing behavior.

## User Impact

Users can select a plugin detail tab while plugin information loads and keep that tab open when the remaining information arrives.

## Evidence

A controlled reconnect defers inspection after README disappears, activates the displayed Configuration fallback, then supplies README again. All three regression cases (mouse, Enter, Space) fail on the original production code because the URL never records `#configuration`; all three pass with this repair.

The complete mocked-Gateway browser file passes all 9 scenarios, and 31 tests pass across the shared tabs, session tabs, plugin catalog detail, and plugin-page suites. The changed-file gate passes, and managed P2 review found no actionable findings. This is isolated browser boundary proof using synthetic Workboard data.

![Before: README replaces Configuration after inspection](https://github.com/user-attachments/assets/abe1aa9b-c5df-4788-833c-faa98474e7e4)

![After: Configuration remains selected after inspection](https://github.com/user-attachments/assets/04dfd27c-5657-453b-a115-c1452f7422ff)
