### PR TITLE
refactor(ui): share setup and plugin icon lifecycle

### DIFF
--- a/ui/src/pages/model-setup/model-setup-icon-loader.ts
+++ b/ui/src/pages/model-setup/model-setup-icon-loader.ts
@@ -6,6 +6,7 @@ import {
   renderProviderFallbackIcon,
 } from "../../components/provider-icon.ts";
 import { fetchCatalogIconBlobUrl } from "../plugins/icon-loader.ts";
+import { PluginIconController } from "../plugins/plugin-icon-controller.ts";
 import type { ModelSetupPageState } from "./state.ts";
 
 type SetupIconEntry = {
@@ -46,83 +47,52 @@ export function renderProviderIcon(
   />`;
 }
 
-type IconRequest = {
-  controller: AbortController;
-  timeout: ReturnType<typeof setTimeout>;
-};
-
 export class ModelSetupIconLoader {
-  private urls: Record<string, string> = {};
-  private readonly misses = new Set<string>();
-  private readonly requests = new Map<string, IconRequest>();
+  private readonly loader: PluginIconController;
 
   constructor(
     private readonly getContext: () => ApplicationContext,
     private readonly getPageState: () => ModelSetupPageState,
     private readonly onChange: (urls: Record<string, string>) => void,
-  ) {}
+  ) {
+    this.loader = new PluginIconController({
+      getFetchContext: () => {
+        const context = this.getContext();
+        return {
+          resourceBasePath: context.resourceBasePath,
+          gatewayUrl: context.gateway.connection.gatewayUrl,
+          auth: {
+            hello: context.gateway.snapshot.hello,
+            settings: { token: context.gateway.connection.token },
+            password: context.gateway.connection.password,
+          },
+        };
+      },
+      // Eligibility can change before Lit's next reconciliation callback.
+      isConnected: (iconUrl) =>
+        this.getContext().gateway.snapshot.phase === "connected" &&
+        this.currentIconUrls().has(iconUrl),
+      fetchIcon: (iconUrl, context, signal) =>
+        fetchCatalogIconBlobUrl({ iconUrl, ...context, signal }),
+      timeoutError: () => new DOMException("catalog icon fetch timed out", "TimeoutError"),
+      onUrlsChange: (urls) => this.onChange(urls),
+    });
+  }
 
   reconcile(): void {
     const eligible = this.currentIconUrls();
-    const nextUrls = { ...this.urls };
-    let changed = false;
-    for (const [iconUrl, blobUrl] of Object.entries(nextUrls)) {
-      if (!eligible.has(iconUrl)) {
-        URL.revokeObjectURL(blobUrl);
-        delete nextUrls[iconUrl];
-        changed = true;
-      }
-    }
-    if (changed) {
-      this.publish(nextUrls);
-    }
-    for (const [iconUrl, request] of this.requests) {
-      if (!eligible.has(iconUrl)) {
-        clearTimeout(request.timeout);
-        request.controller.abort();
-        this.requests.delete(iconUrl);
-      }
-    }
-    for (const iconUrl of this.misses) {
-      if (!eligible.has(iconUrl)) {
-        this.misses.delete(iconUrl);
-      }
-    }
+    this.loader.reconcileKeys(eligible);
     for (const iconUrl of eligible) {
-      if (!this.urls[iconUrl] && !this.misses.has(iconUrl) && !this.requests.has(iconUrl)) {
-        this.fetch(iconUrl);
-      }
+      this.loader.load(iconUrl);
     }
   }
 
   invalidate(iconUrl: string): void {
-    const request = this.requests.get(iconUrl);
-    if (request) {
-      clearTimeout(request.timeout);
-      request.controller.abort();
-      this.requests.delete(iconUrl);
-    }
-    const blobUrl = this.urls[iconUrl];
-    if (blobUrl) {
-      URL.revokeObjectURL(blobUrl);
-    }
-    const nextUrls = { ...this.urls };
-    delete nextUrls[iconUrl];
-    this.publish(nextUrls);
-    this.misses.add(iconUrl);
+    this.loader.handleError(iconUrl);
   }
 
   reset(): void {
-    for (const request of this.requests.values()) {
-      clearTimeout(request.timeout);
-      request.controller.abort();
-    }
-    for (const blobUrl of Object.values(this.urls)) {
-      URL.revokeObjectURL(blobUrl);
-    }
-    this.requests.clear();
-    this.misses.clear();
-    this.publish({});
+    this.loader.reset();
   }
 
   private currentIconUrls(): Set<string> {
@@ -141,60 +111,5 @@ export class ModelSetupIconLoader {
         ...(result.recommendedInstalls ?? []),
       ].flatMap((entry) => (entry.icon && !resolveSetupBrandIcon(entry) ? [entry.icon] : [])),
     );
-  }
-
-  private fetch(iconUrl: string): void {
-    const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(new DOMException("catalog icon fetch timed out", "TimeoutError")),
-      10_000,
-    );
-    const request = { controller, timeout };
-    this.requests.set(iconUrl, request);
-    const context = this.getContext();
-    void fetchCatalogIconBlobUrl({
-      iconUrl,
-      resourceBasePath: context.resourceBasePath,
-      gatewayUrl: context.gateway.connection.gatewayUrl,
-      auth: {
-        hello: context.gateway.snapshot.hello,
-        settings: { token: context.gateway.connection.token },
-        password: context.gateway.connection.password,
-      },
-      signal: controller.signal,
-    })
-      .then((blobUrl) => {
-        if (
-          this.requests.get(iconUrl) !== request ||
-          this.getContext().gateway.snapshot.phase !== "connected" ||
-          !this.currentIconUrls().has(iconUrl)
-        ) {
-          if (blobUrl) {
-            URL.revokeObjectURL(blobUrl);
-          }
-          return;
-        }
-        if (blobUrl) {
-          this.publish({ ...this.urls, [iconUrl]: blobUrl });
-        } else {
-          this.misses.add(iconUrl);
-        }
-      })
-      .catch(() => {
-        if (this.requests.get(iconUrl) === request) {
-          this.misses.add(iconUrl);
-        }
-      })
-      .finally(() => {
-        clearTimeout(timeout);
-        if (this.requests.get(iconUrl) === request) {
-          this.requests.delete(iconUrl);
-        }
-      });
-  }
-
-  private publish(urls: Record<string, string>): void {
-    this.urls = urls;
-    this.onChange(urls);
   }
 }

--- a/ui/src/pages/plugins/plugin-icon-controller.ts
+++ b/ui/src/pages/plugins/plugin-icon-controller.ts
@@ -3,7 +3,13 @@ import { fetchPluginIconBlobUrl, type PluginIconFetchContext } from "./icon-load
 
 type PluginIconControllerHost = {
   getFetchContext: () => PluginIconFetchContext;
-  isConnected: () => boolean;
+  isConnected: (key: string) => boolean;
+  fetchIcon?: (
+    key: string,
+    context: PluginIconFetchContext,
+    signal: AbortSignal,
+  ) => Promise<string | null>;
+  timeoutError?: () => DOMException;
   onUrlsChange: (urls: Record<string, string>) => void;
   onLoadingChange?: () => void;
 };
@@ -26,6 +32,10 @@ export class PluginIconController {
     const eligiblePluginIds = new Set(
       (result?.plugins ?? []).filter((plugin) => plugin.hasIcon).map((plugin) => plugin.id),
     );
+    this.reconcileKeys(eligiblePluginIds);
+  }
+
+  reconcileKeys(eligiblePluginIds: ReadonlySet<string>) {
     const nextUrls = { ...this.urls };
     let urlsChanged = false;
     for (const [pluginId, url] of Object.entries(nextUrls)) {
@@ -112,19 +122,23 @@ export class PluginIconController {
   private fetch(pluginId: string) {
     const controller = new AbortController();
     const timeout = setTimeout(
-      () => controller.abort(new DOMException("plugin icon fetch timed out", "TimeoutError")),
+      () =>
+        controller.abort(
+          this.host.timeoutError?.() ??
+            new DOMException("plugin icon fetch timed out", "TimeoutError"),
+        ),
       10_000,
     );
     const request = { controller, timeout };
     this.requests.set(pluginId, request);
     this.host.onLoadingChange?.();
-    void fetchPluginIconBlobUrl({
-      pluginId,
-      ...this.host.getFetchContext(),
-      signal: controller.signal,
-    })
+    const context = this.host.getFetchContext();
+    const pending = this.host.fetchIcon
+      ? this.host.fetchIcon(pluginId, context, controller.signal)
+      : fetchPluginIconBlobUrl({ pluginId, ...context, signal: controller.signal });
+    void pending
       .then((url) => {
-        if (this.requests.get(pluginId) !== request || !this.host.isConnected()) {
+        if (this.requests.get(pluginId) !== request || !this.host.isConnected(pluginId)) {
           if (url) {
             URL.revokeObjectURL(url);
           }

--- a/ui/src/pages/plugins/plugins-page.icons.test.ts
+++ b/ui/src/pages/plugins/plugins-page.icons.test.ts
@@ -1,9 +1,13 @@
 /* @vitest-environment jsdom */
 
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import type { PluginDiscoveryEntry, PluginListResult } from "../../lib/plugins/index.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { ModelSetupIconLoader } from "../model-setup/model-setup-icon-loader.ts";
+import type { ModelSetupPageState } from "../model-setup/state.ts";
+import { PluginsPageIcons } from "./plugins-page-icons.ts";
 import {
   createClient,
   createContext,
@@ -12,6 +16,7 @@ import {
   createPluginsRouteData,
   createPluginsRouteLocation,
   createResult,
+  deferred,
   mountPage,
   resetPluginsPageTestState,
 } from "./plugins-page.test-support.ts";
@@ -304,5 +309,237 @@ describe("PluginsPage icon routing", () => {
     expect(
       page.querySelector('[data-plugin-id="unsafe-icon"] .plugins-tile--fallback')?.textContent,
     ).toContain("UI");
+  });
+});
+
+describe("Model Setup icon lifecycle through the shared proxy", () => {
+  const iconUrl = "https://cdn.example.com/lifecycle.png";
+  let loader: ModelSetupIconLoader | undefined;
+  let installedIcons: PluginsPageIcons | undefined;
+
+  afterEach(() => {
+    loader?.reset();
+    loader = undefined;
+    installedIcons?.reset();
+    installedIcons = undefined;
+    resetPluginsPageTestState();
+  });
+
+  function setupIcons() {
+    const { client } = createClient(async () => createResult());
+    const gateway = createGateway(client);
+    gateway.gateway.connection.gatewayUrl = window.location.origin.replace(/^http/u, "ws");
+    const context = createContext(gateway.gateway);
+    const ready: Extract<ModelSetupPageState, { phase: "ready" }> = {
+      phase: "ready",
+      result: {
+        candidates: [],
+        manualProviders: [],
+        workspace: "/tmp/icon-fixture",
+        setupComplete: false,
+        recommendedInstalls: [
+          {
+            id: "fixture",
+            label: "Fixture",
+            hint: "Fixture",
+            website: "https://example.com",
+            icon: iconUrl,
+          },
+        ],
+      },
+    };
+    let pageState: ModelSetupPageState = ready;
+    const published = vi.fn<(urls: Record<string, string>) => void>();
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+    let sequence = 0;
+    const revoke = vi.fn();
+    const NativeUrl = URL;
+    vi.stubGlobal(
+      "URL",
+      class extends NativeUrl {
+        static override createObjectURL = vi.fn(() => `blob:icon-${++sequence}`);
+        static override revokeObjectURL = revoke;
+      },
+    );
+    const currentLoader = new ModelSetupIconLoader(
+      () => context,
+      () => pageState,
+      published,
+    );
+    loader = currentLoader;
+    return {
+      loader: currentLoader,
+      fetchMock,
+      published,
+      revoke,
+      gateway,
+      context,
+      eligible: (present: boolean) => {
+        pageState = present
+          ? ready
+          : {
+              phase: "ready",
+              result: { ...ready.result, recommendedInstalls: [] },
+            };
+      },
+    };
+  }
+
+  function iconResponse() {
+    return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+  }
+
+  it.each(["key", "connection"] as const)(
+    "rejects a settled icon after its %s becomes unavailable before reconciliation",
+    async (scope) => {
+      const fixture = setupIcons();
+      const response = deferred<Response>();
+      fixture.fetchMock.mockReturnValueOnce(response.promise);
+      fixture.loader.reconcile();
+      expect(fixture.fetchMock).toHaveBeenCalledOnce();
+      if (scope === "key") {
+        fixture.eligible(false);
+      } else {
+        fixture.gateway.emit(null, false);
+      }
+      response.resolve(iconResponse());
+      await waitForFast(() =>
+        expect(
+          fixture.revoke.mock.calls.length + fixture.published.mock.calls.length,
+        ).toBeGreaterThan(0),
+      );
+      expect(fixture.revoke).toHaveBeenCalledWith("blob:icon-1");
+      expect(fixture.published).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps a replacement icon when an older same-key request settles last", async () => {
+    const fixture = setupIcons();
+    const first = deferred<Response>();
+    const second = deferred<Response>();
+    fixture.fetchMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    fixture.loader.reconcile();
+    fixture.loader.reset();
+    fixture.loader.reconcile();
+    expect(fixture.fetchMock).toHaveBeenCalledTimes(2);
+    expect(fixture.fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    second.resolve(iconResponse());
+    await waitForFast(() =>
+      expect(fixture.published).toHaveBeenLastCalledWith({
+        [iconUrl]: "blob:icon-1",
+      }),
+    );
+    first.resolve(iconResponse());
+    await waitForFast(() =>
+      expect(fixture.revoke.mock.calls.length + fixture.published.mock.calls.length).toBe(3),
+    );
+    expect(fixture.revoke).toHaveBeenCalledWith("blob:icon-2");
+    expect(fixture.published.mock.calls).toEqual([[{}], [{ [iconUrl]: "blob:icon-1" }]]);
+  });
+
+  it.each([
+    { family: "catalog", message: "catalog icon fetch timed out" },
+    { family: "plugin", message: "plugin icon fetch timed out" },
+  ] as const)(
+    "$family times out at ten seconds and retries a missed key only after removal and re-add",
+    async ({ family, message }) => {
+      vi.useFakeTimers();
+      const fixture = setupIcons();
+      const key = family === "plugin" ? "fixture-plugin" : iconUrl;
+      const pluginIcons =
+        family === "plugin"
+          ? new PluginsPageIcons({
+              getContext: () => fixture.context,
+              isConnected: () => fixture.gateway.gateway.snapshot.phase === "connected",
+              onInstalledUrlsChange: fixture.published,
+              onCatalogUrlsChange: vi.fn(),
+            })
+          : undefined;
+      installedIcons = pluginIcons;
+      let present = true;
+      const reconcile = () => {
+        if (!pluginIcons) {
+          fixture.loader.reconcile();
+          return;
+        }
+        const result = createResult(present ? [createPlugin({ id: key, hasIcon: true })] : []);
+        pluginIcons.reconcileInstalled(result);
+        pluginIcons.syncInstalled(result, new Set([key]));
+      };
+      const eligible = (value: boolean) => {
+        present = value;
+        fixture.eligible(value);
+      };
+      fixture.fetchMock
+        .mockImplementationOnce(
+          (_input, init) =>
+            new Promise<Response>((_resolve, reject) => {
+              const signal = init?.signal;
+              if (!signal) {
+                throw new Error("Expected the icon request abort signal");
+              }
+              signal.addEventListener(
+                "abort",
+                () => reject(new Error("fixture fetch aborted", { cause: signal.reason })),
+                { once: true },
+              );
+            }),
+        )
+        .mockResolvedValueOnce(iconResponse());
+      reconcile();
+      expect(fixture.fetchMock).toHaveBeenCalledOnce();
+      const signal = fixture.fetchMock.mock.calls[0]?.[1]?.signal;
+      expect(signal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(signal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(signal?.aborted).toBe(true);
+      expect(signal?.reason).toBeInstanceOf(DOMException);
+      expect(signal?.reason).toMatchObject({
+        name: "TimeoutError",
+        message,
+      });
+      reconcile();
+      expect(fixture.fetchMock).toHaveBeenCalledOnce();
+      eligible(false);
+      reconcile();
+      eligible(true);
+      reconcile();
+      expect(fixture.fetchMock).toHaveBeenCalledTimes(2);
+      await waitForFast(() =>
+        expect(fixture.published).toHaveBeenLastCalledWith({
+          [key]: "blob:icon-1",
+        }),
+      );
+    },
+  );
+
+  it("revokes before invalidation publication and publishes both empty resets", async () => {
+    const fixture = setupIcons();
+    fixture.fetchMock.mockResolvedValueOnce(iconResponse());
+    fixture.loader.reconcile();
+    await waitForFast(() => expect(fixture.published).toHaveBeenCalledOnce());
+    fixture.loader.invalidate(iconUrl);
+    expect(fixture.revoke).toHaveBeenCalledWith("blob:icon-1");
+    expect(fixture.revoke.mock.invocationCallOrder[0]).toBeLessThan(
+      expectDefined(
+        fixture.published.mock.invocationCallOrder[1],
+        "invalidation publication order",
+      ),
+    );
+    fixture.loader.reconcile();
+    expect(fixture.fetchMock).toHaveBeenCalledOnce();
+    fixture.loader.reset();
+    fixture.loader.reset();
+    expect(fixture.published.mock.calls).toEqual([
+      [{ [iconUrl]: "blob:icon-1" }],
+      [{}],
+      [{}],
+      [{}],
+    ]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Model Setup maintained its own icon-request, timeout, miss-cache, and object-URL lifecycle alongside the controller already used by plugin icons. The duplicate lifecycle made it easier for these surfaces to drift when request cleanup or stale-response handling changed.

## Why This Change Was Made

Reuse the existing icon controller as the lifecycle owner, while Model Setup keeps its own eligibility rules, rendering, and catalog-icon HTTP route. Preserve synchronous request initiation, request identity checks, current connection/key checks, exact timeout reasons, miss retry behavior, publication ordering for the real page callbacks, and URL cleanup. Catalog and Channels controllers remain separate.

This removes 71 net production lines (+52/-123). The test extension is +237/-0; no existing assertion, baseline, generated manifest, configuration, public API, or persistent-state contract was removed or changed.

## User Impact

No intentional visual or behavioral change. Model Setup and Plugins keep their current icons, fallback behavior, and retry/cleanup semantics, backed by one shared lifecycle owner.

## Evidence

The refreshed signed commit is `6f3d9ec828698d6aa2e14e64cb793c8ea8cbda64`, based on `2579303af1fba3b8d4bdbb6c38abf7c90dcb07b0`. It preserves the exact three reviewed afterimages and complete patch from the original published `b0e6770` commit.

- **Failure-justified refresh:** the original [PR CI run](https://github.com/openclaw/openclaw/actions/runs/34563681172) failed an incoming session-link browser fixture: it expected `inline-grid` after chat styles made the element a flex item with computed `grid`. The canonical fixture repair landed separately in [#144690](https://github.com/openclaw/openclaw/pull/144690). This refresh includes that prerequisite; it does not alter the Icon patch or blindly rerun the old failing CI. Exact-head PR CI for the refreshed commit remains required.
- **Original/candidate proof on the refreshed base:** all 131 cases passed per role, preserving the original six-file/60-case inventory and adding current Model Setup, Channels, discovery, and canonical browser coverage. The lifecycle cases cover eligibility before reconciliation, stale same-key replies after reset, exact 9,999/10,000 ms boundaries and family-specific timeout reasons, miss removal/re-add, and revocation/publication/reset order. Earlier deliberate owner-fault controls and their exact restorations remain retained. A combined reporter invocation refused the browser lane after the original 127 Node cases passed; those accepted cases were not replayed. The remaining original browser cases and candidate Node/browser cases used the supported separate invocations.
- **Required changed checks:** the [fresh configured gate](https://github.com/openclaw/openclaw/actions/runs/34593268603) completed all 20 selected checks, including core-test/UI typechecks, type-aware lint and style validation, on the exact shipping tree. The wrapper verified the source, completed normally, and stopped its Testbox; the backing Actions lifecycle is not substituted for the native gate result. The earlier test-only Promise-rejection lint correction and failed gate are preserved in the history, not hidden.
- **Builds and budgets:** normal fresh UI and full `pnpm build` completed on the refreshed candidate. The separate enforcing check of the final full-build UI generation passed at 352,965 bytes against the 353,107-byte limit, with no threshold or boot-manifest change. An earlier standalone UI generation measured 352,927 bytes and is recorded separately. Production LOC reduction is not a claim of lower network transfer, latency, or smaller ready-chat output.
- **Bundled-browser proof:** original and candidate each passed all four New Session, Chat, Model Setup and Plugins routes, with no skipped cases. Separate fresh native bundles were bound to complete source maps; Linux, Node 24.19.0, pnpm 12.3.4 and Chromium 144.0.7559.0 matched, including the recorded Node/Chromium binary hashes. Both leases and owned processes were closed. Model Setup and Plugins captures are byte-identical. New Session and Chat are not: the mascot pose differs, and Chat also has 24 plus-glyph edge pixels differing by at most 2/255 RGB, with renderer-level cause unknown. No capture was retaken or adjusted to force image equality.
- **Fresh review:** complete branch review and a separate review of exact signed commit `6f3d9ec` each completed two passes with no actionable P0–P2 findings. The exact-commit report retains a batch-limited first-pass assessment and aggregate confidence of 0.2; its second pass completed without findings. No review was repeated to improve that confidence.

### Before and after

The refreshed Model Setup and Plugins captures are byte-identical before and after this refactor and match the already-published image bytes. Each image below therefore represents both versions; these are synthetic browser fixtures, not a live account.

![Model Setup before and after icon lifecycle consolidation (identical synthetic captures)](https://github.com/user-attachments/assets/77912035-27d6-429c-b706-ec3385f94c15)

![Plugins before and after icon lifecycle consolidation (identical synthetic captures)](https://github.com/user-attachments/assets/758a9071-c3e9-4fed-bb95-54b2c77c1365)

### Scope and limitations

The browser harness fulfilled the icon HTTP responses, covering frontend fetch → Blob URL → native PNG decode, not the Gateway handler, authentication enforcement, or a live provider. Header presence was recorded, not asserted. Source-map membership establishes chunk inclusion, not module execution. Retained asset evidence is metadata/hashes/source membership over the bounded post-ready window, not copies of every temporary asset or an all-future-load guarantee. Native E2E used a fresh canonical test bundle; the synthetic build footer and the separate workstation build are not its source-identity evidence.

Equivalence is scoped to the real page callbacks, not arbitrary synchronous reentrant callbacks. A possible late old Model Setup image error after reset/same-key replacement remains an unconfirmed separate follow-up; this change does not add a speculative generation guard. Current-main qualification is source inspection, not a claim that every newer main commit was rerun in these pinned-base proofs.
