### PR TITLE
feat(memory): shared memory database for multi-agent deployments

### DIFF
--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import path from "node:path";
 // Memory Core plugin module implements the concrete memory index manager.
 import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -75,6 +77,17 @@ export async function closeMemoryIndexManagersForAgent(params: { agentId: string
   for (const purpose of ["default", "maintenance"] as const) {
     await registry.closeForAgent({ ...params, purpose });
   }
+}
+
+function resolveSharedMemoryManagerWorkspaceDir(cfg: OpenClawConfig, agentId: string): string {
+  const systemAgentId = (cfg.agents?.defaults?.systemAgent?.agentId ?? "").trim();
+  const ws = (cfg.agents?.defaults?.workspace ?? "").trim();
+  if (systemAgentId && ws && agentId === systemAgentId) {
+    if (ws === "~") return resolveUserPath(homedir());
+    if (ws.startsWith("~/")) return resolveUserPath(path.join(homedir(), ws.slice(2)));
+    return resolveUserPath(ws);
+  }
+  return resolveAgentWorkspaceDir(cfg, agentId);
 }
 
 export class MemoryIndexManager extends MemorySearchOrchestration implements MemorySearchManager {
@@ -155,7 +168,8 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
           if (!settings) {
             return null;
           }
-          const workspaceDir = source?.workspaceDir ?? resolveAgentWorkspaceDir(cfg, agentId);
+          const workspaceDir =
+            source?.workspaceDir ?? resolveSharedMemoryManagerWorkspaceDir(cfg, agentId);
           const providerRequirement =
             source?.providerRequirement ??
             resolveMemoryEmbeddingProviderRequirement({

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -1,8 +1,11 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
 /**
  * Resolves memory-search source, sync, and ranking configuration.
  */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
 import {
   normalizeConfiguredMemoryExtraPaths,
   resolveRememberAcrossConversations,
@@ -16,7 +19,7 @@ import { assertSecretOwnerAvailable } from "../secrets/runtime-degraded-state.js
 import { runtimeMemorySecretOwnerId } from "../secrets/runtime-memory-secret-owner.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { clampNumber } from "../utils.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { resolveMemorySearchSourcePolicy } from "./memory-search-source-policy.js";
 
 type ProducedMemorySearchConfig = NonNullable<ReturnType<typeof produceMemorySearchConfig>>;
@@ -266,6 +269,32 @@ function produceMemorySearchConfig(cfg: OpenClawConfig, agentId: string) {
     throw new Error(
       'memory.search.multimodal does not support memory.search.fallback. Set fallback to "none".',
     );
+  }
+  // Shared memory: when any agent shares the same workspace as the system agent,
+  // redirect store.databasePath to a shared sqlite keyed by workspace hash.
+  if (resolved.sources.includes("memory")) {
+    const systemAgentId = (cfg.agents?.defaults?.systemAgent?.agentId ?? "").trim();
+    const defaultWorkspace = (cfg.agents?.defaults?.workspace ?? "").trim();
+    if (systemAgentId && defaultWorkspace) {
+      const myWorkspace = resolveAgentWorkspaceDir(cfg, agentId);
+      const systemWorkspace = resolveAgentWorkspaceDir(cfg, systemAgentId);
+      if (
+        myWorkspace &&
+        systemWorkspace &&
+        path.resolve(myWorkspace) === path.resolve(systemWorkspace)
+      ) {
+        const stateDir = resolveStateDir(process.env);
+        const input = JSON.stringify({ workspace: path.resolve(myWorkspace) });
+        const scopeHash = createHash("sha256").update(input).digest("hex").slice(0, 16);
+        const sharedPath = path.join(
+          stateDir,
+          "state",
+          "memory",
+          "shared-" + scopeHash + ".sqlite",
+        );
+        resolved.store = { ...resolved.store, databasePath: sharedPath };
+      }
+    }
   }
   return resolved;
 }

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -99,6 +101,21 @@ function resolveMemoryRuntimeWorkspaceDir(
   cfg: OpenClawConfig,
   agentId: string,
 ): string | undefined {
+  // When the system agent is configured with an explicit default workspace,
+  // use that workspace directly so the shared memory database is keyed from
+  // the canonical workspace path rather than a per-agent subdirectory.
+  const systemAgentId = (cfg.agents?.defaults?.systemAgent?.agentId ?? "").trim();
+  const defaultWorkspace = (cfg.agents?.defaults?.workspace ?? "").trim();
+  if (systemAgentId && defaultWorkspace && agentId === systemAgentId) {
+    if (defaultWorkspace === "~") {
+      return resolveUserPath(homedir());
+    }
+    if (defaultWorkspace.startsWith("~/")) {
+      return resolveUserPath(path.join(homedir(), defaultWorkspace.slice(2)));
+    }
+    return resolveUserPath(defaultWorkspace);
+  }
+
   const dir = resolveAgentWorkspaceDir(cfg, agentId);
   if (typeof dir !== "string" || !dir.trim()) {
     return undefined;

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
 import { MEMORY_INDEX_CHUNK_PROVENANCE_TABLE } from "../../packages/memory-host-sdk/src/host/memory-schema-provenance.js";
@@ -308,6 +309,9 @@ export function readExistingAgentSchemaMeta(db: DatabaseSync): ExistingAgentSche
   };
 }
 
+function isOpenClawSharedMemoryDatabasePath(pathname: string): boolean {
+  return pathname.includes(path.sep + "memory" + path.sep + "shared-");
+}
 export function assertExistingAgentSchemaOwner(
   existing: ExistingAgentSchemaMeta | null,
   agentId: string,
@@ -326,6 +330,9 @@ export function assertExistingAgentSchemaOwner(
     throw new Error(`OpenClaw agent database ${pathname} has no agent owner.`);
   }
   if (normalizeAgentId(existing.agentId) !== agentId) {
+    if (isOpenClawSharedMemoryDatabasePath(pathname)) {
+      return;
+    }
     throw new Error(
       `OpenClaw agent database ${pathname} belongs to agent ${existing.agentId}; requested agent ${agentId}.`,
     );


### PR DESCRIPTION
## What Problem This Solves

When multiple agents share the same workspace, each agent creates its own memory SQLite database. This causes:
1. **Duplicate storage** — identical notes indexed multiple times
2. **Inconsistent search** — agents miss notes from other agents' indexes
3. **Wasted resources** — redundant embedding computation and storage

This PR redirects agents sharing the system agent's workspace to a single shared SQLite database keyed by workspace hash.

## Changes

When agents share the same workspace as the system agent:
- **memory-search.ts**: Redirect `store.databasePath` to `<stateDir>/state/memory/shared-<hash>.sqlite`
- **openclaw-agent-db-schema-helpers.ts**: Skip ownership assertion for shared memory database paths
- **manager.ts**: Use canonical workspace for system agent in memory-core
- **memory-runtime.ts**: Use canonical workspace for system agent in plugin loader

## Evidence

### Configuration

```yaml
agents:
  defaults:
    workspace: ~/my-workspace
    systemAgent:
      agentId: system
```

### Behavior

1. **Before this PR**: Each agent creates `~/.openclaw/state/memory/<agent-id>.sqlite`
2. **After this PR**: All agents with matching workspace share `~/.openclaw/state/memory/shared-<hash>.sqlite`

### Verification

- Existing per-agent databases remain unaffected
- Agents with different workspaces get isolated databases
- The enabled gate is preserved (no global `enabled=true` override)
- Compatible with OpenClaw 2026.9.3

## Related

- Closes #95724
- Replaces #140042 (rebased and refactored for 9.3)