### PR TITLE
fix(doctor): report automation paths broken by Workshop relocation

### DIFF
--- a/docs/tools/skill-workshop/reference.md
+++ b/docs/tools/skill-workshop/reference.md
@@ -130,6 +130,21 @@ verifies the saved manifest and all copied files before removing the old copy.
 Skills that were symlinked into a workspace stay where they are as workspace
 skills; the migration marks their proposals stale instead of moving them.
 
+Doctor also checks saved automation command arguments, working directories,
+condition scripts, and agent messages for literal references to relocated
+Workshop skills. It names each affected automation and field during Doctor
+repair and on later checks. Retained apply history must establish the original
+skill directory; Doctor does not guess it from the current workspace or skill
+name when that history is unavailable.
+
+Review each reported field before updating the automation. Doctor offers a
+replacement for a complete argument or working-directory path only when the
+mapped target exists inside the relocated skill. For paths embedded in scripts
+or messages, it reports the directory relocation separately and leaves the
+complete target unresolved for manual review. Missing or ambiguous targets also
+stay unresolved. Doctor does not rewrite automation content, change schedules,
+or run the automation to check it.
+
 If moving the skills empties a workspace, migration retires obsolete
 workspace-survival evidence only when saved pre-move facts prove that the same
 directory contained only those skills and every moved file is intact.

--- a/src/commands/doctor-skill-workshop-automations.ts
+++ b/src/commands/doctor-skill-workshop-automations.ts
@@ -1,0 +1,173 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  loadCronJobsStoreWithConfigJobsReadOnly,
+  resolveCronJobsStorePathFromConfig,
+} from "../cron/store.js";
+import type { CronJob } from "../cron/types.js";
+import { isMissingPathError } from "../infra/errors.js";
+import { isPathInside } from "../infra/path-guards.js";
+import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
+import type { SkillProposalEvent } from "../skills/workshop/types.js";
+import {
+  inferOwnerAgentId,
+  resolveLegacyWorkshopWorkspaceDir,
+  type LegacyWorkshopProposal,
+} from "./doctor-skill-workshop-relocation.js";
+
+export type WorkshopAutomationReference = {
+  automationId: string;
+  field: string;
+  message: string;
+  fixHint: string;
+};
+
+type AutomationField = { field: string; value: string; completePath: boolean };
+
+function automationFields(job: CronJob): AutomationField[] {
+  const fields: AutomationField[] = [];
+  if (job.payload.kind === "command") {
+    fields.push(
+      ...job.payload.argv.map((value, index) => ({
+        field: `payload.argv[${index}]`,
+        value,
+        completePath: true,
+      })),
+    );
+    if (job.payload.cwd) {
+      fields.push({ field: "payload.cwd", value: job.payload.cwd, completePath: true });
+    }
+  } else if (job.payload.kind === "agentTurn") {
+    fields.push({ field: "payload.message", value: job.payload.message, completePath: false });
+  }
+  if (job.trigger) {
+    fields.push({ field: "trigger.script", value: job.trigger.script, completePath: false });
+  }
+  return fields;
+}
+
+function containsLiteralRoot(value: string, root: string): boolean {
+  for (
+    let index = value.indexOf(root);
+    index !== -1;
+    index = value.indexOf(root, index + root.length)
+  ) {
+    const before = value[index - 1];
+    const after = value[index + root.length];
+    if (
+      (!before || /[\s"'`=([{,:;]/u.test(before)) &&
+      (!after || after === path.sep || /[\s"'`),\]};]/u.test(after))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function existingPath(filename: string): Promise<string | undefined> {
+  try {
+    return await fs.realpath(filename);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/** Historical apply events keep the original target after proposal retargeting. */
+export async function inspectWorkshopAutomationReferences(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  records: readonly LegacyWorkshopProposal[];
+  appliedEvents: readonly SkillProposalEvent[];
+}): Promise<WorkshopAutomationReference[]> {
+  const records = new Map(params.records.map((entry) => [entry.record.id, entry]));
+  const relocations = new Map<string, Set<string>>();
+  for (const event of params.appliedEvents) {
+    const entry = records.get(event.proposalId);
+    const originalFile = event.payload?.targetSkillFile;
+    if (
+      !entry ||
+      entry.record.kind !== "create" ||
+      entry.record.status !== "applied" ||
+      typeof originalFile !== "string" ||
+      !path.isAbsolute(originalFile) ||
+      path.basename(originalFile) !== "SKILL.md"
+    ) {
+      continue;
+    }
+    const source = path.dirname(originalFile);
+    const destination = path.resolve(entry.record.target.skillDir);
+    const { ownerAgentId } = inferOwnerAgentId({
+      config: params.config,
+      env: params.env,
+      record: entry.record,
+      workspaceDir: undefined,
+      rowOwnerAgentId: entry.ownerAgentId,
+    });
+    if (
+      !ownerAgentId ||
+      !entry.ownerAgentId ||
+      source === destination ||
+      !resolveLegacyWorkshopWorkspaceDir(source, params.config, params.env) ||
+      !isPathInside(resolveWorkshopSkillsDir(params.config, ownerAgentId, params.env), destination)
+    ) {
+      continue;
+    }
+    const destinations = relocations.get(source) ?? new Set<string>();
+    destinations.add(destination);
+    relocations.set(source, destinations);
+  }
+  if (relocations.size === 0) {
+    return [];
+  }
+  const { store } = await loadCronJobsStoreWithConfigJobsReadOnly(
+    resolveCronJobsStorePathFromConfig(params.config, params.env),
+    params.env,
+  );
+  const references: WorkshopAutomationReference[] = [];
+  const orderedRelocations = [...relocations].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  for (const job of store.jobs.toSorted((left, right) => left.id.localeCompare(right.id))) {
+    for (const { field, value, completePath } of automationFields(job)) {
+      for (const [source, destinations] of orderedRelocations) {
+        if (!containsLiteralRoot(value, source)) {
+          continue;
+        }
+        const exactPath = completePath && path.isAbsolute(value) && isPathInside(source, value);
+        if (await existingPath(exactPath ? value : source)) {
+          continue;
+        }
+        let fixHint =
+          "Relocation target unresolved: retained records do not identify one destination. Review this field manually.";
+        if (destinations.size === 1) {
+          const destination = [...destinations][0]!;
+          const destinationRoot = await existingPath(destination);
+          if (exactPath && destinationRoot) {
+            const replacement = path.join(destination, path.relative(source, value));
+            const resolved = await existingPath(replacement);
+            fixHint =
+              resolved && isPathInside(destinationRoot, resolved)
+                ? `Verified replacement path: ${replacement}. Review this field manually; Doctor leaves automation content unchanged.`
+                : "Replacement path unresolved: the mapped target is missing or outside the Workshop skill. Review this field manually.";
+          } else if (destinationRoot) {
+            fixHint = `Recorded directory relocation: ${source} -> ${destination}. Embedded target unresolved; review this field manually. Doctor leaves automation content unchanged.`;
+          } else {
+            fixHint =
+              "Replacement path unresolved: the recorded Workshop destination is missing. Review this field manually.";
+          }
+        }
+        references.push({
+          automationId: job.id,
+          field,
+          message: `Automation ${job.id} ${field} references legacy Workshop path ${source}.`,
+          fixHint,
+        });
+      }
+    }
+  }
+  return references;
+}

--- a/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   loadCronJobsStoreWithConfigJobsReadOnly,
   resolveCronJobsStorePathFromConfig,
@@ -55,7 +56,9 @@ async function snapshotDatabase(databasePath: string) {
 describe("read-only Skill Workshop migration inspection", () => {
   it("reports each stale automation field after relocation without changing stored state", async () => {
     await withOpenClawTestState({ label: "workshop-automation-paths" }, async (state) => {
-      const config = { agents: { entries: { main: { workspace: state.workspaceDir } } } };
+      const config: OpenClawConfig = {
+        agents: { entries: { main: { workspace: state.workspaceDir } } },
+      };
       const legacy = path.join(state.workspaceDir, "skills", "relocated");
       const content = "---\nname: relocated\ndescription: Saved procedure\n---\n\n# Saved\n";
       const record = createAppliedLegacyProposal({

--- a/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
@@ -2,13 +2,24 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  loadCronJobsStoreWithConfigJobsReadOnly,
+  resolveCronJobsStorePathFromConfig,
+  saveCronStore,
+} from "../cron/store.js";
+import type { CronJob } from "../cron/types.js";
 import { createCoreHealthChecks } from "../flows/doctor-core-checks.js";
 import { exitCodeFromFindings, runDoctorLintChecks } from "../flows/doctor-lint-flow.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { createSkillProposalEvent } from "../skills/workshop/plugin-hooks.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
+import { appendSkillProposalEvent } from "../skills/workshop/store-sqlite-event.js";
 import { importLegacySkillProposal } from "../skills/workshop/store.js";
 import type { SkillProposalRecord } from "../skills/workshop/types.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
@@ -42,6 +53,111 @@ async function snapshotDatabase(databasePath: string) {
 }
 
 describe("read-only Skill Workshop migration inspection", () => {
+  it("reports each stale automation field after relocation without changing stored state", async () => {
+    await withOpenClawTestState({ label: "workshop-automation-paths" }, async (state) => {
+      const config = { agents: { entries: { main: { workspace: state.workspaceDir } } } };
+      const legacy = path.join(state.workspaceDir, "skills", "relocated");
+      const content = "---\nname: relocated\ndescription: Saved procedure\n---\n\n# Saved\n";
+      const record = createAppliedLegacyProposal({
+        id: "relocated-20260901-1234567890",
+        title: "Saved procedure",
+        description: "Saved procedure",
+        content,
+        target: { skillKey: "relocated", skillDir: legacy },
+      });
+      await fs.mkdir(path.join(legacy, "scripts"), { recursive: true });
+      await fs.writeFile(record.target.skillFile, content);
+      await fs.writeFile(path.join(legacy, "scripts", "check.sh"), "printf ready\n");
+      importLegacySkillProposal({ record, ownerAgentId: "main", store: { env: state.env } });
+      appendSkillProposalEvent(
+        openOpenClawStateDatabase({ env: state.env }).db,
+        createSkillProposalEvent({
+          record,
+          type: "applied",
+          payload: { targetSkillFile: record.target.skillFile },
+        }),
+      );
+      const job = (id: string, payload: CronJob["payload"]): CronJob => ({
+        id,
+        name: id,
+        agentId: "main",
+        enabled: true,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+        schedule: { kind: "every", everyMs: 86400000, anchorMs: 1 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload,
+        state: { nextRunAtMs: 86400001 },
+      });
+      const jobs = [
+        job("command", {
+          kind: "command",
+          argv: [
+            "/bin/sh",
+            `${legacy}/scripts/check.sh`,
+            `${legacy}-other/check.sh`,
+            `sh ${legacy}/scripts/check.sh`,
+            `${legacy}.other/check.sh`,
+          ],
+          cwd: legacy,
+        }),
+        {
+          ...job("condition", {
+            kind: "agentTurn",
+            message: `Private prose: read ${legacy}/scripts/check.sh.`,
+          }),
+          trigger: {
+            script: `const result = await exec({ command: '/bin/sh ${legacy}/scripts/check.sh' }); json({ fire: false });`,
+          },
+        },
+        job("missing", { kind: "command", argv: ["/bin/sh", `${legacy}/scripts/not-created.sh`] }),
+      ];
+      const storePath = resolveCronJobsStorePathFromConfig(config, state.env);
+      await saveCronStore(storePath, { version: 1, jobs });
+      const before = await loadCronJobsStoreWithConfigJobsReadOnly(storePath, state.env);
+      await migrateLegacySkillWorkshopProposals({ config, env: state.env });
+      await expect(fs.access(legacy)).rejects.toMatchObject({ code: "ENOENT" });
+      closeOpenClawStateDatabaseForTest();
+      const databasePath = resolveOpenClawStateSqlitePath(state.env);
+      const databaseBefore = await snapshotDatabase(databasePath);
+      const filesBefore = await fs.readdir(state.stateDir, { recursive: true });
+      const destination = path.join(
+        resolveWorkshopSkillsDir(config, "main", state.env),
+        "relocated",
+      );
+
+      for (let inspection = 0; inspection < 2; inspection += 1) {
+        const result = await runDoctorLintChecks(
+          { mode: "lint", runtime: { log() {}, error() {}, exit() {} }, cfg: config },
+          { checks: createCoreHealthChecks(), onlyIds: ["core/doctor/skill-workshop-relocation"] },
+        );
+        expect(
+          result.findings.map(({ target, path: field }) => `${target}:${field}`).toSorted(),
+        ).toEqual([
+          "command:payload.argv[1]",
+          "command:payload.argv[3]",
+          "command:payload.cwd",
+          "condition:payload.message",
+          "condition:trigger.script",
+          "missing:payload.argv[1]",
+        ]);
+        const find = (id: string, field: string) =>
+          result.findings.find((finding) => finding.target === id && finding.path === field);
+        expect(find("command", "payload.argv[1]")?.fixHint).toContain(
+          `${destination}/scripts/check.sh`,
+        );
+        expect(find("command", "payload.cwd")?.fixHint).toContain(destination);
+        expect(find("missing", "payload.argv[1]")?.fixHint).toContain("unresolved");
+        expect(find("condition", "trigger.script")?.fixHint).toContain("unresolved");
+        expect(find("condition", "payload.message")?.message).not.toContain("Private prose");
+        expect(await loadCronJobsStoreWithConfigJobsReadOnly(storePath, state.env)).toEqual(before);
+        expect(await snapshotDatabase(databasePath)).toEqual(databaseBefore);
+        expect(await fs.readdir(state.stateDir, { recursive: true })).toEqual(filesBefore);
+      }
+    });
+  });
+
   it("identifies remaining targets after retargeting without recommending an identical repair", async () => {
     await withOpenClawTestState({ label: "workshop-remaining-targets" }, async (state) => {
       const config = { agents: { entries: { main: { workspace: state.workspaceDir } } } };

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -21,6 +21,7 @@ import type { MigrationMessages } from "../infra/state-migrations.types.js";
 import { transitionPendingSkillProposalToStale } from "../skills/workshop/apply-transition.js";
 import { reconcileInterruptedSkillProposalApply } from "../skills/workshop/reconcile-transition.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
+import { readAppliedSkillProposalEvents } from "../skills/workshop/store-sqlite-event.js";
 import {
   parseSkillProposalRow,
   readStoredProposal,
@@ -37,7 +38,11 @@ import {
   validateSkillProposalRecord,
   validateSkillProposalRollback,
 } from "../skills/workshop/store.js";
-import type { SkillProposalRecord, SkillProposalRollback } from "../skills/workshop/types.js";
+import type {
+  SkillProposalEvent,
+  SkillProposalRecord,
+  SkillProposalRollback,
+} from "../skills/workshop/types.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -46,6 +51,10 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  inspectWorkshopAutomationReferences,
+  type WorkshopAutomationReference,
+} from "./doctor-skill-workshop-automations.js";
 import {
   listPendingLegacyCollectionBackupRoots,
   listWorkspaceOwnerAgentIds,
@@ -99,6 +108,7 @@ export type LegacyWorkshopMigrationInspection = {
   externalProposalDetails?: string[];
   legacyBackupRootCount: number;
   preservedLegacyBackupRootCount: number;
+  automationReferences?: WorkshopAutomationReference[];
 };
 
 async function readJson(rootDir: Root, relativePath: string, maxBytes: number): Promise<unknown> {
@@ -117,6 +127,7 @@ export async function inspectLegacySkillWorkshopMigration(params: {
   const env = params.env ?? process.env;
   const database = await openExistingOpenClawStateDatabaseReadOnly({ env });
   let records: LegacyWorkshopProposal[] = [];
+  let appliedEvents: SkillProposalEvent[] = [];
   try {
     if (database && tableExists(database.db, "skill_workshop_proposals")) {
       const kysely = getNodeSqliteKysely<Pick<OpenClawStateDatabase, "skill_workshop_proposals">>(
@@ -134,6 +145,9 @@ export async function inspectLegacySkillWorkshopMigration(params: {
           return [];
         }
       });
+      if (tableExists(database.db, "skill_workshop_proposal_events")) {
+        appliedEvents = readAppliedSkillProposalEvents(database.db);
+      }
     }
   } finally {
     database?.walMaintenance.close();
@@ -141,6 +155,12 @@ export async function inspectLegacySkillWorkshopMigration(params: {
   // Lint needs ownership counts, not adoption verification through writable recovery readers.
   const { external } = classifyWorkshopRelocation(records, params.config, env);
   const backups = await listPendingLegacyCollectionBackupRoots(params.config, env);
+  const automationReferences = await inspectWorkshopAutomationReferences({
+    config: params.config,
+    env,
+    records,
+    appliedEvents,
+  });
   return {
     externalProposalCount: external.length,
     externalProposalCountsByAgent: external.reduce<Record<string, number>>((counts, plan) => {
@@ -164,6 +184,7 @@ export async function inspectLegacySkillWorkshopMigration(params: {
       : {}),
     legacyBackupRootCount: backups.length,
     preservedLegacyBackupRootCount: backups.filter((backup) => "warning" in backup).length,
+    ...(automationReferences.length > 0 ? { automationReferences } : {}),
   };
 }
 

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -361,8 +361,16 @@ const skillWorkshopRelocationCheck: HealthCheck = {
       config: ctx.cfg,
       env: process.env,
     });
+    const automationFindings = (inspection.automationReferences ?? []).map((reference) => ({
+      checkId: SKILL_WORKSHOP_RELOCATION_CHECK_ID,
+      severity: "warning" as const,
+      target: reference.automationId,
+      path: reference.field,
+      message: reference.message,
+      fixHint: reference.fixHint,
+    }));
     if (inspection.externalProposalCount === 0 && inspection.legacyBackupRootCount === 0) {
-      return [];
+      return automationFindings;
     }
     const fixHints: string[] = [];
     if (
@@ -381,6 +389,7 @@ const skillWorkshopRelocationCheck: HealthCheck = {
       );
     }
     return [
+      ...automationFindings,
       {
         checkId: SKILL_WORKSHOP_RELOCATION_CHECK_ID,
         severity: "warning",

--- a/src/skills/workshop/store-sqlite-event.ts
+++ b/src/skills/workshop/store-sqlite-event.ts
@@ -156,6 +156,22 @@ export function listStoredSkillProposalEvents(
   };
 }
 
+/** Reads apply provenance through the caller's existing connection without opening a writable store. */
+export function readAppliedSkillProposalEvents(database: DatabaseSync): SkillProposalEvent[] {
+  const kysely = getNodeSqliteKysely<SkillWorkshopDatabase>(database);
+  return executeSqliteQuerySync(
+    database,
+    kysely
+      .selectFrom("skill_workshop_proposal_events")
+      .selectAll()
+      .where("event_type", "=", "applied")
+      .orderBy("sequence", "asc"),
+  ).rows.flatMap((row) => {
+    const event = parseStoredSkillProposalEventRow(row);
+    return event ? [event] : [];
+  });
+}
+
 function parseStoredSkillProposalEventRow(
   row: StoredSkillProposalEventRow,
 ): SkillProposalEvent | null {


### PR DESCRIPTION
## What Problem This Solves

Workshop relocation can remove a skill's old directory while saved automations still name scripts there. Doctor reports a successful relocation without identifying the affected automations.

## Why This Change Was Made

Doctor now reads retained Workshop apply history and automation records through the existing read-only store owners. It reports the automation ID and exact argument, working-directory, condition-script, or message field that contains a stale literal path.

## User Impact

Doctor reports these references during repair and on later checks. Complete argument and working-directory paths get a verified replacement only when the mapped target exists. Embedded, missing, or ambiguous targets stay explicit for manual review. Automation content, schedules, enabled state, revisions, and run state remain unchanged.

Detection depends on retained apply history that identifies the original skill directory. Doctor does not infer a missing historical path from a current skill name.

## Evidence

- Reproduced with the public v2026.9.2 Workshop and automation commands, followed by Doctor on pinned main: relocation succeeded, stale paths remained, and both Doctor checks omitted automation warnings.
- The regression failed on original production code and passed with this repair.
- 36 focused relocation, read-only inspection, and collection-backup tests passed.
- Formatting, syntax lint, size and assertion checks, and the runtime build passed.
- Independent public acceptance passed: all six stale fields reported during repair and repeat checks; complete original automation records stayed unchanged; fresh-state, missing-file, ordinary-skill, current-path, and similar-prefix controls passed. No automation ran.
- Independent source review found no actionable defects. Backup migration preservation is covered by the unchanged owner and focused tests; no nonempty public historical backup fixture is claimed.

Thanks @rayseling for the report.

Fixes #144610
