### PR TITLE
fix(macos): avoid stale dashboard command assertions

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
@@ -20,6 +20,7 @@ private actor DashboardReconnectAuthGate {
 @MainActor
 struct DashboardReconnectTests {
     @Test func `primary discovery failure preserves commands owned by a pending picker`() async throws {
+        let responseGate = DashboardWindowOwnershipPresentationGate()
         let discoveryGate = DashboardWindowOwnershipPresentationGate()
         let profileGate = DashboardWindowOwnershipPresentationGate()
         let failDiscovery = LockIsolated(false)
@@ -35,7 +36,8 @@ struct DashboardReconnectTests {
             window.dispatchEvent(new Event('openclaw:native-commands-state'));
             </script></body></html>
             """,
-            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'")
+            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'",
+            beforeResponse: { await responseGate.waitForRelease() })
         defer { server.stop() }
         let target = DashboardGatewayTarget.profile("secondary")
         let manager = DashboardManager._testMake(
@@ -98,11 +100,28 @@ struct DashboardReconnectTests {
             let replacement = try #require(window.windowController as? DashboardWindowController)
             let expected = ["new-session", "palette", "palette"]
             var events: [String] = []
+            var samples = 0
             let deadline = ContinuousClock.now + .seconds(5)
             repeat {
+                samples += 1
                 events = await (try? replacement.webView.evaluateJavaScript("window.commandEvents") as? [String]) ?? []
                 if !replacement.webView.isLoading, events == expected { break }
-                try await Task.sleep(for: .milliseconds(10))
+                if samples == 1 {
+                    try #require(events.isEmpty, "The held response must make the first sample empty")
+                    await responseGate.release()
+                    // Proof-only delayed consumer: the original five-second deadline is unchanged.
+                    try await Task.sleep(for: .seconds(6))
+                    let delivered = try await replacement.webView
+                        .evaluateJavaScript("window.commandEvents") as? [String]
+                    try #require(delivered == expected, "The page must already have received all three commands")
+                    try #require(ContinuousClock.now >= deadline, "The consumer must resume after its deadline")
+                    print("""
+                    Dashboard reconnect scheduling proof (original): fresh WebKit read delivered all three commands;
+                    consumer resumed after unchanged deadline; stored sample=\(events), samples=\(samples)
+                    """)
+                } else {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
             } while ContinuousClock.now < deadline
             #expect(manager._testAuxiliaryWindows().first?.target == target)
             #expect(replacement !== original)
@@ -112,6 +131,7 @@ struct DashboardReconnectTests {
         } catch {
             result = .failure(error)
         }
+        await responseGate.release()
         await discoveryGate.release()
         await profileGate.release()
         await discovery?.value

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
@@ -20,7 +20,6 @@ private actor DashboardReconnectAuthGate {
 @MainActor
 struct DashboardReconnectTests {
     @Test func `primary discovery failure preserves commands owned by a pending picker`() async throws {
-        let responseGate = DashboardWindowOwnershipPresentationGate()
         let discoveryGate = DashboardWindowOwnershipPresentationGate()
         let profileGate = DashboardWindowOwnershipPresentationGate()
         let failDiscovery = LockIsolated(false)
@@ -36,8 +35,7 @@ struct DashboardReconnectTests {
             window.dispatchEvent(new Event('openclaw:native-commands-state'));
             </script></body></html>
             """,
-            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'",
-            beforeResponse: { await responseGate.waitForRelease() })
+            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'")
         defer { server.stop() }
         let target = DashboardGatewayTarget.profile("secondary")
         let manager = DashboardManager._testMake(
@@ -116,22 +114,7 @@ struct DashboardReconnectTests {
                 if !replacement.webView.isLoading, events == expected { break }
                 // A delayed main-actor resumption must check fresh events before expiring.
                 if ContinuousClock.now >= deadline { break }
-                if samples == 1 {
-                    try #require(events.isEmpty, "The held response must make the first sample empty")
-                    await responseGate.release()
-                    // Proof-only delayed consumer: the original five-second deadline is unchanged.
-                    try await Task.sleep(for: .seconds(6))
-                    let delivered = try await replacement.webView
-                        .evaluateJavaScript("window.commandEvents") as? [String]
-                    try #require(delivered == expected, "The page must already have received all three commands")
-                    try #require(ContinuousClock.now >= deadline, "The consumer must resume after its deadline")
-                    print("""
-                    Dashboard reconnect scheduling proof (fixed): fresh WebKit read delivered all three commands;
-                    consumer resumed after unchanged deadline; stored sample=\(events), samples=\(samples)
-                    """)
-                } else {
-                    try await Task.sleep(for: .milliseconds(10))
-                }
+                try await Task.sleep(for: .milliseconds(10))
             }
             #expect(manager._testAuxiliaryWindows().first?.target == target)
             #expect(replacement !== original)
@@ -145,7 +128,6 @@ struct DashboardReconnectTests {
         } catch {
             result = .failure(error)
         }
-        await responseGate.release()
         await discoveryGate.release()
         await profileGate.release()
         await discovery?.value

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
@@ -101,11 +101,21 @@ struct DashboardReconnectTests {
             let expected = ["new-session", "palette", "palette"]
             var events: [String] = []
             var samples = 0
+            var observation = "not sampled"
             let deadline = ContinuousClock.now + .seconds(5)
-            repeat {
+            while true {
                 samples += 1
-                events = await (try? replacement.webView.evaluateJavaScript("window.commandEvents") as? [String]) ?? []
+                do {
+                    let received = try await replacement.webView.evaluateJavaScript("window.commandEvents") as? [String]
+                    events = received ?? []
+                    observation = received == nil ? "missing event array" : "event array"
+                } catch {
+                    events = []
+                    observation = "JavaScript error code \((error as NSError).code)"
+                }
                 if !replacement.webView.isLoading, events == expected { break }
+                // A delayed main-actor resumption must check fresh events before expiring.
+                if ContinuousClock.now >= deadline { break }
                 if samples == 1 {
                     try #require(events.isEmpty, "The held response must make the first sample empty")
                     await responseGate.release()
@@ -116,17 +126,21 @@ struct DashboardReconnectTests {
                     try #require(delivered == expected, "The page must already have received all three commands")
                     try #require(ContinuousClock.now >= deadline, "The consumer must resume after its deadline")
                     print("""
-                    Dashboard reconnect scheduling proof (original): fresh WebKit read delivered all three commands;
+                    Dashboard reconnect scheduling proof (fixed): fresh WebKit read delivered all three commands;
                     consumer resumed after unchanged deadline; stored sample=\(events), samples=\(samples)
                     """)
                 } else {
                     try await Task.sleep(for: .milliseconds(10))
                 }
-            } while ContinuousClock.now < deadline
+            }
             #expect(manager._testAuxiliaryWindows().first?.target == target)
             #expect(replacement !== original)
             #expect(replacement.auth.token == "secondary")
-            #expect(events == expected)
+            #expect(events == expected, """
+            samples=\(samples), observation=\(observation), loading=\(replacement.webView.isLoading),
+            failure=\(replacement.isShowingFailurePage), deliverable=\(replacement.canDeliverNativeCommands),
+            pending=\(replacement._testPendingNativeCommands)
+            """)
             result = .success(())
         } catch {
             result = .failure(error)


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the macOS reconnect test can report missing dashboard commands after a delayed polling task resumes, even when the page has already received them.

## Why This Change Was Made

Read the current WebKit events before deciding that the existing five-second deadline has expired. Keep the ordered three-command assertion and 10 ms polling interval unchanged, and include safe loading, failure, queue, and evaluation diagnostics if delivery still fails.

## User Impact

More reliable native CI evidence. Product behavior is unchanged.

## Evidence

Repository SwiftFormat and `git diff --check` pass. The final candidate and both disposable scheduling probes separately passed managed P2 review with no actionable findings.

The [original controlled native run](https://github.com/openclaw/openclaw/actions/runs/34567216977/job/103161802306) proved the stale-sample failure: a fresh WebKit read saw all three commands after the deadline, while the loop still asserted its earlier empty sample. That exact assertion was the sole failure across 2,139 native tests at width three.

The [fixed controlled native run](https://github.com/openclaw/openclaw/actions/runs/34568681317/job/103166070446), at head `83c4e439befceac691e7ff869455efa78a40428e`, confirmed the same stale first sample and verified delivery after the unchanged deadline, then passed the exact-event test. All 2,139 default-profile tests and both named-profile tests passed at width three.

The instrumentation-free [final native run](https://github.com/openclaw/openclaw/actions/runs/34571256379/job/103173807798), at head `0e9b0844289a8a03518120c7855c967def3444f8`, passed all 2,146 default-profile tests and both named-profile tests at width three. The reconnect test passed in 3.633 seconds, and the completed log contains no controlled-probe markers. All response gating, deliberate consumer delay, independent probe reads, and marker output have been removed from the final patch. The controlled experiment establishes the polling defect; the original unrelated CI log did not record enough WebKit state to establish that incident's precise failure ordering.
