### PR TITLE
fix: session link browser test fails after chat styles load

### DIFF
--- a/ui/src/components/session-link-presentation.browser.test.ts
+++ b/ui/src/components/session-link-presentation.browser.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import "../styles/base.css";
 import "../styles/chat/text.css";
+import "../styles/sidebar-markdown.css";
+import "../styles/chat/grouped.css";
 
 const title = "A resolved session title long enough to need truncation in a narrow chat bubble";
 
@@ -56,18 +58,19 @@ describe("session link presentation", () => {
     },
   );
 
-  it.each(["sidebar-markdown", "chat-reply-attribution"])(
-    "shares the titled-link treatment in %s",
-    (className) => {
-      const host = document.createElement("div");
-      host.id = "session-link-proof";
-      host.className = className;
-      host.innerHTML = `<a class="markdown-session-link markdown-session-link--titled"><span class="session-label">${title}</span></a><a class="markdown-session-link">untitled</a>`;
-      document.body.append(host);
-      const [titled, untitled] = host.querySelectorAll("a");
-      expect(getComputedStyle(titled!).color).toBe(getComputedStyle(untitled!).color);
-      expect(getComputedStyle(titled!).display).toBe("inline-grid");
-      expect(getComputedStyle(titled!.firstElementChild!).textOverflow).toBe("ellipsis");
-    },
-  );
+  // Flex items blockify inline-grid; ordinary Markdown links retain their inline outer display.
+  it.each([
+    ["sidebar-markdown", "inline-grid"],
+    ["chat-reply-attribution", "grid"],
+  ])("shares the titled-link treatment in %s", (className, expectedDisplay) => {
+    const host = document.createElement("div");
+    host.id = "session-link-proof";
+    host.className = className;
+    host.innerHTML = `<a class="markdown-session-link markdown-session-link--titled"><span class="session-label">${title}</span></a><a class="markdown-session-link">untitled</a>`;
+    document.body.append(host);
+    const [titled, untitled] = host.querySelectorAll("a");
+    expect(getComputedStyle(titled!).color).toBe(getComputedStyle(untitled!).color);
+    expect(getComputedStyle(titled!).display).toBe(expectedDisplay);
+    expect(getComputedStyle(titled!.firstElementChild!).textOverflow).toBe("ellipsis");
+  });
 });


### PR DESCRIPTION
Related: #139428, #144359

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where the session-link browser test passes alone but fails in the shared UI shard after chat styles have loaded. The attribution case expects an inline display even though its real parent uses flex layout.

## Why This Change Was Made

Load the owning sidebar and attribution styles explicitly, in the canonical chat stylesheet order. Assert `inline-grid` for sidebar links and `grid` for attribution links: CSS blockification changes the outer display of a flex item while preserving its grid contents. Keep all four cases and their color, ellipsis, baseline, width, and icon assertions. No production styles change.

## User Impact

Reliable browser coverage of both actual layout contexts. No user-visible product behavior changes.

## Evidence

- Reused the failed UI job from PR #144359 (run `34563571171`); test, CSS, render owner, and browser configuration match its actual merge commit `f921a5de`.
- Unchanged focused test: 4 passed. The same unchanged test with the real attribution stylesheet loaded: 3 passed, attribution failed with expected `inline-grid` / actual `grid`, matching CI. Focused candidate: all 4 passed.
- CI's browser-session log records panels-tools-skills → menu-surface → tooltip-title → session-link. Menu-surface loads the shared chat stylesheet chain. Two local ordered-replay attempts were limited by Vite dependency optimization reloads: the first collected no tests; the warmed attempt passed 27 predecessor cases before another reload prevented the remaining files from collecting. Neither is claimed as a successful historical replay; the successful canonical shared-context CI coverage below provides the landing proof.
- Mapped changed checks, formatting, deslop, and independent P2 review passed. Formatter AST equivalence is recorded. Net change: three test lines; all cases retained.

- Exact-head CI [34565385035](https://github.com/openclaw/openclaw/actions/runs/34565385035) passed. Its canonical shared UI shard passed all 358 files / 5,940 tests, including all four repaired cases and all recorded predecessor files. The scheduler used a different browser-session assignment; this is not an exact historical-order replay. The tested merge `e73b0b86` contains the exact reviewed test bytes.
