### PR TITLE
refactor(slack): preserve SDK types in slash command wiring

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1127,7 +1127,7 @@ extensions/slack/src/monitor/provider-support.ts	3
 extensions/slack/src/monitor/provider.ts	5
 extensions/slack/src/monitor/reconnect-policy.ts	6
 extensions/slack/src/monitor/relay-source.ts	2
-extensions/slack/src/monitor/slash.ts	11
+extensions/slack/src/monitor/slash.ts	10
 extensions/slack/src/monitor/thread-resolution.ts	1
 extensions/slack/src/monitor/thread.ts	2
 extensions/slack/src/native-data-blocks.ts	1

--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -247,6 +247,10 @@ throw createChannelPartialDeliveryError(cause, {
 });
 ```
 
+Errors created by this helper retain the original failure in `cause`. After
+`isChannelPartialDeliveryError(error)`, `error.cause` is `unknown`; structural
+envelopes may omit it.
+
 Core emits a failed terminal observation with that provider-visible content and
 identity, then keeps the delivery failed so callers do not mistake partial
 success for a clean send. Do not report `visibleReplySent: false` after any

--- a/extensions/slack/src/monitor/slash-commands.runtime.ts
+++ b/extensions/slack/src/monitor/slash-commands.runtime.ts
@@ -1,48 +1,7 @@
-// Slack plugin module implements slash commands behavior.
-import {
-  buildCommandTextFromArgs as buildCommandTextFromArgsImpl,
-  findCommandByNativeName as findCommandByNativeNameImpl,
-  listNativeCommandSpecsForConfig as listNativeCommandSpecsForConfigImpl,
-  parseCommandArgs as parseCommandArgsImpl,
-  resolveCommandArgMenu as resolveCommandArgMenuImpl,
+export {
+  buildCommandTextFromArgs,
+  findCommandByNativeName,
+  listNativeCommandSpecsForConfig,
+  parseCommandArgs,
+  resolveCommandArgMenu,
 } from "openclaw/plugin-sdk/command-auth-native";
-
-type BuildCommandTextFromArgs =
-  typeof import("openclaw/plugin-sdk/command-auth-native").buildCommandTextFromArgs;
-type FindCommandByNativeName =
-  typeof import("openclaw/plugin-sdk/command-auth-native").findCommandByNativeName;
-type ListNativeCommandSpecsForConfig =
-  typeof import("openclaw/plugin-sdk/command-auth-native").listNativeCommandSpecsForConfig;
-type ParseCommandArgs = typeof import("openclaw/plugin-sdk/command-auth-native").parseCommandArgs;
-type ResolveCommandArgMenu =
-  typeof import("openclaw/plugin-sdk/command-auth-native").resolveCommandArgMenu;
-
-export function buildCommandTextFromArgs(
-  ...args: Parameters<BuildCommandTextFromArgs>
-): ReturnType<BuildCommandTextFromArgs> {
-  return buildCommandTextFromArgsImpl(...args);
-}
-
-export function findCommandByNativeName(
-  ...args: Parameters<FindCommandByNativeName>
-): ReturnType<FindCommandByNativeName> {
-  return findCommandByNativeNameImpl(...args);
-}
-
-export function listNativeCommandSpecsForConfig(
-  ...args: Parameters<ListNativeCommandSpecsForConfig>
-): ReturnType<ListNativeCommandSpecsForConfig> {
-  return listNativeCommandSpecsForConfigImpl(...args);
-}
-
-export function parseCommandArgs(
-  ...args: Parameters<ParseCommandArgs>
-): ReturnType<ParseCommandArgs> {
-  return parseCommandArgsImpl(...args);
-}
-
-export function resolveCommandArgMenu(
-  ...args: Parameters<ResolveCommandArgMenu>
-): ReturnType<ResolveCommandArgMenu> {
-  return resolveCommandArgMenuImpl(...args);
-}

--- a/extensions/slack/src/monitor/slash-dispatch.runtime.ts
+++ b/extensions/slack/src/monitor/slash-dispatch.runtime.ts
@@ -1,76 +1,9 @@
-// Slack plugin module implements slash dispatch behavior.
-import {
-  dispatchChannelInboundTurn as dispatchChannelInboundTurnImpl,
-  isChannelPartialDeliveryError as isChannelPartialDeliveryErrorImpl,
+export {
+  dispatchChannelInboundTurn,
+  isChannelPartialDeliveryError,
 } from "openclaw/plugin-sdk/channel-inbound";
-import { resolveConversationLabel as resolveConversationLabelImpl } from "openclaw/plugin-sdk/conversation-runtime";
-import { resolveMarkdownTableMode as resolveMarkdownTableModeImpl } from "openclaw/plugin-sdk/markdown-table-runtime";
-import {
-  finalizeInboundContext as finalizeInboundContextImpl,
-  resolveChunkMode as resolveChunkModeImpl,
-} from "openclaw/plugin-sdk/reply-runtime";
-import { resolveAgentRoute as resolveAgentRouteImpl } from "openclaw/plugin-sdk/routing";
-import { deliverSlackSlashReplies as deliverSlackSlashRepliesImpl } from "./replies.js";
-export { sanitizeSlackMonitorReplyPayload } from "./replies.js";
-
-type ResolveChunkMode = typeof import("openclaw/plugin-sdk/reply-runtime").resolveChunkMode;
-type FinalizeInboundContext =
-  typeof import("openclaw/plugin-sdk/reply-runtime").finalizeInboundContext;
-type DispatchChannelInboundTurn =
-  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
-type IsChannelPartialDeliveryError =
-  typeof import("openclaw/plugin-sdk/channel-inbound").isChannelPartialDeliveryError;
-type ResolveConversationLabel =
-  typeof import("openclaw/plugin-sdk/conversation-runtime").resolveConversationLabel;
-type ResolveMarkdownTableMode =
-  typeof import("openclaw/plugin-sdk/markdown-table-runtime").resolveMarkdownTableMode;
-type ResolveAgentRoute = typeof import("openclaw/plugin-sdk/routing").resolveAgentRoute;
-type DeliverSlackSlashReplies = typeof import("./replies.js").deliverSlackSlashReplies;
-
-export function resolveChunkMode(
-  ...args: Parameters<ResolveChunkMode>
-): ReturnType<ResolveChunkMode> {
-  return resolveChunkModeImpl(...args);
-}
-
-export function finalizeInboundContext(
-  ...args: Parameters<FinalizeInboundContext>
-): ReturnType<FinalizeInboundContext> {
-  return finalizeInboundContextImpl(...args);
-}
-
-export function dispatchChannelInboundTurn(
-  ...args: Parameters<DispatchChannelInboundTurn>
-): ReturnType<DispatchChannelInboundTurn> {
-  return dispatchChannelInboundTurnImpl(...args);
-}
-
-export function isChannelPartialDeliveryError(
-  ...args: Parameters<IsChannelPartialDeliveryError>
-): ReturnType<IsChannelPartialDeliveryError> {
-  return isChannelPartialDeliveryErrorImpl(...args);
-}
-
-export function resolveConversationLabel(
-  ...args: Parameters<ResolveConversationLabel>
-): ReturnType<ResolveConversationLabel> {
-  return resolveConversationLabelImpl(...args);
-}
-
-export function resolveMarkdownTableMode(
-  ...args: Parameters<ResolveMarkdownTableMode>
-): ReturnType<ResolveMarkdownTableMode> {
-  return resolveMarkdownTableModeImpl(...args);
-}
-
-export function resolveAgentRoute(
-  ...args: Parameters<ResolveAgentRoute>
-): ReturnType<ResolveAgentRoute> {
-  return resolveAgentRouteImpl(...args);
-}
-
-export function deliverSlackSlashReplies(
-  ...args: Parameters<DeliverSlackSlashReplies>
-): ReturnType<DeliverSlackSlashReplies> {
-  return deliverSlackSlashRepliesImpl(...args);
-}
+export { resolveConversationLabel } from "openclaw/plugin-sdk/conversation-runtime";
+export { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
+export { finalizeInboundContext, resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
+export { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+export { deliverSlackSlashReplies, sanitizeSlackMonitorReplyPayload } from "./replies.js";

--- a/extensions/slack/src/monitor/slash-skill-commands.runtime.ts
+++ b/extensions/slack/src/monitor/slash-skill-commands.runtime.ts
@@ -1,11 +1,1 @@
-// Slack plugin module implements slash skill commands behavior.
-import { listSkillCommandsForAgents as listSkillCommandsForAgentsImpl } from "openclaw/plugin-sdk/command-auth-native";
-
-type ListSkillCommandsForAgents =
-  typeof import("openclaw/plugin-sdk/command-auth-native").listSkillCommandsForAgents;
-
-export function listSkillCommandsForAgents(
-  ...args: Parameters<ListSkillCommandsForAgents>
-): ReturnType<ListSkillCommandsForAgents> {
-  return listSkillCommandsForAgentsImpl(...args);
-}
+export { listSkillCommandsForAgents } from "openclaw/plugin-sdk/command-auth-native";

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -923,7 +923,7 @@ export function createSlackCommandHandler(params: {
               );
             } catch (error) {
               const unsettledError = isChannelPartialDeliveryError(error)
-                ? ((error as Error).cause ?? error)
+                ? (error.cause ?? error)
                 : error;
               for (const [replyIndex, entry] of pending.entries()) {
                 if (!settled.has(replyIndex)) {

--- a/src/channels/turn/delivery-result.ts
+++ b/src/channels/turn/delivery-result.ts
@@ -66,6 +66,7 @@ export function createSuppressedChannelDeliveryResult(params: {
 const CHANNEL_PARTIAL_DELIVERY_ERROR_CODE = "CHANNEL_PARTIAL_DELIVERY";
 
 type ChannelPartialDeliveryEnvelope = {
+  cause?: unknown;
   code: typeof CHANNEL_PARTIAL_DELIVERY_ERROR_CODE;
   deliveryResult: ChannelDeliveryOutcome & { visibleReplySent: true };
 };


### PR DESCRIPTION
Closes #144733

## What Problem This Solves

Slack slash-command wiring duplicates forwarding declarations and erases the shared SDK's precise types, adding maintenance work and requiring an unnecessary `Error` assertion.

## Why This Change Was Made

Replace three private forwarding modules with named re-exports while retaining their lazy module paths. Declare the partial-delivery envelope's existing optional `cause?: unknown` contract, remove the assertion, and shrink its baseline entry from 11 to 10.

## User Impact

No runtime behavior changes. Command registration, reply settlement, and cause handling for plain and cross-realm objects stay intact. Plugin developers get accurate optional-cause typing.

## Evidence

- Existing delivery-result and Slack slash tests: 80 passed before and 80 after; no test changes.
- Full changed checks, all four typecheck lanes, import/dead-export guards, and `pnpm build` passed.
- SDK diff: one reachable declaration changed across three existing exports; acknowledged digest `75a65945`.
- Independent P2 review: no findings. Removes 97 production code lines and 117 production physical lines; including documentation, the tracked diff removes 113 physical lines.
