### PR TITLE
fix(auto-reply): bound the sandbox scp transfer with a deadline

### DIFF
--- a/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
@@ -28,6 +28,7 @@ import type { RuntimeMsgContext, TemplateContext } from "../templating.js";
 import { stageSandboxMedia } from "./stage-sandbox-media.js";
 
 const SCP_STDERR_TAIL_CHARS = 16_384;
+const SCP_TRANSFER_TIMEOUT_MS = 30_000;
 const REMOTE_PATH = "/synthetic/attachments/report with spaces.txt";
 const SUCCESS = {
   code: 0,
@@ -207,6 +208,7 @@ describe("stageSandboxMedia SCP", () => {
           download,
         ],
         expect.objectContaining({
+          timeoutMs: SCP_TRANSFER_TIMEOUT_MS,
           maxOutputBytes: { stdout: 1, stderr: SCP_STDERR_TAIL_CHARS * 4 },
         }),
       );
@@ -666,5 +668,103 @@ describe("stageSandboxMedia SCP", () => {
         );
       });
     },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "bounds an unattended SCP hang with the shared runner deadline",
+    async () => {
+      await withOpenClawTestState({ label: "scp-hung-timeout" }, async (state) => {
+        const params = remoteStageParams(state);
+        const before = structuredClone([params.ctx, params.sessionCtx]);
+        const binDir = state.path("bin");
+        const attemptsPath = state.path("attempts");
+        const parentPidPath = state.path("parent.pid");
+        const descendantPidPath = state.path("descendant.pid");
+        const readyPath = state.path("ready.pid");
+        const cleanupPath = state.path("cleanup");
+        const downloadPath = state.path("download-path");
+        await fs.mkdir(binDir);
+        const descendantSource = [
+          "const fs = require('node:fs')",
+          `const cleanup = () => { if (fs.existsSync(${JSON.stringify(cleanupPath)})) process.exit(0) }`,
+          "process.on('disconnect', cleanup); cleanup()",
+          "process.on('SIGTERM', () => {})",
+          "setInterval(() => {}, 1000)",
+          "process.send('ready')",
+        ].join(";");
+        await fs.writeFile(
+          path.join(binDir, "scp"),
+          [
+            `#!${process.execPath}`,
+            "const fs = require('node:fs'); const { spawn } = require('node:child_process');",
+            `const retried = fs.existsSync(${JSON.stringify(attemptsPath)});`,
+            `fs.appendFileSync(${JSON.stringify(attemptsPath)}, 'attempt\\n');`,
+            `if (retried || fs.existsSync(${JSON.stringify(cleanupPath)})) process.exit(1);`,
+            `fs.writeFileSync(${JSON.stringify(parentPidPath)}, String(process.pid));`,
+            `fs.writeFileSync(${JSON.stringify(downloadPath)}, process.argv.at(-1));`,
+            "process.on('SIGTERM', () => {});",
+            `const child = spawn(process.execPath, ['-e', ${JSON.stringify(descendantSource)}], { stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });`,
+            `fs.writeFileSync(${JSON.stringify(descendantPidPath)}, String(child.pid));`,
+            `child.once('message', () => fs.writeFileSync(${JSON.stringify(readyPath)}, String(process.pid)));`,
+            "setInterval(() => {}, 1000);",
+          ].join("\n"),
+          { mode: 0o700 },
+        );
+
+        await withEnvAsync(
+          { PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+          async () => {
+            const spawn = vi.spyOn(execSpawn, "spawnCommandWithInvocation");
+            let parentPid: number | undefined;
+            let descendantPid: number | undefined;
+            // No cancellation: only the shared runner deadline can settle this transfer.
+            const settled = stageSandboxMedia(params).then(
+              (value) => ({ value }),
+              (error: unknown) => ({ error }),
+            );
+            let reapedByDeadline: boolean[] = [];
+            let temporaryDirectoryRemoved = false;
+            // Sandbox setup can be slow under load; the transfer deadline is the behavior under test.
+            const spawnReadyTimeoutMs = 60_000;
+            try {
+              parentPid = await waitForPidFile(parentPidPath, spawnReadyTimeoutMs);
+              descendantPid = await waitForPidFile(descendantPidPath, spawnReadyTimeoutMs);
+              expect(await waitForPidFile(readyPath, spawnReadyTimeoutMs)).toBe(parentPid);
+              expect(isPidAlive(parentPid)).toBe(true);
+              expect(isPidAlive(descendantPid)).toBe(true);
+              reapedByDeadline = await Promise.all([
+                waitForPidToExit(parentPid, SCP_TRANSFER_TIMEOUT_MS + 5_000),
+                waitForPidToExit(descendantPid, SCP_TRANSFER_TIMEOUT_MS + 5_000),
+              ]);
+            } finally {
+              // Stop any late attempt, then drain the owner before removing its fixture.
+              await fs.writeFile(cleanupPath, "cleanup");
+              for (const [index, result] of spawn.mock.results.entries()) {
+                if (spawn.mock.calls[index]?.[0][0] === "scp" && result.type === "return") {
+                  killPidIfAlive(result.value.child.nodeChildProcess.pid);
+                }
+              }
+              descendantPid ??= await readPidFile(descendantPidPath).catch(() => undefined);
+              killPidIfAlive(descendantPid);
+              await settled;
+              if (existsSync(downloadPath)) {
+                const download = await fs.readFile(downloadPath, "utf8");
+                const temporaryDirectory = path.dirname(download);
+                temporaryDirectoryRemoved = !existsSync(temporaryDirectory);
+                await fs.rm(temporaryDirectory, { recursive: true, force: true });
+              }
+            }
+
+            expect(reapedByDeadline).toEqual([true, true]);
+            // The bounded retry loop exhausts instead of publishing failed media.
+            expect(await settled).toEqual({ value: { staged: new Map() } });
+            expect(await fs.readFile(attemptsPath, "utf8")).toBe("attempt\n".repeat(3));
+            expect([params.ctx, params.sessionCtx]).toEqual(before);
+            expect(temporaryDirectoryRemoved).toBe(true);
+          },
+        );
+      });
+    },
+    180_000,
   );
 });

--- a/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
@@ -25,10 +25,18 @@ import {
   waitForPidToExit,
 } from "../../test-utils/process-tree.js";
 import type { RuntimeMsgContext, TemplateContext } from "../templating.js";
-import { stageSandboxMedia } from "./stage-sandbox-media.js";
+import {
+  resolveScpTransferTimeoutMs,
+  SANDBOX_MEDIA_MAX_BYTES,
+  SCP_MIN_SUPPORTED_THROUGHPUT_BYTES_PER_SEC,
+  SCP_TRANSFER_TIMEOUT_FLOOR_MS,
+  stageSandboxMedia,
+} from "./stage-sandbox-media.js";
 
 const SCP_STDERR_TAIL_CHARS = 16_384;
-const SCP_TRANSFER_TIMEOUT_MS = 30_000;
+const SCP_TRANSFER_TIMEOUT_MS = resolveScpTransferTimeoutMs();
+/** Small budget so the real hang and slow-transfer cases reach their deadline/margin in seconds. */
+const TEST_TRANSFER_BUDGET_MS = 5_000;
 const REMOTE_PATH = "/synthetic/attachments/report with spaces.txt";
 const SUCCESS = {
   code: 0,
@@ -180,6 +188,30 @@ function releaseInstalledOwnerSnapshot(): void {
 }
 
 afterEach(() => vi.restoreAllMocks());
+
+describe("sandbox SCP transfer budget", () => {
+  it("derives the deadline from the size cap instead of a fixed cutoff", () => {
+    // 50 MiB at the slowest supported throughput; still bounded, but far above
+    // the previous fixed cutoff that failed every transfer slower than 30s.
+    expect(resolveScpTransferTimeoutMs({})).toBe(
+      Math.ceil((SANDBOX_MEDIA_MAX_BYTES / SCP_MIN_SUPPORTED_THROUGHPUT_BYTES_PER_SEC) * 1000),
+    );
+    expect(resolveScpTransferTimeoutMs({})).toBeGreaterThan(SCP_TRANSFER_TIMEOUT_FLOOR_MS);
+    // 40 MiB over a 1 MiB/s link needs ~40s, which the old 30s cutoff could never allow.
+    expect(resolveScpTransferTimeoutMs({}, 40 * 1024 * 1024)).toBe(160_000);
+  });
+
+  it("keeps the floor for small transfers and honours the operator override", () => {
+    expect(resolveScpTransferTimeoutMs({}, 1024)).toBe(SCP_TRANSFER_TIMEOUT_FLOOR_MS);
+    expect(resolveScpTransferTimeoutMs({ OPENCLAW_SANDBOX_SCP_TIMEOUT_MS: "5000" })).toBe(5_000);
+    expect(resolveScpTransferTimeoutMs({ OPENCLAW_SANDBOX_SCP_TIMEOUT_MS: "0" })).toBe(
+      SCP_TRANSFER_TIMEOUT_MS,
+    );
+    expect(resolveScpTransferTimeoutMs({ OPENCLAW_SANDBOX_SCP_TIMEOUT_MS: "nope" })).toBe(
+      SCP_TRANSFER_TIMEOUT_MS,
+    );
+  });
+});
 
 describe("stageSandboxMedia SCP", () => {
   it("stages bytes and both contexts through the strict bounded SCP command", async () => {
@@ -671,6 +703,49 @@ describe("stageSandboxMedia SCP", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "publishes a slow transfer that stays inside the budget",
+    async () => {
+      await withOpenClawTestState({ label: "scp-slow-success" }, async (state) => {
+        const params = remoteStageParams(state);
+        const binDir = state.path("bin");
+        await fs.mkdir(binDir);
+        // A real process that needs seconds to finish: the old fixed cutoff killed
+        // transfers like this mid-flight and skipped the attachment.
+        await fs.writeFile(
+          path.join(binDir, "scp"),
+          [
+            `#!${process.execPath}`,
+            "const fs = require('node:fs');",
+            "const target = process.argv.at(-1);",
+            "setTimeout(() => {",
+            "  fs.writeFileSync(target, 'slow but healthy bytes');",
+            "  process.exit(0);",
+            "}, 2_000);",
+          ].join("\n"),
+          { mode: 0o700 },
+        );
+
+        await withEnvAsync(
+          {
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            OPENCLAW_SANDBOX_SCP_TIMEOUT_MS: String(TEST_TRANSFER_BUDGET_MS),
+          },
+          async () => {
+            const started = Date.now();
+            const result = await stageSandboxMedia(params);
+            expect(Date.now() - started).toBeGreaterThanOrEqual(2_000);
+            const fact = params.ctx.media?.[0];
+            expect(result.staged.size).toBe(1);
+            expect(await fs.readFile(path.join(fact!.workspaceDir!, fact!.path!), "utf8")).toBe(
+              "slow but healthy bytes",
+            );
+          },
+        );
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "bounds an unattended SCP hang with the shared runner deadline",
     async () => {
       await withOpenClawTestState({ label: "scp-hung-timeout" }, async (state) => {
@@ -712,7 +787,10 @@ describe("stageSandboxMedia SCP", () => {
         );
 
         await withEnvAsync(
-          { PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+          {
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            OPENCLAW_SANDBOX_SCP_TIMEOUT_MS: String(TEST_TRANSFER_BUDGET_MS),
+          },
           async () => {
             const spawn = vi.spyOn(execSpawn, "spawnCommandWithInvocation");
             let parentPid: number | undefined;
@@ -733,8 +811,8 @@ describe("stageSandboxMedia SCP", () => {
               expect(isPidAlive(parentPid)).toBe(true);
               expect(isPidAlive(descendantPid)).toBe(true);
               reapedByDeadline = await Promise.all([
-                waitForPidToExit(parentPid, SCP_TRANSFER_TIMEOUT_MS + 5_000),
-                waitForPidToExit(descendantPid, SCP_TRANSFER_TIMEOUT_MS + 5_000),
+                waitForPidToExit(parentPid, TEST_TRANSFER_BUDGET_MS + 5_000),
+                waitForPidToExit(descendantPid, TEST_TRANSFER_BUDGET_MS + 5_000),
               ]);
             } finally {
               // Stop any late attempt, then drain the owner before removing its fixture.
@@ -758,7 +836,9 @@ describe("stageSandboxMedia SCP", () => {
             expect(reapedByDeadline).toEqual([true, true]);
             // The bounded retry loop exhausts instead of publishing failed media.
             expect(await settled).toEqual({ value: { staged: new Map() } });
-            expect(await fs.readFile(attemptsPath, "utf8")).toBe("attempt\n".repeat(3));
+            // A deadline kill means the copy stopped progressing, so it is not retried:
+            // one bounded wait, then the attachment is skipped.
+            expect(await fs.readFile(attemptsPath, "utf8")).toBe("attempt\n");
             expect([params.ctx, params.sessionCtx]).toEqual(before);
             expect(temporaryDirectoryRemoved).toBe(true);
           },

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -31,11 +31,49 @@ import type { RuntimeMsgContext as MsgContext, TemplateContext } from "../templa
 /** Maximum size of one file copied into an agent sandbox or staging workspace. */
 export const SANDBOX_MEDIA_MAX_BYTES = 50 * 1024 * 1024;
 const SCP_STDERR_TAIL_CHARS = 16_384;
+/** Slowest sustained throughput still treated as a healthy remote transfer. */
+export const SCP_MIN_SUPPORTED_THROUGHPUT_BYTES_PER_SEC = 256 * 1024;
+/** Floor so the derived budget never gets unreasonably tight for small files. */
+export const SCP_TRANSFER_TIMEOUT_FLOOR_MS = 30_000;
+
 /**
- * Per-transfer deadline for sandbox SCP staging. The shared runner owns the
- * timer, process-tree termination, and settlement; do not reimplement them here.
+ * Deadline for one sandbox SCP transfer. Derived from the size cap instead of a
+ * fixed cutoff so a slow but healthy transfer is not killed mid-flight: 50 MiB at
+ * the supported 256 KiB/s floor needs ~200s, while a fixed 30s cutoff would fail
+ * every attempt and silently skip the attachment. The budget stays bounded, so a
+ * stalled transfer still dies instead of waiting forever.
+ * `OPENCLAW_SANDBOX_SCP_TIMEOUT_MS` overrides it (operator knob; tests use it to
+ * exercise the deadline without waiting minutes).
+ * The shared runner owns the timer, process-tree termination, and settlement.
  */
-const SCP_TRANSFER_TIMEOUT_MS = 30_000;
+export function resolveScpTransferTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env,
+  maxBytes: number = SANDBOX_MEDIA_MAX_BYTES,
+): number {
+  const override = Number(env.OPENCLAW_SANDBOX_SCP_TIMEOUT_MS);
+  if (Number.isFinite(override) && override > 0) {
+    return Math.floor(override);
+  }
+  const scaled = Math.ceil((maxBytes / SCP_MIN_SUPPORTED_THROUGHPUT_BYTES_PER_SEC) * 1000);
+  return Math.max(SCP_TRANSFER_TIMEOUT_FLOOR_MS, scaled);
+}
+
+/**
+ * A transfer the shared runner killed on the staging deadline. The copy stopped
+ * making progress, so retrying the same stalled transfer only multiplies the
+ * wait; callers get one bounded failure instead.
+ */
+class ScpTransferDeadlineError extends Error {
+  readonly timeoutMs: number;
+  constructor(timeoutMs: number, stderr: string) {
+    super(
+      `scp transfer exceeded its ${Math.round(timeoutMs / 1000)}s staging deadline` +
+        (stderr ? `: ${stderr}` : ""),
+    );
+    this.name = "ScpTransferDeadlineError";
+    this.timeoutMs = timeoutMs;
+  }
+}
 
 // Attachment indexes are the staging identity. Callers use this map to detect
 // partial failures without matching rewritten strings back to source paths.
@@ -290,6 +328,7 @@ async function stageRemoteFileIntoRoot(params: {
   await fs.mkdir(tmpRoot, { recursive: true });
   const tmpDir = await fs.mkdtemp(path.join(tmpRoot, "stage-sandbox-media-"));
   const tmpPath = path.join(tmpDir, "download");
+  const scpTransferTimeoutMs = resolveScpTransferTimeoutMs();
   try {
     await retryAsync(
       async () => {
@@ -311,7 +350,7 @@ async function stageRemoteFileIntoRoot(params: {
             // The runner owns the deadline, descendants, and settlement before temp cleanup.
             signal: abortSignal,
             killProcessTree: true,
-            timeoutMs: SCP_TRANSFER_TIMEOUT_MS,
+            timeoutMs: scpTransferTimeoutMs,
             // Four UTF-8 bytes retain the existing UTF-16 diagnostic tail bound.
             maxOutputBytes: { stdout: 1, stderr: SCP_STDERR_TAIL_CHARS * 4 },
           },
@@ -322,10 +361,20 @@ async function stageRemoteFileIntoRoot(params: {
             return;
           }
           const stderr = sliceUtf16Safe(result.stderr, -SCP_STDERR_TAIL_CHARS).trim();
+          if (result.termination === "timeout") {
+            throw new ScpTransferDeadlineError(scpTransferTimeoutMs, stderr);
+          }
           throw new Error(`scp failed (${result.code}): ${stderr}`);
         }
       },
-      { attempts: 3, label: "remote inbound media SCP", shouldRetry: () => !abortSignal?.aborted },
+      {
+        attempts: 3,
+        label: "remote inbound media SCP",
+        // A deadline kill means the copy stopped progressing: retrying it only
+        // re-waits the whole budget, so surface one bounded failure instead.
+        shouldRetry: (error) =>
+          !abortSignal?.aborted && !(error instanceof ScpTransferDeadlineError),
+      },
     );
     // Preserve arbitrary abort reasons outside retry's Error normalization.
     abortSignal?.throwIfAborted();

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -31,6 +31,11 @@ import type { RuntimeMsgContext as MsgContext, TemplateContext } from "../templa
 /** Maximum size of one file copied into an agent sandbox or staging workspace. */
 export const SANDBOX_MEDIA_MAX_BYTES = 50 * 1024 * 1024;
 const SCP_STDERR_TAIL_CHARS = 16_384;
+/**
+ * Per-transfer deadline for sandbox SCP staging. The shared runner owns the
+ * timer, process-tree termination, and settlement; do not reimplement them here.
+ */
+const SCP_TRANSFER_TIMEOUT_MS = 30_000;
 
 // Attachment indexes are the staging identity. Callers use this map to detect
 // partial failures without matching rewritten strings back to source paths.
@@ -303,9 +308,10 @@ async function stageRemoteFileIntoRoot(params: {
             tmpPath,
           ],
           {
-            // The runner owns both descendants and settlement before temp cleanup.
+            // The runner owns the deadline, descendants, and settlement before temp cleanup.
             signal: abortSignal,
             killProcessTree: true,
+            timeoutMs: SCP_TRANSFER_TIMEOUT_MS,
             // Four UTF-8 bytes retain the existing UTF-16 diagnostic tail bound.
             maxOutputBytes: { stdout: 1, stderr: SCP_STDERR_TAIL_CHARS * 4 },
           },


### PR DESCRIPTION
## What Problem This Solves

Sandbox media staging shells out to `scp`, and that spawn had **no deadline**: a hung transfer (dead peer, wedged ssh, a dropped TCP session that never resets) left the child process alive indefinitely and the caller awaiting a promise that never settles — one leaked `scp` per stalled staging attempt, with no bound on how long the turn could hang.

This gives the transfer a bounded deadline **through the shared process-lifecycle runner rather than by owning the spawn directly**, which is the direction #98141 was closed toward: that PR was closed as "superseded by the current process-lifecycle architecture, not because the linked defect is fixed" — so the timeout belongs on the existing runner call, not on a locally-owned `child_process.spawn`.

## Evidence

The change is two files:

```
src/auto-reply/reply/stage-sandbox-media.ts          |  8 +-
src/auto-reply/reply/stage-sandbox-media.scp.test.ts | 101 ++++++++++++++++++-
```

- `stage-sandbox-media.ts` derives the per-transfer budget (`resolveScpTransferTimeoutMs()`: size cap / supported throughput, 30s floor, `OPENCLAW_SANDBOX_SCP_TIMEOUT_MS` override) and passes it as `timeoutMs` on the existing shared-runner invocation — the runner already owns deadlines and descendant-tree termination.
- The test suite asserts the deadline reaches the runner (`expect.objectContaining({ timeoutMs: SCP_TRANSFER_TIMEOUT_MS })`) so the wiring cannot silently regress, and adds a real-process hang case: a fake `scp` on `PATH` that spawns a descendant, ignores `SIGTERM`, and never exits. The assertion is that the transfer is rejected by the deadline and **both the parent and the descendant are gone afterwards** (via the repo's existing `test-utils/process-tree` helpers), plus a negative control that a normal transfer still succeeds unchanged.

```
node node_modules/vitest/vitest.mjs run src/auto-reply/reply/stage-sandbox-media.scp.test.ts --maxWorkers=1 --no-file-parallelism
Test Files  1 passed (1)
Tests  13 passed | 2 skipped (15)
```

## Verification

The deadline wiring and the normal-transfer assertions run and pass here; the two skipped cases are the POSIX-only hang cases (`it.runIf(process.platform !== "win32")`) — this machine is Windows, so the process-tree termination assertion itself is **not exercised locally**. I am stating that rather than implying it: it needs a POSIX CI lane to run, and that is the one part of this change I could not observe directly.

Partial fix for #98468: the deadline wiring, the revised budget, and real timeout recovery (process tree + temporary cleanup) are verified here; the remaining unobserved part is a real multi-hour suspend/transfer scenario on a POSIX lane, which CI's Linux lane runs via the committed cases.

## Context worth knowing before review

- Three prior attempts exist on this issue: #98141 (closed as superseded by the lifecycle architecture — see above), #101473 (long review loop, closed), #132552 (merged, but that was the *cancellation* half of staging, not the transfer deadline).
- The issue currently also carries `clawsweeper:queueable-fix`. If the automated fix lane produces a PR for the same deadline, take that one — the intent here is to have the fix available in the architecture the maintainer pointed at, not to race a bot.

## Revision 2 — revised transfer budget + real transport proof (head `8707115c920`)

**Decision answer (the question the review asked): revise the deadline instead of an unconditional 30s cutoff.**
`resolveScpTransferTimeoutMs()` derives the per-transfer budget from the size cap and the slowest throughput still called supported, keeps it bounded, and is overridable:

| Case | Budget |
|---|---|
| 50 MiB cap at the 256 KiB/s supported floor | **200s** |
| review example: 40 MiB at 1 MiB/s (~40s) | **160s** (the old fixed 30s could never allow it) |
| small transfers | 30s floor |
| `OPENCLAW_SANDBOX_SCP_TIMEOUT_MS` | operator override (tests use it to reach the deadline in seconds) |

The deadline remains an absolute, bounded value owned by the shared runner, so an unattended hang still dies; it just no longer kills a slow-but-healthy copy. A deadline kill is also no longer retried (one bounded wait instead of three): retrying a copy that stopped progressing only re-waits the whole budget. If maintainers want a different number, or a config field instead of the env override, name it and I'll switch it.

### Real behavior proof (no mocks: real spawned transport through staging, Windows)

A compiled stand-in transport is spawned through the same argv/PATH path the runner uses, so the real spawn, deadline, tree kill, and temp cleanup all execute:

```
[proof] slow transfer staged=1 elapsed=7965ms
[proof] staged bytes=real transport bytes
[proof] hung transport pid=22892 alive=true
[proof] descendant pid=54128 alive=true
[proof] reaped by deadline: parent=true descendant=true
[proof] surface={"value":{"staged":{}}}
[proof] attempts="attempt\n"
[proof] temp dir removed=true
 ✓ windows real transport proof > publishes a real slow transport that finishes inside the budget 8044ms
 ✓ windows real transport proof > kills a real hung transport tree on the deadline without retrying 8507ms
```

Both Windows-native cases pass (17 passed | 3 skipped with the scratch cases in place) and the same file without them is **15 passed | 3 skipped, exit 0**; `oxfmt --check` clean on both files. The three skips are the POSIX-gated cases (they spawn a shebang script), which is why the Windows run above uses a compiled stand-in. `oxlint` produced no verdict for explicit paths in this junction worktree, so I am not claiming a lint verdict — CI's lint lane judges.

The new committed cases: the derived-budget unit math (including the 40 MiB / 160s case), a real slow transfer that publishes, and the hung tree + descendant reaped on the deadline with one attempt and the temp dir removed.
