### PR TITLE
fix: keep memory writes and indexing correct under Bun

### DIFF
--- a/extensions/memory-core/src/short-term-promotion-memory-write.test.ts
+++ b/extensions/memory-core/src/short-term-promotion-memory-write.test.ts
@@ -6,6 +6,7 @@ import {
   commitMemoryContent,
   hashMemoryContent,
   MemoryWriteConflictError,
+  resolveMemoryWritePath,
 } from "./short-term-promotion-memory-write.js";
 
 const openState = vi.hoisted(() => ({
@@ -88,6 +89,26 @@ it.runIf(process.platform !== "win32")(
 
     expect((await fs.stat(memoryPath)).mode & 0o777).toBe(0o640);
     expect(await fs.readFile(memoryPath, "utf-8")).toContain("replacement entry");
+  },
+);
+
+it.runIf(Boolean(process.versions.bun) && process.platform !== "win32")(
+  "rejects a non-directory symlink before a parent traversal",
+  async () => {
+    const tempRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "memory-write-not-directory-")),
+    );
+    cleanups.push(async () => await fs.rm(tempRoot, { recursive: true, force: true }));
+    const regularFile = path.join(tempRoot, "regular-file");
+    const regularLink = path.join(tempRoot, "regular-link");
+    const collision = path.join(tempRoot, "collision.md");
+    await fs.writeFile(regularFile, "regular");
+    await fs.writeFile(collision, "collision");
+    await fs.symlink(regularFile, regularLink);
+
+    const invalidPath = `${regularLink}${path.sep}..${path.sep}${path.basename(collision)}`;
+    await expect(resolveMemoryWritePath(invalidPath)).rejects.toMatchObject({ code: "ENOTDIR" });
+    expect(await fs.readFile(collision, "utf8")).toBe("collision");
   },
 );
 

--- a/extensions/memory-core/src/short-term-promotion-memory-write.ts
+++ b/extensions/memory-core/src/short-term-promotion-memory-write.ts
@@ -21,9 +21,43 @@ export class MemoryWriteConflictError extends Error {
   }
 }
 
+async function realpathMemoryPath(filePath: string): Promise<string> {
+  if (!process.versions.bun || process.platform === "win32") {
+    return await fs.realpath(filePath);
+  }
+
+  // Bun compatibility: keep this segment-wise path walk until fs.realpath preserves
+  // symlink semantics for `symlink/..`; lexical normalization can escape the target dir.
+  const parsed = path.parse(filePath);
+  let current = parsed.root || (await fs.realpath("."));
+  const relative = parsed.root ? filePath.slice(parsed.root.length) : filePath;
+  const assertDirectory = async () => {
+    await fs.stat(`${current}${path.sep}`);
+  };
+  for (const segment of relative.split(path.sep)) {
+    if (!segment) {
+      continue;
+    }
+    if (segment === ".") {
+      await assertDirectory();
+      continue;
+    }
+    if (segment === "..") {
+      await assertDirectory();
+      current = path.dirname(current);
+      continue;
+    }
+    current = await fs.realpath(path.join(current, segment));
+  }
+  if (relative.endsWith(path.sep)) {
+    await assertDirectory();
+  }
+  return current;
+}
+
 export async function resolveMemoryWritePath(filePath: string): Promise<string> {
   try {
-    return await fs.realpath(filePath);
+    return await realpathMemoryPath(filePath);
   } catch (err) {
     const hasTrailingSeparator =
       filePath.endsWith(path.sep) ||
@@ -35,7 +69,7 @@ export async function resolveMemoryWritePath(filePath: string): Promise<string> 
 
   // Canonicalize each parent before applying a relative link target. Lexical
   // normalization would change `..` semantics when an earlier component is a symlink.
-  const parentPath = await fs.realpath(path.dirname(filePath));
+  const parentPath = await realpathMemoryPath(path.dirname(filePath));
   const canonicalPath = path.join(parentPath, path.basename(filePath));
   let linkTarget: string;
   try {

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -3174,6 +3174,8 @@ describe("short-term promotion", () => {
           expect((await fs.stat(sharedDir)).mode & 0o7777).toBe(0o755);
 
           const secondSnippet = "Keep writing through a shared read-only directory.";
+          const lexicalCollisionPath = path.join(workspaceDir, "memory-alias.md");
+          await fs.writeFile(lexicalCollisionPath, "Do not overwrite this lexical collision.");
           await writeDailyMemoryNote(workspaceDir, "2026-04-30", [secondSnippet]);
           await recordMemoryRecalls(
             workspaceAlias,
@@ -3191,6 +3193,9 @@ describe("short-term promotion", () => {
             });
             expect(applied.applied).toBe(1);
             expect(await fs.readFile(targetPath, "utf-8")).toContain(secondSnippet);
+            expect(await fs.readFile(lexicalCollisionPath, "utf-8")).toBe(
+              "Do not overwrite this lexical collision.",
+            );
             expect((await fs.stat(sharedDir)).mode & 0o7777).toBe(0o555);
           } finally {
             await fs.chmod(sharedDir, 0o755);

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -247,7 +247,7 @@ async function collectMemoryFilesFromDir(
   if (operationalFailure) {
     throw new MemorySourceScanError(operationalFailure.path, operationalFailure.error);
   }
-  files.push(...scan.entries.map((entry) => entry.path));
+  files.push(...scan.entries.map((entry) => entry.path).toSorted());
 }
 
 export async function listMemoryFiles(

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -34,6 +35,15 @@ const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
 function createTempDatabasePath(): string {
   const tempDir = tempDirs.make("openclaw-sqlite-readonly-");
   return path.join(tempDir, "state.sqlite");
+}
+
+function workerPreloadEnv(preloadPath: string): Record<string, string> {
+  if (!process.versions.bun) {
+    return { NODE_OPTIONS: `--require=${preloadPath}` };
+  }
+  const preloadUrl = pathToFileURL(preloadPath).href;
+  const loader = Buffer.from(`import ${JSON.stringify(preloadUrl)};`).toString("base64");
+  return { BUN_OPTIONS: `--preload=data:text/javascript;base64,${loader}` };
 }
 
 async function expectPublicSnapshot(
@@ -558,7 +568,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
     );
     const missingPath = path.join(tempDir, "missing.db");
 
-    await withEnvAsync({ NODE_OPTIONS: `--require=${preloadPath}` }, async () => {
+    await withEnvAsync(workerPreloadEnv(preloadPath), async () => {
       let message = "";
       try {
         await prepareSqliteReadOnlyLocation(missingPath);

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -1,5 +1,5 @@
 // Covers SQLite WAL maintenance configuration.
-import { AsyncLocalStorage, createHook } from "node:async_hooks";
+import { AsyncLocalStorage } from "node:async_hooks";
 import childProcess, { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -550,12 +550,10 @@ describe("sqlite WAL maintenance", () => {
     const session = {};
     const timerContexts: Array<[object | undefined, object | undefined]> = [];
     const periodic = createDeferredCore<[object | undefined, object | undefined]>();
-    const hook = createHook({
-      init(_asyncId, type) {
-        if (type === "Timeout") {
-          timerContexts.push([requestScope.getStore(), sessionScope.getStore()]);
-        }
-      },
+    const setIntervalNative = globalThis.setInterval;
+    vi.spyOn(globalThis, "setInterval").mockImplementation((callback, delay, ...args) => {
+      timerContexts.push([requestScope.getStore(), sessionScope.getStore()]);
+      return setIntervalNative(callback, delay, ...args);
     });
     const db = createMockDb();
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");
@@ -568,12 +566,7 @@ describe("sqlite WAL maintenance", () => {
     try {
       await requestScope.run(request, () =>
         sessionScope.run(session, async () => {
-          hook.enable();
-          try {
-            maintenance = configureSqliteWalMaintenance(db, { checkpointIntervalMs: 5 });
-          } finally {
-            hook.disable();
-          }
+          maintenance = configureSqliteWalMaintenance(db, { checkpointIntervalMs: 5 });
           expect(requestScope.getStore()).toBe(request);
           expect(sessionScope.getStore()).toBe(session);
           // The native resource must be detached at allocation, not only when its callback runs.
@@ -596,7 +589,6 @@ describe("sqlite WAL maintenance", () => {
         }),
       );
     } finally {
-      hook.disable();
       maintenance?.close();
       requestScope.disable();
       sessionScope.disable();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Bun users could index memory files in filesystem-dependent order and could write a promoted `MEMORY.md` entry to the wrong lexical path when a symlink target contained `..`.

The same Bun run also exposed two Node-specific test assumptions that prevented the SQLite compatibility suite from measuring the intended behavior.

## Why This Change Was Made

Memory-directory scans now sort discovered paths before batching. On Bun POSIX runtimes, promotion writes resolve path components one at a time so symlinks are applied before `..`, while preserving `ENOTDIR` checks and dangling-target behavior. The adapter carries a removal note for the corresponding Bun runtime fix.

Upstream runtime fix: oven-sh/bun#42277.

The SQLite tests now observe timer allocation directly and select Bun's documented `BUN_OPTIONS --preload` mechanism when Bun owns a worker process.

## User Impact

Bun users get deterministic memory embedding batches and promotion writes stay bound to the intended symlink target. Node behavior remains unchanged.

## Evidence

- Exact fork runtime: Bun `1.4.3-canary.1+900eae300`, SQLite `3.53.2`, binary SHA-256 `8f5cd0eef24262326edc07b0d1bec0de69eaa737178e086a7923695b810c9c40`.
- Exact PR head `69b9d2246aeb1996c08e2361d58460edddba5151` on sanitized AWS Crabbox `c7a.8xlarge`:
  - repaired SQLite focus: 107 passed
  - SQLite infra: 363 passed, 2 platform skips
  - memory-core: 1,542 passed, 3 platform skips
- Local Node focused suites passed for SQLite context/stderr handling, memory path resolution, and memory-host discovery.
- `pnpm check:changed` passed through all type, boundary, schema, dead-export, and lint checks after the repair; the final narrow directory-check follow-up also passed affected extension typechecks, lint, formatting, and focused tests.
- Independent P0-P2 autoreview: scoped clean after resolving two path-resolution findings.
