### PR TITLE
refactor(cli): simplify QA and memory command dispatch

### DIFF
--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -34,71 +34,6 @@ const loadMemoryCliRuntime = createLazyRuntimeModule(() => import("./cli.runtime
 const DECIMAL_NUMBER_RE = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const DEFAULT_SESSION_BACKFILL_LIMIT_DAYS = 92;
 
-async function runMemoryStatus(opts: MemoryCommandOptions, hostOptions?: MemoryCoreRuntimeHost) {
-  const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryStatus(opts, hostOptions);
-}
-
-async function runMemoryIndex(opts: MemoryCommandOptions, hostOptions?: MemoryCoreRuntimeHost) {
-  const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryIndex(opts, hostOptions);
-}
-
-async function runMemorySearch(
-  queryArg: string | undefined,
-  opts: MemorySearchCommandOptions,
-  hostOptions?: MemoryCoreRuntimeHost,
-) {
-  const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemorySearch(queryArg, opts, hostOptions);
-}
-
-async function runMemoryForget(opts: MemoryForgetCommandOptions) {
-  const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryForget(opts);
-}
-
-async function runMemoryPromote(
-  opts: MemoryPromoteCommandOptions,
-  hostOptions?: MemoryCoreRuntimeHost,
-) {
-  const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryPromote(opts, hostOptions);
-}
-
-async function runMemoryPromoteExplain(
-  selectorArg: string | undefined,
-  opts: MemoryPromoteExplainOptions,
-  hostOptions?: MemoryCoreRuntimeHost,
-) {
-  const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryPromoteExplain(selectorArg, opts, hostOptions);
-}
-
-async function runMemoryRemHarness(
-  opts: MemoryRemHarnessOptions,
-  hostOptions?: MemoryCoreRuntimeHost,
-) {
-  const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryRemHarness(opts, hostOptions);
-}
-
-async function runMemoryRemBackfill(
-  opts: MemoryRemBackfillOptions,
-  hostOptions?: MemoryCoreRuntimeHost,
-) {
-  const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryRemBackfill(opts, hostOptions);
-}
-
-async function runMemorySessionBackfill(
-  opts: MemorySessionBackfillOptions,
-  hostOptions?: MemoryCoreRuntimeHost,
-) {
-  const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemorySessionBackfill(opts, hostOptions);
-}
-
 function invalidCliArgument(message: string): Error & { code: string; exitCode: number } {
   const error = new Error(message) as Error & { code: string; exitCode: number };
   error.name = "InvalidArgumentError";
@@ -206,7 +141,8 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     .option("--fix", "Repair stale recall locks and normalize promotion metadata")
     .option("--verbose", "Verbose logging", false)
     .action(async (opts: MemoryCommandOptions & { force?: boolean }) => {
-      await runMemoryStatus(opts, hostOptions);
+      const runtime = await loadMemoryCliRuntime();
+      await runtime.runMemoryStatus(opts, hostOptions);
     });
 
   memory
@@ -216,7 +152,8 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     .option("--force", "Force full reindex", false)
     .option("--verbose", "Verbose logging", false)
     .action(async (opts: MemoryCommandOptions) => {
-      await runMemoryIndex(opts, hostOptions);
+      const runtime = await loadMemoryCliRuntime();
+      await runtime.runMemoryIndex(opts, hostOptions);
     });
 
   memory
@@ -243,7 +180,8 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     )
     .option("--json", "Print JSON")
     .action(async (queryArg: string | undefined, opts: MemorySearchCommandOptions) => {
-      await runMemorySearch(queryArg, opts, hostOptions);
+      const runtime = await loadMemoryCliRuntime();
+      await runtime.runMemorySearch(queryArg, opts, hostOptions);
     });
 
   memory
@@ -272,7 +210,8 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     .option("--dry-run", "Report everything that would be deleted without writing", false)
     .option("--json", "Print the complete machine-readable deletion report")
     .action(async (opts: MemoryForgetCommandOptions) => {
-      await runMemoryForget(opts);
+      const runtime = await loadMemoryCliRuntime();
+      await runtime.runMemoryForget(opts);
     });
 
   memory
@@ -301,7 +240,8 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     .option("--include-promoted", "Include already promoted candidates", false)
     .option("--json", "Print JSON")
     .action(async (opts: MemoryPromoteCommandOptions) => {
-      await runMemoryPromote(opts, hostOptions);
+      const runtime = await loadMemoryCliRuntime();
+      await runtime.runMemoryPromote(opts, hostOptions);
     });
 
   memory
@@ -312,7 +252,8 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     .option("--include-promoted", "Include already promoted candidates", false)
     .option("--json", "Print JSON")
     .action(async (selectorArg: string | undefined, opts: MemoryPromoteExplainOptions) => {
-      await runMemoryPromoteExplain(selectorArg, opts, hostOptions);
+      const runtime = await loadMemoryCliRuntime();
+      await runtime.runMemoryPromoteExplain(selectorArg, opts, hostOptions);
     });
 
   memory
@@ -324,7 +265,8 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     .option("--include-promoted", "Include already promoted deep candidates", false)
     .option("--json", "Print JSON")
     .action(async (opts: MemoryRemHarnessOptions) => {
-      await runMemoryRemHarness(opts, hostOptions);
+      const runtime = await loadMemoryCliRuntime();
+      await runtime.runMemoryRemHarness(opts, hostOptions);
     });
 
   memory
@@ -345,7 +287,8 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     )
     .option("--json", "Print JSON")
     .action(async (opts: MemoryRemBackfillOptions) => {
-      await runMemoryRemBackfill(opts, hostOptions);
+      const runtime = await loadMemoryCliRuntime();
+      await runtime.runMemoryRemBackfill(opts, hostOptions);
     });
 
   memory
@@ -373,7 +316,8 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     )
     .option("--json", "Print JSON")
     .action(async (opts: MemorySessionBackfillOptions) => {
-      await runMemorySessionBackfill(opts, hostOptions);
+      const runtime = await loadMemoryCliRuntime();
+      await runtime.runMemorySessionBackfill(opts, hostOptions);
     });
 
   memory.action(() => {

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -22,7 +22,7 @@ import {
   QA_FRONTIER_PARITY_BASELINE_LABEL,
   QA_FRONTIER_PARITY_CANDIDATE_LABEL,
 } from "./providers/live-frontier/parity.js";
-import type { QaProviderMode, QaProviderModeInput } from "./run-config.js";
+import type { QaProviderModeInput } from "./run-config.js";
 import { hasQaScenarioPack } from "./scenario-catalog.js";
 
 type QaScenarioRunCliOptions = {
@@ -162,206 +162,6 @@ function validateQaScenarioSelection(opts: QaScenarioRunCliOptions, command: Com
   }
 }
 
-async function runQaSelfCheck(opts: QaLabSelfCheckCommandOptions) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaLabSelfCheckCommand(opts);
-}
-
-async function runQaParityReport(opts: {
-  repoRoot?: string;
-  candidateSummary?: string;
-  baselineSummary?: string;
-  candidateLabel?: string;
-  baselineLabel?: string;
-  outputDir?: string;
-  runtimeAxis?: boolean;
-  summary?: string;
-  tokenEfficiency?: boolean;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaParityReportCommand(opts);
-}
-
-async function runQaConfidenceReport(opts: {
-  repoRoot?: string;
-  manifest: string;
-  artifactRoot?: string;
-  outputDir?: string;
-  strictZeroUnknowns?: boolean;
-  strictGlobalPass?: boolean;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaConfidenceReportCommand(opts);
-}
-
-async function runQaConfidenceSelfTest(opts: { repoRoot?: string; outputDir?: string }) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaConfidenceSelfTestCommand(opts);
-}
-
-async function runQaCoverageReport(opts: {
-  repoRoot?: string;
-  output?: string;
-  json?: boolean;
-  tools?: boolean;
-  summary?: string;
-  match?: string[];
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaCoverageReportCommand(opts);
-}
-
-async function runQaJsonlReplay(opts: {
-  repoRoot?: string;
-  transcripts?: string;
-  outputDir?: string;
-  runtimePair?: string;
-  providerMode?: QaProviderModeInput;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaJsonlReplayCommand(opts);
-}
-
-async function runQaCharacterEval(opts: {
-  repoRoot?: string;
-  outputDir?: string;
-  model?: string[];
-  scenario?: string;
-  fast?: boolean;
-  thinking?: string;
-  modelThinking?: string[];
-  judgeModel?: string[];
-  judgeTimeoutMs?: number;
-  blindJudgeModels?: boolean;
-  concurrency?: number;
-  judgeConcurrency?: number;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaCharacterEvalCommand(opts);
-}
-
-async function runQaManualLane(opts: {
-  repoRoot?: string;
-  transportId?: string;
-  providerMode?: QaProviderModeInput;
-  primaryModel?: string;
-  alternateModel?: string;
-  fastMode?: boolean;
-  message: string;
-  timeoutMs?: number;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaManualLaneCommand(opts);
-}
-
-async function runQaCredentialsAdd(opts: {
-  actorId?: string;
-  endpointPrefix?: string;
-  json?: boolean;
-  kind: string;
-  note?: string;
-  payloadFile: string;
-  repoRoot?: string;
-  siteUrl?: string;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaCredentialsAddCommand(opts);
-}
-
-async function runQaCredentialsRemove(opts: {
-  actorId?: string;
-  credentialId: string;
-  endpointPrefix?: string;
-  json?: boolean;
-  siteUrl?: string;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaCredentialsRemoveCommand(opts);
-}
-
-async function runQaCredentialsList(opts: {
-  actorId?: string;
-  endpointPrefix?: string;
-  json?: boolean;
-  kind?: string;
-  limit?: number;
-  showSecrets?: boolean;
-  siteUrl?: string;
-  status?: string;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaCredentialsListCommand(opts);
-}
-
-async function runQaCredentialsDoctor(opts: {
-  actorId?: string;
-  endpointPrefix?: string;
-  json?: boolean;
-  siteUrl?: string;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaCredentialsDoctorCommand(opts);
-}
-
-async function runQaUi(opts: {
-  repoRoot?: string;
-  host?: string;
-  port?: number;
-  advertiseHost?: string;
-  advertisePort?: number;
-  controlUiUrl?: string;
-  controlUiProxyTarget?: string;
-  uiDistDir?: string;
-  autoKickoffTarget?: string;
-  embeddedGateway?: string;
-  sendKickoffOnStart?: boolean;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaLabUiCommand(opts);
-}
-
-async function runQaDockerScaffold(opts: {
-  repoRoot?: string;
-  outputDir: string;
-  gatewayPort?: number;
-  qaLabPort?: number;
-  providerBaseUrl?: string;
-  image?: string;
-  usePrebuiltImage?: boolean;
-  bindUiDist?: boolean;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaDockerScaffoldCommand(opts);
-}
-
-async function runQaDockerBuildImage(opts: { repoRoot?: string; image?: string }) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaDockerBuildImageCommand(opts);
-}
-
-async function runQaDockerUp(opts: {
-  repoRoot?: string;
-  outputDir?: string;
-  gatewayPort?: number;
-  qaLabPort?: number;
-  providerBaseUrl?: string;
-  image?: string;
-  usePrebuiltImage?: boolean;
-  bindUiDist?: boolean;
-  skipUiBuild?: boolean;
-}) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaDockerUpCommand(opts);
-}
-
-async function runQaProviderServer(
-  providerMode: QaProviderMode,
-  opts: { host?: string; port?: number },
-) {
-  const runtime = await loadQaLabCliRuntime();
-  await runtime.runQaProviderServerCommand(providerMode, opts);
-}
-
 export function isQaLabCliAvailable(): boolean {
   return hasQaScenarioPack();
 }
@@ -444,10 +244,12 @@ export function registerQaLabCli(program: Command) {
       });
       return;
     }
-    await runQaSelfCheck({
+    const selfCheckOptions = {
       repoRoot: opts.repoRoot,
       output: opts.output,
-    });
+    };
+    const runtime = await loadQaLabCliRuntime();
+    await runtime.runQaLabSelfCheckCommand(selfCheckOptions);
   });
 
   qa.command("suite")
@@ -564,7 +366,8 @@ export function registerQaLabCli(program: Command) {
         summary?: string;
         tokenEfficiency?: boolean;
       }) => {
-        await runQaParityReport(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaParityReportCommand(opts);
       },
     );
 
@@ -590,7 +393,8 @@ export function registerQaLabCli(program: Command) {
         summary?: string;
         match?: string[];
       }) => {
-        await runQaCoverageReport(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaCoverageReportCommand(opts);
       },
     );
 
@@ -619,7 +423,8 @@ export function registerQaLabCli(program: Command) {
         strictZeroUnknowns?: boolean;
         strictGlobalPass?: boolean;
       }) => {
-        await runQaConfidenceReport(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaConfidenceReportCommand(opts);
       },
     );
 
@@ -628,7 +433,8 @@ export function registerQaLabCli(program: Command) {
     .option("--repo-root <path>", "Repository root to target when running from a neutral cwd")
     .option("--output-dir <path>", "Artifact directory for the confidence self-test")
     .action(async (opts: { repoRoot?: string; outputDir?: string }) => {
-      await runQaConfidenceSelfTest(opts);
+      const runtime = await loadQaLabCliRuntime();
+      await runtime.runQaConfidenceSelfTestCommand(opts);
     });
 
   qa.command("jsonl-replay")
@@ -654,7 +460,8 @@ export function registerQaLabCli(program: Command) {
         providerMode?: QaProviderModeInput;
         outputDir?: string;
       }) => {
-        await runQaJsonlReplay(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaJsonlReplayCommand(opts);
       },
     );
 
@@ -714,7 +521,8 @@ export function registerQaLabCli(program: Command) {
         concurrency?: number;
         judgeConcurrency?: number;
       }) => {
-        await runQaCharacterEval(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaCharacterEvalCommand(opts);
       },
     );
 
@@ -741,7 +549,7 @@ export function registerQaLabCli(program: Command) {
         fast?: boolean;
         timeoutMs?: number;
       }) => {
-        await runQaManualLane({
+        const manualOptions = {
           repoRoot: opts.repoRoot,
           transportId: opts.transport,
           providerMode: opts.providerMode,
@@ -750,7 +558,9 @@ export function registerQaLabCli(program: Command) {
           fastMode: opts.fast,
           message: opts.message,
           timeoutMs: opts.timeoutMs,
-        });
+        };
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaManualLaneCommand(manualOptions);
       },
     );
 
@@ -772,7 +582,8 @@ export function registerQaLabCli(program: Command) {
         actorId?: string;
         json?: boolean;
       }) => {
-        await runQaCredentialsDoctor(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaCredentialsDoctorCommand(opts);
       },
     );
 
@@ -798,7 +609,8 @@ export function registerQaLabCli(program: Command) {
         actorId?: string;
         json?: boolean;
       }) => {
-        await runQaCredentialsAdd(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaCredentialsAddCommand(opts);
       },
     );
 
@@ -818,7 +630,8 @@ export function registerQaLabCli(program: Command) {
         actorId?: string;
         json?: boolean;
       }) => {
-        await runQaCredentialsRemove(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaCredentialsRemoveCommand(opts);
       },
     );
 
@@ -846,7 +659,8 @@ export function registerQaLabCli(program: Command) {
         actorId?: string;
         json?: boolean;
       }) => {
-        await runQaCredentialsList(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaCredentialsListCommand(opts);
       },
     );
 
@@ -888,7 +702,8 @@ export function registerQaLabCli(program: Command) {
         embeddedGateway?: string;
         sendKickoffOnStart?: boolean;
       }) => {
-        await runQaUi(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaLabUiCommand(opts);
       },
     );
 
@@ -921,7 +736,8 @@ export function registerQaLabCli(program: Command) {
         usePrebuiltImage?: boolean;
         bindUiDist?: boolean;
       }) => {
-        await runQaDockerScaffold(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaDockerScaffoldCommand(opts);
       },
     );
 
@@ -930,7 +746,8 @@ export function registerQaLabCli(program: Command) {
     .option("--repo-root <path>", "Repository root to target when running from a neutral cwd")
     .option("--image <name>", "Image tag", "openclaw:qa-local-prebaked")
     .action(async (opts: { repoRoot?: string; image?: string }) => {
-      await runQaDockerBuildImage(opts);
+      const runtime = await loadQaLabCliRuntime();
+      await runtime.runQaDockerBuildImageCommand(opts);
     });
 
   qa.command("up")
@@ -964,7 +781,8 @@ export function registerQaLabCli(program: Command) {
         bindUiDist?: boolean;
         skipUiBuild?: boolean;
       }) => {
-        await runQaDockerUp(opts);
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaDockerUpCommand(opts);
       },
     );
 
@@ -976,7 +794,9 @@ export function registerQaLabCli(program: Command) {
         parseQaCliTcpPortOption(value, "--port"),
       )
       .action(async (opts: { host?: string; port?: number }) => {
-        await runQaProviderServer(providerCommand.providerMode, opts);
+        const providerMode = providerCommand.providerMode;
+        const runtime = await loadQaLabCliRuntime();
+        await runtime.runQaProviderServerCommand(providerMode, opts);
       });
   }
 


### PR DESCRIPTION
## What Problem This Solves

QA Lab and Memory Core command handlers route through private, single-use forwarding functions that repeat the same lazy load and runtime call, adding redundant wiring and option declarations to maintain.

## Why This Change Was Made

Remove 26 private, single-use async forwarders and invoke the same runtime namespace methods directly from their existing Commander actions. The existing cached lazy loaders remain; QA's two projected option objects and provider mode are captured before the import await to preserve evaluation timing. Memory's action and host parameters keep their original references and argument order.

## User Impact

No user-visible behavior change: command names, help, options, validation, results, errors, and runtime resource ownership remain unchanged. The two-file change removes 210 production code lines (236 physical lines, 5,140 bytes), with no new helper, dependency, or test source.

## Evidence

- Original memory CLI and shared loader suites: 134 tests passed.
- Combined memory CLI, QA CLI, scenario-selection, and shared loader suites: 220 tests passed across five files.
- The CLI suites exercise real Commander registration and parsing; memory cases also cover output, persistence completion, and cleanup.
- Combined pinned-base changed-file gate: passed.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: passed, including both touched CLI build entries.
- Fresh combined P2 review: scoped-clean, no actionable findings.

Tests use isolated state and mocked provider/host boundaries. No live provider, credential-management operation, or operator Gateway was used.
