### PR TITLE
feat(fleet): show the recorded container runtime in status

### DIFF
--- a/docs/cli/fleet.md
+++ b/docs/cli/fleet.md
@@ -149,6 +149,11 @@ openclaw fleet status acme
 openclaw fleet status acme --json
 ```
 
+Human-readable status includes `Runtime: docker` or `Runtime: podman` from the cell's
+recorded runtime. This identifies the container engine selected for the cell, not
+whether that engine is currently available. JSON output retains the existing
+`runtime` field.
+
 Status combines the fleet registry row, live container inspection, and a short best-effort request to:
 
 ```text

--- a/src/cli/fleet-cli/commands.runtime.ts
+++ b/src/cli/fleet-cli/commands.runtime.ts
@@ -150,6 +150,7 @@ export async function runFleetStatusCommand(options: {
   }
   defaultRuntime.log(`Tenant: ${result.tenant}`);
   defaultRuntime.log(`Container: ${result.containerName}`);
+  defaultRuntime.log(`Runtime: ${result.runtime}`);
   defaultRuntime.log(`State: ${result.container.state}`);
   defaultRuntime.log(`Port: ${result.port}`);
   defaultRuntime.log(`Image: ${result.image}`);

--- a/src/cli/fleet-cli/commands.status-runtime.test.ts
+++ b/src/cli/fleet-cli/commands.status-runtime.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { createFleetService } from "../../fleet/service.runtime.js";
+
+type FleetStatus = Awaited<ReturnType<ReturnType<typeof createFleetService>["status"]>>;
+
+const mocks = await vi.hoisted(async () => {
+  const { createCliRuntimeMock } = await import("../test-runtime-mock.js");
+  return { ...createCliRuntimeMock(vi), status: vi.fn() };
+});
+vi.mock("../../runtime.js", () => ({ defaultRuntime: mocks.defaultRuntime }));
+vi.mock("../../fleet/service.runtime.js", () => ({
+  createFleetService: () => ({ status: mocks.status }),
+}));
+
+import { runFleetStatusCommand } from "./commands.runtime.js";
+
+function statusResult(runtime: "docker" | "podman"): FleetStatus {
+  return {
+    tenant: "acme",
+    containerName: "openclaw-cell-acme",
+    runtime,
+    port: 19_100,
+    image: "image",
+    created: "2026-01-01T00:00:00.000Z",
+    dataDir: "/tmp/acme",
+    container: { state: "running", running: true, managed: true },
+    health: { status: "ok", url: "http://127.0.0.1:19100/healthz", httpStatus: 200 },
+  };
+}
+
+describe("fleet status runtime projection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runtimeLogs.length = 0;
+    mocks.runtimeErrors.length = 0;
+  });
+
+  it.each(["docker", "podman"] as const)("shows the recorded %s runtime", async (runtime) => {
+    mocks.status.mockResolvedValue(statusResult(runtime));
+    await runFleetStatusCommand({ tenant: "acme", json: false });
+    expect(mocks.status).toHaveBeenCalledExactlyOnceWith("acme");
+    expect(mocks.runtimeLogs).toEqual([
+      "Tenant: acme",
+      "Container: openclaw-cell-acme",
+      `Runtime: ${runtime}`,
+      "State: running",
+      "Port: 19100",
+      "Image: image",
+      "Created: 2026-01-01T00:00:00.000Z",
+      "Data: /tmp/acme",
+      "Health: ok (HTTP 200)",
+    ]);
+    expect(mocks.defaultRuntime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it.each(["docker", "podman"] as const)("leaves %s JSON unchanged", async (runtime) => {
+    const result = statusResult(runtime);
+    const before = structuredClone(result);
+    mocks.status.mockResolvedValue(result);
+    await runFleetStatusCommand({ tenant: "acme", json: true });
+    expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledExactlyOnceWith(before);
+    expect(mocks.defaultRuntime.writeJson.mock.calls[0]?.[0]).toBe(result);
+    expect(mocks.runtimeLogs).toEqual([JSON.stringify(before, null, 2)]);
+    expect(result).toEqual(before);
+  });
+
+  it.each(["missing", "unknown"] as const)(
+    "does not confuse runtime identity with container state %s",
+    async (state) => {
+      const result = statusResult("podman");
+      result.container =
+        state === "unknown"
+          ? { state, running: false, managed: false, error: "Runtime unavailable" }
+          : { state, running: false, managed: false };
+      result.health = { status: "skipped", url: result.health.url, reason: "No endpoint" };
+      mocks.status.mockResolvedValue(result);
+      await runFleetStatusCommand({ tenant: "acme", json: false });
+      expect(mocks.runtimeLogs).toContain("Runtime: podman");
+      expect(mocks.runtimeLogs).toContain(`State: ${state}`);
+      expect(mocks.runtimeLogs).toContain("Health: skipped (No endpoint)");
+    },
+  );
+
+  it("preserves service errors without emitting a partial status", async () => {
+    mocks.status.mockRejectedValueOnce(new Error("Unknown fleet tenant"));
+    await expect(runFleetStatusCommand({ tenant: "acme", json: false })).rejects.toThrow(
+      "Unknown fleet tenant",
+    );
+    expect(mocks.runtimeLogs).toEqual([]);
+    expect(mocks.defaultRuntime.writeJson).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #144675

<details><summary>Additional instructions</summary>
Keep Allow edits from maintainers enabled.
</details>

## What Problem This Solves

Operators inspecting `openclaw fleet status` cannot identify the cell's recorded container engine in normal text output. Docker and Podman cells can use similar container names; operators currently need a separate JSON invocation to confirm which engine Fleet selected.

## Why This Change Was Made

Human-readable status prints `Runtime: docker` or `Runtime: podman` from the existing service result. The canonical SQLite record already owns this fact. This adds a text projection and its CLI documentation; runtime selection, availability detection, ownership inspection, health checks, and JSON behavior are unchanged.

## User Impact

Operators see the recorded engine alongside the container identity, including when inspection is unavailable or the container is missing. This line identifies the recorded engine and does not claim it is running. No configuration or additional setup is needed.

## Evidence

The contribution changes three files: one production line, five documentation lines, and 91 lines of focused tests. Both engine labels, JSON values and serialization, source-result preservation, missing or unavailable container state, and service errors without partial output are covered. The later test correction removes one unnecessary object-identity constraint; the production change is unchanged.

### Recorded-state behavior

The baseline at `068318110aec933f9c6c5ea1981489d6c39ca283` omitted the Runtime line for both Docker and Podman while JSON already returned the recorded engine. The original candidate at `2ffa3f9002e164387df7eafe75c2d5bf69be4db3` displayed each matching line exactly once. These checks reserved real cells in an isolated canonical SQLite registry and invoked the registered Fleet CLI in child processes, with no handler, service, registry, or output mocks. Engine binaries were intentionally unavailable: state remained `unknown`, health remained `skipped`, registry readback was unchanged, and temporary state was removed.

[Baseline run and receipt](https://github.com/Alix-007/openclaw/actions/runs/34563611325) · [original candidate run and receipt](https://github.com/Alix-007/openclaw/actions/runs/34563829922) · [pinned proof harness](https://github.com/Alix-007/openclaw/tree/23937c4856ba48b0f72b99db0ff409942bb17e35/.github/proof/p11). Both artifact checksums and the original candidate's three file hashes were independently verified. The baseline tests had four intended text-acceptance failures and three preservation passes; all 30 focused/sibling cases passed on the candidate.

### Current candidate verification

Head `bf27cfe60da9eb32e42eb3db07c2f695a605052d`, tree `d694428fa90b62c467f1051258f574f12a4198e6`, passed formatting, targeted core lint, diff hygiene, and all 30 focused/sibling tests in secretless AWS through Crabbox. The same registered CLI/SQLite proof also passed for both engines on that exact tree, using Node 24.19.0 and SQLite 3.53.3. Source review and automated review found no remaining actionable defects.

The contribution was also applied to main `01ca58c2830bfd351ff6d10c32b69c8bb27ba27f`, which uses SQLite workers for Fleet registry access. The tested combined tree `321be2785df3e87cf70e5211bb268c8b32ec34d0` matches Git’s merge result. Both Docker and Podman passed the registered-command before/after check through that worker path: the Runtime line changed from absent to exactly one, while JSON runtime, `unknown`/`skipped` results and registry readback were preserved. All 35 current-main focused/sibling cases passed, and temporary state was removed.

[CI for the updated head](https://github.com/openclaw/openclaw/actions/runs/35455488387) passed, including the applicable security gate. [ClawSweeper’s exact-head review](https://github.com/openclaw/openclaw/pull/144691#issuecomment-5630944935) is Platinum overall, with Diamond proof confidence and no findings.

This proof exercises the registered source command. It does not claim packaged root bootstrap, a running container, a Docker/Podman daemon, a network health endpoint, or a production instance.
