### PR TITLE
fix(update): candidate snapshot fails on Windows when a registered agent path carries the extended-length prefix

### DIFF
--- a/src/infra/update-candidate-paths.ts
+++ b/src/infra/update-candidate-paths.ts
@@ -10,23 +10,25 @@ export function resolveUpdateCandidateStatePath(
   targetRoot: string,
   source: string,
 ): string {
-  // Extended-length \\?\ spellings name the same files as their plain
-  // counterparts, but path.relative cannot see across the namespace prefix: it
-  // returns the absolute source unchanged, and joining that under the target
-  // root would embed the prefix mid-path. Rebase through the case-preserving
-  // plain spelling so namespaced registered paths project like any other.
-  const projectionRoot =
-    process.platform === "win32" ? normalizeWindowsPathPreservingCase(sourceRoot) : sourceRoot;
-  const projectionSource =
-    process.platform === "win32" ? normalizeWindowsPathPreservingCase(source) : source;
-  // Registered link/../ locators can identify a different inode from their
-  // normalized spelling; flattening them would overwrite another copied database.
-  const relative =
-    path.normalize(projectionSource) === projectionSource &&
-    isPathInside(projectionRoot, projectionSource)
-      ? path.relative(projectionRoot, projectionSource)
-      : path.join("candidate-external", sha256Hex(source));
-  return path.join(targetRoot, relative);
+  // The canonical-spelling guard reads the raw locator first: only a canonically
+  // spelled in-root source is an alias eligible for rebasing.
+  if (path.normalize(source) === source && isPathInside(sourceRoot, source)) {
+    // Extended-length \\?\ spellings name the same files as their plain
+    // counterparts, but path.relative cannot see across the namespace prefix: it
+    // returns the absolute source unchanged, and joining that under the target
+    // root would embed the prefix mid-path. Rebase in-root aliases through the
+    // case-preserving plain spelling.
+    const projectionRoot =
+      process.platform === "win32" ? normalizeWindowsPathPreservingCase(sourceRoot) : sourceRoot;
+    const projectionSource =
+      process.platform === "win32" ? normalizeWindowsPathPreservingCase(source) : source;
+    return path.join(targetRoot, path.relative(projectionRoot, projectionSource));
+  }
+  // External and noncanonical locators keep their raw spelling as their
+  // projection identity: registered link/../ locators can identify a different
+  // inode from their normalized spelling; flattening them would overwrite
+  // another copied database.
+  return path.join(targetRoot, "candidate-external", sha256Hex(source));
 }
 
 /** Plugin locators cannot overwrite the separately snapshotted state databases. */

--- a/src/infra/update-candidate-paths.ts
+++ b/src/infra/update-candidate-paths.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { sha256Hex } from "./crypto-digest.js";
-import { isPathInside } from "./path-guards.js";
+import { isPathInside, normalizeWindowsPathPreservingCase } from "./path-guards.js";
 
 // Keep path projection independent of snapshot orchestration: the snapshot owner
 // dynamically loads plugin projection, so importing it back creates a worker build cycle.
@@ -10,11 +10,21 @@ export function resolveUpdateCandidateStatePath(
   targetRoot: string,
   source: string,
 ): string {
+  // Extended-length \\?\ spellings name the same files as their plain
+  // counterparts, but path.relative cannot see across the namespace prefix: it
+  // returns the absolute source unchanged, and joining that under the target
+  // root would embed the prefix mid-path. Rebase through the case-preserving
+  // plain spelling so namespaced registered paths project like any other.
+  const projectionRoot =
+    process.platform === "win32" ? normalizeWindowsPathPreservingCase(sourceRoot) : sourceRoot;
+  const projectionSource =
+    process.platform === "win32" ? normalizeWindowsPathPreservingCase(source) : source;
   // Registered link/../ locators can identify a different inode from their
   // normalized spelling; flattening them would overwrite another copied database.
   const relative =
-    path.normalize(source) === source && isPathInside(sourceRoot, source)
-      ? path.relative(sourceRoot, source)
+    path.normalize(projectionSource) === projectionSource &&
+    isPathInside(projectionRoot, projectionSource)
+      ? path.relative(projectionRoot, projectionSource)
       : path.join("candidate-external", sha256Hex(source));
   return path.join(targetRoot, relative);
 }

--- a/src/infra/update-candidate-paths.ts
+++ b/src/infra/update-candidate-paths.ts
@@ -2,6 +2,22 @@ import path from "node:path";
 import { sha256Hex } from "./crypto-digest.js";
 import { isPathInside, normalizeWindowsPathPreservingCase } from "./path-guards.js";
 
+/**
+ * One projection identity per locator, matching the raw canonical-spelling
+ * eligibility of the rebase branch in resolveUpdateCandidateStatePath: only
+ * canonically spelled in-root aliases take their case-preserving plain
+ * spelling; external and noncanonical locators keep their raw spelling.
+ * Discovery dedupes on this identity so the copy and the registry rebound
+ * write always agree on one destination for every spelling of a database.
+ */
+export function resolveUpdateCandidateStateIdentity(sourceRoot: string, source: string): string {
+  return process.platform === "win32" &&
+    path.normalize(source) === source &&
+    isPathInside(sourceRoot, source)
+    ? normalizeWindowsPathPreservingCase(source)
+    : source;
+}
+
 // Keep path projection independent of snapshot orchestration: the snapshot owner
 // dynamically loads plugin projection, so importing it back creates a worker build cycle.
 /** Shared with config projection so custom agent directories use their copied database. */
@@ -20,9 +36,10 @@ export function resolveUpdateCandidateStatePath(
     // case-preserving plain spelling.
     const projectionRoot =
       process.platform === "win32" ? normalizeWindowsPathPreservingCase(sourceRoot) : sourceRoot;
-    const projectionSource =
-      process.platform === "win32" ? normalizeWindowsPathPreservingCase(source) : source;
-    return path.join(targetRoot, path.relative(projectionRoot, projectionSource));
+    return path.join(
+      targetRoot,
+      path.relative(projectionRoot, resolveUpdateCandidateStateIdentity(sourceRoot, source)),
+    );
   }
   // External and noncanonical locators keep their raw spelling as their
   // projection identity: registered link/../ locators can identify a different

--- a/src/infra/update-candidate-state.namespaced-paths.test.ts
+++ b/src/infra/update-candidate-state.namespaced-paths.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, expect, it } from "vitest";
 import { runCommandBuffered } from "../process/exec.js";
+import { readStateSchemaContentVersion } from "../state/openclaw-state-db-schema-version.js";
 import {
   closeOpenClawStateDatabaseByPath,
   closeOpenClawStateDatabaseForTest,
@@ -11,9 +12,11 @@ import {
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+import { readSqliteUserVersion } from "./sqlite-user-version.js";
 import {
   readUpdateStateSchemaVersions,
   type snapshotUpdateCandidateState,
+  updateStateSchemaVersionsMatch,
   UpdateCandidateStateSnapshotSchema,
 } from "./update-candidate-state.js";
 
@@ -88,9 +91,10 @@ it.skipIf(process.platform !== "win32")(
       targetStateDir: target,
       config: {},
     });
-    // The namespaced registration dedupes to the database's plain spelling.
+    // The physical copy dedupes to one identity, but the published versions
+    // keep every raw alias so released mixed-alias baselines still match.
     expect(versions.map((entry) => entry.path)).toContain(canonical);
-    expect(versions.map((entry) => entry.path)).not.toContain(namespaced);
+    expect(versions.map((entry) => entry.path)).toContain(namespaced);
     const copied = openNodeSqliteDatabase(
       path.join(target, "agents", "main", "agent", "openclaw-agent.sqlite"),
     );
@@ -237,6 +241,71 @@ it.skipIf(process.platform !== "win32")(
     expect(path.isAbsolute(rebound.path)).toBe(false);
     // The rebound registry entry must name exactly the one copied database.
     const copied = openNodeSqliteDatabase(path.join(target, rebound.path));
+    expect(copied.prepare("SELECT value FROM evidence").get()).toMatchObject({
+      value: "preserved",
+    });
+    copied.close();
+  },
+);
+
+// Released 2026.9.3/2026.9.4 workers reported every discovered spelling, so a
+// host whose registry carries both a relative row and a \\?\-prefixed row for
+// one database produced a mixed-alias versions baseline. The released Doctor
+// update path compares those exact paths against the candidate's response:
+// the candidate must publish every raw alias while still deduping the physical
+// snapshot copies, or the schema comparison fails on exactly the Windows
+// installs this fix targets.
+it.skipIf(process.platform !== "win32")(
+  "keeps every raw alias in the versions response for a released mixed-alias baseline",
+  async () => {
+    const source = path.join(root, "source");
+    const target = path.join(root, "copy");
+    const canonical = path.join(source, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await createDatabase(canonical);
+    const namespaced = `\\\\?\\${canonical}`;
+    const shared = path.join(source, "state", "openclaw.sqlite");
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: source } }).db;
+    const insert = registry.prepare(
+      "INSERT INTO agent_databases (agent_id, path, schema_version, last_seen_at) VALUES (?, ?, 3, 0)",
+    );
+    insert.run("main", path.join("agents", "main", "agent", "openclaw-agent.sqlite"));
+    insert.run("main", namespaced);
+    closeOpenClawStateDatabaseByPath(shared);
+    // Hand-built to mirror a released worker's response: every discovered
+    // spelling, with versions read straight from the physical databases rather
+    // than from a patched worker's response.
+    const sharedDb = openNodeSqliteDatabase(shared, { readOnly: true });
+    const releasedBaseline = [
+      {
+        path: shared,
+        userVersion: readSqliteUserVersion(sharedDb),
+        contentVersion: readStateSchemaContentVersion(sharedDb),
+      },
+      { path: canonical, userVersion: 3 },
+      { path: namespaced, userVersion: 3 },
+    ];
+    sharedDb.close();
+    const inspected = await readUpdateStateSchemaVersions({
+      stateDir: source,
+      config: {},
+    });
+    expect(inspected.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining([shared, canonical, namespaced]),
+    );
+    expect(inspected).toHaveLength(3);
+    expect(
+      updateStateSchemaVersionsMatch(releasedBaseline, inspected, { sharedPath: shared }),
+    ).toBe(true);
+    const versions = await runSnapshotWorker({
+      stateDir: source,
+      targetStateDir: target,
+      config: {},
+    });
+    // Snapshot mode publishes the same aliases but copies each database once.
+    expect(versions).toEqual(inspected);
+    const copied = openNodeSqliteDatabase(
+      path.join(target, "agents", "main", "agent", "openclaw-agent.sqlite"),
+    );
     expect(copied.prepare("SELECT value FROM evidence").get()).toMatchObject({
       value: "preserved",
     });

--- a/src/infra/update-candidate-state.namespaced-paths.test.ts
+++ b/src/infra/update-candidate-state.namespaced-paths.test.ts
@@ -150,3 +150,43 @@ it.skipIf(process.platform !== "win32")(
     copied.close();
   },
 );
+
+// A noncanonical in-root registration (dot segments) is not eligible for
+// rebasing: the copy and the rebound registry entry must keep the raw
+// locator's hashed candidate-external destination.
+it.skipIf(process.platform !== "win32")(
+  "keeps a noncanonical in-root registered database on its raw projection identity",
+  async () => {
+    const source = path.join(root, "source");
+    const target = path.join(root, "copy");
+    const canonical = path.join(source, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await createDatabase(canonical);
+    const noncanonical =
+      source + path.sep + ["agents", "main", ".", "agent", "openclaw-agent.sqlite"].join(path.sep);
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: source } }).db;
+    registry
+      .prepare(
+        "INSERT INTO agent_databases (agent_id, path, schema_version, last_seen_at) VALUES (?, ?, 3, 0)",
+      )
+      .run("main", noncanonical);
+    closeOpenClawStateDatabaseByPath(path.join(source, "state", "openclaw.sqlite"));
+    await runSnapshotWorker({
+      stateDir: source,
+      targetStateDir: target,
+      config: {},
+    });
+    const copiedRegistry = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));
+    const rebound = copiedRegistry
+      .prepare("SELECT path FROM agent_databases WHERE agent_id = 'main'")
+      .get() as { path: string };
+    copiedRegistry.close();
+    expect(path.isAbsolute(rebound.path)).toBe(false);
+    expect(rebound.path).toMatch(/^candidate-external/);
+    // The rebound registry entry must name the database the snapshot copied.
+    const copied = openNodeSqliteDatabase(path.join(target, rebound.path));
+    expect(copied.prepare("SELECT value FROM evidence").get()).toMatchObject({
+      value: "preserved",
+    });
+    copied.close();
+  },
+);

--- a/src/infra/update-candidate-state.namespaced-paths.test.ts
+++ b/src/infra/update-candidate-state.namespaced-paths.test.ts
@@ -12,6 +12,7 @@ import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import {
+  readUpdateStateSchemaVersions,
   type snapshotUpdateCandidateState,
   UpdateCandidateStateSnapshotSchema,
 } from "./update-candidate-state.js";
@@ -209,11 +210,25 @@ it.skipIf(process.platform !== "win32")(
       )
       .run("main", path.join("agents", "main", "agent", "openclaw-agent.sqlite"));
     closeOpenClawStateDatabaseByPath(path.join(plainState, "state", "openclaw.sqlite"));
-    await runSnapshotWorker({
+    const inspected = await readUpdateStateSchemaVersions({
+      stateDir: namespacedState,
+      config: {},
+    });
+    // Older updaters captured rollback baselines with the namespaced spelling;
+    // versions-mode responses must keep that path identity.
+    const namespacedDb =
+      namespacedState +
+      path.sep +
+      ["agents", "main", "agent", "openclaw-agent.sqlite"].join(path.sep);
+    expect(inspected.map((entry) => entry.path)).toContain(namespacedDb);
+    expect(inspected.map((entry) => entry.path)).not.toContain(canonical);
+    const versions = await runSnapshotWorker({
       stateDir: namespacedState,
       targetStateDir: target,
       config: {},
     });
+    // Snapshot mode reports the same legacy identities for the deduped copy.
+    expect(versions).toEqual(inspected);
     const copiedRegistry = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));
     const rebound = copiedRegistry
       .prepare("SELECT path FROM agent_databases WHERE agent_id = 'main'")

--- a/src/infra/update-candidate-state.namespaced-paths.test.ts
+++ b/src/infra/update-candidate-state.namespaced-paths.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { runCommandBuffered } from "../process/exec.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+import {
+  type snapshotUpdateCandidateState,
+  UpdateCandidateStateSnapshotSchema,
+} from "./update-candidate-state.js";
+
+let root: string;
+beforeEach(async () => {
+  root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "candidate-state-paths-")));
+});
+afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+async function createDatabase(file: string): Promise<void> {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const db = openNodeSqliteDatabase(file);
+  try {
+    db.exec(
+      "PRAGMA user_version = 3; CREATE TABLE evidence(value TEXT); INSERT INTO evidence VALUES ('preserved');",
+    );
+  } finally {
+    db.close();
+  }
+}
+
+async function runSnapshotWorker(
+  input: Omit<Parameters<typeof snapshotUpdateCandidateState>[0], "candidateRoot">,
+) {
+  // Backup/VACUUM cannot be cancelled in-process; use the canary's worker before fixture cleanup.
+  const result = await runCommandBuffered(
+    [
+      process.execPath,
+      ...resolveRuntimeWorkerArgv(
+        resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.updateCandidateState),
+      ),
+    ],
+    {
+      input: JSON.stringify({
+        ...input,
+        candidateRoot: path.join(root, "candidate-host"),
+        mode: "snapshot",
+      }),
+      timeoutMs: 30_000,
+      killGraceMs: 500,
+      maxOutputBytes: { stdout: 1024 * 1024, stderr: 20_000 },
+    },
+  );
+  expect(result.code, result.stderr.toString("utf8")).toBe(0);
+  return UpdateCandidateStateSnapshotSchema.parse(JSON.parse(result.stdout.toString("utf8")))
+    .versions;
+}
+
+// Windows registries can carry extended-length \\?\ agent paths (issue #144581):
+// projection must rebase them under the candidate root instead of embedding the
+// namespace prefix mid-path and failing the snapshot mkdir.
+it.skipIf(process.platform !== "win32")(
+  "projects extended-length registered agent paths under the candidate state root",
+  async () => {
+    const source = path.join(root, "source");
+    const target = path.join(root, "copy");
+    const canonical = path.join(source, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await createDatabase(canonical);
+    const namespaced = `\\\\?\\${canonical}`;
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: source } }).db;
+    registry
+      .prepare(
+        "INSERT INTO agent_databases (agent_id, path, schema_version, last_seen_at) VALUES (?, ?, 3, 0)",
+      )
+      .run("main", namespaced);
+    closeOpenClawStateDatabaseByPath(path.join(source, "state", "openclaw.sqlite"));
+    const versions = await runSnapshotWorker({
+      stateDir: source,
+      targetStateDir: target,
+      config: {},
+    });
+    // The namespaced registration dedupes to the database's plain spelling.
+    expect(versions.map((entry) => entry.path)).toContain(canonical);
+    expect(versions.map((entry) => entry.path)).not.toContain(namespaced);
+    const copied = openNodeSqliteDatabase(
+      path.join(target, "agents", "main", "agent", "openclaw-agent.sqlite"),
+    );
+    expect(copied.prepare("SELECT value FROM evidence").get()).toMatchObject({
+      value: "preserved",
+    });
+    copied.close();
+    const copiedRegistry = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));
+    const rebound = copiedRegistry
+      .prepare("SELECT path FROM agent_databases WHERE agent_id = 'main'")
+      .get() as { path: string };
+    copiedRegistry.close();
+    expect(path.isAbsolute(rebound.path)).toBe(false);
+    expect(rebound.path.split(/[\\/]/)).toEqual([
+      "agents",
+      "main",
+      "agent",
+      "openclaw-agent.sqlite",
+    ]);
+  },
+);

--- a/src/infra/update-candidate-state.namespaced-paths.test.ts
+++ b/src/infra/update-candidate-state.namespaced-paths.test.ts
@@ -190,3 +190,41 @@ it.skipIf(process.platform !== "win32")(
     copied.close();
   },
 );
+
+// With an extended-length state root, directory discovery queues the
+// namespaced spelling while a relative registration resolves to the same
+// database; both must dedupe to one copy at one projection identity.
+it.skipIf(process.platform !== "win32")(
+  "dedupes a relative registration under a namespaced state root",
+  async () => {
+    const plainState = path.join(root, "source");
+    const namespacedState = `\\\\?\\${plainState}`;
+    const target = path.join(root, "copy");
+    const canonical = path.join(plainState, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await createDatabase(canonical);
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: plainState } }).db;
+    registry
+      .prepare(
+        "INSERT INTO agent_databases (agent_id, path, schema_version, last_seen_at) VALUES (?, ?, 3, 0)",
+      )
+      .run("main", path.join("agents", "main", "agent", "openclaw-agent.sqlite"));
+    closeOpenClawStateDatabaseByPath(path.join(plainState, "state", "openclaw.sqlite"));
+    await runSnapshotWorker({
+      stateDir: namespacedState,
+      targetStateDir: target,
+      config: {},
+    });
+    const copiedRegistry = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));
+    const rebound = copiedRegistry
+      .prepare("SELECT path FROM agent_databases WHERE agent_id = 'main'")
+      .get() as { path: string };
+    copiedRegistry.close();
+    expect(path.isAbsolute(rebound.path)).toBe(false);
+    // The rebound registry entry must name exactly the one copied database.
+    const copied = openNodeSqliteDatabase(path.join(target, rebound.path));
+    expect(copied.prepare("SELECT value FROM evidence").get()).toMatchObject({
+      value: "preserved",
+    });
+    copied.close();
+  },
+);

--- a/src/infra/update-candidate-state.namespaced-paths.test.ts
+++ b/src/infra/update-candidate-state.namespaced-paths.test.ts
@@ -111,3 +111,42 @@ it.skipIf(process.platform !== "win32")(
     ]);
   },
 );
+
+// A namespaced registration outside the state root must keep one projection
+// identity: the copy and the rebound registry entry must name the same hashed
+// candidate-external destination.
+it.skipIf(process.platform !== "win32")(
+  "keeps a namespaced external registered database on one hashed projection identity",
+  async () => {
+    const source = path.join(root, "source");
+    const target = path.join(root, "copy");
+    const external = path.join(root, "external", "openclaw-agent.sqlite");
+    await createDatabase(external);
+    const namespacedExternal = `\\\\?\\${external}`;
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: source } }).db;
+    registry
+      .prepare(
+        "INSERT INTO agent_databases (agent_id, path, schema_version, last_seen_at) VALUES (?, ?, 3, 0)",
+      )
+      .run("external", namespacedExternal);
+    closeOpenClawStateDatabaseByPath(path.join(source, "state", "openclaw.sqlite"));
+    await runSnapshotWorker({
+      stateDir: source,
+      targetStateDir: target,
+      config: {},
+    });
+    const copiedRegistry = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));
+    const rebound = copiedRegistry
+      .prepare("SELECT path FROM agent_databases WHERE agent_id = 'external'")
+      .get() as { path: string };
+    copiedRegistry.close();
+    expect(path.isAbsolute(rebound.path)).toBe(false);
+    expect(rebound.path).toMatch(/^candidate-external/);
+    // The rebound registry entry must name the database the snapshot copied.
+    const copied = openNodeSqliteDatabase(path.join(target, rebound.path));
+    expect(copied.prepare("SELECT value FROM evidence").get()).toMatchObject({
+      value: "preserved",
+    });
+    copied.close();
+  },
+);

--- a/src/infra/update-candidate-state.test.ts
+++ b/src/infra/update-candidate-state.test.ts
@@ -178,54 +178,6 @@ it.each(["DELETE", "WAL"])(
   },
 );
 
-// Windows registries can carry extended-length \\?\ agent paths (issue #144581):
-// projection must rebase them under the candidate root instead of embedding the
-// namespace prefix mid-path and failing the snapshot mkdir.
-it.skipIf(process.platform !== "win32")(
-  "projects extended-length registered agent paths under the candidate state root",
-  async () => {
-    const source = path.join(root, "source");
-    const target = path.join(root, "copy");
-    const canonical = path.join(source, "agents", "main", "agent", "openclaw-agent.sqlite");
-    await createDatabase(canonical);
-    const namespaced = `\\\\?\\${canonical}`;
-    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: source } }).db;
-    registry
-      .prepare(
-        "INSERT INTO agent_databases (agent_id, path, schema_version, last_seen_at) VALUES (?, ?, 3, 0)",
-      )
-      .run("main", namespaced);
-    closeOpenClawStateDatabaseByPath(path.join(source, "state", "openclaw.sqlite"));
-    const versions = await runSnapshotWorker({
-      stateDir: source,
-      targetStateDir: target,
-      config: {},
-    });
-    // The namespaced registration dedupes to the database's plain spelling.
-    expect(versions.map((entry) => entry.path)).toContain(canonical);
-    expect(versions.map((entry) => entry.path)).not.toContain(namespaced);
-    const copied = openNodeSqliteDatabase(
-      path.join(target, "agents", "main", "agent", "openclaw-agent.sqlite"),
-    );
-    expect(copied.prepare("SELECT value FROM evidence").get()).toMatchObject({
-      value: "preserved",
-    });
-    copied.close();
-    const copiedRegistry = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));
-    const rebound = copiedRegistry
-      .prepare("SELECT path FROM agent_databases WHERE agent_id = 'main'")
-      .get() as { path: string };
-    copiedRegistry.close();
-    expect(path.isAbsolute(rebound.path)).toBe(false);
-    expect(rebound.path.split(/[\\/]/)).toEqual([
-      "agents",
-      "main",
-      "agent",
-      "openclaw-agent.sqlite",
-    ]);
-  },
-);
-
 it("retains deferred content in both inspection and rehearsal snapshots", async () => {
   const stateDir = path.join(root, "deferred");
   const file = path.join(stateDir, "state", "openclaw.sqlite");

--- a/src/infra/update-candidate-state.test.ts
+++ b/src/infra/update-candidate-state.test.ts
@@ -178,6 +178,54 @@ it.each(["DELETE", "WAL"])(
   },
 );
 
+// Windows registries can carry extended-length \\?\ agent paths (issue #144581):
+// projection must rebase them under the candidate root instead of embedding the
+// namespace prefix mid-path and failing the snapshot mkdir.
+it.skipIf(process.platform !== "win32")(
+  "projects extended-length registered agent paths under the candidate state root",
+  async () => {
+    const source = path.join(root, "source");
+    const target = path.join(root, "copy");
+    const canonical = path.join(source, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await createDatabase(canonical);
+    const namespaced = `\\\\?\\${canonical}`;
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: source } }).db;
+    registry
+      .prepare(
+        "INSERT INTO agent_databases (agent_id, path, schema_version, last_seen_at) VALUES (?, ?, 3, 0)",
+      )
+      .run("main", namespaced);
+    closeOpenClawStateDatabaseByPath(path.join(source, "state", "openclaw.sqlite"));
+    const versions = await runSnapshotWorker({
+      stateDir: source,
+      targetStateDir: target,
+      config: {},
+    });
+    // The namespaced registration dedupes to the database's plain spelling.
+    expect(versions.map((entry) => entry.path)).toContain(canonical);
+    expect(versions.map((entry) => entry.path)).not.toContain(namespaced);
+    const copied = openNodeSqliteDatabase(
+      path.join(target, "agents", "main", "agent", "openclaw-agent.sqlite"),
+    );
+    expect(copied.prepare("SELECT value FROM evidence").get()).toMatchObject({
+      value: "preserved",
+    });
+    copied.close();
+    const copiedRegistry = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));
+    const rebound = copiedRegistry
+      .prepare("SELECT path FROM agent_databases WHERE agent_id = 'main'")
+      .get() as { path: string };
+    copiedRegistry.close();
+    expect(path.isAbsolute(rebound.path)).toBe(false);
+    expect(rebound.path.split(/[\\/]/)).toEqual([
+      "agents",
+      "main",
+      "agent",
+      "openclaw-agent.sqlite",
+    ]);
+  },
+);
+
 it("retains deferred content in both inspection and rehearsal snapshots", async () => {
   const stateDir = path.join(root, "deferred");
   const file = path.join(stateDir, "state", "openclaw.sqlite");

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -13,7 +13,7 @@ import { resolveOpenClawRegisteredAgentDatabasePath } from "../state/openclaw-st
 import { resolveUserPath } from "./home-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
-import { hasNodeErrorCode } from "./path-guards.js";
+import { hasNodeErrorCode, normalizeWindowsPathPreservingCase } from "./path-guards.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import { prepareSqliteReadOnlyLocationSyncInProcess } from "./sqlite-readonly-location.js";
@@ -104,9 +104,14 @@ function collectRegisteredPaths(db: DatabaseSync, shared: string, files: string[
     : [];
   return rows.map(({ path: stored }) => {
     const source = resolveOpenClawRegisteredAgentDatabasePath(shared, stored);
+    // Windows registries can carry extended-length \\?\ spellings of a database
+    // that directory discovery already listed; both spellings project to the same
+    // candidate target, so discover the case-preserving plain spelling once.
+    const discovered =
+      process.platform === "win32" ? normalizeWindowsPathPreservingCase(source) : source;
     // Discover registrations from the exact private generation being inspected.
-    if (!files.includes(source)) {
-      files.push(source);
+    if (!files.includes(discovered)) {
+      files.push(discovered);
     }
     return { stored, source };
   });
@@ -294,10 +299,18 @@ export async function snapshotUpdateCandidateState(
                 for (const { stored, source } of collectRegisteredPaths(db, shared, files)) {
                   const rebound = targetPath(source);
                   const reboundStored = path.relative(input.targetStateDir, rebound);
-                  if (
-                    stored !== reboundStored &&
-                    source === resolveOpenClawRegisteredAgentDatabasePath(shared, reboundStored)
-                  ) {
+                  const resolvedRebound = resolveOpenClawRegisteredAgentDatabasePath(
+                    shared,
+                    reboundStored,
+                  );
+                  // Extended-length \\?\ and plain spellings of one registered database
+                  // are the same duplicate pair as a legacy absolute/relative pair.
+                  const sameRegisteredDatabase =
+                    source === resolvedRebound ||
+                    (process.platform === "win32" &&
+                      normalizeWindowsPathPreservingCase(source) ===
+                        normalizeWindowsPathPreservingCase(resolvedRebound));
+                  if (stored !== reboundStored && sameRegisteredDatabase) {
                     // A legacy absolute/relative pair names exactly the same source.
                     // Collapse only that duplicate in the copy before its unique-key update.
                     executeSqliteQuerySync(

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -98,7 +98,29 @@ async function fileExists(file: string): Promise<boolean> {
   }
 }
 
-function collectRegisteredPaths(db: DatabaseSync, shared: string, files: Map<string, string>) {
+/** Every raw spelling discovered for one database, grouped by projection identity. */
+type StateDatabaseDiscovery = { spellings: [string, ...string[]] };
+
+function queueStateDatabaseSpelling(
+  files: Map<string, StateDatabaseDiscovery>,
+  identity: string,
+  file: string,
+): void {
+  const discovery = files.get(identity);
+  if (discovery) {
+    if (!discovery.spellings.includes(file)) {
+      discovery.spellings.push(file);
+    }
+    return;
+  }
+  files.set(identity, { spellings: [file] });
+}
+
+function collectRegisteredPaths(
+  db: DatabaseSync,
+  shared: string,
+  files: Map<string, StateDatabaseDiscovery>,
+) {
   const rows = tableExists(db, "agent_databases")
     ? executeSqliteQuerySync(
         db,
@@ -110,16 +132,15 @@ function collectRegisteredPaths(db: DatabaseSync, shared: string, files: Map<str
     : [];
   return rows.map(({ path: stored }) => {
     const source = resolveOpenClawRegisteredAgentDatabasePath(shared, stored);
-    // Discover registrations from the exact private generation being inspected,
-    // deduped on one projection identity per database while keeping the raw
-    // spelling as the published path identity.
-    const identity = resolveUpdateCandidateStateIdentity(
-      resolveOpenClawStateDirForDatabasePath(shared),
+    // Discover registrations from the exact private generation being inspected.
+    // Spellings dedupe on one projection identity per database, but every raw
+    // alias stays queued: released workers reported them all, and released
+    // rollback baselines compare exact paths against the versions response.
+    queueStateDatabaseSpelling(
+      files,
+      resolveUpdateCandidateStateIdentity(resolveOpenClawStateDirForDatabasePath(shared), source),
       source,
     );
-    if (!files.has(identity)) {
-      files.set(identity, source);
-    }
     return { stored, source };
   });
 }
@@ -154,21 +175,20 @@ async function withStateDatabaseSnapshot<T>(
   return outcome.value;
 }
 
-async function collectStateDatabasePaths(input: StateInput): Promise<Map<string, string>> {
+async function collectStateDatabasePaths(
+  input: StateInput,
+): Promise<Map<string, StateDatabaseDiscovery>> {
   const shared = path.resolve(input.stateDir, "state", "openclaw.sqlite");
   // Every discovery source queues one projection identity per database: with an
   // extended-length state root, directory enumeration and a registry
   // registration spell the same file differently, and queuing both copies
-  // breaks the snapshot with a duplicate destination. The first raw spelling
-  // wins so versions-mode responses keep the path identities older updaters
-  // captured in their rollback baselines.
+  // breaks the snapshot with a duplicate destination. Each identity keeps
+  // every raw spelling so the published versions response matches the mixed
+  // alias baselines released updaters captured.
   const stateRoot = path.resolve(input.stateDir);
-  const files = new Map<string, string>();
+  const files = new Map<string, StateDatabaseDiscovery>();
   const queue = (file: string) => {
-    const identity = resolveUpdateCandidateStateIdentity(stateRoot, file);
-    if (!files.has(identity)) {
-      files.set(identity, file);
-    }
+    queueStateDatabaseSpelling(files, resolveUpdateCandidateStateIdentity(stateRoot, file), file);
   };
   queue(shared);
   let directories: string[] = [];
@@ -197,20 +217,45 @@ async function collectStateDatabasePaths(input: StateInput): Promise<Map<string,
   for (const id of new Set(["main", ...directories])) {
     queue(path.resolve(input.stateDir, "agents", id, "agent", "openclaw-agent.sqlite"));
   }
-  return new Map([...files.entries()].toSorted(([, a], [, b]) => (a < b ? -1 : a > b ? 1 : 0)));
+  return new Map(
+    [...files.entries()].toSorted(([, a], [, b]) =>
+      a.spellings[0] < b.spellings[0] ? -1 : a.spellings[0] > b.spellings[0] ? 1 : 0,
+    ),
+  );
+}
+
+/** Released updaters compare exact response paths, so every raw alias is published. */
+function publishStateDatabaseVersions(
+  files: Map<string, StateDatabaseDiscovery>,
+  inspected: Map<string, Omit<UpdateStateSchemaVersion, "path">>,
+): UpdateStateSchemaVersion[] {
+  const versions: UpdateStateSchemaVersion[] = [];
+  for (const [identity, discovery] of files) {
+    const result = inspected.get(identity);
+    if (!result) {
+      continue;
+    }
+    for (const spelling of discovery.spellings) {
+      versions.push({ path: spelling, ...result });
+    }
+  }
+  return versions;
 }
 
 /** Missing databases stay explicit so creation is schema-checked and loss blocks rollback. */
 export async function readUpdateStateSchemaVersionsInProcess(
   input: StateInput,
 ): Promise<UpdateStateSchemaVersion[]> {
-  const versions: UpdateStateSchemaVersion[] = [];
   const shared = path.resolve(input.stateDir, "state", "openclaw.sqlite");
   const files = await collectStateDatabasePaths(input);
-  for (const file of files.values()) {
-    versions.push({
-      path: file,
-      ...((await fileExists(file))
+  // Inspect each physical database once on its first spelling; every raw alias
+  // publishes the same result so released mixed-alias baselines still match.
+  const inspected = new Map<string, Omit<UpdateStateSchemaVersion, "path">>();
+  for (const [identity, discovery] of files) {
+    const file = discovery.spellings[0];
+    inspected.set(
+      identity,
+      (await fileExists(file))
         ? await withStateDatabaseSnapshot(file, (location) => {
             const db = openNodeSqliteDatabase(location, { readOnly: true });
             try {
@@ -225,10 +270,10 @@ export async function readUpdateStateSchemaVersionsInProcess(
               db.close();
             }
           })
-        : { userVersion: null }),
-    });
+        : { userVersion: null },
+    );
   }
-  return versions;
+  return publishStateDatabaseVersions(files, inspected);
 }
 
 /** Schema fencing reads private copies in a child under a fixed inspection deadline. */
@@ -292,11 +337,14 @@ export async function snapshotUpdateCandidateState(
       resolveUpdateCandidateStatePath(sourceRoot, input.targetStateDir, path.dirname(source)),
       path.basename(source),
     );
-  const versions: UpdateStateSchemaVersion[] = [];
+  // Physical copies dedupe on projection identity; the published versions
+  // keep every raw alias so released rollback baselines still match.
   const files = await collectStateDatabasePaths(input);
-  for (const file of files.values()) {
+  const inspected = new Map<string, Omit<UpdateStateSchemaVersion, "path">>();
+  for (const [identity, discovery] of files) {
+    const file = discovery.spellings[0];
     if (!(await fileExists(file))) {
-      versions.push({ path: file, userVersion: null });
+      inspected.set(identity, { userVersion: null });
       continue;
     }
     const target = targetPath(file);
@@ -362,12 +410,12 @@ export async function snapshotUpdateCandidateState(
           : {}),
       }),
     );
-    versions.push({
-      path: file,
+    inspected.set(identity, {
       userVersion: snapshot.userVersion,
       ...(contentVersion === undefined ? {} : { contentVersion }),
     });
   }
+  const versions = publishStateDatabaseVersions(files, inspected);
   const { projectUpdateCandidatePlugins } = await import("./update-candidate-plugins.js");
   const pluginPaths = await projectUpdateCandidatePlugins(input);
   return { versions, pluginPaths };

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -197,7 +197,7 @@ async function collectStateDatabasePaths(input: StateInput): Promise<Map<string,
   for (const id of new Set(["main", ...directories])) {
     queue(path.resolve(input.stateDir, "agents", id, "agent", "openclaw-agent.sqlite"));
   }
-  return new Map([...files.entries()].sort(([, a], [, b]) => (a < b ? -1 : a > b ? 1 : 0)));
+  return new Map([...files.entries()].toSorted(([, a], [, b]) => (a < b ? -1 : a > b ? 1 : 0)));
 }
 
 /** Missing databases stay explicit so creation is schema-checked and loss blocks rollback. */

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -16,16 +16,15 @@ import {
 import { resolveUserPath } from "./home-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
-import {
-  hasNodeErrorCode,
-  isPathInside,
-  normalizeWindowsPathPreservingCase,
-} from "./path-guards.js";
+import { hasNodeErrorCode, normalizeWindowsPathPreservingCase } from "./path-guards.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import { prepareSqliteReadOnlyLocationSyncInProcess } from "./sqlite-readonly-location.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
-import { resolveUpdateCandidateStatePath } from "./update-candidate-paths.js";
+import {
+  resolveUpdateCandidateStateIdentity,
+  resolveUpdateCandidateStatePath,
+} from "./update-candidate-paths.js";
 
 const UpdateStateSchemaVersionsSchema = z.array(
   z.object({
@@ -111,19 +110,13 @@ function collectRegisteredPaths(db: DatabaseSync, shared: string, files: string[
     : [];
   return rows.map(({ path: stored }) => {
     const source = resolveOpenClawRegisteredAgentDatabasePath(shared, stored);
-    // Discover one projection identity per database, using the same raw
-    // eligibility as resolveUpdateCandidateStatePath: a canonically spelled
-    // in-root extended-length \\?\ alias dedupes against the plain spelling
-    // directory discovery already listed, because projection rebases both to
-    // the same candidate path. External and non-canonical locators keep their
-    // raw spelling so the copy and the registry rebound write share one
-    // destination.
-    const discovered =
-      process.platform === "win32" &&
-      path.normalize(source) === source &&
-      isPathInside(resolveOpenClawStateDirForDatabasePath(shared), source)
-        ? normalizeWindowsPathPreservingCase(source)
-        : source;
+    // Discover one projection identity per database so every spelling of a
+    // database dedupes to the destination the copy and the registry rebound
+    // write both derive.
+    const discovered = resolveUpdateCandidateStateIdentity(
+      resolveOpenClawStateDirForDatabasePath(shared),
+      source,
+    );
     // Discover registrations from the exact private generation being inspected.
     if (!files.includes(discovered)) {
       files.push(discovered);
@@ -165,6 +158,12 @@ async function withStateDatabaseSnapshot<T>(
 async function collectStateDatabasePaths(input: StateInput): Promise<string[]> {
   const shared = path.resolve(input.stateDir, "state", "openclaw.sqlite");
   const files = new Set([shared]);
+  // Every discovery source queues one projection identity per database: with an
+  // extended-length state root, directory enumeration and a registry
+  // registration spell the same file differently, and queuing both copies
+  // breaks the snapshot with a duplicate destination.
+  const stateRoot = path.resolve(input.stateDir);
+  const queue = (file: string) => files.add(resolveUpdateCandidateStateIdentity(stateRoot, file));
   let directories: string[] = [];
   try {
     directories = (await fs.readdir(path.join(input.stateDir, "agents"), { withFileTypes: true }))
@@ -178,18 +177,18 @@ async function collectStateDatabasePaths(input: StateInput): Promise<string[]> {
   const configured = Object.entries(input.config.agents?.entries ?? {});
   for (const directory of [input.env?.OPENCLAW_AGENT_DIR, input.env?.PI_CODING_AGENT_DIR]) {
     if (directory?.trim()) {
-      files.add(path.join(resolveUserPath(directory, input.env), "openclaw-agent.sqlite"));
+      queue(path.join(resolveUserPath(directory, input.env), "openclaw-agent.sqlite"));
     }
   }
   const projected = (input.config.agents?.list ?? []).map((agent) => [agent.id, agent] as const);
   for (const [id, agent] of [...configured, ...projected]) {
     directories.push(id);
     if (agent.agentDir) {
-      files.add(path.join(resolveUserPath(agent.agentDir, input.env), "openclaw-agent.sqlite"));
+      queue(path.join(resolveUserPath(agent.agentDir, input.env), "openclaw-agent.sqlite"));
     }
   }
   for (const id of new Set(["main", ...directories])) {
-    files.add(path.resolve(input.stateDir, "agents", id, "agent", "openclaw-agent.sqlite"));
+    queue(path.resolve(input.stateDir, "agents", id, "agent", "openclaw-agent.sqlite"));
   }
   return [...files].toSorted();
 }

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -98,7 +98,7 @@ async function fileExists(file: string): Promise<boolean> {
   }
 }
 
-function collectRegisteredPaths(db: DatabaseSync, shared: string, files: string[]) {
+function collectRegisteredPaths(db: DatabaseSync, shared: string, files: Map<string, string>) {
   const rows = tableExists(db, "agent_databases")
     ? executeSqliteQuerySync(
         db,
@@ -110,16 +110,15 @@ function collectRegisteredPaths(db: DatabaseSync, shared: string, files: string[
     : [];
   return rows.map(({ path: stored }) => {
     const source = resolveOpenClawRegisteredAgentDatabasePath(shared, stored);
-    // Discover one projection identity per database so every spelling of a
-    // database dedupes to the destination the copy and the registry rebound
-    // write both derive.
-    const discovered = resolveUpdateCandidateStateIdentity(
+    // Discover registrations from the exact private generation being inspected,
+    // deduped on one projection identity per database while keeping the raw
+    // spelling as the published path identity.
+    const identity = resolveUpdateCandidateStateIdentity(
       resolveOpenClawStateDirForDatabasePath(shared),
       source,
     );
-    // Discover registrations from the exact private generation being inspected.
-    if (!files.includes(discovered)) {
-      files.push(discovered);
+    if (!files.has(identity)) {
+      files.set(identity, source);
     }
     return { stored, source };
   });
@@ -155,15 +154,23 @@ async function withStateDatabaseSnapshot<T>(
   return outcome.value;
 }
 
-async function collectStateDatabasePaths(input: StateInput): Promise<string[]> {
+async function collectStateDatabasePaths(input: StateInput): Promise<Map<string, string>> {
   const shared = path.resolve(input.stateDir, "state", "openclaw.sqlite");
-  const files = new Set([shared]);
   // Every discovery source queues one projection identity per database: with an
   // extended-length state root, directory enumeration and a registry
   // registration spell the same file differently, and queuing both copies
-  // breaks the snapshot with a duplicate destination.
+  // breaks the snapshot with a duplicate destination. The first raw spelling
+  // wins so versions-mode responses keep the path identities older updaters
+  // captured in their rollback baselines.
   const stateRoot = path.resolve(input.stateDir);
-  const queue = (file: string) => files.add(resolveUpdateCandidateStateIdentity(stateRoot, file));
+  const files = new Map<string, string>();
+  const queue = (file: string) => {
+    const identity = resolveUpdateCandidateStateIdentity(stateRoot, file);
+    if (!files.has(identity)) {
+      files.set(identity, file);
+    }
+  };
+  queue(shared);
   let directories: string[] = [];
   try {
     directories = (await fs.readdir(path.join(input.stateDir, "agents"), { withFileTypes: true }))
@@ -190,7 +197,7 @@ async function collectStateDatabasePaths(input: StateInput): Promise<string[]> {
   for (const id of new Set(["main", ...directories])) {
     queue(path.resolve(input.stateDir, "agents", id, "agent", "openclaw-agent.sqlite"));
   }
-  return [...files].toSorted();
+  return new Map([...files.entries()].sort(([, a], [, b]) => (a < b ? -1 : a > b ? 1 : 0)));
 }
 
 /** Missing databases stay explicit so creation is schema-checked and loss blocks rollback. */
@@ -200,7 +207,7 @@ export async function readUpdateStateSchemaVersionsInProcess(
   const versions: UpdateStateSchemaVersion[] = [];
   const shared = path.resolve(input.stateDir, "state", "openclaw.sqlite");
   const files = await collectStateDatabasePaths(input);
-  for (const file of files) {
+  for (const file of files.values()) {
     versions.push({
       path: file,
       ...((await fileExists(file))
@@ -287,7 +294,7 @@ export async function snapshotUpdateCandidateState(
     );
   const versions: UpdateStateSchemaVersion[] = [];
   const files = await collectStateDatabasePaths(input);
-  for (const file of files) {
+  for (const file of files.values()) {
     if (!(await fileExists(file))) {
       versions.push({ path: file, userVersion: null });
       continue;

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -9,11 +9,18 @@ import type { OpenClawSchemaVersions } from "../state/openclaw-schema-versions.j
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import { readStateSchemaContentVersion } from "../state/openclaw-state-db-schema-version.js";
 import type { DB } from "../state/openclaw-state-db.generated.js";
-import { resolveOpenClawRegisteredAgentDatabasePath } from "../state/openclaw-state-db.paths.js";
+import {
+  resolveOpenClawRegisteredAgentDatabasePath,
+  resolveOpenClawStateDirForDatabasePath,
+} from "../state/openclaw-state-db.paths.js";
 import { resolveUserPath } from "./home-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
-import { hasNodeErrorCode, normalizeWindowsPathPreservingCase } from "./path-guards.js";
+import {
+  hasNodeErrorCode,
+  isPathInside,
+  normalizeWindowsPathPreservingCase,
+} from "./path-guards.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import { prepareSqliteReadOnlyLocationSyncInProcess } from "./sqlite-readonly-location.js";
@@ -104,11 +111,16 @@ function collectRegisteredPaths(db: DatabaseSync, shared: string, files: string[
     : [];
   return rows.map(({ path: stored }) => {
     const source = resolveOpenClawRegisteredAgentDatabasePath(shared, stored);
-    // Windows registries can carry extended-length \\?\ spellings of a database
-    // that directory discovery already listed; both spellings project to the same
-    // candidate target, so discover the case-preserving plain spelling once.
+    // Discover one projection identity per database. An in-root extended-length
+    // \\?\ alias dedupes against the plain spelling directory discovery already
+    // listed, because projection rebases both to the same candidate path. External
+    // locators keep their raw spelling so the copy and the registry rebound write
+    // share one hashed destination.
     const discovered =
-      process.platform === "win32" ? normalizeWindowsPathPreservingCase(source) : source;
+      process.platform === "win32" &&
+      isPathInside(resolveOpenClawStateDirForDatabasePath(shared), source)
+        ? normalizeWindowsPathPreservingCase(source)
+        : source;
     // Discover registrations from the exact private generation being inspected.
     if (!files.includes(discovered)) {
       files.push(discovered);

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -111,13 +111,16 @@ function collectRegisteredPaths(db: DatabaseSync, shared: string, files: string[
     : [];
   return rows.map(({ path: stored }) => {
     const source = resolveOpenClawRegisteredAgentDatabasePath(shared, stored);
-    // Discover one projection identity per database. An in-root extended-length
-    // \\?\ alias dedupes against the plain spelling directory discovery already
-    // listed, because projection rebases both to the same candidate path. External
-    // locators keep their raw spelling so the copy and the registry rebound write
-    // share one hashed destination.
+    // Discover one projection identity per database, using the same raw
+    // eligibility as resolveUpdateCandidateStatePath: a canonically spelled
+    // in-root extended-length \\?\ alias dedupes against the plain spelling
+    // directory discovery already listed, because projection rebases both to
+    // the same candidate path. External and non-canonical locators keep their
+    // raw spelling so the copy and the registry rebound write share one
+    // destination.
     const discovered =
       process.platform === "win32" &&
+      path.normalize(source) === source &&
       isPathInside(resolveOpenClawStateDirForDatabasePath(shared), source)
         ? normalizeWindowsPathPreservingCase(source)
         : source;


### PR DESCRIPTION
Closes #144581

## What Problem This Solves

Fixes an issue where users on Windows running `openclaw update` from a git source checkout (dev channel) would have the update fail at the **candidate snapshot** step with `runtime-verification-failed`, because the snapshot tried to create a malformed directory with a `\\?\` extended-length prefix embedded mid-path:

```
mkdir '~\AppData\Local\Temp\openclaw-update-canary-XdvR42\?\$OPENCLAW_STATE_DIR\agents\main\agent'
```

(The `$OPENCLAW_STATE_DIR` token in that log is diagnostic redaction, not a failed expansion.) The malformed path appears whenever a registered agent database path carries the Windows extended-length `\\?\` prefix. `isPathInside` treats the prefixed spelling as inside the state root (it strips the prefix for comparison), but `path.relative` cannot see across the prefix and returns the absolute source unchanged; joining that under the canary directory embeds the prefix mid-path and the mkdir is rejected. The same defect breaks the P0 npm-channel report #144791.

## Why This Change Was Made

`update-candidate-paths.ts` now owns one projection identity per locator (`resolveUpdateCandidateStateIdentity`): a canonically spelled in-root alias takes its case-preserving plain spelling (`normalizeWindowsPathPreservingCase`, the existing guard helper), while external and non-canonical locators keep their raw spelling. The projection helper keeps its raw-locator guard first and rebases eligible in-root aliases through that identity, so a namespaced in-root path projects to `<target>\agents\main\agent\...` instead of embedding the prefix mid-path.

Every database discovery source — directory enumeration, env/config agent dirs, and registry registrations — groups spellings by that identity: physical snapshot copies dedupe to one per database (including when the state root itself is `\\?\`-prefixed), while the published versions response keeps **every raw alias** so the exact-path comparison against rollback baselines captured by released 2026.9.x updaters (including the Doctor update path, which captures baselines without `validateCandidate`) still matches. Copying and registry rebinding always derive one shared destination. The copied registry's legacy absolute/relative duplicate collapse now also recognizes a prefixed/plain pair, so updating both rows to the rebound relative path cannot violate the unique key.

## User Impact

`openclaw update` on Windows proceeds past candidate snapshot for state directories whose agent registry contains extended-length `\\?\` paths (including `\\?\`-prefixed state roots), instead of failing into repair with `runtime-verification-failed`. Rollback schema verification keeps working across the upgrade. No behavior change on other platforms or for plain path spellings.

## Evidence

Five Windows-gated regression tests in `src/infra/update-candidate-state.namespaced-paths.test.ts` run the real snapshot/versions workers end to end:

1. **In-root namespaced**: registers `\\?\<stateDir>\agents\main\agent\openclaw-agent.sqlite`; on unmodified `main` the test reproduces the issue's exact failure (`ENOENT ... mkdir '<canary>\?\C:\...\source\agents\main\agent'`), and with the fix the database lands at `<target>\agents\main\agent\openclaw-agent.sqlite` with content preserved and the registry row rebound to the relative path.
2. **External namespaced**: registers `\\?\<external>\openclaw-agent.sqlite` outside the state root; copy and rebind share one `candidate-external/<hash>` destination.
3. **Noncanonical in-root**: registers `C:\state\agents\main\.\agent\openclaw-agent.sqlite` (dot segment); the raw locator keeps its hashed destination.
4. **Namespaced state root**: runs the worker with `stateDir = \\?\<stateDir>` and a relative registration; previously this scheduled the same database twice and failed with `SQLite snapshot target already exists`, now exactly one copy is made, and the versions response keeps the legacy namespaced spelling.
5. **Mixed-alias baseline** (per maintainer F3): registers both a relative and a `\\?\`-prefixed row for one database, builds a baseline the way a released 2026.9.3/2026.9.4 worker reports it (versions read straight from the physical databases), and asserts `updateStateSchemaVersionsMatch` passes against the new worker's response while the snapshot copies the database exactly once.

Each scenario was verified to fail on the revision before its fix and pass at this head.

- `node scripts/run-vitest.mjs src/infra/update-candidate-state.test.ts src/infra/update-candidate-state.cleanup.test.ts src/infra/update-candidate-canary.test.ts src/infra/update-candidate-state.namespaced-paths.test.ts` — 52 passed; the only failures are 12 pre-existing `EPERM: operation not permitted, symlink` plugin-topology tests that fail identically on unmodified `main` on this machine (Windows without Developer Mode symlink privilege).
- `tsgo -p tsconfig.core.json` reports an identical 218-error baseline with and without this change (all in unrelated `*.test-support.ts` files; zero errors in the touched files).
- Touched files formatted with the repo's `oxfmt`; `git diff --check` clean.

Known limitation: the full `openclaw update` flow was not re-run end to end on a live install; validation is through the real snapshot worker entry point used by the update pipeline.