### PR TITLE
fix(update): unblock pnpm 12 global updates

### DIFF
--- a/docs/install/updating/update-methods.md
+++ b/docs/install/updating/update-methods.md
@@ -251,6 +251,11 @@ install there.
 
 pnpm 12 retains the `global/v11` layout; the layout number does not need to match
 the pnpm CLI major version.
+Staged pnpm updates isolate both the global project and its launchers. OpenClaw
+sets the staging bin through CLI configuration for pnpm 10/11 and child-process
+environment configuration for pnpm 12, then verifies both destinations before
+installation. A manager that still reports a live destination stops the update
+before activation.
 
 If OpenClaw shares a pnpm global install group with another package, the
 automatic updater stops before changing the group. Update the original

--- a/src/infra/package-update-steps.native-transaction.test.ts
+++ b/src/infra/package-update-steps.native-transaction.test.ts
@@ -12,25 +12,36 @@ import {
 import { writePackageRoot } from "./package-update-steps.test-support.js";
 import type { ResolvedGlobalInstallTarget } from "./update-global.js";
 
-function readPnpmStageArgs(argv: string[]) {
+function readPnpmStageArgs(argv: string[], env?: NodeJS.ProcessEnv, pnpm12 = false) {
   return {
     projectRoot: argv
       .find((arg) => arg.startsWith("--config.global-dir="))
       ?.slice("--config.global-dir=".length),
-    binDir: argv
-      .find((arg) => arg.startsWith("--config.global-bin-dir="))
-      ?.slice("--config.global-bin-dir=".length),
+    // pnpm 12 ignores the CLI bin override and reads its environment config.
+    binDir: pnpm12
+      ? (env?.pnpm_config_global_bin_dir ?? env?.PNPM_CONFIG_GLOBAL_BIN_DIR)
+      : argv
+          .find((arg) => arg.startsWith("--config.global-bin-dir="))
+          ?.slice("--config.global-bin-dir=".length),
   };
 }
 
 describe.runIf(process.platform !== "win32")("native package transactions", () => {
   it.each([
+    {
+      layout: "pnpm11",
+      siblingChange: "none",
+      shimFailure: false,
+      rollbackFailure: "none",
+      pnpm12: true,
+    } as const,
     ...(["pnpm10", "pnpm11", "bun"] as const).flatMap((layout) =>
       (["none", "before", "after", "upgrade", "remove"] as const).map((siblingChange) => ({
         layout,
         siblingChange,
         shimFailure: false,
         rollbackFailure: "none" as const,
+        pnpm12: false,
       })),
     ),
     {
@@ -38,12 +49,14 @@ describe.runIf(process.platform !== "win32")("native package transactions", () =
       siblingChange: "none",
       shimFailure: true,
       rollbackFailure: "none",
+      pnpm12: false,
     } as const,
     {
       layout: "pnpm11",
       siblingChange: "none",
       shimFailure: true,
       rollbackFailure: "launcher-owner",
+      pnpm12: false,
     } as const,
     ...(
       [
@@ -59,10 +72,11 @@ describe.runIf(process.platform !== "win32")("native package transactions", () =
       siblingChange: "none" as const,
       shimFailure: false,
       rollbackFailure,
+      pnpm12: false,
     })),
   ])(
-    "preserves $layout native project ownership (sibling change=$siblingChange, shim failure=$shimFailure, rollback failure=$rollbackFailure)",
-    async ({ layout, siblingChange, shimFailure, rollbackFailure }) => {
+    "preserves $layout native project ownership (pnpm12=$pnpm12, sibling change=$siblingChange, shim failure=$shimFailure, rollback failure=$rollbackFailure)",
+    async ({ layout, siblingChange, shimFailure, rollbackFailure, pnpm12 }) => {
       await withTestDir({ prefix: "openclaw-native-update-" }, async (base) => {
         const manager = layout === "bun" ? "bun" : "pnpm";
         const project = path.join(base, manager, "global");
@@ -148,15 +162,15 @@ describe.runIf(process.platform !== "win32")("native package transactions", () =
             PNPM_HOME: path.dirname(project),
             pnpm_config_global_dir: project,
             pnpm_config_global_bin_dir: binDir,
+            PNPM_CONFIG_GLOBAL_BIN_DIR: binDir,
             BUN_INSTALL_GLOBAL_DIR: project,
             BUN_INSTALL_BIN: binDir,
           },
           runCommand: async (argv, options) => {
-            const stage = readPnpmStageArgs(argv);
+            const stage = readPnpmStageArgs(argv, options.env, pnpm12);
             if (stage.projectRoot) {
               expect(options.cwd).toBe(stage.projectRoot);
               expect(stage.projectRoot).not.toBe(project);
-              expect(stage.binDir).not.toBe(binDir);
               phases.push(`probe ${argv[1]}`);
             }
             return {
@@ -169,7 +183,7 @@ describe.runIf(process.platform !== "win32")("native package transactions", () =
           },
           runStep: async ({ name, argv, cwd, env }) => {
             expect(argv[0]).toBe(manager);
-            const stageArgs = readPnpmStageArgs(argv);
+            const stageArgs = readPnpmStageArgs(argv, env, pnpm12);
             const stageProject =
               manager === "bun" ? env?.BUN_INSTALL_GLOBAL_DIR : stageArgs.projectRoot;
             const stageBin = manager === "bun" ? env?.BUN_INSTALL_BIN : stageArgs.binDir;
@@ -178,6 +192,7 @@ describe.runIf(process.platform !== "win32")("native package transactions", () =
             }
             expect(cwd).toBe(stageProject);
             expect(stageProject).not.toBe(project);
+            expect(stageBin).not.toBe(binDir);
             await expect(
               fs.readFile(path.join(stageProject, "sibling-package"), "utf8"),
             ).resolves.toBe("unrelated package\n");

--- a/src/infra/update-native-package-stage.ts
+++ b/src/infra/update-native-package-stage.ts
@@ -191,6 +191,11 @@ export async function prepareNativePackageStage(params: {
       installTarget.manager === "pnpm"
         ? [`--config.global-dir=${projectRoot}`, `--config.global-bin-dir=${binDir}`]
         : [];
+    if (installTarget.manager === "pnpm") {
+      // pnpm 12 ignores the CLI bin override; its lower-case env key wins.
+      env.pnpm_config_global_bin_dir = binDir;
+      env.PNPM_CONFIG_GLOBAL_BIN_DIR = binDir;
+    }
     if (installTarget.manager === "bun") {
       env.BUN_INSTALL_GLOBAL_DIR = projectRoot;
       env.BUN_INSTALL_BIN = binDir;


### PR DESCRIPTION
Fixes #144667

## What Problem This Solves

Fixes an issue where users updating a global pnpm installation would stop at `validating` / `pnpm staging preflight` with pnpm 12.1.0, even though OpenClaw had requested a temporary bin directory. Thanks to @xilopaint for the report and package-manager comparison.

## Why This Change Was Made

The staging owner now sets both existing pnpm environment spellings of `global_bin_dir` to the staged bin. It retains the CLI override required by pnpm 10/11. The same environment and arguments reach destination probes and installation; the guard still refuses a manager that reports a live destination.

pnpm 12.1.0's [config resolver](https://github.com/pnpm/pnpm/blob/v12.1.0/pnpm/crates/config/src/lib.rs#L3740-L3758) reads the pnpm environment override before falling back to `PNPM_HOME/bin`; [lowercase takes precedence](https://github.com/pnpm/pnpm/blob/v12.1.0/pnpm/crates/config/src/lib.rs#L3941-L3949). Its [CLI override parser](https://github.com/pnpm/pnpm/blob/v12.1.0/pnpm/crates/cli/src/config_overrides.rs#L84-L98) silently drops unimplemented keys, including `global-bin-dir`. pnpm 11 [derives the bin before its environment overlay](https://github.com/pnpm/pnpm/blob/v11.24.0/pnpm11/config/reader/src/index.ts#L422-L437), so its CLI configuration remains necessary.

## User Impact

Global pnpm 12 updates can stage launchers without changing the live bin directory before activation. No new configuration option, environment-variable name, dependency, schema, or recovery policy is introduced. The environment-variable budget remains 493/493.

Release-note context: fix pnpm 12 global updates stopping at the isolated staging-bin preflight; preserve pnpm 10/11 behavior and the live-destination refusal. Credit: @xilopaint.

## Evidence

Read-only `corepack pnpm@<version> bin -g --config.global-bin-dir=<stage-bin>` probes, with both bin directories on PATH:

| pnpm | CLI override only | CLI plus staged pnpm environment |
| --- | --- | --- |
| 11.24.0 | stage bin, exit 0 | stage bin, exit 0 |
| 12.1.0 | live bin, exit 0 | stage bin, exit 0 |

The transaction regression fixtures pnpm 12's manager response at the existing command boundary. Before the production fix:

```text
FAIL preserves pnpm11 native project ownership (pnpm12=true, ...)
name: pnpm staging preflight
stderrTail: pnpm bin selected <live-bin>, expected staged destination <stage-bin>.
The live installation was left unchanged.
Tests 1 failed | 27 skipped
```

After the fix:

```sh
node scripts/run-vitest.mjs src/infra/package-update-steps.native-transaction.test.ts src/infra/update-native-package-stage.test.ts src/infra/package-update-steps.pnpm11-guard.test.ts
# Test Files 3 passed; Tests 47 passed
```

This includes native staging, activation, rollback, and refusal of live or failed destination probes. The published 2026.9.3 package installed with pnpm 12.1.0 also reproduced the exact staging-preflight failure against 2026.9.4, preserving 2026.9.3.

Known first-hop limitation: this repair belongs to the running updater. Installing a candidate target cannot repair stock 2026.9.3 before its preflight runs. Users on the affected updater need a manual package-manager update to acquire the repaired driver. Live proof uses isolated HOME, PNPM_HOME, OpenClaw state/config, and a distinct service label; it does not exercise the reporter's Linux systemd service.

Validation: `node scripts/check-changed.mjs`, `pnpm check:env-var-count` (493/493), `git diff --check`, and `pnpm build` pass. A lint finding in the initial test-table construction was fixed, and the full changed check and 47 focused tests then passed. The committed-branch Codex review is also clean at P1.

Live proof on macOS arm64 / Node 26.8.1, with pnpm 12.1.0 through Corepack:

- Stock 2026.9.3 → published 2026.9.4: reproduced the bin mismatch at staging preflight; the original package remained intact.
- Manually bootstrapped branch driver → published 2026.9.4: `global update`, every candidate check including the Gateway canary, and `global install swap` all returned 0. Post-activation Doctor failed with `Candidate executor binding does not match its parent` / `existing managed handoff lease is incompatible`. This separate handoff failure is retained as a known gap; no claim of a successful published-target update.
- Fresh isolated prefix, branch driver → the branch-built tarball: completed with exit 0, `status: ok`, `mode: pnpm`, and `serviceRestartSafe: true`. The explicit artifact forces package replacement even though the version/build match. Installation, pnpm lifecycle scripts, candidate checks, canary, swap, and Doctor all returned 0; plugin convergence reported `status: ok` with no changes or warnings. Both live attempts used `--yes --no-restart`; service management was intentionally skipped for isolated state.

The candidate tarball embeds commit `82b39cdfdb8fb435c3a99c2bb5e3c26c6fa401b2`; SHA-256: `d26dca2571e9b304a65eb42a095f7b7f6ee3b71cc2aa330eacdfb9a980971991`.

Exact-head CI: [run 34567277855](https://github.com/openclaw/openclaw/actions/runs/34567277855), watcher result `GREEN`, GitHub rollup `SUCCESS`, zero pending checks for `82b39cdfdb8fb435c3a99c2bb5e3c26c6fa401b2`.

## Maintainer review resolution

ClawSweeper's September 11 review requests a maintainer decision on the disclosed Linux systemd restart and published-2026.9.4 handoff proof gaps. Accepted for this scoped repair: destination selection stays in the existing staging owner, pnpm 10/11 CLI compatibility and the live-destination refusal remain intact, and the manual package-manager update route acquires the repaired driver. The exact-head pnpm 12 tarball update exercises the changed staging path through installation, canary, activation, and Doctor successfully.

Additional Linux service/restart proof and repair of the separately observed published-target Doctor handoff failure remain separate follow-up work. This five-line staging environment change does not alter service management or handoff semantics. Those limitations remain explicit above; they do not require a fallback, a broader update rewrite, or a claim of successful published-target completion to land this fix. No code findings or other Rank-up moves remain.
