### PR TITLE
fix: allow cross-browser steering of active sessions

### DIFF
--- a/docs/concepts/queue-steering.md
+++ b/docs/concepts/queue-steering.md
@@ -61,6 +61,15 @@ If four users send messages while the agent is executing a tool call:
 
 Steering always targets the current active session run. It does not create a new session, change the active run's tool policy, or split messages by sender. In multi-user channels, inbound prompts already include sender and route context, so the next model call can see who sent each message.
 
+Authorized participants with matching tool permissions can steer from different
+browsers. The running turn keeps its original approval destination. A different
+browser identity alone does not defer the message, but changes to permissions,
+execution policy, workspace, or bound tools can require a followup turn.
+
+The Control UI labels accepted messages that are still waiting for the agent as
+queued. A visible message or send acknowledgment does not mean the active runtime
+has consumed it.
+
 Use `followup` or `collect` when you want messages to queue by default instead of steering the active run. Use `interrupt` when the newest prompt should replace the active run.
 
 ## Debounce

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -442,44 +442,97 @@ describe("runReplyAgent media path normalization", () => {
     },
   );
 
-  it("steers active non-streaming prompts in steer queue mode", async () => {
-    queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
-      queued: true,
-      sessionId,
-      target: "embedded_run",
-      gatewayHealth: "live",
-    }));
-    const followupRun = createMediaFollowupRun({ prompt: "generate chart" });
-    followupRun.run.taskSuggestionDeliveryMode = "gateway";
+  it.each(["device-a", "device-b"])(
+    "steers active non-streaming prompts from reviewer %s in steer queue mode",
+    async (approvalReviewerDeviceId) => {
+      queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(
+        async (sessionId: string) => ({
+          queued: true,
+          sessionId,
+          target: "embedded_run",
+          gatewayHealth: "live",
+        }),
+      );
+      const followupRun = createMediaFollowupRun({ prompt: "generate chart" });
+      followupRun.run.taskSuggestionDeliveryMode = "gateway";
+      followupRun.run.approvalReviewerDeviceId = "device-a";
 
-    await runReplyAgent(
-      makeRunReplyAgentParams({
+      const params = makeRunReplyAgentParams({
         resolvedQueue: { mode: "steer" } as QueueSettings,
         shouldSteer: true,
         shouldFollowup: true,
         isActive: true,
         followupRun,
-      }),
-    );
+      });
+      followupRun.run.approvalReviewerDeviceId = approvalReviewerDeviceId;
 
-    expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).toHaveBeenLastCalledWith(
-      "session",
-      "generate chart",
-      {
-        abortSignal: undefined,
-        steeringMode: "all",
-        isInboundUserMessage: true,
-        waitForTranscriptCommit: true,
-        queueIdentity: EXPECTED_STEER_QUEUE_IDENTITY,
-        onQueueAccepted: expect.any(Function),
-        taskSuggestionDeliveryMode: "gateway",
-        toolAuthorityFingerprint: resolveFollowupRunToolAuthorityFingerprint(followupRun),
-      },
-    );
-    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
-    expect(parkedSteerConsumeMock).toHaveBeenCalledOnce();
-    expect(parkedSteerFallbackMock).not.toHaveBeenCalled();
-  });
+      await runReplyAgent(params);
+
+      expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).toHaveBeenCalledOnce();
+      expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).toHaveBeenLastCalledWith(
+        "session",
+        "generate chart",
+        {
+          abortSignal: undefined,
+          steeringMode: "all",
+          isInboundUserMessage: true,
+          waitForTranscriptCommit: true,
+          queueIdentity: EXPECTED_STEER_QUEUE_IDENTITY,
+          onQueueAccepted: expect.any(Function),
+          taskSuggestionDeliveryMode: "gateway",
+          toolAuthorityFingerprint: resolveFollowupRunToolAuthorityFingerprint(followupRun),
+        },
+      );
+      expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+      expect(parkedSteerConsumeMock).toHaveBeenCalledOnce();
+      expect(parkedSteerFallbackMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { label: "permission mode", run: { permissionMode: "guarded" } },
+    { label: "tool overrides", run: { toolOverrides: { webSearch: false } } },
+    { label: "execution policy", run: { execOverrides: { security: "deny" } } },
+    { label: "elevation", run: { elevatedLevel: "full" } },
+    {
+      label: "shell elevation",
+      run: { bashElevated: { enabled: true, allowed: true, defaultLevel: "full" } },
+    },
+    { label: "workspace", run: { workspaceDir: "/tmp/different-steering-workspace" } },
+    { label: "client capabilities", run: { clientCaps: ["changed-capability"] } },
+    {
+      label: "tool bindings",
+      run: { toolBindings: { browser: { clientId: "different-browser" } } },
+    },
+  ] satisfies { label: string; run: Partial<FollowupRun["run"]> }[])(
+    "queues a different browser's prompt when its $label differs",
+    async ({ run }) => {
+      const followupRun = createMediaFollowupRun({
+        prompt: "generate chart",
+        run: { permissionMode: "full", approvalReviewerDeviceId: "device-a" },
+      });
+      const params = makeRunReplyAgentParams({
+        resolvedQueue: { mode: "steer" } as QueueSettings,
+        shouldSteer: true,
+        shouldFollowup: true,
+        isActive: true,
+        isRunActive: () => true,
+        followupRun,
+      });
+      followupRun.run = {
+        ...followupRun.run,
+        ...run,
+        approvalReviewerDeviceId: "device-b",
+      };
+
+      await runReplyAgent(params);
+
+      expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).not.toHaveBeenCalled();
+      expect(parkSteerCandidateMock).not.toHaveBeenCalled();
+      expect(enqueueFollowupRunMock).toHaveBeenCalledOnce();
+      expect(enqueueFollowupRunMock.mock.calls[0]?.[1]).toBe(followupRun);
+    },
+  );
 
   it("steers ordered current-turn images with the active prompt", async () => {
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -2177,54 +2177,59 @@ describe("reply run registry", () => {
     ).resolves.toEqual({ status: "accepted" });
   });
 
-  it("projects inbound authority before backend admission without forwarding the overlay", async () => {
-    const run = createQueueTestRun({ prompt: "projected inbound" });
-    const route = { provider: "openai", model: "gpt-primary" };
-    const overlay = toolAuthorityOverlay(run);
-    const queueMessage = vi.fn(
-      async (_text: string, _options?: ReplyBackendQueueMessageOptions) => {},
-    );
-    const operation = createTestReplyOperation({ sessionId: "session-projected-authority" });
-    operation.bindToolAuthoritySnapshot(prepareReplyToolAuthority(run));
-    operation.bindToolAuthorityRoute(route);
-    operation.attachBackend({
-      kind: "embedded",
-      cancel: vi.fn(),
-      isStreaming: () => true,
-      queueMessage,
-    });
-    operation.setPhase("running");
+  it.each(["device-a", "device-b", undefined])(
+    "projects inbound authority from reviewer %s without forwarding its approval destination",
+    async (approvalReviewerDeviceId) => {
+      const run = createQueueTestRun({ prompt: "projected inbound" });
+      run.run.approvalReviewerDeviceId = "device-a";
+      run.run.permissionMode = "full";
+      const route = { provider: "openai", model: "gpt-primary" };
+      const overlay = { ...toolAuthorityOverlay(run), approvalReviewerDeviceId };
+      const queueMessage = vi.fn(
+        async (_text: string, _options?: ReplyBackendQueueMessageOptions) => {},
+      );
+      const operation = createTestReplyOperation({ sessionId: "session-projected-authority" });
+      operation.bindToolAuthoritySnapshot(prepareReplyToolAuthority(run));
+      operation.bindToolAuthorityRoute(route);
+      operation.attachBackend({
+        kind: "embedded",
+        cancel: vi.fn(),
+        isStreaming: () => true,
+        queueMessage,
+      });
+      operation.setPhase("running");
 
-    await expect(
-      queueCurrentReplyRunMessage("session-projected-authority", "same authority", {
+      await expect(
+        queueCurrentReplyRunMessage("session-projected-authority", "same authority", {
+          isInboundUserMessage: true,
+          toolAuthorityFingerprint: "caller-cannot-override-projection",
+          toolAuthorityOverlay: overlay,
+        }),
+      ).resolves.toEqual({ status: "accepted" });
+      const forwardedOptions = queueMessage.mock.calls[0]?.[1];
+      expect(forwardedOptions).toMatchObject({
         isInboundUserMessage: true,
-        toolAuthorityFingerprint: "caller-cannot-override-projection",
-        toolAuthorityOverlay: overlay,
-      }),
-    ).resolves.toEqual({ status: "accepted" });
-    const forwardedOptions = queueMessage.mock.calls[0]?.[1];
-    expect(forwardedOptions).toMatchObject({
-      isInboundUserMessage: true,
-      toolAuthorityFingerprint: resolveFollowupRunToolAuthorityFingerprint(run, route),
-    });
-    expect(forwardedOptions).not.toHaveProperty("toolAuthorityOverlay");
+        toolAuthorityFingerprint: resolveFollowupRunToolAuthorityFingerprint(run, route),
+      });
+      expect(forwardedOptions).not.toHaveProperty("toolAuthorityOverlay");
+      expect(forwardedOptions).not.toHaveProperty("approvalReviewerDeviceId");
+      expect(queueMessage).toHaveBeenCalledOnce();
 
-    await expect(
-      queueCurrentReplyRunMessage("session-projected-authority", "changed authority", {
-        isInboundUserMessage: true,
-        toolAuthorityOverlay: { ...overlay, clientCaps: ["changed-capability"] },
-      }),
-    ).resolves.toMatchObject({ status: "rejected", reason: "tool_authority_mismatch" });
-    expect(queueMessage).toHaveBeenCalledOnce();
-
-    await expect(
-      queueCurrentReplyRunMessage("session-projected-authority", "restricted authority", {
-        isInboundUserMessage: true,
-        toolAuthorityOverlay: { ...overlay, permissionMode: "guarded" },
-      }),
-    ).resolves.toMatchObject({ status: "rejected", reason: "tool_authority_mismatch" });
-    expect(queueMessage).toHaveBeenCalledOnce();
-  });
+      for (const restricted of [
+        { clientCaps: ["changed-capability"] },
+        { toolBindings: { browser: { clientId: "different-browser" } } },
+        { permissionMode: "guarded" },
+      ] satisfies Partial<ReplyToolAuthorityOverlay>[]) {
+        await expect(
+          queueCurrentReplyRunMessage("session-projected-authority", "changed authority", {
+            isInboundUserMessage: true,
+            toolAuthorityOverlay: { ...overlay, ...restricted },
+          }),
+        ).resolves.toMatchObject({ status: "rejected", reason: "tool_authority_mismatch" });
+        expect(queueMessage).toHaveBeenCalledOnce();
+      }
+    },
+  );
 
   it("refuses stale injectable owners for admission and delivery until activity resumes", async () => {
     vi.useFakeTimers();

--- a/src/auto-reply/reply/reply-tool-authority.ts
+++ b/src/auto-reply/reply/reply-tool-authority.ts
@@ -236,6 +236,7 @@ function resolveReplyToolAuthorityInputFingerprint(
     scheduledToolPolicy: execution.scheduledToolPolicy,
     runtimePluginToolGrant: execution.runtimePluginToolGrant,
   });
+  // Steering keeps the active run's approval destination; browser identity is not a tool grant.
   return createHash("sha256")
     .update(
       stableStringify({
@@ -257,7 +258,6 @@ function resolveReplyToolAuthorityInputFingerprint(
         elevatedLevel: execution.elevatedLevel,
         bashElevated: execution.bashElevated,
         traceAuthorized: execution.traceAuthorized === true,
-        approvalReviewerDeviceId: execution.approvalReviewerDeviceId,
         authProfileId: execution.authProfileId,
         clientCaps: [...new Set(execution.clientCaps ?? [])].toSorted(),
         toolBindings: execution.toolBindings,

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -554,8 +554,9 @@ export function restoreCliBackendLiveEnv(snapshot: CliBackendLiveEnvSnapshot): v
 
 export async function ensurePairedTestGatewayClientIdentity(params?: {
   displayName?: string;
+  identityKey?: string;
 }): Promise<DeviceIdentity> {
-  const identity = loadOrCreateDeviceIdentity();
+  const identity = loadOrCreateDeviceIdentity({ identityKey: params?.identityKey });
   const publicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
   const requiredScopes = ["operator.admin"];
   const paired = await getPairedDevice(identity.deviceId);

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -575,6 +575,7 @@ async function writeLiveGatewayConfig(params: {
   compactionMode: CodexCompactionStressMode;
   nativeSupervision?: { command: string };
   loopDetectionPreToolUseRelay?: boolean;
+  queueMode?: "steer";
   configPath: string;
   modelKey: string;
   port: number;
@@ -584,6 +585,7 @@ async function writeLiveGatewayConfig(params: {
   const parsedModel = parseModelKey(params.modelKey);
   const appServerArgs = buildCodexCompactionAppServerArgs(params.compactionMode);
   const cfg: OpenClawConfig = {
+    ...(params.queueMode ? { messages: { queue: { mode: params.queueMode } } } : {}),
     gateway: {
       mode: "local",
       port: params.port,
@@ -2156,6 +2158,183 @@ async function verifyCodexSessionDeletion(params: {
 }
 
 describeLive("gateway live (Codex harness)", () => {
+  it.skipIf(CODEX_HARNESS_AUTH_MODE !== "api-key")(
+    "steers an active turn from another paired device with equivalent permissions",
+    async () => {
+      const modelKey = process.env.OPENCLAW_LIVE_CODEX_HARNESS_MODEL ?? DEFAULT_CODEX_MODEL;
+      logCodexLiveStep("cross-device-steering-start", { modelKey });
+      const token = `test-${randomUUID()}`;
+      const instance = await createCodexHarnessLiveInstance(token, "api-key");
+      logCodexLiveStep("cross-device-steering-instance-ready");
+      const clients: GatewayClient[] = [];
+      const gatewayEvents: EventFrame[] = [];
+      try {
+        instance.state.applyEnv();
+        const workspace = instance.state.workspaceDir;
+        await createLiveWorkspace(workspace);
+        await writeLiveGatewayConfig({
+          configPath: instance.configPath,
+          modelKey,
+          port: instance.port,
+          token,
+          workspace,
+          compactionMode: { kind: "off" },
+          queueMode: "steer",
+        });
+        logCodexLiveStep("cross-device-steering-config-ready");
+        const identities = [];
+        for (const identityKey of ["steering-first-browser", "steering-second-browser"]) {
+          identities.push(await ensurePairedTestGatewayClientIdentity({ identityKey }));
+        }
+        expect(identities[0]?.deviceId).not.toBe(identities[1]?.deviceId);
+        logCodexLiveStep("cross-device-steering-devices-paired");
+        await instance.startGateway();
+        logCodexLiveStep("cross-device-steering-gateway-started");
+        for (const [index, deviceIdentity] of identities.entries()) {
+          clients.push(
+            await connectTestGatewayClient({
+              url: instance.url,
+              token,
+              deviceIdentity,
+              caps: CODEX_HARNESS_CLIENT_CAPS,
+              timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
+              requestTimeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
+              ...(index === 0 ? { onEvent: (event) => gatewayEvents.push(event) } : {}),
+            }),
+          );
+        }
+        const [firstClient, secondClient] = clients;
+        if (!firstClient || !secondClient) {
+          throw new Error("missing paired steering clients");
+        }
+        logCodexLiveStep("cross-device-steering-clients-connected");
+        for (const mode of ["explicit", "inherited"] as const) {
+          const sessionKey = `agent:dev:live-codex-steering-${mode}`;
+          const runId = `steering-root-${randomUUID()}`;
+          const steerRunId = `steering-input-${randomUUID()}`;
+          const marker = `CODEX-STEER-${randomBytes(8).toString("hex").toUpperCase()}`;
+          const startedPath = path.join(workspace, `${mode}-started`);
+          const releasePath = path.join(workspace, `${mode}-release`);
+          const commandPath = path.join(workspace, `${mode}-wait.cjs`);
+          await fs.writeFile(
+            commandPath,
+            [
+              'const fs = require("node:fs");',
+              `fs.writeFileSync(${JSON.stringify(startedPath)}, "started");`,
+              "const deadline = Date.now() + 90000;",
+              "const timer = setInterval(() => {",
+              `  if (fs.existsSync(${JSON.stringify(releasePath)})) {`,
+              "    clearInterval(timer);",
+              '    console.log("STEERING-BARRIER-RELEASED");',
+              "  } else if (Date.now() > deadline) {",
+              '    console.error("steering barrier timed out");',
+              "    process.exit(1);",
+              "  }",
+              "}, 100);",
+            ].join("\n"),
+          );
+          const started = await firstClient.request<{ runId: string; status: string }>(
+            "chat.send",
+            {
+              sessionKey,
+              idempotencyKey: runId,
+              message: [
+                "This is a synthetic live steering test.",
+                `Run the native exec_command tool with command: node ${JSON.stringify(commandPath)}`,
+                "Use yield_time_ms=1000 for exec_command and every write_stdin poll. The test harness alone will create the release file.",
+                "Wait for the command to complete, polling its session as needed. Do not create or modify any files.",
+                "After the command finishes, reply exactly ORIGINAL-STEERING-REPLY unless a later user message changes the requested reply.",
+              ].join("\n"),
+            },
+          );
+          expect(started).toMatchObject({ runId, status: "started" });
+          logCodexLiveStep("cross-device-steering-root-ack", { mode });
+          await expect
+            .poll(
+              () =>
+                fs.access(startedPath).then(
+                  () => true,
+                  () => false,
+                ),
+              {
+                timeout: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
+                interval: 100,
+              },
+            )
+            .toBe(true);
+          logCodexLiveStep("cross-device-steering-command-started", { mode });
+          try {
+            const accepted = await secondClient.request<{ runId: string; status: string }>(
+              "chat.send",
+              {
+                sessionKey,
+                idempotencyKey: steerRunId,
+                message: `After the running command finishes, reply exactly ${marker} and nothing else. Keep waiting for the command; do not create or modify files.`,
+                ...(mode === "explicit" ? { queueMode: "steer" } : {}),
+              },
+            );
+            expect(accepted).toMatchObject({ runId: steerRunId, status: "started" });
+            logCodexLiveStep("cross-device-steering-steer-ack", { mode });
+            // The command yields, so Codex can consume steering while it remains active.
+            // An inherited-mode ACK precedes dispatch; releasing there races the old reply.
+            await expect
+              .poll(
+                async () => {
+                  const history = await firstClient.request<{ messages: unknown[] }>(
+                    "chat.history",
+                    {
+                      sessionKey,
+                      limit: 100,
+                    },
+                  );
+                  return history.messages
+                    .map(asOptionalRecord)
+                    .filter(
+                      (message) =>
+                        message?.role === "user" &&
+                        extractFirstTextBlock(message)?.includes(marker),
+                    )
+                    .map((message) => asOptionalRecord(message?.["__openclaw"])?.steerTargetRunId);
+                },
+                { timeout: 60_000, interval: 100 },
+              )
+              .toEqual([runId]);
+          } finally {
+            await fs.writeFile(releasePath, "release");
+          }
+          await waitForChatAgentRunOk(firstClient, runId);
+          const finalText = await waitForChatFinalText({
+            events: gatewayEvents,
+            runId,
+            timeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
+          });
+          expect(finalText.trim()).toBe(marker);
+          const nativeStarts = gatewayEvents.filter((event) => {
+            const payload = asOptionalRecord(event.payload);
+            return (
+              event.event === "agent" &&
+              payload?.sessionKey === sessionKey &&
+              payload.stream === "codex_app_server.lifecycle" &&
+              asOptionalRecord(payload.data)?.phase === "turn_starting"
+            );
+          });
+          expect(nativeStarts).toHaveLength(1);
+          logCodexLiveStep("cross-device-steering", { mode, sameTurn: true, consumedOnce: true });
+        }
+      } catch (error) {
+        console.error(instance.logs());
+        throw error;
+      } finally {
+        try {
+          await Promise.all(clients.map((client) => client.stopAndWait()));
+        } finally {
+          await instance.cleanup();
+        }
+      }
+    },
+    CODEX_HARNESS_TIMEOUT_MS,
+  );
+
   it.skipIf(CODEX_HARNESS_AUTH_MODE !== "api-key")(
     "forks a supervised canonical message and continues its cold descendant on the native model",
     async () => {

--- a/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
@@ -381,7 +381,9 @@ suite.define(() => {
       });
       await gateway.resolveDeferred("chat.startup");
       await expect.poll(() => metadataRequested).toBe(true);
-      expect(await page.locator(".chat-notice").count()).toBe(0);
+      await expect
+        .poll(async () => (await page.locator(".chat-notice").textContent())?.trim())
+        .toBe("Queued · waiting for the agent");
       const working = page.locator('.chat-working-indicator[role="status"]');
       await pollLocatorText(working).toContain("Preparing workspace…");
       if (artifactDir) {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5646,6 +5646,7 @@ export const en: TranslationMap & {
         "Use arrow keys or Home and End to choose a marker, Enter or Space to jump, and Escape to return to the conversation. Tab leaves the rail.",
     },
     pendingInputs: {
+      waitingForAgent: "Queued · waiting for the agent",
       waitingForWorkspaceSync: "Received · waiting for workspace sync",
       waitingForWorkerSetup: "Received · waiting for worker setup",
       resuming:

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -124,7 +124,7 @@ describe("server-owned pending input display", () => {
   });
 
   it.each([
-    { state: "queued", runId: undefined, notice: undefined },
+    { state: "queued", runId: undefined, notice: "Queued · waiting for the agent" },
     {
       state: "interrupted",
       runId: "run-queued",
@@ -919,14 +919,14 @@ describe("server-owned pending input display", () => {
     });
   });
 
-  it("places accepted input at its acceptance time instead of after newer history", () => {
+  it("labels unconsumed input as queued between its acceptance time and later output", () => {
     const earlier = { role: "assistant", content: "Earlier reply", timestamp: 50 };
     const later = { role: "assistant", content: "Later reply", timestamp: 150 };
     const items = buildChatItems({
       paneId: "chronological-pending-pane",
       sessionKey,
       messages: [earlier, later],
-      pendingInputs: page.items,
+      pendingInputs: [{ ...input, state: "queued" }],
       queue: [],
       toolMessages: [],
       streamSegments: [],
@@ -942,7 +942,11 @@ describe("server-owned pending input display", () => {
         role: "user",
         messages: [{ message: { content: "Keep my accepted input" } }],
       },
-      { kind: "notice", timestamp: input.acceptedAt },
+      {
+        kind: "notice",
+        timestamp: input.acceptedAt,
+        text: "Queued · waiting for the agent",
+      },
       { kind: "group", role: "assistant", messages: [{ message: later }] },
     ]);
   });

--- a/ui/src/pages/chat/chat-pending-inputs.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.ts
@@ -55,18 +55,18 @@ export function buildPendingInputItems(
       ),
     );
     if (input.state === "queued") {
-      if (input.runId && (workerSetupPending || workspaceSyncPendingRunIds.includes(input.runId))) {
-        items.push({
-          kind: "notice",
-          key: `pending-input:${input.id}:workspace-sync`,
-          timestamp: input.acceptedAt,
-          text: t(
-            workerSetupPending
+      items.push({
+        kind: "notice",
+        key: `pending-input:${input.id}:state`,
+        timestamp: input.acceptedAt,
+        text: t(
+          input.runId && (workerSetupPending || workspaceSyncPendingRunIds.includes(input.runId))
+            ? workerSetupPending
               ? "chat.pendingInputs.waitingForWorkerSetup"
-              : "chat.pendingInputs.waitingForWorkspaceSync",
-          ),
-        });
-      }
+              : "chat.pendingInputs.waitingForWorkspaceSync"
+            : "chat.pendingInputs.waitingForAgent",
+        ),
+      });
       continue;
     }
     items.push({

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -176,8 +176,12 @@ it("invalidates cached custody notices when workspace sync ownership changes", (
   });
   const active = buildCachedChatItems(input);
 
-  expect(waiting.some((item) => item.kind === "notice")).toBe(true);
-  expect(active.some((item) => item.kind === "notice")).toBe(false);
+  expect(waiting.filter((item) => item.kind === "notice").map((item) => item.text)).toEqual([
+    "Received · waiting for workspace sync",
+  ]);
+  expect(active.filter((item) => item.kind === "notice").map((item) => item.text)).toEqual([
+    "Queued · waiting for the agent",
+  ]);
 });
 
 function queuedSend(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users steering an active shared session from another browser would have their messages queued until the run ended, even when their tool permissions matched. The Control UI displayed those waiting messages as ordinary chat bubbles, making it appear that the agent had read and ignored them.

## Why This Change Was Made

Compare tool permissions independently of the approval-reviewer device identity. The running turn retains its original approval destination; permission modes, execution policy, elevation, workspace, client capabilities, concrete tool bindings, and live-owner checks still apply. Both explicit and inherited steering use this owner. Separately executed collected turns retain their existing reviewer partitioning.

The Control UI now labels accepted but unconsumed input **Queued · waiting for the agent**, while preserving the more specific worker-setup and workspace-sync notices. This follows Codex's [same-turn steering contract](https://github.com/openai/codex/blob/da20788df913189878ebca7f4963d8a363ee6bf2/codex-rs/core/src/session/turn_input.rs#L576): input joins the active turn without replacing its execution settings.

## User Impact

Authorized participants with matching permissions can redirect the running agent from another browser. Messages that must wait are visibly identified, and steering does not transfer approval ownership or grant additional tool access.

## Evidence

- Before the fix, three cross-device regression cases failed with rejected or missing backend delivery. Same-device controls and eight substantive policy-mismatch cases passed.
- After the fix, **651 tests passed** across nine selected steering, approval-routing, collected-turn, and UI files.
- **Five new-session browser E2E cases passed**, retaining exact queued-status, workspace-progress, attachment-continuity, and single-submission checks. CI identified an old zero-notice assertion; it now checks the intended label.
- **Four session-link browser tests passed** after repairing the fixture stylesheet dependency. That repair landed independently in #144690 and is no longer part of this diff.
- **Six memory temporal-ranking tests passed** after repairing the FTS-unavailable fixture. Main now owns this repair through #144761 and subsequent memory work; it is no longer part of this diff.
- **Live OpenAI API-key proof passed** using `openai/gpt-5.6-luna` and the real built Gateway plus the pinned Codex app-server. Two independently paired devices exercised explicit and inherited steering. Each case confirmed exactly one canonical user message with the original run's consumption marker, the exact requested final reply, and a single native turn.
- The live fixture holds a yielding native command until consumption is confirmed, then releases it; send acknowledgment alone cannot satisfy the test. Both cases passed with unchanged timeouts and no retry logic, using an empty source home and only the requested API key.
- A new-main daemon-install test exceeded its executable-line lint limit by one line. A semantics-preserving mock-factory simplification passed all **42 daemon-install tests**, targeted lint, formatting, and independent review. Main subsequently split the fixture in #145113; that supersedes our temporary correction, which is no longer in this diff.
- The pre-rebase real-Gateway job passed 45/46 cases, with one startup timeout waiting for the Send button before any submission. All three approval/delegation cases passed unchanged against a fresh local build. Its targeted rerun was superseded by the required conflict rebase. No timeouts, assertions, or retry logic changed.
- Final-head CI: https://github.com/openclaw/openclaw/actions/runs/34633810879. The final conflict rebase preserves both remaining patches exactly, confirmed by range-diff.
- `pnpm build` and `node scripts/check-changed.mjs` passed; changed checks also passed after the conflict rebase. Independent review found no actionable P0/P1 findings.

The before/after captures below use synthetic conversation data. No live user transcript or credentials are included.

![Before: queued input looks delivered](https://github.com/user-attachments/assets/98da7df1-f71c-4cc5-b6f6-b014c60c6dbe)

![After: queued input is visibly labeled](https://github.com/user-attachments/assets/7516257d-53ed-428f-83d3-9dc48005a2e9)
Landing note: the maintainer explicitly waived the additional local ClawSweeper completion gate for this PR because the review queue was stalled. Normal GitHub checks remain required. The recovered ClawSweeper service subsequently completed this PR review with no actionable findings.
