### PR TITLE
fix(ci): allow FRV binary artifact reads

### DIFF
--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -3,6 +3,7 @@
 import {
   execFileSync,
   spawnSync,
+  type ExecFileSyncOptionsWithBufferEncoding,
   type ExecFileSyncOptionsWithStringEncoding,
 } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
@@ -321,6 +322,19 @@ function commandFailureMessage(error: unknown): string {
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+function isUnsupportedAllowEscapeSequencesFlag(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const stderr = (error as Error & { stderr?: unknown }).stderr;
+  const text =
+    typeof stderr === "string" ? stderr : Buffer.isBuffer(stderr) ? stderr.toString("utf8") : "";
+  return text
+    .replaceAll("\r\n", "\n")
+    .split("\n")
+    .some((line) => line.trim() === "unknown flag: --allow-escape-sequences");
 }
 
 function createTemporaryRef(ref: string, sha: string, dryRun: boolean) {
@@ -1167,19 +1181,31 @@ async function readDispatchWitness(request: DispatchRequest, observed: DispatchR
     "Dispatch witness metadata changed from its exact artifact tuple",
   );
   // Keep credentials and redirects owned by the selected CLI; ZIP bytes must not be decoded.
-  const archiveBytes = execPlainGh(
-    [
-      "api",
-      "--method",
-      "GET",
-      `${artifactEndpoint}/zip`,
-      "--hostname",
-      "github.com",
-      "-H",
-      GH_NO_CACHE_HEADER,
-    ],
-    { ...GH_READ_OPTIONS, encoding: null, maxBuffer: MAX_WITNESS_ARCHIVE_BYTES },
-  );
+  const archiveArgs = [
+    "api",
+    "--method",
+    "GET",
+    `${artifactEndpoint}/zip`,
+    "--hostname",
+    "github.com",
+    "-H",
+    GH_NO_CACHE_HEADER,
+  ];
+  const archiveOptions = {
+    ...GH_READ_OPTIONS,
+    encoding: null,
+    maxBuffer: MAX_WITNESS_ARCHIVE_BYTES,
+    stdio: ["ignore", "pipe", "pipe"],
+  } satisfies ExecFileSyncOptionsWithBufferEncoding;
+  let archiveBytes: Uint8Array<ArrayBuffer>;
+  try {
+    archiveBytes = execPlainGh([...archiveArgs, "--allow-escape-sequences"], archiveOptions);
+  } catch (error) {
+    if (!isUnsupportedAllowEscapeSequencesFlag(error)) {
+      throw error;
+    }
+    archiveBytes = execPlainGh(archiveArgs, archiveOptions);
+  }
   requireDispatch(
     archiveBytes.byteLength === metadata.size_in_bytes &&
       `sha256:${createHash("sha256").update(archiveBytes).digest("hex")}` === metadata.digest,

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -87,6 +87,7 @@ function createDispatchFixture(
     artifactMetadata?: Record<string, unknown>;
     exactArtifactMetadata?: Record<string, unknown>;
     artifactReadError?: "metadata" | "archive";
+    archiveEscapeFlag?: "required" | "unsupported";
     oversizedArtifactMetadata?: boolean;
     archiveFailure?: "oversized" | "truncated" | "corrupt" | "digest";
     inventoryError?: string;
@@ -501,6 +502,14 @@ if (args[0] === "api" && method === "POST" && endpoint.endsWith("/git/refs")) {
     throw new Error("artifact reads require exact-host GET without response headers");
   }
   const archive = endpoint.endsWith("/zip");
+  if (archive && ${JSON.stringify(options.archiveEscapeFlag ?? "")} === "unsupported" && args.includes("--allow-escape-sequences")) {
+    console.error("unknown flag: --allow-escape-sequences");
+    process.exit(1);
+  }
+  if (archive && ${JSON.stringify(options.archiveEscapeFlag ?? "")} === "required" && !args.includes("--allow-escape-sequences")) {
+    console.error("refusing to output binary content without --allow-escape-sequences");
+    process.exit(1);
+  }
   if (${JSON.stringify(options.artifactReadError ?? "")} === (archive ? "archive" : "metadata")) {
     console.error("artifact read denied (HTTP 403)");
     process.exit(1);
@@ -1358,7 +1367,11 @@ describe("full-release-validation-at-sha", () => {
   ])(
     "reads witness bytes through $ghRoute CLI without Node fetch (token=$tokenPresent)",
     ({ ghRoute, tokenPresent }) => {
-      const fixture = createDispatchFixture({ ghRoute, tokenPresent });
+      const fixture = createDispatchFixture({
+        archiveEscapeFlag: "required",
+        ghRoute,
+        tokenPresent,
+      });
       try {
         const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
         expect(result.status, result.stderr).toBe(0);
@@ -1386,6 +1399,7 @@ describe("full-release-validation-at-sha", () => {
         expect(ghApiEndpoint(reads[1].args)).toBe(
           "repos/openclaw/openclaw/actions/artifacts/9001/zip",
         );
+        expect(reads[1].args).toContain("--allow-escape-sequences");
         expect(fixture.readCalls(fixture.pathGhCallsPath)).toEqual(ghRoute === "path" ? calls : []);
         expect(JSON.parse(readFileSync(fixture.requestPath(), "utf8")).phase).toBe("observed");
       } finally {
@@ -1393,6 +1407,45 @@ describe("full-release-validation-at-sha", () => {
       }
     },
   );
+
+  it("falls back once when gh does not support the binary-output flag", () => {
+    const fixture = createDispatchFixture({ archiveEscapeFlag: "unsupported" });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(0);
+      const archiveReads = readFileSync(fixture.artifactTransportPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line))
+        .filter(({ args }) => ghApiEndpoint(args).endsWith("/zip"));
+      expect(archiveReads).toHaveLength(2);
+      expect(archiveReads[0].args).toContain("--allow-escape-sequences");
+      expect(archiveReads[1].args).not.toContain("--allow-escape-sequences");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("does not retry unrelated witness archive failures", () => {
+    const fixture = createDispatchFixture({
+      archiveEscapeFlag: "required",
+      artifactReadError: "archive",
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("dispatch=unknown");
+      const archiveReads = readFileSync(fixture.artifactTransportPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line))
+        .filter(({ args }) => ghApiEndpoint(args).endsWith("/zip"));
+      expect(archiveReads).toHaveLength(1);
+      expect(archiveReads[0].args).toContain("--allow-escape-sequences");
+    } finally {
+      fixture.cleanup();
+    }
+  });
 
   it.each([
     { name: "nonpositive ID", artifactMetadata: { id: 0 } },


### PR DESCRIPTION
## What Problem This Solves

The local full-release qualification controller cannot read the dispatch witness ZIP with current GitHub CLI releases. `gh api` now refuses binary output unless `--allow-escape-sequences` is explicit, leaving an accepted hosted FRV run locally unresolved.

## Why This Change Was Made

Request binary artifact output explicitly for the SHA-pinned dispatch witness. Preserve older GitHub CLI compatibility with one unflagged retry only when captured stderr contains the exact unknown-flag diagnostic; unrelated archive failures remain fail-closed and single-attempt.

## User Impact

Maintainer FRV dispatch and reconciliation can verify exact witness artifacts with current and older supported GitHub CLI versions without weakening size, digest, identity, or ZIP-policy checks.

## Evidence

- Reproduced against hosted FRV run https://github.com/openclaw/openclaw/actions/runs/34569732886: local witness ZIP download was refused until the binary-output flag was supplied.
- Regression selection failed before the production repair for the intended missing-flag reason.
- `node scripts/run-vitest.mjs test/scripts/full-release-validation-at-sha.test.ts`: 162/162 passed.
- Focused modern CLI, legacy fallback, and unrelated-failure cases: 5/5 passed after the repair.
- `oxlint`, `oxfmt --check`, and `git diff --check` passed.
- `check:changed` passed through script erasability, then the worktree policy rejected the required external `node_modules` symlink at the tsgo lane. Direct tsgo reported zero errors in the touched script; remaining diagnostics are unrelated missing dependencies in the shared install.
- Independent P0-P2 autoreview: scoped clean.
