### PR TITLE
improve: use compiled Doctor contracts in built checkouts

### DIFF
--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -102,9 +102,9 @@ Add gateway CLI flags after `gateway:watch` and they pass through on each restar
 When you run `pnpm openclaw`, `pnpm dev`, or a Gateway development runner from
 a checkout, the runner selects that checkout's plugins ahead of tracked global
 copies with the same id. Built plugin output remains preferred when available,
-including for separately published checkout plugins and Doctor's provider/tool
-checks. Source-only plugins still load from the checkout. Rebuild to pick up
-source changes when using built output. Intentional source-entry selections and
+including for separately published checkout plugins, Doctor contracts, and Doctor's
+provider/tool checks. Source-only plugins still load from the checkout. Rebuild to
+pick up source changes when using built output. Intentional source-entry selections and
 mounted source overlays keep using source instead of their compiled peers.
 
 This selection is separate from the `--dev` profile. It does not grant trusted

--- a/src/acp/runtime/session-meta-doctor.test.ts
+++ b/src/acp/runtime/session-meta-doctor.test.ts
@@ -5,7 +5,7 @@ import { AcpxRuntime, createAgentRegistry, createFileSessionStore } from "acpx/r
 import { expect, it } from "vitest";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { createPluginDoctorStateMigrationContext } from "../../infra/state-migrations.plugin-doctor-context.js";
-import { resolvePluginDoctorContractArtifactPath } from "../../plugins/doctor-contract-artifact.js";
+import { resolvePluginDoctorContractArtifact } from "../../plugins/doctor-contract-artifact.js";
 import {
   coercePluginDoctorContractModule,
   type PluginDoctorContractModule,
@@ -176,7 +176,11 @@ it.each(["global", "shared-project"])(
       expect(before.incomplete).toEqual([]);
       expect(before.claims).toHaveLength(2);
       const rootDir = path.resolve("extensions/acpx");
-      const modulePath = resolvePluginDoctorContractArtifactPath(rootDir)!;
+      const modulePath = resolvePluginDoctorContractArtifact({
+        rootDir,
+        origin: "bundled",
+        sourcePreferred: true,
+      })!.modulePath;
       const load = getCachedPluginModuleLoader({
         modulePath,
         rootDir,

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -55,10 +55,8 @@ import {
   makeRegistry,
 } from "../config/plugin-auto-enable.test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  bindPluginRuntimeArtifactSelection,
-  resolvePluginRuntimeArtifactSelection,
-} from "../plugins/plugin-runtime-artifact-selection.js";
+import { bindPluginRuntimeArtifactSelection } from "../plugins/plugin-runtime-artifact-binding.js";
+import { resolvePluginRuntimeArtifactSelection } from "../plugins/plugin-runtime-artifact-selection.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   getPluginRuntimeGatewayRequestScope,

--- a/src/plugins/active-runtime-registry.ts
+++ b/src/plugins/active-runtime-registry.ts
@@ -3,7 +3,7 @@ import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core
 import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
 import type { PluginLoadOptions } from "./loader-types.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
-import { matchesPluginRuntimeArtifactSelection } from "./plugin-runtime-artifact-selection.js";
+import { matchesPluginRuntimeArtifactSelection } from "./plugin-runtime-artifact-binding.js";
 import type { PluginRecord, PluginRegistry } from "./registry-types.js";
 import {
   getActivePluginRegistry,

--- a/src/plugins/doctor-contract-artifact.test.ts
+++ b/src/plugins/doctor-contract-artifact.test.ts
@@ -1,0 +1,364 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { build } from "esbuild";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { spawnNodeEvalSync } from "../test-utils/node-process.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function contract(marker: string, extension: string): string {
+  const rules = JSON.stringify([{ path: ["doctor-fixture"], message: marker }]);
+  const migrations = `[{ id: "fixture-state", label: "Fixture state", detectLegacyState() { return { preview: [${JSON.stringify(marker)}] }; }, migrateLegacyState() { return { changes: [${JSON.stringify(marker)}], warnings: [] }; } }]`;
+  return extension === ".cjs" || extension === ".cts"
+    ? `module.exports = { legacyConfigRules: ${rules}, stateMigrations: ${migrations} };\n`
+    : `export const legacyConfigRules = ${rules}; export const stateMigrations = ${migrations};\n`;
+}
+
+describe("Doctor artifact hash and loading agreement", () => {
+  it("keeps the selected bytes consistent across source and built hosts", async () => {
+    const root = fs.realpathSync(tempDirs.make("openclaw-doctor-artifacts-"));
+    const bundled = await build({
+      stdin: {
+        contents: [
+          'export { loadInstalledPluginIndex } from "./src/plugins/installed-plugin-index.ts";',
+          'export { writePersistedInstalledPluginIndexSync } from "./src/plugins/installed-plugin-index-store-write.ts";',
+          'export { readPersistedInstalledPluginIndexSync } from "./src/plugins/installed-plugin-index-store.ts";',
+          'export { loadPluginRegistrySnapshotWithMetadata } from "./src/plugins/plugin-registry-snapshot.ts";',
+          'export { loadPluginMetadataSnapshot } from "./src/plugins/plugin-metadata-snapshot.ts";',
+          'export { withPluginMetadataSnapshotScope } from "./src/plugins/current-plugin-metadata-snapshot.ts";',
+          'export { listPluginDoctorLegacyConfigRules, listPluginDoctorStateMigrationEntries } from "./src/plugins/doctor-contract-registry.ts";',
+          'export { adoptProcessPluginCache, createPluginCache, resetPluginCache, withPluginCache } from "./src/plugins/plugin-cache.ts";',
+        ].join("\n"),
+        resolveDir: process.cwd(),
+      },
+      bundle: true,
+      packages: "external",
+      platform: "node",
+      format: "esm",
+      write: false,
+      logLevel: "silent",
+    });
+    const output = bundled.outputFiles[0];
+    if (!output) {
+      throw new Error("missing compiled Doctor fixture owner");
+    }
+    fs.symlinkSync(path.resolve("node_modules"), path.join(root, "node_modules"), "junction");
+    for (const mode of ["source", "dist"]) {
+      fs.mkdirSync(path.join(root, mode));
+      fs.writeFileSync(path.join(root, mode, "owner.mjs"), output.contents);
+      for (const schema of ["openclaw-agent-schema.sql", "openclaw-state-schema.sql"]) {
+        fs.copyFileSync(path.resolve("src/state", schema), path.join(root, mode, schema));
+      }
+    }
+    // The same compiled bytes run from real source/dist locations. No host-mode override.
+    const rows = [
+      { name: "source host", mode: "source", expected: "extensions/demo/doctor-contract-api.ts" },
+      {
+        name: "built ESM",
+        extension: ".js",
+        expected: "dist/extensions/demo/doctor-contract-api.js",
+      },
+      {
+        name: "built MJS",
+        extension: ".mjs",
+        expected: "dist/extensions/demo/doctor-contract-api.mjs",
+      },
+      {
+        name: "built CJS",
+        extension: ".cjs",
+        expected: "dist/extensions/demo/doctor-contract-api.cjs",
+      },
+      {
+        name: "canonical replaces staging",
+        staging: true,
+        expected: "dist/extensions/demo/doctor-contract-api.js",
+      },
+      {
+        name: "staging link to canonical",
+        staging: true,
+        stagingSymlink: true,
+        expected: "dist/extensions/demo/doctor-contract-api.js",
+      },
+      {
+        name: "canonical directory link",
+        staging: true,
+        canonicalDirectorySymlink: true,
+        expected: "dist/extensions/demo/doctor-contract-api.js",
+      },
+      {
+        name: "staging file and canonical directory links",
+        staging: true,
+        stagingSymlink: true,
+        canonicalDirectorySymlink: true,
+        expected: "dist/extensions/demo/doctor-contract-api.js",
+      },
+      {
+        name: "staging without canonical",
+        staging: true,
+        noCanonical: true,
+        expected: "dist-runtime/extensions/demo/doctor-contract-api.js",
+      },
+      {
+        name: "partial canonical build",
+        staging: true,
+        noCanonical: true,
+        partialCanonical: true,
+        expected: "dist-runtime/extensions/demo/doctor-contract-api.js",
+      },
+      {
+        name: "configured source",
+        sourcePreferred: true,
+        expected: "extensions/demo/doctor-contract-api.ts",
+      },
+      {
+        name: "local MTS order",
+        sourceExtension: ".mts",
+        local: true,
+        expected: "extensions/demo/dist/doctor-contract-api.js",
+      },
+      {
+        name: "local CTS order",
+        sourceExtension: ".cts",
+        local: true,
+        expected: "extensions/demo/dist/doctor-contract-api.js",
+      },
+      {
+        name: "source external",
+        bundledDist: false,
+        local: true,
+        expected: "dist/extensions/demo/doctor-contract-api.js",
+      },
+      {
+        name: "no root anchor",
+        bundledDist: false,
+        local: true,
+        noAnchor: true,
+        expected: "extensions/demo/dist/doctor-contract-api.js",
+      },
+      {
+        name: "external install",
+        origin: "global",
+        expected: "state/extensions/demo/doctor-contract-api.ts",
+      },
+      {
+        name: "missing emitted metadata",
+        noMetadata: true,
+        expected: "extensions/demo/doctor-contract-api.ts",
+      },
+      {
+        name: "ambiguous emitted format",
+        ambiguous: true,
+        expected: "extensions/demo/doctor-contract-api.ts",
+      },
+    ];
+    const fixtures = rows.map((row, ordinal) => {
+      const fixtureRoot = path.join(root, `fixture-${ordinal}`);
+      const relativePluginRoot =
+        row.origin === "global" ? "state/extensions/demo" : "extensions/demo";
+      const pluginRoot = path.join(fixtureRoot, relativePluginRoot);
+      const builtRoot = path.join(fixtureRoot, "dist", "extensions", "demo");
+      const stagingRoot = path.join(fixtureRoot, "dist-runtime", "extensions", "demo");
+      const sourceExtension = row.sourceExtension ?? ".ts";
+      const extension = row.extension ?? ".js";
+      const packageManifest = {
+        extensions: ["./index.ts"],
+        build: { bundledDist: row.bundledDist },
+      };
+      for (const dir of [
+        pluginRoot,
+        stagingRoot,
+        path.join(pluginRoot, "dist"),
+        ...(row.noCanonical && !row.partialCanonical
+          ? []
+          : [builtRoot, path.join(builtRoot, "dist")]),
+      ]) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      fs.writeFileSync(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({ name: "doctor-fixture", type: "module", openclaw: packageManifest }),
+      );
+      fs.writeFileSync(
+        path.join(pluginRoot, "index.ts"),
+        'throw new Error("runtime must remain unloaded");\n',
+      );
+      fs.writeFileSync(
+        path.join(pluginRoot, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: "demo",
+          configSchema: { type: "object" },
+          doctorContract: { configRepair: true, stateMigrations: [{ id: "fixture-state" }] },
+        }),
+      );
+      const contents = new Map<string, string>();
+      if (!row.noAnchor) {
+        contents.set(
+          `${relativePluginRoot}/doctor-contract-api${sourceExtension}`,
+          contract("source", sourceExtension),
+        );
+      }
+      if (!row.noCanonical) {
+        contents.set(
+          `dist/extensions/demo/doctor-contract-api${extension}`,
+          contract("built", extension),
+        );
+      }
+      if (row.staging) {
+        if (!row.stagingSymlink) {
+          contents.set(
+            `dist-runtime/extensions/demo/doctor-contract-api${extension}`,
+            contract("staging", extension),
+          );
+        }
+        fs.writeFileSync(
+          path.join(stagingRoot, "package.json"),
+          JSON.stringify({ type: "module", openclaw: { extensions: [`./index${extension}`] } }),
+        );
+      }
+      // A broader contract must never replace the selected Doctor basename.
+      contents.set(`${relativePluginRoot}/contract-api.js`, contract("broad", ".js"));
+      if (row.local) {
+        for (const localExtension of [".js", ".mjs", ".cjs"]) {
+          contents.set(
+            `${relativePluginRoot}/dist/doctor-contract-api${localExtension}`,
+            contract(`local${localExtension}`, localExtension),
+          );
+        }
+        contents.set("dist/extensions/demo/dist/doctor-contract-api.js", contract("nested", ".js"));
+      }
+      for (const [relative, bytes] of contents) {
+        fs.writeFileSync(path.join(fixtureRoot, relative), bytes);
+      }
+      if (row.stagingSymlink) {
+        fs.symlinkSync(
+          path.join(builtRoot, `doctor-contract-api${extension}`),
+          path.join(stagingRoot, `doctor-contract-api${extension}`),
+        );
+      }
+      if (!row.noMetadata && !row.noCanonical) {
+        fs.writeFileSync(
+          path.join(builtRoot, "package.json"),
+          JSON.stringify({
+            type: "module",
+            openclaw: {
+              extensions: row.ambiguous ? ["./index.js", "./other.cjs"] : [`./index${extension}`],
+            },
+          }),
+        );
+      }
+      if (row.canonicalDirectorySymlink) {
+        const outputRoot = path.join(fixtureRoot, "outputs");
+        fs.renameSync(builtRoot, outputRoot);
+        fs.symlinkSync(outputRoot, builtRoot, "junction");
+      }
+      const expectedBytes = contents.get(row.expected);
+      if (!expectedBytes) {
+        throw new Error(`missing literal expected artifact for ${row.name}`);
+      }
+      return Object.assign(row, {
+        root: fixtureRoot,
+        pluginRoot,
+        packageManifest,
+        expectedHash: crypto.createHash("sha256").update(expectedBytes).digest("hex"),
+        sourceHash: crypto
+          .createHash("sha256")
+          .update(contract("source", sourceExtension))
+          .digest("hex"),
+        replacementBytes: contract("replacement", extension),
+        expectedMarker: row.expected.startsWith("dist/")
+          ? "built"
+          : row.expected.startsWith("dist-runtime/")
+            ? "staging"
+            : row.expected.includes("/dist/")
+              ? "local.js"
+              : "source",
+      });
+    });
+    const result = spawnNodeEvalSync(
+      `
+      import assert from "node:assert/strict";
+      import fs from "node:fs";
+      import path from "node:path";
+      const owners = {
+        source: await import(${JSON.stringify(pathToFileURL(path.join(root, "source", "owner.mjs")).href)}),
+        dist: await import(${JSON.stringify(pathToFileURL(path.join(root, "dist", "owner.mjs")).href)}),
+      };
+      for (const row of ${JSON.stringify(fixtures)}) {
+        const owner = owners[row.mode ?? "dist"];
+        const cache = owner.createPluginCache();
+        owner.adoptProcessPluginCache(cache);
+        owner.withPluginCache(cache, () => {
+          const env = { HOME: row.root, OPENCLAW_STATE_DIR: path.join(row.root, "state"), OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(row.root, "extensions"), OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1", OPENCLAW_VERSION: "2026.9.2", VITEST: "true" };
+          const config = { plugins: { entries: { demo: { enabled: true } }, ...(row.sourcePreferred ? { load: { paths: [row.pluginRoot] } } : {}) } };
+          const candidate = { idHint: "demo", rootDir: row.pluginRoot, source: path.join(row.pluginRoot, "index.ts"), packageDir: row.pluginRoot, origin: row.origin ?? "bundled", packageManifest: row.packageManifest, ...(row.sourcePreferred ? { sourcePreferred: true } : {}) };
+          const index = owner.loadInstalledPluginIndex({ candidates: [candidate], config, env });
+          assert.equal(index.plugins[0]?.doctorContractHash, row.expectedHash, row.name);
+          const snapshot = owner.loadPluginMetadataSnapshot({ index, config, env });
+          const rules = owner.withPluginMetadataSnapshotScope(snapshot, () => owner.listPluginDoctorLegacyConfigRules({ config, env, pluginIds: ["demo"] }), { config, env });
+          assert.deepEqual(rules, [{ path: ["doctor-fixture"], message: row.expectedMarker }], row.name);
+          const entries = owner.withPluginMetadataSnapshotScope(snapshot, () => owner.listPluginDoctorStateMigrationEntries({ config, env, pluginIds: ["demo"] }), { config, env });
+          assert.equal(entries.length, 1, row.name);
+          assert.equal(entries[0].migration.id, "fixture-state", row.name);
+          const input = { config, env, stateDir: env.OPENCLAW_STATE_DIR, oauthDir: path.join(row.root, "oauth"), context: {} };
+          assert.deepEqual(entries[0].migration.detectLegacyState(input), { preview: [row.expectedMarker] }, row.name);
+          assert.deepEqual(entries[0].migration.migrateLegacyState(input), { changes: [row.expectedMarker], warnings: [] }, row.name);
+          if (row.name === "built ESM") {
+            const sourceConfig = { plugins: { ...config.plugins, load: { paths: [row.pluginRoot] } } };
+            const sourceIndex = owner.loadInstalledPluginIndex({ candidates: [{ ...candidate, sourcePreferred: true }], config: sourceConfig, env });
+            assert.equal(sourceIndex.plugins[0]?.doctorContractHash, row.sourceHash);
+            const repeated = owner.loadInstalledPluginIndex({ candidates: [candidate], config, env });
+            assert.equal(repeated.plugins[0]?.doctorContractHash, row.expectedHash);
+            owner.writePersistedInstalledPluginIndexSync(index, { env });
+            const replacement = row.replacementBytes;
+            fs.writeFileSync(path.join(row.root, row.expected), replacement);
+            assert.equal(snapshot.index.plugins[0].doctorContractHash, row.expectedHash);
+          }
+        });
+        owner.resetPluginCache();
+      }
+      console.log("doctor-artifacts:18");
+    `,
+      { timeout: 30_000 },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe("doctor-artifacts:18");
+    const replacementFixture = fixtures.find((row) => row.name === "built ESM");
+    expect(replacementFixture).toBeDefined();
+    // Compiled ESM changes take effect after restart, not by evicting require.cache.
+    const restarted = spawnNodeEvalSync(
+      `
+      import assert from "node:assert/strict";
+      import crypto from "node:crypto";
+      import path from "node:path";
+      const owner = await import(${JSON.stringify(pathToFileURL(path.join(root, "dist", "owner.mjs")).href)});
+      const row = ${JSON.stringify(replacementFixture)};
+      const env = { HOME: row.root, OPENCLAW_STATE_DIR: path.join(row.root, "state"), OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(row.root, "extensions"), OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1", OPENCLAW_VERSION: "2026.9.2", VITEST: "true" };
+      const config = { plugins: { entries: { demo: { enabled: true } } } };
+      const previous = owner.readPersistedInstalledPluginIndexSync({ env });
+      assert.equal(previous.plugins[0].doctorContractHash, row.expectedHash);
+      const refreshed = owner.loadPluginRegistrySnapshotWithMetadata({ config, env, allowCurrent: false });
+      assert.equal(refreshed.source, "derived");
+      const plugin = refreshed.snapshot.plugins.find((entry) => entry.pluginId === "demo");
+      assert.equal(plugin.doctorContractHash, crypto.createHash("sha256").update(row.replacementBytes).digest("hex"));
+      assert.equal(plugin.manifestHash, previous.plugins[0].manifestHash);
+      assert.equal(plugin.packageJson.hash, previous.plugins[0].packageJson.hash);
+      const next = owner.loadPluginMetadataSnapshot({ index: refreshed.snapshot, config, env });
+      const rules = owner.withPluginMetadataSnapshotScope(next, () => owner.listPluginDoctorLegacyConfigRules({ config, env, pluginIds: ["demo"] }), { config, env });
+      assert.deepEqual(rules, [{ path: ["doctor-fixture"], message: "replacement" }]);
+      const entries = owner.withPluginMetadataSnapshotScope(next, () => owner.listPluginDoctorStateMigrationEntries({ config, env, pluginIds: ["demo"] }), { config, env });
+      const input = { config, env, stateDir: env.OPENCLAW_STATE_DIR, oauthDir: path.join(row.root, "oauth"), context: {} };
+      assert.deepEqual(entries[0].migration.detectLegacyState(input), { preview: ["replacement"] });
+      assert.deepEqual(entries[0].migration.migrateLegacyState(input), { changes: ["replacement"], warnings: [] });
+      console.log("doctor-artifact-restart:replacement");
+    `,
+      { timeout: 30_000 },
+    );
+    expect(restarted.error).toBeUndefined();
+    expect(restarted.status, restarted.stderr).toBe(0);
+    expect(restarted.stdout.trim()).toBe("doctor-artifact-restart:replacement");
+  }, 60_000);
+});

--- a/src/plugins/doctor-contract-artifact.ts
+++ b/src/plugins/doctor-contract-artifact.ts
@@ -1,7 +1,14 @@
-/** Resolves the doctor-contract artifact shared by loading and installed-index hashing. */
+/** Resolves the Doctor artifact shared by loading, index hashing, and freshness. */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import type { OpenClawPackageManifest } from "./manifest.js";
+import { pluginCacheRealpathSync } from "./plugin-cache-files.js";
 import { getPluginCacheRoot } from "./plugin-cache.js";
+import type { PluginOrigin } from "./plugin-origin.types.js";
+import {
+  resolvePluginRuntimeExecutionArtifact,
+  resolvePreferredBundledRootArtifact,
+} from "./plugin-runtime-artifact-selection.js";
 import { resolvePluginRootArtifactPath } from "./root-artifact-path.js";
 
 const CONTRACT_API_EXTENSIONS = [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts"] as const;
@@ -9,26 +16,72 @@ const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
 const RUNNING_FROM_BUILT_ARTIFACT =
   CURRENT_MODULE_PATH.includes(`${path.sep}dist${path.sep}`) ||
   CURRENT_MODULE_PATH.includes(`${path.sep}dist-runtime${path.sep}`);
-const CACHE_KEY = `doctor-contract:${RUNNING_FROM_BUILT_ARTIFACT}`;
 const ORDERED_EXTENSIONS = RUNNING_FROM_BUILT_ARTIFACT
   ? CONTRACT_API_EXTENSIONS
   : ([...CONTRACT_API_EXTENSIONS.slice(3), ...CONTRACT_API_EXTENSIONS.slice(0, 3)] as const);
-// Keep this ordering stable: the installed index must hash the exact artifact
-// that doctor contract loading would execute.
-const ARTIFACT_PATHS = ["doctor-contract-api", "contract-api"].flatMap((basename) =>
-  ORDERED_EXTENSIONS.flatMap((extension) => {
-    const filename = `${basename}${extension}`;
-    return [filename, path.join("dist", filename)];
-  }),
-);
+const ARTIFACT_CANDIDATES = ["doctor-contract-api", "contract-api"].map((basename) => {
+  const rootPaths = ORDERED_EXTENSIONS.map((extension) => `${basename}${extension}`);
+  return {
+    rootPaths,
+    paths: rootPaths.flatMap((filename) => [filename, path.join("dist", filename)]),
+  };
+});
 
-export function resolvePluginDoctorContractArtifactPath(rootDir: string): string | null {
-  const artifacts = getPluginCacheRoot(rootDir).artifacts;
-  const cached = artifacts.get(CACHE_KEY);
+type DoctorArtifactSelection = {
+  rootDir: string;
+  origin: PluginOrigin;
+  sourcePreferred?: boolean;
+  packageManifest?: OpenClawPackageManifest;
+};
+
+export function resolvePluginDoctorContractArtifact(
+  params: DoctorArtifactSelection,
+): { modulePath: string; boundaryRoot: string } | null {
+  const artifacts = getPluginCacheRoot(params.rootDir).artifacts;
+  const key = JSON.stringify([
+    "doctor-contract",
+    RUNNING_FROM_BUILT_ARTIFACT,
+    params.origin,
+    params.sourcePreferred === true,
+    params.packageManifest?.build?.bundledDist,
+  ]);
+  const cached = artifacts.get(key);
   if (cached !== undefined) {
-    return cached?.modulePath ?? null;
+    return cached;
   }
-  const modulePath = resolvePluginRootArtifactPath(rootDir, ARTIFACT_PATHS);
-  artifacts.set(CACHE_KEY, modulePath ? { modulePath, boundaryRoot: rootDir } : null);
-  return modulePath;
+  for (const { rootPaths, paths } of ARTIFACT_CANDIDATES) {
+    const modulePath = resolvePluginRootArtifactPath(params.rootDir, paths);
+    if (!modulePath) {
+      continue;
+    }
+    let artifact = { modulePath, boundaryRoot: params.rootDir };
+    if (RUNNING_FROM_BUILT_ARTIFACT && params.origin === "bundled" && !params.sourcePreferred) {
+      // Preserve Doctor's package-local extension order. Source-external plugins
+      // instead anchor the canonical build at an available root source file.
+      const source =
+        params.packageManifest?.build?.bundledDist === false
+          ? resolvePluginRootArtifactPath(params.rootDir, rootPaths)
+          : rootPaths.includes(path.relative(params.rootDir, modulePath))
+            ? modulePath
+            : null;
+      if (source) {
+        const selected = resolvePluginRuntimeExecutionArtifact(
+          resolvePreferredBundledRootArtifact({
+            rootDir: params.rootDir,
+            source,
+            packageManifest: params.packageManifest,
+          }),
+        );
+        artifact = { modulePath: selected.source, boundaryRoot: selected.rootDir };
+      }
+    }
+    const resolved = {
+      modulePath: pluginCacheRealpathSync(artifact.modulePath) ?? artifact.modulePath,
+      boundaryRoot: pluginCacheRealpathSync(artifact.boundaryRoot) ?? artifact.boundaryRoot,
+    };
+    artifacts.set(key, resolved);
+    return resolved;
+  }
+  artifacts.set(key, null);
+  return null;
 }

--- a/src/plugins/doctor-contract-closure-guard.test.ts
+++ b/src/plugins/doctor-contract-closure-guard.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import { collectModuleReferencesFromSource } from "../../scripts/lib/guard-inventory-utils.mjs";
-import { resolvePluginDoctorContractArtifactPath } from "./doctor-contract-artifact.js";
+import { resolvePluginDoctorContractArtifact } from "./doctor-contract-artifact.js";
 import { loadBundledPluginManifestRegistry } from "./manifest-registry.js";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
@@ -302,7 +302,11 @@ function collectClosureEntries(): ClosureEntry[] {
   };
   for (const record of loadBundledPluginManifestRegistry({ env }).plugins) {
     const pluginRoot = path.resolve(record.rootDir);
-    const doctorContractPath = resolvePluginDoctorContractArtifactPath(pluginRoot);
+    const doctorContractPath = resolvePluginDoctorContractArtifact({
+      ...record,
+      rootDir: pluginRoot,
+      sourcePreferred: true,
+    })?.modulePath;
     // A declaration listing no surface gates the artifact off every enumeration
     // path, exactly as `resolvePluginDoctorContracts` does, so its closure cost
     // is never paid. Absent declarations still load eagerly and are enforced.

--- a/src/plugins/doctor-contract-declarations.test.ts
+++ b/src/plugins/doctor-contract-declarations.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { resolvePluginDoctorContractArtifactPath } from "./doctor-contract-artifact.js";
+import { resolvePluginDoctorContractArtifact } from "./doctor-contract-artifact.js";
 import { coercePluginDoctorContractModule } from "./doctor-contract-module.js";
 import { loadBundledPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginManifestDoctorContract } from "./manifest-types.js";
@@ -25,7 +25,10 @@ describe("bundled plugin doctor contract declarations", () => {
         loadBundledPluginManifestRegistry({ env: sourceManifestEnv }).plugins.map(
           async (record) => {
             const pluginMismatches: string[] = [];
-            const artifactPath = resolvePluginDoctorContractArtifactPath(record.rootDir);
+            const artifactPath = resolvePluginDoctorContractArtifact({
+              ...record,
+              sourcePreferred: true,
+            })?.modulePath;
             if (!artifactPath) {
               return pluginMismatches;
             }
@@ -80,7 +83,10 @@ describe("bundled plugin doctor contract declarations", () => {
             if (!Array.isArray(declaration)) {
               return [];
             }
-            const artifactPath = resolvePluginDoctorContractArtifactPath(record.rootDir);
+            const artifactPath = resolvePluginDoctorContractArtifact({
+              ...record,
+              sourcePreferred: true,
+            })?.modulePath;
             if (!artifactPath) {
               return [`${record.id}: missing Doctor contract artifact`];
             }

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
-import { resolvePluginDoctorContractArtifactPath } from "./doctor-contract-artifact.js";
+import { resolvePluginDoctorContractArtifact } from "./doctor-contract-artifact.js";
 import { createPluginCache, withPluginCache } from "./plugin-cache.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 import {
@@ -123,7 +123,12 @@ describe("doctor-contract-registry module loader", () => {
     }
 
     const originalOwner = createPluginCache();
-    const resolvePath = () => resolvePluginDoctorContractArtifactPath(pluginRoot);
+    const resolvePath = () =>
+      resolvePluginDoctorContractArtifact({
+        rootDir: pluginRoot,
+        origin: "bundled",
+        sourcePreferred: true,
+      })?.modulePath ?? null;
     expect(withPluginCache(originalOwner, resolvePath)).toBe(candidates[0]);
     for (const candidate of candidates) {
       expect(withPluginCache(createPluginCache(), resolvePath)).toBe(candidate);

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -17,7 +17,7 @@ import { areBundledPluginsDisabled } from "./bundled-dir.js";
 import { resolveBundledPluginScanDir } from "./bundled-plugin-scan.js";
 import { hasPluginConfigMigrationSource } from "./config-contract-matches.js";
 import { normalizePluginsConfig } from "./config-state.js";
-import { resolvePluginDoctorContractArtifactPath } from "./doctor-contract-artifact.js";
+import { resolvePluginDoctorContractArtifact } from "./doctor-contract-artifact.js";
 import {
   coercePluginDoctorContractModule,
   type PluginDoctorContractModule,
@@ -162,16 +162,19 @@ function loadPluginDoctorContractEntry(
   if (declaration && !declaresPluginDoctorContractSurface(declaration, surface)) {
     return null;
   }
-  const contractSource = resolvePluginDoctorContractArtifactPath(record.rootDir);
-  if (!contractSource) {
+  const contractArtifact = resolvePluginDoctorContractArtifact(record);
+  if (!contractArtifact) {
     return null;
   }
   let mod: PluginDoctorContractModule;
   try {
-    mod = loadPluginDoctorContractModule({ modulePath: contractSource, rootDir: record.rootDir });
+    mod = loadPluginDoctorContractModule({
+      modulePath: contractArtifact.modulePath,
+      rootDir: contractArtifact.boundaryRoot,
+    });
   } catch (error) {
     log.warn(
-      `failed to load doctor contract for ${record.id} from ${contractSource}: ${formatErrorMessage(error)}`,
+      `failed to load doctor contract for ${record.id} from ${contractArtifact.modulePath}: ${formatErrorMessage(error)}`,
     );
     return null;
   }

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -12,7 +12,7 @@ import type { PluginCompatCode } from "./compat/registry.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import type { PluginCandidate } from "./discovery.js";
-import { resolvePluginDoctorContractArtifactPath } from "./doctor-contract-artifact.js";
+import { resolvePluginDoctorContractArtifact } from "./doctor-contract-artifact.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import type { PluginInstallSourceInfo } from "./install-source-info.js";
 import { describePluginInstallSource } from "./install-source-info.js";
@@ -195,13 +195,15 @@ function hashManifestlessBundleRecord(record: PluginManifestRecord): string {
 function readRecordFile(params: {
   record: PluginManifestRecord;
   filePath: string;
+  boundaryRoot?: string;
   rejectHardlinks: boolean;
   required: boolean;
   diagnostics: PluginDiagnostic[];
 }) {
+  const rootDir = params.boundaryRoot ?? params.record.rootDir;
   const file = readPluginCacheFile({
-    rootDir: params.record.rootDir,
-    relativePath: path.relative(params.record.rootDir, params.filePath),
+    rootDir,
+    relativePath: path.relative(rootDir, params.filePath),
     rejectHardlinks: params.rejectHardlinks,
     ...(params.required && path.extname(params.filePath) === ".json"
       ? { maxBytes: 256 * 1024 }
@@ -275,11 +277,12 @@ export function buildInstalledPluginIndexRecords(params: {
     const manifestHash = manifestless
       ? hashManifestlessBundleRecord(record)
       : (manifestFile?.hash ?? "");
-    const doctorContractPath = resolvePluginDoctorContractArtifactPath(record.rootDir);
-    const doctorContractFile = doctorContractPath
+    const doctorContractArtifact = resolvePluginDoctorContractArtifact(record);
+    const doctorContractFile = doctorContractArtifact
       ? readRecordFile({
           record,
-          filePath: doctorContractPath,
+          filePath: doctorContractArtifact.modulePath,
+          boundaryRoot: doctorContractArtifact.boundaryRoot,
           rejectHardlinks,
           diagnostics: params.diagnostics,
           required: false,

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -42,9 +42,9 @@ import type { PluginManifestRecord } from "./manifest-registry.js";
 import { resolveExternalPluginRuntimeDependencyRepairHint } from "./official-external-plugin-repair-hints.js";
 import { withProfile } from "./plugin-load-profile.js";
 import { preparePluginModule } from "./plugin-module-loader-cache.js";
+import { bindPluginRuntimeArtifactSelection } from "./plugin-runtime-artifact-binding.js";
 import { resolvePluginRuntimeArtifact } from "./plugin-runtime-artifact-resolution.js";
 import {
-  bindPluginRuntimeArtifactSelection,
   resolvePluginRuntimeExecutionArtifact,
   prefersBuiltPluginArtifacts,
 } from "./plugin-runtime-artifact-selection.js";

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -497,6 +497,44 @@ export function selectInstalledPluginManifestRecords(
   );
 }
 
+/** Prepares transient candidates without loading a registry or Doctor artifact bytes. */
+export function prepareInstalledPluginCandidateResolver(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): (plugin: InstalledPluginIndexRecord) => PluginCandidate {
+  const env = params.env ?? process.env;
+  // These selections belong to this process, not the persisted installation inventory.
+  const sourceRoots = new Set(
+    listBundledSourceOverlayDirs({ bundledRoot: resolveBundledPluginsDir(env), env }).map(
+      (root) => pluginCacheRealpathSync(root) ?? root,
+    ),
+  );
+  const loadPaths = params.config?.plugins?.load?.paths ?? [];
+  const configuredSources = new Set(
+    loadPaths.length > 0
+      ? discoverConfiguredPluginLoadPaths({
+          loadPaths,
+          env,
+          workspaceDir: params.workspaceDir,
+        }).candidates.map(
+          (candidate) => pluginCacheRealpathSync(candidate.source) ?? candidate.source,
+        )
+      : [],
+  );
+  return (plugin) => {
+    const candidate = toPluginCandidate(plugin, env);
+    if (
+      candidate.origin === "bundled" &&
+      (sourceRoots.has(pluginCacheRealpathSync(candidate.rootDir) ?? candidate.rootDir) ||
+        configuredSources.has(pluginCacheRealpathSync(candidate.source) ?? candidate.source))
+    ) {
+      candidate.sourcePreferred = true;
+    }
+    return candidate;
+  };
+}
+
 export function loadPluginManifestRegistryForInstalledIndex(params: {
   registryPath?: string;
   index: InstalledPluginIndex;
@@ -533,38 +571,15 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
           diagnostics: [...diagnostics],
         };
       }
-      // These selections belong to this process, not the persisted installation inventory.
-      const sourceRoots = new Set(
-        listBundledSourceOverlayDirs({ bundledRoot: resolveBundledPluginsDir(env), env }).map(
-          (root) => pluginCacheRealpathSync(root) ?? root,
-        ),
-      );
-      const loadPaths = params.config?.plugins?.load?.paths ?? [];
-      const configuredSources = new Set(
-        loadPaths.length > 0
-          ? discoverConfiguredPluginLoadPaths({
-              loadPaths,
-              env,
-              workspaceDir: params.workspaceDir,
-            }).candidates.map(
-              (candidate) => pluginCacheRealpathSync(candidate.source) ?? candidate.source,
-            )
-          : [],
-      );
+      const resolveCandidate = prepareInstalledPluginCandidateResolver({
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        env,
+      });
       const candidates = params.index.plugins
         .filter((plugin) => params.includeDisabled || plugin.enabled)
         .filter((plugin) => !pluginIdSet || pluginIdSet.has(plugin.pluginId))
-        .map((plugin) => {
-          const candidate = toPluginCandidate(plugin, env);
-          if (
-            candidate.origin === "bundled" &&
-            (sourceRoots.has(pluginCacheRealpathSync(candidate.rootDir) ?? candidate.rootDir) ||
-              configuredSources.has(pluginCacheRealpathSync(candidate.source) ?? candidate.source))
-          ) {
-            candidate.sourcePreferred = true;
-          }
-          return candidate;
-        });
+        .map(resolveCandidate);
       return loadPluginManifestRegistryCore({
         registryPath: params.registryPath,
         config: params.config,

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -14,7 +14,7 @@ import {
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { resolveOpenClawDevSourceRoot } from "./dev-source-root.js";
 import { discoverConfiguredPluginLoadPaths, type PluginDiscoveryResult } from "./discovery.js";
-import { resolvePluginDoctorContractArtifactPath } from "./doctor-contract-artifact.js";
+import { resolvePluginDoctorContractArtifact } from "./doctor-contract-artifact.js";
 import { safeFileSignature, safeHashFile } from "./installed-plugin-index-hash.js";
 import { hasOptionalMissingPluginManifestFile } from "./installed-plugin-index-manifest.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
@@ -36,6 +36,7 @@ import {
   type LoadInstalledPluginIndexParams,
 } from "./installed-plugin-index.js";
 import { hasMissingInstalledPluginOwnerMetadata } from "./installed-plugin-package-ownership.js";
+import { prepareInstalledPluginCandidateResolver } from "./manifest-registry-installed.js";
 import {
   loadPluginManifestRegistryCore,
   type PluginManifestRegistry,
@@ -164,21 +165,32 @@ function fileContentMatches(
   return safeHashFile({ filePath, diagnostics: [], required: false }) === hash;
 }
 
-function hasStaleDoctorContractFile(
-  plugin: InstalledPluginIndexRecord,
-  rootExists: boolean,
+function hasStaleDoctorContractFiles(
+  index: InstalledPluginIndex,
+  params: LoadPluginRegistryParams,
 ): boolean {
-  if (!rootExists && !plugin.enabled) {
-    return false;
-  }
-  const contractPath = resolvePluginDoctorContractArtifactPath(plugin.rootDir);
-  return contractPath
-    ? !plugin.doctorContractHash ||
-        !fileContentMatches(contractPath, plugin.doctorContractHash, plugin.doctorContractFile)
-    : plugin.doctorContractHash !== undefined || plugin.doctorContractFile !== undefined;
+  const resolveCandidate = prepareInstalledPluginCandidateResolver({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  return index.plugins.some((plugin) => {
+    if (!plugin.enabled && !fs.existsSync(plugin.rootDir)) {
+      return false;
+    }
+    const artifact = resolvePluginDoctorContractArtifact(resolveCandidate(plugin));
+    return artifact
+      ? !plugin.doctorContractHash ||
+          !fileContentMatches(
+            artifact.modulePath,
+            plugin.doctorContractHash,
+            plugin.doctorContractFile,
+          )
+      : plugin.doctorContractHash !== undefined || plugin.doctorContractFile !== undefined;
+  });
 }
 
-function hasStalePersistedPluginFiles(index: InstalledPluginIndex): boolean {
+function hasStalePersistedPluginMetadataFiles(index: InstalledPluginIndex): boolean {
   const realpathCache = new Map<string, string>();
   return index.plugins.some((plugin) => {
     if (!isContainedPluginPath(plugin.rootDir, plugin.rootDir, realpathCache)) {
@@ -210,9 +222,6 @@ function hasStalePersistedPluginFiles(index: InstalledPluginIndex): boolean {
       ) {
         return true;
       }
-    }
-    if (hasStaleDoctorContractFile(plugin, rootExists)) {
-      return true;
     }
     if (!plugin.packageJson) {
       return false;
@@ -426,7 +435,12 @@ export function loadPluginRegistrySnapshotWithMetadata(
   const persistedIndex = readPersistedInstalledPluginIndexSync(params);
   let stalePluginFiles: boolean | undefined;
   const hasStalePluginFiles = () =>
-    (stalePluginFiles ??= persistedIndex ? hasStalePersistedPluginFiles(persistedIndex) : false);
+    (stalePluginFiles ??= persistedIndex
+      ? // Check metadata before configured discovery can cache its bytes. That scanner
+        // never reads Doctor bytes, which remain fresh until the second check below.
+        hasStalePersistedPluginMetadataFiles(persistedIndex) ||
+        hasStaleDoctorContractFiles(persistedIndex, params)
+      : false);
   if (!persistedIndex) {
     diagnostics.push({
       level: "info",

--- a/src/plugins/plugin-runtime-artifact-binding.ts
+++ b/src/plugins/plugin-runtime-artifact-binding.ts
@@ -1,0 +1,104 @@
+/** Binds selected artifacts and completed registration to their loaded runtime record. */
+import type { OpenClawPackageManifest } from "./manifest.js";
+import {
+  resolvePluginRuntimeArtifactSelection,
+  resolvePluginRuntimeExecutionArtifact,
+  type PluginRuntimeArtifact,
+} from "./plugin-runtime-artifact-selection.js";
+import type { PluginRecord } from "./registry-types.js";
+
+const RUNTIME_ARTIFACT_SELECTION = Symbol.for("openclaw.pluginRuntimeArtifactSelection");
+type RuntimeArtifactSelection = {
+  sourcePreferred: boolean;
+  sourceExternal: boolean;
+  runtimeEntry: PluginRuntimeArtifact;
+  setupEntry?: PluginRuntimeArtifact;
+  preferBuiltPluginArtifacts?: boolean;
+  runtimeRegistrationComplete: boolean;
+};
+type ArtifactBoundRecord = PluginRecord & {
+  [RUNTIME_ARTIFACT_SELECTION]?: RuntimeArtifactSelection;
+};
+
+type RuntimeArtifactSelectionInput = {
+  sourcePreferred?: boolean;
+  setupSource?: string;
+  packageManifest?: OpenClawPackageManifest;
+  preferBuiltPluginArtifacts?: boolean;
+};
+
+/** Preserve selection inputs on the loaded owner, outside status/protocol serialization. */
+export function bindPluginRuntimeArtifactSelection(
+  record: PluginRecord,
+  params: RuntimeArtifactSelectionInput & {
+    runtimeEntry: PluginRuntimeArtifact;
+    setupEntry?: PluginRuntimeArtifact;
+  },
+): RuntimeArtifactSelection {
+  const selection = {
+    sourcePreferred: params.sourcePreferred === true,
+    sourceExternal: params.packageManifest?.build?.bundledDist === false,
+    runtimeEntry: params.runtimeEntry,
+    setupEntry: params.setupEntry,
+    preferBuiltPluginArtifacts: params.preferBuiltPluginArtifacts,
+    runtimeRegistrationComplete: false,
+  };
+  Object.defineProperty(record, RUNTIME_ARTIFACT_SELECTION, { value: selection });
+  return selection;
+}
+
+export function hasCompletedPluginRuntimeRegistration(record: ArtifactBoundRecord): boolean {
+  return (
+    record.status === "loaded" &&
+    record[RUNTIME_ARTIFACT_SELECTION]?.runtimeRegistrationComplete === true
+  );
+}
+
+export function matchesPluginRuntimeArtifactSelection(
+  record: ArtifactBoundRecord,
+  params: RuntimeArtifactSelectionInput & { rootDir: string; source: string },
+  preferBuiltPluginArtifacts?: boolean,
+): boolean {
+  const loaded = record[RUNTIME_ARTIFACT_SELECTION];
+  if (
+    (loaded?.sourcePreferred === true) !== (params.sourcePreferred === true) ||
+    (loaded?.sourceExternal === true) !== (params.packageManifest?.build?.bundledDist === false) ||
+    // Bounded reuse keeps an unspecified policy; exact loads compare the full loader key.
+    (preferBuiltPluginArtifacts !== undefined &&
+      loaded?.preferBuiltPluginArtifacts !== preferBuiltPluginArtifacts)
+  ) {
+    return false;
+  }
+  if (!loaded) {
+    // Bundle-format records are metadata-only and never select executable artifacts.
+    return (
+      record.format === "bundle" &&
+      record.rootDir === params.rootDir &&
+      record.source === params.source
+    );
+  }
+  // Source/build names alone do not prove shared execution. Compare the loader's
+  // selected artifacts while retaining the policy that produced this owner.
+  const matchesEntry = (
+    entry: PluginRuntimeArtifact,
+    source: string,
+    entryKind: "runtime" | "setup",
+  ): boolean => {
+    const selected = resolvePluginRuntimeExecutionArtifact(
+      resolvePluginRuntimeArtifactSelection({
+        ...params,
+        source,
+        entryKind,
+        origin: record.origin,
+        preferBuiltPluginArtifacts: loaded.preferBuiltPluginArtifacts === true,
+      }),
+    );
+    return entry.rootDir === selected.rootDir && entry.source === selected.source;
+  };
+  return (
+    matchesEntry(loaded.runtimeEntry, params.source, "runtime") &&
+    (!loaded.setupEntry ||
+      (params.setupSource !== undefined &&
+        matchesEntry(loaded.setupEntry, params.setupSource, "setup")))
+  );
+}

--- a/src/plugins/plugin-runtime-artifact-resolution.test.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.test.ts
@@ -9,6 +9,7 @@ import {
   clearPluginRuntimeArtifactResolutionMemo,
   resolvePluginRuntimeArtifact,
 } from "./plugin-runtime-artifact-resolution.js";
+import { resolvePluginRuntimeExecutionArtifact } from "./plugin-runtime-artifact-selection.js";
 import { getActivePluginChannelRegistry } from "./runtime.js";
 
 const tempDirs: string[] = [];
@@ -78,6 +79,53 @@ afterEach(() => {
 });
 
 describe("resolvePluginRuntimeArtifact", () => {
+  it.each(["missing", "present", "staging-symlink", "canonical-directory-symlink"])(
+    "keeps the execution entry and boundary together for a %s canonical entry",
+    (layout) => {
+      const fixture = createBundledPluginFixture();
+      const packageRoot = path.dirname(path.dirname(fixture.rootDir));
+      const stagingRoot = path.join(packageRoot, "dist-runtime", "extensions", "fixture");
+      const stagingSource = path.join(stagingRoot, "setup-entry.js");
+      const builtRoot = path.dirname(fixture.builtSource);
+      const builtSource = path.join(builtRoot, "setup-entry.js");
+      if (layout === "canonical-directory-symlink") {
+        const outputRoot = path.join(packageRoot, "outputs");
+        fs.renameSync(builtRoot, outputRoot);
+        fs.symlinkSync(outputRoot, builtRoot, "junction");
+      }
+      fs.mkdirSync(stagingRoot, { recursive: true });
+      const canonicalEntryExists = layout !== "missing";
+      if (canonicalEntryExists) {
+        fs.writeFileSync(builtSource, "module.exports = {};\n");
+      }
+      if (layout === "staging-symlink" || layout === "canonical-directory-symlink") {
+        fs.symlinkSync(builtSource, stagingSource);
+      } else {
+        fs.writeFileSync(stagingSource, "module.exports = {};\n");
+      }
+      const selected = { source: stagingSource, rootDir: stagingRoot };
+      const expected = canonicalEntryExists
+        ? { source: fs.realpathSync(builtSource), rootDir: builtRoot }
+        : selected;
+
+      expect(
+        resolvePluginRuntimeExecutionArtifact({
+          ...selected,
+          source: fs.realpathSync(stagingSource),
+        }),
+      ).toEqual(expected);
+      expect(
+        resolvePluginRuntimeArtifact({
+          ...selected,
+          pluginId: "fixture",
+          entryKind: "setup",
+          origin: "bundled",
+          preferBuiltPluginArtifacts: false,
+        }),
+      ).toEqual(expected);
+    },
+  );
+
   it.each([".cjs", ".js"])(
     "uses the emitted %s entry rather than a stale format neighbor",
     (extension) => {

--- a/src/plugins/plugin-runtime-artifact-selection.ts
+++ b/src/plugins/plugin-runtime-artifact-selection.ts
@@ -16,10 +16,9 @@ import {
 } from "./plugin-cache-files.js";
 import { getPluginCacheRoot } from "./plugin-cache.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
-import type { PluginRecord } from "./registry-types.js";
 
 export type PluginRuntimeArtifactPreference = "source" | "bundled" | "all";
-type PluginRuntimeArtifact = { source: string; rootDir: string };
+export type PluginRuntimeArtifact = { source: string; rootDir: string };
 export type PluginRuntimeArtifactSelectionParams = PluginRuntimeArtifact & {
   entryKind: "runtime" | "setup" | "provider-discovery" | "capability-catalog";
   origin: PluginOrigin;
@@ -27,102 +26,6 @@ export type PluginRuntimeArtifactSelectionParams = PluginRuntimeArtifact & {
   sourcePreferred?: boolean;
   packageManifest?: OpenClawPackageManifest;
 };
-
-const RUNTIME_ARTIFACT_SELECTION = Symbol.for("openclaw.pluginRuntimeArtifactSelection");
-type RuntimeArtifactSelection = {
-  sourcePreferred: boolean;
-  sourceExternal: boolean;
-  runtimeEntry: PluginRuntimeArtifact;
-  setupEntry?: PluginRuntimeArtifact;
-  preferBuiltPluginArtifacts?: boolean;
-  runtimeRegistrationComplete: boolean;
-};
-type ArtifactBoundRecord = PluginRecord & {
-  [RUNTIME_ARTIFACT_SELECTION]?: RuntimeArtifactSelection;
-};
-
-type RuntimeArtifactSelectionInput = {
-  sourcePreferred?: boolean;
-  setupSource?: string;
-  packageManifest?: OpenClawPackageManifest;
-  preferBuiltPluginArtifacts?: boolean;
-};
-
-/** Preserve selection inputs on the loaded owner, outside status/protocol serialization. */
-export function bindPluginRuntimeArtifactSelection(
-  record: PluginRecord,
-  params: RuntimeArtifactSelectionInput & {
-    runtimeEntry: PluginRuntimeArtifact;
-    setupEntry?: PluginRuntimeArtifact;
-  },
-): RuntimeArtifactSelection {
-  const selection = {
-    sourcePreferred: params.sourcePreferred === true,
-    sourceExternal: params.packageManifest?.build?.bundledDist === false,
-    runtimeEntry: params.runtimeEntry,
-    setupEntry: params.setupEntry,
-    preferBuiltPluginArtifacts: params.preferBuiltPluginArtifacts,
-    runtimeRegistrationComplete: false,
-  };
-  Object.defineProperty(record, RUNTIME_ARTIFACT_SELECTION, { value: selection });
-  return selection;
-}
-
-export function hasCompletedPluginRuntimeRegistration(record: ArtifactBoundRecord): boolean {
-  return (
-    record.status === "loaded" &&
-    record[RUNTIME_ARTIFACT_SELECTION]?.runtimeRegistrationComplete === true
-  );
-}
-
-export function matchesPluginRuntimeArtifactSelection(
-  record: ArtifactBoundRecord,
-  params: RuntimeArtifactSelectionInput & { rootDir: string; source: string },
-  preferBuiltPluginArtifacts?: boolean,
-): boolean {
-  const loaded = record[RUNTIME_ARTIFACT_SELECTION];
-  if (
-    (loaded?.sourcePreferred === true) !== (params.sourcePreferred === true) ||
-    (loaded?.sourceExternal === true) !== (params.packageManifest?.build?.bundledDist === false) ||
-    // Bounded reuse keeps an unspecified policy; exact loads compare the full loader key.
-    (preferBuiltPluginArtifacts !== undefined &&
-      loaded?.preferBuiltPluginArtifacts !== preferBuiltPluginArtifacts)
-  ) {
-    return false;
-  }
-  if (!loaded) {
-    // Bundle-format records are metadata-only and never select executable artifacts.
-    return (
-      record.format === "bundle" &&
-      record.rootDir === params.rootDir &&
-      record.source === params.source
-    );
-  }
-  // Source/build names alone do not prove shared execution. Compare the loader's
-  // selected artifacts while retaining the policy that produced this owner.
-  const matchesEntry = (
-    entry: PluginRuntimeArtifact,
-    source: string,
-    entryKind: "runtime" | "setup",
-  ): boolean => {
-    const selected = resolvePluginRuntimeExecutionArtifact(
-      resolvePluginRuntimeArtifactSelection({
-        ...params,
-        source,
-        entryKind,
-        origin: record.origin,
-        preferBuiltPluginArtifacts: loaded.preferBuiltPluginArtifacts === true,
-      }),
-    );
-    return entry.rootDir === selected.rootDir && entry.source === selected.source;
-  };
-  return (
-    matchesEntry(loaded.runtimeEntry, params.source, "runtime") &&
-    (!loaded.setupEntry ||
-      (params.setupSource !== undefined &&
-        matchesEntry(loaded.setupEntry, params.setupSource, "setup")))
-  );
-}
 
 /** Canonical packaged runtime replaces staging-only dist-runtime artifacts. */
 export function resolveCanonicalDistRuntimeSource(source: string): string {

--- a/src/plugins/plugin-runtime-artifact-selection.ts
+++ b/src/plugins/plugin-runtime-artifact-selection.ts
@@ -1,6 +1,7 @@
 /** Selects built plugin artifacts without importing active runtime state. */
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { isPathInside } from "../infra/path-guards.js";
 import type { OpenClawPackageManifest } from "./manifest.js";
 import {
   isTypeScriptPackageEntry,
@@ -140,9 +141,20 @@ export function resolvePluginRuntimeExecutionArtifact(
 ): PluginRuntimeArtifact {
   // This is the loader's existing final pass, not recursive normalization:
   // nested staging paths can make another pass select a different file.
+  const source = resolveCanonicalDistRuntimeSource(selected.source);
+  const rootDir = resolveCanonicalDistRuntimeSource(selected.rootDir);
   return {
-    source: resolveCanonicalDistRuntimeSource(selected.source),
-    rootDir: resolveCanonicalDistRuntimeSource(selected.rootDir),
+    source,
+    // A partial build can have the canonical directory without this entry;
+    // a staging symlink can also have already resolved into the canonical tree.
+    rootDir:
+      rootDir !== selected.rootDir &&
+      !isPathInside(
+        pluginCacheRealpathSync(rootDir) ?? rootDir,
+        pluginCacheRealpathSync(source) ?? source,
+      )
+        ? selected.rootDir
+        : rootDir,
   };
 }
 
@@ -150,9 +162,10 @@ export function resolvePluginRuntimeExecutionArtifact(
 export function resolvePluginRuntimeArtifactSelection(
   params: PluginRuntimeArtifactSelectionParams,
 ): PluginRuntimeArtifact {
-  const rootDir = resolveCanonicalDistRuntimeSource(
-    pluginCacheRealpathSync(params.rootDir) ?? path.resolve(params.rootDir),
-  );
+  const { source, rootDir } = resolvePluginRuntimeExecutionArtifact({
+    source: pluginCacheRealpathSync(params.source) ?? path.resolve(params.source),
+    rootDir: pluginCacheRealpathSync(params.rootDir) ?? path.resolve(params.rootDir),
+  });
   const artifacts = getPluginCacheRoot(rootDir).runtimeArtifacts;
   const key = JSON.stringify([
     params.source,
@@ -164,14 +177,9 @@ export function resolvePluginRuntimeArtifactSelection(
   ]);
   let resolved = artifacts.get(key);
   if (!resolved) {
-    const source = resolveCanonicalDistRuntimeSource(
-      pluginCacheRealpathSync(params.source) ?? path.resolve(params.source),
+    resolved = resolvePluginRuntimeExecutionArtifact(
+      resolvePreferredBuiltRuntimeArtifact({ ...params, source, rootDir }),
     );
-    const preferred = resolvePreferredBuiltRuntimeArtifact({ ...params, source, rootDir });
-    resolved = {
-      source: resolveCanonicalDistRuntimeSource(preferred.source),
-      rootDir: resolveCanonicalDistRuntimeSource(preferred.rootDir),
-    };
     artifacts.set(key, resolved);
   }
   return resolved;

--- a/src/plugins/providers.runtime-core.ts
+++ b/src/plugins/providers.runtime-core.ts
@@ -19,7 +19,7 @@ import type { PluginLoadOptions } from "./loader-types.js";
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
 import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
-import { hasCompletedPluginRuntimeRegistration } from "./plugin-runtime-artifact-selection.js";
+import { hasCompletedPluginRuntimeRegistration } from "./plugin-runtime-artifact-binding.js";
 import { hasExplicitPluginIdScope } from "./plugin-scope.js";
 import { resolveProviderConfigApiOwnerHint } from "./provider-config-owner.js";
 import {

--- a/src/plugins/providers.runtime.consult-current-snapshot.test.ts
+++ b/src/plugins/providers.runtime.consult-current-snapshot.test.ts
@@ -11,10 +11,8 @@ import { createPluginRecord } from "./loader-records.js";
 import type { PluginManifestRegistry } from "./manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
-import {
-  bindPluginRuntimeArtifactSelection,
-  resolvePluginRuntimeArtifactSelection,
-} from "./plugin-runtime-artifact-selection.js";
+import { bindPluginRuntimeArtifactSelection } from "./plugin-runtime-artifact-binding.js";
+import { resolvePluginRuntimeArtifactSelection } from "./plugin-runtime-artifact-selection.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
 import { withPluginRuntimeGenerationScope } from "./runtime/generation-scope.js";

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -17,10 +17,8 @@ import { AsyncWorkScope, getAsyncWorkSignal, trackAsyncWork } from "../shared/as
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { createPluginRecord } from "./loader-records.js";
 import type { PluginLoadOptions } from "./loader-types.js";
-import {
-  bindPluginRuntimeArtifactSelection,
-  resolvePluginRuntimeArtifactSelection,
-} from "./plugin-runtime-artifact-selection.js";
+import { bindPluginRuntimeArtifactSelection } from "./plugin-runtime-artifact-binding.js";
+import { resolvePluginRuntimeArtifactSelection } from "./plugin-runtime-artifact-selection.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { markPluginRegistryRetired } from "./registry-lifecycle.js";
 import type { PluginRegistry } from "./registry-types.js";

--- a/test/canonical-descendant.integration.test.ts
+++ b/test/canonical-descendant.integration.test.ts
@@ -44,8 +44,8 @@ import {
 import { createRuntimePluginManifestLookup } from "../src/plugins/active-runtime-registry.js";
 import { resolvePluginCapabilityCatalogContext } from "../src/plugins/loader-runtime-load.js";
 import { resolvePluginMetadataSnapshot } from "../src/plugins/plugin-metadata-snapshot.js";
+import { bindPluginRuntimeArtifactSelection } from "../src/plugins/plugin-runtime-artifact-binding.js";
 import {
-  bindPluginRuntimeArtifactSelection,
   resolvePluginRuntimeArtifactSelection,
   resolvePluginRuntimeExecutionArtifact,
 } from "../src/plugins/plugin-runtime-artifact-selection.js";

--- a/test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts
+++ b/test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts
@@ -122,16 +122,6 @@ describe("Doctor plugin index persistence built CLI proof", () => {
 
     clearPluginMetadataLifecycleCaches();
     closeOpenClawStateDatabaseForTest();
-    const reread = loadPluginMetadataSnapshot({
-      config,
-      env: instance.env,
-      stateDir: instance.stateDir,
-      workspaceDir,
-      allowCurrent: false,
-    });
-    expect(reread.registrySource, instance.logs()).toBe("persisted");
-    expect(reread.registryDiagnostics, instance.logs()).toStrictEqual([]);
-
     const persisted = readPersistedInstalledPluginIndexSync({ env: instance.env });
     const persistedPlugin = persisted?.plugins.find((plugin) => plugin.pluginId === pluginId);
     expect(persistedPlugin, instance.logs()).toMatchObject({
@@ -143,5 +133,20 @@ describe("Doctor plugin index persistence built CLI proof", () => {
       doctorContractHash: expect.stringMatching(/^[a-f0-9]{64}$/u),
       packageBuild: { bundledDist: false },
     });
+
+    // Source readers intentionally select different bundled Doctor contracts.
+    // Observe the repaired index through the same built host as the Gateway.
+    const listed = await instance.cli(["plugins", "list", "--json"]);
+    expect(listed.code, listed.stderr).toBe(0);
+    expect(listed.signal).toBeNull();
+    const reread = JSON.parse(listed.stdout) as {
+      registry: { source: string; diagnostics: unknown[] };
+    };
+    expect(reread.registry.source, instance.logs()).toBe("persisted");
+    expect(reread.registry.diagnostics, instance.logs()).toStrictEqual([]);
+
+    clearPluginMetadataLifecycleCaches();
+    closeOpenClawStateDatabaseForTest();
+    expect(readPersistedInstalledPluginIndexSync({ env: instance.env })).toEqual(persisted);
   }, 120_000);
 });


### PR DESCRIPTION
Related: #136399

## What Problem This Solves

Resolves a problem where built-checkout Gateway startup and Doctor could still load source contracts despite an available compiled copy. Partial builds could also pair an available staging entry with a canonical directory that did not contain it, leaving the selected Doctor contract without its expected hash.

## Why This Change Was Made

One Doctor artifact descriptor now supplies the selected file and its root to loading, installed-index hashing, and freshness checks. It reuses the existing compiled-artifact selector and keeps execution files and roots together across partial builds and filesystem symlinks. Installed metadata reconstruction shares the existing source-preference preparation rather than introducing another cache.

Explicit source selections, external-plugin ownership, package-local extension precedence, migration declarations, and trust policy remain intact. No configuration option, database schema, retention policy, or migration action changes. The additional production code keeps all three consumers aligned instead of optimizing loading alone.

## User Impact

Built checkouts can reuse compiled Doctor contracts consistently with the rest of plugin startup. Operators retain the same migration coverage, including disabled-plugin configuration repair and existing external-plugin compatibility. Selected contract bytes remain correctly tracked when canonical output is incomplete or reached through symlinks.

## Evidence

- Original code fails the built-contract hash selection and partial-build file/root regressions; 20 controls pass. The candidate passes the focused artifact, registry, and runtime-resolution checks, including 18 source/built layouts, real selected detection/migration results, and replacement loading in a fresh Node process.
- The 29 checks selected by `check:changed` are complete across the initial successful stages and the scoped lint/tail recovery. The fixture-only lint repair also passed its behavioral test, mapped test typecheck, and formatting. No checks or assertions were disabled.
- Additional Doctor declaration, closure, installed-index, registry freshness/checkpoint, and ACP ownership suites were exercised. An existing mocked-Windows fixture failure was reproduced on baseline and traced to the validation temp directory inheriting the checkout's ESM package scope; baseline and candidate pass in private system temp without changing that fixture's assertions.
- Fresh independent Codex review of the complete staged repair is clean at P2 and above. Source-only filesystem-boundary findings were fixed and covered before review.
- The final candidate's normal build with source maps passed in 172.791 seconds. The corrected built-CLI persistence proof also passed against that build. Build manifests and selected embedded source-map contents bind the baseline and candidate outputs to their respective commits.
- Twelve unprofiled, fresh-state Gateway starts passed in fixed B0/C0/C1/B1 order, three starts per cohort. Median HTTP readiness improved from 4095.71 to 3331.46 ms (**18.66%**) and from 4026.88 to 3662.26 ms (**9.05%**) in the two orders. All six indexed readiness comparisons improved. Whole-process wall, CPU, and peak RSS median/mean and indexed comparisons also improved in this sample. Each start reached HTTP 200, exited gracefully, and released its port. These are one-host, warm-filesystem, polling-based startup measurements, not model or agent-turn latency, and three samples per cohort do not establish statistical confidence.
- Separate baseline/candidate Node profiles completed successfully. The observed module cache contained 21 Doctor contracts in each: baseline used source TypeScript for Discord, iMessage, Matrix, and WhatsApp; candidate used compiled contracts for all 21. An earlier diagnostic observer failed because Node contexts shared its output path. That failed profile remains separate; the corrected observer is scoped to the Gateway main process and uses its PID. None of the 12 primary timing samples was rerun or mixed with profiles.
- Exact-head CI is green on the unchanged candidate after one targeted retry: 111 jobs passed and 16 skipped. Native maintainer landing remains pending.


### CI follow-up

The first published head exposed a type-dependency cycle through the runtime-record type and a built-CLI test that reread compiled contract hashes through source-mode rules. The repair separates the unchanged runtime binding functions into their own owner, migrates every caller, and retains the real record type without a shim or cycle exception. Both cycle checks now pass, along with 149 existing runtime tests and 71 canonical-descendant integration tests.

The persistence test still requires a persisted registry with no diagnostics. It now checks the repaired raw index before invoking the existing built `plugins list --json`, then verifies that the read-only command leaves the index unchanged. The corrected observer passes against the baseline and first built candidate; source-mode diagnostics showed that only bundled contract hashes differed, while the external legacy record was already correctly repaired.

The complete repair passed its selected local checks and a fresh Codex review. On the current head, all three original CI failures pass, including build-artifacts, architecture, and the CUA extension bundle. The earlier MCP cleanup failure is retained without claiming an established cause.

The initial current-head CI run has one remaining workload failure: both layouts in the worker-transformation test exceed their unchanged 120-second deadline while repeatedly preparing complete worker generations. The test and compiler owners are unchanged from the PR base.

A subsequent baseline/candidate comparison ran those same two cases in separate Linux x64 Node 24.19 containers, each limited to two CPUs and 8 GiB. Baseline passed in 40.486/39.944 seconds; candidate passed in 36.962/45.810 seconds. All 20 transport observations retained the required modes, values, transform counts, and 16 distinct compiled generations. Both installs/tests joined their processes and released resource claims; both containers exited normally and were removed. Candidate timings are mixed, and these containers are not identical to the hosted CI machines, so this does not establish the original timeout's cause or prove flakiness.

The local supervisor later hit its disk floor and exited 143. The already-completed remote evidence was recovered read-only: 44 files and their hashes were independently checked, and the owned lease was stopped. That outer failure remains recorded. One targeted retry of the failed CI workload and aggregate gate passed on unchanged `c6099189d4fec17b378e80d58a0f2993ac2be479`: [CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/34567614441/attempts/2), 111 jobs passed and 16 skipped. No code, checks, timeouts, or assertions were changed.

### Compatibility review disposition

The requested data-model compatibility confirmation is covered by the existing derived-index contract and its recorded proof. The [index types](https://github.com/openclaw/openclaw/blob/c6099189d4fec17b378e80d58a0f2993ac2be479/src/plugins/installed-plugin-index-types.ts), [parser](https://github.com/openclaw/openclaw/blob/c6099189d4fec17b378e80d58a0f2993ac2be479/src/plugins/installed-plugin-index-store.ts), writer, and startup persistence owner are unchanged from the PR base. Index and migration versions remain 1; Doctor hash/signature fields remain optional. This repairs artifact identity within the existing reconstructible index, without a new stored representation or migration policy.

The exact-head [built-CLI case](https://github.com/openclaw/openclaw/blob/c6099189d4fec17b378e80d58a0f2993ac2be479/test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts) removes both optional Doctor fields from persisted records, starts the built Gateway, verifies restored hashes/signatures, then confirms that built `plugins list --json` reads a persisted registry with no diagnostics and leaves the stored index unchanged. That targeted case passed; the separate empty legacy-directory case was skipped. The [artifact fixture](https://github.com/openclaw/openclaw/blob/c6099189d4fec17b378e80d58a0f2993ac2be479/src/plugins/doctor-contract-artifact.test.ts) separately covers source/built selection and refreshing a populated stale compiled hash after restart, while preserving manifest/package hashes and executing the selected migration callbacks.

These are compatibility checks at the affected owner boundaries, not a release-binary upgrade or downgrade campaign. The synthetic legacy plugin's version stamp is fixture data, and the artifact fixture does not persist its source-preferred index before switching to compiled mode. Maintainer and independent source review found the existing evidence sufficient for this unchanged derived-index contract; no new persistent-state design or schema migration is introduced.
