### PR TITLE
fix: keep subagent completions on the selected conversation

### DIFF
--- a/docs/tools/subagents/announce.md
+++ b/docs/tools/subagents/announce.md
@@ -27,7 +27,9 @@ For top-level requester sessions, completion-mode direct delivery first
 resolves any bound conversation/thread route and hook override, then fills
 missing channel-target fields from the requester session's stored route.
 That keeps completions on the right chat/topic even when the completion
-origin only identifies the channel.
+origin only identifies the channel. When an override selects a different
+chat or topic, it does not inherit the previous route's thread. An explicit
+thread from the binding or hook is preserved.
 
 Child completion aggregation is scoped to the current requester run when
 building nested completion findings, preventing stale prior-run child

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -23,11 +23,6 @@ import {
   PlatformMessageNotDispatchedError,
 } from "../../../infra/outbound/deliver-types.js";
 import { sendMessage as runtimeSendMessage } from "../../../infra/outbound/message.js";
-import {
-  testing as sessionBindingServiceTesting,
-  registerSessionBindingAdapter,
-} from "../../../infra/outbound/session-binding-service.js";
-import { normalizeLegacySessionEntryDelivery } from "../../../infra/state-migrations.legacy-session-store.js";
 import { setActivePluginRegistry } from "../../../plugins/runtime.js";
 import { createDeferredCore } from "../../../shared/deferred.js";
 import {
@@ -58,10 +53,6 @@ import {
   loadRequesterSessionEntry,
 } from "./subagent-announce-delivery.test-support.js";
 import { runDescendantWake } from "./subagent-announce-descendant-wake.js";
-import {
-  resolveAnnounceOrigin,
-  resolveSubagentCompletionOrigin,
-} from "./subagent-announce-origin.js";
 
 const sessionDeliveryQueueMocks = vi.hoisted(() => ({
   enqueueClaimedSessionDelivery: vi.fn((_payload: unknown, _leaseMs: number) => ({
@@ -99,7 +90,6 @@ type EmbeddedAgentQueueFailureReason = Extract<
 
 afterEach(() => {
   vi.useRealTimers();
-  sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();
   setActivePluginRegistry(createTestRegistry());
   testing.setDepsForTest();
   sessionDeliveryQueueMocks.enqueueClaimedSessionDelivery.mockClear();
@@ -409,33 +399,6 @@ function registerDirectTargetTestChannel(channelId: string): void {
   );
 }
 
-function registerTestSessionBindings(
-  channel: string,
-  accountId: string,
-  bindings: ReadonlyArray<{
-    targetSessionKey: string;
-    targetKind: "session" | "subagent";
-    conversationId: string;
-  }>,
-): void {
-  registerSessionBindingAdapter({
-    channel,
-    accountId,
-    listBySession: (targetSessionKey) =>
-      bindings
-        .filter((binding) => binding.targetSessionKey === targetSessionKey)
-        .map((binding) => ({
-          bindingId: `${channel}:${accountId}:${binding.conversationId}`,
-          targetSessionKey,
-          targetKind: binding.targetKind,
-          conversation: { channel, accountId, conversationId: binding.conversationId },
-          status: "active" as const,
-          boundAt: 1,
-        })),
-    resolveByConversation: () => null,
-  });
-}
-
 function expectGatewayAgentParams(
   callGateway: typeof runtimeCallGateway,
   expected: Record<string, unknown>,
@@ -729,162 +692,6 @@ async function deliverSlackChannelAnnouncement(params: {
     isSourceSessionEffectsAllowed: params.isSourceSessionEffectsAllowed,
   });
 }
-
-describe("resolveAnnounceOrigin threaded route targets", () => {
-  it.each([
-    {
-      name: "does not inherit a target or thread from another account on the same channel",
-      stored: {
-        lastChannel: "telegram",
-        lastTo: "peer-b",
-        lastAccountId: "bot-b",
-        lastThreadId: 99,
-      },
-      requester: { channel: "telegram", accountId: "bot-a" },
-      expected: { channel: "telegram", to: undefined, accountId: "bot-a" },
-    },
-    {
-      name: "preserves stored thread ids when requester origin omits one for the same chat",
-      stored: {
-        lastChannel: "topicchat",
-        lastTo: "topicchat:room-a:topic:99",
-        lastThreadId: 99,
-      },
-      requester: { channel: "topicchat", to: "topicchat:room-a" },
-      expected: { channel: "topicchat", to: "topicchat:room-a", threadId: 99 },
-    },
-    {
-      name: "preserves stored thread ids for group-prefixed requester targets",
-      stored: {
-        lastChannel: "topicchat",
-        lastTo: "topicchat:room-a:topic:99",
-        lastThreadId: 99,
-      },
-      requester: { channel: "topicchat", to: "group:room-a" },
-      expected: { channel: "topicchat", to: "group:room-a", threadId: 99 },
-    },
-    {
-      name: "still strips stale thread ids when the stored route points at a different chat",
-      stored: {
-        lastChannel: "topicchat",
-        lastTo: "topicchat:room-b:topic:99",
-        lastThreadId: 99,
-      },
-      requester: { channel: "topicchat", to: "topicchat:room-a" },
-      expected: { channel: "topicchat", to: "topicchat:room-a" },
-    },
-  ])("$name", ({ stored, requester, expected }) => {
-    expect(
-      resolveAnnounceOrigin(
-        normalizeLegacySessionEntryDelivery(stored as unknown as SessionEntry),
-        requester,
-      ),
-    ).toEqual(expected);
-  });
-});
-
-describe("resolveSubagentCompletionOrigin", () => {
-  it.each([
-    {
-      name: "resolves bound completion delivery from the requester session, not the child session",
-      bindings: [
-        {
-          channel: "discord",
-          accountId: "bot-alpha",
-          targetSessionKey: "agent:worker:subagent:child",
-          targetKind: "subagent" as const,
-          conversationId: "child-window",
-        },
-        {
-          channel: "discord",
-          accountId: "acct-1",
-          targetSessionKey: "agent:main:main",
-          targetKind: "session" as const,
-          conversationId: "parent-main",
-        },
-      ],
-      childSessionKey: "agent:worker:subagent:child",
-      requesterOrigin: {
-        channel: "discord",
-        accountId: "acct-1",
-        to: "channel:parent-main",
-      },
-      expected: { channel: "discord", accountId: "acct-1", to: "channel:parent-main" },
-      spawnMode: "session" as const,
-    },
-    {
-      name: "prefers requester binding when child and requester share the same channel and accountId",
-      bindings: [
-        {
-          channel: "telegram",
-          accountId: "bot-1",
-          targetSessionKey: "agent:main:telegram:default:direct:123",
-          targetKind: "subagent" as const,
-          conversationId: "direct:123",
-        },
-        {
-          channel: "telegram",
-          accountId: "bot-1",
-          targetSessionKey: "agent:main:main",
-          targetKind: "session" as const,
-          conversationId: "direct:789",
-        },
-      ],
-      childSessionKey: "agent:main:telegram:default:direct:123",
-      requesterOrigin: {
-        channel: "telegram",
-        accountId: "bot-1",
-        to: "telegram:direct:789",
-      },
-      expected: { channel: "telegram", accountId: "bot-1", to: "telegram:direct:789" },
-      spawnMode: "run" as const,
-    },
-    {
-      name: "falls back to child binding when requester has no binding",
-      bindings: [
-        {
-          channel: "telegram",
-          accountId: "bot-1",
-          targetSessionKey: "agent:main:telegram:default:direct:123",
-          targetKind: "subagent" as const,
-          conversationId: "direct:123",
-        },
-      ],
-      childSessionKey: "agent:main:telegram:default:direct:123",
-      requesterOrigin: {
-        channel: "telegram",
-        accountId: "bot-1",
-        to: "telegram:direct:123",
-      },
-      expected: { channel: "telegram", accountId: "bot-1", to: "telegram:direct:123" },
-      spawnMode: "run" as const,
-    },
-  ])("$name", async ({ bindings, childSessionKey, requesterOrigin, expected, spawnMode }) => {
-    const bindingGroups = new Map<string, (typeof bindings)[number][]>();
-    for (const binding of bindings) {
-      const key = `${binding.channel}\0${binding.accountId}`;
-      const group = bindingGroups.get(key) ?? [];
-      group.push(binding);
-      bindingGroups.set(key, group);
-    }
-    for (const group of bindingGroups.values()) {
-      const binding = group[0];
-      if (binding) {
-        registerTestSessionBindings(binding.channel, binding.accountId, group);
-      }
-    }
-
-    const origin = await resolveSubagentCompletionOrigin({
-      childSessionKey,
-      requesterSessionKey: "agent:main:main",
-      requesterOrigin,
-      spawnMode,
-      expectsCompletionMessage: true,
-    });
-
-    expect(origin).toEqual(expected);
-  });
-});
 
 describe("deliverSubagentAnnouncement active requester steering", () => {
   it("loads a custom main alias through its canonical requester key", () => {

--- a/src/agents/subagents/announce/subagent-announce-origin.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-origin.test.ts
@@ -1,0 +1,593 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ChannelPlugin } from "../../../channels/plugins/types.plugin.js";
+import type { SessionEntry } from "../../../config/sessions.js";
+import {
+  testing as sessionBindingServiceTesting,
+  registerSessionBindingAdapter,
+} from "../../../infra/outbound/session-binding-service.js";
+import { normalizeLegacySessionEntryDelivery } from "../../../infra/state-migrations.legacy-session-store.js";
+import { setActivePluginRegistry } from "../../../plugins/runtime.js";
+import { loadBundledPluginFacade } from "../../../test-utils/bundled-plugin-public-surface.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../../test-utils/channel-plugins.js";
+import {
+  resolveAnnounceOrigin,
+  resolveCompletionDeliveryOrigins,
+  resolveGeneratedMediaSessionDeliveryRoute,
+  resolveSubagentCompletionOrigin,
+} from "./subagent-announce-origin.js";
+
+afterEach(() => {
+  sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();
+  setActivePluginRegistry(createTestRegistry());
+});
+
+function registerTestSessionBindings(
+  channel: string,
+  accountId: string,
+  bindings: ReadonlyArray<{
+    targetSessionKey: string;
+    targetKind: "session" | "subagent";
+    conversationId: string;
+    parentConversationId?: string;
+  }>,
+): void {
+  registerSessionBindingAdapter({
+    channel,
+    accountId,
+    listBySession: (targetSessionKey) =>
+      bindings
+        .filter((binding) => binding.targetSessionKey === targetSessionKey)
+        .map((binding) => ({
+          bindingId: `${channel}:${accountId}:${binding.conversationId}`,
+          targetSessionKey,
+          targetKind: binding.targetKind,
+          conversation: {
+            channel,
+            accountId,
+            conversationId: binding.conversationId,
+            parentConversationId: binding.parentConversationId,
+          },
+          status: "active" as const,
+          boundAt: 1,
+        })),
+    resolveByConversation: () => null,
+  });
+}
+
+const foldedChatPlugin: ChannelPlugin = {
+  ...createChannelTestPluginBase({ id: "folded-chat" }),
+  messaging: { targetIdComparison: "lowercase" },
+};
+
+const topicConversationFixtures = new Map<string, { id: string; threadId: string }>([
+  ["room-a:topic:99", { id: "room-a", threadId: "99" }],
+  ["room-b:topic:99", { id: "room-b", threadId: "99" }],
+]);
+
+const resolveFixtureTopicConversation = ({ rawId }: { rawId: string }) =>
+  topicConversationFixtures.get(rawId) ?? null;
+
+describe("resolveAnnounceOrigin threaded route targets", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "topicchat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "topicchat" }),
+            messaging: { resolveSessionConversation: resolveFixtureTopicConversation },
+          },
+        },
+      ]),
+    );
+  });
+
+  it.each([
+    {
+      name: "does not inherit a target or thread from another account on the same channel",
+      stored: {
+        lastChannel: "telegram",
+        lastTo: "peer-b",
+        lastAccountId: "bot-b",
+        lastThreadId: 99,
+      },
+      requester: { channel: "telegram", accountId: "bot-a" },
+      expected: { channel: "telegram", to: undefined, accountId: "bot-a" },
+    },
+    {
+      name: "preserves stored thread ids when requester origin omits one for the same chat",
+      stored: {
+        lastChannel: "topicchat",
+        lastTo: "topicchat:room-a:topic:99",
+        lastThreadId: 99,
+      },
+      requester: { channel: "topicchat", to: "topicchat:room-a" },
+      expected: { channel: "topicchat", to: "topicchat:room-a", threadId: 99 },
+    },
+    {
+      name: "preserves stored thread ids for group-prefixed requester targets",
+      stored: {
+        lastChannel: "topicchat",
+        lastTo: "topicchat:room-a:topic:99",
+        lastThreadId: 99,
+      },
+      requester: { channel: "topicchat", to: "group:room-a" },
+      expected: { channel: "topicchat", to: "group:room-a", threadId: 99 },
+    },
+    {
+      name: "still strips stale thread ids when the stored route points at a different chat",
+      stored: {
+        lastChannel: "topicchat",
+        lastTo: "topicchat:room-b:topic:99",
+        lastThreadId: 99,
+      },
+      requester: { channel: "topicchat", to: "topicchat:room-a" },
+      expected: { channel: "topicchat", to: "topicchat:room-a" },
+    },
+  ])("$name", ({ stored, requester, expected }) => {
+    expect(
+      resolveAnnounceOrigin(
+        normalizeLegacySessionEntryDelivery(stored as unknown as SessionEntry),
+        requester,
+      ),
+    ).toEqual(expected);
+  });
+});
+
+describe("resolveSubagentCompletionOrigin", () => {
+  beforeEach(async () => {
+    const { slackPlugin } = await loadBundledPluginFacade<{ slackPlugin: ChannelPlugin }>({
+      pluginId: "slack",
+      artifactBasename: "api.js",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "slack", source: "test", plugin: slackPlugin },
+        { pluginId: "folded-chat", source: "test", plugin: foldedChatPlugin },
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "matrix" }),
+            messaging: {
+              targetIdComparison: "case-sensitive",
+              resolveDeliveryTarget: ({ conversationId }: { conversationId: string }) => ({
+                to: `room:${conversationId}`,
+              }),
+            },
+          },
+        },
+      ]),
+    );
+  });
+
+  it.each([
+    ...["slack", "folded-chat"].map((channel) => ({
+      name: `preserves a thread for case-folded ${channel} bound targets`,
+      bindings: [
+        {
+          channel,
+          accountId: "acct-1",
+          targetSessionKey: "agent:main:main",
+          targetKind: "session" as const,
+          conversationId: "C123",
+        },
+      ],
+      childSessionKey: "agent:worker:subagent:child",
+      requesterOrigin: {
+        channel,
+        accountId: "acct-1",
+        to: "channel:c123",
+        threadId: "reply-1",
+      },
+      expected: {
+        channel,
+        accountId: "acct-1",
+        to: channel === "slack" ? "channel:c123" : "channel:C123",
+        threadId: "reply-1",
+      },
+      spawnMode: "session" as const,
+    })),
+    {
+      name: "retargets distinct case-sensitive bound conversation ids",
+      bindings: [
+        {
+          channel: "matrix",
+          accountId: "acct-1",
+          targetSessionKey: "agent:main:main",
+          targetKind: "session" as const,
+          conversationId: "!room:server",
+        },
+      ],
+      childSessionKey: "agent:worker:subagent:child",
+      requesterOrigin: { channel: "matrix", accountId: "acct-1", to: "channel:!Room:server" },
+      expected: { channel: "matrix", accountId: "acct-1", to: "room:!room:server" },
+      spawnMode: "session" as const,
+    },
+    ...[
+      {
+        name: "drops the requester thread when a binding selects another top-level conversation",
+        conversationId: "bound-room",
+        expected: { to: "channel:bound-room" },
+      },
+      {
+        name: "preserves the requester thread when a binding stays in the same room",
+        conversationId: "requester-room",
+        expected: { to: "channel:requester-room", threadId: "requester-thread" },
+      },
+      {
+        name: "preserves the requester target when its thread is the bound conversation",
+        conversationId: "requester-thread",
+        expected: { to: "channel:requester-room", threadId: "requester-thread" },
+      },
+      {
+        name: "uses the bound child thread instead of the requester thread",
+        conversationId: "bound-thread",
+        parentConversationId: "bound-room",
+        expected: { to: "channel:bound-thread", threadId: "bound-thread" },
+      },
+    ].map(({ name, conversationId, parentConversationId, expected }) => ({
+      name,
+      bindings: [
+        {
+          channel: "discord",
+          accountId: "acct-1",
+          targetSessionKey: "agent:main:main",
+          targetKind: "session" as const,
+          conversationId,
+          parentConversationId,
+        },
+      ],
+      childSessionKey: "agent:worker:subagent:child",
+      requesterOrigin: {
+        channel: "discord",
+        accountId: "acct-1",
+        to: "channel:requester-room",
+        threadId: "requester-thread",
+      },
+      expected: { channel: "discord", accountId: "acct-1", ...expected },
+      spawnMode: "session" as const,
+    })),
+    {
+      name: "resolves bound completion delivery from the requester session, not the child session",
+      bindings: [
+        {
+          channel: "discord",
+          accountId: "bot-alpha",
+          targetSessionKey: "agent:worker:subagent:child",
+          targetKind: "subagent" as const,
+          conversationId: "child-window",
+        },
+        {
+          channel: "discord",
+          accountId: "acct-1",
+          targetSessionKey: "agent:main:main",
+          targetKind: "session" as const,
+          conversationId: "parent-main",
+        },
+      ],
+      childSessionKey: "agent:worker:subagent:child",
+      requesterOrigin: {
+        channel: "discord",
+        accountId: "acct-1",
+        to: "channel:parent-main",
+      },
+      expected: { channel: "discord", accountId: "acct-1", to: "channel:parent-main" },
+      spawnMode: "session" as const,
+    },
+    {
+      name: "prefers requester binding when child and requester share the same channel and accountId",
+      bindings: [
+        {
+          channel: "telegram",
+          accountId: "bot-1",
+          targetSessionKey: "agent:main:telegram:default:direct:123",
+          targetKind: "subagent" as const,
+          conversationId: "direct:123",
+        },
+        {
+          channel: "telegram",
+          accountId: "bot-1",
+          targetSessionKey: "agent:main:main",
+          targetKind: "session" as const,
+          conversationId: "direct:789",
+        },
+      ],
+      childSessionKey: "agent:main:telegram:default:direct:123",
+      requesterOrigin: {
+        channel: "telegram",
+        accountId: "bot-1",
+        to: "telegram:direct:789",
+      },
+      expected: { channel: "telegram", accountId: "bot-1", to: "telegram:direct:789" },
+      spawnMode: "run" as const,
+    },
+    {
+      name: "falls back to child binding when requester has no binding",
+      bindings: [
+        {
+          channel: "telegram",
+          accountId: "bot-1",
+          targetSessionKey: "agent:main:telegram:default:direct:123",
+          targetKind: "subagent" as const,
+          conversationId: "direct:123",
+        },
+      ],
+      childSessionKey: "agent:main:telegram:default:direct:123",
+      requesterOrigin: {
+        channel: "telegram",
+        accountId: "bot-1",
+        to: "telegram:direct:123",
+      },
+      expected: { channel: "telegram", accountId: "bot-1", to: "telegram:direct:123" },
+      spawnMode: "run" as const,
+    },
+  ])("$name", async ({ bindings, childSessionKey, requesterOrigin, expected, spawnMode }) => {
+    const bindingGroups = new Map<string, (typeof bindings)[number][]>();
+    for (const binding of bindings) {
+      const key = `${binding.channel}\0${binding.accountId}`;
+      const group = bindingGroups.get(key) ?? [];
+      group.push(binding);
+      bindingGroups.set(key, group);
+    }
+    for (const group of bindingGroups.values()) {
+      const binding = group[0];
+      if (binding) {
+        registerTestSessionBindings(binding.channel, binding.accountId, group);
+      }
+    }
+
+    const origin = await resolveSubagentCompletionOrigin({
+      childSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin,
+      spawnMode,
+      expectsCompletionMessage: true,
+    });
+
+    const { effectiveDirectOrigin } = resolveCompletionDeliveryOrigins({
+      expectsCompletionMessage: true,
+      completionDirectOrigin: origin,
+      directOrigin: requesterOrigin,
+      requesterSessionOrigin: requesterOrigin,
+    });
+    expect({
+      origin,
+      effectiveDirectOrigin,
+      media: resolveGeneratedMediaSessionDeliveryRoute({
+        sessionKey: "agent:main:main",
+        completionDirectOrigin: origin,
+        directOrigin: requesterOrigin,
+        requesterSessionOrigin: requesterOrigin,
+      }),
+    }).toEqual({
+      origin: expected,
+      effectiveDirectOrigin: expected,
+      media: {
+        deliveryContext: expected,
+        route: {
+          ...expected,
+          chatType: ["telegram", "matrix"].includes(expected.channel) ? "direct" : "channel",
+        },
+      },
+    });
+  });
+});
+
+describe("completion delivery route fallback", () => {
+  type MediaRoute = ReturnType<typeof resolveGeneratedMediaSessionDeliveryRoute>["route"];
+  type CompletionRouteCase = Omit<
+    Parameters<typeof resolveCompletionDeliveryOrigins>[0],
+    "expectsCompletionMessage"
+  > & {
+    name: string;
+    expected: NonNullable<
+      ReturnType<typeof resolveCompletionDeliveryOrigins>["effectiveDirectOrigin"]
+    >;
+    expectedChatType?: MediaRoute["chatType"];
+    expectedRoute?: MediaRoute;
+  };
+
+  const scopedConversationFixtures = new Map([
+    ["alias-a", { id: "room:topic:root:sender:a", baseConversationId: "room" }],
+    ["alias-b", { id: "room:topic:root:sender:b", baseConversationId: "room" }],
+    ["alias-upper", { id: "room:topic:root:sender:A", baseConversationId: "room" }],
+    ["room:topic:root:sender:a", { id: "room:topic:root:sender:a", baseConversationId: "room" }],
+  ]);
+
+  beforeEach(async () => {
+    const { telegramPlugin } = await loadBundledPluginFacade<{ telegramPlugin: ChannelPlugin }>({
+      pluginId: "telegram",
+      artifactBasename: "api.js",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "slack" }),
+            messaging: { normalizeTarget: (to: string) => `channel:${to.toLowerCase()}` },
+          },
+        },
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: telegramPlugin,
+        },
+        { pluginId: "folded-chat", source: "test", plugin: foldedChatPlugin },
+        {
+          pluginId: "scoped-chat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "scoped-chat" }),
+            messaging: {
+              targetIdComparison: "lowercase",
+              resolveSessionConversation: ({ rawId }: { rawId: string }) =>
+                scopedConversationFixtures.get(rawId) ?? null,
+            },
+          },
+        },
+      ]),
+    );
+  });
+
+  const requesterSessionOrigin = {
+    channel: "slack",
+    accountId: "acct-1",
+    to: "channel:requester-room",
+    threadId: "requester-thread",
+  };
+  const retargetedOrigin = { channel: "slack", accountId: "acct-1", to: "channel:bound-room" };
+  const topicOrigin = {
+    channel: "telegram",
+    accountId: "bot-1",
+    to: "telegram:123:topic:99",
+    threadId: 99,
+  };
+  const retargetedTopic = { channel: "telegram", accountId: "bot-1", to: "telegram:123:topic:100" };
+
+  it.each<CompletionRouteCase>([
+    ...["completionDirectOrigin", "directOrigin"].map((field) => ({
+      name: `a case-folded ${field} target`,
+      directOrigin: { channel: "folded-chat", to: "channel:c123", threadId: "reply-1" },
+      requesterSessionOrigin: { channel: "folded-chat", to: "channel:c123", threadId: "reply-1" },
+      [field]: { channel: "folded-chat", to: "channel:C123" },
+      expected: { channel: "folded-chat", to: "channel:C123", threadId: "reply-1" },
+    })),
+    ...[
+      {
+        name: "a to-only override to another topic",
+        completionDirectOrigin: { to: retargetedTopic.to },
+        expected: retargetedTopic,
+      },
+      {
+        name: "a direct origin retargeted to another topic",
+        directOrigin: retargetedTopic,
+        expected: retargetedTopic,
+      },
+      {
+        name: "an explicit primary thread on a topic-qualified target",
+        completionDirectOrigin: { ...retargetedTopic, threadId: 100 },
+        expected: { ...retargetedTopic, threadId: 100 },
+        expectedRoute: { ...retargetedTopic, threadId: "100", chatType: "direct" as const },
+      },
+      {
+        name: "an unqualified target in the same topic's room",
+        completionDirectOrigin: { to: "telegram:123" },
+        expected: { ...topicOrigin, to: "telegram:123" },
+        expectedRoute: {
+          ...topicOrigin,
+          to: "telegram:123",
+          threadId: "99",
+          chatType: "direct" as const,
+        },
+      },
+    ].map((scenario) =>
+      Object.assign(
+        {
+          directOrigin: topicOrigin,
+          requesterSessionOrigin: topicOrigin,
+          expectedChatType: "direct" as const,
+        },
+        scenario,
+      ),
+    ),
+    ...["same", "different-port", "shorter"].map((destination) => {
+      const opaqueOrigin = {
+        channel: "matrix",
+        to: "room:!example:topic:100",
+        threadId: "$reply",
+      };
+      const to =
+        destination === "same"
+          ? opaqueOrigin.to
+          : destination === "shorter"
+            ? "room:!example"
+            : "room:!example:topic:101";
+      return {
+        name: `an opaque Matrix room with ${destination} identity`,
+        requesterSessionOrigin: opaqueOrigin,
+        directOrigin: opaqueOrigin,
+        completionDirectOrigin: {
+          to,
+        },
+        expected: destination === "same" ? opaqueOrigin : { channel: "matrix", to },
+        expectedChatType: "direct" as const,
+      };
+    }),
+    ...[false, true].map((retargeted) => {
+      const scopedOrigin = {
+        channel: "scoped-chat",
+        to: "room:topic:root:sender:a",
+        threadId: "reply-a",
+      };
+      const to = retargeted ? "alias-b" : "alias-a";
+      return {
+        name: retargeted ? "a different scoped identity with the same parent" : "a scoped alias",
+        requesterSessionOrigin: scopedOrigin,
+        directOrigin: scopedOrigin,
+        completionDirectOrigin: { to },
+        expected: retargeted ? { channel: "scoped-chat", to } : { ...scopedOrigin, to },
+        expectedChatType: "direct" as const,
+      };
+    }),
+    {
+      name: "a case-distinct canonical identity on a channel with folded target ids",
+      directOrigin: { channel: "scoped-chat", to: "alias-a", threadId: "reply-a" },
+      requesterSessionOrigin: { channel: "scoped-chat", to: "alias-a", threadId: "reply-a" },
+      completionDirectOrigin: { channel: "scoped-chat", to: "alias-upper" },
+      expected: { channel: "scoped-chat", to: "alias-upper" },
+      expectedChatType: "direct",
+    },
+    {
+      name: "a retargeted completion override",
+      completionDirectOrigin: retargetedOrigin,
+      expected: retargetedOrigin,
+    },
+    {
+      name: "a retargeted direct origin",
+      directOrigin: retargetedOrigin,
+      expected: retargetedOrigin,
+    },
+    {
+      name: "a partial completion origin",
+      completionDirectOrigin: { channel: "slack" },
+      expected: requesterSessionOrigin,
+    },
+    {
+      name: "a to-only completion origin for the same target",
+      completionDirectOrigin: { to: requesterSessionOrigin.to },
+      expected: requesterSessionOrigin,
+    },
+    {
+      name: "a to-only completion origin for a different target",
+      completionDirectOrigin: { to: retargetedOrigin.to },
+      expected: retargetedOrigin,
+    },
+    {
+      name: "an explicit completion thread",
+      completionDirectOrigin: { ...retargetedOrigin, threadId: "bound-thread" },
+      expected: { ...retargetedOrigin, threadId: "bound-thread" },
+    },
+  ])(
+    "uses $name for completion and generated-media delivery",
+    ({ name: _name, expected, expectedChatType = "channel", expectedRoute, ...override }) => {
+      const origins = { directOrigin: requesterSessionOrigin, requesterSessionOrigin, ...override };
+      expect(
+        resolveCompletionDeliveryOrigins({ ...origins, expectsCompletionMessage: true })
+          .effectiveDirectOrigin,
+      ).toEqual(expected);
+      expect(
+        resolveGeneratedMediaSessionDeliveryRoute({ sessionKey: "agent:main:main", ...origins }),
+      ).toEqual({
+        deliveryContext: expected,
+        route: expectedRoute ?? { ...expected, chatType: expectedChatType },
+      });
+    },
+  );
+});

--- a/src/agents/subagents/announce/subagent-announce-origin.ts
+++ b/src/agents/subagents/announce/subagent-announce-origin.ts
@@ -14,7 +14,6 @@ import type { SessionEntry } from "../../../config/sessions/types.js";
 import {
   stripOutboundTargetKindPrefix,
   stripTargetProviderPrefix,
-  stripTargetTopicSuffix,
 } from "../../../infra/outbound/channel-target-prefix.js";
 import type { ConversationRef } from "../../../infra/outbound/session-binding-service.js";
 import type { SessionDeliveryRoute } from "../../../infra/session-delivery-queue-storage.js";
@@ -42,26 +41,42 @@ import {
 } from "./subagent-announce-delivery.runtime.js";
 export type { DeliveryContext } from "../../../utils/delivery-context.types.js";
 
-function normalizeAnnounceRouteTarget(context?: DeliveryContext): string | undefined {
+function normalizeAnnounceRouteTarget(
+  context?: DeliveryContext,
+  fallbackChannel?: string,
+): { id: string; threadId?: string } | undefined {
   const rawTo = normalizeOptionalString(context?.to);
   if (!rawTo) {
     return undefined;
   }
-  const channel = normalizeOptionalString(context?.channel);
+  const channel = normalizeOptionalString(context?.channel ?? fallbackChannel);
   const messaging = channel
     ? getLoadedChannelPluginForRead(channel as ChannelId)?.messaging
     : undefined;
-  const route = stripTargetTopicSuffix(
-    stripOutboundTargetKindPrefix(stripTargetProviderPrefix(rawTo, channel ?? ""), [
+  const stripPrefixes = (value: string) =>
+    stripOutboundTargetKindPrefix(stripTargetProviderPrefix(value, channel ?? ""), [
       "group",
       "channel",
-    ]),
-  );
-  const normalized = messaging?.normalizeTarget?.(route) ?? route;
-  return normalized || undefined;
+    ]);
+  const target = stripPrefixes(rawTo);
+  const normalized = messaging?.normalizeTarget?.(target) ?? target;
+  // Target normalizers can add prefixes; conversation IDs use the unqualified domain.
+  const rawId = stripPrefixes(normalized);
+  if (!rawId) {
+    return undefined;
+  }
+  const conversation = messaging?.resolveSessionConversation?.({
+    kind: inferDeliveryTargetChatType({ channel, to: rawTo }) === "group" ? "group" : "channel",
+    rawId,
+  });
+  const id = normalizeOptionalString(conversation?.id);
+  return {
+    id: id ?? (messaging?.targetIdComparison === "lowercase" ? rawId.toLowerCase() : rawId),
+    threadId: id ? normalizeOptionalString(conversation?.threadId) : undefined,
+  };
 }
 
-function shouldStripThreadFromAnnounceEntry(
+function shouldStripThreadFromAnnounceFallback(
   normalizedRequester?: DeliveryContext,
   normalizedEntry?: DeliveryContext,
 ): boolean {
@@ -72,12 +87,36 @@ function shouldStripThreadFromAnnounceEntry(
   ) {
     return false;
   }
-  const requesterTarget = normalizeAnnounceRouteTarget(normalizedRequester);
-  const entryTarget = normalizeAnnounceRouteTarget(normalizedEntry);
+  const requesterTarget = normalizeAnnounceRouteTarget(
+    normalizedRequester,
+    normalizedEntry?.channel,
+  );
+  const entryTarget = normalizeAnnounceRouteTarget(normalizedEntry, normalizedRequester.channel);
   if (requesterTarget && entryTarget) {
-    return requesterTarget !== entryTarget;
+    return (
+      requesterTarget.id !== entryTarget.id ||
+      (requesterTarget.threadId !== undefined &&
+        requesterTarget.threadId !== stringifyRouteThreadId(normalizedEntry.threadId))
+    );
   }
   return false;
+}
+
+function mergeAnnounceDeliveryContext(
+  primary?: DeliveryContext,
+  fallback?: DeliveryContext,
+): DeliveryContext | undefined {
+  const normalizedPrimary = normalizeDeliveryContext(primary);
+  const normalizedFallback = normalizeDeliveryContext(fallback);
+  if (
+    normalizedFallback &&
+    shouldStripThreadFromAnnounceFallback(normalizedPrimary, normalizedFallback)
+  ) {
+    // A stored thread only applies to the same normalized route target.
+    const { threadId: _ignore, ...rest } = normalizedFallback;
+    return mergeDeliveryContext(normalizedPrimary, rest);
+  }
+  return mergeDeliveryContext(normalizedPrimary, normalizedFallback);
 }
 
 /** Resolve the delivery origin for a subagent completion announcement. */
@@ -96,15 +135,7 @@ export function resolveAnnounceOrigin(
       normalizedEntry,
     );
   }
-  const entryForMerge =
-    normalizedEntry && shouldStripThreadFromAnnounceEntry(normalizedRequester, normalizedEntry)
-      ? (() => {
-          // A stored thread only applies to the same normalized route target.
-          const { threadId: _ignore, ...rest } = normalizedEntry;
-          return rest;
-        })()
-      : normalizedEntry;
-  return mergeDeliveryContext(normalizedRequester, entryForMerge);
+  return mergeAnnounceDeliveryContext(normalizedRequester, normalizedEntry);
 }
 
 function resolveBoundConversationOrigin(params: {
@@ -120,17 +151,12 @@ function resolveBoundConversationOrigin(params: {
   const boundTarget = deliveryContextFromConversation(conversation);
   const inferredThreadId =
     boundTarget?.threadId ??
-    (parentConversationId && parentConversationId !== conversationId
-      ? conversationId
-      : undefined) ??
-    (params.requesterOrigin?.threadId != null && params.requesterOrigin.threadId !== ""
-      ? stringifyRouteThreadId(params.requesterOrigin.threadId)
-      : undefined);
+    (parentConversationId && parentConversationId !== conversationId ? conversationId : undefined);
   if (
     requesterTo &&
     conversationId &&
     requesterConversationId &&
-    conversationId.toLowerCase() === requesterConversationId.toLowerCase()
+    conversationId === requesterConversationId
   ) {
     return {
       channel: conversation.channel,
@@ -177,7 +203,7 @@ export async function resolveSubagentCompletionOrigin(params: {
       failClosed: true,
     });
     if (route.mode === "bound" && route.binding) {
-      return mergeDeliveryContext(
+      return mergeAnnounceDeliveryContext(
         resolveBoundConversationOrigin({
           bindingConversation: route.binding.conversation,
           requesterConversation,
@@ -211,7 +237,7 @@ export async function resolveSubagentCompletionOrigin(params: {
     const hookOrigin = normalizeDeliveryContext(result?.origin);
     return !hookOrigin || (hookOrigin.channel && isInternalMessageChannel(hookOrigin.channel))
       ? requesterOrigin
-      : mergeDeliveryContext(hookOrigin, requesterOrigin);
+      : mergeAnnounceDeliveryContext(hookOrigin, requesterOrigin);
   } catch {
     return requesterOrigin;
   }
@@ -239,12 +265,15 @@ export function resolveCompletionDeliveryOrigins(params: {
 }) {
   const directOrigin = normalizeDeliveryContext(params.directOrigin);
   const requesterSessionOrigin = normalizeDeliveryContext(params.requesterSessionOrigin);
-  const completionFallbackOrigin = mergeDeliveryContext(directOrigin, requesterSessionOrigin);
+  const completionFallbackOrigin = mergeAnnounceDeliveryContext(
+    directOrigin,
+    requesterSessionOrigin,
+  );
   return {
     directOrigin,
     requesterSessionOrigin,
     effectiveDirectOrigin: params.expectsCompletionMessage
-      ? mergeDeliveryContext(
+      ? mergeAnnounceDeliveryContext(
           stripNonDeliverableChannel(params.completionDirectOrigin),
           completionFallbackOrigin,
         )

--- a/test/subagent-announce-origin.integration.test.ts
+++ b/test/subagent-announce-origin.integration.test.ts
@@ -1,23 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { ChannelPlugin } from "../../../channels/plugins/types.plugin.js";
-import type { SessionEntry } from "../../../config/sessions.js";
-import {
-  testing as sessionBindingServiceTesting,
-  registerSessionBindingAdapter,
-} from "../../../infra/outbound/session-binding-service.js";
-import { normalizeLegacySessionEntryDelivery } from "../../../infra/state-migrations.legacy-session-store.js";
-import { setActivePluginRegistry } from "../../../plugins/runtime.js";
-import { loadBundledPluginFacade } from "../../../test-utils/bundled-plugin-public-surface.js";
-import {
-  createChannelTestPluginBase,
-  createTestRegistry,
-} from "../../../test-utils/channel-plugins.js";
 import {
   resolveAnnounceOrigin,
   resolveCompletionDeliveryOrigins,
   resolveGeneratedMediaSessionDeliveryRoute,
   resolveSubagentCompletionOrigin,
-} from "./subagent-announce-origin.js";
+} from "../src/agents/subagents/announce/subagent-announce-origin.js";
+import type { ChannelPlugin } from "../src/channels/plugins/types.plugin.js";
+import type { SessionEntry } from "../src/config/sessions.js";
+import {
+  testing as sessionBindingServiceTesting,
+  registerSessionBindingAdapter,
+} from "../src/infra/outbound/session-binding-service.js";
+import { normalizeLegacySessionEntryDelivery } from "../src/infra/state-migrations.legacy-session-store.js";
+import { setActivePluginRegistry } from "../src/plugins/runtime.js";
+import { loadBundledPluginFacade } from "../src/test-utils/bundled-plugin-public-surface.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../src/test-utils/channel-plugins.js";
 
 afterEach(() => {
   sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();

--- a/test/subagent-announce-origin.integration.test.ts
+++ b/test/subagent-announce-origin.integration.test.ts
@@ -147,6 +147,11 @@ describe("resolveSubagentCompletionOrigin", () => {
     setActivePluginRegistry(
       createTestRegistry([
         { pluginId: "slack", source: "test", plugin: slackPlugin },
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: createChannelTestPluginBase({ id: "discord" }),
+        },
         { pluginId: "folded-chat", source: "test", plugin: foldedChatPlugin },
         {
           pluginId: "matrix",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a subagent completion retargeted to a different conversation could retain the requester's old thread. Later fallback merges could restore that stale thread even after a binding or hook selected another destination, including the generated-media route.

## Why This Change Was Made

The announcement owner now applies one fallback merge consistently to bound, hook, direct, and final delivery origins. It inherits a thread only when the target identity still matches, and preserves an explicit thread from the binding or hook.

Conversation identity comes from the already-loaded channel's existing contract. Topic parsing stays channel-owned, normalizer-added prefixes are handled consistently, and opaque Matrix IDs remain intact. Declared case folding applies to raw target fallbacks; canonical IDs returned by channel hooks remain exact. Bound canonical IDs also retain their case. The announcement docs describe this thread-inheritance behavior.

The origin integration suite lives in the permitted root test layer, where it can compose real public plugins independently of the large delivery suite's mutable mocks. Its generic Discord routing cases now register a synthetic Discord plugin explicitly. This five-line fixture correction prevents those cases from unnecessarily loading the real bundled plugin; the real Slack and Telegram normalization controls remain intact.

## User Impact

Completion text and generated media use the selected conversation without carrying a stale thread into another room or topic. Same-conversation fallback threads, explicit overrides, partial origins, and channel/account pairing retain their intended behavior.

## Evidence

Before/after regressions cover retargeted bindings, final fallback merges, topic-qualified overrides, opaque IDs, case-sensitive bindings, and metadata-only case-folding channels. Tests compose the actual public Telegram plugin's normalizer and conversation hook. A real Slack control and scoped canonical-ID controls distinguish normalization from raw case folding.

The first CI run correctly rejected the suite's original core-test placement. Relocating its 32 cases preserved their bodies and resolved imports, without an allowlist or boundary exception. The subsequent tooling failure was reproduced on Linux with Node 24.19, source-only artifacts, the recorded nine-file prefix, and one worker: **258 passed / 18 failed before**, then **276 passed / zero failed** after only the five-line Discord registration. Both runs used the same 120-second test timeout, recorded 300-second no-output watchdog, and zero retries. All original assertions, including the 17 LINE identity assertions, remain unchanged. This establishes the fixture trigger; exact runtime loader-cache identity sharing was not instrumented. [Linux proof run](https://github.com/openclaw/openclaw/actions/runs/34574120177).

Final candidate validation passed **74 selected tests and 16 changed-file stages**, including all 32 origin cases and the complete 10-case architecture boundary suite. The earlier relocation passed 78 selected tests and 23 checks; its four hook cases were not rerun for the final fixture-only change. The earlier complete repair passed 29 checks, and its production and documentation bytes remain unchanged through these test repairs. These counts overlap and belong to their respective source states; they are not additive.

Fresh independent review of the complete staged candidate finished six clean passes through P2. CI for the new head, `d871e0f82f76d80818db19a04da8a96f325f68ce`, is pending. A separate extension-job failure in the previous CI run remains unattributed because its captured log was truncated; the Linux routing proof does not resolve that failure.

Proof uses local routing, public plugin functions, and existing hook/Gateway fixtures. The macOS runs retained generated artifacts and did not reproduce the source-only Linux failure, so they do not establish Linux behavior. No live Telegram, Matrix, Slack, Discord, native client, or provider execution is claimed. The change adds no parser, plugin/SDK contract, configuration, or persistence format, and the fixture repair changes no production loader, global cache, runner setting, or assertion.
