### PR TITLE
refactor: consolidate Mantis Crabbox lease handling

### DIFF
--- a/extensions/qa-lab/src/mantis/crabbox-runtime.ts
+++ b/extensions/qa-lab/src/mantis/crabbox-runtime.ts
@@ -115,80 +115,89 @@ export async function runCommand(params: {
   });
 }
 
-export async function warmupCrabbox(params: {
+export function createMantisCrabboxSession(params: {
   crabboxBin: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
-  idleTimeout: string;
-  machineClass: string;
-  market?: string;
-  provider: string;
-  runner: CommandRunner;
-  ttl: string;
-}) {
-  const marketArgs = params.market ? ["--market", params.market] : [];
-  const result = await runCommand({
-    command: params.crabboxBin,
-    args: [
-      "warmup",
-      "--provider",
-      params.provider,
-      "--desktop",
-      "--browser",
-      "--class",
-      params.machineClass,
-      ...marketArgs,
-      "--idle-timeout",
-      params.idleTimeout,
-      "--ttl",
-      params.ttl,
-    ],
-    cwd: params.cwd,
-    env: params.env,
-    runner: params.runner,
-    stdio: "inherit",
-  });
-  const leaseId = extractLeaseId(`${result.stdout}\n${result.stderr}`);
-  if (!leaseId) {
-    throw new Error("Crabbox warmup did not print a lease id.");
-  }
-  return leaseId;
-}
-
-export async function inspectCrabbox(params: {
-  crabboxBin: string;
-  cwd: string;
-  env: NodeJS.ProcessEnv;
-  leaseId: string;
+  leaseId?: string;
   provider: string;
   runner: CommandRunner;
 }) {
-  const result = await runCommand({
-    command: params.crabboxBin,
-    args: ["inspect", "--provider", params.provider, "--id", params.leaseId, "--json"],
-    cwd: params.cwd,
-    env: params.env,
-    runner: params.runner,
-  });
-  return JSON.parse(result.stdout) as CrabboxInspect;
-}
-
-export async function stopCrabbox(params: {
-  crabboxBin: string;
-  cwd: string;
-  env: NodeJS.ProcessEnv;
-  leaseId: string;
-  provider: string;
-  runner: CommandRunner;
-}) {
-  await runCommand({
-    command: params.crabboxBin,
-    args: ["stop", "--provider", params.provider, params.leaseId],
-    cwd: params.cwd,
-    env: params.env,
-    runner: params.runner,
-    stdio: "inherit",
-  });
+  let leaseId = params.leaseId;
+  const createdLease = leaseId === undefined;
+  const run = (args: readonly string[], stdio?: "inherit" | "pipe") =>
+    runCommand({ ...params, command: params.crabboxBin, args, stdio });
+  const requireLeaseId = () => {
+    if (!leaseId) {
+      throw new Error("Crabbox lease id is unavailable before acquisition.");
+    }
+    return leaseId;
+  };
+  return {
+    createdLease,
+    get leaseId() {
+      return leaseId;
+    },
+    async acquire(options: {
+      idleTimeout: string;
+      machineClass: string;
+      market?: string;
+      ttl: string;
+    }) {
+      if (leaseId !== undefined) {
+        return leaseId;
+      }
+      const result = await run(
+        [
+          "warmup",
+          "--provider",
+          params.provider,
+          "--desktop",
+          "--browser",
+          "--class",
+          options.machineClass,
+          ...(options.market ? ["--market", options.market] : []),
+          "--idle-timeout",
+          options.idleTimeout,
+          "--ttl",
+          options.ttl,
+        ],
+        "inherit",
+      );
+      const acquired = extractLeaseId(`${result.stdout}\n${result.stderr}`);
+      if (!acquired) {
+        throw new Error("Crabbox warmup did not print a lease id.");
+      }
+      leaseId = acquired;
+      return acquired;
+    },
+    async inspect() {
+      const result = await run([
+        "inspect",
+        "--provider",
+        params.provider,
+        "--id",
+        requireLeaseId(),
+        "--json",
+      ]);
+      return JSON.parse(result.stdout) as CrabboxInspect;
+    },
+    describe(inspected?: CrabboxInspect) {
+      return {
+        bin: params.crabboxBin,
+        createdLease,
+        id: leaseId ?? "unallocated",
+        provider: params.provider,
+        ...(inspected ? { slug: inspected.slug, state: inspected.state } : {}),
+        vncCommand: leaseId
+          ? `${params.crabboxBin} vnc --provider ${params.provider} --id ${leaseId} --open`
+          : "unallocated",
+      };
+    },
+    async stop() {
+      await run(["stop", "--provider", params.provider, requireLeaseId()], "inherit");
+    },
+  };
 }
 
 function crabboxSshPortCandidates(inspect: Pick<CrabboxInspect, "sshFallbackPorts" | "sshPort">) {

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
@@ -66,7 +66,7 @@ describe("mantis desktop browser smoke runtime", () => {
           return {
             stdout: `${JSON.stringify({
               host: "203.0.113.10",
-              id: "cbx_abc123",
+              id: "cbx_decaf",
               provider: "hetzner",
               slug: "brisk-mantis",
               sshKey: "/tmp/key",
@@ -306,44 +306,65 @@ describe("mantis desktop browser smoke runtime", () => {
     expect(summary.crabbox.provider).toBe("blacksmith-testbox");
   });
 
-  it("keeps an existing lease and writes failure reports when the remote run fails", async () => {
-    const commands: { args: readonly string[]; command: string }[] = [];
-    const runner = vi.fn(async (command: string, args: readonly string[]) => {
-      commands.push({ command, args });
-      if (command === "/tmp/crabbox" && args[0] === "inspect") {
-        return {
-          stdout: `${JSON.stringify({
-            host: "203.0.113.10",
-            id: "cbx_existing",
-            provider: "hetzner",
-            sshKey: "/tmp/key",
-            sshPort: "2222",
-            sshUser: "crabbox",
-          })}\n`,
-          stderr: "",
-        };
-      }
-      if (command === "/tmp/crabbox" && args[0] === "run") {
-        throw new Error("remote chrome failed");
-      }
-      return { stdout: "", stderr: "" };
-    });
+  it.each([
+    ["run", "cbx_existing", "cbx_existing", ["inspect", "run"]],
+    ["warmup", undefined, "unallocated", ["warmup"]],
+    ["inspect", undefined, "cbx_abc123", ["warmup", "inspect"]],
+  ] as const)(
+    "retains the lease identity when %s fails",
+    async (failure, leaseId, expectedId, operations) => {
+      const commands: { args: readonly string[]; command: string }[] = [];
+      const runner = vi.fn(async (command: string, args: readonly string[]) => {
+        commands.push({ command, args });
+        if (command === "/tmp/crabbox" && args[0] === failure) {
+          throw new Error(`${failure} failed`);
+        }
+        if (command === "/tmp/crabbox" && args[0] === "warmup") {
+          return { stdout: "ready lease cbx_abc123\n", stderr: "" };
+        }
+        if (command === "/tmp/crabbox" && args[0] === "inspect") {
+          return {
+            stdout: `${JSON.stringify({
+              host: "203.0.113.10",
+              id: "cbx_decaf",
+              provider: "hetzner",
+              slug: "brisk-mantis",
+              state: "active",
+              sshKey: "/tmp/key",
+              sshPort: "2222",
+              sshUser: "crabbox",
+            })}\n`,
+            stderr: "",
+          };
+        }
+        return { stdout: "", stderr: "" };
+      });
 
-    const result = await runMantisDesktopBrowserSmoke({
-      commandRunner: runner,
-      crabboxBin: "/tmp/crabbox",
-      leaseId: "cbx_existing",
-      outputDir: ".artifacts/qa-e2e/mantis/desktop-browser-fail",
-      repoRoot,
-    });
+      const result = await runMantisDesktopBrowserSmoke({
+        commandRunner: runner,
+        crabboxBin: "/tmp/crabbox",
+        leaseId,
+        outputDir: ".artifacts/qa-e2e/mantis/desktop-browser-fail",
+        repoRoot,
+      });
 
-    expect(result.status).toBe("fail");
-    expect(commands.map((entry) => [entry.command, entry.args[0]])).toEqual([
-      ["/tmp/crabbox", "inspect"],
-      ["/tmp/crabbox", "run"],
-    ]);
-    await expect(fs.readFile(path.join(result.outputDir, "error.txt"), "utf8")).resolves.toContain(
-      "remote chrome failed",
-    );
-  });
+      expect(result.status).toBe("fail");
+      expect(JSON.parse(await fs.readFile(result.summaryPath, "utf8")).crabbox).toEqual({
+        bin: "/tmp/crabbox",
+        createdLease: leaseId === undefined,
+        id: expectedId,
+        provider: "hetzner",
+        vncCommand:
+          expectedId === "unallocated"
+            ? "unallocated"
+            : `/tmp/crabbox vnc --provider hetzner --id ${expectedId} --open`,
+      });
+      expect(commands.map((entry) => [entry.command, entry.args[0]])).toEqual(
+        operations.map((operation) => ["/tmp/crabbox", operation]),
+      );
+      await expect(
+        fs.readFile(path.join(result.outputDir, "error.txt"), "utf8"),
+      ).resolves.toContain(`${failure} failed`);
+    },
+  );
 });

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
@@ -9,12 +9,10 @@ import {
   copyCrabboxArtifacts,
   type CommandRunner,
   defaultCommandRunner,
-  inspectCrabbox,
+  createMantisCrabboxSession,
   resolveCrabboxBin,
   runCommand,
   shellQuote,
-  stopCrabbox,
-  warmupCrabbox,
 } from "./crabbox-runtime.js";
 import { renderMantisCrabboxReport, type MantisCrabboxReportSummary } from "./report.js";
 
@@ -298,34 +296,22 @@ export async function runMantisDesktopBrowserSmoke(
   const runner = opts.commandRunner ?? defaultCommandRunner;
   const explicitLeaseId = trimToValue(opts.leaseId) ?? trimToValue(env[CRABBOX_LEASE_ID_ENV]);
   const keepLease = opts.keepLease ?? isTruthyOptIn(env[CRABBOX_KEEP_ENV]);
-  const createdLease = explicitLeaseId === undefined;
   const remoteOutputDir = `/tmp/openclaw-mantis-desktop-${startedAt
     .toISOString()
     .replace(/[^0-9A-Za-z]/gu, "-")}`;
-  let leaseId = explicitLeaseId;
+  const session = createMantisCrabboxSession({
+    crabboxBin,
+    cwd: repoRoot,
+    env,
+    leaseId: explicitLeaseId,
+    provider,
+    runner,
+  });
   let summary: MantisDesktopBrowserSmokeSummary | undefined;
 
   try {
-    leaseId =
-      leaseId ??
-      (await warmupCrabbox({
-        crabboxBin,
-        cwd: repoRoot,
-        env,
-        idleTimeout,
-        machineClass,
-        provider,
-        runner,
-        ttl,
-      }));
-    const inspected = await inspectCrabbox({
-      crabboxBin,
-      cwd: repoRoot,
-      env,
-      leaseId,
-      provider,
-      runner,
-    });
+    const leaseId = await session.acquire({ idleTimeout, machineClass, ttl });
+    const inspected = await session.inspect();
     await runCommand({
       command: crabboxBin,
       args: [
@@ -377,15 +363,7 @@ export async function runMantisDesktopBrowserSmoke(
       },
       browserUrl,
       htmlFile,
-      crabbox: {
-        bin: crabboxBin,
-        createdLease,
-        id: leaseId,
-        provider,
-        slug: inspected.slug,
-        state: inspected.state,
-        vncCommand: `${crabboxBin} vnc --provider ${provider} --id ${leaseId} --open`,
-      },
+      crabbox: session.describe(inspected),
       finishedAt: new Date().toISOString(),
       outputDir,
       remoteOutputDir,
@@ -408,15 +386,7 @@ export async function runMantisDesktopBrowserSmoke(
       },
       browserUrl,
       htmlFile,
-      crabbox: {
-        bin: crabboxBin,
-        createdLease,
-        id: leaseId ?? "unallocated",
-        provider,
-        vncCommand: leaseId
-          ? `${crabboxBin} vnc --provider ${provider} --id ${leaseId} --open`
-          : "unallocated",
-      },
+      crabbox: session.describe(),
       error: formatErrorMessage(error),
       finishedAt: new Date().toISOString(),
       outputDir,
@@ -437,8 +407,8 @@ export async function runMantisDesktopBrowserSmoke(
       await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
       await fs.writeFile(reportPath, renderReport(summary), "utf8");
     }
-    if (summary?.status === "pass" && createdLease && leaseId && !keepLease) {
-      await stopCrabbox({ crabboxBin, cwd: repoRoot, env, leaseId, provider, runner });
+    if (summary?.status === "pass" && session.createdLease && session.leaseId && !keepLease) {
+      await session.stop();
     }
   }
 }

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
@@ -764,58 +764,70 @@ describe("mantis Slack desktop smoke runtime", () => {
     },
   );
 
-  it("stops a created no-keep lease when the remote Slack QA run fails", async () => {
-    const commands: { args: readonly string[]; command: string }[] = [];
-    const runner = vi.fn(async (command: string, args: readonly string[]) => {
-      commands.push({ command, args });
-      if (command === "/tmp/crabbox" && args[0] === "warmup") {
-        return { stdout: "ready lease cbx_fade123\n", stderr: "" };
-      }
-      if (command === "/tmp/crabbox" && args[0] === "inspect") {
-        return {
-          stdout: `${JSON.stringify({
-            host: "203.0.113.10",
-            id: "cbx_fade123",
-            provider: "hetzner",
-            sshKey: "/tmp/key",
-            sshPort: "2222",
-            sshUser: "crabbox",
-          })}\n`,
-          stderr: "",
-        };
-      }
-      if (command === "/tmp/crabbox" && args[0] === "run") {
-        throw new Error("remote Slack QA failed");
-      }
-      if (command === "rsync") {
-        const outputDir = args.at(-1);
-        await fs.mkdir(outputDir as string, { recursive: true });
-        if (!String(outputDir).endsWith("slack-qa/")) {
-          await fs.writeFile(path.join(outputDir as string, "slack-desktop-smoke.png"), "png");
-          await fs.writeFile(path.join(outputDir as string, "remote-metadata.json"), "{}\n");
+  it.each(["run", "inspect"] as const)(
+    "stops a created no-keep lease when %s fails",
+    async (failure) => {
+      const commands: { args: readonly string[]; command: string }[] = [];
+      const runner = vi.fn(async (command: string, args: readonly string[]) => {
+        commands.push({ command, args });
+        if (command === "/tmp/crabbox" && args[0] === failure) {
+          throw new Error(`${failure} failed`);
         }
-      }
-      return { stdout: "", stderr: "" };
-    });
+        if (command === "/tmp/crabbox" && args[0] === "warmup") {
+          return { stdout: "ready lease cbx_fade123\n", stderr: "" };
+        }
+        if (command === "/tmp/crabbox" && args[0] === "inspect") {
+          return {
+            stdout: `${JSON.stringify({
+              host: "203.0.113.10",
+              id: "cbx_fade123",
+              provider: "hetzner",
+              slug: "brisk-mantis",
+              state: "active",
+              sshKey: "/tmp/key",
+              sshPort: "2222",
+              sshUser: "crabbox",
+            })}\n`,
+            stderr: "",
+          };
+        }
+        if (command === "rsync") {
+          const outputDir = args.at(-1);
+          await fs.mkdir(outputDir as string, { recursive: true });
+          if (!String(outputDir).endsWith("slack-qa/")) {
+            await fs.writeFile(path.join(outputDir as string, "slack-desktop-smoke.png"), "png");
+            await fs.writeFile(path.join(outputDir as string, "remote-metadata.json"), "{}\n");
+          }
+        }
+        return { stdout: "", stderr: "" };
+      });
 
-    const result = await runMantisSlackDesktopSmoke({
-      commandRunner: runner,
-      crabboxBin: "/tmp/crabbox",
-      keepLease: false,
-      outputDir: ".artifacts/qa-e2e/mantis/slack-desktop-created-fail",
-      repoRoot,
-    });
+      const result = await runMantisSlackDesktopSmoke({
+        commandRunner: runner,
+        crabboxBin: "/tmp/crabbox",
+        keepLease: false,
+        outputDir: ".artifacts/qa-e2e/mantis/slack-desktop-created-fail",
+        repoRoot,
+      });
 
-    expect(result.status).toBe("fail");
-    expect(
-      commands.some(
-        (entry) =>
-          entry.command === "/tmp/crabbox" &&
-          JSON.stringify(entry.args) ===
-            JSON.stringify(["stop", "--provider", "hetzner", "cbx_fade123"]),
-      ),
-    ).toBe(true);
-  });
+      expect(result.status).toBe("fail");
+      expect(JSON.parse(await fs.readFile(result.summaryPath, "utf8")).crabbox).toEqual({
+        bin: "/tmp/crabbox",
+        createdLease: true,
+        id: "cbx_fade123",
+        provider: "hetzner",
+        vncCommand: "/tmp/crabbox vnc --provider hetzner --id cbx_fade123 --open",
+      });
+      expect(
+        commands.some(
+          (entry) =>
+            entry.command === "/tmp/crabbox" &&
+            JSON.stringify(entry.args) ===
+              JSON.stringify(["stop", "--provider", "hetzner", "cbx_fade123"]),
+        ),
+      ).toBe(true);
+    },
+  );
 
   it("passes gateway setup when Crabbox returns non-zero after remote metadata proves success", async () => {
     const runner = vi.fn(async (command: string, args: readonly string[]) => {

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -15,12 +15,10 @@ import {
   copyCrabboxArtifacts,
   type CommandRunner,
   defaultCommandRunner,
-  inspectCrabbox,
+  createMantisCrabboxSession,
   resolveCrabboxBin,
   runCommand,
   shellQuote,
-  stopCrabbox,
-  warmupCrabbox,
 } from "./crabbox-runtime.js";
 import { renderMantisCrabboxReport, type MantisCrabboxReportSummary } from "./report.js";
 
@@ -1265,13 +1263,19 @@ export async function runMantisSlackDesktopSmoke(
   const runner = opts.commandRunner ?? defaultCommandRunner;
   const explicitLeaseId = trimToValue(opts.leaseId) ?? trimToValue(env[CRABBOX_LEASE_ID_ENV]);
   const keepLease = opts.keepLease ?? (gatewaySetup || isTruthyOptIn(env[CRABBOX_KEEP_ENV]));
-  const createdLease = explicitLeaseId === undefined;
   const remoteOutputDir = `/tmp/openclaw-mantis-slack-desktop-${startedAt
     .toISOString()
     .replace(/[^0-9A-Za-z]/gu, "-")}`;
   let credentialLease: SlackGatewayCredentialLease | undefined;
   let leaseHeartbeat: SlackGatewayCredentialHeartbeat | undefined;
-  let leaseId = explicitLeaseId;
+  const session = createMantisCrabboxSession({
+    crabboxBin,
+    cwd: repoRoot,
+    env,
+    leaseId: explicitLeaseId,
+    provider,
+    runner,
+  });
   let summary: MantisSlackDesktopSmokeSummary | undefined;
   let screenshotPath: string | undefined;
   let slackQaDir: string | undefined;
@@ -1280,35 +1284,12 @@ export async function runMantisSlackDesktopSmoke(
   let approvalCheckpointArtifacts: MantisApprovalCheckpointArtifacts | undefined;
 
   try {
-    leaseId =
-      leaseId ??
+    const resolvedLeaseId =
+      session.leaseId ??
       (await timer.timePhase("crabbox.warmup", () =>
-        warmupCrabbox({
-          crabboxBin,
-          cwd: repoRoot,
-          env,
-          idleTimeout,
-          machineClass,
-          market,
-          provider,
-          runner,
-          ttl,
-        }),
+        session.acquire({ idleTimeout, machineClass, market, ttl }),
       ));
-    if (!leaseId) {
-      throw new Error("Crabbox lease id was not resolved.");
-    }
-    const resolvedLeaseId = leaseId;
-    const inspected = await timer.timePhase("crabbox.inspect", () =>
-      inspectCrabbox({
-        crabboxBin,
-        cwd: repoRoot,
-        env,
-        leaseId: resolvedLeaseId,
-        provider,
-        runner,
-      }),
-    );
+    const inspected = await timer.timePhase("crabbox.inspect", () => session.inspect());
     const preparedCredentialEnv = await timer.timePhase("credentials.prepare", () =>
       prepareGatewayCredentialEnv({
         credentialRole,
@@ -1421,15 +1402,7 @@ export async function runMantisSlackDesktopSmoke(
         summaryPath,
         videoPath,
       },
-      crabbox: {
-        bin: crabboxBin,
-        createdLease,
-        id: resolvedLeaseId,
-        provider,
-        slug: inspected.slug,
-        state: inspected.state,
-        vncCommand: `${crabboxBin} vnc --provider ${provider} --id ${resolvedLeaseId} --open`,
-      },
+      crabbox: session.describe(inspected),
       finishedAt: new Date().toISOString(),
       hydrateMode: normalizeHydrateMode(remoteMetadata?.hydrateMode) ?? hydrateMode,
       outputDir,
@@ -1460,15 +1433,7 @@ export async function runMantisSlackDesktopSmoke(
         summaryPath,
         videoPath,
       },
-      crabbox: {
-        bin: crabboxBin,
-        createdLease,
-        id: leaseId ?? "unallocated",
-        provider,
-        vncCommand: leaseId
-          ? `${crabboxBin} vnc --provider ${provider} --id ${leaseId} --open`
-          : "unallocated",
-      },
+      crabbox: session.describe(),
       error: formatErrorMessage(error),
       finishedAt: new Date().toISOString(),
       hydrateMode,
@@ -1498,8 +1463,8 @@ export async function runMantisSlackDesktopSmoke(
       }
     } finally {
       try {
-        if (createdLease && leaseId && !keepLease) {
-          await stopCrabbox({ crabboxBin, cwd: repoRoot, env, leaseId, provider, runner });
+        if (session.createdLease && session.leaseId && !keepLease) {
+          await session.stop();
         }
       } finally {
         try {

--- a/extensions/qa-lab/src/mantis/visual-task.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/visual-task.runtime.test.ts
@@ -213,6 +213,15 @@ describe("mantis visual task runtime", () => {
     });
 
     expect(result.status).toBe("fail");
+    expect(JSON.parse(await fs.readFile(result.summaryPath, "utf8")).crabbox).toEqual({
+      bin: "/tmp/crabbox",
+      createdLease: true,
+      id: "cbx_abc123",
+      provider: "hetzner",
+      slug: "brisk-mantis",
+      state: "active",
+      vncCommand: "/tmp/crabbox vnc --provider hetzner --id cbx_abc123 --open",
+    });
     expect(result.videoPath).toBeUndefined();
     expect(commands.map((entry) => [entry.command, entry.args[0]])).toEqual([
       ["/tmp/crabbox", "warmup"],

--- a/extensions/qa-lab/src/mantis/visual-task.runtime.ts
+++ b/extensions/qa-lab/src/mantis/visual-task.runtime.ts
@@ -9,11 +9,9 @@ import {
   type CommandRunner,
   type CrabboxInspect,
   defaultCommandRunner,
-  inspectCrabbox,
+  createMantisCrabboxSession,
   resolveCrabboxBin,
   runCommand,
-  stopCrabbox,
-  warmupCrabbox,
 } from "./crabbox-runtime.js";
 import { renderMantisCrabboxReport, type MantisCrabboxReportSummary } from "./report.js";
 
@@ -597,37 +595,25 @@ export async function runMantisVisualTask(
   const ttl = trimToValue(opts.ttl) ?? trimToValue(env[CRABBOX_TTL_ENV]) ?? DEFAULT_TTL;
   const explicitLeaseId = trimToValue(opts.leaseId) ?? trimToValue(env[CRABBOX_LEASE_ID_ENV]);
   const keepLease = opts.keepLease ?? isTruthyOptIn(env[CRABBOX_KEEP_ENV]);
-  const createdLease = explicitLeaseId === undefined;
   const browserUrl = trimToValue(opts.browserUrl) ?? DEFAULT_BROWSER_URL;
   const expectText = trimToValue(opts.expectText);
   const visionMode = normalizeVisionMode(opts.visionMode);
   const visionPrompt = buildVisionPrompt(opts.visionPrompt, expectText);
   const runner = opts.commandRunner ?? defaultCommandRunner;
-  let leaseId = explicitLeaseId;
+  const session = createMantisCrabboxSession({
+    crabboxBin,
+    cwd: repoRoot,
+    env,
+    leaseId: explicitLeaseId,
+    provider,
+    runner,
+  });
   let inspected: CrabboxInspect = {};
   let summary: MantisVisualTaskSummary | undefined;
 
   try {
-    leaseId =
-      leaseId ??
-      (await warmupCrabbox({
-        crabboxBin,
-        cwd: repoRoot,
-        env,
-        idleTimeout,
-        machineClass,
-        provider,
-        runner,
-        ttl,
-      }));
-    inspected = await inspectCrabbox({
-      crabboxBin,
-      cwd: repoRoot,
-      env,
-      leaseId,
-      provider,
-      runner,
-    });
+    const leaseId = await session.acquire({ idleTimeout, machineClass, ttl });
+    inspected = await session.inspect();
     let recordingError: string | undefined;
     const activeLeaseId = leaseId;
     if (!activeLeaseId) {
@@ -696,15 +682,7 @@ export async function runMantisVisualTask(
         videoPath: copiedVideo,
       },
       browserUrl,
-      crabbox: {
-        bin: crabboxBin,
-        createdLease,
-        id: leaseId,
-        provider,
-        slug: inspected.slug,
-        state: inspected.state,
-        vncCommand: `${crabboxBin} vnc --provider ${provider} --id ${leaseId} --open`,
-      },
+      crabbox: session.describe(inspected),
       driver,
       error: recordingFailure,
       finishedAt: new Date().toISOString(),
@@ -734,17 +712,7 @@ export async function runMantisVisualTask(
         videoPath: (await pathExists(videoPath)) ? videoPath : undefined,
       },
       browserUrl,
-      crabbox: {
-        bin: crabboxBin,
-        createdLease,
-        id: leaseId ?? "unallocated",
-        provider,
-        slug: inspected.slug,
-        state: inspected.state,
-        vncCommand: leaseId
-          ? `${crabboxBin} vnc --provider ${provider} --id ${leaseId} --open`
-          : "unallocated",
-      },
+      crabbox: session.describe(inspected),
       error: formatErrorMessage(error),
       finishedAt: new Date().toISOString(),
       outputDir,
@@ -770,8 +738,8 @@ export async function runMantisVisualTask(
       await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
       await fs.writeFile(reportPath, renderReport(summary), "utf8");
     }
-    if (summary?.status === "pass" && createdLease && leaseId && !keepLease) {
-      await stopCrabbox({ crabboxBin, cwd: repoRoot, env, leaseId, provider, runner });
+    if (summary?.status === "pass" && session.createdLease && session.leaseId && !keepLease) {
+      await session.stop();
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Mantis desktop-browser, Slack-desktop, and visual-task runs repeat the same lease acquisition, inspection, identity reporting, and stop command construction. That spreads one lease identity across several local variables and repeated request/summary objects.

## Why This Change Was Made

Use one private session in the existing Crabbox runtime helper to bind command context and the supplied or acquired lease ID. All three callers use its acquisition, inspection, summary, and stop operations while retaining their existing cleanup decisions. Inspection metadata never replaces the lease ID.

## User Impact

No user-facing behavior change is intended. Supplied leases remain caller-owned, `--keep-lease` remains effective, desktop/visual failures retain their leases, and Slack preserves cleanup after remote, report-write, and stop failures. Command arguments, remote scripts, CLI options, and report fields retain their existing contracts.

## Evidence

The four focused Mantis suites passed 45 tests against both the original production code and this candidate. Existing failure fixtures now supply inspection metadata when testing its omission, and an inspect result uses a different ID to prove it cannot replace the acquired identity. Three additional parameterized cases cover warmup failure and post-acquisition inspection failures with the different caller cleanup policies.

The complete changed-check gate passed, including extension production/test typechecks, Doctor contract tests, all Knip scans, scoped lint, storage/runtime guards, and import-cycle checks. Fresh managed P2 review completed with no actionable findings. No real leases, Slack sends, or private credentials were used.

Byte comparisons confirm unchanged desktop/Slack remote-script generators, visual driver and recording logic, transport/artifact-copy code, CLI adapters, and shared report renderer. No new module, import edge, public export, or runtime dependency was added, so a full build was not selected.

Complete cost, including strengthened tests: 86 production code lines removed and 42 test lines added, for a net reduction of 44 code lines, 46 physical lines, and 48 bytes. Both cloc 2.10 counting modes agree with a 30-second timeout and checked stdout/stderr diagnostics. This is a small ownership consolidation.
