### PR TITLE
feat(ui): trace the run arc around collaborative session avatars

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -2025,6 +2025,28 @@ async function createChatPickerScenario(
       status: "failed",
       lastRunError: "Model access expired: openai/gpt-5-mini",
     }),
+    // Running rows with participants exercise the collaborative orbit in the lead slot.
+    sessionRow("agent:main:release-prep", "Release 2026.9.4 preparation", baseTime - 82_000, {
+      createdActor: MOCK_ACTOR_PETER,
+      execCwd: "/Users/demo/Work/openclaw",
+      hasActiveRun: true,
+      owner: { actor: MOCK_ACTOR_PETER },
+      participantCount: 1,
+      participants: [{ identity: { type: "profile", id: "profile-mira" }, label: "Mira" }],
+      status: "running",
+    }),
+    sessionRow("agent:main:release-notes", "Release notes review", baseTime - 83_000, {
+      createdActor: MOCK_ACTOR_MIRA,
+      execCwd: "/Users/demo/Work/openclaw",
+      hasActiveRun: true,
+      owner: { actor: MOCK_ACTOR_MIRA },
+      participantCount: 2,
+      participants: [
+        { identity: { type: "profile", id: "profile-riley" }, label: "Riley" },
+        { identity: { type: "profile", id: "profile-sam" }, label: "Sam" },
+      ],
+      status: "running",
+    }),
     sessionRow("agent:main:work-openclaw", "OpenClaw work checkout", baseTime - 85_000, {
       createdActor: MOCK_ACTOR_PETER,
       execCwd: "/Users/demo/Work/openclaw",

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -2025,7 +2025,7 @@ async function createChatPickerScenario(
       status: "failed",
       lastRunError: "Model access expired: openai/gpt-5-mini",
     }),
-    // Running rows with participants exercise the collaborative orbit in the lead slot.
+    // Running rows with participants exercise the paired run trace in the lead slot.
     sessionRow("agent:main:release-prep", "Release 2026.9.4 preparation", baseTime - 82_000, {
       createdActor: MOCK_ACTOR_PETER,
       execCwd: "/Users/demo/Work/openclaw",

--- a/ui/src/components/session-glyph.ts
+++ b/ui/src/components/session-glyph.ts
@@ -3,6 +3,34 @@ import { t } from "../i18n/index.ts";
 
 type SessionGlyphContent = TemplateResult | typeof nothing;
 
+/** Run-state shape: a circle around one face, or a trace around the owner stack's pair. */
+export type SessionGlyphRing = "circle" | "pair";
+
+// Union outline of the two-identity owner stack, 2px outside its 18px faces:
+// radius-11 circles at x = ±5 around the glyph center (see .session-owner-stack
+// in components.css); the cusps sit at x = 0, y = ±sqrt(11² − 5²).
+const PAIR_TRACE_PATH = "M0,-9.798A11,11 0 1 1 0,9.798A11,11 0 1 1 0,-9.798Z";
+
+function renderRunRing(ring: SessionGlyphRing, queued: boolean): TemplateResult {
+  const label = t(queued ? "sessionsView.statusQueued" : "sessionsView.activeRun");
+  if (ring === "pair") {
+    return html`<svg
+      class="session-glyph__trace${queued ? " session-glyph__trace--queued" : ""}"
+      viewBox="-16 -11 32 22"
+      role="img"
+      aria-label=${label}
+    >
+      <path class="session-glyph__trace-track" d=${PAIR_TRACE_PATH}></path>
+      <path class="session-glyph__trace-run" d=${PAIR_TRACE_PATH} pathLength="100"></path>
+    </svg>`;
+  }
+  return html`<span
+    class="session-glyph__ring${queued ? " session-glyph__ring--queued" : ""}"
+    role="img"
+    aria-label=${label}
+  ></span>`;
+}
+
 /**
  * Persistent artwork in the sidebar's leading slot (owner avatar, page icon,
  * attention glyph). Callers can carry run state as a ring when that surface
@@ -16,23 +44,22 @@ export function renderSessionGlyph(options: {
   queued?: boolean;
   circular?: boolean;
   badge?: SessionGlyphContent;
+  ring?: SessionGlyphRing;
 }): TemplateResult {
-  const { content, running, queued = false, circular = false, badge = nothing } = options;
+  const {
+    content,
+    running,
+    queued = false,
+    circular = false,
+    badge = nothing,
+    ring = "circle",
+  } = options;
   // A glyph-less row still owns its run state in the lead slot; the bare
   // modifier lets CSS draw a compact ring there instead of a 24px empty circle.
   const modifiers = `${circular ? " session-glyph--circular" : ""}${running ? " session-glyph--running" : ""}${content === nothing ? " session-glyph--bare" : ""}`;
   return html`<span class="session-glyph${modifiers}">
     <span class="session-glyph__content">${content}</span>
-    ${
-      running
-        ? html`<span
-            class="session-glyph__ring${queued ? " session-glyph__ring--queued" : ""}"
-            role="img"
-            aria-label=${t(queued ? "sessionsView.statusQueued" : "sessionsView.activeRun")}
-          ></span>`
-        : nothing
-    }
-    ${badge}
+    ${running ? renderRunRing(ring, queued) : nothing} ${badge}
   </span>`;
 }
 

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -155,6 +155,9 @@ export function renderSessionLeadingState(
     };
   }
   if (ownerChip) {
+    // The chip stacks a second face (or +N) behind the owner whenever anyone
+    // else participates; the run state then traces that pair instead of a circle.
+    const stackedParticipants = participantCount ?? participants?.length ?? 0;
     return {
       running,
       leadingIndicator: renderSessionGlyph({
@@ -163,11 +166,12 @@ export function renderSessionLeadingState(
         queued,
         badge: session.unread && !session.hasActiveRun ? renderSessionUnreadBadge() : nothing,
         circular: true,
+        ring: stackedParticipants > 0 ? "pair" : "circle",
       }),
       // Exclude only visible avatars; a +N stack still needs individual live viewers.
       renderedIdentities: [
         ...(ownerActor?.identity ? [ownerActor.identity] : []),
-        ...((participantCount ?? participants?.length) === 1
+        ...(stackedParticipants === 1
           ? (participants ?? []).slice(0, 1).map((participant) => participant.identity)
           : []),
       ],

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -208,55 +208,6 @@ openclaw-session-owner-chip {
   height: 18px;
 }
 
-/* Two identities on one running row orbit each other in a shallow 3D circle:
-   perspective scales the nearer face up and the farther face down. Only the
-   run state animates; the rest pose stays untransformed so idle geometry is
-   exact. Each face starts from its own slot: --orbit-rest recenters it and
-   --orbit-phase places it on the circle where that slot already sits. */
-.session-glyph--running .session-owner-stack {
-  perspective: 44px;
-  transform-style: preserve-3d;
-}
-
-.session-glyph--running .session-owner-stack__back,
-.session-glyph--running .session-owner-stack__front {
-  animation: session-owner-orbit 3.2s linear infinite;
-}
-
-.session-glyph--running .session-owner-stack__back {
-  --orbit-rest: 5px;
-  --orbit-phase: 270deg;
-}
-
-.session-glyph--running .session-owner-stack__front {
-  --orbit-rest: -5px;
-  --orbit-phase: 90deg;
-}
-
-.session-glyph:has(.session-glyph__ring--queued) .session-owner-stack__back,
-.session-glyph:has(.session-glyph__ring--queued) .session-owner-stack__front {
-  animation-play-state: paused;
-}
-
-@keyframes session-owner-orbit {
-  from {
-    transform: translateX(var(--orbit-rest)) rotateY(var(--orbit-phase)) translateZ(5px)
-      rotateY(calc(-1 * var(--orbit-phase)));
-  }
-
-  to {
-    transform: translateX(var(--orbit-rest)) rotateY(calc(var(--orbit-phase) + 360deg))
-      translateZ(5px) rotateY(calc(-1 * var(--orbit-phase) - 360deg));
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .session-glyph--running .session-owner-stack__back,
-  .session-glyph--running .session-owner-stack__front {
-    animation: none;
-  }
-}
-
 /* Leading slot shared by every sidebar row: the row's own artwork plus a run
    ring and corner badge, so run state always reads at the row's left edge. */
 .session-glyph {
@@ -332,6 +283,37 @@ openclaw-session-owner-chip {
    slot used to draw; a full-size empty circle reads as a missing icon. */
 .session-glyph--bare .session-glyph__ring {
   inset: 4px;
+}
+
+/* Two identities share one run: the arc traces the union outline of the owner
+   stack's pair instead of a circle. Sized to .session-owner-stack (18px faces
+   at ±5px around the glyph center) plus the ring's 2px gap. */
+.session-glyph__trace {
+  position: absolute;
+  top: -1px;
+  left: -6px;
+  width: 32px;
+  height: 22px;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.session-glyph__trace path {
+  fill: none;
+  stroke-width: 1.5;
+}
+
+.session-glyph__trace-track {
+  stroke: color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+/* The arc covers the same share of its outline as the ring's quarter turn and
+   moves at the ring's linear speed (~45px/s). */
+.session-glyph__trace-run {
+  stroke: var(--accent);
+  stroke-linecap: round;
+  stroke-dasharray: 25 75;
+  animation: session-run-trace 2s linear infinite;
 }
 
 .session-glyph__badge {
@@ -6040,7 +6022,8 @@ td.data-table-key-col {
   animation: session-run-spin 1.6s linear infinite;
 }
 
-.session-glyph__ring--queued {
+.session-glyph__ring--queued,
+.session-glyph__trace--queued .session-glyph__trace-run {
   animation-play-state: paused;
 }
 
@@ -6050,11 +6033,25 @@ td.data-table-key-col {
   }
 }
 
+@keyframes session-run-trace {
+  to {
+    stroke-dashoffset: -100;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .session-run-spinner,
   .session-glyph__ring {
     animation: none;
     border-color: var(--accent);
+  }
+
+  .session-glyph__trace-run {
+    display: none;
+  }
+
+  .session-glyph__trace-track {
+    stroke: var(--accent);
   }
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -208,6 +208,55 @@ openclaw-session-owner-chip {
   height: 18px;
 }
 
+/* Two identities on one running row orbit each other in a shallow 3D circle:
+   perspective scales the nearer face up and the farther face down. Only the
+   run state animates; the rest pose stays untransformed so idle geometry is
+   exact. Each face starts from its own slot: --orbit-rest recenters it and
+   --orbit-phase places it on the circle where that slot already sits. */
+.session-glyph--running .session-owner-stack {
+  perspective: 44px;
+  transform-style: preserve-3d;
+}
+
+.session-glyph--running .session-owner-stack__back,
+.session-glyph--running .session-owner-stack__front {
+  animation: session-owner-orbit 3.2s linear infinite;
+}
+
+.session-glyph--running .session-owner-stack__back {
+  --orbit-rest: 5px;
+  --orbit-phase: 270deg;
+}
+
+.session-glyph--running .session-owner-stack__front {
+  --orbit-rest: -5px;
+  --orbit-phase: 90deg;
+}
+
+.session-glyph:has(.session-glyph__ring--queued) .session-owner-stack__back,
+.session-glyph:has(.session-glyph__ring--queued) .session-owner-stack__front {
+  animation-play-state: paused;
+}
+
+@keyframes session-owner-orbit {
+  from {
+    transform: translateX(var(--orbit-rest)) rotateY(var(--orbit-phase)) translateZ(5px)
+      rotateY(calc(-1 * var(--orbit-phase)));
+  }
+
+  to {
+    transform: translateX(var(--orbit-rest)) rotateY(calc(var(--orbit-phase) + 360deg))
+      translateZ(5px) rotateY(calc(-1 * var(--orbit-phase) - 360deg));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-glyph--running .session-owner-stack__back,
+  .session-glyph--running .session-owner-stack__front {
+    animation: none;
+  }
+}
+
 /* Leading slot shared by every sidebar row: the row's own artwork plus a run
    ring and corner badge, so run state always reads at the row's left edge. */
 .session-glyph {

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -342,6 +342,43 @@ describe("AppSidebar session ownership", () => {
     expect(harness.list).toHaveBeenCalledWith(expect.objectContaining({ involvingMe: true }));
   });
 
+  it("traces the run around a stacked owner row and rings a solo owner row", async () => {
+    const gateway = createGatewayHarness({} as GatewayBrowserClient);
+    const harness = createSessionsHarness("main", [
+      "agent:main:main",
+      "agent:main:solo",
+      "agent:main:collab",
+    ]);
+    const result = harness.sessions.state.result!;
+    const solo = result.sessions.find((row) => row.key.endsWith(":solo"))!;
+    const collab = result.sessions.find((row) => row.key.endsWith(":collab"))!;
+    setEffectiveOwner(solo, { type: "human", id: "profile-ada", label: "Ada" });
+    setEffectiveOwner(collab, { type: "human", id: "profile-ada", label: "Ada" });
+    collab.participants = [{ identity: { type: "profile", id: "profile-bob" }, label: "Bob" }];
+    collab.participantCount = 1;
+    for (const row of [solo, collab]) {
+      row.hasActiveRun = true;
+      row.status = "running";
+    }
+    result.owners = [
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
+    ];
+    const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
+    harness.publishList({ result, agentId: "main" });
+    await sidebar.updateComplete;
+    const soloRow = sidebar.querySelector('[data-session-key="agent:main:solo"]')!;
+    const collabRow = sidebar.querySelector('[data-session-key="agent:main:collab"]')!;
+    expect(soloRow.querySelector(".session-glyph__ring")).not.toBeNull();
+    expect(soloRow.querySelector(".session-glyph__trace")).toBeNull();
+    expect(collabRow.querySelector(".session-glyph__ring")).toBeNull();
+    const trace = collabRow.querySelector(".session-glyph__trace");
+    expect(trace?.getAttribute("aria-label")).toBe("Active run");
+    expect(trace?.querySelector(".session-glyph__trace-run")?.getAttribute("pathLength")).toBe(
+      "100",
+    );
+  });
+
   it.each([
     ["peeking participant", 1, undefined, true, ["profile-carol"]],
     ["implicit participant count", undefined, undefined, true, ["profile-carol"]],


### PR DESCRIPTION
## What Problem This Solves

Sidebar rows for sessions with an owner plus participants show a two-face stack in the lead slot (owner in front, the participant or a "+N" bubble behind). While such a session was running, the run indicator was still the single-face ring: a 24px circle around the slot center that cut through the 28px stack and read as one identity working, not two.

## Why This Change Was Made

The glyph now takes a run-ring shape. For the stacked pair it renders a small inline SVG whose path is the union outline of the two faces (radius-11 circles at ±5px around the slot center, the same 2px gap the ring keeps around a single face). A faint track shows the whole outline and a quarter-length accent arc flows along it at the ring's linear speed, dipping through the cusps between the faces. Single-face rows keep the untouched round ring; queued runs pause the arc and reduced motion draws the outline solid, mirroring the ring's rules. The faces themselves stay static. Idle geometry is unchanged. The mock dev scenario gains two running collaborative rows so the state is reachable in `pnpm dev:ui:mock`.

An earlier commit on this branch prototyped a CSS 3D orbit of the two faces; it is replaced by this trace and does not survive the squash.

## User Impact

A running collaborative session now shows one run arc wrapping both identities, so the lead slot reads as "these two are working on this run" instead of an oddly placed ring. Solo sessions look exactly as before.

## Evidence

Mocked Control UI (`pnpm dev:ui:mock`, fixture data only), captured at 3× with Playwright.

Before (round ring on the two-face stack) and after (three phases of the trace), dark theme:

![Before: round ring around the two-face stack](https://github.com/user-attachments/assets/948d3ab4-9a20-46be-92d6-de8f2f9306f2)

![After: trace flowing around the union outline, three phases](https://github.com/user-attachments/assets/29cd9f38-f6c6-4ac3-bec4-bb15eb1dfafb)

One full cycle:

![Trace animation, one cycle](https://github.com/user-attachments/assets/b537b635-2e99-4050-b8bf-dc54d5b361f9)

Light theme, before and after:

![Before, light theme](https://github.com/user-attachments/assets/cacc4ed2-586f-4291-aa39-de711a72bc2d)

![After, light theme, three phases](https://github.com/user-attachments/assets/40613c5a-cffb-4989-b22f-5326a72afe52)

- WebKit (Playwright `webkit`) renders the trace identically to Chromium; reduced motion yields identical frames with a solid outline.
- New sidebar unit case asserts the pair trace on a running stacked row and the round ring on a running solo row; `app-sidebar.test.ts` + `session-owner-chip.test.ts` pass (358 tests).
- `session-ownership.e2e.test.ts` (pinned idle stack geometry) and `session-management.queue.e2e.test.ts` (ring aria-label, `session-run-spin`, queued play state) pass (15 tests).
- stylelint, oxfmt, and the UI tsgo lane are clean; Codex autoreview (P2 threshold) reported no findings.

Known gap: three or more identities still collapse to owner + "+N" (the trace wraps that bubble). Showing three actual faces in a cluster is a separate owner-chip layout change.
