### PR TITLE
fix(ui): give plugin tabs more vertical space

### DIFF
--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -25,6 +25,7 @@
 .content-header.plugins-hub-header .hub-page-header__tabs {
   grid-area: tabs;
   justify-self: start;
+  padding-block: var(--space-2);
 }
 
 .plugins-hub-header .hub-tabs--sub wa-tab.hub-tab::part(base) {


### PR DESCRIPTION
## What Problem This Solves

The Plugins, Skills, and Skill workshop navigation sits too tightly against the top of the page and its heading.

## Why This Change Was Made

Add 8 px of vertical padding on each side of the shared Plugins hub tab wrapper, using the existing spacing token. The page owns this spacing, so other hub headers and the tabs' appearance and click targets keep their current behavior.

## User Impact

The three Plugins workspace pages have more breathing room around their navigation on mobile and desktop.

## Evidence

Compared baseline `068318110aec` with this one-line CSS change in the real local Control UI at `/plugins`, `/skills`, and `/skills/workshop`, using the repository's deterministic mock Gateway and identical dark-theme fixtures. All 12 route/viewport comparisons show 8 px above and below the strip, +16 px wrapper height, unchanged width, and no horizontal page overflow. Inspected every comparison below.

- Viewports: 390×844, 768×1024, 1366×768, 1440×900.
- `oxfmt --check ui/src/styles/plugins.css`, targeted stylelint, and `git diff --check`: passed.
- Independent autoreview through P2: scoped-clean, no findings.
- `node scripts/check-changed.mjs -- ui/src/styles/plugins.css`: formatting and repository guards passed; core-test typechecking stopped because borrowed compiler/declaration dependencies are outside this checkout. Hosted [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34562128285) subsequently passed, including UI E2E, real-Gateway tests, typechecks, and the required gate.
- Existing `plugins-hub-navigation.e2e.test.ts`: local launch initially hit Vitest 4 versus the pinned Vitest 5; retry with Vitest 5 stopped at an unrelated missing `markdown-it-cjk-friendly` dependency while building the whole UI. The standalone browser proof successfully exercised all three routes and active tab transitions.
- Loading, empty, and content-heavy catalog variants are omitted: the changed header has fixed navigation content and does not depend on catalog state. The longest tab label and wrapping workshop subtitle are covered.
- Production delta: +1 CSS line; tests: unchanged. No new test for this reversible spacing preference; existing navigation coverage and measured browser comparisons cover the affected layout.

### Mobile — before / after

![mobile comparison](https://github.com/user-attachments/assets/60c26c25-61ea-4b85-a1b8-40ff8cd94e64)

### Tablet — before / after

![tablet comparison](https://github.com/user-attachments/assets/1bef2245-c42d-42d2-a078-0e0ed852e9f6)

### Laptop — before / after

![laptop comparison](https://github.com/user-attachments/assets/79842522-2989-48ec-8835-5fad7302ecbf)

### Desktop — before / after

![desktop comparison](https://github.com/user-attachments/assets/b7839b85-e6d0-4901-b2ec-d31cb54410e5)


