### PR TITLE
fix(process): preserve respawn child signals

### DIFF
--- a/node-runtime-recovery.mjs
+++ b/node-runtime-recovery.mjs
@@ -151,6 +151,15 @@ export const runRespawnedChild = (command, args, env) => {
   child.once("exit", (code, signal) => {
     detach();
     if (signal) {
+      if (process.platform !== "win32") {
+        try {
+          process.kill(process.pid, signal);
+        } catch {
+          // Fall through to a numeric failure when the signal cannot be relayed.
+        }
+        process.exit(1);
+        return;
+      }
       const forwardedSignalExitCode =
         !hardKillBackstopStarted && signal === firstForwardedSignal
           ? signal === "SIGINT"

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -67,6 +67,7 @@ describe("entry compile cache", () => {
   let argv: string[];
   let child: ChildProcess;
   let kill: Mock<ChildProcess["kill"]>;
+  let signalSelf: MockInstance<typeof process.kill>;
   let exit: MockInstance<typeof process.exit>;
   let writeStderr: MockInstance<typeof process.stderr.write>;
   let envSnapshot: ReturnType<typeof captureEnv>;
@@ -86,13 +87,14 @@ describe("entry compile cache", () => {
     deleteTestEnvValue("OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED");
     enableCompileCache.mockReset();
     getCompileCacheDir.mockReset();
-    attachChildProcessBridge.mockReset();
+    attachChildProcessBridge.mockReset().mockReturnValue({ detach: vi.fn() });
     child = new EventEmitter() as ChildProcess;
     kill = vi.fn(() => true);
     child.kill = kill;
     spawn.mockReset().mockReturnValue(child);
     vi.spyOn(process, "argv", "get").mockImplementation(() => argv);
     vi.spyOn(process, "execArgv", "get").mockReturnValue(["--no-warnings"]);
+    signalSelf = vi.spyOn(process, "kill").mockReturnValue(true);
     exit = vi.spyOn(process, "exit").mockImplementation(vi.fn<typeof process.exit>());
     writeStderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
   });
@@ -258,10 +260,15 @@ describe("entry compile cache", () => {
     expect(writeStderr).not.toHaveBeenCalled();
   });
 
-  it("marks signal-terminated compile-cache respawn children as failed without forcing another exit", async () => {
+  it("preserves signal-terminated compile-cache respawn children", async () => {
     await markSourceCheckout();
     await respawnWithoutOpenClawCompileCacheIfNeeded({ currentFile: entryFile, installRoot: root });
     child.emit("exit", null, "SIGTERM");
+    if (process.platform === "win32") {
+      expect(signalSelf).not.toHaveBeenCalled();
+    } else {
+      expect(signalSelf).toHaveBeenCalledWith(process.pid, "SIGTERM");
+    }
     expect(exit).toHaveBeenCalledExactlyOnceWith(1);
   });
 

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -165,6 +165,9 @@ export async function respawnWithoutOpenClawCompileCacheIfNeeded(params: {
       ? {
           spawn,
           attachChildProcessBridge,
+          signalSelf: (signal) => {
+            process.kill(process.pid, signal);
+          },
           exit: process.exit.bind(process) as (code?: number) => never,
           writeError,
         }
@@ -178,6 +181,9 @@ function runOpenClawCompileCacheRespawnPlan(
   runtime: OpenClawCompileCacheRespawnRuntime = {
     spawn,
     attachChildProcessBridge,
+    signalSelf: (signal) => {
+      process.kill(process.pid, signal);
+    },
     exit: process.exit.bind(process) as (code?: number) => never,
     writeError: (message: string) => {
       process.stderr.write(message);

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -402,7 +402,8 @@ describe("runCliRespawnPlan", () => {
   it("spawns and bridges the respawn child", () => {
     const child = new EventEmitter() as ChildProcess;
     const spawn = vi.fn(() => child);
-    const attachChildProcessBridge = vi.fn();
+    const detach = vi.fn();
+    const attachChildProcessBridge = vi.fn(() => ({ detach }));
     const exit = vi.fn<(code?: number) => never>();
     const writeError = vi.fn();
 
@@ -416,6 +417,7 @@ describe("runCliRespawnPlan", () => {
       {
         spawn: spawn as unknown as typeof import("node:child_process").spawn,
         attachChildProcessBridge,
+        signalSelf: vi.fn(),
         exit,
         writeError,
       },
@@ -439,6 +441,7 @@ describe("runCliRespawnPlan", () => {
 
     child.emit("exit", 0, null);
 
+    expect(detach).toHaveBeenCalledOnce();
     expect(exit).toHaveBeenCalledWith(0);
     expect(writeError).not.toHaveBeenCalled();
   });

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -170,6 +170,9 @@ export function runCliRespawnPlan(
   const resolvedRuntime: CliRespawnRuntime = runtime ?? {
     spawn,
     attachChildProcessBridge,
+    signalSelf: (signal) => {
+      process.kill(process.pid, signal);
+    },
     exit: process.exit.bind(process) as (code?: number) => never,
     writeError,
   };

--- a/src/process/respawn-child-runner.test.ts
+++ b/src/process/respawn-child-runner.test.ts
@@ -42,6 +42,7 @@ describe("runRespawnChildWithSignalBridge", () => {
       runtime: {
         spawn: spawnChild as unknown as typeof spawn,
         attachChildProcessBridge: vi.fn(),
+        signalSelf: vi.fn(),
         exit: vi.fn<RespawnChildRuntime["exit"]>(),
       },
       onError: vi.fn(),
@@ -57,8 +58,11 @@ describe("runRespawnChildWithSignalBridge", () => {
   it.each([
     { signal: "SIGINT" as const, laterSignal: "SIGTERM" as const, exitCode: 130 },
     { signal: "SIGTERM" as const, laterSignal: "SIGINT" as const, exitCode: 143 },
-  ])("exits $exitCode when the child exits by forwarded $signal", (testCase) => {
+  ])("preserves the child outcome after forwarded $signal", (testCase) => {
     const { child } = createChild(2345);
+    const lifecycle: string[] = [];
+    const detach = vi.fn(() => lifecycle.push("detach"));
+    const signalSelf = vi.fn(() => lifecycle.push("signalSelf"));
     const exit = vi.fn<RespawnChildRuntime["exit"]>();
     let onSignal: ((signal: NodeJS.Signals) => void) | undefined;
 
@@ -70,8 +74,9 @@ describe("runRespawnChildWithSignalBridge", () => {
         spawn: vi.fn(() => child) as unknown as typeof spawn,
         attachChildProcessBridge: vi.fn((_child, options) => {
           onSignal = options?.onSignal;
-          return { detach: vi.fn() };
+          return { detach };
         }),
+        signalSelf,
         exit,
       },
       onError: vi.fn(),
@@ -81,7 +86,14 @@ describe("runRespawnChildWithSignalBridge", () => {
     onSignal?.(testCase.laterSignal);
     child.emit("exit", null, testCase.signal);
 
-    expect(exit).toHaveBeenCalledWith(testCase.exitCode);
+    if (process.platform === "win32") {
+      expect(signalSelf).not.toHaveBeenCalled();
+      expect(exit).toHaveBeenCalledWith(testCase.exitCode);
+    } else {
+      expect(lifecycle).toEqual(["detach", "signalSelf"]);
+      expect(signalSelf).toHaveBeenCalledWith(testCase.signal);
+      expect(exit).toHaveBeenCalledWith(1);
+    }
   });
 
   it("signals detached respawn process groups after forwarded signal grace", () => {
@@ -104,6 +116,7 @@ describe("runRespawnChildWithSignalBridge", () => {
             onSignal = options?.onSignal;
             return { detach: vi.fn() };
           }),
+          signalSelf: vi.fn(),
           exit,
         },
         onError: vi.fn(),
@@ -159,6 +172,7 @@ describe("runRespawnChildWithSignalBridge", () => {
             onSignal = options?.onSignal;
             return { detach: vi.fn() };
           }),
+          signalSelf: vi.fn(),
           exit,
         },
         onError: vi.fn(),
@@ -194,6 +208,7 @@ describe("runRespawnChildWithSignalBridge", () => {
       runtime: {
         spawn: spawnChild as unknown as typeof spawn,
         attachChildProcessBridge: vi.fn(),
+        signalSelf: vi.fn(),
         exit: vi.fn<RespawnChildRuntime["exit"]>(),
       },
       onError: vi.fn(),
@@ -222,6 +237,7 @@ describe("runRespawnChildWithSignalBridge", () => {
       runtime: {
         spawn: vi.fn(() => child) as unknown as typeof spawn,
         attachChildProcessBridge: vi.fn(),
+        signalSelf: vi.fn(),
         exit,
       },
       onError,
@@ -248,6 +264,7 @@ describe("runRespawnChildWithSignalBridge", () => {
         runtime: {
           spawn: vi.fn(() => child) as unknown as typeof spawn,
           attachChildProcessBridge: vi.fn(),
+          signalSelf: vi.fn(),
           exit,
         },
         onError,
@@ -284,6 +301,7 @@ describe("runRespawnChildWithSignalBridge", () => {
             throw error;
           }) as unknown as typeof spawn,
           attachChildProcessBridge: vi.fn(),
+          signalSelf: vi.fn(),
           exit,
         },
         onError,
@@ -311,6 +329,7 @@ describe("runRespawnChildWithSignalBridge", () => {
             onSignal = options?.onSignal;
             return { detach: vi.fn() };
           }),
+          signalSelf: vi.fn(),
           exit,
         },
         onError,

--- a/src/process/respawn-child-runner.ts
+++ b/src/process/respawn-child-runner.ts
@@ -10,6 +10,7 @@ const RESPAWN_SIGNAL_HARD_EXIT_GRACE_MS = 1_000;
 export type RespawnChildRuntime = {
   spawn: typeof spawn;
   attachChildProcessBridge: typeof attachChildProcessBridge;
+  signalSelf: (signal: NodeJS.Signals) => void;
   exit: (code?: number) => never;
 };
 
@@ -96,16 +97,26 @@ export function runRespawnChildWithSignalBridge(params: {
     signalExitTimer.unref?.();
   };
 
-  runtime.attachChildProcessBridge(child, {
+  const bridge = runtime.attachChildProcessBridge(child, {
     onSignal: scheduleParentExit,
   });
 
   child.once("exit", (code, signal) => {
+    bridge.detach();
     if (parentSignalReceived && detachForProcessTree) {
       forceKillChild();
     }
     clearSignalTimers();
     if (signal) {
+      if (process.platform !== "win32") {
+        try {
+          runtime.signalSelf(signal);
+        } catch {
+          // Fall through to a numeric failure when the signal cannot be relayed.
+        }
+        runtime.exit(1);
+        return;
+      }
       const forwardedSignalExitCode =
         !hardKillBackstopStarted && signal === firstForwardedSignal
           ? signal === "SIGINT"

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -1327,57 +1327,123 @@ describe("openclaw launcher", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32").each([
-    { signal: "SIGINT" as const, exitCode: 130 },
-    { signal: "SIGTERM" as const, exitCode: 143 },
-  ])("exits $exitCode when the respawn child terminates from $signal", async (testCase) => {
+  it.runIf(process.platform !== "win32").each(["SIGINT", "SIGTERM"] as const)(
+    "preserves $signal when the respawn child terminates from the forwarded signal",
+    async (signal) => {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      await addGitMarker(fixtureRoot);
+      const childInfoPath = path.join(fixtureRoot, "child-info.json");
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          `writeFileSync(${JSON.stringify(childInfoPath)}, JSON.stringify({ pid: process.pid }) + "\\n");`,
+          'process.title = "openclaw-launcher-default-signal-test-child";',
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const launcher = spawn(process.execPath, [path.join(fixtureRoot, "openclaw.mjs")], {
+        cwd: fixtureRoot,
+        env: launcherEnv({
+          NODE_COMPILE_CACHE: path.join(fixtureRoot, ".node-compile-cache"),
+        }),
+        stdio: "ignore",
+      });
+      let respawnChildPid: number | undefined;
+
+      try {
+        const childInfo = await waitForJsonFile<{ pid: number }>(childInfoPath, 5000);
+        respawnChildPid = childInfo.pid;
+
+        launcher.kill(signal);
+
+        await expect(waitForProcessExit(launcher, "launcher", 5000)).resolves.toEqual({
+          code: null,
+          signal,
+        });
+        expect(isProcessAlive(respawnChildPid)).toBe(false);
+      } finally {
+        if (isProcessAlive(respawnChildPid)) {
+          process.kill(respawnChildPid!, "SIGKILL");
+        }
+        if (isProcessAlive(launcher.pid)) {
+          process.kill(launcher.pid!, "SIGKILL");
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves SIGKILL when the respawn child is killed directly",
+    async () => {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      await addGitMarker(fixtureRoot);
+      const childInfoPath = path.join(fixtureRoot, "child-info.json");
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          `writeFileSync(${JSON.stringify(childInfoPath)}, JSON.stringify({ pid: process.pid }) + "\\n");`,
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const launcher = spawn(process.execPath, [path.join(fixtureRoot, "openclaw.mjs")], {
+        cwd: fixtureRoot,
+        env: launcherEnv({
+          NODE_COMPILE_CACHE: path.join(fixtureRoot, ".node-compile-cache"),
+        }),
+        stdio: "ignore",
+      });
+      let respawnChildPid: number | undefined;
+
+      try {
+        respawnChildPid = (await waitForJsonFile<{ pid: number }>(childInfoPath, 5000)).pid;
+        process.kill(respawnChildPid, "SIGKILL");
+
+        await expect(waitForProcessExit(launcher, "launcher", 5000)).resolves.toEqual({
+          code: null,
+          signal: "SIGKILL",
+        });
+      } finally {
+        if (isProcessAlive(respawnChildPid)) {
+          process.kill(respawnChildPid!, "SIGKILL");
+        }
+        if (isProcessAlive(launcher.pid)) {
+          process.kill(launcher.pid!, "SIGKILL");
+        }
+      }
+    },
+  );
+
+  it.each([23, 143])("preserves explicit respawn child exit code %s", async (exitCode) => {
     const fixtureRoot = await makeLauncherFixture(fixtureRoots);
     await addGitMarker(fixtureRoot);
-    const childInfoPath = path.join(fixtureRoot, "child-info.json");
     await fs.writeFile(
       path.join(fixtureRoot, "dist", "entry.js"),
-      [
-        'import { writeFileSync } from "node:fs";',
-        `writeFileSync(${JSON.stringify(childInfoPath)}, JSON.stringify({ pid: process.pid }) + "\\n");`,
-        'process.title = "openclaw-launcher-default-signal-test-child";',
-        "setInterval(() => {}, 1000);",
-        "",
-      ].join("\n"),
+      `process.exit(${exitCode});\n`,
       "utf8",
     );
 
-    const launcher = spawn(process.execPath, [path.join(fixtureRoot, "openclaw.mjs")], {
+    const result = spawnSync(process.execPath, [path.join(fixtureRoot, "openclaw.mjs")], {
       cwd: fixtureRoot,
       env: launcherEnv({
         NODE_COMPILE_CACHE: path.join(fixtureRoot, ".node-compile-cache"),
       }),
-      stdio: "ignore",
+      encoding: "utf8",
     });
-    let respawnChildPid: number | undefined;
 
-    try {
-      const childInfo = await waitForJsonFile<{ pid: number }>(childInfoPath, 5000);
-      respawnChildPid = childInfo.pid;
-
-      launcher.kill(testCase.signal);
-
-      await expect(waitForProcessExit(launcher, "launcher", 5000)).resolves.toEqual({
-        code: testCase.exitCode,
-        signal: null,
-      });
-      expect(isProcessAlive(respawnChildPid)).toBe(false);
-    } finally {
-      if (isProcessAlive(respawnChildPid)) {
-        process.kill(respawnChildPid!, "SIGKILL");
-      }
-      if (isProcessAlive(launcher.pid)) {
-        process.kill(launcher.pid!, "SIGKILL");
-      }
-    }
+    expect(result.status).toBe(exitCode);
+    expect(result.signal).toBeNull();
   });
 
   it.runIf(process.platform !== "win32")(
-    "exits after SIGTERM when the respawn child ignores the forwarded signal",
+    "preserves forced SIGKILL when the respawn child ignores the forwarded signal",
     async () => {
       const fixtureRoot = await makeLauncherFixture(fixtureRoots);
       await addGitMarker(fixtureRoot);
@@ -1411,8 +1477,8 @@ describe("openclaw launcher", () => {
         launcher.kill("SIGTERM");
 
         await expect(waitForProcessExit(launcher, "launcher", 5000)).resolves.toEqual({
-          code: 1,
-          signal: null,
+          code: null,
+          signal: "SIGKILL",
         });
         expect(isProcessAlive(launcher.pid)).toBe(false);
         expect(isProcessAlive(respawnChildPid)).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

Unix source and built-entry respawn launchers converted a child signal into a normal numeric exit. Supervisors therefore could not distinguish a real signal such as SIGTERM or SIGKILL from an explicit exit code such as 143.

Fixes #144200.

## Why This Change Was Made

Detach the launcher signal bridge before re-signaling the wrapper with the child's terminating signal on Unix. Keep a numeric failure fallback when self-signaling cannot terminate the wrapper, and preserve the existing Windows mapping.

## User Impact

Callers supervising a respawned OpenClaw launcher now receive the runtime child's actual Unix signal. Explicit numeric exits and acknowledged shutdowns remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/process/respawn-child-runner.test.ts src/entry.compile-cache.test.ts src/entry.respawn.test.ts` — 63 passed
- `node scripts/run-vitest.mjs src/infra/node-runtime-recovery.test.ts test/openclaw-launcher.e2e.test.ts` — both shards passed; launcher 103 passed, 1 platform skip
- Regression matrix covers forwarded SIGINT/SIGTERM, direct and escalated SIGKILL, explicit exits 23/143, and handled shutdown 0
- Exact-head dual private review completed; one test-portability defect and one fallthrough guard were fixed and retested

AI assistance: Codex implemented and tested the change; independent Claude and Codex reviews were completed before publication.
