### PR TITLE
fix(gateway): skip restart sentinel for hot-applied config writes

### DIFF
--- a/src/gateway/server-methods/config-write-flow.integration.test.ts
+++ b/src/gateway/server-methods/config-write-flow.integration.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+const restartMocks = vi.hoisted(() => ({
+  scheduleGatewaySigusr1Restart: vi.fn(() => ({
+    scheduled: true,
+    delayMs: 1_000,
+    coalesced: false,
+  })),
+}));
+
+vi.mock("../../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: restartMocks.scheduleGatewaySigusr1Restart,
+}));
+
+vi.mock("../../version.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../version.js")>();
+  return {
+    ...actual,
+    resolveRuntimeServiceCommit: () => "testcomm",
+    resolveRuntimeServiceVersion: () => "testversion",
+  };
+});
+
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { withTestDir } from "../../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { resolveGatewayConfigRestartWriteResult } from "./config-write-flow.js";
+
+type GatewayRestartSentinelDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_sentinel">;
+
+function readCurrentSentinelRow() {
+  const { db } = openOpenClawStateDatabase();
+  const stateDb = getNodeSqliteKysely<GatewayRestartSentinelDatabase>(db);
+  return executeSqliteQueryTakeFirstSync(
+    db,
+    stateDb
+      .selectFrom("gateway_restart_sentinel")
+      .select(["sentinel_key", "kind", "status", "payload_json"])
+      .where("sentinel_key", "=", "current"),
+  );
+}
+
+async function withStateDir(run: () => Promise<void>): Promise<void> {
+  await withTestDir({ prefix: "openclaw-config-sentinel-" }, async (tempDir) => {
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: tempDir }, run);
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+    }
+  });
+}
+
+const ACTOR = {
+  actor: "openclaw-control-ui",
+  deviceId: "device-1",
+  clientIp: "127.0.0.1",
+  connId: "conn-1",
+} as const;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveGatewayConfigRestartWriteResult real persistence", () => {
+  beforeEach(() => {
+    restartMocks.scheduleGatewaySigusr1Restart.mockClear();
+  });
+
+  it("does not persist a restart sentinel row for a hot-applied write", async () => {
+    await withStateDir(async () => {
+      const result = await resolveGatewayConfigRestartWriteResult({
+        requestParams: {},
+        kind: "config-patch",
+        mode: "config.patch",
+        configPath: "/tmp/openclaw.json",
+        changedPaths: ["agents.defaults.model"],
+        previousConfig: { agents: { defaults: { model: "old-model" } } } as OpenClawConfig,
+        nextConfig: { agents: { defaults: { model: "new-model" } } } as OpenClawConfig,
+        actor: ACTOR,
+      });
+
+      expect(result.sentinelPersisted).toBe(false);
+      expect(result.payload.doctorHint).toBeNull();
+      expect(result.payload.stats?.requiresRestart).toBe(false);
+
+      // Real DB: no sentinel row exists for a hot-applied write.
+      const row = readCurrentSentinelRow();
+      expect(row).toBeUndefined();
+    });
+  });
+
+  it("persists a restart sentinel row for a restart-requiring write", async () => {
+    await withStateDir(async () => {
+      const result = await resolveGatewayConfigRestartWriteResult({
+        requestParams: {},
+        kind: "config-patch",
+        mode: "config.patch",
+        configPath: "/tmp/openclaw.json",
+        changedPaths: ["gateway.port"],
+        previousConfig: { gateway: { port: 4_000 } } as OpenClawConfig,
+        nextConfig: { gateway: { port: 4_001 } } as OpenClawConfig,
+        actor: ACTOR,
+      });
+
+      expect(result.sentinelPersisted).toBe(true);
+      expect(result.payload.doctorHint).toContain("openclaw doctor --non-interactive");
+      expect(result.payload.stats?.requiresRestart).toBe(true);
+
+      // Real DB: a sentinel row exists for a restart-requiring write.
+      const row = readCurrentSentinelRow();
+      expect(row).toBeDefined();
+      expect(row?.kind).toBe("config-patch");
+      expect(row?.status).toBe("ok");
+      const persistedPayload = JSON.parse(row?.payload_json ?? "{}");
+      expect(persistedPayload.stats?.requiresRestart).toBe(true);
+      expect(persistedPayload.doctorHint).toContain("openclaw doctor --non-interactive");
+    });
+  });
+});

--- a/src/gateway/server-methods/config-write-flow.test.ts
+++ b/src/gateway/server-methods/config-write-flow.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRuntimeConfigWriteApplication } from "../../config/runtime-write-application.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
 
 const configMocks = vi.hoisted(() => ({
   replaceConfigFile: vi.fn(),
@@ -11,6 +12,16 @@ const secretsMocks = vi.hoisted(() => ({
     sourceConfig: OpenClawConfig;
     config: OpenClawConfig;
   } | null,
+}));
+const restartSentinelMocks = vi.hoisted(() => ({
+  writeRestartSentinel: vi.fn(async (_payload: RestartSentinelPayload) => undefined),
+}));
+const restartMocks = vi.hoisted(() => ({
+  scheduleGatewaySigusr1Restart: vi.fn(() => ({
+    scheduled: true,
+    delayMs: 1_000,
+    coalesced: false,
+  })),
 }));
 
 vi.mock("../../config/config.js", async (importOriginal) => {
@@ -30,9 +41,22 @@ vi.mock("../../secrets/runtime-state.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../../infra/restart-sentinel.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/restart-sentinel.js")>();
+  return {
+    ...actual,
+    writeRestartSentinel: restartSentinelMocks.writeRestartSentinel,
+  };
+});
+
+vi.mock("../../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: restartMocks.scheduleGatewaySigusr1Restart,
+}));
+
 import {
   commitGatewayConfigWrite,
   didActiveSharedGatewayAuthChange,
+  resolveGatewayConfigRestartWriteResult,
   shouldAwaitGatewayConfigApplication,
 } from "./config-write-flow.js";
 
@@ -209,5 +233,70 @@ describe("didActiveSharedGatewayAuthChange", () => {
         next: { gateway: { auth: { mode: "token", token: "new-token" } } },
       }),
     ).toBe(true);
+  });
+});
+
+describe("resolveGatewayConfigRestartWriteResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not persist a restart sentinel for a hot-applied write", async () => {
+    // agents.defaults.model is hot-applied; no gateway restart is required.
+    const previousConfig: OpenClawConfig = { agents: { defaults: { model: "old-model" } } };
+    const nextConfig: OpenClawConfig = { agents: { defaults: { model: "new-model" } } };
+
+    const result = await resolveGatewayConfigRestartWriteResult({
+      requestParams: {},
+      kind: "config-patch",
+      mode: "config.patch",
+      configPath: "/tmp/openclaw.json",
+      changedPaths: ["agents.defaults.model"],
+      previousConfig,
+      nextConfig,
+      actor: {
+        actor: "openclaw-control-ui",
+        deviceId: "device-1",
+        clientIp: "127.0.0.1",
+        connId: "conn-1",
+      },
+    });
+
+    expect(result.sentinelPersisted).toBe(false);
+    expect(result.restart).toBeUndefined();
+    expect(restartSentinelMocks.writeRestartSentinel).not.toHaveBeenCalled();
+    expect(restartMocks.scheduleGatewaySigusr1Restart).not.toHaveBeenCalled();
+    expect(result.payload.stats?.requiresRestart).toBe(false);
+    // A hot-applied write carries no doctor hint: there is no restart to follow
+    // up on, and doctor --non-interactive has write semantics (#144063).
+    expect(result.payload.doctorHint).toBeNull();
+  });
+
+  it("persists a restart sentinel with a doctor hint for a restart-requiring write", async () => {
+    // gateway.port requires a gateway restart.
+    const previousConfig: OpenClawConfig = { gateway: { port: 4_000 } };
+    const nextConfig: OpenClawConfig = { gateway: { port: 4_001 } };
+
+    const result = await resolveGatewayConfigRestartWriteResult({
+      requestParams: {},
+      kind: "config-patch",
+      mode: "config.patch",
+      configPath: "/tmp/openclaw.json",
+      changedPaths: ["gateway.port"],
+      previousConfig,
+      nextConfig,
+      actor: {
+        actor: "openclaw-control-ui",
+        deviceId: "device-1",
+        clientIp: "127.0.0.1",
+        connId: "conn-1",
+      },
+    });
+
+    expect(result.sentinelPersisted).toBe(true);
+    expect(restartSentinelMocks.writeRestartSentinel).toHaveBeenCalledOnce();
+    expect(result.payload.stats?.requiresRestart).toBe(true);
+    expect(result.payload.doctorHint).not.toBeNull();
+    expect(result.payload.doctorHint).toContain("openclaw doctor --non-interactive");
   });
 });

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -211,7 +211,10 @@ function buildConfigRestartSentinelPayload(params: {
     deliveryContext: params.deliveryContext,
     threadId: params.threadId,
     message: params.note ?? null,
-    doctorHint: formatDoctorNonInteractiveHint(),
+    // A hot-applied write requires no restart, so a diagnostic follow-up with
+    // write semantics (doctor --non-interactive) is not actionable. Only a
+    // restart-requiring write carries the doctor hint for post-restart checks.
+    doctorHint: params.requiresRestart ? formatDoctorNonInteractiveHint() : null,
     stats: {
       mode: params.mode,
       root: params.configPath,
@@ -328,7 +331,13 @@ export async function resolveGatewayConfigRestartWriteResult(params: {
     threadId,
     note,
   });
-  const sentinelPersisted = await tryWriteRestartSentinelPayload(payload);
+  // Persist the restart sentinel only when the write actually requires a
+  // Gateway restart. A hot-applied write has no restart notice to deliver on
+  // the next start; persisting it anyway causes a stale notice to replay on an
+  // unrelated later startup (see #144063).
+  const sentinelPersisted = restartRequirement.requiresRestart
+    ? await tryWriteRestartSentinelPayload(payload)
+    : false;
   const restart = restartRequirement.scheduleDirectRestart
     ? scheduleGatewaySigusr1Restart({
         delayMs: restartDelayMs,

--- a/src/gateway/server.config-policy-response.test.ts
+++ b/src/gateway/server.config-policy-response.test.ts
@@ -1,8 +1,8 @@
 // A config writer receives the committed revision before its own policy retires its socket.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as config from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
-import * as restartSentinel from "../infra/restart-sentinel.js";
 import { resetLogger } from "../logging/logger.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { createDeferredCore } from "../shared/deferred.js";
@@ -71,12 +71,16 @@ describe("config writer policy-close ordering", () => {
       server = await startGatewayServerCore(port, { controlUiEnabled: false });
       await server.startupSettled;
       const held = createDeferredCore();
-      const published = createDeferredCore<restartSentinel.RestartSentinelPayload>();
-      const writeSentinel = restartSentinel.writeRestartSentinel;
-      vi.spyOn(restartSentinel, "writeRestartSentinel").mockImplementation(async (payload) => {
-        published.resolve(payload);
+      // Hold at replaceConfigFile: it is awaited before the RPC acknowledgement
+      // in commitGatewayConfigWrite, so it is a pre-ack barrier for both
+      // hot-applied and restart-requiring writes. The earlier sentinel spy hold
+      // no longer fires for hot-applied writes (#144063 skips sentinel
+      // persistence), which would race the policy-close handshake.
+      const replaceConfigFile = config.replaceConfigFile;
+      vi.spyOn(config, "replaceConfigFile").mockImplementation(async (...args) => {
+        const result = await replaceConfigFile(...args);
         await held.promise;
-        return await writeSentinel(payload);
+        return result;
       });
       const connect = async (credential: string, browser = false) => {
         const closed = createDeferredCore();
@@ -142,13 +146,13 @@ describe("config writer policy-close ordering", () => {
             : {}),
         });
         void result.catch(() => {});
-        const publication = await Promise.race([
-          published.promise,
-          result.then(() => {
-            throw new Error("RPC completed before its sentinel");
-          }),
-        ]);
-        expect(publication.stats?.requiresRestart).toBe(false);
+        // The pre-ack hold is on replaceConfigFile (awaited before
+        // acknowledgement in commitGatewayConfigWrite). Hot-applied writes
+        // skip sentinel persistence (#144063), so the hold moved here from the
+        // sentinel spy to preserve the barrier for both write kinds. After
+        // replaceConfigFile returns, the config is committed to disk; the hold
+        // delays the ack so peer-close and stale-read assertions run before the
+        // writer's socket is retired.
         await peer.closed;
         expect(writer.didClose()).toBe(false);
         const staleRead = writer.client.request("health");


### PR DESCRIPTION
Related to #144063

## What Problem This Solves

A hot-applied `config.patch` (e.g. `agents.defaults.model`) requires no Gateway restart, but `resolveGatewayConfigRestartWriteResult` persisted a restart sentinel unconditionally. The next unrelated Gateway start — a container upgrade hours later — then replayed the stale notice with the old config-patch reason and a `doctor --non-interactive` recommendation that `doctor --help` describes as "Run without prompts (safe migrations only)", not a read-only check.

## Why This Change Was Made

The restart sentinel is now persisted only when the config write actually requires a Gateway restart.

- `resolveGatewayConfigRestartWriteResult` gates `tryWriteRestartSentinelPayload` on `restartRequirement.requiresRestart`. A hot-applied write returns `sentinelPersisted: false` and never calls `writeRestartSentinel`, so no stale row survives for the next start to consume.
- `buildConfigRestartSentinelPayload` withholds the doctor hint for hot-applied writes (`doctorHint: null`). There is no restart to follow up on, and `doctor --non-interactive` can apply safe migrations — not a read-only check.
- Restart-requiring writes (`gateway.port`, `reload.mode: off`, `plan.restartGateway`) still persist the sentinel and carry the `doctor --non-interactive` hint as before.
- The consumer (`loadRestartSentinelStartupTask`) is unchanged. It still serves update-kind sentinels and legitimate restart-requiring config sentinels. The fix is at the producer owner, which Codex confirmed is "narrower than suppressing all restart notifications or adding a new setting."
- `formatDoctorNonInteractiveHint` is unchanged. It is shared by four callers (`/restart`, update, update-restart-sentinel-payload, config); a global `--lint` change would affect restart-requiring and update paths where safe-migration semantics are intentional.

## User Impact

Owners no longer receive a stale "Gateway restart config-patch ok" notice on an unrelated later Gateway start after a hot-applied config change. The misleading `doctor --non-interactive` recommendation no longer follows a write that required no restart. Restart-requiring config writes are unaffected.

## Evidence

Current main persists the restart sentinel for every `config.patch`/`config.apply` write, even when `resolveConfigRestartRequirement` returns `requiresRestart: false`. PR #83041 (commit `96e27c6ea8c`) introduced the `requiresRestart` field into `payload.stats` but did not connect it to the persistence gate. Codex review (2026-09-10) confirmed: "a successful hot-applicable config.patch persists a nonempty notice that startup later consumes without checking restart necessity or age."

Exact head gates persistence on `requiresRestart`. Live proof calling the exported production function `shouldAwaitGatewayConfigApplication` (returns `!requiresRestart`):

```console
$ node --import tsx --input-type=module <<'NODE'
import { shouldAwaitGatewayConfigApplication } from "./src/gateway/server-methods/config-write-flow.ts";
const hot = shouldAwaitGatewayConfigApplication({
  changedPaths: ["agents.defaults.model"],
  previousConfig: { agents: { defaults: { model: "old-model" } } },
  nextConfig: { agents: { defaults: { model: "new-model" } } },
});
const restart = shouldAwaitGatewayConfigApplication({
  changedPaths: ["gateway.port"],
  previousConfig: { gateway: { port: 4000 } },
  nextConfig: { gateway: { port: 4001 } },
});
console.log("hot-apply agents.defaults.model:", hot, "(true = no restart required)");
console.log("restart-requiring gateway.port:", restart, "(false = restart required)");
NODE
hot-apply agents.defaults.model: true (true = no restart required)
restart-requiring gateway.port: false (false = restart required)
```

Regression tests verify the gate and the conditional doctor hint (mocked sentinel persistence):

```console
$ node scripts/run-vitest.mjs src/gateway/server-methods/config-write-flow.test.ts -- --reporter=verbose
 ✓ |gateway-methods| src/gateway/server-methods/config-write-flow.test.ts > resolveGatewayConfigRestartWriteResult > does not persist a restart sentinel for a hot-applied write 6ms
 ✓ |gateway-methods| src/gateway/server-methods/config-write-flow.test.ts > resolveGatewayConfigRestartWriteResult > persists a restart sentinel with a doctor hint for a restart-requiring write 5ms
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

The hot-applied test asserts `sentinelPersisted === false`, `writeRestartSentinel` not called, and `doctorHint === null`. The restart-requiring test asserts `sentinelPersisted === true`, `writeRestartSentinel` called once, and `doctorHint` contains `openclaw doctor --non-interactive`.

Real persistence proof (no mocks on `writeRestartSentinel`; real temp SQLite state DB via `OPENCLAW_STATE_DIR`):

```console
$ node scripts/run-vitest.mjs src/gateway/server-methods/config-write-flow.integration.test.ts -- --reporter=verbose
 ✓ |gateway-methods| src/gateway/server-methods/config-write-flow.integration.test.ts > resolveGatewayConfigRestartWriteResult real persistence > does not persist a restart sentinel row for a hot-applied write 322ms
 ✓ |gateway-methods| src/gateway/server-methods/config-write-flow.integration.test.ts > resolveGatewayConfigRestartWriteResult real persistence > persists a restart sentinel row for a restart-requiring write 220ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

The hot-applied integration test reads the real `gateway_restart_sentinel` table after `resolveGatewayConfigRestartWriteResult` and asserts the `current` row is `undefined` — no stale row survives for a later startup to consume. The restart-requiring integration test asserts the `current` row exists with `kind: "config-patch"`, `status: "ok"`, `stats.requiresRestart: true`, and `doctorHint` containing `openclaw doctor --non-interactive`. This proves the changed persistence behavior end-to-end at the storage owner, not just the mocked call path.

Config-write/startup flow proof (real Gateway + config.patch RPC + DB + startup consumer input):

```console
$ node --import tsx /tmp/proof-144063.mts
=== Scenario 1: hot-applied config.patch (agents.defaults.model) ===
RPC ack sentinel.persisted: false
RPC ack sentinel.payload.stats.requiresRestart: false
RPC ack sentinel.payload.doctorHint: null
DB gateway_restart_sentinel current row: NONE (no row)
readRestartSentinel() (startup consumer input): null (no startup task)

=== Scenario 2: restart-requiring config.patch (gateway.port) ===
RPC ack sentinel.persisted: true
RPC ack sentinel.payload.stats.requiresRestart: true
RPC ack sentinel.payload.doctorHint: PRESENT
DB gateway_restart_sentinel current row: kind=config-patch status=ok
readRestartSentinel() (startup consumer input): HAS PAYLOAD (would create startup task)
```

This exercises the full flow: a real `startGatewayServerCore` Gateway receives `config.patch` over WebSocket, the producer gates persistence on `requiresRestart`, the `gateway_restart_sentinel` SQLite table reflects the gate, and `readRestartSentinel()` — the input to `loadRestartSentinelStartupTask` on the next Gateway start — returns `null` for hot-applied writes (no startup task, no stale notice) and a payload for restart-requiring writes (startup task preserved).

Adjacent sentinel suites pass with no regressions:

```console
$ node scripts/run-vitest.mjs src/infra/restart-sentinel.test.ts src/gateway/server-methods/config.shared-auth.test.ts src/gateway/server-restart-sentinel.test.ts
# 39 + adjacent tests passed
```

The `server.config-policy-response.test.ts` suite (4 cases covering token/origin revocation policy-close ordering) was adapted: the pre-acknowledgement hold moved from the `writeRestartSentinel` spy to a `replaceConfigFile` spy. Hot-applied writes skip sentinel persistence (#144063), so the sentinel spy no longer fires for them — `replaceConfigFile` is awaited before the RPC acknowledgement in `commitGatewayConfigWrite` and runs for both write kinds, preserving the barrier that keeps `peer.closed`, `writer.didClose()`, and `staleRead` assertions deterministic before the writer's socket is retired. The `requiresRestart` assertion moved to the ack's `sentinel.payload` where it is always available. All 4 cases pass.

Production code is net +11 lines. The growth gates sentinel persistence on the existing `requiresRestart` classification and makes the doctor hint conditional. Tests are net +219 lines across three files (mocked unit tests, real-persistence integration test, policy-close ordering adaptation). Formatting (`oxfmt --check`) and `git diff --check` pass.

### Preexisting unrelated CI failure

The `checks-node-core-test-nondist-shard` reported one failure in `extensions/memory-core/src/memory/manager-temporal-ranking.test.ts:156` — the test asserts FTS `available: false` but the runtime reports `available: true`. This PR does not touch `extensions/memory-core/` or any memory/FTS code path; the changed files are all under `src/gateway/server-methods/` and `src/gateway/server.config-policy-response.test.ts`. This failure is preexisting on main and unrelated to this PR.

### What was not tested

Full Gateway runtime with a real Telegram channel across a container upgrade (the issue's exact 14-hour delivery path) was not exercised. The config-write/startup flow is verified through a real Gateway (`startGatewayServerCore`) receiving `config.patch` over WebSocket, with the `gateway_restart_sentinel` SQLite table and `readRestartSentinel()` (the input to `loadRestartSentinelStartupTask`) confirming the changed behavior. The `formatDoctorNonInteractiveHint` global function is unchanged.

### Why Telegram Test Server E2E was not provided

The `proof: telegram-e2e` label requests Telegram Test Server proof, but this is not feasible for an external contributor and is not the right boundary for this fix:

1. **Credential gate**: AGENTS.md states "Telegram claims require Test Server userbot proof with **Convex-leased credentials**." These credentials are maintainer-owned and not available to external contributors. The `telegram-e2e-userbot` skill requires leased credentials that cannot be self-provisioned.

2. **Wrong boundary for this fix**: The fix is at the **persistence producer** (`config-write-flow.ts`), not the Telegram delivery layer. The logical chain is: producer does not write a sentinel row → consumer (`loadRestartSentinelStartupTask`) has no row to read on startup → no stale notice is formatted or routed to any channel (Telegram or otherwise). The real persistence proof above closes this chain at the storage owner. A Telegram E2E would re-prove "no row means no delivery," which is already established by the consumer's source contract (`readRestartSentinel()` returns `null` → `loadRestartSentinelStartupTask` returns `null` → no startup task).

3. **Codex's own standard**: The issue-level Codex review accepted source inspection ("Reproducibility: yes. by source inspection... No runtime reproduction was executed") and noted "diagnostic logs and terminal output also count" — not only screenshots. The real DB integration test provides terminal output proving the changed persistence behavior, which is the actual changed code path.

4. **Maintainer resources**: If a maintainer with Convex-leased credentials wishes to run the Telegram Test Server E2E, the branch is ready. The scenario would be: `config.patch` `agents.defaults.model` (hot-apply) → restart Gateway → assert no Telegram notice is delivered; then `config.patch` `gateway.port` (restart-requiring) → restart → assert the restart notice is delivered as before.

## AI Assistance 🤖

- **AI-assisted**: Yes
- **AI model**: Claude (GLM-5.2-FP8)
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

**Highest-risk area**: Restart sentinel persistence for config writes — a regression here could either re-introduce stale notices (if gate is removed) or suppress legitimate restart notices (if gate is too broad).

**Mitigation**: The gate is strictly `restartRequirement.requiresRestart ? persist : false`, reusing the existing `resolveConfigRestartRequirement` classification that PR #83041 already established. Restart-requiring writes still persist. Two regression tests assert both branches. Adjacent sentinel suites pass with no regressions.

**Compatibility impact**: No breaking change. Hot-applied writes stop persisting a sentinel they should never have persisted. The `sentinel: { persisted: false, payload }` RPC ack shape is unchanged — `persisted: false` is the correct semantic for a write with no restart notice to deliver.

**Trade-off**: The Codex best-solution suggestion "use doctor --lint for diagnostic-only follow-up" is partially addressed. Hot-applied writes (the issue's scenario) now carry `doctorHint: null` (stricter than `--lint` — no follow-up needed when no restart occurred). Restart-requiring config writes still use `--non-interactive` because `formatDoctorNonInteractiveHint` is shared by `/restart` and update paths where safe-migration semantics are intentional. A global `--lint` change is out of scope for this issue and would require separate verification of update and `/restart` paths.
