### PR TITLE
fix: refreshing the plugin catalog with a trailing slash returns 404

### DIFF
--- a/src/gateway/control-ui-routing.test.ts
+++ b/src/gateway/control-ui-routing.test.ts
@@ -195,6 +195,12 @@ describe("classifyControlUiRequest", () => {
         { kind: "serve" as const, spaFallback: true },
       ],
       [
+        "serves the marketplace document at the plugin root slash",
+        "/plugins/",
+        "GET",
+        { kind: "serve" as const, spaFallback: true },
+      ],
+      [
         "keeps API routes outside the SPA catch-all",
         "/api/sessions",
         "GET",
@@ -356,6 +362,42 @@ describe("classifyControlUiRequest", () => {
     });
   });
 
+  describe("plugin catalogue documents vs plugin HTTP", () => {
+    it.each([
+      {
+        name: "serves HTML GET for the catalogue root slash",
+        pathname: "/plugins/",
+        method: "GET",
+        accept: "text/html",
+        expected: { kind: "serve" as const, spaFallback: true },
+      },
+      {
+        name: "keeps JSON catalogue reads outside the SPA",
+        pathname: "/plugins",
+        method: "GET",
+        accept: "application/json",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps JSON catalogue slash reads outside the SPA",
+        pathname: "/plugins/",
+        method: "GET",
+        accept: "application/json",
+        expected: { kind: "not-control-ui" as const },
+      },
+    ])("$name", ({ pathname, method, accept, expected }) => {
+      expect(
+        classifyControlUiRequest({
+          basePath: "",
+          pathname,
+          search: "",
+          method,
+          accept,
+        }),
+      ).toEqual(expected);
+    });
+  });
+
   describe("basePath-mounted control ui", () => {
     it.each<[string, string, string, string, ReturnType<typeof classifyControlUiRequest>]>([
       [
@@ -370,6 +412,27 @@ describe("classifyControlUiRequest", () => {
         "/openclaw/chat",
         "",
         "HEAD",
+        { kind: "serve" as const, spaFallback: true },
+      ],
+      [
+        "serves the plugin catalogue under a configured basePath",
+        "/openclaw/plugins",
+        "",
+        "GET",
+        { kind: "serve" as const, spaFallback: true },
+      ],
+      [
+        "serves the plugin catalogue slash under a configured basePath",
+        "/openclaw/plugins/",
+        "",
+        "GET",
+        { kind: "serve" as const, spaFallback: true },
+      ],
+      [
+        "serves the plugin manager under a configured basePath",
+        "/openclaw/settings/plugins",
+        "",
+        "GET",
         { kind: "serve" as const, spaFallback: true },
       ],
       [

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -92,11 +92,12 @@ export function classifyControlUiRequest(params: {
     if (classifyNodeWorkspaceTransferPath(pathname) !== "outside") {
       return { kind: "not-control-ui" };
     }
-    // Marketplace documents own the root and canonical generated catalog IDs.
+    // Marketplace documents own the catalogue root and canonical generated catalog IDs.
     // Other descendants and non-document requests remain plugin HTTP routes.
     if (pathname === "/plugins" || pathname.startsWith("/plugins/")) {
       const marketplaceDocument =
         pathname === "/plugins" ||
+        pathname === "/plugins/" ||
         resolvePluginDiscoveryIdentity(pathname.slice("/plugins/".length)) !== undefined;
       if (!marketplaceDocument || !isReadHttpMethod(method) || !spaFallback) {
         return { kind: "not-control-ui" };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -4019,7 +4019,7 @@ describe("handleControlUiHttpRequest", () => {
   it("does not handle plugin HTTP descendants when basePath is empty", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        for (const pluginPath of ["/plugins/", "/plugins/diffs/view/abc/def"]) {
+        for (const pluginPath of ["/plugins/webhook", "/plugins/diffs/view/abc/def"]) {
           const { handled } = await runControlUiRequest({
             url: pluginPath,
             method: "GET",

--- a/src/gateway/server-http.control-ui.test.ts
+++ b/src/gateway/server-http.control-ui.test.ts
@@ -188,7 +188,12 @@ it("serves marketplace browser reads while preserving plugin HTTP boundaries", a
         isStartupPluginRuntimeReady: () => true,
       },
       run: async (server) => {
-        const documentPaths = ["/plugins", "/plugins/ch_bWF0cml4", "/plugins/local_bWVtb3J5"];
+        const documentPaths = [
+          "/plugins",
+          "/plugins/",
+          "/plugins/ch_bWF0cml4",
+          "/plugins/local_bWVtb3J5",
+        ];
         for (const pathname of documentPaths) {
           for (const method of ["GET", "HEAD"]) {
             const { res, getBody } = await sendRequest(server, {
@@ -225,6 +230,13 @@ it("serves marketplace browser reads while preserving plugin HTTP boundaries", a
         });
         expect(plugin.res.statusCode).toBe(202);
         expect(plugin.getBody()).toBe("plugin response");
+        const pluginManager = await sendRequest(server, {
+          path: "/settings/plugins",
+          method: "GET",
+          headers: { accept: "text/html" },
+        });
+        expect(pluginManager.res.statusCode).toBe(200);
+        expect(pluginManager.getBody()).toContain("spa fallback");
       },
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Opening or refreshing the Plugins catalog with a trailing slash returned a plain-text 404 when the Control UI was served at the website root.

Fixes #144721

Original fix and commit authorship: @gokay-ai. Original report: @Conan-Scott.

## Why This Change Was Made

The Gateway document classifier treated the catalog's trailing-slash root as a plugin request. It now recognizes that root as a catalog page before resolving individual plugin pages.

## User Impact

Direct navigation and refresh at `/plugins/` load the catalog. Plugin settings and plugin HTTP endpoints keep their existing behavior.

## Evidence

- In a real browser against an isolated Gateway, catalog navigation and reload returned HTTP 404 before the fix and HTTP 200 with the visible catalog after it.
- The slashless catalog and separate plugin settings page continued to load.
- The Diffs plugin's JavaScript endpoint continued to return JavaScript.
- [Sanitized before/after browser captures](https://gist.github.com/obviyus/dd01be4e2f59b5996026da9c3df85f76) show the failed refresh and restored catalog.

## Consumers

- Browser visitors to `/plugins/`: direct navigation and refresh now open the Plugins catalog.
