### PR TITLE
refactor(tasks): await fresh owner reads in media and prompts

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -193,7 +193,6 @@ vi.mock("../media-generation-task-status.js", () => ({
   buildActiveImageGenerationTaskPromptContextForSession: vi.fn(() => undefined),
   buildImageGenerationTaskStatusDetails: vi.fn(() => ({})),
   buildImageGenerationTaskStatusText: vi.fn(() => ""),
-  findActiveImageGenerationTaskForSession: vi.fn(() => undefined),
   MUSIC_GENERATION_TASK_KIND: "music_generation",
   buildActiveMusicGenerationTaskPromptContextForSession: vi.fn(() => undefined),
   buildMusicGenerationTaskStatusDetails: vi.fn(() => ({})),
@@ -672,9 +671,9 @@ describe("prepareCliRunContext", () => {
     });
     mockGetGlobalHookRunner.mockReturnValue(null);
     getRuntimeConfigMock.mockReturnValue({});
-    mockBuildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(undefined);
-    mockBuildActiveVideoGenerationTaskPromptContextForSession.mockReturnValue(undefined);
-    mockBuildActiveMusicGenerationTaskPromptContextForSession.mockReturnValue(undefined);
+    mockBuildActiveImageGenerationTaskPromptContextForSession.mockResolvedValue(undefined);
+    mockBuildActiveVideoGenerationTaskPromptContextForSession.mockResolvedValue(undefined);
+    mockBuildActiveMusicGenerationTaskPromptContextForSession.mockResolvedValue(undefined);
     ensureSandboxWorkspaceForSessionMock.mockReset();
     ensureSandboxWorkspaceForSessionMock.mockResolvedValue(null);
     fixture = createCliRunnerPrepareFixture(prepareCliRunContext);
@@ -2710,6 +2709,80 @@ describe("prepareCliRunContext", () => {
     expect(dispose).not.toHaveBeenCalled();
   });
 
+  it.each(["cancelled", "retired", "lookup-failed"] as const)(
+    "rechecks CLI ownership after a delayed media lookup is %s",
+    async (scenario) => {
+      const lookupStarted = createDeferred();
+      const lookup = createDeferred<string | undefined>();
+      const abort = new AbortController();
+      let current = true;
+      const engineId = `cli-media-lookup-${scenario}`;
+      const factory = vi.fn((): ContextEngine => ({
+        info: { id: engineId, name: "CLI media lookup" },
+        ingest: async () => ({ ingested: true }),
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+        compact: async () => ({ ok: true, compacted: false }),
+      }));
+      registerTestContextEngine(engineId, factory);
+      const config = createCliBackendConfig({ bundleMcp: true });
+      setCliRunnerPrepareTestDeps({
+        getActiveMcpLoopbackRuntime: vi.fn(() => ({
+          port: 31783,
+          ownerToken: "loopback-owner-token",
+          nonOwnerToken: "loopback-non-owner-token",
+        })),
+        resolveMcpLoopbackScopedTools: vi.fn(() => ({
+          agentId: "main",
+          tools: [
+            {
+              name: "image_generate",
+              label: "image_generate",
+              description: "image_generate",
+              parameters: Type.Object({}),
+              execute: vi.fn(),
+            },
+          ],
+        })),
+      });
+      mockBuildActiveImageGenerationTaskPromptContextForSession.mockImplementation(() => {
+        lookupStarted.resolve();
+        return lookup.promise;
+      });
+      const preparation = fixture.prepare({
+        config: { ...config, plugins: { slots: { contextEngine: engineId } } },
+        sessionKey: "agent:main:test",
+        abortSignal: abort.signal,
+        assertCurrent: () => {
+          if (!current) {
+            throw new Error("CLI owner retired");
+          }
+        },
+      });
+      const outcome = preparation.then(
+        (context) => ({ prompt: context.params.prompt }),
+        (error: unknown) => ({ error: String(error) }),
+      );
+      await lookupStarted.promise;
+      expect(factory).not.toHaveBeenCalled();
+      if (scenario === "cancelled") {
+        abort.abort(new Error("CLI lookup cancelled"));
+      } else if (scenario === "retired") {
+        current = false;
+      }
+      if (scenario === "lookup-failed") {
+        lookup.reject(new Error("optional media lookup failed"));
+        expect(await outcome).toEqual({ prompt: "latest ask" });
+        expect(factory).toHaveBeenCalledOnce();
+      } else {
+        lookup.resolve("active image task");
+        expect(await outcome).toEqual({
+          error: `Error: ${scenario === "cancelled" ? "CLI lookup cancelled" : "CLI owner retired"}`,
+        });
+        expect(factory).not.toHaveBeenCalled();
+      }
+    },
+  );
+
   it("cleans up prepared CLI backend when context-engine host validation fails", async () => {
     installTestPluginRegistry();
     const engineId = `cli-cleanup-engine-${Date.now().toString(36)}`;
@@ -3520,7 +3593,7 @@ describe("prepareCliRunContext", () => {
           }),
         });
       }
-      mockBuildActiveVideoGenerationTaskPromptContextForSession.mockReturnValue(
+      mockBuildActiveVideoGenerationTaskPromptContextForSession.mockResolvedValue(
         "active video task",
       );
       const hookRunner = {
@@ -3540,11 +3613,11 @@ describe("prepareCliRunContext", () => {
           prompt: "latest ask",
           transcriptPrompt: "latest ask",
         });
-      mockBuildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
+      mockBuildActiveImageGenerationTaskPromptContextForSession.mockResolvedValue(
         "image task queued",
       );
       const first = await prepareTurn();
-      mockBuildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
+      mockBuildActiveImageGenerationTaskPromptContextForSession.mockResolvedValue(
         "image task running",
       );
       const second = await prepareTurn();

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -2073,16 +2073,15 @@ async function prepareCliRunContextWithinReadFence(
         ]
           .filter((value): value is string => Boolean(value?.trim()))
           .join("\n\n");
+        const mediaTaskContext = await buildMediaTaskRuntimeContext({
+          capabilityToolNames: new Set(promptTools.map((tool) => tool.name)),
+          sessionKey: params.sessionKey,
+          agentId: sessionAgentId,
+        });
         const appendContext = [
           hookResult?.appendContext,
           authorizedPromptBuildResult?.appendContext,
-          buildRuntimeContextCustomMessage(
-            buildMediaTaskRuntimeContext({
-              capabilityToolNames: new Set(promptTools.map((tool) => tool.name)),
-              sessionKey: params.sessionKey,
-              agentId: sessionAgentId,
-            }),
-          )?.content,
+          buildRuntimeContextCustomMessage(mediaTaskContext)?.content,
         ]
           .filter((value): value is string => Boolean(value?.trim()))
           .join("\n\n");
@@ -2113,6 +2112,8 @@ async function prepareCliRunContextWithinReadFence(
       } catch (error) {
         cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);
       }
+      params.assertCurrent?.();
+      params.abortSignal?.throwIfAborted();
     }
     let historyPromptCurrentTurn = preparedPrompt;
     if (!skipsTurnPreparation) {

--- a/src/agents/embedded-agent-runner/run/abortable.ts
+++ b/src/agents/embedded-agent-runner/run/abortable.ts
@@ -19,7 +19,7 @@ function tagAsAbortableWrapper(err: Error): Error {
   return err;
 }
 
-function makeAbortError(signal: AbortSignal): Error {
+export function createAbortableError(signal: AbortSignal): Error {
   const reason = getAbortReason(signal);
   if (reason instanceof Error) {
     const err = new Error(reason.message, { cause: reason });
@@ -92,12 +92,12 @@ export function joinWithRunLivenessDeadline(input: {
  */
 export function abortable<T>(signal: AbortSignal, promise: Promise<T>): Promise<T> {
   if (signal.aborted) {
-    return Promise.reject(makeAbortError(signal));
+    return Promise.reject(createAbortableError(signal));
   }
   return new Promise<T>((resolve, reject) => {
     const onAbort = () => {
       signal.removeEventListener("abort", onAbort);
-      reject(makeAbortError(signal));
+      reject(createAbortableError(signal));
     };
     signal.addEventListener("abort", onAbort, { once: true });
     promise.then(

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
@@ -87,6 +87,7 @@ type EmbeddedAttemptSteeringLease = {
 };
 
 type EmbeddedAttemptPromptAssembly = {
+  assertHostActive?: () => void;
   hookCtx: PromptBuildHookContext;
   effectivePrompt: string;
   promptBuildPrependContext?: string;
@@ -331,6 +332,7 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
       : undefined;
 
   return {
+    assertHostActive,
     hookCtx,
     effectivePrompt,
     promptBuildPrependContext,
@@ -390,7 +392,7 @@ type EmbeddedAttemptPromptContext = {
   systemPromptForHook: string;
 };
 
-export function prepareEmbeddedAttemptPromptContext(input: {
+export async function prepareEmbeddedAttemptPromptContext(input: {
   sessionVersion?: number;
   appendOnlyRuntimeContext?: boolean;
   attempt: PromptContextAttempt;
@@ -406,7 +408,7 @@ export function prepareEmbeddedAttemptPromptContext(input: {
   systemPromptReport?: SessionSystemPromptReport;
   systemPromptText: string;
   toolResultPromptProjectionState: ToolResultPromptProjectionState;
-}): EmbeddedAttemptPromptContext {
+}): Promise<EmbeddedAttemptPromptContext> {
   const { attempt } = input;
   const preparedUserTurnTimestamp = (
     input.preparedUserTurnMessage as { timestamp?: unknown } | undefined
@@ -512,7 +514,7 @@ export function prepareEmbeddedAttemptPromptContext(input: {
   const runtimeFacts =
     input.isRawModelRun || attempt.operation === "settled-tool-finalization"
       ? []
-      : buildRuntimeFactsContext({
+      : await buildRuntimeFactsContext({
           capabilityToolNames: input.capabilityToolNames,
           cfg: attempt.config ?? {},
           sessionKey: attempt.sessionKey,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
@@ -124,7 +124,7 @@ beforeEach(() => {
   vi.spyOn(
     mediaTaskStatus,
     "buildActiveImageGenerationTaskPromptContextForSession",
-  ).mockReturnValue(undefined);
+  ).mockResolvedValue(undefined);
   resetSubagentRegistryForTests();
   hoisted.promptPressureKeys.clear();
   hoisted.reconcileToolResultPromptProjectionState.mockReset();
@@ -146,16 +146,16 @@ afterEach(() => {
 
 describe("prepareEmbeddedAttemptPromptContext", () => {
   it("carries current Windows approval hints without changing system or user prompt bytes", () =>
-    withMockedPlatform("win32", () => {
+    withMockedPlatform("win32", async () => {
       const load = vi.spyOn(execApprovals, "loadExecApprovals").mockReturnValue({ version: 1 });
       const fixture = createInput();
       fixture.input.capabilityToolNames.add("exec");
-      const before = prepareEmbeddedAttemptPromptContext(fixture.input);
+      const before = await prepareEmbeddedAttemptPromptContext(fixture.input);
       load.mockReturnValue({
         version: 1,
         agents: { "agent-1": { allowlist: [{ pattern: "C:\\Tools\\node.exe" }] } },
       });
-      const after = prepareEmbeddedAttemptPromptContext(fixture.input);
+      const after = await prepareEmbeddedAttemptPromptContext(fixture.input);
       expect(before.runtimeContextMessageForCurrentTurn?.content).toContain(
         "## Approved executables\nnone",
       );
@@ -165,17 +165,17 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
       expect(after.systemPromptForHook).toBe(before.systemPromptForHook);
       expect(after.promptForSession).toBe(before.promptForSession);
     }));
-  it("carries execution-owned processes in id order without elapsed time or output", () => {
+  it("carries execution-owned processes in id order without elapsed time or output", async () => {
     const fixture = createInput();
     fixture.input.capabilityToolNames.add("process");
-    const idle = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const idle = await prepareEmbeddedAttemptPromptContext(fixture.input);
     for (const id of ["exec-z", "exec-a"]) {
       const session = createProcessSessionFixture({ id, backgrounded: true });
       session.scopeKey = fixture.input.attempt.sessionKey;
       session.tail = "private output tail";
       addSession(session);
     }
-    const active = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const active = await prepareEmbeddedAttemptPromptContext(fixture.input);
     expect(active.systemPromptForHook).toBe(idle.systemPromptForHook);
     const content = active.runtimeContextMessageForCurrentTurn?.content;
     expect(content).toContain("Active exec sessions:");
@@ -189,7 +189,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     expect(active.promptForSession).toBe("Visible request");
   });
 
-  it("carries changed subagent status without rewriting the system prompt", () => {
+  it("carries changed subagent status without rewriting the system prompt", async () => {
     const fixture = createInput();
     fixture.input.sessionAgentId = "main";
     fixture.input.capabilityToolNames.add("sessions_spawn");
@@ -206,34 +206,34 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
       execution: { status: "queued" },
     } satisfies SubagentRunRecord;
     addSubagentRunForTests(run);
-    const queued = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const queued = await prepareEmbeddedAttemptPromptContext(fixture.input);
     addSubagentRunForTests({ ...run, execution: { status: "running", startedAt: 2 } });
-    const running = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const running = await prepareEmbeddedAttemptPromptContext(fixture.input);
     expect(running.systemPromptForHook).toBe(queued.systemPromptForHook);
     expect(queued.runtimeContextMessageForCurrentTurn?.content).toContain("status=queued");
     expect(running.runtimeContextMessageForCurrentTurn?.content).toContain("status=running");
     resetSubagentRegistryForTests();
-    const completed = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const completed = await prepareEmbeddedAttemptPromptContext(fixture.input);
     expect(completed.runtimeContextMessageForCurrentTurn?.content).toContain(
       "## Active Subagents\nnone",
     );
   });
 
-  it("carries changed media progress without rewriting the system prompt", () => {
+  it("carries changed media progress without rewriting the system prompt", async () => {
     const fixture = createInput();
     fixture.input.capabilityToolNames.add("image_generate");
     vi.mocked(
       mediaTaskStatus.buildActiveImageGenerationTaskPromptContextForSession,
-    ).mockReturnValue(
+    ).mockResolvedValue(
       '- tool=image_generate; task=image-1; status=running; progress_json="Rendering"',
     );
-    const rendering = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const rendering = await prepareEmbeddedAttemptPromptContext(fixture.input);
     vi.mocked(
       mediaTaskStatus.buildActiveImageGenerationTaskPromptContextForSession,
-    ).mockReturnValue(
+    ).mockResolvedValue(
       '- tool=image_generate; task=image-1; status=running; progress_json="Encoding"',
     );
-    const encoding = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const encoding = await prepareEmbeddedAttemptPromptContext(fixture.input);
     expect(encoding.systemPromptForHook).toBe(rendering.systemPromptForHook);
     expect(rendering.runtimeContextMessageForCurrentTurn?.content).toContain(
       'progress_json="Rendering"',
@@ -244,7 +244,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     expect(encoding.runtimeContextMessageForCurrentTurn?.content).not.toContain("Rendering");
   });
 
-  it("supersedes retained active facts with explicit empty snapshots", () => {
+  it("supersedes retained active facts with explicit empty snapshots", async () => {
     const fixture = createInput();
     fixture.input.capabilityToolNames = new Set(["process", "sessions_spawn", "image_generate"]);
     const process = createProcessSessionFixture({ id: "exec-a", backgrounded: true });
@@ -252,13 +252,13 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     addSession(process);
     vi.mocked(
       mediaTaskStatus.buildActiveImageGenerationTaskPromptContextForSession,
-    ).mockReturnValue("- tool=image_generate; task=image-1; status=running");
-    const active = prepareEmbeddedAttemptPromptContext(fixture.input);
+    ).mockResolvedValue("- tool=image_generate; task=image-1; status=running");
+    const active = await prepareEmbeddedAttemptPromptContext(fixture.input);
     deleteSession("exec-a");
     vi.mocked(
       mediaTaskStatus.buildActiveImageGenerationTaskPromptContextForSession,
-    ).mockReturnValue(undefined);
-    const empty = prepareEmbeddedAttemptPromptContext({
+    ).mockResolvedValue(undefined);
+    const empty = await prepareEmbeddedAttemptPromptContext({
       ...fixture.input,
       appendOnlyRuntimeContext: true,
       messages: [...messages, active.runtimeContextMessageForCurrentTurn!],
@@ -276,9 +276,12 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     expect(empty.runtimeContextMessageForCurrentTurn?.content).not.toContain("image-1");
   });
 
-  it("quotes producer data in the new-session model prompt while retaining transcript bytes", () => {
+  it("quotes producer data in the new-session model prompt while retaining transcript bytes", async () => {
     const fixture = createInput();
-    const result = prepareEmbeddedAttemptPromptContext({ ...fixture.input, sessionVersion: 4 });
+    const result = await prepareEmbeddedAttemptPromptContext({
+      ...fixture.input,
+      sessionVersion: 4,
+    });
     expect(result.promptForSession).toBe("Visible request");
     expect(result.llmBoundaryPromptForPrecheck).toBe("Visible request");
     expect(result.systemPromptForHook).toBe("Base system prompt");
@@ -293,16 +296,16 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     );
   });
 
-  it("carries next-turn runtime context as the delimited body only", () => {
+  it("carries next-turn runtime context as the delimited body only", async () => {
     const fixture = createInput();
-    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const result = await prepareEmbeddedAttemptPromptContext(fixture.input);
     expect(result.runtimeContextMessageForCurrentTurn?.content).toBe(
       "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nConversation info: channel=telegram\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
     );
   });
   it.each(["Please recall my preference.", "Current time: noon. Please recall my preference."])(
     "preserves active-memory hook context at the model boundary: %s",
-    (prompt) => {
+    async (prompt) => {
       const memory = "Context:\n<active_memory_plugin>\nsaved preference\n</active_memory_plugin>";
       const modelPrompt = `${memory}\n\n${prompt}`;
       const fixture = createInput({
@@ -312,7 +315,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
         }),
       });
 
-      const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+      const result = await prepareEmbeddedAttemptPromptContext(fixture.input);
 
       expect(result.promptForSession).toBe(prompt);
       expect(result.llmBoundaryPromptForPrecheck).toBe(modelPrompt);
@@ -320,10 +323,10 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     },
   );
 
-  it("keeps the transcript prompt bare while carrying inbound context to hooks", () => {
+  it("keeps the transcript prompt bare while carrying inbound context to hooks", async () => {
     const fixture = createInput();
 
-    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const result = await prepareEmbeddedAttemptPromptContext(fixture.input);
 
     expect(result.promptForSession).toBe("Visible request");
     expect(result.promptForModel).toBe("Visible request");
@@ -354,7 +357,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     expect(clonedProjectionState).not.toBe(projectionState);
   });
 
-  it("includes persisted sender context in the overflow-precheck prompt", () => {
+  it("includes persisted sender context in the overflow-precheck prompt", async () => {
     const fixture = createInput({
       preparedUserTurnMessage: {
         role: "user",
@@ -364,23 +367,23 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
       } as AgentMessage,
     });
 
-    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const result = await prepareEmbeddedAttemptPromptContext(fixture.input);
 
     expect(result.llmBoundaryPromptForPrecheck).toContain('"name":"Alice"');
     expect(result.llmBoundaryPromptForPrecheck).toContain("Visible request");
   });
 
-  it("does not reconcile session projection state for raw probes", () => {
+  it("does not reconcile session projection state for raw probes", async () => {
     const fixture = createInput();
 
-    prepareEmbeddedAttemptPromptContext({ ...fixture.input, isRawModelRun: true });
+    await prepareEmbeddedAttemptPromptContext({ ...fixture.input, isRawModelRun: true });
 
     expect(hoisted.reconcileToolResultPromptProjectionState).not.toHaveBeenCalled();
   });
 
-  it("injects the latest heartbeat outcome only as hidden runtime context", () => {
+  it("injects the latest heartbeat outcome only as hidden runtime context", async () => {
     const fixture = createInput();
-    const result = prepareEmbeddedAttemptPromptContext({
+    const result = await prepareEmbeddedAttemptPromptContext({
       ...fixture.input,
       attempt: {
         ...fixture.input.attempt,
@@ -396,7 +399,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     expect(result.llmBoundaryPromptForPrecheck).not.toContain("deployment finished");
   });
 
-  it("reports aggregate tool-result pressure for compact-then-truncate routing", () => {
+  it("reports aggregate tool-result pressure for compact-then-truncate routing", async () => {
     hoisted.truncateOversizedToolResultsInMessages.mockImplementation((inputMessages) => ({
       messages: [...inputMessages],
       truncatedCount: 2,
@@ -408,7 +411,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
       attempt: createAttempt({ sessionId: "pressure-session", sessionKey: "pressure-session" }),
     });
 
-    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const result = await prepareEmbeddedAttemptPromptContext(fixture.input);
 
     expect(result.aggregatePressureEngaged).toBe(true);
     expect(hoisted.warn).toHaveBeenCalledWith(
@@ -416,7 +419,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     );
   });
 
-  it("deduplicates aggregate pressure warnings per session key", () => {
+  it("deduplicates aggregate pressure warnings per session key", async () => {
     hoisted.truncateOversizedToolResultsInMessages.mockImplementation((inputMessages) => ({
       messages: [...inputMessages],
       truncatedCount: 1,
@@ -426,17 +429,17 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     }));
     const attempt = createAttempt({ sessionId: "dup-session", sessionKey: "dup-session" });
 
-    prepareEmbeddedAttemptPromptContext(createInput({ attempt }).input);
+    await prepareEmbeddedAttemptPromptContext(createInput({ attempt }).input);
     expect(hoisted.warn).toHaveBeenCalledTimes(1);
     hoisted.warn.mockClear();
 
-    prepareEmbeddedAttemptPromptContext(createInput({ attempt }).input);
+    await prepareEmbeddedAttemptPromptContext(createInput({ attempt }).input);
     expect(hoisted.warn).not.toHaveBeenCalled();
   });
 
   it.each([3, 4])(
     "carries version %s runtime-only events in the message tail carrier without rewriting system prompt",
-    (sessionVersion) => {
+    async (sessionVersion) => {
       const fixture = createInput({
         attempt: createAttempt({
           currentInboundContext: {
@@ -452,7 +455,10 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
       });
 
       fixture.input.capabilityToolNames.add("process");
-      const result = prepareEmbeddedAttemptPromptContext({ ...fixture.input, sessionVersion });
+      const result = await prepareEmbeddedAttemptPromptContext({
+        ...fixture.input,
+        sessionVersion,
+      });
 
       expect(result.systemPromptForHook).toBe("Base system prompt");
       expect(result.systemPromptForHook).not.toContain("OpenClaw runtime event.");
@@ -472,9 +478,9 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     },
   );
 
-  it("preserves identical system prompt bytes across normal turns and runtime-only event turns", () => {
+  it("preserves identical system prompt bytes across normal turns and runtime-only event turns", async () => {
     const fixture = createInput();
-    const normalTurn = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const normalTurn = await prepareEmbeddedAttemptPromptContext(fixture.input);
 
     const runtimeEventFixture = createInput({
       attempt: createAttempt({
@@ -488,9 +494,9 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
         effectiveTranscriptPrompt: "",
       }),
     });
-    const runtimeTurn = prepareEmbeddedAttemptPromptContext(runtimeEventFixture.input);
+    const runtimeTurn = await prepareEmbeddedAttemptPromptContext(runtimeEventFixture.input);
 
-    const normalTurnAfter = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const normalTurnAfter = await prepareEmbeddedAttemptPromptContext(fixture.input);
 
     expect(normalTurn.systemPromptForHook).toBe("Base system prompt");
     expect(runtimeTurn.systemPromptForHook).toBe(normalTurn.systemPromptForHook);
@@ -500,7 +506,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     );
   });
 
-  it("keeps a pure heartbeat task active while persisting only the poll marker", () => {
+  it("keeps a pure heartbeat task active while persisting only the poll marker", async () => {
     const taskPrompt = "Check the deployment and report any failures.";
     const transcriptPrompt = "[OpenClaw heartbeat poll]";
     const fixture = createInput({
@@ -511,7 +517,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
       }),
     });
 
-    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const result = await prepareEmbeddedAttemptPromptContext(fixture.input);
 
     expect(result.promptForSession).toBe(transcriptPrompt);
     expect(result.promptForModel).toBe(taskPrompt);
@@ -519,7 +525,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     expect(result.runtimeContextMessageForCurrentTurn).toBeUndefined();
   });
 
-  it("keeps the live orphan-repair heartbeat task active without parsing its marker", () => {
+  it("keeps the live orphan-repair heartbeat task active without parsing its marker", async () => {
     const taskPrompt = "Check the deployment and report any failures.";
     const transcriptPrompt = "[OpenClaw heartbeat poll]";
     const mergedModelPrompt = [QUEUED_USER_MESSAGE_MARKER, transcriptPrompt, "", taskPrompt].join(
@@ -533,7 +539,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
       }),
     });
 
-    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const result = await prepareEmbeddedAttemptPromptContext(fixture.input);
 
     expect(result.promptForSession).toBe(transcriptPrompt);
     expect(result.promptForModel).toBe(mergedModelPrompt);
@@ -541,7 +547,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     expect(result.runtimeContextMessageForCurrentTurn).toBeUndefined();
   });
 
-  it("keeps producer source context separate on a no-hook user turn", () => {
+  it("keeps producer source context separate on a no-hook user turn", async () => {
     const sourceContext = "Cross-session source: agent:research";
     const visiblePrompt = "Visible request";
     const fixture = createInput({
@@ -557,7 +563,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
       }),
     });
 
-    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+    const result = await prepareEmbeddedAttemptPromptContext(fixture.input);
 
     expect(result.promptForSession).toBe(visiblePrompt);
     expect(result.promptForModel).toBe(visiblePrompt);

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -1,9 +1,14 @@
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { Context, Model, SimpleStreamOptions } from "../../../llm/types.js";
 import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../../state/openclaw-agent-db.js";
+import {
+  prepareSystemAgentRunAdmission,
+  resolveAdmittedRunActiveAssertion,
+} from "../../admitted-run-context.js";
 import type { StreamFn } from "../../runtime/index.js";
 import {
   createAssistant,
@@ -94,7 +99,6 @@ import {
   projectAgentRunAttemptTerminal,
   type AgentRunAttemptTerminal,
 } from "../../agent-run-terminal-outcome.js";
-import { abortable } from "./abortable.js";
 import {
   runEmbeddedAttemptPromptPhase,
   type EmbeddedAttemptPromptState,
@@ -319,7 +323,9 @@ function createFixture({ pendingPrompt = "hello", pendingImageCount = 1 } = {}) 
 }
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  for (const mock of Object.values(mocks)) {
+    mock.mockReset();
+  }
   mocks.applyPromptToolsAllow.mockReturnValue({
     activeToolNames: ["read"],
     effectiveTools: [{ name: "read" }],
@@ -776,6 +782,40 @@ describe("runEmbeddedAttemptPromptPhase", () => {
     expect(mocks.releasePendingSteering).not.toHaveBeenCalled();
   });
 
+  it("withholds prompt hooks and submission after its owner retires during context lookup", async () => {
+    const fixture = createFixture();
+    const admission = prepareSystemAgentRunAdmission({}, "prompt-owner", "main", "prompt-session");
+    try {
+      const admitted = await admission.admit("embedded");
+      const prepareAssembly = mocks.preparePromptAssembly.getMockImplementation()!;
+      mocks.preparePromptAssembly.mockImplementationOnce(async (...args) => ({
+        ...(await prepareAssembly(...args)),
+        assertHostActive: resolveAdmittedRunActiveAssertion(admitted),
+      }));
+      const context = mocks.preparePromptContext.getMockImplementation()!();
+      const lookup = createDeferred<typeof context>();
+      const entered = createDeferred();
+      mocks.preparePromptContext.mockImplementationOnce(() => {
+        entered.resolve();
+        return lookup.promise;
+      });
+      const pending = runEmbeddedAttemptPromptPhase(fixture.input, fixture.promptState);
+      await entered.promise;
+      admission.close();
+      lookup.resolve(context);
+      await pending;
+      expect(mocks.beforeAgentRun).not.toHaveBeenCalled();
+      expect(mocks.submitPrompt).not.toHaveBeenCalled();
+      expect(mocks.handlePromptError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ message: "admitted run authority is no longer active" }),
+        }),
+      );
+    } finally {
+      admission.close();
+    }
+  });
+
   it("skips before_agent_run for settled-turn finalization", async () => {
     const fixture = createFixture();
     fixture.input.attempt.operation = "settled-tool-finalization";
@@ -894,17 +934,13 @@ describe("runEmbeddedAttemptPromptPhase", () => {
     const fixture = createFixture();
     fixture.input.state.terminal = { kind: "timeout", phase: "prompt", source: "run_budget" };
     fixture.input.runAbortController.abort(new Error("request timed out"));
-    const timeoutAbort = await abortable(
-      fixture.input.runAbortController.signal,
-      Promise.resolve(),
-    ).catch((error: unknown) => error);
-    mocks.submitPrompt.mockRejectedValueOnce(timeoutAbort);
-    mocks.handlePromptError.mockResolvedValueOnce({
-      promptFailure: { error: timeoutAbort, source: "prompt" },
-    });
+    mocks.handlePromptError.mockImplementationOnce(async (input: PromptErrorCall) => ({
+      promptFailure: { error: input.error, source: "prompt" },
+    }));
 
     await runEmbeddedAttemptPromptPhase(fixture.input, fixture.promptState);
 
+    expect(mocks.submitPrompt).not.toHaveBeenCalled();
     expect(fixture.readState().promptError).toBeNull();
     expect(fixture.readState().promptErrorSource).toBeNull();
   });

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -16,7 +16,7 @@ import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
 import { persistToolResultProjections } from "../session-prompt-state.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
-import { isOpenClawAbortableWrapper } from "./abortable.js";
+import { createAbortableError, isOpenClawAbortableWrapper } from "./abortable.js";
 import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
 import type { EmbeddedAttemptExecutionPhaseInput } from "./attempt-execution-types.js";
 import {
@@ -178,7 +178,7 @@ export async function runEmbeddedAttemptPromptPhase(
   leasedSteering = promptAssembly.leasedSteering ?? leasedSteering;
 
   try {
-    const promptContext = prepareEmbeddedAttemptPromptContext({
+    const promptContext = await prepareEmbeddedAttemptPromptContext({
       sessionVersion: sessionManager.getHeader()?.version,
       attempt,
       capabilityToolNames: prepared.toolCatalog.toolSearchRunPlan.capabilityToolNames,
@@ -197,6 +197,10 @@ export async function runEmbeddedAttemptPromptPhase(
       systemPromptText,
       toolResultPromptProjectionState,
     });
+    if (runAbortController.signal.aborted) {
+      throw createAbortableError(runAbortController.signal);
+    }
+    promptAssembly.assertHostActive?.();
     const { hookMessagesForCurrentPrompt, promptForModel, systemPromptForHook } = promptContext;
     sessionRuntimeState.prePromptMessageCount = promptContext.prePromptMessageCount;
     setCurrentUserTimestampOverride(promptContext.currentUserTimestampOverride);

--- a/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
@@ -29,15 +29,15 @@ beforeEach(() => {
   vi.spyOn(
     mediaTaskStatus,
     "buildActiveImageGenerationTaskPromptContextForSession",
-  ).mockReturnValue(undefined);
+  ).mockResolvedValue(undefined);
   vi.spyOn(
     mediaTaskStatus,
     "buildActiveVideoGenerationTaskPromptContextForSession",
-  ).mockReturnValue(undefined);
+  ).mockResolvedValue(undefined);
   vi.spyOn(
     mediaTaskStatus,
     "buildActiveMusicGenerationTaskPromptContextForSession",
-  ).mockReturnValue(undefined);
+  ).mockResolvedValue(undefined);
 });
 afterEach(() => vi.restoreAllMocks());
 
@@ -92,7 +92,7 @@ async function createTurnFixture(systemPromptOverride?: string) {
   return async (progress?: string) => {
     vi.mocked(
       mediaTaskStatus.buildActiveImageGenerationTaskPromptContextForSession,
-    ).mockReturnValue(
+    ).mockResolvedValue(
       progress
         ? `- tool=image_generate; task=task-1; status=running; progress_json="${progress}"`
         : undefined,

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -106,14 +106,14 @@ function makeToolResult(text: string, toolCallId = "call_1", details?: unknown):
   };
 }
 
-function preparePromptProjectionStateForTest(params: {
+async function preparePromptProjectionStateForTest(params: {
   sessionId: string;
   messages: AgentMessage[];
   state: ToolResultPromptProjectionState;
   raw?: boolean;
 }) {
   const prompt = params.raw ? "raw probe" : "continue";
-  prepareEmbeddedAttemptPromptContext({
+  await prepareEmbeddedAttemptPromptContext({
     capabilityToolNames: new Set(),
     attempt: {
       config: {},
@@ -867,7 +867,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(second.messages.slice(0, history.length)).toEqual(first.messages);
   });
 
-  it("reclaims #99495 state from canonical compaction, not filtered projections", () => {
+  it("reclaims #99495 state from canonical compaction, not filtered projections", async () => {
     const sessionId = "session-99495-reclamation";
     const state = getEmbeddedSessionPromptState(sessionId).toolResults;
     const removed = makeToolResult("removed".repeat(100_000), "removed_after_compaction");
@@ -884,10 +884,10 @@ describe("truncateOversizedToolResultsInMessages", () => {
     truncateOversizedToolResultsInMessages([retained], 128_000, 5_000, 20_000, state);
     expect(state.sourceHashByKey.size).toBe(2);
 
-    preparePromptProjectionStateForTest({ sessionId, messages: [], state, raw: true });
+    await preparePromptProjectionStateForTest({ sessionId, messages: [], state, raw: true });
     expect(state.sourceHashByKey.size).toBe(2);
 
-    preparePromptProjectionStateForTest({ sessionId, messages: [retained], state });
+    await preparePromptProjectionStateForTest({ sessionId, messages: [retained], state });
 
     expect(state.sourceHashByKey.size).toBe(1);
     expect(state.frozen.size).toBe(1);
@@ -1524,14 +1524,14 @@ describe("truncateOversizedToolResultsInMessages", () => {
       ["a", "bc"],
     ],
     [["\ud800"], ["\ud801"]],
-  ])("invalidates rewritten canonical text with preserved framing: %j", (before, after) => {
+  ])("invalidates rewritten canonical text with preserved framing: %j", async (before, after) => {
     const state = createPromptProjectionStateForTest();
     const source = makeToolResult("", "rewritten-source");
     const blocks = (parts: string[]) => parts.map((text) => ({ type: "text" as const, text }));
     source.content = blocks(["x".repeat(15_000), ...before]);
     truncateOversizedToolResultsInMessages([source], 128_000, 5_000, 20_000, state);
     const rewritten = { ...source, content: blocks(["x".repeat(15_000), ...after]) };
-    preparePromptProjectionStateForTest({
+    await preparePromptProjectionStateForTest({
       sessionId: "rewritten-source",
       messages: [rewritten],
       state,
@@ -1540,7 +1540,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(state.frozen.size).toBe(0);
   });
 
-  it("freezes #99495 ambiguous-key projections across filtered history", () => {
+  it("freezes #99495 ambiguous-key projections across filtered history", async () => {
     const projectionState = createPromptProjectionStateForTest();
     const duplicate = (text: string) => ({
       role: "toolResult" as const,
@@ -1567,7 +1567,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
 
     expect(first.messages[0]).not.toEqual(first.messages[1]);
     expect(filtered.messages[0]).toEqual(first.messages[1]);
-    preparePromptProjectionStateForTest({
+    await preparePromptProjectionStateForTest({
       sessionId: "ambiguous-filtered-history",
       messages: [duplicate("b".repeat(100))],
       state: projectionState,
@@ -1585,7 +1585,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
         projectionState,
       ).messages[0],
     ).toEqual(first.messages[1]);
-    preparePromptProjectionStateForTest({
+    await preparePromptProjectionStateForTest({
       sessionId: "ambiguous-removed-history",
       messages: [],
       state: projectionState,
@@ -1593,7 +1593,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(projectionState.ambiguousBaseKeys.size).toBe(0);
   });
 
-  it("drops an unselected identical-occurrence key without changing projected bytes", () => {
+  it("drops an unselected identical-occurrence key without changing projected bytes", async () => {
     const projectionState = createPromptProjectionStateForTest();
     const duplicate = (): ToolResultMessage => ({
       role: "toolResult",
@@ -1614,7 +1614,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     const stateWithStaleOccurrence = cloneToolResultPromptProjectionState(projectionState);
     expect(stateWithStaleOccurrence.frozen.size).toBe(2);
 
-    preparePromptProjectionStateForTest({
+    await preparePromptProjectionStateForTest({
       sessionId: "identical-occurrence-compaction",
       messages: [duplicate()],
       state: projectionState,
@@ -1813,7 +1813,7 @@ describe("truncateOversizedToolResultsInSession", () => {
     expect(projectionState.sourceHashByKey.size).toBe(0);
     expect(projectionState.replacements.size).toBe(0);
     expect(projectionState.frozen.size).toBe(0);
-    preparePromptProjectionStateForTest({
+    await preparePromptProjectionStateForTest({
       sessionId,
       messages: SessionManager.open(scope).buildSessionContext().messages,
       state: staleProjectionState,

--- a/src/agents/media-generation-task-status-shared.test.ts
+++ b/src/agents/media-generation-task-status-shared.test.ts
@@ -61,17 +61,17 @@ beforeEach(() => {
 });
 
 describe("media generation delivery-phase prompt guard", () => {
-  it("does not warn about a task waiting only for completion delivery", () => {
+  it("does not warn about a task waiting only for completion delivery", async () => {
     taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue([
       makeTask({ progressSummary: MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS }),
     ]);
 
     expect(
-      videoTaskStatusOwner.buildActiveTaskPromptContextForSession("session/A"),
+      await videoTaskStatusOwner.buildActiveTaskPromptContextForSession("session/A"),
     ).toBeUndefined();
   });
 
-  it("carries only bounded single-line facts while media generation is running", () => {
+  it("carries only bounded single-line facts while media generation is running", async () => {
     taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue([
       makeTask({
         taskId: `task-${"t".repeat(150)}`,
@@ -80,12 +80,12 @@ describe("media generation delivery-phase prompt guard", () => {
       }),
     ]);
 
-    expect(videoTaskStatusOwner.buildActiveTaskPromptContextForSession("session/A")).toBe(
+    expect(await videoTaskStatusOwner.buildActiveTaskPromptContextForSession("session/A")).toBe(
       `- tool=video_generate; task=task-${"t".repeat(123)}; status=running; provider_json="${"p".repeat(128)}"; progress_json="Generatingvideo${"x".repeat(305)}"`,
     );
   });
 
-  it("keeps a bounded task snapshot stable across registry order and elapsed time", () => {
+  it("keeps a bounded task snapshot stable across registry order and elapsed time", async () => {
     const tasks = Array.from({ length: 10 }, (_, index) =>
       makeTask({
         taskId: `task-${index}`,
@@ -95,7 +95,7 @@ describe("media generation delivery-phase prompt guard", () => {
     );
     taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue(tasks.toReversed());
 
-    const context = videoTaskStatusOwner.buildActiveTaskPromptContextForSession("session/A");
+    const context = await videoTaskStatusOwner.buildActiveTaskPromptContextForSession("session/A");
     expect(context).toBe(
       [
         "- tool=video_generate; task=task-0; status=queued",
@@ -114,18 +114,20 @@ describe("media generation delivery-phase prompt guard", () => {
       task.lastEventAt = task.createdAt + 60_000;
     }
     taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue(tasks);
-    expect(videoTaskStatusOwner.buildActiveTaskPromptContextForSession("session/A")).toBe(context);
+    expect(await videoTaskStatusOwner.buildActiveTaskPromptContextForSession("session/A")).toBe(
+      context,
+    );
   });
 
-  it("keeps delivery-phase tasks available to duplicate/status lookups", () => {
+  it("keeps delivery-phase tasks available to duplicate/status lookups", async () => {
     const task = makeTask({ progressSummary: MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS });
     taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue([task]);
 
-    expect(videoTaskStatusOwner.listActiveTasksForSession("session/A")).toEqual([task]);
-    expect(videoTaskStatusOwner.findActiveTaskForSession("session/A")).toEqual(task);
+    expect(await videoTaskStatusOwner.listActiveTasksForSession("session/A")).toEqual([task]);
+    expect(await videoTaskStatusOwner.findActiveTaskForSession("session/A")).toEqual(task);
   });
 
-  it("keeps restored legacy bare tasks visible only to their persisted requester owner", () => {
+  it("keeps restored legacy bare tasks visible only to their persisted requester owner", async () => {
     const task = makeTask({
       requesterSessionKey: "global",
       ownerKey: "global",
@@ -135,14 +137,14 @@ describe("media generation delivery-phase prompt guard", () => {
     });
     taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue([task]);
 
-    expect(videoTaskStatusOwner.listActiveTasksForSession("global", "ops")).toEqual([task]);
-    expect(videoTaskStatusOwner.findActiveTaskForSession("global", { agentId: "ops" })).toEqual(
-      task,
-    );
-    expect(videoTaskStatusOwner.listActiveTasksForSession("global", "research")).toEqual([]);
+    expect(await videoTaskStatusOwner.listActiveTasksForSession("global", "ops")).toEqual([task]);
+    expect(
+      await videoTaskStatusOwner.findActiveTaskForSession("global", { agentId: "ops" }),
+    ).toEqual(task);
+    expect(await videoTaskStatusOwner.listActiveTasksForSession("global", "research")).toEqual([]);
   });
 
-  it("blocks the same prompt while allowing a distinct prompt", () => {
+  it("blocks the same prompt while allowing a distinct prompt", async () => {
     const task = makeTask({
       task: "generate clip 01",
       progressSummary: MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS,
@@ -150,12 +152,12 @@ describe("media generation delivery-phase prompt guard", () => {
     taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue([task]);
 
     expect(
-      videoTaskStatusOwner.findDuplicateGuardTaskForSession("session/A", {
+      await videoTaskStatusOwner.findDuplicateGuardTaskForSession("session/A", {
         prompt: "generate clip 01",
       }),
     ).toEqual(task);
     expect(
-      videoTaskStatusOwner.findDuplicateGuardTaskForSession("session/A", {
+      await videoTaskStatusOwner.findDuplicateGuardTaskForSession("session/A", {
         prompt: "generate clip 02",
       }),
     ).toBeUndefined();

--- a/src/agents/media-generation-task-status-shared.ts
+++ b/src/agents/media-generation-task-status-shared.ts
@@ -150,13 +150,13 @@ function recentMediaGenerationTaskStartMatches(
 }
 
 function findPersistedTaskForRecentMediaGenerationStart(params: {
-  sessionKey: string;
+  tasks: readonly TaskRecord[];
   agentId?: string;
   cachedTask: TaskRecord;
   taskKind: string;
   sourcePrefix: string;
 }): TaskRecord | undefined {
-  return listFreshTasksForOwnerKey(params.sessionKey).find((task) => {
+  return params.tasks.find((task) => {
     if (
       task.runtime !== "cli" ||
       task.scopeKind !== "session" ||
@@ -239,6 +239,7 @@ export function recordRecentMediaGenerationTaskStartForSession(params: {
 
 /** Finds a recent started media task from memory or persisted task state. */
 function findRecentStartedMediaGenerationTaskForSession(params: {
+  tasks: readonly TaskRecord[];
   sessionKey?: string;
   agentId?: string;
   taskKind: string;
@@ -267,8 +268,8 @@ function findRecentStartedMediaGenerationTaskForSession(params: {
   for (const entry of entries.toReversed()) {
     const task = entry.task;
     const persistedTask = findPersistedTaskForRecentMediaGenerationStart({
-      sessionKey,
       agentId: params.agentId,
+      tasks: params.tasks,
       cachedTask: task,
       taskKind: params.taskKind,
       sourcePrefix: params.sourcePrefix,
@@ -336,33 +337,40 @@ function getMediaGenerationTaskProviderId(
 }
 
 /** Finds the highest-priority active media generation task for a session. */
-function findActiveMediaGenerationTaskForSession(params: {
+async function findActiveMediaGenerationTaskForSession(params: {
   sessionKey?: string;
   agentId?: string;
   taskKind: string;
   sourcePrefix: string;
   taskLabel?: string;
   excludeDeliveringCompletion?: boolean;
-}): TaskRecord | undefined {
-  return listActiveMediaGenerationTasksForSession(params)[0];
+}): Promise<TaskRecord | undefined> {
+  return (await listActiveMediaGenerationTasksForSession(params))[0];
 }
 
 /** Lists active media generation tasks for a session, preferring running tasks. */
-function listActiveMediaGenerationTasksForSession(params: {
+async function listActiveMediaGenerationTasksForSession(params: {
   sessionKey?: string;
   agentId?: string;
   taskKind: string;
   sourcePrefix: string;
   taskLabel?: string;
   excludeDeliveringCompletion?: boolean;
-}): TaskRecord[] {
+}): Promise<TaskRecord[]> {
   const sessionKey = normalizeOptionalString(params.sessionKey);
   if (!sessionKey) {
     return [];
   }
+  return selectActiveMediaGenerationTasks(params, await listFreshTasksForOwnerKey(sessionKey));
+}
+
+function selectActiveMediaGenerationTasks(
+  params: Parameters<typeof listActiveMediaGenerationTasksForSession>[0],
+  tasks: readonly TaskRecord[],
+): TaskRecord[] {
   const taskLabel = normalizeOptionalString(params.taskLabel);
   const sourcePrefix = normalizeOptionalString(params.sourcePrefix);
-  const matches = listFreshTasksForOwnerKey(sessionKey).filter((task) => {
+  const matches = tasks.filter((task) => {
     if (
       task.runtime !== "cli" ||
       task.scopeKind !== "session" ||
@@ -395,7 +403,7 @@ function listActiveMediaGenerationTasksForSession(params: {
 }
 
 /** Finds a task that should block duplicate media generation for a session. */
-function findDuplicateGuardMediaGenerationTaskForSession(params: {
+async function findDuplicateGuardMediaGenerationTaskForSession(params: {
   sessionKey?: string;
   agentId?: string;
   taskKind: string;
@@ -403,17 +411,15 @@ function findDuplicateGuardMediaGenerationTaskForSession(params: {
   taskLabel?: string;
   requestKey?: string;
   maxAgeMs: number;
-}): TaskRecord | undefined {
+}): Promise<TaskRecord | undefined> {
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  if (!sessionKey) {
+    return undefined;
+  }
+  const tasks = await listFreshTasksForOwnerKey(sessionKey);
   return (
-    findRecentStartedMediaGenerationTaskForSession(params) ??
-    findActiveMediaGenerationTaskForSession({
-      sessionKey: params.sessionKey,
-      agentId: params.agentId,
-      taskKind: params.taskKind,
-      sourcePrefix: params.sourcePrefix,
-      taskLabel: params.taskLabel,
-    }) ??
-    undefined
+    findRecentStartedMediaGenerationTaskForSession({ ...params, sessionKey, tasks }) ??
+    selectActiveMediaGenerationTasks(params, tasks)[0]
   );
 }
 
@@ -501,13 +507,13 @@ function buildMediaGenerationTaskStatusListText(params: {
 }
 
 /** Builds bounded current-turn facts without instructions or elapsed-time fields. */
-function buildActiveMediaGenerationTaskPromptContextForSession(params: {
+async function buildActiveMediaGenerationTaskPromptContextForSession(params: {
   sessionKey?: string;
   agentId?: string;
   taskKind: string;
   sourcePrefix: string;
-}): string | undefined {
-  const tasks = listActiveMediaGenerationTasksForSession({
+}): Promise<string | undefined> {
+  const tasks = await listActiveMediaGenerationTasksForSession({
     sessionKey: params.sessionKey,
     agentId: params.agentId,
     taskKind: params.taskKind,

--- a/src/agents/media-generation-task-status.test.ts
+++ b/src/agents/media-generation-task-status.test.ts
@@ -1,12 +1,13 @@
 // Verifies media-generation task lookup, duplicate guards, and prompt status text.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { recordRecentMediaGenerationTaskStartForSession } from "./media-generation-task-status-shared.js";
 import { resetRecentMediaGenerationDuplicateGuardsForTests } from "./media-generation-task-status-shared.test-support.js";
 import {
   buildActiveImageGenerationTaskPromptContextForSession,
   buildImageGenerationTaskStatusDetails,
   buildImageGenerationTaskStatusText,
-  findActiveImageGenerationTaskForSession,
   findDuplicateGuardImageGenerationTaskForSession,
   IMAGE_GENERATION_TASK_KIND,
   buildActiveVideoGenerationTaskPromptContextForSession,
@@ -31,8 +32,8 @@ const taskRuntimeInternalMocks = vi.hoisted(() => {
 vi.mock("../tasks/runtime-internal.js", () => taskRuntimeInternalMocks);
 
 function expectActiveImageGenerationTask(
-  task: ReturnType<typeof findActiveImageGenerationTaskForSession>,
-): NonNullable<ReturnType<typeof findActiveImageGenerationTaskForSession>> {
+  task: Awaited<ReturnType<typeof findDuplicateGuardImageGenerationTaskForSession>>,
+): NonNullable<Awaited<ReturnType<typeof findDuplicateGuardImageGenerationTaskForSession>>> {
   // Narrows optional lookups in tests that need status helper calls.
   if (task == null) {
     throw new Error("Expected active image generation task");
@@ -52,7 +53,7 @@ describe("image generation task status", () => {
     resetRecentMediaGenerationDuplicateGuardsForTests();
   });
 
-  it("prefers a running task over queued session siblings", () => {
+  it("prefers a running task over queued session siblings", async () => {
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
       {
         taskId: "task-queued",
@@ -85,7 +86,7 @@ describe("image generation task status", () => {
       },
     ]);
 
-    const task = findActiveImageGenerationTaskForSession("agent:main");
+    const task = await findDuplicateGuardImageGenerationTaskForSession("agent:main");
 
     expect(task?.taskId).toBe("task-running");
     const activeTask = expectActiveImageGenerationTask(task);
@@ -101,7 +102,7 @@ describe("image generation task status", () => {
     expect(details.progressSummary).toBe("Generating image");
   });
 
-  it("can restrict active lookup to the matching image prompt", () => {
+  it("can restrict active lookup to the matching image prompt", async () => {
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
       {
         taskId: "task-first",
@@ -134,18 +135,20 @@ describe("image generation task status", () => {
     ]);
 
     expect(
-      findActiveImageGenerationTaskForSession("agent:main", {
-        prompt: "Second diagram prompt",
-      })?.taskId,
+      (
+        await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+          prompt: "Second diagram prompt",
+        })
+      )?.taskId,
     ).toBe("task-second");
     expect(
-      findActiveImageGenerationTaskForSession("agent:main", {
+      await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
         prompt: "Third diagram prompt",
       }),
     ).toBeUndefined();
   });
 
-  it("uses a matching recent-start request key as a succeeded duplicate guard", () => {
+  it("uses a matching recent-start request key as a succeeded duplicate guard", async () => {
     // The request key ties a tool call to its persisted completion so the
     // model gets status guidance instead of starting the same image twice.
     const now = Date.now();
@@ -181,7 +184,7 @@ describe("image generation task status", () => {
       },
     ]);
 
-    const task = findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+    const task = await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
       requestKey: "image-request:a",
     });
 
@@ -195,7 +198,7 @@ describe("image generation task status", () => {
     );
   });
 
-  it("does not use a delivery-blocked image task as a succeeded duplicate guard", () => {
+  it("does not use a delivery-blocked image task as a succeeded duplicate guard", async () => {
     // If completion delivery failed, suppressing a retry would strand the
     // requester without an image even though the provider task succeeded.
     const now = Date.now();
@@ -234,13 +237,13 @@ describe("image generation task status", () => {
     ]);
 
     expect(
-      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+      await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
         requestKey: "image-request:blocked",
       }),
     ).toBeUndefined();
   });
 
-  it("does not use a recent succeeded image task without a matching request key", () => {
+  it("does not use a recent succeeded image task without a matching request key", async () => {
     const now = Date.now();
     recordRecentMediaGenerationTaskStartForSession({
       sessionKey: "agent:main",
@@ -275,13 +278,13 @@ describe("image generation task status", () => {
     ]);
 
     expect(
-      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+      await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
         requestKey: "image-request:b",
       }),
     ).toBeUndefined();
   });
 
-  it("preserves earlier recent request keys when another image request starts", () => {
+  it("preserves earlier recent request keys when another image request starts", async () => {
     // Multiple image requests can be active/recent in the same session; a new
     // request must not erase an older request key that can still match status.
     const now = Date.now();
@@ -296,6 +299,11 @@ describe("image generation task status", () => {
       providerId: "xai",
       progressSummary: "Generating first image",
       nowMs: now - 30_000,
+    });
+    const lookup = createDeferred<TaskRecord[]>();
+    taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValueOnce(lookup.promise);
+    const pending = findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+      requestKey: "image-request:other",
     });
     recordRecentMediaGenerationTaskStartForSession({
       sessionKey: "agent:main",
@@ -346,14 +354,44 @@ describe("image generation task status", () => {
       },
     ]);
 
+    lookup.resolve(taskRuntimeInternalMocks.listTasksForOwnerKey("agent:main"));
+    expect(await pending).toBeUndefined();
+
     expect(
-      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
-        requestKey: "image-request:first",
-      })?.taskId,
+      (
+        await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+          requestKey: "image-request:first",
+        })
+      )?.taskId,
     ).toBe("task-first");
+    expect(
+      (
+        await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+          requestKey: "image-request:second",
+        })
+      )?.taskId,
+    ).toBe("task-second");
   });
 
-  it("prunes stale same-session recent starts when another image request starts", () => {
+  it("observes a recent start recorded while the first owner lookup is pending", async () => {
+    const lookup = createDeferred<TaskRecord[]>();
+    taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValueOnce(lookup.promise);
+    const pending = findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+      prompt: "new image",
+    });
+    recordRecentMediaGenerationTaskStartForSession({
+      sessionKey: "agent:main",
+      taskKind: IMAGE_GENERATION_TASK_KIND,
+      sourcePrefix: "image_generate",
+      taskId: "task-started-during-read",
+      taskLabel: "new image",
+      progressSummary: "Generating image",
+    });
+    lookup.resolve([]);
+    expect(await pending).toMatchObject({ taskId: "task-started-during-read", status: "running" });
+  });
+
+  it("prunes stale same-session recent starts when another image request starts", async () => {
     const now = Date.now();
     recordRecentMediaGenerationTaskStartForSession({
       sessionKey: "agent:main",
@@ -381,20 +419,22 @@ describe("image generation task status", () => {
     });
 
     expect(
-      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+      await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
         prompt: "stale prompt",
         requestKey: "image-request:stale",
       }),
     ).toBeUndefined();
     expect(
-      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
-        prompt: "fresh prompt",
-        requestKey: "image-request:fresh",
-      })?.taskId,
+      (
+        await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+          prompt: "fresh prompt",
+          requestKey: "image-request:fresh",
+        })
+      )?.taskId,
     ).toBe("task-fresh");
   });
 
-  it("expires recent image starts after the canonical 120-second guard window", () => {
+  it("expires recent image starts after the canonical 120-second guard window", async () => {
     const now = Date.now();
     recordRecentMediaGenerationTaskStartForSession({
       sessionKey: "agent:main",
@@ -410,14 +450,14 @@ describe("image generation task status", () => {
     });
 
     expect(
-      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+      await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
         prompt: "stale prompt",
         requestKey: "image-request:stale",
       }),
     ).toBeUndefined();
   });
 
-  it("does not block a distinct prompt from a cached active recent start", () => {
+  it("does not block a distinct prompt from a cached active recent start", async () => {
     recordRecentMediaGenerationTaskStartForSession({
       sessionKey: "agent:main",
       taskKind: IMAGE_GENERATION_TASK_KIND,
@@ -431,13 +471,13 @@ describe("image generation task status", () => {
     });
 
     expect(
-      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+      await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
         prompt: "second prompt",
       }),
     ).toBeUndefined();
   });
 
-  it("uses a recent persisted completion instead of pruning a stale recent-start cache", () => {
+  it("uses a recent persisted completion instead of pruning a stale recent-start cache", async () => {
     const now = Date.now();
     recordRecentMediaGenerationTaskStartForSession({
       sessionKey: "agent:main",
@@ -471,7 +511,7 @@ describe("image generation task status", () => {
       },
     ]);
 
-    const task = findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+    const task = await findDuplicateGuardImageGenerationTaskForSession("agent:main", {
       requestKey: "image-request:stale",
     });
 
@@ -481,7 +521,7 @@ describe("image generation task status", () => {
     );
   });
 
-  it("clears the recent-start cache when the persisted task has failed", () => {
+  it("clears the recent-start cache when the persisted task has failed", async () => {
     const now = Date.now();
     recordRecentMediaGenerationTaskStartForSession({
       sessionKey: "agent:main",
@@ -514,10 +554,10 @@ describe("image generation task status", () => {
       },
     ]);
 
-    expect(findDuplicateGuardImageGenerationTaskForSession("agent:main")).toBeUndefined();
+    expect(await findDuplicateGuardImageGenerationTaskForSession("agent:main")).toBeUndefined();
   });
 
-  it("builds prompt context for active session work", () => {
+  it("builds prompt context for active session work", async () => {
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
       {
         taskId: "task-running",
@@ -536,7 +576,7 @@ describe("image generation task status", () => {
       },
     ]);
 
-    const context = buildActiveImageGenerationTaskPromptContextForSession("agent:main");
+    const context = await buildActiveImageGenerationTaskPromptContextForSession("agent:main");
 
     expect(context).toBe(
       '- tool=image_generate; task=task-running; status=running; provider_json="openai"; progress_json="Generating image"',
@@ -545,8 +585,8 @@ describe("image generation task status", () => {
 });
 
 function expectActiveVideoGenerationTask(
-  task: ReturnType<typeof findActiveVideoGenerationTaskForSession>,
-): NonNullable<ReturnType<typeof findActiveVideoGenerationTaskForSession>> {
+  task: Awaited<ReturnType<typeof findActiveVideoGenerationTaskForSession>>,
+): NonNullable<Awaited<ReturnType<typeof findActiveVideoGenerationTaskForSession>>> {
   if (task == null) {
     throw new Error("Expected active video generation task");
   }
@@ -565,7 +605,7 @@ describe("video generation task status", () => {
     resetRecentMediaGenerationDuplicateGuardsForTests();
   });
 
-  it("recognizes active session-backed video generation tasks", () => {
+  it("recognizes active session-backed video generation tasks", async () => {
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
       {
         taskId: "task-1",
@@ -597,10 +637,10 @@ describe("video generation task status", () => {
       },
     ]);
 
-    expect(findActiveVideoGenerationTaskForSession("agent:main")?.taskId).toBe("task-1");
+    expect((await findActiveVideoGenerationTaskForSession("agent:main"))?.taskId).toBe("task-1");
   });
 
-  it("prefers a running task over queued session siblings", () => {
+  it("prefers a running task over queued session siblings", async () => {
     // Running work should suppress duplicate generation even when older queued
     // siblings still exist for the same session owner.
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
@@ -635,7 +675,7 @@ describe("video generation task status", () => {
       },
     ]);
 
-    const task = findActiveVideoGenerationTaskForSession("agent:main");
+    const task = await findActiveVideoGenerationTaskForSession("agent:main");
 
     expect(task?.taskId).toBe("task-running");
     const activeTask = expectActiveVideoGenerationTask(task);
@@ -651,7 +691,7 @@ describe("video generation task status", () => {
     expect(details.progressSummary).toBe("Generating video");
   });
 
-  it("builds prompt context for active session work", () => {
+  it("builds prompt context for active session work", async () => {
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
       {
         taskId: "task-running",
@@ -670,7 +710,7 @@ describe("video generation task status", () => {
       },
     ]);
 
-    const context = buildActiveVideoGenerationTaskPromptContextForSession("agent:main");
+    const context = await buildActiveVideoGenerationTaskPromptContextForSession("agent:main");
 
     expect(context).toBe(
       '- tool=video_generate; task=task-running; status=running; provider_json="openai"; progress_json="Generating video"',

--- a/src/agents/media-generation-task-status.ts
+++ b/src/agents/media-generation-task-status.ts
@@ -10,7 +10,6 @@ export const IMAGE_GENERATION_TASK_KIND = "image_generation";
 
 /** Image generation keeps multi-task status and prompt-specific duplicate lookup. */
 export const {
-  findActiveTaskForSession: findActiveImageGenerationTaskForSession,
   listActiveTasksForSession: listActiveImageGenerationTasksForSession,
   findDuplicateGuardTaskForSession: findDuplicateGuardImageGenerationTaskForSession,
   buildTaskStatusDetails: buildImageGenerationTaskStatusDetails,

--- a/src/agents/runtime-facts-prompt.test.ts
+++ b/src/agents/runtime-facts-prompt.test.ts
@@ -9,7 +9,7 @@ afterEach(() => vi.restoreAllMocks());
 
 describe("approved executable runtime facts", () => {
   it("sorts current agent and wildcard hints, preserves paths and argument notes, and clears stale hints", () =>
-    withMockedPlatform("win32", () => {
+    withMockedPlatform("win32", async () => {
       const file: execApprovals.ExecApprovalsFile = {
         version: 1,
         agents: {
@@ -19,10 +19,10 @@ describe("approved executable runtime facts", () => {
         },
       };
       vi.spyOn(execApprovals, "loadExecApprovals").mockImplementation(() => file);
-      expect(buildRuntimeFactsContext(params)).toEqual([
+      expect(await buildRuntimeFactsContext(params)).toEqual([
         { kind: "conversation-data", text: expect.any(String) },
       ]);
-      const before = buildRuntimeFactsContext(params).at(0)?.text;
+      const before = (await buildRuntimeFactsContext(params)).at(0)?.text;
       expect(before).toContain("## Approved executables");
       expect(before).toContain(
         "exact arguments are enforced at runtime; no approval prompt needed when args match",
@@ -32,16 +32,18 @@ describe("approved executable runtime facts", () => {
       );
       expect(before).not.toContain("other.exe");
       file.agents!.main!.allowlist!.unshift({ pattern: "C:\\Tools\\b.exe" });
-      const added = buildRuntimeFactsContext(params).at(0)?.text;
+      const added = (await buildRuntimeFactsContext(params)).at(0)?.text;
       expect(added).toContain("b.exe (any arguments)");
       file.agents!.main!.allowlist!.reverse();
-      expect(buildRuntimeFactsContext(params).at(0)?.text).toBe(added);
+      expect((await buildRuntimeFactsContext(params)).at(0)?.text).toBe(added);
       file.agents = {};
-      expect(buildRuntimeFactsContext(params).at(0)?.text).toBe("## Approved executables\nnone");
+      expect((await buildRuntimeFactsContext(params)).at(0)?.text).toBe(
+        "## Approved executables\nnone",
+      );
     }));
 
   it("bounds hints and omits command approvals, global wildcards, bare names, and unsafe or oversized tokens", () =>
-    withMockedPlatform("win32", () => {
+    withMockedPlatform("win32", async () => {
       vi.spyOn(execApprovals, "loadExecApprovals").mockReturnValue({
         version: 1,
         agents: {
@@ -62,7 +64,7 @@ describe("approved executable runtime facts", () => {
         },
       });
       const facts = expectDefined(
-        buildRuntimeFactsContext(params).at(0),
+        (await buildRuntimeFactsContext(params)).at(0),
         "approved executable facts",
       ).text;
       expect(facts.match(/\(any arguments\)/g)).toHaveLength(10);
@@ -75,15 +77,15 @@ describe("approved executable runtime facts", () => {
   it.each(["linux", "darwin", "win32"] as const)(
     "gates approval reads on Windows and exec capability: %s",
     (platform) =>
-      withMockedPlatform(platform, () => {
+      withMockedPlatform(platform, async () => {
         const load = vi.spyOn(execApprovals, "loadExecApprovals").mockImplementation(() => {
           throw new Error("unavailable");
         });
         expect(
-          buildRuntimeFactsContext({ ...params, capabilityToolNames: new Set(["read"]) }),
+          await buildRuntimeFactsContext({ ...params, capabilityToolNames: new Set(["read"]) }),
         ).toEqual([]);
         expect(load).not.toHaveBeenCalled();
-        const facts = buildRuntimeFactsContext(params).at(0)?.text;
+        const facts = (await buildRuntimeFactsContext(params)).at(0)?.text;
         if (platform === "win32") {
           expect(facts).toBe("## Approved executables\nunavailable");
         } else {

--- a/src/agents/runtime-facts-prompt.ts
+++ b/src/agents/runtime-facts-prompt.ts
@@ -23,17 +23,22 @@ type RuntimeFactsParams = {
 };
 
 /** Shared by embedded carriers and CLI current-turn context. */
-export function buildMediaTaskRuntimeContext(
+export async function buildMediaTaskRuntimeContext(
   params: Pick<RuntimeFactsParams, "capabilityToolNames" | "sessionKey" | "agentId">,
-): string | undefined {
+): Promise<string | undefined> {
   const sections = [
     ["image_generate", buildActiveImageGenerationTaskPromptContextForSession],
     ["music_generate", buildActiveMusicGenerationTaskPromptContextForSession],
     ["video_generate", buildActiveVideoGenerationTaskPromptContextForSession],
   ] as const;
-  const facts = sections
-    .filter(([tool]) => params.capabilityToolNames.has(tool))
-    .map(([tool, build]) => build(params.sessionKey, params.agentId) ?? `- tool=${tool}; none`);
+  const facts = await Promise.all(
+    sections
+      .filter(([tool]) => params.capabilityToolNames.has(tool))
+      .map(
+        async ([tool, build]) =>
+          (await build(params.sessionKey, params.agentId)) ?? `- tool=${tool}; none`,
+      ),
+  );
   return facts.length ? ["## Media Generation Tasks", ...facts].join("\n") : undefined;
 }
 
@@ -74,7 +79,9 @@ function buildApprovedExecutablesRuntimeContext(agentId: string): string {
   }
 }
 
-export function buildRuntimeFactsContext(params: RuntimeFactsParams): RuntimeContextFragment[] {
+export async function buildRuntimeFactsContext(
+  params: RuntimeFactsParams,
+): Promise<RuntimeContextFragment[]> {
   const sections: string[] = [];
   if (process.platform === "win32" && params.capabilityToolNames.has("exec")) {
     sections.push(buildApprovedExecutablesRuntimeContext(params.agentId));
@@ -107,7 +114,7 @@ export function buildRuntimeFactsContext(params: RuntimeFactsParams): RuntimeCon
       }) ?? "## Active Subagents\nnone",
     );
   }
-  const media = buildMediaTaskRuntimeContext(params);
+  const media = await buildMediaTaskRuntimeContext(params);
   if (media) {
     sections.push(media);
   }

--- a/src/agents/tools/image-generate-tool.actions.ts
+++ b/src/agents/tools/image-generate-tool.actions.ts
@@ -11,14 +11,13 @@ import {
   buildImageGenerationTaskStatusListText,
   buildImageGenerationTaskStatusDetails,
   buildImageGenerationTaskStatusText,
-  findActiveImageGenerationTaskForSession,
   findDuplicateGuardImageGenerationTaskForSession,
   listActiveImageGenerationTasksForSession,
 } from "../media-generation-task-status.js";
 import {
   createMediaGenerateDuplicateGuardResult,
   createMediaGenerateProviderListActionResult,
-  createMediaGenerateTaskStatusActions,
+  createMediaGenerateTaskStatusResult,
   type MediaGenerateActionResult,
 } from "./media-generate-tool-actions-shared.js";
 
@@ -101,20 +100,12 @@ export function createImageGenerateListActionResult(params: {
   });
 }
 
-const imageGenerateTaskStatusActions = createMediaGenerateTaskStatusActions({
-  inactiveText: "No active image generation task is currently running for this session.",
-  findActiveTask: (sessionKey, agentId) =>
-    findActiveImageGenerationTaskForSession(sessionKey, { agentId }) ?? undefined,
-  buildStatusText: buildImageGenerationTaskStatusText,
-  buildStatusDetails: buildImageGenerationTaskStatusDetails,
-});
-
 /** Builds status output for active image-generation tasks in the current session. */
-export function createImageGenerateStatusActionResult(
+export async function createImageGenerateStatusActionResult(
   sessionKey?: string,
   agentId?: string,
-): ImageGenerateActionResult {
-  const activeTasks = listActiveImageGenerationTasksForSession(sessionKey, agentId);
+): Promise<ImageGenerateActionResult> {
+  const activeTasks = await listActiveImageGenerationTasksForSession(sessionKey, agentId);
   if (activeTasks.length > 1) {
     return {
       content: [{ type: "text", text: buildImageGenerationTaskStatusListText(activeTasks) }],
@@ -124,14 +115,19 @@ export function createImageGenerateStatusActionResult(
       },
     };
   }
-  return imageGenerateTaskStatusActions.createStatusActionResult(sessionKey, agentId);
+  return createMediaGenerateTaskStatusResult({
+    activeTask: activeTasks[0],
+    inactiveText: "No active image generation task is currently running for this session.",
+    buildStatusText: buildImageGenerationTaskStatusText,
+    buildStatusDetails: buildImageGenerationTaskStatusDetails,
+  });
 }
 
 /** Returns duplicate-guard status output when a matching image task is already active. */
 export function createImageGenerateDuplicateGuardResult(
   sessionKey?: string,
   params?: { prompt?: string; requestKey?: string; agentId?: string },
-): ImageGenerateActionResult | undefined {
+): Promise<ImageGenerateActionResult | undefined> {
   return createMediaGenerateDuplicateGuardResult({
     sessionKey,
     prompt: params?.prompt,

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -3,6 +3,7 @@
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const taskRuntimeInternalMocks = vi.hoisted(() => {
@@ -958,6 +959,45 @@ describe("createImageGenerateTool", () => {
       expect(generateImage).not.toHaveBeenCalled();
     },
   );
+
+  it("does not acquire image providers when the caller aborts a pending duplicate lookup", async () => {
+    const acquireProviders = vi.mocked(
+      mediaGenerationToolProviders.acquireImageGenerationToolProviders,
+    );
+    const lookup = createDeferred<[]>();
+    taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue(lookup.promise);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage");
+    const scheduleBackgroundWork = vi.fn();
+    const agentSessionKey = "agent:main:discord:direct:123";
+    const tool = requireImageGenerateTool(
+      createImageGenerateTool({
+        config: {
+          agents: {
+            defaults: { mediaModels: { image: { primary: "openai/gpt-image-1" } } },
+          },
+        },
+        agentSessionKey,
+        requesterOrigin: { channel: "discord", to: "dm:123" },
+        scheduleBackgroundWork,
+      }),
+    );
+    const controller = new AbortController();
+    const abortReason = new Error("image requester cancelled during task lookup");
+
+    const pending = tool.execute("call-image-lookup", { prompt: "an image" }, controller.signal);
+    expect(taskRuntimeInternalMocks.listFreshTasksForOwnerKey).toHaveBeenCalledWith(
+      agentSessionKey,
+    );
+    expect(acquireProviders).not.toHaveBeenCalled();
+    controller.abort(abortReason);
+    lookup.resolve([]);
+
+    await expect(pending).rejects.toBe(abortReason);
+    expect(acquireProviders).not.toHaveBeenCalled();
+    expect(taskRuntimeMocks.createRunningTaskRun).not.toHaveBeenCalled();
+    expect(scheduleBackgroundWork).not.toHaveBeenCalled();
+    expect(generateImage).not.toHaveBeenCalled();
+  });
 
   it("stops loading later image references when the caller aborts a pending reference", async () => {
     stubImageGenerationProviders();

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -183,16 +183,12 @@ function resolveRequestedCount(args: Record<string, unknown>): number {
   if (readSnakeCaseParamRaw(args, "count") === null) {
     throw new ToolInputError(`count must be between 1 and ${MAX_COUNT}`);
   }
-  const count = readPositiveIntegerParam(args, "count", {
-    message: `count must be between 1 and ${MAX_COUNT}`,
-  });
-  if (count === undefined) {
-    return DEFAULT_COUNT;
-  }
-  if (count < 1 || count > MAX_COUNT) {
-    throw new ToolInputError(`count must be between 1 and ${MAX_COUNT}`);
-  }
-  return count;
+  return (
+    readPositiveIntegerParam(args, "count", {
+      message: `count must be between 1 and ${MAX_COUNT}`,
+      max: MAX_COUNT,
+    }) ?? DEFAULT_COUNT
+  );
 }
 
 const parseImageOption = createEnumOptionParser(ToolInputError);
@@ -454,20 +450,21 @@ export function createImageGenerateTool(options?: {
               providers: [],
             })
           : null;
-      const readRequest = () => {
+      const readRequest = async () => {
         const prompt = readToolStringParam(params, "prompt", { required: true });
         return {
           prompt,
-          duplicate: createImageGenerateDuplicateGuardResult(options?.agentSessionKey, {
+          duplicate: await createImageGenerateDuplicateGuardResult(options?.agentSessionKey, {
             prompt,
             agentId: options?.requesterAgentId,
           }),
         };
       };
-      const configuredRequest = configuredModel ? readRequest() : undefined;
+      const configuredRequest = configuredModel ? await readRequest() : undefined;
       if (configuredRequest?.duplicate) {
         return configuredRequest.duplicate;
       }
+      signal?.throwIfAborted();
       const acquired = await acquireImageGenerationToolProviders({
         cfg: configuredModel
           ? (applyAgentDefaultModelConfig(cfg, "image", configuredModel) ?? cfg)
@@ -493,10 +490,12 @@ export function createImageGenerateTool(options?: {
         const effectiveCfg =
           applyAgentDefaultModelConfig(cfg, "image", imageGenerationModelConfig) ?? cfg;
         const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
-        const { prompt, duplicate } = configuredRequest ?? readRequest();
+        const { prompt, duplicate } = configuredRequest ?? (await readRequest());
         if (duplicate) {
           return { kind: "result" as const, result: duplicate };
         }
+        signal?.throwIfAborted();
+        acquired.assertOpen();
 
         const imageInputs = normalizeReferenceImages(params);
         const filename = readToolStringParam(params, "filename");
@@ -573,13 +572,15 @@ export function createImageGenerateTool(options?: {
           filename,
           providerOptions,
         });
-        const duplicateGuardResult = createImageGenerateDuplicateGuardResult(
+        const duplicateGuardResult = await createImageGenerateDuplicateGuardResult(
           options?.agentSessionKey,
           { prompt, requestKey, agentId: options?.requesterAgentId },
         );
         if (duplicateGuardResult) {
           return { kind: "result" as const, result: duplicateGuardResult };
         }
+        signal?.throwIfAborted();
+        acquired.assertOpen();
         validateImageGenerationCapabilities({
           provider: selectedProvider,
           count,

--- a/src/agents/tools/media-generate-tool-actions-shared.ts
+++ b/src/agents/tools/media-generate-tool-actions-shared.ts
@@ -21,7 +21,7 @@ type MediaGenerateActionResult = {
 type TaskStatusTextBuilder<Task> = (task: Task, params?: { duplicateGuard?: boolean }) => string;
 type MediaGenerateTaskStatusParams<Task> = {
   inactiveText: string;
-  findActiveTask: (sessionKey?: string, agentId?: string) => Task | undefined;
+  findActiveTask: (sessionKey?: string, agentId?: string) => Promise<Task | undefined>;
   buildStatusText: TaskStatusTextBuilder<Task>;
   buildStatusDetails: (task: Task) => Record<string, unknown>;
 };
@@ -158,28 +158,20 @@ export function createMediaGenerateProviderListActionResult<
   };
 }
 
-/** Creates status action helpers for a media generation task type. */
-export function createMediaGenerateTaskStatusActions<Task>(
-  params: MediaGenerateTaskStatusParams<Task>,
-) {
-  return {
-    createStatusActionResult(
-      this: void,
-      sessionKey?: string,
-      agentId?: string,
-    ): MediaGenerateActionResult {
-      const activeTask = params.findActiveTask(sessionKey, agentId);
-      return activeTask
-        ? {
-            content: [{ type: "text", text: params.buildStatusText(activeTask) }],
-            details: { action: "status", ...params.buildStatusDetails(activeTask) },
-          }
-        : {
-            content: [{ type: "text", text: params.inactiveText }],
-            details: { action: "status", active: false },
-          };
-    },
-  };
+/** Formats a selected task without reading its store again. */
+export function createMediaGenerateTaskStatusResult<Task>(
+  params: Omit<MediaGenerateTaskStatusParams<Task>, "findActiveTask"> & { activeTask?: Task },
+): MediaGenerateActionResult {
+  const { activeTask } = params;
+  return activeTask
+    ? {
+        content: [{ type: "text", text: params.buildStatusText(activeTask) }],
+        details: { action: "status", ...params.buildStatusDetails(activeTask) },
+      }
+    : {
+        content: [{ type: "text", text: params.inactiveText }],
+        details: { action: "status", active: false },
+      };
 }
 
 /** Creates status and duplicate-guard actions from one media-task owner. */
@@ -188,11 +180,16 @@ export function createMediaGenerateTaskActions<Task>(
     findDuplicateTask: (
       sessionKey?: string,
       request?: { prompt?: string; requestKey?: string; agentId?: string },
-    ) => Task | undefined;
+    ) => Promise<Task | undefined>;
   },
 ) {
   return {
-    ...createMediaGenerateTaskStatusActions(params),
+    async createStatusActionResult(this: void, sessionKey?: string, agentId?: string) {
+      return createMediaGenerateTaskStatusResult({
+        ...params,
+        activeTask: await params.findActiveTask(sessionKey, agentId),
+      });
+    },
     createDuplicateGuardResult(
       this: void,
       sessionKey?: string,
@@ -204,7 +201,7 @@ export function createMediaGenerateTaskActions<Task>(
 }
 
 /** Builds duplicate-guard status output for a media generation task type. */
-export function createMediaGenerateDuplicateGuardResult<Task>(params: {
+export async function createMediaGenerateDuplicateGuardResult<Task>(params: {
   sessionKey?: string;
   prompt?: string;
   requestKey?: string;
@@ -212,11 +209,11 @@ export function createMediaGenerateDuplicateGuardResult<Task>(params: {
   findDuplicateTask: (
     sessionKey?: string,
     params?: { prompt?: string; requestKey?: string; agentId?: string },
-  ) => Task | undefined;
+  ) => Promise<Task | undefined>;
   buildStatusText: TaskStatusTextBuilder<Task>;
   buildStatusDetails: (task: Task) => Record<string, unknown>;
-}): MediaGenerateActionResult | undefined {
-  const blockingTask = params.findDuplicateTask(params.sessionKey, {
+}): Promise<MediaGenerateActionResult | undefined> {
+  const blockingTask = await params.findDuplicateTask(params.sessionKey, {
     prompt: params.prompt,
     requestKey: params.requestKey,
     agentId: params.agentId,

--- a/src/agents/tools/media-generate-tool.resources.test.ts
+++ b/src/agents/tools/media-generate-tool.resources.test.ts
@@ -16,6 +16,7 @@ import {
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createDeferredCore } from "../../shared/deferred.js";
+import * as taskRuntime from "../../tasks/runtime-internal.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { resetRecentMediaGenerationDuplicateGuardsForTests } from "../media-generation-task-status-shared.test-support.js";
 import { prepareConfiguredRuntimeFacts } from "../prepared-model-runtime.configured-catalog.js";
@@ -294,74 +295,105 @@ describe.each(["image", "music", "video"] as const)(
       music: musicGenerationTaskLifecycle,
       video: videoGenerationTaskLifecycle,
     }[kind];
-    it("refuses new paid admission when the prepared owner releases during reference loading", async () => {
-      const fixture = createNativeFixture(kind, true);
-      const referenceStarted = createDeferredCore();
-      const resumeReference = createDeferredCore();
-      try {
-        await fixture.withEnvironment(async () => {
-          useNoBundledPlugins();
-          const first = await acquirePluginRegistryForInspection({ config: fixture.config });
-          const referencePath = path.join(fixture.dir, "reference.png");
-          fs.writeFileSync(referencePath, png);
-          const snapshot = await prepareSnapshot(fixture, first.registry);
-          const createTask = vi.spyOn(lifecycle, "createTaskRun").mockReturnValue({
-            taskId: "preflight-image-task",
-            runId: "preflight-image-run",
-            requesterSessionKey: "agent:main:discord:direct:synthetic-media",
-            taskLabel: "Synthetic media edit",
-          });
-          const schedule = vi.fn();
-          const loadReference = webMedia.loadWebMedia;
-          vi.spyOn(webMedia, "loadWebMedia").mockImplementation(async (...args) => {
-            referenceStarted.resolve();
-            await resumeReference.promise;
-            return loadReference(...args);
-          });
-          const tool = createTool({
-            config: fixture.config,
-            agentDir: snapshot.agentDir,
-            workspaceDir: fixture.dir,
-            preparedModelRuntime: snapshot,
-            agentSessionKey: "agent:main:discord:direct:synthetic-media",
-            scheduleBackgroundWork: schedule,
-          });
-          const outcome = tool!
-            .execute("preflight-image-call", {
-              prompt: "Synthetic media edit",
-              image: referencePath,
-            })
-            .then(
-              (value) => ({ value, error: undefined }),
-              (error: unknown) => ({ value: undefined, error }),
+    it.each(["request lookup", "duplicate lookup", "reference loading"] as const)(
+      "refuses preflight work when the prepared owner releases during %s",
+      async (pause) => {
+        const fixture = createNativeFixture(kind, true);
+        const preflightPaused = createDeferredCore();
+        const resumePreflight = createDeferredCore();
+        try {
+          await fixture.withEnvironment(async () => {
+            useNoBundledPlugins();
+            const first = await acquirePluginRegistryForInspection({ config: fixture.config });
+            const referencePath = path.join(fixture.dir, "reference.png");
+            fs.writeFileSync(referencePath, png);
+            const snapshot = await prepareSnapshot(fixture, first.registry);
+            const createTask = vi.spyOn(lifecycle, "createTaskRun").mockReturnValue({
+              taskId: "preflight-image-task",
+              runId: "preflight-image-run",
+              requesterSessionKey: "agent:main:discord:direct:synthetic-media",
+              taskLabel: "Synthetic media edit",
+            });
+            const schedule = vi.fn();
+            const loadReference = webMedia.loadWebMedia;
+            const reference = vi
+              .spyOn(webMedia, "loadWebMedia")
+              .mockImplementation(async (...args) => {
+                if (pause === "reference loading") {
+                  preflightPaused.resolve();
+                  await resumePreflight.promise;
+                }
+                return loadReference(...args);
+              });
+            const readTasks = taskRuntime.listFreshTasksForOwnerKey;
+            let lookups = 0;
+            vi.spyOn(taskRuntime, "listFreshTasksForOwnerKey").mockImplementation(
+              async (ownerKey) => {
+                const tasks = await readTasks(ownerKey);
+                if (
+                  pause !== "reference loading" &&
+                  ++lookups === (pause === "request lookup" ? 1 : 2)
+                ) {
+                  preflightPaused.resolve();
+                  await resumePreflight.promise;
+                }
+                return tasks;
+              },
             );
-          try {
-            await Promise.race([
-              referenceStarted.promise,
-              outcome.then(() => {
-                throw new Error("Media preflight settled before reading its reference");
-              }),
-            ]);
-            await first.release();
-            resumeReference.resolve();
-            const result = await outcome;
-            expect(result.error).toBeInstanceOf(Error);
-            expect(result.value).toBeUndefined();
-            expect(createTask).not.toHaveBeenCalled();
-            expect(schedule).not.toHaveBeenCalled();
-            expect(fixture.connections[0]!.generated).toBe(0);
-            expect(fixture.connections[0]!.database.isOpen).toBe(false);
-            expect(fixture.connections[0]!.disposals).toBe(1);
-          } finally {
-            resumeReference.resolve();
-            await outcome;
-            await first.release();
-          }
-        });
-      } finally {
-        fixture.cleanup();
-      }
-    });
+            const tool = createTool({
+              config: {
+                ...fixture.config,
+                agents: pause === "request lookup" ? undefined : fixture.config.agents,
+              },
+              agentDir: snapshot.agentDir,
+              workspaceDir: fixture.dir,
+              preparedModelRuntime: snapshot,
+              agentSessionKey: "agent:main:discord:direct:synthetic-media",
+              scheduleBackgroundWork: schedule,
+            });
+            const outcome = tool!
+              .execute("preflight-image-call", {
+                prompt: "Synthetic media edit",
+                image: referencePath,
+              })
+              .then(
+                (value) => ({ value, error: undefined }),
+                (error: unknown) => ({ value: undefined, error }),
+              );
+            try {
+              await Promise.race([
+                preflightPaused.promise,
+                outcome.then(() => {
+                  throw new Error(`Media preflight settled before ${pause}`);
+                }),
+              ]);
+              await first.release();
+              resumePreflight.resolve();
+              const result = await outcome;
+              expect(result.error).toBeInstanceOf(Error);
+              expect(result.value).toBeUndefined();
+              if (pause !== "reference loading") {
+                expect(reference).not.toHaveBeenCalled();
+              }
+              if (pause === "request lookup") {
+                expect(lookups).toBe(1);
+              }
+              expect(createTask).not.toHaveBeenCalled();
+              expect(schedule).not.toHaveBeenCalled();
+              expect(fixture.connections[0]!.generated).toBe(0);
+              expect(fixture.connections[0]!.database.isOpen).toBe(false);
+              expect(fixture.connections[0]!.disposals).toBe(1);
+            } finally {
+              resumePreflight.resolve();
+              await outcome;
+              await first.release();
+            }
+          });
+        } finally {
+          fixture.cleanup();
+        }
+      },
+    );
 
     it.each(
       kind === "video"

--- a/src/agents/tools/music-generate-tool.status.test.ts
+++ b/src/agents/tools/music-generate-tool.status.test.ts
@@ -44,7 +44,7 @@ describe("createMusicGenerateTool status actions", () => {
     vi.unstubAllEnvs();
   });
 
-  it("returns active task status instead of starting a duplicate generation", () => {
+  it("returns active task status instead of starting a duplicate generation", async () => {
     // Duplicate guard responses prevent agents from launching parallel provider
     // jobs while a matching request is still running.
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
@@ -66,7 +66,7 @@ describe("createMusicGenerateTool status actions", () => {
       },
     ]);
 
-    const result = createMusicGenerateDuplicateGuardResult("agent:main:discord:direct:123", {
+    const result = await createMusicGenerateDuplicateGuardResult("agent:main:discord:direct:123", {
       prompt: "night-drive synthwave",
     });
 
@@ -105,7 +105,7 @@ describe("createMusicGenerateTool status actions", () => {
     expect(details?.progressSummary).toBe("Generating music");
   });
 
-  it("reports active task status when action=status is requested", () => {
+  it("reports active task status when action=status is requested", async () => {
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
       {
         taskId: "task-active",
@@ -125,7 +125,7 @@ describe("createMusicGenerateTool status actions", () => {
       },
     ]);
 
-    const result = createMusicGenerateStatusActionResult("agent:main:discord:direct:123");
+    const result = await createMusicGenerateStatusActionResult("agent:main:discord:direct:123");
     const text = (result.content?.[0] as { text: string } | undefined)?.text ?? "";
 
     expect(text).toContain("Music generation task task-active is already queued with minimax.");
@@ -149,7 +149,7 @@ describe("createMusicGenerateTool status actions", () => {
     expect(details.progressSummary).toBe("Queued music generation");
   });
 
-  it("returns recent succeeded music status instead of starting a duplicate generation", () => {
+  it("returns recent succeeded music status instead of starting a duplicate generation", async () => {
     const now = Date.now();
     recordRecentMediaGenerationTaskStartForSession({
       sessionKey: "agent:main:discord:direct:123",
@@ -183,7 +183,7 @@ describe("createMusicGenerateTool status actions", () => {
       },
     ]);
 
-    const result = createMusicGenerateDuplicateGuardResult("agent:main:discord:direct:123", {
+    const result = await createMusicGenerateDuplicateGuardResult("agent:main:discord:direct:123", {
       requestKey: "music-request:night-drive",
     });
     const text = (result?.content?.[0] as { text: string } | undefined)?.text ?? "";

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -304,20 +304,21 @@ export function createMusicGenerateTool(options?: {
               providers: [],
             })
           : null;
-      const readRequest = () => {
+      const readRequest = async () => {
         const prompt = readToolStringParam(args, "prompt", { required: true });
         return {
           prompt,
-          duplicate: createMusicGenerateDuplicateGuardResult(options?.agentSessionKey, {
+          duplicate: await createMusicGenerateDuplicateGuardResult(options?.agentSessionKey, {
             prompt,
             agentId: options?.requesterAgentId,
           }),
         };
       };
-      const configuredRequest = configuredModel ? readRequest() : undefined;
+      const configuredRequest = configuredModel ? await readRequest() : undefined;
       if (configuredRequest?.duplicate) {
         return configuredRequest.duplicate;
       }
+      signal?.throwIfAborted();
       const acquired = options?.preparedModelRuntime?.acquireMediaCapabilityProviders
         ? await acquireMusicGenerationToolProviders({
             cfg: configuredModel
@@ -345,10 +346,12 @@ export function createMusicGenerateTool(options?: {
         }
         const effectiveCfg =
           applyAgentDefaultModelConfig(cfg, "music", musicGenerationModelConfig) ?? cfg;
-        const { prompt, duplicate } = configuredRequest ?? readRequest();
+        const { prompt, duplicate } = configuredRequest ?? (await readRequest());
         if (duplicate) {
           return { kind: "result" as const, result: duplicate };
         }
+        signal?.throwIfAborted();
+        acquired?.assertOpen();
 
         const lyrics = readToolStringParam(args, "lyrics");
         const instrumental = readBooleanParam(args, "instrumental");
@@ -400,13 +403,15 @@ export function createMusicGenerateTool(options?: {
           filename,
           imageInputs,
         });
-        const duplicateGuardResult = createMusicGenerateDuplicateGuardResult(
+        const duplicateGuardResult = await createMusicGenerateDuplicateGuardResult(
           options?.agentSessionKey,
           { prompt, requestKey, agentId: options?.requesterAgentId },
         );
         if (duplicateGuardResult) {
           return { kind: "result" as const, result: duplicateGuardResult };
         }
+        signal?.throwIfAborted();
+        acquired?.assertOpen();
         const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
         const loadedReferenceImages = await loadReferenceImages({
           inputs: imageInputs,

--- a/src/agents/tools/video-generate-tool.status.test.ts
+++ b/src/agents/tools/video-generate-tool.status.test.ts
@@ -44,7 +44,7 @@ describe("createVideoGenerateTool status actions", () => {
     vi.unstubAllEnvs();
   });
 
-  it("returns active task status instead of starting a duplicate generation", () => {
+  it("returns active task status instead of starting a duplicate generation", async () => {
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
       {
         taskId: "task-active",
@@ -64,7 +64,7 @@ describe("createVideoGenerateTool status actions", () => {
       },
     ]);
 
-    const result = createVideoGenerateDuplicateGuardResult("agent:main:discord:direct:123", {
+    const result = await createVideoGenerateDuplicateGuardResult("agent:main:discord:direct:123", {
       prompt: "friendly lobster surfing",
     });
 
@@ -103,7 +103,7 @@ describe("createVideoGenerateTool status actions", () => {
     expect(details?.progressSummary).toBe("Generating video");
   });
 
-  it("reports active task status when action=status is requested", () => {
+  it("reports active task status when action=status is requested", async () => {
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
       {
         taskId: "task-active",
@@ -123,7 +123,7 @@ describe("createVideoGenerateTool status actions", () => {
       },
     ]);
 
-    const result = createVideoGenerateStatusActionResult("agent:main:discord:direct:123");
+    const result = await createVideoGenerateStatusActionResult("agent:main:discord:direct:123");
     const text = (result.content?.[0] as { text: string } | undefined)?.text ?? "";
 
     expect(text).toContain("Video generation task task-active is already queued with google.");
@@ -147,7 +147,7 @@ describe("createVideoGenerateTool status actions", () => {
     expect(details.progressSummary).toBe("Queued video generation");
   });
 
-  it("returns recent succeeded video status instead of starting a duplicate generation", () => {
+  it("returns recent succeeded video status instead of starting a duplicate generation", async () => {
     // A recently completed request is still a duplicate from the user's
     // perspective; report status instead of spending another provider call.
     const now = Date.now();
@@ -183,7 +183,7 @@ describe("createVideoGenerateTool status actions", () => {
       },
     ]);
 
-    const result = createVideoGenerateDuplicateGuardResult("agent:main:discord:direct:123", {
+    const result = await createVideoGenerateDuplicateGuardResult("agent:main:discord:direct:123", {
       requestKey: "video-request:friendly-lobster",
     });
     const text = (result?.content?.[0] as { text: string } | undefined)?.text ?? "";

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -412,20 +412,21 @@ export function createVideoGenerateTool(options?: {
               providers: [],
             })
           : null;
-      const readRequest = () => {
+      const readRequest = async () => {
         const prompt = readToolStringParam(args, "prompt", { required: true });
         return {
           prompt,
-          duplicate: createVideoGenerateDuplicateGuardResult(options?.agentSessionKey, {
+          duplicate: await createVideoGenerateDuplicateGuardResult(options?.agentSessionKey, {
             prompt,
             agentId: options?.requesterAgentId,
           }),
         };
       };
-      const configuredRequest = configuredModel ? readRequest() : undefined;
+      const configuredRequest = configuredModel ? await readRequest() : undefined;
       if (configuredRequest?.duplicate) {
         return configuredRequest.duplicate;
       }
+      signal?.throwIfAborted();
       const acquired = options?.preparedModelRuntime?.acquireMediaCapabilityProviders
         ? await acquireVideoGenerationToolProviders({
             cfg: configuredModel
@@ -454,10 +455,12 @@ export function createVideoGenerateTool(options?: {
         const effectiveCfg =
           applyAgentDefaultModelConfig(cfg, "video", videoGenerationModelConfig) ?? cfg;
         const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
-        const { prompt, duplicate } = configuredRequest ?? readRequest();
+        const { prompt, duplicate } = configuredRequest ?? (await readRequest());
         if (duplicate) {
           return { kind: "result" as const, result: duplicate };
         }
+        signal?.throwIfAborted();
+        acquired?.assertOpen();
 
         const filename = readToolStringParam(args, "filename");
         const size = readToolStringParam(args, "size");
@@ -560,13 +563,15 @@ export function createVideoGenerateTool(options?: {
           audioInputs,
           audioRoles,
         });
-        const duplicateGuardResult = createVideoGenerateDuplicateGuardResult(
+        const duplicateGuardResult = await createVideoGenerateDuplicateGuardResult(
           options?.agentSessionKey,
           { prompt, requestKey, agentId: options?.requesterAgentId },
         );
         if (duplicateGuardResult) {
           return { kind: "result" as const, result: duplicateGuardResult };
         }
+        signal?.throwIfAborted();
+        acquired?.assertOpen();
         const loadedReferenceImages = await loadReferenceAssets({
           inputs: imageInputs,
           expectedKind: "image",

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -364,7 +364,7 @@ export function listTasksForOwnerKey(ownerKey: string): TaskRecord[] {
   return listTasksFromIndex(taskIdsByOwnerKey, key);
 }
 
-export function listFreshTasksForOwnerKey(ownerKey: string): TaskRecord[] {
+export async function listFreshTasksForOwnerKey(ownerKey: string): Promise<TaskRecord[]> {
   ensureTaskRegistryReady();
   const key = normalizeOptionalString(ownerKey);
   if (!key) {
@@ -374,7 +374,7 @@ export function listFreshTasksForOwnerKey(ownerKey: string): TaskRecord[] {
   if (store.listTasksForOwnerKey) {
     try {
       const merged = new Map<string, TaskRecord>();
-      for (const task of store.listTasksForOwnerKey(key)) {
+      for (const task of await store.listTasksForOwnerKey(key)) {
         merged.set(task.taskId, cloneTaskRecord(normalizeTaskTimestamps(task)));
       }
       return [...merged.values()]

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -407,7 +407,9 @@ export function loadTaskRegistryStateFromSqliteReadOnlyResult(): TaskRegistryRea
   );
 }
 
-export function listTaskRegistryRecordsByOwnerKeyFromSqlite(ownerKey: string): TaskRecord[] {
+export async function listTaskRegistryRecordsByOwnerKeyFromSqlite(
+  ownerKey: string,
+): Promise<TaskRecord[]> {
   const key = ownerKey.trim();
   if (!key) {
     return [];

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -3,6 +3,7 @@ import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { AdmittedRunContext } from "../agents/admitted-run-context.js";
 import { createExecutionIdentityAdmissionToken } from "../audit/execution-identity-admission.js";
 import { bindExecutionOwnerLifecycleMetadata } from "../audit/execution-owner-lifecycle-binding-store.js";
@@ -402,13 +403,14 @@ describe("task-registry store runtime", () => {
     expect(cleanLoad).toHaveBeenCalledTimes(1);
   });
 
-  it("uses scoped owner lookups for fresh owner task reads", () => {
+  it("uses scoped owner lookups for fresh owner task reads", async () => {
     const storedTask = createStoredTask();
     const loadSnapshot = vi.fn(() => ({
       tasks: new Map(),
       deliveryStates: new Map(),
     }));
-    const listTasksForOwnerKey = vi.fn(() => [storedTask]);
+    const lookup = createDeferred<TaskRecord[]>();
+    const listTasksForOwnerKey = vi.fn(() => lookup.promise);
     configureTaskRegistryRuntime({
       store: {
         ...createInMemoryTaskRegistryStore(),
@@ -417,11 +419,31 @@ describe("task-registry store runtime", () => {
       },
     });
 
-    const tasks = listFreshTasksForOwnerKey("agent:main:main");
+    const pending = listFreshTasksForOwnerKey("agent:main:main");
+    lookup.resolve([storedTask]);
+    const tasks = await pending;
 
     expect(tasks.map((task) => task.taskId)).toEqual(["task-restored"]);
     expect(listTasksForOwnerKey).toHaveBeenCalledWith("agent:main:main");
     expect(loadSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the current memory snapshot when a delayed owner lookup fails", async () => {
+    const storedTask = createStoredTask();
+    const lookup = createDeferred<TaskRecord[]>();
+    configureTaskRegistryRuntime({
+      store: {
+        ...createInMemoryTaskRegistryStore({
+          tasks: new Map([[storedTask.taskId, storedTask]]),
+          deliveryStates: new Map(),
+        }),
+        listTasksForOwnerKey: () => lookup.promise,
+      },
+    });
+    const pending = listFreshTasksForOwnerKey(storedTask.ownerKey);
+    updateTaskNotifyPolicyById({ taskId: storedTask.taskId, notifyPolicy: "silent" });
+    lookup.reject(new Error("owner lookup unavailable"));
+    expect(await pending).toMatchObject([{ taskId: storedTask.taskId, notifyPolicy: "silent" }]);
   });
 
   it("does not clone non-blocker details when inspecting restart blockers", () => {
@@ -969,7 +991,7 @@ describe("task-registry store runtime", () => {
           deliveryStatus: "not_applicable",
           notifyPolicy: "silent",
         });
-        expect(listFreshTasksForOwnerKey(ownerKey).map((task) => task.taskId)).toContain(
+        expect((await listFreshTasksForOwnerKey(ownerKey)).map((task) => task.taskId)).toContain(
           target.taskId,
         );
 
@@ -993,7 +1015,7 @@ describe("task-registry store runtime", () => {
         expect(() => loadTaskRegistryStateFromSqlite()).toThrow(
           /integrity_check failed.*idx_task_runs_owner_key/iu,
         );
-        expect(listFreshTasksForOwnerKey(ownerKey).map((task) => task.taskId)).toContain(
+        expect((await listFreshTasksForOwnerKey(ownerKey)).map((task) => task.taskId)).toContain(
           target.taskId,
         );
 
@@ -1619,7 +1641,7 @@ describe("task-registry store runtime", () => {
     );
   });
 
-  it("does not throw or diverge sqlite-direct reads when an upsert persist fails", () => {
+  it("does not throw or diverge sqlite-direct reads when an upsert persist fails", async () => {
     const ownerKey = "agent:main:main";
     // sqlite holds the source-of-truth row. status=running (current). When the
     // upsert throws, sqlite keeps this value (withWriteTransaction ROLLBACK +
@@ -1647,7 +1669,7 @@ describe("task-registry store runtime", () => {
     });
     // sqlite-direct reader (listFreshTasksForOwnerKey -> store.listTasksForOwnerKey).
     // Always returns the sqlite source of truth.
-    const listTasksForOwnerKey = vi.fn((key: string) =>
+    const listTasksForOwnerKey = vi.fn(async (key: string) =>
       [...sqliteState.values()].filter((task) => task.ownerKey === key),
     );
 
@@ -1665,7 +1687,7 @@ describe("task-registry store runtime", () => {
     });
 
     // in-memory loads the same row via loadSnapshot. Start state: both running.
-    const initial = listFreshTasksForOwnerKey(ownerKey);
+    const initial = await listFreshTasksForOwnerKey(ownerKey);
     expect(initial.find((task) => task.taskId === "task-diverge")?.status).toBe("running");
 
     // Attempt a transition running -> succeeded. updateTask must persist before
@@ -1690,7 +1712,7 @@ describe("task-registry store runtime", () => {
 
     // The sqlite-direct reader (used by media-generation-task-status-shared)
     // also keeps "running", so both read paths agree.
-    const after = listFreshTasksForOwnerKey(ownerKey);
+    const after = await listFreshTasksForOwnerKey(ownerKey);
     const seen = after.find((task) => task.taskId === "task-diverge");
     expect(seen?.status).toBe("running");
   });

--- a/src/tasks/task-registry.store.ts
+++ b/src/tasks/task-registry.store.ts
@@ -14,7 +14,7 @@ export type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
 
 export type TaskRegistryStore = {
   loadSnapshot: () => TaskRegistryStoreSnapshot;
-  listTasksForOwnerKey?: (ownerKey: string) => TaskRecord[];
+  listTasksForOwnerKey?: (ownerKey: string) => Promise<TaskRecord[]>;
   upsertTaskWithDeliveryState: (params: {
     task: TaskRecord;
     deliveryState?: TaskDeliveryState;


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Media status, duplicate detection and agent prompts still consume fresh task queries synchronously. Introducing awaited reads requires callers to retain current authority before starting generation or preparing more plugin work.

## Why This Change Was Made

Await the existing owner query and migrate its actual media/status/prompt callers. Reuse one scoped snapshot and remove unused status/factory aliases. Recheck cancellation and provider ownership after awaited phases; CLI liveness failures escape optional prompt-context recovery before context-engine initialization.

## User Impact

Media and prompt behavior stays compatible while storage completion becomes explicit. Retired requests cannot begin generation or additional plugin initialization after delayed task reads. Current main's message-tail runtime context and stable system-prompt behavior are preserved.

## Evidence

- All 464 focused final-candidate tests passed: 176 CLI, 44 embedded/cache/truncation, 52 native task-store and 192 media/status/tool/resource cases.
- Full selected changed checks and fresh independent Codex review through P2 passed on the current-main composition.
- Real isolated SQLite write/read and fresh-process reopen proof preserves owner scope, stale-memory bypass, duplicate retirement and deterministic prompt ordering. Twenty-five warm three-row queries observed median 0.111 ms/p95 0.129 ms; no speedup is claimed.
- Delayed abort/retirement regressions fail before the CLI fix and pass afterward. Ordinary optional-context lookup failures retain their fallback.
- This is API/caller groundwork. Task/flow mutation coordination and native worker execution remain separate work under the umbrella issue.
