### PR TITLE
refactor(tests): invoke cron submit fixtures directly

### DIFF
--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -372,7 +372,7 @@ describe("cron controller", () => {
   ] as const)(
     "preserves an explicit zero timeout in %s payloads",
     async (method, _editingJobId) => {
-      const { submit } = createCronSubmitHarness("no-timeout-job", {
+      const submitted = await createCronSubmitHarness("no-timeout-job", {
         method,
         listExisting: false,
         form: {
@@ -380,9 +380,7 @@ describe("cron controller", () => {
           payloadText: "Run until complete",
           timeoutSeconds: "0",
         },
-      });
-
-      const submitted = await submit();
+      }).submit();
       expect(submitted.result).toEqual({ saved: true, jobId: "no-timeout-job" });
 
       const call = submitted.call;
@@ -396,22 +394,20 @@ describe("cron controller", () => {
   );
 
   it.each(["", "   "])("omits an inherited timeout from cron.add: %j", async (timeoutSeconds) => {
-    const { submit } = createCronSubmitHarness("inherited-timeout-job", {
+    const submitted = await createCronSubmitHarness("inherited-timeout-job", {
       form: {
         name: "Inherited timeout",
         payloadText: "Use the default timeout",
         timeoutSeconds,
       },
-    });
-
-    const submitted = await submit();
+    }).submit();
     expect(submitted.result).toEqual({ saved: true, jobId: "inherited-timeout-job" });
     const payload = requireRecord(requestPayload(submitted.call).payload, "cron.add agent payload");
     expect(payload).not.toHaveProperty("timeoutSeconds");
   });
 
   it("forwards webhook delivery in cron.add payload", async () => {
-    const { submit } = createCronSubmitHarness("job-1", {
+    const submitted = await createCronSubmitHarness("job-1", {
       form: {
         name: "webhook job",
         scheduleKind: "every",
@@ -422,9 +418,7 @@ describe("cron controller", () => {
         deliveryMode: "webhook",
         deliveryTo: "https://example.invalid/cron",
       },
-    });
-
-    const submitted = await submit();
+    }).submit();
 
     expect(submitted.result.saved).toBe(true);
     const payload = requestPayload(submitted.call);
@@ -464,7 +458,7 @@ describe("cron controller", () => {
   });
 
   it("forwards sessionKey and delivery accountId in cron.add payload", async () => {
-    const { submit } = createCronSubmitHarness("job-3", {
+    const { call } = await createCronSubmitHarness("job-3", {
       form: {
         name: "account-routed",
         scheduleKind: "cron",
@@ -474,9 +468,7 @@ describe("cron controller", () => {
         deliveryMode: "announce",
         deliveryAccountId: "ops-bot",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     const payload = requestPayload(call);
     expectRecordFields(payload, {
@@ -489,7 +481,7 @@ describe("cron controller", () => {
   });
 
   it("omits a blank delivery accountId from cron.add payloads", async () => {
-    const { submit } = createCronSubmitHarness("job-blank-account-id", {
+    const { call } = await createCronSubmitHarness("job-blank-account-id", {
       form: {
         name: "implicit account",
         scheduleKind: "cron",
@@ -498,15 +490,13 @@ describe("cron controller", () => {
         deliveryMode: "announce",
         deliveryAccountId: "   ",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expect(requireRecord(requestPayload(call).delivery, "delivery").accountId).toBeUndefined();
   });
 
   it('omits delivery.channel when the form still uses the "last" sentinel', async () => {
-    const { submit } = createCronSubmitHarness("job-last-add", {
+    const { call } = await createCronSubmitHarness("job-last-add", {
       form: {
         name: "implicit channel",
         scheduleKind: "cron",
@@ -516,9 +506,7 @@ describe("cron controller", () => {
         deliveryMode: "announce",
         deliveryChannel: "last",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectRecordFields(requireRecord(requestPayload(call).delivery, "delivery"), {
       mode: "announce",
@@ -529,7 +517,7 @@ describe("cron controller", () => {
   });
 
   it("forwards lightContext in cron payload", async () => {
-    const { submit } = createCronSubmitHarness("job-light", {
+    const { call } = await createCronSubmitHarness("job-light", {
       form: {
         name: "light-context job",
         scheduleKind: "cron",
@@ -537,9 +525,7 @@ describe("cron controller", () => {
         payloadText: "run this",
         payloadLightContext: true,
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectNestedRecordFields(requestPayload(call), "payload", {
       kind: "agentTurn",
@@ -562,7 +548,7 @@ describe("cron controller", () => {
   });
 
   it('sends delivery: { mode: "none" } explicitly in cron.update patch', async () => {
-    const { submit } = createCronSubmitHarness("job-none-update", {
+    const { call } = await createCronSubmitHarness("job-none-update", {
       method: "cron.update",
       form: {
         name: "switch to none",
@@ -570,9 +556,7 @@ describe("cron controller", () => {
         payloadText: "do work",
         deliveryMode: "none",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expect((call[1] as { patch?: { delivery?: unknown } } | undefined)?.patch?.delivery).toEqual({
       mode: "none",
@@ -580,7 +564,7 @@ describe("cron controller", () => {
   });
 
   it("sends explicit null model/thinking clears when blanking stored overrides on edit", async () => {
-    const { submit } = createCronSubmitHarness("job-clear-overrides", {
+    const { call } = await createCronSubmitHarness("job-clear-overrides", {
       method: "cron.update",
       jobs: [
         {
@@ -600,9 +584,7 @@ describe("cron controller", () => {
         payloadModel: "",
         payloadThinking: "",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectNestedRecordFields(requestPatch(call), "payload", {
       kind: "agentTurn",
@@ -613,7 +595,7 @@ describe("cron controller", () => {
   });
 
   it("does not send null model/thinking for a new job with blank fields", async () => {
-    const { submit } = createCronSubmitHarness("job-new-blank", {
+    const { call } = await createCronSubmitHarness("job-new-blank", {
       listExisting: true,
       form: {
         name: "new blank",
@@ -622,9 +604,7 @@ describe("cron controller", () => {
         payloadModel: "",
         payloadThinking: "",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     // A new job never had a stored override, so a blank field stays omitted
     // (no explicit null clear) rather than being mistaken for a cleared value.
@@ -1051,7 +1031,7 @@ describe("cron controller", () => {
       name: "clear account",
       delivery: { mode: "announce", accountId: "ops-bot" },
     });
-    const { submit } = createCronSubmitHarness(job.id, {
+    const { call } = await createCronSubmitHarness(job.id, {
       method: "cron.update",
       jobs: [job],
       form: {
@@ -1063,9 +1043,7 @@ describe("cron controller", () => {
         deliveryMode: "announce",
         deliveryAccountId: "   ",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectRecordFields(requestPayload(call), {
       id: "job-clear-account-id",
@@ -1082,7 +1060,7 @@ describe("cron controller", () => {
       name: "clear to",
       delivery: { mode: "announce", channel: "telegram", to: "12345" },
     });
-    const { submit } = createCronSubmitHarness(job.id, {
+    const { call } = await createCronSubmitHarness(job.id, {
       method: "cron.update",
       jobs: [job],
       form: {
@@ -1094,9 +1072,7 @@ describe("cron controller", () => {
         deliveryMode: "announce",
         deliveryTo: "   ",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectRecordFields(requireRecord(requestPatch(call).delivery, "delivery"), {
       mode: "announce",
@@ -1311,7 +1287,7 @@ describe("cron controller", () => {
   ] as const)(
     "preserves configured duration precision for $staggerAmount $staggerUnit stagger",
     async ({ staggerAmount, staggerUnit, staggerMs }) => {
-      const { submit } = createCronSubmitHarness("job-decimal-stagger", {
+      const { call, result } = await createCronSubmitHarness("job-decimal-stagger", {
         form: {
           name: "Decimal stagger",
           scheduleKind: "cron",
@@ -1320,9 +1296,7 @@ describe("cron controller", () => {
           staggerUnit,
           payloadText: "run",
         },
-      });
-
-      const { call, result } = await submit();
+      }).submit();
 
       expect(result.saved).toBe(true);
       expect(requestPayload(call).schedule).toEqual({ kind: "cron", expr: "0 * * * *", staggerMs });
@@ -1445,7 +1419,7 @@ describe("cron controller", () => {
   });
 
   it("includes trigger/model/thinking/stagger/bestEffort in cron.update patch", async () => {
-    const { submit } = createCronSubmitHarness("job-2", {
+    const { call } = await createCronSubmitHarness("job-2", {
       method: "cron.update",
       form: {
         name: "advanced edit",
@@ -1463,9 +1437,7 @@ describe("cron controller", () => {
         deliveryMode: "announce",
         deliveryBestEffort: true,
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectRecordFields(requestPayload(call), {
       id: "job-2",
@@ -1606,7 +1578,7 @@ describe("cron controller", () => {
       wakeMode: "now",
       payload: { kind: "agentTurn", message: "run", lightContext: true },
     });
-    const { submit } = createCronSubmitHarness(job.id, {
+    const { call } = await createCronSubmitHarness(job.id, {
       method: "cron.update",
       jobs: [job],
       form: {
@@ -1617,9 +1589,7 @@ describe("cron controller", () => {
         payloadText: "run",
         payloadLightContext: false,
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectRecordFields(requestPayload(call), {
       id: "job-clear-light",
@@ -1631,7 +1601,7 @@ describe("cron controller", () => {
   });
 
   it("includes custom failureAlert fields in cron.update patch", async () => {
-    const { submit } = createCronSubmitHarness("job-alert", {
+    const { call } = await createCronSubmitHarness("job-alert", {
       method: "cron.update",
       form: {
         name: "alert job",
@@ -1644,9 +1614,7 @@ describe("cron controller", () => {
         failureAlertChannel: "telegram",
         failureAlertTo: "123456",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectRecordFields(requestPayload(call), {
       id: "job-alert",
@@ -1662,7 +1630,7 @@ describe("cron controller", () => {
   });
 
   it("includes failure alert mode/accountId in cron.update patch", async () => {
-    const { submit } = createCronSubmitHarness("job-alert-mode", {
+    const { call } = await createCronSubmitHarness("job-alert-mode", {
       method: "cron.update",
       form: {
         name: "alert mode job",
@@ -1673,9 +1641,7 @@ describe("cron controller", () => {
         failureAlertDeliveryMode: "webhook",
         failureAlertAccountId: "bot-a",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectRecordFields(requestPayload(call), {
       id: "job-alert-mode",
@@ -1731,7 +1697,7 @@ describe("cron controller", () => {
   });
 
   it("omits failureAlert.cooldownMs when custom cooldown is left blank", async () => {
-    const { submit } = createCronSubmitHarness("job-alert-no-cooldown", {
+    const { call } = await createCronSubmitHarness("job-alert-no-cooldown", {
       method: "cron.update",
       form: {
         name: "alert job no cooldown",
@@ -1743,9 +1709,7 @@ describe("cron controller", () => {
         failureAlertChannel: "telegram",
         failureAlertTo: "123456",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectRecordFields(requestPayload(call), {
       id: "job-alert-no-cooldown",
@@ -1818,7 +1782,7 @@ describe("cron controller", () => {
   });
 
   it("includes failureAlert=false when disabled per job", async () => {
-    const { submit } = createCronSubmitHarness("job-no-alert", {
+    const { call } = await createCronSubmitHarness("job-no-alert", {
       method: "cron.update",
       form: {
         name: "alert off",
@@ -1826,9 +1790,7 @@ describe("cron controller", () => {
         payloadText: "run it",
         failureAlertMode: "disabled",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expectRecordFields(requestPayload(call), {
       id: "job-no-alert",
@@ -1999,7 +1961,7 @@ describe("cron controller", () => {
   ] as const)(
     "accepts a condition-triggered interval at the Gateway minimum: %s %s",
     async (everyAmount, everyUnit) => {
-      const { submit } = createCronSubmitHarness("job-trigger-boundary", {
+      const { call, result } = await createCronSubmitHarness("job-trigger-boundary", {
         form: {
           name: "Boundary automation",
           everyAmount,
@@ -2009,9 +1971,7 @@ describe("cron controller", () => {
           triggerScript: "json({ fire: true })",
           deliveryMode: "none",
         },
-      });
-
-      const { call, result } = await submit();
+      }).submit();
 
       expect(result.saved).toBe(true);
       expect(requestPayload(call).schedule).toEqual({ kind: "every", everyMs: 30_000 });
@@ -2077,7 +2037,7 @@ describe("cron controller", () => {
   ] as const)(
     "converts %s %s to safe integer milliseconds",
     async (everyAmount, everyUnit, expectedEveryMs) => {
-      const { submit } = createCronSubmitHarness("job-decimal", {
+      const submitted = await createCronSubmitHarness("job-decimal", {
         form: {
           name: "decimal interval",
           everyAmount,
@@ -2085,9 +2045,7 @@ describe("cron controller", () => {
           payloadText: "run",
           deliveryMode: "none",
         },
-      });
-
-      const submitted = await submit();
+      }).submit();
 
       expect(submitted.result.saved).toBe(true);
       expect(requestPayload(submitted.call).schedule).toEqual({
@@ -3468,16 +3426,14 @@ describe("failure alert form round trips", () => {
     { seconds: "0.0009", cooldownMs: 0 },
     { seconds: "8640000000000.001", cooldownMs: 8_640_000_000_000_001 },
   ])("serializes explicit cooldown seconds $seconds", async ({ seconds, cooldownMs }) => {
-    const { submit } = createCronSubmitHarness("authored-cooldown", {
+    const { call } = await createCronSubmitHarness("authored-cooldown", {
       form: {
         name: "Authored cooldown",
         payloadText: "Run report",
         failureAlertMode: "custom",
         failureAlertCooldownSeconds: seconds,
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expect(validateCronAddParams(requestPayload(call))).toBe(true);
     expectRecordFields(requireRecord(requestPayload(call).failureAlert, "failureAlert"), {
@@ -3491,16 +3447,14 @@ describe("failure alert form round trips", () => {
       ["0b10", 2_000],
       ["0o10", 8_000],
     ] as const) {
-      const { submit } = createCronSubmitHarness("prefixed-cooldown", {
+      const { call } = await createCronSubmitHarness("prefixed-cooldown", {
         form: {
           name: "Existing numeric spelling",
           payloadText: "Run report",
           failureAlertMode: "custom",
           failureAlertCooldownSeconds: seconds,
         },
-      });
-
-      const { call } = await submit();
+      }).submit();
 
       expect(validateCronAddParams(requestPayload(call))).toBe(true);
       expectRecordFields(requireRecord(requestPayload(call).failureAlert, "failureAlert"), {
@@ -3529,11 +3483,9 @@ describe("failure alert form round trips", () => {
   });
 
   it("creates an explicit policy without materializing inherited defaults", async () => {
-    const { submit } = createCronSubmitHarness("custom-inherited-policy", {
+    const { call } = await createCronSubmitHarness("custom-inherited-policy", {
       form: { name: "Use global policy", payloadText: "Run report", failureAlertMode: "custom" },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expect(validateCronAddParams(requestPayload(call))).toBe(true);
     // oxlint-disable-next-line unicorn/prefer-structured-clone -- assert omitted fields on the websocket wire
@@ -3658,16 +3610,14 @@ describe("failure alert form round trips", () => {
   });
 
   it("keeps flooring a fractional alert threshold of at least one", async () => {
-    const { submit } = createCronSubmitHarness("valid-fractional-threshold", {
+    const { call } = await createCronSubmitHarness("valid-fractional-threshold", {
       form: {
         name: "Valid fractional threshold",
         payloadText: "Run report",
         failureAlertMode: "custom",
         failureAlertAfter: "1.5",
       },
-    });
-
-    const { call } = await submit();
+    }).submit();
 
     expect(validateCronAddParams(requestPayload(call))).toBe(true);
     expectRecordFields(requireRecord(requestPayload(call).failureAlert, "failureAlert"), {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Cron UI tests retain temporary submit bindings that are used only by the immediately following call.

## Why This Change Was Made

Invoke the existing harness submit closure directly at 25 sites, removing 50 lines while preserving every fixture argument, awaited result, and assertion.

## User Impact

No user-visible behavior change. The test scenarios and production helpers are unchanged.

## Evidence

The complete Cron test file passed all 202 tests before and after, with identical ordered case records and no skips. Whole-file inverse reconstruction preserved the original inputs and assertions. The mapped changed-code gate and fresh independent review passed. No runtime improvement is claimed.
