### PR TITLE
refactor(memory): await core KV provenance operations

### DIFF
--- a/src/memory/memory-artifact-provenance.test.ts
+++ b/src/memory/memory-artifact-provenance.test.ts
@@ -1,7 +1,10 @@
 import { mkdir, symlink } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as pluginState from "../plugin-state/plugin-state-store.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
   clearMemoryArtifactProvenance,
@@ -12,10 +15,89 @@ import {
 } from "./memory-artifact-provenance.js";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   resetPluginStateStoreForTests();
 });
 
 describe("memory artifact provenance", () => {
+  it.each(
+    (["write", "restore", "remove", "clear"] as const).flatMap((operation) =>
+      (["resolve", "reject"] as const).map((outcome) => ({ operation, outcome })),
+    ),
+  )("awaits $operation persistence through $outcome", async ({ operation, outcome }) => {
+    await withStateDirEnv("openclaw-memory-artifact-", async ({ tempRoot }) => {
+      const address = { workspaceDir: tempRoot, relativePath: "MEMORY.md" };
+      const write = (contentBefore: string, contentAfter: string, observedAt: number) =>
+        recordMemoryArtifactWriteProvenance({
+          ...address,
+          contentBefore,
+          contentAfter,
+          originClass: "agent",
+          observedAt,
+        });
+      let rollback: (() => Promise<void>) | undefined;
+      if (operation !== "write") {
+        rollback = await write("", "first", 1);
+        if (operation === "restore") {
+          rollback = await write("first", "second", 2);
+        }
+      }
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      const createStore = pluginState.createCorePluginStateKeyedStore;
+      vi.spyOn(pluginState, "createCorePluginStateKeyedStore").mockImplementation((options) => {
+        const store = createStore(options);
+        const delay = async () => {
+          entered.resolve();
+          await release.promise;
+        };
+        return {
+          ...store,
+          update: async (...args) => {
+            await delay();
+            return store.update(...args);
+          },
+          deleteIf: async (...args) => {
+            await delay();
+            return store.deleteIf(...args);
+          },
+        };
+      });
+      const pending =
+        operation === "write"
+          ? write("", "first", 1)
+          : operation === "clear"
+            ? clearMemoryArtifactProvenance({ ...address, contentBefore: "first" })
+            : expectDefined(rollback, "provenance rollback")();
+      const settled = pending.then(
+        () => "settled",
+        () => "settled",
+      );
+      try {
+        expect(await Promise.race([entered.promise.then(() => "waiting"), settled])).toBe(
+          "waiting",
+        );
+        if (outcome === "reject") {
+          const error = new Error("synthetic persistence rejection");
+          release.reject(error);
+          await expect(pending).rejects.toBe(error);
+        } else {
+          release.resolve();
+          await pending;
+          const stored = await readMemoryArtifactProvenance(address);
+          if (operation === "write" || operation === "restore") {
+            expect(stored).toMatchObject({ observedAt: 1 });
+          } else {
+            expect(stored).toBeUndefined();
+          }
+        }
+      } finally {
+        release.resolve();
+        await settled;
+      }
+    });
+  });
+
   it("uses the same workspace identity through symlink aliases", async () => {
     await withStateDirEnv("openclaw-memory-artifact-", async ({ tempRoot }) => {
       const workspaceDir = path.join(tempRoot, "workspace");
@@ -63,6 +145,8 @@ describe("memory artifact provenance", () => {
         originClass: "agent",
         observedAt: 2,
       });
+
+      resetPluginStateStoreForTests();
 
       await expect(readMemoryArtifactProvenance(address)).resolves.toMatchObject({
         originClass: "untrusted",

--- a/src/memory/memory-artifact-provenance.ts
+++ b/src/memory/memory-artifact-provenance.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { realpathSync } from "node:fs";
 import path from "node:path";
 import { isMissingPathError } from "../infra/errors.js";
-import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
+import { createCorePluginStateKeyedStore } from "../plugin-state/plugin-state-store.js";
 
 const MEMORY_ARTIFACT_PROVENANCE_OWNER_ID = "core:memory-artifact-provenance";
 const MEMORY_ARTIFACT_PROVENANCE_NAMESPACE = "workspace-files";
@@ -89,7 +89,7 @@ function resolveAddress(params: {
 }
 
 function openStore() {
-  return createCorePluginStateSyncKeyedStore<StoredMemoryArtifactProvenance>({
+  return createCorePluginStateKeyedStore<StoredMemoryArtifactProvenance>({
     ownerId: MEMORY_ARTIFACT_PROVENANCE_OWNER_ID,
     namespace: MEMORY_ARTIFACT_PROVENANCE_NAMESPACE,
     maxEntries: MEMORY_ARTIFACT_PROVENANCE_MAX_ENTRIES,
@@ -143,7 +143,7 @@ export async function recordMemoryArtifactWriteProvenance(params: {
   const store = openStore();
   const reservationId = randomUUID();
   let previous: StoredMemoryArtifactProvenance | undefined;
-  store.update(address.storeKey, (current) => {
+  await store.update(address.storeKey, (current) => {
     previous = normalizeStoredProvenance(current, address);
     const originClass =
       params.originClass === "agent" &&
@@ -167,12 +167,15 @@ export async function recordMemoryArtifactWriteProvenance(params: {
   return async () => {
     const rollbackStore = openStore();
     if (previous) {
-      rollbackStore.update(address.storeKey, (current) =>
+      await rollbackStore.update(address.storeKey, (current) =>
         current?.reservationId === reservationId ? previous : undefined,
       );
       return;
     }
-    rollbackStore.deleteIf(address.storeKey, (current) => current.reservationId === reservationId);
+    await rollbackStore.deleteIf(
+      address.storeKey,
+      (current) => current.reservationId === reservationId,
+    );
   };
 }
 
@@ -186,7 +189,7 @@ export async function clearMemoryArtifactProvenance(params: {
     return;
   }
   const expectedHash = sha256(params.contentBefore);
-  openStore().deleteIf(address.storeKey, (current) => current.fileHash === expectedHash);
+  await openStore().deleteIf(address.storeKey, (current) => current.fileHash === expectedHash);
 }
 
 export async function readMemoryArtifactProvenance(params: {
@@ -197,7 +200,7 @@ export async function readMemoryArtifactProvenance(params: {
   if (!address) {
     return undefined;
   }
-  const stored = normalizeStoredProvenance(openStore().lookup(address.storeKey), address);
+  const stored = normalizeStoredProvenance(await openStore().lookup(address.storeKey), address);
   return stored ? toPublicProvenance(stored) : undefined;
 }
 
@@ -206,8 +209,7 @@ export async function listMemoryArtifactProvenance(params: {
 }): Promise<Array<{ relativePath: string; provenance: MemoryArtifactProvenance }>> {
   const workspaceKey = sha256(normalizeWorkspaceKey(params.workspaceDir));
   const prefix = `${workspaceKey}:`;
-  return openStore()
-    .entries()
+  return (await openStore().entries())
     .filter((entry) => entry.key.startsWith(prefix))
     .flatMap((entry) => {
       const address = {

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   closePluginStateDatabase,
   countPluginStateLiveEntries,
+  createCorePluginStateKeyedStore,
   createCorePluginStateSyncKeyedStore,
   createPluginStateKeyedStore,
   createPluginStateSyncKeyedStore,
@@ -605,14 +606,27 @@ describe("plugin state keyed store", () => {
 
   it("allows core owners and reserves core-prefixed plugin ids", async () => {
     await withPluginStateTestState(async () => {
-      const store = createCorePluginStateSyncKeyedStore<{ stopped: boolean }>({
-        ownerId: "core:channel-intent",
+      const options = {
+        ownerId: "core:channel-intent" as const,
         namespace: "stopped",
         maxEntries: 10,
-      });
+      };
+      const store = createCorePluginStateSyncKeyedStore<{ stopped: boolean }>(options);
+      const asyncStore = createCorePluginStateKeyedStore<{ stopped: boolean }>(options);
       expect(store.update("telegram:personal", () => ({ stopped: true }))).toBe(true);
-      expect(store.lookup("telegram:personal")).toEqual({ stopped: true });
-      expect(store.deleteIf("telegram:personal", (current) => current.stopped)).toBe(true);
+      closePluginStateDatabase();
+      await expect(asyncStore.lookup("telegram:personal")).resolves.toEqual({ stopped: true });
+      await expect(
+        asyncStore.update("telegram:personal", () => ({ stopped: false })),
+      ).resolves.toBe(true);
+      expect(store.lookup("telegram:personal")).toEqual({ stopped: false });
+      await expect(
+        asyncStore.deleteIf("telegram:personal", (current) => !current.stopped),
+      ).resolves.toBe(true);
+      await expect(asyncStore.lookup(" ")).rejects.toThrow(PluginStateStoreError);
+      expect(() => createCorePluginStateKeyedStore({ ...options, maxEntries: 11 })).toThrow(
+        PluginStateStoreError,
+      );
       expect(() =>
         createPluginStateKeyedStore("core:not-a-plugin", { namespace: "bad", maxEntries: 10 }),
       ).toThrow(PluginStateStoreError);

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -512,6 +512,13 @@ export function importPluginStateEntriesForDoctor(
   flush();
 }
 
+/** Opens an async plugin-state namespace for a trusted core owner id. */
+export function createCorePluginStateKeyedStore<T>(
+  options: OpenKeyedStoreOptions & { ownerId: `core:${string}` },
+): Required<PluginStateKeyedStore<T>> {
+  return createKeyedStoreForPluginId<T>(options.ownerId, options);
+}
+
 /** Opens a sync plugin-state namespace for a trusted core owner id. */
 export function createCorePluginStateSyncKeyedStore<T>(
   options: OpenKeyedStoreOptions & { ownerId: `core:${string}` },


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Memory artifact provenance exposes asynchronous operations but uses synchronous core KV access internally. Its write and rollback callers need to retain persistence completion when the store becomes asynchronous.

## Why This Change Was Made

Add the missing core-owner factory through the existing async KV facade and namespace policy. Migrate provenance reads, enumeration, writes, conditional clearing and both rollback paths to await their operations. Reservation checks and atomic update/delete callbacks remain inside the existing SQLite owner.

## User Impact

Memory-file operations wait for their provenance write or rollback to settle. Storage failures remain attached to the operation that owns them. No schema, namespace, quota or trust policy changes.

## Evidence

- 53 focused store and caller tests passed. Eight delayed completion/rejection cases fail before the provenance cutover and pass afterward.
- Full selected changed checks and fresh independent Codex review through P2 passed.
- Two-process production-source smoke wrote a synthetic memory file and provenance to SQLite, reopened it, and verified conditional deletion. Phase timings were 612.64 ms for write/setup and 125.90 ms for reopen/read/delete; these are not comparative latency benchmarks.
