### PR TITLE
refactor(tui): observe picker selection through callbacks

### DIFF
--- a/src/tui/components/filterable-select-list.test.ts
+++ b/src/tui/components/filterable-select-list.test.ts
@@ -1,6 +1,6 @@
 // Filterable select list tests cover keyboard filtering and cursor behavior.
-import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
-import { describe, expect, it } from "vitest";
+import { CURSOR_MARKER, type SelectItem, visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { FilterableSelectList, type FilterableSelectItem } from "./filterable-select-list.js";
 
@@ -31,6 +31,14 @@ const testItems: FilterableSelectItem[] = [
 ];
 
 describe("FilterableSelectList", () => {
+  function selectByEnter(list: FilterableSelectList) {
+    const onSelect = vi.fn<(item: SelectItem) => void>();
+    list.onSelect = onSelect;
+    list.handleInput("\r");
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    return onSelect.mock.calls[0]?.[0];
+  }
+
   function typeInput(list: FilterableSelectList, text: string) {
     for (const ch of text) {
       list.handleInput(ch);
@@ -94,23 +102,23 @@ describe("FilterableSelectList", () => {
     list.handleInput(query);
 
     expect(stripAnsi(list.render(80)[0] ?? "").trimEnd()).toBe(`>Filter: <> ${query}`);
-    expect(list.getSelectedItem()?.value).toBe(expectedValue);
+    expect(selectByEnter(list)?.value).toBe(expectedValue);
   });
 
   it("preserves arrow and Ctrl-key navigation", () => {
     const list = new FilterableSelectList(testItems, 5, mockTheme);
 
     list.handleInput("\x1b[B");
-    expect(list.getSelectedItem()?.value).toBe("session-2");
+    expect(selectByEnter(list)?.value).toBe("session-2");
 
     list.handleInput("\u0010");
-    expect(list.getSelectedItem()?.value).toBe("session-1");
+    expect(selectByEnter(list)?.value).toBe("session-1");
 
     list.handleInput("\u000e");
-    expect(list.getSelectedItem()?.value).toBe("session-2");
+    expect(selectByEnter(list)?.value).toBe("session-2");
 
     list.handleInput("\x1b[A");
-    expect(list.getSelectedItem()?.value).toBe("session-1");
+    expect(selectByEnter(list)?.value).toBe("session-1");
   });
 
   it.each([
@@ -127,13 +135,13 @@ describe("FilterableSelectList", () => {
 
     typeInput(list, "beta");
     expect(stripAnsi(list.render(80)[0] ?? "").trimEnd()).toBe(">Filter: <> beta");
-    expect(list.getSelectedItem()?.value).toBe("session-2");
+    expect(selectByEnter(list)?.value).toBe("session-2");
 
     list.handleInput(key);
 
     expect(cancelled).toBe(false);
     expect(stripAnsi(list.render(80)[0] ?? "").trimEnd()).toBe(">Filter: <>");
-    expect(list.getSelectedItem()?.value).toBe("session-1");
+    expect(selectByEnter(list)?.value).toBe("session-1");
     expect(list.render(80).join("\n")).toContain("first session");
     expect(list.render(80).join("\n")).toContain("second session");
     list.handleInput(key);
@@ -149,7 +157,7 @@ describe("FilterableSelectList", () => {
 
     typeInput(list, "codex52");
 
-    expect(list.getSelectedItem()?.value).toBe("codex");
+    expect(selectByEnter(list)?.value).toBe("codex");
   });
 
   it("sanitizes rendered fields without changing filtering or the selected value", () => {
@@ -177,8 +185,10 @@ describe("FilterableSelectList", () => {
       mockTheme,
     );
     let selectedValue: string | undefined;
+    let selectedItem: FilterableSelectItem | undefined;
     list.onSelect = (item) => {
       selectedValue = item.value;
+      selectedItem = item;
     };
 
     typeInput(list, "raw-filter-target");
@@ -197,8 +207,8 @@ describe("FilterableSelectList", () => {
     // Text removed from display remains part of the original search fields.
     list.handleInput("\x1b");
     typeInput(list, "filter-title");
-    expect(list.getSelectedItem()).toMatchObject({ searchText: "raw-filter-target" });
     list.handleInput("\r");
+    expect(selectedItem).toMatchObject({ searchText: "raw-filter-target" });
     expect(selectedValue).toBe(rawValue);
   });
 
@@ -206,14 +216,14 @@ describe("FilterableSelectList", () => {
     const item = { value: "session", label: "Before", searchText: "old-name" };
     const first = new FilterableSelectList([item], 5, mockTheme);
     typeInput(first, "old-name");
-    expect(first.getSelectedItem()?.value).toBe("session");
+    expect(selectByEnter(first)?.value).toBe("session");
 
     item.label = "After";
     item.searchText = "new-name";
     const reopened = new FilterableSelectList([item], 5, mockTheme);
     typeInput(reopened, "new-name");
 
-    expect(reopened.getSelectedItem()).toMatchObject(item);
+    expect(selectByEnter(reopened)).toMatchObject(item);
     expect(reopened.render(80).join("\n")).toContain("After");
   });
 });

--- a/src/tui/components/filterable-select-list.ts
+++ b/src/tui/components/filterable-select-list.ts
@@ -140,8 +140,4 @@ export class FilterableSelectList implements Component, Focusable {
       this.applyFilter();
     }
   }
-
-  getSelectedItem(): SelectItem | null {
-    return this.selectList.getSelectedItem();
-  }
 }

--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -1,8 +1,12 @@
 // Searchable select list tests cover filtering and selection behavior.
 import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
-import { SearchableSelectList, type SearchableSelectListTheme } from "./searchable-select-list.js";
+import {
+  SearchableSelectList,
+  type SearchableSelectItem,
+  type SearchableSelectListTheme,
+} from "./searchable-select-list.js";
 
 const mockTheme: SearchableSelectListTheme = {
   selectedPrefix: (t) => `[${t}]`,
@@ -43,6 +47,14 @@ const testItems = [
 ];
 
 describe("SearchableSelectList", () => {
+  function selectByEnter(list: SearchableSelectList) {
+    const onSelect = vi.fn<(item: SearchableSelectItem) => void>();
+    list.onSelect = onSelect;
+    list.handleInput("\r");
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    return onSelect.mock.calls[0]?.[0];
+  }
+
   function typeInput(list: SearchableSelectList, text: string) {
     for (const ch of text) {
       list.handleInput(ch);
@@ -55,7 +67,7 @@ describe("SearchableSelectList", () => {
     expectedValue: string,
   ) {
     typeInput(list, query);
-    const selected = list.getSelectedItem();
+    const selected = selectByEnter(list);
     expect(selected?.value).toBe(expectedValue);
   }
 
@@ -227,7 +239,7 @@ describe("SearchableSelectList", () => {
     // Simulate typing "gemini" - unique enough to narrow down
     typeInput(list, "gemini");
 
-    const selected = list.getSelectedItem();
+    const selected = selectByEnter(list);
     expect(selected?.value).toBe("google/gemini-pro");
   });
 
@@ -248,7 +260,7 @@ describe("SearchableSelectList", () => {
     typeInput(list, "opus");
 
     // First result should be "opus-direct" where "opus" appears at position 0
-    const selected = list.getSelectedItem();
+    const selected = selectByEnter(list);
     expect(selected?.value).toBe("opus-direct");
   });
 
@@ -277,7 +289,7 @@ describe("SearchableSelectList", () => {
     typeInput(list, "opus");
 
     // Label match should win over description match
-    const selected = list.getSelectedItem();
+    const selected = selectByEnter(list);
     expect(selected?.value).toBe("provider/opus-model");
   });
 
@@ -297,7 +309,7 @@ describe("SearchableSelectList", () => {
     // Simulate typing "gpt" which should match openai/gpt-4 models
     typeInput(list, "gpt");
 
-    const selected = list.getSelectedItem();
+    const selected = selectByEnter(list);
     expect(selected?.value).toContain("gpt");
   });
 
@@ -320,7 +332,7 @@ describe("SearchableSelectList", () => {
 
     typeInput(list, "g4");
 
-    const selected = list.getSelectedItem();
+    const selected = selectByEnter(list);
     expect(selected?.value).toBe("gpt-4");
   });
 
@@ -361,12 +373,12 @@ describe("SearchableSelectList", () => {
     const list = new SearchableSelectList(testItems, 5, mockTheme);
 
     // Initially first item is selected
-    expect(list.getSelectedItem()?.value).toBe("anthropic/claude-3-opus");
+    expect(selectByEnter(list)?.value).toBe("anthropic/claude-3-opus");
 
     // Press down arrow (escape sequence for down arrow)
     list.handleInput("\x1b[B");
 
-    expect(list.getSelectedItem()?.value).toBe("anthropic/claude-3-sonnet");
+    expect(selectByEnter(list)?.value).toBe("anthropic/claude-3-sonnet");
   });
 
   it.each([
@@ -385,7 +397,7 @@ describe("SearchableSelectList", () => {
 
     list.handleInput(query);
 
-    expect(list.getSelectedItem()?.value).toBe(expectedValue);
+    expect(selectByEnter(list)?.value).toBe(expectedValue);
     expect(stripAnsi(list.render(80)[0] ?? "")).toContain(query);
   });
 
@@ -465,10 +477,10 @@ describe("SearchableSelectList", () => {
     };
 
     typeInput(list, query);
-    const selected = list.getSelectedItem();
+    const selected = selectByEnter(list);
     list.handleInput(key);
 
     expect(cancelled).toBe(true);
-    expect(list.getSelectedItem()).toBe(selected);
+    expect(selectByEnter(list)).toBe(selected);
   });
 });

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -373,8 +373,4 @@ export class SearchableSelectList implements Component, Focusable {
       this.updateFilter();
     }
   }
-
-  getSelectedItem(): SearchableSelectItem | null {
-    return this.filteredItems[this.selectedIndex] ?? null;
-  }
 }


### PR DESCRIPTION
## What Problem This Solves

The TUI picker tests inspected selection through two methods that no production caller uses. That kept test-only API surface on both OpenClaw picker components and allowed the tests to observe an item without proving that Enter actually emits the selection used by the overlay.

## Why This Change Was Made

Remove only the two OpenClaw `getSelectedItem()` wrappers and make the existing component assertions observe `onSelect` after Enter, including an exact single-callback assertion. The existing sanitizer test keeps its meaningful callback and raw-value assertions. Pi's real `SelectList.getSelectedItem()` call in Filterable's Enter handler remains unchanged.

The pickers deliberately stay separate: Filterable clears a filter before cancelling, wraps navigation and emits sanitized row copies; Searchable cancels immediately, clamps navigation and emits original items. Their ranking, layout, highlighting and terminal-sanitization behavior are preserved. Production **+0/−8**; tests **+48/−26**. No dependency, configuration, storage, protocol or public plugin API change.

## User Impact

No intended user-visible behavior or appearance change. TUI picker behavior remains the same, while tests now observe the callback contract consumed by production overlays rather than a test-only accessor.

## Evidence

- Original unchanged component suites: **72 passed**. Migrated assertions on original production: **72 passed**. Candidate and final candidate: **72 passed** each, with identical leaf inventory and per-file order.
- An omitted Enter callback in each owner makes its selected regression assertion fail for the intended `expected 1 callback, got 0` reason. Exact inverses restore both selected cases to green.
- The unchanged native PTY suite passed **9 original + 9 candidate cases** on Linux Node **24.19.0**, pnpm **12.3.4**, Pi **0.84.4** and node-pty **1.2.0-beta.15**, with matching actual runtime/dependency bindings. All **21 recorded selection/cancellation frame and call records** match between original and candidate. This covers editing while a model update is pending, model cancellation and the session picker's clear-first behavior across four cancellation encodings.
- The ordinary changed gate passed all **29 selected checks**, including both core type graphs, exact-file lint with zero warnings/errors, dead exports and the selected ownership guards. [Changed-gate run](https://github.com/openclaw/openclaw/actions/runs/34565480833).
- Complete independent precommit review and separate authenticated exact-commit review of `6034c746f956292a1f01f0c03439a14187b3250f`: both scoped-clean through **P2**, with all four changed files and complete owner/caller/dependency context. No prior review verdict was supplied as input to the exact-commit review.

The signed commit has raw parent `bfac43ad2e78a21676eb36079111e5efb528e4dd` and the exact tested tree `a5b6df0c9238efd0eb049c893cb5f0e55d411938`. The complete 40,762-entry physical/committed source map was verified, not only the four changed files. The proof leases and their recorded processes, keys, claims and temporary sync checkouts are closed. [Original PTY environment](https://github.com/openclaw/openclaw/actions/runs/34553284921) · [Candidate PTY environment](https://github.com/openclaw/openclaw/actions/runs/34564004795).

<details>
<summary>Proof boundaries and retained recovery limitations</summary>

The PTY suite runs the real TUI loop and terminal process with its existing synthetic backend. It is not live Gateway, provider, authentication, session-persistence or screenshot proof. Recorded frames are terminal observations, not image captures. Test duration differences are not a performance claim.

The original run's native completion and provider timing report exit 0, but its old local session handle was unavailable during recovery; its local wrapper/tee exit codes remain unknown. The original worktree setup likewise has verified complete materialization but unavailable separate Git/tee exits. Neither operation was replayed to manufacture cleaner history.

Original-run raw index bytes changed without retained earlier bytes to establish why. Logical index/flags, source contents and the complete physical map were independently unchanged; the cause is not labeled a stat-cache refresh. Candidate PTY and changed-gate raw index checks remained equal.

Local component proof used the ordinary Node 26.8.1 binding. A later metadata-only Bash capture resolved Node 26.5.0; it ran no test or lease, and the normal shell binding was separately recorded before wrapper work. No PATH, runtime, heap, worker, provider, timeout or offline override was used. Optional `fd` was absent in the Linux observations; the selected picker flows do not require it. The TUI's ordinary asynchronous helper provisioning path remains possible, so the invocation is not claimed network-free or proof of successful provisioning.

Process evidence covers the recorded identities and fixture namespaces, not an exhaustive descendant trace. The existing first-case disposal path can synthesize exit 137 during forced cleanup; this is not relabeled as an observed native exit. One task-owned idle SSH mux left after the changed gate was positively attributed and closed separately after its control socket had disappeared. Initial guard self-parent bookkeeping and an archive-order observer mismatch are retained as caller/observer corrections; no native test was replayed or weakened.

The linked Actions runs provision the Testbox environments. Native wrapper/completion results, not a backing-run color after lease cleanup, establish the reported outcomes. Post-completion portal-sync warnings are retained.

</details>
