### PR TITLE
fix(launcher): report external child kills as 128+signum, not exit 1

### DIFF
--- a/node-runtime-recovery.mjs
+++ b/node-runtime-recovery.mjs
@@ -159,7 +159,15 @@ export const runRespawnedChild = (command, args, env) => {
               ? 143
               : undefined
           : undefined;
-      process.exit(forwardedSignalExitCode ?? 1);
+      if (forwardedSignalExitCode !== undefined) {
+        process.exit(forwardedSignalExitCode);
+      }
+      // The child died by a signal we never forwarded (e.g. an external
+      // SIGKILL): report it with the shell's 128+signum convention so the
+      // caller can still tell an interrupted run from an ordinary exit 1
+      // (#144200).
+      const signalNumber = os.constants.signals[signal];
+      process.exit(signalNumber ? 128 + signalNumber : 1);
     }
     process.exit(code ?? 1);
   });

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -1377,6 +1377,56 @@ describe("openclaw launcher", () => {
   });
 
   it.runIf(process.platform !== "win32")(
+    "reports 128+signum when an external signal kills the respawn child (#144200)",
+    async () => {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      await addGitMarker(fixtureRoot);
+      const childInfoPath = path.join(fixtureRoot, "child-info.json");
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          `writeFileSync(${JSON.stringify(childInfoPath)}, JSON.stringify({ pid: process.pid }) + "\\n");`,
+          'process.title = "openclaw-launcher-external-kill-test-child";',
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const launcher = spawn(process.execPath, [path.join(fixtureRoot, "openclaw.mjs")], {
+        cwd: fixtureRoot,
+        env: launcherEnv({
+          NODE_COMPILE_CACHE: path.join(fixtureRoot, ".node-compile-cache"),
+        }),
+        stdio: "ignore",
+      });
+      let respawnChildPid: number | undefined;
+
+      try {
+        const childInfo = await waitForJsonFile<{ pid: number }>(childInfoPath, 5000);
+        respawnChildPid = childInfo.pid;
+
+        // Kill the child from outside: the launcher must not report this as a
+        // plain exit 1, which reads as an ordinary failure instead of a kill.
+        process.kill(respawnChildPid, "SIGKILL");
+
+        await expect(waitForProcessExit(launcher, "launcher", 5000)).resolves.toEqual({
+          code: 137,
+          signal: null,
+        });
+      } finally {
+        if (isProcessAlive(respawnChildPid)) {
+          process.kill(respawnChildPid!, "SIGKILL");
+        }
+        if (isProcessAlive(launcher.pid)) {
+          process.kill(launcher.pid!, "SIGKILL");
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "exits after SIGTERM when the respawn child ignores the forwarded signal",
     async () => {
       const fixtureRoot = await makeLauncherFixture(fixtureRoots);


### PR DESCRIPTION
## Evidence

Fixes #144200. Verified against current main with a fixture reproducing the issue's probe: a source-checkout launcher (`openclaw.mjs` + `node-runtime-recovery.mjs` + `node-sqlite.mjs` + `node-version.mjs` copied unmodified, a controlled `dist/entry.js` that prints its pid and idles). Sending SIGKILL to the respawned child's pid makes the launcher report `(code: 1, signal: null)` on current main and `code: 137` with this change.

## What changed

`runRespawnedChild`'s exit handler (`node-runtime-recovery.mjs`) fell through to `process.exit(1)` whenever the child died from a signal the launcher never forwarded. Unforwarded signal deaths now exit with the shell's 128+signum convention (SIGKILL -> 137); forwarded-signal exits keep their existing 130/143 codes, and the hard-kill backstop path is unchanged.

## Tests

An E2E case in `test/openclaw-launcher.e2e.test.ts` pins the 137 contract on the same fixture shape as the neighboring signal-forwarding cases. The repo's e2e vitest config could not run on this checkout (a pre-existing TUI build failure in this sparse tree blocks its global setup), so the contract was verified by running the fixture directly against current main and this change; both runs are quoted in Evidence.

## Notes

- macOS arm64, Node 26.5.0.
- The launcher comment asking to keep `src/entry.compile-cache.ts` in sync no longer applies to this handler: on current main the forwarding logic lives only here.

[AI-assisted]
