### PR TITLE
refactor(tests): reuse skills CLI assertion helpers

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -8,6 +8,11 @@ import {
   type AgentSelectionContext,
 } from "../agents/agent-scope-config.js";
 import { GatewayTransportError } from "../gateway/transport-error.js";
+import {
+  expectObjectFields,
+  mockCall,
+  mockFirstObjectArg,
+} from "../test-utils/mock-call-assertions.js";
 import { registerSkillsCli } from "./skills-cli.js";
 
 const ORIGINAL_STDIN_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
@@ -187,33 +192,6 @@ afterEach(() => {
   restoreTty();
   vi.unstubAllEnvs();
 });
-
-function mockCall(mock: unknown, index = 0): Array<unknown> {
-  const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
-  const call = calls.at(index);
-  if (!call) {
-    throw new Error(`Expected mock call ${index + 1}`);
-  }
-  return call;
-}
-
-function mockFirstObjectArg(mock: unknown): Record<string, unknown> {
-  const [arg] = mockCall(mock);
-  if (!arg || typeof arg !== "object") {
-    throw new Error("expected first mock argument object");
-  }
-  return arg as Record<string, unknown>;
-}
-
-function expectObjectFields(value: unknown, expected: Record<string, unknown>): void {
-  if (!value || typeof value !== "object") {
-    throw new Error("expected object fields");
-  }
-  const record = value as Record<string, unknown>;
-  for (const [key, expectedValue] of Object.entries(expected)) {
-    expect(record[key], key).toEqual(expectedValue);
-  }
-}
 
 function expectLogger(value: unknown): void {
   if (!value || typeof value !== "object") {


### PR DESCRIPTION
## What Problem This Solves

The skills CLI command tests carried local copies of three assertion helpers already maintained in `src/test-utils/mock-call-assertions.ts`. Keeping identical copies adds maintenance work and makes later assertion improvements easier to apply inconsistently.

## Why This Change Was Made

Replace the local `mockCall`, `mockFirstObjectArg`, and `expectObjectFields` declarations with imports from the existing shared owner, also used by the secrets CLI tests. The helper bodies match exactly, and every other test-source byte is unchanged apart from the import block. No test cases, assertion inputs, command invocations, or mock setup are removed or changed.

## User Impact

No production or CLI behavior changes. This one-file test cleanup adds five lines and removes 27, a net reduction of 22 lines, with no new dependency.

## Evidence

The skills CLI and secrets CLI suites passed before and after: 169 tests total (141 skills and 28 secrets), with the same per-file case inventory and order. Source hashes stayed unchanged during both runs and the recorded native groups closed. Independent source review found no actionable P0-P2 issue and confirmed identical helper semantics and preservation of the remaining test source.

All 20 checks in the normal changed-file gate passed, including the selected CLI test graph, formatting, lint, and full unused-export audit. Bounded archive/current-index checks found no matching cleanup PR.
