### PR TITLE
improve: avoid repeated model resolution in status summaries

### DIFF
--- a/src/commands/status.summary.runtime.normalization.test.ts
+++ b/src/commands/status.summary.runtime.normalization.test.ts
@@ -64,18 +64,12 @@ describe("statusSummaryRuntime configured model normalization", () => {
 
   it("skips manifest and plugin model normalization for providerless persisted session models", async () => {
     const { statusSummaryRuntime } = await import("../status/summary.runtime.js");
-    const cfg = {
-      agents: {
-        defaults: {
-          model: { primary: "anthropic/claude-sonnet-4-6" },
-        },
-      },
-    } as never;
+    const configured = { provider: "anthropic", model: "claude-sonnet-4-6" };
 
     normalizeProviderModelIdWithRuntimeMock.mockReturnValue("runtime-normalized-opus");
 
     expect(
-      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+      statusSummaryRuntime.resolveSessionModelRef(configured, {
         model: "opus-4.6",
       }),
     ).toEqual({
@@ -84,7 +78,7 @@ describe("statusSummaryRuntime configured model normalization", () => {
     });
 
     expect(
-      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+      statusSummaryRuntime.resolveSessionModelRef(configured, {
         model: "fallback-runtime-model",
         modelOverride: "opus-4.6",
       }),

--- a/src/commands/status.summary.runtime.test.ts
+++ b/src/commands/status.summary.runtime.test.ts
@@ -304,17 +304,11 @@ describe("statusSummaryRuntime.resolveSessionRuntime", () => {
 });
 
 describe("statusSummaryRuntime.resolveSessionModelRef", () => {
-  const cfg = {
-    agents: {
-      defaults: {
-        model: { primary: "anthropic/claude-sonnet-4-6" },
-      },
-    },
-  } as never;
+  const configured = { provider: "anthropic", model: "claude-sonnet-4-6" };
 
   it("preserves explicit runtime providers for vendor-prefixed model ids", () => {
     expect(
-      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+      statusSummaryRuntime.resolveSessionModelRef(configured, {
         modelProvider: "openrouter",
         model: "anthropic/claude-haiku-4.5",
       }),
@@ -326,7 +320,7 @@ describe("statusSummaryRuntime.resolveSessionModelRef", () => {
 
   it("splits legacy combined overrides when provider is missing", () => {
     expect(
-      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+      statusSummaryRuntime.resolveSessionModelRef(configured, {
         modelOverride: "ollama-beelink2/qwen2.5-coder:7b",
       }),
     ).toEqual({
@@ -338,13 +332,7 @@ describe("statusSummaryRuntime.resolveSessionModelRef", () => {
   it("uses the configured default provider for providerless runtime models", () => {
     expect(
       statusSummaryRuntime.resolveSessionModelRef(
-        {
-          agents: {
-            defaults: {
-              model: { primary: "openai/gpt-5.5" },
-            },
-          },
-        } as never,
+        { provider: "openai", model: "gpt-5.5" },
         {
           model: "gpt-5.5",
         },
@@ -357,7 +345,7 @@ describe("statusSummaryRuntime.resolveSessionModelRef", () => {
 
   it("prefers explicit overrides ahead of fallback runtime fields", () => {
     expect(
-      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+      statusSummaryRuntime.resolveSessionModelRef(configured, {
         providerOverride: "openai",
         modelOverride: "gpt-5.4",
         modelProvider: "amazon-bedrock",
@@ -371,7 +359,7 @@ describe("statusSummaryRuntime.resolveSessionModelRef", () => {
 
   it("falls back to configured defaults when persisted session model fields are malformed", () => {
     expect(
-      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+      statusSummaryRuntime.resolveSessionModelRef(configured, {
         modelProvider: { provider: "openai" },
         model: false,
         providerOverride: ["anthropic"],

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -1065,9 +1065,10 @@ describe("getStatusSummary", () => {
 
   it("resolves aggregate selected models from each row's agent", async () => {
     const models: Record<string, string> = { ops: "ops", research: "research" };
-    vi.mocked(statusSummaryRuntime.resolveSessionModelRef).mockImplementation(
-      (_cfg, _entry, id) => ({ provider: "openai", model: models[id ?? ""] ?? "global" }),
+    vi.mocked(statusSummaryRuntime.resolveConfiguredStatusModelRef).mockImplementation(
+      ({ agentId }) => ({ provider: "openai", model: models[agentId ?? ""] ?? "global" }),
     );
+    vi.mocked(statusSummaryRuntime.resolveSessionModelRef).mockImplementation((model) => model);
     statusSummaryMocks.listSessionEntriesCore.mockReturnValue(
       toSessionEntrySummaries({
         "agent:ops:main": { sessionId: "ops-session", updatedAt: 3 },

--- a/src/status/summary.runtime.ts
+++ b/src/status/summary.runtime.ts
@@ -18,7 +18,7 @@ import {
   resolveContextTokensForModelFromCache as resolveContextTokensForModel,
 } from "../agents/context-resolution.js";
 import { waitForContextWindowCacheLoad } from "../agents/context.js";
-import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { parseModelRef, resolvePersistedSelectedModelRef } from "../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -157,18 +157,11 @@ function resolveStatusModelComparisonLabel(params: {
 }
 
 function resolveSessionModelRef(
-  cfg: OpenClawConfig,
+  resolved: { provider: string; model: string },
   entry?:
     | SessionEntry
     | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
-  agentId?: string,
 ): { provider: string; model: string } {
-  const resolved = resolveConfiguredStatusModelRef({
-    cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel: DEFAULT_MODEL,
-    agentId,
-  });
   const defaultProvider = resolved.provider || DEFAULT_PROVIDER;
   const providerlessPersisted =
     resolveProviderlessPersistedStatusModelRef({

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -231,7 +231,7 @@ async function prepareSessionStatusDetails(cfg: OpenClawConfig, now: number) {
         });
         const configuredSessionModel = configuredForSession.model ?? DEFAULT_MODEL;
         const configuredSessionModelLabel = `${configuredForSession.provider ?? DEFAULT_PROVIDER}/${configuredSessionModel}`;
-        const resolvedModel = resolveSessionModelRef(cfg, entry, agentId);
+        const resolvedModel = resolveSessionModelRef(configuredForSession, entry);
         const model = resolvedModel.model ?? configuredSessionModel ?? null;
         const lookupModel =
           resolveStatusModelLookupRef({


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Status summaries for large multi-agent configurations spend avoidable time preparing each session's model information, especially when configured model aliases require long scans.

## Why This Change Was Made

Status session rows resolved their configured model twice in succession. The row builder already needed that result for its configured-model label, but the selected-model helper repeated the same agent/default/alias resolution before examining persisted session fields. Large configured alias lists paid for that duplicate scan on every projected session.

Pass the prepared provider/model into the internal selected-model helper and remove its configuration and agent inputs. Its sole production caller supplies the same result immediately before the next await. Persisted-model precedence, providerless text, context caps, and read-only/lazy behavior remain unchanged. No cache or compatibility wrapper is added. The change removes seven production lines and seventeen test lines.

## User Impact

Session model labels, overrides, context caps, and read-only behavior remain unchanged. The alias-heavy fleet fixture benefits, but smaller/control fixtures were slower in this fixed comparison. This is a bounded cleanup with a narrow measured benefit, not a general status-speed claim.

## Evidence

- The same four whole suites passed 70 tests on baseline and 70 on candidate: status summary, runtime resolution, normalization isolation, and read-only summary integration.
- All 29 selected changed-code checks passed, including production and test typechecks, targeted lint, formatting, and repository guards.
- Independent Codex review found no actionable P0–P2 issues.
- A fixed local ABBA comparison made 220 actual `getStatusSummary` calls with isolated synthetic stores on Node 26.8.1. All complete decoded output graphs matched, including property order and own undefined values. The comparator also checks reference topology; this corpus contains no shared-reference edges. Inputs remained unchanged. Each fixture had one first call, one warmup, and nine steady calls per cohort.

Warm median changes below are candidate relative to baseline; positive values are slower.

| Full-summary fixture | B0 → C0 | B1 → C1 |
| --- | ---: | ---: |
| Empty store | +6.10% | +2.57% |
| One agent, ten sessions, configured default | +0.94% | +2.40% |
| One agent, ten sessions, configured provider fallback | +3.65% | +0.44% |
| Sixteen agents, ten sessions each, late alias in 256 configured aliases | −5.62% | −1.97% |
| Hidden-session fleet control | +8.43% | +7.41% |

The alias-heavy fleet medians fell from 641.829 to 605.750 ms and from 617.131 to 605.001 ms. Eight of ten medians, 40 of 60 timing statistics, and 66 of 110 indexed comparisons were adverse; all remain in the retained evidence. This supports a narrower fleet benefit and a simpler implementation, not a uniform speedup, Gateway throughput improvement, or inference latency claim.

Whole-cohort peak memory was also higher: kernel child peak RSS increased 12.06% and 7.89%, and observed process-tree peak RSS increased 11.77% and 7.57%. These four adverse resource comparisons are retained. Whole-cohort wall and CPU times fell in both orders, but those measurements include imports, fixture setup, capture, and cleanup; they do not isolate the changed function or establish an allocation improvement.

The first measurement attempt stopped during baseline because it compared noncanonical V8 serialization bytes. All 36 completed calls were retained. Their decoded values, own-property order, and object graphs matched; the differing arrays reserialized identically after decoding. The corrected comparison used explicit graph equality, passed a separate 15-call baseline preflight, and ran a fresh complete ABBA sequence without pooling earlier samples. All task processes closed and candidate sources were restored.

Measurements are tied to baseline `ae94766f288b54ec7ac840cc4e1479232405949b`; required PR CI and native landing checks remain pending. Independent numerical audit reproduced all reported timing deltas and closure evidence.
