### PR TITLE
fix(android): wait for rendered connection status in tests

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasAnyChild
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -345,7 +346,7 @@ class SettingsScreensContrastTest {
       gateway.healthReady = false
       model.refreshChat()
     }
-    awaitConnectedHealthFailure(model)
+    awaitConnectedHealthFailure(model, showHeader = false)
     chatHealthStatusValue("Not ready").performScrollTo().assertIsDisplayed()
   }
 
@@ -367,14 +368,20 @@ class SettingsScreensContrastTest {
       gateway.healthReady = false
       model.refreshChat()
     }
-    awaitConnectedHealthFailure(model)
+    awaitConnectedHealthFailure(model, showHeader = true)
     composeRule.onNodeWithContentDescription(readyDescription.removeSuffix(ready) + nativeString("Not ready")).assertIsDisplayed()
   }
 
-  private fun chatHealthStatusValue(value: String) =
-    composeRule.onNode(
-      hasText(nativeString(value)) and hasAnyAncestor(hasAnyChild(hasText(nativeString("Chat")))),
-    )
+  private fun chatHealthStatusValue(value: String) = composeRule.onNode(chatStatusMatcher(showHeader = false, value = value))
+
+  private fun chatStatusMatcher(
+    showHeader: Boolean,
+    value: String,
+  ) = if (showHeader) {
+    hasContentDescription(", ${nativeString(value)}", substring = true)
+  } else {
+    hasText(nativeString(value)) and hasAnyAncestor(hasAnyChild(hasText(nativeString("Chat"))))
+  }
 
   private fun showLiveChatStatus(showHeader: Boolean): MainViewModel {
     app = RuntimeEnvironment.getApplication() as NodeApp
@@ -406,17 +413,21 @@ class SettingsScreensContrastTest {
       }
     }
     composeRule.runOnIdle { model.connect(gateway.endpoint) }
-    awaitHealthyChatStatus(model)
+    awaitHealthyChatStatus(model, showHeader)
     return model
   }
 
-  private fun awaitHealthyChatStatus(model: MainViewModel) {
+  private fun awaitHealthyChatStatus(
+    model: MainViewModel,
+    showHeader: Boolean,
+  ) {
     composeRule.waitUntil(10_000) {
       // Live runtime updates reach ViewModel flows through Robolectric's paused main looper.
       shadowOf(Looper.getMainLooper()).idle()
       model.gatewayConnectionDisplay.value.isConnected && model.chatHealthOk.value &&
         !model.chatHistoryLoading.value && model.chatMessages.value.isEmpty() &&
-        model.pendingRunCount.value == 0 && !model.chatSessionCreating.value
+        model.pendingRunCount.value == 0 && !model.chatSessionCreating.value &&
+        composeRule.onAllNodes(chatStatusMatcher(showHeader, "Ready")).fetchSemanticsNodes().isNotEmpty()
     }
   }
 
@@ -427,7 +438,8 @@ class SettingsScreensContrastTest {
     composeRule.runOnIdle { model.disconnect() }
     composeRule.waitUntil(10_000) {
       shadowOf(Looper.getMainLooper()).idle()
-      !model.gatewayConnectionDisplay.value.isConnected && !model.isConnected.value && !model.chatHealthOk.value
+      !model.gatewayConnectionDisplay.value.isConnected && !model.isConnected.value && !model.chatHealthOk.value &&
+        composeRule.onAllNodesWithText(nativeString(if (showHeader) "Gateway offline" else "Offline")).fetchSemanticsNodes().isNotEmpty()
     }
     if (showHeader) {
       composeRule.onAllNodesWithText(nativeString("Gateway offline"))[0].assertIsDisplayed()
@@ -435,15 +447,19 @@ class SettingsScreensContrastTest {
       composeRule.onAllNodesWithText(nativeString("Offline"))[0].performScrollTo().assertIsDisplayed()
     }
     composeRule.runOnIdle { model.connect(gateway.endpoint) }
-    awaitHealthyChatStatus(model)
+    awaitHealthyChatStatus(model, showHeader)
   }
 
-  private fun awaitConnectedHealthFailure(model: MainViewModel) {
+  private fun awaitConnectedHealthFailure(
+    model: MainViewModel,
+    showHeader: Boolean,
+  ) {
     composeRule.waitUntil(10_000) {
       shadowOf(Looper.getMainLooper()).idle()
       model.gatewayConnectionDisplay.value.isConnected && !model.chatHealthOk.value &&
         !model.chatHistoryLoading.value && model.chatMessages.value.isEmpty() &&
-        model.pendingRunCount.value == 0 && !model.chatSessionCreating.value
+        model.pendingRunCount.value == 0 && !model.chatSessionCreating.value &&
+        composeRule.onAllNodes(chatStatusMatcher(showHeader, "Not ready")).fetchSemanticsNodes().isNotEmpty()
     }
   }
 


### PR DESCRIPTION
Related: #143128

## What Problem This Solves

Resolves intermittent Android CI failures after connection, reconnect, or a failed chat health check. The status test can see updated ViewModel values before the Chat header or Settings screen has rendered them.

This is a maintainer-requested repair of the observed main failure.

## Why This Change Was Made

The existing waits now require the expected rendered status as well as the existing model conditions. A shared matcher keeps Settings assertions and readiness checks aligned. Every display assertion and the 10-second timeout remain unchanged.

## User Impact

Android validation observes the actual screen state before asserting it. Product code and behavior are unchanged.

## Evidence

- On main `0b48b3e78c91576a2ad9d02654f474d694d3fae6`, the exact third-party unit-test command failed `SettingsScreensContrastTest.chatHeaderDoesNotAnnounceOfflineForConnectedHealthFailure`: `New chat, Ready` was not displayed after reconnect. The Play command passed.
- The changed Settings/header suite and the neighboring `GatewayExecApprovalRuntimeTest` pass on the candidate.
- A temporary control changed only the header's connected-but-unhealthy text to `Gateway offline`. The retained test rejected that behavior at the unchanged 10-second timeout. Production source was restored afterward.
- Android test-source formatting and `git diff --check` pass.
- Control UI performance already passes without a budget change. The final candidate measures 352878 bytes against the unchanged 353107-byte startup limit.

- Full candidate Android commands passed on `03e4e9bd3c441443560aaca05001c801f7be03ed`: Play unit tests plus shared Wear tests (6m27s) and lint (1m59s); third-party unit tests (6m40s) and lint (1m47s).
