### PR TITLE
refactor(tests): share CI checkout auth fixture launcher

### DIFF
--- a/test/scripts/ci-checkout-auth.test-support.ts
+++ b/test/scripts/ci-checkout-auth.test-support.ts
@@ -1,0 +1,29 @@
+import path from "node:path";
+import { expect } from "vitest";
+import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
+
+export async function runAuthFixture(mode: string, script?: string) {
+  let stdout = "";
+  let stderr = "";
+  const code = await runManagedCommand({
+    bin: "python3",
+    args: [
+      "-I",
+      "-S",
+      "test/scripts/fixtures/ci-checkout-auth.py",
+      path.resolve(".github/actions/git-owner/owner.py"),
+      mode,
+      ...(script ? [script] : []),
+    ],
+    stdio: ["ignore", "pipe", "pipe"],
+    timeoutMs: 30_000,
+    timeoutKillGraceMs: 12_000,
+    requireProcessTreeExit: true,
+    onReady(child) {
+      child.stdout?.on("data", (chunk) => (stdout += String(chunk)));
+      child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
+    },
+  });
+  expect(code, stderr).toBe(0);
+  return JSON.parse(stdout);
+}

--- a/test/scripts/ci-git-owner-auth.test.ts
+++ b/test/scripts/ci-git-owner-auth.test.ts
@@ -1,35 +1,8 @@
 import { readFileSync } from "node:fs";
-import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { expect, it } from "vitest";
 import { parse } from "yaml";
-import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
-
-async function runAuthFixture(mode: string, script?: string) {
-  let stdout = "";
-  let stderr = "";
-  const code = await runManagedCommand({
-    bin: "python3",
-    args: [
-      "-I",
-      "-S",
-      "test/scripts/fixtures/ci-checkout-auth.py",
-      path.resolve(".github/actions/git-owner/owner.py"),
-      mode,
-      ...(script ? [script] : []),
-    ],
-    stdio: ["ignore", "pipe", "pipe"],
-    timeoutMs: 30_000,
-    timeoutKillGraceMs: 12_000,
-    requireProcessTreeExit: true,
-    onReady(child) {
-      child.stdout?.on("data", (chunk) => (stdout += String(chunk)));
-      child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
-    },
-  });
-  expect(code, stderr).toBe(0);
-  return JSON.parse(stdout);
-}
+import { runAuthFixture } from "./ci-checkout-auth.test-support.js";
 
 it.skipIf(process.platform === "win32").each(["fetch-only", "checkout"])(
   "keeps checkout HTTP authentication transient and scoped (%s)",

--- a/test/scripts/ci-git-prerequisites.test.ts
+++ b/test/scripts/ci-git-prerequisites.test.ts
@@ -1,9 +1,8 @@
-import path from "node:path";
 import { expect, it } from "vitest";
 import prerequisites from "../../.github/actions/git-owner/test-prerequisites.json" with { type: "json" };
 import { resolveTestGitCommits } from "../../.github/actions/git-owner/test-prerequisites.mjs";
 import { createNodeTestShardBundles } from "../../scripts/lib/ci-node-test-plan.mts";
-import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
+import { runAuthFixture } from "./ci-checkout-auth.test-support.js";
 import { runCiGitStep } from "./ci-git-owner.test-support.js";
 
 const reader = prerequisites.outboundMessageTerminalReader;
@@ -11,28 +10,7 @@ const reader = prerequisites.outboundMessageTerminalReader;
 it.skipIf(process.platform === "win32").each(["historical", "base"])(
   "reads the %s prerequisite after checkout authentication has ended",
   async (mode) => {
-    let stdout = "";
-    let stderr = "";
-    const code = await runManagedCommand({
-      bin: "python3",
-      args: [
-        "-I",
-        "-S",
-        "test/scripts/fixtures/ci-checkout-auth.py",
-        path.resolve(".github/actions/git-owner/owner.py"),
-        mode,
-      ],
-      stdio: ["ignore", "pipe", "pipe"],
-      timeoutMs: 30_000,
-      timeoutKillGraceMs: 12_000,
-      requireProcessTreeExit: true,
-      onReady(child) {
-        child.stdout?.on("data", (chunk) => (stdout += String(chunk)));
-        child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
-      },
-    });
-    expect(code, stderr).toBe(0);
-    expect(JSON.parse(stdout)).toEqual({
+    expect(await runAuthFixture(mode)).toEqual({
       mode,
       preparedObjectsReadable: true,
       credentialPersisted: false,


### PR DESCRIPTION
## What Problem This Solves

Two CI checkout-auth suites duplicated the launcher for the same synthetic Git HTTP fixture.

## Why This Change Was Made

Move that launcher into one test-support module and use it from both suites. The existing helper body is preserved apart from its export, including the optional workflow-script behavior. Python isolation flags, all timeouts, Windows skip predicates, numeric-success checks, and process-tree cleanup requirements remain unchanged.

## User Impact

No production behavior changes. All 32 existing cases remain. The test/support diff adds 32 lines and removes 52: **20 fewer lines**.

## Evidence

Both complete suites passed before and after: **32/32 cases**, with identical expanded per-file inventory and order under the ordinary runner. Real Git HTTP requests use the synthetic local fixture; this is not live-service verification. Each run preserved its own source, dependency, index, and status bindings, with the new support file absent in baseline and exactly pinned but untracked in candidate. Independent source review found no actionable P0-P2 issue.

All 16 selected checks passed, including root-test typechecking, script lint, formatting, and the script, production, and full-tree unused-export scans. Process evidence covers the joined launcher and its terminal process group, not an exhaustive descendant census.
