### PR TITLE
refactor(tests): reuse Vydra speech response fixtures

### DIFF
--- a/extensions/vydra/speech-provider.test.ts
+++ b/extensions/vydra/speech-provider.test.ts
@@ -2,6 +2,7 @@ import { bufferedOversizedJsonResponse as oversizedJsonResponse } from "openclaw
 // Vydra tests cover speech provider plugin behavior.
 import { installPinnedHostnameTestHooks } from "openclaw/plugin-sdk/test-media-understanding";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { binaryResponse, jsonResponse, stubFetch } from "./provider-test-helpers.js";
 import { buildVydraSpeechProvider } from "./speech-provider.js";
 
 describe("vydra speech provider", () => {
@@ -32,26 +33,10 @@ describe("vydra speech provider", () => {
   });
 
   it("posts to the tts endpoint and downloads the audio", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            audioUrl: "https://www.vydra.ai/generated/test.mp3",
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(Buffer.from("mp3-data"), {
-          status: 200,
-          headers: { "Content-Type": "audio/mpeg" },
-        }),
-      );
-    vi.stubGlobal("fetch", fetchMock);
+    const fetchMock = stubFetch(
+      jsonResponse({ audioUrl: "https://www.vydra.ai/generated/test.mp3" }),
+      binaryResponse("mp3-data", "audio/mpeg"),
+    );
 
     const result = await provider.synthesize({
       text: "OpenClaw test",
@@ -105,26 +90,10 @@ describe("vydra speech provider", () => {
   });
 
   it("rejects generated audio downloads that exceed the configured media cap", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            audioUrl: "https://cdn.vydra.ai/generated/test.mp3",
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(Buffer.from("too-large"), {
-          status: 200,
-          headers: { "Content-Type": "audio/mpeg" },
-        }),
-      );
-    vi.stubGlobal("fetch", fetchMock);
+    stubFetch(
+      jsonResponse({ audioUrl: "https://cdn.vydra.ai/generated/test.mp3" }),
+      binaryResponse("too-large", "audio/mpeg"),
+    );
 
     await expect(
       provider.synthesize({


### PR DESCRIPTION
## What Problem This Solves

Two Vydra speech tests duplicated response queues already covered by the plugin's shared JSON, binary-response, and fetch fixtures.

## Why This Change Was Made

Reuse those existing helpers and remove the duplicated setup. All source outside the two queues and their import is unchanged, including every assertion and the separate oversized-JSON fixture. The change adds nine test lines and removes 40: **31 fewer lines**, with no production change.

The helper import moves existing auth bindings and test-global initialization earlier. Existing media setup initializes the registry before collection, and speech already loads that auth graph before resolving synthesis credentials. The speech tests do not call the helper's optional auth-stubbing function.

## User Impact

No provider runtime or API behavior changes. This is test-fixture consolidation.

## Evidence

All **34 tests passed before and after** under the same normal media configuration: six speech, six image, seven video, and 15 shared cases, with identical per-file inventory and order. The 19-check changed gate passed, and independent source review found no actionable P0-P2 issue. Source/dependency hashes stayed unchanged during proof; the launcher was joined and its group checked at terminal. These are local fixture tests, not live Vydra API proof.
