### PR TITLE
fix(ui): retain controls after partial catalog refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2854,6 +2854,7 @@ jobs:
             ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts \
             ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts \
             ui/src/e2e/model-api-keys.real-gateway.e2e.test.ts \
+            ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts \
             ui/src/e2e/model-picker-search.real-gateway.e2e.test.ts \
             ui/src/e2e/device-alias-rename.real-gateway.e2e.test.ts \
             ui/src/e2e/device-platform-family.real-gateway.e2e.test.ts \

--- a/src/config/config-startup-corpus.test.ts
+++ b/src/config/config-startup-corpus.test.ts
@@ -73,6 +73,7 @@ const expectations: Record<
   "legacy-roster.json": { providers: ["openai"] },
   "models-allow.json": { providers: ["fixture-provider"], model: "fixture-model" },
   "oauth-only.json": { providers: ["openai"] },
+  "provider-partially-unavailable.json": { providers: ["openai"], model: "gpt-5.4" },
   "operator-container.json": { providers: ["openai", "xai"], model: "grok-4.3" },
   "operator-host.json": { providers: ["xai"], model: "grok-4.3" },
   "peanutto.json": {

--- a/test/fixtures/config-corpus/provider-partially-unavailable.json
+++ b/test/fixtures/config-corpus/provider-partially-unavailable.json
@@ -1,0 +1,23 @@
+{
+  "gateway": { "mode": "local", "auth": { "mode": "token", "token": "FAKE_CONFIG_CORPUS_CREDENTIAL" } },
+  "agents": {
+    "defaults": {
+      "model": "openai/gpt-5.4",
+      "modelPolicy": { "allow": ["openai/*", "github-copilot/*"] }
+    },
+    "entries": { "main": {} }
+  },
+  "plugins": {
+    "entries": { "openai": { "enabled": true }, "github-copilot": { "enabled": true } }
+  },
+  "models": {
+    "providers": {
+      "openai": {
+        "apiKey": "FAKE_CONFIG_CORPUS_CREDENTIAL",
+        "baseUrl": "http://127.0.0.1:9/v1",
+        "models": [{ "id": "gpt-5.4", "name": "GPT-5.4", "reasoning": true }]
+      },
+      "github-copilot": { "apiKey": "FAKE_CONFIG_CORPUS_CREDENTIAL", "models": [] }
+    }
+  }
+}

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -13388,6 +13388,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "ui/src/e2e/mobile-chat-session-menu.e2e.test.ts",
       "ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts",
       "ui/src/e2e/model-api-keys.real-gateway.e2e.test.ts",
+      "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
       "ui/src/e2e/model-picker-search.real-gateway.e2e.test.ts",
       "ui/src/e2e/new-session-page.cloud-startup.runtime-load.e2e.test.ts",
       "ui/src/e2e/session-management.delete.e2e.test.ts",

--- a/test/vitest-ui-e2e-config.test.ts
+++ b/test/vitest-ui-e2e-config.test.ts
@@ -124,6 +124,7 @@ const realGatewayFiles = [
   "logs-lifecycle",
   "mcp-app-conformance",
   "model-api-keys.real-gateway",
+  "model-catalog-partial-refresh.real-gateway",
   "model-picker-search.real-gateway",
   "profile-page.real-gateway",
   "session-progress-hovercard.real-gateway",
@@ -584,6 +585,13 @@ describe("Control UI E2E resource ownership", () => {
         },
         {
           file: "ui/src/e2e/model-api-keys.real-gateway.e2e.test.ts",
+          project: "ui-e2e-serial-standalone",
+          phase: 1,
+          workers: 1,
+          fileParallelism: false,
+        },
+        {
+          file: "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
           project: "ui-e2e-serial-standalone",
           phase: 1,
           workers: 1,

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -25,8 +25,8 @@ const uiE2eIncludePatterns = [
   automationManagementRealGatewayTest,
 ];
 export const uiE2eRealGatewayTestFiles = [
-  "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
   "ui/src/e2e/model-api-keys.real-gateway.e2e.test.ts",
+  "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
   "ui/src/e2e/worker-initial-setup.real-gateway.e2e.test.ts",
   "ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts",
   "ui/src/e2e/chat-composer-websearch-kill-switch.real-gateway.e2e.test.ts",
@@ -56,7 +56,6 @@ export const uiE2eRealGatewayTestFiles = [
 // These files own their server instead of leasing the global production bundle.
 // Keep any shared source-module optimizer cache under one worker.
 export const uiE2ePrivateServerTestFiles = [
-  "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
   "ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts",
   "ui/src/e2e/approval-bootstrap.e2e.test.ts",
   "ui/src/e2e/build-info-unicode.e2e.test.ts",
@@ -85,6 +84,7 @@ export const uiE2ePrivateServerTestFiles = [
   "ui/src/e2e/mobile-chat-session-menu.e2e.test.ts",
   "ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts",
   "ui/src/e2e/model-api-keys.real-gateway.e2e.test.ts",
+  "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
   "ui/src/e2e/model-picker-search.real-gateway.e2e.test.ts",
   "ui/src/e2e/mount-recovery.e2e.test.ts",
   "ui/src/e2e/native-notifications-loading.e2e.test.ts",

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -25,6 +25,7 @@ const uiE2eIncludePatterns = [
   automationManagementRealGatewayTest,
 ];
 export const uiE2eRealGatewayTestFiles = [
+  "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
   "ui/src/e2e/model-api-keys.real-gateway.e2e.test.ts",
   "ui/src/e2e/worker-initial-setup.real-gateway.e2e.test.ts",
   "ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts",
@@ -55,6 +56,7 @@ export const uiE2eRealGatewayTestFiles = [
 // These files own their server instead of leasing the global production bundle.
 // Keep any shared source-module optimizer cache under one worker.
 export const uiE2ePrivateServerTestFiles = [
+  "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
   "ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts",
   "ui/src/e2e/approval-bootstrap.e2e.test.ts",
   "ui/src/e2e/build-info-unicode.e2e.test.ts",

--- a/ui/src/e2e/model-catalog-partial-refresh.e2e.test.ts
+++ b/ui/src/e2e/model-catalog-partial-refresh.e2e.test.ts
@@ -1,0 +1,312 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import partialConfig from "../../../test/fixtures/config-corpus/provider-partially-unavailable.json";
+import type { ModelCatalogResult } from "../api/types.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Partial provider refresh controls" });
+const levels = ["off", "low", "medium", "high", "xhigh", "max", "ultra"].map((id) => ({
+  id,
+  label: id,
+}));
+const catalog: ModelCatalogResult = {
+  models: [
+    {
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      provider: "openai",
+      available: true,
+      reasoning: true,
+      supportsFastMode: true,
+      thinkingLevels: levels,
+      thinkingDefault: "high",
+    },
+    {
+      id: "unavailable-model",
+      name: "Unavailable Copilot model",
+      provider: "github-copilot",
+      available: false,
+      unavailableReason: "missing-auth",
+      thinkingLevels: [],
+    },
+  ],
+  refreshFailed: true,
+  providerOutcomes: [
+    { provider: "openai", status: "ready" },
+    { provider: "github-copilot", status: "unavailable" },
+  ],
+};
+
+async function captureControls(page: Page, stage: string) {
+  const controls = await page
+    .locator(".agent-chat__input")
+    .first()
+    .evaluate((composer) => {
+      const effort = composer.querySelector<HTMLElement>("[data-chat-thinking-select]");
+      return {
+        text: composer.textContent,
+        notice: composer.querySelector("[data-chat-model-catalog-state]")?.textContent,
+        effort: effort
+          ? {
+              label: effort.getAttribute("aria-label"),
+              visible: effort.checkVisibility({ visibilityProperty: true }),
+              disabled: effort.getAttribute("aria-disabled"),
+              reserved: effort.closest("details")?.getAttribute("aria-hidden"),
+              value: effort.getAttribute("data-chat-thinking-value"),
+              fast: effort.getAttribute("data-chat-fast-mode"),
+            }
+          : null,
+      };
+    });
+  await writeFile(path.join(suite.artifactDir, `${stage}.json`), JSON.stringify(controls, null, 2));
+  await page.screenshot({
+    path: path.join(suite.artifactDir, `${stage}.png`),
+    animations: "disabled",
+  });
+}
+
+suite.define(() => {
+  it.each(["new", "chat"])(
+    "keeps effort, speed and the model picker usable in %s",
+    async (route) => {
+      await suite.withPage(
+        { locale: "en-US", viewport: { width: 1280, height: 900 } },
+        async ({ page }) => {
+          const gateway = await installMockGateway(page, {
+            agentModel: partialConfig.agents.defaults.model,
+            models: catalog.models,
+            sessionInfo: {
+              model: "gpt-5.4",
+              modelProvider: "openai",
+              thinkingLevels: levels,
+              thinkingDefault: "high",
+            },
+            methodResponses: {
+              "models.list": catalog,
+              "sessions.list": {
+                ts: 1,
+                path: "",
+                count: 1,
+                defaults: {
+                  model: "gpt-5.4",
+                  modelProvider: "openai",
+                  thinkingLevels: levels,
+                  thinkingDefault: "high",
+                },
+                sessions: [
+                  {
+                    key: "agent:main:main",
+                    kind: "direct",
+                    model: "gpt-5.4",
+                    modelProvider: "openai",
+                    thinkingLevels: levels,
+                    thinkingDefault: "high",
+                  },
+                ],
+              },
+            },
+          });
+          await page.goto(`${suite.server.baseUrl}${route}`);
+          const composer = page.locator(".agent-chat__input").first();
+          const model = composer.locator("[data-chat-model-select]");
+          await expect.poll(() => model.getAttribute("aria-busy")).toBe("false");
+          await model.click();
+          await page
+            .getByText("Some models could not be refreshed. Open Models to try again.", {
+              exact: true,
+            })
+            .waitFor();
+          const available = composer.locator('[data-chat-model-option="openai/gpt-5.4"]');
+          await expect.poll(() => available.isVisible()).toBe(true);
+          await page.screenshot({
+            path: path.join(suite.artifactDir, `${route}-catalog.png`),
+            animations: "disabled",
+          });
+          await model.click();
+          await page.screenshot({
+            path: path.join(suite.artifactDir, `${route}-composer.png`),
+            animations: "disabled",
+          });
+          const effort = composer.locator("[data-chat-thinking-select]");
+          await expect.poll(() => effort.isVisible()).toBe(true);
+          await effort.click();
+          const slider = composer.locator("[data-chat-thinking-slider]");
+          await expect
+            .poll(() => slider.getAttribute("data-chat-thinking-values"))
+            .toBe(levels.map(({ id }) => id).join(","));
+          const sliderBounds = await slider.boundingBox();
+          expect(sliderBounds).not.toBeNull();
+          await slider.click({
+            position: { x: sliderBounds!.width - 2, y: sliderBounds!.height / 2 },
+          });
+          await expect.poll(() => effort.getAttribute("data-chat-thinking-value")).toBe("ultra");
+          if (route === "chat") {
+            expect((await gateway.waitForRequest("sessions.patch")).params).toMatchObject({
+              key: "agent:main:main",
+              thinkingLevel: "ultra",
+            });
+          }
+          const speed = composer.getByRole("switch", { name: /Fast responses/ });
+          await expect.poll(() => speed.isEnabled()).toBe(true);
+          await page.screenshot({
+            path: path.join(suite.artifactDir, `${route}-effort.png`),
+            animations: "disabled",
+          });
+          await speed.click();
+          if (route === "chat") {
+            await expect
+              .poll(async () =>
+                (await gateway.getRequests("sessions.patch")).map(({ params }) => params),
+              )
+              .toContainEqual({ key: "agent:main:main", fastMode: true });
+          }
+          await page.keyboard.press("Escape");
+          await model.click();
+          expect(await composer.locator('[data-chat-model-catalog-state="error"]').count()).toBe(0);
+          for (const [index, refreshFailed] of [false, true, false].entries()) {
+            await gateway.setMethodResponse("models.list", { ...catalog, refreshFailed });
+            await gateway.emitGatewayEvent("chat.metadata.changed", {});
+            const notice = composer.locator("[data-chat-model-catalog-state]");
+            await expect.poll(() => notice.count()).toBe(refreshFailed ? 1 : 0);
+            await expect.poll(() => effort.getAttribute("data-chat-thinking-value")).toBe("ultra");
+            expect(await effort.getAttribute("data-chat-fast-mode")).toBe("true");
+            expect(await model.textContent()).toContain("GPT-5.4");
+            await captureControls(page, `${route}-recovery-${index}`);
+          }
+        },
+      );
+    },
+  );
+
+  it("keeps usable effort controls when the selected model is locked during a partial refresh", async () => {
+    await suite.withPage({ locale: "en-US" }, async ({ page }) => {
+      await installMockGateway(page, {
+        agentModel: partialConfig.agents.defaults.model,
+        models: catalog.models,
+        methodResponses: {
+          "models.list": catalog,
+          "sessions.list": {
+            ts: 1,
+            path: "",
+            count: 1,
+            defaults: {},
+            sessions: [
+              {
+                key: "agent:main:main",
+                kind: "direct",
+                model: "gpt-5.4",
+                modelProvider: "openai",
+                modelSelectionLocked: true,
+                thinkingLevels: levels,
+                thinkingDefault: "high",
+              },
+            ],
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const effort = page.locator("[data-chat-thinking-select]");
+      await expect.poll(() => effort.isVisible()).toBe(true);
+      expect(await effort.getAttribute("aria-disabled")).toBe("false");
+      expect(await page.locator(".chat-controls__effort-picker").getAttribute("aria-hidden")).toBe(
+        "false",
+      );
+      expect(
+        await page.locator("[data-chat-model-select]").getAttribute("data-chat-model-locked"),
+      ).toBe("true");
+      await effort.click();
+      await expect.poll(() => page.locator("[data-chat-thinking-slider]").isEnabled()).toBe(true);
+    });
+  });
+
+  it.each(["empty", "rejected", "retained rejection", "selected unavailable", "non-reasoning"])(
+    "does not expose usable effort for %s",
+    async (condition) => {
+      await suite.withPage({ locale: "en-US" }, async ({ page }) => {
+        const selected = {
+          ...catalog.models[0]!,
+          available: condition !== "selected unavailable",
+          supportsFastMode: condition !== "non-reasoning",
+          reasoning: condition !== "non-reasoning",
+          thinkingLevels: condition === "non-reasoning" ? [] : levels,
+        };
+        const models =
+          condition === "empty"
+            ? []
+            : [selected, { id: "other", name: "Other", provider: "example", available: true }];
+        const failure = { __mockError: { code: "UNAVAILABLE", message: "Catalog request failed" } };
+        const gateway = await installMockGateway(page, {
+          agentModel: partialConfig.agents.defaults.model,
+          models,
+          sessionInfo: {
+            model: selected.id,
+            modelProvider: selected.provider,
+            thinkingLevels: selected.thinkingLevels,
+          },
+          methodResponses: {
+            "models.list": condition === "rejected" ? failure : { ...catalog, models },
+            "sessions.list": {
+              ts: 1,
+              path: "",
+              count: 1,
+              defaults: {
+                model: selected.id,
+                modelProvider: selected.provider,
+                thinkingLevels: selected.thinkingLevels,
+                thinkingDefault: condition === "non-reasoning" ? "off" : "high",
+              },
+              sessions: [
+                {
+                  key: "agent:main:main",
+                  kind: "direct",
+                  model: selected.id,
+                  modelProvider: selected.provider,
+                  thinkingLevels: selected.thinkingLevels,
+                  thinkingDefault: condition === "non-reasoning" ? "off" : "high",
+                },
+              ],
+            },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const model = page.locator("[data-chat-model-select]");
+        await expect.poll(() => model.getAttribute("aria-busy")).toBe("false");
+        if (condition === "retained rejection") {
+          await expect
+            .poll(() => page.locator("[data-chat-thinking-select]").isVisible())
+            .toBe(true);
+          await gateway.setMethodResponse("models.list", failure);
+        }
+        await model.click();
+        await expect
+          .poll(() => page.locator("[data-chat-model-catalog-state]").isVisible())
+          .toBe(true);
+        const effort = page.locator(".chat-controls__effort-picker");
+        await expect
+          .poll(
+            async () =>
+              (await effort.count()) === 0 ||
+              (await effort.getAttribute("aria-hidden")) === "true" ||
+              (await page.locator("[data-chat-thinking-select]").getAttribute("aria-disabled")) ===
+                "true",
+          )
+          .toBe(true);
+        await captureControls(page, `${condition}-open`);
+        await model.click();
+        await expect
+          .poll(
+            async () =>
+              (await effort.count()) === 0 ||
+              (await page.locator("[data-chat-thinking-select]").getAttribute("aria-disabled")) ===
+                "true",
+          )
+          .toBe(true);
+        await captureControls(page, `${condition}-closed`);
+        expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
+      });
+    },
+  );
+});

--- a/ui/src/e2e/model-catalog-partial-refresh.e2e.test.ts
+++ b/ui/src/e2e/model-catalog-partial-refresh.e2e.test.ts
@@ -40,8 +40,8 @@ const catalog: ModelCatalogResult = {
   ],
 };
 
-async function captureControls(page: Page, stage: string) {
-  const controls = await page
+function readControls(page: Page) {
+  return page
     .locator(".agent-chat__input")
     .first()
     .evaluate((composer) => {
@@ -61,6 +61,10 @@ async function captureControls(page: Page, stage: string) {
           : null,
       };
     });
+}
+
+async function captureControls(page: Page, stage: string) {
+  const controls = await readControls(page);
   await writeFile(path.join(suite.artifactDir, `${stage}.json`), JSON.stringify(controls, null, 2));
   await page.screenshot({
     path: path.join(suite.artifactDir, `${stage}.png`),
@@ -291,25 +295,19 @@ suite.define(() => {
         await expect
           .poll(() => page.locator("[data-chat-model-catalog-state]").isVisible())
           .toBe(true);
-        const effort = page.locator(".chat-controls__effort-picker");
         await expect
-          .poll(
-            async () =>
-              (await effort.count()) === 0 ||
-              (await effort.getAttribute("aria-hidden")) === "true" ||
-              (await page.locator("[data-chat-thinking-select]").getAttribute("aria-disabled")) ===
-                "true",
-          )
+          .poll(async () => {
+            const { effort } = await readControls(page);
+            return !effort || effort.reserved === "true" || effort.disabled === "true";
+          })
           .toBe(true);
         await captureControls(page, `${condition}-open`);
         await model.click();
         await expect
-          .poll(
-            async () =>
-              (await effort.count()) === 0 ||
-              (await page.locator("[data-chat-thinking-select]").getAttribute("aria-disabled")) ===
-                "true",
-          )
+          .poll(async () => {
+            const { effort } = await readControls(page);
+            return !effort || effort.disabled === "true";
+          })
           .toBe(true);
         await captureControls(page, `${condition}-closed`);
         expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);

--- a/ui/src/e2e/model-catalog-partial-refresh.e2e.test.ts
+++ b/ui/src/e2e/model-catalog-partial-refresh.e2e.test.ts
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
-import partialConfig from "../../../test/fixtures/config-corpus/provider-partially-unavailable.json";
+import partialConfig from "../../../test/fixtures/config-corpus/provider-partially-unavailable.json" with { type: "json" };
 import type { ModelCatalogResult } from "../api/types.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -167,7 +167,14 @@ suite.define(() => {
           await model.click();
           expect(await composer.locator('[data-chat-model-catalog-state="error"]').count()).toBe(0);
           for (const [index, refreshFailed] of [false, true, false].entries()) {
-            await gateway.setMethodResponse("models.list", { ...catalog, refreshFailed });
+            await gateway.setMethodResponse("models.list", {
+              ...catalog,
+              refreshFailed,
+              providerOutcomes: [
+                { provider: "openai", status: "ready" },
+                { provider: "github-copilot", status: refreshFailed ? "unavailable" : "ready" },
+              ],
+            });
             await gateway.emitGatewayEvent("chat.metadata.changed", {});
             const notice = composer.locator("[data-chat-model-catalog-state]");
             await expect.poll(() => notice.count()).toBe(refreshFailed ? 1 : 0);

--- a/ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import config from "../../../test/fixtures/config-corpus/provider-partially-unavailable.json";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../../../test/helpers/openclaw-test-instance.ts";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.ts";
+import type { ModelCatalogResult } from "../api/types.ts";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+let instance: OpenClawTestInstance;
+const tempDirs = createTempDirTracker();
+const suite = createControlUiE2eSuite({
+  name: "Partial refresh with a real Gateway",
+  startServerBeforeBrowser: true,
+  async startServer() {
+    const mockProvider = path.join(tempDirs.make("partial-refresh-provider-"), "copilot.mjs");
+    await fs.writeFile(
+      mockProvider,
+      `
+      const fetch = globalThis.fetch;
+      globalThis.fetch = (input, init) => {
+        const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+        if (url.href === "https://api.github.com/copilot_internal/user") {
+          return Promise.resolve(new Response("Fixture provider unavailable", { status: 503 }));
+        }
+        if (url.hostname === "127.0.0.1" || url.hostname === "localhost") {
+          return fetch(input, init);
+        }
+        throw new Error("Unexpected external request in partial-refresh fixture");
+      };
+    `,
+    );
+    instance = await createOpenClawTestInstance({
+      name: "partial-refresh",
+      env: {
+        OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        VITEST: undefined,
+        NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${mockProvider}`,
+      },
+      config: {
+        ...config,
+        gateway: { ...config.gateway, controlUi: { enabled: true } },
+        models: { ...config.models, catalogRefresh: { enabled: false } },
+        cron: { enabled: false },
+      },
+    });
+    try {
+      await instance.startGateway();
+      return {
+        baseUrl: `http://127.0.0.1:${instance.port}/`,
+        close: async () => {
+          await instance.cleanup();
+          tempDirs.cleanup();
+        },
+      };
+    } catch (error) {
+      await instance.cleanup();
+      tempDirs.cleanup();
+      throw error;
+    }
+  },
+});
+
+suite.define(() => {
+  it("retains existing-chat controls after another provider fails to refresh", async () => {
+    const call = async (method: string, params: Record<string, unknown>) => {
+      const result = await instance.cli([
+        "gateway",
+        "call",
+        method,
+        "--json",
+        "--timeout",
+        "30000",
+        "--params",
+        JSON.stringify(params),
+      ]);
+      expect(result.code, result.stderr).toBe(0);
+      return result.stdout;
+    };
+    const key = "agent:main:partial-refresh";
+    await call("sessions.create", {
+      key,
+      agentId: "main",
+      label: "Partial refresh",
+      model: "openai/gpt-5.4",
+    });
+    await call("sessions.patch", { key, thinkingLevel: "high" });
+    const catalog: ModelCatalogResult = JSON.parse(
+      await call("models.list", { agentId: "main", view: "configured", refresh: true }),
+    );
+    await fs.writeFile(
+      path.join(suite.artifactDir, "models-list.json"),
+      JSON.stringify(catalog, null, 2),
+    );
+    expect(catalog.refreshFailed).toBe(true);
+    expect(catalog.providerOutcomes).toContainEqual({
+      provider: "github-copilot",
+      status: "unavailable",
+    });
+    expect(catalog.models).toContainEqual(
+      expect.objectContaining({ provider: "openai", id: "gpt-5.4", available: true }),
+    );
+    for (const route of ["new", "chat/main/partial-refresh"]) {
+      await suite.withPage(
+        { locale: "en-US", viewport: { width: 1280, height: 900 } },
+        async ({ page }) => {
+          const dashboard = await instance.cli(["dashboard", "--json"]);
+          expect(dashboard.code, dashboard.stderr).toBe(0);
+          const { browserUrl }: { browserUrl: string } = JSON.parse(dashboard.stdout);
+          const url = new URL(browserUrl);
+          url.pathname = `/${route}`;
+          await page.goto(url.href);
+          await waitForControlUiGatewayReady(page);
+          const composer = page.locator(".agent-chat__input").first();
+          const model = composer.locator("[data-chat-model-select]");
+          await model.click();
+          await page
+            .getByText("Some models could not be refreshed. Open Models to try again.", {
+              exact: true,
+            })
+            .waitFor();
+          const stage = route === "new" ? "new" : "chat";
+          await page.screenshot({
+            path: path.join(suite.artifactDir, `${stage}-catalog.png`),
+            animations: "disabled",
+          });
+          await model.click();
+          await page.screenshot({
+            path: path.join(suite.artifactDir, `${stage}-composer.png`),
+            animations: "disabled",
+          });
+          const effort = composer.locator("[data-chat-thinking-select]");
+          await expect.poll(() => effort.isVisible()).toBe(true);
+          expect(await effort.getAttribute("aria-disabled")).toBe("false");
+          await effort.click();
+          await expect
+            .poll(() => composer.locator("[data-chat-thinking-slider]").isEnabled())
+            .toBe(true);
+          await page.screenshot({
+            path: path.join(suite.artifactDir, `${stage}-effort.png`),
+            animations: "disabled",
+          });
+        },
+      );
+    }
+  }, 120_000);
+});

--- a/ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
-import config from "../../../test/fixtures/config-corpus/provider-partially-unavailable.json";
+import config from "../../../test/fixtures/config-corpus/provider-partially-unavailable.json" with { type: "json" };
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -108,6 +108,12 @@ suite.define(() => {
       await suite.withPage(
         { locale: "en-US", viewport: { width: 1280, height: 900 } },
         async ({ page }) => {
+          await page.addInitScript(() => {
+            localStorage.setItem(
+              "openclaw:control-ui:community-invite",
+              JSON.stringify({ dismissedAtMs: 1770000000000 }),
+            );
+          });
           const dashboard = await instance.cli(["dashboard", "--json"]);
           expect(dashboard.code, dashboard.stderr).toBe(0);
           const { browserUrl }: { browserUrl: string } = JSON.parse(dashboard.stdout);

--- a/ui/src/lib/model-catalog-store.ts
+++ b/ui/src/lib/model-catalog-store.ts
@@ -9,6 +9,31 @@ export type ModelCatalogReadScope = Pick<
   "agentId" | "sessionKey" | "authProfileId"
 >;
 
+export type ChatModelCatalogState = {
+  hasSnapshot: boolean;
+  refreshFailed?: boolean;
+  status: "idle" | "loading" | "ready" | "error" | "offline";
+};
+
+export function resolveModelCatalogState(
+  result: Pick<ModelCatalogResult, "models" | "refreshFailed">,
+  {
+    connected = true,
+    loading = false,
+    error = null,
+  }: {
+    connected?: boolean;
+    loading?: boolean;
+    error?: string | null;
+  } = {},
+): ChatModelCatalogState {
+  return {
+    hasSnapshot: result.models.length > 0 || (!loading && !error),
+    refreshFailed: result.refreshFailed,
+    status: !connected ? "offline" : error ? "error" : loading ? "loading" : "ready",
+  };
+}
+
 export function modelCatalogRefreshError(
   result: ModelCatalogResult,
   failureMessage?: string,

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -2,6 +2,7 @@ import { html } from "lit";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
 import { t } from "../../i18n/index.ts";
+import { resolveModelCatalogState } from "../../lib/model-catalog-store.ts";
 import {
   readSessionMethodAccess,
   type SessionMethodAccess,
@@ -20,10 +21,7 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { refreshChatModelCatalogOnDemand } from "./chat-state-refresh.ts";
 import type { ChatProps } from "./chat-view.ts";
 import { renderChatModelAccountControl } from "./components/chat-model-account-control.ts";
-import {
-  renderChatModelControls,
-  type ChatModelCatalogState,
-} from "./components/chat-model-controls.ts";
+import { renderChatModelControls } from "./components/chat-model-controls.ts";
 import type { ChatPermissionPickerProps } from "./components/chat-permission-picker.ts";
 
 type SessionActionAccess = ReturnType<typeof readChatSessionActionAccess>;
@@ -65,26 +63,6 @@ export function readChatPaneMutationAccess(
       method: "sessions.patch",
       params: { key: sessionKey, archived: false },
     }),
-  };
-}
-
-function resolveChatModelCatalogState(
-  state: Pick<
-    ChatPageHost,
-    "chatModelCatalog" | "chatModelCatalogError" | "chatModelsLoading" | "connected"
-  >,
-): ChatModelCatalogState {
-  const hasSnapshot =
-    state.chatModelCatalog.length > 0 || (!state.chatModelsLoading && !state.chatModelCatalogError);
-  return {
-    hasSnapshot,
-    status: !state.connected
-      ? "offline"
-      : state.chatModelCatalogError
-        ? "error"
-        : state.chatModelsLoading
-          ? "loading"
-          : "ready",
   };
 }
 
@@ -153,7 +131,14 @@ export function renderChatPaneComposerControls(params: {
   const permissionPending = Boolean(
     currentChange?.pending || selectedSession?.permissionModePending,
   );
-  const modelCatalogState = resolveChatModelCatalogState(state);
+  const modelCatalogState = resolveModelCatalogState(
+    { models: state.chatModelCatalog, refreshFailed: state.chatModelCatalogRefreshFailed },
+    {
+      connected: state.connected,
+      loading: state.chatModelsLoading,
+      error: state.chatModelCatalogError,
+    },
+  );
   const thinkingLevelOverride = state.sessions.think(sessionKey, agentScope.agentId);
   const thinkingSession = thinkingLevelOverride
     ? { ...selectedSession, thinkingLevel: thinkingLevelOverride }

--- a/ui/src/pages/chat/chat-state-host.ts
+++ b/ui/src/pages/chat/chat-state-host.ts
@@ -77,6 +77,7 @@ export type ChatPageHost = ChatHost &
     chatModelPickerOpenSessionKey?: string | null;
     chatModelCatalog: ModelCatalogEntry[];
     chatModelCatalogError: string | null;
+    chatModelCatalogRefreshFailed?: boolean;
     chatAccountSelection?: ChatAccountSelection | null;
     modelAuthStatusRequestVersion: number;
     modelAuthStatusResult: ModelAuthStatusResult | null;

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -9,7 +9,7 @@ import {
 } from "../../lib/chat/chat-metadata-store.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { loadModelAuthStatus } from "../../lib/model-auth.ts";
-import { loadModelCatalog, modelCatalogRefreshError } from "../../lib/model-catalog-store.ts";
+import { loadModelCatalog } from "../../lib/model-catalog-store.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { reconcileSessionHistory } from "../../lib/sessions/reconcile.ts";
 import {
@@ -62,6 +62,7 @@ export function retireChatMetadataRequests(host: ChatPageHost): void {
   metadataBindings.delete(host);
   host.chatModelCatalog = [];
   host.chatModelCatalogError = null;
+  host.chatModelCatalogRefreshFailed = undefined;
   host.chatModelsLoading = false;
   host.chatAccountSelection = null;
 }
@@ -244,7 +245,8 @@ async function loadChatModelCatalog(
         }
         host.chatModelCatalog = result.models;
         host.chatAccountSelection = result.accountSelection ?? null;
-        host.chatModelCatalogError = modelCatalogRefreshError(result);
+        host.chatModelCatalogError = null;
+        host.chatModelCatalogRefreshFailed = result.refreshFailed;
         return true;
       },
       (error: unknown) => {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -4487,15 +4487,15 @@ describe("refreshChatMetadata", () => {
     const state = createMetadataState(request);
     await refreshChatModelCatalogOnDemand(state);
     expect(state.chatModelCatalog).toEqual([model]);
-    expect(state.chatModelCatalogError).toBe(
-      "Some models could not be refreshed. Open Models to try again.",
-    );
+    expect(state.chatModelCatalogError).toBeNull();
+    expect(state.chatModelCatalogRefreshFailed).toBe(true);
     await refreshChatModelCatalogOnDemand(state);
     expect(state.chatModelCatalog).toEqual([model]);
     expect(state.chatModelCatalogError).toBe("catalog transport failed");
     await refreshChatModelCatalogOnDemand(state);
     expect(state.chatModelCatalog).toEqual([]);
     expect(state.chatModelCatalogError).toBeNull();
+    expect(state.chatModelCatalogRefreshFailed).toBeUndefined();
   });
 
   it("keeps fallback slash commands when chat metadata omits commands", async () => {

--- a/ui/src/pages/chat/components/chat-model-catalog-state.ts
+++ b/ui/src/pages/chat/components/chat-model-catalog-state.ts
@@ -1,12 +1,9 @@
 import { html, nothing } from "lit";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
+import type { ChatModelCatalogState } from "../../../lib/model-catalog-store.ts";
 
-export type ChatModelCatalogState = {
-  hasSnapshot: boolean;
-  refreshFailed?: boolean;
-  status: "idle" | "loading" | "ready" | "error" | "offline";
-};
+export type { ChatModelCatalogState } from "../../../lib/model-catalog-store.ts";
 
 export function renderChatModelCatalogState(
   state: ChatModelCatalogState | undefined,
@@ -19,14 +16,15 @@ export function renderChatModelCatalogState(
   if (!state) {
     return nothing;
   }
-  const status = state.status === "ready" && state.refreshFailed ? "error" : state.status;
-  if (status === "ready" && hasSelectableOptions) {
+  const { status } = state;
+  const refreshWarning = status === "ready" && state.refreshFailed;
+  if (status === "ready" && hasSelectableOptions && !refreshWarning) {
     return nothing;
   }
   const label =
     status === "offline"
       ? t("common.offline")
-      : status === "error"
+      : status === "error" || refreshWarning
         ? hasOptions
           ? t("chat.modelControls.modelsRefreshFailed")
           : errorLabel
@@ -39,10 +37,11 @@ export function renderChatModelCatalogState(
         hasOptions ? "" : "chat-controls__model-catalog-state--empty"
       }"
       data-chat-model-catalog-state=${status}
+      role="status"
       aria-live="polite"
     >
       <span class="chat-controls__model-catalog-state-label">
-        ${status === "error" ? icons.alertTriangle : nothing}
+        ${status === "error" || refreshWarning ? icons.alertTriangle : nothing}
         <span>${label}</span>
       </span>
       ${

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -380,12 +380,10 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     modelOptions.length,
     selectionKnown,
   );
-  // A verified-empty catalog means there is nothing to reason about: the effort
-  // picker would only steer a model that cannot be selected, so it hides with it.
   const hasResolvableModel =
     managedCatalog.status === "ready" &&
-    (modelOptions.some((option) => !option.disabled) ||
-      (props.modelSelectionLocked === true && activeModelOption !== undefined));
+    activeModelOption !== undefined &&
+    !activeModelOption.disabled;
   const busy =
     props.loading || props.sending || Boolean(props.activeRunId) || props.stream !== null;
   const commonDisabled =

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -382,8 +382,8 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   );
   const hasResolvableModel =
     managedCatalog.status === "ready" &&
-    activeModelOption !== undefined &&
-    !activeModelOption.disabled;
+    activeModelOption?.disabled !== true &&
+    modelOptions.some((option) => !option.disabled);
   const busy =
     props.loading || props.sending || Boolean(props.activeRunId) || props.stream !== null;
   const commonDisabled =

--- a/ui/src/pages/new-session/draft-place-state.test.ts
+++ b/ui/src/pages/new-session/draft-place-state.test.ts
@@ -27,18 +27,19 @@ function createRepositoryFixture(
   const persistPreference = vi.fn();
   const readPreference = vi.fn<() => NewSessionPreference>(() => ({ worktree: true }));
   const request = vi.fn<(method: string) => Promise<unknown>>(async (method) =>
-    method === "models.list"
-      ? { models: [] }
-      : method === "fs.listDir"
-        ? { path: "/plain", entries: [] }
-        : { repositoryStatus: options.unavailable ? "unavailable" : "not_git", branches: [] },
+    method === "fs.listDir"
+      ? { path: "/plain", entries: [] }
+      : { repositoryStatus: options.unavailable ? "unavailable" : "not_git", branches: [] },
   );
   const context = {
     gateway: {
       subscribeEvents: () => () => undefined,
       snapshot: {
         phase: "connected",
-        client: { request },
+        client: {
+          request: async (method: string) =>
+            method === "models.list" ? { models: [] } : request(method),
+        },
         hello: { auth: { role: "operator", scopes: ["operator.admin"] } },
       },
     },

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -21,6 +21,7 @@ import {
 import { resolveThinkingProfileForSession } from "../../lib/chat/thinking.ts";
 import {
   loadModelCatalog,
+  resolveModelCatalogState,
   subscribeModelCatalogChanges,
   type ModelCatalogReadScope,
 } from "../../lib/model-catalog-store.ts";
@@ -170,9 +171,7 @@ export class NewSessionModelControl {
     this.metadataState = {
       catalog: result.models,
       accountSelection: result.accountSelection,
-      hasSnapshot: true,
-      status: "ready",
-      refreshFailed: result.refreshFailed,
+      ...resolveModelCatalogState(result),
     };
     if (!this.draftAccount && this.pendingSelectionGeneration === this.selectionGeneration) {
       this.restorePreference(this.pendingPreference, this.pendingAgent, this.pendingContext);


### PR DESCRIPTION
Fixes #144726.

## What Problem This Solves

Fixes an issue where existing chats lost effort and speed controls when another provider failed to refresh, even though usable model choices remained.

## Why This Change Was Made

Existing chat and New Session now share catalog readiness. Partial-refresh warnings remain separate from failed requests, and supported controls use the selected model’s published capabilities and availability.

## User Impact

Usable models keep their effort and speed controls while the refresh notice stays visible. No schema or protocol change.

Consumers: existing-chat and New Session controls share readiness semantics.

## Evidence

Mock and real-Gateway browser reproductions failed before the fix and passed afterward. Eight browser scenarios covered partial failure, recovery, locks, empty or rejected results and unsupported controls. Eleven browser regressions/siblings and 127 capability/default tests passed. Telegram acknowledged the native effort command. An unrelated session-link layout test remained failing on the base.
