### PR TITLE
refactor(feishu): reuse bot-menu test fixtures

### DIFF
--- a/extensions/feishu/src/monitor.bot-menu.lifecycle.test-support.ts
+++ b/extensions/feishu/src/monitor.bot-menu.lifecycle.test-support.ts
@@ -8,9 +8,8 @@ import {
   resetFeishuLifecycleTestMocks,
 } from "./lifecycle.test-support.js";
 import {
-  createFeishuLifecycleConfig,
+  createFeishuLifecycleFixture,
   createFeishuLifecycleReplyDispatcher,
-  createResolvedFeishuLifecycleAccount,
   expectFeishuReplyDispatcherSentFinalReplyOnce,
   expectFeishuReplyPipelineDedupedAcrossReplay,
   expectFeishuReplyPipelineDedupedAfterPostSendFailure,
@@ -34,7 +33,7 @@ const {
 } = getFeishuLifecycleTestMocks();
 let lastRuntime = createRuntimeEnv();
 const originalStateDir = process.env.OPENCLAW_STATE_DIR;
-const lifecycleConfig = createFeishuLifecycleConfig({
+const { cfg: lifecycleConfig, account: lifecycleAccount } = createFeishuLifecycleFixture({
   accountId: "acct-menu",
   appId: "cli_test",
   appSecret: "secret_test",
@@ -43,16 +42,6 @@ const lifecycleConfig = createFeishuLifecycleConfig({
     allowFrom: ["ou_user1"],
   },
   accountConfig: {
-    dmPolicy: "open",
-    allowFrom: ["ou_user1"],
-  },
-});
-
-const lifecycleAccount = createResolvedFeishuLifecycleAccount({
-  accountId: "acct-menu",
-  appId: "cli_test",
-  appSecret: "secret_test",
-  config: {
     dmPolicy: "open",
     allowFrom: ["ou_user1"],
   },

--- a/extensions/feishu/src/monitor.bot-menu.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.test.ts
@@ -162,7 +162,7 @@ describe("Feishu bot menu handler", () => {
   });
 
   it("reopens replay for explicit retryable fallback failures", async () => {
-    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as RuntimeEnv;
+    const runtime = createRuntimeSpies() as RuntimeEnv;
     const onBotMenu = await registerHandlers({ runtime });
     sendCardFeishuMock
       .mockImplementationOnce(async () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Feishu bot-menu tests duplicate config/account construction and a runtime-spy literal already owned by shared test helpers.

## Why This Change Was Made

Reuse `createFeishuLifecycleFixture` for the existing lifecycle config/account pair and `createRuntimeSpies` for the explicit retry case. Keep the account values, independent channel/account policy objects, mock import order, assertions, and teardown unchanged.

## User Impact

No production or user-visible behavior change. Two test-support files change; all cases remain. This is mocked Feishu boundary coverage, not live channel proof.

## Evidence

- Normal lifecycle and bot-menu suites: 22 passed, zero skipped.
- Targeted formatting and diff checks passed.
- The 20-command changed-check plan passed 15 guards before extension typechecking failed on an existing missing QA Lab workspace dependency link. The four previously unrun guards then passed in their original order, including all three zero-entry Knip scans and targeted lint.
- The original local typecheck failure is retained; no local dependencies, aliases, or guards were changed. This is not a full local-gate pass.
- One scoped independent review completed with no findings.
- CI run 34562554250, attempt 1, passed for this head, including the required CI gate. The successful `check-test-types` job executed full `pnpm tsgo:extensions:test` after normal frozen dependency setup on a cache hit.
- The actual CI-generated merge checkout, parents, relevant inputs, and exact patch were verified. This is not a literal-head checkout or whole-repository/environment equality claim.
