### PR TITLE
fix: make session link browser checks use production attribution styles

### DIFF
--- a/ui/src/components/session-link-presentation.browser.test.ts
+++ b/ui/src/components/session-link-presentation.browser.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import "../styles/base.css";
 import "../styles/chat/text.css";
+import "../styles/chat/grouped.css";
 
 const title = "A resolved session title long enough to need truncation in a narrow chat bubble";
 
@@ -56,18 +57,18 @@ describe("session link presentation", () => {
     },
   );
 
-  it.each(["sidebar-markdown", "chat-reply-attribution"])(
-    "shares the titled-link treatment in %s",
-    (className) => {
-      const host = document.createElement("div");
-      host.id = "session-link-proof";
-      host.className = className;
-      host.innerHTML = `<a class="markdown-session-link markdown-session-link--titled"><span class="session-label">${title}</span></a><a class="markdown-session-link">untitled</a>`;
-      document.body.append(host);
-      const [titled, untitled] = host.querySelectorAll("a");
-      expect(getComputedStyle(titled!).color).toBe(getComputedStyle(untitled!).color);
-      expect(getComputedStyle(titled!).display).toBe("inline-grid");
-      expect(getComputedStyle(titled!.firstElementChild!).textOverflow).toBe("ellipsis");
-    },
-  );
+  it.each([
+    ["sidebar-markdown", "inline-grid"],
+    ["chat-reply-attribution", "grid"],
+  ])("shares the titled-link treatment in %s", (className, expectedDisplay) => {
+    const host = document.createElement("div");
+    host.id = "session-link-proof";
+    host.className = className;
+    host.innerHTML = `<a class="markdown-session-link markdown-session-link--titled"><span class="session-label">${title}</span></a><a class="markdown-session-link">untitled</a>`;
+    document.body.append(host);
+    const [titled, untitled] = host.querySelectorAll("a");
+    expect(getComputedStyle(titled!).color).toBe(getComputedStyle(untitled!).color);
+    expect(getComputedStyle(titled!).display).toBe(expectedDisplay);
+    expect(getComputedStyle(titled!.firstElementChild!).textOverflow).toBe("ellipsis");
+  });
 });


### PR DESCRIPTION
Related: #144251, #144647

<details>
<summary>Additional instructions</summary>

This branch is in openclaw/openclaw, so repository maintainers can edit it.

</details>

## What Problem This Solves

Resolves a problem where the session-link browser test fails in the reply-attribution context when other browser tests have already loaded the production parent styles. This blocked the Control UI check on #144647 after the session-link coverage from #144251 landed on main.

## Why This Change Was Made

The test now loads the actual attribution stylesheet in production order and checks each context's exact computed display. Standalone sidebar links remain `inline-grid`; attribution links are flex items and correctly compute `grid`. Existing baseline, truncation, color, icon, and ellipsis checks remain intact.

## User Impact

No runtime behavior changes. The browser test now exercises the real attribution layout consistently, independent of other tests loading its parent styles.

## Evidence

Loading only the production parent stylesheet with the original assertion reproduces the CI failure: the attribution case fails with expected `inline-grid`, received `grid`, while the other three cases pass. The corrected four-case file and the related file-link and GitHub-link browser suites pass all 29 tests.

The changed-file gate, formatting, and diff checks pass. Managed P2 review is clean with no actionable findings. This patch changes one test file and no production CSS.

Original failure: [checks-ui (3/3), run 34561737708](https://github.com/openclaw/openclaw/actions/runs/34561737708/job/103145835359).
