### PR TITLE
feat(codex): answer async questions while agents keep working

### DIFF
--- a/docs/plugins/codex-harness-runtime/permissions.md
+++ b/docs/plugins/codex-harness-runtime/permissions.md
@@ -70,5 +70,25 @@ Only an explicit field `isSecret: true` or Codex question
 at a time through the warned ephemeral text-reply path and never create durable
 Gateway question records. OpenClaw does not infer secrecy from field names.
 
+## Async questions
+
+When the selected Codex model advertises `request_user_input_async`, Codex can
+ask structured questions while continuing work. The tool returns immediately.
+OpenClaw preserves the questions on the async assistant message, and the Control
+UI shows suggested answers and a free-text field. Selecting a suggestion does
+not send it; the user must explicitly submit an answer.
+
+Answers use normal chat delivery: they steer an active turn or start a new turn
+in the same conversation after it finishes. The question is quoted alongside
+the answer so Codex can identify which question it addresses. Async questions
+do not create a waiting tool call or use the blocking question queue above.
+They follow the same tool and message-delivery restrictions as other native
+async messages. Silence and preselected answers never grant approval.
+
+Channels receive Codex's readable question text and choices and accept normal
+replies. The Control UI supports up to 12 questions per message and four choices
+per question, with titles up to 4,096 characters and choices up to 256 characters.
+Unsupported structured payloads retain the complete plain-text question.
+
 For the general plugin approval flow that carries these prompts, see
 [Plugin permission requests](/plugins/plugin-permission-requests).

--- a/extensions/codex/src/app-server/async-questions.real-binary.live.test.ts
+++ b/extensions/codex/src/app-server/async-questions.real-binary.live.test.ts
@@ -1,0 +1,251 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createAgentHarnessHostCapabilitiesForTest } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { readSessionTranscriptEvents } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveCodexAppServerHomeDir,
+  resolveCodexAppServerUserHomeDir,
+} from "./auth-start-options.js";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { setManagedCodexPluginRoot } from "./managed-binary.js";
+import { isJsonObject } from "./protocol.js";
+import { runCodexAppServerAttempt } from "./run-attempt.js";
+import {
+  createCodexTestBindingStore,
+  sessionBindingIdentity,
+} from "./session-binding.test-helpers.js";
+import { createIsolatedCodexAppServerClient } from "./shared-client.js";
+
+const LIVE =
+  process.env.OPENCLAW_LIVE_TEST === "1" && process.env.OPENCLAW_LIVE_CODEX_ASYNC_QUESTIONS === "1";
+const describeLive = LIVE ? describe : describe.skip;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  setManagedCodexPluginRoot(undefined);
+  vi.unstubAllEnvs();
+});
+
+describeLive("Codex async questions real-binary bridge", () => {
+  it("continues work before an answer and consumes a later ordinary reply on the same thread", async () => {
+    const runtimeModelId = process.env.OPENCLAW_LIVE_CODEX_MODEL?.trim();
+    if (!runtimeModelId) {
+      throw new Error("Set OPENCLAW_LIVE_CODEX_MODEL to a model with async question support");
+    }
+    const root = tempDirs.make("openclaw-codex-async-questions-");
+    const workspace = path.join(root, "workspace");
+    const agentDir = path.join(root, "agent");
+    const nativeHome = resolveCodexAppServerHomeDir(agentDir);
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(nativeHome, { recursive: true, mode: 0o700 });
+    // Copy only the existing login into the disposable home, never user config or sessions.
+    const authFile = path.join(nativeHome, "auth.json");
+    await fs.copyFile(path.join(resolveCodexAppServerUserHomeDir(), "auth.json"), authFile);
+    await fs.chmod(authFile, 0o600);
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
+    setManagedCodexPluginRoot(path.resolve(import.meta.dirname, "../.."));
+
+    const pluginConfig = { appServer: { homeScope: "agent" } };
+    const runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig, env: {} });
+    const client = await createIsolatedCodexAppServerClient({
+      startOptions: runtime.start,
+      agentDir,
+      authProfileId: null,
+      timeoutMs: 120_000,
+    });
+    let closeHost: (() => void) | undefined;
+    try {
+      const completedKinds: string[] = [];
+      const questionItemIds: string[] = [];
+      const serverRequestMethods: string[] = [];
+      client.addRequestHandler((request) => {
+        serverRequestMethods.push(request.method);
+        return undefined;
+      });
+      client.addNotificationHandler((notification) => {
+        if (notification.method !== "item/completed" || !isJsonObject(notification.params)) {
+          return;
+        }
+        const item = notification.params.item;
+        if (!isJsonObject(item) || typeof item.type !== "string") {
+          return;
+        }
+        if (
+          item.type === "agentMessage" &&
+          item.delivery === "async" &&
+          Array.isArray(item.questions) &&
+          typeof item.id === "string"
+        ) {
+          questionItemIds.push(item.id);
+          completedKinds.push("asyncQuestion");
+        } else {
+          completedKinds.push(item.type);
+        }
+      });
+
+      const questions = [
+        { title: "Which output format?", options: ["Markdown", "Plain text"] },
+        { title: "Who is the audience?" },
+      ];
+      const deliveredTexts: string[] = [];
+      const modelId = runtimeModelId;
+      const sessionTarget = {
+        agentId: "async-questions",
+        sessionId: "async-questions-session",
+        sessionKey: "agent:async-questions:main",
+        storePath: path.join(agentDir, "openclaw-agent.sqlite"),
+      };
+      const params = {
+        agentId: sessionTarget.agentId,
+        sessionId: sessionTarget.sessionId,
+        sessionKey: sessionTarget.sessionKey,
+        sessionTarget,
+        sessionFile: path.join(root, "session.jsonl"),
+        workspaceDir: workspace,
+        cwd: workspace,
+        agentDir,
+        provider: "openai",
+        modelId,
+        model: {
+          id: modelId,
+          name: modelId,
+          provider: "openai",
+          api: "openai-chatgpt-responses",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200_000,
+          maxTokens: 8_000,
+          compat: { supportsTools: false },
+        },
+        prompt: [
+          "This is a synthetic async question integration check. All files belong to this disposable workspace.",
+          "First call request_user_input_async exactly once with these exact arguments:",
+          JSON.stringify({ questions }),
+          "These are optional preferences. Immediately after that tool returns, continue independent work without waiting for an answer.",
+          "Use a native shell command to create async-question-marker.txt containing exactly AFTER_ASYNC_QUESTION followed by a newline.",
+          "Then end this turn with QUESTION_READY. Do not use request_user_input or ask another question.",
+        ].join("\n"),
+        runId: "async-questions-first-run",
+        contextTokenBudget: 150_000,
+        contextWindowInfo: {
+          tokens: 150_000,
+          referenceTokens: 200_000,
+          source: "agentContextTokens",
+        },
+        thinkLevel: "medium",
+        disableTools: false,
+        config: { tools: { web: { search: { enabled: false } } } },
+        timeoutMs: 180_000,
+        trigger: "user",
+        oneShotCliRun: true,
+        senderIsOwner: true,
+        authStorage: {},
+        authProfileStore: { version: 1, profiles: {} },
+        modelRegistry: {},
+        onBlockReply: async (payload: { text?: string }) => {
+          if (payload.text) {
+            deliveredTexts.push(payload.text);
+          }
+        },
+      } as unknown as EmbeddedRunAttemptParams;
+      await upsertSessionEntry({
+        ...sessionTarget,
+        entry: {
+          sessionId: sessionTarget.sessionId,
+          sessionFile: params.sessionFile,
+          updatedAt: Date.now(),
+        },
+      });
+      const host = await createAgentHarnessHostCapabilitiesForTest({
+        attempt: params,
+        pluginId: "codex",
+      });
+      params.hostCapabilities = host.capabilities;
+      closeHost = host.close;
+      const bindingStore = createCodexTestBindingStore();
+      const options = {
+        bindingStore,
+        pluginConfig,
+        clientFactory: async () => client,
+      };
+      const first = await runCodexAppServerAttempt(params, options);
+
+      expect(first.terminal.kind).toBe("ok");
+      expect(questionItemIds).toHaveLength(1);
+      expect(completedKinds.indexOf("commandExecution")).toBeGreaterThan(
+        completedKinds.indexOf("asyncQuestion"),
+      );
+      expect(await fs.readFile(path.join(workspace, "async-question-marker.txt"), "utf8")).toBe(
+        "AFTER_ASYNC_QUESTION\n",
+      );
+      expect(
+        first.messagesSnapshot.filter(
+          (message) => message.role === "assistant" && "openclawAsyncDelivery" in message,
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          openclawAsyncDelivery: { itemId: questionItemIds[0], questions },
+        }),
+      ]);
+      expect(deliveredTexts).toHaveLength(1);
+      expect(deliveredTexts[0]).toContain("Which output format?");
+      expect(deliveredTexts[0]).toContain("Who is the audience?");
+      const persisted = await readSessionTranscriptEvents(sessionTarget);
+      expect(
+        persisted.filter(
+          (event) =>
+            isJsonObject(event) &&
+            isJsonObject(event.message) &&
+            isJsonObject(event.message.openclawAsyncDelivery),
+        ),
+      ).toHaveLength(1);
+      expect(serverRequestMethods).not.toContain("item/tool/requestUserInput");
+      const firstBinding = bindingStore.read(sessionBindingIdentity(params));
+      expect(firstBinding).toBeDefined();
+      expect(firstBinding?.model === runtimeModelId).toBe(true);
+      const firstThreadId = firstBinding?.threadId;
+      expect(firstThreadId).toEqual(expect.any(String));
+
+      closeHost();
+      closeHost = undefined;
+      const followUp = {
+        ...params,
+        runId: "async-questions-answer-run",
+        prompt: [
+          "> Which output format?",
+          "",
+          "Plain text",
+          "",
+          "> Who is the audience?",
+          "",
+          "release reviewers",
+          "",
+          "Use those answers to create async-question-answer.txt containing the chosen format, a vertical bar, then the audience, followed by a newline.",
+          "Do not ask further questions. Then reply ANSWER_USED.",
+        ].join("\n"),
+      };
+      const answerHost = await createAgentHarnessHostCapabilitiesForTest({
+        attempt: followUp,
+        pluginId: "codex",
+      });
+      followUp.hostCapabilities = answerHost.capabilities;
+      closeHost = answerHost.close;
+      const answered = await runCodexAppServerAttempt(followUp, options);
+
+      expect(answered.terminal.kind).toBe("ok");
+      expect(bindingStore.read(sessionBindingIdentity(followUp))?.threadId).toBe(firstThreadId);
+      expect(await fs.readFile(path.join(workspace, "async-question-answer.txt"), "utf8")).toBe(
+        "Plain text|release reviewers\n",
+      );
+      expect(serverRequestMethods).not.toContain("item/tool/requestUserInput");
+    } finally {
+      closeHost?.();
+      await client.closeAndWait();
+    }
+  }, 480_000);
+});

--- a/extensions/codex/src/app-server/async-questions.ts
+++ b/extensions/codex/src/app-server/async-questions.ts
@@ -1,0 +1,39 @@
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export type CodexAsyncQuestion = {
+  title: string;
+  options?: string[];
+};
+
+/** Keep unsupported question payloads on Codex's complete plain-text fallback. */
+export function readCodexAsyncQuestions(value: unknown): CodexAsyncQuestion[] | undefined {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 12) {
+    return undefined;
+  }
+  const questions: CodexAsyncQuestion[] = [];
+  for (const entry of value) {
+    const question = asOptionalRecord(entry);
+    if (!question || !isQuestionText(question.title, 4_096)) {
+      return undefined;
+    }
+    const options = question.options;
+    if (options === undefined || options === null) {
+      questions.push({ title: question.title });
+      continue;
+    }
+    if (
+      !Array.isArray(options) ||
+      options.length === 0 ||
+      options.length > 4 ||
+      !options.every((option): option is string => isQuestionText(option, 256))
+    ) {
+      return undefined;
+    }
+    questions.push({ title: question.title, options: [...options] });
+  }
+  return questions;
+}
+
+function isQuestionText(value: unknown, maxLength: number): value is string {
+  return typeof value === "string" && value.length <= maxLength && value.trim().length > 0;
+}

--- a/extensions/codex/src/app-server/event-projector-assistant-message.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant-message.ts
@@ -4,6 +4,7 @@ import {
   type AgentHarnessAttemptParamsV2,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AssistantMessage, Usage } from "openclaw/plugin-sdk/llm";
+import type { CodexAsyncQuestion } from "./async-questions.js";
 import type { CodexProviderRefusal } from "./event-projector-values.js";
 import {
   resolveCodexLocalRuntimeAttribution,
@@ -31,7 +32,7 @@ export type AssistantMessageOptions = {
 };
 
 export type CodexAsyncAssistantMessage = AssistantMessage & {
-  openclawAsyncDelivery: { itemId: string };
+  openclawAsyncDelivery: { itemId: string; questions?: CodexAsyncQuestion[] };
 };
 
 const ZERO_USAGE: Usage = {
@@ -142,10 +143,11 @@ export function createAssistantAsyncMessage(
   text: string,
   itemId: string,
   timestamp: number,
+  questions?: CodexAsyncQuestion[],
 ): CodexAsyncAssistantMessage {
   return {
     ...createNonterminalAssistantMessage(params, [{ type: "text", text }], timestamp),
-    openclawAsyncDelivery: { itemId },
+    openclawAsyncDelivery: { itemId, ...(questions ? { questions } : {}) },
   };
 }
 

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -2,6 +2,7 @@ import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "ope
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { isSilentReplyPayloadText } from "openclaw/plugin-sdk/reply-chunking";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { readCodexAsyncQuestions, type CodexAsyncQuestion } from "./async-questions.js";
 import {
   createAssistantAsyncMessage as buildAssistantAsyncMessage,
   createAssistantCommentaryMessage as buildAssistantCommentaryMessage,
@@ -22,6 +23,7 @@ export class CodexAssistantProjection {
   private readonly assistantTimestampByItem = new Map<string, number>();
   private readonly assistantPhaseByItem = new Map<string, string>();
   private readonly assistantDeliveryByItem = new Map<string, string>();
+  private readonly assistantQuestionsByItem = new Map<string, CodexAsyncQuestion[]>();
   private latestTerminalAssistantCandidateItemId: string | undefined;
   private latestTerminalAssistantCandidateSuperseded = false;
   private terminalAssistantCandidateEarlierActiveItemIds = new Set<string>();
@@ -348,20 +350,8 @@ export class CodexAssistantProjection {
 
   collectAsyncMessages(): Array<{ itemId: string; message: AssistantMessage }> {
     return this.assistantItemOrder.flatMap((itemId) => {
-      if (!this.isAsyncAssistantItem(itemId)) {
-        return [];
-      }
-      const text = this.assistantTextByItem.get(itemId)?.trim();
-      const timestamp = this.assistantTimestampByItem.get(itemId);
-      if (!text || timestamp === undefined) {
-        return [];
-      }
-      return [
-        {
-          itemId,
-          message: buildAssistantAsyncMessage(this.params, text, itemId, timestamp),
-        },
-      ];
+      const delivery = this.createAsyncDelivery(itemId);
+      return delivery ? [{ itemId, message: delivery.message }] : [];
     });
   }
 
@@ -489,6 +479,14 @@ export class CodexAssistantProjection {
     const delivery = readItemString(item, "delivery");
     if (delivery) {
       this.assistantDeliveryByItem.set(item.id, delivery);
+    }
+    if (item.questions !== undefined) {
+      const questions = readCodexAsyncQuestions(item.questions);
+      if (questions && delivery === "async") {
+        this.assistantQuestionsByItem.set(item.id, questions);
+      } else {
+        this.assistantQuestionsByItem.delete(item.id);
+      }
     }
   }
 
@@ -695,7 +693,13 @@ export class CodexAssistantProjection {
     }
     return {
       itemId,
-      message: buildAssistantAsyncMessage(this.params, text, itemId, timestamp),
+      message: buildAssistantAsyncMessage(
+        this.params,
+        text,
+        itemId,
+        timestamp,
+        this.assistantQuestionsByItem.get(itemId),
+      ),
       text,
     };
   }

--- a/extensions/codex/src/app-server/event-projector.async-delivery.test.ts
+++ b/extensions/codex/src/app-server/event-projector.async-delivery.test.ts
@@ -34,6 +34,7 @@ describe("CodexAppServerEventProjector async delivery", () => {
           phase: "final_answer",
           delivery: "async",
           text: "This restricted update must not reach a user.",
+          questions: [{ title: "Should I continue?", options: ["Yes", "No"] }],
         },
       }),
     );
@@ -54,133 +55,179 @@ describe("CodexAppServerEventProjector async delivery", () => {
     ).not.toContain("restricted update");
   });
 
-  it("persists async delivery once without selecting it as the final answer", async () => {
-    const onAgentEvent = vi.fn();
-    const onBlockReply = vi.fn();
-    const params = await createParams();
-    const sessionId = expectDefined(params.sessionId, "Codex async delivery test session");
-    const storePath = `${params.workspaceDir}/openclaw-agent.sqlite`;
-    params.sessionKey = "agent:main:session-1";
-    const sessionTarget = {
-      agentId: "main",
-      sessionId,
-      sessionKey: params.sessionKey,
-      storePath,
-    };
-    params.sessionTarget = sessionTarget;
-    await upsertSessionEntry({
-      agentId: "main",
-      sessionKey: params.sessionKey,
-      storePath,
-      entry: {
-        sessionFile: params.sessionFile,
-        sessionId,
-        updatedAt: Date.now(),
-      },
-    });
-    const projector = await createProjector(
-      {
-        ...params,
-        onAgentEvent,
-        onBlockReply,
-      },
-      {
-        onAsyncDelivery: async (delivery) => {
-          return await codexTranscriptMirrorRuntime.deliverAsyncMessageBestEffort({
-            params: { ...params, onAgentEvent, onBlockReply },
-            cwd: params.workspaceDir,
-            threadId: "thread-1",
-            turnId: TURN_ID,
-            ...delivery,
-          });
-        },
-      },
-    );
-
+  it.each([
+    {
+      name: "too many options",
+      questions: [{ title: "Pick a format", options: ["A", "B", "C", "D", "E"] }],
+    },
+    { name: "a blank title", questions: [{ title: " " }] },
+    { name: "an oversized title", questions: [{ title: "Q".repeat(4_097) }] },
+  ])("keeps the text fallback for $name", async ({ questions }) => {
+    const onAsyncDelivery = vi.fn().mockResolvedValue("settled");
+    const projector = await createProjector(undefined, { onAsyncDelivery });
     await projector.handleNotification(
       forCurrentTurn("item/completed", {
         item: {
           type: "agentMessage",
-          id: "terminal-answer",
+          id: "fallback-question",
           phase: "final_answer",
-          text: "Finished.",
+          delivery: "async",
+          text: "Complete question and all choices.",
+          questions,
         },
       }),
     );
-    const asyncCompletion = forCurrentTurn("item/completed", {
-      item: {
-        type: "agentMessage",
-        id: "async-update",
-        phase: "final_answer",
-        delivery: "async",
-        text: "Background agent update.",
-      },
-    });
-    await projector.handleNotification(asyncCompletion);
-    expect(onBlockReply).toHaveBeenCalledOnce();
-    expect(onBlockReply).toHaveBeenCalledWith(
-      { text: "Background agent update." },
-      {
-        deliveryIntentId: `block-reply:v1:codex-app-server:thread-1:${TURN_ID}:async-update`,
-      },
-    );
-    await projector.handleNotification(asyncCompletion);
-    expect(onBlockReply).toHaveBeenCalledOnce();
-    await projector.handleNotification(
-      turnCompleted([
+    expect(onAsyncDelivery).toHaveBeenCalledOnce();
+    const delivery = onAsyncDelivery.mock.calls[0]?.[0];
+    expect(delivery.text).toBe("Complete question and all choices.");
+    expect(delivery.message.openclawAsyncDelivery).toEqual({ itemId: "fallback-question" });
+  });
+
+  it.each([
+    { name: "message", questions: undefined },
+    {
+      name: "questions",
+      questions: [
+        { title: "Which format should I use?", options: ["Markdown", "Plain text"] },
+        { title: "Who is the audience?" },
+      ],
+    },
+  ])(
+    "persists async $name once without selecting it as the final answer",
+    async ({ questions }) => {
+      const onAgentEvent = vi.fn();
+      const onBlockReply = vi.fn();
+      const params = await createParams();
+      const sessionId = expectDefined(params.sessionId, "Codex async delivery test session");
+      const storePath = `${params.workspaceDir}/openclaw-agent.sqlite`;
+      params.sessionKey = "agent:main:session-1";
+      const sessionTarget = {
+        agentId: "main",
+        sessionId,
+        sessionKey: params.sessionKey,
+        storePath,
+      };
+      params.sessionTarget = sessionTarget;
+      await upsertSessionEntry({
+        agentId: "main",
+        sessionKey: params.sessionKey,
+        storePath,
+        entry: {
+          sessionFile: params.sessionFile,
+          sessionId,
+          updatedAt: Date.now(),
+        },
+      });
+      const projector = await createProjector(
         {
+          ...params,
+          onAgentEvent,
+          onBlockReply,
+        },
+        {
+          onAsyncDelivery: async (delivery) => {
+            return await codexTranscriptMirrorRuntime.deliverAsyncMessageBestEffort({
+              params: { ...params, onAgentEvent, onBlockReply },
+              cwd: params.workspaceDir,
+              threadId: "thread-1",
+              turnId: TURN_ID,
+              ...delivery,
+            });
+          },
+        },
+      );
+
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: {
+            type: "agentMessage",
+            id: "terminal-answer",
+            phase: "final_answer",
+            text: "Finished.",
+          },
+        }),
+      );
+      const asyncCompletion = forCurrentTurn("item/completed", {
+        item: {
           type: "agentMessage",
           id: "async-update",
           phase: "final_answer",
           delivery: "async",
           text: "Background agent update.",
+          ...(questions ? { questions } : {}),
         },
+      });
+      await projector.handleNotification(asyncCompletion);
+      expect(onBlockReply).toHaveBeenCalledOnce();
+      expect(onBlockReply).toHaveBeenCalledWith(
+        { text: "Background agent update." },
         {
-          type: "agentMessage",
-          id: "terminal-answer",
-          phase: "final_answer",
-          text: "Finished.",
+          deliveryIntentId: `block-reply:v1:codex-app-server:thread-1:${TURN_ID}:async-update`,
         },
-      ]),
-    );
-    expect(onBlockReply).toHaveBeenCalledOnce();
+      );
+      await projector.handleNotification(asyncCompletion);
+      expect(onBlockReply).toHaveBeenCalledOnce();
+      await projector.handleNotification(
+        turnCompleted([
+          {
+            type: "agentMessage",
+            id: "async-update",
+            phase: "final_answer",
+            delivery: "async",
+            text: "Background agent update.",
+            ...(questions ? { questions } : {}),
+          },
+          {
+            type: "agentMessage",
+            id: "terminal-answer",
+            phase: "final_answer",
+            text: "Finished.",
+          },
+        ]),
+      );
+      expect(onBlockReply).toHaveBeenCalledOnce();
 
-    const result = projector.buildResult(buildEmptyToolTelemetry());
-    expect(result.assistantTexts).toEqual(["Finished."]);
-    expect(result.currentAttemptAssistant?.content).toEqual([{ type: "text", text: "Finished." }]);
-    const asyncMessages = result.messagesSnapshot.filter(
-      (message) =>
-        (message as { openclawAsyncDelivery?: { itemId?: unknown } }).openclawAsyncDelivery
-          ?.itemId === "async-update",
-    );
-    expect(asyncMessages).toHaveLength(1);
-    expect(asyncMessages[0]).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "Background agent update." }],
-      openclawAsyncDelivery: { itemId: "async-update" },
-      __openclaw: { mirrorIdentity: `${TURN_ID}:async:async-update` },
-    });
-    const transcriptMessages = (await readSessionTranscriptEvents(sessionTarget))
-      .map((event) => (event as { message?: unknown }).message)
-      .filter((message): message is Record<string, unknown> => Boolean(message));
-    expect(
-      transcriptMessages.filter(
+      const result = projector.buildResult(buildEmptyToolTelemetry());
+      expect(result.assistantTexts).toEqual(["Finished."]);
+      expect(result.currentAttemptAssistant?.content).toEqual([
+        { type: "text", text: "Finished." },
+      ]);
+      const asyncMessages = result.messagesSnapshot.filter(
+        (message) =>
+          (message as { openclawAsyncDelivery?: { itemId?: unknown } }).openclawAsyncDelivery
+            ?.itemId === "async-update",
+      );
+      expect(asyncMessages).toHaveLength(1);
+      expect(asyncMessages[0]).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: "Background agent update." }],
+        openclawAsyncDelivery: { itemId: "async-update", ...(questions ? { questions } : {}) },
+        __openclaw: { mirrorIdentity: `${TURN_ID}:async:async-update` },
+      });
+      const transcriptMessages = (await readSessionTranscriptEvents(sessionTarget))
+        .map((event) => (event as { message?: unknown }).message)
+        .filter((message): message is Record<string, unknown> => Boolean(message));
+      const persisted = transcriptMessages.filter(
         (message) =>
           (message.openclawAsyncDelivery as { itemId?: unknown } | undefined)?.itemId ===
           "async-update",
-      ),
-    ).toHaveLength(1);
-    expect(
-      onAgentEvent.mock.calls
-        .map((call) => call[0])
-        .filter(
-          (event) =>
-            event.stream === "item" &&
-            event.data.itemId === "async-update" &&
-            event.data.kind === "answer_candidate",
-        ),
-    ).toEqual([]);
-  });
+      );
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0]).toMatchObject({
+        openclawAsyncDelivery: { itemId: "async-update", ...(questions ? { questions } : {}) },
+      });
+      expect(
+        onAgentEvent.mock.calls
+          .map((call) => call[0])
+          .filter(
+            (event) =>
+              event.stream === "item" &&
+              event.data.itemId === "async-update" &&
+              event.data.kind === "answer_candidate",
+          ),
+      ).toEqual([]);
+    },
+  );
 
   it("settles sessionless async delivery once across completion and terminal replay", async () => {
     const params = await createParams();
@@ -293,6 +340,7 @@ describe("CodexAppServerEventProjector async delivery", () => {
         phase: "final_answer",
         delivery: "async",
         text: "Delivered while the client was reconnecting.",
+        questions: [{ title: "What should I do next?", options: null }],
       },
       {
         type: "agentMessage",
@@ -327,6 +375,10 @@ describe("CodexAppServerEventProjector async delivery", () => {
           role: "assistant",
           content: [{ type: "text", text: "Delivered while the client was reconnecting." }],
           __openclaw: { mirrorIdentity: `${TURN_ID}:async:async-reconnect` },
+          openclawAsyncDelivery: {
+            itemId: "async-reconnect",
+            questions: [{ title: "What should I do next?" }],
+          },
         },
       ]);
     }

--- a/extensions/codex/src/app-server/transcript-history-projection.ts
+++ b/extensions/codex/src/app-server/transcript-history-projection.ts
@@ -4,6 +4,7 @@ import type { AssistantMessage, Usage } from "openclaw/plugin-sdk/llm";
 import type { SessionTranscriptMessageEntry } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf8Prefix } from "openclaw/plugin-sdk/text-utility-runtime";
+import { readCodexAsyncQuestions } from "./async-questions.js";
 import { auditNativeToolName, itemName, itemStatus } from "./event-projector-items.js";
 import type { CodexThread, CodexTurn, JsonValue } from "./protocol.js";
 import type { CodexHistoryItemEntry } from "./thread-history-page.js";
@@ -158,6 +159,7 @@ function projectCodexThreadHistory(params: {
       const phase =
         item.phase === "commentary" || item.phase === "final_answer" ? item.phase : undefined;
       const asyncDelivery = item.delivery === "async";
+      const questions = asyncDelivery ? readCodexAsyncQuestions(item.questions) : undefined;
       const message =
         role === "assistant"
           ? attachCodexMirrorIdentity(
@@ -181,7 +183,9 @@ function projectCodexThreadHistory(params: {
                   ? { errorMessage: turn.error.message }
                   : {}),
                 ...(phase ? { phase } : {}),
-                ...(asyncDelivery && itemId ? { openclawAsyncDelivery: { itemId } } : {}),
+                ...(asyncDelivery && itemId
+                  ? { openclawAsyncDelivery: { itemId, ...(questions ? { questions } : {}) } }
+                  : {}),
                 timestamp,
               } satisfies AssistantMessage,
               identity,

--- a/extensions/codex/src/app-server/transcript-mirror-attestation.ts
+++ b/extensions/codex/src/app-server/transcript-mirror-attestation.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { readCodexAsyncQuestions } from "./async-questions.js";
 import type { AttemptSettlementWarning } from "./attempt-terminal.js";
 import type { CodexAsyncAssistantMessage } from "./event-projector-assistant-message.js";
 import { readMirrorIdentity, readUpstreamUserText } from "./upstream-prompt-provenance.js";
@@ -103,9 +104,13 @@ export function readCodexMirrorSourceFingerprint(message: AgentMessage): string 
 
 export function serializeCodexMirrorSourceEvidence(message: AgentMessage): string {
   const content = "content" in message ? message.content : undefined;
+  const questions = isMirroredAgentMessage(message)
+    ? readCodexAsyncQuestions(message.openclawAsyncDelivery?.questions)
+    : undefined;
   return JSON.stringify({
     role: message.role,
     content,
+    ...(questions ? { questions } : {}),
     ...(message.role === "user" ? { upstreamUserText: readUpstreamUserText(message) } : {}),
     ...(message.role === "toolResult"
       ? {

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -17,6 +17,7 @@ import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { readSessionTranscriptEvents } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   castAgentMessage,
   makeAgentAssistantMessage,
@@ -704,6 +705,9 @@ describe("projectBoundedCodexThreadHistory", () => {
               text: "Which environment should I use?",
               phase: "final_answer",
               delivery: "async",
+              questions: [
+                { title: "Which environment should I use?", options: ["Staging", "Local"] },
+              ],
             },
             {
               id: "final-history",
@@ -726,7 +730,10 @@ describe("projectBoundedCodexThreadHistory", () => {
     expect(projection.transcriptMessages[1]).toMatchObject({ phase: "commentary" });
     expect(projection.transcriptMessages[2]).toMatchObject({
       phase: "final_answer",
-      openclawAsyncDelivery: { itemId: "async-history" },
+      openclawAsyncDelivery: {
+        itemId: "async-history",
+        questions: [{ title: "Which environment should I use?", options: ["Staging", "Local"] }],
+      },
     });
     expect(JSON.stringify(projection.responseItems)).not.toContain(
       "Which environment should I use?",
@@ -1143,15 +1150,23 @@ describe("mirrorCodexAppServerTranscript", () => {
       createMockPluginRegistry([
         {
           hookName: "before_message_write",
-          handler: () => ({
-            message: castAgentMessage({
-              ...makeAgentAssistantMessage({
-                content: [{ type: "text", text: "[redacted async update]" }],
-                timestamp: Date.now(),
+          handler: (event) => {
+            const message = asOptionalRecord(asOptionalRecord(event)?.message);
+            expect(message).toHaveProperty("openclawAsyncDelivery.questions");
+            const firstBlock = asOptionalRecord(
+              Array.isArray(message?.content) ? message.content[0] : undefined,
+            );
+            if (!firstBlock) {
+              throw new Error("Expected the async question text block");
+            }
+            firstBlock.text = "[redacted async update]";
+            return {
+              message: castAgentMessage({
+                ...message,
+                phase: "final_answer",
               }),
-              phase: "final_answer",
-            }),
-          }),
+            };
+          },
         },
       ]),
     );
@@ -1161,7 +1176,10 @@ describe("mirrorCodexAppServerTranscript", () => {
         timestamp: Date.now(),
       }),
       phase: "final_answer",
-      openclawAsyncDelivery: { itemId: "async-update" },
+      openclawAsyncDelivery: {
+        itemId: "async-update",
+        questions: [{ title: "Sensitive question?", options: ["Sensitive choice"] }],
+      },
     });
     const onBlockReply = vi.fn();
     const runParams = {
@@ -1217,6 +1235,7 @@ describe("mirrorCodexAppServerTranscript", () => {
       idempotencyKey: "codex-app-server:thread-1:turn-1:async:async-update",
       openclawAsyncDelivery: { itemId: "async-update" },
     });
+    expect(updates[0]?.update?.message).not.toHaveProperty("openclawAsyncDelivery.questions");
   });
 
   it("retries a durable async callback from the persisted row", async () => {

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -16,6 +16,7 @@ import {
   type SessionTranscriptWriteLockParams,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { readCodexAsyncQuestions } from "./async-questions.js";
 import type { AttemptSettlementWarning, EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import type { CodexAsyncDeliverySettlement } from "./event-projector-options.js";
 import type { CodexThread } from "./protocol.js";
@@ -449,6 +450,10 @@ async function mirror(params: {
             preparedUserMessage["__openclaw"].humanMentions,
           );
         }
+        const asyncSourceText =
+          message.role === "assistant" && message.openclawAsyncDelivery
+            ? readMirroredAssistantText(message)
+            : undefined;
         const nextMessage = runAgentHarnessBeforeMessageWriteHook({
           message: transcriptMessage,
           agentId: params.agentId,
@@ -496,8 +501,17 @@ async function mirror(params: {
         if (message.role === "assistant" && message.openclawAsyncDelivery) {
           // Async delivery ownership is provider-authored. Whole-message hooks may
           // rewrite content, but must not turn the durable row into a terminal answer.
+          // Controls must not re-expose source text that a hook rewrote or redacted.
+          const questions =
+            isMirroredAgentMessage(messageToAppend) &&
+            readMirroredAssistantText(messageToAppend) === asyncSourceText
+              ? readCodexAsyncQuestions(messageToAppend.openclawAsyncDelivery?.questions)
+              : undefined;
           messageToAppend = Object.assign(messageToAppend, {
-            openclawAsyncDelivery: { itemId: message.openclawAsyncDelivery.itemId },
+            openclawAsyncDelivery: {
+              itemId: message.openclawAsyncDelivery.itemId,
+              ...(questions ? { questions } : {}),
+            },
           });
         }
         // Whole-message hooks can replace metadata, but cannot erase source-owned taint.

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -273,7 +273,7 @@ function buildDefaultCollaborationInstructions(): string {
     "",
     "Use the `request_user_input` tool only when it is listed in the available tools for this turn.",
     "",
-    "In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.",
+    "In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. When a missing preference, constraint, or clarification warrants a question, use `request_user_input_async` if it is available and continue independent work. Answers arrive as ordinary user messages. A suggested or preselected answer is not consent; wait for explicit approval before dependent actions that require it. If neither question tool is available, ask a concise plain-text question. Never write a multiple choice question as a textual assistant message.",
   ].join("\n");
 }
 

--- a/ui/src/e2e/chat-async-questions.e2e.test.ts
+++ b/ui/src/e2e/chat-async-questions.e2e.test.ts
@@ -1,0 +1,232 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import {
+  createChatFlowE2eSuite,
+  expectRequestCountStable,
+  installMockGateway,
+  requireRecord,
+} from "./chat-flow.test-support.ts";
+import { readOutboxQueue } from "./chat-outbox-payloads.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const title = "Which audience should the summary address?";
+const questionMessage = {
+  role: "assistant",
+  content: `${title}\n\n1. Engineers\n2. Everyone`,
+  timestamp: 1_789_000_000_000,
+  openclawAsyncDelivery: {
+    itemId: "audience-question",
+    questions: [{ title, options: ["Engineers", "Everyone"] }],
+  },
+};
+
+suite.define(() => {
+  it.each([false, true])(
+    "submits an async answer as ordinary chat with an active run=%s",
+    async (active) => {
+      const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
+      const page = await context.newPage();
+      const followUpTitle = "What should I emphasize?";
+      const multipleQuestions = {
+        ...questionMessage,
+        content: `${questionMessage.content}\n\n${followUpTitle}`,
+        openclawAsyncDelivery: {
+          ...questionMessage.openclawAsyncDelivery,
+          questions: [...questionMessage.openclawAsyncDelivery.questions, { title: followUpTitle }],
+        },
+      };
+      const replyMessage = {
+        role: "user",
+        content: "A separate discussion for later.",
+        timestamp: questionMessage.timestamp - 1_000,
+        __openclaw: { id: "composer-reply-target", seq: 1 },
+      };
+      const gateway = await installMockGateway(page, {
+        historyMessages: [replyMessage, multipleQuestions],
+        inFlightRun: { runId: "working-run", startedAt: Date.now(), text: "" },
+        sessionInfo: { hasActiveRun: true, activeRunIds: ["working-run"] },
+      });
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await page.locator(".chat-thread").getByText(title, { exact: true }).waitFor();
+        const artifactDir = createControlUiE2eArtifactDir(
+          `async-question-${active ? "active" : "idle"}`,
+        );
+        await page.screenshot({
+          path: path.join(artifactDir, "initial.png"),
+          animations: "disabled",
+        });
+        const card = page.locator("openclaw-chat-async-question");
+        await card.getByRole("radio", { name: /Engineers/ }).waitFor();
+        expect(
+          await card.getByRole("radio", { name: /Engineers/ }).getAttribute("aria-checked"),
+        ).toBe("true");
+        await expectRequestCountStable(gateway, "chat.send", 0);
+        await page.locator(".chat-group.user .chat-bubble").hover();
+        await page
+          .locator(".chat-group.user")
+          .getByRole("button", { name: "Reply to message", exact: true })
+          .click();
+        const composerReply = page.locator(".chat-reply-preview").filter({
+          has: page.getByRole("button", { name: "Cancel reply" }),
+        });
+        await expect.poll(() => composerReply.textContent()).toContain(replyMessage.content);
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.fill("Keep this separate composer draft.");
+        const custom = card.getByRole("textbox", { name: `Your own answer for ${title}` });
+        await custom.fill("/stop is an example for the whole team");
+        expect(
+          await card.getByRole("radio", { name: /Engineers/ }).getAttribute("aria-checked"),
+        ).toBe("false");
+        await card.getByRole("button", { name: "Next", exact: true }).click();
+        const freeText = card.getByRole("textbox", { name: "Answer", exact: true });
+        await freeText.fill("Include one practical example.");
+        if (!active) {
+          await gateway.setMethodResponse("chat.history", {
+            messages: [replyMessage, multipleQuestions],
+            sessionInfo: { hasActiveRun: false, activeRunIds: [] },
+          });
+          await gateway.emitChatFinal({ runId: "working-run", text: "I finished the draft." });
+          await page
+            .getByRole("button", { name: "Stop generating" })
+            .waitFor({ state: "detached" });
+          expect(await freeText.inputValue()).toBe("Include one practical example.");
+        }
+        await page.screenshot({
+          path: path.join(artifactDir, "question.png"),
+          animations: "disabled",
+        });
+        await card.getByRole("button", { name: "Submit", exact: true }).click();
+        const request = await gateway.waitForRequest("chat.send");
+        const params = requireRecord(request.params);
+        expect(params.message).toBe(
+          `> ${title}\n\n/stop is an example for the whole team\n\n> ${followUpTitle}\n\nInclude one practical example.`,
+        );
+        expect(params.queueMode).toBe(active ? "steer" : undefined);
+        expect(params).not.toHaveProperty("replyToId");
+        expect(await composer.inputValue()).toBe("Keep this separate composer draft.");
+        expect(await composerReply.textContent()).toContain(replyMessage.content);
+        expect(await gateway.getRequests("chat.abort")).toHaveLength(0);
+        expect(await gateway.getRequests("question.resolve")).toHaveLength(0);
+        await card.getByRole("status").waitFor();
+        await expectRequestCountStable(gateway, "chat.send", 1);
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
+
+  it("transfers rejected answers to the existing outbox retry without a second form submission", async () => {
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, { historyMessages: [questionMessage] });
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const card = page.locator("openclaw-chat-async-question");
+      const custom = card.getByRole("textbox", { name: `Your own answer for ${title}` });
+      await custom.fill("The customer support team");
+      await gateway.deferNext("chat.send");
+      await card.getByRole("button", { name: "Submit", exact: true }).click();
+      await gateway.waitForRequest("chat.send");
+      await gateway.resolveDeferred("chat.send", {
+        __mockError: { code: "UNAVAILABLE", message: "Synthetic send rejection" },
+      });
+      await card.getByRole("status").waitFor();
+      expect(await card.getByRole("button", { name: "Submit", exact: true }).count()).toBe(0);
+      expect(await card.getByRole("status").textContent()).toContain("The customer support team");
+      const failedSend = page.locator('.chat-send-status[data-send-state="failed"]');
+      const retry = failedSend.getByRole("button", { name: "Retry queued message" });
+      await retry.waitFor();
+      expect(await failedSend.getAttribute("title")).toBe("Synthetic send rejection");
+      const queued = await readOutboxQueue(page);
+      expect(queued).toHaveLength(1);
+      const queueId = queued[0]?.id;
+      expect(queueId).toBeTruthy();
+      await expectRequestCountStable(gateway, "chat.send", 1);
+      await gateway.deferNext("chat.send");
+      await retry.click();
+      const retried = await gateway.waitForRequest("chat.send", { after: 1 });
+      expect(requireRecord(retried.params).message).toBe(`> ${title}\n\nThe customer support team`);
+      const userMessages = page.locator(".chat-group.user .chat-bubble");
+      expect(await userMessages.count()).toBe(1);
+      expect((await readOutboxQueue(page)).map((item) => item.id)).toEqual([queueId]);
+      await gateway.resolveDeferred("chat.send");
+      await failedSend.waitFor({ state: "detached" });
+      expect(await userMessages.count()).toBe(1);
+      expect(await card.getByRole("button", { name: "Submit", exact: true }).count()).toBe(0);
+      await expectRequestCountStable(gateway, "chat.send", 2);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps every question and option readable when sending is unavailable", async () => {
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
+    const page = await context.newPage();
+    const followUpTitle = "What should I emphasize?";
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          ...questionMessage,
+          content: `${questionMessage.content}\n\n${followUpTitle}`,
+          openclawAsyncDelivery: {
+            ...questionMessage.openclawAsyncDelivery,
+            questions: [
+              ...questionMessage.openclawAsyncDelivery.questions,
+              { title: followUpTitle },
+            ],
+          },
+        },
+      ],
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const card = page.locator("openclaw-chat-async-question");
+      await card.getByRole("radio", { name: /Engineers/ }).waitFor();
+      await gateway.setOnline(false);
+      await card.waitFor({ state: "detached" });
+      const transcript = page.locator(".chat-text");
+      await transcript.getByText(followUpTitle, { exact: true }).waitFor();
+      expect(await transcript.textContent()).toContain(title);
+      expect(await transcript.textContent()).toContain("Engineers");
+      expect(await transcript.textContent()).toContain("Everyone");
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps malformed question metadata as the original transcript text", async () => {
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      historyMessages: [{ ...questionMessage, openclawAsyncDelivery: undefined }],
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.locator(".chat-text").getByText(title).waitFor();
+      const artifactDir = createControlUiE2eArtifactDir("async-question-plain-text");
+      await page.screenshot({
+        path: path.join(artifactDir, "before-without-metadata.png"),
+        animations: "disabled",
+      });
+      await gateway.setHistoryMessages([
+        {
+          ...questionMessage,
+          openclawAsyncDelivery: {
+            ...questionMessage.openclawAsyncDelivery,
+            questions: [{ title, options: ["One", "Two", "Three", "Four", "Five"] }],
+          },
+        },
+      ]);
+      await page.reload();
+      await page.locator(".chat-text").getByText(title).waitFor();
+      expect(await page.locator("openclaw-chat-async-question").count()).toBe(0);
+      expect(await page.locator(".chat-text").textContent()).toContain("Engineers");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5342,6 +5342,9 @@ export const en: TranslationMap & {
       showDetails: "Show goal details",
       hideDetails: "Hide goal details",
     },
+    asyncQuestions: {
+      sendFailed: "Could not send your answer. Your draft is preserved.",
+    },
     questions: {
       other: "Type your own answer here",
       answer: "Answer",

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -2,7 +2,6 @@ import type { ProgressCard } from "@openclaw/gateway-protocol";
 import { html, nothing } from "lit";
 import { findInlineApproval } from "../../app/approval-presentation.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
-import { cancelQuestionPrompt, submitQuestionPrompt } from "../../app/question-prompt.ts";
 import { patchSettings } from "../../app/settings.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../../app/user-profile.ts";
 import { navigateMarkdownSession } from "../../components/markdown-session-links.ts";
@@ -47,6 +46,7 @@ import {
   resolveAssistantAttachmentAuthToken,
   resolveChatArtifactDownload,
 } from "./chat-pane-state.ts";
+import { createChatQuestionActions } from "./chat-question-actions.ts";
 import { dismissRealtimeTalkError } from "./chat-realtime.ts";
 import { activeChatRunStartupStatus } from "./chat-run-startup.ts";
 import { chatSendHoldReason } from "./chat-send-support.ts";
@@ -392,13 +392,13 @@ export class ChatPane extends ChatPaneLayoutRender {
       collapseTaskProgress: state.settings.chatCollapseTaskProgress === true,
       onDismissProgressCard,
       gatewayQuestionPrompts: catalogKey || sessionParticipationBlocked ? [] : this.questionPrompts,
-      onGatewayQuestionChange: () => {
-        this.questionPrompts = [...this.questionPrompts];
-        this.requestUpdate();
-      },
-      onGatewayQuestionSubmit: (id, answers) =>
-        submitQuestionPrompt(this.questionPromptState, id, answers),
-      onGatewayQuestionSkip: (id) => cancelQuestionPrompt(this.questionPromptState, id),
+      ...createChatQuestionActions({
+        state,
+        questionState: this.questionPromptState,
+        canSend:
+          composerAvailability.canSend && !catalogKey && !suggestionViewer && state.connected,
+        isCurrent: () => this.state === state,
+      }),
       messages: catalogKey ? this.catalogMessages : state.chatMessages,
       historyPagination:
         historyHasMore || this.loadingOlder

--- a/ui/src/pages/chat/chat-question-actions.test.ts
+++ b/ui/src/pages/chat/chat-question-actions.test.ts
@@ -1,0 +1,70 @@
+/* @vitest-environment jsdom */
+
+import { expect, it, vi } from "vitest";
+import { createQuestionPromptState } from "../../app/question-prompt.ts";
+import { createChatQuestionActions } from "./chat-question-actions.ts";
+import { createAsyncQuestionPresentation } from "./components/chat-async-question.ts";
+
+it.each(["session", "connection", "pane"] as const)(
+  "does not admit a retained question submission after its %s changes",
+  async (changed) => {
+    const send = vi.fn(async () => true);
+    const state = {
+      sessionKey: "agent:main:one",
+      connectionEpoch: 1,
+      handleSendChat: send,
+      lastError: null,
+    };
+    let current = true;
+    const actions = createChatQuestionActions({
+      state,
+      questionState: createQuestionPromptState(() => {}),
+      canSend: true,
+      isCurrent: () => current,
+    });
+    if (changed === "session") {
+      state.sessionKey = "agent:main:two";
+    } else if (changed === "connection") {
+      state.connectionEpoch += 1;
+    } else {
+      current = false;
+    }
+    expect(await actions.onAsyncQuestionSubmit?.("> Which audience?\n\nEveryone")).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  },
+);
+
+it.each(["session", "connection", "agent", "drafts"] as const)(
+  "does not route a retained question card through the latest callback after %s rollover",
+  async (changed) => {
+    const originalSend = vi.fn(async () => true);
+    const nextSend = vi.fn(async () => true);
+    const state: Parameters<typeof createAsyncQuestionPresentation>[0] = {
+      asyncQuestionDrafts: new Map(),
+      transcriptRenderContext: { onAsyncQuestionSubmit: originalSend },
+    };
+    const props = {
+      sessionKey: "global",
+      currentAgentId: "main",
+      connectionEpoch: 1,
+      onAsyncQuestionSubmit: originalSend,
+    };
+    const retained = createAsyncQuestionPresentation(state, props);
+    if (changed === "session") {
+      props.sessionKey = "agent:main:two";
+    } else if (changed === "connection") {
+      props.connectionEpoch += 1;
+    } else if (changed === "agent") {
+      props.currentAgentId = "other";
+    } else {
+      state.asyncQuestionDrafts = new Map();
+    }
+    state.transcriptRenderContext.onAsyncQuestionSubmit = nextSend;
+    const current = createAsyncQuestionPresentation(state, props);
+    expect(await retained.submit?.("> Which audience?\n\nEveryone")).toBe(false);
+    expect(originalSend).not.toHaveBeenCalled();
+    expect(nextSend).not.toHaveBeenCalled();
+    expect(await current.submit?.("> Which audience?\n\nEngineers")).toBe(true);
+    expect(nextSend).toHaveBeenCalledExactlyOnceWith("> Which audience?\n\nEngineers");
+  },
+);

--- a/ui/src/pages/chat/chat-question-actions.ts
+++ b/ui/src/pages/chat/chat-question-actions.ts
@@ -1,0 +1,62 @@
+import { cancelQuestionPrompt, submitQuestionPrompt } from "../../app/question-prompt.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import type { ChatProps } from "./chat-view.ts";
+
+type QuestionActionOptions = {
+  state: Pick<ChatPageHost, "sessionKey" | "connectionEpoch" | "handleSendChat" | "lastError">;
+  questionState: Parameters<typeof submitQuestionPrompt>[0];
+  canSend: boolean;
+  isCurrent: () => boolean;
+};
+
+export function createChatQuestionActions({
+  state,
+  questionState,
+  canSend,
+  isCurrent,
+}: QuestionActionOptions): Pick<
+  ChatProps,
+  | "onGatewayQuestionChange"
+  | "onGatewayQuestionSubmit"
+  | "onGatewayQuestionSkip"
+  | "onAsyncQuestionSubmit"
+> {
+  const sessionKey = state.sessionKey;
+  const connectionEpoch = state.connectionEpoch;
+  const ownsSubmission = () =>
+    state.sessionKey === sessionKey && state.connectionEpoch === connectionEpoch && isCurrent();
+  return {
+    onGatewayQuestionChange: questionState.onChange,
+    onGatewayQuestionSubmit: (id, answers) => submitQuestionPrompt(questionState, id, answers),
+    onGatewayQuestionSkip: (id) => cancelQuestionPrompt(questionState, id),
+    onAsyncQuestionSubmit: canSend
+      ? async (message) => {
+          if (!ownsSubmission()) {
+            return false;
+          }
+          let outboxAdmitted = false;
+          let accepted: boolean | void = undefined;
+          try {
+            accepted = await state.handleSendChat(message, {
+              followUpMode: "steer",
+              replyTargetOverride: null,
+              onOutboxAdmitted: () => {
+                outboxAdmitted = true;
+              },
+            });
+          } catch (error) {
+            if (!outboxAdmitted) {
+              throw error;
+            }
+          }
+          if (!ownsSubmission()) {
+            return false;
+          }
+          if (!outboxAdmitted && !accepted && state.lastError) {
+            throw new Error(state.lastError);
+          }
+          return outboxAdmitted || accepted === true;
+        }
+      : undefined,
+  };
+}

--- a/ui/src/pages/chat/chat-send-composer.ts
+++ b/ui/src/pages/chat/chat-send-composer.ts
@@ -18,6 +18,22 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { chatAttachmentDraftSignature } from "./durable-composer-persistence.ts";
 import { resetChatInputHistoryNavigation } from "./input-history.ts";
 
+export function prependReplyQuote(
+  message: string,
+  replyTarget: NonNullable<ChatHost["chatReplyTarget"]>,
+): string {
+  const label = (replyTarget.senderLabel ?? "User").replace(/([\\`*_{}[\]()#+\-.!|>])/g, "\\$1");
+  const text = replyTarget.text.trim();
+  if (!text.includes("\n")) {
+    return `> **${label}:** ${text}\n\n${message}`;
+  }
+  const quoted = text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+  return `> **${label}:**\n${quoted}\n\n${message}`;
+}
+
 export function chatSubmitKey(
   host: ChatHost,
   kind: "detached" | "local" | "message" | "queued-edit" | "goal",

--- a/ui/src/pages/chat/chat-send-composer.ts
+++ b/ui/src/pages/chat/chat-send-composer.ts
@@ -18,22 +18,6 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { chatAttachmentDraftSignature } from "./durable-composer-persistence.ts";
 import { resetChatInputHistoryNavigation } from "./input-history.ts";
 
-export function prependReplyQuote(
-  message: string,
-  replyTarget: NonNullable<ChatHost["chatReplyTarget"]>,
-): string {
-  const label = (replyTarget.senderLabel ?? "User").replace(/([\\`*_{}[\]()#+\-.!|>])/g, "\\$1");
-  const text = replyTarget.text.trim();
-  if (!text.includes("\n")) {
-    return `> **${label}:** ${text}\n\n${message}`;
-  }
-  const quoted = text
-    .split("\n")
-    .map((line) => `> ${line}`)
-    .join("\n");
-  return `> **${label}:**\n${quoted}\n\n${message}`;
-}
-
 export function chatSubmitKey(
   host: ChatHost,
   kind: "detached" | "local" | "message" | "queued-edit" | "goal",

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -36,6 +36,7 @@ import {
   chatSubmitKey,
   clearOwnedCommandComposerFallback,
   clearSubmittedComposerState,
+  prependReplyQuote,
   commandComposerFallbackRetainsAttachments,
   restoreFailedCommandComposer,
   snapshotChatAttachments,
@@ -88,6 +89,9 @@ export type ChatSendSubmitOptions = {
   intent?: ChatSendIntent;
   attachmentsOverride?: readonly ChatAttachment[];
   mentionsOverride?: readonly HumanMention[];
+  replyTargetOverride?: ChatHost["chatReplyTarget"];
+  /** Ordinary message admission transfers retry custody, including volatile sends. */
+  onOutboxAdmitted?: () => void;
   followUpMode?: ControlUiFollowUpMode;
   /** Only the inline queued-row submit may resume and replace an edited row. */
   resumeQueuedMessageEditId?: string;
@@ -500,7 +504,11 @@ export async function handleSendChat(
     }
   }
 
-  const replyTarget = isInlineEditSubmission ? null : host.chatReplyTarget;
+  const replyTarget = isInlineEditSubmission
+    ? null
+    : opts?.replyTargetOverride === undefined
+      ? host.chatReplyTarget
+      : opts.replyTargetOverride;
   // Persisted ids use replyToId; synthetic replies fall back to a quote.
   const replyToId = isInlineEditSubmission
     ? inlineEdit.replyToId
@@ -689,6 +697,7 @@ export async function handleSendChat(
       setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       return;
     }
+    opts?.onOutboxAdmitted?.();
     let deliveryItem: typeof queued | null = queued;
     if (admittedDurably && submissionAction && typeof MessageChannel !== "undefined") {
       // The outbox now owns the prompt across reloads. Return control before

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -503,11 +503,8 @@ export async function handleSendChat(
     }
   }
 
-  const replyTarget = isInlineEditSubmission
-    ? null
-    : opts?.replyTargetOverride === undefined
-      ? host.chatReplyTarget
-      : opts.replyTargetOverride;
+  const { replyTargetOverride = host.chatReplyTarget } = opts ?? {};
+  const replyTarget = isInlineEditSubmission ? null : replyTargetOverride;
   // Persisted ids use replyToId; synthetic replies fall back to a quote.
   const replyToId = isInlineEditSubmission
     ? inlineEdit.replyToId

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -36,7 +36,6 @@ import {
   chatSubmitKey,
   clearOwnedCommandComposerFallback,
   clearSubmittedComposerState,
-  prependReplyQuote,
   commandComposerFallbackRetainsAttachments,
   restoreFailedCommandComposer,
   snapshotChatAttachments,

--- a/ui/src/pages/chat/components/chat-async-question.ts
+++ b/ui/src/pages/chat/components/chat-async-question.ts
@@ -1,0 +1,196 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { html, nothing } from "lit";
+import { property } from "lit/decorators.js";
+import { keyed } from "lit/directives/keyed.js";
+import { t } from "../../../i18n/index.ts";
+import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
+import type { ChatThreadProps, ChatThreadState } from "./chat-thread-interactions.ts";
+import "./chat-question-card.ts";
+
+type AsyncQuestions = {
+  itemId: string;
+  questions: { title: string; options?: string[] }[];
+};
+
+export type AsyncQuestionDraft = {
+  answers: Record<string, string[]>;
+  status?: "submitting" | "submitted" | "skipped";
+  error?: string;
+};
+
+export type AsyncQuestionPresentation = {
+  drafts: Map<string, AsyncQuestionDraft>;
+  submit?: (message: string) => Promise<boolean>;
+};
+
+export function createAsyncQuestionPresentation(
+  state: Pick<
+    ChatThreadState,
+    "asyncQuestionScope" | "asyncQuestionDrafts" | "transcriptRenderContext"
+  >,
+  props: Pick<
+    ChatThreadProps,
+    "sessionKey" | "currentAgentId" | "connectionEpoch" | "onAsyncQuestionSubmit"
+  >,
+): AsyncQuestionPresentation {
+  const scope = JSON.stringify([props.sessionKey, props.currentAgentId, props.connectionEpoch]);
+  if (state.asyncQuestionScope !== scope) {
+    state.asyncQuestionScope = scope;
+    state.asyncQuestionDrafts = new Map();
+  }
+  const drafts = state.asyncQuestionDrafts;
+  return {
+    drafts,
+    submit: props.onAsyncQuestionSubmit
+      ? async (message) => {
+          if (state.asyncQuestionScope !== scope || state.asyncQuestionDrafts !== drafts) {
+            return false;
+          }
+          return (await state.transcriptRenderContext.onAsyncQuestionSubmit?.(message)) === true;
+        }
+      : undefined,
+  };
+}
+
+function boundedText(value: unknown, limit: number): value is string {
+  return typeof value === "string" && value.length <= limit && value.trim().length > 0;
+}
+
+export function readAsyncQuestions(message: unknown): AsyncQuestions | null {
+  if (!isRecord(message) || message.role !== "assistant") {
+    return null;
+  }
+  const metadata = message.openclawAsyncDelivery;
+  if (
+    !isRecord(metadata) ||
+    !boundedText(metadata.itemId, 256) ||
+    !Array.isArray(metadata.questions) ||
+    metadata.questions.length === 0 ||
+    metadata.questions.length > 12
+  ) {
+    return null;
+  }
+  const questions: AsyncQuestions["questions"] = [];
+  for (const question of metadata.questions) {
+    if (
+      !isRecord(question) ||
+      !boundedText(question.title, 4096) ||
+      (question.options !== undefined &&
+        (!Array.isArray(question.options) ||
+          question.options.length === 0 ||
+          question.options.length > 4 ||
+          !question.options.every((option) => boundedText(option, 256))))
+    ) {
+      return null;
+    }
+    questions.push({ title: question.title, options: question.options });
+  }
+  return { itemId: metadata.itemId, questions };
+}
+
+function quoteQuestion(title: string): string {
+  const encoder = new TextEncoder();
+  let quote = "";
+  let bytes = 0;
+  for (const character of title) {
+    bytes += encoder.encode(character).length;
+    if (bytes > 512) {
+      break;
+    }
+    quote += character;
+  }
+  return `> ${quote.replace(/[\r\n]/g, " ")}`;
+}
+
+class ChatAsyncQuestion extends OpenClawLightDomElement {
+  @property({ attribute: false }) questions?: AsyncQuestions;
+  @property({ attribute: false }) presentation?: AsyncQuestionPresentation;
+
+  override render() {
+    const { questions, presentation } = this;
+    if (!questions || !presentation) {
+      return nothing;
+    }
+    let draft = presentation.drafts.get(questions.itemId);
+    if (!draft) {
+      draft = {
+        answers: Object.fromEntries(
+          questions.questions.map((question, index) => [
+            String(index),
+            (question.options ?? []).slice(0, 1),
+          ]),
+        ),
+      };
+      presentation.drafts.set(questions.itemId, draft);
+    }
+    const currentDraft = draft;
+    if (draft.status === "submitted" || draft.status === "skipped") {
+      return html`<div class="chat-question-summary" role="status">
+        ${questions.questions.map(
+          (question, index) => html`<div>
+            <strong>${question.title}</strong>
+            <div>
+              ${draft.status === "skipped" ? t("chat.questions.skipped") : draft.answers[String(index)]?.join(", ")}
+            </div>
+          </div>`,
+        )}
+      </div>`;
+    }
+    return keyed(
+      presentation.drafts,
+      html`<openclaw-chat-question-panel
+        .props=${{
+          model: {
+            requestKey: questions.itemId,
+            title: t("chat.questions.eyebrow"),
+            questions: questions.questions.map((question, index) => ({
+              questionId: String(index),
+              header: question.options ? question.title : t("chat.questions.answer"),
+              question: question.title,
+              options: (question.options ?? []).map((label) => ({ label })),
+              isOther: true,
+            })),
+            autoFocus: false,
+            collapsed: false,
+            disabled: !presentation.submit,
+            submitting: draft.status === "submitting",
+            answersById: draft.answers,
+            error: draft.error,
+          },
+          onAnswersChange: (answers: Record<string, string[]>) => {
+            currentDraft.answers = answers;
+          },
+          onSkip: () => {
+            currentDraft.status = "skipped";
+            this.requestUpdate();
+          },
+          onSubmit: async (answers: Record<string, string[]>) => {
+            currentDraft.status = "submitting";
+            currentDraft.error = undefined;
+            this.requestUpdate();
+            const message = questions.questions
+              .map(
+                (question, index) =>
+                  `${quoteQuestion(question.title)}\n\n${answers[String(index)]?.join(", ") ?? ""}`,
+              )
+              .join("\n\n");
+            try {
+              if (!(await presentation.submit?.(message))) {
+                throw new Error(t("chat.asyncQuestions.sendFailed"));
+              }
+              currentDraft.status = "submitted";
+            } catch (error) {
+              currentDraft.status = undefined;
+              currentDraft.error = error instanceof Error ? error.message : String(error);
+              throw error;
+            } finally {
+              this.requestUpdate();
+            }
+          },
+        }}
+      ></openclaw-chat-question-panel>`,
+    );
+  }
+}
+
+customElements.define("openclaw-chat-async-question", ChatAsyncQuestion);

--- a/ui/src/pages/chat/components/chat-async-question.ts
+++ b/ui/src/pages/chat/components/chat-async-question.ts
@@ -4,7 +4,6 @@ import { property } from "lit/decorators.js";
 import { keyed } from "lit/directives/keyed.js";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
-import type { ChatThreadProps, ChatThreadState } from "./chat-thread-interactions.ts";
 import "./chat-question-card.ts";
 
 type AsyncQuestions = {
@@ -24,14 +23,17 @@ export type AsyncQuestionPresentation = {
 };
 
 export function createAsyncQuestionPresentation(
-  state: Pick<
-    ChatThreadState,
-    "asyncQuestionScope" | "asyncQuestionDrafts" | "transcriptRenderContext"
-  >,
-  props: Pick<
-    ChatThreadProps,
-    "sessionKey" | "currentAgentId" | "connectionEpoch" | "onAsyncQuestionSubmit"
-  >,
+  state: {
+    asyncQuestionScope?: string;
+    asyncQuestionDrafts: Map<string, AsyncQuestionDraft>;
+    transcriptRenderContext: { onAsyncQuestionSubmit?: AsyncQuestionPresentation["submit"] };
+  },
+  props: {
+    sessionKey: string;
+    currentAgentId?: string;
+    connectionEpoch?: number;
+    onAsyncQuestionSubmit?: AsyncQuestionPresentation["submit"];
+  },
 ): AsyncQuestionPresentation {
   const scope = JSON.stringify([props.sessionKey, props.currentAgentId, props.connectionEpoch]);
   if (state.asyncQuestionScope !== scope) {

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -34,6 +34,7 @@ import "./chat-clawhub-card.ts";
 import type { PluginToolIcons } from "../chat-tool-icon-controller.ts";
 import type { LinkFaviconFetcher } from "../link-favicon-loader.ts";
 import { workspaceResultConflictFromTranscript } from "../workspace-conflict.ts";
+import { readAsyncQuestions, type AsyncQuestionPresentation } from "./chat-async-question.ts";
 import {
   renderAssistantAttachments,
   renderMessageAttachment,
@@ -224,6 +225,7 @@ export function renderGroupedMessage(
     showReasoning: boolean;
     showToolCalls?: boolean;
     runActive?: boolean;
+    asyncQuestions?: AsyncQuestionPresentation;
     autoExpandToolCalls?: boolean;
     isToolMessageExpanded?: (messageId: string) => boolean | undefined;
     onToggleToolMessageExpanded?: (messageId: string, expanded?: boolean) => void;
@@ -263,6 +265,7 @@ export function renderGroupedMessage(
   const m = message as Record<string, unknown>;
   const role = typeof m.role === "string" ? m.role : "unknown";
   const sourceRole = normalizeRoleForGrouping(role);
+  const asyncQuestions = opts.asyncQuestions?.submit ? readAsyncQuestions(message) : null;
   const normalizedRole = normalizeRoleForGrouping(normalizedMessage.role);
   const workspaceConflict = workspaceResultConflictFromTranscript(message);
   if (workspaceConflict) {
@@ -348,6 +351,7 @@ export function renderGroupedMessage(
   // Suppress empty bubbles when tool cards are the only content and toggle is off
   if (
     !markdown &&
+    !asyncQuestions &&
     !reasoningMarkdown &&
     !hasToolCards &&
     !hasImages &&
@@ -459,17 +463,25 @@ export function renderGroupedMessage(
 
   const toolRenderOptions = { ...opts, messageKey, onOpenSidebar };
   const renderText = () =>
-    jsonResult
-      ? renderMessageJson(jsonResult, isStandaloneToolMessage && Boolean(opts.autoExpandToolCalls))
-      : bodyMarkdown
-        ? renderMessageMarkdown(
-            bodyMarkdown,
-            messageKey,
-            { ...opts, role: isStandaloneToolMessage ? "tool" : normalizedRole },
-            markdownRenderOptions,
-            duplicateSuffix,
+    asyncQuestions
+      ? html`<openclaw-chat-async-question
+          .questions=${asyncQuestions}
+          .presentation=${opts.asyncQuestions}
+        ></openclaw-chat-async-question>`
+      : jsonResult
+        ? renderMessageJson(
+            jsonResult,
+            isStandaloneToolMessage && Boolean(opts.autoExpandToolCalls),
           )
-        : nothing;
+        : bodyMarkdown
+          ? renderMessageMarkdown(
+              bodyMarkdown,
+              messageKey,
+              { ...opts, role: isStandaloneToolMessage ? "tool" : normalizedRole },
+              markdownRenderOptions,
+              duplicateSuffix,
+            )
+          : nothing;
   // Collapsed tool results must not load attachments or render hidden markdown.
   // Retained panes use opacity, so hidden transcripts must unmount video previews.
   const renderBody = () => html`

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -31,6 +31,7 @@ type StreamMessageOptions = Pick<
   | "boardProvider"
   | "agentId"
   | "runActive"
+  | "asyncQuestions"
   | "onRequestUpdate"
   | "canvasPluginSurfaceUrl"
   | "resourceBasePath"

--- a/ui/src/pages/chat/components/chat-question-card.ts
+++ b/ui/src/pages/chat/components/chat-question-card.ts
@@ -18,6 +18,7 @@ type QuestionPanelViewModel = {
   sessionKey?: string;
   secretStoreAllowedHostsDraft?: string;
   collapsed: boolean;
+  autoFocus?: boolean;
   disabled: boolean;
   submitting?: boolean;
   answersById?: Record<string, string[]>;
@@ -211,7 +212,7 @@ class ChatQuestionPanel extends LitElement {
       this.pendingAction = null;
       this.syncedAnswersSignature = null;
       this.collapsed = nextCollapsed;
-      this.focusAfterUpdate = !nextCollapsed;
+      this.focusAfterUpdate = !nextCollapsed && model?.autoFocus !== false;
     } else if (this.props?.onCollapsedChange) {
       if (this.collapsed && !nextCollapsed) {
         this.focusAfterUpdate = true;

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -34,6 +34,7 @@ import type { LinkFaviconFetcher } from "../link-favicon-loader.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
 import type { ChatRunUiStatus } from "../run-lifecycle.ts";
 import type { CompactionStatus, RunOutputUsage } from "../tool-stream-contract.ts";
+import type { AsyncQuestionDraft } from "./chat-async-question.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
 import type { ChatHistoryBoundaryProps } from "./chat-history-boundary.ts";
 import type { MessageActionDetails } from "./chat-message-markdown.ts";
@@ -48,6 +49,8 @@ import { handleChatSelectionPointerUp, removeChatSelectionPopup } from "./chat-s
 import type { SidebarContent, SidebarFullMessageLoader } from "./chat-sidebar.ts";
 
 export type ChatThreadState = {
+  asyncQuestionDrafts: Map<string, AsyncQuestionDraft>;
+  asyncQuestionScope?: string;
   turnRecapWatch: TurnRecapWatch | null;
   searchOpen: boolean;
   searchQuery: string;
@@ -58,6 +61,7 @@ export type ChatThreadState = {
   transcriptRenderContext: {
     onSetReply?: (target: MessageReplyTarget) => void;
     onOpenReply?: (replyToId: string) => void;
+    onAsyncQuestionSubmit?: (message: string) => Promise<boolean>;
   };
 };
 
@@ -107,6 +111,7 @@ export type ChatThreadProps = ChatSendStatusActions & {
   startupLabel?: string;
   waitingApproval?: boolean;
   questionPrompts?: readonly QuestionPrompt[];
+  onAsyncQuestionSubmit?: (message: string) => Promise<boolean>;
   sessions: SessionsListResult | null;
   /** Host context resolving global-alias session keys (scope=global fleets). */
   sessionHost?: UiSessionDefaultsHost | null;
@@ -178,6 +183,7 @@ type TranscriptInteractionProps = Pick<
 
 function createTranscriptState(): ChatThreadState {
   return {
+    asyncQuestionDrafts: new Map(),
     turnRecapWatch: null,
     searchOpen: false,
     searchQuery: "",
@@ -217,6 +223,7 @@ export function resetTranscriptSession(paneId: string, owner?: ParentNode): void
   owner?.querySelectorAll<HTMLElement>(".chat-thread").forEach(releaseMarkdownTables);
   const state = transcriptStates.get(paneId);
   if (state) {
+    state.asyncQuestionDrafts = new Map();
     // Search input belongs to the outgoing transcript. Other fields are pane
     // preferences or dependency memos and invalidate themselves on new props.
     state.searchOpen = false;

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -33,6 +33,7 @@ import {
 } from "../chat-thread.ts";
 import { hasForwardedSource } from "../chat-turn-boundary.ts";
 import { renderAgentRunFrame } from "./chat-agent-run-frame.ts";
+import { createAsyncQuestionPresentation } from "./chat-async-question.ts";
 import { resolveChatDefaultAvatarPlacement } from "./chat-author-avatar.ts";
 import { renderBackgroundTasksStatusRow } from "./chat-background-tasks-status.ts";
 import { renderChatDivider, renderChatNotice } from "./chat-divider.ts";
@@ -78,6 +79,7 @@ export function projectChatTranscript(
   transcript: ChatTranscriptSession,
 ): ChatTranscriptProjection {
   const state = getTranscriptState(props.paneId);
+  const asyncQuestions = createAsyncQuestionPresentation(state, props);
   const requestUpdate = props.onRequestUpdate ?? (() => {});
   const displayStream = props.stream ?? null;
   const sessionHost = props.sessionHost ?? null;
@@ -286,6 +288,7 @@ export function projectChatTranscript(
     boardProvider: props.boardProvider,
     agentId: props.currentAgentId ?? props.fullMessageAgentId,
     runActive: props.runActive,
+    asyncQuestions,
     onOpenWorkspaceFile: props.onOpenWorkspaceFile,
     onRequestUpdate: requestUpdate,
     resourceBasePath: props.resourceBasePath,
@@ -688,6 +691,7 @@ export function projectChatTranscript(
     props.githubRepo?.repo,
     threadContextWindow,
     Boolean(props.onSetReply),
+    Boolean(props.onAsyncQuestionSubmit),
     Boolean(props.onRetryQueuedMessage),
     Boolean(props.onDiscardQueuedMessage),
     props.queuedMessageAction?.id,
@@ -700,6 +704,7 @@ export function projectChatTranscript(
     props.runStatus?.occurredAt ?? 0,
   ]);
   state.transcriptRenderContext.onSetReply = props.onSetReply;
+  state.transcriptRenderContext.onAsyncQuestionSubmit = props.onAsyncQuestionSubmit;
   state.transcriptRenderContext.onOpenReply = (replyToId) => {
     const loaded = loadedReplySources.get(replyToId);
     if (loaded && resolveMessageReplyText(loaded.message)) {

--- a/ui/src/styles/chat/question-card.css
+++ b/ui/src/styles/chat/question-card.css
@@ -8,6 +8,12 @@ openclaw-chat-question-panel {
   display: block;
 }
 
+openclaw-chat-async-question {
+  display: block;
+  width: 620px;
+  max-width: 100%;
+}
+
 .chat-question-panel {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
Closes #144643

## What Problem This Solves

Fixes an issue where users received plain text instead of answer controls when Codex asked structured async questions. The questions could arrive while the agent continued working, but the Control UI lost their suggested answers and free-text form.

## Why This Change Was Made

Codex emits these questions as async assistant messages and accepts answers as ordinary user messages. Preserve that metadata through projection, transcript mirroring, and native history, then reuse the existing Control UI question panel and normal chat/steering path. No waiting question RPC or additional answer store is introduced.

The existing outbox owns retries after admission, including failed sends. Answering leaves unrelated composer text, attachments, and Reply drafts intact. Restricted native message delivery remains enforced; unsupported metadata, read-only views, and message text rewritten by hooks retain the readable text fallback.

## User Impact

Users can choose a suggestion or enter their own answer while the agent works, or after its turn finishes. The first suggestion is selected for convenience but never submitted automatically. Multi-question messages remain readable offline. Channel users continue to receive the complete question text and reply normally.

## Evidence

- Researched the native [async-question handler](https://github.com/openai/codex/blob/7c88f037d935b4e78311027c32da4f046fd84058/codex-rs/core/src/tools/handlers/request_user_input_async.rs) and [bounded answer framing](https://github.com/openai/codex/blob/7c88f037d935b4e78311027c32da4f046fd84058/codex-rs/context-fragments/src/answered_question.rs) directly.
- Demonstrated the metadata-loss regression before the fix; the repaired projection, persistence, replay, restriction, and hook-redaction tests pass.
- Live managed Codex app-server 0.153.4: verified the exact requested model binding, two native questions, independent shell work before any answer, durable async-message persistence, and a later ordinary answer used on the same native thread. No legacy input-request RPC was emitted.
- Five Chromium E2E cases with a mocked Gateway cover active-turn steering, answers after turn completion, composer/Reply preservation, one outbox owner across failed-send retry, offline readability, and malformed-metadata fallback. Inspected synthetic before/after captures are attached.
- 347 existing chat-send tests, 64 Codex projection/mirror tests, seven turn-parameter tests, and 28 question action/panel tests passed. The final in-place hook-redaction regression also passed.
- Full `node scripts/check-changed.mjs` gate passed, including all affected type checks, full extension lint, UI lint/styles, export scans, and architecture guards. Production Control UI build, i18n verification, and diff checks passed.
- Initial CI caught a type-only UI import cycle. Removed the transcript-state back-edge with a component-local contract; `check:madge-import-cycles` reports zero cycles, and UI types plus all seven scope tests pass.
- The next CI run exposed a session-link fixture defect newly merged into `main` by #144251. Reproduced and corrected the layout expectation; main subsequently landed the same correction in #144690, so the duplicate test-only commit was dropped during conflict resolution.
- Repeated the live model/app-server proof on pre-rebase head `84d93317c44`: passed. Its [CI run 34564274043](https://github.com/openclaw/openclaw/actions/runs/34564274043) also passed, including the real-Gateway UI suite. The current head rebases this implementation onto main, retaining main’s shared reply-quote helper and removing our duplicate. All 79 focused sender/readiness/question cases and a fresh isolated P0–P2 integration review pass. That rebase exposed the sender’s line limit after combining main’s additions; simplified reply-target defaulting without changing null/undefined behavior. Focused tests, independent review, and all local changed-file checks pass on the final candidate. Final-head [CI run 34614673597](https://github.com/openclaw/openclaw/actions/runs/34614673597) is green at `e7c3a700c94b`, including the real-Gateway suite and required aggregate gate.
- Independent Codex review at P0–P2: no remaining actionable findings after fixing retry custody and read-only navigation.

![Before: async questions appear only as plain text (synthetic fixture)](https://github.com/user-attachments/assets/7e1102a1-2758-45a5-9bd1-da02b0ab8cc3)

![After: suggested answers while the agent keeps working (synthetic fixture)](https://github.com/user-attachments/assets/46e44503-7846-4afc-a14d-ac473792b0b3)

![After: a free-text answer remains available after the turn ends (synthetic fixture)](https://github.com/user-attachments/assets/55571a81-898f-4be6-bf56-7c66ebabaa45)



