### PR TITLE
fix(tests): restore heartbeat fixtures when setup fails

### DIFF
--- a/src/infra/heartbeat-outcome-store.test.ts
+++ b/src/infra/heartbeat-outcome-store.test.ts
@@ -1,7 +1,5 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   prepareSystemAgentRunAdmission,
   resolveAdmittedRunActiveAssertion,
@@ -18,12 +16,10 @@ import {
   persistHeartbeatOutcome,
 } from "./heartbeat-outcome-store.js";
 
-const tempDirs: string[] = [];
+const tempDirs = createTempDirTracker();
 
 async function createEnv(): Promise<NodeJS.ProcessEnv> {
-  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-heartbeat-outcome-"));
-  tempDirs.push(stateDir);
-  const env = { OPENCLAW_STATE_DIR: stateDir };
+  const env = { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-heartbeat-outcome-") };
   await upsertSessionEntryCore(
     { agentId: "main", env, sessionKey: "agent:main:main" },
     { sessionId: "heartbeat-outcome-test", updatedAt: 1 },
@@ -34,9 +30,7 @@ async function createEnv(): Promise<NodeJS.ProcessEnv> {
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  tempDirs.cleanup();
 });
 
 describe("heartbeat outcome store", () => {

--- a/src/infra/heartbeat-runner.test-utils.test.ts
+++ b/src/infra/heartbeat-runner.test-utils.test.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { withTempDir } from "../test-utils/temp-dir.js";
+import { withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+
+it("restores the heartbeat sandbox when real scratch storage setup fails", async () => {
+  // The outer scope rescues leaked state when this runs against the broken helper.
+  await withTempDir("openclaw-hb-setup-", async (outer) => {
+    // openclaw-temp-dir: allow verifies cleanup of a real obstructed sandbox
+    const sandbox = await fs.mkdtemp(path.join(await fs.realpath(outer), "sandbox-"));
+    const obstruction = path.join(sandbox, "state", "state");
+    await fs.mkdir(path.dirname(obstruction));
+    await fs.writeFile(obstruction, "owned obstruction", { flag: "wx" });
+    const outerState = path.join(outer, "state-owner");
+    await withEnvAsync(
+      {
+        OPENCLAW_STATE_DIR: outerState,
+        TELEGRAM_BOT_TOKEN: "synthetic-heartbeat-token",
+      },
+      async () => {
+        const callback = vi.fn(async () => undefined);
+        const directoryCreation = vi.spyOn(fs, "mkdtemp").mockResolvedValueOnce(sandbox);
+        try {
+          await expect(
+            withTempHeartbeatSandbox(callback, {
+              unsetEnvVars: ["TELEGRAM_BOT_TOKEN", "OPENCLAW_STATE_DIR", "TELEGRAM_BOT_TOKEN"],
+            }),
+          ).rejects.toMatchObject({
+            // Keep the owned filesystem failure independent of platform/probe errno.
+            code: expect.any(String),
+            syscall: expect.any(String),
+            path: expect.stringContaining(obstruction),
+          });
+          expect(callback).not.toHaveBeenCalled();
+          expect({
+            state: process.env.OPENCLAW_STATE_DIR,
+            token: process.env.TELEGRAM_BOT_TOKEN,
+            directoryExists: existsSync(sandbox),
+          }).toEqual({
+            state: outerState,
+            token: "synthetic-heartbeat-token",
+            directoryExists: false,
+          });
+        } finally {
+          directoryCreation.mockRestore();
+          closeOpenClawStateDatabaseForTest();
+        }
+      },
+    );
+  });
+});

--- a/src/infra/heartbeat-runner.test-utils.ts
+++ b/src/infra/heartbeat-runner.test-utils.ts
@@ -1,6 +1,4 @@
 // Shared heartbeat runner fixtures for infra tests.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { vi } from "vitest";
 import { heartbeatRunnerTelegramPlugin } from "../../test/helpers/infra/heartbeat-runner-channel-plugins.js";
@@ -20,6 +18,8 @@ import { resolveCronJobsStorePath } from "../cron/store.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { withTempDir } from "../test-utils/temp-dir.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import type { HeartbeatDeps } from "./heartbeat-runner.js";
@@ -165,30 +165,26 @@ export async function withTempHeartbeatSandbox<T>(
     unsetEnvVars?: string[];
   },
 ): Promise<T> {
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), options?.prefix ?? "openclaw-hb-"));
-  const storePath = path.join(tmpDir, "sessions.json");
-  const replySpy = createHeartbeatReplySpy();
-  const previousEnv = new Map<string, string | undefined>();
-  const envNames = new Set(["OPENCLAW_STATE_DIR", ...(options?.unsetEnvVars ?? [])]);
-  for (const envName of envNames) {
-    previousEnv.set(envName, process.env[envName]);
-    process.env[envName] = envName === "OPENCLAW_STATE_DIR" ? path.join(tmpDir, "state") : "";
-  }
-  await seedHeartbeatScratchForTest({ content: "- Check status\n" });
-  try {
-    return await fn({ tmpDir, storePath, replySpy });
-  } finally {
-    replySpy.mockReset();
-    closeOpenClawStateDatabaseForTest();
-    for (const [envName, previousValue] of previousEnv.entries()) {
-      if (previousValue === undefined) {
-        delete process.env[envName];
-      } else {
-        process.env[envName] = previousValue;
+  return withTempDir(options?.prefix ?? "openclaw-hb-", async (tmpDir) => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = createHeartbeatReplySpy();
+    const envNames = new Set(["OPENCLAW_STATE_DIR", ...(options?.unsetEnvVars ?? [])]);
+    const env = Object.fromEntries(
+      [...envNames].map((envName) => [
+        envName,
+        envName === "OPENCLAW_STATE_DIR" ? path.join(tmpDir, "state") : "",
+      ]),
+    );
+    return withEnvAsync(env, async () => {
+      try {
+        await seedHeartbeatScratchForTest({ content: "- Check status\n" });
+        return await fn({ tmpDir, storePath, replySpy });
+      } finally {
+        replySpy.mockReset();
+        closeOpenClawStateDatabaseForTest();
       }
-    }
-    await fs.rm(tmpDir, { recursive: true, force: true });
-  }
+    });
+  });
 }
 
 /** Run a Telegram heartbeat test with Telegram credentials removed. */


### PR DESCRIPTION
## What Problem This Solves

The heartbeat test sandbox seeded scratch storage before entering its cleanup scope. If real storage setup failed, the callback never ran and the fixture left its state-directory override, cleared token value, and temporary directory behind, contaminating later tests.

## Why This Change Was Made

Compose the existing asynchronous environment and temporary-directory helpers so setup and callback execution share the same cleanup lifetime. Reset the reply spy and close shared state before restoring the environment and removing the directory. Use the existing temporary-directory tracker in the heartbeat outcome-store tests while retaining database-before-directory cleanup ordering.

All existing tests remain. Add one real-storage regression that obstructs the sandbox's database directory, proves setup fails before the callback, and checks environment restoration and directory removal before independent rescue. It also covers duplicate unset names and the fixture-owned state-directory precedence.

## User Impact

This repairs test fixtures only; production code and user-facing runtime behavior are unchanged. Existing test/support edits are +25/-35 lines; the 55-line regression makes the complete test/support change +80/-35 (net +45). The added test protects a setup-failure lifecycle that generic helper tests and successful heartbeat runs do not cover.

## Evidence

The same 27 existing test files passed before and after: 376 passed and one expected Windows-only skip, with the same per-file test inventory and order. The exact permanent regression failed on the original helper at its cleanup assertion and passed on the repaired helper; its owned filesystem rejection and callback non-entry assertions passed on both. All recorded native children joined, and source/dependency integrity was verified.

Independent source review found no actionable P0-P2 issue. All 29 checks in the normal changed-file gate passed, including both selected type graphs, formatting, lint, and the complete unused-export audit.
