### PR TITLE
fix(macos): dismiss approval panels resolved elsewhere

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovalQueueStore.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalQueueStore.swift
@@ -5,7 +5,7 @@ import OpenClawProtocol
 import OSLog
 
 struct ExecApprovalQueueItem: Decodable, Identifiable {
-    enum ApprovalKind {
+    enum ApprovalKind: Hashable {
         case exec
         case systemAgent
     }

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
@@ -11,6 +11,24 @@ final class ExecApprovalsGatewayPrompter {
     private let logger = Logger(subsystem: "ai.openclaw", category: "exec-approvals.gateway")
     private let gateway: GatewayConnection
     private var task: Task<Void, Never>?
+    private var promptTasks: [PromptKey: PromptTask] = [:]
+
+    private struct PromptKey: Hashable {
+        let id: String
+        let kind: ExecApprovalQueueItem.ApprovalKind
+        let serverLease: GatewayConnection.ServerLease
+    }
+
+    private struct PromptTask {
+        let token: UUID
+        let task: Task<Void, Never>
+        var phase: PromptPhase
+    }
+
+    private enum PromptPhase {
+        case presenting
+        case resolving
+    }
 
     init(gateway: GatewayConnection = .shared) {
         self.gateway = gateway
@@ -24,32 +42,49 @@ final class ExecApprovalsGatewayPrompter {
     }
 
     func start() {
-        SimpleTaskSupport.start(task: &self.task) { [weak self] in
-            await self?.run()
+        let gateway = self.gateway
+        SimpleTaskSupport.start(task: &self.task) { @MainActor [weak self, gateway] in
+            await GatewayPushSubscription.consume(connection: gateway, bufferingNewest: 200) { [weak self] delivery in
+                self?.handle(delivery: delivery)
+            }
         }
     }
 
     func stop() {
         SimpleTaskSupport.stop(task: &self.task)
+        self.cancelAllPrompts()
     }
 
-    private func run() async {
-        let stream = await self.gateway.subscribe(bufferingNewest: 200)
-        for await delivery in stream {
-            if Task.isCancelled {
+    private func handle(delivery: GatewayConnection.PushDelivery) {
+        guard let push = delivery.push else {
+            self.cancelPrompts(serverLease: delivery.serverLease)
+            return
+        }
+        guard delivery.isCurrent, case let .event(evt) = push, let payload = evt.payload else { return }
+        let kind: ExecApprovalQueueItem.ApprovalKind
+        switch evt.event {
+        case "exec.approval.requested", "exec.approval.resolved":
+            kind = .exec
+        case "openclaw.approval.requested", "openclaw.approval.resolved":
+            kind = .systemAgent
+        default:
+            return
+        }
+
+        if evt.event.hasSuffix(".resolved") {
+            guard let resolved = try? GatewayPayloadDecoding.decode(payload, as: ResolvedApproval.self) else {
                 return
             }
-            await self.handle(delivery: delivery)
+            // The Gateway echoes our own successful resolution before its RPC response.
+            // Dismiss pending UI, but let an in-flight decision observe that response.
+            self.cancelPrompt(
+                PromptKey(id: resolved.id, kind: kind, serverLease: delivery.serverLease),
+                ifPresentingOnly: true)
+            return
         }
-    }
 
-    private func handle(delivery: GatewayConnection.PushDelivery) async {
-        guard delivery.isCurrent, let push = delivery.push, case let .event(evt) = push else { return }
-        guard evt.event == "exec.approval.requested" || evt.event == "openclaw.approval.requested" else { return }
-        guard let payload = evt.payload else { return }
         do {
-            let data = try JSONEncoder().encode(payload)
-            let request = try JSONDecoder().decode(GatewayApprovalRequest.self, from: data)
+            let request = try GatewayPayloadDecoding.decode(payload, as: GatewayApprovalRequest.self)
             // The Gateway emitted this event because its own policy requires a
             // decision. If this Mac cannot present UI, leave the request
             // unresolved so the Gateway applies its current timeout fallback.
@@ -57,28 +92,105 @@ final class ExecApprovalsGatewayPrompter {
             let nowMs = Int(Date().timeIntervalSince1970 * 1000)
             let (remainingMs, overflow) = request.expiresAtMs.subtractingReportingOverflow(nowMs)
             guard !overflow, remainingMs > 0 else { return }
-            guard let decision = await ExecApprovalsPromptPresenter.prompt(
-                request.request,
-                timeoutMs: remainingMs)
-            else {
-                return
+            let key = PromptKey(id: request.id, kind: kind, serverLease: delivery.serverLease)
+            guard self.promptTasks[key] == nil else { return }
+            let token = UUID()
+            let gateway = self.gateway
+            let task = Task { [weak self, gateway] in
+                guard let self else { return }
+                defer { self.finishPrompt(key: key, token: token) }
+                await self.present(
+                    request: request,
+                    kind: kind,
+                    key: key,
+                    token: token,
+                    gateway: gateway)
             }
-            guard delivery.isCurrent else {
-                self.logger.info("exec approval decision discarded after the Gateway connection changed")
-                return
-            }
-            let isSystemAgent = evt.event == "openclaw.approval.requested"
-            var params = ["id": AnyCodable(request.id), "decision": AnyCodable(decision.rawValue)]
-            if isSystemAgent { params["kind"] = AnyCodable("system-agent") }
-            let method: GatewayConnection.Method = isSystemAgent ? .approvalResolve : .execApprovalResolve
-            _ = try await self.gateway.request(
-                method: method.rawValue,
-                params: params,
-                timeoutMs: 10000,
-                ifCurrentServerLease: delivery.serverLease)
+            self.promptTasks[key] = PromptTask(token: token, task: task, phase: .presenting)
         } catch {
             self.logger.error("exec approval handling failed \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    private func present(
+        request: GatewayApprovalRequest,
+        kind: ExecApprovalQueueItem.ApprovalKind,
+        key: PromptKey,
+        token: UUID,
+        gateway: GatewayConnection) async
+    {
+        var hasLocalDecision = false
+        do {
+            let nowMs = Int(Date().timeIntervalSince1970 * 1000)
+            let (remainingMs, overflow) = request.expiresAtMs.subtractingReportingOverflow(nowMs)
+            guard !overflow, remainingMs > 0 else { return }
+            guard let decision = await ExecApprovalsPromptPresenter.prompt(
+                request.request,
+                timeoutMs: remainingMs,
+                isStillEligible: { self.shouldPresent(request: request) })
+            else {
+                return
+            }
+            guard gateway.serverLeaseMatchesCurrentState(key.serverLease) else {
+                self.logger.info("exec approval decision discarded after the Gateway connection changed")
+                return
+            }
+            var params = ["id": AnyCodable(request.id), "decision": AnyCodable(decision.rawValue)]
+            if kind == .systemAgent { params["kind"] = AnyCodable("system-agent") }
+            let method: GatewayConnection.Method = kind == .systemAgent ? .approvalResolve : .execApprovalResolve
+            hasLocalDecision = true
+            self.markResolving(key: key, token: token)
+            _ = try await gateway.request(
+                method: method.rawValue,
+                params: params,
+                timeoutMs: 10000,
+                ifCurrentServerLease: key.serverLease)
+        } catch is CancellationError {
+            // Cancellation before a local decision means another owner won. Once the user
+            // decides, retain a diagnostic if ownership changes before the RPC completes.
+            if hasLocalDecision {
+                self.logger.info("exec approval decision discarded after approval ownership changed")
+            }
+        } catch {
+            self.logger.error("exec approval handling failed \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func cancelPrompt(_ key: PromptKey, ifPresentingOnly: Bool = false) {
+        guard let promptTask = self.promptTasks[key], !ifPresentingOnly || promptTask.phase == .presenting else {
+            return
+        }
+        self.promptTasks.removeValue(forKey: key)
+        promptTask.task.cancel()
+    }
+
+    private func cancelPrompts(serverLease: GatewayConnection.ServerLease) {
+        let keys = self.promptTasks.keys.filter { $0.serverLease == serverLease }
+        for key in keys {
+            self.cancelPrompt(key)
+        }
+    }
+
+    private func cancelAllPrompts() {
+        let tasks = self.promptTasks.values.map(\.task)
+        self.promptTasks.removeAll()
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    private func finishPrompt(key: PromptKey, token: UUID) {
+        guard self.promptTasks[key]?.token == token else { return }
+        self.promptTasks.removeValue(forKey: key)
+    }
+
+    private func markResolving(key: PromptKey, token: UUID) {
+        guard self.promptTasks[key]?.token == token else { return }
+        self.promptTasks[key]?.phase = .resolving
+    }
+
+    private struct ResolvedApproval: Decodable {
+        let id: String
     }
 
     private func shouldPresent(request: GatewayApprovalRequest) -> Bool {
@@ -129,6 +241,12 @@ final class ExecApprovalsGatewayPrompter {
 
 #if DEBUG
 extension ExecApprovalsGatewayPrompter {
+    func _testHandle(deliveries: [GatewayConnection.PushDelivery]) {
+        for delivery in deliveries {
+            self.handle(delivery: delivery)
+        }
+    }
+
     static func _testShouldPresent(
         mode: AppState.ConnectionMode,
         activeSession: String?,

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsPromptPresenter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsPromptPresenter.swift
@@ -23,7 +23,8 @@ enum ExecApprovalsPromptPresenter {
     @MainActor
     static func prompt(
         _ request: ExecApprovalPromptRequest,
-        timeoutMs: Int? = nil) async -> ExecApprovalDecision?
+        timeoutMs: Int? = nil,
+        isStillEligible: @MainActor () -> Bool = { true }) async -> ExecApprovalDecision?
     {
         if let timeoutMs, timeoutMs <= 0 { return nil }
         let promptID = UUID()
@@ -43,6 +44,10 @@ enum ExecApprovalsPromptPresenter {
         return await withTaskCancellationHandler {
             guard !Task.isCancelled, await self.acquirePrompt(id: promptID) else { return nil }
             guard !Task.isCancelled, self.activePrompt?.cancelled != true else {
+                self.releasePrompt(id: promptID)
+                return nil
+            }
+            guard isStillEligible() else {
                 self.releasePrompt(id: promptID)
                 return nil
             }

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
@@ -6,46 +6,78 @@ import Testing
 @MainActor
 struct ExecApprovalPromptLayoutTests {
     @Test func `queued prompt expires without later presentation`() async throws {
-        let reservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
-        defer { ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation) }
+        try await TestIsolation.withIsolatedState {
+            let reservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
+            defer { ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation) }
 
-        let decision = await ExecApprovalsPromptPresenter.prompt(
-            ExecApprovalPromptRequest(command: "/usr/bin/printf ok"),
-            timeoutMs: 1)
+            let decision = await ExecApprovalsPromptPresenter.prompt(
+                ExecApprovalPromptRequest(command: "/usr/bin/printf ok"),
+                timeoutMs: 1)
 
-        #expect(decision == nil)
-        #expect(ExecApprovalsPromptPresenter.pendingPromptCountForTesting == 0)
+            #expect(decision == nil)
+            #expect(ExecApprovalsPromptPresenter.pendingPromptCountForTesting == 0)
+        }
     }
 
     @Test func `active prompt expiry releases presentation for the next request`() async throws {
-        for command in ["/usr/bin/printf first", "/usr/bin/printf second"] {
-            let decision = await ExecApprovalsPromptPresenter.prompt(
-                ExecApprovalPromptRequest(command: command),
-                timeoutMs: 20)
+        try await TestIsolation.withIsolatedState {
+            for command in ["/usr/bin/printf first", "/usr/bin/printf second"] {
+                let decision = await ExecApprovalsPromptPresenter.prompt(
+                    ExecApprovalPromptRequest(command: command),
+                    timeoutMs: 20)
 
-            #expect(decision == nil)
-            let reservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
-            ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation)
+                #expect(decision == nil)
+                let reservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
+                ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation)
+            }
         }
     }
 
     @Test func `cancelling an active prompt releases presentation for the next request`() async throws {
-        let prompt = Task {
-            await ExecApprovalsPromptPresenter.prompt(
-                ExecApprovalPromptRequest(command: "/usr/bin/printf cancelled"))
-        }
-        defer { prompt.cancel() }
-        await Task.yield()
-        try await Task.sleep(for: .milliseconds(20))
-        prompt.cancel()
+        try await TestIsolation.withIsolatedState {
+            let prompt = Task {
+                await ExecApprovalsPromptPresenter.prompt(
+                    ExecApprovalPromptRequest(command: "/usr/bin/printf cancelled"))
+            }
+            defer { prompt.cancel() }
+            await Task.yield()
+            try await Task.sleep(for: .milliseconds(20))
+            prompt.cancel()
 
-        #expect(await prompt.value == nil)
-        let reservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
-        ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation)
-        let nextDecision = await ExecApprovalsPromptPresenter.prompt(
-            ExecApprovalPromptRequest(command: "/usr/bin/printf next"),
-            timeoutMs: 20)
-        #expect(nextDecision == nil)
+            #expect(await prompt.value == nil)
+            let reservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
+            ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation)
+            let nextDecision = await ExecApprovalsPromptPresenter.prompt(
+                ExecApprovalPromptRequest(command: "/usr/bin/printf next"),
+                timeoutMs: 20)
+            #expect(nextDecision == nil)
+        }
+    }
+
+    @Test func `queued prompt rechecks eligibility before presentation`() async throws {
+        try await TestIsolation.withIsolatedState {
+            let reservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
+            var eligible = true
+            var eligibilityChecks = 0
+            let prompt = Task {
+                await ExecApprovalsPromptPresenter.prompt(
+                    ExecApprovalPromptRequest(command: "/usr/bin/printf stale"),
+                    timeoutMs: 100,
+                    isStillEligible: {
+                        eligibilityChecks += 1
+                        return eligible
+                    })
+            }
+            #expect(await Self.waitForPendingPromptCount(1))
+
+            eligible = false
+            ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation)
+
+            #expect(await prompt.value == nil)
+            #expect(eligibilityChecks == 1)
+            let nextReservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
+            ExecApprovalsPromptPresenter.releasePromptForTesting(id: nextReservation)
+        }
     }
 
     @Test func `allowed decisions omit durable approval even when ask allows it`() {
@@ -240,6 +272,16 @@ struct ExecApprovalPromptLayoutTests {
             ExecApprovalsPromptPresenter.sanitizedContextValue(spoofed) ==
                 "safe\\u{202E}txt\\u{A}next")
         #expect(ExecApprovalsPromptPresenter.sanitizedContextValue(" \n\t ") == nil)
+    }
+
+    private static func waitForPendingPromptCount(_ count: Int) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ExecApprovalsPromptPresenter.pendingPromptCountForTesting != count,
+              ContinuousClock.now < deadline
+        {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        return ExecApprovalsPromptPresenter.pendingPromptCountForTesting == count
     }
 
     private func descendants(of view: NSView) -> [NSView] {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsGatewayPrompterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsGatewayPrompterTests.swift
@@ -1,6 +1,87 @@
+import Foundation
+import OpenClawProtocol
 import Testing
 @testable import OpenClaw
+@testable import OpenClawKit
 
+@MainActor
+private final class ApprovalPrompterGatewayFixture {
+    let gateway: GatewayConnection
+
+    init() {
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                guard sendIndex > 0, let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+                socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+            }, receiveHook: { socket, receiveIndex in
+                if receiveIndex == 0 { return .data(GatewayWebSocketTestSupport.connectChallengeData()) }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: socket.snapshotConnectRequestID() ?? "connect"))
+            })
+        })
+        self.gateway = GatewayConnection(
+            configProvider: { (URL(string: "ws://127.0.0.1:49258")!, nil, nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+    }
+
+    func connect() async throws {
+        _ = try await self.gateway.request(method: "health", params: nil, retryTransportFailures: false)
+    }
+
+    func sendRequested(id: String, systemAgent: Bool = false) async {
+        let nowMs = Int(Date().timeIntervalSince1970 * 1000)
+        let payload = AnyCodable([
+            "id": id,
+            "request": ["command": "echo safe"],
+            "createdAtMs": nowMs,
+            "expiresAtMs": nowMs + 60000,
+        ])
+        await self.sendEvent(
+            name: systemAgent ? "openclaw.approval.requested" : "exec.approval.requested",
+            payload: payload)
+    }
+
+    func sendResolved(id: String, systemAgent: Bool = false) async {
+        await self.sendEvent(
+            name: systemAgent ? "openclaw.approval.resolved" : "exec.approval.resolved",
+            payload: AnyCodable(["id": id]))
+    }
+
+    func disconnect() async {
+        await self.gateway._test_handleDisconnect(socketGeneration: 1)
+    }
+
+    func resolvedThenRequestedDeliveries(id: String) async throws -> [GatewayConnection.PushDelivery] {
+        let resolved = try #require(await self.gateway.makePushDelivery(.event(Self.resolvedEvent(id: id))))
+        let requested = try #require(await self.gateway.makePushDelivery(.event(Self.requestedEvent(id: id))))
+        return [resolved, requested]
+    }
+
+    private func sendEvent(name: String, payload: AnyCodable) async {
+        await self.gateway._test_handlePush(
+            .event(EventFrame(type: "event", event: name, payload: payload)),
+            socketGeneration: 1)
+    }
+
+    private static func requestedEvent(id: String) -> EventFrame {
+        let nowMs = Int(Date().timeIntervalSince1970 * 1000)
+        return EventFrame(
+            type: "event",
+            event: "exec.approval.requested",
+            payload: AnyCodable([
+                "id": id,
+                "request": ["command": "echo safe"],
+                "createdAtMs": nowMs,
+                "expiresAtMs": nowMs + 60000,
+            ]))
+    }
+
+    private static func resolvedEvent(id: String) -> EventFrame {
+        EventFrame(type: "event", event: "exec.approval.resolved", payload: AnyCodable(["id": id]))
+    }
+}
+
+@Suite(.serialized)
 @MainActor
 struct ExecApprovalsGatewayPrompterTests {
     @Test func `session match prefers active session`() {
@@ -51,5 +132,87 @@ struct ExecApprovalsGatewayPrompterTests {
             requestSession: nil,
             lastInputSeconds: 400)
         #expect(!remote)
+    }
+
+    @Test func `external resolution cancels only the matching queued prompt`() async throws {
+        try await self.withPrompter { fixture, _ in
+            await fixture.sendRequested(id: "approval-a")
+            #expect(await Self.waitForPendingPromptCount(1))
+
+            await fixture.sendResolved(id: "approval-a", systemAgent: true)
+            await fixture.sendResolved(id: "approval-b")
+            try await Task.sleep(for: .milliseconds(20))
+            #expect(ExecApprovalsPromptPresenter.pendingPromptCountForTesting == 1)
+
+            await fixture.sendResolved(id: "approval-a")
+            #expect(await Self.waitForPendingPromptCount(0))
+        }
+    }
+
+    @Test func `connection retirement cancels its queued prompt`() async throws {
+        try await self.withPrompter { fixture, _ in
+            await fixture.sendRequested(id: "approval-a")
+            #expect(await Self.waitForPendingPromptCount(1))
+
+            await fixture.disconnect()
+            #expect(await Self.waitForPendingPromptCount(0))
+        }
+    }
+
+    @Test func `replacement survives stale task completion and stop cancels it`() async throws {
+        try await self.withPrompter { fixture, prompter in
+            await fixture.sendRequested(id: "approval-a")
+            #expect(await Self.waitForPendingPromptCount(1))
+
+            let replacement = try await fixture.resolvedThenRequestedDeliveries(id: "approval-a")
+            prompter._testHandle(deliveries: replacement)
+            try await Task.sleep(for: .milliseconds(20))
+            #expect(await Self.waitForPendingPromptCount(1))
+
+            prompter.stop()
+            #expect(await Self.waitForPendingPromptCount(0))
+        }
+    }
+
+    private func withPrompter(
+        _ body: (ApprovalPrompterGatewayFixture, ExecApprovalsGatewayPrompter) async throws -> Void) async throws
+    {
+        try await TestIsolation.withIsolatedState {
+            let previousMode = AppStateStore.shared.connectionMode
+            AppStateStore.shared.connectionMode = .local
+            defer { AppStateStore.shared.connectionMode = previousMode }
+
+            let reservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
+            let fixture = ApprovalPrompterGatewayFixture()
+            let prompter = ExecApprovalsGatewayPrompter(gateway: fixture.gateway)
+            try await fixture.connect()
+            prompter.start()
+            try await Task.sleep(for: .milliseconds(20))
+
+            do {
+                try await body(fixture, prompter)
+            } catch {
+                prompter.stop()
+                _ = await Self.waitForPendingPromptCount(0)
+                ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation)
+                await fixture.gateway.shutdown()
+                throw error
+            }
+
+            prompter.stop()
+            _ = await Self.waitForPendingPromptCount(0)
+            ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation)
+            await fixture.gateway.shutdown()
+        }
+    }
+
+    private static func waitForPendingPromptCount(_ count: Int) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ExecApprovalsPromptPresenter.pendingPromptCountForTesting != count,
+              ContinuousClock.now < deadline
+        {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        return ExecApprovalsPromptPresenter.pendingPromptCountForTesting == count
     }
 }


### PR DESCRIPTION
Closes #142553

## What Problem This Solves

Fixes an issue where macOS users would keep seeing an obsolete command approval panel after another client had already resolved the request.

## Why This Change Was Made

The Gateway prompter now consumes approval events without blocking on modal UI and cancels only the matching presentation task for the approval kind, request ID, and Gateway lease. It preserves display-time session eligibility, reconnect ownership, and successful self-echoed resolution RPCs.

## User Impact

Approval panels now dismiss when the same request is resolved elsewhere, while unrelated, replacement, and in-flight locally decided approvals retain their existing behavior.

## Evidence

- Added macOS regression coverage for exact kind/ID cancellation, connection retirement, same-ID replacement ownership, stop cleanup, and queued eligibility revalidation.
- `scripts/format-swift.sh macos` (SwiftFormat 0.63.0): pass.
- `swiftc -parse` for all five changed Swift files: pass.
- `git diff --check origin/main...HEAD`: pass.
- `node scripts/check-changed.mjs`: all non-native lanes reached before `lint apps` passed.
- Full native compile, focused tests, and SwiftLint require the repository's full-Xcode CI runner; this host has Command Line Tools only.

AI assistance: Codex implemented and tested this change; independent Codex and Claude review returned clean on the pushed head.
