### PR TITLE
docs: publish release notes for v2026.9.4

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3195,6 +3195,7 @@
                 "group": "Release notes",
                 "pages": [
                   "releases/index",
+                  "releases/2026.9.4",
                   "releases/2026.9.3",
                   "releases/2026.9.2",
                   "releases/2026.9.1",

--- a/docs/releases/2026.9.4.md
+++ b/docs/releases/2026.9.4.md
@@ -1,0 +1,4832 @@
+---
+title: "v2026.9.4"
+summary: "Plugin and skill discovery, visible skill learning, cloud-worker controls, GPT Image 2.5, and terminal questions."
+description: "OpenClaw v2026.9.4 brings plugin and skill discovery, visible learning from past conversations, cloud operating-system and snapshot controls, GPT Image 2.5, native Codex subagent transcripts, and questions in the terminal."
+keywords:
+  - OpenClaw
+  - v2026.9.4
+  - release notes
+---
+
+# v2026.9.4
+
+OpenClaw 2026.9.4 makes it easier to find what your Claw can use next. The Plugins page brings installed plugins and available listings together, while Skills searches across installed skills, your library, and ClawHub. Your Claw can recommend official plugins in chat, and learning from past conversations now opens a conversation you can follow, steer, or stop in Skill Workshop.
+
+There is more to work with once you get started. Cloud sessions gain operating-system choices and controls for building, pinning, and selecting prepared project snapshots. GPT Image 2.5 adds new image-generation and editing options through OpenAI and fal. You can inspect native Codex subagent transcripts, answer questions directly in the terminal, and submit requested secrets there when connected to a Gateway. The release also repairs specific update failures, keeps more completed memory work available, and improves message delivery across channels.
+
+**Release scale:** 1,558 pull requests, 20 direct commits, and 293 contributors.
+
+## Installation and Onboarding
+
+OpenClaw can now recover from an incompatible Node installation by finding a usable copy already on your computer, or offering to install a private copy with your permission. Setup also handles existing protected provider keys, lets multi-agent users choose the workspace they are configuring, and preserves a new Claw's first conversation when an empty background memory sweep runs before you get there.
+
+<AccordionGroup>
+
+<Accordion title="Start OpenClaw when Node needs attention">
+
+When Node cannot run OpenClaw, the launcher now looks for a compatible installed copy and retries your command, including the Doctor step used by older updaters. If it cannot find one, an interactive terminal can offer a [private Node installation](/install/node#update-from-the-cli) without replacing your system Node or shell defaults. The first installation requires your consent; later launches can reuse it unattended. Automatic installation covers x64 and ARM64 Macs, Windows, and glibc-based Linux; Alpine and other unsupported systems still need manual installation.
+
+Startup also checks whether Node's SQLite implementation can read stored values correctly, catching defective builds even when their version number looks supported. The [supported version range](/install/node-compatibility) stays the same. Limited help, version, and read-only diagnostics remain available on eligible unsupported runtimes, but normal operation still requires a compatible runtime. For a background Gateway pointing to an old or missing Node, `openclaw gateway install` can select an available supported replacement without `--force`; installing a private CLI runtime alone does not repair that service.
+
+For Mac users running Bun, compatibility checks now use the selected SQLite library, and managed services retain the library settings from the installing shell. Existing services need an explicit reinstall with `--runtime bun --force` to pick up those settings. The [Bun compatibility guide](/install/bun-compatibility) explains the requirements; check Doctor's proposed repair before accepting it, because its separate repair path can still switch a Bun service to Node.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Avoid loading error diagnostics during healthy startup [#142371](https://github.com/openclaw/openclaw/pull/142371).
+- Offer a private Node.js update when the CLI cannot start [#142742](https://github.com/openclaw/openclaw/pull/142742). Thanks @jason-allen-oneal, @morrow-bluedot, @jialele.
+
+**Bug fixes**
+
+- Explain unusable macOS SQLite overrides [#141948](https://github.com/openclaw/openclaw/pull/141948).
+- Check the selected SQLite library during Bun installation and diagnostics [#142186](https://github.com/openclaw/openclaw/pull/142186).
+- Repair stale Gateway service Node runtimes without forcing reinstall [#143159](https://github.com/openclaw/openclaw/pull/143159). Thanks @jialele, @TheAngryPit.
+- Restore diagnostics on unsupported Node runtimes [#143344](https://github.com/openclaw/openclaw/pull/143344).
+- Reuse compatible installed Node during startup and upgrades [#143464](https://github.com/openclaw/openclaw/pull/143464). Thanks @aeoess.
+- Allow short help and version flags during Node recovery [#143485](https://github.com/openclaw/openclaw/pull/143485).
+- Preserve macOS Bun SQLite settings in managed services [#143651](https://github.com/openclaw/openclaw/pull/143651).
+
+**Documentation**
+
+- Document Node as a workaround for Bun SQLite file-release limits [#141846](https://github.com/openclaw/openclaw/pull/141846).
+- Add Node.js and Bun compatibility references [#142156](https://github.com/openclaw/openclaw/pull/142156).
+
+**Limits and compatibility**
+
+- Check SQLite behavior before accepting Node runtimes [#143312](https://github.com/openclaw/openclaw/pull/143312). Thanks @aeoess.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Install on Mac, Linux, and Docker">
+
+Mac installers now switch to system Bash when newer Homebrew Bash would leave them hanging before producing useful output, so the normal piped installation command continues to work. [Docker source builds](/install/docker) also include the required dependency-check script before installing packages, fixing the missing-file failure that stopped image builds.
+
+For Linux system services, the guide now puts choosing the non-root account that owns your configuration before activation, and service-install help explains that installation starts the service and a forced reinstall may restart it. Completion setup also recognizes supported HOME-relative hooks in Bash, Zsh, and Fish, preserving those user-managed profile lines when installing again or repairing a missing completion cache.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Prevent installer hangs with newer Homebrew Bash [#141884](https://github.com/openclaw/openclaw/pull/141884).
+- Restore Docker source dependency installation [#142073](https://github.com/openclaw/openclaw/pull/142073). Thanks @vincentkoc.
+- Preserve portable shell completion hooks during installation [#143282](https://github.com/openclaw/openclaw/pull/143282). Thanks @LiuwqGit, @obviyus, @jlapenna.
+
+**Documentation**
+
+- Clarify the Node 26 recommendation for package installs [#135539](https://github.com/openclaw/openclaw/pull/135539). Thanks @kvnloo, @obviyus.
+- Clarify Gateway service account and shutdown guidance [#136266](https://github.com/openclaw/openclaw/pull/136266). Thanks @yetval, @obviyus, @abacha.
+- Explain startup and restart effects before service installation [#139562](https://github.com/openclaw/openclaw/pull/139562). Thanks @TheCrazyLex, @obviyus.
+- Clarify automatic system-Bash handling for installers [#142038](https://github.com/openclaw/openclaw/pull/142038).
+- Split Docker reference material into focused guides [#143087](https://github.com/openclaw/openclaw/pull/143087). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Connect a provider and reach the first conversation">
+
+New Agent setup can use provider keys already held in OpenClaw's protected store, so a working provider connection no longer needs a plaintext-key workaround for that setup failure. Moonshot's China API-key option also reaches credential entry and model selection without repeatedly asking you to reinstall an enabled provider. Provider guides also clarify that server credentials belong on the computer running the Gateway, and configuring a remote client does not configure them there.
+
+Browser sign-in now explains when a pasted value is a recognizable mobile setup code and directs you to the appropriate credential. In token mode, `openclaw gateway auth-token --show` retrieves the shared token; password-mode connections still need their configured password. And if an empty background memory sweep runs before your first message, it no longer creates placeholder files that make a fresh workspace skip its naming conversation. Workspaces already marked as set up keep their existing state.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Explain mobile setup codes pasted into browser sign-in [#141717](https://github.com/openclaw/openclaw/pull/141717). Thanks @DonnieFi.
+
+**Bug fixes**
+
+- Use protected provider keys in New Agent setup [#141586](https://github.com/openclaw/openclaw/pull/141586). Thanks @miguelbranco80, @IWhatsskill, @wenbiyou, @lisheguo.
+- Preserve first-run setup after empty dreaming sweeps [#141808](https://github.com/openclaw/openclaw/pull/141808). Thanks @SunnyShu0925, @obviyus, @dh-js, @ayaangazali.
+- Stop Moonshot China authentication reinstall loops [#143742](https://github.com/openclaw/openclaw/pull/143742). Thanks @zwyhmcn.
+
+**Documentation**
+
+- Align setup and rotation guidance around one Gateway secret [#141723](https://github.com/openclaw/openclaw/pull/141723).
+- Correct Gateway-host provider setup instructions [#143983](https://github.com/openclaw/openclaw/pull/143983). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose the agent for setup">
+
+Guided channel setup now asks which agent workspace to use when a multi-agent installation has no default setup owner, then lets you choose message routing separately. Scripted setup in that situation still needs `--agent`. [Onboarding recommendation commands](/cli/onboard) accept the same selector for reading, refreshing, acknowledging, and retrying recommendations, including when you put it after the action; recommendations continue to belong to the selected workspace.
+
+After channel settings are saved, connection checks use resolved environment values while keeping your variable references in the configuration file. Node setup instructions also carry the manual process through device approval, reconnecting a paused node, and approving its commands, with those approvals kept distinct from permission to execute commands locally.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Choose an agent workspace during guided channel setup [#128738](https://github.com/openclaw/openclaw/pull/128738). Thanks @Leon-SK668, @obviyus, @JunfXiao.
+- Select an agent for onboarding recommendations [#141775](https://github.com/openclaw/openclaw/pull/141775). Thanks @ChrisCantwell, @obviyus.
+- Resolve environment values for channel setup checks [#141781](https://github.com/openclaw/openclaw/pull/141781).
+- Accept agent selection after recommendation subcommands [#142019](https://github.com/openclaw/openclaw/pull/142019). Thanks @obviyus.
+
+**Documentation**
+
+- Complete node setup and command-approval instructions [#136268](https://github.com/openclaw/openclaw/pull/136268). Thanks @yetval, @obviyus, @ccaprani.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Connect a phone to OpenClaw">
+
+CLI help now points phone users to [`openclaw qr`](/cli/qr) and explains that a node join URL is a different kind of setup link. The [Android guide](/platforms/android) fills in the reachable address, saved binding, and authentication steps needed before your phone can connect, with separate instructions for a trusted local network and managed Tailscale Serve. The accompanying browser guidance explains that private same-origin HTTP can support browser identity, but HTTPS remains preferred because HTTP does not encrypt your credentials or traffic.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Correct Android pairing and browser access guidance [4ccdd7e](https://github.com/openclaw/openclaw/commit/4ccdd7e005754b426483d78d2c00064df14216a6). Thanks @yetval.
+- Point mobile setup users to the QR command in CLI help [#141756](https://github.com/openclaw/openclaw/pull/141756). Thanks @chelsealong, @obviyus, @tomdailey55.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Finish importing an existing setup">
+
+Completed memory imports and optional setup results remain available when final plugin cleanup reports an error. A retry of the same retained Gateway request can also reuse the completed result instead of importing again. If an error says the import finished but its result could not be returned, [inspect the report and destination files](/web/control-ui/settings) before starting another import. Cleanup warnings do not undo copied files, and retry protection ends when the Gateway restarts or forgets the request.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve completed import results through cleanup errors and matching request retries [#142738](https://github.com/openclaw/openclaw/pull/142738).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Remove an installation">
+
+The [uninstall guide](/install/uninstall) now matches removal steps to how OpenClaw was installed, including Git launchers and dedicated installation directories. Help and completion messages point to that guide without promising the CLI always survives state removal. Follow the steps for your installation, remove its service first, and preserve the configuration, workspaces, and shared tools you want to keep before deleting installation files.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Explain removal for Git and dedicated-prefix installations [#127254](https://github.com/openclaw/openclaw/pull/127254).
+- Correct uninstall help and completion guidance [#142629](https://github.com/openclaw/openclaw/pull/142629).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Follow complete setup instructions">
+
+The setup guides fill in missing prerequisites and replace incomplete examples, including plugin installation, provider credentials, Render troubleshooting, and matching the Mac app to its CLI version. The [first-run FAQ](/help/faq-first-run/quick-start) now separates setup questions from provider and hosting choices, while workspace templates and related guides are linked where you need them.
+
+These documentation updates explain existing behavior, including which ClawHub skills need explicit selection and which migration steps require stopping and backing up your Gateway. The setup agent can also read configuration keys containing literal dots or brackets. Quoted or escaped keys now return the existing setting instead of reporting it missing, with credentials still redacted.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Read quoted configuration keys in the setup agent [#143601](https://github.com/openclaw/openclaw/pull/143601).
+
+**Documentation**
+
+- Correct setup routing, Gateway port spacing, logging styles, and existing Windows, channel, Codex, and provider guidance [#141214](https://github.com/openclaw/openclaw/pull/141214). Thanks @vincentkoc.
+- Split Why OpenClaw architecture and comparison references into focused pages [#142989](https://github.com/openclaw/openclaw/pull/142989). Thanks @vincentkoc.
+- Link workspace templates, macOS Skills, and related setup guides directly [#143022](https://github.com/openclaw/openclaw/pull/143022). Thanks @vincentkoc.
+- Correct copied setup commands, token-display instructions, memory examples, and retry and heartbeat guidance [#143029](https://github.com/openclaw/openclaw/pull/143029). Thanks @vincentkoc.
+- Split first-run FAQ into focused setup and hosting pages [#143148](https://github.com/openclaw/openclaw/pull/143148). Thanks @vincentkoc.
+- Correct Diffs installation, Ollama credentials, IMAP account examples, and CLI and tool guidance [#143179](https://github.com/openclaw/openclaw/pull/143179). Thanks @vincentkoc.
+- Clarify explicit ClawHub skill selection [#143371](https://github.com/openclaw/openclaw/pull/143371).
+- Clarify voice-call and acpx prerequisites, text-model validation, memory setup, and delegate examples [#143927](https://github.com/openclaw/openclaw/pull/143927). Thanks @vincentkoc.
+- Correct transcription models, camera flags, Matrix defaults, Signal checks, and existing media-migration guidance [#143950](https://github.com/openclaw/openclaw/pull/143950). Thanks @vincentkoc.
+- Complete remote Mac, Arcee, and plugin SDK examples and clarify documented version history [#144032](https://github.com/openclaw/openclaw/pull/144032). Thanks @vincentkoc.
+- Clarify memory CLI defaults, stop/backup/start migration steps, Reef setup, and status and group links [#144083](https://github.com/openclaw/openclaw/pull/144083). Thanks @vincentkoc.
+- Add installation prerequisites and clarify Render troubleshooting, Ollama credentials, Mac version matching, and existing client controls [#144085](https://github.com/openclaw/openclaw/pull/144085). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## The New Web UI
+
+The browser app gives you more ways to follow a conversation and the work happening around it. A compact message rail helps you return to a particular reply, selected text can go straight into your next draft, and Tasks now opens the conversation behind native Codex subagents. Files, attachments, and Settings also get practical improvements that make it easier to keep your place while reading, editing, or waiting for work to finish.
+
+<AccordionGroup>
+
+<Accordion title="Find and organize conversations">
+
+[Conversations and the sidebar](/web/control-ui/sessions-and-sidebar) keep up with changes as you move between chats. Delayed responses no longer undo newer names, settings, or status, manually chosen names stay in place, and a failed automatic naming attempt can fall back to a readable topic. New device and cloud sessions can also get a useful name while their worker is being prepared.
+
+Opening the app recovers a remembered chat that no longer exists to a usable main conversation, while an explicit link to a missing chat keeps its recovery page. Sidebar controls stay separated from long labels, the visible Other heading can start an ungrouped draft, and adopted Codex and Claude sessions keep the actions their provider actually supports.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Start ungrouped sessions from the Other heading [#142544](https://github.com/openclaw/openclaw/pull/142544). Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Recover stale remembered chats when opening the web UI [#133653](https://github.com/openclaw/openclaw/pull/133653). Thanks @RomneyDa.
+- Keep readable chat titles and preserve manual names [#141600](https://github.com/openclaw/openclaw/pull/141600). Thanks @DonnieFi, @IWhatsskill, @jjjhenriksen.
+- Align sidebar session counts [#141924](https://github.com/openclaw/openclaw/pull/141924). Thanks @RomneyDa.
+- Prevent overlapping sidebar session controls [#142042](https://github.com/openclaw/openclaw/pull/142042). Thanks @RomneyDa.
+- Clear previous session timing when a new run starts [#142187](https://github.com/openclaw/openclaw/pull/142187).
+- Remove unintended underlines from Online sidebar names [#142217](https://github.com/openclaw/openclaw/pull/142217). Thanks @vyctorbrzezowski.
+- Remove phantom sidebar children after subagent deletion [#142438](https://github.com/openclaw/openclaw/pull/142438). Thanks @jalehman, @vyctorbrzezowski.
+- Finish opening the mobile sidebar after a swipe [#142578](https://github.com/openclaw/openclaw/pull/142578). Thanks @jalehman.
+- Keep session details, child breadcrumbs and history retries consistent [#143049](https://github.com/openclaw/openclaw/pull/143049).
+- Restore multi-agent session lists after model fallback [#143337](https://github.com/openclaw/openclaw/pull/143337).
+- Preserve native session actions after adoption [#143342](https://github.com/openclaw/openclaw/pull/143342). Thanks @sunlit-deng, @obviyus, @bricelb.
+- Name device and cloud sessions before their first turn [#143760](https://github.com/openclaw/openclaw/pull/143760).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Move through a long conversation">
+
+The [chat navigation rail](/web/control-ui/chat) moves into the left gutter, with a mark for each loaded message that has a saved identity. Hover or focus a mark to preview the text, then jump to that part of the conversation with a brief highlight showing where you landed. Previews render Markdown and, for attributed messages in shared chats, show the sender's name and avatar or initials.
+
+The rail has its own scrolling area so you can look for a destination without moving the conversation first. It appears on desktop panes with enough space and covers the messages already loaded.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Navigate long chats with a compact per-message rail [#142227](https://github.com/openclaw/openclaw/pull/142227). Thanks @vyctorbrzezowski.
+- Show senders in shared-chat navigation previews [#143486](https://github.com/openclaw/openclaw/pull/143486). Thanks @vyctorbrzezowski.
+
+**Bug fixes**
+
+- Render Markdown in conversation rail previews [#142442](https://github.com/openclaw/openclaw/pull/142442). Thanks @jalehman.
+- Smooth the Scroll to latest transition [#142720](https://github.com/openclaw/openclaw/pull/142720). Thanks @vyctorbrzezowski.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read cached content while reconnecting">
+
+Returning users with a retained token or paired-device token can see cached sidebar entries and available conversation text while the app reconnects. A Connecting indicator stays visible until live information takes over, and old running indicators are removed from the cached list. [Warm reload](/web/control-ui/offline-and-reconnect#warm-reload) makes existing content available earlier; actions still wait for authentication.
+
+Other authentication modes keep the initial connection screen. There is also a remaining limitation when one browser origin serves multiple Gateways with matching conversation keys, where another Gateway's cached transcript can appear until live data replaces it. Conversation switches separately gain delayed, fading loading placeholders, avoiding a brief flash when the destination loads quickly.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Delay and fade conversation loading placeholders [3c322522](https://github.com/openclaw/openclaw/commit/3c322522d8413702c8bfed211fb02a443e047906). Context [#134868](https://github.com/openclaw/openclaw/pull/134868). Thanks @jesse-merhi.
+- Show cached chat and sidebar content while reconnecting [#141121](https://github.com/openclaw/openclaw/pull/141121). Context [#141690](https://github.com/openclaw/openclaw/issues/141690).
+- Reduce startup JavaScript while retaining translated Settings help [#143376](https://github.com/openclaw/openclaw/pull/143376). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Quote text and keep drafts readable">
+
+Select a passage and choose Add to chat to append an editable quote to your main draft, keeping anything you have already typed and putting the cursor back in the composer. The quote is limited to 300 characters, and you still choose when to send it; Ask in side chat keeps its separate destination.
+
+Long drafts stay readable while you type, with the edge fades returning when you deliberately scroll through them. Attachment rows line up with the draft and refresh their overflow cues as files or panel widths change. In shared chats, stopping typing in one browser tab replaces or clears that tab's stale preview while another tab can remain active.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add selected text to the main chat draft [#142543](https://github.com/openclaw/openclaw/pull/142543). Thanks @Patrick-Erichsen.
+- Translate Add to chat across 20 existing locales [#142576](https://github.com/openclaw/openclaw/pull/142576).
+
+**Bug fixes**
+
+- Fix mobile chat spacing, scrolling previews, and keyboard focus [#142143](https://github.com/openclaw/openclaw/pull/142143). Thanks @IWhatsskill, @vyctorbrzezowski.
+- Refresh attachment overflow cues after changes and resizing [#142577](https://github.com/openclaw/openclaw/pull/142577).
+- Align composer attachments with draft text [#142658](https://github.com/openclaw/openclaw/pull/142658). Thanks @vyctorbrzezowski.
+- Keep long drafts readable while typing [#142955](https://github.com/openclaw/openclaw/pull/142955). Thanks @jalehman.
+- Refresh shared-chat previews when a tab stops typing [#143400](https://github.com/openclaw/openclaw/pull/143400).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Follow images and documents in chat">
+
+Sent images stay visible while delivery confirmation and saved history catch up, and scrolling back to an already loaded image can reuse its still-valid preview information. Files now shows a loading state while an attachment is being resolved, keeps its identity visible if loading fails, and preserves the video player while it waits for a frame.
+
+User document cards sit above their accompanying text, with file-only messages losing the empty colored bubble. Images, videos, and files align with the sender's side of a shared conversation, while desktop avatars stay beside the text. Related history fixes keep the same saved reply from appearing twice when live events overlap a history refresh.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Place file cards above text and align participant media [#142671](https://github.com/openclaw/openclaw/pull/142671). Thanks @vyctorbrzezowski.
+
+**Bug fixes**
+
+- Keep loaded images visible when scrolling back through chat [#138303](https://github.com/openclaw/openclaw/pull/138303). Context [#138301](https://github.com/openclaw/openclaw/issues/138301). Thanks @vyctorbrzezowski.
+- Make chat attachment spacing consistent [#142246](https://github.com/openclaw/openclaw/pull/142246). Thanks @vyctorbrzezowski.
+- Prevent duplicate final replies as chat history loads [#142422](https://github.com/openclaw/openclaw/pull/142422). Thanks @jalehman.
+- Show loading progress while attachment previews resolve [#142613](https://github.com/openclaw/openclaw/pull/142613). Thanks @vyctorbrzezowski.
+- Align attachment placeholders with Open buttons [#142665](https://github.com/openclaw/openclaw/pull/142665). Thanks @vyctorbrzezowski.
+- Align sender avatars with attachment text [#142694](https://github.com/openclaw/openclaw/pull/142694). Thanks @vyctorbrzezowski.
+- Prevent duplicate bubbles after CLI history refresh [#142725](https://github.com/openclaw/openclaw/pull/142725).
+- Keep sent images visible during history loading [#143407](https://github.com/openclaw/openclaw/pull/143407).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preview videos before sending">
+
+You can recognize a selected recording before sending it, with a locally generated still frame and play badge in Chat and New Session. Making that preview does not upload the file. After sending, user videos appear alongside images above the message text, and selecting one opens it in Files.
+
+Preview availability depends on the browser's codec support and access to the file. Unsupported or unavailable previews keep their existing icon or openable card, and assistant-sent videos retain inline playback.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Preview selected videos before sending [#142623](https://github.com/openclaw/openclaw/pull/142623). Thanks @vyctorbrzezowski.
+- Show user video previews above chat text [#142639](https://github.com/openclaw/openclaw/pull/142639). Thanks @vyctorbrzezowski.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Browse files and protect newer edits">
+
+[Files](/web/control-ui/chat) now keeps search and filters above one scrolling list, so long Changed, Read, Artifacts, and Project sections remain reachable. You can choose changed files, read files, or artifacts, and Show in Files clears the current search and filter before revealing its destination. Failed opens explain the error in Review instead of showing unrelated changes, while phone previews leave more space for content and retain the filename and path when expanded.
+
+In Agents → Files, saving a draft opened before the workspace file changed now reports a conflict and keeps your draft. Reload takes the current workspace text, while Overwrite explicitly replaces it with your draft. These choices do not merge the two versions, and external programs writing at the same moment remain outside this protection.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Protect newer workspace edits from stale editor saves [#135865](https://github.com/openclaw/openclaw/pull/135865). Context [#127592](https://github.com/openclaw/openclaw/issues/127592). Thanks @yetval, @obviyus.
+- Correct expanded file-preview tooltips [#142039](https://github.com/openclaw/openclaw/pull/142039).
+- Compact phone file previews and retain fullscreen identity [#142536](https://github.com/openclaw/openclaw/pull/142536). Thanks @vyctorbrzezowski.
+- Browse long file lists with search and filters [#143854](https://github.com/openclaw/openclaw/pull/143854).
+- Show why a file could not open [#143958](https://github.com/openclaw/openclaw/pull/143958). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read native Codex subagent conversations">
+
+Select a native Codex subagent in Tasks to read the messages, available thinking, and expandable tool activity behind its work. Show earlier loads older messages, activity refreshes the view, and failed reads offer Retry. You can move into Files and return to the still-selected task without reloading its transcript.
+
+New native tasks retain their original transcript source when later parent turns replace the Codex thread. Session resets, account or native-store changes can still prevent access, and missing ownership information is not reconstructed for older tasks. Tasks without readable history keep their existing inspector; this release's native transcript support is for Codex.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Read native Codex subagent transcripts in the Tasks sidebar [#143747](https://github.com/openclaw/openclaw/pull/143747).
+
+**Bug fixes**
+
+- Retain subagent transcripts across parent turns [#143869](https://github.com/openclaw/openclaw/pull/143869).
+- Preserve Review transcripts across Files navigation [#144073](https://github.com/openclaw/openclaw/pull/144073).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Follow ongoing and completed work">
+
+Completed and cancelled subagent rows drop obsolete working text while keeping their final file-change summaries, and long reports scroll above the view-only footer and its Open parent session button. Compact activity previews also turn unfinished Markdown into readable text, with the full formatted conversation available in task details.
+
+Assistant commentary stays visible through history refreshes without repeating the same occurrence, and displayed saved reasoning keeps its paragraphs and code blocks under the existing visibility settings. Agents also receive clearer guidance to reserve progress cards for substantial work with multiple meaningful steps.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Clear stale activity text when subagent tasks finish [#129610](https://github.com/openclaw/openclaw/pull/129610). Thanks @jalehman.
+- Keep tool commentary single and visible after refresh [#140834](https://github.com/openclaw/openclaw/pull/140834). Thanks @leapdragon, @obviyus.
+- Preserve paragraphs and code blocks in displayed reasoning [#142231](https://github.com/openclaw/openclaw/pull/142231).
+- Keep subagent reports above the view-only footer [#142275](https://github.com/openclaw/openclaw/pull/142275). Thanks @vyctorbrzezowski.
+- Preserve literal text in tool activity previews [#142436](https://github.com/openclaw/openclaw/pull/142436).
+- Discourage progress cards for quick requests [#142696](https://github.com/openclaw/openclaw/pull/142696). Thanks @vyctorbrzezowski.
+- Make subagent activity previews readable [#143741](https://github.com/openclaw/openclaw/pull/143741).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Expand Dashboard and keep its context">
+
+Click the [Dashboard](/web/dashboards) side-panel tab to expand it across the task area, then click again to restore the original split and size. Drafts, widget input, and terminal sessions stay in place. The side-panel Expand control works for other active panels too, including Terminal, without entering browser fullscreen.
+
+A dashboard progress widget now follows the conversation it targets even when another agent is selected elsewhere. Older unfinished steps stay paused while a later run is queued, so waiting work is not mistaken for a task already running.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Expand Dashboard and restore the original split [#143579](https://github.com/openclaw/openclaw/pull/143579). Thanks @fuller-stack-dev.
+
+**Bug fixes**
+
+- Show activity for the dashboard widget's target session [#137255](https://github.com/openclaw/openclaw/pull/137255). Context [#137188](https://github.com/openclaw/openclaw/issues/137188). Thanks @sunlit-deng, @obviyus, @Richard355168, @benjaml4.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Upload files and restore terminal tabs">
+
+Picking or dropping files into supported paired-node Claude Code, Codex, OpenCode, and Pi terminals now inserts their editable paths using the format the receiving terminal expects. It does not press Enter, leaving you to check the input and submit it. Terminal tabs also survive a reload or reconnect that interrupts restoration of several saved sessions.
+
+Uploads can recover after a temporary failure to release their staging lock. Crash recovery remains manual, with [terminal recovery guidance](/web/control-ui/panels) identifying the machine that owns the terminal and the lock to remove only after every host process sharing that staging area has stopped.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover terminal uploads after failed lock release [#141250](https://github.com/openclaw/openclaw/pull/141250). Context [#137116](https://github.com/openclaw/openclaw/issues/137116). Thanks @shakkernerd.
+- Insert uploaded paths into paired-node coding terminals [#142001](https://github.com/openclaw/openclaw/pull/142001). Thanks @shakkernerd.
+- Keep terminal tabs during interrupted restoration [#144015](https://github.com/openclaw/openclaw/pull/144015). Thanks @vincentkoc.
+
+**Documentation**
+
+- Translate terminal upload-path errors [#142077](https://github.com/openclaw/openclaw/pull/142077).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Search and edit Settings">
+
+[Settings](/web/control-ui/settings) keeps unfinished list edits and validation messages with their rows when you remove an earlier item or change another field. You can correct the value without retyping it, although invalid text remains unsaved and these drafts do not survive leaving or reloading Settings. Search also keeps matching a phrase when a tag filter sits between its words, and step buttons start empty bounded integer fields at the first allowed value.
+
+Agents settings opens on Overview while explicit panel links keep their destination, and its name and emoji fields fit within the identity card. Web search controls now agree with the global disable setting, explaining why search is unavailable and allowing an authorized user to clear an old enable override without turning search on.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Open Agents settings on Overview [#142884](https://github.com/openclaw/openclaw/pull/142884). Thanks @jalehman.
+
+**Bug fixes**
+
+- Match Web search controls to the global disable setting [#121557](https://github.com/openclaw/openclaw/pull/121557). Context [#121401](https://github.com/openclaw/openclaw/issues/121401). Thanks @zyw02, @obviyus.
+- Distinguish Mac and iPad browser labels [#136545](https://github.com/openclaw/openclaw/pull/136545). Context [#136544](https://github.com/openclaw/openclaw/issues/136544). Thanks @TheAngryPit, @obviyus.
+- Keep shortened account labels valid Unicode [#137686](https://github.com/openclaw/openclaw/pull/137686). Thanks @ly85206559, @obviyus.
+- Start empty numeric settings at the first allowed value [#142201](https://github.com/openclaw/openclaw/pull/142201).
+- Keep unfinished Settings edits when list rows move [#142564](https://github.com/openclaw/openclaw/pull/142564).
+- Preserve Settings phrase matches around tag filters [#142618](https://github.com/openclaw/openclaw/pull/142618).
+- Keep agent identity fields inside their card [#143763](https://github.com/openclaw/openclaw/pull/143763).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recognize people and agents">
+
+Mention suggestions remain available while you refine searches that can safely reuse the loaded results, and necessary reloads keep a steadier placeholder. Person labels are simpler, avatars are clearer, and offline people remain available to select.
+
+Agent images load through the existing authenticated path in both the picker and Settings, with text or emoji fallbacks for unusable images. Smaller replacement avatars can be saved, and changes to an agent's name or emoji reach an open chat without losing its draft. Shared Gateway connections also gain a Shared owner label, though an agent whose ID is `gateway-owner` can still be mislabeled in some participant text.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Simplify mention labels and improve picker layout [#142274](https://github.com/openclaw/openclaw/pull/142274). Thanks @vyctorbrzezowski.
+- Reduce repeated presence reads across watched sessions [#142612](https://github.com/openclaw/openclaw/pull/142612).
+
+**Bug fixes**
+
+- Restore picker avatars on authenticated Gateways [#140954](https://github.com/openclaw/openclaw/pull/140954). Context [#140879](https://github.com/openclaw/openclaw/issues/140879). Thanks @LiuwqGit, @obviyus, @dimonnld, @rondavis007.
+- Label shared Gateway owner presence in the web UI [#141863](https://github.com/openclaw/openclaw/pull/141863).
+- Restore saved avatars in agent settings [#142015](https://github.com/openclaw/openclaw/pull/142015). Thanks @LiuwqGit, @obviyus, @lei-happy.
+- Keep person mention suggestions available while typing [#142332](https://github.com/openclaw/openclaw/pull/142332). Thanks @vyctorbrzezowski.
+- Refresh open-chat identity after agent edits [#142581](https://github.com/openclaw/openclaw/pull/142581). Thanks @aim9sour.
+- Save smaller replacement agent avatars without size-drop rejection [#143147](https://github.com/openclaw/openclaw/pull/143147). Thanks @LiuwqGit, @obviyus, @skaneta.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read usage and system status">
+
+Usage now counts the rows actually shown in All or Recently viewed while keeping the loaded total separate. When you inspect sessions across agents, the timeline and conversation follow the selected owner, and a late response for the previous owner cannot replace those details.
+
+On affected Linux Bun installations, System busyness can show CPU usage and event-loop delay again after the first sampling window. An initial dash still means the first sample is not ready.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Match Usage session counts to the visible list [#141749](https://github.com/openclaw/openclaw/pull/141749).
+- Keep Usage details tied to the selected agent [#143457](https://github.com/openclaw/openclaw/pull/143457).
+- Restore CPU and delay readings on Linux Bun [#143805](https://github.com/openclaw/openclaw/pull/143805).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover a stale or failed chat display">
+
+If chat still shows Stop after a turn has finished, clicking it can refresh the confirmed conversation state and restore Send with the completed reply. Work that is still finalizing stays active, and a failed refresh leaves the recovery available to try again. The change provides a way back when completion notifications have not reached the browser.
+
+Mobile chats keep delivery status and available Retry or Discard controls visible after failed or unconfirmed sends. A turn that times out before replying can also leave a notice that survives reload and remains in later conversation context. Check the conversation before resending when delivery is uncertain, since a display or connection failure does not establish that the work never ran.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep chat delivery recovery controls visible on mobile [#141798](https://github.com/openclaw/openclaw/pull/141798). Thanks @Takhoffman.
+- Keep no-reply timeout notices in conversation history [#142135](https://github.com/openclaw/openclaw/pull/142135). Thanks @chelsealong, @obviyus, @von8794.
+- Ask for a Gateway token after remembered device credentials fail [#143156](https://github.com/openclaw/openclaw/pull/143156).
+- Restore Send when Stop finds a finished run [#143437](https://github.com/openclaw/openclaw/pull/143437). Thanks @ylcn91, @obviyus, @YanHE1169.
+
+**Documentation**
+
+- Match connection guidance to Gateway UI labels [#141789](https://github.com/openclaw/openclaw/pull/141789).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read replies and use familiar controls">
+
+The command palette keeps the messages and draft behind it readable, and successful copying stays a compact green check instead of widening the chat footer. GitHub link previews stay quiet until useful details are available, ordinary content links keep their underlines, and the first assistant reply no longer triggers confetti.
+
+On Mac, the sidebar, transcript search, and command palette use Command+B, Command+F, and Command+K, leaving Control+B/F/K available for text editing. Windows and Linux keep Control for those actions. Custom message widths reject invalid expressions without replacing your saved reading width, and the desktop Inbox prepares its panel before you open it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Use a neutral border around user avatars [#138285](https://github.com/openclaw/openclaw/pull/138285). Context [#138277](https://github.com/openclaw/openclaw/issues/138277). Thanks @vyctorbrzezowski.
+- Prepare the Inbox panel before opening [#142316](https://github.com/openclaw/openclaw/pull/142316). Thanks @vyctorbrzezowski.
+- Keep background text readable behind the command palette [#142944](https://github.com/openclaw/openclaw/pull/142944). Thanks @jalehman.
+- Remove first-reply confetti from chat [#143167](https://github.com/openclaw/openclaw/pull/143167). Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Offer automatic host selection in the exec picker [#137565](https://github.com/openclaw/openclaw/pull/137565). Thanks @jalehman.
+- Preserve Unicode when shortening Mermaid errors [#137669](https://github.com/openclaw/openclaw/pull/137669). Thanks @ly85206559, @obviyus.
+- Keep unavailable GitHub previews quiet [#141896](https://github.com/openclaw/openclaw/pull/141896). Thanks @RomneyDa.
+- Skip rejected read updates in restricted chats [#142043](https://github.com/openclaw/openclaw/pull/142043).
+- Match menu highlights to the active theme [#142243](https://github.com/openclaw/openclaw/pull/142243). Thanks @vyctorbrzezowski.
+- Release temporary focus handlers after using chat pickers [#142258](https://github.com/openclaw/openclaw/pull/142258).
+- Remove unintended underlines from button links [#142335](https://github.com/openclaw/openclaw/pull/142335). Thanks @vyctorbrzezowski.
+- Reject invalid custom chat message widths [#142635](https://github.com/openclaw/openclaw/pull/142635).
+- Remove duplicate tooltips from GitHub preview links [#142637](https://github.com/openclaw/openclaw/pull/142637). Thanks @vyctorbrzezowski.
+- Preserve Mac text-editing Control shortcuts [#142674](https://github.com/openclaw/openclaw/pull/142674). Thanks @jalehman.
+- Show the correct Option/Alt+Click session-selection shortcut [#143051](https://github.com/openclaw/openclaw/pull/143051). Thanks @vincentkoc.
+- Align chat actions and retain green copy confirmation [#143425](https://github.com/openclaw/openclaw/pull/143425). Thanks @Patrick-Erichsen.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand broken interactive widgets">
+
+[Interactive widgets](/tools/show-widget) now have two clearer ways to report a broken script. Inline JavaScript syntax errors can be rejected before a card appears, with a location the agent can correct. If a displayed widget fails while running or when you use it, the Control UI can show a Script error notice and notify the agent for a recent widget.
+
+Syntax checking does not establish that a script will work, and some browser-valid SVG forms remain unsupported by the checker. Runtime notification applies to recent Control UI widgets and does not guarantee an immediate replacement; older restored widgets can show the error without waking the agent.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show widget script failures and notify the agent [#142225](https://github.com/openclaw/openclaw/pull/142225).
+
+**Bug fixes**
+
+- Catch widget script syntax errors before display [#141939](https://github.com/openclaw/openclaw/pull/141939).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read updated interface guidance">
+
+Existing interface languages receive updated guidance for connection recovery, plugin browsing, Files, and cloud-worker snapshot controls. Core Settings labels, help, and search now use matching translations when available, with current source text as the fallback. Selected parent-session translations also distinguish the parent conversation from the main one, making the route back from subagent work clearer.
+
+These updates extend translated coverage in existing languages. German and Simplified Chinese plugin next-page labels still have known wording errors.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Translate connection progress and setup-code guidance [#141750](https://github.com/openclaw/openclaw/pull/141750).
+- Translate Shared owner labels in the web UI [#141881](https://github.com/openclaw/openclaw/pull/141881).
+- Translate board-widget script error labels [#142147](https://github.com/openclaw/openclaw/pull/142147).
+- Translate model-discovery status and retry messages [#142334](https://github.com/openclaw/openclaw/pull/142334).
+- Refresh translations across 20 interface languages [#142699](https://github.com/openclaw/openclaw/pull/142699).
+- Refresh plugin-screen translations in 20 languages [#143622](https://github.com/openclaw/openclaw/pull/143622).
+- Refresh cloud-worker and notice translations [#143868](https://github.com/openclaw/openclaw/pull/143868).
+- Translate file and snapshot controls [#143924](https://github.com/openclaw/openclaw/pull/143924).
+- Translate snapshot-building controls and errors [#144011](https://github.com/openclaw/openclaw/pull/144011).
+
+**Bug fixes**
+
+- Apply available translations to core Settings fields [#137192](https://github.com/openclaw/openclaw/pull/137192). Context [#137190](https://github.com/openclaw/openclaw/issues/137190). Thanks @husodrn46, @obviyus.
+- Localize the picker's No matches message [#142255](https://github.com/openclaw/openclaw/pull/142255).
+- Correct parent-session and dashboard translations [#142327](https://github.com/openclaw/openclaw/pull/142327).
+
+**Documentation**
+
+- Refresh translated Gateway connection guidance [#141803](https://github.com/openclaw/openclaw/pull/141803).
+- Align maturity documentation with current product names [#142065](https://github.com/openclaw/openclaw/pull/142065). Thanks @RomneyDa.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Updates and Maintenance
+
+Updates can get past specific failures that left an installation waiting for repair or its Gateway stopped, with fixes for older stable releases, plugin maintenance, and checking databases that are still in use. Recovery gives you a clearer account of what happened and what needs attention, while Doctor, backups, and history cleanup preserve more of the working setup around them.
+
+<AccordionGroup>
+
+<Accordion title="Complete managed Gateway updates">
+
+Managed upgrades from 2026.9.2 and 2026.9.3 can finish and restart when their older handoff lacks information the new updater expected. Packages also retain the helpers needed by recorded 2026.9.1–2026.9.3 updaters to finish after replacement, including the affected 2026.9.1 Git build. Updates launched from the browser or a managed service can get past the missing-file failure that prevented their helper from starting, and Linux installations confirmed to have no Gateway service can enter the update flow too.
+
+Busy but compatible agent databases can now pass update checks while OpenClaw continues saving activity. Development updates check the selected revision's Node requirements before installing dependencies, and managed pnpm updates follow the newly activated package directory. These latter fixes must already be in the updater that starts the operation. If an older updater is blocked by the busy-database check, a supported manual update or a quiet database window is still needed to acquire the repair. [How updates run](/cli/update/how-updates-run) explains the checks and restart sequence.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Let older updaters finish and restart the Gateway [#142195](https://github.com/openclaw/openclaw/pull/142195) Thanks @Newsstand.
+- Check Node compatibility before dev-update installation [#142248](https://github.com/openclaw/openclaw/pull/142248) Thanks @TheAngryPit, @jialele, @obviyus.
+- Correct Node compatibility advice during updates [#142322](https://github.com/openclaw/openclaw/pull/142322) Thanks @SunnyShu0925, @guarismo.
+- Allow update checks while agent databases are busy [#142419](https://github.com/openclaw/openclaw/pull/142419) Thanks @jalehman.
+- Restore restart launch after updates from the 2026.9.1 Git build 0229a108 [#142631](https://github.com/openclaw/openclaw/pull/142631) Thanks @jason-allen-oneal.
+- Follow the activated package directory during managed pnpm updates [#143137](https://github.com/openclaw/openclaw/pull/143137) Thanks @timetrvlr.
+- Preserve bundled-plugin trust during update trials [#143190](https://github.com/openclaw/openclaw/pull/143190) Thanks @DonnieFi.
+- Restore upgrades from older stable releases [#143859](https://github.com/openclaw/openclaw/pull/143859)
+- Verify the same Gateway through update checks [#143863](https://github.com/openclaw/openclaw/pull/143863) Thanks @fuller-stack-dev.
+- Fix managed-update helper startup [#144031](https://github.com/openclaw/openclaw/pull/144031) Thanks @IWhatsskill, @fuller-stack-dev.
+- Allow confirmed service-less Linux updates, keep transcript stdout clean, preserve custom root/account schema types, and reuse warm Claude CLI processes when prepared skills are unchanged [#144402](https://github.com/openclaw/openclaw/pull/144402) Thanks @vincentkoc.
+
+**Limits and compatibility**
+
+- Align package versions and extension compatibility requirements [86ef455b](https://github.com/openclaw/openclaw/commit/86ef455b05483a94947ba26777ca94a9cc5d27d9)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Update a Git installation">
+
+Git installations using a saved stable or beta channel can update after upstream recreates a release tag, while keeping local-only tags and the existing branch protections. If you have several remotes without `origin` or a declared release source, select the intended remote with `branch.main.remote` before retrying. The [development-channel guide](/install/development-channels) explains that choice.
+
+Status also warns when a recorded failed fetch leaves its update information stale, instead of calling the installation up to date. Only a later successful fetch recorded by the updater clears that historical warning, so a manual fetch or a separate fresh status check does not erase it. Windows source updates also receive the Git configuration-path fix used by the affected cloning and repository operations.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover Git updates when upstream release tags move [#126816](https://github.com/openclaw/openclaw/pull/126816) Thanks @ruel225, @zhangguiping-xydt, @ToneLoke. Context [#123318](https://github.com/openclaw/openclaw/issues/123318).
+- Sync source assets with unusual filenames [#142024](https://github.com/openclaw/openclaw/pull/142024)
+- Warn when failed update fetches leave status information stale [#142199](https://github.com/openclaw/openclaw/pull/142199) Thanks @ToneLoke.
+- Fix Windows Git configuration paths for updates and cloning [#142749](https://github.com/openclaw/openclaw/pull/142749) Thanks @pengzh1, @aevgeniou, @jalehman.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Restore only compatible packages">
+
+A failed update can restore the retained package when the current configuration and databases are still compatible with it, and an initial startup refusal preserves existing state before migration so repair remains possible. Package replacement cannot undo a database migration or restore a full-state checkpoint. Keep an independent verified backup if you need to recover migrated state, and follow the [rollback and recovery guide](/install/updating/rollback-and-recovery).
+
+Updates stop further protected package, launcher, and plugin writes when the original updater loses ownership, leaving remaining recovery material available for inspection. Work already started can still leave partial changes, and some post-activation inspection or cleanup failures leave the candidate installed because automatic rollback cannot be verified. Plugin downloads and required follow-up migrations finish before the managed Gateway restarts, so that work is part of the downtime.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve existing state when Gateway startup needs repair [#141451](https://github.com/openclaw/openclaw/pull/141451) Thanks @Lendersmark, @jerabinovich.
+- Correct version checks after failed-update recovery [#142817](https://github.com/openclaw/openclaw/pull/142817) Thanks @wangmiao0668000666.
+- Stop rollback after updater ownership is lost [#143791](https://github.com/openclaw/openclaw/pull/143791) Thanks @vincentkoc, @fuller-stack-dev.
+- Report failed temporary-copy cleanup [#143844](https://github.com/openclaw/openclaw/pull/143844) Thanks @fuller-stack-dev.
+- Stop plugin writes after update ownership loss [#144130](https://github.com/openclaw/openclaw/pull/144130) Thanks @fuller-stack-dev.
+
+**Limits and compatibility**
+
+- Guard compatible package rollback and interrupted updates, finish plugin work before restart, add copied-agent preflight, honor same-version package artifacts, and suppress unsolicited standalone restart notices [000af986](https://github.com/openclaw/openclaw/commit/000af986dc991e9cef3d10663c121503606f25cc) Thanks @fuller-stack-dev. Context [#140339](https://github.com/openclaw/openclaw/pull/140339).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Release abandoned update records">
+
+A stuck update card can now release the settings and provider sign-in actions it was blocking when the saved record meets the recovery conditions. `openclaw update repair` can immediately reconcile a recent abandoned run when every recorded updater is positively dead, no unidentified replacement updater is recorded, and the matching installed Gateway is healthy, without stopping that working service.
+
+There is also automatic recovery for an untouched legacy record more than 24 hours old that never progressed beyond its initial request and has no recorded drivers or retained recovery descriptor. Age alone does not make an arbitrary update eligible. Both paths keep failed history visible, and the legacy case offers retry guidance instead of starting another update for you.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Repair abandoned update runs without an unnecessary 30-minute wait [#143136](https://github.com/openclaw/openclaw/pull/143136) Thanks @yncubys, @guarismo, @SunnyShu0925.
+- Clear abandoned legacy updates that block settings writes [#143774](https://github.com/openclaw/openclaw/pull/143774) Thanks @Colton-Harris, @syfvb, @ElvisIO7, @rlosito, @alexph-dev, @aaajiao, @c0ncatenate, @unknowbug, @KingAkrej, @DasX, @jlacroix82, @mikronn2, @najef1979-code.
+
+**Documentation**
+
+- Explain automatic expiry of old update records [#143974](https://github.com/openclaw/openclaw/pull/143974)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Let required repairs finish">
+
+Large installations can let update Doctor repairs finish beyond the former automatic deadline, while failures to remove certain disposable caches or temporary copies can be reported as warnings with repair guidance. Required migrations, imports, required consent, ownership, and readiness checks still have to pass before the update can complete.
+
+Repair Doctor has no automatic wall-clock deadline, so use `--timeout <seconds>` if you need a limit. That allowance applies per finalization phase and its child commands, not to the whole update, and a stalled Doctor can otherwise wait indefinitely. The separate post-plugin validation and readiness checks retain their own limits; terminating the updater with SIGTERM can still leave a snapshot child running.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Allow long update Doctor repairs to finish [#143321](https://github.com/openclaw/openclaw/pull/143321) Thanks @fuller-stack-dev.
+- Continue updates after recoverable cleanup failures [#143767](https://github.com/openclaw/openclaw/pull/143767)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose what follows a failed update">
+
+After a failed update successfully restores and verifies the previous installation, the interactive menu explains that outcome and defaults to Exit. Diagnosis runs when you choose it, reporting shows a sanitized preview before asking to submit, and the command still returns a failure status because the requested update did not succeed. Quiet invocations skip this optional follow-up.
+
+For other eligible interactive failures, the automatic repair prompt identifies the agent and warns that it will use your account quota or model tokens. You can decline and keep the saved diagnostics and manual handoff, but Enter accepts and an unanswered prompt continues after 30 seconds. Direct interactive Claude repairs use safe mode to avoid waiting on project startup hooks, which requires supported Claude Code versions and excludes custom hooks, plugins, skills, MCP servers, and project instructions. Use the printed manual command if the repair needs those customizations; the [triage guide](/cli/triage) covers both paths.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Offer a choice before automatic update repair launches an agent [#143139](https://github.com/openclaw/openclaw/pull/143139)
+
+**Bug fixes**
+
+- Make diagnosis optional after verified update rollback [#143657](https://github.com/openclaw/openclaw/pull/143657) Thanks @fuller-stack-dev.
+
+**Documentation**
+
+- Clarify update failure recovery choices [#143723](https://github.com/openclaw/openclaw/pull/143723)
+
+**Limits and compatibility**
+
+- Start direct Claude triage in safe mode with advertised support, documented for Claude Code 2.1.169 or newer [#143474](https://github.com/openclaw/openclaw/pull/143474) Thanks @RomneyDa.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand update progress and warnings">
+
+Update progress, history, and the final report now keep the same observed outcome, including a failed update whose rollback was verified. Final reports wait for the updater's last ownership checks, and warnings identify retained obsolete backups or remaining Doctor findings so you can decide what to inspect next. If saved history cannot be read, update availability and runtime guidance remain available with an explicit history error.
+
+Troubleshooting also keeps bounded, redacted Doctor output when finalization times out and identifies child processes behind a stalled phase. Routine update repair skips unrelated advisory checks; run `openclaw doctor` afterward for the full set of advice. Focused [status and history](/cli/update/status-and-history) and [repair guides](/cli/update/repair-and-recovery) explain the reports, while refreshed Git commit counts keep the browser's update confirmation in step with Settings.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Identify child processes in stalled update diagnostics [#141740](https://github.com/openclaw/openclaw/pull/141740) Thanks @hannesrudolph.
+- Skip unrelated Doctor diagnostics during updates [#142675](https://github.com/openclaw/openclaw/pull/142675) Thanks @fuller-stack-dev.
+
+**Bug fixes**
+
+- Skip optional update probes and retain Doctor warnings [#141995](https://github.com/openclaw/openclaw/pull/141995) Thanks @hannesrudolph.
+- Preserve core Doctor warnings during updates [#142091](https://github.com/openclaw/openclaw/pull/142091)
+- Retain Doctor diagnostics when update finalization times out [#142672](https://github.com/openclaw/openclaw/pull/142672) Thanks @fuller-stack-dev.
+- Show refreshed commit counts before updating [#142837](https://github.com/openclaw/openclaw/pull/142837) Thanks @jalehman.
+- Keep update guidance available when history fails [#143557](https://github.com/openclaw/openclaw/pull/143557)
+- Load update history without pausing other Gateway work [#143605](https://github.com/openclaw/openclaw/pull/143605)
+- Stop advertising unavailable update-report files [#143748](https://github.com/openclaw/openclaw/pull/143748)
+- Correct agent guidance for authorized SSH updates to a different host while retaining normal approvals [#143754](https://github.com/openclaw/openclaw/pull/143754)
+- Report final update results and retained backups [#143921](https://github.com/openclaw/openclaw/pull/143921) Thanks @fuller-stack-dev.
+- Keep update progress consistent with final reports [#143965](https://github.com/openclaw/openclaw/pull/143965)
+
+**Documentation**
+
+- Split update documentation into focused guides [#142858](https://github.com/openclaw/openclaw/pull/142858) Thanks @vincentkoc.
+- Split updating guidance into focused pages [#142993](https://github.com/openclaw/openclaw/pull/142993) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Update plugins when core is current">
+
+If you upgraded core separately, `openclaw update` still runs eligible plugin maintenance even when OpenClaw itself is already current. Changed plugins go through the existing validation and managed restart path, while unchanged plugins avoid redundant completion work. `--no-restart` keeps the manual restart step, and a service that was already stopped stays stopped.
+
+Intentional version pins remain yours to change. When a newer official plugin release is observed, update and repair output makes the retained pin visible and gives the command to replace it. For an official ClawHub pin, that is an explicit `openclaw plugins install clawhub:<package> --force`, retaining the beta selector where applicable. A newer release notice is availability information, not a finding that your installed version is incompatible.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Skip unnecessary plugin scans during updates [#143783](https://github.com/openclaw/openclaw/pull/143783)
+
+**Bug fixes**
+
+- Report newer releases without replacing official plugin pins [#137892](https://github.com/openclaw/openclaw/pull/137892) Thanks @pfrederiksen, @vincentkoc. Context [#137624](https://github.com/openclaw/openclaw/issues/137624).
+- Show warnings for retained official plugin pins [#142457](https://github.com/openclaw/openclaw/pull/142457) Thanks @PollyBot13, @obviyus, @martins-oss.
+- Run plugin maintenance when core is already current [#143174](https://github.com/openclaw/openclaw/pull/143174) Thanks @martins-oss, @fulgerulnegru, @kesslerio, @guojiongming, @soroyue, @Sedrak-Hovhannisyan.
+- Skip redundant completion when updates change nothing [#143462](https://github.com/openclaw/openclaw/pull/143462) Thanks @RomneyDa.
+- Skip plugins already repaired under new IDs [#143861](https://github.com/openclaw/openclaw/pull/143861)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Repair older settings and moved workspaces">
+
+Doctor can restore valid older multi-agent backups without asking you to hand-edit their ownership setting, and repair old model and account references while retaining the selected provider, account, execution backend, and fallback order. If a workspace moved, Doctor can confirm that it is the same workspace and carry its setup and migration history across; affected messages receive repair guidance instead of holding later messages in the queue. Conflicting or uncertain records remain for review rather than being merged by guesswork.
+
+Users with Claude sessions stored only in the retired conversation field must run `openclaw doctor --fix` before resuming those sessions. The [Doctor checks guide](/cli/doctor/checks) explains that migration and the warnings for bindings that need manual reconciliation. Account repair also preserves verified mappings through interrupted retries, though changes across separate stores do not form one atomic operation.
+
+Diagnostics identify the actual source directories during full lint, give verified-backup guidance for unreadable state, and explain incomplete project clones without automatically rewriting them. Updates can also finish with a valid absent configuration file, leaving it absent, and an implicit Codex preference no longer makes a missing optional plugin a requirement.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Fix optional Codex checks, configuration-less update finalization, and private Doctor snapshot cleanup [f212072e](https://github.com/openclaw/openclaw/commit/f212072e4c6e5f67f356b4b213a0059bbdb07db2)
+- Repair moved workspaces without blocking queued messages [#133198](https://github.com/openclaw/openclaw/pull/133198) Thanks @safzanpirani, @obviyus. Context [#133172](https://github.com/openclaw/openclaw/issues/133172).
+- Preserve Unicode in shortened SQLite worker errors [#137675](https://github.com/openclaw/openclaw/pull/137675) Thanks @ly85206559, @obviyus.
+- Wait for cooperating plugins to release Doctor inspection resources through their registration-local disposal callback [#141692](https://github.com/openclaw/openclaw/pull/141692)
+- Show backup recovery guidance for unreadable Doctor state [#141776](https://github.com/openclaw/openclaw/pull/141776)
+- Stop Doctor suggesting the skill repair already underway [#141866](https://github.com/openclaw/openclaw/pull/141866)
+- Explain shallow snapshot failures and incomplete clones [#141936](https://github.com/openclaw/openclaw/pull/141936)
+- Preserve model choices and backends during Doctor migration [#142284](https://github.com/openclaw/openclaw/pull/142284) Thanks @obviyus.
+- Respect search-provider choice in missing-plugin repair; the separate release-repair path can still select Brave from environment credentials [#142640](https://github.com/openclaw/openclaw/pull/142640) Thanks @vincentkoc.
+- Correct full Doctor lint paths and preserve inspected sidecars and skill links; ordinary lint retains its separate shared-memory limitation [#142839](https://github.com/openclaw/openclaw/pull/142839) Thanks @thien-ngn, @obviyus.
+- Restore legacy multi-agent backups without manual ownership edits [#143202](https://github.com/openclaw/openclaw/pull/143202) Thanks @GitHoubi.
+- Repair legacy music-model references with Doctor [#143235](https://github.com/openclaw/openclaw/pull/143235) Thanks @obviyus.
+- Preserve saved accounts through Doctor migration [#143429](https://github.com/openclaw/openclaw/pull/143429) Thanks @obviyus.
+
+**Documentation**
+
+- Organize Doctor guidance by repair task [#141961](https://github.com/openclaw/openclaw/pull/141961) Thanks @vincentkoc.
+- Organize Doctor CLI documentation by task [#142855](https://github.com/openclaw/openclaw/pull/142855) Thanks @vincentkoc.
+
+**Limits and compatibility**
+
+- Migrate legacy Claude conversation bindings with Doctor [#143347](https://github.com/openclaw/openclaw/pull/143347) Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve supported legacy session content">
+
+Fresh imports of legacy Codex conversations preserve assistant replies in their original order alongside user messages and tool results. For sessions already imported incompletely, recovery can add missing replies to the stored history, but those replies append at the end and do not reconstruct the same active conversation as a fresh import.
+
+Doctor's repaired attachment metadata now survives recreation of archived session files. If a legacy session file shares its contents through a hard link, the refusal identifies the file and explains the [recovery procedure](/cli/doctor/sqlite-maintenance#hard-linked-legacy-artifacts). That protection remains in place, and an interrupted migration with recorded recovery material must use its existing recovery path before replacing files.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve Codex replies during legacy session import [#140296](https://github.com/openclaw/openclaw/pull/140296) Thanks @ylcn91, @ikenraf. Context [#140100](https://github.com/openclaw/openclaw/issues/140100).
+- Explain hard-linked session migration refusals with recovery guidance [#143195](https://github.com/openclaw/openclaw/pull/143195) Thanks @GitHoubi.
+- Preserve repaired media metadata in session archives [#143595](https://github.com/openclaw/openclaw/pull/143595) Thanks @fuller-stack-dev.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Include the configuration a backup needs">
+
+Full backups now include the nested configuration files your root configuration depends on, even when they live outside the state directory or inside an excluded workspace. The archive preserves their authored contents, including comments and environment placeholders, and refuses an incomplete or changing include graph instead of quietly producing an incomplete backup. `--only-config` remains a root-file-only export.
+
+Backups can also finish when a temporary SQLite companion file disappears after its database has already been captured consistently. Configuration and individual databases are captured at different times, so the archive is not one atomic snapshot of the whole installation, and included configuration files may themselves contain secrets. The [backup guide](/cli/backup) explains the capture and restore boundaries.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep backups running when snapshotted SQLite sidecars disappear [#141161](https://github.com/openclaw/openclaw/pull/141161) Thanks @LiuwqGit, @vincentkoc, @Cobblestone-Digital1, @legupsystems. Context [#141042](https://github.com/openclaw/openclaw/issues/141042). Context [#67417](https://github.com/openclaw/openclaw/issues/67417).
+- Preserve required configuration includes in full backups [#143693](https://github.com/openclaw/openclaw/pull/143693) Thanks @fuller-stack-dev.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Inspect large or busy databases">
+
+Large databases get a size-based allowance for integrity checks and private snapshot preparation instead of the same short deadline as a small installation. Applicable stable snapshots need one full temporary copy rather than two, reducing disk pressure, and Doctor avoids repeated table scans when the database is healthy while retaining the full integrity and foreign-key checks. Longer allowances give the work time to finish; they do not make every scan faster.
+
+When a check fails, diagnostics name the last observed phase and the repair command where appropriate, and slow session-cleanup operations can be identified even when each individual write was quick. The phase is a troubleshooting clue, not a diagnosis of the cause. Operators also have a read-only `openclaw database preflight-agent <copied-agent.sqlite> --agent-id <id> --json` check for a consolidated copied agent database with its exact agent ID and no sidecars.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show the last observed database integrity-check phase [#141669](https://github.com/openclaw/openclaw/pull/141669)
+- Reduce temporary disk space for applicable SQLite inspection snapshots [#141773](https://github.com/openclaw/openclaw/pull/141773)
+- Report slow session-cleanup worker operations [#142525](https://github.com/openclaw/openclaw/pull/142525)
+- Reduce database snapshot startup overhead [#144022](https://github.com/openclaw/openclaw/pull/144022)
+
+**Bug fixes**
+
+- Allow large databases more startup-check time [#141918](https://github.com/openclaw/openclaw/pull/141918)
+- Give large database inspections a size-based timeout [#142179](https://github.com/openclaw/openclaw/pull/142179)
+- Avoid redundant database scans during Doctor repair [#142669](https://github.com/openclaw/openclaw/pull/142669) Thanks @fuller-stack-dev.
+- Keep healthy memory database handles open when no repair is needed and skip GitHub credential and bootstrap-size advisories during updates [#143361](https://github.com/openclaw/openclaw/pull/143361) Thanks @fuller-stack-dev.
+- Name the Doctor repair command in SQLite startup errors [#143531](https://github.com/openclaw/openclaw/pull/143531) Thanks @RomneyDa.
+
+**Documentation**
+
+- Organize database reference and recovery guidance [#143152](https://github.com/openclaw/openclaw/pull/143152) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep OpenClaw responsive during history cleanup">
+
+Session deletion, edits, and history cleanup can reopen their database without running the full validation scan on the Gateway's main thread, allowing other work to continue while those checks finish. The same handling extends through history planning, archive pruning, and explicit cleanup finalization, with the existing ordering and deletion protections retained.
+
+Cleanup also rechecks whether a conversation has become protected and whether disk pressure still requires another deletion. If another operation already freed enough space, it leaves the next eligible history in place. Retention settings stay the same, and this preserves history during the covered cleanup races without recovering conversations deleted earlier.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recheck protected history and disk pressure during cleanup [#142505](https://github.com/openclaw/openclaw/pull/142505) Thanks @HermanZeng.
+- Move cold session-cleanup checks off the Gateway main thread [#143226](https://github.com/openclaw/openclaw/pull/143226)
+- Stop excess session cleanup after disk pressure clears [#143285](https://github.com/openclaw/openclaw/pull/143285)
+- Move cold database checks out of history cleanup planning [#143332](https://github.com/openclaw/openclaw/pull/143332)
+- Avoid Gateway pauses during archive database reopening [#143379](https://github.com/openclaw/openclaw/pull/143379)
+- Keep session updates responsive during database reopening [#143434](https://github.com/openclaw/openclaw/pull/143434)
+- Reopen cleanup databases without blocking other work [#143602](https://github.com/openclaw/openclaw/pull/143602)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Restart and stop the intended service">
+
+Linux systemd restarts with no-respawn enabled now let the old Gateway exit so the service manager can start its replacement, instead of leaving the service waiting in deactivation. Conflicting effective settings, such as a LAN bind combined with Tailscale Serve, stop repeated restart attempts with configuration guidance. Check both saved settings and service overrides before starting again.
+
+Shutdown keeps shared state available until the tracked hooks and plugin cleanup actually finish, including returned Talk connection cleanup. Slow callbacks can therefore delay graceful shutdown, and a callback that never settles may require interruption. The affected automatic macOS CLI exit path with system certificate support likewise waits for pending cleanup, allowing final writes to finish.
+
+Service diagnostics avoid false repair advice for intentionally masked systemd units, and startup logs follow the active plugin configuration. Reconnects also share the [health refresh cadence](/gateway/health), avoiding repeated background collection while preserving explicit live probes and immediate refreshes for missing or stale snapshots.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Avoid false repair advice for masked systemd services [#137869](https://github.com/openclaw/openclaw/pull/137869) Thanks @teddytennant, @obviyus, @aniruddhaadak80. Context [#128928](https://github.com/openclaw/openclaw/issues/128928).
+- Prevent managed systemd restarts from hanging [#140914](https://github.com/openclaw/openclaw/pull/140914) Thanks @NianJiuZst, @rboy1, @obviyus. Context [#140821](https://github.com/openclaw/openclaw/issues/140821).
+- Keep affected CLI-started Gateways running after transient DNS rejections without retrying the failed operation [#141163](https://github.com/openclaw/openclaw/pull/141163) Thanks @ly85206559, @orangejon. Context [#141123](https://github.com/openclaw/openclaw/issues/141123).
+- Return service-unavailable responses when a Gateway handshake fails before WebSocket transfer [#141303](https://github.com/openclaw/openclaw/pull/141303) Thanks @hugenshen, @obviyus.
+- Wait for Talk connection cleanup during shutdown [#141706](https://github.com/openclaw/openclaw/pull/141706)
+- Keep startup logs current after plugin reloads [#141736](https://github.com/openclaw/openclaw/pull/141736)
+- Stop restart loops caused by conflicting Gateway settings [#141771](https://github.com/openclaw/openclaw/pull/141771) Thanks @chelsealong, @tomdailey55, @jalehman.
+- Keep shared Gateway state available through cleanup [#142286](https://github.com/openclaw/openclaw/pull/142286)
+- Finish pending cleanup before automatic macOS CLI exit [#142814](https://github.com/openclaw/openclaw/pull/142814)
+- Avoid repeated health collection on reconnects [#143384](https://github.com/openclaw/openclaw/pull/143384)
+- Preserve restart options during schema upgrades [#143738](https://github.com/openclaw/openclaw/pull/143738) Thanks @RomneyDa.
+
+**Documentation**
+
+- Split Gateway CLI reference by operator task [#143005](https://github.com/openclaw/openclaw/pull/143005) Thanks @vincentkoc.
+- Organize Gateway troubleshooting by symptom [#143160](https://github.com/openclaw/openclaw/pull/143160) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep deployment-owned configuration intact">
+
+If a deployment system owns your configuration, you can now set `OPENCLAW_CONFIG_READONLY=1` in both the Gateway and CLI host environments without also selecting Nix mode. OpenClaw's configuration writes and automatic backup recovery respect that choice, while model changes can remain session-only. Runtime state still needs writable storage, and the setting belongs in the service or container environment, not inside the configuration's own environment variables. The [externally managed configuration guide](/cli/config#externally-managed-config) explains setup.
+
+Refused changes point you back to the external source instead of suggesting a crash repair. Saved configuration revisions also refresh after agent changes, avoiding false conflicts on the next edit, while remaining distinct from the configuration currently running. With reload mode set to `off`, OpenClaw still watches and validates files; a manual restart applies the changes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add a read-only mode for externally managed configuration [#140719](https://github.com/openclaw/openclaw/pull/140719) Thanks @sallyom. Context [#140706](https://github.com/openclaw/openclaw/issues/140706). Context [#103606](https://github.com/openclaw/openclaw/issues/103606).
+
+**Bug fixes**
+
+- Refresh configuration revisions after agent changes [#142169](https://github.com/openclaw/openclaw/pull/142169) Thanks @ceckert, @obviyus.
+- Explain managed-configuration refusals without crash diagnostics [#143140](https://github.com/openclaw/openclaw/pull/143140)
+
+**Documentation**
+
+- Clarify manual restart requirements in reload-off mode [#127205](https://github.com/openclaw/openclaw/pull/127205) Context [#127203](https://github.com/openclaw/openclaw/issues/127203).
+- Split Gateway configuration guidance into topic pages [#143456](https://github.com/openclaw/openclaw/pull/143456) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Operate Windows Gateway services">
+
+Stopping an ordinary generated Windows Gateway task now stops its descendants too, freeing the port and state directory for a fresh start, and early child failures reach the Gateway log. Executable wrappers or additional CMD layers can still fail the launcher's ancestry check before startup. Those launch chains remain affected.
+
+Update service checks honor the requested `--timeout` and retry one timed-out inspection. Each attempt receives the full per-step allowance, so two hung probes at the default can take an hour. Repeated timeouts or other inspection failures still stop the update before package changes, with clearer guidance about the failure.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Stop Windows Gateway task descendants and log child failures [#141744](https://github.com/openclaw/openclaw/pull/141744) Thanks @akagifreeez, @Devin-Linux, @unknowbug.
+- Honor update timeouts for Windows service checks [#143292](https://github.com/openclaw/openclaw/pull/143292) Thanks @fanyuantaier.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Find operating and monitoring guidance">
+
+The [OpenTelemetry guide](/gateway/opentelemetry) now separates setup, configuration, privacy and trace context, model metrics, and spans and events into focused pages. You can get directly to the monitoring instructions you need while existing section links still lead through the retained index; telemetry capabilities and export defaults are unchanged.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Split OpenTelemetry guidance into focused pages [#142951](https://github.com/openclaw/openclaw/pull/142951) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Messaging
+
+Long replies keep their prose and code readable as they arrive, Feishu workspace tools are available again in affected message-driven conversations, and Talk can bring delegated answers back to the active voice conversation. Across the messaging channels, this release also preserves more of the content people send and makes account selection and failed delivery easier to understand.
+
+<AccordionGroup>
+
+<Accordion title="Keep replies and their status together">
+
+Incoming channel messages now wait in the durable queue while the Gateway is suspended and resume when it accepts work again, instead of repeatedly attempting dispatch during the pause. Recovery also keeps unfinished replies pending when a stalled task is cleared, so freeing a task slot no longer makes an unsent reply appear complete.
+
+With the tool activity log enabled, progress previews keep newer activity and the plan visible after repeated command exits, while approvals and explicit failures retain priority. Message-tool-only groups keep internal finalizer placeholders private, and missing-reply notices explain the failure more accurately with a troubleshooting reference when one is available.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Hide internal finalizer placeholders in message-only groups [73ca607b1d99](https://github.com/openclaw/openclaw/commit/73ca607b1d9940ecb040527da0a3c610d15bc64a). Thanks @razvangirgiz, @obviyus, @omarshahine. Contextual provenance [#138645](https://github.com/openclaw/openclaw/pull/138645).
+- Keep unfinished replies pending during forced cleanup [#141900](https://github.com/openclaw/openclaw/pull/141900). Thanks @Takhoffman.
+- Pause message retries during Gateway suspension [#142064](https://github.com/openclaw/openclaw/pull/142064). Thanks @goutamadwant, @obviyus, @Stephane-fci.
+- Keep plans and newer activity visible after repeated command exits [#142802](https://github.com/openclaw/openclaw/pull/142802). Thanks @obviyus.
+
+**Improvements**
+
+- Add clearer missing-reply notices and run references [#136462](https://github.com/openclaw/openclaw/pull/136462). Thanks @RomneyDa, @sloptop-the-terrible.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read streamed prose and code">
+
+[Streamed replies](/concepts/streaming) wait for natural prose breaks while there is room, and long code blocks keep their formatting when they continue into another message. Successfully delivered code is recognized when the final answer arrives, avoiding a repeated full answer while retaining a fallback for a continuation that failed to send.
+
+Quoted code keeps meaningful spaces when delivery directives are removed, literal message-ID examples remain visible, and short columns align in code-block tables. Images already converted to PNG, JPEG, or WebP also keep their original bytes when they meet the existing limits, even if their filename still ends in `.heic`.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve paragraph boundaries between streamed assistant messages [#140833](https://github.com/openclaw/openclaw/pull/140833). Thanks @leapdragon, @obviyus.
+- Preserve quoted code spacing when removing delivery directives [#141767](https://github.com/openclaw/openclaw/pull/141767). Thanks @Alix-007, @obviyus.
+- Preserve message-ID code examples in conversation displays [#141769](https://github.com/openclaw/openclaw/pull/141769). Thanks @Alix-007, @obviyus.
+- Preserve converted images that retain HEIC filenames [#142263](https://github.com/openclaw/openclaw/pull/142263).
+- Align short and empty code-table columns [#142406](https://github.com/openclaw/openclaw/pull/142406).
+- Keep streamed prose and code formatted without duplicate finals [#143722](https://github.com/openclaw/openclaw/pull/143722). Thanks @obviyus, @rgregg.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read Telegram formatting and media">
+
+With [Telegram rich messages](/channels/telegram) enabled, styled links remain clickable inside expandable details, lists, and quotes, while literal examples and body spacing retain their intended form. HTML entities decode once, preserving deliberately escaped examples. Ordinary Telegram messages and captions also preserve code-example spacing, including examples that contain their own fence markers.
+
+Static sticker descriptions use your configured image model and remain available for the first reply. Description generation tries one selected model and leaves failed descriptions out of the cache.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve styled links and formatting in rich messages [#139976](https://github.com/openclaw/openclaw/pull/139976).
+- Honor image defaults and retain sticker descriptions [#142023](https://github.com/openclaw/openclaw/pull/142023). Thanks @obviyus.
+- Preserve code-example spacing in Telegram text and captions [#142504](https://github.com/openclaw/openclaw/pull/142504).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use Telegram mentions and commands">
+
+Telegram groups recognize identity-backed mentions of the bot in text and photo captions, while keeping the existing sender and group permissions. When native commands are disabled, a text directive such as `/think high` can be followed by a task on later lines without losing the task; strict native commands keep their existing argument rules.
+
+The `/think` menu shows the thinking default for the agent assigned to the conversation, and canceled message preparation stops old timers from replacing a valid acknowledgment with a late stall reaction. The [Telegram guides](/channels/telegram) now separate setup, permissions, message behavior, and troubleshooting into focused pages.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recognize bot identity mentions in text and captions [#140266](https://github.com/openclaw/openclaw/pull/140266). Thanks @cai-ops, @obviyus.
+- Stop stale stall reactions after cancelled preparation [#141079](https://github.com/openclaw/openclaw/pull/141079). Thanks @ooiuuii, @obviyus.
+- Preserve tasks after multiline Telegram directives [#142008](https://github.com/openclaw/openclaw/pull/142008). Thanks @wangmiao0668000666, @obviyus.
+- Show the routed agent's thinking default in Telegram [#143789](https://github.com/openclaw/openclaw/pull/143789).
+
+**Documentation**
+
+- Organize Telegram documentation by task [#142963](https://github.com/openclaw/openclaw/pull/142963). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Retry eligible Telegram delivery failures">
+
+Telegram replies can remain queued for retry when a proxy refuses its tunnel before the request reaches Telegram, including across a restart. Once the proxy returns, normal recovery can send the reply; uncertain sends and failures after the tunnel opens keep their existing protection against duplicate delivery. Previously failed queue entries are not automatically repaired.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover queued replies after proxy tunnel refusals [#140388](https://github.com/openclaw/openclaw/pull/140388). Thanks @Hekzory, @MAG-Linares-Andalucia.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read Discord replies and delegated work">
+
+[Discord](/channels/discord) preserves more of what belongs in the conversation, including repeated paragraphs in attachment captions, emoji on link buttons, and the spoken words from voice notes in channels that already allow ambient observation. Allowed commentary reaches the chat, and a failed final send leaves the visible progress message in place so the task does not simply disappear.
+
+Permitted system-agent requests from ordinary server messages can delegate again without losing their authorization along the way. Member information also uses presence supplied at startup or reconnect when the existing presence intent is enabled, rather than waiting for each person to change status.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Populate member presence from startup and reconnect snapshots [#141218](https://github.com/openclaw/openclaw/pull/141218). Thanks @harshitgupta31415, @vincentkoc, @nissl24.
+- Preserve Discord commentary and progress after send failures [#141621](https://github.com/openclaw/openclaw/pull/141621). Thanks @anyech, @obviyus, @dw1161.
+- Preserve repeated Discord captions and link-button emoji [#142342](https://github.com/openclaw/openclaw/pull/142342).
+- Preserve voice-note words in Discord ambient conversations [#142860](https://github.com/openclaw/openclaw/pull/142860). Thanks @ericcaiwx-star, @aatreya, @jalehman.
+- Restore permitted system-agent delegation in Discord guild messages [#143006](https://github.com/openclaw/openclaw/pull/143006). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus, @0xCyda, @lisheguo.
+
+**Documentation**
+
+- Organize Discord documentation into focused guides [#142666](https://github.com/openclaw/openclaw/pull/142666). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep Slack messages and acknowledgements readable">
+
+Slack can show the configured acknowledgment when an eligible mention is picked up even with status reactions turned off, including in groups that send replies through the message tool. Long messages containing code-formatted Windows paths also keep the following prose out of accidental code formatting.
+
+For Slack Enterprise installations, an owner heartbeat addressed only by user ID can resolve a verified shared workspace without needing an earlier incoming message. Explicit workspace choices stay in place. The [Slack formatting guide](/channels/slack/media) explains the existing message presentation options.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Resolve a shared workspace for owner heartbeat DMs [#138689](https://github.com/openclaw/openclaw/pull/138689). Thanks @Kimiyu-186.
+- Keep Slack prose out of code formatting after Windows paths [#142288](https://github.com/openclaw/openclaw/pull/142288).
+- Keep Slack acknowledgements when status reactions are off [#142595](https://github.com/openclaw/openclaw/pull/142595). Thanks @sunlit-deng, @alexjpanagis.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use Feishu workspace tools and rich posts">
+
+Affected external Feishu installations regain document, wiki, Drive, and Bitable tools during message-driven work, with existing tool policies and Feishu permissions still in effect. Applied tool and default-account settings also take effect for new turns without a restart; tools already created for ongoing work keep their original settings.
+
+Received rich posts preserve emphasis on text, links, and mentions in both agent input and message reads. The reorganized [Feishu configuration guidance](/channels/feishu/advanced-configuration) makes the account and tool settings easier to find.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Skip unnecessary table parsing for plain Feishu cards and stop checking over-limit cards [#141770](https://github.com/openclaw/openclaw/pull/141770). Table-heavy cases do not share a general speedup.
+
+**Bug fixes**
+
+- Restore Feishu workspace tools in message-driven runs [#141984](https://github.com/openclaw/openclaw/pull/141984). Thanks @SunnyShu0925, @hayden-cc, @lizhengwu, @jalehman, @seven7763, @itanyplus.
+- Apply updated Feishu tool settings to new turns [#141993](https://github.com/openclaw/openclaw/pull/141993).
+- Preserve Feishu inline styles in received posts [#142627](https://github.com/openclaw/openclaw/pull/142627).
+
+**Documentation**
+
+- Organize Feishu documentation by task [#143085](https://github.com/openclaw/openclaw/pull/143085). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read Matrix text, reactions, and literal mentions">
+
+Matrix keeps ordinary text in conversation context when a remote message uses an unfamiliar message type, and escaped user or room mentions remain literal after an unmatched backtick. Reaction listings in the CLI show the reaction label alongside its count and users, with raw values still available through `--json`. The [Matrix guides](/channels/matrix) now provide separate routes to setup, encryption, messaging, and account instructions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve Matrix text for unknown message types [#135359](https://github.com/openclaw/openclaw/pull/135359). Thanks @teddytennant, @obviyus.
+- Show Matrix reaction labels in CLI listings [#141811](https://github.com/openclaw/openclaw/pull/141811).
+- Keep escaped Matrix mentions literal after unmatched backticks [#142369](https://github.com/openclaw/openclaw/pull/142369).
+
+**Documentation**
+
+- Organize Matrix documentation into focused guides [#142996](https://github.com/openclaw/openclaw/pull/142996). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve Teams text">
+
+HTML-only Teams messages pass their intended punctuation and symbols to the agent, decoding once so deliberately literal text stays literal. Plain message text still takes precedence when present, and the reorganized [Teams guides](/channels/msteams) put setup, authentication, permissions, and messaging instructions on separate pages.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Decode HTML-only Teams message text correctly [#142496](https://github.com/openclaw/openclaw/pull/142496).
+
+**Documentation**
+
+- Organize Teams documentation into focused guides [#142986](https://github.com/openclaw/openclaw/pull/142986). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve Signal reply quotes">
+
+With Signal configured to quote only the first reply, a failed streamed send no longer uses up that quote. The first successful reply keeps its reference to the incoming message, and the [Signal guide](/channels/signal) now explains the existing table-formatting choices and their default.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Document Signal table modes, default bullets, and block-to-code fallback [#138160](https://github.com/openclaw/openclaw/pull/138160). Thanks @SunnyShu0925, @obviyus.
+
+**Bug fixes**
+
+- Preserve Signal quotes after failed streamed sends [#142600](https://github.com/openclaw/openclaw/pull/142600).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep assistant prefixes out of incoming WhatsApp text">
+
+Incoming WhatsApp messages keep the sender’s text without an added assistant reply label. Your configured outgoing prefixes continue to work, and prefix-like text someone actually typed remains part of their message.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep reply prefixes out of incoming WhatsApp messages [#138819](https://github.com/openclaw/openclaw/pull/138819). Thanks @sunlit-deng, @vincentkoc, @Jackten.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recognize iMessage conversations">
+
+iMessage conversations use available contact and group names to help you recognize them in session lists, while preserving manual labels and existing group titles. Names still depend on what the bridge or resolver supplies. The [iMessage guides](/channels/imessage) separate setup and operating instructions, and maturity documentation distinguishes current iMessage support from historical BlueBubbles migration guidance.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Clarify current iMessage support in maturity docs [#141963](https://github.com/openclaw/openclaw/pull/141963). Thanks @RomneyDa.
+- Organize iMessage guides by setup and messaging task [#143038](https://github.com/openclaw/openclaw/pull/143038). Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Show resolved iMessage contact and group names [#142128](https://github.com/openclaw/openclaw/pull/142128). Thanks @omarshahine.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep Mattermost accounts and progress current">
+
+Changing one Mattermost account's settings can leave the other working accounts connected when valid token secret references are in use. Global changes can still restart all accounts. Progress previews also survive overlapping removal and replacement, even when the new plan has identical text; a failed old-preview deletion gets another cleanup attempt when the turn ends.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep other Mattermost accounts connected during settings reloads [#142193](https://github.com/openclaw/openclaw/pull/142193). Thanks @ceckert, @obviyus.
+- Preserve replacement Mattermost progress previews [#143621](https://github.com/openclaw/openclaw/pull/143621).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reply to the saved Google Chat destination">
+
+When work resumes a Google Chat conversation and sends a reply without an explicit destination, OpenClaw can recover the exact space-ID casing from matching saved session information. This prevents the lowercased destination from causing a permission error, while explicitly supplied targets remain authoritative.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve destination casing for resumed Google Chat replies [#140418](https://github.com/openclaw/openclaw/pull/140418). Thanks @aeoess, @obviyus, @jailbirt.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Finish Nextcloud Talk responses without capture waits">
+
+Nextcloud Talk reactions can return their selected result without waiting for diagnostic capture to finish reading an open response body. The same cleanup correction applies to sends, room lookups, and bot checks. A capture interrupted by cleanup may be incomplete even when the reaction succeeded.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Avoid diagnostic-capture delays in Nextcloud Talk responses [#141307](https://github.com/openclaw/openclaw/pull/141307). Thanks @hugenshen, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Identify missing Tlon account settings">
+
+A Tlon send blocked by incomplete configuration now names the selected account and the missing connection settings, so you can tell whether to supply the ship, URL, or login code. The error lists field names without revealing their values; the [Tlon guide](/channels/tlon) covers setup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Identify missing Tlon account settings in send errors [#137664](https://github.com/openclaw/openclaw/pull/137664). Thanks @ly85206559, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Migrate older Zalo Personal policies">
+
+For older Zalo Personal configurations with root policies and named accounts but no default account, `openclaw doctor --fix --non-interactive` now moves the eligible policies into the account configuration. It preserves root and named-account profiles, explicit overrides, and deliberately empty allowlists.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Restore Zalo Personal policy migration [#143860](https://github.com/openclaw/openclaw/pull/143860). Thanks @wangmiao0668000666, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Select and inspect the intended account">
+
+Account inspection now reflects the configured scope more accurately. Agent listings expand wildcard bindings into known accounts, health diagnostics include implicit default-account bindings, and configured channels retain their subtitles before the plugin loads.
+
+Scripts using [directory](/cli/directory), message, or the affected channel commands must omit `--account` to request the existing default behavior instead of passing an empty value. Directory limits must be positive integers when supplied; omit `--limit` for the plugin default. Blank group IDs fail before plugin setup. [Channel removal](/cli/channels) reports unknown accounts or ineffective deletions with exit status 1 instead of claiming success, although its existing runtime-stop attempt can occur first.
+
+In multi-agent setups, [message commands](/cli/message) now give the supported remedy when no owner is selected. Choosing an existing agent through `agents.defaults.systemAgent.agentId` also assigns other ambient system work to that agent.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Limits and compatibility**
+
+- Reject blank account options in directory commands [#137334](https://github.com/openclaw/openclaw/pull/137334). Thanks @Alix-007, @obviyus.
+- Reject explicitly empty directory listing limits [#141738](https://github.com/openclaw/openclaw/pull/141738). Thanks @hugenshen, @obviyus.
+- Reject empty account selectors in message and channel commands [#143088](https://github.com/openclaw/openclaw/pull/143088). Thanks @ly85206559, @obviyus.
+
+**Bug fixes**
+
+- Show channel account selectors correctly in agent listings [#141724](https://github.com/openclaw/openclaw/pull/141724).
+- Give message commands a working ownership remedy [#141886](https://github.com/openclaw/openclaw/pull/141886). Thanks @Dreamer-HIT, @obviyus, @schwanncells.
+- Include implicit default accounts in health output and listBoundAccountIds [#143319](https://github.com/openclaw/openclaw/pull/143319). Thanks @qingminglong, @obviyus.
+- Preserve channel subtitles before plugins load [#143416](https://github.com/openclaw/openclaw/pull/143416).
+- Reject blank directory groups before plugin setup [#143440](https://github.com/openclaw/openclaw/pull/143440).
+- Reject unknown channel accounts during removal [#143561](https://github.com/openclaw/openclaw/pull/143561). Thanks @masatohoshino, @obviyus.
+
+**Documentation**
+
+- Split channel configuration documentation into focused pages [#142910](https://github.com/openclaw/openclaw/pull/142910). Thanks @vincentkoc.
+- Correct Matrix token and restart steps, Tlon login guidance, Yuanbao App Key instructions, and plugin publishing and SDK examples [#144018](https://github.com/openclaw/openclaw/pull/144018). Thanks @vincentkoc, @sunnyiren-max.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue speaking while work is delegated">
+
+[Talk](/nodes/talk) can acknowledge delegated work, keep listening, and return the consolidated answer to the active voice conversation as well as chat. Follow-up speech stays with the accepted task on supported Gateway-backed runners, and the answer can still return after successive rounds of delegation.
+
+Canceled or replaced voice sessions cannot receive a late answer from the old task. The voice connection to delegated work remains local to the running process and expires, so continuing the work does not promise a spoken result after the process or session is replaced.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep voice follow-ups and replies with the active task [#129186](https://github.com/openclaw/openclaw/pull/129186). Thanks @vincentkoc.
+- Return delegated answers to the active Talk session [#129535](https://github.com/openclaw/openclaw/pull/129535). Thanks @vincentkoc.
+- Deliver Talk answers after repeated delegation [#142830](https://github.com/openclaw/openclaw/pull/142830).
+
+**Documentation**
+
+- Organize Talk guidance into focused pages [#143149](https://github.com/openclaw/openclaw/pull/143149). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Handle phone and realtime audio interruptions">
+
+Phone interruptions now account for the assistant audio that the carrier has confirmed playing, including zero duration for speech that was still queued. That keeps the conversation from treating an unheard answer as something the caller already heard. Unexpected Twilio status values also leave valid calls tracked until genuine completion.
+
+Gateway-relayed GPT-Live calls can continue after isolated recoverable audio-packet errors, though a brief gap is possible and persistent or terminal failures still end the call. The [Voice Call guides](/plugins/voice-call) now separate configuration, audio, interfaces, and troubleshooting.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Restore the default Twilio voice for certain unrecognized names [#137678](https://github.com/openclaw/openclaw/pull/137678). Thanks @teddytennant, @obviyus.
+- Keep unknown call statuses from ending active calls [#137679](https://github.com/openclaw/openclaw/pull/137679). Thanks @teddytennant, @obviyus.
+- Track confirmed phone playback when callers interrupt [#138619](https://github.com/openclaw/openclaw/pull/138619). Thanks @LiuwqGit, @obviyus, @fabiolr, @xueqingli1.
+- Keep GPT-Live calls connected after recoverable audio errors [#140702](https://github.com/openclaw/openclaw/pull/140702). Thanks @zenglingbiao, @obviyus.
+- Return clear errors for unknown voice stream paths [#141315](https://github.com/openclaw/openclaw/pull/141315). Thanks @hugenshen, @obviyus.
+
+**Documentation**
+
+- Organize Voice Call guidance into focused topic pages [#143055](https://github.com/openclaw/openclaw/pull/143055). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Memory
+
+Memory search keeps its leading matches when you ask for fewer results, and remembered context can still reach a conversation when an optional lookup stalls or a managed local embedding service needs time to start. Long conversations also get fixes for reopening older search results and carrying readable history into the next turn, with clearer guidance about what remains searchable after you delete a session.
+
+<AccordionGroup>
+
+<Accordion title="Find useful memories through interruptions">
+
+Asking for one memory result should give you the best match from the same search, so requests for between 1 and 200 results now rank a shared candidate pool before trimming the answer. That consistency does more retrieval work for small requests, while searches interrupted by a replaced memory manager can retry once without telling you to rebuild a healthy index.
+
+Active Memory can continue with normal recall when its optional preliminary lookup times out. Managed local embedding services also get their configured startup allowance before the search timer resumes, so a cold start does not consume the time needed to find your memories. Completed primary results survive a timeout in the accompanying wiki search, and messages delivered by another agent or a finished child task skip unnecessary recall while later human messages remain eligible.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep top memory matches consistent at small result limits [ff1d91f](https://github.com/openclaw/openclaw/commit/ff1d91f6711b301ad0bb8f8f9485bfb05d770d84). Thanks @linhongyu510.
+- Recover memory searches after manager replacement [#141879](https://github.com/openclaw/openclaw/pull/141879).
+- Preserve Active Memory recall after optional lookup timeouts [#142567](https://github.com/openclaw/openclaw/pull/142567). Thanks @ylcn91, @obviyus, @BsnizND.
+- Allow local embedding startup before timing memory searches [#143590](https://github.com/openclaw/openclaw/pull/143590). Thanks @wangmiao0668000666, @obviyus, @PeterHodl.
+- Skip unnecessary recall for agent deliveries [#143903](https://github.com/openclaw/openclaw/pull/143903). Thanks @LiuwqGit, @obviyus, @kiagentkronos-cell, @syfvb.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Build and inspect the intended memory index">
+
+Memory indexing can wait through temporary embedding-provider cooldowns, while interactive searches keep a shorter, cancellable retry budget. If your primary embedding provider cannot start, the configured fallback uses its own model, and deep memory status recognizes a valid fallback-built index even after the primary recovers. An index built for an incompatible model still needs an explicit rebuild with `openclaw memory index --force`.
+
+On macOS with Bun, installing SQLite through `brew install sqlite` lets OpenClaw discover a suitable library for native vector searches in both the main process and its search subprocess. If you use a custom `Database.setCustomSQLite` preload script, remove it and use `OPENCLAW_SQLITE_LIBRARY` instead. An invalid override stops startup with an error; installations without a suitable discovered library retain the existing scan fallback.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Enable native memory search with Homebrew SQLite on macOS Bun; replace custom SQLite preloads with `OPENCLAW_SQLITE_LIBRARY`, and replace the removed `OPENCLAW_CLAUDE_CLI_LOG_OUTPUT` alias with `OPENCLAW_CLI_BACKEND_LOG_OUTPUT` [#141854](https://github.com/openclaw/openclaw/pull/141854).
+
+**Bug fixes**
+
+- Respect provider cooldowns during memory indexing [#134959](https://github.com/openclaw/openclaw/pull/134959). Thanks @shojikumaru, @obviyus, @developercrocodiles.
+- Use the fallback provider's model for memory embeddings [#142364](https://github.com/openclaw/openclaw/pull/142364). Thanks @Yigtwxx, @obviyus.
+- Recognize fallback-built indexes in deep memory status [#142609](https://github.com/openclaw/openclaw/pull/142609). Thanks @Yigtwxx, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep automatic memory promotion tied to recall">
+
+Repeated background scans no longer stand in for distinct recall queries when deciding what belongs in long-term memory. With the default query-diversity requirement, a note must build that evidence through actual recall, alongside the existing relevance and frequency checks. Older records that mixed recall with background-scan evidence may need fresh queries before they qualify, so promotion can slow down after upgrading; memories already saved in `MEMORY.md` stay in place.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Require distinct recall queries for automatic memory promotion; configurations with `minUniqueQueries=0` retain their existing allowance [#119624](https://github.com/openclaw/openclaw/pull/119624). Thanks @pcpilot-dev, @RomneyDa, @sunnyandtec-ak, @zachisfine.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Return to retained conversation context">
+
+[Session search](/concepts/session-search) can reopen retained messages from before a reset and show their original surrounding context. When a result falls outside the current conversation view, that history stays within its original reset interval. The agent's history tool also accepts a redundant offset when a message anchor already identifies what to open.
+
+Queued replies can continue after conversation compaction and large-history handoffs with readable history ready for the next turn. Preparing that handoff may take longer because OpenClaw waits for the history rebuild to finish. Long-conversation checks also retain less temporary data without truncating stored context, and private memory maintenance respects the conversation's context budget even when its selected model supports a larger window.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce temporary memory during long-conversation checks [#143175](https://github.com/openclaw/openclaw/pull/143175).
+
+**Bug fixes**
+
+- Open retained session search results after a reset [#141437](https://github.com/openclaw/openclaw/pull/141437). Thanks @VACInc.
+- Accept redundant offsets in anchored session-history requests [#141664](https://github.com/openclaw/openclaw/pull/141664). Thanks @FlagshipClaw, @obviyus, @VACInc, @brainatworkharris.
+- Prevent lost replies after compaction and session handoff [#141718](https://github.com/openclaw/openclaw/pull/141718). Thanks @VACInc.
+- Avoid full-history reads for delivery confirmations [#142453](https://github.com/openclaw/openclaw/pull/142453). Thanks @VACInc, @todddickerson.
+- Keep memory maintenance within the conversation context budget [#143193](https://github.com/openclaw/openclaw/pull/143193). Thanks @KirDE, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand memory maintenance and retention">
+
+Deleting a session now tells you when its retained archive can still appear in memory search and gives you the owning agent's cleanup command. [Forgetting those memories](/cli/memory#memory-forget) remains a separate action, run on the computer or container hosting OpenClaw with the correct state and configuration, including when you deleted the session remotely.
+
+Operator logs now explain selected policy and session reasons for skipped recall, and warn when an automatic memory-saving run has no authorized write tool, naming the file it cannot save. Those messages help diagnose the missing work; they do not save it. Doctor can also inspect memory readiness while the agent database is busy, and continues past empty shared-memory layouts or advisory edited-archive warnings while preserving existing data and still refusing unsafe migration sources.
+
+The [Active Memory guides](/concepts/active-memory) now separate setup, controls, and troubleshooting into focused pages. The Lossless Claw recipe explains the parent-agent tool grants needed for recall, including that those grants also give the parent agent access and remain subject to other restrictions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Warn when memory flushes cannot write their target file [#127031](https://github.com/openclaw/openclaw/pull/127031). Thanks @ayaangazali, @fede-kamel, @vincentkoc.
+- Show selected recall-skip reasons in default logs [#138658](https://github.com/openclaw/openclaw/pull/138658). Thanks @DasX, @obviyus, @Oliverbot26.
+- Explain memory cleanup after deleting a session [#141841](https://github.com/openclaw/openclaw/pull/141841). Thanks @glenn-agent, @obviyus, @dh-js, @he-yufeng.
+- Check memory readiness while agent databases are busy [#142361](https://github.com/openclaw/openclaw/pull/142361).
+- Avoid unnecessary Doctor refusals for shared-memory layouts; preserve edited archives without importing their changes, and defer later event generations in that workspace [#143138](https://github.com/openclaw/openclaw/pull/143138).
+
+**Documentation**
+
+- Explain tool grants for Lossless Claw recall [#142705](https://github.com/openclaw/openclaw/pull/142705). Thanks @MasterSwords1, @obviyus, @guarismo.
+- Split Active Memory guidance into task-specific pages [#143057](https://github.com/openclaw/openclaw/pull/143057). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep context engines available through cleanup">
+
+If you use a [context-engine plugin](/concepts/context-engine) to manage conversation history, accepted compaction and background maintenance keep the managed resources they use, including databases and tool services, available until the outstanding work and cleanup finish. Turns retain their selected engine through startup, including prepared runs using copied engines, instead of unexpectedly switching to a fallback as the original registry retires.
+
+Cancellation and timeout can still return promptly and revoke permission to write to the conversation. Keeping resources open gives already-started work time to finish cleanup; plugin authors must return their asynchronous work so OpenClaw can track and await it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep background compaction resources through cleanup [#143426](https://github.com/openclaw/openclaw/pull/143426).
+- Retain context engines through turn cleanup [#143491](https://github.com/openclaw/openclaw/pull/143491).
+- Keep compaction databases open through pending cleanup [#143592](https://github.com/openclaw/openclaw/pull/143592).
+- Keep copied context engines available through cleanup [#143626](https://github.com/openclaw/openclaw/pull/143626).
+- Keep compaction tool services available through outstanding work [#143633](https://github.com/openclaw/openclaw/pull/143633).
+
+</details>
+
+</Accordion>
+
+<Accordion title="See externally written LanceDB memories">
+
+The [LanceDB memory extension](/plugins/memory-lancedb) can see memories committed by an external importer or another process on its next operation, without restarting OpenClaw or making a local write first. Recall, listing, and deletion refresh the retained table before using it, while each operation still works from its own snapshot, so a write committed during that operation may appear on the following one.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Refresh LanceDB reads after external memory writes [#137806](https://github.com/openclaw/openclaw/pull/137806). Thanks @azuretek, @obviyus.
+
+**Documentation**
+
+- Clarify the existing LanceDB requirements for OpenClaw host version `>=2026.5.31` and plugin API `>=2026.9.3`, which must both pass [#142827](https://github.com/openclaw/openclaw/pull/142827). Thanks @obviyus, @ly85206559.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Skills
+
+You can now search the skills you already have alongside the ones available on ClawHub, then move into Skill Workshop to build on what your Claw has learned. Learning from past conversations also happens in a chat you can follow and steer, giving you a visible place to decide what should become a reusable skill.
+
+<AccordionGroup>
+
+<Accordion title="Search installed skills and ClawHub together">
+
+The [Skills page](/tools/skills) brings installed skills, library entries, and ClawHub results into one search, with compact cards showing what is installed and what you can add. With an empty search you can browse Trending, and your local skills remain visible if ClawHub is unavailable. Switching agents keeps you on the page and shows that agent's inventory, while shared tabs take you directly between Plugins, Skills, and Skill Workshop. Installation waits until the destination library or workspace is known.
+
+Installed cards explain whether a skill is ready, disabled, or missing setup, and show security findings where those are available. Those indicators do not mean every skill has been scanned. Skill titles and ClawHub details are also easier to read, with formatted changelogs and contained scrolling that keeps the Install action visible.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Search installed skills and ClawHub together [#143758](https://github.com/openclaw/openclaw/pull/143758). Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Find repository skills in separate execution workspaces [#141966](https://github.com/openclaw/openclaw/pull/141966). Thanks @obviyus.
+- Show and find skills by their actual titles [#142535](https://github.com/openclaw/openclaw/pull/142535).
+- Keep ClawHub details and changelogs readable in dialogs [#142555](https://github.com/openclaw/openclaw/pull/142555). Thanks @vyctorbrzezowski.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Import, install, and read skills">
+
+Importing a skill now shows the files or folder you selected, with a Clear action so you can change your selection before importing. Skill dialogs fit short content and keep longer instructions scrollable within the screen, with Close beside the title. Slower dependency installations from the Control UI also get the installer's existing five-minute allowance for each command, instead of being cut off after two minutes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show and clear selected files during skill import [#142540](https://github.com/openclaw/openclaw/pull/142540). Thanks @vyctorbrzezowski.
+
+**Bug fixes**
+
+- Fit skill dialogs to content with compact Close controls [#142550](https://github.com/openclaw/openclaw/pull/142550). Thanks @vyctorbrzezowski.
+- Allow slower Control UI skill dependency installs to finish [#143000](https://github.com/openclaw/openclaw/pull/143000). Thanks @gozu, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Learn from past conversations in a visible chat">
+
+“Learn from past conversations” in [Skill Workshop](/tools/skill-workshop) now opens a normal chat, where you can watch the work, give it more direction, or stop it. Your Claw can inspect accessible conversations and existing skills, with Auto allowing justified improvements and Propose leaving suggestions for your approval. You can start this manually while self-learning is off without enabling it, and the usual model costs, permissions, and conversation access apply.
+
+This replaces the old history scanner. Clients using `skills.proposals.historyStatus` or `skills.proposals.historyScan` need to move to the new learning-session flow, and saved scan cursors or pending scan batches cannot resume. Existing installed skills and proposals remain available. For automatic self-learning, Workshop also explains when weekly reviews are paused because scheduling is disabled and links to the setting needed to resume them.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Learn from past conversations in a steerable chat [#142909](https://github.com/openclaw/openclaw/pull/142909). Thanks @obviyus.
+- Explain paused weekly skill reviews [#142840](https://github.com/openclaw/openclaw/pull/142840). Thanks @obviyus.
+
+**Bug fixes**
+
+- Ground Workshop review targets and restore the Team Reports listing [#141575](https://github.com/openclaw/openclaw/pull/141575).
+
+**Documentation**
+
+- Split Skill Workshop documentation into focused guides [#143079](https://github.com/openclaw/openclaw/pull/143079). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep current skill instructions available">
+
+Existing conversations pick up updated file-backed skills on the next turn after a Gateway restart, even when file watching is disabled, so you can keep the conversation and its history. Installed or edited workspace skills also appear through status checks, including repaired files on the first check after watching starts or resumes. Managed library selections keep their pinned revisions until you explicitly refresh them.
+
+New Workshop drafts preserve the full skill description separately from the short proposal label, keeping the instructions that help your Claw recognize when to use a skill. Previously lost descriptions and older pending drafts are not repaired automatically. Agents also receive clearer guidance for requested edits to repository-owned skill files, while Workshop-owned changes retain their approval path, and sandboxed plugin agents receive skill paths they can actually open inside their workspace.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Refresh session skills after Gateway restarts [#122110](https://github.com/openclaw/openclaw/pull/122110). Thanks @sappkevin, @obviyus, @kashivreddy, @aspalagin.
+- Preserve full skill descriptions through Workshop updates [#140864](https://github.com/openclaw/openclaw/pull/140864). Thanks @LiuwqGit, @obviyus, @XX441, @laisonamarante, @RuiCatalao7, @thomasmoenco.
+- Refresh skill availability after installs and edits [#141979](https://github.com/openclaw/openclaw/pull/141979). Thanks @RomneyDa.
+- Show repaired skills on the first status check [#142123](https://github.com/openclaw/openclaw/pull/142123). Thanks @ericcaiwx-star, @aspalagin, @obviyus.
+- Clarify how agents should make requested repository skill edits outside Workshop [#142844](https://github.com/openclaw/openclaw/pull/142844). Thanks @Finn763, @obviyus, @jmissig.
+- Give sandboxed plugin agents readable skill paths [#143291](https://github.com/openclaw/openclaw/pull/143291). Thanks @sallyom, @sercada, @Artemeey.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Prepare skills for remote work">
+
+Cloud and SSH turns now transfer skill files in batches, reducing the repeated network requests that could delay work before the model started. Skills still receive fresh copies each turn, with the largest benefit for collections containing many small files.
+
+Cloud workers can also use local skills with contained file aliases, such as `CLAUDE.md` pointing to `AGENTS.md`, because delivery copies the target's contents into an ordinary file. The target must be an included file inside the same skill. Links outside it, excluded files, directory links, broken or cyclic links, and hard links remain rejected, and managed library content still needs to be link-free.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Batch skill transfers before remote turns [#142440](https://github.com/openclaw/openclaw/pull/142440).
+
+**Bug fixes**
+
+- Deliver contained skill file aliases to cloud workers [#143378](https://github.com/openclaw/openclaw/pull/143378).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover recognized Workshop migrations">
+
+Doctor can get past several specific Workshop upgrade failures, including unfinished ownership migrations and obsolete generated review jobs. If startup reports the leftover review index that refers to `workspace_dir`, run `openclaw doctor --fix` to repair that index while keeping its review history. Valid proposals and backups whose owner is uncertain stay in place for manual review, with paths and possible owners shown, while other eligible repairs can continue.
+
+These repairs remain limited to recognized older state. Corrupt artifacts, unfinished apply recovery, unknown database structures, and unsupported versions still need attention before work can continue. The unfinished ownership migration follows existing rules that can discard review history without an identifiable owner and mark proposals as stale. Custom indexes that depend on retired columns also need to be resolved before that migration can finish.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Repair the legacy Workshop review index with Doctor [1e7797ad9836](https://github.com/openclaw/openclaw/commit/1e7797ad983683a3cd691887f1b398164ddc6282). Thanks @jjjhenriksen, @RomneyDa.
+- Continue Doctor repairs while preserving ambiguous Workshop artifacts [#143141](https://github.com/openclaw/openclaw/pull/143141). Thanks @fahrenhe1t, @GitHoubi, @cjn119-ui, @obviyus.
+- Repair recognized unfinished Workshop database upgrades [#143153](https://github.com/openclaw/openclaw/pull/143153). Thanks @syfvb, @pbergeot, @rjamoul, @cjn119-ui.
+- Ignore retired Workshop jobs during Doctor preflight [#143325](https://github.com/openclaw/openclaw/pull/143325). Thanks @cjn119-ui, @jerabinovich, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Replace the retired video-frames helper">
+
+The bundled `video-frames` skill and its `scripts/frame.sh` helper have been removed. If a workflow uses them to produce image files from a video, switch it to direct `ffmpeg` use or a separately installed frame-extraction skill. Native video understanding can analyze video, but it does not replace those extracted image files, and this change supplies no automatic migration.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Limits and compatibility**
+
+- Retire the bundled video-frames skill and helper [#142232](https://github.com/openclaw/openclaw/pull/142232).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Native Apps
+
+Android makes it easier to stay with a conversation, inspect completed work, and reply from a notification without losing track of what happened. Across the mobile and desktop apps, connection guidance is clearer, Mac setup preserves the connection and profile you chose, and Linux remote connections preserve credential references and leave remote Gateways alone when the desktop sleeps.
+
+<AccordionGroup>
+
+<Accordion title="Find Android conversations and follow work">
+
+The [Android app](/platforms/android) keeps the paragraph or image you are reading in place while a reply grows or the window changes size. Expanding a message reveals its opening, and code navigation brings the requested lines into view. Jump to latest resumes following the conversation when you are ready to catch up.
+
+Completed tools now appear in the conversation with expandable command previews, so you can inspect what your Claw did instead of finding a blank gap. In dashboard conversations, finished commentary and tools fold under “Worked for…” while the final answer stays visible. Those previews are bounded and share the existing offline history budget with messages.
+
+Search and sidebar activity follow each conversation, completed summaries remain visible, and a failed session-list refresh leaves loaded pages available with an error. Chat readiness is also distinguished from a lost connection, with refreshed translations for the affected labels. On folding screens, Thinking and Fast controls, Background Tasks, and branch choices fit within usable panes; an invalidated panel closes and can be reopened in the current conversation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Translate Android chat-readiness messages [#142267](https://github.com/openclaw/openclaw/pull/142267).
+- Translate Android readiness and empty-state labels [#143203](https://github.com/openclaw/openclaw/pull/143203).
+- Refresh Android chat and activity translations [#143397](https://github.com/openclaw/openclaw/pull/143397).
+
+**Bug fixes**
+
+- Keep Android reading position while replies grow, and reveal expanded messages and code endpoints [#140759](https://github.com/openclaw/openclaw/pull/140759).
+- Show Android session refresh errors without losing loaded pages [#141603](https://github.com/openclaw/openclaw/pull/141603).
+- Keep Android Thinking and Fast controls clear of folds [#141860](https://github.com/openclaw/openclaw/pull/141860). Thanks @vincentkoc.
+- Thread activity labels follow the right conversation [#141883](https://github.com/openclaw/openclaw/pull/141883).
+- Keep Background Tasks inside foldable panes [#141899](https://github.com/openclaw/openclaw/pull/141899). Thanks @vincentkoc.
+- Keep matching Android threads in view [#142046](https://github.com/openclaw/openclaw/pull/142046).
+- Distinguish Android chat readiness from Gateway disconnection [#142182](https://github.com/openclaw/openclaw/pull/142182).
+- Keep Android branch choices inside usable fold panes [#142418](https://github.com/openclaw/openclaw/pull/142418). Thanks @vincentkoc.
+- Restore Android tool activity and fold completed work [#142810](https://github.com/openclaw/openclaw/pull/142810). Thanks @ansxor, @IWhatsskill.
+- Distinguish Android chat readiness from Gateway connection status [#143128](https://github.com/openclaw/openclaw/pull/143128).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reply from Android notifications">
+
+Opening or replying to an Android notification reconnects its saved Gateway when needed, while preserving a connection or certificate approval already in progress. An unavailable target leads to Gateway settings, and an older reply result cannot overwrite a newer notification.
+
+Reply feedback now distinguishes queued, failed, and unknown outcomes, including translated messages in existing languages. “Reply queued” means the message entered the persistent send queue. If its status is unknown, open the conversation before sending again; required certificate approval still applies.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Translate Android reply status messages [#143928](https://github.com/openclaw/openclaw/pull/143928).
+
+**Bug fixes**
+
+- Keep notification actions on their saved Gateway, clarify reply status, and leave dismissed approval feedback closed [#143812](https://github.com/openclaw/openclaw/pull/143812).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Wait for Android attachments before sending">
+
+Android keeps Send unavailable while selected attachments are loading, so a caption cannot leave before its files are ready. Cancelling an import keeps the caption, another conversation remains independently sendable, and failed document or video imports show an attachment warning.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Wait for Android attachments before sending captions and clarify import warnings [#143162](https://github.com/openclaw/openclaw/pull/143162).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Connect and recover mobile apps">
+
+Android and iOS now show a readable connection failure with a separate Retry action when the saved computer cannot be reached. iOS retries the intended setup target, and addresses that suggest Tailscale receive conditional setup guidance. Certificate and authentication problems keep their own handling, while Android may still need to finish stopping an earlier network request before a retry starts.
+
+Android setup also exposes the selected connection-security option to assistive services. When your Claw checks a device, Android, iOS, and watchOS supply an explicit battery percentage alongside the existing fractional reading, making a full battery distinguishable from a one-percent charge.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Refresh native connection and recovery translations [#142807](https://github.com/openclaw/openclaw/pull/142807).
+
+**Bug fixes**
+
+- Add explicit battery percentages to mobile status responses [#141069](https://github.com/openclaw/openclaw/pull/141069). Thanks @NullArbitrage, @obviyus.
+- Expose Android connection-security selection to assistive services [#142131](https://github.com/openclaw/openclaw/pull/142131).
+- Show mobile connection failures with targeted retry actions [#142651](https://github.com/openclaw/openclaw/pull/142651). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Find the official mobile apps">
+
+The [iPhone setup guide](/platforms/ios) now links directly to the official App Store listing. For Android users installing outside Google Play, the [installation guide](/platforms/android) explains how to find a GitHub release containing both the APK and its checksum, then verify the download. Android assets appear on selected releases and can arrive after the release is public, so the guide also retains Google Play and source-build alternatives.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Find Android release downloads with both APK and checksum [#141762](https://github.com/openclaw/openclaw/pull/141762). Thanks @xiaoguomeiyitian, @obviyus, @tomdailey55.
+- Link the official iPhone app from its setup guide [#142132](https://github.com/openclaw/openclaw/pull/142132). Thanks @mgabor3141, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read iOS session counts">
+
+The iOS session-list notice now names the number of sessions displayed separately from the total, including in its existing translations. That makes a partially loaded list easier to understand while keeping Refresh as the way to load the remainder.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Clarify displayed and total iOS session counts [#142324](https://github.com/openclaw/openclaw/pull/142324).
+- Clarify localized iOS session counts; carried Wear OS typing and hold hints retain known translation errors [#142381](https://github.com/openclaw/openclaw/pull/142381).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Manage Mac connections and setup credentials">
+
+The Mac app now remembers an intentionally cleared Gateway instead of restoring the previous remote connection after a reload, and shows a warning when saving the change fails. Remote onboarding also reveals its secure credential field when a password is required and explains how to retry. Older Gateway builds need updating to accept the password through the field labeled Gateway token.
+
+For [offline remote setup](/platforms/mac/remote), `openclaw-mac configure-remote` accepts token or password input from a private file or standard input, keeping the secret out of command arguments. Legacy argument forms remain available with deprecation warnings; each secret takes one source, and only one can use standard input. Named profiles now write and read their own configuration and preferences. Use `primary set` when changing the connection of an app that is already running.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show password recovery during macOS remote onboarding [#141857](https://github.com/openclaw/openclaw/pull/141857).
+- Preserve Gateway clearing and accept file-based macOS setup credentials [#141872](https://github.com/openclaw/openclaw/pull/141872).
+- Honor selected macOS profiles in offline remote setup [#142163](https://github.com/openclaw/openclaw/pull/142163).
+
+**Documentation**
+
+- Refresh translated Gateway password instructions [#141906](https://github.com/openclaw/openclaw/pull/141906).
+- Translate Gateway settings save-failure guidance [#141962](https://github.com/openclaw/openclaw/pull/141962).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Close the focused Mac side-panel tab">
+
+In the native Mac app, Command-W closes the active tab in the focused side panel and leaves the main window open. Focus stays with any remaining tabs so you can close them in sequence; closing the last tab dismisses the panel. With focus in the main chat, Command-W keeps its normal window-closing behavior.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Close focused macOS side-panel tabs with Cmd+W [#142634](https://github.com/openclaw/openclaw/pull/142634). Thanks @Patrick-Erichsen.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Diagnose Mac Gateway startup and restart jobs">
+
+Mac Gateway startup errors now go to the regular service log, making failures before normal application logging starts easier to diagnose. Existing installations pick up the destination when installation or an ordinary restart rewrites the service definition; a restart that preserves the definition keeps the old destination.
+
+For repeated restarts, `openclaw gateway status` and `openclaw doctor` now expose suspicious OpenClaw launchd jobs without requiring a deep scan. The [bundled Gateway guide](/platforms/mac/bundled-gateway) explains the diagnostic path. Review a job before removing it, because a known limitation can misclassify commands launched through `env`; the diagnostic result alone is not enough to justify automatic cleanup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Diagnose stray macOS Gateway restart jobs [#142230](https://github.com/openclaw/openclaw/pull/142230). Thanks @piotx, @rondavis007, @jodok, @jarvismazz.
+- Preserve macOS Gateway startup errors in the service log [#143519](https://github.com/openclaw/openclaw/pull/143519). Thanks @RomneyDa, @Enominera, @igs-rogenlo, @lonexreb.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep Linux companion connections usable">
+
+The [Linux companion](/platforms/linux) now honors the port configured for an SSH alias unless you explicitly enter another one. Reconnecting a saved remote connection also preserves file and environment credential references, so later launches can pick up rotated secrets without replacing the reference with plaintext. References overwritten by earlier versions still need to be restored manually.
+
+Putting the desktop to sleep leaves remote Gateways alone, including those reached through SSH tunnels, while locally managed Gateways retain sleep coordination. Update notifications and tray actions remain available after navigating into the dashboard, and a ready update survives failed checks or replacement downloads so it can be retried. The maturity documentation also recognizes the existing companion as Beta.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep desktop update notices and retry actions available [#121938](https://github.com/openclaw/openclaw/pull/121938). Thanks @vincentkoc.
+- Honor SSH alias ports in the Linux companion [#142900](https://github.com/openclaw/openclaw/pull/142900). Thanks @vincentkoc.
+- Keep Linux sleep from suspending remote Gateways [#142913](https://github.com/openclaw/openclaw/pull/142913). Thanks @vincentkoc.
+
+**Security and trust**
+
+- Preserve remote credential references on Linux reconnect [#142907](https://github.com/openclaw/openclaw/pull/142907). Thanks @vincentkoc.
+
+**Documentation**
+
+- Correct the Linux companion maturity description [#141955](https://github.com/openclaw/openclaw/pull/141955). Thanks @RomneyDa.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Speak ordinary formatted explanations">
+
+Ordinary explanations containing inline code or following quoted code blocks remain eligible for [spoken replies](/tools/tts), so [Talk](/nodes/talk) can read the explanation instead of sending you to the screen. Replies that are mostly code still use the existing suppression or screen fallback, and your speech settings continue to apply.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Speak ordinary Markdown explanations while retaining code-heavy reply fallback [#142415](https://github.com/openclaw/openclaw/pull/142415).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Models and Providers
+
+Model browsing now follows the Gateway and agent you selected, with saved models keeping their own settings and capabilities through more of the places you use them. Searchable pickers make long lists easier to work with, Thinking and Fast controls reflect the selected model, and provider sign-ins and coding sessions recover from more specific failures. GPT Image 2.5 and Deepgram Flux also bring new choices for making images and transcribing voice notes.
+
+<AccordionGroup>
+
+<Accordion title="Browse the selected Gateway's models">
+
+Model browsing now shows the inventory published by the Gateway and agent you selected, so the CLI, chat, and model controls are working from the same list. Ordinary browsing and capability checks do not quietly ask providers to discover models again; use Refresh or `openclaw models list --refresh` when you need new inventory, as described in [model browsing](/concepts/models). Failed refreshes explain what happened while retaining compatible choices, and a successful empty result clears old entries instead of bringing them back.
+
+Upgrade the Gateway before the CLI, because the new CLI requires its published-catalog support and will ask you to update or reconnect rather than substitute a different local list. Scripts must stop relying on the removed `missing` JSON field, and current promotions are available through `openclaw promos list`. The separate `openclaw models refresh` command downloads hosted model information; the running Gateway still needs a restart to apply those model and price updates, with clearer log guidance when a download is waiting. Public SDK catalog calls continue to discover by default; callers wanting a passive read must set `readOnly: true`.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Browse the selected Gateway's model inventory [#142063](https://github.com/openclaw/openclaw/pull/142063). Thanks @obviyus.
+- Reduce first-use Copilot metadata loading [#142134](https://github.com/openclaw/openclaw/pull/142134)
+- Load less session code during model discovery [#143146](https://github.com/openclaw/openclaw/pull/143146). Thanks @vincentkoc.
+- Avoid unused preparation when browsing models [#144095](https://github.com/openclaw/openclaw/pull/144095)
+
+**Bug fixes**
+
+- Refresh model availability after token expiry or cooldown [#141727](https://github.com/openclaw/openclaw/pull/141727). Thanks @obviyus.
+- Show when refreshed model information needs a restart [#141885](https://github.com/openclaw/openclaw/pull/141885). Thanks @obviyus.
+- Warn about incomplete model refreshes [#141951](https://github.com/openclaw/openclaw/pull/141951). Thanks @obviyus.
+- Keep inference model inspection within the agent catalog [#142367](https://github.com/openclaw/openclaw/pull/142367). Thanks @obviyus.
+- Stop model selection from triggering extra provider discovery [#142375](https://github.com/openclaw/openclaw/pull/142375). Thanks @obviyus.
+- Keep internal catalog reads passive and forward explicit refreshes [#142557](https://github.com/openclaw/openclaw/pull/142557). Thanks @obviyus.
+- Restore public SDK model discovery defaults [#142620](https://github.com/openclaw/openclaw/pull/142620). Thanks @obviyus.
+- Clear stale catalog warnings when the source changes [#142622](https://github.com/openclaw/openclaw/pull/142622). Thanks @obviyus.
+- Keep saved models visible after startup [#142766](https://github.com/openclaw/openclaw/pull/142766). Thanks @obviyus.
+- Avoid unrelated provider loading during cold session resets [#143254](https://github.com/openclaw/openclaw/pull/143254)
+- Keep model catalog resources through asynchronous reads [#143492](https://github.com/openclaw/openclaw/pull/143492)
+
+**Documentation**
+
+- Clarify model status and catalog refresh guidance [#141927](https://github.com/openclaw/openclaw/pull/141927). Thanks @obviyus.
+- Translate model-refresh retry guidance [#142000](https://github.com/openclaw/openclaw/pull/142000)
+- Fix the model guide's Gateway catalog link [#142379](https://github.com/openclaw/openclaw/pull/142379). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep exact model choices and capabilities">
+
+A saved model choice now keeps its own identity and capabilities through more catalog, session, and refresh paths. Models whose names differ by capitalization or include provider prefixes and slashes remain distinct, exact entries take precedence over aliases, and an alias is resolved once instead of walking on to another model. That keeps the chosen model's context limit, image support, and tool compatibility from being replaced by a similarly named entry's settings.
+
+Child chats also show the model they inherit consistently across session views. Choosing Default remains a durable choice through resets and restarts and retains configured fallback behavior, while an explicit model pin stays strict. API clients should use `sessions.patch` with `model: null` for Default; sending a concrete model value pins it even when it happens to equal today's default. In the terminal picker, models confirmed unavailable stay visible with a reason, and selecting one leaves the session unchanged; unknown availability remains selectable.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Align child-session model display and routing [#131805](https://github.com/openclaw/openclaw/pull/131805); contextual [#86174](https://github.com/openclaw/openclaw/issues/86174). Thanks @jalehman, @rqlangley, @wpu911.
+- Resolve Anthropic aliases consistently across status and permissions [#137376](https://github.com/openclaw/openclaw/pull/137376). Thanks @Yigtwxx, @obviyus.
+- Respect explicit visibility policies for CLI-backed models in /models [#141642](https://github.com/openclaw/openclaw/pull/141642). Thanks @IWhatsskill, @NovaUnboundAi.
+- Resolve model aliases with the selected provider plugin [#141679](https://github.com/openclaw/openclaw/pull/141679)
+- Honor the selected agent in model catalog commands [#141859](https://github.com/openclaw/openclaw/pull/141859). Thanks @obviyus.
+- Explain unavailable models before terminal selection [#142160](https://github.com/openclaw/openclaw/pull/142160). Thanks @obviyus.
+- Keep distinct model IDs and metadata visible in catalogs [#142285](https://github.com/openclaw/openclaw/pull/142285). Thanks @obviyus.
+- Show inherited models consistently across session views [#142751](https://github.com/openclaw/openclaw/pull/142751)
+- Prefer exact model metadata when aliases coexist [#143686](https://github.com/openclaw/openclaw/pull/143686)
+- Prefer exact model spelling when inferring providers [#143708](https://github.com/openclaw/openclaw/pull/143708)
+- Preserve catalog model identities and capability metadata [#143777](https://github.com/openclaw/openclaw/pull/143777)
+- Preserve distinct model entries and metadata [#143872](https://github.com/openclaw/openclaw/pull/143872)
+- Keep distinct allowed models visible [#143954](https://github.com/openclaw/openclaw/pull/143954)
+- Preserve model identities through catalog refresh [#143967](https://github.com/openclaw/openclaw/pull/143967)
+- Preserve saved model choices when reading sessions [#143975](https://github.com/openclaw/openclaw/pull/143975)
+- Preserve selected models and matching image limits [#143994](https://github.com/openclaw/openclaw/pull/143994). Thanks @elikampf.
+- Resolve configured aliases once [#143999](https://github.com/openclaw/openclaw/pull/143999)
+- Use the selected model context limit [#144009](https://github.com/openclaw/openclaw/pull/144009)
+- Use selected-model tool capabilities [#144010](https://github.com/openclaw/openclaw/pull/144010)
+- Select exact model entries before defaults [#144034](https://github.com/openclaw/openclaw/pull/144034)
+- Honor selected-model image and compaction limits [#144060](https://github.com/openclaw/openclaw/pull/144060)
+- Use selected-provider settings for tools [#144107](https://github.com/openclaw/openclaw/pull/144107)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose models and accounts in Settings">
+
+Long model menus can be searched by name or model reference, with the current choice left alone until you select a result. Chat choices follow the conversation's saved account, and New Session can preview another account you own without changing the default for future chats. Large catalogs also require less repeated work when selecting a Chat model or typing in New Session.
+
+In Models Settings, the first picker open discovers additional choices and shows progress or Retry when needed; reopening after completion reads the published list, while Retry deliberately discovers again. Saved unavailable choices remain visible and removable without being offered as new selections. Editing backup models preserves an inherited primary, clearing every fallback stays empty after reload, and abandoning a search no longer saves unfinished text as a model. The page now labels Global defaults explicitly and points to Agents → Overview for an individual agent's model.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Search long model menus [#141894](https://github.com/openclaw/openclaw/pull/141894). Thanks @obviyus.
+- Match chat model choices to the saved or previewed account [#142165](https://github.com/openclaw/openclaw/pull/142165). Thanks @obviyus.
+- Translate global model settings guidance [#143449](https://github.com/openclaw/openclaw/pull/143449)
+
+**Bug fixes**
+
+- Discard unconfirmed fallback-model searches [#141953](https://github.com/openclaw/openclaw/pull/141953). Thanks @shakkernerd.
+- Preserve model inheritance when editing fallbacks [#141967](https://github.com/openclaw/openclaw/pull/141967). Thanks @shakkernerd, @najef1979-code.
+- Preserve case-sensitive fallback references [#141997](https://github.com/openclaw/openclaw/pull/141997). Thanks @shakkernerd.
+- Keep unavailable saved models visible but unselectable [#142048](https://github.com/openclaw/openclaw/pull/142048). Thanks @obviyus.
+- Load more default-model choices when pickers open [#142105](https://github.com/openclaw/openclaw/pull/142105). Thanks @xiaoguomeiyitian, @obviyus, @dh-js.
+- Restore model discovery in settings pickers [#142346](https://github.com/openclaw/openclaw/pull/142346). Thanks @vyctorbrzezowski.
+- Show failed model-list refreshes in the Control UI [#142372](https://github.com/openclaw/openclaw/pull/142372). Thanks @obviyus.
+- Avoid repeated model discovery when reopening Settings pickers [#142384](https://github.com/openclaw/openclaw/pull/142384). Thanks @vyctorbrzezowski.
+- Reduce model-picker lag with large catalogs [#142465](https://github.com/openclaw/openclaw/pull/142465)
+- Clarify global model defaults and agent settings [#143424](https://github.com/openclaw/openclaw/pull/143424). Thanks @obviyus, @schjonhaug.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use the selected model's Thinking and Fast controls">
+
+Thinking controls now use the selected model's published choices and default across Chat, Sessions, and New Session, including after history refreshes. A model that offers no adjustable levels keeps an empty list, missing information stays unknown, and a saved Off choice remains explicit. That removes guessed effort levels without changing the model's reasoning capabilities.
+
+Fast follows the selected request more closely too. Confirmed ineffective choices are disabled for the covered Anthropic, OpenAI, xAI, and MiniMax routes, while existing saved preferences remain clearable and unknown support retains its existing behavior. This tells you whether OpenClaw can apply Fast to the request; the provider still determines availability, price, and the response you receive.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Hide thinking choices the selected model does not support [#141696](https://github.com/openclaw/openclaw/pull/141696). Thanks @obviyus.
+- Disable Fast when it cannot affect the selected request [#141852](https://github.com/openclaw/openclaw/pull/141852). Thanks @obviyus.
+- Use published model thinking choices across the UI [#142646](https://github.com/openclaw/openclaw/pull/142646). Thanks @obviyus.
+- Disable Fast choices that cannot change the request [#142682](https://github.com/openclaw/openclaw/pull/142682). Thanks @obviyus.
+- Keep thinking choices aligned with the model [#142790](https://github.com/openclaw/openclaw/pull/142790). Thanks @obviyus.
+- Preserve explicit thinking Off with empty choices [#142822](https://github.com/openclaw/openclaw/pull/142822). Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve configured provider routes">
+
+Custom model connections retain their authored endpoints, headers, and request settings when generated catalogs overlap them. Exact configured entries take precedence over aliases, manual models survive merge-mode refreshes, and saved local endpoints remain identified as local. Several provider setup flows also save the connection without copying a built-in model list into your configuration.
+
+If you point an existing provider at a custom endpoint, declare that endpoint's supported models under `models.providers.<id>.models`; it no longer automatically inherits the native service's list. Session SDK integrations must also use a current auth profile or authored request configuration, because generated catalogs now supply inventory without authorizing requests through cached keys, authentication modes, or headers. Authored credentials remain scoped to the endpoints declared with them.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Keep generated model lists out of ordinary setup for Cloudflare AI Gateway, Featherless, Hugging Face, LongCat, Meta, Mistral, NVIDIA, Synthetic, Together, Xiaomi pay-as-you-go, and Z.AI [#142202](https://github.com/openclaw/openclaw/pull/142202). Thanks @obviyus.
+
+**Bug fixes**
+
+- Honor session-affinity settings for managed OpenAI and Azure Responses proxies [#141107](https://github.com/openclaw/openclaw/pull/141107); contextual [#140918](https://github.com/openclaw/openclaw/issues/140918). Thanks @louisfy, @obviyus, @alexph-dev.
+- Preserve manual models during generated catalog refresh [#142302](https://github.com/openclaw/openclaw/pull/142302). Thanks @obviyus.
+- Preserve saved endpoints in configured model lists [#143643](https://github.com/openclaw/openclaw/pull/143643). Thanks @obviyus.
+- Preserve authored SDK routes and require current authentication instead of generated-catalog credentials [#143664](https://github.com/openclaw/openclaw/pull/143664). Thanks @obviyus.
+- Honor exact configured model settings before aliases [#143822](https://github.com/openclaw/openclaw/pull/143822)
+- Honor merged provider runtime settings [#143848](https://github.com/openclaw/openclaw/pull/143848)
+- Quiet intentional provider tuning warnings [#92288](https://github.com/openclaw/openclaw/pull/92288). Thanks @ai-hpc, @obviyus, @kingkong9817.
+
+**Limits and compatibility**
+
+- Require explicit model lists for custom provider endpoints [#142158](https://github.com/openclaw/openclaw/pull/142158). Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reuse and repair provider sign-ins">
+
+Supported OpenAI login methods can now reuse eligible credentials already stored by Codex, saving another key paste or sign-in while preserving existing model choices. Device-code login may reuse an eligible stored account too; explicit force, profile, or default-selection options retain the normal sign-in path. When credentials save successfully but the running Gateway cannot apply them, the command explains that distinction and points you to the correct computer for recovery.
+
+Agents sharing an OAuth sign-in coordinate refreshes so they do not reuse a consumed token or overwrite a newer login. A retained Codex client can use a refresh that finished after its previous callback timed out, although that first slow callback can still fail. Deleted or replaced selected profiles can require an explicit sign-in, and interrupted shared refreshes may require `/login <provider>`. A pending legacy-credential migration now leaves unrelated authenticated providers usable; affected or unidentifiable credentials still need `openclaw doctor --fix`.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse supported Codex credentials during provider login [#142933](https://github.com/openclaw/openclaw/pull/142933). Thanks @obviyus.
+
+**Bug fixes**
+
+- Explain saved credentials and failed Gateway refresh separately [#131968](https://github.com/openclaw/openclaw/pull/131968); contextual [#131944](https://github.com/openclaw/openclaw/issues/131944). Thanks @vyctorbrzezowski, @obviyus.
+- Coordinate shared OAuth refresh without reusing consumed tokens [#141477](https://github.com/openclaw/openclaw/pull/141477). Thanks @vincentkoc, @kopl-blip, @100yenadmin.
+- Recognize scoped native Codex login during model discovery [#141759](https://github.com/openclaw/openclaw/pull/141759). Thanks @DonnieFi, @obviyus.
+- Reuse completed Codex sign-in refreshes [#142628](https://github.com/openclaw/openclaw/pull/142628). Thanks @vincentkoc, @kopl-blip, @zhuyankarl, @100yenadmin.
+- Keep OpenAI, xAI, and Copilot device sign-in links clickable in Slack [#142873](https://github.com/openclaw/openclaw/pull/142873). Thanks @obviyus.
+- Keep unrelated providers available during credential migration [#143310](https://github.com/openclaw/openclaw/pull/143310). Thanks @tskerpnext.
+- Keep model setup resources through background work [#143542](https://github.com/openclaw/openclaw/pull/143542)
+- Preserve case in model authentication evidence [#143780](https://github.com/openclaw/openclaw/pull/143780)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover eligible model failures and explain refusals">
+
+A malformed tool call no longer has to end an otherwise silent task immediately. Completed Anthropic calls can repair specific string-encoding problems such as raw newlines or invalid backslash escapes, while rejected calls can use the existing bounded retry and configured fallback paths when replay is safe. Truncated or otherwise invalid calls remain non-executable, and visible output, accepted actions, possible side effects, or approval prompts still prevent replay. Persistent failures can use three retries after the first request, adding requests and possible cost before fallback or the final error.
+
+The failure you see is more useful too. Known network errors identify DNS, refused connections, interruptions, or unreachable endpoints; invalid parameters stop without pointless retries or compaction, and unfinished tool-call explanations remain in reloaded history beside valid partial replies. Fallback diagnostics explain covered terminal stops, the terminal footer follows accepted fallback events, and intentional silent replies avoid an erroneous missing-output retry. Before continuing after an unfinished call, check whether earlier actions already completed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Refresh backup model aliases after plugin reloads [0e1f60ec](https://github.com/openclaw/openclaw/commit/0e1f60ec03b06127ef2a7b81413f817985113ac1); contextual [#133633](https://github.com/openclaw/openclaw/pull/133633)
+- Preserve final ChatGPT events without a closing blank line [#120902](https://github.com/openclaw/openclaw/pull/120902). Thanks @zenglingbiao, @obviyus.
+- Stop retrying wrapped parameter rejections [#140991](https://github.com/openclaw/openclaw/pull/140991); contextual [#140987](https://github.com/openclaw/openclaw/issues/140987). Thanks @ooiuuii, @obviyus.
+- Repair string encoding in completed Anthropic tool arguments [#141323](https://github.com/openclaw/openclaw/pull/141323); contextual [#135111](https://github.com/openclaw/openclaw/issues/135111). Thanks @lraesly, @1Vision365-PeterTijsma, @infocus13, @peterkaynie, @jalehman, @MaxVidkrytaklishnya, @chrislro, @narbs.
+- Refresh the terminal footer when the model falls back [#141436](https://github.com/openclaw/openclaw/pull/141436). Thanks @ooiuuii.
+- Explain why a model fallback attempt stops [#141658](https://github.com/openclaw/openclaw/pull/141658). Thanks @von8794, @obviyus.
+- Show specific provider network errors after redaction [#141665](https://github.com/openclaw/openclaw/pull/141665). Thanks @SunnyShu0925, @obviyus, @DonnieFi.
+- Correct fallback warnings and preserve intentional silent replies [#141725](https://github.com/openclaw/openclaw/pull/141725). Thanks @leilei3167, @obviyus, @markthebest12.
+- Keep unfinished tool-call explanations in chat history [#141870](https://github.com/openclaw/openclaw/pull/141870). Thanks @Takhoffman.
+- Retry replay-safe malformed tool-call failures [#142176](https://github.com/openclaw/openclaw/pull/142176). Thanks @lraesly, @obviyus, @1Vision365-PeterTijsma, @peterkaynie, @infocus13, @MaxVidkrytaklishnya, @chrislro, @narbs.
+- Explain fallback stops after terminal timeouts [#142278](https://github.com/openclaw/openclaw/pull/142278). Thanks @MoerAI, @obviyus, @von8794.
+- Explain provider authentication and model errors in history and status [#143243](https://github.com/openclaw/openclaw/pull/143243)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reuse cached prompts">
+
+Anthropic tool conversations keep temporary context away from reusable cache boundaries while still sending that context to the model, avoiding unnecessary rewrites of growing conversation history. Eligible local-model requests also place changing session facts after the stable instructions-and-tools prefix, so a new conversation can reuse that prefix when the server and chat template support it. Actual cache reuse and charges still depend on the provider and workload.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve reusable local-model prompt prefixes [#137371](https://github.com/openclaw/openclaw/pull/137371); contextual [#137257](https://github.com/openclaw/openclaw/issues/137257). Thanks @gwiltschek, @obviyus.
+- Preserve Anthropic cache reuse during tool continuations and omit empty thinking-disabled beta headers [#140621](https://github.com/openclaw/openclaw/pull/140621); contextual [#140607](https://github.com/openclaw/openclaw/issues/140607). Thanks @LightningWareLLC, @he-yufeng, @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep Codex workspace guidance and history">
+
+[Managed Codex conversations](/plugins/codex-harness-runtime) regain current workspace personality, preferences, skill listings, and memory guidance, including later edits and removal. This delivery applies to the bundled stdio app-server on supported accounts and standard OpenAI endpoints; other connection types retain their existing delivery path with a warning. Newly supplied parent guidance stays out of native child and internal requests, while existing history and explicit handoffs remain intact. Explicitly configured native workspace-instruction budgets are also respected, so a larger `AGENTS.md` chain is no longer silently capped by OpenClaw's default.
+
+Long ordinary Codex conversations can recover a final answer after completing tool work without replaying those actions, using complete current-turn evidence and the nearest earlier exchanges that fit. Supervised Codex Sessions retain their separate fallback behavior. Follow-ups after successful final message-tool delivery also stop resending already covered history while keeping fresh corrections, and the managed relay accepts Responses Lite requests that omit a separate instructions field.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Restore workspace instructions in managed Codex conversations [#142276](https://github.com/openclaw/openclaw/pull/142276). Thanks @vincentkoc.
+- Accept Codex Responses Lite requests without separate instructions [#142823](https://github.com/openclaw/openclaw/pull/142823). Thanks @jalehman.
+- Honor configured Codex workspace instruction limits [#142932](https://github.com/openclaw/openclaw/pull/142932). Thanks @ashawwal, @obviyus.
+- Recover final answers after tool work in long Codex conversations [#143081](https://github.com/openclaw/openclaw/pull/143081). Thanks @barbarhan, @obviyus.
+- Avoid repeated Codex history after final message delivery [#143506](https://github.com/openclaw/openclaw/pull/143506). Thanks @sunlit-deng, @dbarbatti, @obviyus.
+
+**Documentation**
+
+- Split the Codex harness reference by topic [#142803](https://github.com/openclaw/openclaw/pull/142803). Thanks @vincentkoc.
+- Split Codex runtime guidance into focused pages [#143458](https://github.com/openclaw/openclaw/pull/143458). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue connected coding-agent sessions">
+
+Returning to a Claude-backed conversation keeps its native session identity when overlapping history is combined, and a resumed turn no longer appears twice just because it carries OpenClaw's generated context note. Compatible warm Claude CLI processes can also survive skill-watcher readiness when the prepared skill content has not changed; real instruction changes still invalidate reuse.
+
+Pasted text reaches adopted or forked Codex sessions with locked model selection under the existing extraction limits. Connected ACP agents can finish valid forms with no fields, and elapsed-time fixes keep covered ACP startup and Codex operation waits from being distorted by clock corrections. CLI backend plugins also receive the effective Fast setting after preparation and queue waits, so a plugin that supports it can apply the right value when it launches.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce cold setup for Anthropic CLI history [#142801](https://github.com/openclaw/openclaw/pull/142801)
+
+**Bug fixes**
+
+- Preserve Claude session identity when combining duplicate history [#130494](https://github.com/openclaw/openclaw/pull/130494); contextual [#130456](https://github.com/openclaw/openclaw/issues/130456). Thanks @jalehman.
+- Complete valid ACP forms with no fields [#133269](https://github.com/openclaw/openclaw/pull/133269). Thanks @xydt-juyaohui, @obviyus.
+- Keep ACP startup waits consistent through clock changes [#137303](https://github.com/openclaw/openclaw/pull/137303). Thanks @qingminglong, @obviyus.
+- Forward effective Fast settings to CLI plugins and preserve the selected account [#138667](https://github.com/openclaw/openclaw/pull/138667). Thanks @Szqub, @obviyus.
+- Keep Codex operation timeouts stable through clock corrections [#141071](https://github.com/openclaw/openclaw/pull/141071); contextual [#141000](https://github.com/openclaw/openclaw/issues/141000). Thanks @ooiuuii, @obviyus.
+- Restore pasted text in model-locked Codex sessions [#142021](https://github.com/openclaw/openclaw/pull/142021). Thanks @RomneyDa.
+- Avoid duplicate user turns after Claude resume [#143960](https://github.com/openclaw/openclaw/pull/143960). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
+
+**Documentation**
+
+- Split ACP guidance by task [#142958](https://github.com/openclaw/openclaw/pull/142958). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use discovered local model limits">
+
+Self-hosted discovery now reads the context limits advertised by vLLM, SGLang, and compatible servers, including eligible direct-parent limits for adapters, instead of falling back to an inaccurate generic budget. Explicit configuration still wins. First-use vLLM metadata reads also avoid unnecessary provider-code loading, and Ollama's existing setup and troubleshooting guidance is split into focused pages.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Use advertised context limits for self-hosted models [#141113](https://github.com/openclaw/openclaw/pull/141113). Thanks @vincentkoc.
+- Avoid unnecessary loading for first-use vLLM model information [#142125](https://github.com/openclaw/openclaw/pull/142125)
+
+**Documentation**
+
+- Organize Ollama documentation into focused guides [#143004](https://github.com/openclaw/openclaw/pull/143004). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Select Tencent Hy4 preview">
+
+Tencent TokenHub and TokenPlan now offer Hy4 preview, with fresh setup selecting it and existing pinned models preserved. Its catalog describes a 1,024,000-token context window and a 64,000-token output limit; your key must allow access to the model. Hy4 exposes none/high reasoning, so intermediate choices such as Low map to High and can affect thinking time and usage. Doctor still migrates an old TokenHub `hy3-preview` primary to Hy3 rather than silently moving an existing setup to Hy4.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add Hy4 preview to Tencent TokenHub and TokenPlan [#131598](https://github.com/openclaw/openclaw/pull/131598). Thanks @chl-0537, @hxy91819.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use current Grok defaults">
+
+New xAI setups and web search, X search, and code-execution tools without explicit model overrides now use Grok 4.6. Existing explicit selections stay in place, while retired subscription `xai/auto` choices can be repaired with `openclaw doctor --fix` or replaced with a permitted concrete model. The changed tool default can affect cost or account availability, and a zero estimate for an unknown price does not mean the request is free.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Limits and compatibility**
+
+- Use Grok 4.6 defaults and repair retired subscription auto selections [#142136](https://github.com/openclaw/openclaw/pull/142136). Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Send standalone OpenCode requests">
+
+Standalone OpenCode Go and Zen completions now receive the routing identity their native endpoints require, including local inference and prepared SDK requests without a persistent conversation. Explicit session headers retain precedence without discarding other provider routing headers, and retries reuse the same invocation identity. Custom endpoints retain their existing exclusions, and low-level stream callers still need to supply a session ID.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Supply routing identity for sessionless OpenCode Go calls [#143558](https://github.com/openclaw/openclaw/pull/143558). Thanks @RomneyDa.
+- Supply routing identity for standalone OpenCode completions [#143659](https://github.com/openclaw/openclaw/pull/143659). Thanks @HAPPYFAPTAIN, @obviyus, @GDXbsv, @spectrl.
+- Preserve routing with explicit OpenCode sessions [#143890](https://github.com/openclaw/openclaw/pull/143890). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use the selected Arcee account">
+
+Arcee through OpenRouter now uses the matching saved OpenRouter account without requiring a duplicate Arcee credential. The selected model keeps its authored endpoint, headers, limits, and aliases, while equivalent Arcee names stop producing misleading model-switch notices. Direct Arcee connections and explicit model endpoints keep their corresponding account selection.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Use the selected Arcee account and preserve model settings [#142898](https://github.com/openclaw/openclaw/pull/142898). Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recognize Kimi quota failures">
+
+An explicit Kimi weekly-quota error now follows rate-limit handling instead of telling you that a valid key is wrong and blocking the provider's other configured models. A configured alternative can be tried when available, but replacing the key will not restore spent quota; wait for Kimi's quota window or use another provider. Genuine invalid-key and access-denied errors keep their authentication handling.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Treat explicit Kimi quota failures as rate limits [#142656](https://github.com/openclaw/openclaw/pull/142656). Thanks @RileyJJY, @obviyus, @rico007, @shaozhengkun123.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Generate and edit with GPT Image 2.5">
+
+You can [generate and edit images](/tools/image-generation) with GPT Image 2.5 Flare or Sunburst through direct OpenAI access or fal, using the existing image tool and CLI. Both variants offer model-specific quality choices through xhigh and max, flexible dimensions, and PNG, JPEG, or WebP output, with transparent backgrounds available in PNG and WebP.
+
+Direct [OpenAI access](/providers/openai/image-and-video#gpt-image-2.5) requires API-key authentication, including explicit selection when an OAuth profile is already present; fal uses its own credentials. OpenAI edits accept up to five reference images and fal edits up to sixteen, with both retaining the four-output limit and existing default model. Custom dimensions must satisfy the documented size and aspect-ratio limits.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add GPT Image 2.5 Flare and Sunburst through OpenAI [#143068](https://github.com/openclaw/openclaw/pull/143068). Thanks @vincentkoc.
+- Add GPT Image 2.5 through fal with 16-reference editing [#143069](https://github.com/openclaw/openclaw/pull/143069). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Transcribe voice notes with Deepgram Flux">
+
+Incoming voice notes can now use Deepgram's Flux English or multilingual transcription models through the existing media settings, with the resulting text entering the normal conversation. Install ffmpeg on the computer running the Gateway before selecting Flux; Nova remains the default. The multilingual model accepts a language hint, while English-only Flux ignores language selection and both omit unsupported batch options such as punctuation and automatic language detection. The [Deepgram guide](/providers/deepgram) covers setup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Transcribe voice notes with Deepgram Flux [#141836](https://github.com/openclaw/openclaw/pull/141836). Thanks @obviyus, @safzanpirani.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use current search models and setup guidance">
+
+Gemini web search now uses stable Gemini 3.6 Flash when no search model is pinned, addressing unavailable-default errors for affected API keys while preserving explicit choices and leaving the primary chat model unchanged. The billing distinction matters on upgrade, because Gemini 3 grounding charges per search query compared with Gemini 2.5's per-prompt basis. Search setup guidance also includes [Kimi's required plugin and restart](/tools/kimi-search), and explains how to [send Ollama search to the cloud](/tools/ollama-search) while keeping model traffic local.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Use Gemini 3.6 Flash for unconfigured web searches [#111964](https://github.com/openclaw/openclaw/pull/111964); contextual [#96974](https://github.com/openclaw/openclaw/issues/96974). Thanks @dillona, @vincentkoc, @anguslogan01.
+
+**Documentation**
+
+- Document search plugin installation and restarts, local Ollama model routing, browser ports, optional jq, /tell, patch syntax, approval inspection, node selection, reactions, and screen availability [#143856](https://github.com/openclaw/openclaw/pull/143856). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand model usage and estimates">
+
+Usage reports now separate explicitly reported cache-write tokens from ordinary input and fill missing estimates for eligible OpenRouter `:nitro` and `:floor` requests using base-model pricing. Recorded billed amounts and explicit prices retain precedence. Cost summaries also label cached totals that may still be incomplete, so a temporary zero is less likely to be mistaken for no usage; provider bills remain authoritative.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Count reported cache writes separately from ordinary input [#141377](https://github.com/openclaw/openclaw/pull/141377); contextual [#141374](https://github.com/openclaw/openclaw/issues/141374). Thanks @ooiuuii, @obviyus.
+- Avoid delayed ClawRouter usage errors during diagnostic capture [#141818](https://github.com/openclaw/openclaw/pull/141818). Thanks @Alix-007, @obviyus.
+- Label incomplete usage-cost totals [#141917](https://github.com/openclaw/openclaw/pull/141917)
+- Fill missing estimates for OpenRouter routing shortcuts [#142138](https://github.com/openclaw/openclaw/pull/142138). Thanks @fabiolr, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep model requests available through cleanup">
+
+Accepted model work keeps the resources it needs through authentication, cancellation, and response cleanup. Anthropic cancellation can return promptly while cleanup finishes, and OpenRouter music results or known usage errors no longer wait unnecessarily for optional diagnostic capture to reach the end of the response. That capture may consequently finish as incomplete.
+
+Model probes retain temporary credentials, sessions, and the direct CLI state lock until accepted cleanup finishes, even if a result has already appeared. Stop a running Gateway before using direct `openclaw models status --probe`, and do not treat a result or timeout as proof that its lock has been released.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Avoid OpenRouter capture waits after music completion or usage errors [#141754](https://github.com/openclaw/openclaw/pull/141754). Thanks @Alix-007, @obviyus.
+- Retain Anthropic resources through cancellation cleanup [#143377](https://github.com/openclaw/openclaw/pull/143377)
+- Retain model probe resources through cleanup [#143658](https://github.com/openclaw/openclaw/pull/143658)
+- Keep prepared model limits and credentials when skipping discovery [#143695](https://github.com/openclaw/openclaw/pull/143695)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Find provider setup and operating details">
+
+[OpenAI](/providers/openai) and [model-provider documentation](/concepts/model-providers) now start with an index that leads directly to the task at hand, from connecting an account to checking model costs, media support, Azure settings, or a custom endpoint. Existing section links retain a route to the moved material, making the guides easier to navigate without changing the behavior they describe.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Organize OpenAI guidance into focused task pages [#141224](https://github.com/openclaw/openclaw/pull/141224). Thanks @vincentkoc.
+- Organize model-provider documentation by setup task [#143058](https://github.com/openclaw/openclaw/pull/143058). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Automations and Scheduling
+
+Scheduled work gets fixes from the moment a job starts to the point its result returns to your conversation. Automations are also easier to find and edit, with saved friendly names, direct links from agent settings, and less waiting while large lists prepare delivery destinations.
+
+<AccordionGroup>
+
+<Accordion title="Run scheduled work with the intended tools and model">
+
+Scheduled conditions and script jobs can run their allowed commands on the computer hosting OpenClaw while secret egress protection stays enabled. Codex-backed chats can also create automations using the tool names in their catalog, without having to translate those names by hand. Both paths keep their existing permission limits.
+
+Scheduled model calls can continue when OpenClaw refreshes its model setup during job preparation, and an unrelated disabled fallback plugin no longer prevents an available model from running. Disabled plugins stay disabled. When all attempted providers fail, the job preserves their original errors so you can see what went wrong.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep scheduled jobs running through runtime refreshes [84fd689](https://github.com/openclaw/openclaw/commit/84fd689763c410dc32d43302c589f09d2f22d462). Thanks @ekinnee, @84dnnvbdvp-debug.
+- Preserve usable cron models and fallback failure details [855c9de](https://github.com/openclaw/openclaw/commit/855c9de4a2a7c8015d4fa78b28d00f330c0649ba). Thanks @Marvinthebored, @obviyus.
+- Restore scheduled commands with secret egress enabled [#142074](https://github.com/openclaw/openclaw/pull/142074). Thanks @tilor, @obviyus.
+- Accept Codex catalog tool names in automation allowlists [#142382](https://github.com/openclaw/openclaw/pull/142382). Thanks @sercada, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover scheduler reservations and delegated work">
+
+Conflicting reservations for scheduled jobs no longer cause an endless retry loop that can leave OpenClaw unresponsive. The scheduler lets the current attempt finish and checks again normally; pending jobs can proceed once the conflict clears.
+
+Scheduled agents that delegate work also avoid entering a pause they cannot resume. They finish their turn and leave delivery to the scheduler's existing policy, while supported child agents and interactive conversations retain their ability to pause and resume.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Prevent scheduled agents from entering an unresumable yield [#135318](https://github.com/openclaw/openclaw/pull/135318). Thanks @LiuwqGit, @obviyus, @youens, @postoso, @BottaniCals.
+- Stop stalled scheduled-job reservation loops and clean up resources after failed database opens [#142741](https://github.com/openclaw/openclaw/pull/142741). Thanks @galiniliev.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Finish background work and handle cancellation">
+
+A command running in the background can now bring its result back to the originating chat after the assistant has finished its earlier reply. History distinguishes command completions and other automatic events from routine heartbeat checks, so it is easier to see why the conversation resumed.
+
+Quiet heartbeat checks can finish silently without a retry demanding an answer. Their status recognizes a confirmed message send without adding a duplicate acknowledgment, and distinguishes work that has started in the background from work that has finished.
+
+If an automation result is waiting for an active conversation turn, cancellation can release that wait so actions such as pinning the conversation can proceed. Once cancellation reaches the waiting result, it leaves the active turn running and does not append the canceled result to chat history.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep quiet heartbeats silent and report completed sends [#140115](https://github.com/openclaw/openclaw/pull/140115). Thanks @ruel225, @obviyus, @laurencebrown.
+- Release session updates after cancellation [#143832](https://github.com/openclaw/openclaw/pull/143832).
+- Keep background completions and delayed skill experience reviews working after replies, with clearer event origins in history [#143866](https://github.com/openclaw/openclaw/pull/143866).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Find and edit automations">
+
+You can open an automation's editor directly from Settings → Agents → Automations, including for paused jobs. Saved friendly names now appear in automation lists, detail headings, and actions, while scheduled conversations sort and group under their visible cron label in the Sessions table.
+
+Full automation lists spend less time preparing delivery destinations when there are many jobs or sessions. If loading is still slow, enabled diagnostics break down where the list request spent its time. CLI errors also give more relevant guidance for missing jobs, blank IDs, and invalid options. When automatic scheduling is disabled, the warning explains how configuration and the environment used to launch OpenClaw can each keep scheduling off.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Edit automations directly from an agent's settings [#139782](https://github.com/openclaw/openclaw/pull/139782). Thanks @jjjhenriksen, @vyctorbrzezowski.
+- Explain time spent loading automation lists when diagnostics are enabled [#141805](https://github.com/openclaw/openclaw/pull/141805).
+
+**Bug fixes**
+
+- Show saved friendly automation names [#142076](https://github.com/openclaw/openclaw/pull/142076).
+- Show direct automation error guidance in JSON mode [#142113](https://github.com/openclaw/openclaw/pull/142113). Thanks @DasX, @obviyus.
+- Explain how to restore automatic scheduling by enabling cron, clearing `OPENCLAW_SKIP_CRON=1` from the Gateway's launch environment, and restarting [#142185](https://github.com/openclaw/openclaw/pull/142185).
+- Reject blank automation job IDs with clear guidance [#142264](https://github.com/openclaw/openclaw/pull/142264).
+- Sort and group scheduled sessions by displayed kind [#142554](https://github.com/openclaw/openclaw/pull/142554).
+- Reduce waits for automation delivery previews [#144014](https://github.com/openclaw/openclaw/pull/144014).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Follow triggers, reset times, and hook guidance">
+
+If you use daily conversation resets, they now avoid clearing context early around spring daylight-saving changes. Reset times still follow the local timezone of the computer running OpenClaw.
+
+The automation reference brings the existing [schedule types](/automation/cron-jobs/schedules#schedule-types) together, including triggers based on a command finishing or batches of its output. The [hooks guide](/automation/hooks) also has focused pages for writing hooks, configuration, event details, and troubleshooting, making the existing instructions easier to find when you need them.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Prevent premature daily resets near daylight-saving changes [#142482](https://github.com/openclaw/openclaw/pull/142482).
+
+**Documentation**
+
+- Document all automation schedule types and option constraints [#135964](https://github.com/openclaw/openclaw/pull/135964). Thanks @qingminglong, @obviyus.
+- Split hooks guidance into focused reference pages [#143041](https://github.com/openclaw/openclaw/pull/143041). Thanks @vincentkoc.
+- Clarify that there is no native WebSocket schedule source and legacy `cron.failureDestination` settings are not read directly [#144039](https://github.com/openclaw/openclaw/pull/144039). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Browser and Computer Use
+
+Working alongside your Claw in a browser now leaves your active tab alone when the Browser panel updates, while shared desktops follow the machine running your chat and let you paste local text through the Keyboard field. Computer use also gets fixes for the first action, window selection, and browser dialogs, so an ordinary step like finding a window or answering a second prompt can carry the task forward.
+
+<AccordionGroup>
+<Accordion title="Keep the Browser panel on the intended page">
+
+The [Browser panel](/tools/browser) can follow your Claw's latest result without pulling you away from the tab you are using. Choosing Open or selecting a different panel tab still brings that page forward, and a historical tab that has disappeared now tells you to select another one.
+
+After an established stream disconnects, the panel requests a fresh screenshot and retries the connection, keeping a pinned annotation or inspection image in place until you finish with it. Blank and internal pages also stop producing misleading chat preview cards, while their original results remain available in the activity details.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep browser focus during automatic panel updates [5c70585](https://github.com/openclaw/openclaw/commit/5c70585f93cf5ab22893266b22cd767e1eb9d056). Thanks @scotthuang.
+- Recover the Browser panel after stream disconnects [#141576](https://github.com/openclaw/openclaw/pull/141576). Thanks @safzanpirani, @obviyus. An open connection that never sends its first frame remains outside this repair.
+- Hide preview cards for blank and internal browser pages [#142213](https://github.com/openclaw/openclaw/pull/142213). Thanks @vyctorbrzezowski.
+
+**Documentation**
+
+- Split browser documentation into focused guides [#142984](https://github.com/openclaw/openclaw/pull/142984). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+
+<Accordion title="Control dialogs and action deadlines">
+
+[Browser commands](/cli/browser) now explain when a dialog is blocking an action, identify the dialog to answer, and report which steps were skipped when a batch stops. Sequential dialogs also remain available to answer when delayed cleanup from the first action finishes, so responding to the next prompt does not fail just because the previous one has settled.
+
+For an existing browser session, waits and evaluations now honor their supported time budgets without the premature connection cutoffs covered by these fixes. Filling and submitting a form share one action deadline, and cancellation reaches navigation checks. Cancellation does not undo changes already made to the page, and scripts should inspect action results because a dialog block or interruption alone does not produce a nonzero exit.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report blocked and interrupted browser actions [#142480](https://github.com/openclaw/openclaw/pull/142480).
+- Keep sequential browser dialogs available for responses [#142608](https://github.com/openclaw/openclaw/pull/142608).
+- Honor existing-browser timeouts and cancellation [#143365](https://github.com/openclaw/openclaw/pull/143365).
+
+**Limits and compatibility**
+
+- Reject invalid Browser CLI mouse-button values [#140976](https://github.com/openclaw/openclaw/pull/140976). Thanks @WOLIKIMCHENG, @DilapidatedDolphin98, @obviyus. Supplied values must be exactly `left`, `right`, or `middle`.
+
+</details>
+</Accordion>
+
+<Accordion title="Find and act on the correct window">
+
+Supported actions on a paired desktop are available to your Claw on its first call, and the CUA computer-use driver can list windows first without needing a retry or a preliminary screenshot. Successful window activation is also reported as success, letting the task continue after bringing the intended window forward.
+
+Requests for a particular window's image now receive guidance to use the [window observation action](/nodes/computer-use) when they are sent to a desktop-only screenshot command, instead of silently returning the whole desktop. The selected machine still needs to support the action and grant the required permissions. For [Codex Computer Use](/plugins/codex-computer-use), disabled native plugins now produce a prompt setup explanation instead of waiting through marketplace discovery, with instructions to enable `features.plugins` and rerun `/codex computer-use install`.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Skip the discovery wait when native Codex plugins are disabled [#137485](https://github.com/openclaw/openclaw/pull/137485). Thanks @shojikumaru, @noelillinger, @obviyus.
+- Make supported paired-desktop actions available on the first call [#141277](https://github.com/openclaw/openclaw/pull/141277). Thanks @oywino, @obviyus. Existing vision and permission restrictions still apply.
+- Fix first-action CUA window discovery [#143736](https://github.com/openclaw/openclaw/pull/143736).
+- Fix activation results and targeted capture guidance [#143953](https://github.com/openclaw/openclaw/pull/143953). Window input uses the `observationId` returned by `get_window_state` with `includeScreenshot`, rather than a whole-desktop frame reference.
+
+</details>
+</Accordion>
+
+<Accordion title="Use and hand over a shared desktop">
+
+Opening [Desktop from a chat](/gateway/cloud-sessions) now goes to the machine running that session, with connection progress and Retry if it is unavailable. A desktop that remains visible in a split pane stays connected while you type elsewhere, and worker connections correctly use the desktop password they are given.
+
+To paste text from your own clipboard, choose Take control, open Keyboard, and use your usual paste shortcut once the control connection is ready. The Keyboard field sends the text to the remote application; shortcuts sent directly to the desktop canvas still act on the remote machine. When another authenticated operator takes control, the handoff notice now shows their name or user ID, with the generic notice retained when neither is available.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show who took control of a shared desktop [#143828](https://github.com/openclaw/openclaw/pull/143828).
+
+**Bug fixes**
+
+- Paste local text through Desktop Keyboard [#141986](https://github.com/openclaw/openclaw/pull/141986).
+- Desktop follows the chat machine [#143831](https://github.com/openclaw/openclaw/pull/143831). Desktop support must be enabled; opening still starts view-only under the existing permissions.
+
+</details>
+</Accordion>
+
+<Accordion title="Wait for computer sessions to close">
+
+Stopping a node now waits for its computer-use provider to finish closing the active session, and another session cannot take its place while that cleanup is unfinished. If the provider fails to close, the failure remains visible and can block a new session until resolved, keeping a failed cleanup from being treated as a successful handoff.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Wait for computer sessions to close before node shutdown [#142787](https://github.com/openclaw/openclaw/pull/142787).
+
+</details>
+</Accordion>
+
+<Accordion title="Use supported Azure cloud desktops">
+
+[Azure cloud-worker profiles](/gateway/cloud-workers) can now enable desktop access through the existing direct or managed-coordinator setup. Enable the Cloud Worker Desktop lab and a desktop-enabled profile, then stop and reprovision existing workers that were created without desktop support. Translated setup guidance also includes Azure and these requirements; GCP desktop profiles remain unsupported.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Remove a redundant cloud-desktop startup request [#142172](https://github.com/openclaw/openclaw/pull/142172).
+
+**Bug fixes**
+
+- Enable desktop access for Azure cloud workers [#141895](https://github.com/openclaw/openclaw/pull/141895).
+
+**Documentation**
+
+- Update translated Azure desktop guidance [#141909](https://github.com/openclaw/openclaw/pull/141909).
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## Plugins and Integrations
+
+Plugins now have a connected path from finding a capability to reading its documentation, reviewing installation, and finishing setup, including recommendations you can open directly from chat. Cloud workers can also reuse completed project setup, keep running spares for later sessions, offer more operating-system choices, and manage snapshots from Settings.
+
+<AccordionGroup>
+
+<Accordion title="Browse plugins and open recommendations from chat">
+
+The Plugins workspace brings installed and available plugins into one searchable catalog, with categories, Featured and Trending shelves, and automatic loading of browse pages. Ordinary browsing puts official plugins first, while search and ranked shelves keep their own ordering. Matching bundled and catalog entries share their installation identity, and packages from a different ClawHub registry no longer make an unrelated listing look installed.
+
+You can also ask for a capability in [Control UI chat](/web/control-ui/chat) and open an official plugin or skill recommendation from the reply. The agent needs the message tool enabled and can show up to three recommendations; Install takes you to review or details, where you can decide what to add. An Installed badge means the package or skill is present, so configuration and account connection may still be needed.
+
+Plugin authors can declare up to three ordered categories. The field remains optional for external plugins, but an invalid declaration now prevents the manifest from loading.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Browse and filter ClawHub plugins in the web UI [#137659](https://github.com/openclaw/openclaw/pull/137659) — Thanks @Patrick-Erichsen.
+- Inspect plugin documentation and compatibility in detail pages [#137846](https://github.com/openclaw/openclaw/pull/137846) — Thanks @Patrick-Erichsen.
+- Include local plugins and locally backed details in discovery [#137856](https://github.com/openclaw/openclaw/pull/137856) — Thanks @Patrick-Erichsen.
+- Unify bundled and ClawHub plugin browsing [#138755](https://github.com/openclaw/openclaw/pull/138755) — Thanks @Patrick-Erichsen.
+- Add Gateway-backed ClawHub catalog discovery [#139042](https://github.com/openclaw/openclaw/pull/139042) — Thanks @Patrick-Erichsen.
+- Reuse prepared plugin catalog metadata [#142500](https://github.com/openclaw/openclaw/pull/142500)
+- Use package categories in plugin discovery [#142711](https://github.com/openclaw/openclaw/pull/142711) — Thanks @Patrick-Erichsen.
+- Group installed plugins by purpose [#142712](https://github.com/openclaw/openclaw/pull/142712) — Thanks @Patrick-Erichsen.
+- Unify plugin browsing and add ClawHub chat cards [#142782](https://github.com/openclaw/openclaw/pull/142782) — Thanks @Patrick-Erichsen.
+- Load plugin catalog pages automatically [#143731](https://github.com/openclaw/openclaw/pull/143731) — Thanks @Patrick-Erichsen.
+- Load less unused code for bundled channels [#143846](https://github.com/openclaw/openclaw/pull/143846)
+
+**Limits and compatibility**
+
+- Declare ordered plugin categories [#142710](https://github.com/openclaw/openclaw/pull/142710) — Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Match installed plugins to the correct ClawHub registry [#143644](https://github.com/openclaw/openclaw/pull/143644)
+- Correct plugin ranking, bundled identities, and skill names [#143730](https://github.com/openclaw/openclaw/pull/143730) — Thanks @Patrick-Erichsen.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Review, configure, and install the selected plugin">
+
+Once you choose a plugin, its detail page brings documentation, setup requirements, compatibility, and version information together, while [Settings → Plugins](/plugins/manage-plugins) gives each installed plugin a place for configuration, access information, diagnostics, and lifecycle controls. Setup-required messages explain what is missing and keep enablement unavailable until the required configuration is complete.
+
+The installation flow carries authorized users through source and capability review, required settings, and reconnects after a restart. Current details survive delayed catalog responses after autosave, and an older selection can no longer replace the plugin you are reviewing or installing. Completion waits for the new running instance and inventory confirmation. Administrator permissions and explicit consent still apply; package updates and arbitrary-source installations remain CLI tasks, and bundled plugins cannot be removed here.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Browse and search installed plugins in the Plugins workspace [#135839](https://github.com/openclaw/openclaw/pull/135839) — Thanks @Patrick-Erichsen.
+- Manage installed plugins on dedicated settings pages [#135840](https://github.com/openclaw/openclaw/pull/135840) — Thanks @Patrick-Erichsen.
+- Install and configure plugins from their detail pages [#137886](https://github.com/openclaw/openclaw/pull/137886) — Thanks @Patrick-Erichsen.
+- Organize installed-plugin details into tabs [#142713](https://github.com/openclaw/openclaw/pull/142713) — Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Clarify plugin setup states and package icons [#142624](https://github.com/openclaw/openclaw/pull/142624) — Thanks @Patrick-Erichsen, @jalehman.
+- Correct recovery commands after plugin capability-consent rejection [#143125](https://github.com/openclaw/openclaw/pull/143125) — Thanks @liuwqgit, @obviyus, @yxloveql.
+- Keep plugin selections and installation progress current [#143671](https://github.com/openclaw/openclaw/pull/143671)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Install and inspect plugins with useful diagnostics">
+
+Plugin commands now give recovery advice for the installation you are actually using, preserving the selected profile or container and explaining when a restart is automatic or needs your attention. Compatibility notices and registry mismatch reports also identify the relevant loaded plugin and the information that changed. ClawHub metadata and error responses respect their request deadline even when data arrives slowly, while successful downloads can continue as long as they keep making progress.
+
+Runtime inspection, chat inspection, and Plugin Doctor release their temporary resources before reporting success, with cleanup failures reported as errors. The [plugin CLI reference](/cli/plugins) is organized by task, and inspection distinguishes discoverable OpenClaw hook collections from unsupported JSON automation. A supported hook layout describes what OpenClaw can discover, not proof that the running instance has activated it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Enforce deadlines for ClawHub metadata and error responses [#109092](https://github.com/openclaw/openclaw/pull/109092) — Thanks @Pick-cat, @obviyus.
+- Keep profile and container context in plugin recovery commands [#117631](https://github.com/openclaw/openclaw/pull/117631)
+- Release plugin resources before reporting inspection success [#141780](https://github.com/openclaw/openclaw/pull/141780)
+- Close chat plugin-inspection resources before replying [#141819](https://github.com/openclaw/openclaw/pull/141819)
+- Release Plugin Doctor resources before reporting completion [#141845](https://github.com/openclaw/openclaw/pull/141845)
+- Close Workboard connections after plugin inspections [#141858](https://github.com/openclaw/openclaw/pull/141858)
+- Recover notices for already loaded plugins [#141930](https://github.com/openclaw/openclaw/pull/141930)
+- Clarify restart requirements after installing plugins [#142129](https://github.com/openclaw/openclaw/pull/142129) — Thanks @WOLIKIMCHENG, @obviyus, @dh-js.
+- Identify changed plugin registry records in diagnostics [#142192](https://github.com/openclaw/openclaw/pull/142192)
+- Release plugin CLI resources after cleanup finishes [#142388](https://github.com/openclaw/openclaw/pull/142388)
+- Keep resources alive through plugin registration cleanup [#142636](https://github.com/openclaw/openclaw/pull/142636)
+- Preserve bundled plugin trust for development path installs [#143516](https://github.com/openclaw/openclaw/pull/143516) — Thanks @RomneyDa.
+- Report supported bundle hook layouts accurately [#143687](https://github.com/openclaw/openclaw/pull/143687)
+
+**Documentation**
+
+- Split the plugins CLI reference by task [#142980](https://github.com/openclaw/openclaw/pull/142980) — Thanks @vincentkoc.
+- Clarify default plugin package resolution [#143867](https://github.com/openclaw/openclaw/pull/143867) — Thanks @vincentkoc.
+
+**Improvements**
+
+- Skip unused installation detail work in plugin summary tables [#143105](https://github.com/openclaw/openclaw/pull/143105)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Build against the current plugin SDK">
+
+Plugin authors get more accurate types for multi-account channel schemas, including custom root and account fields and transformations, and valid interface-typed inbound hook contexts compile again. The catchall helper now exposes its actual extended schema type, so generic wrappers that assumed it returned the original input type may need an annotation update. These are type-contract repairs; runtime validation keeps its existing behavior.
+
+Source-plugin builds include declared and generated assets even before the package is tracked by Git, and plugins in another OpenClaw checkout use the running host's SDK unless an explicit development override selects another source. The [SDK overview](/plugins/sdk-overview) and related references are split into focused guides, with corrected examples and compatibility guidance. For interface work, the opt-in [Control UI development proxy](/web/control-ui/development) brings real plugin panels and resources into hot reload while retaining normal authentication, pairing, and allowed-origin checks.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Document the private completion helper in the SDK catalog [#111706](https://github.com/openclaw/openclaw/pull/111706) — Thanks @xydt-tanshanshan, @obviyus, @chegherian.
+- Split provider SDK guidance into focused references [#141958](https://github.com/openclaw/openclaw/pull/141958) — Thanks @vincentkoc.
+- Organize plugin hook guidance by task [#142605](https://github.com/openclaw/openclaw/pull/142605) — Thanks @vincentkoc.
+- Split SDK migration guidance into focused pages [#142607](https://github.com/openclaw/openclaw/pull/142607) — Thanks @vincentkoc.
+- Organize the SDK overview into focused references [#142641](https://github.com/openclaw/openclaw/pull/142641) — Thanks @vincentkoc.
+- Split channel SDK guidance into focused references [#142703](https://github.com/openclaw/openclaw/pull/142703) — Thanks @vincentkoc.
+- Split plugin architecture into focused guides [#142730](https://github.com/openclaw/openclaw/pull/142730) — Thanks @vincentkoc.
+- Split the agent-harness SDK reference into focused pages [#142889](https://github.com/openclaw/openclaw/pull/142889) — Thanks @vincentkoc.
+- Split plugin entry-point documentation into focused references [#143151](https://github.com/openclaw/openclaw/pull/143151) — Thanks @vincentkoc.
+- Correct plugin examples and capability guidance [#143857](https://github.com/openclaw/openclaw/pull/143857) — Thanks @vincentkoc.
+- Correct provider catalog and Claude bundle guidance [#143895](https://github.com/openclaw/openclaw/pull/143895) — Thanks @vincentkoc.
+- Clarify plugin migration history and examples [#143982](https://github.com/openclaw/openclaw/pull/143982) — Thanks @vincentkoc.
+
+**Limits and compatibility**
+
+- Expose the actual catchall multi-account schema type [#141796](https://github.com/openclaw/openclaw/pull/141796) — Thanks @RomneyDa.
+
+**Bug fixes**
+
+- Accept interface-typed inbound hook contexts [#141934](https://github.com/openclaw/openclaw/pull/141934) — Thanks @RomneyDa.
+- Use the running Gateway SDK for sibling-checkout plugins [#142508](https://github.com/openclaw/openclaw/pull/142508)
+- Include declared assets in untracked source-plugin builds [#142527](https://github.com/openclaw/openclaw/pull/142527)
+
+**Improvements**
+
+- Develop Control UI plugins against a real Gateway with hot reload [#143052](https://github.com/openclaw/openclaw/pull/143052) — Thanks @shakkernerd.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep accepted plugin work alive through cleanup">
+
+Plugin tools and model requests keep the resources they need through accepted work and its cleanup, including work that finishes after cancellation or after the caller receives a result. Reload can publish a replacement while the previous registration finishes cleaning up, and shutdown waits for that earlier work before closing shared resources. Cancellation also retains the identity of the plugin doing the work.
+
+For plugin authors, [prepared models and provider callbacks](/plugins/sdk-runtime/models) belong to their original host lifetime. Once that host closes, prepare a fresh model under an open host before starting another request. Retiring a registration stops new work immediately; cleanup that never settles can still keep graceful shutdown waiting.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Stop advertising retired native-hook relay endpoints [#141608](https://github.com/openclaw/openclaw/pull/141608)
+- Keep model state alive through plugin completions [#141938](https://github.com/openclaw/openclaw/pull/141938)
+- Retain plugin model resources through cancellation cleanup [#142197](https://github.com/openclaw/openclaw/pull/142197)
+- Preserve plugin resources through reload cleanup [#142519](https://github.com/openclaw/openclaw/pull/142519)
+- Retain provider resources through host cleanup [#142838](https://github.com/openclaw/openclaw/pull/142838)
+- Preserve provider context while listing tools [#142896](https://github.com/openclaw/openclaw/pull/142896)
+- Release temporary plugin resources after model checks finish [#143109](https://github.com/openclaw/openclaw/pull/143109)
+- Keep local model resources through request cleanup [#143302](https://github.com/openclaw/openclaw/pull/143302)
+- Preserve plugin identity when tools are cancelled [#143305](https://github.com/openclaw/openclaw/pull/143305)
+- Keep isolated model calls alive through cleanup [#143414](https://github.com/openclaw/openclaw/pull/143414)
+- Fix runtime-specific environment listing from the CLI [#143446](https://github.com/openclaw/openclaw/pull/143446) — Thanks @jalehman.
+- Keep plugin resources through late agent cleanup [#143490](https://github.com/openclaw/openclaw/pull/143490)
+- Release model-selected plugin resources after agent work [#143725](https://github.com/openclaw/openclaw/pull/143725)
+
+**Documentation**
+
+- Split tool configuration references into focused pages [#142960](https://github.com/openclaw/openclaw/pull/142960) — Thanks @vincentkoc.
+
+**Improvements**
+
+- Reduce repeated checks when selecting plugin providers [#143091](https://github.com/openclaw/openclaw/pull/143091)
+
+**Limits and compatibility**
+
+- Retain plugin-prepared models until host work finishes [#143270](https://github.com/openclaw/openclaw/pull/143270)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Finish media generation and analysis">
+
+Accepted image, music, and video jobs keep their original providers through generation, saving, and rollback, so releasing the preparation that started a job no longer closes resources it still needs. If the provider setup retires during reference-file checks, the request is refused before a new job starts and can be retried with the current setup. A Started response acknowledges acceptance, and accepted paid work may continue after the caller cancels.
+
+Buffered speech and phone-call speech keep their providers through synthesis, while audio streams retain the final queued chunk and their provider through cleanup. Image and PDF analysis also retain managed resources while slow or cancelled work settles, and multiple images reach a plugin's own single-image handler in order when it has no batch handler. The [SDK lifetime guide](/plugins/sdk-overview/host-hooks) explains caller-owned resources and explicit stream-release obligations.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Remove false empty-body explanations from media-download errors [#141674](https://github.com/openclaw/openclaw/pull/141674)
+- Close music plugin resources after generation finishes [#142834](https://github.com/openclaw/openclaw/pull/142834)
+- Retain image plugin resources until generation finishes [#142843](https://github.com/openclaw/openclaw/pull/142843)
+- Retain video plugin resources until generation finishes [#142876](https://github.com/openclaw/openclaw/pull/142876)
+- Keep accepted image jobs alive through provider cleanup [#142991](https://github.com/openclaw/openclaw/pull/142991)
+- Keep music jobs alive through saving and cleanup [#143060](https://github.com/openclaw/openclaw/pull/143060)
+- Keep telephony speech providers alive through synthesis and cleanup [#143065](https://github.com/openclaw/openclaw/pull/143065)
+- Keep video providers available until background jobs finish [#143260](https://github.com/openclaw/openclaw/pull/143260)
+- Keep speech resources through synthesis and cleanup [#143313](https://github.com/openclaw/openclaw/pull/143313)
+- Keep speech providers through stream cleanup [#143369](https://github.com/openclaw/openclaw/pull/143369)
+- Keep image provider resources through cleanup [#143403](https://github.com/openclaw/openclaw/pull/143403)
+- Keep PDF provider resources through cancellation cleanup [#143460](https://github.com/openclaw/openclaw/pull/143460)
+- Keep prepared speech settings usable until host shutdown [#143493](https://github.com/openclaw/openclaw/pull/143493)
+- Keep plugin resources through media task cleanup [#143530](https://github.com/openclaw/openclaw/pull/143530)
+- Retain managed speech-summary resources through cleanup [#143627](https://github.com/openclaw/openclaw/pull/143627)
+- Preserve plugin image handlers for multiple images [#143717](https://github.com/openclaw/openclaw/pull/143717)
+
+**Documentation**
+
+- Organize text-to-speech documentation by task [#142992](https://github.com/openclaw/openclaw/pull/142992) — Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Inspect extension storage and telemetry">
+
+Large plugin-state listings avoid keeping a second complete copy of serialized rows while building the decoded results, and quota checks can read expiry information directly from the listing index. The returned list can still be large. The [index update](/reference/database-schemas#plugin-state-listing-index) rebuilds on the first writable open or Doctor repair, which needs additional work and temporary disk space; tools that validate the full schema need the matching definition.
+
+Local telemetry exporters keep their resources through cleanup, and Prometheus skips private diagnostic-content copies it does not use while retaining its metrics.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce database reads during plugin-state quota checks [#142318](https://github.com/openclaw/openclaw/pull/142318)
+- Reduce temporary memory when listing plugin state [#142568](https://github.com/openclaw/openclaw/pull/142568) — Thanks @arcabotai.
+
+**Bug fixes**
+
+- Release local telemetry resources after cleanup settles [#142423](https://github.com/openclaw/openclaw/pull/142423)
+- Avoid unused private diagnostic copies in Prometheus [#144109](https://github.com/openclaw/openclaw/pull/144109)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use MCP results and shut down cleanly">
+
+Text-heavy results from MCP tools on connected devices no longer carry a redundant text copy in serialized snapshots, while model output and the original result used by Code Mode remain available. MCP HTTP cleanup can also finish after the server accepts termination even if cancelling the response body stalls.
+
+Standalone MCP services wait for accepted handlers and tracked cleanup before releasing plugin resources, and report shutdown failures to their caller. A rejected remote termination still leaves an uncertain outcome. The [MCP reference](/cli/mcp) now separates serving, saved servers, transports, browser settings, and apps into focused guides.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Finish MCP cleanup without waiting on stalled cancellation [#141289](https://github.com/openclaw/openclaw/pull/141289) — Thanks @hugenshen, @obviyus.
+- Wait for MCP tool cleanup before resource release [#142632](https://github.com/openclaw/openclaw/pull/142632)
+- Keep MCP plugin resources available through shutdown cleanup [#143031](https://github.com/openclaw/openclaw/pull/143031)
+
+**Improvements**
+
+- Remove duplicate text from node-hosted MCP snapshots [#142518](https://github.com/openclaw/openclaw/pull/142518)
+
+**Documentation**
+
+- Split MCP documentation by task [#142995](https://github.com/openclaw/openclaw/pull/142995) — Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Run commands on the intended connected device">
+
+Commands sent to connected devices keep one elapsed-time budget across checks, wake-up, readiness retries, and the response, so a system-clock adjustment no longer shortens or extends that budget. Explicitly empty numeric options now fail before device lookup; scripts that want a default should omit the flag instead of passing an empty shell variable. The [Nodes reference](/cli/nodes) explains the command options, with pairing and command authorization remaining separate steps.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep node command timeouts stable across clock changes [#137147](https://github.com/openclaw/openclaw/pull/137147) — Thanks @qingminglong, @obviyus.
+
+**Limits and compatibility**
+
+- Reject empty numeric node command options [#137311](https://github.com/openclaw/openclaw/pull/137311) — Thanks @Alix-007, @obviyus.
+
+**Documentation**
+
+- Split Nodes documentation by task [#142779](https://github.com/openclaw/openclaw/pull/142779) — Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Consult agents and clean up failed meeting starts">
+
+A Google Meet or realtime voice session started from a model-locked conversation can now consult a separate configured agent using its own model and session. The [dedicated-agent setup](/plugins/google-meet/tool-and-modes) keeps locked target sessions protected and does not copy the requesting conversation's history. If Chrome startup fails after acquiring audio, Meet also attempts to stop that audio before rolling back a tab opened by that attempt, preserving tabs that were already there.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Organize Google Meet guidance by task [#142729](https://github.com/openclaw/openclaw/pull/142729) — Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Allow separate-agent consultations from model-locked sessions [#142736](https://github.com/openclaw/openclaw/pull/142736) — Thanks @RileyJJY, @jai-assistant, @jalehman.
+- Clean up Google Meet audio after Chrome startup failure [#143408](https://github.com/openclaw/openclaw/pull/143408)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Route A2A requests to the configured agent">
+
+Incoming [A2A requests](/channels/a2a) now honor the configured peer-to-agent assignment even when the request includes a conversation context. An exact conversation binding still takes priority, and each peer and conversation keeps its separate session, so a dedicated agent can receive a peer's work without a binding for every new context ID.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Honor A2A peer-to-agent bindings [#142485](https://github.com/openclaw/openclaw/pull/142485) — Thanks @eleqtrizit.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read accurate API results and references">
+
+Applications can now distinguish an answer that reached its output limit from one that finished naturally. [Chat Completions](/gateway/openai-http-api) returns `finish_reason` as `length`, while the [Responses API](/gateway/openresponses-http-api) marks the response and final message `incomplete`, supplies `max_output_tokens` as the reason, and emits `response.incomplete` for streaming clients. The partial answer remains available for the application to handle.
+
+Configuration patches also return the effective changed paths after validation and secret restoration, without exposing configuration values. The [Gateway RPC reference](/gateway/protocol/rpc-methods) is organized into focused method and event pages for clients that need those contracts.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report output-limited Chat Completions accurately [#141268](https://github.com/openclaw/openclaw/pull/141268) — Thanks @ooiuuii, @obviyus.
+- Report output-limited Responses answers as incomplete [#142778](https://github.com/openclaw/openclaw/pull/142778) — Thanks @zhangguiping-xydt, @obviyus, @ooiuuii.
+
+**Improvements**
+
+- Report effective changed paths from configuration patches [#141757](https://github.com/openclaw/openclaw/pull/141757)
+
+**Documentation**
+
+- Expose Gateway RPC method groups as headings [#143459](https://github.com/openclaw/openclaw/pull/143459) — Thanks @vincentkoc.
+- Correct Gateway reference hierarchy and model-view link [#143472](https://github.com/openclaw/openclaw/pull/143472) — Thanks @vincentkoc.
+- Split Gateway RPC guidance into focused topic pages [#143515](https://github.com/openclaw/openclaw/pull/143515) — Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Open plugin panels and Reports">
+
+Installed plugins can use short bookmarkable tab addresses, with [Team Reports](/plugins/team-reports) opening at `/reports` inside the Control UI. Reports and other embedded pages fill the available content area and fit short windows, while generated plugin assets are readable by a container's runtime user when the surrounding installation paths allow access.
+
+Existing Team Reports HTTP, report, and export clients need an update. Their default paths move from `/reports/...` to `/plugins/team-reports/...` without a redirect. You can explicitly keep the old HTTP location with `plugins.entries.team-reports.config.basePath` set to `/reports`; when that route shadows the short tab address, the tab uses its generic URL. Reports remain authenticated.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Make generated plugin panels readable by container runtime users [#142997](https://github.com/openclaw/openclaw/pull/142997) — Thanks @ylcn91, @obviyus, @Conan-Scott.
+- Let embedded reports fill the content area [#143765](https://github.com/openclaw/openclaw/pull/143765)
+
+**Limits and compatibility**
+
+- Add short plugin-tab URLs and move Team Reports HTTP defaults [#143183](https://github.com/openclaw/openclaw/pull/143183)
+
+**Improvements**
+
+- Use full page width for Team Reports [#143340](https://github.com/openclaw/openclaw/pull/143340)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reuse completed project setup">
+
+Cloud sessions can reuse a project's completed checkout and setup at stable workspace and HOME paths. A matching commit skips that work, while a compatible source change reruns the authorized setup recipe and preserves reusable caches. Initial synchronization keeps setup-generated files unless the session changed the same path, and already-bound sessions retain their accepted edits across restart.
+
+Eligible public GitHub repositories can use the same [prepared-project workflow](/gateway/cloud-workers/warm-images) without a local clone on the Gateway machine. Repository-only sessions from private GitHub repositories continue through cold checkout; eligible local Gateway worktree projects retain their preparation path. Reusing a prepared image still requires starting a machine unless a running spare is available.
+
+This feature upgrades global state to schema 17. Before upgrading, stop older writers and take a verified backup that includes SQLite WAL data, following the [schema migration instructions](/reference/database-schemas/state-schema-history). Older schema-16 readers refuse the upgraded database; rollback requires restoring the pre-upgrade backup with a compatible binary and loses writes made afterward.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse prepared workers for public GitHub repositories [2bcb98a4b280](https://github.com/openclaw/openclaw/commit/2bcb98a4b2807cd0ac014517d4ecdad4f42e557f)
+- Reuse completed project setup across fresh cloud-worker sessions [#143227](https://github.com/openclaw/openclaw/pull/143227)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep workers ready for later sessions">
+
+A later cloud session can take an already running, prepared worker instead of waiting for another machine to start, with a replacement prepared in the background. Administrators can also request project preparation before opening a session. This applies to eligible dedicated Linux workers with warm images, a known machine class, and immutable setup inputs without `setupEnv`, including the supported public GitHub project path.
+
+[Ready workers](/gateway/cloud-workers/warm-images#ready-workers) default to one spare per project and profile, with four across the Gateway. These are running machines with charges until deletion is confirmed, including unresolved cleanup. Set `cloudWorkers.profiles.<id>.readyWorkers` to `0` to disable that profile's reserves, or `cloudWorkers.preparedPool.maxTotal` to `0` to drain unused reserves across the Gateway. Active sessions remain intact. Expiry runs from the successful activation that created demand, using the provider’s idle timeout; refills and restarts do not extend that window.
+
+Existing warm-image state needs the documented migration to envelope v3. Stop the owning Gateway and original capture processes, then run `openclaw doctor --fix` under the exclusive maintenance lock before provisioning again.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Keep prepared cloud workers ready for later sessions [#143372](https://github.com/openclaw/openclaw/pull/143372)
+- Prepare cloud workers on demand [#143838](https://github.com/openclaw/openclaw/pull/143838)
+
+**Bug fixes**
+
+- Preserve worker bundles during provisioning [#143663](https://github.com/openclaw/openclaw/pull/143663)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose Linux, Windows, WSL2, or macOS workers">
+
+Cloud-worker profiles and individual sessions can choose Linux, native Windows, Windows through WSL2, or macOS when the backend supports the target. The picker shows compatible machine classes and preserves the chosen operating system for moves and recovery. The final supported Crabbox baseline for this release is 0.55.0.
+
+Native Windows uses PowerShell setup and requires supported Node.js, npm, and the managed launcher; WSL2 runs work inside its managed Linux environment. AWS macOS needs an available EC2 Mac Dedicated Host and On-Demand capacity. Linux remains the default, and desktop and warm-image features remain Linux-only. The [placement guide](/gateway/cloud-workers/placement-and-machine-selection#choose-an-operating-system-and-machine-class-per-session) explains the target choices and [native Windows prerequisites](/gateway/cloud-workers/setup-and-bundle-installation#native-windows-prerequisites).
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Choose provider-defined cloud-session operating systems [#142095](https://github.com/openclaw/openclaw/pull/142095)
+- Enable Windows WSL2 cloud workers with compatible Crabbox [#142679](https://github.com/openclaw/openclaw/pull/142679)
+- Run macOS cloud workers through Crabbox [#143463](https://github.com/openclaw/openclaw/pull/143463)
+- Run cloud workers on native Windows [#143769](https://github.com/openclaw/openclaw/pull/143769)
+
+**Documentation**
+
+- Translate cloud-worker operating-system controls [#142120](https://github.com/openclaw/openclaw/pull/142120)
+
+**Bug fixes**
+
+- Explain unavailable cloud operating systems [#143798](https://github.com/openclaw/openclaw/pull/143798)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Prepare Crabbox and configure worker profiles">
+
+OpenClaw now reuses a supported Crabbox installation or prepares a verified 0.55.0 distribution in its managed tools directory when the preferred executable is missing or outdated. Doctor can prepare that copy explicitly, without overwriting your installed binary. On restricted hosts, stage a supported copy before upgrading OpenClaw, because even inspecting or stopping an existing lease requires it; the [Crabbox profile guide](/gateway/config-cloud-workers#crabbox-profile) covers the available paths.
+
+Cloud workers settings also exposes advanced profile options, ready-pool limits, and repository-to-profile defaults that previously required manual configuration edits. Saves require a Gateway restart. Session hovercards and placement tooltips show known operating-system and machine specifications, making the chosen capacity visible beside the conversation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Correct Node requirements in cloud-worker setup guidance [#141871](https://github.com/openclaw/openclaw/pull/141871)
+- Split Cloud Workers guidance into focused topic pages [#143158](https://github.com/openclaw/openclaw/pull/143158) — Thanks @vincentkoc.
+
+**Improvements**
+
+- Automatically prepare a supported Crabbox CLI [#143768](https://github.com/openclaw/openclaw/pull/143768)
+- Edit advanced worker settings and repository defaults [#143801](https://github.com/openclaw/openclaw/pull/143801)
+- See cloud session machine specifications [#143864](https://github.com/openclaw/openclaw/pull/143864)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Build, pin, and restore worker checkpoints">
+
+Administrators can [build project snapshots from Settings](/gateway/cloud-workers/warm-images), follow progress, cancel builds, and manage current and previous checkpoints from the same view. Build uses the committed HEAD and setup recipe of a repository on the Gateway machine. Rebuild needs a recorded local checkout and follows normal reuse rules, so it does not force a replacement when the existing preparation is reusable.
+
+Pinning protects a checkpoint from ordinary expiry and deletion during replacement, and rollback selects a recorded previous generation for later allocations. Running workers keep their original checkpoint. Deletion refuses images that are pinned, held, or capturing, and two pinned generations block another replacement until one is unpinned. [Retention settings](/gateway/cloud-workers/warm-images#retention-policy) can preserve one previous generation and require a restart after changes.
+
+Slow captures now receive wait and inspect guidance rather than being treated as uncertain solely because of their age. Recovering an uncertain reservation still requires acknowledging that its workers and capture have stopped and provider artifacts have been reconciled; the button clears only that reservation. Failed optional uploads also release their occupied transfer slots so later checkpoints can proceed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Clear cloud snapshot reservations after confirmed rejection [#142221](https://github.com/openclaw/openclaw/pull/142221)
+- Allow cloud-worker snapshots to finish before enrollment [#143288](https://github.com/openclaw/openclaw/pull/143288)
+- Clean up abandoned uploads and failed checkpoint handoffs [#143675](https://github.com/openclaw/openclaw/pull/143675)
+
+**Improvements**
+
+- Inspect and recover cloud snapshots in the Control UI [#143814](https://github.com/openclaw/openclaw/pull/143814)
+- Pin, delete, and roll back cloud-worker images [#143893](https://github.com/openclaw/openclaw/pull/143893)
+- Build project snapshots from Settings [#143929](https://github.com/openclaw/openclaw/pull/143929)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue cloud work through preparation and updates">
+
+Messages accepted during healthy worker setup or file synchronization remain queued for their intended environment and start when it is ready, with a receipt explaining what they are waiting for. You no longer need to copy and resend a message just because normal synchronization outlasted the earlier wait.
+
+Supported cloud machines also keep their workspace, installed tools, and desktop through an ordinary Gateway update, with the worker software refreshed in place. A submitted turn that has not reached the worker can retry once through a compatible refresh without duplicating the message. [Session lifecycle guidance](/gateway/cloud-workers/session-lifecycle) covers the supported installer and reconnection requirements, recovery of pending node-backed results, and cases that still need cleanup. Already-started tool work is not replayed, and Stop, Move, provider loss, or persistent renewal failures retain their own failure behavior.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep accepted messages queued through worker setup and file sync [#137576](https://github.com/openclaw/openclaw/pull/137576) — Thanks @jalehman.
+- Retain cloud-worker renewals after temporary heartbeat failures [#142194](https://github.com/openclaw/openclaw/pull/142194)
+- Keep configured cloud machines through updates [#143858](https://github.com/openclaw/openclaw/pull/143858)
+- Continue unstarted turns through worker updates [#143910](https://github.com/openclaw/openclaw/pull/143910)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Capture and transfer remote workspace files">
+
+Capturing a remote workspace with many small files can finish sooner by reading several files concurrently, and transferred file inventories can use gzip while preserving their decoded contents and validation. Deeply nested prepared workspace paths also pass the corrected launch check, subject to the operating system's own limits.
+
+Cancelling preparation stops new scanning and hashing while work already started finishes closing its handles. Cancelled uploads disconnect even after their last byte has arrived, and growing or oversized files are rejected earlier without publishing a partial manifest. These changes preserve the existing workspace size and filesystem restrictions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Allow long prepared workspace paths at worker launch [#142198](https://github.com/openclaw/openclaw/pull/142198)
+- Stop cancelled cloud workspace uploads from hanging [#142237](https://github.com/openclaw/openclaw/pull/142237)
+- Skip unused workspace files during worker startup [#143721](https://github.com/openclaw/openclaw/pull/143721)
+- Stop workspace scans when worker preparation is canceled [#143746](https://github.com/openclaw/openclaw/pull/143746)
+- Stop excessive reads during worker workspace capture [#143795](https://github.com/openclaw/openclaw/pull/143795)
+
+**Improvements**
+
+- Compress cloud workspace file inventories during transfer [#142242](https://github.com/openclaw/openclaw/pull/142242)
+- Capture many-file remote workspaces faster [#144017](https://github.com/openclaw/openclaw/pull/144017)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand cloud cleanup and failure reports">
+
+Cloud-worker cleanup now reports the original failure and the latest cleanup cause without accumulating repeated stale errors. If an optional image capture fails but the source machine is confirmed stopped, stop or reclaim can succeed with a capture warning, leaving any uncertain snapshot available for reconciliation.
+
+Unused image cleanup also works across profiles using different Crabbox executables. A failed deletion keeps its obligation visible for retry, so an unresolved cleanup can still hold capacity and continue incurring provider charges.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Restore Crabbox image cleanup across multiple CLI executables [#142166](https://github.com/openclaw/openclaw/pull/142166)
+- Keep cloud-worker cleanup errors current [#143345](https://github.com/openclaw/openclaw/pull/143345)
+- Separate successful Crabbox cleanup from capture warnings [#143349](https://github.com/openclaw/openclaw/pull/143349)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Find and connect Codex plugins">
+
+Owners and administrators can [find and connect Codex plugins](/plugins/codex-native-plugins) with searchable catalog pages, retained setup links, and a status view that separates OpenClaw access permissions from bundle enablement and hosted-app connection flags. Opening a setup link leaves its question pending until you return and submit the completion response.
+
+After connecting an app, `/codex plugins refresh` requests fresh hosted-app inventory for the current account, and `/new` or `/reset` starts the session where required. Refreshing does not sign you in, enable a plugin, change permissions, or reload native MCP servers, so the status view keeps those remaining steps visible.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Find, connect and inspect Codex plugins [#132158](https://github.com/openclaw/openclaw/pull/132158) — Thanks @stevenlee-oai.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Security and Privacy
+
+Automatic command review can now consider what you asked your Claw to do, let eligible work proceed, refuse a command with guidance, or bring the decision back to you. Alongside that change, workspace-restricted attachments respect the active sandbox, standalone MCP Apps preserve read-only access, and backup exports recognize private update captures even after their directory moves, provided its privacy marker stays intact.
+
+<AccordionGroup>
+
+<Accordion title="Review commands against the requested task">
+
+In existing automatic and workspace permission modes, [command review](/tools/exec) can now allow an eligible low- or medium-risk command once, deny it with an explanation and safer-action guidance, or ask a person to decide. This takes effect in existing sessions without another setting, so routine work can proceed after review and a refusal can send the agent back to find a materially safer approach. On the Gateway, the third consecutive reviewer denial goes to a human.
+
+For embedded agent runs, review also receives a limited, redacted excerpt of the conversation so it can compare the proposed command with the user's request. That excerpt is treated as untrusted evidence and can omit relevant history; it is not a guarantee that the reviewer understands intent. Explicit requests for high-risk actions still go through human approval, modes that always ask retain that requirement, and executable checks remain in place. Direct node calls, widgets, the SDK facade, and the Codex bridge do not receive this conversation context. Slow or failed review still falls back promptly to human approval while pending cleanup finishes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Let automatic command review allow, deny, or ask [#141987](https://github.com/openclaw/openclaw/pull/141987). SDK consumers must handle denial without executing the command or automatically converting it into a human request.
+- Give command auto-review the user's conversation context [#142279](https://github.com/openclaw/openclaw/pull/142279).
+
+**Bug fixes**
+
+- Keep timed-out command review from releasing model resources before cleanup finishes [#143308](https://github.com/openclaw/openclaw/pull/143308).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand and preserve approval boundaries">
+
+Runs started with tools disabled now retain that restriction when handed to a supported plugin runtime, including when resuming a Copilot session that previously allowed tools. A runtime that cannot enforce the restriction refuses the handoff, so affected users need to switch runtimes or upgrade the plugin. The English Read Only description also makes its existing scope clearer — agent tools can read within the session root, but cannot write or run commands.
+
+Agent instructions no longer impose a blanket refusal on owner-authorized browser logins or commands using existing workspace credentials. When setup tools are unavailable, the instructions direct users to masked terminal setup instead, while group login codes still belong in private delivery. This changes the guidance given to the model, and existing runtime permissions continue to govern what it can do. Approval commands also return useful usage instructions for invalid decisions, and model-assisted interpretation of approval replies keeps its resources available through overlapping requests and cleanup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Clarify the existing scope of Read Only permissions in the English interface [#141283](https://github.com/openclaw/openclaw/pull/141283). Thanks @north-echo and @obviyus.
+
+**Bug fixes**
+
+- Show usage for invalid approval decisions and accept unusual IDs with valid decisions [#137877](https://github.com/openclaw/openclaw/pull/137877). Thanks @teddytennant and @obviyus.
+- Remove blanket credential-use refusals and correct setup routing [#143238](https://github.com/openclaw/openclaw/pull/143238). Thanks @ejc3, @Stephane-fci, and @Sedrak-Hovhannisyan. SDK callers should replace the legacy string argument to `buildCredentialSafetyPrompt` with `{ controlToolsAvailable }`; legacy strings remain accepted through November 30, 2026.
+- Keep approval-reply interpretation resources until cleanup ends [#143307](https://github.com/openclaw/openclaw/pull/143307).
+
+**Security and trust**
+
+- Preserve disabled tools across plugin handoffs [#142093](https://github.com/openclaw/openclaw/pull/142093). Thanks @pgondhi987. For [plugin authors](/plugins/sdk-agent-harness), an empty runtime `toolsAllow` list means deny all, while an empty configuration `allow` list remains unrestricted.
+
+**Documentation**
+
+- Clarify full-mode command approval, strict inline-code review, and waiting behavior [#142368](https://github.com/openclaw/openclaw/pull/142368). Thanks @Glucksberg, @obviyus, @JKamgang, and @russellweiss. This documents existing policy; strict inline evaluation remains off by default.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Protect and recover credentials">
+
+Gateway password authentication now rejects blank passwords, published example placeholders, and the literal values `undefined` and `null`, with security-audit findings that explain what needs attention. If a deployment uses one of those values, replace it with a real secret, restart the Gateway, and update its clients. Real passwords shorter than 24 characters receive a warning rather than a new startup block. Eligible password-only connections also stop depending on saved device credentials they do not use, avoiding failures when that unrelated local store cannot be read.
+
+WebSocket inference and the bundled autoreview helper can use protected credentials through [managed secret egress](/gateway/secrets) without a per-command opt-out. Substitution covers the connection's handshake URL and headers; subsequent message frames pass through unchanged. Credential recovery notices also stop implying that a working credential was available throughout an outage.
+
+For older node tokens carrying invalid operator permissions, Doctor now gives a working [device-token recovery command](/cli/devices) using `--role node --no-scopes`. Recovery requires administrator permission and preserves operator access. A node using a separate state directory needs valid shared Gateway authentication and a restart to refresh its own credentials.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Reject placeholder Gateway passwords and audit password strength [#141720](https://github.com/openclaw/openclaw/pull/141720).
+
+**Bug fixes**
+
+- Skip unused saved credentials for eligible password-only connections [#142290](https://github.com/openclaw/openclaw/pull/142290). This applies to signed clients using read-only local shared state, without an origin-specific credential scope or another credential type.
+- Correct credential recovery notices [#142498](https://github.com/openclaw/openclaw/pull/142498). Thanks @obviyus.
+- Restore WebSocket inference through managed secret egress, and synchronize bundled autoreview authentication handling and machine-readable status output [#143354](https://github.com/openclaw/openclaw/pull/143354). Thanks @fuller-stack-dev. The helper sync also removes its TruffleHog dependency; autoreview no longer runs that external secret scanner.
+- Recover legacy node tokens with `--no-scopes` [#143599](https://github.com/openclaw/openclaw/pull/143599). Thanks @obviyus and @matthewmoroz. The option cannot be combined with `--scope`; cleanup removes only the matching local legacy node credential.
+
+**Documentation**
+
+- Split secrets guidance into focused runtime, SecretRef, store and egress, integration, and operations guides [#143520](https://github.com/openclaw/openclaw/pull/143520). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Validate network and webhook boundaries">
+
+Slack HTTP webhooks now finish a bounded request read before signature processing, enforcing body-size, read-time, and concurrency limits while retaining normal signature verification. Feishu and Lark signed webhooks reject callbacks dated more than one hour before or after the Gateway's clock. Keep that clock synchronized, and check [Feishu troubleshooting](/channels/feishu/troubleshooting) if a relay holding an old signed request begins receiving a rejection. WebSocket mode is unaffected.
+
+For reverse proxies and node pairing, [IPv4-mapped network ranges](/gateway/trusted-proxy-auth) now match their full declared IPv4 range. Review existing broad allowlists before relying on them — a mapped prefix at or below `/96` includes all IPv4 addresses, including loopback. Explicit loopback consent and the other authentication and approval checks remain in place.
+
+The optional IPv6 fake-IP proxy compatibility setting also preserves the block on the known AWS IPv6 metadata endpoint for guarded requests. Tlon validates quoted-post references before authenticated lookups, allowing surrounding message text to survive malformed citations.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Enforce Slack HTTP webhook limits before processing, including a 1 MiB body limit and 30-second read deadline [c11ea063](https://github.com/openclaw/openclaw/commit/c11ea06355b094e29c9fe5fcfe309fdbaae6d17b). Thanks @drobison00. Contextual intent and review reference [#136508](https://github.com/openclaw/openclaw/pull/136508).
+- Preserve IPv6 cloud metadata blocking with proxy compatibility enabled [#137684](https://github.com/openclaw/openclaw/pull/137684). Thanks @eleqtrizit.
+- Reject malformed Tlon citations before authenticated lookups [#142041](https://github.com/openclaw/openclaw/pull/142041). Thanks @pgondhi987.
+- Reject stale signed Feishu and Lark webhook callbacks outside the fixed one-hour clock window [#143484](https://github.com/openclaw/openclaw/pull/143484). Thanks @eleqtrizit.
+
+**Limits and compatibility**
+
+- Honor IPv4-mapped network ranges in proxy and pairing rules [#137668](https://github.com/openclaw/openclaw/pull/137668). Thanks @elbourne12345 and @obviyus. Native IPv6 peers do not match these ranges, and catch-all proxy trust can still prevent correct client attribution.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read only the authorized workspace and artifacts">
+
+With workspace-only policy enabled, an agent can attach output from its active sandbox without gaining attachment access to another session's sandbox. Core replies carry the active workspace through automatically; [channel plugins](/plugins/sdk-channel-plugins/status-and-media) that call the media helpers must supply it from trusted session context. Missing context now denies sandbox attachment access. Agents already allowed broader host-file access retain those permissions.
+
+Fresh artifact listings, inspection, and downloads also follow a conversation's draft visibility when no Gateway roles are configured, bringing file access into line with chat history. Previously issued download tickets keep their existing lifetime, and people sharing one Gateway still need to trust one another. For older file-transfer permissions, a dedicated [migration reference](/cli/file-transfer) explains the existing review command, dry runs, and script exit codes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Prevent attachment reads from sibling sandboxes under workspace-only policy [#143521](https://github.com/openclaw/openclaw/pull/143521). Thanks @eleqtrizit, @yetval, and @yangxiansheng.
+
+**Bug fixes**
+
+- Apply draft visibility to fresh artifact reads and downloads [#143873](https://github.com/openclaw/openclaw/pull/143873). Thanks @vincentkoc.
+
+**Documentation**
+
+- Split sandboxing guidance into focused backend, workspace, image, and setup pages [#143522](https://github.com/openclaw/openclaw/pull/143522). Thanks @vincentkoc.
+- Document file-transfer approval migration and clarify SecretRef fields, the Moonshot model example, and plugin-reference navigation [#144029](https://github.com/openclaw/openclaw/pull/144029). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve permissions in MCP Apps and local requests">
+
+Opening an MCP App in a standalone view now preserves the issuing client's read-only restriction. A reader can still render the App and access permitted resources, but the standalone view cannot list or call tools that the client's direct connection is forbidden to use. Authorized tool use continues to depend on the App's current grant.
+
+On the authenticated local MCP connection, an oversized rejected upload also prevents a queued request behind it from executing a tool. Valid requests at the existing size limit continue to work, while an upload declaring an excessive size is rejected immediately.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Preserve read-only permissions in standalone MCP Apps [#142661](https://github.com/openclaw/openclaw/pull/142661). Thanks @eleqtrizit. Client tool permission is captured when the launch ticket is issued; the ongoing check concerns the live App grant.
+- Block queued MCP tool execution after rejected uploads on the authenticated loopback connection [#143724](https://github.com/openclaw/openclaw/pull/143724).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep shared history and private update captures protected">
+
+[Deleting an agent](/cli/agents) now refuses to remove the physical owner of a history database while another configured agent depends on it, including when you choose to retain files. Keep that owner configured, since moving shared history to another owner is not yet supported. Failed cleanup remains available to retry after restart; if configuration removal has already committed but history cleanup fails, repair the reported storage problem and retry the same deletion command.
+
+Gateway-connected deletion also handles agent files on external state volumes that were previously rejected merely for being outside the home or temporary directory. Check workspace symlinks before deleting files through the Gateway — it can also move a target beside the link to Trash, while the offline CLI moves only the link.
+
+[Backups and support exports](/cli/backup) exclude recognized private update-capture directories and refuse protected files selected directly as inputs. A moved or copied directory stays protected when its privacy marker remains intact, including after its original owner directory is removed. Keep that marker with the directory; protection does not follow detached, unmarked files copied elsewhere. These changes govern export exclusion, not creation of captures or interrupted-update recovery.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve shared history and retryable cleanup during agent deletion [#141731](https://github.com/openclaw/openclaw/pull/141731). Thanks @andrea-kingautomation.
+- Clean up deleted agents on external state volumes, with the Gateway's same-parent workspace-symlink behavior described above [#142130](https://github.com/openclaw/openclaw/pull/142130).
+
+**Security and trust**
+
+- Keep recognized private update captures out of backups and support exports [#143799](https://github.com/openclaw/openclaw/pull/143799). Thanks @fuller-stack-dev.
+- Exclude moved private capture directories when their marker stays intact, and refuse invalid markers [#143899](https://github.com/openclaw/openclaw/pull/143899). Thanks @fuller-stack-dev.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve WhatsApp group allowlists during repair">
+
+Running `openclaw security audit --fix` now preserves existing WhatsApp group allowlists instead of adding paired senders to a policy you already restricted. Converting an open policy can still seed approved senders when no explicit sender list exists. Entries added by an earlier repair are not removed automatically, so review those separately if you were affected.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Preserve WhatsApp group allowlists during security repair [#142589](https://github.com/openclaw/openclaw/pull/142589). Thanks @eleqtrizit.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand telemetry and security guidance">
+
+The [telemetry guide](/gateway/telemetry) now explains the difference between optional feature statistics and approximate location derived by the hosted receiver from an update request. Its disclosure covers country, region, city, and timezone, why those fields cannot appear in a client-only preview, and the documented three-month retention. Disabling optional statistics or setting `DO_NOT_TRACK` does not stop baseline update requests; the guide points to the existing controls for stopping automatic update requests. This is a documentation disclosure, not a new client location-collection setting, and request origin may reflect a VPN, proxy, or remote server.
+
+Security, [policy](/cli/policy), and [threat-model guidance](/security/THREAT-MODEL-ATLAS) also have focused pages for the task or risk you want to understand. Setup and troubleshooting corrections explain saving an Anthropic setup token from an interactive terminal on the Gateway host, the existing team-only secret-store scope, shared HTTP write limits, and how proxy validation failures should be interpreted.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Normalize public-provider names in optional statistics and their preview, while retaining the private-provider filter and existing consent settings [#141134](https://github.com/openclaw/openclaw/pull/141134). Thanks @vincentkoc.
+
+**Documentation**
+
+- Organize Gateway security guidance into focused setup, trust, audit, and incident-response pages [#141162](https://github.com/openclaw/openclaw/pull/141162). Thanks @vincentkoc.
+- Split policy command guidance into authoring, rules, scopes, checks, attestation, and findings guides [#142961](https://github.com/openclaw/openclaw/pull/142961). Thanks @vincentkoc.
+- Explain approximate location in hosted update telemetry, preview limits, retention, and request controls [#143311](https://github.com/openclaw/openclaw/pull/143311). Thanks @vincentkoc.
+- Organize the threat catalog into focused pages while retaining shared risk context [#143517](https://github.com/openclaw/openclaw/pull/143517). Thanks @vincentkoc.
+- Clarify Anthropic setup-token login, secret scope, approvals upgrade guidance, shared rate limits, and proxy validation failures [#144030](https://github.com/openclaw/openclaw/pull/144030). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Quality-of-Life Improvements
+
+You can answer your Claw’s questions and enter Gateway-backed secrets directly in the terminal, with readable output and clearer guidance when a command needs your attention. Worktree setup and recovery also handle more everyday cases, while conversation instructions and reorganized documentation help keep the right information close to the task.
+
+<AccordionGroup>
+
+<Accordion title="Answer questions and secrets requests in the terminal">
+
+You can now answer your Claw's questions directly in the [terminal interface](/web/tui), choosing an option, selecting several answers, or typing your own response without leaving the conversation. An eligible plain reply can reach the question immediately even when the running task is waiting for it. Press Esc to put a question aside and `/question` to reopen it.
+
+Gateway-connected sessions also give [secret requests](/tools/secrets) their own masked input, keeping submitted values out of chat and input history. The input accepts one line and shows the proposed allowed hosts, which you can change in the Control UI. Local terminal sessions can answer ordinary questions, but storing a requested secret requires a running Gateway, and local questions do not survive closing the process.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Answer agent questions and Gateway secret requests in the terminal [#143273](https://github.com/openclaw/openclaw/pull/143273). Thanks @Sedrak-Hovhannisyan.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read clean terminal output">
+
+Terminal chat keeps long email addresses, words, and identifiers intact when they wrap, so copying a value does not pick up spaces that were never there. Multiline tables preserve deliberate blank lines and keep neighboring columns aligned, while progress indicators fit narrow windows and send valid updates to supported terminals.
+
+Scripts also get cleaner command output. Local approvals edits suppress the human write announcement in JSON mode, and transcript lists, summaries, and paths no longer pick up unrelated startup warnings.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Load less provider runtime code during CLI startup [#142460](https://github.com/openclaw/openclaw/pull/142460).
+- Reduce duplicate work when refreshing shell completions [#143025](https://github.com/openclaw/openclaw/pull/143025).
+
+**Bug fixes**
+
+- Keep progress indicators within narrow terminals [#141401](https://github.com/openclaw/openclaw/pull/141401). Thanks @ooiuuii.
+- Restore native CLI progress indicators [#142071](https://github.com/openclaw/openclaw/pull/142071). Thanks @Xuxyyy, @obviyus.
+- Suppress approvals write announcements in JSON output [#142152](https://github.com/openclaw/openclaw/pull/142152).
+- Preserve blank lines in multiline terminal tables [#142196](https://github.com/openclaw/openclaw/pull/142196).
+- Preserve long words and email addresses in terminal chat [#142210](https://github.com/openclaw/openclaw/pull/142210).
+- Keep wrapped multiline terminal cells aligned [#142305](https://github.com/openclaw/openclaw/pull/142305).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Follow actionable command diagnostics">
+
+When `openclaw agent` times out or loses its connection after the Gateway has accepted a task, the error now includes the accepted run ID. Use it to check the session transcript and Gateway status before retrying, since acceptance alone does not tell you whether the task is still running or has finished.
+
+Missing credentials and ambiguous agent selections now lead with the option you need to supply, while a command error is distinguished from a failure to start the CLI. Full status reports also show the Gateway details already available instead of replacing them with “unknown.”
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show accepted run IDs in connection-loss and timeout hints [#111899](https://github.com/openclaw/openclaw/pull/111899). Thanks @xialonglee, @MrNozz, @obviyus.
+- Distinguish command errors from CLI startup failures [#142109](https://github.com/openclaw/openclaw/pull/142109).
+- Show direct credential guidance for Gateway overrides [#142112](https://github.com/openclaw/openclaw/pull/142112). Thanks @DasX, @obviyus.
+- Show available Gateway details in full status reports [#142174](https://github.com/openclaw/openclaw/pull/142174).
+- Explain when CLI commands require an explicit agent [#143266](https://github.com/openclaw/openclaw/pull/143266).
+
+**Documentation**
+
+- Document system command port and password options [#139071](https://github.com/openclaw/openclaw/pull/139071). Thanks @qingminglong, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use Code Mode results and recover failed cells">
+
+[Code Mode](/tools/code-mode) fits and delivers structured results using compact JSON, leaving more of the existing allowance for the data your Claw needs. The terminal displays those results literally, preserving values, escapes, and Markdown characters when you inspect them, while existing output limits still apply.
+
+Excessive recursion in a fresh or resumed cell now returns a normal failed-cell error that the recovery flow can handle. You can correct the code and continue without that particular failure turning into a low-level runtime trap.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Fit compact Code Mode results and show literal JSON [#141417](https://github.com/openclaw/openclaw/pull/141417).
+- Keep recursive Code Mode cells recoverable [#141960](https://github.com/openclaw/openclaw/pull/141960). Thanks @vincentkoc.
+
+**Documentation**
+
+- Organize Code Mode guidance by task [#142425](https://github.com/openclaw/openclaw/pull/142425). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Start and restore the intended worktree">
+
+Starting a session in a [managed worktree](/concepts/managed-worktrees) keeps the accepted starting commit fixed across setup retries, even if the branch moves in the meantime. Invalid refs produce an actionable error, and repositories with many branches keep the Worktree option available. If your branch or commit is missing from the suggestions, you can type it directly and it still has to resolve before the worktree is created.
+
+Cleanup and restoration also preserve replacement content when a file becomes a folder or a folder becomes a file. Copied worktree IDs with surrounding spaces are accepted by Gateway remove and restore operations, removing a small but frustrating obstacle to using an existing recovery snapshot.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Validate worktree starting refs and preserve accepted commits [#135917](https://github.com/openclaw/openclaw/pull/135917). Thanks @RomneyDa.
+- Accept surrounding spaces in managed-worktree IDs [#141373](https://github.com/openclaw/openclaw/pull/141373). Thanks @nocodet888-arch, @obviyus.
+- Keep worktree sessions available in repositories with many branches [#143205](https://github.com/openclaw/openclaw/pull/143205).
+- Preserve file and folder replacements in worktree recovery [#143324](https://github.com/openclaw/openclaw/pull/143324).
+
+**Documentation**
+
+- Add worktree commands to the CLI index [#137422](https://github.com/openclaw/openclaw/pull/137422). Thanks @qingminglong, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep conversation instructions and side questions useful">
+
+Long workspace instructions retain more of the context that makes them useful. Shortened `AGENTS.md` content keeps an example's immediately adjacent introduction attached to its quotation, and the digest recognizes additional Traditional Chinese rule markers within the existing space limits. Git co-author guidance now sits in conditional session instructions, keeping eligible credit available without repeating it in individual messages; incognito sessions and isolated scheduled runs omit it.
+
+Rejected goal updates tell the agent to stop retrying the update and respond to you. Side questions keep the managed resources they started with through their answer and cleanup, and completed direct `/btw` answers can report supplied usage to configured diagnostics. That usage remains outside session-derived `/usage` cost totals.
+
+Preparing large lists of unpinned sessions also avoids repeated checks, reducing the work needed to return their metadata.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce repeated work when listing unpinned sessions [#141788](https://github.com/openclaw/openclaw/pull/141788).
+
+**Bug fixes**
+
+- Preserve adjacent example framing in shortened instructions [#137974](https://github.com/openclaw/openclaw/pull/137974). Thanks @SunnyShu0925, @obviyus, @Hawk5150.
+- Report usage from direct /btw answers [#141620](https://github.com/openclaw/openclaw/pull/141620).
+- Guide agents after rejected goal updates [#142808](https://github.com/openclaw/openclaw/pull/142808). Thanks @SunnyShu0925, @obviyus, @aminekhettat.
+- Repair native Git attribution replay before its move to session instructions [#142869](https://github.com/openclaw/openclaw/pull/142869). Thanks @Marvinthebored, @obviyus.
+- Retain Traditional Chinese rules in oversized instructions [#142915](https://github.com/openclaw/openclaw/pull/142915). Thanks @sunlit-deng, @obviyus, @igs-rogenlo.
+- Keep eligible Git co-author guidance in conditional session instructions [#143198](https://github.com/openclaw/openclaw/pull/143198). Thanks @Marvinthebored.
+- Keep side-question resources available through cleanup [#143366](https://github.com/openclaw/openclaw/pull/143366).
+
+**Documentation**
+
+- Organize the session reference by operator task [#143082](https://github.com/openclaw/openclaw/pull/143082). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Inspect and bound delegated tasks">
+
+Visible subagents now receive the time budget selected for their initial turn, so a longer delegated task is not cut short by the ordinary agent deadline. The budget applies to that first turn; later turns use normal timeout policy, and separate watchdogs still apply.
+
+Restored results on multi-agent Gateways use the recorded requesting agent when the saved session key lacks that identity. Independent child runs also get past a startup rejection caused by inheriting the parent's caller context. If a required child's tracking record is missing, the remaining children can no longer make the whole batch look fully handed off. The [subagent guides](/tools/subagents) organize inspection, completion, and recovery instructions into focused pages.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Route restored subagent results to their saved requester [#141480](https://github.com/openclaw/openclaw/pull/141480). Thanks @aeoess, @obviyus, @laurenceputra, @toraiwa.
+- Reject incomplete subagent continuation handoffs [#141901](https://github.com/openclaw/openclaw/pull/141901). Thanks @Takhoffman.
+- Allow independent child runs to register from parent tools [#142652](https://github.com/openclaw/openclaw/pull/142652). Thanks @jalehman.
+- Honor initial visible-subagent time limits [#142812](https://github.com/openclaw/openclaw/pull/142812). Thanks @fanyangCS, @obviyus.
+
+**Documentation**
+
+- Split sub-agent guidance into focused linked pages [#142999](https://github.com/openclaw/openclaw/pull/142999). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Find guidance by the task at hand">
+
+The [FAQ](/help/faq) now routes common questions into focused topics, while the documentation home offers direct paths to releases, skills, automations, and plugin building. Separate Releases and Contributing tabs make it easier to find the right material, with matching Simplified Chinese labels and additional translated sidebar groups.
+
+Across the guides, related links, visible section headings, and repaired older bookmarks bring you closer to the instructions you need. Help links in errors and support replies point to their current sections, configuration examples and terminology are clearer, and documentation maps keep headings inside code examples out of page navigation. These changes help you use the existing features described in those guides.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Fix the troubleshooting link in automated support replies [#143194](https://github.com/openclaw/openclaw/pull/143194). Thanks @vincentkoc.
+- Keep example headings out of documentation maps [#143299](https://github.com/openclaw/openclaw/pull/143299). Thanks @qingminglong, @obviyus.
+- Repair documentation links in errors and troubleshooting [#143497](https://github.com/openclaw/openclaw/pull/143497). Thanks @vincentkoc.
+
+**Documentation**
+
+- Correct Windows, ChromeOS, and durable-work maturity listings [#142066](https://github.com/openclaw/openclaw/pull/142066). Thanks @RomneyDa.
+- Connect related plugin and provider guides [#143021](https://github.com/openclaw/openclaw/pull/143021). Thanks @vincentkoc.
+- Add related-guide links and Chinese label translations [#143040](https://github.com/openclaw/openclaw/pull/143040). Thanks @vincentkoc.
+- Organize the FAQ into focused topic pages [#143150](https://github.com/openclaw/openclaw/pull/143150). Thanks @vincentkoc.
+- Improve links between guides and command references [#143157](https://github.com/openclaw/openclaw/pull/143157). Thanks @vincentkoc.
+- Restore legacy documentation section links [#143586](https://github.com/openclaw/openclaw/pull/143586). Thanks @vincentkoc.
+- Clarify setup guidance, pruning defaults, and Exa modes [#143770](https://github.com/openclaw/openclaw/pull/143770). Thanks @vincentkoc.
+- Improve navigation between documentation guides [#143773](https://github.com/openclaw/openclaw/pull/143773). Thanks @vincentkoc.
+- Reorganize CLI and tool documentation [#143775](https://github.com/openclaw/openclaw/pull/143775). Thanks @vincentkoc.
+- Correct Gateway and provider setup documentation [#143796](https://github.com/openclaw/openclaw/pull/143796). Thanks @vincentkoc.
+- Add bot-loop, transcripts, Copilot, Baseten, and incident-response guides to the sidebar [#143845](https://github.com/openclaw/openclaw/pull/143845). Thanks @vincentkoc.
+- Improve Chinese documentation labels [#143853](https://github.com/openclaw/openclaw/pull/143853). Thanks @vincentkoc.
+- Improve guide links and section navigation [#143855](https://github.com/openclaw/openclaw/pull/143855). Thanks @vincentkoc.
+- Repair concept and troubleshooting links [#143923](https://github.com/openclaw/openclaw/pull/143923). Thanks @vincentkoc.
+- Improve channel and plugin guide navigation [#143926](https://github.com/openclaw/openclaw/pull/143926). Thanks @vincentkoc.
+- Simplify setup and concept documentation [#143931](https://github.com/openclaw/openclaw/pull/143931). Thanks @vincentkoc.
+- Reorganize setup and operating guides [#143977](https://github.com/openclaw/openclaw/pull/143977). Thanks @vincentkoc.
+- Clarify tool and channel reference prose [#143979](https://github.com/openclaw/openclaw/pull/143979). Thanks @vincentkoc.
+- Improve documentation tabs and headings [#144021](https://github.com/openclaw/openclaw/pull/144021). Thanks @vincentkoc.
+- Align Chinese release and contributor navigation [#144037](https://github.com/openclaw/openclaw/pull/144037). Thanks @RomneyDa, @vincentkoc.
+- Restore Windows maturity section links [#144067](https://github.com/openclaw/openclaw/pull/144067).
+- Clarify agent setup and Gateway concepts [#144086](https://github.com/openclaw/openclaw/pull/144086). Thanks @vincentkoc.
+- Improve documentation home links and wording [#144089](https://github.com/openclaw/openclaw/pull/144089). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Other Bug Fixes
+
+When your Claw has finished the work, it should be able to tell you what happened, and when you reset a conversation, its child tasks should stay stopped. This release fixes several ways those expectations could break, along with command failures, unreadable history, and missing diagnostic information that made problems harder to investigate.
+
+<AccordionGroup>
+
+<Accordion title="Recover a final answer after completed work">
+
+A conversation can now recover its missing final answer after certain interrupted provider streams or an earlier tool error, once the final tool work has finished successfully. The recovery asks for a text-only explanation with tools disabled, so it can summarize completed work without running those actions again. Progress messages no longer stand in for that final answer, and a recovered reply can report the correct completion status.
+
+Recovery still depends on the provider responding and the work being settled. Background work or an answer already delivered can prevent another attempt, and an explanation of a fatal scheduled-run failure does not turn that run into a success.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Clarify text-only recovery for missing final answers [#141705](https://github.com/openclaw/openclaw/pull/141705). Thanks @fabiolr, @adinballew, @RomneyDa.
+- Recover final replies after interrupted provider streams [#142168](https://github.com/openclaw/openclaw/pull/142168). Thanks @liuwqgit, @obviyus, @wpu911.
+- Recover final answers after earlier tool errors [#143598](https://github.com/openclaw/openclaw/pull/143598). Thanks @harjothkhara, @obviyus, @CK-XYZ.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read and reset the intended history">
+
+Resetting a conversation with a large history of child tasks does less repeated work, and active or waiting children stay canceled when delayed results arrive. Finished results and unrelated conversations remain available. Standalone [`/new` and `/reset`](/tools/slash-commands) commands also avoid waiting for unnecessary thinking settings, while commands with follow-up text still use the configured model settings.
+
+History can load when a malformed custom message belongs to an inactive branch or overly nested plugin metadata falls before the reset boundary. Long conversations also keep recent context readable during supported cleanup when an agent pauses for other work. These fixes preserve retained history, and malformed content still reports an error when you actually select it. When a partial text answer fails, the next model request now retains a short failure record without replaying the unfinished text.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Retain failed partial-answer context for the next model request [989abf6](https://github.com/openclaw/openclaw/commit/989abf68703796dedcdd91d0ab7116684de69b8d), with contextual provenance in [#125977](https://github.com/openclaw/openclaw/pull/125977). Thanks @ayaangazali.
+- Keep inactive custom messages from breaking session history [#125413](https://github.com/openclaw/openclaw/pull/125413).
+- Keep long histories readable during yield cleanup [#137381](https://github.com/openclaw/openclaw/pull/137381), related to [issue #109638](https://github.com/openclaw/openclaw/issues/109638). Thanks @jalehman, @samrrr, @VACInc.
+- Avoid thinking-lookup delays for standalone session resets [#143281](https://github.com/openclaw/openclaw/pull/143281).
+- Keep current history readable after a reset [#143726](https://github.com/openclaw/openclaw/pull/143726).
+- Reduce repeated reset work while keeping child tasks stopped [#143916](https://github.com/openclaw/openclaw/pull/143916). Thanks @obviyus, @aleps001, @zhangguiping-xydt.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Run commands and inspect failed file actions">
+
+Service-managed SSH commands can finish after closing inherited file handles, and successful commands on macOS and Linux avoid a race that could incorrectly report a cleanup failure. Linux also gains bounded cleanup for defunct child processes adopted after covered command timeouts. If you updated with `--no-restart`, restart the running Gateway to pick up the cleanup acknowledgement fix.
+
+Failed workspace writes now explain whether permissions, a read-only filesystem, or a full disk prevented the change, giving you and your Claw a useful next step. Tool Search also preserves supplied parameters when a model includes an empty argument wrapper beside them, so a file path no longer disappears before reaching the read tool. Existing permissions and tool validation still apply.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Explain filesystem causes of failed workspace writes [#116378](https://github.com/openclaw/openclaw/pull/116378), related to [issue #115920](https://github.com/openclaw/openclaw/issues/115920). Thanks @sloptop-the-terrible, @obviyus, @609NFT, @geekforlife.
+- Clean up adopted Linux processes after command timeouts [#139548](https://github.com/openclaw/openclaw/pull/139548), a partial repair for [issue #97616](https://github.com/openclaw/openclaw/issues/97616). Cleanup is best effort and stops after 30 seconds. Thanks @srikolagani, @obviyus, @avp717, @Grynn, @islandpreneur007, @jinngimk-lang.
+- Let service-managed SSH commands finish normally after closing inherited file handles [#141463](https://github.com/openclaw/openclaw/pull/141463). The demonstrated repair is on Linux. Thanks @jjjhenriksen, @obviyus, @manumadrigal09, @ouioui33, @avcarp, @kaspnov.
+- Avoid false cleanup failures after successful POSIX commands [#143240](https://github.com/openclaw/openclaw/pull/143240).
+- Preserve tool arguments beside empty wrappers [#143729](https://github.com/openclaw/openclaw/pull/143729). Thanks @xydigitLybnnnn, @obviyus, @nkdmike.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand database and export failures">
+
+Fresh shared-state reads now wait through brief database locks within the existing five-second limit, and failed database opens preserve the original error instead of replacing it with a cleanup error. Protective SQLite shutdowns also retain their diagnostic when a worker thread triggers them. For operators investigating slow saves or cleanup, [structured logs](/logging) identify the operation, distinguish waiting from work, and add detail about preparation and worker release. With process diagnostics enabled, they can also show which operation currently holds a session queue. Their elapsed timings help narrow an investigation but do not measure CPU use or establish the underlying cause.
+
+Session exports preserve paginated file reads and their continuation instructions, while enabled trajectory capture includes tool calls and outcomes from fallback model attempts. Opt-in debug capture keeps response content already observed before an interruption and records it under the original capture session. Existing redaction and size limits remain, and enabling capture cannot restore records that were never collected.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Identify slow and failed SQLite session writes [#143451](https://github.com/openclaw/openclaw/pull/143451).
+- Identify execution threads in SQLite warnings [#143629](https://github.com/openclaw/openclaw/pull/143629).
+- Identify operations holding session queues [#143886](https://github.com/openclaw/openclaw/pull/143886).
+- Explain slow session cleanup preparation [#143942](https://github.com/openclaw/openclaw/pull/143942).
+- Clarify SQLite write and worker-release diagnostics [#144038](https://github.com/openclaw/openclaw/pull/144038). A release event alone does not establish successful cleanup or commit.
+
+**Bug fixes**
+
+- Include fallback tool activity in trajectory exports [#114662](https://github.com/openclaw/openclaw/pull/114662), related to [issue #114602](https://github.com/openclaw/openclaw/issues/114602). Thanks @synthalorian, @obviyus, @jackatagenticforce.
+- Preserve SQLite fatal diagnostics from worker threads [#143039](https://github.com/openclaw/openclaw/pull/143039).
+- Preserve partial debug captures and report shutdown storage failures [#143107](https://github.com/openclaw/openclaw/pull/143107). Thanks @vincentkoc.
+- Preserve the initiating database error during cleanup [#143574](https://github.com/openclaw/openclaw/pull/143574).
+- Wait for brief locks during state reads [#143908](https://github.com/openclaw/openclaw/pull/143908). Persistent locks can still fail. Thanks @pash-openai.
+- Keep paginated file reads in session exports [#143930](https://github.com/openclaw/openclaw/pull/143930). Thanks @linhongyu510, @obviyus, @cp1369.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Maintainer and Internal Changes
+
+This section accounts for 692 maintainer-only units across runtime refactors, tests, CI, packaging, release operations, and contributor tools. The work includes changes to how OpenClaw is built and checked, documentation maintenance, and a canceled UI adjustment retained for complete accounting. The source lists keep those details available without treating them as new product features.
+
+<AccordionGroup>
+
+<Accordion title="Runtime implementation and type contracts">
+
+Internal code shares more of its existing helpers and types across agents, channels, plugins, and storage. These refactors remove duplicate decisions, unused wrappers, and redundant state while keeping established behavior at the center of the work. Narrow reductions in allocations and repeated work do not establish an application-wide performance improvement.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+The inbound-hook mapper compatibility concern is addressed by the separately documented public repair. Two terminal-writer cleanups remove private reset and closed-state helpers; compatibility with untracked consumers of private imports is not established.
+
+**Improvements**
+
+- Remove the fixed orphan-prompt strategy wrapper [746e53f2](https://github.com/openclaw/openclaw/commit/746e53f21fe9fa671030343545daf65588816dd0)
+- Simplify shared tool-summary formatting [#136181](https://github.com/openclaw/openclaw/pull/136181)
+- Remove the unused internal health-check execution path [#138211](https://github.com/openclaw/openclaw/pull/138211)
+- Remove unused Doctor health-check arguments [#141475](https://github.com/openclaw/openclaw/pull/141475). Thanks @vincentkoc.
+- Return cron activation state from its existing transaction [#141676](https://github.com/openclaw/openclaw/pull/141676). Thanks @RomneyDa.
+- Skip unused distance calculations for trailing wake names [#141683](https://github.com/openclaw/openclaw/pull/141683)
+- Type incoming Reef versions as unverified input [#141687](https://github.com/openclaw/openclaw/pull/141687). Thanks @RomneyDa.
+- Separate cron script-result parsing from execution [#141688](https://github.com/openclaw/openclaw/pull/141688)
+- Separate transcript summary persistence from live capture [#141695](https://github.com/openclaw/openclaw/pull/141695)
+- Separate prepared-runtime snapshot construction [#141711](https://github.com/openclaw/openclaw/pull/141711)
+- Remove redundant CLI binary-name resolution [#141713](https://github.com/openclaw/openclaw/pull/141713)
+- Remove unused restart test overrides [#141714](https://github.com/openclaw/openclaw/pull/141714)
+- Share HTML tag scanning between web-fetch stages [#141726](https://github.com/openclaw/openclaw/pull/141726)
+- Separate prepared-runtime retention and auth invalidation [#141728](https://github.com/openclaw/openclaw/pull/141728)
+- Unify Profile identity-save handling [#141730](https://github.com/openclaw/openclaw/pull/141730)
+- Share Slack reply preparation without changing delivery order [#141733](https://github.com/openclaw/openclaw/pull/141733)
+- Share the CLI local-onboarding decision [#141735](https://github.com/openclaw/openclaw/pull/141735)
+- Centralize native approval adapter type handling [#141737](https://github.com/openclaw/openclaw/pull/141737). Thanks @RomneyDa.
+- Centralize native WebKit bridge message types [#141764](https://github.com/openclaw/openclaw/pull/141764). Thanks @RomneyDa.
+- Share the transcript idempotency-key reader [#141772](https://github.com/openclaw/openclaw/pull/141772). Thanks @vincentkoc.
+- Remove unused UI text-formatting options [#141783](https://github.com/openclaw/openclaw/pull/141783). Thanks @vincentkoc.
+- Reuse Doctor's shared legacy source-identity comparison [#141784](https://github.com/openclaw/openclaw/pull/141784). Thanks @vincentkoc.
+- Separate model-catalog source preparation [#141810](https://github.com/openclaw/openclaw/pull/141810)
+- Share model-catalog presentation across local readers [#141815](https://github.com/openclaw/openclaw/pull/141815). Thanks @obviyus.
+- Move cached turn replay into the dedupe module [#141824](https://github.com/openclaw/openclaw/pull/141824)
+- Reuse Doctor's path-containment helper [#141828](https://github.com/openclaw/openclaw/pull/141828). Thanks @vincentkoc.
+- Simplify built-in memory runtime delegation [#141847](https://github.com/openclaw/openclaw/pull/141847)
+- Centralize memory dreaming types in the host SDK [#141873](https://github.com/openclaw/openclaw/pull/141873). Thanks @RomneyDa.
+- Share ClawHub skill response types through the protocol [#141874](https://github.com/openclaw/openclaw/pull/141874). Thanks @RomneyDa.
+- Derive conversation capability types from their resolver [#141878](https://github.com/openclaw/openclaw/pull/141878). Thanks @RomneyDa.
+- Derive inbound hook context types from their producer [#141880](https://github.com/openclaw/openclaw/pull/141880). Thanks @RomneyDa.
+- Share provider request secret-field definitions [#141882](https://github.com/openclaw/openclaw/pull/141882)
+- Reuse channel setup configuration writers [#141929](https://github.com/openclaw/openclaw/pull/141929)
+- Simplify Markdown span ordering bookkeeping [#141945](https://github.com/openclaw/openclaw/pull/141945). Thanks @vincentkoc.
+- Remove unreachable TUI streaming state [#141999](https://github.com/openclaw/openclaw/pull/141999)
+- Avoid duplicate validation when listing sessions [#142005](https://github.com/openclaw/openclaw/pull/142005)
+- Preserve plugin types during search setup [#142006](https://github.com/openclaw/openclaw/pull/142006)
+- Derive UI session types from Gateway definitions [#142025](https://github.com/openclaw/openclaw/pull/142025). Thanks @RomneyDa.
+- Derive Matrix configuration types from schemas [#142026](https://github.com/openclaw/openclaw/pull/142026). Thanks @RomneyDa.
+- Derive Nextcloud Talk types from schemas [#142027](https://github.com/openclaw/openclaw/pull/142027). Thanks @RomneyDa.
+- Derive Mattermost types from schemas [#142028](https://github.com/openclaw/openclaw/pull/142028). Thanks @RomneyDa.
+- Share activation configuration merging [#142045](https://github.com/openclaw/openclaw/pull/142045)
+- Remove an ineffective source-loader option [#142050](https://github.com/openclaw/openclaw/pull/142050)
+- Consolidate plugin install metadata classification [#142075](https://github.com/openclaw/openclaw/pull/142075)
+- Remove unused plugin-loader cache bookkeeping [#142078](https://github.com/openclaw/openclaw/pull/142078). Thanks @vincentkoc.
+- Remove unused board notice injection inputs [#142101](https://github.com/openclaw/openclaw/pull/142101)
+- Remove unused plugin install option forwarding [#142121](https://github.com/openclaw/openclaw/pull/142121)
+- Remove unused configuration path from lock handles [#142127](https://github.com/openclaw/openclaw/pull/142127). Thanks @vincentkoc.
+- Avoid recounting plugin state after quota eviction [#142148](https://github.com/openclaw/openclaw/pull/142148)
+- Share assignment detection across redaction outputs [#142183](https://github.com/openclaw/openclaw/pull/142183)
+- Remove redundant duplicate tracking from buffered replies [#142205](https://github.com/openclaw/openclaw/pull/142205)
+- Separate plugin inspection authority from resource lifetime [#142214](https://github.com/openclaw/openclaw/pull/142214)
+- Skip unused Markdown scans during reply parsing [#142220](https://github.com/openclaw/openclaw/pull/142220)
+- Reduce temporary collection work in agent rosters [#142229](https://github.com/openclaw/openclaw/pull/142229)
+- Share session-list selection logic [#142239](https://github.com/openclaw/openclaw/pull/142239)
+- Reuse the prepared plugin-tool manifest lookup [#142249](https://github.com/openclaw/openclaw/pull/142249)
+- Avoid repeating rich-reply preparation for command delivery [#142252](https://github.com/openclaw/openclaw/pull/142252)
+- Reduce repeated URL preparation in terminal messages [#142262](https://github.com/openclaw/openclaw/pull/142262)
+- Share sandbox filesystem operation encoding [#142269](https://github.com/openclaw/openclaw/pull/142269)
+- Narrow Memory Core's configuration import [#142270](https://github.com/openclaw/openclaw/pull/142270)
+- Avoid redundant HTTP conversation-history copies [#142309](https://github.com/openclaw/openclaw/pull/142309)
+- Skip unused settings preparation for reduced prompts [#142311](https://github.com/openclaw/openclaw/pull/142311)
+- Avoid duplicate copies of matching read-tool text [#142354](https://github.com/openclaw/openclaw/pull/142354)
+- Share plugin registration provenance types [#142359](https://github.com/openclaw/openclaw/pull/142359)
+- Share Android durable chat send dispatch [#142363](https://github.com/openclaw/openclaw/pull/142363)
+- Reduce temporary allocations when matching plugin commands [#142374](https://github.com/openclaw/openclaw/pull/142374)
+- Stop forwarded-avatar selection when its slots are filled [#142387](https://github.com/openclaw/openclaw/pull/142387)
+- Avoid unused copies during history image pruning [#142391](https://github.com/openclaw/openclaw/pull/142391)
+- Reuse shared configuration scans in plugin planning [#142396](https://github.com/openclaw/openclaw/pull/142396)
+- Consolidate equivalent Nodes dispatch cases [#142402](https://github.com/openclaw/openclaw/pull/142402)
+- Skip unused Telegram draft prefix preparation [#142404](https://github.com/openclaw/openclaw/pull/142404)
+- Derive Google Meet types from resolved settings [#142407](https://github.com/openclaw/openclaw/pull/142407). Thanks @RomneyDa.
+- Derive IRC configuration types from its schema [#142408](https://github.com/openclaw/openclaw/pull/142408). Thanks @RomneyDa.
+- Share plugin manifest and registry types [#142409](https://github.com/openclaw/openclaw/pull/142409). Thanks @RomneyDa.
+- Reuse Gateway types for Workshop storage [#142410](https://github.com/openclaw/openclaw/pull/142410). Thanks @RomneyDa.
+- Share bounded web response-byte reading [#142413](https://github.com/openclaw/openclaw/pull/142413)
+- Avoid redundant chat code-block preparation [#142444](https://github.com/openclaw/openclaw/pull/142444)
+- Reduce temporary Discord formatting allocations [#142447](https://github.com/openclaw/openclaw/pull/142447)
+- Avoid intermediate arrays in model-message preparation [#142450](https://github.com/openclaw/openclaw/pull/142450)
+- Remove unused prompt-based queue deduplication [#142455](https://github.com/openclaw/openclaw/pull/142455)
+- Simplify extra bootstrap file loading [#142469](https://github.com/openclaw/openclaw/pull/142469)
+- Reduce temporary Swarm roster collections [#142488](https://github.com/openclaw/openclaw/pull/142488)
+- Avoid unused display preparation during chat export [#142491](https://github.com/openclaw/openclaw/pull/142491)
+- Remove unused setup callback authentication argument [#142494](https://github.com/openclaw/openclaw/pull/142494). Thanks @vincentkoc.
+- Remove unreachable Matrix forced-reset retry [#142495](https://github.com/openclaw/openclaw/pull/142495)
+- Share diagnostic listener registration [#142499](https://github.com/openclaw/openclaw/pull/142499). Thanks @vincentkoc.
+- Consolidate Gateway restart health finalization [#142513](https://github.com/openclaw/openclaw/pull/142513)
+- Reuse prepared LINE table cells [#142542](https://github.com/openclaw/openclaw/pull/142542)
+- Reuse message preparation during chat renders [#142570](https://github.com/openclaw/openclaw/pull/142570)
+- Share startup plugin membership checks [#142587](https://github.com/openclaw/openclaw/pull/142587). Thanks @vincentkoc.
+- Simplify pending tool-result bookkeeping [#142599](https://github.com/openclaw/openclaw/pull/142599)
+- Centralize Apple Gateway error presentation overrides [#142601](https://github.com/openclaw/openclaw/pull/142601)
+- Share Go and UV skill package validation [#142625](https://github.com/openclaw/openclaw/pull/142625). Thanks @vincentkoc.
+- Extract Codex feature-list protocol types [#142648](https://github.com/openclaw/openclaw/pull/142648). Thanks @RomneyDa.
+- Simplify internal status-report formatting [#142707](https://github.com/openclaw/openclaw/pull/142707)
+- Share route restoration across Control UI pages [#142709](https://github.com/openclaw/openclaw/pull/142709). Thanks @vincentkoc.
+- Isolate model-policy integer parsing [#142804](https://github.com/openclaw/openclaw/pull/142804)
+- Reuse prepared provider ownership metadata [#142818](https://github.com/openclaw/openclaw/pull/142818)
+- Simplify outbound reply mirroring [#142819](https://github.com/openclaw/openclaw/pull/142819)
+- Simplify interactive SDK exports [#142824](https://github.com/openclaw/openclaw/pull/142824)
+- Reduce media-reference formatting overhead [#142836](https://github.com/openclaw/openclaw/pull/142836)
+- Render HTTP history without intermediate entry copies [#142856](https://github.com/openclaw/openclaw/pull/142856)
+- Remove duplicate configuration tag preparation [#142864](https://github.com/openclaw/openclaw/pull/142864). Thanks @vincentkoc.
+- Reuse plugin metadata during contribution discovery [#142975](https://github.com/openclaw/openclaw/pull/142975)
+- Remove unused plugin metadata discovery fallback [#143020](https://github.com/openclaw/openclaw/pull/143020)
+- Reuse prepared paths in Claude plugin manifest loading [#143027](https://github.com/openclaw/openclaw/pull/143027)
+- Avoid redundant JSON-mode invocation parsing [#143097](https://github.com/openclaw/openclaw/pull/143097)
+- Share sandbox filesystem parameter types [#143189](https://github.com/openclaw/openclaw/pull/143189)
+- Share host desktop status formatting [#143223](https://github.com/openclaw/openclaw/pull/143223)
+- Consolidate post-update continuation handling [#143269](https://github.com/openclaw/openclaw/pull/143269)
+- Remove obsolete node CLI timeout overrides [#143330](https://github.com/openclaw/openclaw/pull/143330)
+- Unify Android capability approval state [#143352](https://github.com/openclaw/openclaw/pull/143352)
+- Simplify Synology webhook body handling [#143360](https://github.com/openclaw/openclaw/pull/143360)
+- Reuse shared dreaming statistics types [#143368](https://github.com/openclaw/openclaw/pull/143368)
+- Share Pi and Claude transcript range reading [#143374](https://github.com/openclaw/openclaw/pull/143374)
+- Share paired-node request assembly [#143380](https://github.com/openclaw/openclaw/pull/143380)
+- Remove unused chat-history configuration argument [#143395](https://github.com/openclaw/openclaw/pull/143395). Thanks @vincentkoc.
+- Remove duplicate Automations editor state [#143405](https://github.com/openclaw/openclaw/pull/143405)
+- Unify missing-command ownership resolution [#143411](https://github.com/openclaw/openclaw/pull/143411)
+- Share wizard prompt argument construction [#143430](https://github.com/openclaw/openclaw/pull/143430)
+- Consolidate hook-source selection policy [#143439](https://github.com/openclaw/openclaw/pull/143439)
+- Avoid repeated system-message trimming [#143453](https://github.com/openclaw/openclaw/pull/143453)
+- Reuse normalized channel setup metadata [#143470](https://github.com/openclaw/openclaw/pull/143470)
+- Simplify internal CLI help context [#143477](https://github.com/openclaw/openclaw/pull/143477)
+- Avoid an extra Code Mode diagnostic array copy [#143482](https://github.com/openclaw/openclaw/pull/143482)
+- Share Doctor session migration validation [#143507](https://github.com/openclaw/openclaw/pull/143507)
+- Reuse shared channel configuration writers [#143547](https://github.com/openclaw/openclaw/pull/143547)
+- Derive sandbox settings types from validation schemas [#143551](https://github.com/openclaw/openclaw/pull/143551). Thanks @RomneyDa.
+- Derive installation record types from validation schemas [#143552](https://github.com/openclaw/openclaw/pull/143552). Thanks @RomneyDa.
+- Derive Codex configuration types from existing schemas [#143553](https://github.com/openclaw/openclaw/pull/143553). Thanks @RomneyDa.
+- Share agent configuration schemas and types [#143554](https://github.com/openclaw/openclaw/pull/143554). Thanks @RomneyDa.
+- Share Memory Wiki report and index rendering [#143568](https://github.com/openclaw/openclaw/pull/143568)
+- Centralize Policy document validation [#143600](https://github.com/openclaw/openclaw/pull/143600)
+- Share Comfy workflow polling [#143653](https://github.com/openclaw/openclaw/pull/143653)
+- Consolidate worker validation and workspace reconciliation [#143667](https://github.com/openclaw/openclaw/pull/143667)
+- Reuse shared Markdown rendering for assistant messages [#143706](https://github.com/openclaw/openclaw/pull/143706)
+- Re-export shared provider ID helpers [#143712](https://github.com/openclaw/openclaw/pull/143712)
+- Share model catalog metadata merging [#143715](https://github.com/openclaw/openclaw/pull/143715)
+- Share completion and speech-summary cleanup ownership [#143716](https://github.com/openclaw/openclaw/pull/143716)
+- Remove redundant completion media checks [#143734](https://github.com/openclaw/openclaw/pull/143734)
+- Remove obsolete Discord thread-expiry fallback [#143737](https://github.com/openclaw/openclaw/pull/143737)
+- Consolidate Matrix action parsing and invalid-operation diagnostics [#143759](https://github.com/openclaw/openclaw/pull/143759)
+- Share question validation and terminal state handling [#143766](https://github.com/openclaw/openclaw/pull/143766)
+- Remove Doctor's unused standalone transcript writer [#143772](https://github.com/openclaw/openclaw/pull/143772)
+- Share prepared completion resource cleanup [#143792](https://github.com/openclaw/openclaw/pull/143792)
+- Reuse Gateway session response types in the UI [#143803](https://github.com/openclaw/openclaw/pull/143803)
+- Consolidate fast-mode state construction [#143816](https://github.com/openclaw/openclaw/pull/143816)
+- Share thinking-default policy resolution [#143849](https://github.com/openclaw/openclaw/pull/143849)
+- Share image-request resource ownership [#143871](https://github.com/openclaw/openclaw/pull/143871)
+- Share browser action execution options [#143887](https://github.com/openclaw/openclaw/pull/143887)
+- Simplify migration stop tracking [#143912](https://github.com/openclaw/openclaw/pull/143912)
+- Simplify inference command registration [#143920](https://github.com/openclaw/openclaw/pull/143920)
+- Share desktop rendering inputs [#143922](https://github.com/openclaw/openclaw/pull/143922)
+- Share Mattermost reaction dispatch [#143949](https://github.com/openclaw/openclaw/pull/143949)
+- Remove unused terminal writer reset [#143969](https://github.com/openclaw/openclaw/pull/143969)
+- Consolidate root option forwarding [#143993](https://github.com/openclaw/openclaw/pull/143993)
+- Verify terminal closure through write behavior [#144007](https://github.com/openclaw/openclaw/pull/144007)
+- Reuse model catalog deduplication [#144012](https://github.com/openclaw/openclaw/pull/144012)
+- Simplify provider secret marker restoration [#144036](https://github.com/openclaw/openclaw/pull/144036)
+- Share realtime Talk response types [#144077](https://github.com/openclaw/openclaw/pull/144077)
+- Carry model selection together through recovery [#144088](https://github.com/openclaw/openclaw/pull/144088)
+- Avoid unused task-detail copies in notifications [#144115](https://github.com/openclaw/openclaw/pull/144115)
+- Simplify compaction setup [#144121](https://github.com/openclaw/openclaw/pull/144121)
+
+**Bug fixes**
+
+- Restore desktop lint checks [#143889](https://github.com/openclaw/openclaw/pull/143889)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Tests and fixtures">
+
+Tests wait for the events they actually depend on, keep temporary state isolated, and check results more directly. Shared fixtures also remove repeated setup across many suites. Together, these changes make regression coverage easier to maintain and reduce avoidable test work, while the full test-audit campaign and release qualification remain separate efforts.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+Reported timings cover different local workloads and cannot be added into a release-wide speedup. Test-only changes below do not establish new behavior in the running application.
+
+**Improvements**
+
+- Reuse the deferred-promise helper in Gateway tests [2a4d6a10](https://github.com/openclaw/openclaw/commit/2a4d6a10ae6013ece39ae581762daf13b84ff1c9)
+- Keep interactive preview actions consistent with fixture state [#138350](https://github.com/openclaw/openclaw/pull/138350). Thanks @vyctorbrzezowski.
+- Disable unrelated catalog refreshes in isolated tests [#141266](https://github.com/openclaw/openclaw/pull/141266). Thanks @vincentkoc.
+- Test the existing Parallels log-tail boundary [#141470](https://github.com/openclaw/openclaw/pull/141470)
+- Reuse provider registries in catalog-auth tests [#141682](https://github.com/openclaw/openclaw/pull/141682)
+- Avoid redundant waits in Kova authentication tests [#141693](https://github.com/openclaw/openclaw/pull/141693)
+- Synchronize terminal startup tests with history loading [#141704](https://github.com/openclaw/openclaw/pull/141704)
+- Skip browser asset preparation in config RPC tests [#141741](https://github.com/openclaw/openclaw/pull/141741)
+- Share unreachable Gateway probe test fixtures [#141758](https://github.com/openclaw/openclaw/pull/141758)
+- Clean up security-scan fixture lint violations [#141778](https://github.com/openclaw/openclaw/pull/141778)
+- Share migration-test snapshot inputs [#141782](https://github.com/openclaw/openclaw/pull/141782)
+- Avoid idle-connection waits in webhook handoff tests [#141790](https://github.com/openclaw/openclaw/pull/141790)
+- Make web-search validator fixtures independent of client defaults [#141792](https://github.com/openclaw/openclaw/pull/141792)
+- Simplify Discord recording test branches [#141804](https://github.com/openclaw/openclaw/pull/141804)
+- Keep the image-probe reply matcher private [#141823](https://github.com/openclaw/openclaw/pull/141823)
+- Compact Code Mode source-validation test matrices [#141831](https://github.com/openclaw/openclaw/pull/141831). Thanks @RomneyDa.
+- Compact CLI argument test matrices [#141832](https://github.com/openclaw/openclaw/pull/141832). Thanks @RomneyDa.
+- Compact reasoning-tag test fixtures [#141833](https://github.com/openclaw/openclaw/pull/141833). Thanks @RomneyDa.
+- Compact Control UI routing test fixtures [#141834](https://github.com/openclaw/openclaw/pull/141834). Thanks @RomneyDa.
+- Remove an unused Comfy test fixture option [#141844](https://github.com/openclaw/openclaw/pull/141844)
+- Consolidate model-command policy tests [#141861](https://github.com/openclaw/openclaw/pull/141861). Thanks @RomneyDa.
+- Test the HTML comparison script's actual response limit [#141877](https://github.com/openclaw/openclaw/pull/141877)
+- Simplify Crabbox shell-detection test tables [#141888](https://github.com/openclaw/openclaw/pull/141888). Thanks @RomneyDa.
+- Simplify Doctor plugin repair test tables [#141889](https://github.com/openclaw/openclaw/pull/141889). Thanks @RomneyDa.
+- Simplify Active Memory policy test tables [#141890](https://github.com/openclaw/openclaw/pull/141890). Thanks @RomneyDa.
+- Simplify message account-isolation test tables [#141891](https://github.com/openclaw/openclaw/pull/141891). Thanks @RomneyDa.
+- Consolidate Vitest project-loading checks [#141908](https://github.com/openclaw/openclaw/pull/141908)
+- Share fresh logger fixtures across core tests [#141911](https://github.com/openclaw/openclaw/pull/141911)
+- Remove implementation-specific configuration assertions [#141919](https://github.com/openclaw/openclaw/pull/141919)
+- Simplify Google image test fixtures [#141926](https://github.com/openclaw/openclaw/pull/141926)
+- Verify playback cache limits through writes [#141944](https://github.com/openclaw/openclaw/pull/141944)
+- Use runtime context in plugin compatibility tests [#141989](https://github.com/openclaw/openclaw/pull/141989)
+- Use controlled timing in fatal Git-outcome tests [#142009](https://github.com/openclaw/openclaw/pull/142009)
+- Compact channel account-helper test tables [#142029](https://github.com/openclaw/openclaw/pull/142029). Thanks @RomneyDa.
+- Compact execution-wrapper test fixtures [#142030](https://github.com/openclaw/openclaw/pull/142030). Thanks @RomneyDa.
+- Compact secrets runtime test matrices [#142031](https://github.com/openclaw/openclaw/pull/142031). Thanks @RomneyDa.
+- Simplify npm registry test tables [#142032](https://github.com/openclaw/openclaw/pull/142032). Thanks @RomneyDa.
+- Test scroll reset within the existing preview [#142044](https://github.com/openclaw/openclaw/pull/142044)
+- Reuse text tool-result fixtures in agent tests [#142051](https://github.com/openclaw/openclaw/pull/142051)
+- Add an Android branch-switching test scene [#142057](https://github.com/openclaw/openclaw/pull/142057). Thanks @vincentkoc.
+- Test watcher shutdown with real default intervals [#142079](https://github.com/openclaw/openclaw/pull/142079)
+- Simplify inline-command test tables [#142081](https://github.com/openclaw/openclaw/pull/142081). Thanks @RomneyDa.
+- Compact Gateway network-policy tests [#142082](https://github.com/openclaw/openclaw/pull/142082). Thanks @RomneyDa.
+- Compact CLI configuration-guard tests [#142083](https://github.com/openclaw/openclaw/pull/142083). Thanks @RomneyDa.
+- Compact WhatsApp formatting tests [#142084](https://github.com/openclaw/openclaw/pull/142084). Thanks @RomneyDa.
+- Share timestamped tool-result fixtures [#142094](https://github.com/openclaw/openclaw/pull/142094)
+- Align Mac script tests with system Bash [#142096](https://github.com/openclaw/openclaw/pull/142096)
+- Reuse deferred promises in chat lifecycle tests [#142098](https://github.com/openclaw/openclaw/pull/142098)
+- Simplify memory recall timeout test setup [#142108](https://github.com/openclaw/openclaw/pull/142108)
+- Strengthen Feishu permission-error regressions [#142117](https://github.com/openclaw/openclaw/pull/142117)
+- Reuse xAI video response fixtures [#142118](https://github.com/openclaw/openclaw/pull/142118)
+- Remove unused language-hint test options [#142119](https://github.com/openclaw/openclaw/pull/142119)
+- Share user and assistant message test fixtures [#142133](https://github.com/openclaw/openclaw/pull/142133)
+- Avoid repeated compilation in Doctor process tests [#142140](https://github.com/openclaw/openclaw/pull/142140)
+- Add bounded failure details to Code Mode polling tests [#142157](https://github.com/openclaw/openclaw/pull/142157)
+- Remove duplicate Discord retry tests [#142177](https://github.com/openclaw/openclaw/pull/142177)
+- Share timestamped assistant test inputs [#142184](https://github.com/openclaw/openclaw/pull/142184)
+- Share API-key credential test fixtures [#142245](https://github.com/openclaw/openclaw/pull/142245)
+- Share OAuth credential test fixtures [#142272](https://github.com/openclaw/openclaw/pull/142272)
+- Verify the merge method actually dispatched in tests [#142329](https://github.com/openclaw/openclaw/pull/142329)
+- Reduce the Telegram Markdown chunking test fixture [#142365](https://github.com/openclaw/openclaw/pull/142365)
+- Consolidate duplicate group-policy resolver tests [#142366](https://github.com/openclaw/openclaw/pull/142366)
+- Share cloud-agent fixtures across New Session tests [#142376](https://github.com/openclaw/openclaw/pull/142376)
+- Report successful installation in Docker test logs [#142405](https://github.com/openclaw/openclaw/pull/142405). Thanks @vincentkoc.
+- Remove unused Telegram edit-test branches [#142411](https://github.com/openclaw/openclaw/pull/142411)
+- Share plugin installation test path checks [#142448](https://github.com/openclaw/openclaw/pull/142448). Thanks @vincentkoc.
+- Remove an unreachable process-poll test branch [#142466](https://github.com/openclaw/openclaw/pull/142466)
+- Consolidate memory-flush test coverage [#142478](https://github.com/openclaw/openclaw/pull/142478)
+- Reuse compiled CLI code in message-cleanup tests [#142503](https://github.com/openclaw/openclaw/pull/142503)
+- Remove unused Doctor configuration test mocks [#142507](https://github.com/openclaw/openclaw/pull/142507)
+- Settle composer animations before alignment tests [#142509](https://github.com/openclaw/openclaw/pull/142509). Thanks @RomneyDa.
+- Remove redundant Matrix QA scenario forwarding [#142546](https://github.com/openclaw/openclaw/pull/142546)
+- Remove real timeout waits from Telegram observation tests [#142602](https://github.com/openclaw/openclaw/pull/142602)
+- Remove unused terminal mocks from skills tests [#142604](https://github.com/openclaw/openclaw/pull/142604)
+- Remove duplicate deep-transcript import stress coverage [#142614](https://github.com/openclaw/openclaw/pull/142614)
+- Share changelog fixtures in release-note verifier tests [#142659](https://github.com/openclaw/openclaw/pull/142659)
+- Clarify generated markers in live file-read tests [#142685](https://github.com/openclaw/openclaw/pull/142685). Thanks @RomneyDa.
+- Share Discord action expectations across tests [#142690](https://github.com/openclaw/openclaw/pull/142690)
+- Share Codex lifecycle test fixtures [#142732](https://github.com/openclaw/openclaw/pull/142732)
+- Remove idle delay from cleanup regression testing [#142733](https://github.com/openclaw/openclaw/pull/142733)
+- Simplify native chat test fixtures [#142757](https://github.com/openclaw/openclaw/pull/142757)
+- Reduce plugin loading in storage migration tests [#142777](https://github.com/openclaw/openclaw/pull/142777)
+- Isolate plugin inputs in migration tests [#142785](https://github.com/openclaw/openclaw/pull/142785)
+- Check live meeting-title drafts in regression tests [#142795](https://github.com/openclaw/openclaw/pull/142795)
+- Make Signal test reply policy explicit [#142796](https://github.com/openclaw/openclaw/pull/142796)
+- Reuse model fixtures in native command tests [#142797](https://github.com/openclaw/openclaw/pull/142797)
+- Share Gateway scope expectations in tests [#142806](https://github.com/openclaw/openclaw/pull/142806)
+- Share independent replay test expectations [#142816](https://github.com/openclaw/openclaw/pull/142816)
+- Simplify session tests and expose early rollback setup failures [#142833](https://github.com/openclaw/openclaw/pull/142833)
+- Share reply-dispatch test expectations [#142845](https://github.com/openclaw/openclaw/pull/142845)
+- Simplify worker lifecycle test gates [#142865](https://github.com/openclaw/openclaw/pull/142865)
+- Remove real deadline waits from Swift polling tests [#142882](https://github.com/openclaw/openclaw/pull/142882). Thanks @vincentkoc.
+- Remove real-time waits from Mermaid timeout tests [#142886](https://github.com/openclaw/openclaw/pull/142886). Thanks @vincentkoc.
+- Reuse deferred fixtures in cron lifecycle tests [#142887](https://github.com/openclaw/openclaw/pull/142887)
+- Remove duplicate OpenCode Go metadata testing [#142894](https://github.com/openclaw/openclaw/pull/142894). Thanks @vincentkoc.
+- Consolidate duplicate setup inference tests [#142899](https://github.com/openclaw/openclaw/pull/142899)
+- Advance ngrok startup deadlines in process tests [#142903](https://github.com/openclaw/openclaw/pull/142903)
+- Reuse builds in service-worker update tests [#142904](https://github.com/openclaw/openclaw/pull/142904). Thanks @vincentkoc.
+- Reduce repeated compilation in worker-cache tests [#142911](https://github.com/openclaw/openclaw/pull/142911). Thanks @vincentkoc.
+- Reduce startup work for focused fast tests [#142912](https://github.com/openclaw/openclaw/pull/142912)
+- Reduce upgrade-test configuration launches [#142917](https://github.com/openclaw/openclaw/pull/142917). Thanks @vincentkoc.
+- Reuse shared response-cancellation fixtures [#142919](https://github.com/openclaw/openclaw/pull/142919)
+- Share Google web-search test options [#142928](https://github.com/openclaw/openclaw/pull/142928)
+- Reuse Memory Wiki source-state fixtures [#142934](https://github.com/openclaw/openclaw/pull/142934)
+- Share agent-turn test input fixtures [#142962](https://github.com/openclaw/openclaw/pull/142962)
+- Reuse package fixtures in security-scan tests [#142982](https://github.com/openclaw/openclaw/pull/142982). Thanks @vincentkoc.
+- Share cron context-window test fixtures [#142985](https://github.com/openclaw/openclaw/pull/142985)
+- Remove duplicate model-usage aggregation testing [#142990](https://github.com/openclaw/openclaw/pull/142990). Thanks @vincentkoc.
+- Remove redundant worker-transform test compilation [#143009](https://github.com/openclaw/openclaw/pull/143009)
+- Reuse isolated Git fixtures in release-evidence tests [#143014](https://github.com/openclaw/openclaw/pull/143014). Thanks @vincentkoc.
+- Serialize worker-transform test sequences [#143034](https://github.com/openclaw/openclaw/pull/143034)
+- Share Codex context-engine test setup [#143035](https://github.com/openclaw/openclaw/pull/143035)
+- Build phone recovery test fixture once per suite [#143046](https://github.com/openclaw/openclaw/pull/143046). Thanks @vincentkoc.
+- Reuse Doctor plugin-repair success fixtures [#143047](https://github.com/openclaw/openclaw/pull/143047)
+- Consolidate duplicate QA Lab image-result coverage [#143048](https://github.com/openclaw/openclaw/pull/143048)
+- Remove duplicate warm chat metadata coverage [#143059](https://github.com/openclaw/openclaw/pull/143059)
+- Reuse compiled feature-plugin test fixtures [#143062](https://github.com/openclaw/openclaw/pull/143062). Thanks @vincentkoc.
+- Consolidate xAI credential-reference test fixtures [#143075](https://github.com/openclaw/openclaw/pull/143075)
+- Share Doctor routing-warning fixtures [#143076](https://github.com/openclaw/openclaw/pull/143076)
+- Share Memory Wiki session-search fixtures [#143084](https://github.com/openclaw/openclaw/pull/143084)
+- Remove obsolete WhatsApp session snapshot coverage [#143104](https://github.com/openclaw/openclaw/pull/143104). Thanks @vincentkoc.
+- Reuse remaining xAI secret-reference test fixtures [#143108](https://github.com/openclaw/openclaw/pull/143108)
+- Consolidate proof-policy identity test setup [#143112](https://github.com/openclaw/openclaw/pull/143112)
+- Reuse the diagnostics installation test package [#143116](https://github.com/openclaw/openclaw/pull/143116). Thanks @vincentkoc.
+- Consolidate provider authentication precedence tests [#143117](https://github.com/openclaw/openclaw/pull/143117)
+- Remove duplicate MiniMax M2.7 input coverage [#143122](https://github.com/openclaw/openclaw/pull/143122). Thanks @vincentkoc.
+- Share status-rendering test fixtures [#143124](https://github.com/openclaw/openclaw/pull/143124)
+- Shorten deliberate SQLite timeout test waits [#143130](https://github.com/openclaw/openclaw/pull/143130). Thanks @vincentkoc.
+- Reuse Git seed setup in Testbox tests [#143154](https://github.com/openclaw/openclaw/pull/143154). Thanks @vincentkoc.
+- Share agent-turn execution test defaults [#143166](https://github.com/openclaw/openclaw/pull/143166)
+- Remove redundant Mistral cache-cost arithmetic coverage [#143172](https://github.com/openclaw/openclaw/pull/143172). Thanks @vincentkoc.
+- Share Memory Wiki visibility test callbacks [#143181](https://github.com/openclaw/openclaw/pull/143181)
+- Reduce Telegram policy test startup overhead [#143192](https://github.com/openclaw/openclaw/pull/143192). Thanks @vincentkoc.
+- Share mcporter security-audit test inputs [#143209](https://github.com/openclaw/openclaw/pull/143209)
+- Share Codex migration request fixtures [#143221](https://github.com/openclaw/openclaw/pull/143221)
+- Remove duplicate xAI stream tests [#143222](https://github.com/openclaw/openclaw/pull/143222). Thanks @vincentkoc.
+- Reuse initial certificates in proxy lifecycle tests [#143247](https://github.com/openclaw/openclaw/pull/143247). Thanks @vincentkoc.
+- Reuse prepared CLI artifacts in Telegram QA tests [#143253](https://github.com/openclaw/openclaw/pull/143253). Thanks @vincentkoc.
+- Share ACP metadata-update test setup [#143261](https://github.com/openclaw/openclaw/pull/143261)
+- Reduce repeated manifest searches during test-worker preparation [#143271](https://github.com/openclaw/openclaw/pull/143271)
+- Remove unused Doctor catalog test setup [#143272](https://github.com/openclaw/openclaw/pull/143272). Thanks @vincentkoc.
+- Reuse certificate setup in proxy tests [#143298](https://github.com/openclaw/openclaw/pull/143298). Thanks @vincentkoc.
+- Share Codex conversation test clients [#143300](https://github.com/openclaw/openclaw/pull/143300)
+- Share Docker timeout test fixtures [#143309](https://github.com/openclaw/openclaw/pull/143309)
+- Check authoritative restart state in update tests [#143316](https://github.com/openclaw/openclaw/pull/143316)
+- Remove redundant usage-cost coverage [#143318](https://github.com/openclaw/openclaw/pull/143318). Thanks @vincentkoc.
+- Reduce media QA startup overhead [#143326](https://github.com/openclaw/openclaw/pull/143326). Thanks @vincentkoc.
+- Share Feishu reply account test fixtures [#143336](https://github.com/openclaw/openclaw/pull/143336)
+- Share Docker package-builder fixtures [#143338](https://github.com/openclaw/openclaw/pull/143338)
+- Test archive installation with real workspaces [#143339](https://github.com/openclaw/openclaw/pull/143339)
+- Reuse shared assertions in DeepSeek tests [#143346](https://github.com/openclaw/openclaw/pull/143346)
+- Share Meta and Xiaomi test guards [#143358](https://github.com/openclaw/openclaw/pull/143358)
+- Share Feishu fetched-message fixtures [#143362](https://github.com/openclaw/openclaw/pull/143362)
+- Reuse Slack approval test configuration [#143370](https://github.com/openclaw/openclaw/pull/143370)
+- Remove unused channel catalog fixtures [#143373](https://github.com/openclaw/openclaw/pull/143373). Thanks @vincentkoc.
+- Simplify Chutes test responses [#143382](https://github.com/openclaw/openclaw/pull/143382)
+- Share deferred fixtures in routing tests [#143383](https://github.com/openclaw/openclaw/pull/143383)
+- Avoid cold plugin loading in fallback tests [#143392](https://github.com/openclaw/openclaw/pull/143392)
+- Remove redundant browser annotation tests [#143402](https://github.com/openclaw/openclaw/pull/143402)
+- Exercise real inbound orchestration in Signal tests [#143412](https://github.com/openclaw/openclaw/pull/143412)
+- Reuse compiled SDK fixtures in MCP tests [#143415](https://github.com/openclaw/openclaw/pull/143415)
+- Reuse prepared CLI in JSON-error tests [#143427](https://github.com/openclaw/openclaw/pull/143427)
+- Remove duplicate Discord presence coverage [#143435](https://github.com/openclaw/openclaw/pull/143435). Thanks @vincentkoc.
+- Share image resource test setup [#143443](https://github.com/openclaw/openclaw/pull/143443)
+- Reuse pristine Git seeds in worktree tests [#143469](https://github.com/openclaw/openclaw/pull/143469). Thanks @RomneyDa.
+- Run isolated CLI cleanup tests concurrently [#143481](https://github.com/openclaw/openclaw/pull/143481)
+- Reuse TypeScript transforms in update tests [#143487](https://github.com/openclaw/openclaw/pull/143487)
+- Remove unnecessary diagnostic timeout test waiting [#143514](https://github.com/openclaw/openclaw/pull/143514). Thanks @RomneyDa.
+- Reuse source transforms in proxy exit tests [#143527](https://github.com/openclaw/openclaw/pull/143527)
+- Simplify exec-host approval test fixtures [#143529](https://github.com/openclaw/openclaw/pull/143529)
+- Share Signal quote test inputs [#143532](https://github.com/openclaw/openclaw/pull/143532)
+- Compact shell-completion test tables [#143533](https://github.com/openclaw/openclaw/pull/143533). Thanks @RomneyDa.
+- Compact reply-payload test matrices [#143534](https://github.com/openclaw/openclaw/pull/143534). Thanks @RomneyDa.
+- Compact CI concurrency test cases [#143535](https://github.com/openclaw/openclaw/pull/143535). Thanks @RomneyDa.
+- Compact Labs configuration tests [#143536](https://github.com/openclaw/openclaw/pull/143536). Thanks @RomneyDa.
+- Share Discord REST proxy test spies [#143537](https://github.com/openclaw/openclaw/pull/143537)
+- Share empty plugin metadata fixtures [#143544](https://github.com/openclaw/openclaw/pull/143544)
+- Reuse transforms across cron output tests [#143559](https://github.com/openclaw/openclaw/pull/143559)
+- Exercise Teams timeout handling through Gateway send [#143572](https://github.com/openclaw/openclaw/pull/143572). Thanks @RomneyDa.
+- Share QA mock-provider decisions [#143603](https://github.com/openclaw/openclaw/pull/143603)
+- Strengthen optional plugin-tool environment coverage [#143613](https://github.com/openclaw/openclaw/pull/143613)
+- Reuse transformed code across native Gateway tests [#143628](https://github.com/openclaw/openclaw/pull/143628)
+- Narrow Anthropic cache-check loader types [#143634](https://github.com/openclaw/openclaw/pull/143634)
+- Remove duplicate Teams threading tests [#143636](https://github.com/openclaw/openclaw/pull/143636)
+- Reuse the provider prompt error-stream fixture [#143637](https://github.com/openclaw/openclaw/pull/143637)
+- Consolidate Windows CI checks with stronger assertions [#143642](https://github.com/openclaw/openclaw/pull/143642)
+- Reuse scoped environments in wizard tests [#143652](https://github.com/openclaw/openclaw/pull/143652)
+- Share runtime spy fixtures across channel tests [#143655](https://github.com/openclaw/openclaw/pull/143655)
+- Reuse Gateway acquisition test transforms [#143660](https://github.com/openclaw/openclaw/pull/143660)
+- Remove unused formatter fixture directories [#143662](https://github.com/openclaw/openclaw/pull/143662)
+- Simplify DeepInfra catalog fixtures [#143680](https://github.com/openclaw/openclaw/pull/143680)
+- Reuse Android swarm test controller setup [#143684](https://github.com/openclaw/openclaw/pull/143684)
+- Reuse runtime spies in plugin tests [#143690](https://github.com/openclaw/openclaw/pull/143690)
+- Reuse storage fixtures in sidebar tests [#143697](https://github.com/openclaw/openclaw/pull/143697)
+- Remove obsolete Venice test environment overrides [#143720](https://github.com/openclaw/openclaw/pull/143720)
+- Share SQLite index-drift test setup [#143749](https://github.com/openclaw/openclaw/pull/143749)
+- Speed up SQLite snapshot test byte comparisons [#143751](https://github.com/openclaw/openclaw/pull/143751). Thanks @RomneyDa.
+- Simplify configuration test environment fixtures [#143815](https://github.com/openclaw/openclaw/pull/143815)
+- Remove Responses transport test globals [#143850](https://github.com/openclaw/openclaw/pull/143850)
+- Remove model planner test hooks [#143851](https://github.com/openclaw/openclaw/pull/143851)
+- Simplify image-generation test fixtures [#143862](https://github.com/openclaw/openclaw/pull/143862)
+- Remove duplicate Signal access test [#143870](https://github.com/openclaw/openclaw/pull/143870). Thanks @vincentkoc.
+- Remove models-writer test plumbing [#143874](https://github.com/openclaw/openclaw/pull/143874)
+- Cover update permission loss during discovery [#143877](https://github.com/openclaw/openclaw/pull/143877). Thanks @fuller-stack-dev.
+- Move type contracts to compiler-owned checks [#143888](https://github.com/openclaw/openclaw/pull/143888)
+- Share sidebar drag-data fixtures [#143901](https://github.com/openclaw/openclaw/pull/143901)
+- Remove duplicate Telegram history coverage [#143904](https://github.com/openclaw/openclaw/pull/143904). Thanks @vincentkoc.
+- Simplify configuration environment fixtures [#143925](https://github.com/openclaw/openclaw/pull/143925)
+- Remove duplicate WhatsApp listener tests [#143962](https://github.com/openclaw/openclaw/pull/143962). Thanks @vincentkoc.
+- Share Memory Wiki deferred fixtures [#143978](https://github.com/openclaw/openclaw/pull/143978)
+- Remove duplicate inbound-audio coverage [#143996](https://github.com/openclaw/openclaw/pull/143996). Thanks @vincentkoc.
+- Test usage authentication through owning helpers [#143997](https://github.com/openclaw/openclaw/pull/143997)
+- Reuse auto-reply promise fixtures [#144004](https://github.com/openclaw/openclaw/pull/144004)
+- Exercise shared HTTP behavior in media tests [#144024](https://github.com/openclaw/openclaw/pull/144024)
+- Remove duplicate reply cancellation coverage [#144028](https://github.com/openclaw/openclaw/pull/144028). Thanks @vincentkoc.
+- Simplify Discord directory fixtures [#144033](https://github.com/openclaw/openclaw/pull/144033)
+- Decouple UI behavior tests from class lists [#144050](https://github.com/openclaw/openclaw/pull/144050)
+- Remove duplicate login-shell PATH test [#144051](https://github.com/openclaw/openclaw/pull/144051). Thanks @vincentkoc.
+- Reuse terminal deferred fixtures [#144058](https://github.com/openclaw/openclaw/pull/144058)
+- Remove duplicate metadata scope test [#144072](https://github.com/openclaw/openclaw/pull/144072). Thanks @vincentkoc.
+- Share Slack approval configuration fixtures [#144076](https://github.com/openclaw/openclaw/pull/144076)
+- Simplify source-reply test inputs [#144080](https://github.com/openclaw/openclaw/pull/144080)
+- Reuse ClawHub HTTP test helpers [#144090](https://github.com/openclaw/openclaw/pull/144090)
+- Remove duplicate missing-exporter test [#144091](https://github.com/openclaw/openclaw/pull/144091). Thanks @vincentkoc.
+- Consolidate package-source update tests [#144097](https://github.com/openclaw/openclaw/pull/144097)
+- Remove duplicate realtime authentication test [#144105](https://github.com/openclaw/openclaw/pull/144105). Thanks @vincentkoc.
+- Reuse compiled source in startup tests [#144110](https://github.com/openclaw/openclaw/pull/144110)
+- Reuse terminal upload and queue fixtures [#144116](https://github.com/openclaw/openclaw/pull/144116)
+- Consolidate Brave startup fixtures [#144117](https://github.com/openclaw/openclaw/pull/144117)
+- Simplify Firecrawl credential fixtures [#144122](https://github.com/openclaw/openclaw/pull/144122)
+- Remove duplicate CLI session-cleanup coverage [#144126](https://github.com/openclaw/openclaw/pull/144126). Thanks @vincentkoc.
+- Simplify Quick Chat test inputs [#144135](https://github.com/openclaw/openclaw/pull/144135)
+
+**Bug fixes**
+
+- Load browser cleanup before ACP test deadlines [441f69b2](https://github.com/openclaw/openclaw/commit/441f69b21fd77839345dfe247d82cbba8135984f). Thanks @Baumus.
+- Require completed installation in Claw export fixtures [#120843](https://github.com/openclaw/openclaw/pull/120843). Thanks @vincentkoc.
+- Find Slack QA presentations by exact message timestamp [#127300](https://github.com/openclaw/openclaw/pull/127300). Thanks @RomneyDa.
+- Require completed serving evidence in managed upgrade tests [#141663](https://github.com/openclaw/openclaw/pull/141663)
+- Set explicit permissions for Doctor test state [#141672](https://github.com/openclaw/openclaw/pull/141672)
+- Restore the resize observer after multi-select tests [#141673](https://github.com/openclaw/openclaw/pull/141673)
+- Synchronize containment tests with real process stops [#141681](https://github.com/openclaw/openclaw/pull/141681)
+- Preserve onboarding-test installation failure diagnostics [#141689](https://github.com/openclaw/openclaw/pull/141689). Thanks @vincentkoc and @RomneyDa.
+- Preserve Doctor-written configuration in secret-reference tests [#141768](https://github.com/openclaw/openclaw/pull/141768)
+- Complete manifest fixtures in capability-provider tests [#141855](https://github.com/openclaw/openclaw/pull/141855)
+- Isolate plugin artifact loader test fixtures [#141887](https://github.com/openclaw/openclaw/pull/141887)
+- Preserve inbound references on queued QA replies [#141905](https://github.com/openclaw/openclaw/pull/141905)
+- Align plugin install and removal QA expectations [#141964](https://github.com/openclaw/openclaw/pull/141964). Thanks @RomneyDa.
+- Prepare Docker images for sandbox QA [#141965](https://github.com/openclaw/openclaw/pull/141965). Thanks @RomneyDa.
+- Remove QA credentials through Gateway logout [#141974](https://github.com/openclaw/openclaw/pull/141974). Thanks @RomneyDa.
+- Align Claude QA fixture with session initialization [#141978](https://github.com/openclaw/openclaw/pull/141978). Thanks @RomneyDa.
+- Select compact progress for Slack draft QA [#141980](https://github.com/openclaw/openclaw/pull/141980). Thanks @RomneyDa.
+- Target Teams QA timeouts at message activities [#141985](https://github.com/openclaw/openclaw/pull/141985). Thanks @RomneyDa.
+- Drain heartbeat wakes before plugin test teardown [#142036](https://github.com/openclaw/openclaw/pull/142036)
+- Isolate keyless model tests from host credentials [#142049](https://github.com/openclaw/openclaw/pull/142049)
+- Finish mock-provider continuations after settled work [#142060](https://github.com/openclaw/openclaw/pull/142060). Thanks @RomneyDa.
+- Remove port-reuse races from probe tests [#142088](https://github.com/openclaw/openclaw/pull/142088). Thanks @RomneyDa.
+- Correct core session status in browser fixtures [#142097](https://github.com/openclaw/openclaw/pull/142097)
+- Isolate fresh mock write scenarios from earlier completions [#142137](https://github.com/openclaw/openclaw/pull/142137)
+- Isolate mocked Chromium selection from host settings [#142150](https://github.com/openclaw/openclaw/pull/142150)
+- Use system Bash in installer tests [#142161](https://github.com/openclaw/openclaw/pull/142161)
+- Keep canonical integration fixtures on source plugins [#142171](https://github.com/openclaw/openclaw/pull/142171)
+- Wait for audio transcript completion in Gateway tests [#142178](https://github.com/openclaw/openclaw/pull/142178)
+- Wait for triage test processes before deleting fixtures [#142215](https://github.com/openclaw/openclaw/pull/142215)
+- Prepare provider runtimes before Telegram sticker tests [#142234](https://github.com/openclaw/openclaw/pull/142234)
+- Align auth and Workshop QA with current runtime behavior [#142280](https://github.com/openclaw/openclaw/pull/142280)
+- Avoid unnecessary provider discovery in sticker tests [#142281](https://github.com/openclaw/openclaw/pull/142281)
+- Finish Activity test imports before teardown [#142282](https://github.com/openclaw/openclaw/pull/142282)
+- Wait for Gateway event-log test cleanup [#142314](https://github.com/openclaw/openclaw/pull/142314)
+- Wait for startup completion in first-run recovery tests [#142339](https://github.com/openclaw/openclaw/pull/142339). Thanks @vyctorbrzezowski.
+- Keep upgrade-test registry helpers on the same version [#142353](https://github.com/openclaw/openclaw/pull/142353). Thanks @RomneyDa.
+- Refresh Telegram QA button lookup after menu edits [#142473](https://github.com/openclaw/openclaw/pull/142473)
+- Stabilize Windows Claude CLI test fixtures [#142520](https://github.com/openclaw/openclaw/pull/142520). Thanks @vincentkoc.
+- Recognize unavailable upstream models in live tests [#142561](https://github.com/openclaw/openclaw/pull/142561). Thanks @RomneyDa.
+- Show nested onboarding failures in validation logs [#142645](https://github.com/openclaw/openclaw/pull/142645). Thanks @vincentkoc.
+- Wait for settled attachment test geometry [#142728](https://github.com/openclaw/openclaw/pull/142728)
+- Stabilize Android image-decoding tests on Linux [#142752](https://github.com/openclaw/openclaw/pull/142752). Thanks @vincentkoc.
+- Synchronize cloud-worker settings browser tests [#142763](https://github.com/openclaw/openclaw/pull/142763)
+- Wait for Signal delivery completion in tests [#142775](https://github.com/openclaw/openclaw/pull/142775). Thanks @vincentkoc.
+- Exercise same-version candidates in upgrade tests [#142811](https://github.com/openclaw/openclaw/pull/142811)
+- Run packaged QA commands with the selected candidate [#142925](https://github.com/openclaw/openclaw/pull/142925). Thanks @vincentkoc.
+- Close reloaded database caches in token tests [#142978](https://github.com/openclaw/openclaw/pull/142978)
+- Isolate managed-update tests from host system services [#143013](https://github.com/openclaw/openclaw/pull/143013). Thanks @vincentkoc.
+- Close Gateway test databases across module resets [#143045](https://github.com/openclaw/openclaw/pull/143045)
+- Close skill-upload test databases during cleanup [#143071](https://github.com/openclaw/openclaw/pull/143071)
+- Stabilize Gateway compaction race test synchronization [#143072](https://github.com/openclaw/openclaw/pull/143072)
+- Prepare Gateway test startup and preserve Cron cleanup errors [#143102](https://github.com/openclaw/openclaw/pull/143102). Thanks @vincentkoc.
+- Measure attachment layout within one browser frame [#143103](https://github.com/openclaw/openclaw/pull/143103)
+- Wait for socket closure before stream-test cleanup finishes [#143133](https://github.com/openclaw/openclaw/pull/143133)
+- Allow more startup time for systemd test fixtures [#143134](https://github.com/openclaw/openclaw/pull/143134). Thanks @vincentkoc.
+- Isolate the Gateway prewarm test repository [#143161](https://github.com/openclaw/openclaw/pull/143161)
+- Close paired-device test databases before deleting files [#143168](https://github.com/openclaw/openclaw/pull/143168)
+- Clean up chat preview listeners in UI tests [#143191](https://github.com/openclaw/openclaw/pull/143191)
+- Prevent stale connections in Telegram model callback tests [#143197](https://github.com/openclaw/openclaw/pull/143197)
+- Isolate Windows media file-URL test providers [#143213](https://github.com/openclaw/openclaw/pull/143213)
+- Avoid slow-startup failures in Matrix steering tests [#143249](https://github.com/openclaw/openclaw/pull/143249)
+- Isolate subagent announcement tests [#143251](https://github.com/openclaw/openclaw/pull/143251)
+- Stabilize Doctor source-isolation tests on tmpfs [#143258](https://github.com/openclaw/openclaw/pull/143258)
+- Restore empty-transcript compaction coverage [#143317](https://github.com/openclaw/openclaw/pull/143317)
+- Allow subpixel rounding in attachment layout tests [#143333](https://github.com/openclaw/openclaw/pull/143333). Thanks @vincentkoc.
+- Close Control UI test databases before cleanup [#143398](https://github.com/openclaw/openclaw/pull/143398)
+- Close pairing test databases before cleanup [#143401](https://github.com/openclaw/openclaw/pull/143401)
+- Close token-store test databases before cleanup [#143409](https://github.com/openclaw/openclaw/pull/143409)
+- Close node-pairing test databases before cleanup [#143418](https://github.com/openclaw/openclaw/pull/143418)
+- Complete bundled plugin directory test mock [#143444](https://github.com/openclaw/openclaw/pull/143444). Thanks @RomneyDa.
+- Synchronize model catalog browser tests [#143445](https://github.com/openclaw/openclaw/pull/143445). Thanks @RomneyDa.
+- Allow Chrome tab indexing time in extension tests [#143447](https://github.com/openclaw/openclaw/pull/143447). Thanks @RomneyDa.
+- Recognize expected MCP resolver test diagnostics [#143450](https://github.com/openclaw/openclaw/pull/143450). Thanks @RomneyDa.
+- Isolate announcement test dependencies [#143465](https://github.com/openclaw/openclaw/pull/143465). Thanks @vincentkoc.
+- Recognize Slack card progress in QA checks [#143562](https://github.com/openclaw/openclaw/pull/143562). Thanks @RomneyDa.
+- Correct Telegram QA receipt and preview expectations [#143563](https://github.com/openclaw/openclaw/pull/143563). Thanks @RomneyDa.
+- Run repository CLI health scenarios exclusively [#143564](https://github.com/openclaw/openclaw/pull/143564). Thanks @RomneyDa.
+- Correct package uninstall assertions [#143565](https://github.com/openclaw/openclaw/pull/143565). Thanks @RomneyDa.
+- Accept intentional memory preparation diagnostics in QA [#143570](https://github.com/openclaw/openclaw/pull/143570). Thanks @RomneyDa.
+- Coordinate Matrix QA progress with command completion [#143573](https://github.com/openclaw/openclaw/pull/143573). Thanks @RomneyDa.
+- Isolate CLI announcement checks and await transcript replies [#143576](https://github.com/openclaw/openclaw/pull/143576). Thanks @RomneyDa.
+- Bundle Telegram QA evidence helpers [#143582](https://github.com/openclaw/openclaw/pull/143582). Thanks @RomneyDa.
+- Isolate Codex auth-refresh integration providers [#143585](https://github.com/openclaw/openclaw/pull/143585)
+- Close heartbeat test databases before fixture deletion [#143606](https://github.com/openclaw/openclaw/pull/143606)
+- Repair worker setup browser fixtures [#143666](https://github.com/openclaw/openclaw/pull/143666)
+- Align QA Lab OpenAI defaults with canonical model IDs [#143674](https://github.com/openclaw/openclaw/pull/143674)
+- Correct Discord transcript provider assertions [#143689](https://github.com/openclaw/openclaw/pull/143689). Thanks @RomneyDa.
+- Refresh model catalogs before ClawRouter assertions [#143692](https://github.com/openclaw/openclaw/pull/143692). Thanks @RomneyDa.
+- Align timeout tests with direct Claude CLI execution [#143696](https://github.com/openclaw/openclaw/pull/143696). Thanks @RomneyDa.
+- Correct Telegram model-picker recovery tests [#143704](https://github.com/openclaw/openclaw/pull/143704). Thanks @RomneyDa.
+- Wait for updater process-group cleanup in tests [#143705](https://github.com/openclaw/openclaw/pull/143705)
+- Stabilize concurrent ClawHub catalog assertions [#143710](https://github.com/openclaw/openclaw/pull/143710)
+- Consolidate config environments and isolate Doctor fixtures [#143762](https://github.com/openclaw/openclaw/pull/143762)
+- Close CLI test databases before fixture deletion [#143782](https://github.com/openclaw/openclaw/pull/143782)
+- Close Watch HTTP test databases before fixture deletion [#143793](https://github.com/openclaw/openclaw/pull/143793)
+- Serialize database test worker shutdown [#143813](https://github.com/openclaw/openclaw/pull/143813)
+- Wait for final history placeholder styles in browser tests [#143824](https://github.com/openclaw/openclaw/pull/143824)
+- Isolate legacy handoff fixtures [#143875](https://github.com/openclaw/openclaw/pull/143875)
+- Restore config drainage test collection [#143913](https://github.com/openclaw/openclaw/pull/143913)
+- Isolate Doctor runtime fixtures [#143919](https://github.com/openclaw/openclaw/pull/143919)
+- Keep hardlink fixtures on one filesystem [#143945](https://github.com/openclaw/openclaw/pull/143945)
+- Drain transcript indexing before test cleanup [#143964](https://github.com/openclaw/openclaw/pull/143964)
+- Align dependency-locking navigation tests [#144002](https://github.com/openclaw/openclaw/pull/144002)
+- Stabilize Telegram replacement-session tests [#144049](https://github.com/openclaw/openclaw/pull/144049). Thanks @crash2kx.
+- Coordinate update-ledger test shutdown [#144054](https://github.com/openclaw/openclaw/pull/144054)
+- Restore complete navigation regression guards [#144075](https://github.com/openclaw/openclaw/pull/144075)
+- Drain session fixtures before state removal [#144087](https://github.com/openclaw/openclaw/pull/144087)
+- Isolate npm-only Featured test inputs [#144092](https://github.com/openclaw/openclaw/pull/144092)
+- Keep Pi rename fixtures on one filesystem [#144096](https://github.com/openclaw/openclaw/pull/144096)
+- Isolate reset tests from ambient heartbeats [#144108](https://github.com/openclaw/openclaw/pull/144108)
+
+</details>
+
+</Accordion>
+
+<Accordion title="CI and performance assessment">
+
+CI skips unrelated jobs for isolated test changes and keeps timing estimates tied to the tests they describe. Performance assessment corrects process discovery, CPU accounting, and historical-release calibration. Build prerequisites and language-bundle checks also receive fixes, including checks for each language's budget and a single deferred bundle per language.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+The later historical 2026.7.33 evaluator pin restores its 250% status allowance alongside the accounting fixes. Successful live qualification with that pin is not established here. CPU measurements whose uncertainty crosses a limit remain blocked. The CodeQL follow-up repairs the earlier hosted-runner timeout path; these scanning changes are not vulnerability fixes.
+
+**Improvements**
+
+- Add opt-in runtime memory attribution to CLI benchmarks [#127746](https://github.com/openclaw/openclaw/pull/127746). Thanks @vincentkoc.
+- Reuse verified runner archives and handle CI inventory growth [#140680](https://github.com/openclaw/openclaw/pull/140680). Thanks @vincentkoc.
+- Move macOS CodeQL to GitHub-hosted runners [#141761](https://github.com/openclaw/openclaw/pull/141761). Thanks @vincentkoc.
+- Advance the historical evaluator before its calibration correction [#142058](https://github.com/openclaw/openclaw/pull/142058). Thanks @RomneyDa.
+- Skip unrelated upgrade checks for test-only changes [#142154](https://github.com/openclaw/openclaw/pull/142154)
+- Skip unrelated UI E2E jobs for isolated unit-test changes [#142350](https://github.com/openclaw/openclaw/pull/142350)
+- Move TUI test typechecking into the command shard [#142385](https://github.com/openclaw/openclaw/pull/142385)
+- Reuse prerequisite decisions in CI test planning [#142630](https://github.com/openclaw/openclaw/pull/142630)
+- Reuse verified Bun archives in Linux CI [#142849](https://github.com/openclaw/openclaw/pull/142849). Thanks @vincentkoc.
+- Reuse Android build timestamps across CI tests and lint [#143207](https://github.com/openclaw/openclaw/pull/143207)
+
+**Bug fixes**
+
+- Update the evaluator for late-discovered processes [#141675](https://github.com/openclaw/openclaw/pull/141675). Thanks @RomneyDa.
+- Provision ripgrep for filesystem contract tests [#141794](https://github.com/openclaw/openclaw/pull/141794)
+- Let macOS security scans finish within hosted runner limits [#141851](https://github.com/openclaw/openclaw/pull/141851). Thanks @vincentkoc.
+- Preserve heap settings across scorecard builds [#141915](https://github.com/openclaw/openclaw/pull/141915). Thanks @RomneyDa.
+- Scope historical status CPU allowance to July release [#141935](https://github.com/openclaw/openclaw/pull/141935). Thanks @RomneyDa.
+- Update performance evaluator CPU measurement pin [#142053](https://github.com/openclaw/openclaw/pull/142053). Thanks @RomneyDa.
+- Update Gateway startup CPU accounting [#142085](https://github.com/openclaw/openclaw/pull/142085). Thanks @RomneyDa.
+- Update performance evaluator startup discovery [#142104](https://github.com/openclaw/openclaw/pull/142104). Thanks @RomneyDa.
+- Retry failed performance artifact uploads once [#142344](https://github.com/openclaw/openclaw/pull/142344). Thanks @RomneyDa.
+- Correct the historical 2026.7.33 Kova benchmark pin [#142348](https://github.com/openclaw/openclaw/pull/142348). Thanks @RomneyDa.
+- Bound TypeScript preflight resources on constrained CI [#142472](https://github.com/openclaw/openclaw/pull/142472). Thanks @RomneyDa.
+- Use corrected release CPU calibration [#142537](https://github.com/openclaw/openclaw/pull/142537). Thanks @RomneyDa.
+- Retain test timing estimates across inventory changes [#142719](https://github.com/openclaw/openclaw/pull/142719). Thanks @RomneyDa and @vincentkoc.
+- Reject stale or unusable CI timing samples [#143182](https://github.com/openclaw/openclaw/pull/143182). Thanks @vincentkoc.
+- Budget deferred translation catalogs separately in CI [#143219](https://github.com/openclaw/openclaw/pull/143219). Thanks @vincentkoc.
+- Enforce one deferred bundle per language [#143297](https://github.com/openclaw/openclaw/pull/143297). Thanks @vincentkoc.
+- Preserve timing identities for expanded test chunks [#143639](https://github.com/openclaw/openclaw/pull/143639)
+- Correct CPU measurement bounds in release validation [#143808](https://github.com/openclaw/openclaw/pull/143808)
+- Install search test prerequisites [#143835](https://github.com/openclaw/openclaw/pull/143835). Thanks @fuller-stack-dev.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Build and package verification">
+
+Package checks trace dependency ownership through built plugin chunks and use the selected source's companion manifests during preparation. Other fixes cover nested optional dependencies, Bun built-ins, and Markdown guides that belong in shipped packages. These changes help maintainers check complete artifacts without mistaking legitimate package contents for missing or unexpected dependencies.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+Preparation uses the frozen source manifests where required; installed-package verification retains its own manifest checks. These changes do not by themselves establish that packages were published or are available in an installed release.
+
+**Improvements**
+
+- Use pnpm's override parser in npm lock generation [#141862](https://github.com/openclaw/openclaw/pull/141862). Thanks @RomneyDa.
+- Simplify package import scanning [#142859](https://github.com/openclaw/openclaw/pull/142859). Thanks @vincentkoc.
+- Simplify package dependency path resolution [#143063](https://github.com/openclaw/openclaw/pull/143063)
+
+**Bug fixes**
+
+- Recognize extension-owned package dependencies [#141647](https://github.com/openclaw/openclaw/pull/141647). Thanks @RomneyDa.
+- Preserve version comparisons in npm dependency evidence [#141800](https://github.com/openclaw/openclaw/pull/141800). Thanks @RomneyDa.
+- Verify dependency ownership for built plugin chunks [#141876](https://github.com/openclaw/openclaw/pull/141876). Thanks @RomneyDa.
+- Use source companion manifests in package verification [#142033](https://github.com/openclaw/openclaw/pull/142033). Thanks @RomneyDa.
+- Handle nested optional plugin dependencies [#142126](https://github.com/openclaw/openclaw/pull/142126)
+- Initialize ClawHub bootstrap packaging dependencies [#142191](https://github.com/openclaw/openclaw/pull/142191)
+- Recognize Bun built-ins in package checks [#143436](https://github.com/openclaw/openclaw/pull/143436). Thanks @RomneyDa.
+- Allow shipped Markdown guides in npm checks [#143699](https://github.com/openclaw/openclaw/pull/143699)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Release preparation and recovery tooling">
+
+Release tooling prepares package artifacts before publication, retains dispatch requests after lost responses, and makes partial publication results easier to inspect. Recovery checks can reconcile separately completed npm and Docker runs. Verification also detects selected packages whose beta tag trails stable, with manual repair still required.
+
+Historical-release tests use the selected source's capabilities and matching helpers, with explicit omissions for unsupported default scenarios. The committed-source readers require Git 2.45 or newer, and the bundle resolver also needs the trusted TypeScript parser. Standalone preflight checks include the repaired Docker aliases; workflow-wide enforcement remains separate. Mobile release work adds signing preparation, Ubuntu KVM emulator support, and diagnostic capture, without establishing complete screenshot, signing, or upload success.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+A recovered dispatch or collected publication status is an observation, not a passed validation or permission to publish. Expired dispatch witnesses can leave recovery unresolved, and separate hosts are not globally deduplicated. Omitted historical scenarios are not passed tests. Bun installation checks retain Bun when its probe succeeds and select Node only for the recognized Bun/node:sqlite rejection; other failures remain errors. Requested diagnostic maturity scorecards may be published before the workflow reports failed or blocked results. Prior-release pages and version metadata below remain historical records.
+
+**Improvements**
+
+- Prepare package artifacts before release publication [#136466](https://github.com/openclaw/openclaw/pull/136466). Thanks @vincentkoc.
+- Add the Node smoke path later replaced by runtime selection [#142034](https://github.com/openclaw/openclaw/pull/142034). Thanks @RomneyDa.
+- Add published 2026.9.3 to the Mac update feed [#142235](https://github.com/openclaw/openclaw/pull/142235)
+- Align main with published 2026.9.3 metadata [#142240](https://github.com/openclaw/openclaw/pull/142240)
+- Match default Telegram package tests to frozen source capabilities [#142378](https://github.com/openclaw/openclaw/pull/142378). Thanks @RomneyDa.
+- Add a manual Android emulator diagnostic [#142780](https://github.com/openclaw/openclaw/pull/142780). Thanks @vincentkoc.
+- Capture emulator boot diagnostics [#142809](https://github.com/openclaw/openclaw/pull/142809). Thanks @vincentkoc.
+- Retain diagnostics after emulator readiness timeout [#142835](https://github.com/openclaw/openclaw/pull/142835). Thanks @vincentkoc.
+- Complete emulator cold-boot diagnostics [#142891](https://github.com/openclaw/openclaw/pull/142891). Thanks @vincentkoc.
+- Recover release-validation dispatches after lost responses [#142927](https://github.com/openclaw/openclaw/pull/142927). Thanks @vincentkoc.
+- Move Android emulator workflows to Ubuntu KVM [#142979](https://github.com/openclaw/openclaw/pull/142979). Thanks @vincentkoc.
+- Show publication observations alongside release validation status [#143171](https://github.com/openclaw/openclaw/pull/143171). Thanks @vincentkoc.
+- Reject releases with beta tags older than stable [#143669](https://github.com/openclaw/openclaw/pull/143669)
+- Validate frozen release targets from committed source [#144023](https://github.com/openclaw/openclaw/pull/144023). Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Use established session tests for historical Node checks [#141640](https://github.com/openclaw/openclaw/pull/141640). Thanks @RomneyDa.
+- Accept opted-in historical same-version updater results [#141652](https://github.com/openclaw/openclaw/pull/141652). Thanks @RomneyDa.
+- Correct release source checks and upgrade-test selection [#141746](https://github.com/openclaw/openclaw/pull/141746)
+- Validate frozen releases with their shipped scenarios [#141774](https://github.com/openclaw/openclaw/pull/141774). Thanks @RomneyDa.
+- Preserve frozen-release Gateway test client imports [#141814](https://github.com/openclaw/openclaw/pull/141814). Thanks @RomneyDa.
+- Place frozen-release test clients beside installed dependencies [#141827](https://github.com/openclaw/openclaw/pull/141827). Thanks @RomneyDa.
+- Install dependencies for the trusted native live-test harness [#141829](https://github.com/openclaw/openclaw/pull/141829). Thanks @RomneyDa.
+- Fetch release-candidate history through its canonical branch [#141840](https://github.com/openclaw/openclaw/pull/141840). Thanks @RomneyDa.
+- Recognize the July filesystem validation contract [#141892](https://github.com/openclaw/openclaw/pull/141892). Thanks @RomneyDa.
+- Keep historical Docker validation scenarios consistent [#141893](https://github.com/openclaw/openclaw/pull/141893). Thanks @RomneyDa.
+- Add maturity-result completeness checks [#141931](https://github.com/openclaw/openclaw/pull/141931). Thanks @RomneyDa.
+- Repair Gateway release-test capacity and scenario selection [#141954](https://github.com/openclaw/openclaw/pull/141954)
+- Keep frozen upgrade tests with matching helpers [#142007](https://github.com/openclaw/openclaw/pull/142007). Thanks @RomneyDa.
+- Record authorized unsupported Docker lanes as no-ops [#142020](https://github.com/openclaw/openclaw/pull/142020). Thanks @RomneyDa.
+- Publish diagnostic scorecards before reporting QA failure [#142040](https://github.com/openclaw/openclaw/pull/142040). Thanks @RomneyDa.
+- Use trusted tooling for preflight plugin plans [#142055](https://github.com/openclaw/openclaw/pull/142055). Thanks @RomneyDa.
+- Omit unsupported historical corrupt-plugin checks [#142061](https://github.com/openclaw/openclaw/pull/142061). Thanks @RomneyDa.
+- Bound ClawHub ancestry verification responses [#142072](https://github.com/openclaw/openclaw/pull/142072). Thanks @vincentkoc.
+- Install trusted tooling dependencies for plugin previews [#142103](https://github.com/openclaw/openclaw/pull/142103)
+- Keep release helpers from dirtying mobile source checks [#142115](https://github.com/openclaw/openclaw/pull/142115). Thanks @vincentkoc.
+- Keep Docker approval waits outside the publication queue [#142250](https://github.com/openclaw/openclaw/pull/142250)
+- Keep changelog credit within verified release history [#142261](https://github.com/openclaw/openclaw/pull/142261). Thanks @vincentkoc.
+- Keep Docker upgrade tests on an older starting version [#142273](https://github.com/openclaw/openclaw/pull/142273)
+- Verify closeout after separate npm and Docker recovery runs [#142291](https://github.com/openclaw/openclaw/pull/142291)
+- Restore Sparkle build-number output from symlinked checkouts [#142315](https://github.com/openclaw/openclaw/pull/142315)
+- Handle large tooling archives during mobile beta authorization [#142360](https://github.com/openclaw/openclaw/pull/142360). Thanks @vincentkoc.
+- Restore Bun execution in installation smoke checks [#142428](https://github.com/openclaw/openclaw/pull/142428). Thanks @RomneyDa.
+- Supply the release Node version to frozen installer tests [#142431](https://github.com/openclaw/openclaw/pull/142431). Thanks @RomneyDa.
+- Keep mobile beta authorization valid as main advances [#142432](https://github.com/openclaw/openclaw/pull/142432). Thanks @vincentkoc.
+- Repair helper loading for historical upgrade checks [#142441](https://github.com/openclaw/openclaw/pull/142441). Thanks @RomneyDa.
+- Align frozen 2026.7.33 Docker validation [#142456](https://github.com/openclaw/openclaw/pull/142456). Thanks @RomneyDa.
+- Match frozen onboarding tests to release helpers [#142467](https://github.com/openclaw/openclaw/pull/142467). Thanks @RomneyDa.
+- Record the reviewed Codex test scan finding [#142474](https://github.com/openclaw/openclaw/pull/142474). Thanks @vincentkoc.
+- Set mobile beta screenshot prerequisites [#142523](https://github.com/openclaw/openclaw/pull/142523). Thanks @vincentkoc.
+- Match ClawHub fixture requests to frozen candidates [#142551](https://github.com/openclaw/openclaw/pull/142551). Thanks @RomneyDa.
+- Forward release Node version to Rocky installer probes [#142562](https://github.com/openclaw/openclaw/pull/142562). Thanks @RomneyDa.
+- Select a supported runtime for Bun install checks [#142563](https://github.com/openclaw/openclaw/pull/142563). Thanks @RomneyDa.
+- Repair frozen-package update validation fixtures [#142573](https://github.com/openclaw/openclaw/pull/142573). Thanks @RomneyDa.
+- Fetch release ancestry branches independently [#142643](https://github.com/openclaw/openclaw/pull/142643). Thanks @RomneyDa.
+- Derive frozen-release expectations from selected source [#142683](https://github.com/openclaw/openclaw/pull/142683). Thanks @RomneyDa.
+- Preserve Git selection in frozen-release tests [#142686](https://github.com/openclaw/openclaw/pull/142686). Thanks @RomneyDa.
+- Match frozen-package Telegram tests to supported scenarios [#142687](https://github.com/openclaw/openclaw/pull/142687). Thanks @RomneyDa.
+- Correct frozen dirty-checkout exit expectations [#142727](https://github.com/openclaw/openclaw/pull/142727). Thanks @RomneyDa.
+- Qualify Telegram progress tests against frozen source [#142731](https://github.com/openclaw/openclaw/pull/142731). Thanks @RomneyDa.
+- Prepare Watch Rust tools for iOS beta builds [#142762](https://github.com/openclaw/openclaw/pull/142762). Thanks @vincentkoc.
+- Isolate iOS release signing keys [#142846](https://github.com/openclaw/openclaw/pull/142846). Thanks @vincentkoc.
+- Identify incompatible release-validation evidence [#142906](https://github.com/openclaw/openclaw/pull/142906). Thanks @vincentkoc.
+- Check image size limits before Vercel copying [#142908](https://github.com/openclaw/openclaw/pull/142908). Thanks @vincentkoc.
+- Match frozen bundle validation clients to source [#142926](https://github.com/openclaw/openclaw/pull/142926). Thanks @vincentkoc.
+- Stop frozen checks on committed-source read errors [#142930](https://github.com/openclaw/openclaw/pull/142930). Thanks @vincentkoc.
+- Isolate frozen-suite compatibility checks [#142935](https://github.com/openclaw/openclaw/pull/142935). Thanks @vincentkoc.
+- Accept native iOS signing keychain filenames [#142968](https://github.com/openclaw/openclaw/pull/142968). Thanks @vincentkoc.
+- Preserve the iOS signing tool environment [#143301](https://github.com/openclaw/openclaw/pull/143301). Thanks @vincentkoc.
+- Match validation runs with omitted empty inputs [#143421](https://github.com/openclaw/openclaw/pull/143421). Thanks @RomneyDa.
+- Include required plugins in candidate preparation [#143452](https://github.com/openclaw/openclaw/pull/143452). Thanks @RomneyDa.
+- Validate Anthropic cache behavior against candidate capabilities [#143508](https://github.com/openclaw/openclaw/pull/143508). Thanks @RomneyDa.
+- Match Telegram release checks to package source [#143510](https://github.com/openclaw/openclaw/pull/143510). Thanks @RomneyDa.
+- Exclude unpublished same-version upgrade baselines [#143567](https://github.com/openclaw/openclaw/pull/143567). Thanks @RomneyDa.
+- Use published plugins for correction-version upgrade baselines [#143681](https://github.com/openclaw/openclaw/pull/143681)
+- Register the 2026.9.4 plugin scan policy [#143807](https://github.com/openclaw/openclaw/pull/143807)
+- Load older candidates in Anthropic cache checks [#143810](https://github.com/openclaw/openclaw/pull/143810). Thanks @RomneyDa.
+- Match Telegram queue validation to candidate capabilities [#143811](https://github.com/openclaw/openclaw/pull/143811). Thanks @RomneyDa.
+- Validate contracts for omitted Docker test aliases [#144129](https://github.com/openclaw/openclaw/pull/144129). Thanks @vincentkoc.
+
+**Documentation**
+
+- Refresh release summaries and contribution records [685ae1b0](https://github.com/openclaw/openclaw/commit/685ae1b0c81ca9dec95e3c10f3d4b4ffffe69d46)
+- Add the 2026.9.4 changelog section [dd178db5](https://github.com/openclaw/openclaw/commit/dd178db54d088b3ee251f5e99e4081bad0f8fc51)
+- Document qualification with final release notes already committed [#141786](https://github.com/openclaw/openclaw/pull/141786)
+- Add the v2026.9.3 release documentation page [#142277](https://github.com/openclaw/openclaw/pull/142277). Thanks @hannesrudolph.
+- Align v2026.9.3 release-page framing with its announcement [#142307](https://github.com/openclaw/openclaw/pull/142307). Thanks @hannesrudolph.
+- Align release validation guidance with notes preparation [#142328](https://github.com/openclaw/openclaw/pull/142328)
+- Temporarily rename the v2026.9.3 statistics label [#142437](https://github.com/openclaw/openclaw/pull/142437). Thanks @hannesrudolph.
+- Correct ClawHub release-verification instructions [#142458](https://github.com/openclaw/openclaw/pull/142458)
+- Correct extended-stable validation instructions [#142538](https://github.com/openclaw/openclaw/pull/142538). Thanks @RomneyDa.
+- Restore the v2026.9.3 statistics label [#142541](https://github.com/openclaw/openclaw/pull/142541). Thanks @hannesrudolph.
+- Organize release validation guidance by task [#142774](https://github.com/openclaw/openclaw/pull/142774). Thanks @vincentkoc.
+- Split release-validation documentation into focused guides [#143163](https://github.com/openclaw/openclaw/pull/143163). Thanks @vincentkoc.
+- Use HTTP liveness for unauthenticated release checks [#143709](https://github.com/openclaw/openclaw/pull/143709). Thanks @vincentkoc.
+- Record landed repairs and contributor credit [#144440](https://github.com/openclaw/openclaw/pull/144440). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Contributor tools and documentation">
+
+Source contributors get consistent local test scheduling, fewer unnecessary compiler and build starts, and earlier unused-export feedback. Testing and CI guides are organized by task, while documentation tools preserve fenced examples and report the correct source lines. Source checkouts need owned dependencies or an explicitly configured dependency location when dependencies are missing; normal installs refuse borrowed checkout roots.
+
+Documentation publishing reuses matching successful checks and validates the final rebased content before each push attempt. Translation tooling can refresh selected entries while preserving unselected aliases, and generated translation records receive maintenance updates.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+The dependency-install guard is bypassed when lifecycle scripts are disabled and does not lock against concurrent path replacement. Unix development runners preserve interruption signals; detached workers may still need cleanup, and Windows retains its existing handling. Tool-specific measurements do not establish faster model responses or total publication times. Generated translation records and maturity snapshots do not establish new languages, visible app changes, or blanket readiness.
+
+**Improvements**
+
+- Reuse UTF-8 truncation in SDK change reports [#141660](https://github.com/openclaw/openclaw/pull/141660)
+- Remove unused QA script test accessors [#141751](https://github.com/openclaw/openclaw/pull/141751)
+- Run package contract tests without unrelated runtime builds [#142159](https://github.com/openclaw/openclaw/pull/142159)
+- Preserve human credit in squash merge messages [#142167](https://github.com/openclaw/openclaw/pull/142167)
+- Add tooling for captioned and zoomed PR videos without audio [#142259](https://github.com/openclaw/openclaw/pull/142259)
+- Refresh selected translations with native context and retained aliases [#142260](https://github.com/openclaw/openclaw/pull/142260)
+- Load the compiler only when development checks need it [#142338](https://github.com/openclaw/openclaw/pull/142338)
+- Remove unused update-triage result metadata [#142345](https://github.com/openclaw/openclaw/pull/142345). Thanks @vincentkoc.
+- Reduce documentation sync source downloads [#142400](https://github.com/openclaw/openclaw/pull/142400). Thanks @hannesrudolph.
+- Remove obsolete people-loading translation data [#142420](https://github.com/openclaw/openclaw/pull/142420)
+- Combine duplicate architecture-checker scans [#142451](https://github.com/openclaw/openclaw/pull/142451)
+- Reuse documentation checks and validate after rebase [#142475](https://github.com/openclaw/openclaw/pull/142475). Thanks @hannesrudolph.
+- Reduce repeated lint startup for larger changes [#142691](https://github.com/openclaw/openclaw/pull/142691)
+- Synchronize a screenshot-fixture translation label [#142714](https://github.com/openclaw/openclaw/pull/142714)
+- Consolidate QA Lab YAML validation diagnostics [#143016](https://github.com/openclaw/openclaw/pull/143016). Thanks @vincentkoc.
+- Route session-history HTTP tests without full build prerequisites [#143096](https://github.com/openclaw/openclaw/pull/143096). Thanks @vincentkoc.
+- Remove unused global documentation audit indexes [#143164](https://github.com/openclaw/openclaw/pull/143164)
+- Reuse numeric flag parsing in performance tests [#143237](https://github.com/openclaw/openclaw/pull/143237)
+- Clarify CI watcher progress and timeout output [#143320](https://github.com/openclaw/openclaw/pull/143320)
+- Avoid repeated SDK export traversal [#143393](https://github.com/openclaw/openclaw/pull/143393)
+- Skip unnecessary SDK guard parsing [#143513](https://github.com/openclaw/openclaw/pull/143513). Thanks @RomneyDa.
+- Share task audit summary counting [#143682](https://github.com/openclaw/openclaw/pull/143682). Thanks @vincentkoc.
+- Share dead-code scan orchestration [#143745](https://github.com/openclaw/openclaw/pull/143745). Thanks @vincentkoc.
+- Refresh translation records for Skills screens [#143806](https://github.com/openclaw/openclaw/pull/143806)
+- Refresh snapshot translation records [#143914](https://github.com/openclaw/openclaw/pull/143914)
+- Reuse plugin metadata during docs generation [#144120](https://github.com/openclaw/openclaw/pull/144120)
+
+**Bug fixes**
+
+- Keep local test worker counts consistent across projects [#141716](https://github.com/openclaw/openclaw/pull/141716)
+- Prevent source installs from modifying another checkout's dependencies [#141719](https://github.com/openclaw/openclaw/pull/141719)
+- Label pull requests editing split documentation pages [#142677](https://github.com/openclaw/openclaw/pull/142677). Thanks @vincentkoc.
+- Extend plugin documentation label coverage [#142735](https://github.com/openclaw/openclaw/pull/142735). Thanks @vincentkoc.
+- Track shared native-translation inputs [#142786](https://github.com/openclaw/openclaw/pull/142786). Thanks @vincentkoc.
+- Distinguish declared ClawHub routes from unverified headings in audits [#143002](https://github.com/openclaw/openclaw/pull/143002). Thanks @vincentkoc.
+- Allow the approved historical pnpm pin in isolated checks [#143129](https://github.com/openclaw/openclaw/pull/143129). Thanks @vincentkoc.
+- Audit unused exports after script and root-test changes [#143268](https://github.com/openclaw/openclaw/pull/143268)
+- Preserve fenced examples during documentation formatting [#143394](https://github.com/openclaw/openclaw/pull/143394)
+- Report original source lines in documentation errors [#143404](https://github.com/openclaw/openclaw/pull/143404)
+- Detect overdue documentation during steady edits [#143455](https://github.com/openclaw/openclaw/pull/143455)
+- Distinguish interrupted development runners from completed stops [#143676](https://github.com/openclaw/openclaw/pull/143676). Thanks @shakkernerd.
+- Recover locale imports after source errors [#143776](https://github.com/openclaw/openclaw/pull/143776)
+
+**Documentation**
+
+- Organize testing guidance by task [#141221](https://github.com/openclaw/openclaw/pull/141221). Thanks @vincentkoc.
+- Refresh maturity evidence and coverage reports [#141910](https://github.com/openclaw/openclaw/pull/141910)
+- Split testing guidance into focused pages [#141968](https://github.com/openclaw/openclaw/pull/141968). Thanks @vincentkoc.
+- Validate maturity documentation routes and anchors [#141977](https://github.com/openclaw/openclaw/pull/141977). Thanks @RomneyDa.
+- Refresh maturity scorecard evidence [#142114](https://github.com/openclaw/openclaw/pull/142114)
+- Split QA automation guidance into focused pages [#142426](https://github.com/openclaw/openclaw/pull/142426). Thanks @vincentkoc.
+- Link live-test filtering guidance to its current page [#142560](https://github.com/openclaw/openclaw/pull/142560). Thanks @vincentkoc.
+- Keep SDK alias removal pending review [#142708](https://github.com/openclaw/openclaw/pull/142708)
+- Keep routine repository output inline [#142946](https://github.com/openclaw/openclaw/pull/142946). Thanks @vincentkoc.
+- Organize live-testing documentation by test task [#143042](https://github.com/openclaw/openclaw/pull/143042). Thanks @vincentkoc.
+- Split CI routing guidance into focused pages [#143053](https://github.com/openclaw/openclaw/pull/143053). Thanks @vincentkoc.
+- Refresh CI and plugin validation guidance [#143287](https://github.com/openclaw/openclaw/pull/143287)
+- Document temporary defensive-work model routing [#143698](https://github.com/openclaw/openclaw/pull/143698)
+- Consolidate contributor guidance and subsystem ownership [#143785](https://github.com/openclaw/openclaw/pull/143785). Thanks @obviyus and @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reverted work retained in history">
+
+A conversation-rail spacing adjustment and its full rollback are both retained here. The pair leaves no surviving spacing change and does not remove the earlier compact left rail.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Record the reverted conversation rail spacing adjustment [#142667](https://github.com/openclaw/openclaw/pull/142667). Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Revert the canceled conversation rail spacing adjustment [#142684](https://github.com/openclaw/openclaw/pull/142684). Thanks @Patrick-Erichsen.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -11,6 +11,7 @@ changelog first.
 
 ## Releases
 
+- [v2026.9.4](/releases/2026.9.4) - Plugin and skill discovery, visible skill learning, cloud-worker controls, GPT Image 2.5, and terminal questions.
 - [v2026.9.3](/releases/2026.9.3) - Clean update recovery, faster session reconnects, live browser automation, revocable chat links, searchable meeting transcripts, and repository-backed cloud work. Also includes persistent Workshop skills, native Mac tabs, and provider account controls.
 - [v2026.9.2](/releases/2026.9.2) - Reliability and recovery improvements, OpenAI GPT-6 Astra and Meta Muse Spark 1.3 support, and flexible task workspaces.
 - [v2026.9.1](/releases/2026.9.1) - Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and lower overhead for long conversations and large installations.


### PR DESCRIPTION
Closes #144657

## What Problem This Solves

OpenClaw v2026.9.4 needs a reader-facing release page that explains the shipped changes without requiring readers to work through the complete contribution history.

## Why This Change Was Made

Add the detailed v2026.9.4 release notes and make them discoverable from the release archive and documentation navigation. The page uses the established product categories, topic accordions, and collapsed source and contributor lists.

This PR is for review. It does not change runtime code, rewrite CHANGELOG.md, or update the GitHub release body.

## User Impact

Readers can find the changes relevant to their setup, understand what they can do or expect, and expand the source lists for individual changes and contributor credit.

## Evidence

- The final v2026.9.4 tag peels to `3a9d69db306cd7f081e06254cb89c4bcc14a7107`, exactly matching the prepared evidence and analysis endpoint.
- Release membership comprises 1,558 pull requests and 20 direct commits relative to the v2026.9.3 release boundary.
- All 1,578 changes appear exactly once, with 293 contributors credited. The 692 maintainer-only changes are confined to the final internal section.
- The lead editor and a separate reviewer each read the complete candidate. Independent semantic review approved it for human review with no unresolved findings.
- Focused MDX validation passed. All 125 internal documentation links and anchors passed against the source docs.
- Repository autoreview returned scoped-clean at its default P0 threshold. Navigation entries and `git diff --check` passed.
- Runtime suites were not run for this documentation-only change. Production deployment is not part of this PR's validation.
