### PR TITLE
fix(ui): increase plugin tab padding to 16px

### DIFF
--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -25,7 +25,7 @@
 .content-header.plugins-hub-header .hub-page-header__tabs {
   grid-area: tabs;
   justify-self: start;
-  padding-block: var(--space-2);
+  padding-block: var(--space-4);
 }
 
 .plugins-hub-header .hub-tabs--sub wa-tab.hub-tab::part(base) {


### PR DESCRIPTION
## What Problem This Solves

The Plugins workspace tab strip needs more vertical breathing room than the 8 px spacing added in [PR #144652](https://github.com/openclaw/openclaw/pull/144652). This follows the maintainer's request to make it 16 px.

## Why This Change Was Made

Use the existing 16 px spacing token on the shared Plugins hub tab wrapper. One value changes; tab styling, click targets, and unrelated headers retain their existing behavior.

## User Impact

Plugins, Skills, and Skill workshop each have 16 px of padding above and below their shared navigation, across mobile and desktop layouts.

## Evidence

Compared baseline `086982881fef` (8 px) against this change (16 px) in the real local Control UI, with identical dark-theme synthetic Gateway fixtures at `/plugins`, `/skills`, and `/skills/workshop`. All 12 route/viewport comparisons confirm 16 px padding on each side, +16 px total wrapper height over the baseline, unchanged width, and no horizontal overflow. Every paired screenshot below was inspected.

- Viewports: 390×844, 768×1024, 1366×768, 1440×900.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/plugins-hub-navigation.e2e.test.ts`: **5 tests passed**, including production UI build and navigation through all three pages at four widths.
- `oxfmt --check ui/src/styles/plugins.css`, targeted stylelint, and `git diff --check`: passed.
- Fresh independent autoreview through P2: scoped-clean, no findings.
- Production delta: +1/−1 CSS line, net zero. Tests unchanged; the existing navigation suite and measured browser comparisons cover this reversible spacing preference.
- Loading, empty, and dense catalog variants are unrelated to this fixed-content header. The longest tab label and wrapping workshop subtitle are covered. Screenshots use the real UI with a deterministic mock Gateway, not the production team Gateway.

### Mobile — 8 px before / 16 px after

![mobile comparison](https://github.com/user-attachments/assets/dddef59a-b373-4b62-a797-47398d62c512)

### Tablet — 8 px before / 16 px after

![tablet comparison](https://github.com/user-attachments/assets/461274d1-d55c-4670-88a7-6696b93cf634)

### Laptop — 8 px before / 16 px after

![laptop comparison](https://github.com/user-attachments/assets/19296c42-5fea-48fb-a36d-05243efadfde)

### Desktop — 8 px before / 16 px after

![desktop comparison](https://github.com/user-attachments/assets/69720f40-e2ae-45d3-958c-5dcd307bb7f8)

