### PR TITLE
refactor: simplify Obsidian CLI discovery

### DIFF
--- a/extensions/memory-wiki/src/obsidian.test.ts
+++ b/extensions/memory-wiki/src/obsidian.test.ts
@@ -1,4 +1,3 @@
-// Memory Wiki tests cover obsidian plugin behavior.
 import { describe, expect, it } from "vitest";
 import { resolveMemoryWikiConfig } from "./config.js";
 import { runObsidianDaily, runObsidianSearch } from "./obsidian.js";
@@ -24,15 +23,11 @@ describe("runObsidianSearch", () => {
       calls.push({ command, argv: argv ? [...argv] : [], options });
       return { stdout: "search output\n", stderr: "" };
     };
-    const exec = execImpl as unknown as NonNullable<
-      NonNullable<Parameters<typeof runObsidianSearch>[0]["deps"]>["exec"]
-    >;
-
     const result = await runObsidianSearch({
       config,
       query: "agent memory",
       deps: {
-        exec,
+        exec: execImpl,
         resolveCommand: async () => "/usr/local/bin/obsidian",
       },
     });

--- a/extensions/memory-wiki/src/obsidian.ts
+++ b/extensions/memory-wiki/src/obsidian.ts
@@ -1,4 +1,3 @@
-// Memory Wiki plugin module implements obsidian behavior.
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -47,10 +46,6 @@ async function resolveCommandOnPath(command: string): Promise<string | null> {
       ? (process.env.PATHEXT?.split(";").filter(Boolean) ?? [".EXE", ".CMD", ".BAT"])
       : [""];
 
-  if (command.includes(path.sep)) {
-    return (await isExecutableFile(command)) ? command : null;
-  }
-
   for (const dir of pathEntries) {
     for (const extension of windowsExts) {
       const candidate = path.join(dir, extension ? `${command}${extension}` : command);
@@ -61,10 +56,6 @@ async function resolveCommandOnPath(command: string): Promise<string | null> {
   }
 
   return null;
-}
-
-function buildVaultPrefix(config: ResolvedMemoryWikiConfig): string[] {
-  return config.obsidian.vaultName ? [`vault=${config.obsidian.vaultName}`] : [];
 }
 
 export async function probeObsidianCli(
@@ -84,12 +75,16 @@ async function runObsidianCli(params: {
   args?: string[];
   deps?: ObsidianCliDeps;
 }): Promise<ObsidianCliResult> {
-  const resolveCommand = params.deps?.resolveCommand ?? resolveCommandOnPath;
-  const probe = await probeObsidianCli({ resolveCommand });
+  const probe = await probeObsidianCli(params.deps);
   if (!probe.command) {
     throw new Error("Obsidian CLI is not available on PATH.");
   }
-  const argv = [...buildVaultPrefix(params.config), params.subcommand, ...(params.args ?? [])];
+  const { vaultName } = params.config.obsidian;
+  const argv = [
+    ...(vaultName ? [`vault=${vaultName}`] : []),
+    params.subcommand,
+    ...(params.args ?? []),
+  ];
   const exec = params.deps?.exec ?? runExec;
   const { stdout, stderr } = await exec(probe.command, argv, {
     logOutput: false,


### PR DESCRIPTION
## What Problem This Solves

Obsidian CLI discovery retained an unreachable explicit-path branch and selected the same resolver in two places. Its invocation test also hid an already-compatible executor behind a type assertion.

## Why This Change Was Made

Keep resolver selection in the existing availability probe, remove the dead path branch, and construct the vault argument alongside the command arguments. Pass the test executor directly so TypeScript verifies its contract.

## User Impact

No intended behavior change. Discovery order, executable-file checks, injected resolver paths, command arguments, and the ten-second timeout are preserved.

## Evidence

Existing discovery and invocation tests pass: 10 cases, with the Windows-only PATHEXT case skipped on macOS. All 25 changed-file checks passed on the original patch, including production and test typechecking. No assertions or test scenarios were added or weakened. Independent review through P2 found no actionable findings.

This removes five production lines and five test lines. No external Obsidian process or live Gateway was used; Windows execution is not claimed.

The first CI run exposed a pre-existing memory-core FTS fixture failure, reproduced independently of this cleanup. PR #144761 repaired that fixture on main. This branch is rebased onto that repair; the two-file patch and all 12 reviewed source inputs are byte-identical, so the scoped local proof and review remain applicable. [CI for the rebased head passed](https://github.com/openclaw/openclaw/actions/runs/34586322324).
