### PR TITLE
fix: attribute slow worktree cleanup

### DIFF
--- a/docs/gateway/diagnostics.md
+++ b/docs/gateway/diagnostics.md
@@ -148,6 +148,18 @@ keys. Repeated stage visits contribute to the counts and totals. Parallel and
 nested stages can overlap, so their totals are neither an exclusive breakdown
 of request time nor CPU measurements.
 
+Two related info-level records help attribute slow worktree cleanup:
+`slow managed worktree removal` separates allocation admission, callback work,
+and final settlement; `slow Git ref mutation` separates directory resolution,
+queue waiting, and queued work. Both require diagnostics and info-level logging,
+emit only after an operation lasting at least one second settles, and have
+separate fixed budgets of 60 records per minute per runtime isolate with
+`omittedObservations` counts. They retain fixed scalar fields and existing traces,
+without adding private paths or new identities. Their elapsed intervals can nest
+inside `worktreeCleanup` and include asynchronous waits; they are not CPU or
+individual child-command timings. See [Slow worktree cleanup](/logging#slow-worktree-cleanup)
+for fields and missing-record limits.
+
 SQLite session-write warnings also separate `queueWaitMs`, `writerExecutionMs`,
 and `completionDelayMs`. These measure time until the writer starts, work and
 awaits inside the writer lane, and time until its caller resumes after execution.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -332,6 +332,48 @@ for the entire wait or which work consumed CPU. These are ordinary performance
 logs. They do not use or change [audit identity](/gateway/audit), decisions,
 retention, principal attribution or admission authority.
 
+### Slow worktree cleanup
+
+With process diagnostics and info-level logging enabled, two subsystems log
+operations lasting at least one second after they return or throw:
+
+- `agents/worktrees`: `slow managed worktree removal` measures removal through
+  allocation-lease settlement. `admissionMs` covers acquisition attempts,
+  backoff, setup, and scheduling before the removal callback starts. `bodyMs`
+  covers that callback; `finalizeMs` covers drainage, final authority checks,
+  lease release, and completion delivery. Create and restore operations do not
+  emit this record.
+- `git/ref-mutation`: `slow Git ref mutation` measures shared Git-ref queue
+  operations. `resolveMs` covers common-directory resolution; `queueWaitMs`
+  covers time from enqueue to callback entry; `queuedOperationMs` covers the
+  callback and delivery of its settlement. It can include multiple Git commands
+  and does not identify a queue holder or every predecessor.
+
+Both records include `durationMs` in integer milliseconds, `callbackEntered`, and
+`outcome` (`returned` or `threw`). Removal that never enters its callback reports
+all elapsed time as `admissionMs` and omits `bodyMs` and `finalizeMs`. Git directory
+resolution failure reports `resolveMs` and omits unreached queue and operation
+durations. Phase durations partition each record's interval before rounding.
+These intervals include asynchronous waits: admission is not pure lock wait,
+and queued operation time is not child-process CPU time. They nest within
+broader operations such as session-patch `worktreeCleanup`; do not add nested
+durations to the enclosing total.
+
+Each subsystem has a separate fixed budget of 60 records per 60-second window
+per JavaScript runtime isolate. Bursts across window boundaries remain possible.
+`omittedObservations` reports suppressed records on the next emitted record,
+then resets. Pending operations emit nothing until they settle; disabled
+diagnostics, log levels, thresholds, and budgets can also leave no record.
+Missing records never prove there was no delay.
+
+The added fields are fixed scalar timings, outcomes, counts, `pid`, `threadId`,
+and `isMainThread`. They omit repository paths, refs, arguments, raw errors, and
+command output. Records preserve an existing valid diagnostic trace when
+available; they create no trace, operation identity, or private-identity hash.
+Use the trace to associate nested records, without treating elapsed time as CPU
+attribution. These diagnostics measure cleanup without changing its ordering or
+completion behavior.
+
 ### Slow agent database opens
 
 The `slow OpenClaw agent database open` warning includes `phaseDurationsMs` when

--- a/src/agents/worktrees/service.diagnostics.test.ts
+++ b/src/agents/worktrees/service.diagnostics.test.ts
@@ -2,13 +2,31 @@ import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { promisify } from "node:util";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isMainThread, threadId } from "node:worker_threads";
+import { Logger } from "tslog";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  areDiagnosticsEnabledForProcess,
+  onInternalDiagnosticEvent,
+  setDiagnosticsEnabledForProcess,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
+import { runWithDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
+import { flushLogger, resetLogger, setLoggerOverride } from "../../logging/logger.js";
 import * as commandExec from "../../process/exec.js";
 import type { SpawnResult } from "../../process/exec.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import * as stateLease from "../../state/openclaw-state-lease.js";
 import { ManagedWorktreeService } from "./service.js";
-import { useManagedWorktreeTestRepository } from "./service.test-support.js";
+import {
+  materializeManagedWorktreeFixture,
+  useManagedWorktreeTestRepository,
+} from "./service.test-support.js";
 
 const execFileAsync = promisify(execFile);
 const realRunCommand = commandExec.runCommandWithTimeout;
@@ -280,5 +298,305 @@ describe("ManagedWorktreeService failure diagnostics", () => {
     expect(allocatedPath).toBeDefined();
     expect(await git(repo, "worktree", "list", "--porcelain")).toContain(allocatedPath);
     expect(await git(allocatedPath!, "branch", "--show-current")).toBe(branch);
+  });
+});
+
+describe("ManagedWorktreeService removal timing", { concurrent: false }, () => {
+  const initializeRepository = useManagedWorktreeTestRepository();
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  const trace = {
+    traceId: "1234567890abcdef1234567890abcdef",
+    spanId: "1234567890abcdef",
+    parentSpanId: "abcdef1234567890",
+    traceFlags: "01",
+  };
+  const leaseContext: stateLease.OpenClawStateLeaseContext = {
+    signal: new AbortController().signal,
+    assertOwned: () => {},
+    assertOwnedInTransaction: () => {},
+  };
+  const identityFields = {
+    subsystem: "agents/worktrees",
+    pid: process.pid,
+    threadId,
+    isMainThread,
+  };
+  let clock = 120_000;
+  let clockSpy: MockInstance<() => number>;
+  let root: string;
+  let logFile: string;
+  let service: ManagedWorktreeService;
+  let diagnosticsWereEnabled: boolean;
+  let unsubscribe: () => void;
+  let records: Array<Extract<DiagnosticEventPayload, { type: "log.record" }>>;
+
+  beforeEach(() => {
+    root = tempDirs.make("openclaw-removal-timing-");
+    logFile = path.join(root, "runtime.log");
+    service = new ManagedWorktreeService({
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "private-state") },
+    });
+    diagnosticsWereEnabled = areDiagnosticsEnabledForProcess();
+    setDiagnosticsEnabledForProcess(true);
+    resetLogger();
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file: logFile });
+    clock += 120_000;
+    clockSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    records = [];
+    unsubscribe = onInternalDiagnosticEvent(
+      (event) => {
+        if (event.type === "log.record" && event.message === "slow managed worktree removal") {
+          records.push(event);
+        }
+      },
+      { include: ["log.record"] },
+    );
+  });
+
+  afterEach(async () => {
+    await waitForDiagnosticEventsDrained();
+    unsubscribe();
+    await flushLogger();
+    vi.restoreAllMocks();
+    closeOpenClawStateDatabaseForTest();
+    setDiagnosticsEnabledForProcess(diagnosticsWereEnabled);
+    setLoggerOverride(null);
+    resetLogger();
+  });
+
+  it.each([false, true])(
+    "attributes admission, body and finalization without completing early (logger fails=%s)",
+    async (loggerFails) => {
+      const repo = await initializeRepository(root);
+      const stateDir = path.join(root, "private-state");
+      const worktree = await materializeManagedWorktreeFixture({
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        stateDir,
+        repoRoot: repo,
+        name: "private-removal",
+        now: Date.now(),
+      });
+      const admissionEntered = createDeferredCore();
+      const releaseAdmission = createDeferredCore();
+      const bodyEntered = createDeferredCore();
+      const releaseBody = createDeferredCore();
+      const finalizeEntered = createDeferredCore();
+      const releaseFinalize = createDeferredCore();
+      let callbackResult: unknown;
+      vi.spyOn(stateLease, "withOpenClawStateLease").mockImplementation(async (_options, run) => {
+        admissionEntered.resolve();
+        await releaseAdmission.promise;
+        const result = await run(leaseContext);
+        callbackResult = result;
+        finalizeEntered.resolve();
+        await releaseFinalize.promise;
+        return result;
+      });
+      vi.spyOn(commandExec, "runCommandWithTimeout").mockImplementationOnce(async (...args) => {
+        bodyEntered.resolve();
+        await releaseBody.promise;
+        return await realRunCommand(...args);
+      });
+      let completed = false;
+      const pending = runWithDiagnosticTraceContext(trace, () =>
+        service.remove({ id: worktree.id, reason: "private-removal-reason" }),
+      ).then((result) => {
+        completed = true;
+        return result;
+      });
+      try {
+        await Promise.race([admissionEntered.promise, pending]);
+        clock += 1_100;
+        releaseAdmission.resolve();
+        await Promise.race([bodyEntered.promise, pending]);
+        clock += 200;
+        releaseBody.resolve();
+        await Promise.race([finalizeEntered.promise, pending]);
+        await waitForDiagnosticEventsDrained();
+        expect(completed).toBe(false);
+        expect(records).toEqual([]);
+        const failedLogger = loggerFails
+          ? vi.spyOn(Logger.prototype, "info").mockImplementation(() => {
+              throw new Error("diagnostic logger unavailable");
+            })
+          : undefined;
+        clock += 300;
+        releaseFinalize.resolve();
+        const result = await pending;
+        expect(result).toBe(callbackResult);
+        expect(result.removed).toBe(true);
+        await waitForDiagnosticEventsDrained();
+        if (failedLogger) {
+          expect(failedLogger).toHaveBeenCalled();
+        } else {
+          expect(records).toHaveLength(1);
+          expect(records[0]?.trace).toEqual(trace);
+          expect(records[0]?.attributes).toEqual({
+            ...identityFields,
+            durationMs: 1_600,
+            admissionMs: 1_100,
+            bodyMs: 200,
+            finalizeMs: 300,
+            callbackEntered: true,
+            outcome: "returned",
+            omittedObservations: expect.any(Number),
+          });
+        }
+      } finally {
+        releaseAdmission.resolve();
+        releaseBody.resolve();
+        releaseFinalize.resolve();
+        await Promise.allSettled([pending]);
+      }
+    },
+  );
+
+  it("reports only reached phases at the slow threshold without retaining private input or inventing a trace", async () => {
+    const operationError = new Error("private repository /private/source failed for private-owner");
+    const failBeforeEntry = async (duration: number) => {
+      vi.spyOn(stateLease, "withOpenClawStateLease").mockImplementationOnce(async () => {
+        clock += duration;
+        throw operationError;
+      });
+      await expect(
+        service.remove({ id: "private-worktree-id", reason: "private-removal-reason" }),
+      ).rejects.toBe(operationError);
+      await waitForDiagnosticEventsDrained();
+    };
+    await runWithDiagnosticTraceContext(undefined, async () => {
+      await failBeforeEntry(999);
+      expect(records).toEqual([]);
+      await failBeforeEntry(1_000);
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0]?.trace).toBeUndefined();
+    expect(records[0]?.attributes).toEqual({
+      ...identityFields,
+      durationMs: 1_000,
+      admissionMs: 1_000,
+      callbackEntered: false,
+      outcome: "threw",
+      omittedObservations: expect.any(Number),
+    });
+  });
+
+  it.each([false, true])(
+    "preserves body errors through finalization (logger fails=%s)",
+    async (loggerFails) => {
+      const operationError = new Error("private owner authority expired");
+      vi.spyOn(stateLease, "withOpenClawStateLease").mockImplementation(async (_options, run) => {
+        clock += 400;
+        try {
+          return await run(leaseContext);
+        } finally {
+          clock += 250;
+        }
+      });
+      const failedLogger = loggerFails
+        ? vi.spyOn(Logger.prototype, "info").mockImplementation(() => {
+            throw new Error("diagnostic logger unavailable");
+          })
+        : undefined;
+      await expect(
+        service.remove({
+          id: "private-worktree-id",
+          reason: "private-removal-reason",
+          commitGuard: () => {
+            clock += 350;
+            throw operationError;
+          },
+        }),
+      ).rejects.toBe(operationError);
+      await waitForDiagnosticEventsDrained();
+      if (failedLogger) {
+        expect(failedLogger).toHaveBeenCalled();
+      } else {
+        expect(records).toHaveLength(1);
+        expect(records[0]?.attributes).toMatchObject({
+          durationMs: 1_000,
+          admissionMs: 400,
+          bodyMs: 350,
+          finalizeMs: 250,
+          callbackEntered: true,
+          outcome: "threw",
+        });
+      }
+    },
+  );
+
+  it.each(["diagnostics", "info logger"] as const)(
+    "checks %s at entry and settlement without timing a disabled call",
+    async (gate) => {
+      const setGate = (enabled: boolean) => {
+        if (gate === "diagnostics") {
+          setDiagnosticsEnabledForProcess(enabled);
+        } else {
+          setLoggerOverride({
+            level: enabled ? "info" : "warn",
+            consoleLevel: "silent",
+            file: logFile,
+          });
+        }
+      };
+      const operationError = new Error("lease acquisition failed");
+      setGate(false);
+      vi.spyOn(stateLease, "withOpenClawStateLease").mockImplementationOnce(async () => {
+        setGate(true);
+        clock += 1_000;
+        throw operationError;
+      });
+      await expect(service.remove({ id: "private-id", reason: "test" })).rejects.toBe(
+        operationError,
+      );
+      expect(clockSpy).not.toHaveBeenCalled();
+      vi.spyOn(stateLease, "withOpenClawStateLease").mockImplementationOnce(async () => {
+        setGate(false);
+        clock += 1_000;
+        throw operationError;
+      });
+      await expect(service.remove({ id: "private-id", reason: "test" })).rejects.toBe(
+        operationError,
+      );
+      await waitForDiagnosticEventsDrained();
+      expect(records).toEqual([]);
+    },
+  );
+
+  it("bounds simultaneous slow removals and carries omitted observations into the next window", async () => {
+    const operationError = new Error("lease unavailable");
+    vi.spyOn(stateLease, "withOpenClawStateLease").mockImplementation(async () => {
+      clock += 1_000;
+      throw operationError;
+    });
+    // Drain any omissions left by an earlier logger-failure case without resetting private state.
+    await expect(service.remove({ id: "private-id", reason: "test" })).rejects.toBe(operationError);
+    await waitForDiagnosticEventsDrained();
+    records.length = 0;
+    clock += 60_000;
+    const release = createDeferredCore();
+    vi.spyOn(stateLease, "withOpenClawStateLease").mockImplementation(async () => {
+      await release.promise;
+      throw operationError;
+    });
+    const pending = Array.from({ length: 62 }, () =>
+      service.remove({ id: "private-id", reason: "test" }).catch((error: unknown) => error),
+    );
+    clock += 1_000;
+    release.resolve();
+    expect(await Promise.all(pending)).toEqual(Array.from({ length: 62 }, () => operationError));
+    await waitForDiagnosticEventsDrained();
+    expect(records).toHaveLength(60);
+    clock += 60_000;
+    vi.spyOn(stateLease, "withOpenClawStateLease").mockImplementation(async () => {
+      clock += 1_000;
+      throw operationError;
+    });
+    await expect(service.remove({ id: "private-id", reason: "test" })).rejects.toBe(operationError);
+    await waitForDiagnosticEventsDrained();
+    expect(records).toHaveLength(61);
+    expect(records.at(-1)?.attributes?.omittedObservations).toBe(2);
+    await expect(service.remove({ id: "private-id", reason: "test" })).rejects.toBe(operationError);
+    await waitForDiagnosticEventsDrained();
+    expect(records.at(-1)?.attributes?.omittedObservations).toBe(0);
   });
 });

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -2,10 +2,18 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getRuntimeConfig, type OpenClawConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
+import { areDiagnosticsEnabledForProcess } from "../../infra/diagnostic-events.js";
+import {
+  getActiveDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
 import { isMissingPathError, formatErrorMessage } from "../../infra/errors.js";
+import { createFixedWindowBudget } from "../../infra/fixed-window-rate-limit.js";
 import { root as fsRoot } from "../../infra/fs-safe.js";
 import { normalizeGitPathForFilesystem, requireGitCommandOutput } from "../../infra/git-exec.js";
 import { isPathInside } from "../../infra/path-guards.js";
@@ -16,6 +24,7 @@ import {
 } from "../../media/staged-inputs.js";
 import { createCommandError } from "../../process/command-error.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { withOpenClawStateLease } from "../../state/openclaw-state-lease.js";
 import { createCrustaceanSlug } from "../session-slug.js";
 import { resolveWorktreeBase } from "./base-ref.js";
@@ -130,6 +139,73 @@ export function classifyWorktreeRemovalError(error: unknown): WorktreeRemovalFai
 export class WorktreeRepositoryError extends Error {}
 const SNAPSHOT_REF_PREFIX = "refs/openclaw/snapshots";
 const log = createSubsystemLogger("agents/worktrees");
+
+function startRemovalTiming() {
+  try {
+    if (!areDiagnosticsEnabledForProcess() || !log.isEnabled("info")) {
+      return undefined;
+    }
+    const startedAt = performance.now();
+    const trace = getActiveDiagnosticTraceContext();
+    let enteredAt: number | undefined;
+    let bodyFinishedAt: number | undefined;
+    return {
+      enter() {
+        enteredAt = performance.now();
+      },
+      finishBody() {
+        bodyFinishedAt = performance.now();
+      },
+      finish(outcome: "returned" | "threw") {
+        try {
+          const endedAt = performance.now();
+          const durationMs = endedAt - startedAt;
+          if (durationMs < 1_000 || !areDiagnosticsEnabledForProcess() || !log.isEnabled("info")) {
+            return;
+          }
+          const state = resolveGlobalSingleton(
+            Symbol.for("openclaw.worktreeRemovalDiagnostics"),
+            () => ({
+              budget: createFixedWindowBudget({
+                maxRequests: 60,
+                windowMs: 60_000,
+                now: () => performance.now(),
+              }),
+              omitted: 0,
+            }),
+          );
+          if (!state.budget.consume().allowed) {
+            state.omitted = Math.min(Number.MAX_SAFE_INTEGER, state.omitted + 1);
+            return;
+          }
+          runWithDiagnosticTraceContext(trace, () =>
+            log.info("slow managed worktree removal", {
+              pid: process.pid,
+              threadId,
+              isMainThread,
+              durationMs: Math.round(durationMs),
+              admissionMs: Math.round((enteredAt ?? endedAt) - startedAt),
+              ...(enteredAt !== undefined && bodyFinishedAt !== undefined
+                ? {
+                    bodyMs: Math.round(bodyFinishedAt - enteredAt),
+                    finalizeMs: Math.round(endedAt - bodyFinishedAt),
+                  }
+                : {}),
+              callbackEntered: enteredAt !== undefined,
+              outcome,
+              omittedObservations: state.omitted,
+            }),
+          );
+          state.omitted = 0;
+        } catch {
+          // Diagnostics must preserve removal's result and original cleanup error.
+        }
+      },
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 type ServiceOptions = {
   env?: NodeJS.ProcessEnv;
@@ -1270,10 +1346,22 @@ export class ManagedWorktreeService {
   }
 
   async remove(params: RemoveWorktreeParams): Promise<RemoveManagedWorktreeResult> {
-    return await this.withAllocationLease(
-      params,
-      async (guard) => await this.removeWithAllocation({ ...params, ...guard }),
-    );
+    const timing = startRemovalTiming();
+    let outcome: "returned" | "threw" = "threw";
+    try {
+      const result = await this.withAllocationLease(params, async (guard) => {
+        timing?.enter();
+        try {
+          return await this.removeWithAllocation({ ...params, ...guard });
+        } finally {
+          timing?.finishBody();
+        }
+      });
+      outcome = "returned";
+      return result;
+    } finally {
+      timing?.finish(outcome);
+    }
   }
 
   private async removeWithAllocation(

--- a/src/infra/git-exec.test.ts
+++ b/src/infra/git-exec.test.ts
@@ -1,14 +1,25 @@
 import { spawnSync } from "node:child_process";
 import fsSync from "node:fs";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import * as execRunner from "../process/exec-runner.js";
 import * as processExec from "../process/exec.js";
 import type { SpawnResult } from "../process/exec.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
+import * as diagnosticEvents from "./diagnostic-events.js";
+import {
+  getActiveDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+  type DiagnosticTraceContext,
+} from "./diagnostic-trace-context.js";
 import {
   createGitCommandError,
+  enqueueGitRefMutation,
   executeGitCommand,
   gitNullConfigPath,
   normalizeGitPathForFilesystem,
@@ -17,7 +28,260 @@ import {
   requireGitCommandRaw,
 } from "./git-exec.js";
 
+const refLogs = vi.hoisted(() => ({ info: vi.fn(), isEnabled: vi.fn() }));
+vi.mock("../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => ({
+      ...actual.createSubsystemLogger(subsystem),
+      ...(subsystem === "git/ref-mutation" ? refLogs : {}),
+    }),
+  };
+});
+
 afterEach(() => vi.restoreAllMocks());
+
+describe("Git ref mutation timing", () => {
+  let clock = 0;
+  let clockEpoch = 0;
+  let clockSpy: MockInstance<() => number>;
+  const traces: Array<DiagnosticTraceContext | undefined> = [];
+  const processMetadata = { pid: process.pid, threadId, isMainThread };
+
+  beforeEach(() => {
+    // Advance past the previous owner's window without resetting its live singleton.
+    clockEpoch += 120_000;
+    clock = clockEpoch;
+    clockSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    vi.spyOn(diagnosticEvents, "areDiagnosticsEnabledForProcess").mockReturnValue(true);
+    vi.spyOn(fs, "realpath").mockImplementation(async (filename) => String(filename));
+    refLogs.isEnabled.mockReset().mockReturnValue(true);
+    refLogs.info.mockReset().mockImplementation(() => {
+      traces.push(getActiveDiagnosticTraceContext());
+    });
+    traces.length = 0;
+  });
+
+  it("attributes a held same-directory predecessor separately from resolution and callback work", async () => {
+    const holderEntered = createDeferred();
+    const releaseHolder = createDeferred();
+    const callbackEntered = createDeferred();
+    const releaseCallback = createDeferred();
+    const resolved = createDeferred<string>();
+    const trace = {
+      traceId: "1234567890abcdef1234567890abcdef",
+      spanId: "1234567890abcdef",
+      traceFlags: "01",
+    };
+    const result = { privateResult: "refs/private/result" };
+    vi.mocked(diagnosticEvents.areDiagnosticsEnabledForProcess).mockReturnValue(false);
+    vi.mocked(fs.realpath).mockResolvedValueOnce("/private/shared.git");
+    const holder = enqueueGitRefMutation("/private/holder", ".git", async () => {
+      holderEntered.resolve();
+      await releaseHolder.promise;
+    });
+    const pending: Promise<unknown>[] = [holder];
+    try {
+      await holderEntered.promise;
+      vi.mocked(diagnosticEvents.areDiagnosticsEnabledForProcess).mockReturnValue(true);
+      vi.mocked(fs.realpath).mockImplementationOnce(() => resolved.promise);
+      const callback = vi.fn(async () => {
+        callbackEntered.resolve();
+        await releaseCallback.promise;
+        return result;
+      });
+      const queued = runWithDiagnosticTraceContext(trace, () =>
+        enqueueGitRefMutation("/private/linked-checkout", "../shared.git", callback),
+      );
+      pending.push(queued);
+      clock += 25;
+      resolved.resolve("/private/shared.git");
+      const independent = { independent: true };
+      await expect(
+        enqueueGitRefMutation("/private/other", ".git", async () => independent),
+      ).resolves.toBe(independent);
+      expect(callback).not.toHaveBeenCalled();
+      expect(refLogs.info).not.toHaveBeenCalled();
+
+      clock += 1_200;
+      releaseHolder.resolve();
+      await callbackEntered.promise;
+      expect(refLogs.info).not.toHaveBeenCalled();
+      clock += 175;
+      releaseCallback.resolve();
+      await expect(queued).resolves.toBe(result);
+      expect(refLogs.info).toHaveBeenCalledExactlyOnceWith("slow Git ref mutation", {
+        ...processMetadata,
+        durationMs: 1_400,
+        resolveMs: 25,
+        queueWaitMs: 1_200,
+        queuedOperationMs: 175,
+        callbackEntered: true,
+        outcome: "returned",
+        omittedObservations: 0,
+      });
+      expect(traces).toEqual([trace]);
+    } finally {
+      resolved.resolve("/private/shared.git");
+      releaseHolder.resolve();
+      releaseCallback.resolve();
+      await Promise.allSettled(pending);
+    }
+  });
+
+  it("reports only reached resolution time and preserves the original failure without inventing a trace", async () => {
+    const error = new Error("cannot resolve /private/repository/refs/private");
+    const callback = vi.fn();
+    vi.mocked(fs.realpath).mockImplementationOnce(async () => {
+      clock += 1_000;
+      throw error;
+    });
+    await expect(
+      runWithDiagnosticTraceContext(undefined, () =>
+        enqueueGitRefMutation("/private/repository", "refs/private", callback),
+      ),
+    ).rejects.toBe(error);
+    expect(callback).not.toHaveBeenCalled();
+    expect(refLogs.info).toHaveBeenCalledExactlyOnceWith("slow Git ref mutation", {
+      ...processMetadata,
+      durationMs: 1_000,
+      resolveMs: 1_000,
+      callbackEntered: false,
+      outcome: "threw",
+      omittedObservations: 0,
+    });
+    expect(traces).toEqual([undefined]);
+  });
+
+  it.each(["sync", "async"] as const)(
+    "preserves a %s callback error and reports no private error content",
+    async (mode) => {
+      const error = new Error("failed update-ref refs/private at /private/repository");
+      const callback = () => {
+        clock += 1_000;
+        if (mode === "sync") {
+          throw error;
+        }
+        return Promise.reject(error);
+      };
+      await expect(enqueueGitRefMutation("/private/repository", ".git", callback)).rejects.toBe(
+        error,
+      );
+      expect(refLogs.info).toHaveBeenCalledExactlyOnceWith("slow Git ref mutation", {
+        ...processMetadata,
+        durationMs: 1_000,
+        resolveMs: 0,
+        queueWaitMs: 0,
+        queuedOperationMs: 1_000,
+        callbackEntered: true,
+        outcome: "threw",
+        omittedObservations: 0,
+      });
+      const next = { next: true };
+      await expect(
+        enqueueGitRefMutation("/private/repository", ".git", async () => next),
+      ).resolves.toBe(next);
+    },
+  );
+
+  it.each([
+    { name: "diagnostics disabled at entry", gate: "diagnostics", atEntry: true },
+    { name: "info disabled at entry", gate: "info", atEntry: true },
+    { name: "diagnostics disabled at settlement", gate: "diagnostics", atEntry: false },
+    { name: "info disabled at settlement", gate: "info", atEntry: false },
+  ])("does not emit when $name", async ({ gate, atEntry }) => {
+    const disable = () => {
+      if (gate === "diagnostics") {
+        vi.mocked(diagnosticEvents.areDiagnosticsEnabledForProcess).mockReturnValue(false);
+      } else {
+        refLogs.isEnabled.mockReturnValue(false);
+      }
+    };
+    if (atEntry) {
+      disable();
+    }
+    const result = { preserved: true };
+    await expect(
+      enqueueGitRefMutation("/private/repository", ".git", async () => {
+        clock += 1_000;
+        disable();
+        return result;
+      }),
+    ).resolves.toBe(result);
+    expect(refLogs.info).not.toHaveBeenCalled();
+    if (atEntry) {
+      expect(clockSpy).not.toHaveBeenCalled();
+    }
+  });
+
+  it("keeps operations below the raw one-second threshold silent", async () => {
+    await enqueueGitRefMutation("/private/repository", ".git", async () => {
+      clock += 999.75;
+    });
+    expect(refLogs.info).not.toHaveBeenCalled();
+  });
+
+  it.each(["returned", "threw"] as const)(
+    "preserves the %s outcome when the diagnostic sink throws",
+    async (outcome) => {
+      const original = new Error("original outcome");
+      refLogs.info.mockImplementation(() => {
+        throw new Error("diagnostic sink failed");
+      });
+      const operation = enqueueGitRefMutation("/private/repository", ".git", async () => {
+        clock += 1_000;
+        if (outcome === "threw") {
+          throw original;
+        }
+        return original;
+      });
+      if (outcome === "threw") {
+        await expect(operation).rejects.toBe(original);
+      } else {
+        await expect(operation).resolves.toBe(original);
+      }
+      expect(refLogs.info).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("bounds records across different directories and reports omissions in the next window", async () => {
+    const allEntered = createDeferred();
+    const release = createDeferred();
+    let entered = 0;
+    const pending = Array.from({ length: 64 }, (_, index) =>
+      enqueueGitRefMutation(`/private/repository-${index}`, ".git", async () => {
+        entered += 1;
+        if (entered === 64) {
+          allEntered.resolve();
+        }
+        await release.promise;
+        return index;
+      }),
+    );
+    try {
+      await allEntered.promise;
+      clock += 1_000;
+      release.resolve();
+      expect(await Promise.all(pending)).toEqual(Array.from({ length: 64 }, (_, index) => index));
+      expect(refLogs.info).toHaveBeenCalledTimes(60);
+      clock += 60_000;
+      await enqueueGitRefMutation("/private/next-window", ".git", async () => {
+        clock += 1_000;
+      });
+      expect(refLogs.info).toHaveBeenCalledTimes(61);
+      expect(refLogs.info.mock.lastCall?.[1]).toMatchObject({ omittedObservations: 4 });
+      await enqueueGitRefMutation("/private/next-window", ".git", async () => {
+        clock += 1_000;
+      });
+      expect(refLogs.info).toHaveBeenCalledTimes(62);
+      expect(refLogs.info.mock.lastCall?.[1]).toMatchObject({ omittedObservations: 0 });
+    } finally {
+      release.resolve();
+      await Promise.allSettled(pending);
+    }
+  });
+});
 
 describe("Git filesystem paths", () => {
   it.each([

--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -1,10 +1,19 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import { createCommandError } from "../process/command-error.js";
 import type { SpawnResult } from "../process/exec-result.js";
 import { runCommandBuffered, runCommandWithTimeout, type CommandOptions } from "../process/exec.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { areDiagnosticsEnabledForProcess } from "./diagnostic-events.js";
+import {
+  getActiveDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+} from "./diagnostic-trace-context.js";
+import { createFixedWindowBudget } from "./fixed-window-rate-limit.js";
 
 export const GIT_TIMEOUT_MS = 120_000;
 // Keep live writers ordered across runtime chunks and shutdown. Settled tails
@@ -13,18 +22,107 @@ const gitRefMutations = resolveGlobalSingleton(
   Symbol.for("openclaw.gitRefMutations"),
   () => new KeyedAsyncQueue(),
 );
+const refMutationLog = createSubsystemLogger("git/ref-mutation");
+
+function startRefMutationTiming() {
+  try {
+    if (!areDiagnosticsEnabledForProcess() || !refMutationLog.isEnabled("info")) {
+      return undefined;
+    }
+    const startedAt = performance.now();
+    const trace = getActiveDiagnosticTraceContext();
+    let enqueuedAt: number | undefined;
+    let enteredAt: number | undefined;
+    return {
+      enqueue() {
+        enqueuedAt = performance.now();
+      },
+      enter() {
+        enteredAt = performance.now();
+      },
+      finish(outcome: "returned" | "threw") {
+        try {
+          const endedAt = performance.now();
+          const durationMs = endedAt - startedAt;
+          if (
+            durationMs < 1_000 ||
+            !areDiagnosticsEnabledForProcess() ||
+            !refMutationLog.isEnabled("info")
+          ) {
+            return;
+          }
+          const state = resolveGlobalSingleton(
+            Symbol.for("openclaw.gitRefMutationDiagnostics"),
+            () => ({
+              budget: createFixedWindowBudget({
+                maxRequests: 60,
+                windowMs: 60_000,
+                now: () => performance.now(),
+              }),
+              omitted: 0,
+            }),
+          );
+          if (!state.budget.consume().allowed) {
+            state.omitted = Math.min(Number.MAX_SAFE_INTEGER, state.omitted + 1);
+            return;
+          }
+          runWithDiagnosticTraceContext(trace, () =>
+            refMutationLog.info("slow Git ref mutation", {
+              pid: process.pid,
+              threadId,
+              isMainThread,
+              durationMs: Math.round(durationMs),
+              resolveMs: Math.round((enqueuedAt ?? endedAt) - startedAt),
+              ...(enqueuedAt !== undefined && enteredAt !== undefined
+                ? {
+                    queueWaitMs: Math.round(enteredAt - enqueuedAt),
+                    queuedOperationMs: Math.round(endedAt - enteredAt),
+                  }
+                : {}),
+              callbackEntered: enteredAt !== undefined,
+              outcome,
+              omittedObservations: state.omitted,
+            }),
+          );
+          state.omitted = 0;
+        } catch {
+          // Diagnostics must preserve the queued operation's result or original error.
+        }
+      },
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 export async function enqueueGitRefMutation<T>(
   cwd: string,
   commonDirectory: string,
   run: () => Promise<T>,
 ): Promise<T> {
-  const commonPath = normalizeGitPathForFilesystem(commonDirectory);
-  const commonDir = await fs.realpath(path.resolve(cwd, commonPath));
-  const key = process.platform === "win32" ? commonDir.toLowerCase() : commonDir;
-  // Even deleting a loose ref locks shared packed-refs. Queue every ref owner
-  // across linked worktrees; external contention retains its native error.
-  return await gitRefMutations.enqueue(key, run);
+  const timing = startRefMutationTiming();
+  let outcome: "returned" | "threw" = "threw";
+  try {
+    const commonPath = normalizeGitPathForFilesystem(commonDirectory);
+    const commonDir = await fs.realpath(path.resolve(cwd, commonPath));
+    const key = process.platform === "win32" ? commonDir.toLowerCase() : commonDir;
+    // Even deleting a loose ref locks shared packed-refs. Queue every ref owner
+    // across linked worktrees; external contention retains its native error.
+    timing?.enqueue();
+    const result = await gitRefMutations.enqueue(
+      key,
+      timing
+        ? () => {
+            timing.enter();
+            return run();
+          }
+        : run,
+    );
+    outcome = "returned";
+    return result;
+  } finally {
+    timing?.finish(outcome);
+  }
 }
 
 type GitCommandResult = SpawnResult & { timeoutMs: number };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators investigating slow task archives could see one `worktreeCleanup` duration but could not distinguish allocation admission, removal work, lease finalization, or waits in the shared Git ref queue.

## Why This Change Was Made

Add two settled-only, payload-free diagnostic records at the existing removal and Git ref queue owners. They use the existing diagnostics gate, logger, trace context, and fixed-window rate limiter, with at most 60 records per owner per minute. The records retain only fixed scalar timings, outcomes, process/thread facts, and omission counts; they add no repository paths, refs, arguments, output, or error text.

Lease ownership, snapshot safety, queue ordering, deadlines, cancellation, and completion behavior stay intact. Admission includes setup and backoff, and queued operation includes promise settlement; the fields are elapsed intervals rather than CPU measurements.

## User Impact

Operators can correlate a slow archive with its inner admission and queue durations using an existing request trace. These diagnostics improve attribution; they do not make cleanup faster or establish the cause of a historical slow operation. No new configuration or storage schema is introduced.

## Evidence

- Both attribution regressions fail on original production at `068318110aec933f9c6c5ea1981489d6c39ca283` because the diagnostic record is absent, after preserving the original behavior assertions.
- Local focused owners and existing Git/ref-queue siblings: 123 passed, 2 existing skipped cases.
- [Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34564871555): all 20 new diagnostic cases, an ordinary canonical archive/restore preserving dirty and untracked files and the transcript, and the real capacity-wait control passed. The command reached its completion marker. Provider cleanup subsequently timed out; an independent exact lease status read confirmed completion.
- A disposable same-process probe retained all 64 blocks and 1,024 calls, using exact original source copies beside the candidate. Each comparison below contains eight alternating pairs of 16 calls per mode, with no timing assertions, warmup, or discarded samples.

| Boundary / comparison | Total baseline → candidate, ms | Median paired delta per 16 calls, ms |
| --- | ---: | ---: |
| Git queue: original disabled → candidate disabled | 1.433193 → 1.431550 | +0.008230 |
| Git queue: candidate disabled → enabled | 0.952418 → 1.237565 | +0.024151 |
| Removal guard: original disabled → candidate disabled | 122.596211 → 128.931687 | −0.923215 |
| Removal guard: candidate disabled → enabled | 156.973103 → 154.127688 | +0.002515 |

The probe ran on Linux x64 / Node 24.19.0. Git calls used real path resolution and the idle queue; removal calls acquired the real isolated allocation lease and rejected at the existing caller guard before worktree effects. Removal measurements were noisy. Enabled mode also enables existing diagnostics. The probe used no request trace and no call emitted a slow record, so log-write overhead, cold module startup, and successful archive overhead are unmeasured. The measurements support no zero-overhead or runtime-speed claim.

The final independent Codex review is clean through P2. The full docs anchor audit reports the same 53 unrelated failures on the original base and candidate; it adds no failures and reports none in the edited pages. The full `node scripts/check-changed.mjs` gate passed, including core/core-test typechecks, lint, and runtime import-cycle checks.

Current-head [CI passed on attempt 2](https://github.com/openclaw/openclaw/actions/runs/34566136413/attempts/2). The first attempt timed out in two unchanged Discord WAV-backlog tests; one rerun of only that failed job passed without source or deadline changes. Their capture-only path does not call either modified timing owner, but the timeout cause remains unlocalized.
