### PR TITLE
fix(codex): show the reason when receiver startup is aborted

### DIFF
--- a/docs/cli/gateway/query.md
+++ b/docs/cli/gateway/query.md
@@ -314,6 +314,18 @@ openclaw gateway call health --port 18999
 openclaw gateway call logs.tail --params '{"limit": 200}'
 ```
 
+For `sessions.send` and `chat.send`, JSON `timeoutMs` is the receiving agent's
+execution budget, not an acknowledgment timeout. Omit it for ordinary
+coordination; `--timeout` independently limits how long this CLI waits:
+
+```bash
+openclaw gateway call sessions.send --params '{"key":"<session-key>","message":"Status update"}' --timeout 10000
+```
+
+A `started` response confirms acceptance, not a completed reply. Agents should
+normally use [`sessions_send` with `timeoutSeconds: 0`](/concepts/session-tool#sending-cross-session-messages)
+for nonblocking coordination.
+
 <ParamField path="--params <json>" type="string" default="{}">
   JSON object string for params.
 </ParamField>

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -142,6 +142,13 @@ During healthy worker provisioning or workspace preparation, accepted input stay
 - **Fire-and-forget:** set `timeoutSeconds: 0` to enqueue and return immediately.
 - **Wait for reply:** set a timeout and get the response inline.
 
+`timeoutSeconds` limits the sending tool's wait, not the receiver's execution
+budget. For nonblocking coordination, use `sessions_send` with `timeoutSeconds: 0`.
+The low-level Gateway `sessions.send` RPC has a different contract: its JSON
+`timeoutMs` limits **receiver execution**, just like `chat.send`. Omit that field
+to keep the receiver's configured budget; bound the CLI wait separately with
+[`gateway call --timeout`](/cli/gateway/query#gateway-call-method).
+
 An accepted result keeps target admission separate from announcement delivery.
 `targetDisposition` is `queued` for a new turn or `steered` for an active turn;
 `delivery.status` describes only the later announcement as `pending` or `skipped`.

--- a/extensions/codex/src/app-server/client-cancellation.test.ts
+++ b/extensions/codex/src/app-server/client-cancellation.test.ts
@@ -1,0 +1,180 @@
+import { once } from "node:events";
+import { formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { createCodexAttemptDeadlineController } from "./attempt-deadlines.js";
+import {
+  CodexAppServerClient,
+  isCodexAppServerIndeterminateRequestCancellationError,
+  isCodexAppServerIndeterminateTransportError,
+  isCodexAppServerPrewriteRequestCancellationError,
+  isCodexAppServerRequestTimeoutError,
+} from "./client.js";
+import { createClientHarness } from "./test-support.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+const clients: CodexAppServerClient[] = [];
+afterEach(() => {
+  for (const client of clients.splice(0)) {
+    client.close();
+  }
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("Codex app-server cancellation diagnostics", () => {
+  it.each(["before request", "pending request", "overload backoff", "config fence"] as const)(
+    "preserves the cancellation cause and write certainty during %s",
+    async (phase) => {
+      vi.useFakeTimers();
+      const harness = createClientHarness();
+      clients.push(harness.client);
+      const controller = new AbortController();
+      const reason = new Error("receiver execution budget timed out");
+      if (phase === "before request") {
+        controller.abort(reason);
+      }
+      if (phase === "config fence") {
+        harness.client.setThreadSessionRequestGuard(
+          ({ abortMessage }) =>
+            new Promise((_resolve, reject) => {
+              controller.signal.addEventListener("abort", () => reject(new Error(abortMessage)), {
+                once: true,
+              });
+            }),
+        );
+      }
+      const method = phase === "config fence" ? "thread/resume" : "turn/start";
+      const result = harness.client
+        .request(method, { threadId: "receiver" }, { signal: controller.signal })
+        .catch((error: unknown) => error);
+      if (phase === "overload backoff") {
+        const sent = JSON.parse(await harness.waitForWrite(0));
+        harness.send({ id: sent.id, error: { code: -32001, message: "Server overloaded" } });
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      controller.abort(reason);
+      const error = await result;
+      expect(error).toMatchObject({
+        name: "CodexAppServerLocalRequestCancellationError",
+        code: "CODEX_APP_SERVER_LOCAL_REQUEST_CANCELLED",
+        reason: "aborted",
+        cause: reason,
+      });
+      expect(formatErrorMessage(error)).toContain(reason.message);
+      const written = phase === "pending request";
+      expect(isCodexAppServerIndeterminateRequestCancellationError(error)).toBe(written);
+      expect(isCodexAppServerPrewriteRequestCancellationError(error)).toBe(!written);
+      expect(isCodexAppServerRequestTimeoutError(error)).toBe(false);
+      expect(isCodexAppServerIndeterminateTransportError(error)).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(harness.writes).toHaveLength(
+        phase === "pending request" || phase === "overload backoff" ? 1 : 0,
+      );
+      expect(harness.client.getCloseError()).toBeUndefined();
+    },
+  );
+
+  it("projects an elapsed receiver deadline through a real WebSocket request", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    const controller = new AbortController();
+    const reason = new Error("codex app-server execution budget timed out");
+    const requests: string[] = [];
+    let releaseLateReply = () => {};
+    let receivedTurn: () => void = () => {};
+    const turnReceived = new Promise<void>((resolve) => {
+      receivedTurn = resolve;
+    });
+    server.on("connection", (socket) => {
+      socket.on("message", (data) => {
+        if (!Buffer.isBuffer(data)) {
+          throw new Error("expected a WebSocket Buffer");
+        }
+        const request = JSON.parse(data.toString("utf8"));
+        requests.push(request.method);
+        if (request.method === "initialize") {
+          socket.send(
+            JSON.stringify({
+              id: request.id,
+              result: { userAgent: `openclaw/${CODEX_APP_SERVER_VERSION}` },
+            }),
+          );
+        } else if (request.method === "turn/start") {
+          releaseLateReply = () =>
+            socket.send(JSON.stringify({ id: request.id, result: { turn: { id: "late-turn" } } }));
+          receivedTurn();
+        } else if (request.method === "model/list") {
+          socket.send(JSON.stringify({ id: request.id, result: { data: [] } }));
+        }
+      });
+    });
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback test port");
+    }
+    const client = await CodexAppServerClient.start({
+      transport: "websocket",
+      url: `ws://127.0.0.1:${address.port}`,
+    });
+    clients.push(client);
+    try {
+      await client.initialize();
+      const result = client
+        .request("turn/start", { threadId: "receiver" }, { signal: controller.signal })
+        .catch((error: unknown) => error);
+      await turnReceived;
+      const onTimeout = vi.fn(() => controller.abort(reason));
+      const deadline = createCodexAttemptDeadlineController({
+        startedAtMs: Date.now() - 15_000,
+        timeoutMs: 1_000,
+        signal: controller.signal,
+        onTimeout,
+      });
+      try {
+        const error = await result;
+        expect(onTimeout).toHaveBeenCalledExactlyOnceWith({
+          kind: "execution",
+          elapsedMs: expect.any(Number),
+          timeoutMs: 1_000,
+        });
+        expect(formatErrorMessage(error)).toBe(
+          "turn/start aborted: codex app-server execution budget timed out",
+        );
+        expect(isCodexAppServerIndeterminateRequestCancellationError(error)).toBe(true);
+        releaseLateReply();
+        await expect(client.request("model/list", {})).resolves.toEqual({ data: [] });
+        expect(requests).toEqual(["initialize", "initialized", "turn/start", "model/list"]);
+      } finally {
+        deadline.dispose();
+      }
+    } finally {
+      client.close();
+      for (const socket of server.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("keeps explicit cancellation distinct from the local request timer", async () => {
+    vi.useFakeTimers();
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    const controller = new AbortController();
+    const cancelled = harness.client
+      .request("turn/start", {}, { signal: controller.signal })
+      .catch((error: unknown) => error);
+    controller.abort("operator cancelled this run");
+    expect(formatErrorMessage(await cancelled)).toContain("operator cancelled this run");
+    expect(isCodexAppServerRequestTimeoutError(await cancelled)).toBe(false);
+    const timedOut = harness.client
+      .request("turn/start", {}, { timeoutMs: 100 })
+      .catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(await timedOut).toMatchObject({ message: "turn/start timed out", reason: "timed out" });
+    expect(isCodexAppServerRequestTimeoutError(await timedOut)).toBe(true);
+  });
+});

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -97,8 +97,11 @@ class CodexAppServerLocalRequestCancellationError extends Error {
     method: string,
     readonly reason: "aborted" | "timed out",
     readonly mayHaveWritten: boolean,
+    cause?: unknown,
   ) {
-    super(`${method} ${reason}`);
+    const detail =
+      cause instanceof Error || typeof cause === "string" ? coerceErrorMessage(cause) : undefined;
+    super(`${method} ${reason}${detail ? `: ${detail}` : ""}`, { cause });
     this.name = "CodexAppServerLocalRequestCancellationError";
   }
 }
@@ -429,7 +432,12 @@ export class CodexAppServerClient {
     }
     if (options.signal?.aborted) {
       return Promise.reject(
-        new CodexAppServerLocalRequestCancellationError(method, "aborted", false),
+        new CodexAppServerLocalRequestCancellationError(
+          method,
+          "aborted",
+          false,
+          options.signal?.reason,
+        ),
       );
     }
     const guard =
@@ -466,7 +474,12 @@ export class CodexAppServerClient {
             throw new CodexAppServerLocalRequestCancellationError(method, "timed out", false);
           }
           if (error instanceof Error && error.message === abortMessage) {
-            throw new CodexAppServerLocalRequestCancellationError(method, "aborted", false);
+            throw new CodexAppServerLocalRequestCancellationError(
+              method,
+              "aborted",
+              false,
+              options.signal?.reason,
+            );
           }
           throw error;
         }
@@ -529,7 +542,12 @@ export class CodexAppServerClient {
         : undefined;
     for (let retry = 0; ; retry += 1) {
       if (options.signal?.aborted) {
-        throw new CodexAppServerLocalRequestCancellationError(method, "aborted", false);
+        throw new CodexAppServerLocalRequestCancellationError(
+          method,
+          "aborted",
+          false,
+          options.signal?.reason,
+        );
       }
       const remainingTimeoutMs = deadline === undefined ? undefined : deadline - Date.now();
       if (remainingTimeoutMs !== undefined && remainingTimeoutMs <= 0) {
@@ -572,7 +590,12 @@ export class CodexAppServerClient {
     signal: AbortSignal | undefined,
   ): Promise<void> {
     if (signal?.aborted) {
-      throw new CodexAppServerLocalRequestCancellationError(method, "aborted", false);
+      throw new CodexAppServerLocalRequestCancellationError(
+        method,
+        "aborted",
+        false,
+        signal?.reason,
+      );
     }
     const remainingMs = deadline === undefined ? undefined : deadline - Date.now();
     if (remainingMs !== undefined && remainingMs <= 0) {
@@ -587,7 +610,9 @@ export class CodexAppServerClient {
       timer.unref?.();
       const abortListener = () => {
         cleanup();
-        reject(new CodexAppServerLocalRequestCancellationError(method, "aborted", false));
+        reject(
+          new CodexAppServerLocalRequestCancellationError(method, "aborted", false, signal?.reason),
+        );
       };
       const cleanup = () => {
         clearTimeout(timer);
@@ -611,7 +636,12 @@ export class CodexAppServerClient {
     }
     if (options.signal?.aborted) {
       return Promise.reject(
-        new CodexAppServerLocalRequestCancellationError(method, "aborted", false),
+        new CodexAppServerLocalRequestCancellationError(
+          method,
+          "aborted",
+          false,
+          options.signal?.reason,
+        ),
       );
     }
     const id = this.nextId++;
@@ -664,7 +694,12 @@ export class CodexAppServerClient {
       if (options.signal) {
         const abortListener = () =>
           rejectPending(
-            new CodexAppServerLocalRequestCancellationError(method, "aborted", mayHaveWritten),
+            new CodexAppServerLocalRequestCancellationError(
+              method,
+              "aborted",
+              mayHaveWritten,
+              options.signal?.reason,
+            ),
           );
         options.signal.addEventListener("abort", abortListener, { once: true });
         cleanupAbort = () => options.signal?.removeEventListener("abort", abortListener);
@@ -689,7 +724,14 @@ export class CodexAppServerClient {
         cleanup,
       });
       if (options.signal?.aborted) {
-        rejectPending(new CodexAppServerLocalRequestCancellationError(method, "aborted", false));
+        rejectPending(
+          new CodexAppServerLocalRequestCancellationError(
+            method,
+            "aborted",
+            false,
+            options.signal?.reason,
+          ),
+        );
         return;
       }
       try {

--- a/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
@@ -720,7 +720,12 @@ describe("Codex app-server main thread cleanup", () => {
         const unsubscribe = await waitForHarnessRequest(harness, "thread/unsubscribe");
         harness.send({ id: unsubscribe.id, result: {} });
       }
-      await expect(failure).resolves.toMatchObject({ message: "turn/start aborted" });
+      await expect(failure).resolves.toMatchObject({
+        message: "turn/start aborted: cancelled",
+        cause: "cancelled",
+        reason: "aborted",
+        mayHaveWritten: true,
+      });
       expect(harness.writes.map((entry) => JSON.parse(entry).method)).toEqual([
         "initialize",
         "initialized",

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -4261,7 +4261,12 @@ describe("runCodexAppServerSideQuestion", () => {
       }
       await expect(failure).resolves.toMatchObject(
         written
-          ? { message: "turn/start aborted" }
+          ? {
+              message: "turn/start aborted: side-start-cancelled",
+              cause: "side-start-cancelled",
+              reason: "aborted",
+              mayHaveWritten: true,
+            }
           : {
               name: "CodexThreadPolicyHandoffError",
               outcome: "acknowledged",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users coordinating Codex-backed sessions see only `turn/start aborted` when the receiver's explicitly requested execution budget expires during startup. The existing deadline owner supplies a useful reason, but the app-server request cancellation wrapper discards it before the terminal error is projected.

## Why This Change Was Made

Preserve the originating abort reason as `Error.cause` and include its Error/string text in the existing typed local-cancellation error. Keep its cancellation category and request-write certainty, so interruption, cleanup, retry decisions, and late-response handling continue to use the same contract.

The investigated expiry itself was caller misuse: raw Gateway `sessions.send` JSON `timeoutMs: 1000` deliberately requests a one-second **receiver execution** budget. A separate CLI `--timeout 10000` only bounds the caller's RPC wait. The two call-reference pages now explain that distinction and recommend normal `sessions_send` with `timeoutSeconds: 0` for nonblocking coordination, or omitting raw JSON `timeoutMs`.

No execution-budget defaults, deadline renewal, timeout resolution, cancellation policy, retries, protocol/schema, persistence, dependency, or deployment changes. The production change stays in the existing Codex client error owner; no broad runtime workaround for the incorrect caller override.

## User Impact

A receiver deadline now retains its explanation, for example:

```text
turn/start aborted: codex app-server execution budget timed out
```

Explicit operator cancellation also keeps its reason. Local request timers remain typed `timed out`; signal cancellation remains typed `aborted`. Legitimate receiver budgets still expire, and nonblocking sends do not acquire a one-second receiver budget.

## Evidence

Current head: `53d30e0e2eb29e921055b737c0bc8e3d1aaed8ef`.

- Reproduced diagnostic loss on unmodified main `8008b3df496884e80566b9942216a29e8c35f725`: all six focused regressions failed before the production repair. The final focused Codex owner/cleanup/deadline suite passed **87/87**; the final edited fixture separately passed **6/6**.
- Regression matrix covers cancellation before write, while pending, during overload backoff, and at the config fence. It checks cause, typed classification, write certainty, no accidental retries, and healthy-client reuse. Existing real-attempt cleanup assertions now require the preserved cause while retaining interrupt/drain ordering.
- Real loopback WebSocket boundary test drives initialize and pending `turn/start`, expires the production deadline controller, observes the projected message, delivers a late response, and successfully reuses the connection. The server is synthetic: this is transport/deadline boundary proof, **not authenticated external model inference**.
- Existing deadline controls cover unlimited/long-duration execution, settlement, disposal, and cancellation. Existing session-send and Gateway tests cover nonblocking coordination and durable terminal notices.
- Reviewed actual managed Codex **0.153.4** source at immutable commit [`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`](https://github.com/openai/codex/commit/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a), including thread-serialized turn start/interrupt and startup interruption with an empty turn ID. Those contracts are unchanged.
- Disposable Linux Blacksmith Testbox: all five selected files passed across three Vitest projects (Gateway loopback/persistence, session tools, Codex transport/deadlines); wrapper exit **0**. [Environment run](https://github.com/openclaw/openclaw/actions/runs/34563327374). The delegated wrapper receipt is authoritative; stopping the owned lease can mark the carrier Actions job cancelled. Production was identical; the final Buffer type guard and Promise-executor fixture cleanup were verified locally afterward.
- Complete changed-file check plan passed: extension production/test typechecking, format/lint, SDK/storage/dependency guards, dead exports, and runtime import-cycle checks.
- Native review runner passed **57/57** cancellation and turn-watch tests, including elapsed-budget expiry, explicit interruption, and no-replay controls.
- First-head CI found four side-question cleanup assertions still expecting the bare cancellation message. The same PR now strengthens that existing assertion to require the retained cause and write certainty; all **5 selected cleanup cases pass** (87 unrelated cases skipped in that focused local run), followed by the complete native final-head side-question suite passing **92/92**. No additional production change. The test-only changed-file check plan also passed. The corrected head passed [exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34564361489), including `openclaw/ci-gate`, and native preparation.
- Documentation link audit: **13,303 internal links, zero broken links**.
- Required independent autoreview: scoped-clean at **P0** (not an all-priority audit). All later edits are test-fixture/expectation changes; the reviewed production patch is unchanged.

Related but different owners: [#119426](https://github.com/openclaw/openclaw/pull/119426) handles a schema-valid sender timeout result; [#142135](https://github.com/openclaw/openclaw/pull/142135) persists pre-reply failure notices; [#135466](https://github.com/openclaw/openclaw/pull/135466) retains known terminal reasons in sidebar state. None repairs this dropped client cancellation reason. No duplicate or replacement PR is being closed.
