### PR TITLE
refactor(logbook): await storage and retain lifecycle work

### DIFF
--- a/docs/plugins/logbook.md
+++ b/docs/plugins/logbook.md
@@ -107,6 +107,10 @@ Day boundaries and timeline clocks use the Gateway's local timezone, not the
 browser's timezone. Frames and the SQLite timeline database live under
 `<state-dir>/logbook/`.
 
+Startup completes storage recovery and pruning before capture begins. Shutdown
+stops new work and waits for admitted database and model operations before closing
+storage.
+
 ## Model and data flow
 
 Logbook uses two separate model routes:

--- a/extensions/logbook/index.ts
+++ b/extensions/logbook/index.ts
@@ -70,11 +70,15 @@ export default definePluginEntry({
   register(api: OpenClawPluginApi) {
     const config = logbookConfigSchema.parse(api.pluginConfig);
     let service: LogbookService | null = null;
+    let opening: LogbookService | null = null;
+    let generation = 0;
     let stopping: Promise<void> | undefined;
     let retired = false;
     const stopService = () => {
-      const current = service;
+      generation++;
+      const current = service ?? opening;
       service = null;
+      opening = null;
       return (stopping ??= current?.stop());
     };
 
@@ -135,18 +139,38 @@ export default definePluginEntry({
 
     api.registerService({
       id: "logbook",
-      start: (ctx) => {
+      start: async (ctx) => {
         if (retired) {
           throw new Error("Logbook plugin runtime has been retired");
         }
+        const currentGeneration = ++generation;
+        await stopping;
+        if (retired || currentGeneration !== generation) {
+          return;
+        }
         stopping = undefined;
-        service = new LogbookService(config, {
+        const next = new LogbookService(config, {
           runtime: api.runtime,
           fullConfig: ctx.config,
           logger: ctx.logger,
           dataDir: path.join(ctx.stateDir, "logbook"),
         });
-        service.start();
+        opening = next;
+        try {
+          await next.start();
+          if (retired || currentGeneration !== generation) {
+            await next.stop();
+            return;
+          }
+          service = next;
+        } catch (error) {
+          await next.stop();
+          throw error;
+        } finally {
+          if (opening === next) {
+            opening = null;
+          }
+        }
       },
       stop: stopService,
     });
@@ -185,24 +209,26 @@ export default definePluginEntry({
 
     // Raw frame bytes are the most sensitive payload (full screen contents),
     // so they require write scope while derived text stays readable.
-    registerRead("logbook.days", () => ({ days: requireService().listDays() }));
+    registerRead("logbook.days", async () => ({ days: await requireService().listDays() }));
 
     registerRead("logbook.timeline", (params) =>
       requireService().timelineForDay(readDayParam(params)),
     );
 
-    registerWrite("logbook.frames", (params) => {
+    registerWrite("logbook.frames", async (params) => {
       const startMs = readNumberParam(params, "startMs");
       const endMs = readNumberParam(params, "endMs");
-      const frames = requireService()
-        .framesInRange(startMs, endMs)
-        .map((frame) => ({ id: frame.id, capturedAtMs: frame.capturedAtMs, idle: frame.idle }));
+      const frames = (await requireService().framesInRange(startMs, endMs)).map((frame) => ({
+        id: frame.id,
+        capturedAtMs: frame.capturedAtMs,
+        idle: frame.idle,
+      }));
       return { frames };
     });
 
-    registerWrite("logbook.frame", (params) => {
+    registerWrite("logbook.frame", async (params) => {
       const frameId = readNumberParam(params, "frameId");
-      const frame = requireService().frameById(frameId);
+      const frame = await requireService().frameById(frameId);
       if (!frame) {
         throw new Error(`frame ${frameId} not found`);
       }

--- a/extensions/logbook/src/card-reads.test.ts
+++ b/extensions/logbook/src/card-reads.test.ts
@@ -62,7 +62,7 @@ it("hydrates a timeline once and counts status without reading card payloads", a
     config: {},
     logger: { info() {}, warn() {}, error() {}, debug() {} },
   };
-  const store = new LogbookStore(path.join(stateDir, "logbook"));
+  const store = await LogbookStore.open(path.join(stateDir, "logbook"));
   const day = "2026-07-03";
   const startMs = new Date(`${day}T09:00:00`).getTime();
   const drafts = Array.from({ length: 8 }, (_, index) => ({
@@ -75,9 +75,9 @@ it("hydrates a timeline once and counts status without reading card payloads", a
     category: "coding",
     distractions: [{ startMs: startMs + 1, endMs: startMs + 11, title: "Break" }],
   }));
-  store.replaceCardsInWindow(day, 0, Number.MAX_SAFE_INTEGER, drafts);
-  const cards = store.cardsForDay(day);
-  store.close();
+  await store.replaceCardsInWindow(day, 0, Number.MAX_SAFE_INTEGER, drafts);
+  const cards = await store.cardsForDay(day);
+  await store.close();
 
   plugin.register({
     pluginConfig: { captureEnabled: false },

--- a/extensions/logbook/src/observation-reads.test.ts
+++ b/extensions/logbook/src/observation-reads.test.ts
@@ -56,14 +56,14 @@ it.each([0, 199, 200, 201])(
     vi.setSystemTime(new Date("2026-07-03T12:00:00"));
     const dataDir = mkdtempSync(path.join(tmpdir(), "logbook-observation-reads-"));
     const day = "2026-07-03";
-    const store = new LogbookStore(dataDir);
+    const store = await LogbookStore.open(dataDir);
     const segments = Array.from({ length: count }, (_, index) => ({
       startMs: 1 + Math.floor(index / 3) * 1000,
       endMs: 1001 + Math.floor(index / 3) * 1000,
       text: `Observation ${index} 🦞`,
     }));
-    const seedBatch = (batchDay: string) => {
-      const frameId = store.insertFrame({
+    const seedBatch = async (batchDay: string) => {
+      const frameId = await store.insertFrame({
         capturedAtMs: Date.now(),
         day: batchDay,
         path: path.join(dataDir, "synthetic.jpg"),
@@ -72,15 +72,15 @@ it.each([0, 199, 200, 201])(
         contentHash: "synthetic",
         idle: false,
       });
-      return store.createBatch({
+      return await store.createBatch({
         day: batchDay,
         startMs: 1,
         endMs: Number.MAX_SAFE_INTEGER,
         frameIds: [frameId],
       });
     };
-    const batchId = seedBatch(day);
-    store.replaceObservations(batchId, day, [
+    const batchId = await seedBatch(day);
+    await store.replaceObservations(batchId, day, [
       ...segments,
       { startMs: -10, endMs: 0, text: "Excluded end boundary" },
       {
@@ -89,10 +89,10 @@ it.each([0, 199, 200, 201])(
         text: "Excluded start boundary",
       },
     ]);
-    store.replaceObservations(seedBatch("2026-07-04"), "2026-07-04", [
+    await store.replaceObservations(await seedBatch("2026-07-04"), "2026-07-04", [
       { startMs: 1, endMs: 2, text: "Excluded day" },
     ]);
-    store.close();
+    await store.close();
     const runtime = createPluginRuntimeMock();
     const complete = vi.fn<OpenClawPluginApi["runtime"]["llm"]["complete"]>(async () => ({
       text: "Synthetic answer",
@@ -110,7 +110,7 @@ it.each([0, 199, 200, 201])(
       fullConfig: {},
       logger: { info() {}, warn() {}, error() {}, debug() {} },
     });
-    service.start();
+    await service.start();
     try {
       reads.rows = 0;
       expect(await service.ask(day, "What happened?")).toBe("Synthetic answer");

--- a/extensions/logbook/src/service-lifecycle.test.ts
+++ b/extensions/logbook/src/service-lifecycle.test.ts
@@ -9,7 +9,8 @@ import {
   createCapturedPluginRegistration,
   createPluginRuntimeMock,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import plugin from "../index.js";
 import { resolveLogbookConfig } from "./config.js";
 import { LogbookService } from "./service.js";
@@ -17,6 +18,9 @@ import { dayKeyFor, LogbookStore } from "./store.js";
 
 const quietLogger = { info() {}, warn() {}, error() {}, debug() {} };
 const snapshot = { payload: { base64: Buffer.from("synthetic image").toString("base64") } };
+
+afterEach(() => vi.restoreAllMocks());
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function completion(
   text: string,
@@ -33,153 +37,311 @@ function completion(
 }
 
 describe("Logbook service disposal", () => {
-  it.each(["capture-list", "capture-invoke", "vision-success", "vision-error", "standup"])(
-    "drains %s before closing SQLite",
-    async (kind) => {
-      const dataDir = realpathSync(mkdtempSync(path.join(tmpdir(), "logbook-service-drain-")));
-      const entered = createDeferred<void>();
-      const release = createDeferred<void>();
-      const runtime = createPluginRuntimeMock();
-      const day = dayKeyFor(Date.now());
-      const startMs = new Date(`${day}T10:00:00`).getTime();
-      const logger = { ...quietLogger, error: vi.fn(), warn: vi.fn() };
-      const nodes = { nodes: [{ nodeId: "synthetic-node", commands: ["screen.snapshot"] }] };
-      runtime.nodes.list = vi.fn(async () => {
-        if (kind === "capture-list") {
-          entered.resolve();
-          await release.promise;
-        }
-        return nodes;
-      });
-      runtime.nodes.invoke = vi.fn(async () => {
-        if (kind === "capture-invoke") {
-          entered.resolve();
-          await release.promise;
-        }
-        return snapshot;
-      });
-      runtime.mediaUnderstanding.extractStructuredWithModel = vi.fn(async () => {
+  it("joins a pending database open and asynchronous close when the runtime retires", async () => {
+    const stateDir = tempDirs.make("logbook-opening-");
+    const store = await LogbookStore.open(path.join(stateDir, "logbook"));
+    const opened = createDeferred<void>();
+    const releaseOpen = createDeferred<void>();
+    const closing = createDeferred<void>();
+    const releaseClose = createDeferred<void>();
+    vi.spyOn(LogbookStore, "open").mockImplementationOnce(async () => {
+      opened.resolve();
+      await releaseOpen.promise;
+      return store;
+    });
+    const closeStore = store.close.bind(store);
+    vi.spyOn(store, "close").mockImplementationOnce(async () => {
+      closing.resolve();
+      await releaseClose.promise;
+      await closeStore();
+    });
+    const captured = createCapturedPluginRegistration({ id: "logbook" });
+    captured.api.pluginConfig = { captureEnabled: false };
+    const services: OpenClawPluginService[] = [];
+    captured.api.registerService = (service) => services.push(service);
+    plugin.register(captured.api);
+    const service = services[0]!;
+    const context = { config: {}, stateDir, logger: quietLogger };
+    const starting = service.start(context);
+    await opened.promise;
+    const completed = vi.fn();
+    const stopping = Promise.all(
+      captured.runtimeLifecycles.map(async (lifecycle) => {
+        await lifecycle.cleanup?.({ reason: "disable" });
+      }),
+    ).then(completed);
+    try {
+      releaseOpen.resolve();
+      await closing.promise;
+      expect(completed).not.toHaveBeenCalled();
+      await expect(service.start(context)).rejects.toThrow("runtime has been retired");
+    } finally {
+      releaseOpen.resolve();
+      releaseClose.resolve();
+      await Promise.all([starting, stopping]);
+    }
+    await expect(store.lastFrame()).rejects.toThrow();
+  });
+
+  it("closes storage when startup recovery fails without publishing a running service", async () => {
+    const dataDir = tempDirs.make("logbook-startup-failure-");
+    const close = vi.spyOn(LogbookStore.prototype, "close");
+    vi.spyOn(LogbookStore.prototype, "resetRunningBatches").mockRejectedValueOnce(
+      new Error("storage unavailable"),
+    );
+    const service = new LogbookService(resolveLogbookConfig({ captureEnabled: false }), {
+      dataDir,
+      runtime: createPluginRuntimeMock(),
+      fullConfig: {},
+      logger: quietLogger,
+    });
+    try {
+      await expect(service.start()).rejects.toThrow("storage unavailable");
+      await expect(service.status()).rejects.toThrow("not running");
+    } finally {
+      await service.stop();
+    }
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("owns delayed manual analysis preparation through rejection and stop", async () => {
+    const dataDir = tempDirs.make("logbook-analysis-admission-");
+    const service = new LogbookService(
+      resolveLogbookConfig({ captureEnabled: false, visionModel: "synthetic/vision" }),
+      {
+        dataDir,
+        runtime: createPluginRuntimeMock(),
+        fullConfig: {},
+        logger: quietLogger,
+      },
+    );
+    await service.start();
+    const entered = createDeferred<void>();
+    const reset = createDeferred<number>();
+    vi.spyOn(LogbookStore.prototype, "resetErrorBatches").mockImplementationOnce(() => {
+      entered.resolve();
+      return reset.promise;
+    });
+    const close = vi.spyOn(LogbookStore.prototype, "close");
+    const analysis = service.analyzeNow();
+    const rejected = expect(analysis).rejects.toThrow("storage unavailable");
+    await entered.promise;
+    expect(await service.analyzeNow()).toEqual({
+      started: false,
+      reason: "analysis already running",
+    });
+    const stopping = service.stop();
+    try {
+      await setImmediate();
+      expect(close).not.toHaveBeenCalled();
+      await expect(service.analyzeNow()).rejects.toThrow("not running");
+    } finally {
+      reset.reject(new Error("storage unavailable"));
+      await rejected;
+      await stopping;
+    }
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "capture-list",
+    "capture-invoke",
+    "capture-write",
+    "vision-success",
+    "vision-error",
+    "standup",
+    "standup-write",
+    "status-read",
+    "ask-read",
+  ])("drains %s before closing SQLite", async (kind) => {
+    const dataDir = realpathSync(mkdtempSync(path.join(tmpdir(), "logbook-service-drain-")));
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const runtime = createPluginRuntimeMock();
+    const day = dayKeyFor(Date.now());
+    const startMs = new Date(`${day}T10:00:00`).getTime();
+    const logger = { ...quietLogger, error: vi.fn(), warn: vi.fn() };
+    const nodes = { nodes: [{ nodeId: "synthetic-node", commands: ["screen.snapshot"] }] };
+    runtime.nodes.list = vi.fn(async () => {
+      if (kind === "capture-list") {
         entered.resolve();
         await release.promise;
-        if (kind === "vision-error") {
-          throw new Error("synthetic vision failure");
-        }
-        return {
-          text: JSON.stringify([
-            { start: "10:00:00", end: "10:01:00", description: "Synthetic activity" },
-          ]),
-        };
-      });
-      runtime.llm.complete = vi.fn(async () => {
+      }
+      return nodes;
+    });
+    runtime.nodes.invoke = vi.fn(async () => {
+      if (kind === "capture-invoke") {
+        entered.resolve();
+        await release.promise;
+      }
+      return snapshot;
+    });
+    runtime.mediaUnderstanding.extractStructuredWithModel = vi.fn(async () => {
+      entered.resolve();
+      await release.promise;
+      if (kind === "vision-error") {
+        throw new Error("synthetic vision failure");
+      }
+      return {
+        text: JSON.stringify([
+          { start: "10:00:00", end: "10:01:00", description: "Synthetic activity" },
+        ]),
+      };
+    });
+    runtime.llm.complete = vi.fn(async () => {
+      if (kind.startsWith("standup")) {
         if (kind === "standup") {
           entered.resolve();
           await release.promise;
-          return completion("Synthetic standup");
         }
-        return completion(
-          JSON.stringify([
-            {
-              startTime: "10:00:00",
-              endTime: "10:01:00",
-              title: "Synthetic activity",
-              summary: "Completed before shutdown",
-              category: "coding",
-            },
-          ]),
-        );
-      });
-      if (kind.startsWith("vision")) {
-        const seed = new LogbookStore(dataDir);
-        try {
-          for (let index = 0; index < 2; index++) {
-            const time = startMs + index * 120_000;
-            const framePath = seed.frameFilePath(day, time);
-            mkdirSync(path.dirname(framePath), { recursive: true });
-            writeFileSync(framePath, "synthetic image");
-            const frameId = seed.insertFrame({
-              capturedAtMs: time,
-              day,
-              path: framePath,
-              screenIndex: 0,
-              byteSize: 15,
-              contentHash: `synthetic-${index}`,
-              idle: false,
-            });
-            seed.createBatch({ day, startMs: time, endMs: time + 60_000, frameIds: [frameId] });
-          }
-        } finally {
-          seed.close();
-        }
+        return completion("Synthetic standup");
       }
-      const service = new LogbookService(
-        resolveLogbookConfig({
-          captureEnabled: true,
-          captureIntervalSeconds: 600,
-          visionModel: "synthetic/vision",
-        }),
-        { runtime, fullConfig: {}, logger, dataDir },
+      return completion(
+        JSON.stringify([
+          {
+            startTime: "10:00:00",
+            endTime: "10:01:00",
+            title: "Synthetic activity",
+            summary: "Completed before shutdown",
+            category: "coding",
+          },
+        ]),
       );
-      service.start();
-      const ticks = service as unknown as {
-        captureTick(): Promise<void>;
-        analysisTick(): Promise<void>;
-      };
-      const active = kind.startsWith("capture")
-        ? ticks.captureTick()
-        : kind.startsWith("vision")
-          ? ticks.analysisTick()
-          : service.standup(day, true);
-      void active.catch(() => {});
-      await entered.promise;
-      const stopped = vi.fn();
-      const stopping = service.stop();
-      const settled = Promise.resolve(stopping).then(stopped);
+    });
+    if (kind.startsWith("vision")) {
+      const seed = await LogbookStore.open(dataDir);
       try {
-        expect(service.stop()).toBe(stopping);
-        await setImmediate();
-        expect.soft(stopped).not.toHaveBeenCalled();
-        await expect(service.standup(day, true)).rejects.toThrow("not running");
-        await expect(service.analyzeNow()).rejects.toThrow("not running");
-        release.resolve();
-        await active;
-        await settled;
-        expect(logger.error).not.toHaveBeenCalled();
-        const reopened = new LogbookStore(dataDir);
-        try {
-          if (kind.startsWith("capture")) {
-            expect(reopened.countUnbatchedActiveFrames()).toBe(1);
-            expect(runtime.nodes.invoke).toHaveBeenCalledTimes(1);
-          } else if (kind === "standup") {
-            expect(reopened.getStandup(day)?.text).toBe("Synthetic standup");
-          } else {
-            const db = new DatabaseSync(path.join(dataDir, "logbook.sqlite"), { readOnly: true });
-            try {
-              expect(db.prepare("SELECT status, error FROM batches ORDER BY id").all()).toEqual([
-                {
-                  status: kind === "vision-success" ? "done" : "error",
-                  error: kind === "vision-success" ? null : "synthetic vision failure",
-                },
-                { status: "pending", error: null },
-              ]);
-              expect(runtime.mediaUnderstanding.extractStructuredWithModel).toHaveBeenCalledTimes(
-                1,
-              );
-            } finally {
-              db.close();
-            }
-          }
-        } finally {
-          reopened.close();
+        for (let index = 0; index < 2; index++) {
+          const time = startMs + index * 120_000;
+          const framePath = seed.frameFilePath(day, time);
+          mkdirSync(path.dirname(framePath), { recursive: true });
+          writeFileSync(framePath, "synthetic image");
+          const frameId = await seed.insertFrame({
+            capturedAtMs: time,
+            day,
+            path: framePath,
+            screenIndex: 0,
+            byteSize: 15,
+            contentHash: `synthetic-${index}`,
+            idle: false,
+          });
+          await seed.createBatch({
+            day,
+            startMs: time,
+            endMs: time + 60_000,
+            frameIds: [frameId],
+          });
         }
       } finally {
-        release.resolve();
-        await active.catch(() => {});
-        await settled;
-        await service.stop();
-        rmSync(dataDir, { recursive: true, force: true });
+        await seed.close();
       }
-    },
-  );
+    }
+    const activeStore = await LogbookStore.open(dataDir);
+    vi.spyOn(LogbookStore, "open").mockResolvedValueOnce(activeStore);
+    if (kind === "capture-write") {
+      const insertFrame = activeStore.insertFrame.bind(activeStore);
+      vi.spyOn(activeStore, "insertFrame").mockImplementation(async (frame) => {
+        entered.resolve();
+        await release.promise;
+        return await insertFrame(frame);
+      });
+    }
+    if (kind === "standup-write") {
+      const saveStandup = activeStore.saveStandup.bind(activeStore);
+      vi.spyOn(activeStore, "saveStandup").mockImplementation(async (...args) => {
+        entered.resolve();
+        await release.promise;
+        await saveStandup(...args);
+      });
+    }
+    if (kind === "status-read") {
+      const latestBatch = activeStore.latestBatch.bind(activeStore);
+      vi.spyOn(activeStore, "latestBatch").mockImplementation(async () => {
+        entered.resolve();
+        await release.promise;
+        return await latestBatch();
+      });
+    }
+    if (kind === "ask-read") {
+      const observationsInRange = activeStore.observationsInRange.bind(activeStore);
+      vi.spyOn(activeStore, "observationsInRange").mockImplementation(async (...args) => {
+        entered.resolve();
+        await release.promise;
+        return await observationsInRange(...args);
+      });
+    }
+    const service = new LogbookService(
+      resolveLogbookConfig({
+        captureEnabled: true,
+        captureIntervalSeconds: 600,
+        visionModel: "synthetic/vision",
+      }),
+      { runtime, fullConfig: {}, logger, dataDir },
+    );
+    await service.start();
+    const ticks = service as unknown as {
+      captureTick(): Promise<void>;
+      analysisTick(): Promise<void>;
+    };
+    const active = kind.startsWith("capture")
+      ? ticks.captureTick()
+      : kind.startsWith("vision")
+        ? ticks.analysisTick()
+        : kind === "status-read"
+          ? service.status()
+          : kind === "ask-read"
+            ? service.ask(day, "What happened?")
+            : service.standup(day, true);
+    void active.catch(() => {});
+    await entered.promise;
+    const stopped = vi.fn();
+    const stopping = service.stop();
+    const settled = Promise.resolve(stopping).then(stopped);
+    try {
+      expect(service.stop()).toBe(stopping);
+      await setImmediate();
+      expect.soft(stopped).not.toHaveBeenCalled();
+      await expect(service.standup(day, true)).rejects.toThrow("not running");
+      await expect(service.analyzeNow()).rejects.toThrow("not running");
+      release.resolve();
+      await active;
+      await settled;
+      expect(logger.error).not.toHaveBeenCalled();
+      const reopened = await LogbookStore.open(dataDir);
+      try {
+        if (kind.startsWith("capture")) {
+          expect(await reopened.countUnbatchedActiveFrames()).toBe(1);
+          expect(runtime.nodes.invoke).toHaveBeenCalledTimes(1);
+        } else if (kind.startsWith("standup")) {
+          expect((await reopened.getStandup(day))?.text).toBe("Synthetic standup");
+        } else if (kind.endsWith("-read")) {
+          expect(await reopened.latestBatch()).toBeNull();
+        } else {
+          const db = new DatabaseSync(path.join(dataDir, "logbook.sqlite"), { readOnly: true });
+          try {
+            expect(db.prepare("SELECT status, error FROM batches ORDER BY id").all()).toEqual([
+              {
+                status: kind === "vision-success" ? "done" : "error",
+                error: kind === "vision-success" ? null : "synthetic vision failure",
+              },
+              { status: "pending", error: null },
+            ]);
+            expect(runtime.mediaUnderstanding.extractStructuredWithModel).toHaveBeenCalledTimes(1);
+          } finally {
+            db.close();
+          }
+        }
+      } finally {
+        await reopened.close();
+      }
+    } finally {
+      release.resolve();
+      await active.catch(() => {});
+      await settled;
+      await service.stop();
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
 
   it.each(["restart", "disable"] as const)(
     "joins service stop and whole-plugin %s cleanup without stopping sessions",
@@ -237,11 +399,11 @@ describe("Logbook service disposal", () => {
         release.resolve();
         expect((await standup)?.[0]).toBe(true);
         await Promise.all([retiring, stopping, cleanup({ reason })]);
-        const reopened = new LogbookStore(path.join(stateDir, "logbook"));
+        const reopened = await LogbookStore.open(path.join(stateDir, "logbook"));
         try {
-          expect(reopened.getStandup(dayKeyFor(Date.now()))?.text).toBe("Accepted standup");
+          expect((await reopened.getStandup(dayKeyFor(Date.now())))?.text).toBe("Accepted standup");
         } finally {
-          reopened.close();
+          await reopened.close();
         }
       } finally {
         release.resolve();
@@ -263,7 +425,7 @@ describe("Logbook service disposal", () => {
       for (const lifecycle of captured.runtimeLifecycles) {
         await lifecycle.cleanup?.({ reason: "restart" });
       }
-      expect(() => services[0]!.start(context)).toThrow("runtime has been retired");
+      await expect(services[0]!.start(context)).rejects.toThrow("runtime has been retired");
       expect(existsSync(path.join(stateDir, "logbook", "logbook.sqlite"))).toBe(false);
     } finally {
       await services[0]!.stop?.(context);

--- a/extensions/logbook/src/service.test.ts
+++ b/extensions/logbook/src/service.test.ts
@@ -14,7 +14,7 @@ const quietLogger = {
   debug() {},
 };
 
-function makeService(params: {
+async function makeService(params: {
   nodes: NodeRecord[];
   invoke: (args: { nodeId: string; command: string }) => Promise<unknown>;
   config?: Record<string, unknown>;
@@ -40,7 +40,7 @@ function makeService(params: {
       dataDir,
     },
   );
-  service.start();
+  await service.start();
   const tick = () =>
     (service as unknown as { captureTick(): Promise<void> }).captureTick.call(service);
   return { service, invoked, tick, dataDir };
@@ -59,7 +59,7 @@ describe("LogbookService capture node selection", () => {
   });
 
   it("prefers app nodes over headless node hosts regardless of node id order", async () => {
-    const { service, invoked, tick, dataDir } = makeService({
+    const { service, invoked, tick, dataDir } = await makeService({
       nodes: [
         { nodeId: "a-headless", commands: ["logbook.snapshot"] },
         { nodeId: "b-mac-app", commands: ["screen.snapshot"] },
@@ -73,11 +73,11 @@ describe("LogbookService capture node selection", () => {
 
     await tick();
     expect(invoked).toEqual([{ nodeId: "b-mac-app", command: "screen.snapshot" }]);
-    expect(service.status()).toMatchObject({ pendingFrames: 1, lastCaptureError: undefined });
+    expect(await service.status()).toMatchObject({ pendingFrames: 1, lastCaptureError: undefined });
   });
 
   it("rotates to the next capture node after a failure instead of re-picking the broken one", async () => {
-    const { service, invoked, tick, dataDir } = makeService({
+    const { service, invoked, tick, dataDir } = await makeService({
       nodes: [
         { nodeId: "a-broken", commands: ["logbook.snapshot"] },
         { nodeId: "b-working", commands: ["logbook.snapshot"] },
@@ -97,7 +97,7 @@ describe("LogbookService capture node selection", () => {
     await tick();
     await tick();
     expect(invoked.map((call) => call.nodeId)).toEqual(["a-broken", "b-working"]);
-    expect(service.status().lastCaptureError).toBeUndefined();
+    expect((await service.status()).lastCaptureError).toBeUndefined();
   });
 
   it.each([
@@ -105,7 +105,7 @@ describe("LogbookService capture node selection", () => {
     ["object", { encoded: "ZmFrZQ==" }],
     ["array", ["ZmFrZQ=="]],
   ])("rejects a %s snapshot payload before storing a frame", async (_label, base64) => {
-    const { service, tick, dataDir } = makeService({
+    const { service, tick, dataDir } = await makeService({
       nodes: [{ nodeId: "capture-node", commands: ["logbook.snapshot"] }],
       invoke: async () => ({ payload: { format: "jpeg", base64 } }),
     });
@@ -116,7 +116,7 @@ describe("LogbookService capture node selection", () => {
 
     await tick();
 
-    expect(service.status()).toMatchObject({
+    expect(await service.status()).toMatchObject({
       pendingFrames: 0,
       lastCaptureError: "logbook.snapshot returned invalid image payload",
     });
@@ -131,8 +131,8 @@ describe("LogbookService vision model selection", () => {
     }
   });
 
-  it("borrows only a media provider with structured extraction", () => {
-    const { service, dataDir } = makeService({
+  it("borrows only a media provider with structured extraction", async () => {
+    const { service, dataDir } = await makeService({
       nodes: [],
       invoke: async () => framePayload,
       fullConfig: {
@@ -151,14 +151,14 @@ describe("LogbookService vision model selection", () => {
       rmSync(dataDir, { recursive: true, force: true });
     });
 
-    expect(service.status()).toMatchObject({
+    expect(await service.status()).toMatchObject({
       visionModel: "codex/gpt-5.5",
       visionModelSource: "media-defaults",
     });
   });
 
-  it("reports a missing model when borrowed defaults cannot extract structured data", () => {
-    const { service, dataDir } = makeService({
+  it("reports a missing model when borrowed defaults cannot extract structured data", async () => {
+    const { service, dataDir } = await makeService({
       nodes: [],
       invoke: async () => framePayload,
       fullConfig: {
@@ -174,7 +174,7 @@ describe("LogbookService vision model selection", () => {
       rmSync(dataDir, { recursive: true, force: true });
     });
 
-    expect(service.status()).toMatchObject({
+    expect(await service.status()).toMatchObject({
       visionModel: undefined,
       visionModelSource: "missing",
     });
@@ -183,16 +183,16 @@ describe("LogbookService vision model selection", () => {
 
 describe("LogbookService status", () => {
   it("returns the capture-host timezone without exposing the state path", async () => {
-    const { service, dataDir } = makeService({
+    const { service, dataDir } = await makeService({
       nodes: [],
       invoke: async () => framePayload,
     });
 
     try {
-      expect(service.status()).toMatchObject({
+      expect(await service.status()).toMatchObject({
         timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       });
-      expect(service.status()).not.toHaveProperty("dataDir");
+      expect(await service.status()).not.toHaveProperty("dataDir");
     } finally {
       await service.stop();
       rmSync(dataDir, { recursive: true, force: true });

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -77,6 +77,7 @@ export class LogbookService {
   private store: LogbookStore | null = null;
   private readonly operations = new Set<Promise<unknown>>();
   private stopping: Promise<void> | undefined;
+  private starting: Promise<void> | undefined;
   private captureTimer: NodeJS.Timeout | null = null;
   private analysisTimer: NodeJS.Timeout | null = null;
   private pruneTimer: NodeJS.Timeout | null = null;
@@ -103,27 +104,48 @@ export class LogbookService {
     },
   ) {}
 
-  start(): void {
-    this.stopping = undefined;
-    this.store = new LogbookStore(this.deps.dataDir);
-    // Batches interrupted by a gateway restart go back to pending.
-    this.store.resetRunningBatches();
-    this.captureTimer = setInterval(() => {
-      void this.captureTick();
-    }, this.config.captureIntervalSeconds * 1000);
-    this.captureTimer.unref?.();
-    this.analysisTimer = setInterval(() => {
-      void this.analysisTick();
-    }, ANALYSIS_TICK_MS);
-    this.analysisTimer.unref?.();
-    this.pruneTimer = setInterval(() => {
-      this.prune();
-    }, PRUNE_TICK_MS);
-    this.pruneTimer.unref?.();
-    this.prune();
-    this.deps.logger.info(
-      `logbook: started (capture every ${this.config.captureIntervalSeconds}s, analysis window ${this.config.analysisIntervalMinutes}m, data ${this.deps.dataDir})`,
-    );
+  async start(): Promise<void> {
+    if (this.starting || this.stopping) {
+      throw new Error("Logbook service cannot be started again");
+    }
+    this.starting = this.trackOperation(async () => {
+      const store = await LogbookStore.open(this.deps.dataDir);
+      this.store = store;
+      try {
+        if (this.stopping) {
+          return;
+        }
+        // Batches interrupted by a gateway restart go back to pending.
+        await store.resetRunningBatches();
+        if (this.stopping) {
+          return;
+        }
+        await this.pruneStore(store);
+        if (this.stopping) {
+          return;
+        }
+        this.captureTimer = setInterval(() => {
+          void this.captureTick();
+        }, this.config.captureIntervalSeconds * 1000);
+        this.captureTimer.unref?.();
+        this.analysisTimer = setInterval(() => {
+          void this.analysisTick();
+        }, ANALYSIS_TICK_MS);
+        this.analysisTimer.unref?.();
+        this.pruneTimer = setInterval(() => {
+          void this.prune();
+        }, PRUNE_TICK_MS);
+        this.pruneTimer.unref?.();
+        this.deps.logger.info(
+          `logbook: started (capture every ${this.config.captureIntervalSeconds}s, analysis window ${this.config.analysisIntervalMinutes}m, data ${this.deps.dataDir})`,
+        );
+      } catch (error) {
+        this.store = null;
+        await store.close();
+        throw error;
+      }
+    });
+    await this.starting;
   }
 
   stop(): Promise<void> {
@@ -138,11 +160,11 @@ export class LogbookService {
     this.captureTimer = null;
     this.analysisTimer = null;
     this.pruneTimer = null;
-    const store = this.store;
     // Admitted work retains its connection through its final writes and error recording.
-    this.stopping = Promise.allSettled(this.operations).then(() => {
-      store?.close();
+    this.stopping = Promise.allSettled(this.operations).then(async () => {
+      const store = this.store;
       this.store = null;
+      await store?.close();
     });
     return this.stopping;
   }
@@ -278,12 +300,12 @@ export class LogbookService {
         const contentHash = createHash("sha256").update(buffer).digest("hex");
         // Unchanged consecutive frames mean the user is idle (or away); they are
         // stored for the filmstrip but excluded from analysis batches.
-        const idle = store.lastFrame()?.contentHash === contentHash;
+        const idle = (await store.lastFrame())?.contentHash === contentHash;
         const filePath = store.frameFilePath(day, capturedAtMs);
         // Screen captures can contain secrets; keep them owner-only.
         mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
         writeFileSync(filePath, buffer, { mode: 0o600 });
-        store.insertFrame({
+        await store.insertFrame({
           capturedAtMs,
           day,
           path: filePath,
@@ -363,17 +385,30 @@ export class LogbookService {
     if (!this.resolveVisionModel().ref) {
       return { started: false, reason: MODEL_MISSING_MESSAGE };
     }
-    // Explicit user action is the retry path for failed batches; automatic
-    // retries could loop model spend on a persistently failing batch.
-    store.resetErrorBatches();
-    if (!store.nextPendingBatch()) {
-      // Force-close the current window so "analyze now" needs no elapsed time.
-      if (!this.enqueueNextBatch(store, true)) {
-        return { started: false, reason: "no unanalyzed activity captured yet" };
+    this.analysisInFlight = true;
+    return this.trackOperation(async () => {
+      let handedOff = false;
+      try {
+        // Explicit user action is the retry path for failed batches; automatic
+        // retries could loop model spend on a persistently failing batch.
+        await store.resetErrorBatches();
+        if (!(await store.nextPendingBatch())) {
+          // Force-close the current window so "analyze now" needs no elapsed time.
+          if (!(await this.enqueueNextBatch(store, true))) {
+            return { started: false, reason: "no unanalyzed activity captured yet" };
+          }
+        }
+        this.requireStore();
+        this.analysisInFlight = false;
+        void this.analysisTick();
+        handedOff = true;
+        return { started: true };
+      } finally {
+        if (!handedOff) {
+          this.analysisInFlight = false;
+        }
       }
-    }
-    void this.analysisTick();
-    return { started: true };
+    });
   }
 
   private async analysisTick(): Promise<void> {
@@ -398,10 +433,10 @@ export class LogbookService {
         if (this.stopping) {
           return;
         }
-        this.enqueueElapsedWindow(store);
+        await this.enqueueElapsedWindow(store);
         for (let i = 0; i < 4 && !this.stopping; i += 1) {
-          const batch = store.nextPendingBatch();
-          if (!batch) {
+          const batch = await store.nextPendingBatch();
+          if (!batch || this.stopping) {
             return;
           }
           await this.runBatch(store, batch);
@@ -414,9 +449,9 @@ export class LogbookService {
     });
   }
 
-  private enqueueNextBatch(store: LogbookStore, force = false): boolean {
+  private async enqueueNextBatch(store: LogbookStore, force = false): Promise<boolean> {
     const selection = selectBatchFrames({
-      frames: store.unbatchedActiveFrames(2000),
+      frames: await store.unbatchedActiveFrames(2000),
       windowMs: this.config.analysisIntervalMinutes * 60_000,
       nowMs: Date.now(),
       force,
@@ -424,7 +459,7 @@ export class LogbookService {
     if (!selection) {
       return false;
     }
-    store.createBatch({
+    await store.createBatch({
       day: dayKeyFor(selection.startMs),
       startMs: selection.startMs,
       endMs: selection.endMs,
@@ -433,10 +468,10 @@ export class LogbookService {
     return true;
   }
 
-  private enqueueElapsedWindow(store: LogbookStore): void {
+  private async enqueueElapsedWindow(store: LogbookStore): Promise<void> {
     // Windows close on elapsed wall-clock or on a capture gap; both cases are
     // resolved by selectBatchFrames against the oldest unbatched frame.
-    while (this.enqueueNextBatch(store)) {
+    while (!this.stopping && (await this.enqueueNextBatch(store))) {
       // Continue until all elapsed windows are queued.
     }
   }
@@ -447,14 +482,14 @@ export class LogbookService {
       // Stay pending: the analysis tick pauses until a model is configured.
       return;
     }
-    store.setBatchStatus(
+    await store.setBatchStatus(
       batch.id,
       "running",
       undefined,
       `${vision.ref.provider}/${vision.ref.model}`,
     );
     try {
-      const frames = store.batchFrames(batch.id);
+      const frames = await store.batchFrames(batch.id);
       const sampled = sampleFrames(frames, MAX_FRAMES_PER_CALL);
       const images = sampled.map((frame) => ({
         type: "image" as const,
@@ -486,26 +521,26 @@ export class LogbookService {
         endMs: batch.endMs,
       });
       if (segments.length === 0) {
-        store.setBatchStatus(batch.id, "error", "vision model returned no usable segments");
+        await store.setBatchStatus(batch.id, "error", "vision model returned no usable segments");
         return;
       }
-      store.replaceObservations(batch.id, batch.day, segments);
+      await store.replaceObservations(batch.id, batch.day, segments);
       await this.reviseCards(store, batch);
-      store.setBatchStatus(batch.id, "done");
+      await store.setBatchStatus(batch.id, "done");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      store.setBatchStatus(batch.id, "error", message);
+      await store.setBatchStatus(batch.id, "error", message);
       this.deps.logger.warn(`logbook: batch ${batch.id} failed: ${message}`);
     }
   }
 
   private async reviseCards(store: LogbookStore, batch: LogbookBatch): Promise<void> {
     const lookbackStart = batch.startMs - CARD_LOOKBACK_MS;
-    const previousCards = store.cardsForDay(batch.day, {
+    const previousCards = await store.cardsForDay(batch.day, {
       startMs: lookbackStart,
       endMs: batch.endMs,
     });
-    const observations = store.observationsInRange(
+    const observations = await store.observationsInRange(
       batch.day,
       Math.min(lookbackStart, batch.startMs),
       batch.endMs,
@@ -567,13 +602,14 @@ export class LogbookService {
     if (!parsed.ok) {
       throw new Error(`card synthesis failed validation: ${parsed.error}`);
     }
-    const windowFrames = store
-      .framesInRange(window.startMs, window.endMs)
-      .map((frame) => ({ id: frame.id, capturedAtMs: frame.capturedAtMs }));
+    const windowFrames = (await store.framesInRange(window.startMs, window.endMs)).map((frame) => ({
+      id: frame.id,
+      capturedAtMs: frame.capturedAtMs,
+    }));
     const drafts = parsed.drafts.map((draft) =>
       Object.assign(draft, { keyframeId: pickKeyframeId(draft, windowFrames) }),
     );
-    store.replaceCardsInWindow(batch.day, window.startMs, window.endMs, drafts);
+    await store.replaceCardsInWindow(batch.day, window.startMs, window.endMs, drafts);
   }
 
   async standup(
@@ -583,7 +619,7 @@ export class LogbookService {
     const store = this.requireStore();
     return this.trackOperation(async () => {
       if (!refresh) {
-        const cached = store.getStandup(day);
+        const cached = await store.getStandup(day);
         if (cached) {
           return cached;
         }
@@ -595,16 +631,16 @@ export class LogbookService {
             role: "user",
             content: buildStandupPrompt({
               day,
-              cards: store.cardsForDay(day),
-              previousDayCards: store.cardsForDay(previousDay),
+              cards: await store.cardsForDay(day),
+              previousDayCards: await store.cardsForDay(previousDay),
             }),
           },
         ],
         purpose: "logbook.standup",
         maxTokens: 800,
       });
-      store.saveStandup(day, result.text.trim());
-      const saved = store.getStandup(day);
+      await store.saveStandup(day, result.text.trim());
+      const saved = await store.getStandup(day);
       if (!saved) {
         throw new Error("standup save failed");
       }
@@ -614,81 +650,100 @@ export class LogbookService {
 
   async ask(day: string, question: string): Promise<string> {
     const store = this.requireStore();
-    const observations = store.observationsInRange(day, 0, Number.MAX_SAFE_INTEGER, 200);
-    const result = await this.deps.runtime.llm.complete({
-      messages: [
-        {
-          role: "user",
-          content: buildAskPrompt({
-            day,
-            cards: store.cardsForDay(day),
-            observations,
-            question,
-          }),
-        },
-      ],
-      purpose: "logbook.ask",
-      maxTokens: 600,
+    return this.trackOperation(async () => {
+      const observations = await store.observationsInRange(day, 0, Number.MAX_SAFE_INTEGER, 200);
+      const result = await this.deps.runtime.llm.complete({
+        messages: [
+          {
+            role: "user",
+            content: buildAskPrompt({
+              day,
+              cards: await store.cardsForDay(day),
+              observations,
+              question,
+            }),
+          },
+        ],
+        purpose: "logbook.ask",
+        maxTokens: 600,
+      });
+      return result.text.trim();
     });
-    return result.text.trim();
   }
 
-  timelineForDay(day: string): ReturnType<LogbookStore["timelineForDay"]> {
-    return this.requireStore().timelineForDay(day);
-  }
-
-  listDays(): ReturnType<LogbookStore["listDays"]> {
-    return this.requireStore().listDays();
-  }
-
-  frameById(id: number): ReturnType<LogbookStore["frameById"]> {
-    return this.requireStore().frameById(id);
-  }
-
-  framesInRange(startMs: number, endMs: number): ReturnType<LogbookStore["framesInRange"]> {
-    return this.requireStore().framesInRange(startMs, endMs);
-  }
-
-  status(): LogbookStatus {
+  async timelineForDay(day: string): ReturnType<LogbookStore["timelineForDay"]> {
     const store = this.requireStore();
-    const today = dayKeyFor(Date.now());
-    const latestBatch = store.latestBatch();
-    const vision = this.resolveVisionModel();
-    return {
-      captureEnabled: this.config.captureEnabled,
-      capturePaused: this.capturePaused,
-      captureIntervalSeconds: this.config.captureIntervalSeconds,
-      analysisIntervalMinutes: this.config.analysisIntervalMinutes,
-      retentionDays: this.config.retentionDays,
-      nodeId: this.cachedNode?.nodeId ?? this.config.nodeId,
-      nodeName: this.cachedNode?.displayName,
-      lastCaptureAtMs: this.lastCaptureAtMs,
-      lastCaptureError: this.lastCaptureError,
-      pendingFrames: store.countUnbatchedActiveFrames(),
-      analysisRunning: this.analysisInFlight,
-      lastBatch: latestBatch
-        ? {
-            id: latestBatch.id,
-            day: latestBatch.day,
-            status: latestBatch.status,
-            endMs: latestBatch.endMs,
-            error: latestBatch.error,
-          }
-        : undefined,
-      visionModel: vision.ref ? `${vision.ref.provider}/${vision.ref.model}` : undefined,
-      visionModelSource: vision.source,
-      today,
-      todayCards: store.countCardsForDay(today),
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    };
+    return this.trackOperation(() => store.timelineForDay(day));
   }
 
-  private prune(): void {
-    if (!this.store) {
+  async listDays(): ReturnType<LogbookStore["listDays"]> {
+    const store = this.requireStore();
+    return this.trackOperation(() => store.listDays());
+  }
+
+  async frameById(id: number): ReturnType<LogbookStore["frameById"]> {
+    const store = this.requireStore();
+    return this.trackOperation(() => store.frameById(id));
+  }
+
+  async framesInRange(startMs: number, endMs: number): ReturnType<LogbookStore["framesInRange"]> {
+    const store = this.requireStore();
+    return this.trackOperation(() => store.framesInRange(startMs, endMs));
+  }
+
+  async status(): Promise<LogbookStatus> {
+    const store = this.requireStore();
+    return this.trackOperation(async () => {
+      const today = dayKeyFor(Date.now());
+      const latestBatch = await store.latestBatch();
+      const vision = this.resolveVisionModel();
+      return {
+        captureEnabled: this.config.captureEnabled,
+        capturePaused: this.capturePaused,
+        captureIntervalSeconds: this.config.captureIntervalSeconds,
+        analysisIntervalMinutes: this.config.analysisIntervalMinutes,
+        retentionDays: this.config.retentionDays,
+        nodeId: this.cachedNode?.nodeId ?? this.config.nodeId,
+        nodeName: this.cachedNode?.displayName,
+        lastCaptureAtMs: this.lastCaptureAtMs,
+        lastCaptureError: this.lastCaptureError,
+        pendingFrames: await store.countUnbatchedActiveFrames(),
+        analysisRunning: this.analysisInFlight,
+        lastBatch: latestBatch
+          ? {
+              id: latestBatch.id,
+              day: latestBatch.day,
+              status: latestBatch.status,
+              endMs: latestBatch.endMs,
+              error: latestBatch.error,
+            }
+          : undefined,
+        visionModel: vision.ref ? `${vision.ref.provider}/${vision.ref.model}` : undefined,
+        visionModelSource: vision.source,
+        today,
+        todayCards: await store.countCardsForDay(today),
+        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      };
+    });
+  }
+
+  private async prune(): Promise<void> {
+    const store = this.store;
+    if (this.stopping || !store) {
       return;
     }
+    return this.trackOperation(async () => {
+      try {
+        await this.pruneStore(store);
+      } catch (error) {
+        this.deps.logger.error(`logbook: pruning failed: ${String(error)}`);
+      }
+    });
+  }
+
+  private async pruneStore(store: LogbookStore): Promise<void> {
     const cutoff = Date.now() - this.config.retentionDays * 24 * 60 * 60 * 1000;
-    const removed = this.store.pruneFrames(cutoff);
+    const removed = await store.pruneFrames(cutoff);
     if (removed > 0) {
       this.deps.logger.info(
         `logbook: pruned ${removed} frames older than ${this.config.retentionDays}d`,

--- a/extensions/logbook/src/store.test.ts
+++ b/extensions/logbook/src/store.test.ts
@@ -39,22 +39,22 @@ describe("LogbookStore", () => {
   let dir: string;
   let store: LogbookStore;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dir = mkdtempSync(path.join(tmpdir(), "logbook-store-"));
-    store = new LogbookStore(dir);
+    store = await LogbookStore.open(dir);
   });
 
-  afterEach(() => {
-    store.close();
+  afterEach(async () => {
+    await store.close();
     rmSync(dir, { recursive: true, force: true });
   });
 
-  const insertFrame = (capturedAtMs: number, opts?: { idle?: boolean; hash?: string }) => {
+  const insertFrame = async (capturedAtMs: number, opts?: { idle?: boolean; hash?: string }) => {
     const day = dayKeyFor(capturedAtMs);
     const filePath = store.frameFilePath(day, capturedAtMs);
     mkdirSync(path.dirname(filePath), { recursive: true });
     writeFileSync(filePath, "jpeg-bytes");
-    return store.insertFrame({
+    return await store.insertFrame({
       capturedAtMs,
       day,
       path: filePath,
@@ -65,20 +65,20 @@ describe("LogbookStore", () => {
     });
   };
 
-  it("tracks unbatched active frames and excludes idle ones", () => {
+  it("tracks unbatched active frames and excludes idle ones", async () => {
     const t0 = Date.now();
-    insertFrame(t0);
-    insertFrame(t0 + 1000, { idle: true });
-    insertFrame(t0 + 2000);
-    expect(store.countUnbatchedActiveFrames()).toBe(2);
-    const batchId = store.createBatch({
+    await insertFrame(t0);
+    await insertFrame(t0 + 1000, { idle: true });
+    await insertFrame(t0 + 2000);
+    expect(await store.countUnbatchedActiveFrames()).toBe(2);
+    const batchId = await store.createBatch({
       day: dayKeyFor(t0),
       startMs: t0,
       endMs: t0 + 3000,
-      frameIds: store.unbatchedActiveFrames(10).map((frame) => frame.id),
+      frameIds: (await store.unbatchedActiveFrames(10)).map((frame) => frame.id),
     });
-    expect(store.countUnbatchedActiveFrames()).toBe(0);
-    expect(store.batchFrames(batchId)).toHaveLength(2);
+    expect(await store.countUnbatchedActiveFrames()).toBe(0);
+    expect(await store.batchFrames(batchId)).toHaveLength(2);
   });
 
   it("creates every owned table as STRICT with foreign keys enabled", () => {
@@ -169,8 +169,8 @@ describe("LogbookStore", () => {
     },
   );
 
-  it("restores missing schema-1 indexes on reopen without changing the version", () => {
-    store.close();
+  it("restores missing schema-1 indexes on reopen without changing the version", async () => {
+    await store.close();
     const databasePath = path.join(dir, "logbook.sqlite");
     const database = new DatabaseSync(databasePath);
     database.exec(`
@@ -182,7 +182,7 @@ describe("LogbookStore", () => {
     expect(database.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
     database.close();
 
-    store = new LogbookStore(dir);
+    store = await LogbookStore.open(dir);
 
     const reopened = new DatabaseSync(databasePath, { readOnly: true });
     try {
@@ -227,105 +227,105 @@ describe("LogbookStore", () => {
     }
   });
 
-  it("rolls back the whole batch when any frame is missing", () => {
+  it("rolls back the whole batch when any frame is missing", async () => {
     const t0 = Date.now();
-    const frameId = insertFrame(t0);
+    const frameId = await insertFrame(t0);
 
-    expect(() =>
+    await expect(
       store.createBatch({
         day: dayKeyFor(t0),
         startMs: t0,
         endMs: t0 + 1000,
         frameIds: [frameId, 999_999],
       }),
-    ).toThrow("Logbook frame 999999 is missing or already batched");
+    ).rejects.toThrow("Logbook frame 999999 is missing or already batched");
 
-    expect(store.latestBatch()).toBeNull();
-    expect(store.unbatchedActiveFrames(10).map((frame) => frame.id)).toEqual([frameId]);
+    expect(await store.latestBatch()).toBeNull();
+    expect((await store.unbatchedActiveFrames(10)).map((frame) => frame.id)).toEqual([frameId]);
   });
 
-  it("does not steal a frame from an existing batch", () => {
+  it("does not steal a frame from an existing batch", async () => {
     const t0 = Date.now();
-    const firstFrame = insertFrame(t0);
-    const secondFrame = insertFrame(t0 + 1000);
-    const firstBatch = store.createBatch({
+    const firstFrame = await insertFrame(t0);
+    const secondFrame = await insertFrame(t0 + 1000);
+    const firstBatch = await store.createBatch({
       day: dayKeyFor(t0),
       startMs: t0,
       endMs: t0 + 1000,
       frameIds: [firstFrame],
     });
 
-    expect(() =>
+    await expect(
       store.createBatch({
         day: dayKeyFor(t0),
         startMs: t0,
         endMs: t0 + 2000,
         frameIds: [firstFrame, secondFrame],
       }),
-    ).toThrow(`Logbook frame ${firstFrame} is missing or already batched`);
+    ).rejects.toThrow(`Logbook frame ${firstFrame} is missing or already batched`);
 
-    expect(store.latestBatch()?.id).toBe(firstBatch);
-    expect(store.batchFrames(firstBatch).map((frame) => frame.id)).toEqual([firstFrame]);
-    expect(store.unbatchedActiveFrames(10).map((frame) => frame.id)).toEqual([secondFrame]);
+    expect((await store.latestBatch())?.id).toBe(firstBatch);
+    expect((await store.batchFrames(firstBatch)).map((frame) => frame.id)).toEqual([firstFrame]);
+    expect((await store.unbatchedActiveFrames(10)).map((frame) => frame.id)).toEqual([secondFrame]);
   });
 
-  it("rejects empty and duplicate frame claims without leaving a batch", () => {
+  it("rejects empty and duplicate frame claims without leaving a batch", async () => {
     const t0 = Date.now();
-    expect(() =>
+    await expect(
       store.createBatch({ day: DAY, startMs: t0, endMs: t0 + 1000, frameIds: [] }),
-    ).toThrow("Logbook batch requires at least one frame");
-    const frameId = insertFrame(t0);
-    expect(() =>
+    ).rejects.toThrow("Logbook batch requires at least one frame");
+    const frameId = await insertFrame(t0);
+    await expect(
       store.createBatch({
         day: DAY,
         startMs: t0,
         endMs: t0 + 1000,
         frameIds: [frameId, frameId],
       }),
-    ).toThrow(`Logbook frame ${frameId} is missing or already batched`);
-    expect(store.latestBatch()).toBeNull();
-    expect(store.countUnbatchedActiveFrames()).toBe(1);
+    ).rejects.toThrow(`Logbook frame ${frameId} is missing or already batched`);
+    expect(await store.latestBatch()).toBeNull();
+    expect(await store.countUnbatchedActiveFrames()).toBe(1);
   });
 
-  it("resets running batches to pending on startup recovery", () => {
+  it("resets running batches to pending on startup recovery", async () => {
     const t0 = Date.now();
-    insertFrame(t0);
-    const batchId = store.createBatch({
+    await insertFrame(t0);
+    const batchId = await store.createBatch({
       day: dayKeyFor(t0),
       startMs: t0,
       endMs: t0 + 1000,
       frameIds: [1],
     });
-    store.setBatchStatus(batchId, "running");
-    store.resetRunningBatches();
-    expect(store.nextPendingBatch()?.id).toBe(batchId);
+    await store.setBatchStatus(batchId, "running");
+    await store.resetRunningBatches();
+    expect((await store.nextPendingBatch())?.id).toBe(batchId);
   });
 
-  it("replaces only cards overlapping the revision window", () => {
+  it("replaces only cards overlapping the revision window", async () => {
     const base = new Date(`${DAY}T09:00:00`).getTime();
-    store.replaceCardsInWindow(DAY, base, base + 4 * 60 * 60_000, [
+    await store.replaceCardsInWindow(DAY, base, base + 4 * 60 * 60_000, [
       draft({ startMs: base, endMs: base + 30 * 60_000, title: "Early" }),
       draft({ startMs: base + 60 * 60_000, endMs: base + 90 * 60_000, title: "Mid" }),
     ]);
     expect(
-      store.cardsForDay(DAY, { startMs: base + 30 * 60_000, endMs: base + 60 * 60_000 }),
+      await store.cardsForDay(DAY, { startMs: base + 30 * 60_000, endMs: base + 60 * 60_000 }),
     ).toEqual([]);
     expect(
-      store
-        .cardsForDay(DAY, { startMs: base + 50 * 60_000, endMs: base + 2 * 60 * 60_000 })
-        .map((card) => card.title),
+      (
+        await store.cardsForDay(DAY, { startMs: base + 50 * 60_000, endMs: base + 2 * 60 * 60_000 })
+      ).map((card) => card.title),
     ).toEqual(["Mid"]);
     // Revise only the window covering "Mid"; "Early" must survive untouched.
-    store.replaceCardsInWindow(DAY, base + 50 * 60_000, base + 2 * 60 * 60_000, [
+    await store.replaceCardsInWindow(DAY, base + 50 * 60_000, base + 2 * 60 * 60_000, [
       draft({ startMs: base + 55 * 60_000, endMs: base + 95 * 60_000, title: "Mid revised" }),
     ]);
-    const titles = store.cardsForDay(DAY).map((card) => card.title);
+    const titles = (await store.cardsForDay(DAY)).map((card) => card.title);
     expect(titles).toEqual(["Early", "Mid revised"]);
   });
 
-  it("round-trips distractions and computes day stats", () => {
+  it("round-trips distractions and computes day stats", async () => {
     const base = new Date(`${DAY}T10:00:00`).getTime();
-    store.replaceCardsInWindow(DAY, base, base + 60 * 60_000, [
+    await store.replaceCardsInWindow(DAY, base, base + 60 * 60_000, [
       draft({
         distractions: [{ startMs: base + 5 * 60_000, endMs: base + 10 * 60_000, title: "Twitter" }],
       }),
@@ -337,7 +337,7 @@ describe("LogbookStore", () => {
     } finally {
       database.close();
     }
-    const cards = store.cardsForDay(DAY);
+    const cards = await store.cardsForDay(DAY);
     expect(cards.map((card) => card.title)).toEqual(["Card", "Review"]);
     expect(cards[1]).toMatchObject({
       appPrimary: undefined,
@@ -348,7 +348,7 @@ describe("LogbookStore", () => {
     expect(expectDefined(cards[0], "stored logbook card").distractions).toEqual([
       { startMs: base + 5 * 60_000, endMs: base + 10 * 60_000, title: "Twitter" },
     ]);
-    const stats = store.timelineForDay(DAY).stats;
+    const stats = (await store.timelineForDay(DAY)).stats;
     expect(stats.trackedMs).toBe(60 * 60_000);
     expect(stats.distractionMs).toBe(5 * 60_000);
     expect(stats.categories).toEqual([
@@ -356,102 +356,108 @@ describe("LogbookStore", () => {
       { category: "review", ms: 30 * 60_000 },
     ]);
     expect(expectDefined(stats.apps[0], "logbook app statistic").domain).toBe("github.com");
-    expect(store.countCardsForDay(DAY)).toBe(cards.length);
-    expect(store.countCardsForDay("2026-07-04")).toBe(0);
-    expect(store.timelineForDay("2026-07-04")).toEqual({
+    expect(await store.countCardsForDay(DAY)).toBe(cards.length);
+    expect(await store.countCardsForDay("2026-07-04")).toBe(0);
+    expect(await store.timelineForDay("2026-07-04")).toEqual({
       day: "2026-07-04",
       cards: [],
       stats: { trackedMs: 0, distractionMs: 0, categories: [], apps: [] },
     });
   });
 
-  it("prunes old frame rows and files but keeps recent ones", () => {
+  it("prunes old frame rows and files but keeps recent ones", async () => {
     const now = Date.now();
-    const oldId = insertFrame(now - 20 * 24 * 60 * 60_000);
-    const newId = insertFrame(now);
-    const oldPath = store.frameById(oldId)?.path ?? "";
-    expect(store.pruneFrames(now - 14 * 24 * 60 * 60_000)).toBe(1);
-    expect(store.frameById(oldId)).toBeNull();
+    const oldId = await insertFrame(now - 20 * 24 * 60 * 60_000);
+    const newId = await insertFrame(now);
+    const oldPath = (await store.frameById(oldId))?.path ?? "";
+    expect(await store.pruneFrames(now - 14 * 24 * 60 * 60_000)).toBe(1);
+    expect(await store.frameById(oldId)).toBeNull();
     expect(existsSync(oldPath)).toBe(false);
-    expect(store.frameById(newId)).not.toBeNull();
+    expect(await store.frameById(newId)).not.toBeNull();
   });
 
-  it("keeps frame metadata when a retained file cannot be removed", () => {
+  it("keeps frame metadata when a retained file cannot be removed", async () => {
     const now = Date.now();
-    const firstId = insertFrame(now - 21 * 24 * 60 * 60_000);
-    const blockedId = insertFrame(now - 20 * 24 * 60 * 60_000);
-    const blockedPath = expectDefined(store.frameById(blockedId), "blocked frame").path;
+    const firstId = await insertFrame(now - 21 * 24 * 60 * 60_000);
+    const blockedId = await insertFrame(now - 20 * 24 * 60 * 60_000);
+    const blockedPath = expectDefined(await store.frameById(blockedId), "blocked frame").path;
     rmSync(blockedPath);
     mkdirSync(blockedPath);
 
-    expect(() => store.pruneFrames(now - 14 * 24 * 60 * 60_000)).toThrow();
-    expect(store.frameById(firstId)).not.toBeNull();
-    expect(store.frameById(blockedId)).not.toBeNull();
+    await expect(store.pruneFrames(now - 14 * 24 * 60 * 60_000)).rejects.toThrow();
+    expect(await store.frameById(firstId)).not.toBeNull();
+    expect(await store.frameById(blockedId)).not.toBeNull();
 
     rmSync(blockedPath, { recursive: true });
-    expect(store.pruneFrames(now - 14 * 24 * 60 * 60_000)).toBe(2);
-    expect(store.frameById(firstId)).toBeNull();
-    expect(store.frameById(blockedId)).toBeNull();
+    expect(await store.pruneFrames(now - 14 * 24 * 60 * 60_000)).toBe(2);
+    expect(await store.frameById(firstId)).toBeNull();
+    expect(await store.frameById(blockedId)).toBeNull();
   });
 
-  it("detaches pruned keyframes from surviving cards", () => {
+  it("detaches pruned keyframes from surviving cards", async () => {
     const now = Date.now();
-    const oldId = insertFrame(now - 20 * 24 * 60 * 60_000);
-    store.replaceCardsInWindow(DAY, 0, Number.MAX_SAFE_INTEGER, [draft({ keyframeId: oldId })]);
-    store.pruneFrames(now - 14 * 24 * 60 * 60_000);
-    expect(store.cardsForDay(DAY)[0]?.keyframeId).toBeUndefined();
+    const oldId = await insertFrame(now - 20 * 24 * 60 * 60_000);
+    await store.replaceCardsInWindow(DAY, 0, Number.MAX_SAFE_INTEGER, [
+      draft({ keyframeId: oldId }),
+    ]);
+    await store.pruneFrames(now - 14 * 24 * 60 * 60_000);
+    expect((await store.cardsForDay(DAY))[0]?.keyframeId).toBeUndefined();
   });
 
-  it("replaces observations on batch retry instead of appending", () => {
+  it("replaces observations on batch retry instead of appending", async () => {
     const t0 = Date.now();
-    const frameId = insertFrame(t0);
-    const batchId = store.createBatch({
+    const frameId = await insertFrame(t0);
+    const batchId = await store.createBatch({
       day: DAY,
       startMs: t0,
       endMs: t0 + 1000,
       frameIds: [frameId],
     });
-    store.replaceObservations(batchId, DAY, [{ startMs: t0, endMs: t0 + 500, text: "first run" }]);
-    store.replaceObservations(batchId, DAY, [{ startMs: t0, endMs: t0 + 500, text: "retry run" }]);
-    const observations = store.observationsInRange(DAY, 0, Number.MAX_SAFE_INTEGER);
+    await store.replaceObservations(batchId, DAY, [
+      { startMs: t0, endMs: t0 + 500, text: "first run" },
+    ]);
+    await store.replaceObservations(batchId, DAY, [
+      { startMs: t0, endMs: t0 + 500, text: "retry run" },
+    ]);
+    const observations = await store.observationsInRange(DAY, 0, Number.MAX_SAFE_INTEGER);
     expect(observations).toHaveLength(1);
     expect(expectDefined(observations[0], "retried observation").text).toBe("retry run");
   });
 
-  it("rejects observations for a missing batch", () => {
-    expect(() =>
+  it("rejects observations for a missing batch", async () => {
+    await expect(
       store.replaceObservations(999_999, DAY, [
         { startMs: 1, endMs: 2, text: "orphan observation" },
       ]),
-    ).toThrow();
-    expect(store.observationsInRange(DAY, 0, Number.MAX_SAFE_INTEGER)).toEqual([]);
+    ).rejects.toThrow();
+    expect(await store.observationsInRange(DAY, 0, Number.MAX_SAFE_INTEGER)).toEqual([]);
   });
 
-  it("rolls back a card replacement with a missing keyframe", () => {
+  it("rolls back a card replacement with a missing keyframe", async () => {
     const base = new Date(`${DAY}T10:00:00`).getTime();
-    store.replaceCardsInWindow(DAY, base, base + 60_000, [draft({ title: "kept" })]);
+    await store.replaceCardsInWindow(DAY, base, base + 60_000, [draft({ title: "kept" })]);
 
-    expect(() =>
+    await expect(
       store.replaceCardsInWindow(DAY, base, base + 60_000, [
         draft({ title: "invalid", keyframeId: 999_999 }),
       ]),
-    ).toThrow();
-    expect(store.cardsForDay(DAY).map((card) => card.title)).toEqual(["kept"]);
+    ).rejects.toThrow();
+    expect((await store.cardsForDay(DAY)).map((card) => card.title)).toEqual(["kept"]);
   });
 
-  it("requeues errored batches for explicit retry", () => {
+  it("requeues errored batches for explicit retry", async () => {
     const t0 = Date.now();
-    const frameId = insertFrame(t0);
-    const batchId = store.createBatch({
+    const frameId = await insertFrame(t0);
+    const batchId = await store.createBatch({
       day: dayKeyFor(t0),
       startMs: t0,
       endMs: t0 + 1000,
       frameIds: [frameId],
     });
-    store.setBatchStatus(batchId, "error", "boom");
-    expect(store.nextPendingBatch()).toBeNull();
-    expect(store.resetErrorBatches()).toBe(1);
-    const requeued = store.nextPendingBatch();
+    await store.setBatchStatus(batchId, "error", "boom");
+    expect(await store.nextPendingBatch()).toBeNull();
+    expect(await store.resetErrorBatches()).toBe(1);
+    const requeued = await store.nextPendingBatch();
     expect(requeued?.id).toBe(batchId);
     expect(requeued?.error).toBeUndefined();
   });
@@ -463,14 +469,14 @@ describe("LogbookStore", () => {
     expect(mode(path.join(dir, "logbook.sqlite"))).toBe(0o600);
   });
 
-  it("stores and updates standups", () => {
-    store.saveStandup(DAY, "## Done\n- shipped");
-    store.saveStandup(DAY, "## Done\n- shipped more");
-    expect(store.getStandup(DAY)?.text).toContain("shipped more");
+  it("stores and updates standups", async () => {
+    await store.saveStandup(DAY, "## Done\n- shipped");
+    await store.saveStandup(DAY, "## Done\n- shipped more");
+    expect((await store.getStandup(DAY))?.text).toContain("shipped more");
   });
 
-  it("migrates legacy tables to STRICT without losing batch assignments", () => {
-    store.close();
+  it("migrates legacy tables to STRICT without losing batch assignments", async () => {
+    await store.close();
     const databasePath = path.join(dir, "logbook.sqlite");
     rmSync(databasePath, { force: true });
     const legacy = new DatabaseSync(databasePath);
@@ -505,9 +511,9 @@ describe("LogbookStore", () => {
     `);
     legacy.close();
 
-    store = new LogbookStore(dir);
+    store = await LogbookStore.open(dir);
 
-    expect(store.batchFrames(7).map((frame) => frame.id)).toEqual([11]);
+    expect((await store.batchFrames(7)).map((frame) => frame.id)).toEqual([11]);
     const migrated = new DatabaseSync(databasePath, { readOnly: true });
     try {
       expect(
@@ -530,7 +536,7 @@ describe("LogbookStore", () => {
     }
   });
 
-  it("rolls back a legacy STRICT migration when stored data has the wrong type", () => {
+  it("rolls back a legacy STRICT migration when stored data has the wrong type", async () => {
     const legacyDir = path.join(dir, "invalid-legacy");
     mkdirSync(legacyDir);
     const databasePath = path.join(legacyDir, "logbook.sqlite");
@@ -541,7 +547,7 @@ describe("LogbookStore", () => {
     `);
     legacy.close();
 
-    expect(() => new LogbookStore(legacyDir)).toThrow(
+    await expect(LogbookStore.open(legacyDir)).rejects.toThrow(
       "Failed migrating SQLite table standups to STRICT",
     );
 

--- a/extensions/logbook/src/store.ts
+++ b/extensions/logbook/src/store.ts
@@ -179,7 +179,11 @@ export class LogbookStore {
   private readonly walMaintenance: ReturnType<typeof configureSqliteConnectionPragmas>;
   readonly framesDir: string;
 
-  constructor(readonly dataDir: string) {
+  static async open(dataDir: string): Promise<LogbookStore> {
+    return new LogbookStore(dataDir);
+  }
+
+  private constructor(readonly dataDir: string) {
     // Frames and the DB hold raw screen contents; keep everything owner-only
     // even when the surrounding state dir is more permissive.
     mkdirSync(dataDir, { recursive: true, mode: 0o700 });
@@ -248,7 +252,7 @@ export class LogbookStore {
     this.cardsQuery = this.query.selectFrom("cards");
   }
 
-  close(): void {
+  async close(): Promise<void> {
     this.walMaintenance.close();
     this.db.close();
   }
@@ -257,7 +261,7 @@ export class LogbookStore {
     return path.join(this.framesDir, day, `${capturedAtMs}.jpg`);
   }
 
-  insertFrame(params: {
+  async insertFrame(params: {
     capturedAtMs: number;
     day: string;
     path: string;
@@ -267,7 +271,7 @@ export class LogbookStore {
     byteSize: number;
     contentHash: string;
     idle: boolean;
-  }): number {
+  }): Promise<number> {
     const { compiled, bind } = compileSqliteQueryBindings<typeof params>((p) =>
       this.query.insertInto("frames").values({
         captured_at_ms: p((row) => row.capturedAtMs),
@@ -285,7 +289,7 @@ export class LogbookStore {
     return Number(result.lastInsertRowid);
   }
 
-  lastFrame(): { capturedAtMs: number; contentHash: string } | null {
+  async lastFrame(): Promise<{ capturedAtMs: number; contentHash: string } | null> {
     const row = executeSqliteQueryTakeFirstSync(
       this.db,
       this.query
@@ -298,14 +302,14 @@ export class LogbookStore {
     return row ? { capturedAtMs: row.captured_at_ms, contentHash: row.content_hash } : null;
   }
 
-  unbatchedActiveFrames(limit: number): LogbookFrame[] {
+  async unbatchedActiveFrames(limit: number): Promise<LogbookFrame[]> {
     return executeSqliteQuerySync(
       this.db,
       this.framesQuery.where("batch_id", "is", null).where("idle", "=", 0).limit(limit),
     ).rows.map(toFrame);
   }
 
-  countUnbatchedActiveFrames(): number {
+  async countUnbatchedActiveFrames(): Promise<number> {
     const row = executeSqliteQueryTakeFirstSync(
       this.db,
       this.query
@@ -317,19 +321,24 @@ export class LogbookStore {
     return expectDefined(row, "Logbook unbatched frame count").n;
   }
 
-  frameById(id: number): LogbookFrame | null {
+  async frameById(id: number): Promise<LogbookFrame | null> {
     const row = executeSqliteQueryTakeFirstSync(this.db, this.framesQuery.where("id", "=", id));
     return row ? toFrame(row) : null;
   }
 
-  framesInRange(startMs: number, endMs: number): LogbookFrame[] {
+  async framesInRange(startMs: number, endMs: number): Promise<LogbookFrame[]> {
     return executeSqliteQuerySync(
       this.db,
       this.framesQuery.where("captured_at_ms", ">=", startMs).where("captured_at_ms", "<", endMs),
     ).rows.map(toFrame);
   }
 
-  createBatch(params: { day: string; startMs: number; endMs: number; frameIds: number[] }): number {
+  async createBatch(params: {
+    day: string;
+    startMs: number;
+    endMs: number;
+    frameIds: number[];
+  }): Promise<number> {
     if (params.frameIds.length === 0) {
       throw new Error("Logbook batch requires at least one frame");
     }
@@ -379,12 +388,12 @@ export class LogbookStore {
     );
   }
 
-  setBatchStatus(
+  async setBatchStatus(
     batchId: number,
     status: LogbookBatchStatus,
     error?: string,
     model?: string,
-  ): void {
+  ): Promise<void> {
     const { compiled, bind } = compileSqliteQueryBindings<void>((p) =>
       this.query
         .updateTable("batches")
@@ -399,7 +408,7 @@ export class LogbookStore {
     this.db.prepare(compiled.sql).run(...bind());
   }
 
-  latestBatch(): LogbookBatch | null {
+  async latestBatch(): Promise<LogbookBatch | null> {
     const row = executeSqliteQueryTakeFirstSync(
       this.db,
       this.batchesQuery.orderBy("id", "desc").limit(1),
@@ -408,7 +417,7 @@ export class LogbookStore {
   }
 
   /** Requeues batches stuck in `running` after a crash so frames are not orphaned. */
-  resetRunningBatches(): void {
+  async resetRunningBatches(): Promise<void> {
     const { compiled, bind } = compileSqliteQueryBindings<void>((p) =>
       this.query
         .updateTable("batches")
@@ -419,7 +428,7 @@ export class LogbookStore {
   }
 
   /** Requeues failed batches for an explicit user-driven retry (analyze now). */
-  resetErrorBatches(): number {
+  async resetErrorBatches(): Promise<number> {
     const { compiled, bind } = compileSqliteQueryBindings<void>((p) =>
       this.query
         .updateTable("batches")
@@ -430,7 +439,7 @@ export class LogbookStore {
     return Number(result.changes);
   }
 
-  nextPendingBatch(): LogbookBatch | null {
+  async nextPendingBatch(): Promise<LogbookBatch | null> {
     const row = executeSqliteQueryTakeFirstSync(
       this.db,
       this.batchesQuery
@@ -442,7 +451,7 @@ export class LogbookStore {
     return row ? toBatch(row) : null;
   }
 
-  batchFrames(batchId: number): LogbookFrame[] {
+  async batchFrames(batchId: number): Promise<LogbookFrame[]> {
     return executeSqliteQuerySync(
       this.db,
       this.framesQuery.where("batch_id", "=", batchId),
@@ -454,11 +463,11 @@ export class LogbookStore {
    * after an error) rerun the vision stage, so appending would duplicate
    * evidence into card synthesis, standups, and ask answers.
    */
-  replaceObservations(
+  async replaceObservations(
     batchId: number,
     day: string,
     segments: Array<{ startMs: number; endMs: number; text: string }>,
-  ): void {
+  ): Promise<void> {
     const deletion = compileSqliteQueryBindings<void>(() =>
       this.query.deleteFrom("observations").where("batch_id", "=", batchId),
     );
@@ -489,12 +498,12 @@ export class LogbookStore {
     );
   }
 
-  observationsInRange(
+  async observationsInRange(
     day: string,
     startMs: number,
     endMs: number,
     tailLimit?: number,
-  ): LogbookObservation[] {
+  ): Promise<LogbookObservation[]> {
     const direction = tailLimit === undefined ? "asc" : "desc";
     let query = this.query
       .selectFrom("observations")
@@ -522,7 +531,10 @@ export class LogbookStore {
     }));
   }
 
-  cardsForDay(day: string, window?: { startMs: number; endMs: number }): LogbookCard[] {
+  async cardsForDay(
+    day: string,
+    window?: { startMs: number; endMs: number },
+  ): Promise<LogbookCard[]> {
     let query = this.cardsQuery
       .selectAll()
       .where("day", "=", day)
@@ -534,7 +546,7 @@ export class LogbookStore {
     return executeSqliteQuerySync(this.db, query).rows.map(toCard);
   }
 
-  countCardsForDay(day: string): number {
+  async countCardsForDay(day: string): Promise<number> {
     const row = executeSqliteQueryTakeFirstSync(
       this.db,
       this.cardsQuery.select((eb) => eb.fn.countAll<number>().as("count")).where("day", "=", day),
@@ -547,12 +559,12 @@ export class LogbookStore {
    * The analysis lookback treats recent cards as a revisable draft, so partial
    * writes here would surface as duplicated or missing timeline segments.
    */
-  replaceCardsInWindow(
+  async replaceCardsInWindow(
     day: string,
     startMs: number,
     endMs: number,
     drafts: LogbookCardDraft[],
-  ): void {
+  ): Promise<void> {
     const now = Date.now();
     const deletion = compileSqliteQueryBindings<void>(() =>
       this.query
@@ -595,7 +607,9 @@ export class LogbookStore {
     );
   }
 
-  listDays(): Array<{ day: string; cards: number; firstMs: number; lastMs: number }> {
+  async listDays(): Promise<
+    Array<{ day: string; cards: number; firstMs: number; lastMs: number }>
+  > {
     return executeSqliteQuerySync(
       this.db,
       this.cardsQuery
@@ -615,8 +629,10 @@ export class LogbookStore {
     }));
   }
 
-  timelineForDay(day: string): { day: string; cards: LogbookCard[]; stats: LogbookDayStats } {
-    const cards = this.cardsForDay(day);
+  async timelineForDay(
+    day: string,
+  ): Promise<{ day: string; cards: LogbookCard[]; stats: LogbookDayStats }> {
+    const cards = await this.cardsForDay(day);
     const categories = new Map<string, number>();
     const apps = new Map<string, number>();
     let trackedMs = 0;
@@ -647,7 +663,7 @@ export class LogbookStore {
     };
   }
 
-  getStandup(day: string): { day: string; text: string; updatedMs: number } | null {
+  async getStandup(day: string): Promise<{ day: string; text: string; updatedMs: number } | null> {
     const row = executeSqliteQueryTakeFirstSync(
       this.db,
       this.query.selectFrom("standups").selectAll().where("day", "=", day),
@@ -655,7 +671,7 @@ export class LogbookStore {
     return row ? { day: row.day, text: row.text, updatedMs: row.updated_ms } : null;
   }
 
-  saveStandup(day: string, text: string): void {
+  async saveStandup(day: string, text: string): Promise<void> {
     const { compiled, bind } = compileSqliteQueryBindings<void>((p) =>
       this.query
         .insertInto("standups")
@@ -671,7 +687,7 @@ export class LogbookStore {
   }
 
   /** Deletes frame rows and files older than the retention window. */
-  pruneFrames(olderThanMs: number): number {
+  async pruneFrames(olderThanMs: number): Promise<number> {
     const rows = executeSqliteQuerySync(
       this.db,
       this.query


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Logbook uses synchronous storage throughout startup, timeline reads, capture and analysis. Introducing awaited persistence requires a single lifetime owner to retain admitted work until its database operations finish.

## Why This Change Was Made

Make store opening, queries, mutations and close asynchronous, and migrate their actual callers. Extend the existing service operation owner to cover startup, status and reads, manual analysis admission, pruning and day recall. Publish the service after startup recovery and pruning complete; shutdown stops new admission and drains retained operations before closing SQLite.

Native SQLite statements, schema and transaction callbacks are unchanged, and pure path/date helpers remain synchronous.

## User Impact

Timeline and report APIs keep their existing response shapes. Startup completes recovery before capture begins, and shutdown preserves admitted capture, analysis and model work through final persistence.

## Evidence

- All 86 focused tests and full selected changed checks passed.
- Fresh independent Codex review through P2 passed with final source verification.
- Standalone production-source smoke exercised four registered Gateway methods via an isolated loopback bridge, real SQLite writes and fresh reopening. Holding a synthetic standup model result proved stop waits for its final database write.
- Thirty warm samples measured timeline-read and standup-write medians of 0.034 ms and 0.033 ms. No speedup is claimed.
- Smoke inputs were synthetic; this is not full Gateway authentication, real screen capture or an external model call.
