### PR TITLE
fix(update): failed-update records hide the triggering error behind the excerpt tail

### DIFF
--- a/src/commands/triage-update.test.ts
+++ b/src/commands/triage-update.test.ts
@@ -285,4 +285,40 @@ describe("update failure triage diagnostics", () => {
 
     await expect(readTriageUpdateFailure(inputPath, { env: {}, stateDir })).rejects.toThrow(error);
   });
+
+  it("keeps the leading diagnostic of a failed step beside the outcome tail", async () => {
+    const stateDir = tempDirs.make("openclaw-update-triage-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const result: UpdateRunResult = {
+      status: "error",
+      mode: "npm",
+      root: "openclaw",
+      reason: "Package install failed",
+      before: { version: "2026.9.3" },
+      recovery: { serviceRestartSafe: false, reason: "runtime-verification-failed" },
+      durationMs: 10,
+      steps: [
+        {
+          name: "global install swap",
+          command: "swap staged package",
+          cwd: ".",
+          durationMs: 1,
+          exitCode: 1,
+          stdoutTail: null,
+          stderrTail: [
+            "PackageUpdateSwapError: retained package tree changed after a copy fallback",
+            ...Array.from({ length: 30 }, (_, index) => `rollback detail line ${index}`),
+            "Installation recovery is unverified.",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const outputPath = await writeTriageUpdateFailure({ result }, { env });
+    const raw = await fs.readFile(outputPath, "utf8");
+
+    expect(raw).toContain("PackageUpdateSwapError");
+    expect(raw).toContain("recovery is unverified");
+    expect(raw).toContain("...");
+  });
 });

--- a/src/commands/triage-update.ts
+++ b/src/commands/triage-update.ts
@@ -295,7 +295,10 @@ export function sanitizeTriageUpdateFailure(
         name: text(step.name, 64),
         exitCode: step.exitCode,
         termination: step.termination,
-        stderrTail: text(step.stderrTail, 160, "tail"),
+        // Failed-step stderr leads with the triggering error: keep both ends. The 384-byte cap's
+        // tail half is wider than the previous tail-only window, so previously visible excerpts
+        // remain visible; stdout keeps its tail-only outcome excerpt.
+        stderrTail: text(step.stderrTail, 384, "ends"),
         stdoutTail: text(step.stdoutTail, 160, "tail"),
       })),
     },


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.
-->

Related: #144712 (the failure-record observability half; the rollback-verification design and docs asks there remain open)

## What Problem This Solves

Fixes an issue where operators diagnosing a failed `openclaw update` would lose the triggering error whenever a failed step's stderr exceeded the excerpt budget: the update-failure record caps each step's stderr excerpt to a tail-only 160-byte slice, so a multi-part diagnostic (leading error, then recovery verdict) reaches `openclaw-update-failure-*.json` as a mid-word fragment with no root cause. Observed on a 2026.9.3 → 2026.9.4 npm user-global update (#144712): two deterministic `global install swap` failures were recorded as `…etained package tree changed …`, and the swap error that started the rollback was unrecoverable from any artifact — diagnosing it required reading the updater source.

## Why This Change Was Made

Failed-step stderr leads with the triggering error and ends with the outcome, so the stderr excerpt keeps both ends: the sanitizer's existing `ends` mode at a 384-byte cap. The tail half stays wider than the previous tail-only window, so every excerpt that was visible before remains visible; the head now carries the triggering error. stdout excerpts keep their tail-only outcome form. Excerpt caps elsewhere, the 4 KiB prompt-fit loop, and the run-record summary's final-lines-only contract are unchanged — that summary and the live console line are deliberately left as they are (their behavior is pinned by `update-run-report.test.ts`), and both are noted in #144712 for a separate discussion.

## User Impact

Operators and support agents reading `openclaw-update-failure-*.json` or the update triage prompt now see the start of the triggering error (for example, the swap failure reason) next to the final recovery verdict instead of a truncated mid-word fragment, so failed-update diagnosis no longer requires source access. Previously visible excerpts remain visible.

## Evidence

- `src/commands/triage-update.test.ts` gains a case whose stderr leads with the triggering error and spans multiple rollback detail lines: under the new excerpt the record contains the leading diagnostic, the outcome tail, and the ellipsis; the file's suite passes.
- The head assertion is unsatisfiable under the previous tail-only excerpt: the fixture's leading diagnostic lies outside its 160-byte tail window, so the case discriminates the previous behavior.
- Previously visible content stays visible: the new tail window is strictly wider than the previous one, which is what `triage-recovery.test.ts` relies on via `StringContaining` diagnostics.
- `oxfmt --check` clean on the touched files; typecheck and lint run in CI.

### Real-behavior proof (after fix)

A real `openclaw update` run (2026.9.3 → 2026.9.4, npm global install inside an isolated global prefix with a fresh state dir, `--no-restart`) reproduced the #144712 swap failure end to end — staging, migration rehearsal, doctor lint, config validation, plugin resolution, and the gateway canary all passed, then `global install swap` exited 1, matching the deterministic failure reported from two machines. The failure record written by this patch retains both ends of the failed step's stderr:

```json
{"name": "global install swap", "exitCode": 1, "stderrTail": "Package rollback verification timed out Package rollback verification failed: retained package tree changed Installation recovery is unverified; inspect the installation and backups in <globalRoot> before restarting."}
```

The leading sentence — `Package rollback verification timed out` — is the triggering error that every pre-fix record erased: the two records in #144712 and the reporter's diagnostics all begin mid-word with `…etained package tree changed`. Under the previous 160-byte tail-only excerpt this head was unrecoverable; with the 384-byte `ends` excerpt the whole excerpt fits under the cap and is preserved verbatim. The same run also surfaced the likely mechanism behind the deterministic failures: the swap's package integrity scan hits its time budget on real installation trees, which aborts the swap and starts the rollback whose re-verification then reports the tree as changed.
