### PR TITLE
refactor(tests): simplify single-use chat request fixtures

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2906,9 +2906,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("persists non-agent delivery mirrors to SQLite without creating active JSONL", async () => {
     await withSqliteTranscriptFixtureState("openclaw-chat-send-final-sqlite-", async () => {
       mockState.finalText = "sqlite mirror text";
-      const { send } = createChatRequestFixture();
-
-      await send({
+      await createChatRequestFixture().send({
         idempotencyKey: "idem-final-sqlite",
         expectBroadcast: false,
       });
@@ -3012,9 +3010,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       ],
     });
     setAgentRunReplies([sourceReply]);
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-managed-media-partial-failure",
       message: "hello from codex",
     });
@@ -3260,9 +3256,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await createTranscriptFixture("openclaw-chat-send-global-alias-load-");
     useGlobalSessionScope();
     mockState.sessionEntry = { canonicalKey: "global" };
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       sessionKey: "agent:work:main",
       idempotencyKey: "idem-global-alias-load",
       expectBroadcast: false,
@@ -3448,9 +3442,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ]);
     const { storePath, sessionId } = mockState;
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-agent-audio",
       expectBroadcast: false,
       waitFor: "none",
@@ -3520,9 +3512,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ]);
-        const { send } = createChatRequestFixture();
-
-        await send({
+        await createChatRequestFixture().send({
           idempotencyKey: "idem-owned-media",
           expectBroadcast: false,
           waitFor: "dedupe",
@@ -3590,9 +3580,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const { send } = createChatRequestFixture();
-
-        await send({
+        await createChatRequestFixture().send({
           idempotencyKey: "idem-disposed-media-owner",
           expectBroadcast: false,
           waitFor: "dedupe",
@@ -3687,9 +3675,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const { send } = createChatRequestFixture();
-
-        await send({
+        await createChatRequestFixture().send({
           idempotencyKey: "idem-multiple-assistant-media",
           expectBroadcast: false,
           waitFor: "dedupe",
@@ -3740,8 +3726,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const { send } = createChatRequestFixture();
-        await send({
+        await createChatRequestFixture().send({
           idempotencyKey: "idem-queued-tool-media",
           expectBroadcast: false,
           waitFor: "dedupe",
@@ -3775,9 +3760,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ]);
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-agent-tts",
       expectBroadcast: false,
       waitFor: "dedupe",
@@ -4120,9 +4103,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             mediaUrls: [mediaUrl],
           }),
         ]);
-        const { send } = createChatRequestFixture();
-
-        await send({
+        await createChatRequestFixture().send({
           idempotencyKey: "idem-source-reply-sqlite",
           message: "hello from codex",
         });
@@ -4156,9 +4137,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             mediaUrls: [mediaUrl],
           }),
         ]);
-        const { send } = createChatRequestFixture();
-
-        const broadcast = await send({
+        const broadcast = await createChatRequestFixture().send({
           idempotencyKey: "idem-agent-source-reply-deduped",
           message: "hello from codex",
         });
@@ -4213,9 +4192,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             mediaUrls: [secondMediaUrl],
           }),
         ]);
-        const { send } = createChatRequestFixture();
-
-        const broadcast = await send({
+        const broadcast = await createChatRequestFixture().send({
           idempotencyKey: "idem-agent-source-reply-multi",
           message: "hello from codex",
         });
@@ -4262,9 +4239,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             mediaUrls: [secondMediaUrl],
           }),
         ]);
-        const { send } = createChatRequestFixture();
-
-        const broadcast = await send({
+        const broadcast = await createChatRequestFixture().send({
           idempotencyKey: "idem-agent-source-reply-partial",
           message: "hello from codex",
         });
@@ -4310,9 +4285,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             text: "Text-only source reply",
           }),
         ]);
-        const { send } = createChatRequestFixture();
-
-        const broadcast = await send({
+        const broadcast = await createChatRequestFixture().send({
           idempotencyKey: "idem-agent-source-reply-text-tail",
           message: "hello from codex",
         });
@@ -4350,9 +4323,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             mediaUrls: [mediaUrl],
           }),
         ]);
-        const { send } = createChatRequestFixture();
-
-        const broadcast = await send({
+        const broadcast = await createChatRequestFixture().send({
           idempotencyKey: "idem-agent-source-reply-collision",
           message: "hello from codex",
         });
@@ -4380,9 +4351,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         setAgentRunReplies([
           createMainSourceReply({ idempotencyKey: missingMirrorKey, mediaUrls: [mediaUrl] }),
         ]);
-        const { send } = createChatRequestFixture();
-
-        const broadcast = await send({
+        const broadcast = await createChatRequestFixture().send({
           idempotencyKey: "idem-agent-source-reply-media-only",
           message: "hello from codex",
         });
@@ -4414,9 +4383,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           createMainSourceReply({ idempotencyKey: textMirrorKey, text: "Text source reply" }),
           createMainSourceReply({ idempotencyKey: missingMirrorKey, mediaUrls: [mediaUrl] }),
         ]);
-        const { send } = createChatRequestFixture();
-
-        const broadcast = await send({
+        const broadcast = await createChatRequestFixture().send({
           idempotencyKey: "idem-agent-source-reply-media-only-sibling",
           message: "hello from codex",
         });
@@ -4458,9 +4425,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             mediaUrls: [mediaUrl],
           }),
         ]);
-        const { send } = createChatRequestFixture();
-
-        const broadcast = await send({
+        const broadcast = await createChatRequestFixture().send({
           idempotencyKey: "idem-agent-source-reply-later",
           message: "hello from codex",
         });
@@ -4623,9 +4588,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       { kind: "final", payload: { text: "Workspace recovery failed", isError: true } },
       { kind: "final", payload: { text: "Workspace recovery failed", isError: true } },
     ];
-    const { send } = createChatRequestFixture();
-
-    const broadcast = await send({
+    const broadcast = await createChatRequestFixture().send({
       idempotencyKey: "idem-multiple-agent-errors",
       message: "run on the worker",
     });
@@ -4811,9 +4774,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       trustedLocalMedia: true,
       audioAsVoice: true,
     };
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-command-tts",
     });
 
@@ -4898,9 +4859,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-command-block-media",
       message: "/export-trajectory bundle",
     });
@@ -4938,9 +4897,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-command-pair-qr",
       message: "/pair qr",
     });
@@ -4979,9 +4936,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         payload: { text: "Approve once to create the bundle." },
       },
     ];
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-command-block-text",
       message: "/export-trajectory bundle",
     });
@@ -5008,9 +4963,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-command-block-duplicate-text",
       message: "/export-trajectory bundle",
     });
@@ -5044,9 +4997,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         payload: { text: "[[reply_to_current]]" },
       },
     ];
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-command-block-reply-directive",
       message: "/export-trajectory bundle",
     });
@@ -5311,9 +5262,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       text: "Scan this QR code with the OpenClaw iOS app:",
       mediaUrl: `data:image/png;base64,${TINY_PNG_BASE64}`,
     };
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-agent-image",
     });
 
@@ -5348,9 +5297,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         payload: { text: "final answer" },
       },
     ];
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-reasoning-hidden",
     });
 
@@ -5454,9 +5401,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("chat.send non-streaming final keeps message defined for directive-only assistant text", async () => {
     await createTranscriptFixture("openclaw-chat-send-directive-only-");
     mockState.finalText = "[[reply_to_current]]";
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-directive-only",
     });
 
@@ -5471,9 +5416,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("persists inline reply directives as typed facts while stripping them from text", async () => {
     await createTranscriptFixture("openclaw-chat-send-inline-reply-transcript-");
     mockState.finalText = "see[[reply_to_current]]now  with  spacing";
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-inline-reply-transcript",
     });
 
@@ -5649,9 +5592,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("chat.send non-streaming final strips external untrusted wrapper metadata from final payload text", async () => {
     await createTranscriptFixture("openclaw-chat-send-untrusted-meta-");
     mockState.finalText = `hello\n\n${UNTRUSTED_CONTEXT_SUFFIX}`;
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-untrusted-context",
     });
     expect(extractFirstTextBlock(payload)?.trim()).toBe("hello");
@@ -5704,9 +5645,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("chat.send marks user slash commands as text command sources", async () => {
     await createReadyChatTranscript("openclaw-chat-send-text-command-source-");
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-text-command-source",
       message: "/codex status",
       expectBroadcast: false,
@@ -5720,9 +5659,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("chat.send keeps thinking metadata out of command text for normal messages", async () => {
     await createReadyChatTranscript("openclaw-chat-send-thinking-normal-message-");
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-thinking-normal-message",
       message: "hello from phone",
       requestParams: {
@@ -5931,9 +5868,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("chat.send accepts admin-scoped synthetic originating routes without external delivery", async () => {
     await createReadyChatTranscript("openclaw-chat-send-synthetic-origin-admin-");
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-synthetic-origin-admin",
       client: createScopedCliClient(["operator.admin"]),
       requestParams: {
@@ -6029,9 +5964,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("allows admin-scoped clients to inject system provenance without ACP metadata", async () => {
     await createReadyChatTranscript("openclaw-chat-send-system-provenance-admin-");
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-system-provenance-admin",
       message: "ops update",
       client: createScopedCliClient(["operator.admin"], {
@@ -6065,9 +5998,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("forwards gateway caller scopes into the dispatch context", async () => {
     await createReadyChatTranscript("openclaw-chat-send-gateway-client-scopes-");
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-gateway-client-scopes",
       message: "/scopecheck",
       client: createScopedCliClient(["operator.write", "operator.pairing"]),
@@ -6083,9 +6014,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("forwards gateway client capabilities into the dispatch context", async () => {
     await createReadyChatTranscript("openclaw-chat-send-gateway-client-caps-");
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-gateway-client-caps",
       message: "show a widget",
       client: createScopedCliClient([], {}, [GATEWAY_CLIENT_CAPS.INLINE_WIDGETS]),
@@ -6099,9 +6028,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("normalizes missing gateway caller scopes to an empty array before dispatch", async () => {
     await createReadyChatTranscript("openclaw-chat-send-missing-gateway-client-scopes-");
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-gateway-client-scopes-missing",
       message: "/scopecheck",
       client: createScopedCliClient(),
@@ -6196,9 +6123,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           (update.message as { role?: unknown }).role === "user",
       ).length;
     };
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-user-transcript-before-run-gate",
       message: "secret prompt that may be blocked",
       expectBroadcast: false,
@@ -6276,9 +6201,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       ["/tmp/chat-send-image-a.png", "image/png", "chat-send-image-a.png"],
       ["/tmp/chat-send-image-b.jpg", "image/jpeg", "chat-send-image-b.jpg"],
     );
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-user-transcript-images",
       message: "edit these",
       requestParams: {
@@ -6350,9 +6273,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await createReadyChatTranscript("openclaw-chat-send-user-transcript-file-");
     mockState.triggerAgentRunStart = true;
     setSavedMediaResults(["/tmp/chat-send-brief.pdf", "application/pdf"]);
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-user-transcript-file",
       message: "summarize this",
       requestParams: {
@@ -6453,9 +6374,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await createReadyChatTranscript("openclaw-chat-send-user-transcript-acp-images-");
     mockState.triggerAgentRunStart = true;
     setSavedMediaResults(["/tmp/should-not-be-used.png", "image/png"]);
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-user-transcript-acp-images",
       message: "bridge image",
       client: {
@@ -6578,9 +6497,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       mediaUrl: "data:image/png;base64,cG5n",
       sensitiveMedia: true,
     };
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-sensitive-media-final",
     });
 
@@ -6614,9 +6531,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       text: "hello",
       replyToId: "abc]]\n[[audio_as_voice]]",
     };
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-sanitized-reply-id",
     });
 
@@ -6640,9 +6555,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       text: "hello[[reply_to:inline-id]]",
       replyToId: "]]\n[[",
     };
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({
+    const payload = await createChatRequestFixture().send({
       idempotencyKey: "idem-inline-reply-id-fallback",
     });
 
@@ -6662,9 +6575,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("routes text-only image offloads into media-understanding fields", async () => {
     await createReadyChatTranscript("openclaw-chat-send-text-only-attachments-");
     useChatTestModel("text-only");
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-text-only-attachments",
       message: "describe image",
       requestParams: {
@@ -6713,9 +6624,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         input: ["text", "image"],
       },
     ];
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-configured-custom-vision",
       message: "describe image",
       requestParams: {
@@ -6743,9 +6652,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     bindingMocks.resolveByConversation.mockReturnValue({
       targetSessionKey: "agent:claude:acp:spawned",
     });
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-text-only-acp-bound-attachments",
       message: "describe image",
       client: createScopedCliClient(["operator.admin"]),
@@ -6798,9 +6705,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         input: ["text"],
       },
     ];
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       sessionKey: "agent:writer:main",
       idempotencyKey: "idem-agent-scoped-text-only-attachments",
       message: "describe image",
@@ -7435,9 +7340,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("emits a user transcript update when chat.send completes without an agent run", async () => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-user-transcript-no-run-");
     mockState.finalText = "ok";
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-user-transcript-no-run",
       message: "quick command",
       expectBroadcast: false,
@@ -7470,9 +7373,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       { sessionId: mockState.sessionId, updatedAt: 1 },
     );
     mockState.finalText = "ok";
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-stale-transcript-owner",
       message: "keep this Gateway turn",
       sessionKey: staleSessionKey,
@@ -7652,9 +7553,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.triggerAgentRunStart = true;
     mockState.dispatchErrorAfterAgentRunStart = new Error("cli backend unavailable");
     mockState.beforeMessageWriteContent = "[redacted by hook]";
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-user-transcript-error-before-write-redact",
       message: "raw sensitive prompt",
       expectBroadcast: false,
@@ -7864,9 +7763,7 @@ describe("chat.send local operator client sender context", () => {
         },
       });
     };
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-cron-authority-internal-reentry",
       message: "Talk realtime agent consult prompt",
       directExternal: false,
@@ -7962,9 +7859,7 @@ describe("chat.send local operator client sender context", () => {
         },
       });
     };
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: `idem-cron-authority-negative-${testCase.name.replaceAll(" ", "-")}`,
       client: {
         connect: {
@@ -7987,9 +7882,7 @@ describe("chat.send local operator client sender context", () => {
 
   it("does not inject sender identity fields for Control UI clients", async () => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-control-ui-sender-");
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: "idem-control-ui-sender",
       message: "hello from control ui",
       client: {
@@ -8058,8 +7951,7 @@ describe("chat.send local operator client sender context", () => {
       expected: undefined,
     },
   ])("$name", async ({ id, message, clientId, mode, platform, scopes, caps, expected }) => {
-    const { send } = createChatRequestFixture();
-    await send({
+    await createChatRequestFixture().send({
       idempotencyKey: `idem-${id}-task-suggestions`,
       message,
       client: {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Chat directive tests repeat 55 temporary fixture bindings that are each used only by the immediately following request, adding noise around the scenarios.

## Why This Change Was Made

Call the existing fixture's `send` arrow directly at those sites. Fixture construction, request argument evaluation, and the awaited promise retain their order. Multi-use fixtures and helper bodies remain unchanged.

## User Impact

No user-visible behavior change. This removes 108 net test lines while preserving every case and assertion; no runtime improvement is claimed.

## Evidence

The complete `chat.directive-tags.test.ts` file passed all 218 cases before and after, with identical ordered names and statuses. The final source matches the reviewed 55-site projection. Formatting, the changed gate, and fresh independent review passed.
