### PR TITLE
docs: make v2026.9.4 release notes easier to read

### DIFF
--- a/docs/releases/2026.9.4.md
+++ b/docs/releases/2026.9.4.md
@@ -10,9 +10,9 @@ keywords:
 
 # v2026.9.4
 
-OpenClaw 2026.9.4 makes it easier to find what your Claw can use next. The Plugins page brings installed plugins and available listings together, while Skills searches across installed skills, your library, and ClawHub. Your Claw can recommend official plugins in chat, and learning from past conversations now opens a conversation you can follow, steer, or stop in Skill Workshop.
+OpenClaw 2026.9.4 makes plugins and skills easier to find, and lets you turn past conversations into reusable skills through a chat you can steer.
 
-There is more to work with once you get started. Cloud sessions gain operating-system choices and controls for building, pinning, and selecting prepared project snapshots. GPT Image 2.5 adds new image-generation and editing options through OpenAI and fal. You can inspect native Codex subagent transcripts, answer questions directly in the terminal, and submit requested secrets there when connected to a Gateway. The release also repairs specific update failures, keeps more completed memory work available, and improves message delivery across channels.
+It also adds GPT Image 2.5 support, more control over cloud sessions, and interactive questions in the terminal, alongside fixes for updates, memory, and messaging.
 
 **Release scale:** 1,558 pull requests, 20 direct commits, and 293 contributors.
 

--- a/docs/releases/2026.9.4.md
+++ b/docs/releases/2026.9.4.md
@@ -18,17 +18,15 @@ It also adds GPT Image 2.5 support, more control over cloud sessions, and intera
 
 ## Installation and Onboarding
 
-OpenClaw can now recover from an incompatible Node installation by finding a usable copy already on your computer, or offering to install a private copy with your permission. Setup also handles existing protected provider keys, lets multi-agent users choose the workspace they are configuring, and preserves a new Claw's first conversation when an empty background memory sweep runs before you get there.
+OpenClaw can help you get past a Node version problem without replacing your computer's existing Node installation. New-agent setup also works with securely saved API keys, and the instructions for connecting a phone or removing OpenClaw now fill in steps that were missing.
 
 <AccordionGroup>
 
 <Accordion title="Start OpenClaw when Node needs attention">
 
-When Node cannot run OpenClaw, the launcher now looks for a compatible installed copy and retries your command, including the Doctor step used by older updaters. If it cannot find one, an interactive terminal can offer a [private Node installation](/install/node#update-from-the-cli) without replacing your system Node or shell defaults. The first installation requires your consent; later launches can reuse it unattended. Automatic installation covers x64 and ARM64 Macs, Windows, and glibc-based Linux; Alpine and other unsupported systems still need manual installation.
+If OpenClaw will not start because of Node, the software it runs on, it can now find a compatible copy already on your computer or [offer to install one just for OpenClaw](/install/node#update-from-the-cli). You approve the first installation; after that, OpenClaw can reuse it automatically. This gives you a way past the startup problem without changing Node for your other apps. Some systems, including Alpine Linux, still need manual installation. If you cannot start normally, basic help and troubleshooting commands remain available on some older Node versions.
 
-Startup also checks whether Node's SQLite implementation can read stored values correctly, catching defective builds even when their version number looks supported. The [supported version range](/install/node-compatibility) stays the same. Limited help, version, and read-only diagnostics remain available on eligible unsupported runtimes, but normal operation still requires a compatible runtime. For a background Gateway pointing to an old or missing Node, `openclaw gateway install` can select an available supported replacement without `--force`; installing a private CLI runtime alone does not repair that service.
-
-For Mac users running Bun, compatibility checks now use the selected SQLite library, and managed services retain the library settings from the installing shell. Existing services need an explicit reinstall with `--runtime bun --force` to pick up those settings. The [Bun compatibility guide](/install/bun-compatibility) explains the requirements; check Doctor's proposed repair before accepting it, because its separate repair path can still switch a Bun service to Node.
+If the background service is still using an old Node after an upgrade, `openclaw gateway install` can now switch it to an available supported version. This is a separate repair from getting the command line working.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -63,9 +61,7 @@ For Mac users running Bun, compatibility checks now use the selected SQLite libr
 
 <Accordion title="Install on Mac, Linux, and Docker">
 
-Mac installers now switch to system Bash when newer Homebrew Bash would leave them hanging before producing useful output, so the normal piped installation command continues to work. [Docker source builds](/install/docker) also include the required dependency-check script before installing packages, fixing the missing-file failure that stopped image builds.
-
-For Linux system services, the guide now puts choosing the non-root account that owns your configuration before activation, and service-install help explains that installation starts the service and a forced reinstall may restart it. Completion setup also recognizes supported HOME-relative hooks in Bash, Zsh, and Fish, preserving those user-managed profile lines when installing again or repairing a missing completion cache.
+Mac installation no longer gets stuck in the affected Homebrew Bash setups, and people building their own [Docker image](/install/docker) can get past the missing-file error that stopped installation. Linux instructions now explain which user account should run OpenClaw so it finds the right settings, while installation help makes clear when it will start or restart the background service. For people who manage their own terminal settings, supported command-completion entries are also preserved instead of being added again.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -90,9 +86,9 @@ For Linux system services, the guide now puts choosing the non-root account that
 
 <Accordion title="Connect a provider and reach the first conversation">
 
-New Agent setup can use provider keys already held in OpenClaw's protected store, so a working provider connection no longer needs a plaintext-key workaround for that setup failure. Moonshot's China API-key option also reaches credential entry and model selection without repeatedly asking you to reinstall an enabled provider. Provider guides also clarify that server credentials belong on the computer running the Gateway, and configuring a remote client does not configure them there.
+A new agent can now use an API key you have already saved in OpenClaw's protected storage, fixing a setup failure that left ordinary chats working but new-agent setup stuck. Moonshot's China API-key setup also stops asking you to reinstall a provider that is already installed, and browser sign-in explains when you have pasted a phone setup code into the wrong place.
 
-Browser sign-in now explains when a pasted value is a recognizable mobile setup code and directs you to the appropriate credential. In token mode, `openclaw gateway auth-token --show` retrieves the shared token; password-mode connections still need their configured password. And if an empty background memory sweep runs before your first message, it no longer creates placeholder files that make a fresh workspace skip its naming conversation. Workspaces already marked as set up keep their existing state.
+An empty background memory check no longer makes a fresh Claw think setup is already finished, so you still get its first naming conversation.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -118,9 +114,7 @@ Browser sign-in now explains when a pasted value is a recognizable mobile setup 
 
 <Accordion title="Choose the agent for setup">
 
-Guided channel setup now asks which agent workspace to use when a multi-agent installation has no default setup owner, then lets you choose message routing separately. Scripted setup in that situation still needs `--agent`. [Onboarding recommendation commands](/cli/onboard) accept the same selector for reading, refreshing, acknowledging, and retrying recommendations, including when you put it after the action; recommendations continue to belong to the selected workspace.
-
-After channel settings are saved, connection checks use resolved environment values while keeping your variable references in the configuration file. Node setup instructions also carry the manual process through device approval, reconnecting a paused node, and approving its commands, with those approvals kept distinct from permission to execute commands locally.
+If you have several agents, guided messaging setup now lets you choose whose workspace to configure before separately choosing who should receive the messages. You can also [choose an agent when managing setup recommendations](/cli/onboard), so you work with the intended workspace. Setup scripts still need an explicit `--agent` choice when no default is configured. The device setup instructions also explain that connecting a device and approving the commands it can run are separate steps.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -142,7 +136,7 @@ After channel settings are saved, connection checks use resolved environment val
 
 <Accordion title="Connect a phone to OpenClaw">
 
-CLI help now points phone users to [`openclaw qr`](/cli/qr) and explains that a node join URL is a different kind of setup link. The [Android guide](/platforms/android) fills in the reachable address, saved binding, and authentication steps needed before your phone can connect, with separate instructions for a trusted local network and managed Tailscale Serve. The accompanying browser guidance explains that private same-origin HTTP can support browser identity, but HTTPS remains preferred because HTTP does not encrypt your credentials or traffic.
+Phone setup help now points you to [`openclaw qr`](/cli/qr), and the [Android instructions](/platforms/android) explain how to connect to the computer running OpenClaw and set up the login your phone needs. They cover both a trusted home network and Tailscale. Use HTTPS for browser access when possible, because HTTP does not encrypt your login details or messages.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -158,7 +152,7 @@ CLI help now points phone users to [`openclaw qr`](/cli/qr) and explains that a 
 
 <Accordion title="Finish importing an existing setup">
 
-Completed memory imports and optional setup results remain available when final plugin cleanup reports an error. A retry of the same retained Gateway request can also reuse the completed result instead of importing again. If an error says the import finished but its result could not be returned, [inspect the report and destination files](/web/control-ui/settings) before starting another import. Cleanup warnings do not undo copied files, and retry protection ends when the Gateway restarts or forgets the request.
+An error at the very end of an import no longer has to hide work that already finished. OpenClaw preserves completed memory-import results when the final cleanup fails, and can recognize a retry of the same request without copying everything again. If an error says the import completed, [check the report and imported files](/web/control-ui/settings) before starting over. That retry protection is temporary and does not survive restarting OpenClaw.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -173,7 +167,7 @@ Completed memory imports and optional setup results remain available when final 
 
 <Accordion title="Remove an installation">
 
-The [uninstall guide](/install/uninstall) now matches removal steps to how OpenClaw was installed, including Git launchers and dedicated installation directories. Help and completion messages point to that guide without promising the CLI always survives state removal. Follow the steps for your installation, remove its service first, and preserve the configuration, workspaces, and shared tools you want to keep before deleting installation files.
+Removing OpenClaw now comes with instructions that match how you installed it, including Git and installations kept in their own folder. The [uninstall guide](/install/uninstall) explains which files and launchers to remove and which may be shared with other tools. Remove the background service first, and save any settings or workspaces you want to keep before deleting files.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -189,9 +183,7 @@ The [uninstall guide](/install/uninstall) now matches removal steps to how OpenC
 
 <Accordion title="Follow complete setup instructions">
 
-The setup guides fill in missing prerequisites and replace incomplete examples, including plugin installation, provider credentials, Render troubleshooting, and matching the Mac app to its CLI version. The [first-run FAQ](/help/faq-first-run/quick-start) now separates setup questions from provider and hosting choices, while workspace templates and related guides are linked where you need them.
-
-These documentation updates explain existing behavior, including which ClawHub skills need explicit selection and which migration steps require stopping and backing up your Gateway. The setup agent can also read configuration keys containing literal dots or brackets. Quoted or escaped keys now return the existing setting instead of reporting it missing, with credentials still redacted.
+The [first-run help](/help/faq-first-run/quick-start) separates getting started from choosing a provider or hosting service, so you can find the answer for the step you are on. Setup examples also fill in missing tools, credentials, and commands, including how to match the Mac app with the right command-line version. When you ask the setup agent to inspect a setting, it can now find names containing dots or brackets that it previously reported as missing, while keeping secret values hidden.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -223,15 +215,13 @@ These documentation updates explain existing behavior, including which ClawHub s
 
 ## The New Web UI
 
-The browser app gives you more ways to follow a conversation and the work happening around it. A compact message rail helps you return to a particular reply, selected text can go straight into your next draft, and Tasks now opens the conversation behind native Codex subagents. Files, attachments, and Settings also get practical improvements that make it easier to keep your place while reading, editing, or waiting for work to finish.
+In the web app, you can preview an earlier message before jumping back to it, bring a quote into your next reply, and see what Codex's helper agents did while working on your request. There are also fixes for the interruptions that make a conversation harder to follow, from disappearing image previews to finished tasks that still look busy.
 
 <AccordionGroup>
 
 <Accordion title="Find and organize conversations">
 
-[Conversations and the sidebar](/web/control-ui/sessions-and-sidebar) keep up with changes as you move between chats. Delayed responses no longer undo newer names, settings, or status, manually chosen names stay in place, and a failed automatic naming attempt can fall back to a readable topic. New device and cloud sessions can also get a useful name while their worker is being prepared.
-
-Opening the app recovers a remembered chat that no longer exists to a usable main conversation, while an explicit link to a missing chat keeps its recovery page. Sidebar controls stay separated from long labels, the visible Other heading can start an ungrouped draft, and adopted Codex and Claude sessions keep the actions their provider actually supports.
+[Your conversation list](/web/control-ui/sessions-and-sidebar) now keeps the names you choose and avoids changing them back when an older update arrives. Chats can get a useful title even when automatic naming fails, making them easier to recognize later. If the app tries to reopen a chat you deleted, it takes you to a usable conversation instead of leaving you stuck; it does not recover the deleted messages.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -261,9 +251,7 @@ Opening the app recovers a remembered chat that no longer exists to a usable mai
 
 <Accordion title="Move through a long conversation">
 
-The [chat navigation rail](/web/control-ui/chat) moves into the left gutter, with a mark for each loaded message that has a saved identity. Hover or focus a mark to preview the text, then jump to that part of the conversation with a brief highlight showing where you landed. Previews render Markdown and, for attributed messages in shared chats, show the sender's name and avatar or initials.
-
-The rail has its own scrolling area so you can look for a destination without moving the conversation first. It appears on desktop panes with enough space and covers the messages already loaded.
+A slim [message navigator](/web/control-ui/chat) on the left lets you preview a message before jumping to it, so you can find a particular answer without scrolling through the whole conversation. In shared chats, previews also show who wrote the message when that information is available. It appears on desktop when there is enough room and covers the messages already loaded.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -282,11 +270,11 @@ The rail has its own scrolling area so you can look for a destination without mo
 
 </Accordion>
 
-<Accordion title="Read cached content while reconnecting">
+<Accordion title="Read your saved conversation while reconnecting">
 
-Returning users with a retained token or paired-device token can see cached sidebar entries and available conversation text while the app reconnects. A Connecting indicator stays visible until live information takes over, and old running indicators are removed from the cached list. [Warm reload](/web/control-ui/offline-and-reconnect#warm-reload) makes existing content available earlier; actions still wait for authentication.
+When you reload the app, it can show a saved copy of your conversation and sidebar while it reconnects, so you have something to read during the wait. [This works with remembered Gateway tokens or paired-device sign-ins](/web/control-ui/offline-and-reconnect#warm-reload); other sign-in methods still show the connection screen. Sending messages and other actions wait for the connection.
 
-Other authentication modes keep the initial connection screen. There is also a remaining limitation when one browser origin serves multiple Gateways with matching conversation keys, where another Gateway's cached transcript can appear until live data replaces it. Conversation switches separately gain delayed, fading loading placeholders, avoiding a brief flash when the destination loads quickly.
+If you use the same web address to connect to several Gateways, a conversation saved from another Gateway can briefly appear. Wait for the live conversation to load before relying on that view.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -303,9 +291,7 @@ Other authentication modes keep the initial connection screen. There is also a r
 
 <Accordion title="Quote text and keep drafts readable">
 
-Select a passage and choose Add to chat to append an editable quote to your main draft, keeping anything you have already typed and putting the cursor back in the composer. The quote is limited to 300 characters, and you still choose when to send it; Ask in side chat keeps its separate destination.
-
-Long drafts stay readable while you type, with the edge fades returning when you deliberately scroll through them. Attachment rows line up with the draft and refresh their overflow cues as files or panel widths change. In shared chats, stopping typing in one browser tab replaces or clears that tab's stale preview while another tab can remain active.
+Highlight a passage and choose Add to chat to put an editable quote into your draft without losing what you have already written. Quotes include up to 300 characters, and nothing is sent until you send the message yourself. Long drafts are also easier to edit because the line you are typing no longer fades out at the edge of the message box.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -329,9 +315,7 @@ Long drafts stay readable while you type, with the edge fades returning when you
 
 <Accordion title="Follow images and documents in chat">
 
-Sent images stay visible while delivery confirmation and saved history catch up, and scrolling back to an already loaded image can reuse its still-valid preview information. Files now shows a loading state while an attachment is being resolved, keeps its identity visible if loading fails, and preserves the video player while it waits for a frame.
-
-User document cards sit above their accompanying text, with file-only messages losing the empty colored bubble. Images, videos, and files align with the sender's side of a shared conversation, while desktop avatars stay beside the text. Related history fixes keep the same saved reply from appearing twice when live events overlap a history refresh.
+Images you send stay visible while the conversation updates, and scrolling back to a recently loaded image avoids another loading placeholder when its preview is still available. Documents sit above the text that goes with them, making files easier to spot in a busy conversation. Opening a file now shows that it is loading instead of briefly claiming the preview is unavailable.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -357,9 +341,7 @@ User document cards sit above their accompanying text, with file-only messages l
 
 <Accordion title="Preview videos before sending">
 
-You can recognize a selected recording before sending it, with a locally generated still frame and play badge in Chat and New Session. Making that preview does not upload the file. After sending, user videos appear alongside images above the message text, and selecting one opens it in Files.
-
-Preview availability depends on the browser's codec support and access to the file. Unsupported or unavailable previews keep their existing icon or openable card, and assistant-sent videos retain inline playback.
+Selected videos can now show a still image in the message box, so you can tell similar recordings apart before sending one. The preview is made on your device without uploading the video. Sent videos also have previews in the conversation that open in Files when selected; if your browser cannot make a preview, the usual file card or icon remains.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -375,9 +357,9 @@ Preview availability depends on the browser's codec support and access to the fi
 
 <Accordion title="Browse files and protect newer edits">
 
-[Files](/web/control-ui/chat) now keeps search and filters above one scrolling list, so long Changed, Read, Artifacts, and Project sections remain reachable. You can choose changed files, read files, or artifacts, and Show in Files clears the current search and filter before revealing its destination. Failed opens explain the error in Review instead of showing unrelated changes, while phone previews leave more space for content and retain the filename and path when expanded.
+[Files](/web/control-ui/chat) keeps search and filters within reach while you scroll through long lists. You can find files the agent changed, read, or created, and a failed preview explains why the file could not open. Phone previews also leave more room for the document while keeping its name visible.
 
-In Agents → Files, saving a draft opened before the workspace file changed now reports a conflict and keeps your draft. Reload takes the current workspace text, while Overwrite explicitly replaces it with your draft. These choices do not merge the two versions, and external programs writing at the same moment remain outside this protection.
+If an agent file changes after you open it for editing, Save now warns you and keeps your draft. Choose Reload to use the newer file, or Overwrite to replace it with your version. Overwrite discards the newer changes rather than combining them, and the warning cannot catch every simultaneous edit made by another program.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -394,11 +376,9 @@ In Agents → Files, saving a draft opened before the workspace file changed now
 
 </Accordion>
 
-<Accordion title="Read native Codex subagent conversations">
+<Accordion title="See what Codex's helper agents did">
 
-Select a native Codex subagent in Tasks to read the messages, available thinking, and expandable tool activity behind its work. Show earlier loads older messages, activity refreshes the view, and failed reads offer Retry. You can move into Files and return to the still-selected task without reloading its transcript.
-
-New native tasks retain their original transcript source when later parent turns replace the Codex thread. Session resets, account or native-store changes can still prevent access, and missing ownership information is not reconstructed for older tasks. Tasks without readable history keep their existing inspector; this release's native transcript support is for Codex.
+Open a Codex helper agent in Tasks to read its conversation, see its work, and load earlier messages. You can look at a file and return without making the conversation load again. Newly created tasks also stay readable as the main chat continues, although some older tasks still lack readable history, and resetting the chat or changing Codex accounts can prevent access.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -418,9 +398,7 @@ New native tasks retain their original transcript source when later parent turns
 
 <Accordion title="Follow ongoing and completed work">
 
-Completed and cancelled subagent rows drop obsolete working text while keeping their final file-change summaries, and long reports scroll above the view-only footer and its Open parent session button. Compact activity previews also turn unfinished Markdown into readable text, with the full formatted conversation available in task details.
-
-Assistant commentary stays visible through history refreshes without repeating the same occurrence, and displayed saved reasoning keeps its paragraphs and code blocks under the existing visibility settings. Agents also receive clearer guidance to reserve progress cards for substantial work with multiple meaningful steps.
+Finished and cancelled helper tasks stop showing their old working messages, while their summaries of changed files remain available. Long reports stay readable without hiding the button back to the conversation that started the task, and short progress updates no longer show stray formatting symbols. Agents also get clearer instructions to skip progress cards for quick questions and save them for substantial work.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -439,11 +417,9 @@ Assistant commentary stays visible through history refreshes without repeating t
 
 </Accordion>
 
-<Accordion title="Expand Dashboard and keep its context">
+<Accordion title="Enlarge Dashboard and restore your layout">
 
-Click the [Dashboard](/web/dashboards) side-panel tab to expand it across the task area, then click again to restore the original split and size. Drafts, widget input, and terminal sessions stay in place. The side-panel Expand control works for other active panels too, including Terminal, without entering browser fullscreen.
-
-A dashboard progress widget now follows the conversation it targets even when another agent is selected elsewhere. Older unfinished steps stay paused while a later run is queued, so waiting work is not mistaken for a task already running.
+Click the [Dashboard](/web/dashboards) tab to give it the full task area, then click again to return to your previous layout. Your draft and anything entered into the dashboard stay in place. Dashboard progress also follows the conversation it belongs to, so selecting a different agent elsewhere does not make running work look paused.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -462,9 +438,9 @@ A dashboard progress widget now follows the conversation it targets even when an
 
 <Accordion title="Upload files and restore terminal tabs">
 
-Picking or dropping files into supported paired-node Claude Code, Codex, OpenCode, and Pi terminals now inserts their editable paths using the format the receiving terminal expects. It does not press Enter, leaving you to check the input and submit it. Terminal tabs also survive a reload or reconnect that interrupts restoration of several saved sessions.
+When you use Claude Code, Codex, OpenCode, or Pi in a terminal on a paired computer, choosing or dropping a file now puts its location into the terminal for you to use. You can edit it before pressing Enter. Reloading while several terminal tabs are reconnecting also keeps tabs that previously disappeared from the list.
 
-Uploads can recover after a temporary failure to release their staging lock. Crash recovery remains manual, with [terminal recovery guidance](/web/control-ui/panels) identifying the machine that owns the terminal and the lock to remove only after every host process sharing that staging area has stopped.
+If uploads remain blocked after a crash, follow the [terminal recovery steps](/web/control-ui/panels). Stop all OpenClaw host processes sharing the upload folder on the computer running that terminal before removing the lock named in the error.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -485,9 +461,7 @@ Uploads can recover after a temporary failure to release their staging lock. Cra
 
 <Accordion title="Search and edit Settings">
 
-[Settings](/web/control-ui/settings) keeps unfinished list edits and validation messages with their rows when you remove an earlier item or change another field. You can correct the value without retyping it, although invalid text remains unsaved and these drafts do not survive leaving or reloading Settings. Search also keeps matching a phrase when a tag filter sits between its words, and step buttons start empty bounded integer fields at the first allowed value.
-
-Agents settings opens on Overview while explicit panel links keep their destination, and its name and emoji fields fit within the identity card. Web search controls now agree with the global disable setting, explaining why search is unavailable and allowing an authorized user to clear an old enable override without turning search on.
+In [Settings](/web/control-ui/settings), removing an earlier list item no longer throws away unfinished text in another item. Correct and save that text before leaving the page, since unfinished drafts are not kept after a reload. Number buttons also stop skipping the first allowed value, and Web search clearly stays off when the person managing OpenClaw has disabled it.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -512,9 +486,7 @@ Agents settings opens on Overview while explicit panel links keep their destinat
 
 <Accordion title="Recognize people and agents">
 
-Mention suggestions remain available while you refine searches that can safely reuse the loaded results, and necessary reloads keep a steadier placeholder. Person labels are simpler, avatars are clearer, and offline people remain available to select.
-
-Agent images load through the existing authenticated path in both the picker and Settings, with text or emoji fallbacks for unusable images. Smaller replacement avatars can be saved, and changes to an agent's name or emoji reach an open chat without losing its draft. Shared Gateway connections also gain a Shared owner label, though an agent whose ID is `gateway-owner` can still be mislabeled in some participant text.
+The mention picker keeps suggestions available while you refine a search, making it easier to choose someone for a shared chat. Agent pictures now load in the picker and Settings on token-protected connections, and changing an agent's name or emoji updates an open chat without losing your draft.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -539,9 +511,7 @@ Agent images load through the existing authenticated path in both the picker and
 
 <Accordion title="Read usage and system status">
 
-Usage now counts the rows actually shown in All or Recently viewed while keeping the loaded total separate. When you inspect sessions across agents, the timeline and conversation follow the selected owner, and a late response for the previous owner cannot replace those details.
-
-On affected Linux Bun installations, System busyness can show CPU usage and event-loop delay again after the first sampling window. An initial dash still means the first sample is not ready.
+Usage keeps conversation details with the correct agent and counts the conversations actually shown in the list, with the total displayed separately. If you run OpenClaw on Linux with Bun, System busyness can show CPU and delay readings again instead of leaving permanent dashes. A dash just after starting still means the first reading is not ready.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -556,11 +526,9 @@ On affected Linux Bun installations, System busyness can show CPU usage and even
 
 </Accordion>
 
-<Accordion title="Recover a stale or failed chat display">
+<Accordion title="Get back to chatting after a stalled screen">
 
-If chat still shows Stop after a turn has finished, clicking it can refresh the confirmed conversation state and restore Send with the completed reply. Work that is still finalizing stays active, and a failed refresh leaves the recovery available to try again. The change provides a way back when completion notifications have not reached the browser.
-
-Mobile chats keep delivery status and available Retry or Discard controls visible after failed or unconfirmed sends. A turn that times out before replying can also leave a notice that survives reload and remains in later conversation context. Check the conversation before resending when delivery is uncertain, since a display or connection failure does not establish that the work never ran.
+If a reply has finished but the screen still shows Stop, clicking it can bring back the completed reply and Send button without a page reload. On phones, failed messages keep Retry or Discard visible when those actions are available, and a request that times out before replying can leave an explanation that remains after reloading. Before sending again, check whether the first request already did the work, since a connection problem can leave delivery uncertain.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -582,9 +550,7 @@ Mobile chats keep delivery status and available Retry or Discard controls visibl
 
 <Accordion title="Read replies and use familiar controls">
 
-The command palette keeps the messages and draft behind it readable, and successful copying stays a compact green check instead of widening the chat footer. GitHub link previews stay quiet until useful details are available, ordinary content links keep their underlines, and the first assistant reply no longer triggers confetti.
-
-On Mac, the sidebar, transcript search, and command palette use Command+B, Command+F, and Command+K, leaving Control+B/F/K available for text editing. Windows and Linux keep Control for those actions. Custom message widths reject invalid expressions without replacing your saved reading width, and the desktop Inbox prepares its panel before you open it.
+Opening the command palette no longer blurs the conversation behind it, so you can refer to a message while choosing an action. Copying a reply gives a compact green check, GitHub links avoid empty preview popups, and the first reply no longer triggers confetti. On Mac, use Command+B, Command+F, and Command+K for the sidebar, conversation search, and command palette; the Control versions are left for text editing. Windows and Linux keep Control for these shortcuts.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -615,11 +581,9 @@ On Mac, the sidebar, transcript search, and command palette use Command+B, Comma
 
 </Accordion>
 
-<Accordion title="Understand broken interactive widgets">
+<Accordion title="Get an explanation when an interactive card breaks">
 
-[Interactive widgets](/tools/show-widget) now have two clearer ways to report a broken script. Inline JavaScript syntax errors can be rejected before a card appears, with a location the agent can correct. If a displayed widget fails while running or when you use it, the Control UI can show a Script error notice and notify the agent for a recent widget.
-
-Syntax checking does not establish that a script will work, and some browser-valid SVG forms remain unsupported by the checker. Runtime notification applies to recent Control UI widgets and does not guarantee an immediate replacement; older restored widgets can show the error without waking the agent.
+OpenClaw can catch some coding mistakes in [widgets](/tools/show-widget), the small interactive apps an agent can place in chat, before they appear. If a recent card fails while you use it, the web app can show a Script error notice and tell the agent what happened, giving it a chance to help you recover.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -638,9 +602,7 @@ Syntax checking does not establish that a script will work, and some browser-val
 
 <Accordion title="Read updated interface guidance">
 
-Existing interface languages receive updated guidance for connection recovery, plugin browsing, Files, and cloud-worker snapshot controls. Core Settings labels, help, and search now use matching translations when available, with current source text as the fallback. Selected parent-session translations also distinguish the parent conversation from the main one, making the route back from subagent work clearer.
-
-These updates extend translated coverage in existing languages. German and Simplified Chinese plugin next-page labels still have known wording errors.
+More labels and help text are translated in Settings, plugin browsing, Files, and cloud-worker controls. Settings also uses available translations when you search for a field, making it easier to find an option in your chosen language.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -676,15 +638,13 @@ These updates extend translated coverage in existing languages. German and Simpl
 
 ## Updates and Maintenance
 
-Updates can get past specific failures that left an installation waiting for repair or its Gateway stopped, with fixes for older stable releases, plugin maintenance, and checking databases that are still in use. Recovery gives you a clearer account of what happened and what needs attention, while Doctor, backups, and history cleanup preserve more of the working setup around them.
+Updating OpenClaw gets fixes for stalled upgrades, plugins left behind, and confusing recovery messages. There are also improvements to bringing older conversations and settings forward, backing up the files you need, and cleaning up history without getting in the way of other work.
 
 <AccordionGroup>
 
-<Accordion title="Complete managed Gateway updates">
+<Accordion title="Complete an update">
 
-Managed upgrades from 2026.9.2 and 2026.9.3 can finish and restart when their older handoff lacks information the new updater expected. Packages also retain the helpers needed by recorded 2026.9.1–2026.9.3 updaters to finish after replacement, including the affected 2026.9.1 Git build. Updates launched from the browser or a managed service can get past the missing-file failure that prevented their helper from starting, and Linux installations confirmed to have no Gateway service can enter the update flow too.
-
-Busy but compatible agent databases can now pass update checks while OpenClaw continues saving activity. Development updates check the selected revision's Node requirements before installing dependencies, and managed pnpm updates follow the newly activated package directory. These latter fixes must already be in the updater that starts the operation. If an older updater is blocked by the busy-database check, a supported manual update or a quiet database window is still needed to acquire the repair. [How updates run](/cli/update/how-updates-run) explains the checks and restart sequence.
+Updates from recent stable releases can get past failures that prevented them from finishing or left OpenClaw stopped afterward. Updating from the browser also gets a startup fix, and active conversations are less likely to hold up an update. Some fixes only help after the newer updater is installed, so if your current version is stuck, follow the [update guidance](/cli/update/how-updates-run) rather than repeatedly trying the same failing command.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -711,11 +671,9 @@ Busy but compatible agent databases can now pass update checks while OpenClaw co
 
 </Accordion>
 
-<Accordion title="Update a Git installation">
+<Accordion title="Update an installation built from source">
 
-Git installations using a saved stable or beta channel can update after upstream recreates a release tag, while keeping local-only tags and the existing branch protections. If you have several remotes without `origin` or a declared release source, select the intended remote with `branch.main.remote` before retrying. The [development-channel guide](/install/development-channels) explains that choice.
-
-Status also warns when a recorded failed fetch leaves its update information stale, instead of calling the installation up to date. Only a later successful fetch recorded by the updater clears that historical warning, so a manual fetch or a separate fresh status check does not erase it. Windows source updates also receive the Git configuration-path fix used by the affected cloning and repository operations.
+If you run OpenClaw from a Git checkout, updates can recover when an upstream release tag changes, and Windows gets a fix for updates failing before they begin. Status now warns when a failed update check left its information out of date. That warning clears after the updater next fetches successfully. If your checkout has several possible update sources, the [development-channel guide](/install/development-channels) explains how to choose one.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -731,11 +689,9 @@ Status also warns when a recorded failed fetch leaves its update information sta
 
 </Accordion>
 
-<Accordion title="Restore only compatible packages">
+<Accordion title="Recover from a failed update">
 
-A failed update can restore the retained package when the current configuration and databases are still compatible with it, and an initial startup refusal preserves existing state before migration so repair remains possible. Package replacement cannot undo a database migration or restore a full-state checkpoint. Keep an independent verified backup if you need to recover migrated state, and follow the [rollback and recovery guide](/install/updating/rollback-and-recovery).
-
-Updates stop further protected package, launcher, and plugin writes when the original updater loses ownership, leaving remaining recovery material available for inspection. Work already started can still leave partial changes, and some post-activation inspection or cleanup failures leave the candidate installed because automatic rollback cannot be verified. Plugin downloads and required follow-up migrations finish before the managed Gateway restarts, so that work is part of the downtime.
+When an update fails, OpenClaw can put the previous app version back if it still works with your current settings and data. If that cannot be checked, recovery stops and leaves the available recovery files in place for inspection. An interrupted update may still need manual help. Rolling back the app does not restore your data, so [make and verify a backup before updating](/install/updating/rollback-and-recovery).
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -756,11 +712,9 @@ Updates stop further protected package, launcher, and plugin writes when the ori
 
 </Accordion>
 
-<Accordion title="Release abandoned update records">
+<Accordion title="Clear a stuck update message">
 
-A stuck update card can now release the settings and provider sign-in actions it was blocking when the saved record meets the recovery conditions. `openclaw update repair` can immediately reconcile a recent abandoned run when every recorded updater is positively dead, no unidentified replacement updater is recorded, and the matching installed Gateway is healthy, without stopping that working service.
-
-There is also automatic recovery for an untouched legacy record more than 24 hours old that never progressed beyond its initial request and has no recorded drivers or retained recovery descriptor. Age alone does not make an arbitrary update eligible. Both paths keep failed history visible, and the legacy case offers retry guidance instead of starting another update for you.
+An old “update in progress” message can stop blocking settings changes and account sign-in even when the update itself is no longer running. `openclaw update repair` can clear eligible stuck updates once it confirms the updater has stopped and OpenClaw is working. Some older requests that never got started clear automatically after a day, provided nothing still needs recovery. They remain in history as failed attempts, with guidance to retry.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -778,11 +732,9 @@ There is also automatic recovery for an untouched legacy record more than 24 hou
 
 </Accordion>
 
-<Accordion title="Let required repairs finish">
+<Accordion title="Give lengthy repairs time to finish">
 
-Large installations can let update Doctor repairs finish beyond the former automatic deadline, while failures to remove certain disposable caches or temporary copies can be reported as warnings with repair guidance. Required migrations, imports, required consent, ownership, and readiness checks still have to pass before the update can complete.
-
-Repair Doctor has no automatic wall-clock deadline, so use `--timeout <seconds>` if you need a limit. That allowance applies per finalization phase and its child commands, not to the whole update, and a stalled Doctor can otherwise wait indefinitely. The separate post-plugin validation and readiness checks retain their own limits; terminating the updater with SIGTERM can still leave a snapshot child running.
+Updates on larger installations now give Doctor, OpenClaw's repair tool, time to finish work that used to be cut short. Some failures to remove disposable files become warnings with cleanup advice, while problems that prevent the updated app from working still stop the update. A stuck repair can keep waiting unless you set a limit, and stopping the update may leave repair work running, so use the [repair guidance](/cli/update/repair-and-recovery) if progress stops.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -798,9 +750,9 @@ Repair Doctor has no automatic wall-clock deadline, so use `--timeout <seconds>`
 
 <Accordion title="Choose what follows a failed update">
 
-After a failed update successfully restores and verifies the previous installation, the interactive menu explains that outcome and defaults to Exit. Diagnosis runs when you choose it, reporting shows a sanitized preview before asking to submit, and the command still returns a failure status because the requested update did not succeed. Quiet invocations skip this optional follow-up.
+If an update fails but the previous installation is restored and checked, the menu defaults to Exit. You can choose to investigate or preview a report before sending it. For other interactive update failures, the repair prompt tells you which AI agent will run and that it uses your account allowance or paid tokens. You can decline, but pressing Enter accepts and leaving the prompt unanswered starts the agent after 30 seconds.
 
-For other eligible interactive failures, the automatic repair prompt identifies the agent and warns that it will use your account quota or model tokens. You can decline and keep the saved diagnostics and manual handoff, but Enter accepts and an unanswered prompt continues after 30 seconds. Direct interactive Claude repairs use safe mode to avoid waiting on project startup hooks, which requires supported Claude Code versions and excludes custom hooks, plugins, skills, MCP servers, and project instructions. Use the printed manual command if the repair needs those customizations; the [triage guide](/cli/triage) covers both paths.
+Claude-assisted repairs start without project customizations that could delay them. If your repair needs those custom tools or instructions, use the manual command provided instead. The [repair-agent guide](/cli/triage) explains the choices and Claude requirements.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -827,9 +779,7 @@ For other eligible interactive failures, the automatic repair prompt identifies 
 
 <Accordion title="Understand update progress and warnings">
 
-Update progress, history, and the final report now keep the same observed outcome, including a failed update whose rollback was verified. Final reports wait for the updater's last ownership checks, and warnings identify retained obsolete backups or remaining Doctor findings so you can decide what to inspect next. If saved history cannot be read, update availability and runtime guidance remain available with an explicit history error.
-
-Troubleshooting also keeps bounded, redacted Doctor output when finalization times out and identifies child processes behind a stalled phase. Routine update repair skips unrelated advisory checks; run `openclaw doctor` afterward for the full set of advice. Focused [status and history](/cli/update/status-and-history) and [repair guides](/cli/update/repair-and-recovery) explain the reports, while refreshed Git commit counts keep the browser's update confirmation in step with Settings.
+Update progress and the final report now agree about what happened, including when an update failed but the previous version was successfully restored. Warnings keep useful repair advice and identify leftover backup files, and a problem reading history no longer hides other update guidance. If an update stalls, more of its troubleshooting information is kept. You can [inspect the update report](/cli/update/status-and-history), or run `openclaw doctor` afterward for checks that are not needed during the update itself.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -861,11 +811,9 @@ Troubleshooting also keeps bounded, redacted Doctor output when finalization tim
 
 </Accordion>
 
-<Accordion title="Update plugins when core is current">
+<Accordion title="Update plugins when OpenClaw is already current">
 
-If you upgraded core separately, `openclaw update` still runs eligible plugin maintenance even when OpenClaw itself is already current. Changed plugins go through the existing validation and managed restart path, while unchanged plugins avoid redundant completion work. `--no-restart` keeps the manual restart step, and a service that was already stopped stays stopped.
-
-Intentional version pins remain yours to change. When a newer official plugin release is observed, update and repair output makes the retained pin visible and gives the command to replace it. For an official ClawHub pin, that is an explicit `openclaw plugins install clawhub:<package> --force`, retaining the beta selector where applicable. A newer release notice is availability information, not a finding that your installed version is incompatible.
+Running `openclaw update` now checks eligible plugins even if the main app is already up to date, including after you updated it separately. When nothing changes, it skips unnecessary follow-up work. If you deliberately kept a plugin at a particular version, that choice stays in place and notices of newer official releases explain how to change it. Plugin updates may need a restart, and plugin downloads during an app update can extend the time OpenClaw is unavailable.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -888,11 +836,9 @@ Intentional version pins remain yours to change. When a newer official plugin re
 
 <Accordion title="Repair older settings and moved workspaces">
 
-Doctor can restore valid older multi-agent backups without asking you to hand-edit their ownership setting, and repair old model and account references while retaining the selected provider, account, execution backend, and fallback order. If a workspace moved, Doctor can confirm that it is the same workspace and carry its setup and migration history across; affected messages receive repair guidance instead of holding later messages in the queue. Conflicting or uncertain records remain for review rather than being merged by guesswork.
+Doctor can bring more older settings and saved accounts forward without losing your model choices or asking you to edit configuration files by hand. It can also recognize a moved workspace and preserve its setup history, while leaving uncertain matches for review.
 
-Users with Claude sessions stored only in the retired conversation field must run `openclaw doctor --fix` before resuming those sessions. The [Doctor checks guide](/cli/doctor/checks) explains that migration and the warnings for bindings that need manual reconciliation. Account repair also preserves verified mappings through interrupted retries, though changes across separate stores do not form one atomic operation.
-
-Diagnostics identify the actual source directories during full lint, give verified-backup guidance for unreadable state, and explain incomplete project clones without automatically rewriting them. Updates can also finish with a valid absent configuration file, leaving it absent, and an implicit Codex preference no longer makes a missing optional plugin a requirement.
+If an older Claude conversation has not been converted to the current format, run `openclaw doctor --fix` before resuming it. The [Doctor checks guide](/cli/doctor/checks) explains that step and the cases that still need manual help.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -926,11 +872,9 @@ Diagnostics identify the actual source directories during full lint, give verifi
 
 </Accordion>
 
-<Accordion title="Preserve supported legacy session content">
+<Accordion title="Bring older conversations forward">
 
-Fresh imports of legacy Codex conversations preserve assistant replies in their original order alongside user messages and tool results. For sessions already imported incompletely, recovery can add missing replies to the stored history, but those replies append at the end and do not reconstruct the same active conversation as a fresh import.
-
-Doctor's repaired attachment metadata now survives recreation of archived session files. If a legacy session file shares its contents through a hard link, the refusal identifies the file and explains the [recovery procedure](/cli/doctor/sqlite-maintenance#hard-linked-legacy-artifacts). That protection remains in place, and an interrupted migration with recorded recovery material must use its existing recovery path before replacing files.
+Importing older Codex conversations now keeps assistant replies that could previously go missing, in their original order. If you already imported an affected conversation, recovery can add missing replies, but it adds them at the end rather than rebuilding the original conversation order. Repairs to attachment information also survive when saved conversation archives are recreated. If a backup-linked file blocks an import, the error points to the file and the [safe recovery steps](/cli/doctor/sqlite-maintenance#hard-linked-legacy-artifacts).
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -945,11 +889,11 @@ Doctor's repaired attachment metadata now survives recreation of archived sessio
 
 </Accordion>
 
-<Accordion title="Include the configuration a backup needs">
+<Accordion title="Back up all the settings files you need">
 
-Full backups now include the nested configuration files your root configuration depends on, even when they live outside the state directory or inside an excluded workspace. The archive preserves their authored contents, including comments and environment placeholders, and refuses an incomplete or changing include graph instead of quietly producing an incomplete backup. `--only-config` remains a root-file-only export.
+If you split your settings across several files, a full backup now includes the files your main configuration refers to, even outside the usual backup folders. It stops with repair guidance if those files cannot be captured completely. The `--only-config` option still saves just the main file.
 
-Backups can also finish when a temporary SQLite companion file disappears after its database has already been captured consistently. Configuration and individual databases are captured at different times, so the archive is not one atomic snapshot of the whole installation, and included configuration files may themselves contain secrets. The [backup guide](/cli/backup) explains the capture and restore boundaries.
+Backups also handle a disappearing temporary database file when its contents are already safely captured. A backup does not freeze the whole installation at one instant, so changes made while it runs may not all be included. Treat the archive as sensitive because settings files can contain secrets, and follow the [backup guide](/cli/backup) when checking or restoring it.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -963,11 +907,9 @@ Backups can also finish when a temporary SQLite companion file disappears after 
 
 </Accordion>
 
-<Accordion title="Inspect large or busy databases">
+<Accordion title="Check larger installations">
 
-Large databases get a size-based allowance for integrity checks and private snapshot preparation instead of the same short deadline as a small installation. Applicable stable snapshots need one full temporary copy rather than two, reducing disk pressure, and Doctor avoids repeated table scans when the database is healthy while retaining the full integrity and foreign-key checks. Longer allowances give the work time to finish; they do not make every scan faster.
-
-When a check fails, diagnostics name the last observed phase and the repair command where appropriate, and slow session-cleanup operations can be identified even when each individual write was quick. The phase is a troubleshooting clue, not a diagnosis of the cause. Operators also have a read-only `openclaw database preflight-agent <copied-agent.sqlite> --agent-id <id> --json` check for a consolidated copied agent database with its exact agent ID and no sidecars.
+Installations with a lot of saved data get more time to finish database checks, and some checks need less temporary disk space and avoid repeated work. This helps when maintenance previously stopped before it could finish, while keeping the checks for damaged data. If something goes wrong, errors give more useful clues about where the check stopped and when Doctor may be able to help.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -995,11 +937,9 @@ When a check fails, diagnostics name the last observed phase and the repair comm
 
 </Accordion>
 
-<Accordion title="Keep OpenClaw responsive during history cleanup">
+<Accordion title="Keep working during history cleanup">
 
-Session deletion, edits, and history cleanup can reopen their database without running the full validation scan on the Gateway's main thread, allowing other work to continue while those checks finish. The same handling extends through history planning, archive pruning, and explicit cleanup finalization, with the existing ordering and deletion protections retained.
-
-Cleanup also rechecks whether a conversation has become protected and whether disk pressure still requires another deletion. If another operation already freed enough space, it leaves the next eligible history in place. Retention settings stay the same, and this preserves history during the covered cleanup races without recovering conversations deleted earlier.
+Deleting sessions and cleaning up old conversations are less likely to pause other work while OpenClaw checks its saved data. Cleanup also checks again before deleting more history, so it can stop when enough space has been freed and leave newly protected conversations alone. Your retention settings still decide what can be removed.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1018,13 +958,11 @@ Cleanup also rechecks whether a conversation has become protected and whether di
 
 </Accordion>
 
-<Accordion title="Restart and stop the intended service">
+<Accordion title="Restart and shut down OpenClaw">
 
-Linux systemd restarts with no-respawn enabled now let the old Gateway exit so the service manager can start its replacement, instead of leaving the service waiting in deactivation. Conflicting effective settings, such as a LAN bind combined with Tailscale Serve, stop repeated restart attempts with configuration guidance. Check both saved settings and service overrides before starting again.
+Linux users get fixes for restarts that stayed stuck and for conflicting settings that made OpenClaw restart over and over. Those conflicts now leave an error to fix before starting again. Shutdown also gives plugins and voice connections time to finish their cleanup and final writes, though a stuck plugin can still delay it.
 
-Shutdown keeps shared state available until the tracked hooks and plugin cleanup actually finish, including returned Talk connection cleanup. Slow callbacks can therefore delay graceful shutdown, and a callback that never settles may require interruption. The affected automatic macOS CLI exit path with system certificate support likewise waits for pending cleanup, allowing final writes to finish.
-
-Service diagnostics avoid false repair advice for intentionally masked systemd units, and startup logs follow the active plugin configuration. Reconnects also share the [health refresh cadence](/gateway/health), avoiding repeated background collection while preserving explicit live probes and immediate refreshes for missing or stale snapshots.
+Reconnecting avoids repeating unnecessary [health checks](/gateway/health), while fresh checks remain available when needed.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1052,11 +990,11 @@ Service diagnostics avoid false repair advice for intentionally masked systemd u
 
 </Accordion>
 
-<Accordion title="Keep deployment-owned configuration intact">
+<Accordion title="Manage settings outside OpenClaw">
 
-If a deployment system owns your configuration, you can now set `OPENCLAW_CONFIG_READONLY=1` in both the Gateway and CLI host environments without also selecting Nix mode. OpenClaw's configuration writes and automatic backup recovery respect that choice, while model changes can remain session-only. Runtime state still needs writable storage, and the setting belongs in the service or container environment, not inside the configuration's own environment variables. The [externally managed configuration guide](/cli/config#externally-managed-config) explains setup.
+If another tool manages your OpenClaw settings, a new [read-only configuration option](/cli/config#externally-managed-config) keeps OpenClaw from overwriting them, including during automatic recovery. Set `OPENCLAW_CONFIG_READONLY=1` for both the running service and terminal commands. Conversations and other working data still need somewhere writable, and model changes can apply to the current session without changing the saved default.
 
-Refused changes point you back to the external source instead of suggesting a crash repair. Saved configuration revisions also refresh after agent changes, avoiding false conflicts on the next edit, while remaining distinct from the configuration currently running. With reload mode set to `off`, OpenClaw still watches and validates files; a manual restart applies the changes.
+Settings edits after creating or changing an agent also avoid false “changed since last load” errors. Saving and applying settings remain separate, so if you turned automatic reload off, restart OpenClaw to use the changes.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1079,11 +1017,9 @@ Refused changes point you back to the external source instead of suggesting a cr
 
 </Accordion>
 
-<Accordion title="Operate Windows Gateway services">
+<Accordion title="Stop and update OpenClaw on Windows">
 
-Stopping an ordinary generated Windows Gateway task now stops its descendants too, freeing the port and state directory for a fresh start, and early child failures reach the Gateway log. Executable wrappers or additional CMD layers can still fail the launcher's ancestry check before startup. Those launch chains remain affected.
-
-Update service checks honor the requested `--timeout` and retry one timed-out inspection. Each attempt receives the full per-step allowance, so two hung probes at the default can take an hour. Repeated timeouts or other inspection failures still stop the update before package changes, with clearer guidance about the failure.
+For Windows installations using OpenClaw’s standard launcher, stopping the scheduled Gateway task now stops the work it started too, allowing a fresh start without a leftover copy getting in the way. Early startup failures also reach the log. Custom executable wrappers or extra command-shell layers can still prevent startup. Slow Windows service checks get another chance during updates, but a check that keeps hanging can make the wait much longer; if the service cannot be checked, the update stops before replacing the app.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1097,9 +1033,9 @@ Update service checks honor the requested `--timeout` and retry one timed-out in
 
 </Accordion>
 
-<Accordion title="Find operating and monitoring guidance">
+<Accordion title="Find monitoring help">
 
-The [OpenTelemetry guide](/gateway/opentelemetry) now separates setup, configuration, privacy and trace context, model metrics, and spans and events into focused pages. You can get directly to the monitoring instructions you need while existing section links still lead through the retained index; telemetry capabilities and export defaults are unchanged.
+The [monitoring guide](/gateway/opentelemetry) makes it easier to find help setting up monitoring, understanding what information it captures, or using that information in dashboards. The instructions are organized around those tasks, with existing links still leading to the right place.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1116,15 +1052,13 @@ The [OpenTelemetry guide](/gateway/opentelemetry) now separates setup, configura
 
 ## Messaging
 
-Long replies keep their prose and code readable as they arrive, Feishu workspace tools are available again in affected message-driven conversations, and Talk can bring delegated answers back to the active voice conversation. Across the messaging channels, this release also preserves more of the content people send and makes account selection and failed delivery easier to understand.
+This update fixes several ways a conversation could lose its words, its reply, or its place. Long answers keep their formatting, Feishu document tools work again in affected chats, and Talk can bring an answer back after handing work to another agent.
 
 <AccordionGroup>
 
-<Accordion title="Keep replies and their status together">
+<Accordion title="Replies and progress updates">
 
-Incoming channel messages now wait in the durable queue while the Gateway is suspended and resume when it accepts work again, instead of repeatedly attempting dispatch during the pause. Recovery also keeps unfinished replies pending when a stalled task is cleared, so freeing a task slot no longer makes an unsent reply appear complete.
-
-With the tool activity log enabled, progress previews keep newer activity and the plan visible after repeated command exits, while approvals and explicit failures retain priority. Message-tool-only groups keep internal finalizer placeholders private, and missing-reply notices explain the failure more accurately with a troubleshooting reference when one is available.
+Messages arriving while OpenClaw is paused now wait until it is ready again, and unfinished replies are no longer mistaken for completed sends. If you show detailed progress, newer work stays visible instead of being crowded out by old command failures. Missing-reply notices also give a clearer explanation and a reference your administrator can use to investigate.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1144,11 +1078,9 @@ With the tool activity log enabled, progress previews keep newer activity and th
 
 </Accordion>
 
-<Accordion title="Read streamed prose and code">
+<Accordion title="Readable long replies">
 
-[Streamed replies](/concepts/streaming) wait for natural prose breaks while there is room, and long code blocks keep their formatting when they continue into another message. Successfully delivered code is recognized when the final answer arrives, avoiding a repeated full answer while retaining a fallback for a continuation that failed to send.
-
-Quoted code keeps meaningful spaces when delivery directives are removed, literal message-ID examples remain visible, and short columns align in code-block tables. Images already converted to PNG, JPEG, or WebP also keep their original bytes when they meet the existing limits, even if their filename still ends in `.heic`.
+[Long replies](/concepts/streaming) break at more natural places, and code keeps its formatting when it continues into another message. Code that arrived successfully no longer causes the whole answer to be repeated at the end. Quoted examples also keep their spacing, making them easier to read and copy.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1166,11 +1098,9 @@ Quoted code keeps meaningful spaces when delivery directives are removed, litera
 
 </Accordion>
 
-<Accordion title="Read Telegram formatting and media">
+<Accordion title="Telegram formatting and stickers">
 
-With [Telegram rich messages](/channels/telegram) enabled, styled links remain clickable inside expandable details, lists, and quotes, while literal examples and body spacing retain their intended form. HTML entities decode once, preserving deliberately escaped examples. Ordinary Telegram messages and captions also preserve code-example spacing, including examples that contain their own fence markers.
-
-Static sticker descriptions use your configured image model and remain available for the first reply. Description generation tries one selected model and leaves failed descriptions out of the cache.
+If you enable [Telegram rich messages](/channels/telegram), links inside lists, quotes, and expandable sections stay clickable and keep their styling. Code examples keep their spacing in messages and photo captions too. Sticker descriptions now use your chosen image model and reach your Claw in time for its first reply.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1185,11 +1115,9 @@ Static sticker descriptions use your configured image model and remain available
 
 </Accordion>
 
-<Accordion title="Use Telegram mentions and commands">
+<Accordion title="Telegram mentions and commands">
 
-Telegram groups recognize identity-backed mentions of the bot in text and photo captions, while keeping the existing sender and group permissions. When native commands are disabled, a text directive such as `/think high` can be followed by a task on later lines without losing the task; strict native commands keep their existing argument rules.
-
-The `/think` menu shows the thinking default for the agent assigned to the conversation, and canceled message preparation stops old timers from replacing a valid acknowledgment with a late stall reaction. The [Telegram guides](/channels/telegram) now separate setup, permissions, message behavior, and troubleshooting into focused pages.
+[Telegram](/channels/telegram) recognizes mentions that tag the bot’s account in messages and photo captions. If you have native commands turned off, you can write `/think high` on one line and your request below it without losing the request. The `/think` menu also shows the setting for the agent handling that chat, and canceled attempts no longer leave a misleading “stalled” reaction afterward.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1209,9 +1137,9 @@ The `/think` menu shows the thinking default for the agent assigned to the conve
 
 </Accordion>
 
-<Accordion title="Retry eligible Telegram delivery failures">
+<Accordion title="Telegram replies after proxy failures">
 
-Telegram replies can remain queued for retry when a proxy refuses its tunnel before the request reaches Telegram, including across a restart. Once the proxy returns, normal recovery can send the reply; uncertain sends and failures after the tunnel opens keep their existing protection against duplicate delivery. Previously failed queue entries are not automatically repaired.
+If you connect Telegram through a proxy and it refuses the connection before a reply is sent, OpenClaw can keep that reply for another attempt when the connection returns. It still avoids resending messages whose delivery is uncertain, so this does not automatically recover every previously failed reply.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1224,11 +1152,11 @@ Telegram replies can remain queued for retry when a proxy refuses its tunnel bef
 
 </Accordion>
 
-<Accordion title="Read Discord replies and delegated work">
+<Accordion title="Discord messages, voice notes, and progress">
 
-[Discord](/channels/discord) preserves more of what belongs in the conversation, including repeated paragraphs in attachment captions, emoji on link buttons, and the spoken words from voice notes in channels that already allow ambient observation. Allowed commentary reaches the chat, and a failed final send leaves the visible progress message in place so the task does not simply disappear.
+In [Discord](/channels/discord) channels where your Claw can already read messages without being mentioned, voice notes now keep their spoken words in the conversation. Attachment captions also keep repeated instructions, and progress updates remain visible if the final answer cannot be sent.
 
-Permitted system-agent requests from ordinary server messages can delegate again without losing their authorization along the way. Member information also uses presence supplied at startup or reconnect when the existing presence intent is enabled, rather than waiting for each person to change status.
+Requests such as checking OpenClaw’s system status can work again from server messages when you have permission, fixing a case where the request was refused despite the tool being available.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1249,11 +1177,9 @@ Permitted system-agent requests from ordinary server messages can delegate again
 
 </Accordion>
 
-<Accordion title="Keep Slack messages and acknowledgements readable">
+<Accordion title="Slack reactions and message formatting">
 
-Slack can show the configured acknowledgment when an eligible mention is picked up even with status reactions turned off, including in groups that send replies through the message tool. Long messages containing code-formatted Windows paths also keep the following prose out of accidental code formatting.
-
-For Slack Enterprise installations, an owner heartbeat addressed only by user ID can resolve a verified shared workspace without needing an earlier incoming message. Explicit workspace choices stay in place. The [Slack formatting guide](/channels/slack/media) explains the existing message presentation options.
+Slack can show its configured reaction when it picks up your mention even if you have ongoing status reactions turned off. [Messages containing Windows paths](/channels/slack/media) also keep their formatting without accidentally turning the text that follows into code.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1268,11 +1194,9 @@ For Slack Enterprise installations, an owner heartbeat addressed only by user ID
 
 </Accordion>
 
-<Accordion title="Use Feishu workspace tools and rich posts">
+<Accordion title="Feishu documents and formatted messages">
 
-Affected external Feishu installations regain document, wiki, Drive, and Bitable tools during message-driven work, with existing tool policies and Feishu permissions still in effect. Applied tool and default-account settings also take effect for new turns without a restart; tools already created for ongoing work keep their original settings.
-
-Received rich posts preserve emphasis on text, links, and mentions in both agent input and message reads. The reorganized [Feishu configuration guidance](/channels/feishu/advanced-configuration) makes the account and tool settings easier to find.
+If a separately installed Feishu plugin stopped letting your Claw work with documents, wikis, Drive, or Bitable from chat, those tools are available again with your existing permissions. Changes to [tool and account settings](/channels/feishu/advanced-configuration) now apply to new requests without restarting OpenClaw, while work already underway keeps its earlier settings. Your Claw also receives the emphasis you put in formatted messages, links, and mentions.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1295,9 +1219,9 @@ Received rich posts preserve emphasis on text, links, and mentions in both agent
 
 </Accordion>
 
-<Accordion title="Read Matrix text, reactions, and literal mentions">
+<Accordion title="Matrix messages and reactions">
 
-Matrix keeps ordinary text in conversation context when a remote message uses an unfamiliar message type, and escaped user or room mentions remain literal after an unmatched backtick. Reaction listings in the CLI show the reaction label alongside its count and users, with raw values still available through `--json`. The [Matrix guides](/channels/matrix) now provide separate routes to setup, encryption, messaging, and account instructions.
+[Matrix](/channels/matrix) keeps message text that could previously be mistaken for an attachment and disappear from quoted replies or conversation history. A mention marked as plain text also stays plain when earlier code formatting is unfinished. In the terminal, reaction lists show which emoji people used instead of leaving the label blank.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1316,9 +1240,9 @@ Matrix keeps ordinary text in conversation context when a remote message uses an
 
 </Accordion>
 
-<Accordion title="Preserve Teams text">
+<Accordion title="Teams message text">
 
-HTML-only Teams messages pass their intended punctuation and symbols to the agent, decoding once so deliberately literal text stays literal. Plain message text still takes precedence when present, and the reorganized [Teams guides](/channels/msteams) put setup, authentication, permissions, and messaging instructions on separate pages.
+Your Claw now reads punctuation and symbols correctly in [Teams messages](/channels/msteams) supplied as HTML, instead of receiving formatting codes in their place. For example, a copyright symbol arrives as © rather than the code used to represent it.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1335,9 +1259,9 @@ HTML-only Teams messages pass their intended punctuation and symbols to the agen
 
 </Accordion>
 
-<Accordion title="Preserve Signal reply quotes">
+<Accordion title="Signal reply quotes">
 
-With Signal configured to quote only the first reply, a failed streamed send no longer uses up that quote. The first successful reply keeps its reference to the incoming message, and the [Signal guide](/channels/signal) now explains the existing table-formatting choices and their default.
+If you set [Signal](/channels/signal) to quote your message only on the first reply, that quote now stays available when an earlier send fails. The first reply that actually arrives shows what it is answering.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1354,9 +1278,9 @@ With Signal configured to quote only the first reply, a failed streamed send no 
 
 </Accordion>
 
-<Accordion title="Keep assistant prefixes out of incoming WhatsApp text">
+<Accordion title="WhatsApp reply labels">
 
-Incoming WhatsApp messages keep the sender’s text without an added assistant reply label. Your configured outgoing prefixes continue to work, and prefix-like text someone actually typed remains part of their message.
+If you use a custom label at the start of your Claw’s WhatsApp replies, it no longer gets added to messages coming from other people. Your outgoing labels still work, and incoming messages keep what the sender wrote.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1369,9 +1293,9 @@ Incoming WhatsApp messages keep the sender’s text without an added assistant r
 
 </Accordion>
 
-<Accordion title="Recognize iMessage conversations">
+<Accordion title="iMessage conversation names">
 
-iMessage conversations use available contact and group names to help you recognize them in session lists, while preserving manual labels and existing group titles. Names still depend on what the bridge or resolver supplies. The [iMessage guides](/channels/imessage) separate setup and operating instructions, and maturity documentation distinguishes current iMessage support from historical BlueBubbles migration guidance.
+[iMessage](/channels/imessage) conversations can show familiar contact and group names, such as Alice or Family, when that information is available. Names you assigned yourself stay in place, making it easier to find the right chat without sorting through phone numbers or technical IDs.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1389,9 +1313,9 @@ iMessage conversations use available contact and group names to help you recogni
 
 </Accordion>
 
-<Accordion title="Keep Mattermost accounts and progress current">
+<Accordion title="Mattermost connections and progress">
 
-Changing one Mattermost account's settings can leave the other working accounts connected when valid token secret references are in use. Global changes can still restart all accounts. Progress previews also survive overlapping removal and replacement, even when the new plan has identical text; a failed old-preview deletion gets another cleanup attempt when the turn ends.
+For Mattermost setups that store login tokens separately from account settings, editing one account no longer unnecessarily reconnects the others; settings shared by all accounts can still restart them together. A replacement progress message also stays visible while the old one is being removed, even when both contain the same plan.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1405,9 +1329,9 @@ Changing one Mattermost account's settings can leave the other working accounts 
 
 </Accordion>
 
-<Accordion title="Reply to the saved Google Chat destination">
+<Accordion title="Returning to Google Chat conversations">
 
-When work resumes a Google Chat conversation and sends a reply without an explicit destination, OpenClaw can recover the exact space-ID casing from matching saved session information. This prevents the lowercased destination from causing a permission error, while explicitly supplied targets remain authoritative.
+Replies from a resumed Google Chat conversation can use its saved destination correctly again. This fixes a case where changing capital letters in the destination caused a permission error, even though your Claw was allowed to send there.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1420,9 +1344,9 @@ When work resumes a Google Chat conversation and sends a reply without an explic
 
 </Accordion>
 
-<Accordion title="Finish Nextcloud Talk responses without capture waits">
+<Accordion title="Nextcloud Talk reaction delays">
 
-Nextcloud Talk reactions can return their selected result without waiting for diagnostic capture to finish reading an open response body. The same cleanup correction applies to sends, room lookups, and bot checks. A capture interrupted by cleanup may be incomplete even when the reaction succeeded.
+When diagnostic recording is enabled, a successful Nextcloud Talk reaction no longer has to wait for that recording to finish before reporting success. The recording may be incomplete, but it no longer holds up the result.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1435,9 +1359,9 @@ Nextcloud Talk reactions can return their selected result without waiting for di
 
 </Accordion>
 
-<Accordion title="Identify missing Tlon account settings">
+<Accordion title="Missing Tlon setup details">
 
-A Tlon send blocked by incomplete configuration now names the selected account and the missing connection settings, so you can tell whether to supply the ship, URL, or login code. The error lists field names without revealing their values; the [Tlon guide](/channels/tlon) covers setup.
+If a Tlon message cannot send because setup is incomplete, the error now tells you which account needs attention and which settings are missing. You can go straight to the relevant part of [Tlon setup](/channels/tlon) without guessing, and the error does not reveal your login code.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1450,9 +1374,9 @@ A Tlon send blocked by incomplete configuration now names the selected account a
 
 </Accordion>
 
-<Accordion title="Migrate older Zalo Personal policies">
+<Accordion title="Repairing older Zalo Personal settings">
 
-For older Zalo Personal configurations with root policies and named accounts but no default account, `openclaw doctor --fix --non-interactive` now moves the eligible policies into the account configuration. It preserves root and named-account profiles, explicit overrides, and deliberately empty allowlists.
+If you use multiple Zalo Personal accounts with an older setup, `openclaw doctor --fix --non-interactive` can now complete a settings repair it previously skipped. Your account profiles and explicit choices about who may message the bot stay intact.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1465,13 +1389,11 @@ For older Zalo Personal configurations with root policies and named accounts but
 
 </Accordion>
 
-<Accordion title="Select and inspect the intended account">
+<Accordion title="Choosing and managing messaging accounts">
 
-Account inspection now reflects the configured scope more accurately. Agent listings expand wildcard bindings into known accounts, health diagnostics include implicit default-account bindings, and configured channels retain their subtitles before the plugin loads.
+Account lists and health checks more accurately show which accounts your agents use. [Removing an account](/cli/channels) now reports when nothing was removed, and [message-command errors](/cli/message) explain how to choose an agent when one is needed.
 
-Scripts using [directory](/cli/directory), message, or the affected channel commands must omit `--account` to request the existing default behavior instead of passing an empty value. Directory limits must be positive integers when supplied; omit `--limit` for the plugin default. Blank group IDs fail before plugin setup. [Channel removal](/cli/channels) reports unknown accounts or ineffective deletions with exit status 1 instead of claiming success, although its existing runtime-stop attempt can occur first.
-
-In multi-agent setups, [message commands](/cli/message) now give the supported remedy when no owner is selected. Choosing an existing agent through `agents.defaults.systemAgent.agentId` also assigns other ambient system work to that agent.
+If you use scripts, leave out `--account` and the [directory](/cli/directory) option `--limit` when you want their defaults. Passing an empty value now causes an error; a supplied limit must be a positive whole number. Removal scripts must also handle an error when nothing was removed.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1500,11 +1422,9 @@ In multi-agent setups, [message commands](/cli/message) now give the supported r
 
 </Accordion>
 
-<Accordion title="Continue speaking while work is delegated">
+<Accordion title="Keep talking while your Claw delegates work">
 
-[Talk](/nodes/talk) can acknowledge delegated work, keep listening, and return the consolidated answer to the active voice conversation as well as chat. Follow-up speech stays with the accepted task on supported Gateway-backed runners, and the answer can still return after successive rounds of delegation.
-
-Canceled or replaced voice sessions cannot receive a late answer from the old task. The voice connection to delegated work remains local to the running process and expires, so continuing the work does not promise a spoken result after the process or session is replaced.
+[Talk](/nodes/talk) can keep listening while another agent works on your request, then bring the finished answer back to the same voice conversation as well as chat. This also works when the task needs more than one round of help. Keep that voice conversation open to receive the spoken result; ending it or restarting OpenClaw can leave the answer available only through chat.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1523,11 +1443,9 @@ Canceled or replaced voice sessions cannot receive a late answer from the old ta
 
 </Accordion>
 
-<Accordion title="Handle phone and realtime audio interruptions">
+<Accordion title="Phone interruptions and brief audio errors">
 
-Phone interruptions now account for the assistant audio that the carrier has confirmed playing, including zero duration for speech that was still queued. That keeps the conversation from treating an unheard answer as something the caller already heard. Unexpected Twilio status values also leave valid calls tracked until genuine completion.
-
-Gateway-relayed GPT-Live calls can continue after isolated recoverable audio-packet errors, though a brief gap is possible and persistent or terminal failures still end the call. The [Voice Call guides](/plugins/voice-call) now separate configuration, audio, interfaces, and troubleshooting.
+When you interrupt your Claw on a phone call, it now uses the phone service’s playback confirmation to avoid treating an answer you never heard as already spoken. GPT-Live calls through OpenClaw can also continue after an occasional recoverable audio error, though you may hear a brief gap. Repeated failures can still end the call; see the [Voice Call guide](/plugins/voice-call) for setup and troubleshooting.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1552,15 +1470,13 @@ Gateway-relayed GPT-Live calls can continue after isolated recoverable audio-pac
 
 ## Memory
 
-Memory search keeps its leading matches when you ask for fewer results, and remembered context can still reach a conversation when an optional lookup stalls or a managed local embedding service needs time to start. Long conversations also get fixes for reopening older search results and carrying readable history into the next turn, with clearer guidance about what remains searchable after you delete a session.
+Memory fixes help your Claw find remembered details and return to older conversations. There is also clearer guidance when memories cannot be saved, or when deleting a conversation leaves its memories behind.
 
 <AccordionGroup>
 
-<Accordion title="Find useful memories through interruptions">
+<Accordion title="Finding remembered details">
 
-Asking for one memory result should give you the best match from the same search, so requests for between 1 and 200 results now rank a shared candidate pool before trimming the answer. That consistency does more retrieval work for small requests, while searches interrupted by a replaced memory manager can retry once without telling you to rebuild a healthy index.
-
-Active Memory can continue with normal recall when its optional preliminary lookup times out. Managed local embedding services also get their configured startup allowance before the search timer resumes, so a cold start does not consume the time needed to find your memories. Completed primary results survive a timeout in the accompanying wiki search, and messages delivered by another agent or a finished child task skip unnecessary recall while later human messages remain eligible.
+Asking for a short list of memories no longer drops a better match just because you requested fewer results. Your Claw can also keep looking when an optional search gets stuck, and a local memory-search service gets time to start before OpenClaw gives up on it. These fixes help remembered information reach your conversation without unnecessary repair steps.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1577,11 +1493,11 @@ Active Memory can continue with normal recall when its optional preliminary look
 
 </Accordion>
 
-<Accordion title="Build and inspect the intended memory index">
+<Accordion title="Setting up memory search">
 
-Memory indexing can wait through temporary embedding-provider cooldowns, while interactive searches keep a shorter, cancellable retry budget. If your primary embedding provider cannot start, the configured fallback uses its own model, and deep memory status recognizes a valid fallback-built index even after the primary recovers. An index built for an incompatible model still needs an explicit rebuild with `openclaw memory index --force`.
+OpenClaw can wait through temporary limits from your memory-search provider and use the right model when it switches to your configured backup. It also stops telling you to rebuild working memory search just because the main provider has recovered. If you change to an incompatible model, you still need to rebuild with `openclaw memory index --force`.
 
-On macOS with Bun, installing SQLite through `brew install sqlite` lets OpenClaw discover a suitable library for native vector searches in both the main process and its search subprocess. If you use a custom `Database.setCustomSQLite` preload script, remove it and use `OPENCLAW_SQLITE_LIBRARY` instead. An invalid override stops startup with an error; installations without a suitable discovered library retain the existing scan fallback.
+Mac users running OpenClaw with Bun can enable native memory search with `brew install sqlite`. If you previously used a custom SQLite startup script, replace it with the `OPENCLAW_SQLITE_LIBRARY` setting to avoid a startup failure.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1600,9 +1516,9 @@ On macOS with Bun, installing SQLite through `brew install sqlite` lets OpenClaw
 
 </Accordion>
 
-<Accordion title="Keep automatic memory promotion tied to recall">
+<Accordion title="Choosing what becomes long-term memory">
 
-Repeated background scans no longer stand in for distinct recall queries when deciding what belongs in long-term memory. With the default query-diversity requirement, a note must build that evidence through actual recall, alongside the existing relevance and frequency checks. Older records that mixed recall with background-scan evidence may need fresh queries before they qualify, so promotion can slow down after upgrading; memories already saved in `MEMORY.md` stay in place.
+With the default settings, a note no longer becomes long-term memory simply because OpenClaw repeatedly encounters it during background scans. It must also turn up in different memory searches, helping keep incidental notes from being saved just because they keep appearing. After updating, some older notes may take longer to qualify, while memories already saved stay in place.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1615,11 +1531,9 @@ Repeated background scans no longer stand in for distinct recall queries when de
 
 </Accordion>
 
-<Accordion title="Return to retained conversation context">
+<Accordion title="Returning to older conversations">
 
-[Session search](/concepts/session-search) can reopen retained messages from before a reset and show their original surrounding context. When a result falls outside the current conversation view, that history stays within its original reset interval. The agent's history tool also accepts a redundant offset when a message anchor already identifies what to open.
-
-Queued replies can continue after conversation compaction and large-history handoffs with readable history ready for the next turn. Preparing that handoff may take longer because OpenClaw waits for the history rebuild to finish. Long-conversation checks also retain less temporary data without truncating stored context, and private memory maintenance respects the conversation's context budget even when its selected model supports a larger window.
+[Session search](/concepts/session-search) can now open saved messages from before a conversation reset, taking you back to the original discussion instead of an empty page. Fixes also help queued replies continue after OpenClaw shortens a long conversation, so you can pick up where you left off.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1640,13 +1554,11 @@ Queued replies can continue after conversation compaction and large-history hand
 
 </Accordion>
 
-<Accordion title="Understand memory maintenance and retention">
+<Accordion title="Knowing what was saved or forgotten">
 
-Deleting a session now tells you when its retained archive can still appear in memory search and gives you the owning agent's cleanup command. [Forgetting those memories](/cli/memory#memory-forget) remains a separate action, run on the computer or container hosting OpenClaw with the correct state and configuration, including when you deleted the session remotely.
+Deleting a conversation now tells you when its saved history can still appear in memory search and shows the command for [forgetting those memories](/cli/memory#memory-forget). Forgetting remains a separate step, which you need to run on the computer hosting OpenClaw, even if you deleted the conversation remotely.
 
-Operator logs now explain selected policy and session reasons for skipped recall, and warn when an automatic memory-saving run has no authorized write tool, naming the file it cannot save. Those messages help diagnose the missing work; they do not save it. Doctor can also inspect memory readiness while the agent database is busy, and continues past empty shared-memory layouts or advisory edited-archive warnings while preserving existing data and still refusing unsafe migration sources.
-
-The [Active Memory guides](/concepts/active-memory) now separate setup, controls, and troubleshooting into focused pages. The Lossless Claw recipe explains the parent-agent tool grants needed for recall, including that those grants also give the parent agent access and remain subject to other restrictions.
+When an automatic memory save lacks permission to write, the logs now name the file it could not save. They also explain more reasons why [Active Memory](/concepts/active-memory) skipped a search, making missing memories easier to investigate. These are clearer warnings, so a reported save problem still needs attention.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1668,11 +1580,9 @@ The [Active Memory guides](/concepts/active-memory) now separate setup, controls
 
 </Accordion>
 
-<Accordion title="Keep context engines available through cleanup">
+<Accordion title="Keep conversation-history plugins working">
 
-If you use a [context-engine plugin](/concepts/context-engine) to manage conversation history, accepted compaction and background maintenance keep the managed resources they use, including databases and tool services, available until the outstanding work and cleanup finish. Turns retain their selected engine through startup, including prepared runs using copied engines, instead of unexpectedly switching to a fallback as the original registry retires.
-
-Cancellation and timeout can still return promptly and revoke permission to write to the conversation. Keeping resources open gives already-started work time to finish cleanup; plugin authors must return their asynchronous work so OpenClaw can track and await it.
+If you use a [plugin to manage conversation history](/concepts/context-engine), summaries are less likely to fail because a connection closed too soon. OpenClaw also avoids unexpectedly switching to a backup plugin while a turn starts. Cancelling can still stop further changes to the conversation while the plugin finishes closing its connections.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1689,9 +1599,9 @@ Cancellation and timeout can still return promptly and revoke permission to writ
 
 </Accordion>
 
-<Accordion title="See externally written LanceDB memories">
+<Accordion title="Using memories added by other tools">
 
-The [LanceDB memory extension](/plugins/memory-lancedb) can see memories committed by an external importer or another process on its next operation, without restarting OpenClaw or making a local write first. Recall, listing, and deletion refresh the retained table before using it, while each operation still works from its own snapshot, so a write committed during that operation may appear on the following one.
+If another tool adds memories to your [LanceDB memory extension](/plugins/memory-lancedb), your Claw can find them on its next search without restarting OpenClaw. You can also list or delete those newly added memories without first having to make a change from inside OpenClaw.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1712,15 +1622,13 @@ The [LanceDB memory extension](/plugins/memory-lancedb) can see memories committ
 
 ## Skills
 
-You can now search the skills you already have alongside the ones available on ClawHub, then move into Skill Workshop to build on what your Claw has learned. Learning from past conversations also happens in a chat you can follow and steer, giving you a visible place to decide what should become a reusable skill.
+Skills give your Claw reusable instructions for the work you do together. This update makes them easier to find and set up, and lets you watch and guide your Claw as it looks for ways to improve skills using past conversations.
 
 <AccordionGroup>
 
 <Accordion title="Search installed skills and ClawHub together">
 
-The [Skills page](/tools/skills) brings installed skills, library entries, and ClawHub results into one search, with compact cards showing what is installed and what you can add. With an empty search you can browse Trending, and your local skills remain visible if ClawHub is unavailable. Switching agents keeps you on the page and shows that agent's inventory, while shared tabs take you directly between Plugins, Skills, and Skill Workshop. Installation waits until the destination library or workspace is known.
-
-Installed cards explain whether a skill is ready, disabled, or missing setup, and show security findings where those are available. Those indicators do not mean every skill has been scanned. Skill titles and ClawHub details are also easier to read, with formatted changelogs and contained scrolling that keeps the Install action visible.
+The [Skills page](/tools/skills) now searches your installed skills and ClawHub together, so you can see what you already have and what you can add without checking separate places. Cards show which skills are ready or need setup, and switching agents shows the skills available to that agent. You can also browse popular skills without typing a search, while clearer titles and readable descriptions make it easier to choose.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1741,7 +1649,7 @@ Installed cards explain whether a skill is ready, disabled, or missing setup, an
 
 <Accordion title="Import, install, and read skills">
 
-Importing a skill now shows the files or folder you selected, with a Clear action so you can change your selection before importing. Skill dialogs fit short content and keep longer instructions scrollable within the screen, with Close beside the title. Slower dependency installations from the Control UI also get the installer's existing five-minute allowance for each command, instead of being cut off after two minutes.
+When importing a skill, you can now see which files you selected and clear them before continuing. Skill windows fit the screen and keep Close within reach, making longer instructions easier to read on a phone. Installations that need more time to download or set up supporting software can also finish without being cut off as early.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1761,9 +1669,9 @@ Importing a skill now shows the files or folder you selected, with a Clear actio
 
 <Accordion title="Learn from past conversations in a visible chat">
 
-“Learn from past conversations” in [Skill Workshop](/tools/skill-workshop) now opens a normal chat, where you can watch the work, give it more direction, or stop it. Your Claw can inspect accessible conversations and existing skills, with Auto allowing justified improvements and Propose leaving suggestions for your approval. You can start this manually while self-learning is off without enabling it, and the usual model costs, permissions, and conversation access apply.
+Choose “Learn from past conversations” in [Skill Workshop](/tools/skill-workshop) to open a chat where you can follow the work, add direction, or stop it. Auto lets your Claw apply improvements based on what it finds, while Propose leaves suggestions for you to approve. Starting this yourself does not turn on automatic self-learning, and normal model charges and access permissions still apply.
 
-This replaces the old history scanner. Clients using `skills.proposals.historyStatus` or `skills.proposals.historyScan` need to move to the new learning-session flow, and saved scan cursors or pending scan batches cannot resume. Existing installed skills and proposals remain available. For automatic self-learning, Workshop also explains when weekly reviews are paused because scheduling is disabled and links to the setting needed to resume them.
+Old unfinished history scans cannot resume in the new flow, so start a new learning chat instead. Your installed skills and existing proposals stay available. Workshop also explains when automatic weekly reviews are paused because scheduling is off and takes you to the setting.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1787,9 +1695,9 @@ This replaces the old history scanner. Clients using `skills.proposals.historySt
 
 <Accordion title="Keep current skill instructions available">
 
-Existing conversations pick up updated file-backed skills on the next turn after a Gateway restart, even when file watching is disabled, so you can keep the conversation and its history. Installed or edited workspace skills also appear through status checks, including repaired files on the first check after watching starts or resumes. Managed library selections keep their pinned revisions until you explicitly refresh them.
+After restarting OpenClaw, you can continue an existing conversation with updated local skill files on its next turn. Skill lists also pick up newly installed or repaired files more reliably. Skills selected from a managed library keep their chosen version until you refresh them.
 
-New Workshop drafts preserve the full skill description separately from the short proposal label, keeping the instructions that help your Claw recognize when to use a skill. Previously lost descriptions and older pending drafts are not repaired automatically. Agents also receive clearer guidance for requested edits to repository-owned skill files, while Workshop-owned changes retain their approval path, and sandboxed plugin agents receive skill paths they can actually open inside their workspace.
+New Workshop changes preserve the full descriptions that help your Claw recognize when to use a skill, instead of replacing them with short change labels. This protects future edits, but does not restore descriptions already lost or repair older pending proposals.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1807,11 +1715,9 @@ New Workshop drafts preserve the full skill description separately from the shor
 
 </Accordion>
 
-<Accordion title="Prepare skills for remote work">
+<Accordion title="Use skills on cloud and remote computers">
 
-Cloud and SSH turns now transfer skill files in batches, reducing the repeated network requests that could delay work before the model started. Skills still receive fresh copies each turn, with the largest benefit for collections containing many small files.
-
-Cloud workers can also use local skills with contained file aliases, such as `CLAUDE.md` pointing to `AGENTS.md`, because delivery copies the target's contents into an ordinary file. The target must be an included file inside the same skill. Links outside it, excluded files, directory links, broken or cyclic links, and hard links remain rejected, and managed library content still needs to be link-free.
+If your Claw works on a cloud or SSH-connected computer, it now spends less time copying skills before starting, especially when you have lots of small skill files. Cloud workers can also use supported links between instruction files within the same local skill, so you do not have to duplicate those files just to get the skill working there.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1828,11 +1734,9 @@ Cloud workers can also use local skills with contained file aliases, such as `CL
 
 </Accordion>
 
-<Accordion title="Recover recognized Workshop migrations">
+<Accordion title="Fix Workshop problems after updating">
 
-Doctor can get past several specific Workshop upgrade failures, including unfinished ownership migrations and obsolete generated review jobs. If startup reports the leftover review index that refers to `workspace_dir`, run `openclaw doctor --fix` to repair that index while keeping its review history. Valid proposals and backups whose owner is uncertain stay in place for manual review, with paths and possible owners shown, while other eligible repairs can continue.
-
-These repairs remain limited to recognized older state. Corrupt artifacts, unfinished apply recovery, unknown database structures, and unsupported versions still need attention before work can continue. The unfinished ownership migration follows existing rules that can discard review history without an identifiable owner and mark proposals as stale. Custom indexes that depend on retired columns also need to be resolved before that migration can finish.
+Doctor can repair several known Workshop problems that stopped upgrades or prevented OpenClaw from starting. Run `openclaw doctor --fix` when startup asks for it. Proposals and backups that need you to identify their agent remain available for review while other repairs continue. Some older review history may be discarded if its agent cannot be identified, and affected proposals may need reviewing again.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1850,7 +1754,7 @@ These repairs remain limited to recognized older state. Corrupt artifacts, unfin
 
 <Accordion title="Replace the retired video-frames helper">
 
-The bundled `video-frames` skill and its `scripts/frame.sh` helper have been removed. If a workflow uses them to produce image files from a video, switch it to direct `ffmpeg` use or a separately installed frame-extraction skill. Native video understanding can analyze video, but it does not replace those extracted image files, and this change supplies no automatic migration.
+The bundled `video-frames` skill and its helper script have been removed. If you use them to save still images from videos, switch to `ffmpeg` directly or install a separate frame-extraction skill. OpenClaw's video understanding can analyze a video, but does not produce those image files for you, and existing workflows are not converted automatically.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1867,17 +1771,15 @@ The bundled `video-frames` skill and its `scripts/frame.sh` helper have been rem
 
 ## Native Apps
 
-Android makes it easier to stay with a conversation, inspect completed work, and reply from a notification without losing track of what happened. Across the mobile and desktop apps, connection guidance is clearer, Mac setup preserves the connection and profile you chose, and Linux remote connections preserve credential references and leave remote Gateways alone when the desktop sleeps.
+The Android app helps you keep your place while reading, see what your Claw has done, and reply from notifications. There are also clearer ways to reconnect the mobile apps, fixes for Mac setup, and changes that keep a sleeping Linux desktop from interrupting OpenClaw on another computer.
 
 <AccordionGroup>
 
-<Accordion title="Find Android conversations and follow work">
+<Accordion title="Read Android conversations and follow work">
 
-The [Android app](/platforms/android) keeps the paragraph or image you are reading in place while a reply grows or the window changes size. Expanding a message reveals its opening, and code navigation brings the requested lines into view. Jump to latest resumes following the conversation when you are ready to catch up.
+The [Android app](/platforms/android) keeps your place while a reply arrives or you resize the window. Read earlier messages without being pulled away, then use Jump to latest to catch up. You can also open tool details to see what your Claw did, while dashboard chats tuck completed steps away and leave the answer visible.
 
-Completed tools now appear in the conversation with expandable command previews, so you can inspect what your Claw did instead of finding a blank gap. In dashboard conversations, finished commentary and tools fold under “Worked for…” while the final answer stays visible. Those previews are bounded and share the existing offline history budget with messages.
-
-Search and sidebar activity follow each conversation, completed summaries remain visible, and a failed session-list refresh leaves loaded pages available with an error. Chat readiness is also distinguished from a lost connection, with refreshed translations for the affected labels. On folding screens, Thinking and Fast controls, Background Tasks, and branch choices fit within usable panes; an invalidated panel closes and can be reopened in the current conversation.
+Search and the sidebar show which conversation is busy, and a failed refresh keeps the conversations you already loaded. On folding phones, model settings and background tasks stay clear of the fold.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1907,9 +1809,7 @@ Search and sidebar activity follow each conversation, completed summaries remain
 
 <Accordion title="Reply from Android notifications">
 
-Opening or replying to an Android notification reconnects its saved Gateway when needed, while preserving a connection or certificate approval already in progress. An unavailable target leads to Gateway settings, and an older reply result cannot overwrite a newer notification.
-
-Reply feedback now distinguishes queued, failed, and unknown outcomes, including translated messages in existing languages. “Reply queued” means the message entered the persistent send queue. If its status is unknown, open the conversation before sending again; required certificate approval still applies.
+Android notification replies reconnect to the saved computer for that conversation when needed. The notification now tells you whether a reply is queued, failed, or has an unknown status. Queued confirms that the app saved your reply for sending; it does not confirm delivery. If the result is unknown, open the conversation before sending again. You may still need to approve a connection-security prompt before the reply can proceed.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1926,9 +1826,9 @@ Reply feedback now distinguishes queued, failed, and unknown outcomes, including
 
 </Accordion>
 
-<Accordion title="Wait for Android attachments before sending">
+<Accordion title="Send Android attachments with their captions">
 
-Android keeps Send unavailable while selected attachments are loading, so a caption cannot leave before its files are ready. Cancelling an import keeps the caption, another conversation remains independently sendable, and failed document or video imports show an attachment warning.
+Android waits for your selected files to finish loading before enabling Send, so your message cannot go out with its caption but without the attachment. If you cancel a file or it fails to load, the caption stays in place for you to keep working on.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1941,11 +1841,11 @@ Android keeps Send unavailable while selected attachments are loading, so a capt
 
 </Accordion>
 
-<Accordion title="Connect and recover mobile apps">
+<Accordion title="Reconnect the mobile apps">
 
-Android and iOS now show a readable connection failure with a separate Retry action when the saved computer cannot be reached. iOS retries the intended setup target, and addresses that suggest Tailscale receive conditional setup guidance. Certificate and authentication problems keep their own handling, while Android may still need to finish stopping an earlier network request before a retry starts.
+When Android or iPhone cannot reach the computer running OpenClaw, the app now explains the problem and offers Retry. iPhone retries the connection you were setting up, and connections that appear to use Tailscale show relevant setup help. Android may need a moment to finish closing the previous connection before trying again.
 
-Android setup also exposes the selected connection-security option to assistive services. When your Claw checks a device, Android, iOS, and watchOS supply an explicit battery percentage alongside the existing fractional reading, making a full battery distinguishable from a one-percent charge.
+Android setup also makes the selected security option available to accessibility tools. When your Claw checks a phone or Apple Watch battery, the result now includes a clear percentage, helping avoid confusion between a full charge and one percent.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1966,7 +1866,7 @@ Android setup also exposes the selected connection-security option to assistive 
 
 <Accordion title="Find the official mobile apps">
 
-The [iPhone setup guide](/platforms/ios) now links directly to the official App Store listing. For Android users installing outside Google Play, the [installation guide](/platforms/android) explains how to find a GitHub release containing both the APK and its checksum, then verify the download. Android assets appear on selected releases and can arrive after the release is public, so the guide also retains Google Play and source-build alternatives.
+You can now reach the official App Store listing straight from the [iPhone setup guide](/platforms/ios). If you install Android outside Google Play, the [Android guide](/platforms/android) helps you find the app download and check that the file is intact. Downloads are attached to selected releases and may appear later than the release itself.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1980,9 +1880,9 @@ The [iPhone setup guide](/platforms/ios) now links directly to the official App 
 
 </Accordion>
 
-<Accordion title="Read iOS session counts">
+<Accordion title="Understand the iPhone conversation count">
 
-The iOS session-list notice now names the number of sessions displayed separately from the total, including in its existing translations. That makes a partially loaded list easier to understand while keeping Refresh as the way to load the remainder.
+The iPhone app now makes clear how many conversations are showing and how many there are in total, including in its translated messages. If some have not loaded yet, use Refresh to load the rest.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1996,11 +1896,11 @@ The iOS session-list notice now names the number of sessions displayed separatel
 
 </Accordion>
 
-<Accordion title="Manage Mac connections and setup credentials">
+<Accordion title="Set up and change Mac connections">
 
-The Mac app now remembers an intentionally cleared Gateway instead of restoring the previous remote connection after a reload, and shows a warning when saving the change fails. Remote onboarding also reveals its secure credential field when a password is required and explains how to retry. Older Gateway builds need updating to accept the password through the field labeled Gateway token.
+Choosing Set up later or clearing a connection on Mac now stays saved instead of bringing back the old connection when you reopen the app. If saving fails, the app tells you. Password-protected connections also show where to enter the password and try again. Older OpenClaw installations on the other computer need updating to accept a password in the field labeled Gateway token.
 
-For [offline remote setup](/platforms/mac/remote), `openclaw-mac configure-remote` accepts token or password input from a private file or standard input, keeping the secret out of command arguments. Legacy argument forms remain available with deprecation warnings; each secret takes one source, and only one can use standard input. Named profiles now write and read their own configuration and preferences. Use `primary set` when changing the connection of an app that is already running.
+If you prepare Mac setup from the command line, you can now read a password or token from a private file without putting it in the command itself. Setup also respects the profile you chose instead of changing the default profile. The [remote setup guide](/platforms/mac/remote) explains these options and the separate command to use when the app is already running.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2020,9 +1920,9 @@ For [offline remote setup](/platforms/mac/remote), `openclaw-mac configure-remot
 
 </Accordion>
 
-<Accordion title="Close the focused Mac side-panel tab">
+<Accordion title="Close a Mac side-panel tab with Command-W">
 
-In the native Mac app, Command-W closes the active tab in the focused side panel and leaves the main window open. Focus stays with any remaining tabs so you can close them in sequence; closing the last tab dismisses the panel. With focus in the main chat, Command-W keeps its normal window-closing behavior.
+When you are using a side-panel tab in the Mac app, Command-W now closes that tab and leaves the main window open. You can press it again to close the next tab. When you are working in the main chat instead, the shortcut still closes the window as usual.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2035,11 +1935,11 @@ In the native Mac app, Command-W closes the active tab in the focused side panel
 
 </Accordion>
 
-<Accordion title="Diagnose Mac Gateway startup and restart jobs">
+<Accordion title="Troubleshoot Mac startup and repeated restarts">
 
-Mac Gateway startup errors now go to the regular service log, making failures before normal application logging starts easier to diagnose. Existing installations pick up the destination when installation or an ordinary restart rewrites the service definition; a restart that preserves the definition keeps the old destination.
+If OpenClaw fails to start on Mac, its service log can now include errors that used to disappear before normal logging began. Existing installations need their background service setup refreshed before these errors appear in the log. The [Mac troubleshooting guide](/platforms/mac/bundled-gateway) explains the setup and where to look.
 
-For repeated restarts, `openclaw gateway status` and `openclaw doctor` now expose suspicious OpenClaw launchd jobs without requiring a deep scan. The [bundled Gateway guide](/platforms/mac/bundled-gateway) explains the diagnostic path. Review a job before removing it, because a known limitation can misclassify commands launched through `env`; the diagnostic result alone is not enough to justify automatic cleanup.
+Status and Doctor can also point out background jobs that may be repeatedly restarting OpenClaw. These checks can flag a job incorrectly, so review it before removing anything.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2053,11 +1953,11 @@ For repeated restarts, `openclaw gateway status` and `openclaw doctor` now expos
 
 </Accordion>
 
-<Accordion title="Keep Linux companion connections usable">
+<Accordion title="Keep Linux connections and updates working">
 
-The [Linux companion](/platforms/linux) now honors the port configured for an SSH alias unless you explicitly enter another one. Reconnecting a saved remote connection also preserves file and environment credential references, so later launches can pick up rotated secrets without replacing the reference with plaintext. References overwritten by earlier versions still need to be restored manually.
+Putting your Linux desktop to sleep no longer tells OpenClaw on another computer to pause, including when you connect over SSH. Saved SSH connections also use their configured port. If you keep a password or token in a separate file or environment setting, reconnecting preserves that setup so later launches can read the updated secret. Settings overwritten by an older version still need to be restored manually.
 
-Putting the desktop to sleep leaves remote Gateways alone, including those reached through SSH tunnels, while locally managed Gateways retain sleep coordination. Update notifications and tray actions remain available after navigating into the dashboard, and a ready update survives failed checks or replacement downloads so it can be retried. The maturity documentation also recognizes the existing companion as Beta.
+The [Linux companion](/platforms/linux) also keeps update notices and tray actions available while you are using the dashboard. An update that is ready to install stays available for another try if a later check or download fails.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2080,9 +1980,9 @@ Putting the desktop to sleep leaves remote Gateways alone, including those reach
 
 </Accordion>
 
-<Accordion title="Speak ordinary formatted explanations">
+<Accordion title="Hear explanations that include code">
 
-Ordinary explanations containing inline code or following quoted code blocks remain eligible for [spoken replies](/tools/tts), so [Talk](/nodes/talk) can read the explanation instead of sending you to the screen. Replies that are mostly code still use the existing suppression or screen fallback, and your speech settings continue to apply.
+An explanation with a little code in it can now be read aloud instead of being skipped or replaced with a message to look at the screen. This applies to [spoken replies](/tools/tts) and [Talk](/nodes/talk) when speech is enabled. Answers that are mostly code still follow the existing rules for keeping that content on screen.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2099,15 +1999,13 @@ Ordinary explanations containing inline code or following quoted code blocks rem
 
 ## Models and Providers
 
-Model browsing now follows the Gateway and agent you selected, with saved models keeping their own settings and capabilities through more of the places you use them. Searchable pickers make long lists easier to work with, Thinking and Fast controls reflect the selected model, and provider sign-ins and coding sessions recover from more specific failures. GPT Image 2.5 and Deepgram Flux also bring new choices for making images and transcribing voice notes.
+You have more choices for making images and transcribing voice notes, and choosing the model behind your Claw is easier too. Model menus are searchable, saved choices keep the right settings, and the controls stop offering options a model cannot use. For people working with Codex, Claude, or their own AI server, there are also fixes for missing instructions, interrupted work, and confusing sign-in failures.
 
 <AccordionGroup>
 
-<Accordion title="Browse the selected Gateway's models">
+<Accordion title="Model lists from the right Gateway">
 
-Model browsing now shows the inventory published by the Gateway and agent you selected, so the CLI, chat, and model controls are working from the same list. Ordinary browsing and capability checks do not quietly ask providers to discover models again; use Refresh or `openclaw models list --refresh` when you need new inventory, as described in [model browsing](/concepts/models). Failed refreshes explain what happened while retaining compatible choices, and a successful empty result clears old entries instead of bringing them back.
-
-Upgrade the Gateway before the CLI, because the new CLI requires its published-catalog support and will ask you to update or reconnect rather than substitute a different local list. Scripts must stop relying on the removed `missing` JSON field, and current promotions are available through `openclaw promos list`. The separate `openclaw models refresh` command downloads hosted model information; the running Gateway still needs a restart to apply those model and price updates, with clearer log guidance when a download is waiting. Public SDK catalog calls continue to discover by default; callers wanting a passive read must set `readOnly: true`.
+If you connect to more than one Gateway, the [model list](/concepts/models) now follows the Gateway and agent you selected, so you see the choices for the place where your work will run. Browsing the list no longer starts another search for models in the background. Refresh checks for new choices, and a failed refresh shows a warning while keeping compatible saved choices available. Update the Gateway before updating a separate command-line client. Updates to OpenClaw's model-and-price reference still need a Gateway restart before they take effect.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2143,11 +2041,9 @@ Upgrade the Gateway before the CLI, because the new CLI requires its published-c
 
 </Accordion>
 
-<Accordion title="Keep exact model choices and capabilities">
+<Accordion title="Keep the model you chose">
 
-A saved model choice now keeps its own identity and capabilities through more catalog, session, and refresh paths. Models whose names differ by capitalization or include provider prefixes and slashes remain distinct, exact entries take precedence over aliases, and an alias is resolved once instead of walking on to another model. That keeps the chosen model's context limit, image support, and tool compatibility from being replaced by a similarly named entry's settings.
-
-Child chats also show the model they inherit consistently across session views. Choosing Default remains a durable choice through resets and restarts and retains configured fallback behavior, while an explicit model pin stays strict. API clients should use `sessions.patch` with `model: null` for Default; sending a concrete model value pins it even when it happens to equal today's default. In the terminal picker, models confirmed unavailable stay visible with a reason, and selecting one leaves the session unchanged; unknown availability remains selectable.
+Saved model choices are less likely to change unexpectedly, particularly when custom models have almost identical names. Each keeps its own settings for images, tools, and the amount of text it can handle. Chats started from another chat also show the model they actually inherit, and choosing Default stays in place after a restart. Default follows the configured model and its backups; explicitly choosing a particular model keeps the chat pinned to that choice.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2181,11 +2077,11 @@ Child chats also show the model they inherit consistently across session views. 
 
 </Accordion>
 
-<Accordion title="Choose models and accounts in Settings">
+<Accordion title="Find models and edit backup choices">
 
-Long model menus can be searched by name or model reference, with the current choice left alone until you select a result. Chat choices follow the conversation's saved account, and New Session can preview another account you own without changing the default for future chats. Large catalogs also require less repeated work when selecting a Chat model or typing in New Session.
+Searchable model menus make long lists easier to use without changing your choice until you select a result. Chat menus follow the account saved for that conversation, while New Session lets you preview another account you own. If a list fails to load, you can see the problem and try again.
 
-In Models Settings, the first picker open discovers additional choices and shows progress or Retry when needed; reopening after completion reads the published list, while Retry deliberately discovers again. Saved unavailable choices remain visible and removable without being offered as new selections. Editing backup models preserves an inherited primary, clearing every fallback stays empty after reload, and abandoning a search no longer saves unfinished text as a model. The page now labels Global defaults explicitly and points to Agents → Overview for an individual agent's model.
+Editing backup models now preserves an inherited primary model, and removing every backup stays that way after a reload. Unavailable saved choices remain visible so you can remove them. Global defaults labels help distinguish shared settings from an individual agent's choices.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2213,11 +2109,9 @@ In Models Settings, the first picker open discovers additional choices and shows
 
 </Accordion>
 
-<Accordion title="Use the selected model's Thinking and Fast controls">
+<Accordion title="Thinking and Fast controls that match the model">
 
-Thinking controls now use the selected model's published choices and default across Chat, Sessions, and New Session, including after history refreshes. A model that offers no adjustable levels keeps an empty list, missing information stays unknown, and a saved Off choice remains explicit. That removes guessed effort levels without changing the model's reasoning capabilities.
-
-Fast follows the selected request more closely too. Confirmed ineffective choices are disabled for the covered Anthropic, OpenAI, xAI, and MiniMax routes, while existing saved preferences remain clearable and unknown support retains its existing behavior. This tells you whether OpenClaw can apply Fast to the request; the provider still determines availability, price, and the response you receive.
+The Thinking menu now follows the effort levels offered by the selected model, so it no longer invents choices and correctly shows your saved Off setting. When OpenClaw knows that Fast cannot change a request, it disables that choice while still letting you clear an old preference. These controls make it clearer what you can adjust; actual speed, access, and charges still depend on the provider.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2235,11 +2129,9 @@ Fast follows the selected request more closely too. Confirmed ineffective choice
 
 </Accordion>
 
-<Accordion title="Preserve configured provider routes">
+<Accordion title="Keep custom AI connections pointed at the right server">
 
-Custom model connections retain their authored endpoints, headers, and request settings when generated catalogs overlap them. Exact configured entries take precedence over aliases, manual models survive merge-mode refreshes, and saved local endpoints remain identified as local. Several provider setup flows also save the connection without copying a built-in model list into your configuration.
-
-If you point an existing provider at a custom endpoint, declare that endpoint's supported models under `models.providers.<id>.models`; it no longer automatically inherits the native service's list. Session SDK integrations must also use a current auth profile or authored request configuration, because generated catalogs now supply inventory without authorizing requests through cached keys, authentication modes, or headers. Authored credentials remain scoped to the endpoints declared with them.
+People using custom AI servers keep the connection settings they entered when model lists are refreshed, instead of having another model's settings take over. Manually added models also stay in the list. If you use a custom server in place of a provider's usual service, you may need to list the models it supports explicitly. Integrations must use current sign-in details or explicitly configured credentials; old credentials saved only with a downloaded model list no longer authorize requests.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2266,11 +2158,11 @@ If you point an existing provider at a custom endpoint, declare that endpoint's 
 
 </Accordion>
 
-<Accordion title="Reuse and repair provider sign-ins">
+<Accordion title="Reuse sign-ins and recover from login problems">
 
-Supported OpenAI login methods can now reuse eligible credentials already stored by Codex, saving another key paste or sign-in while preserving existing model choices. Device-code login may reuse an eligible stored account too; explicit force, profile, or default-selection options retain the normal sign-in path. When credentials save successfully but the running Gateway cannot apply them, the command explains that distinction and points you to the correct computer for recovery.
+Supported OpenAI sign-in methods can reuse an account or key already saved by Codex, saving you another login or paste. Agents sharing a sign-in also handle renewal more reliably, and a renewal that finished too late for one request can help the next request succeed.
 
-Agents sharing an OAuth sign-in coordinate refreshes so they do not reuse a consumed token or overwrite a newer login. A retained Codex client can use a refresh that finished after its previous callback timed out, although that first slow callback can still fail. Deleted or replaced selected profiles can require an explicit sign-in, and interrupted shared refreshes may require `/login <provider>`. A pending legacy-credential migration now leaves unrelated authenticated providers usable; affected or unidentifiable credentials still need `openclaw doctor --fix`.
+If sign-in still needs attention, OpenClaw better distinguishes saved credentials from a connection that has not picked them up and tells you which computer to check. Older credentials awaiting repair no longer disable unrelated providers; use `openclaw doctor --fix` for the affected accounts.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2294,11 +2186,11 @@ Agents sharing an OAuth sign-in coordinate refreshes so they do not reuse a cons
 
 </Accordion>
 
-<Accordion title="Recover eligible model failures and explain refusals">
+<Accordion title="Recover failed tool requests and explain what stopped">
 
-A malformed tool call no longer has to end an otherwise silent task immediately. Completed Anthropic calls can repair specific string-encoding problems such as raw newlines or invalid backslash escapes, while rejected calls can use the existing bounded retry and configured fallback paths when replay is safe. Truncated or otherwise invalid calls remain non-executable, and visible output, accepted actions, possible side effects, or approval prompts still prevent replay. Persistent failures can use three retries after the first request, adding requests and possible cost before fallback or the final error.
+When a model sends broken instructions for a tool, OpenClaw can try again instead of immediately abandoning the task. With Anthropic, it can also repair certain formatting mistakes. Retries are limited to cases where repeating the request is safe and may add cost. If earlier actions already happened, check their results before asking your Claw to continue.
 
-The failure you see is more useful too. Known network errors identify DNS, refused connections, interruptions, or unreachable endpoints; invalid parameters stop without pointless retries or compaction, and unfinished tool-call explanations remain in reloaded history beside valid partial replies. Fallback diagnostics explain covered terminal stops, the terminal footer follows accepted fallback events, and intentional silent replies avoid an erroneous missing-output retry. Before continuing after an unfinished call, check whether earlier actions already completed.
+Errors also better distinguish connection problems, rejected sign-ins, and requests a provider cannot accept. Explanations stay in chat history, making it easier to understand why work stopped or a backup model was not tried.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2322,9 +2214,9 @@ The failure you see is more useful too. Known network errors identify DNS, refus
 
 </Accordion>
 
-<Accordion title="Reuse cached prompts">
+<Accordion title="Reuse more of the prompt between requests">
 
-Anthropic tool conversations keep temporary context away from reusable cache boundaries while still sending that context to the model, avoiding unnecessary rewrites of growing conversation history. Eligible local-model requests also place changing session facts after the stable instructions-and-tools prefix, so a new conversation can reuse that prefix when the server and chat template support it. Actual cache reuse and charges still depend on the provider and workload.
+Anthropic conversations that use tools can reuse more of the instructions and conversation text already processed, instead of repeatedly saving the same growing history again. Compatible local models also get a more reusable starting prompt when you begin another conversation with the same instructions and tools. This can avoid repeated processing, though any effect on waiting time or charges depends on the provider and workload.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2338,11 +2230,11 @@ Anthropic tool conversations keep temporary context away from reusable cache bou
 
 </Accordion>
 
-<Accordion title="Keep Codex workspace guidance and history">
+<Accordion title="Keep workspace instructions in Codex conversations">
 
-[Managed Codex conversations](/plugins/codex-harness-runtime) regain current workspace personality, preferences, skill listings, and memory guidance, including later edits and removal. This delivery applies to the bundled stdio app-server on supported accounts and standard OpenAI endpoints; other connection types retain their existing delivery path with a warning. Newly supplied parent guidance stays out of native child and internal requests, while existing history and explicit handoffs remain intact. Explicitly configured native workspace-instruction budgets are also respected, so a larger `AGENTS.md` chain is no longer silently capped by OpenClaw's default.
+[Codex conversations managed by OpenClaw](/plugins/codex-harness-runtime) regain workspace personality, preferences, skills, and memory guidance, including later edits. This applies to supported managed connections; other connection types keep their existing handling and may show a warning.
 
-Long ordinary Codex conversations can recover a final answer after completing tool work without replaying those actions, using complete current-turn evidence and the nearest earlier exchanges that fit. Supervised Codex Sessions retain their separate fallback behavior. Follow-ups after successful final message-tool delivery also stop resending already covered history while keeping fresh corrections, and the managed relay accepts Responses Lite requests that omit a separate instructions field.
+Ordinary Codex chats can also recover a missing final answer after finishing work in a long conversation, without repeating those actions. Follow-ups keep fresh corrections without resending history already covered by a successful final reply.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2364,11 +2256,9 @@ Long ordinary Codex conversations can recover a final answer after completing to
 
 </Accordion>
 
-<Accordion title="Continue connected coding-agent sessions">
+<Accordion title="Return to Claude and other coding-agent conversations">
 
-Returning to a Claude-backed conversation keeps its native session identity when overlapping history is combined, and a resumed turn no longer appears twice just because it carries OpenClaw's generated context note. Compatible warm Claude CLI processes can also survive skill-watcher readiness when the prepared skill content has not changed; real instruction changes still invalidate reuse.
-
-Pasted text reaches adopted or forked Codex sessions with locked model selection under the existing extraction limits. Connected ACP agents can finish valid forms with no fields, and elapsed-time fixes keep covered ACP startup and Codex operation waits from being distorted by clock corrections. CLI backend plugins also receive the effective Fast setting after preparation and queue waits, so a plugin that supports it can apply the right value when it launches.
+Returning to a Claude conversation keeps its original chat connection and avoids a repeated user message in the affected resume cases. Claude can also stay running between turns when a skill check finds that nothing changed. In Codex chats with a fixed model choice, pasted text now reaches the agent instead of being lost.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2395,9 +2285,9 @@ Pasted text reaches adopted or forked Codex sessions with locked model selection
 
 </Accordion>
 
-<Accordion title="Use discovered local model limits">
+<Accordion title="Use the right conversation limit for local models">
 
-Self-hosted discovery now reads the context limits advertised by vLLM, SGLang, and compatible servers, including eligible direct-parent limits for adapters, instead of falling back to an inaccurate generic budget. Explicit configuration still wins. First-use vLLM metadata reads also avoid unnecessary provider-code loading, and Ollama's existing setup and troubleshooting guidance is split into focused pages.
+If you run models on your own server, OpenClaw now uses the conversation size reported by vLLM, SGLang, and compatible services instead of falling back to a potentially wrong limit. That helps it budget how much text to send to the model, while any limit you entered yourself still takes priority. Opening vLLM model information for the first time also avoids some unnecessary loading work.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2415,9 +2305,9 @@ Self-hosted discovery now reads the context limits advertised by vLLM, SGLang, a
 
 </Accordion>
 
-<Accordion title="Select Tencent Hy4 preview">
+<Accordion title="Try Tencent Hy4 preview">
 
-Tencent TokenHub and TokenPlan now offer Hy4 preview, with fresh setup selecting it and existing pinned models preserved. Its catalog describes a 1,024,000-token context window and a 64,000-token output limit; your key must allow access to the model. Hy4 exposes none/high reasoning, so intermediate choices such as Low map to High and can affect thinking time and usage. Doctor still migrates an old TokenHub `hy3-preview` primary to Hy3 rather than silently moving an existing setup to Hy4.
+Tencent users can choose Hy4 preview through TokenHub or TokenPlan, and new setups select it by default when the account has access. Existing model choices stay in place, so an upgrade does not silently switch you to the preview. Its thinking options are Off or High; selecting an intermediate level such as Low uses High, which can affect waiting time and usage.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2430,9 +2320,9 @@ Tencent TokenHub and TokenPlan now offer Hy4 preview, with fresh setup selecting
 
 </Accordion>
 
-<Accordion title="Use current Grok defaults">
+<Accordion title="Grok 4.6 becomes the default for new setups">
 
-New xAI setups and web search, X search, and code-execution tools without explicit model overrides now use Grok 4.6. Existing explicit selections stay in place, while retired subscription `xai/auto` choices can be repaired with `openclaw doctor --fix` or replaced with a permitted concrete model. The changed tool default can affect cost or account availability, and a zero estimate for an unknown price does not mean the request is free.
+New xAI setups use Grok 4.6, as do xAI web search, X search, and code-execution tools when you have not chosen a model for them. Your explicit choices stay in place, but the new tool default can change cost or availability for your account. If an older subscription setup still uses the retired Auto choice, run `openclaw doctor --fix` or select an available model yourself.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2445,9 +2335,9 @@ New xAI setups and web search, X search, and code-execution tools without explic
 
 </Accordion>
 
-<Accordion title="Send standalone OpenCode requests">
+<Accordion title="Make one-off OpenCode requests">
 
-Standalone OpenCode Go and Zen completions now receive the routing identity their native endpoints require, including local inference and prepared SDK requests without a persistent conversation. Explicit session headers retain precedence without discarding other provider routing headers, and retries reuse the same invocation identity. Custom endpoints retain their existing exclusions, and low-level stream callers still need to supply a session ID.
+OpenCode Go and Zen requests made outside an ongoing conversation no longer fail just because the service needs session information that was missing. OpenClaw supplies it automatically for the supported direct connections, including requests from the command line and supported integrations. Custom server connections keep their existing requirements.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2462,9 +2352,9 @@ Standalone OpenCode Go and Zen completions now receive the routing identity thei
 
 </Accordion>
 
-<Accordion title="Use the selected Arcee account">
+<Accordion title="Use your saved OpenRouter account with Arcee">
 
-Arcee through OpenRouter now uses the matching saved OpenRouter account without requiring a duplicate Arcee credential. The selected model keeps its authored endpoint, headers, limits, and aliases, while equivalent Arcee names stop producing misleading model-switch notices. Direct Arcee connections and explicit model endpoints keep their corresponding account selection.
+If you use Arcee through OpenRouter, OpenClaw now uses your matching saved OpenRouter account instead of asking for a separate Arcee credential. Your model settings stay attached to that choice, and different spellings of the same Arcee model stop looking like an unexpected model switch.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2477,9 +2367,9 @@ Arcee through OpenRouter now uses the matching saved OpenRouter account without 
 
 </Accordion>
 
-<Accordion title="Recognize Kimi quota failures">
+<Accordion title="Tell a Kimi quota limit from a bad key">
 
-An explicit Kimi weekly-quota error now follows rate-limit handling instead of telling you that a valid key is wrong and blocking the provider's other configured models. A configured alternative can be tried when available, but replacing the key will not restore spent quota; wait for Kimi's quota window or use another provider. Genuine invalid-key and access-denied errors keep their authentication handling.
+When Kimi explicitly reports that you have used up a weekly allowance, OpenClaw no longer treats your valid key as broken. It can try a configured backup without unnecessarily blocking the provider's other models. Changing the key will not restore the allowance, though; wait for Kimi's quota window or use another provider with available capacity.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2494,9 +2384,9 @@ An explicit Kimi weekly-quota error now follows rate-limit handling instead of t
 
 <Accordion title="Generate and edit with GPT Image 2.5">
 
-You can [generate and edit images](/tools/image-generation) with GPT Image 2.5 Flare or Sunburst through direct OpenAI access or fal, using the existing image tool and CLI. Both variants offer model-specific quality choices through xhigh and max, flexible dimensions, and PNG, JPEG, or WebP output, with transparent backgrounds available in PNG and WebP.
+You can [generate and edit images](/tools/image-generation) with GPT Image 2.5 Flare or Sunburst through OpenAI or fal, including custom sizes, higher quality settings, and transparent PNG or WebP output. Edits can use up to five reference images through OpenAI or sixteen through fal, and either route can return up to four images.
 
-Direct [OpenAI access](/providers/openai/image-and-video#gpt-image-2.5) requires API-key authentication, including explicit selection when an OAuth profile is already present; fal uses its own credentials. OpenAI edits accept up to five reference images and fal edits up to sixteen, with both retaining the four-output limit and existing default model. Custom dimensions must satisfy the documented size and aspect-ratio limits.
+Direct [OpenAI access](/providers/openai/image-and-video#gpt-image-2.5) needs an API key, selected explicitly if you already use a ChatGPT sign-in; fal needs its own credentials. Your default image model stays unchanged, so choose one of the new variants when you want to use it.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2510,9 +2400,9 @@ Direct [OpenAI access](/providers/openai/image-and-video#gpt-image-2.5) requires
 
 </Accordion>
 
-<Accordion title="Transcribe voice notes with Deepgram Flux">
+<Accordion title="Turn voice notes into text with Deepgram Flux">
 
-Incoming voice notes can now use Deepgram's Flux English or multilingual transcription models through the existing media settings, with the resulting text entering the normal conversation. Install ffmpeg on the computer running the Gateway before selecting Flux; Nova remains the default. The multilingual model accepts a language hint, while English-only Flux ignores language selection and both omit unsupported batch options such as punctuation and automatic language detection. The [Deepgram guide](/providers/deepgram) covers setup.
+You can now choose [Deepgram Flux](/providers/deepgram) to turn incoming voice notes into text your Claw can use, with English and multilingual options. Install ffmpeg on the computer running OpenClaw before selecting Flux. This is an optional choice in the existing audio settings; Nova remains the default.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2525,9 +2415,9 @@ Incoming voice notes can now use Deepgram's Flux English or multilingual transcr
 
 </Accordion>
 
-<Accordion title="Use current search models and setup guidance">
+<Accordion title="Use Gemini 3.6 Flash for web search">
 
-Gemini web search now uses stable Gemini 3.6 Flash when no search model is pinned, addressing unavailable-default errors for affected API keys while preserving explicit choices and leaving the primary chat model unchanged. The billing distinction matters on upgrade, because Gemini 3 grounding charges per search query compared with Gemini 2.5's per-prompt basis. Search setup guidance also includes [Kimi's required plugin and restart](/tools/kimi-search), and explains how to [send Ollama search to the cloud](/tools/ollama-search) while keeping model traffic local.
+Gemini web search now uses Gemini 3.6 Flash unless you chose a specific search model, helping accounts that could no longer use the old default. Your main chat model stays unchanged. Check the billing difference when upgrading, because Gemini 3 charges for each search query rather than once per prompt. There is also clearer help for [setting up Kimi search](/tools/kimi-search) and [using Ollama cloud search while keeping model conversations local](/tools/ollama-search).
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2544,9 +2434,9 @@ Gemini web search now uses stable Gemini 3.6 Flash when no search model is pinne
 
 </Accordion>
 
-<Accordion title="Understand model usage and estimates">
+<Accordion title="Read usage costs with clearer estimates">
 
-Usage reports now separate explicitly reported cache-write tokens from ordinary input and fill missing estimates for eligible OpenRouter `:nitro` and `:floor` requests using base-model pricing. Recorded billed amounts and explicit prices retain precedence. Cost summaries also label cached totals that may still be incomplete, so a temporary zero is less likely to be mistaken for no usage; provider bills remain authoritative.
+Cost reports now warn when totals may still be incomplete, so a temporary zero is less likely to look like no usage. They also distinguish the tokens used to save reusable prompts from ordinary input and fill gaps in some OpenRouter estimates. These are reporting fixes; the provider's bill remains the amount you actually owe.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2562,11 +2452,11 @@ Usage reports now separate explicitly reported cache-write tokens from ordinary 
 
 </Accordion>
 
-<Accordion title="Keep model requests available through cleanup">
+<Accordion title="Get model results without waiting on diagnostics">
 
-Accepted model work keeps the resources it needs through authentication, cancellation, and response cleanup. Anthropic cancellation can return promptly while cleanup finishes, and OpenRouter music results or known usage errors no longer wait unnecessarily for optional diagnostic capture to reach the end of the response. That capture may consequently finish as incomplete.
+With diagnostic recording enabled, OpenRouter can return finished music or a usage-check error without waiting for the recording to finish. You get the result sooner even if that optional recording is incomplete. Related fixes let stopped requests finish closing their connections without cutting off cleanup.
 
-Model probes retain temporary credentials, sessions, and the direct CLI state lock until accepted cleanup finishes, even if a result has already appeared. Stop a running Gateway before using direct `openclaw models status --probe`, and do not treat a result or timeout as proof that its lock has been released.
+If you run `openclaw models status --probe` directly from the terminal, stop the Gateway first and wait for the command to exit before starting it again. The result can appear while the check is still closing its files and connections.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2582,9 +2472,9 @@ Model probes retain temporary credentials, sessions, and the direct CLI state lo
 
 </Accordion>
 
-<Accordion title="Find provider setup and operating details">
+<Accordion title="Find the provider instructions you need">
 
-[OpenAI](/providers/openai) and [model-provider documentation](/concepts/model-providers) now start with an index that leads directly to the task at hand, from connecting an account to checking model costs, media support, Azure settings, or a custom endpoint. Existing section links retain a route to the moved material, making the guides easier to navigate without changing the behavior they describe.
+Setting up an account or checking a provider's options is easier in the reorganized [OpenAI](/providers/openai) and [model-provider guides](/concepts/model-providers). Shorter pages take you straight to the relevant instructions, and old bookmarks still point you toward the material that moved.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2602,15 +2492,13 @@ Model probes retain temporary credentials, sessions, and the direct CLI state lo
 
 ## Automations and Scheduling
 
-Scheduled work gets fixes from the moment a job starts to the point its result returns to your conversation. Automations are also easier to find and edit, with saved friendly names, direct links from agent settings, and less waiting while large lists prepare delivery destinations.
+Automations are easier to manage, with direct links to edit them and names you can recognize. Scheduled tasks also get fixes for getting stuck, returning results to your chat, and staying quiet when there is nothing to report.
 
 <AccordionGroup>
 
-<Accordion title="Run scheduled work with the intended tools and model">
+<Accordion title="Run scheduled tasks with your chosen tools">
 
-Scheduled conditions and script jobs can run their allowed commands on the computer hosting OpenClaw while secret egress protection stays enabled. Codex-backed chats can also create automations using the tool names in their catalog, without having to translate those names by hand. Both paths keep their existing permission limits.
-
-Scheduled model calls can continue when OpenClaw refreshes its model setup during job preparation, and an unrelated disabled fallback plugin no longer prevents an available model from running. Disabled plugins stay disabled. When all attempted providers fail, the job preserves their original errors so you can see what went wrong.
+Scheduled commands run by OpenClaw can work without turning off secret protection, and Codex chats can set up automations using the tools already available in the conversation. Tasks also avoid startup failures caused by model settings refreshing or an unrelated plugin being disabled. Your existing permissions still apply, and disabled plugins stay off.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2626,11 +2514,9 @@ Scheduled model calls can continue when OpenClaw refreshes its model setup durin
 
 </Accordion>
 
-<Accordion title="Recover scheduler reservations and delegated work">
+<Accordion title="Fixes for stuck scheduled tasks">
 
-Conflicting reservations for scheduled jobs no longer cause an endless retry loop that can leave OpenClaw unresponsive. The scheduler lets the current attempt finish and checks again normally; pending jobs can proceed once the conflict clears.
-
-Scheduled agents that delegate work also avoid entering a pause they cannot resume. They finish their turn and leave delivery to the scheduler's existing policy, while supported child agents and interactive conversations retain their ability to pause and resume.
+A clash between scheduled tasks could make OpenClaw keep retrying until it stopped responding. That loop is fixed. Tasks that hand work to another agent also avoid a pause they could never resume, leaving OpenClaw to deliver the result through the task's existing settings.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2644,13 +2530,11 @@ Scheduled agents that delegate work also avoid entering a pause they cannot resu
 
 </Accordion>
 
-<Accordion title="Finish background work and handle cancellation">
+<Accordion title="Background results and quiet checks">
 
-A command running in the background can now bring its result back to the originating chat after the assistant has finished its earlier reply. History distinguishes command completions and other automatic events from routine heartbeat checks, so it is easier to see why the conversation resumed.
+Background commands can bring their results back to the chat after your Claw's earlier reply has finished. Routine checks with nothing to report can stay quiet instead of sending an unnecessary message.
 
-Quiet heartbeat checks can finish silently without a retry demanding an answer. Their status recognizes a confirmed message send without adding a duplicate acknowledgment, and distinguishes work that has started in the background from work that has finished.
-
-If an automation result is waiting for an active conversation turn, cancellation can release that wait so actions such as pinning the conversation can proceed. Once cancellation reaches the waiting result, it leaves the active turn running and does not append the canceled result to chat history.
+If an automation result is waiting while your Claw answers you, canceling that result can now unblock actions such as pinning the conversation. Your Claw can finish its reply without adding the canceled result to the chat.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2667,9 +2551,9 @@ If an automation result is waiting for an active conversation turn, cancellation
 
 <Accordion title="Find and edit automations">
 
-You can open an automation's editor directly from Settings → Agents → Automations, including for paused jobs. Saved friendly names now appear in automation lists, detail headings, and actions, while scheduled conversations sort and group under their visible cron label in the Sessions table.
+You can jump straight to an automation's editor from Settings → Agents → Automations, even when the task is paused. Lists now show the friendly names you saved, and you can group scheduled conversations together so they are easier to find. Large automation lists also spend less time loading where results will be sent.
 
-Full automation lists spend less time preparing delivery destinations when there are many jobs or sessions. If loading is still slow, enabled diagnostics break down where the list request spent its time. CLI errors also give more relevant guidance for missing jobs, blank IDs, and invalid options. When automatic scheduling is disabled, the warning explains how configuration and the environment used to launch OpenClaw can each keep scheduling off.
+If you manage automations from the command line, missing jobs and invalid options come with more useful guidance. Warnings also explain what to check when a saved task cannot run because scheduling is turned off.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2692,11 +2576,11 @@ Full automation lists spend less time preparing delivery destinations when there
 
 </Accordion>
 
-<Accordion title="Follow triggers, reset times, and hook guidance">
+<Accordion title="Daily resets and automation guides">
 
-If you use daily conversation resets, they now avoid clearing context early around spring daylight-saving changes. Reset times still follow the local timezone of the computer running OpenClaw.
+If you have set conversations to reset each day, they now avoid losing context too early around spring clock changes. The reset still follows the timezone of the computer running OpenClaw.
 
-The automation reference brings the existing [schedule types](/automation/cron-jobs/schedules#schedule-types) together, including triggers based on a command finishing or batches of its output. The [hooks guide](/automation/hooks) also has focused pages for writing hooks, configuration, event details, and troubleshooting, making the existing instructions easier to find when you need them.
+Guidance is easier to find when you want to [start a task at a set time or when a command finishes](/automation/cron-jobs/schedules#schedule-types), or [set up an automatic response to an event with a hook](/automation/hooks). These guides explain existing features, with clearer instructions for choosing and setting them up.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2719,14 +2603,12 @@ The automation reference brings the existing [schedule types](/automation/cron-j
 
 ## Browser and Computer Use
 
-Working alongside your Claw in a browser now leaves your active tab alone when the Browser panel updates, while shared desktops follow the machine running your chat and let you paste local text through the Keyboard field. Computer use also gets fixes for the first action, window selection, and browser dialogs, so an ordinary step like finding a window or answering a second prompt can carry the task forward.
+You can keep using your browser while your Claw works in another tab, and joining it on a remote desktop takes fewer steps. This release fixes interruptions when opening windows, answering website pop-ups, and following along with work on another computer.
 
 <AccordionGroup>
-<Accordion title="Keep the Browser panel on the intended page">
+<Accordion title="Follow browser work without switching tabs">
 
-The [Browser panel](/tools/browser) can follow your Claw's latest result without pulling you away from the tab you are using. Choosing Open or selecting a different panel tab still brings that page forward, and a historical tab that has disappeared now tells you to select another one.
-
-After an established stream disconnects, the panel requests a fresh screenshot and retries the connection, keeping a pinned annotation or inspection image in place until you finish with it. Blank and internal pages also stop producing misleading chat preview cards, while their original results remain available in the activity details.
+The [Browser panel](/tools/browser) can show what your Claw is doing without switching you away from your own tab. You can still choose Open to bring its page forward. If the live view disconnects after it has started, OpenClaw refreshes the picture and tries to reconnect automatically, while keeping any image you are marking up in place. Blank pages also stop appearing as misleading preview cards in chat.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2744,11 +2626,11 @@ After an established stream disconnects, the panel requests a fresh screenshot a
 </details>
 </Accordion>
 
-<Accordion title="Control dialogs and action deadlines">
+<Accordion title="Handle website pop-ups and longer tasks">
 
-[Browser commands](/cli/browser) now explain when a dialog is blocking an action, identify the dialog to answer, and report which steps were skipped when a batch stops. Sequential dialogs also remain available to answer when delayed cleanup from the first action finishes, so responding to the next prompt does not fail just because the previous one has settled.
+When a website pop-up stops a [browser command](/cli/browser), OpenClaw tells you which prompt needs an answer and which steps remain unfinished. Answering one pop-up also no longer prevents the next one from being answered. Longer tasks in an already open browser avoid the premature connection failures covered by these fixes.
 
-For an existing browser session, waits and evaluations now honor their supported time budgets without the premature connection cutoffs covered by these fixes. Filling and submitting a form share one action deadline, and cancellation reaches navigation checks. Cancellation does not undo changes already made to the page, and scripts should inspect action results because a dialog block or interruption alone does not produce a nonzero exit.
+Cancelling cannot undo changes already made to a page. If you automate browser commands, check their reported results before continuing, because a blocked task does not always return an error status.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2766,11 +2648,11 @@ For an existing browser session, waits and evaluations now honor their supported
 </details>
 </Accordion>
 
-<Accordion title="Find and act on the correct window">
+<Accordion title="Find the window your Claw needs">
 
-Supported actions on a paired desktop are available to your Claw on its first call, and the CUA computer-use driver can list windows first without needing a retry or a preliminary screenshot. Successful window activation is also reported as success, letting the task continue after bringing the intended window forward.
+This release fixes [computer-use errors](/nodes/computer-use) that could stop your Claw before it had even found the right window. Supported desktop controls are available from the start, and bringing a window forward no longer looks like a failure when it worked. Your Claw still needs permission to use the computer, and the computer must support the controls it requests.
 
-Requests for a particular window's image now receive guidance to use the [window observation action](/nodes/computer-use) when they are sent to a desktop-only screenshot command, instead of silently returning the whole desktop. The selected machine still needs to support the action and grant the required permissions. For [Codex Computer Use](/plugins/codex-computer-use), disabled native plugins now produce a prompt setup explanation instead of waiting through marketplace discovery, with instructions to enable `features.plugins` and rerun `/codex computer-use install`.
+If [Codex Computer Use](/plugins/codex-computer-use) cannot start because native plugins are disabled, it now explains that promptly and tells you how to enable them and retry installation.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2785,11 +2667,11 @@ Requests for a particular window's image now receive guidance to use the [window
 </details>
 </Accordion>
 
-<Accordion title="Use and hand over a shared desktop">
+<Accordion title="Open a remote desktop and paste text">
 
-Opening [Desktop from a chat](/gateway/cloud-sessions) now goes to the machine running that session, with connection progress and Retry if it is unavailable. A desktop that remains visible in a split pane stays connected while you type elsewhere, and worker connections correctly use the desktop password they are given.
+Opening [Desktop from a chat](/gateway/cloud-sessions) now takes you to the computer running that chat, and the view stays connected while you type in another pane alongside it. Desktop support must be enabled, and you start by watching until you choose Take control.
 
-To paste text from your own clipboard, choose Take control, open Keyboard, and use your usual paste shortcut once the control connection is ready. The Keyboard field sends the text to the remote application; shortcuts sent directly to the desktop canvas still act on the remote machine. When another authenticated operator takes control, the handoff notice now shows their name or user ID, with the generic notice retained when neither is available.
+To paste text from your own computer, choose Take control, open Keyboard, and paste there once the connection is ready. Paste shortcuts used directly on the desktop view are sent to the remote computer. If someone else takes control, the notice now shows their signed-in name or user ID when available.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2806,9 +2688,9 @@ To paste text from your own clipboard, choose Take control, open Keyboard, and u
 </details>
 </Accordion>
 
-<Accordion title="Wait for computer sessions to close">
+<Accordion title="Close a computer session before starting the next">
 
-Stopping a node now waits for its computer-use provider to finish closing the active session, and another session cannot take its place while that cleanup is unfinished. If the provider fails to close, the failure remains visible and can block a new session until resolved, keeping a failed cleanup from being treated as a successful handoff.
+Stopping OpenClaw on a connected computer now lets its active computer-use session finish closing before another one starts. If closing fails, the error stays visible so you know why a new session is blocked and what needs attention.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2820,9 +2702,9 @@ Stopping a node now waits for its computer-use provider to finish closing the ac
 </details>
 </Accordion>
 
-<Accordion title="Use supported Azure cloud desktops">
+<Accordion title="Open a desktop on an Azure cloud worker">
 
-[Azure cloud-worker profiles](/gateway/cloud-workers) can now enable desktop access through the existing direct or managed-coordinator setup. Enable the Cloud Worker Desktop lab and a desktop-enabled profile, then stop and reprovision existing workers that were created without desktop support. Translated setup guidance also includes Azure and these requirements; GCP desktop profiles remain unsupported.
+You can now enable desktop access for [Azure cloud workers](/gateway/cloud-workers), whether OpenClaw manages them directly or through a coordinator. Turn on the Cloud Worker Desktop lab and enable desktop access in the worker profile. Existing workers created without a desktop need to be stopped and set up again with that setting enabled. This adds Azure to the supported desktop options; GCP desktops remain unsupported.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2845,17 +2727,13 @@ Stopping a node now waits for its computer-use provider to finish closing the ac
 
 ## Plugins and Integrations
 
-Plugins now have a connected path from finding a capability to reading its documentation, reviewing installation, and finishing setup, including recommendations you can open directly from chat. Cloud workers can also reuse completed project setup, keep running spares for later sessions, offer more operating-system choices, and manage snapshots from Settings.
+Finding something new for your Claw is easier, whether you browse plugins or ask for a recommendation in chat. You can review and set up plugins in the browser, while cloud workers gain ways to reuse project setup, keep a computer ready for your next session, and choose Windows or macOS when your provider supports them.
 
 <AccordionGroup>
 
 <Accordion title="Browse plugins and open recommendations from chat">
 
-The Plugins workspace brings installed and available plugins into one searchable catalog, with categories, Featured and Trending shelves, and automatic loading of browse pages. Ordinary browsing puts official plugins first, while search and ranked shelves keep their own ordering. Matching bundled and catalog entries share their installation identity, and packages from a different ClawHub registry no longer make an unrelated listing look installed.
-
-You can also ask for a capability in [Control UI chat](/web/control-ui/chat) and open an official plugin or skill recommendation from the reply. The agent needs the message tool enabled and can show up to three recommendations; Install takes you to review or details, where you can decide what to add. An Installed badge means the package or skill is present, so configuration and account connection may still be needed.
-
-Plugin authors can declare up to three ordered categories. The field remains optional for external plugins, but an invalid declaration now prevents the manifest from loading.
+You can now search installed and available plugins together, browse by purpose, and keep exploring without clicking through pages. In [chat](/web/control-ui/chat), your Claw can recommend up to three official plugins or skills and give you a card that opens their details. Recommendations need the message tool enabled, and choosing Install opens a review before anything is added. An installed plugin may still need settings or an account connection before you can use it.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2887,11 +2765,9 @@ Plugin authors can declare up to three ordered categories. The field remains opt
 
 </Accordion>
 
-<Accordion title="Review, configure, and install the selected plugin">
+<Accordion title="Review and set up plugins in the browser">
 
-Once you choose a plugin, its detail page brings documentation, setup requirements, compatibility, and version information together, while [Settings → Plugins](/plugins/manage-plugins) gives each installed plugin a place for configuration, access information, diagnostics, and lifecycle controls. Setup-required messages explain what is missing and keep enablement unavailable until the required configuration is complete.
-
-The installation flow carries authorized users through source and capability review, required settings, and reconnects after a restart. Current details survive delayed catalog responses after autosave, and an older selection can no longer replace the plugin you are reviewing or installing. Completion waits for the new running instance and inventory confirmation. Administrator permissions and explicit consent still apply; package updates and arbitrary-source installations remain CLI tasks, and bundled plugins cannot be removed here.
+You can read what a plugin does, check what it needs, and follow installation through to setup without leaving the browser. [Plugin settings](/plugins/manage-plugins) puts its configuration, permissions, and troubleshooting information together, with clearer messages when setup is unfinished. The install dialog stays with your latest choice and waits through the required restart before confirming completion. Installing or changing plugins still requires the appropriate permissions and your consent.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2913,11 +2789,9 @@ The installation flow carries authorized users through source and capability rev
 
 </Accordion>
 
-<Accordion title="Install and inspect plugins with useful diagnostics">
+<Accordion title="Get useful help when plugin commands fail">
 
-Plugin commands now give recovery advice for the installation you are actually using, preserving the selected profile or container and explaining when a restart is automatic or needs your attention. Compatibility notices and registry mismatch reports also identify the relevant loaded plugin and the information that changed. ClawHub metadata and error responses respect their request deadline even when data arrives slowly, while successful downloads can continue as long as they keep making progress.
-
-Runtime inspection, chat inspection, and Plugin Doctor release their temporary resources before reporting success, with cleanup failures reported as errors. The [plugin CLI reference](/cli/plugins) is organized by task, and inspection distinguishes discoverable OpenClaw hook collections from unsupported JSON automation. A supported hook layout describes what OpenClaw can discover, not proof that the running instance has activated it.
+If you manage plugins from the terminal, [error messages](/cli/plugins) now point to recovery commands for your profile or container and explain whether you need to restart OpenClaw. Plugin checks also report cleanup failures instead of claiming success, and slow catalog responses no longer keep commands waiting indefinitely.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2951,11 +2825,9 @@ Runtime inspection, chat inspection, and Plugin Doctor release their temporary r
 
 </Accordion>
 
-<Accordion title="Build against the current plugin SDK">
+<Accordion title="Build and preview your own plugins">
 
-Plugin authors get more accurate types for multi-account channel schemas, including custom root and account fields and transformations, and valid interface-typed inbound hook contexts compile again. The catchall helper now exposes its actual extended schema type, so generic wrappers that assumed it returned the original input type may need an annotation update. These are type-contract repairs; runtime validation keeps its existing behavior.
-
-Source-plugin builds include declared and generated assets even before the package is tracked by Git, and plugins in another OpenClaw checkout use the running host's SDK unless an explicit development override selects another source. The [SDK overview](/plugins/sdk-overview) and related references are split into focused guides, with corrected examples and compatibility guidance. For interface work, the opt-in [Control UI development proxy](/web/control-ui/development) brings real plugin panels and resources into hot reload while retaining normal authentication, pairing, and allowed-origin checks.
+People building plugins get fixes for type errors and missing supporting files that could stop a build. You can also opt into [live previews in the browser](/web/control-ui/development), seeing changes to your plugin against a real OpenClaw installation. If you wrap the multi-account configuration helper, check its updated types when rebuilding; the [SDK guide](/plugins/sdk-overview) covers development setup.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2993,11 +2865,9 @@ Source-plugin builds include declared and generated assets even before the packa
 
 </Accordion>
 
-<Accordion title="Keep accepted plugin work alive through cleanup">
+<Accordion title="Keep plugin requests from stopping too early">
 
-Plugin tools and model requests keep the resources they need through accepted work and its cleanup, including work that finishes after cancellation or after the caller receives a result. Reload can publish a replacement while the previous registration finishes cleaning up, and shutdown waits for that earlier work before closing shared resources. Cancellation also retains the identity of the plugin doing the work.
-
-For plugin authors, [prepared models and provider callbacks](/plugins/sdk-runtime/models) belong to their original host lifetime. Once that host closes, prepare a fresh model under an open host before starting another request. Retiring a registration stops new work immediately; cleanup that never settles can still keep graceful shutdown waiting.
+Requests using [model plugins](/plugins/sdk-runtime/models) are less likely to fail because a connection closed while work was still finishing. OpenClaw keeps those connections available through cancellation, plugin reloads, and shutdown. A plugin that cannot finish closing can still delay shutdown.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3034,11 +2904,9 @@ For plugin authors, [prepared models and provider callbacks](/plugins/sdk-runtim
 
 </Accordion>
 
-<Accordion title="Finish media generation and analysis">
+<Accordion title="Finish creating and saving images, music, and video">
 
-Accepted image, music, and video jobs keep their original providers through generation, saving, and rollback, so releasing the preparation that started a job no longer closes resources it still needs. If the provider setup retires during reference-file checks, the request is refused before a new job starts and can be retried with the current setup. A Started response acknowledges acceptance, and accepted paid work may continue after the caller cancels.
-
-Buffered speech and phone-call speech keep their providers through synthesis, while audio streams retain the final queued chunk and their provider through cleanup. Image and PDF analysis also retain managed resources while slow or cancelled work settles, and multiple images reach a plugin's own single-image handler in order when it has no batch handler. The [SDK lifetime guide](/plugins/sdk-overview/host-hooks) explains caller-owned resources and explicit stream-release obligations.
+Image, music, and video jobs can finish and save their results even when the plugin setup that started them is replaced. Related fixes keep connections available for speech and document analysis and prevent the last part of streamed audio from being lost. Paid generation that has already started may continue after you cancel.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3070,11 +2938,9 @@ Buffered speech and phone-call speech keep their providers through synthesis, wh
 
 </Accordion>
 
-<Accordion title="Inspect extension storage and telemetry">
+<Accordion title="Use less extra memory for plugin data">
 
-Large plugin-state listings avoid keeping a second complete copy of serialized rows while building the decoded results, and quota checks can read expiry information directly from the listing index. The returned list can still be large. The [index update](/reference/database-schemas#plugin-state-listing-index) rebuilds on the first writable open or Doctor repair, which needs additional work and temporary disk space; tools that validate the full schema need the matching definition.
-
-Local telemetry exporters keep their resources through cleanup, and Prometheus skips private diagnostic-content copies it does not use while retaining its metrics.
+Plugins with lots of saved data use less extra memory when listing it, helping reduce the strain of a large collection. The first use after the [storage update](/reference/database-schemas#plugin-state-listing-index) may take extra time and disk space.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3093,11 +2959,9 @@ Local telemetry exporters keep their resources through cleanup, and Prometheus s
 
 </Accordion>
 
-<Accordion title="Use MCP results and shut down cleanly">
+<Accordion title="Handle large tool replies and disconnects">
 
-Text-heavy results from MCP tools on connected devices no longer carry a redundant text copy in serialized snapshots, while model output and the original result used by Code Mode remain available. MCP HTTP cleanup can also finish after the server accepts termination even if cancelling the response body stalls.
-
-Standalone MCP services wait for accepted handlers and tracked cleanup before releasing plugin resources, and report shutdown failures to their caller. A rejected remote termination still leaves an uncertain outcome. The [MCP reference](/cli/mcp) now separates serving, saved servers, transports, browser settings, and apps into focused guides.
+If you connect external tools through [MCP](/cli/mcp), large text replies from connected devices no longer include an unnecessary duplicate copy. Stopping a standalone MCP service gives ongoing tool work time to finish cleaning up, and an accepted disconnect no longer gets stuck waiting on response cleanup. Failed disconnects still report a problem that may need attention.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3120,9 +2984,9 @@ Standalone MCP services wait for accepted handlers and tracked cleanup before re
 
 </Accordion>
 
-<Accordion title="Run commands on the intended connected device">
+<Accordion title="Use accurate time limits for connected devices">
 
-Commands sent to connected devices keep one elapsed-time budget across checks, wake-up, readiness retries, and the response, so a system-clock adjustment no longer shortens or extends that budget. Explicitly empty numeric options now fail before device lookup; scripts that want a default should omit the flag instead of passing an empty shell variable. The [Nodes reference](/cli/nodes) explains the command options, with pairing and command authorization remaining separate steps.
+Commands on [connected devices](/cli/nodes) no longer time out early or wait longer just because the system clock changed. Time spent waking the device counts toward the same limit as running the command. If you use scripts, omit numeric options when you want their defaults—passing an empty value now gives a clear error before OpenClaw contacts the device.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3143,9 +3007,9 @@ Commands sent to connected devices keep one elapsed-time budget across checks, w
 
 </Accordion>
 
-<Accordion title="Consult agents and clean up failed meeting starts">
+<Accordion title="Get answers from a separate agent in Google Meet">
 
-A Google Meet or realtime voice session started from a model-locked conversation can now consult a separate configured agent using its own model and session. The [dedicated-agent setup](/plugins/google-meet/tool-and-modes) keeps locked target sessions protected and does not copy the requesting conversation's history. If Chrome startup fails after acquiring audio, Meet also attempts to stop that audio before rolling back a tab opened by that attempt, preserving tabs that were already there.
+Google Meet and voice sessions can now ask a [separately configured agent](/plugins/google-meet/tool-and-modes) for help even when the original conversation has a locked model choice. That agent uses its own conversation without copying your earlier chat, and its own model restrictions still apply. Failed Chrome meeting starts also try to stop the audio they opened and close only newly created tabs, leaving your existing tabs alone.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3163,9 +3027,9 @@ A Google Meet or realtime voice session started from a model-locked conversation
 
 </Accordion>
 
-<Accordion title="Route A2A requests to the configured agent">
+<Accordion title="Send A2A work to the agent you chose">
 
-Incoming [A2A requests](/channels/a2a) now honor the configured peer-to-agent assignment even when the request includes a conversation context. An exact conversation binding still takes priority, and each peer and conversation keeps its separate session, so a dedicated agent can receive a peer's work without a binding for every new context ID.
+If you use [A2A to connect agents](/channels/a2a), incoming requests now reach the agent assigned to that connection even when a new conversation begins. You can still choose a different agent for a particular conversation, and separate conversations keep their own history.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3178,11 +3042,9 @@ Incoming [A2A requests](/channels/a2a) now honor the configured peer-to-agent as
 
 </Accordion>
 
-<Accordion title="Read accurate API results and references">
+<Accordion title="Tell connected apps when an answer was cut short">
 
-Applications can now distinguish an answer that reached its output limit from one that finished naturally. [Chat Completions](/gateway/openai-http-api) returns `finish_reason` as `length`, while the [Responses API](/gateway/openresponses-http-api) marks the response and final message `incomplete`, supplies `max_output_tokens` as the reason, and emits `response.incomplete` for streaming clients. The partial answer remains available for the application to handle.
-
-Configuration patches also return the effective changed paths after validation and secret restoration, without exposing configuration values. The [Gateway RPC reference](/gateway/protocol/rpc-methods) is organized into focused method and event pages for clients that need those contracts.
+Apps using OpenClaw through [Chat Completions](/gateway/openai-http-api) or the [Responses API](/gateway/openresponses-http-api) can now tell when an answer stopped at its output limit. They keep the partial answer and receive a clear signal that it was cut short, including during streaming, so they can decide what to show or do next. Connected apps also get a more accurate report of which settings changed after a configuration update.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3206,11 +3068,11 @@ Configuration patches also return the effective changed paths after validation a
 
 </Accordion>
 
-<Accordion title="Open plugin panels and Reports">
+<Accordion title="Open Reports and plugin panels with more room">
 
-Installed plugins can use short bookmarkable tab addresses, with [Team Reports](/plugins/team-reports) opening at `/reports` inside the Control UI. Reports and other embedded pages fill the available content area and fit short windows, while generated plugin assets are readable by a container's runtime user when the surrounding installation paths allow access.
+[Reports](/plugins/team-reports) opens at the short `/reports` address inside OpenClaw, and embedded plugin pages use more of the window. Plugin panels also load in affected containers where file permissions previously got in the way.
 
-Existing Team Reports HTTP, report, and export clients need an update. Their default paths move from `/reports/...` to `/plugins/team-reports/...` without a redirect. You can explicitly keep the old HTTP location with `plugins.entries.team-reports.config.basePath` set to `/reports`; when that route shadows the short tab address, the tab uses its generic URL. Reports remain authenticated.
+If you use separate Team Reports report or export links, change `/reports/...` to `/plugins/team-reports/...`; old links do not redirect automatically. The guide explains how to keep a custom address if you need one.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3232,13 +3094,11 @@ Existing Team Reports HTTP, report, and export clients need an update. Their def
 
 </Accordion>
 
-<Accordion title="Reuse completed project setup">
+<Accordion title="Reuse project setup in new cloud sessions">
 
-Cloud sessions can reuse a project's completed checkout and setup at stable workspace and HOME paths. A matching commit skips that work, while a compatible source change reruns the authorized setup recipe and preserves reusable caches. Initial synchronization keeps setup-generated files unless the session changed the same path, and already-bound sessions retain their accepted edits across restart.
+New cloud sessions can [reuse a project that is already set up](/gateway/cloud-workers/warm-images), saving repeated installation and preparation work while keeping your session’s changes. You can use an eligible local project or start directly from a public GitHub repository. Starting from only a private repository URL still uses a fresh checkout; private projects already checked out locally can use the local-project route. A saved setup still needs a machine to start unless a running spare is available.
 
-Eligible public GitHub repositories can use the same [prepared-project workflow](/gateway/cloud-workers/warm-images) without a local clone on the Gateway machine. Repository-only sessions from private GitHub repositories continue through cold checkout; eligible local Gateway worktree projects retain their preparation path. Reusing a prepared image still requires starting a machine unless a running spare is available.
-
-This feature upgrades global state to schema 17. Before upgrading, stop older writers and take a verified backup that includes SQLite WAL data, following the [schema migration instructions](/reference/database-schemas/state-schema-history). Older schema-16 readers refuse the upgraded database; rollback requires restoring the pre-upgrade backup with a compatible binary and loses writes made afterward.
+Back up OpenClaw’s data before upgrading, following the [backup and rollback instructions](/reference/database-schemas/state-schema-history). Older versions cannot read the updated data format, so rolling back the app alone is not enough. Restoring the earlier backup also discards changes made after it.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3252,13 +3112,11 @@ This feature upgrades global state to schema 17. Before upgrading, stop older wr
 
 </Accordion>
 
-<Accordion title="Keep workers ready for later sessions">
+<Accordion title="Keep a cloud computer ready for your next session">
 
-A later cloud session can take an already running, prepared worker instead of waiting for another machine to start, with a replacement prepared in the background. Administrators can also request project preparation before opening a session. This applies to eligible dedicated Linux workers with warm images, a known machine class, and immutable setup inputs without `setupEnv`, including the supported public GitHub project path.
+[Ready workers](/gateway/cloud-workers/warm-images#ready-workers) let your next matching session use an already running computer while OpenClaw prepares a replacement. Eligible Linux projects get one spare per project and profile by default, with a shared limit of four. These computers cost money until deletion is confirmed. Set a profile's Ready workers value to zero to disable its spares, or the shared Prepared pool limit to zero to remove unused spares without stopping active sessions.
 
-[Ready workers](/gateway/cloud-workers/warm-images#ready-workers) default to one spare per project and profile, with four across the Gateway. These are running machines with charges until deletion is confirmed, including unresolved cleanup. Set `cloudWorkers.profiles.<id>.readyWorkers` to `0` to disable that profile's reserves, or `cloudWorkers.preparedPool.maxTotal` to `0` to drain unused reserves across the Gateway. Active sessions remain intact. Expiry runs from the successful activation that created demand, using the provider’s idle timeout; refills and restarts do not extend that window.
-
-Existing warm-image state needs the documented migration to envelope v3. Stop the owning Gateway and original capture processes, then run `openclaw doctor --fix` under the exclusive maintenance lock before provisioning again.
+If you already use saved worker images, stop OpenClaw and any image captures it started, then follow the [Doctor upgrade step](/gateway/cloud-workers/warm-images) before starting more workers.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3278,9 +3136,7 @@ Existing warm-image state needs the documented migration to envelope v3. Stop th
 
 <Accordion title="Choose Linux, Windows, WSL2, or macOS workers">
 
-Cloud-worker profiles and individual sessions can choose Linux, native Windows, Windows through WSL2, or macOS when the backend supports the target. The picker shows compatible machine classes and preserves the chosen operating system for moves and recovery. The final supported Crabbox baseline for this release is 0.55.0.
-
-Native Windows uses PowerShell setup and requires supported Node.js, npm, and the managed launcher; WSL2 runs work inside its managed Linux environment. AWS macOS needs an available EC2 Mac Dedicated Host and On-Demand capacity. Linux remains the default, and desktop and warm-image features remain Linux-only. The [placement guide](/gateway/cloud-workers/placement-and-machine-selection#choose-an-operating-system-and-machine-class-per-session) explains the target choices and [native Windows prerequisites](/gateway/cloud-workers/setup-and-bundle-installation#native-windows-prerequisites).
+You can choose a cloud computer’s operating system for a profile or an individual session when your provider offers it. Native Windows runs Windows commands, while WSL2 gives you a Linux environment on Windows. Mac workers on AWS require a Dedicated Host and On-Demand capacity; desktop access and reusable worker images remain Linux-only. The [operating-system guide](/gateway/cloud-workers/placement-and-machine-selection#choose-an-operating-system-and-machine-class-per-session) covers availability, with separate [setup requirements for native Windows](/gateway/cloud-workers/setup-and-bundle-installation#native-windows-prerequisites).
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3304,11 +3160,11 @@ Native Windows uses PowerShell setup and requires supported Node.js, npm, and th
 
 </Accordion>
 
-<Accordion title="Prepare Crabbox and configure worker profiles">
+<Accordion title="Set up cloud workers from Settings">
 
-OpenClaw now reuses a supported Crabbox installation or prepares a verified 0.55.0 distribution in its managed tools directory when the preferred executable is missing or outdated. Doctor can prepare that copy explicitly, without overwriting your installed binary. On restricted hosts, stage a supported copy before upgrading OpenClaw, because even inspecting or stopping an existing lease requires it; the [Crabbox profile guide](/gateway/config-cloud-workers#crabbox-profile) covers the available paths.
+Cloud workers settings now lets administrators change advanced options, set spare-computer limits, and choose a default profile for each repository. Save your changes and restart OpenClaw to apply them. You can also hover over a cloud session to see its known operating system, CPU, and memory capacity.
 
-Cloud workers settings also exposes advanced profile options, ready-pool limits, and repository-to-profile defaults that previously required manual configuration edits. Saves require a Gateway restart. Session hovercards and placement tooltips show known operating-system and machine specifications, making the chosen capacity visible beside the conversation.
+OpenClaw can automatically download a supported Crabbox tool when yours is missing or outdated. If your computer blocks those downloads or installations, [prepare Crabbox 0.55.0 or newer before upgrading](/gateway/config-cloud-workers#crabbox-profile), because you need it even to inspect or stop existing cloud workers.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3328,13 +3184,11 @@ Cloud workers settings also exposes advanced profile options, ready-pool limits,
 
 </Accordion>
 
-<Accordion title="Build, pin, and restore worker checkpoints">
+<Accordion title="Save and manage prepared cloud projects">
 
-Administrators can [build project snapshots from Settings](/gateway/cloud-workers/warm-images), follow progress, cancel builds, and manage current and previous checkpoints from the same view. Build uses the committed HEAD and setup recipe of a repository on the Gateway machine. Rebuild needs a recorded local checkout and follows normal reuse rules, so it does not force a replacement when the existing preparation is reusable.
+Administrators can [save a prepared project in Settings](/gateway/cloud-workers/warm-images), watch its progress, cancel it, or pin a useful snapshot to keep it. You can choose a previous snapshot for new workers without changing computers already running. Builds use the project's committed files and setup instructions, and may reuse a suitable existing copy.
 
-Pinning protects a checkpoint from ordinary expiry and deletion during replacement, and rollback selects a recorded previous generation for later allocations. Running workers keep their original checkpoint. Deletion refuses images that are pinned, held, or capturing, and two pinned generations block another replacement until one is unpinned. [Retention settings](/gateway/cloud-workers/warm-images#retention-policy) can preserve one previous generation and require a restart after changes.
-
-Slow captures now receive wait and inspect guidance rather than being treated as uncertain solely because of their age. Recovering an uncertain reservation still requires acknowledging that its workers and capture have stopped and provider artifacts have been reconciled; the button clears only that reservation. Failed optional uploads also release their occupied transfer slots so later checkpoints can proceed.
+Before using Recover after an interrupted capture, stop the affected worker and capture and check the saved images with your provider. Recover only clears OpenClaw's record of the interruption; it does not stop a computer or delete an image for you.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3355,11 +3209,11 @@ Slow captures now receive wait and inspect guidance rather than being treated as
 
 </Accordion>
 
-<Accordion title="Continue cloud work through preparation and updates">
+<Accordion title="Keep messages and cloud computers through updates">
 
-Messages accepted during healthy worker setup or file synchronization remain queued for their intended environment and start when it is ready, with a receipt explaining what they are waiting for. You no longer need to copy and resend a message just because normal synchronization outlasted the earlier wait.
+You can send a message while a cloud session is setting up or syncing files and see what it is waiting for. OpenClaw keeps the message and starts it when the intended computer is ready, saving you from copying and resending it.
 
-Supported cloud machines also keep their workspace, installed tools, and desktop through an ordinary Gateway update, with the worker software refreshed in place. A submitted turn that has not reached the worker can retry once through a compatible refresh without duplicating the message. [Session lifecycle guidance](/gateway/cloud-workers/session-lifecycle) covers the supported installer and reconnection requirements, recovery of pending node-backed results, and cases that still need cleanup. Already-started tool work is not replayed, and Stop, Move, provider loss, or persistent renewal failures retain their own failure behavior.
+Supported cloud computers can also keep their files, installed tools, and desktop through an [OpenClaw update](/gateway/cloud-workers/session-lifecycle). A message that has not started can continue once the worker is updated, but work already underway is not automatically repeated. The computer must support the update and reconnect; this cannot recover a machine lost by the provider.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3375,11 +3229,9 @@ Supported cloud machines also keep their workspace, installed tools, and desktop
 
 </Accordion>
 
-<Accordion title="Capture and transfer remote workspace files">
+<Accordion title="Copy remote workspaces with less waiting">
 
-Capturing a remote workspace with many small files can finish sooner by reading several files concurrently, and transferred file inventories can use gzip while preserving their decoded contents and validation. Deeply nested prepared workspace paths also pass the corrected launch check, subject to the operating system's own limits.
-
-Cancelling preparation stops new scanning and hashing while work already started finishes closing its handles. Cancelled uploads disconnect even after their last byte has arrived, and growing or oversized files are rejected earlier without publishing a partial manifest. These changes preserve the existing workspace size and filesystem restrictions.
+Saving a remote workspace with many small files can finish sooner, and its file list needs fewer bytes to transfer. Cancelling preparation stops new scanning and closes the upload connection instead of leaving it hanging, though file operations already underway may need time to finish. Oversized or changing files are also rejected earlier, without leaving a partial workspace result.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3401,11 +3253,9 @@ Cancelling preparation stops new scanning and hashing while work already started
 
 </Accordion>
 
-<Accordion title="Understand cloud cleanup and failure reports">
+<Accordion title="See what still needs attention after cloud cleanup">
 
-Cloud-worker cleanup now reports the original failure and the latest cleanup cause without accumulating repeated stale errors. If an optional image capture fails but the source machine is confirmed stopped, stop or reclaim can succeed with a capture warning, leaving any uncertain snapshot available for reconciliation.
-
-Unused image cleanup also works across profiles using different Crabbox executables. A failed deletion keeps its obligation visible for retry, so an unresolved cleanup can still hold capacity and continue incurring provider charges.
+When a cloud worker fails, the error now keeps the original problem and the latest cleanup failure visible without piling up repeated messages. Stopping a computer can succeed even if saving an optional image failed, with a warning explaining what remains. Failed image deletion stays visible for retry, and charges may continue until your provider confirms deletion.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3422,9 +3272,7 @@ Unused image cleanup also works across profiles using different Crabbox executab
 
 <Accordion title="Find and connect Codex plugins">
 
-Owners and administrators can [find and connect Codex plugins](/plugins/codex-native-plugins) with searchable catalog pages, retained setup links, and a status view that separates OpenClaw access permissions from bundle enablement and hosted-app connection flags. Opening a setup link leaves its question pending until you return and submit the completion response.
-
-After connecting an app, `/codex plugins refresh` requests fresh hosted-app inventory for the current account, and `/new` or `/reset` starts the session where required. Refreshing does not sign you in, enable a plugin, change permissions, or reload native MCP servers, so the status view keeps those remaining steps visible.
+Owners and administrators can [search Codex plugins](/plugins/codex-native-plugins), open their setup links, and see installation, permission, and account-connection information together. Opening a setup link does not finish the step—return and submit the completion response when you are done. After connecting, use `/codex plugins refresh` to update the app list, then `/new` or `/reset` where required; refreshing does not sign in or enable an app for you.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3441,15 +3289,13 @@ After connecting an app, `/codex plugins refresh` requests fresh hosted-app inve
 
 ## Security and Privacy
 
-Automatic command review can now consider what you asked your Claw to do, let eligible work proceed, refuse a command with guidance, or bring the decision back to you. Alongside that change, workspace-restricted attachments respect the active sandbox, standalone MCP Apps preserve read-only access, and backup exports recognize private update captures even after their directory moves, provided its privacy marker stays intact.
+Your Claw can make more decisions about routine commands without interrupting you, while still asking for approval when needed. There are also fixes for keeping file access within the permissions you chose, protecting shared conversation history when deleting an agent, and keeping private update records out of backups and support bundles.
 
 <AccordionGroup>
 
-<Accordion title="Review commands against the requested task">
+<Accordion title="Decide when commands need your approval">
 
-In existing automatic and workspace permission modes, [command review](/tools/exec) can now allow an eligible low- or medium-risk command once, deny it with an explanation and safer-action guidance, or ask a person to decide. This takes effect in existing sessions without another setting, so routine work can proceed after review and a refusal can send the agent back to find a materially safer approach. On the Gateway, the third consecutive reviewer denial goes to a human.
-
-For embedded agent runs, review also receives a limited, redacted excerpt of the conversation so it can compare the proposed command with the user's request. That excerpt is treated as untrusted evidence and can omit relevant history; it is not a guarantee that the reviewer understands intent. Explicit requests for high-risk actions still go through human approval, modes that always ask retain that requirement, and executable checks remain in place. Direct node calls, widgets, the SDK facade, and the Codex bridge do not receive this conversation context. Slow or failed review still falls back promptly to human approval while pending cleanup finishes.
+[Automatic command review](/tools/exec) can now let suitable routine commands run, refuse a command with an explanation, or ask you to decide. This takes effect in existing automatic and workspace modes. In OpenClaw's built-in agent, the reviewer can use part of your conversation to check whether a command fits your request. High-risk actions still need human approval, and settings that always ask remain in force.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3467,11 +3313,11 @@ For embedded agent runs, review also receives a limited, redacted excerpt of the
 
 </Accordion>
 
-<Accordion title="Understand and preserve approval boundaries">
+<Accordion title="Keep your tool permissions in place">
 
-Runs started with tools disabled now retain that restriction when handed to a supported plugin runtime, including when resuming a Copilot session that previously allowed tools. A runtime that cannot enforce the restriction refuses the handoff, so affected users need to switch runtimes or upgrade the plugin. The English Read Only description also makes its existing scope clearer — agent tools can read within the session root, but cannot write or run commands.
+Turning tools off now carries through to supported connected agents, including Copilot, even when you return to a conversation that previously allowed them. If an integration cannot honor that restriction, OpenClaw stops rather than continuing with tools enabled. Update the plugin or choose a supported agent to continue.
 
-Agent instructions no longer impose a blanket refusal on owner-authorized browser logins or commands using existing workspace credentials. When setup tools are unavailable, the instructions direct users to masked terminal setup instead, while group login codes still belong in private delivery. This changes the guidance given to the model, and existing runtime permissions continue to govern what it can do. Approval commands also return useful usage instructions for invalid decisions, and model-assisted interpretation of approval replies keeps its resources available through overlapping requests and cleanup.
+Your Claw's instructions also allow it to use existing login details for tasks you authorize, such as signing into a website, while keeping your other permissions in place. When it cannot offer secure setup in chat, it directs you to terminal prompts that hide what you type.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3498,13 +3344,11 @@ Agent instructions no longer impose a blanket refusal on owner-authorized browse
 
 </Accordion>
 
-<Accordion title="Protect and recover credentials">
+<Accordion title="Fix password and device sign-in problems">
 
-Gateway password authentication now rejects blank passwords, published example placeholders, and the literal values `undefined` and `null`, with security-audit findings that explain what needs attention. If a deployment uses one of those values, replace it with a real secret, restart the Gateway, and update its clients. Real passwords shorter than 24 characters receive a warning rather than a new startup block. Eligible password-only connections also stop depending on saved device credentials they do not use, avoiding failures when that unrelated local store cannot be read.
+Password login now rejects blank passwords and known example values. If one prevents your Gateway from starting, replace it, restart OpenClaw, and update the apps that connect to it. Short real passwords produce a warning rather than a new startup block.
 
-WebSocket inference and the bundled autoreview helper can use protected credentials through [managed secret egress](/gateway/secrets) without a per-command opt-out. Substitution covers the connection's handshake URL and headers; subsequent message frames pass through unchanged. Credential recovery notices also stop implying that a working credential was available throughout an outage.
-
-For older node tokens carrying invalid operator permissions, Doctor now gives a working [device-token recovery command](/cli/devices) using `--role node --no-scopes`. Recovery requires administrator permission and preserves operator access. A node using a separate state directory needs valid shared Gateway authentication and a restart to refresh its own credentials.
+More model connections can use [protected API keys](/gateway/secrets) without turning protection off. Doctor also gives administrators a working [repair for certain older device sign-in failures](/cli/devices), making it easier to reconnect affected devices.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3528,13 +3372,11 @@ For older node tokens carrying invalid operator permissions, Doctor now gives a 
 
 </Accordion>
 
-<Accordion title="Validate network and webhook boundaries">
+<Accordion title="Protect incoming messages and network access">
 
-Slack HTTP webhooks now finish a bounded request read before signature processing, enforcing body-size, read-time, and concurrency limits while retaining normal signature verification. Feishu and Lark signed webhooks reject callbacks dated more than one hour before or after the Gateway's clock. Keep that clock synchronized, and check [Feishu troubleshooting](/channels/feishu/troubleshooting) if a relay holding an old signed request begins receiving a rejection. WebSocket mode is unaffected.
+For Slack connections using HTTP webhooks, OpenClaw now enforces limits on oversized, slow, or excessive incoming requests before processing them. Feishu and Lark webhooks also reject signed requests dated more than an hour before or after the computer's clock. Keep that clock synchronized, and check [Feishu troubleshooting](/channels/feishu/troubleshooting) if delayed deliveries are rejected. Feishu's WebSocket connection mode is unaffected.
 
-For reverse proxies and node pairing, [IPv4-mapped network ranges](/gateway/trusted-proxy-auth) now match their full declared IPv4 range. Review existing broad allowlists before relying on them — a mapped prefix at or below `/96` includes all IPv4 addresses, including loopback. Explicit loopback consent and the other authentication and approval checks remain in place.
-
-The optional IPv6 fake-IP proxy compatibility setting also preserves the block on the known AWS IPv6 metadata endpoint for guarded requests. Tlon validates quoted-post references before authenticated lookups, allowing surrounding message text to survive malformed citations.
+If you use [IPv4-mapped network rules](/gateway/trusted-proxy-auth) for a reverse proxy or device pairing, review the addresses you allow. Those rules now cover their full stated range, fixing connections that were wrongly rejected. Broad rules may therefore trust more addresses than before, including the computer itself; keep the allowed range as narrow as your setup needs. Other login and approval checks still apply.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3554,11 +3396,11 @@ The optional IPv6 fake-IP proxy compatibility setting also preserves the block o
 
 </Accordion>
 
-<Accordion title="Read only the authorized workspace and artifacts">
+<Accordion title="Keep shared files within their permissions">
 
-With workspace-only policy enabled, an agent can attach output from its active sandbox without gaining attachment access to another session's sandbox. Core replies carry the active workspace through automatically; [channel plugins](/plugins/sdk-channel-plugins/status-and-media) that call the media helpers must supply it from trusted session context. Missing context now denies sandbox attachment access. Agents already allowed broader host-file access retain those permissions.
+When an agent is limited to its workspace, it can now send files from the current chat's sandbox without being able to attach files from another chat's sandbox. Plugins that send these attachments must identify the correct workspace, so some third-party plugins may need an update.
 
-Fresh artifact listings, inspection, and downloads also follow a conversation's draft visibility when no Gateway roles are configured, bringing file access into line with chat history. Previously issued download tickets keep their existing lifetime, and people sharing one Gateway still need to trust one another. For older file-transfer permissions, a dedicated [migration reference](/cli/file-transfer) explains the existing review command, dry runs, and script exit codes.
+Changing a shared conversation to draft now also blocks new file requests from readers who can no longer see it, even without separately configured user roles. Download links issued earlier remain valid until they expire, and people sharing one OpenClaw installation still need to trust one another.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3580,11 +3422,9 @@ Fresh artifact listings, inspection, and downloads also follow a conversation's 
 
 </Accordion>
 
-<Accordion title="Preserve permissions in MCP Apps and local requests">
+<Accordion title="Keep external tool apps read-only">
 
-Opening an MCP App in a standalone view now preserves the issuing client's read-only restriction. A reader can still render the App and access permitted resources, but the standalone view cannot list or call tools that the client's direct connection is forbidden to use. Authorized tool use continues to depend on the App's current grant.
-
-On the authenticated local MCP connection, an oversized rejected upload also prevents a queued request behind it from executing a tool. Valid requests at the existing size limit continue to work, while an upload declaring an excessive size is rejected immediately.
+If you have read-only access, opening an MCP App in a separate view no longer gives you permission to run its tools. You can still view the App and use the resources you are allowed to read. For MCP tools running on the same computer, rejecting an oversized upload also stops a tool command queued behind it from running on that connection.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3598,13 +3438,11 @@ On the authenticated local MCP connection, an oversized rejected upload also pre
 
 </Accordion>
 
-<Accordion title="Keep shared history and private update captures protected">
+<Accordion title="Protect shared history and private update records">
 
-[Deleting an agent](/cli/agents) now refuses to remove the physical owner of a history database while another configured agent depends on it, including when you choose to retain files. Keep that owner configured, since moving shared history to another owner is not yet supported. Failed cleanup remains available to retry after restart; if configuration removal has already committed but history cleanup fails, repair the reported storage problem and retry the same deletion command.
+[Deleting an agent](/cli/agents) now stops if another agent needs it to read shared history. Moving that history is not yet supported, so keep the agent configured. If deletion fails partway through, fix the reported storage problem and retry. Before deleting a workspace that links to a neighboring folder, check what will be removed. Deletion through the Gateway may move that linked folder to Trash too; the offline command removes only the link.
 
-Gateway-connected deletion also handles agent files on external state volumes that were previously rejected merely for being outside the home or temporary directory. Check workspace symlinks before deleting files through the Gateway — it can also move a target beside the link to Trash, while the offline CLI moves only the link.
-
-[Backups and support exports](/cli/backup) exclude recognized private update-capture directories and refuse protected files selected directly as inputs. A moved or copied directory stays protected when its privacy marker remains intact, including after its original owner directory is removed. Keep that marker with the directory; protection does not follow detached, unmarked files copied elsewhere. These changes govern export exclusion, not creation of captures or interrupted-update recovery.
+[Backups and support bundles](/cli/backup) leave out recognized private update records. If you move a protected folder, keep its privacy-marker file with it. Files copied elsewhere without that marker are not protected from export.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3623,9 +3461,9 @@ Gateway-connected deletion also handles agent files on external state volumes th
 
 </Accordion>
 
-<Accordion title="Preserve WhatsApp group allowlists during repair">
+<Accordion title="Keep your WhatsApp group access choices">
 
-Running `openclaw security audit --fix` now preserves existing WhatsApp group allowlists instead of adding paired senders to a policy you already restricted. Converting an open policy can still seed approved senders when no explicit sender list exists. Entries added by an earlier repair are not removed automatically, so review those separately if you were affected.
+Running `openclaw security audit --fix` now keeps the WhatsApp group access list you already chose, instead of adding people just because they had previously paired with your Claw. When changing an open group policy to restricted access, it can still use approved senders if you have not supplied a list. People added by an earlier repair are not removed automatically, so review your list if you were affected.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3638,11 +3476,9 @@ Running `openclaw security audit --fix` now preserves existing WhatsApp group al
 
 </Accordion>
 
-<Accordion title="Understand telemetry and security guidance">
+<Accordion title="Understand what update checks share">
 
-The [telemetry guide](/gateway/telemetry) now explains the difference between optional feature statistics and approximate location derived by the hosted receiver from an update request. Its disclosure covers country, region, city, and timezone, why those fields cannot appear in a client-only preview, and the documented three-month retention. Disabling optional statistics or setting `DO_NOT_TRACK` does not stop baseline update requests; the guide points to the existing controls for stopping automatic update requests. This is a documentation disclosure, not a new client location-collection setting, and request origin may reflect a VPN, proxy, or remote server.
-
-Security, [policy](/cli/policy), and [threat-model guidance](/security/THREAT-MODEL-ATLAS) also have focused pages for the task or risk you want to understand. Setup and troubleshooting corrections explain saving an Anthropic setup token from an interactive terminal on the Gateway host, the existing team-only secret-store scope, shared HTTP write limits, and how proxy validation failures should be interpreted.
+The [telemetry guide](/gateway/telemetry) now explains what an update check can reveal about your approximate location, what the local preview can show, and the documented three-month retention period. Turning off optional statistics or setting `DO_NOT_TRACK` does not stop automatic update checks. If you want to stop those requests too, use the separate controls explained in the guide. The location may be that of a VPN, proxy, or remote computer, rather than where you are sitting.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3667,15 +3503,15 @@ Security, [policy](/cli/policy), and [threat-model guidance](/security/THREAT-MO
 
 ## Quality-of-Life Improvements
 
-You can answer your Claw’s questions and enter Gateway-backed secrets directly in the terminal, with readable output and clearer guidance when a command needs your attention. Worktree setup and recovery also handle more everyday cases, while conversation instructions and reorganized documentation help keep the right information close to the task.
+You can now answer your Claw’s questions and enter secrets from the terminal, with clearer output to read and copy afterward. There are also fixes for starting and restoring coding workspaces, giving delegated tasks enough time, and finding the help you need when something goes wrong.
 
 <AccordionGroup>
 
-<Accordion title="Answer questions and secrets requests in the terminal">
+<Accordion title="Answer questions and enter secrets in the terminal">
 
-You can now answer your Claw's questions directly in the [terminal interface](/web/tui), choosing an option, selecting several answers, or typing your own response without leaving the conversation. An eligible plain reply can reach the question immediately even when the running task is waiting for it. Press Esc to put a question aside and `/question` to reopen it.
+When your Claw needs an answer, you can now choose an option or type a response directly in the [terminal](/web/tui), including while a task is waiting for your reply. Press Esc to put the question aside and `/question` to bring it back.
 
-Gateway-connected sessions also give [secret requests](/tools/secrets) their own masked input, keeping submitted values out of chat and input history. The input accepts one line and shows the proposed allowed hosts, which you can change in the Control UI. Local terminal sessions can answer ordinary questions, but storing a requested secret requires a running Gateway, and local questions do not survive closing the process.
+[Secret requests](/tools/secrets) get a masked entry box that keeps what you type out of the conversation and input history. Saving a secret requires a Gateway connection, and terminal entry accepts one line at a time. Use the web app if you need to change which sites can use it. Local sessions support ordinary questions, which you should answer before closing the terminal.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3688,11 +3524,9 @@ Gateway-connected sessions also give [secret requests](/tools/secrets) their own
 
 </Accordion>
 
-<Accordion title="Read clean terminal output">
+<Accordion title="Read and copy terminal output">
 
-Terminal chat keeps long email addresses, words, and identifiers intact when they wrap, so copying a value does not pick up spaces that were never there. Multiline tables preserve deliberate blank lines and keep neighboring columns aligned, while progress indicators fit narrow windows and send valid updates to supported terminals.
-
-Scripts also get cleaner command output. Local approvals edits suppress the human write announcement in JSON mode, and transcript lists, summaries, and paths no longer pick up unrelated startup warnings.
+Long addresses and other text now wrap in terminal chat without gaining extra spaces, so you can copy them as written. Tables keep related values lined up, and progress indicators stop leaving repeated lines behind in narrow windows. If you use scripts to read command results, approvals JSON and transcript output also keep the unrelated announcements out of the way.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3715,11 +3549,9 @@ Scripts also get cleaner command output. Local approvals edits suppress the huma
 
 </Accordion>
 
-<Accordion title="Follow actionable command diagnostics">
+<Accordion title="Understand command errors">
 
-When `openclaw agent` times out or loses its connection after the Gateway has accepted a task, the error now includes the accepted run ID. Use it to check the session transcript and Gateway status before retrying, since acceptance alone does not tell you whether the task is still running or has finished.
-
-Missing credentials and ambiguous agent selections now lead with the option you need to supply, while a command error is distinguished from a failure to start the CLI. Full status reports also show the Gateway details already available instead of replacing them with “unknown.”
+Command errors do a better job of telling you what to do next, such as supplying login details or choosing which agent to use, without making a missing option look like a broken installation. If `openclaw agent` loses its connection or times out after a task was accepted, the error gives you the task’s ID so you can check what happened before trying again. Check its conversation history and Gateway status first, because the work may have continued after the connection was lost.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3740,11 +3572,9 @@ Missing credentials and ambiguous agent selections now lead with the option you 
 
 </Accordion>
 
-<Accordion title="Use Code Mode results and recover failed cells">
+<Accordion title="Keep more useful Code Mode results">
 
-[Code Mode](/tools/code-mode) fits and delivers structured results using compact JSON, leaving more of the existing allowance for the data your Claw needs. The terminal displays those results literally, preserving values, escapes, and Markdown characters when you inspect them, while existing output limits still apply.
-
-Excessive recursion in a fresh or resumed cell now returns a normal failed-cell error that the recovery flow can handle. You can correct the code and continue without that particular failure turning into a low-level runtime trap.
+[Code Mode](/tools/code-mode) uses less of its result space for formatting, leaving more room for the information your Claw asked for. The terminal also shows that data as written, without treating parts of it as message formatting. Code that calls itself too deeply now returns an error the Claw can work from, making it possible to correct that code and continue.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3762,11 +3592,11 @@ Excessive recursion in a fresh or resumed cell now returns a normal failed-cell 
 
 </Accordion>
 
-<Accordion title="Start and restore the intended worktree">
+<Accordion title="Start and restore coding workspaces">
 
-Starting a session in a [managed worktree](/concepts/managed-worktrees) keeps the accepted starting commit fixed across setup retries, even if the branch moves in the meantime. Invalid refs produce an actionable error, and repositories with many branches keep the Worktree option available. If your branch or commit is missing from the suggestions, you can type it directly and it still has to resolve before the worktree is created.
+A [worktree](/concepts/managed-worktrees) gives your Claw a separate working copy of a code project. Setup retries now keep the version you originally selected, and projects with many branches keep the option to start a worktree available. You can type a branch or commit that is missing from the suggestions, with an error if it cannot be found.
 
-Cleanup and restoration also preserve replacement content when a file becomes a folder or a folder becomes a file. Copied worktree IDs with surrounding spaces are accepted by Gateway remove and restore operations, removing a small but frustrating obstacle to using an existing recovery snapshot.
+Saved worktrees also restore changes that replaced a file with a folder, or a folder with a file, keeping the replacement contents intact.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3786,13 +3616,11 @@ Cleanup and restoration also preserve replacement content when a file becomes a 
 
 </Accordion>
 
-<Accordion title="Keep conversation instructions and side questions useful">
+<Accordion title="Keep instructions and side questions on track">
 
-Long workspace instructions retain more of the context that makes them useful. Shortened `AGENTS.md` content keeps an example's immediately adjacent introduction attached to its quotation, and the digest recognizes additional Traditional Chinese rule markers within the existing space limits. Git co-author guidance now sits in conditional session instructions, keeping eligible credit available without repeating it in individual messages; incognito sessions and isolated scheduled runs omit it.
+When a long `AGENTS.md` instruction file has to be shortened, an example keeps the line directly above it that explains what it is, helping keep a quotation from looking like a new instruction. The shortened instructions also recognize more Traditional Chinese rules, although the available space still limits what can be included.
 
-Rejected goal updates tell the agent to stop retrying the update and respond to you. Side questions keep the managed resources they started with through their answer and cleanup, and completed direct `/btw` answers can report supplied usage to configured diagnostics. That usage remains outside session-derived `/usage` cost totals.
-
-Preparing large lists of unpinned sessions also avoids repeated checks, reducing the work needed to return their metadata.
+If you track model usage, completed `/btw` side answers can now include their reported usage in your configured diagnostics. Those side questions still sit outside the conversation’s `/usage` cost total.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3819,11 +3647,9 @@ Preparing large lists of unpinned sessions also avoids repeated checks, reducing
 
 </Accordion>
 
-<Accordion title="Inspect and bound delegated tasks">
+<Accordion title="Time limits for delegated work">
 
-Visible subagents now receive the time budget selected for their initial turn, so a longer delegated task is not cut short by the ordinary agent deadline. The budget applies to that first turn; later turns use normal timeout policy, and separate watchdogs still apply.
-
-Restored results on multi-agent Gateways use the recorded requesting agent when the saved session key lacks that identity. Independent child runs also get past a startup rejection caused by inheriting the parent's caller context. If a required child's tracking record is missing, the remaining children can no longer make the whole batch look fully handed off. The [subagent guides](/tools/subagents) organize inspection, completion, and recovery instructions into focused pages.
+[Subagents](/tools/subagents) are helpers your Claw can send to work on part of a task. Helpers with visible conversations now get the time selected for their first task, so longer work is not cut short by the ordinary deadline. Later messages use the normal time limit. A separate fix helps finished results return to the right agent after a restart when several agents share one Gateway.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3843,11 +3669,9 @@ Restored results on multi-agent Gateways use the recorded requesting agent when 
 
 </Accordion>
 
-<Accordion title="Find guidance by the task at hand">
+<Accordion title="Find the help you need">
 
-The [FAQ](/help/faq) now routes common questions into focused topics, while the documentation home offers direct paths to releases, skills, automations, and plugin building. Separate Releases and Contributing tabs make it easier to find the right material, with matching Simplified Chinese labels and additional translated sidebar groups.
-
-Across the guides, related links, visible section headings, and repaired older bookmarks bring you closer to the instructions you need. Help links in errors and support replies point to their current sections, configuration examples and terminology are clearer, and documentation maps keep headings inside code examples out of page navigation. These changes help you use the existing features described in those guides.
+The [FAQ](/help/faq) is organized around the question you are trying to answer, and the documentation home gives you direct paths to releases, skills, automations, and building plugins. Setup examples are clearer, and repairs to older bookmarks and help links make the relevant instructions easier to reach. Simplified Chinese navigation also gains translated labels, including separate Releases and Contributing tabs.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3892,15 +3716,13 @@ Across the guides, related links, visible section headings, and repaired older b
 
 ## Other Bug Fixes
 
-When your Claw has finished the work, it should be able to tell you what happened, and when you reset a conversation, its child tasks should stay stopped. This release fixes several ways those expectations could break, along with command failures, unreadable history, and missing diagnostic information that made problems harder to investigate.
+OpenClaw now handles more of the interruptions that can leave you without an answer, stop a conversation from loading, or make a successful task look like it failed. Error messages and troubleshooting records also explain more of what happened.
 
 <AccordionGroup>
 
-<Accordion title="Recover a final answer after completed work">
+<Accordion title="Get the answer after the work is done">
 
-A conversation can now recover its missing final answer after certain interrupted provider streams or an earlier tool error, once the final tool work has finished successfully. The recovery asks for a text-only explanation with tools disabled, so it can summarize completed work without running those actions again. Progress messages no longer stand in for that final answer, and a recovered reply can report the correct completion status.
-
-Recovery still depends on the provider responding and the work being settled. Background work or an answer already delivered can prevent another attempt, and an explanation of a fatal scheduled-run failure does not turn that run into a success.
+Your Claw can recover a missing final reply in more cases where the work finished but the answer never arrived, including after a lost model connection or an earlier tool error. It asks the model for an explanation without repeating completed actions, giving you another chance to see what was done.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3915,11 +3737,11 @@ Recovery still depends on the provider responding and the work being settled. Ba
 
 </Accordion>
 
-<Accordion title="Read and reset the intended history">
+<Accordion title="Start fresh and reopen conversations">
 
-Resetting a conversation with a large history of child tasks does less repeated work, and active or waiting children stay canceled when delayed results arrive. Finished results and unrelated conversations remain available. Standalone [`/new` and `/reset`](/tools/slash-commands) commands also avoid waiting for unnecessary thinking settings, while commands with follow-up text still use the configured model settings.
+Starting over with [`/new` or `/reset`](/tools/slash-commands) avoids unnecessary waits, especially in conversations where your Claw has handed work to other agents, and canceled tasks stay stopped when late results arrive. Your saved history and other conversations remain available.
 
-History can load when a malformed custom message belongs to an inactive branch or overly nested plugin metadata falls before the reset boundary. Long conversations also keep recent context readable during supported cleanup when an agent pauses for other work. These fixes preserve retained history, and malformed content still reports an error when you actually select it. When a partial text answer fails, the next model request now retains a short failure record without replaying the unfinished text.
+Old plugin messages outside the current conversation no longer stop its history from loading, and long conversations keep recent messages available when your Claw pauses to wait for other work. If a text-only reply fails partway through, the model also receives a short note about that failure when you continue, so the attempt no longer disappears from its context.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3937,11 +3759,11 @@ History can load when a malformed custom message belongs to an inactive branch o
 
 </Accordion>
 
-<Accordion title="Run commands and inspect failed file actions">
+<Accordion title="Clearer file errors and command results">
 
-Service-managed SSH commands can finish after closing inherited file handles, and successful commands on macOS and Linux avoid a race that could incorrectly report a cleanup failure. Linux also gains bounded cleanup for defunct child processes adopted after covered command timeouts. If you updated with `--no-restart`, restart the running Gateway to pick up the cleanup acknowledgement fix.
+When your Claw cannot save a file in its workspace, it now explains whether access was denied, the disk is full, or the location is read-only. That gives you a useful starting point for fixing the problem. Tool Search also fixes a case where a supplied file path was lost before the file could be read.
 
-Failed workspace writes now explain whether permissions, a read-only filesystem, or a full disk prevented the change, giving you and your Claw a useful next step. Tool Search also preserves supplied parameters when a model includes an empty argument wrapper beside them, so a file path no longer disappears before reaching the read tool. Existing permissions and tool validation still apply.
+On Linux, affected SSH commands can finish instead of being stopped too early. Commands on macOS and Linux also avoid a false cleanup error after successful work. Restart OpenClaw if you updated with `--no-restart` to get that cleanup fix.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3958,11 +3780,11 @@ Failed workspace writes now explain whether permissions, a read-only filesystem,
 
 </Accordion>
 
-<Accordion title="Understand database and export failures">
+<Accordion title="Troubleshoot errors and exported conversations">
 
-Fresh shared-state reads now wait through brief database locks within the existing five-second limit, and failed database opens preserve the original error instead of replacing it with a cleanup error. Protective SQLite shutdowns also retain their diagnostic when a worker thread triggers them. For operators investigating slow saves or cleanup, [structured logs](/logging) identify the operation, distinguish waiting from work, and add detail about preparation and worker release. With process diagnostics enabled, they can also show which operation currently holds a session queue. Their elapsed timings help narrow an investigation but do not measure CPU use or establish the underlying cause.
+OpenClaw can now wait through a brief database lock instead of immediately failing to read its saved settings. When a database problem does cause a failure or shutdown, error messages preserve more of the information needed to investigate it. [Logs](/logging) also give operators a clearer view of which work is waiting or taking time, with extra detail available when diagnostics are enabled.
 
-Session exports preserve paginated file reads and their continuation instructions, while enabled trajectory capture includes tool calls and outcomes from fallback model attempts. Opt-in debug capture keeps response content already observed before an interruption and records it under the original capture session. Existing redaction and size limits remain, and enabling capture cannot restore records that were never collected.
+Exported conversations keep file-read results that were incorrectly removed, including instructions for reading the next part of a file. With the relevant diagnostic recording enabled, records also include actions taken after switching to a backup model and partial responses received before an interruption. Sensitive information is still removed, and recording size limits still apply.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -3992,13 +3814,13 @@ Session exports preserve paginated file reads and their continuation instruction
 
 ## Maintainer and Internal Changes
 
-This section accounts for 692 maintainer-only units across runtime refactors, tests, CI, packaging, release operations, and contributor tools. The work includes changes to how OpenClaw is built and checked, documentation maintenance, and a canceled UI adjustment retained for complete accounting. The source lists keep those details available without treating them as new product features.
+This release includes 692 maintainer-only units covering code cleanup, testing, release preparation, and contributor tools. Expand the source lists for the full change history.
 
 <AccordionGroup>
 
-<Accordion title="Runtime implementation and type contracts">
+<Accordion title="Internal code cleanup">
 
-Internal code shares more of its existing helpers and types across agents, channels, plugins, and storage. These refactors remove duplicate decisions, unused wrappers, and redundant state while keeping established behavior at the center of the work. Narrow reductions in allocations and repeated work do not establish an application-wide performance improvement.
+Shared code and type definitions replace duplicated logic across OpenClaw. This gives maintainers fewer places to update when changing behavior and removes unused code.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4179,9 +4001,9 @@ The inbound-hook mapper compatibility concern is addressed by the separately doc
 
 </Accordion>
 
-<Accordion title="Tests and fixtures">
+<Accordion title="Test reliability and upkeep">
 
-Tests wait for the events they actually depend on, keep temporary state isolated, and check results more directly. Shared fixtures also remove repeated setup across many suites. Together, these changes make regression coverage easier to maintain and reduce avoidable test work, while the full test-audit campaign and release qualification remain separate efforts.
+Tests are less prone to failures caused by timing, leftover data, or the machine running them. Reusing setup and removing duplicate checks also reduces unnecessary work for contributors.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4540,9 +4362,9 @@ Reported timings cover different local workloads and cannot be added into a rele
 
 </Accordion>
 
-<Accordion title="CI and performance assessment">
+<Accordion title="Automated checks and performance testing">
 
-CI skips unrelated jobs for isolated test changes and keeps timing estimates tied to the tests they describe. Performance assessment corrects process discovery, CPU accounting, and historical-release calibration. Build prerequisites and language-bundle checks also receive fixes, including checks for each language's budget and a single deferred bundle per language.
+Automated checks avoid unrelated work when a change affects only tests. Performance reports also measure CPU use more accurately, helping maintainers distinguish product regressions from measurement errors.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4588,9 +4410,9 @@ The later historical 2026.7.33 evaluator pin restores its 250% status allowance 
 
 </Accordion>
 
-<Accordion title="Build and package verification">
+<Accordion title="Build and package checks">
 
-Package checks trace dependency ownership through built plugin chunks and use the selected source's companion manifests during preparation. Other fixes cover nested optional dependencies, Bun built-ins, and Markdown guides that belong in shipped packages. These changes help maintainers check complete artifacts without mistaking legitimate package contents for missing or unexpected dependencies.
+Build and package checks better recognize which dependencies and files belong in each release package. This reduces false failures when maintainers prepare plugins and check their contents.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4618,11 +4440,9 @@ Preparation uses the frozen source manifests where required; installed-package v
 
 </Accordion>
 
-<Accordion title="Release preparation and recovery tooling">
+<Accordion title="Release preparation and recovery">
 
-Release tooling prepares package artifacts before publication, retains dispatch requests after lost responses, and makes partial publication results easier to inspect. Recovery checks can reconcile separately completed npm and Docker runs. Verification also detects selected packages whose beta tag trails stable, with manual repair still required.
-
-Historical-release tests use the selected source's capabilities and matching helpers, with explicit omissions for unsupported default scenarios. The committed-source readers require Git 2.45 or newer, and the bundle resolver also needs the trusted TypeScript parser. Standalone preflight checks include the repaired Docker aliases; workflow-wide enforcement remains separate. Mobile release work adds signing preparation, Ubuntu KVM emulator support, and diagnostic capture, without establishing complete screenshot, signing, or upload success.
+Release tools make interrupted publishing easier to investigate and recover from. Checks for older releases match the features those versions contain, while mobile release jobs get fixes for build preparation and troubleshooting. The checks that read older releases directly from Git require Git 2.45 or newer.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4735,9 +4555,7 @@ A recovered dispatch or collected publication status is an observation, not a pa
 
 <Accordion title="Contributor tools and documentation">
 
-Source contributors get consistent local test scheduling, fewer unnecessary compiler and build starts, and earlier unused-export feedback. Testing and CI guides are organized by task, while documentation tools preserve fenced examples and report the correct source lines. Source checkouts need owned dependencies or an explicitly configured dependency location when dependencies are missing; normal installs refuse borrowed checkout roots.
-
-Documentation publishing reuses matching successful checks and validates the final rebased content before each push attempt. Translation tooling can refresh selected entries while preserving unselected aliases, and generated translation records receive maintenance updates.
+Contributors get less repeated setup during local checks and clearer testing guides. Documentation tools preserve code examples and point errors to the right line. Normal pnpm installs now reject links to another checkout’s dependency folders. Give each source checkout its own dependencies or explicitly configure the dependency location.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4810,9 +4628,9 @@ The dependency-install guard is bypassed when lifecycle scripts are disabled and
 
 </Accordion>
 
-<Accordion title="Reverted work retained in history">
+<Accordion title="Reverted changes">
 
-A conversation-rail spacing adjustment and its full rollback are both retained here. The pair leaves no surviving spacing change and does not remove the earlier compact left rail.
+A change to conversation-marker spacing was undone. Both changes are listed below; the existing compact left rail remains.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>


### PR DESCRIPTION
Related: #144665

## What Problem This Solves

The v2026.9.4 release introduction is too wordy, and its section and topic prose asks ordinary readers to work through implementation details and caveats before understanding what changed.

## Why This Change Was Made

Use the shorter opening explicitly approved by Hannes and rewrite section introductions and topic prose around recognizable actions, outcomes, and useful changes. Keep implementation detail in the linked PRs and existing collapsed source lists. Preserve actionable warnings without making every topic a technical audit.

Keep the release grouping, complete source lists, contributor counts, frontmatter, and navigation unchanged.

## User Impact

Readers can understand the release without knowing the codebase, while following source links when they want implementation detail.

## Evidence

- The opening matches the exact user-approved replacement.
- All 15 section introductions and 172 topics received individual LLM review. The lead edited the assembled page, a fresh audience reviewer challenged and approved the complete rewrite, and the outer editor read every visible section and topic.
- All 172 source disclosures, their links and contributor credits, the 1,578-change accounting, 293-contributor count, frontmatter, and H2 categories are preserved. No release changes were removed.
- Focused MDX validation, all 117 retained internal documentation links/anchors, and diff hygiene passed. Repository autoreview returned scoped-clean at its default P0 threshold.
- The commit formatter removed only 12 extra blank lines before section headings; the reviewed prose and complete source disclosures are unchanged.
- No runtime behavior changed; runtime suites are not applicable.
