### PR TITLE
improve(ui): remove new session picker tooltips

### DIFF
--- a/ui/src/pages/new-session/project-chip.ts
+++ b/ui/src/pages/new-session/project-chip.ts
@@ -163,7 +163,6 @@ export function renderProjectChip(params: {
         class="new-session-page__trigger ${
           params.popoverHiding ? "new-session-page__trigger--hiding" : ""
         }"
-        title=${t("newSession.what")}
         aria-label="${t("newSession.what")}: ${params.state.label}"
         data-project-id=${params.projectId || nothing}
         aria-haspopup="dialog"

--- a/ui/src/pages/new-session/where-chip.ts
+++ b/ui/src/pages/new-session/where-chip.ts
@@ -254,7 +254,6 @@ export function renderWhereChip(params: {
         class="new-session-page__trigger ${
           params.popoverHiding ? "new-session-page__trigger--hiding" : ""
         }"
-        title=${t("newSession.where")}
         aria-label="${t("newSession.where")}: ${params.state.label}"
         data-cloud-profile=${params.cloudProfileId || nothing}
         data-machine-class=${params.machineClass || nothing}


### PR DESCRIPTION
## What Problem This Solves

Hovering the New Session environment and workspace pickers displays the unhelpful labels “Where” and “What”. This removes both tooltips as requested by the maintainer.

## Why This Change Was Made

Remove the two picker-level `title` attributes at their owning templates. Keep the accessible labels, dropdown behavior, and explanatory tooltips inside the menus.

## User Impact

The Local and workspace controls stay clear while hovered, and both menus work as before.

## Evidence

Real Chromium against an isolated local Gateway at `/new`, using the same workspace, dark theme, locale, and interaction sequence before and after. Baseline: `0b48b3e78c91`; candidate: `ae5545794dda`, the two-line deletion in this PR. Inspected crops below exclude unrelated account/sidebar content.

**Desktop (1440×900):**

![Both picker hover states before and after](https://github.com/user-attachments/assets/940d513e-e62a-4187-baee-47b7418437e2)

**Phone (390×844):**

![Both picker hover states before and after on a phone-sized viewport](https://github.com/user-attachments/assets/72428780-d31f-4887-ae9d-c42cca957722)

Browser assertions verified zero open tooltips after hovering either control at 390×844, 768×1024, 1366×768, and 1440×900. Both menus opened and closed with Escape; accessible names stayed `Where: Local` and `What: workspace-clawhub-demo`. Before the change, the same hover flow displayed “Where” and “What”. The UI entry asset changed from `index-DT62Pscu.js` to `index-DMvxlA0Q.js`.

Validation:

- `pnpm build` — passed.
- `node ../scripts/run-node-package-bin.mts vite build` (from `ui`) — passed.
- `node scripts/run-vitest.mjs ui/src/pages/new-session/where-chip.test.ts ui/src/pages/new-session/project-chip.test.ts` — 52 tests passed.
- Independent autoreview through P2 — no actionable findings.
- `node scripts/check-changed.mjs -- ui/src/pages/new-session/where-chip.ts ui/src/pages/new-session/project-chip.ts` — passed (format, lint, type checks, i18n, guards, and dead-export scans).

No new test was added for this reversible attribute-only removal; real browser comparisons and existing picker tests cover it. Loading, error, and content-heavy screens are unrelated to the removed constant titles. No model turn or channel delivery was needed for this UI-only change. Production LOC: +0/−2; tests: unchanged.
