### PR TITLE
fix(memory): session search hits fail exact retrieval with path required

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -156,6 +156,20 @@ The agent has three tools for working with memory:
 
 All three tools are provided by the active memory plugin (default: `memory-core`).
 
+When session indexing is enabled, `memory_search` can also return session
+transcript hits. Their `sessions/...jsonl` paths are search references, not files
+that `memory_get` can read. Use `sessions_search` with distinctive text from the
+snippet (optionally scope `sessionKey` to the transcript ID), then pass its returned
+`sessionKey`, `messageId`, and `sessionId` to `sessions_history` for a bounded,
+sanitized excerpt. These tools enforce session visibility independently on each
+request. Memory-search line numbers are not session-history offsets.
+
+The recall prompt recommends only enabled tools. Without session-history tools,
+report the excerpt limitation instead of reading raw transcript files.
+`memory_get` reports unsupported paths as read errors, not missing arguments or a
+globally disabled memory service. Memory-file reads and optional wiki reads keep
+their existing range, continuation, and partial-corpus semantics.
+
 ## Memory search
 
 When an embedding provider is configured, `memory_search` uses hybrid search:

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -143,7 +143,7 @@ describe("buildPromptSection", () => {
     });
     expect(result[0]).toBe("## Memory Recall");
     expect(result[1]).toContain("run memory_search");
-    expect(result[1]).toContain("then use memory_get");
+    expect(result[1]).toContain("for memory-file hits, use memory_get");
     expect(result).toContain(
       "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
     );
@@ -166,6 +166,31 @@ describe("buildPromptSection", () => {
     expect(result[0]).toBe("## Memory Recall");
     expect(result[1]).toContain("run memory_get");
     expect(result[1]).not.toContain("run memory_search");
+  });
+
+  it.each([
+    [[], [], ["sessions_search", "sessions_history"]],
+    [["sessions_search"], ["sessions_search"], ["sessions_history"]],
+    [["sessions_history"], ["sessions_history"], ["sessions_search"]],
+    [["sessions_search", "sessions_history"], ["sessions_search", "sessions_history"], []],
+  ])("offers only available session follow-up tools: %j", (sessionTools, included, excluded) => {
+    const prompt = buildMemoryPromptSection({
+      availableTools: new Set(["memory_search", "memory_get", ...sessionTools]),
+    }).join("\n");
+    for (const name of included) {
+      expect(prompt).toContain(name);
+    }
+    for (const name of excluded) {
+      expect(prompt).not.toContain(name);
+    }
+    expect(prompt).toContain("Session search line numbers are not history offsets");
+    expect(prompt).toContain("Never read raw transcript files");
+    if (sessionTools.length === 0) {
+      expect(prompt).toContain("exact session history is unavailable");
+    }
+    if (sessionTools.length === 2) {
+      expect(prompt).toContain("returned sessionKey, messageId, and sessionId");
+    }
   });
 
   it("includes citations-off instruction when citationsMode is off", () => {

--- a/extensions/memory-core/src/memory-get-corpus.test.ts
+++ b/extensions/memory-core/src/memory-get-corpus.test.ts
@@ -168,7 +168,7 @@ describe("memory_get corpus outcomes", () => {
       expected: {
         path: lookup,
         text: "",
-        disabled: true,
+        status: "error",
         corpora: [
           { corpus: "memory", outcome: "unavailable", error: "memory unavailable" },
           { corpus: "wiki", outcome: "unavailable", error: "wiki unavailable" },
@@ -185,7 +185,7 @@ describe("memory_get corpus outcomes", () => {
       expected: {
         path: lookup,
         text: "",
-        disabled: true,
+        status: "error",
         corpora: [
           { corpus: "memory", outcome: "unavailable", error: "memory unavailable" },
           { corpus: "wiki", outcome: "not-registered" },

--- a/extensions/memory-core/src/memory-read-tool.ts
+++ b/extensions/memory-core/src/memory-read-tool.ts
@@ -1,4 +1,4 @@
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { extractErrorCode, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { MemoryReadResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { jsonResult } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import {
@@ -62,7 +62,8 @@ export async function executeMemoryReadResult(
       return jsonResult({
         path: params.relPath,
         text: "",
-        disabled: true,
+        status: "error",
+        code: extractErrorCode(error) ?? "MEMORY_READ_FAILED",
         error: formatErrorMessage(error),
       });
     }
@@ -88,7 +89,7 @@ export async function executeMemoryReadResult(
           : (wikiResult ??
             (memory.outcome === "ok" || wiki.outcome === "ok"
               ? { status: "not_found" as const, path: params.relPath, text: "" as const }
-              : { path: params.relPath, text: "", disabled: true }));
+              : { status: "error", path: params.relPath, text: "" }));
       return jsonResult({ ...result, ...composeMemoryCorpusMetadata([memory, wiki]) });
     },
   });

--- a/extensions/memory-core/src/memory-tool-contract.ts
+++ b/extensions/memory-core/src/memory-tool-contract.ts
@@ -83,14 +83,14 @@ export function resolveMemoryToolContext(options: MemoryToolOptions) {
 const SEARCH_CORPUS_OUTCOME_GUIDANCE =
   "Corpus outcomes cover each requested corpus; a corpus warning means results are partial and must be surfaced to the user.";
 const GET_READ_OUTCOME_GUIDANCE =
-  "status=ok means the requested excerpt was read; status=not_found means every requested available corpus missed.";
+  "status=ok means the requested excerpt was read; status=not_found means every requested available corpus missed; status=error means the requested read failed, not that memory is disabled.";
 
 export const MEMORY_SEARCH_TOOL_CONTRACT = {
   label: "Memory Search",
   name: "memory_search",
   parameters: MemorySearchSchema,
   describe: ({ search }: MemorySourceContract) =>
-    `Mandatory recall step: semantically search ${search} before answering questions about prior work, decisions, dates, people, preferences, or todos. Optional \`corpus=wiki\` or \`corpus=all\` also searches registered compiled-wiki supplements. \`corpus=memory\` restricts hits to indexed memory files (excludes session transcript chunks from ranking). \`corpus=sessions\` restricts hits to the session corpus under the same visibility rules as session history tools. ${SEARCH_CORPUS_OUTCOME_GUIDANCE} If response has disabled=true or stale=true, tell the user and include the warning/action guidance.`,
+    `Mandatory recall step: semantically search ${search} before answering questions about prior work, decisions, dates, people, preferences, or todos. Session results are transcript search references, not readable memory-file paths. Optional \`corpus=wiki\` or \`corpus=all\` also searches registered compiled-wiki supplements. \`corpus=memory\` restricts hits to indexed memory files (excludes session transcript chunks from ranking). \`corpus=sessions\` restricts hits to the session corpus under the same visibility rules as session history tools. ${SEARCH_CORPUS_OUTCOME_GUIDANCE} If response has disabled=true or stale=true, tell the user and include the warning/action guidance.`,
 } as const;
 
 export const MEMORY_GET_TOOL_CONTRACT = {
@@ -98,7 +98,7 @@ export const MEMORY_GET_TOOL_CONTRACT = {
   name: "memory_get",
   parameters: MemoryGetSchema,
   describe: ({ files }: MemorySourceContract) =>
-    `Safe exact excerpt read from ${files}. Defaults to a bounded excerpt when lines are omitted and includes truncation/continuation info when more content exists. \`corpus=wiki\` reads registered compiled-wiki supplements. ${GET_READ_OUTCOME_GUIDANCE} ${SEARCH_CORPUS_OUTCOME_GUIDANCE}`,
+    `Safe exact excerpt read from ${files}. Session transcript paths are unsupported; use the available session-history workflow for session hits. Defaults to a bounded excerpt when lines are omitted and includes truncation/continuation info when more content exists. \`corpus=wiki\` reads registered compiled-wiki supplements. ${GET_READ_OUTCOME_GUIDANCE} ${SEARCH_CORPUS_OUTCOME_GUIDANCE}`,
 } as const;
 
 export type MemoryToolContract =
@@ -118,14 +118,28 @@ export function buildMemoryPromptSection({
   // Code mode may defer tool descriptions; recall and disclosure policy must stay here.
   const guidance = hasMemorySearch
     ? `Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search${
-        hasMemoryGet ? "; then use memory_get to pull only the needed lines" : ""
+        hasMemoryGet ? "; for memory-file hits, use memory_get to pull only the needed lines" : ""
       }. If low confidence after search, say you checked.`
     : "Before answering anything about prior work, decisions, dates, people, preferences, or todos that point to a specific memory file: run memory_get to pull only the needed lines. If low confidence after reading, say you checked.";
+  const sessionGuidance = !hasMemorySearch
+    ? []
+    : [
+        availableTools.has("sessions_search")
+          ? `For session hits, use sessions_search with distinctive snippet text (and sessionKey set to the transcript ID when known)${
+              availableTools.has("sessions_history")
+                ? ", then sessions_history with the returned sessionKey, messageId, and sessionId for a bounded sanitized excerpt"
+                : "; exact session history is unavailable with the enabled tools"
+            }.`
+          : availableTools.has("sessions_history")
+            ? "For session hits, use sessions_history with a known session key or transcript ID and a small limit; paginate its returned history metadata to locate the excerpt."
+            : "Session hits are search snippets only; exact session history is unavailable with the enabled tools.",
+        "Session search line numbers are not history offsets. Never read raw transcript files to expand session hits.",
+      ];
   const outcomeGuidance =
     "Report partial, unavailable, or stale recall to the user, including returned warning and action guidance.";
   const citationGuidance =
     citationsMode === "off"
       ? "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks."
       : "Citations: include Source: <path#line> when it helps the user verify memory snippets.";
-  return ["## Memory Recall", guidance, outcomeGuidance, citationGuidance, ""];
+  return ["## Memory Recall", guidance, ...sessionGuidance, outcomeGuidance, citationGuidance, ""];
 }

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -191,9 +191,9 @@ describe("memory tools", () => {
     expect(getMemoryCloseMockCalls()).toBe(1);
   });
 
-  it("returns disabled details when memory_get fails", async () => {
+  it("reports a failed memory read without disabling memory", async () => {
     setMemoryReadFileImpl(async (_params: MemoryReadParams) => {
-      throw new Error("path required");
+      throw Object.assign(new Error("memory file unreadable"), { code: "EACCES" });
     });
 
     const tool = createMemoryGetToolOrThrow();
@@ -202,8 +202,9 @@ describe("memory tools", () => {
     expect(result.details).toEqual({
       path: "memory/NOPE.md",
       text: "",
-      disabled: true,
-      error: "path required",
+      status: "error",
+      code: "EACCES",
+      error: "memory file unreadable",
     });
   });
 

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -17,7 +17,7 @@ import {
   createManagerIndexFixture,
   type ManagerIndexFixture,
 } from "./memory/manager-index.test-support.js";
-import { createMemorySearchTool, testing } from "./tools.js";
+import { createMemoryGetTool, createMemorySearchTool, testing } from "./tools.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./memory/index.js");
 const { MemoryIndexManager } = await import("./memory/manager.js");
@@ -131,6 +131,64 @@ describe("memory_search real manager", () => {
     expect(await fs.readFile(filePath, "utf8")).toBe(testCase.text);
     expect(fixture.provider.embedBatchCalls).toBe(0);
     expect(fixture.provider.embedQueryCalls).toBe(0);
+  });
+
+  it("rejects a real session search hit as an unsupported file without disabling memory", async () => {
+    const cfg = fixture.createConfig({
+      provider: "none",
+      sources: ["memory", "sessions"],
+      sessionMemory: true,
+      vectorEnabled: false,
+      minScore: 0,
+    });
+    const sessionKey = "agent:main:telegram:direct:excerpt-proof";
+    await fixture.seedSessionTranscript({
+      sessionId: "excerpt-proof",
+      sessionKey,
+      messages: [
+        { role: "user", content: "The excerpt marker is cobalt orchid.", timestamp: Date.now() },
+      ],
+    });
+    const manager = await fixture.getFreshManager(cfg);
+    await manager.sync({ reason: "test", force: true });
+    const options = { config: cfg, agentId: "main", agentSessionKey: sessionKey };
+    const search = createMemorySearchTool(options)!;
+    const get = createMemoryGetTool(options)!;
+    const found = await search.execute("session-search", {
+      query: "cobalt orchid",
+      corpus: "sessions",
+    });
+    const { results } = found.details as {
+      results: Array<{ path: string; startLine: number; source: string }>;
+    };
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      source: "sessions",
+      path: "sessions/main/excerpt-proof.jsonl",
+    });
+    const excerpt = await get.execute("session-excerpt", {
+      path: results[0]!.path,
+      from: results[0]!.startLine,
+      lines: 3,
+    });
+    expect(excerpt.details).toMatchObject({
+      status: "error",
+      code: "MEMORY_PATH_NOT_ALLOWED",
+      text: "",
+    });
+    expect(excerpt.details).not.toHaveProperty("disabled");
+    expect(excerpt.details).not.toHaveProperty("error", "path required");
+    const memory = await get.execute("memory-excerpt", {
+      path: "memory/2026-01-12.md",
+      from: 2,
+      lines: 1,
+    });
+    expect(memory.details).toMatchObject({
+      status: "ok",
+      text: expect.stringContaining("Alpha memory line."),
+      from: 2,
+      lines: 1,
+    });
   });
 
   it("reports current invalid config after replacing the config of a retained tool", async () => {

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -108,7 +108,7 @@ describe("memory host SDK package internals", () => {
       await expect(listMemoryFiles(workspaceDir, [upperPath])).resolves.toEqual([]);
       await expect(
         readMemoryFile({ workspaceDir, extraPaths: [upperPath], relPath: upperPath }),
-      ).rejects.toThrow("path required");
+      ).rejects.toThrow("path is not an allowed Markdown memory file");
     },
   );
 

--- a/packages/memory-host-sdk/src/host/read-file-manager-compat.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file-manager-compat.test.ts
@@ -302,7 +302,7 @@ describe("MemoryIndexManager.readFile", () => {
         extraPaths: [],
         relPath: "NOTES.md",
       }),
-    ).rejects.toThrow("path required");
+    ).rejects.toThrow("path is not an allowed Markdown memory file");
   });
 
   it("allows additional memory paths and blocks symlinks", async () => {
@@ -353,7 +353,7 @@ describe("MemoryIndexManager.readFile", () => {
           extraPaths: [extraDir],
           relPath: "extra/linked.md",
         }),
-      ).rejects.toThrow("path required");
+      ).rejects.toThrow("path is not an allowed Markdown memory file");
     }
   });
 });

--- a/packages/memory-host-sdk/src/host/read-file.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file.test.ts
@@ -49,7 +49,7 @@ describe("readMemoryFile", () => {
           extraPaths: [extraDir],
           relPath: nonDirectoryParentPath,
         }),
-      ).rejects.toThrow("path required");
+      ).rejects.toThrow("path is not an allowed Markdown memory file");
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }
@@ -127,7 +127,7 @@ describe("readMemoryFile", () => {
           ]) {
             await expect(
               readMemoryFile({ workspaceDir, extraPaths: [extraDir], relPath }),
-            ).rejects.toThrow("path required");
+            ).rejects.toThrow("path is not an allowed Markdown memory file");
           }
           await expect(
             readMemoryFile({
@@ -135,7 +135,7 @@ describe("readMemoryFile", () => {
               extraPaths: [{ path: extraDir, pattern: "runbooks/**/*.md" }],
               relPath: target,
             }),
-          ).rejects.toThrow("path required");
+          ).rejects.toThrow("path is not an allowed Markdown memory file");
         } finally {
           lstatSyncSpy.mockRestore();
           lstatSpy.mockRestore();
@@ -175,7 +175,7 @@ describe("readMemoryFile", () => {
           extraPaths: [extraDir],
           relPath: path.join(insideLinkPath, "inside.md"),
         }),
-      ).rejects.toThrow("path required");
+      ).rejects.toThrow("path is not an allowed Markdown memory file");
 
       const outsideLinkPath = path.join(extraDir, "link");
       if (!(await createDirectorySymlink(outsideDir, outsideLinkPath))) {
@@ -188,14 +188,14 @@ describe("readMemoryFile", () => {
           extraPaths: [extraDir],
           relPath: path.join(outsideLinkPath, "private.md"),
         }),
-      ).rejects.toThrow("path required");
+      ).rejects.toThrow("path is not an allowed Markdown memory file");
       await expect(
         readMemoryFile({
           workspaceDir,
           extraPaths: [extraDir],
           relPath: path.join(outsideLinkPath, "missing.md"),
         }),
-      ).rejects.toThrow("path required");
+      ).rejects.toThrow("path is not an allowed Markdown memory file");
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }
@@ -225,7 +225,7 @@ describe("readMemoryFile", () => {
         ).resolves.toMatchObject({ text: "allowed" });
         await expect(
           readAgentMemoryFile({ cfg, agentId: "main", relPath: excludedPath }),
-        ).rejects.toThrow("path required");
+        ).rejects.toThrow("path is not an allowed Markdown memory file");
       } finally {
         await fs.rm(tmpRoot, { recursive: true, force: true });
       }

--- a/packages/memory-host-sdk/src/host/read-file.ts
+++ b/packages/memory-host-sdk/src/host/read-file.ts
@@ -31,6 +31,12 @@ import type { MemoryExtraPath } from "./types.js";
 
 // Secure markdown memory-file reader for workspace and configured extra paths.
 
+function memoryPathNotAllowed(): Error {
+  return Object.assign(new Error("path is not an allowed Markdown memory file"), {
+    code: "MEMORY_PATH_NOT_ALLOWED",
+  });
+}
+
 /** Check that an absolute path stays inside an allowed extra directory without symlink escapes. */
 async function isAllowedAdditionalDirectoryPath(
   additionalPath: string,
@@ -140,10 +146,10 @@ export async function readMemoryFile(params: {
     }
   }
   if (!allowedWorkspace && !allowedAdditional) {
-    throw additionalPathError ?? new Error("path required");
+    throw additionalPathError ?? memoryPathNotAllowed();
   }
   if (!absPath.endsWith(".md") && allowedAdditional !== "file") {
-    throw new Error("path required");
+    throw memoryPathNotAllowed();
   }
   if (allowedWorkspace) {
     try {


### PR DESCRIPTION
Closes #144668
Related: #126552, #139402

## What Problem This Solves

Fixes an issue where users recalling indexed conversations were directed to pass session search hits to `memory_get`, which returned `"path required"` and `disabled: true` even though the path was populated and ordinary memory reads worked.

## Why This Change Was Made

Keep one owner for transcript retrieval: `sessions_search` finds a message reference and `sessions_history` reads its bounded, sanitized context with current visibility checks. The recall prompt now distinguishes memory-file hits from session hits, names only enabled session tools, and explains when exact history is unavailable. It explicitly prevents treating search line numbers as history offsets or expanding hits through raw transcript files.

The existing Markdown reader still rejects exactly the same paths, but labels unsupported paths `MEMORY_PATH_NOT_ALLOWED`. `memory_get` reports read failures as `status: "error"`, preserving underlying error codes, instead of declaring memory globally disabled. Combined reads retain successful content and corpus warnings; failed combined reads no longer claim the memory service is disabled.

No new tools, public SDK exports, configuration, schema, indexing policy, or access grants. No deployment is included.

## User Impact

Agents have a supported search-to-excerpt workflow for session recall. Operators get accurate diagnostics for unsupported memory-file paths. Normal Markdown excerpts, continuation metadata, optional wiki lookups, and partial-result disclosure remain unchanged.

## Evidence

- **Red → green:** a new real-SQLite-manager regression indexes a synthetic session, calls `memory_search(corpus: "sessions")`, passes the actual returned path/range to `memory_get`, and verifies a truthful error followed by a successful memory-file read. It failed on main `8008b3df496884e80566b9942216a29e8c35f725` and passes with this patch.
- **142 focused tests passed** across the memory plugin registration/prompt, real manager, read/corpus, file-access, and manager-compatible reader suites. Existing symlink, extra-path glob, partial-corpus, timeout, and retained-tool revocation coverage remains green.
- **Disposable user-flow proof passed** on Node 24.20.0/macOS: real memory indexing/search → rejected transcript file read → `sessions_search` scoped by transcript ID → `sessions_history` anchored by returned `sessionKey`, `messageId`, and `sessionId` → the expected single synthetic message. This invoked real tool factories and real Gateway read handlers in-process, not a running operator Gateway or an LLM simulation. Cross-session and sandboxed history requests stayed forbidden; traversal/non-Markdown reads stayed denied; `MEMORY.md` excerpts and optional unregistered-wiki behavior passed.
- Independent scoped autoreview completed with no blocking findings. Repository changed-scope checks passed, including all four type lanes, deadcode, lint, boundary and repository guard checks. Exact-head hosted CI and the required hosted review are being completed before landing.

All reproduction data is synthetic. No private transcript content or runtime configuration was published.
