### PR TITLE
feat(memory-wiki): show Obsidian integration is enabled

### DIFF
--- a/docs/cli/wiki.md
+++ b/docs/cli/wiki.md
@@ -81,6 +81,18 @@ digests already carry the active runtime agent context.
 
 Show vault mode and scope, resolved agent, health, and Obsidian CLI availability. Use this first to check whether the intended vault is initialized, bridge mode is healthy, or Obsidian integration is available.
 
+The text output separates configured integration from CLI discovery. The same
+status block appears in `wiki doctor`:
+
+- `Obsidian integration: enabled` or `disabled` reflects `obsidian.enabled`.
+- `Obsidian CLI: available` or `missing` reports discovery on `PATH`, not a
+  successful Obsidian operation. `(requested)` appears only when both
+  `obsidian.enabled` and `obsidian.useOfficialCli` are true.
+
+An available CLI does not mean the integration is enabled. A missing CLI does
+not produce an Obsidian warning unless the CLI is requested. JSON keeps the
+existing `obsidianCli` fields unchanged.
+
 When bridge mode is active and configured to read memory artifacts, this command queries the running Gateway so it sees the same active memory plugin context as agent/runtime memory.
 
 ### `wiki doctor`

--- a/extensions/memory-wiki/src/status.obsidian.test.ts
+++ b/extensions/memory-wiki/src/status.obsidian.test.ts
@@ -1,0 +1,60 @@
+// Configured integration, requested CLI, and detected executable are separate facts.
+import { describe, expect, it } from "vitest";
+import { resolveMemoryWikiConfig } from "./config.js";
+import {
+  buildMemoryWikiDoctorReport,
+  renderMemoryWikiDoctor,
+  renderMemoryWikiStatus,
+  resolveMemoryWikiStatus,
+} from "./status.js";
+
+const cases = [
+  { enabled: false, useOfficialCli: false, available: false },
+  { enabled: false, useOfficialCli: false, available: true },
+  { enabled: false, useOfficialCli: true, available: false },
+  { enabled: false, useOfficialCli: true, available: true },
+  { enabled: true, useOfficialCli: false, available: false },
+  { enabled: true, useOfficialCli: false, available: true },
+  { enabled: true, useOfficialCli: true, available: false },
+  { enabled: true, useOfficialCli: true, available: true },
+];
+
+describe("Obsidian integration status", () => {
+  it.each(cases)(
+    "shows enabled=$enabled, useOfficialCli=$useOfficialCli, available=$available without changing state",
+    async ({ enabled, useOfficialCli, available }) => {
+      const config = resolveMemoryWikiConfig(
+        { obsidian: { enabled, useOfficialCli } },
+        { homedir: "/home/tester" },
+      );
+      const command = available ? "/usr/local/bin/obsidian" : null;
+      const status = await resolveMemoryWikiStatus(config, {
+        pathExists: async () => false,
+        resolveCommand: async () => command,
+      });
+      const requested = enabled && useOfficialCli;
+      expect(status.obsidianCli).toEqual({ enabled, requested, available, command });
+      const jsonBefore = JSON.stringify(status);
+      const report = buildMemoryWikiDoctorReport(status);
+      const reportBefore = JSON.stringify(report);
+      const integrationLine = `Obsidian integration: ${enabled ? "enabled" : "disabled"}`;
+      const cliLine = `Obsidian CLI: ${available ? "available" : "missing"}${requested ? " (requested)" : ""}`;
+
+      for (const rendered of [renderMemoryWikiStatus(status), renderMemoryWikiDoctor(report)]) {
+        const lines = rendered.split("\n");
+        expect(lines.filter((line) => line.startsWith("Obsidian integration:"))).toEqual([
+          integrationLine,
+        ]);
+        expect(lines.filter((line) => line.startsWith("Obsidian CLI:"))).toEqual([cliLine]);
+      }
+      const codes =
+        requested && !available ? ["vault-missing", "obsidian-cli-missing"] : ["vault-missing"];
+      expect(status.warnings.map((warning) => warning.code)).toEqual(codes);
+      expect(report.warningCount).toBe(codes.length);
+      expect(report.fixes.map((fix) => fix.code)).toEqual(codes);
+      expect(report.healthy).toBe(false);
+      expect(JSON.stringify(status)).toBe(jsonBefore);
+      expect(JSON.stringify(report)).toBe(reportBefore);
+    },
+  );
+});

--- a/extensions/memory-wiki/src/status.ts
+++ b/extensions/memory-wiki/src/status.ts
@@ -312,6 +312,7 @@ export function renderMemoryWikiStatus(status: MemoryWikiStatus): string {
     `Vault scope: ${status.vaultScope}${status.agentId ? ` (${status.agentId})` : ""}`,
     `Vault: ${status.vaultExists ? "ready" : "missing"} (${status.vaultPath})`,
     `Render mode: ${status.renderMode}`,
+    `Obsidian integration: ${status.obsidianCli.enabled ? "enabled" : "disabled"}`,
     `Obsidian CLI: ${status.obsidianCli.available ? "available" : "missing"}${status.obsidianCli.requested ? " (requested)" : ""}`,
     `Bridge: ${status.bridge.enabled ? "enabled" : "disabled"}${typeof status.bridgePublicArtifactCount === "number" ? ` (${status.bridgePublicArtifactCount} exported artifact${status.bridgePublicArtifactCount === 1 ? "" : "s"})` : ""}`,
     `Unsafe local: ${status.unsafeLocal.allowPrivateMemoryCoreAccess ? `enabled (${status.unsafeLocal.pathCount} paths)` : "disabled"}`,


### PR DESCRIPTION
Closes #144774

## What Problem This Solves

Wiki operators cannot distinguish a disabled Obsidian integration from an enabled integration that does not request the official CLI by reading the normal status or Doctor text. CLI availability and effective request state alone do not disclose the enabled setting.

## Why This Change Was Made

Display the existing integration-enabled fact in the shared status renderer, which Doctor already reuses. Keep the existing CLI availability/requested line and every JSON field unchanged. Document the distinction between configuration and executable discovery.

## User Impact

`openclaw wiki status` and `openclaw wiki doctor` now show `Obsidian integration: enabled` or `disabled`. No probe, executable invocation, configuration option, warning policy, exit status, or persistence behavior is added.

## Evidence

### September 14 integration refresh

Current head: `598f147f717c9e5e1aa1e2a697668babb509fe99`. Original branch head `c548316b8c7fb722c68b8cfa4416e5ff610f5b23` and pinned main `8b917bc499607eb94bb77358ddd69f6494d26c65` are both preserved as parents; no force-push. Refresh the existing accepted patch onto pinned main to remove stale integration inputs and obtain new-head CI. No new feature or unrelated failure workaround is added. The resulting tree exactly matches the conflict-free git merge-tree result; there are no manual source or test edits.

Validation on Linux / Node 26.1.0 with frozen-lockfile dependencies: No new local runtime test is claimed for this mechanical integration; existing proof keeps its original revision and exact-head hosted CI is required.. The native staged-content/format guard, main-relative diff check, and one fresh independent P0-P2 source review passed. No full build or full type-aware check was rerun locally; new-head CI is tracked separately. Earlier runtime proof below retains its recorded SHA; it is not relabeled as a new execution.


The implementation was prepared from main `1b2b06ed2fc7680648a1a554c100b887a1de39dd`; the exact reviewed product head is `c548316b8c7fb722c68b8cfa4416e5ff610f5b23`. The canonical owner is `extensions/memory-wiki/src/status.ts`; both text commands exercise the same status fact.

### Exact-head built-CLI receipt

- Runtime: Node `v24.16.0`.
- Build: full `pnpm build` completed through the final build phase at the exact product head, including CLI bootstrap, public plugin SDK declarations, Control UI, build info, and CLI startup metadata.
- Production entry: actual built `openclaw.mjs` from an unrelated working directory with isolated HOME/config/state; no renderer mock.
- Scenario: initialize one real isolated wiki vault once, then run `wiki status` and `wiki doctor` in human and JSON modes with `obsidian.enabled=false`, toggle only that setting, and repeat against the same vault with `obsidian.enabled=true`.

Inspectable visible output:

```text
$ openclaw wiki status                 # disabled state
Wiki vault mode: isolated
Vault: ready (.../wiki-shared/wiki)
Obsidian integration: disabled
Obsidian CLI: missing
Bridge: disabled

$ openclaw wiki doctor                 # disabled state
Wiki doctor: healthy
Obsidian integration: disabled
Obsidian CLI: missing

$ openclaw wiki status                 # same vault, enabled state
Wiki vault mode: isolated
Vault: ready (.../wiki-shared/wiki)
Obsidian integration: enabled
Obsidian CLI: missing
Bridge: disabled

$ openclaw wiki doctor                 # same vault, enabled state
Wiki doctor: healthy
Obsidian integration: enabled
Obsidian CLI: missing
```

All nine actual CLI invocations exited `0` without timeout: one `wiki init`, plus status/doctor in human/JSON mode for both setting states.

Acceptance and controls:

- Acceptance-green: the human status and Doctor output each contains exactly one matching `Obsidian integration: disabled|enabled` line.
- Existing visibility retained: `Obsidian CLI: missing` remains present in both states; enabling the integration does not claim that the executable is available or requested.
- JSON contract: `obsidianCli` remains exactly `{ enabled, requested, available, command }`; `requested=false`, `available=false`, and `command=null` in both states.
- Same-state readback: the initialized vault remains ready and healthy; `warnings=[]`; Doctor reports `warningCount=0` and `fixes=[]`.
- Isolation controls: bridge remained explicitly disabled with `readMemoryArtifacts=false`; configuration hashes were unchanged by each diagnostic command.
- Equivalence control: normalized status and Doctor JSON were byte-equivalent between states after projecting `obsidianCli.enabled` to the same value.
- Cleanup: temporary HOME, configuration, state, and vault were removed. No production account, Gateway, channel, credential, or persistent user state was touched.

### Tests and CI

- Acceptance-red on the unchanged base: the same eight-state regression failed because ordinary text did not expose the enabled fact.
- Focused: `node scripts/run-vitest.mjs run extensions/memory-wiki/src/status.obsidian.test.ts extensions/memory-wiki/src/status.test.ts` — 21 tests passed.
- Extension: `pnpm test:extension memory-wiki` — all 45 memory-wiki test files passed.
- Docs: `pnpm docs:check-mdx`; `pnpm docs:check-links` — both passed.
- The hosted exact-head CI red is outside the changed memory-wiki surface: `extensions/memory-core/src/memory/manager-temporal-ranking.test.ts` expected the FTS-unavailable branch while that runner exposed FTS. The build and all scoped memory-wiki/docs checks passed.
- Independent autoreview: pass; no actionable findings.

### Scope and limitations

- Production LOC: +1; test LOC: +60; docs LOC: +12.
- Existing-solutions preflight: JSON already carried the setting, but ordinary diagnostics did not; the existing shared renderer is the canonical seam, so no new plugin, config, or dependency is needed.
- Sibling coverage: `wiki status` and `wiki doctor` share the renderer; JSON output, CLI discovery, warning decisions, and command behavior remain covered.
- Limitation: this proves the built diagnostic commands and real vault readback, not a live Obsidian executable or Gateway session. No Obsidian executable was invoked because executable discovery is intentionally unchanged.
- Config/protocol/schema/security/upgrade impact: none.

AI-assisted. Maintainer edits are enabled.