### PR TITLE
fix: recheck stale WHAM blocks for native runtimes

### DIFF
--- a/src/agents/failover/wham-recovery.test.ts
+++ b/src/agents/failover/wham-recovery.test.ts
@@ -1,0 +1,304 @@
+import { setImmediate } from "node:timers/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import type { AuthProfileStore, ProfileUsageStats } from "../auth-profiles/types.js";
+import { isProfileInCooldown } from "../auth-profiles/usage-state.js";
+import { testing as usageTesting } from "../auth-profiles/usage.test-support.js";
+import { FailoverError } from "../failover-error.js";
+import { clearAgentHarnesses, registerAgentHarness } from "../harness/registry.js";
+import { runWithModelFallback } from "../model-fallback-runner.js";
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn<typeof fetch>(),
+  ensureStore: vi.fn<() => AuthProfileStore>(),
+  loadStore: vi.fn<() => AuthProfileStore>(),
+  order: vi.fn(() => ["openai:primary"]),
+  eligibility: vi.fn(() => ({ eligible: true })),
+  cooldown: vi.fn(() => true),
+  updateStore:
+    vi.fn<typeof import("../auth-profiles/store-runtime.js").updateAuthProfileStoreWithLock>(),
+  resolveOwner: vi.fn((params: { agentDir?: string }) => params.agentDir),
+}));
+
+// Keep store ownership and HTTP at test boundaries; execute the actual WHAM
+// claim, response classification, and compare-and-swap recovery code.
+vi.mock("../auth-profiles/store.js", () => ({
+  resolvePersistedAuthProfileOwnerAgentDir: mocks.resolveOwner,
+}));
+vi.mock("../auth-profiles/store-runtime.js", () => ({
+  updateAuthProfileStoreWithLock: mocks.updateStore,
+}));
+vi.mock("../auth-profiles/source-check.js", () => ({
+  hasAnyAuthProfileStoreSource: () => true,
+}));
+vi.mock("../auth-profiles.runtime.js", async () => {
+  const usage = await import("../auth-profiles/usage.js");
+  return {
+    ensureAuthProfileStore: mocks.ensureStore,
+    loadAuthProfileStoreForRuntime: mocks.loadStore,
+    resolveAuthProfileOrder: mocks.order,
+    resolveAuthProfileEligibility: mocks.eligibility,
+    isProfileInCooldown: mocks.cooldown,
+    getSoonestCooldownExpiry: usage.getSoonestCooldownExpiry,
+    resolveProfilesUnavailableReason: usage.resolveProfilesUnavailableReason,
+    maybeReprobeWhamBlockedProfiles: usage.maybeReprobeWhamBlockedProfiles,
+  };
+});
+vi.mock("../provider-request-config.js", () => ({
+  resolveProviderRequestHeaders: (params: { defaultHeaders: Record<string, string> }) =>
+    params.defaultHeaders,
+}));
+vi.mock("../provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: () => undefined,
+}));
+vi.mock("../../plugins/providers.runtime.js", () => ({
+  isPluginProvidersLoadInFlight: () => false,
+}));
+vi.mock("../../plugins/provider-hook-runtime.js", () => ({
+  resolveProviderRuntimePlugin: () => undefined,
+  resolveLoadedProviderRuntimePlugin: () => undefined,
+  resolveProviderPluginsForHooks: () => [],
+  resolveLoadedProviderPluginsForHooks: () => [],
+}));
+vi.mock("../../plugins/provider-runtime.js", () => ({
+  buildProviderMissingAuthMessageWithPlugin: () => undefined,
+}));
+vi.mock("../session-suspension.js", () => ({
+  suspendSession: vi.fn(),
+  resolveSessionSuspensionReason: () => "quota_exhausted",
+  runWithDeferredSessionSuspension: (run: () => Promise<unknown>) => run(),
+}));
+
+const NOW = 1_700_000_000_000;
+const REPROBE_INTERVAL = 45 * 60 * 1000;
+const PROFILE_ID = "openai:primary";
+const BLOCKED_UNTIL = NOW + 6 * 24 * 60 * 60 * 1000;
+const cfg: OpenClawConfig = {
+  agents: { defaults: { model: { primary: "openai/gpt-5.5", fallbacks: [] } } },
+  models: {
+    providers: {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        agentRuntime: { id: "codex" },
+        models: [],
+      },
+    },
+  },
+};
+let persisted: AuthProfileStore;
+let store: AuthProfileStore;
+const pendingResponses: Array<(response: Response) => void> = [];
+
+function setStats(overrides: Partial<ProfileUsageStats> = {}): void {
+  persisted.usageStats = {
+    [PROFILE_ID]: {
+      blockedUntil: BLOCKED_UNTIL,
+      blockedReason: "subscription_limit",
+      blockedSource: "wham",
+      blockedModel: "gpt-5.5",
+      blockedScope: "model",
+      lastFailureAt: NOW - REPROBE_INTERVAL,
+      lastProbeAt: NOW - REPROBE_INTERVAL,
+      ...overrides,
+    },
+  };
+  store = structuredClone(persisted);
+}
+
+function deferredWhamResponse() {
+  const response = createDeferredCore<Response>();
+  mocks.fetch.mockReturnValueOnce(response.promise);
+  pendingResponses.push(response.resolve);
+  return response.resolve;
+}
+
+function runNativeAttempt() {
+  const run = vi.fn(async () => {
+    if (isProfileInCooldown(persisted, PROFILE_ID, undefined, "gpt-5.5")) {
+      throw new FailoverError("Native harness profile is blocked", {
+        provider: "openai",
+        model: "gpt-5.5",
+        reason: "rate_limit",
+      });
+    }
+    return "native response";
+  });
+  return {
+    run,
+    result: runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-5.5",
+      manifestPlugins: [],
+      run,
+    }),
+  };
+}
+
+async function expectNativeBlocked(): Promise<void> {
+  const attempt = runNativeAttempt();
+  await expect(attempt.result).rejects.toThrow("Native harness profile is blocked");
+  expect(attempt.run).toHaveBeenCalledOnce();
+  expect(mocks.cooldown).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(Date, "now").mockReturnValue(NOW);
+  mocks.fetch.mockReset();
+  vi.stubGlobal("fetch", mocks.fetch);
+  persisted = {
+    version: 1,
+    profiles: {
+      [PROFILE_ID]: {
+        type: "oauth",
+        provider: "openai",
+        access: "synthetic-access",
+        refresh: "synthetic-refresh",
+        expires: NOW + 24 * 60 * 60 * 1000,
+      },
+    },
+  };
+  setStats();
+  mocks.ensureStore.mockImplementation(() => store);
+  mocks.loadStore.mockImplementation(() => structuredClone(persisted));
+  mocks.order.mockImplementation(() => [PROFILE_ID]);
+  mocks.updateStore.mockImplementation(async ({ updater }) => {
+    const fresh = structuredClone(persisted);
+    if (updater(fresh)) {
+      persisted = fresh;
+    }
+    return structuredClone(persisted);
+  });
+  usageTesting.setDepsForTest({ updateAuthProfileStoreWithLock: mocks.updateStore });
+  clearAgentHarnesses();
+  registerAgentHarness(
+    {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => {
+        throw new Error("The supplied run callback owns the native attempt in this test");
+      },
+    },
+    { ownerPluginId: "codex" },
+  );
+});
+
+afterEach(async () => {
+  for (const resolve of pendingResponses.splice(0)) {
+    resolve(new Response("{}", { status: 503 }));
+  }
+  // Drain the background response continuation before resetting its dependency seam.
+  await setImmediate();
+  usageTesting.setDepsForTest(null);
+  usageTesting.resetWhamReprobeStateForTest();
+  clearAgentHarnesses();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("registered Codex harness WHAM recovery through model fallback", () => {
+  it.each([
+    ["account-wide", { blockedModel: undefined, blockedScope: undefined }],
+    ["model-scoped", { blockedModel: "gpt-5.5", blockedScope: "model" }],
+  ] satisfies [string, Partial<ProfileUsageStats>][])(
+    "admits native attempts while background recovery of the %s WHAM block enables the next run",
+    async (_scope, stats) => {
+      setStats(stats);
+      const release = deferredWhamResponse();
+      await expectNativeBlocked();
+      await vi.waitFor(() => expect(mocks.fetch).toHaveBeenCalledOnce());
+      expect(persisted.usageStats?.[PROFILE_ID]?.blockedUntil).toBe(BLOCKED_UNTIL);
+
+      // A second turn while the HTTP response is pending cannot start another probe.
+      await expectNativeBlocked();
+      expect(mocks.fetch).toHaveBeenCalledOnce();
+      release(Response.json({ rate_limit: { limit_reached: false } }));
+      await vi.waitFor(() => {
+        expect(persisted.usageStats?.[PROFILE_ID]?.blockedUntil).toBeUndefined();
+        expect(store.usageStats?.[PROFILE_ID]?.blockedUntil).toBeUndefined();
+      });
+
+      const next = runNativeAttempt();
+      await expect(next.result).resolves.toMatchObject({
+        outcome: "completed",
+        result: "native response",
+        provider: "openai",
+        model: "gpt-5.5",
+      });
+      expect(next.run).toHaveBeenCalledOnce();
+      expect(mocks.cooldown).not.toHaveBeenCalled();
+      expect(mocks.fetch).toHaveBeenCalledOnce();
+      expect(persisted.usageStats?.[PROFILE_ID]?.lastProbeAt).toBe(NOW);
+    },
+  );
+
+  it.each([
+    ["non-WHAM block", { blockedSource: "codex_rate_limits" }],
+    ["recent probe", { lastProbeAt: NOW - REPROBE_INTERVAL + 1 }],
+    ["soon-expiring block", { blockedUntil: NOW + REPROBE_INTERVAL }],
+    ["active auth cooldown", { cooldownUntil: NOW + 60_000 }],
+    ["disabled profile", { disabledUntil: NOW + 60_000 }],
+  ] satisfies [string, Partial<ProfileUsageStats>][])(
+    "preserves %s without starting WHAM recovery or generic admission checks",
+    async (_label, stats) => {
+      setStats(stats);
+      await expectNativeBlocked();
+      expect(mocks.fetch).not.toHaveBeenCalled();
+      expect(mocks.updateStore).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows native execution while preserving another model's WHAM block", async () => {
+    setStats({ blockedModel: "gpt-4.1" });
+    const next = runNativeAttempt();
+    await expect(next.result).resolves.toMatchObject({
+      outcome: "completed",
+      result: "native response",
+    });
+    expect(next.run).toHaveBeenCalledOnce();
+    expect(mocks.cooldown).not.toHaveBeenCalled();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    expect(mocks.updateStore).not.toHaveBeenCalled();
+    expect(persisted.usageStats?.[PROFILE_ID]).toMatchObject({
+      blockedModel: "gpt-4.1",
+      blockedUntil: BLOCKED_UNTIL,
+    });
+  });
+
+  it.each([
+    ["HTTP failure", () => new Response("{}", { status: 503 })],
+    ["unknown capacity", () => Response.json({})],
+  ])("preserves the block after %s and throttles the next probe", async (_label, response) => {
+    mocks.fetch.mockResolvedValueOnce(response());
+    await expectNativeBlocked();
+    await vi.waitFor(() => expect(mocks.fetch).toHaveBeenCalledOnce());
+    await setImmediate();
+    await expectNativeBlocked();
+    expect(persisted.usageStats?.[PROFILE_ID]?.blockedUntil).toBe(BLOCKED_UNTIL);
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+    expect(persisted.usageStats?.[PROFILE_ID]?.lastProbeAt).toBe(NOW);
+  });
+
+  it("does not clear a newer WHAM block with an earlier available response", async () => {
+    const release = deferredWhamResponse();
+    await expectNativeBlocked();
+    await vi.waitFor(() => expect(mocks.fetch).toHaveBeenCalledOnce());
+    const newerUntil = BLOCKED_UNTIL + 60_000;
+    persisted.usageStats = {
+      ...persisted.usageStats,
+      [PROFILE_ID]: {
+        ...persisted.usageStats?.[PROFILE_ID],
+        blockedUntil: newerUntil,
+        lastFailureAt: NOW + 1,
+      },
+    };
+    release(Response.json({ rate_limit: { limit_reached: false } }));
+    await vi.waitFor(() => expect(mocks.updateStore).toHaveBeenCalledTimes(2));
+    expect(persisted.usageStats?.[PROFILE_ID]?.blockedUntil).toBe(newerUntil);
+    await expectNativeBlocked();
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -317,25 +317,27 @@ async function runWithModelFallbackInternal<T>(
           profileId: userLockedAuthProfileId,
           includePendingOAuthRefresh: true,
         }).eligible;
+      let profileIds = authRuntime.resolveAuthProfileOrder({
+        cfg: params.cfg,
+        store: authStore,
+        provider: candidate.provider,
+        forModel: candidate.model,
+        includePendingOAuthRefresh: true,
+      });
+      if (userLockedAuthProfileEligible && userLockedAuthProfileId) {
+        profileIds = [...new Set([userLockedAuthProfileId, ...profileIds])];
+      }
+      // A harness owns admission, but shared WHAM blocks still need their
+      // existing bounded recovery when upstream capacity returns early.
+      authRuntime.maybeReprobeWhamBlockedProfiles({
+        store: authStore,
+        profileIds,
+        agentDir: params.agentDir,
+        forModel: candidate.model,
+      });
       if (!candidateHarnessAuth.skipsProviderAuthCooldown) {
-        candidateAuthProfileIds = authRuntime.resolveAuthProfileOrder({
-          cfg: params.cfg,
-          store: authStore,
-          provider: candidate.provider,
-          forModel: candidate.model,
-          includePendingOAuthRefresh: true,
-        });
-        if (userLockedAuthProfileEligible && userLockedAuthProfileId) {
-          candidateAuthProfileIds.unshift(userLockedAuthProfileId);
-          candidateAuthProfileIds = [...new Set(candidateAuthProfileIds)];
-        }
-        profileIdsByCandidate.set(candidate, candidateAuthProfileIds);
-        authRuntime.maybeReprobeWhamBlockedProfiles({
-          store: authStore,
-          profileIds: candidateAuthProfileIds,
-          agentDir: params.agentDir,
-          forModel: candidate.model,
-        });
+        candidateAuthProfileIds = profileIds;
+        profileIdsByCandidate.set(candidate, profileIds);
       }
     }
     const candidateAuthScope = resolveFallbackAuthScope({


### PR DESCRIPTION
Related: #123009

## What Problem This Solves

Fixes an issue where users of native runtimes could remain behind an OpenClaw-owned WHAM subscription block after their OpenAI capacity returned. Native harnesses bypass generic provider cooldown admission, which also prevented the existing background recovery from being scheduled during model fallback preparation.

## Why This Change Was Made

Schedule the existing WHAM recovery independently of generic cooldown admission, using the candidate provider's ordered profiles and any eligible explicit profile pin. Keep native admission, fallback auth scope, the 45-minute demand-driven interval, in-flight deduplication, and the existing credential/block-generation checks unchanged.

This is a narrow caller repair for the WHAM part of #123009. It does not implement the proposed five-minute native `account/rateLimits/read` reconciler or recovery for `codex_rate_limits` blocks. It introduces no new scheduler, configuration option, storage schema, or recovery writer.

## User Impact

An eligible stale WHAM block can be rechecked while a native runtime serves demand. Confirmed returned capacity releases only the matching block, allowing a subsequent request to reconsider the preferred account. Unknown or failed reads retain the block. Native runtimes continue to own their admission and transport.

## Evidence

- Synthetic regression against base `ed6b7f86991e1bef0b9aacb5d14de7230e507894`: 5 failed / 6 passed before the caller change; all 11 pass with it.
- `node scripts/run-vitest.mjs src/agents/failover/wham-recovery.test.ts`: real fallback runner, registered Codex harness, and real WHAM recovery logic, with mocked HTTP and in-memory persistence. Covers account-wide and model-scoped recovery, next-request success, admission bypass, deduplication, interval boundaries, unrelated-model blocks, failed/unknown reads, and stale-response generation checks.
- `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts src/agents/model-fallback.probe.test.ts src/agents/auth-profiles/usage.test.ts`: 291 passed.
- `node scripts/check-changed.mjs -- src/agents/model-fallback-runner.ts src/agents/failover/wham-recovery.test.ts`: passed, including core and test typechecks, scoped lint, import-cycle and unused-export checks.
- Independent `autoreview` at P0–P2: scoped-clean, no actionable findings. Staged secret scan and outgoing privacy checks passed.

All reproduction inputs are synthetic. The candidate has not been deployed to a live Gateway, so the isolated runner proof is not presented as full live-Gateway or native app-server reconciliation proof. The broader policy and convergence questions in #123009 remain open.

The native protocol boundary was also checked against [openai/codex@3d2ee51](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/app-server/src/request_processors/account_processor.rs#L1131): the rate-limit RPC reads the app-server's current authentication and supplies an optional account ID. This patch retains the existing WHAM owner and does not interpret that separate RPC snapshot.
