### PR TITLE
fix: honor configured endpoints for MiniMax model discovery

### DIFF
--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -92,7 +92,7 @@ describe("minimax provider hooks", () => {
     const expectedBaseUrl = baseUrl?.trim() || `${host ?? "https://api.minimax.io"}/anthropic`;
     const expectedEndpoint = `${expectedBaseUrl.replace(/\/+$/, "")}/v1/models`;
     const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) =>
-      String(input) === expectedEndpoint
+      input === expectedEndpoint
         ? Response.json({ data: [{ id: "MiniMax-M3" }] })
         : new Response(null, { status: 401 }),
     );
@@ -125,7 +125,7 @@ describe("minimax provider hooks", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(expectedEndpoint);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(expectedEndpoint);
     const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
     expect(headers.get("x-api-key")).toBe("selected-api-key");
     expect(headers.get("authorization")).toBeNull();

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -66,6 +66,81 @@ describe("minimax provider hooks", () => {
     expect(headers.get("x-api-key")).toBeNull();
   });
 
+  it.each([
+    { name: "CN configuration", baseUrl: "https://api.minimaxi.com/anthropic" },
+    {
+      name: "Global configuration ahead of the CN environment",
+      baseUrl: "https://api.minimax.io/anthropic",
+      host: "https://api.minimaxi.com",
+    },
+    {
+      name: "custom proxy configuration",
+      baseUrl: " https://minimax-proxy.example.com/prefix/anthropic/ ",
+    },
+    { name: "default Global endpoint", baseUrl: undefined },
+    {
+      name: "environment endpoint without configuration",
+      baseUrl: undefined,
+      host: "https://api.minimaxi.com",
+    },
+    {
+      name: "environment endpoint with blank configuration",
+      baseUrl: " ",
+      host: "https://api.minimaxi.com",
+    },
+  ])("keeps API catalog discovery on the $name", async ({ baseUrl, host }) => {
+    const expectedBaseUrl = baseUrl?.trim() || `${host ?? "https://api.minimax.io"}/anthropic`;
+    const expectedEndpoint = `${expectedBaseUrl.replace(/\/+$/, "")}/v1/models`;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) =>
+      String(input) === expectedEndpoint
+        ? Response.json({ data: [{ id: "MiniMax-M3" }] })
+        : new Response(null, { status: 401 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { providers } = await registerProviderPlugin({
+      plugin: minimaxProviderPlugin,
+      id: "minimax",
+      name: "MiniMax Provider",
+    });
+    const result = await runProviderCatalog({
+      provider: requireRegisteredProvider(providers, "minimax"),
+      config: {
+        models: {
+          providers: {
+            ...(baseUrl !== undefined ? { minimax: { baseUrl, models: [] } } : {}),
+            "minimax-portal": {
+              baseUrl: "https://other-account.example.com/anthropic",
+              models: [],
+            },
+          },
+        },
+      },
+      env: host ? { MINIMAX_API_HOST: host } : {},
+      resolveProviderApiKey: () => ({
+        apiKey: "MINIMAX_API_KEY",
+        discoveryApiKey: "selected-api-key",
+        profileId: "minimax:selected",
+      }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(expectedEndpoint);
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(headers.get("x-api-key")).toBe("selected-api-key");
+    expect(headers.get("authorization")).toBeNull();
+    expect(result).toMatchObject({
+      provider: {
+        baseUrl: expectedBaseUrl,
+        api: "anthropic-messages",
+        authHeader: true,
+        apiKey: "MINIMAX_API_KEY",
+        models: [expect.objectContaining({ id: "MiniMax-M3" })],
+      },
+      outcomes: [{ provider: "minimax", profileId: "minimax:selected", status: "ready" }],
+    });
+  });
+
   it("keeps explicit portal API keys ahead of stored OAuth profiles", async () => {
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -67,79 +67,120 @@ describe("minimax provider hooks", () => {
   });
 
   it.each([
-    { name: "CN configuration", baseUrl: "https://api.minimaxi.com/anthropic" },
+    {
+      name: "CN configuration",
+      baseUrl: "https://api.minimaxi.com/anthropic",
+      expectedEndpoint: "https://api.minimaxi.com/anthropic/v1/models",
+    },
     {
       name: "Global configuration ahead of the CN environment",
       baseUrl: "https://api.minimax.io/anthropic",
       host: "https://api.minimaxi.com",
+      expectedEndpoint: "https://api.minimax.io/anthropic/v1/models",
     },
     {
       name: "custom proxy configuration",
       baseUrl: " https://minimax-proxy.example.com/prefix/anthropic/ ",
+      expectedEndpoint: "https://minimax-proxy.example.com/prefix/anthropic/v1/models",
     },
-    { name: "default Global endpoint", baseUrl: undefined },
+    {
+      name: "default Global endpoint",
+      baseUrl: undefined,
+      expectedEndpoint: "https://api.minimax.io/anthropic/v1/models",
+    },
     {
       name: "environment endpoint without configuration",
       baseUrl: undefined,
       host: "https://api.minimaxi.com",
+      expectedEndpoint: "https://api.minimaxi.com/anthropic/v1/models",
     },
     {
       name: "environment endpoint with blank configuration",
       baseUrl: " ",
       host: "https://api.minimaxi.com",
+      expectedEndpoint: "https://api.minimaxi.com/anthropic/v1/models",
     },
-  ])("keeps API catalog discovery on the $name", async ({ baseUrl, host }) => {
-    const expectedBaseUrl = baseUrl?.trim() || `${host ?? "https://api.minimax.io"}/anthropic`;
-    const expectedEndpoint = `${expectedBaseUrl.replace(/\/+$/, "")}/v1/models`;
-    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) =>
-      input === expectedEndpoint
-        ? Response.json({ data: [{ id: "MiniMax-M3" }] })
-        : new Response(null, { status: 401 }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-    const { providers } = await registerProviderPlugin({
-      plugin: minimaxProviderPlugin,
-      id: "minimax",
-      name: "MiniMax Provider",
-    });
-    const result = await runProviderCatalog({
-      provider: requireRegisteredProvider(providers, "minimax"),
-      config: {
-        models: {
-          providers: {
-            ...(baseUrl !== undefined ? { minimax: { baseUrl, models: [] } } : {}),
-            "minimax-portal": {
-              baseUrl: "https://other-account.example.com/anthropic",
-              models: [],
+    {
+      name: "OpenAI-compatible Global configuration ahead of the CN environment",
+      baseUrl: "https://api.minimax.io/v1",
+      api: "openai-completions" as const,
+      host: "https://api.minimaxi.com",
+      expectedEndpoint: "https://api.minimax.io/v1/models",
+    },
+    {
+      name: "OpenAI-compatible CN configuration",
+      baseUrl: "https://api.minimaxi.com/v1/",
+      api: "openai-completions" as const,
+      expectedEndpoint: "https://api.minimaxi.com/v1/models",
+    },
+    {
+      name: "OpenAI-compatible proxy configuration",
+      baseUrl: " https://minimax-proxy.example.com/prefix/v1/ ",
+      api: "openai-completions" as const,
+      expectedEndpoint: "https://minimax-proxy.example.com/prefix/v1/models",
+    },
+    {
+      name: "OpenAI-compatible proxy with a custom base path",
+      baseUrl: "https://minimax-proxy.example.com/gateway",
+      api: "openai-completions" as const,
+      expectedEndpoint: "https://minimax-proxy.example.com/gateway/models",
+    },
+  ])(
+    "keeps API catalog discovery on the $name",
+    async ({ baseUrl, host, api, expectedEndpoint }) => {
+      const expectedBaseUrl = baseUrl?.trim() || `${host ?? "https://api.minimax.io"}/anthropic`;
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) =>
+        input === expectedEndpoint
+          ? Response.json({ data: [{ id: "MiniMax-M3" }] })
+          : new Response(null, { status: 401 }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const { providers } = await registerProviderPlugin({
+        plugin: minimaxProviderPlugin,
+        id: "minimax",
+        name: "MiniMax Provider",
+      });
+      const result = await runProviderCatalog({
+        provider: requireRegisteredProvider(providers, "minimax"),
+        config: {
+          models: {
+            providers: {
+              ...(baseUrl !== undefined
+                ? { minimax: { baseUrl, ...(api ? { api } : {}), models: [] } }
+                : {}),
+              "minimax-portal": {
+                baseUrl: "https://other-account.example.com/anthropic",
+                models: [],
+              },
             },
           },
         },
-      },
-      env: host ? { MINIMAX_API_HOST: host } : {},
-      resolveProviderApiKey: () => ({
-        apiKey: "MINIMAX_API_KEY",
-        discoveryApiKey: "selected-api-key",
-        profileId: "minimax:selected",
-      }),
-      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
-    });
+        env: host ? { MINIMAX_API_HOST: host } : {},
+        resolveProviderApiKey: () => ({
+          apiKey: "MINIMAX_API_KEY",
+          discoveryApiKey: "selected-api-key",
+          profileId: "minimax:selected",
+        }),
+        resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+      });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0]?.[0]).toBe(expectedEndpoint);
-    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
-    expect(headers.get("x-api-key")).toBe("selected-api-key");
-    expect(headers.get("authorization")).toBeNull();
-    expect(result).toMatchObject({
-      provider: {
-        baseUrl: expectedBaseUrl,
-        api: "anthropic-messages",
-        authHeader: true,
-        apiKey: "MINIMAX_API_KEY",
-        models: [expect.objectContaining({ id: "MiniMax-M3" })],
-      },
-      outcomes: [{ provider: "minimax", profileId: "minimax:selected", status: "ready" }],
-    });
-  });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(expectedEndpoint);
+      const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+      expect(headers.get("x-api-key")).toBe(api ? null : "selected-api-key");
+      expect(headers.get("authorization")).toBe(api ? "Bearer selected-api-key" : null);
+      expect(result).toMatchObject({
+        provider: {
+          baseUrl: expectedBaseUrl,
+          api: api ?? "anthropic-messages",
+          authHeader: true,
+          apiKey: "MINIMAX_API_KEY",
+          models: [expect.objectContaining({ id: "MiniMax-M3" })],
+        },
+        outcomes: [{ provider: "minimax", profileId: "minimax:selected", status: "ready" }],
+      });
+    },
+  );
 
   it("keeps explicit portal API keys ahead of stored OAuth profiles", async () => {
     const fetchMock = vi.fn(

--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -13,17 +13,19 @@ import { MINIMAX_TEXT_MODEL_CATALOG, MINIMAX_TEXT_MODEL_ORDER } from "./provider
 
 export function buildMinimaxModelDiscovery(
   authMode: "api_key" | "oauth" = "api_key",
+  api: ModelProviderConfig["api"] = "anthropic-messages",
 ): OpenAICompatibleModelDiscoveryOptions {
+  const usesOpenAI = api === "openai-completions";
   return {
-    endpointPath: "v1/models",
-    // API-key discovery follows MiniMax's documented X-Api-Key contract;
-    // portal OAuth keeps the Bearer scheme used by its inference transport.
+    endpointPath: usesOpenAI ? "models" : "v1/models",
+    // Anthropic API keys use X-Api-Key; OpenAI-compatible catalogs and portal
+    // OAuth use Bearer authentication.
     buildRequestHeaders: ({ apiKey, discoveryApiKey }): HeadersInit => {
       const requestApiKey = discoveryApiKey ?? apiKey;
       if (!requestApiKey) {
         return {};
       }
-      return authMode === "oauth"
+      return usesOpenAI || authMode === "oauth"
         ? { Authorization: `Bearer ${requestApiKey}` }
         : { "X-Api-Key": requestApiKey };
     },

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -144,7 +144,11 @@ async function resolveApiCatalog(ctx: ProviderCatalogContext) {
   return await buildOpenAICompatibleLiveProviderCatalog({
     discoveryMode: "strict",
     providerId: API_PROVIDER_ID,
-    providerConfig: buildMinimaxProvider(ctx.env),
+    providerConfig: {
+      ...buildMinimaxProvider(ctx.env),
+      baseUrl:
+        getProviderBaseUrl(ctx.config, API_PROVIDER_ID) ?? resolveMinimaxCatalogBaseUrl(ctx.env),
+    },
     apiKey: auth.apiKey,
     discoveryApiKey: auth.discoveryApiKey,
     profileId: auth.profileId,

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -141,18 +141,20 @@ async function resolveApiCatalog(ctx: ProviderCatalogContext) {
   if (!auth.apiKey) {
     return null;
   }
+  const defaults = buildMinimaxProvider(ctx.env);
+  const providerConfig = {
+    ...defaults,
+    baseUrl: getProviderBaseUrl(ctx.config, API_PROVIDER_ID) ?? defaults.baseUrl,
+    api: ctx.config.models?.providers?.[API_PROVIDER_ID]?.api ?? defaults.api,
+  };
   return await buildOpenAICompatibleLiveProviderCatalog({
     discoveryMode: "strict",
     providerId: API_PROVIDER_ID,
-    providerConfig: {
-      ...buildMinimaxProvider(ctx.env),
-      baseUrl:
-        getProviderBaseUrl(ctx.config, API_PROVIDER_ID) ?? resolveMinimaxCatalogBaseUrl(ctx.env),
-    },
+    providerConfig,
     apiKey: auth.apiKey,
     discoveryApiKey: auth.discoveryApiKey,
     profileId: auth.profileId,
-    modelDiscovery: buildMinimaxModelDiscovery(),
+    modelDiscovery: buildMinimaxModelDiscovery("api_key", providerConfig.api),
   });
 }
 


### PR DESCRIPTION
Related: #144776.

## What Problem This Solves

MiniMax API-key catalog discovery ignored the configured regional base URL and API format. An explicit CN endpoint could lose to the environment or Global default, producing a catalog refresh failure while configured models remained available.

## Why This Change Was Made

Keep destination selection in the existing MiniMax catalog owner. Prefer the normalized explicit base URL, retain its path prefix, and preserve environment/Global fallback. Select the discovery contract from the configured API:

- `anthropic-messages`: relative `v1/models`, selected X-Api-Key.
- `openai-completions`: relative `models`, selected Bearer authentication.

Selected credential material and profile identity stay with the existing auth owner. Portal OAuth and API-key selection, inference, shared transport and public error projection are unchanged.

## User Impact and Scope

Eligible configured MiniMax endpoints use their configured protocol and path during catalog refresh. Existing endpoint eligibility still applies: declared native hosts can retain custom path prefixes; arbitrary non-native provider hosts remain excluded from implicit catalogs and retain explicitly authored models. This PR does not enable arbitrary proxy-host discovery or change generic catalog policy.

The original universal path/header diagnosis was [withdrawn by the reporter](https://github.com/openclaw/openclaw/issues/144776#issuecomment-5631271820). Anthropic's model-list path and X-Api-Key are valid. The earlier PR revision also produced `/v1/v1/models` for the supported OpenAI-compatible configuration; `3fed41a1` resolves [that P1 finding](https://github.com/openclaw/openclaw/pull/144782#discussion_r3987125713), including its authentication contract.

## Evidence

Independent acceptance drove a real isolated Gateway through public `models.list` with provider-config view, details and explicit refresh. Two synthetic TLS listeners retained declared MiniMax hostnames; no fetch override, product callback injection or TLS-disable flag was used.

| Public case | Observed result |
| --- | --- |
| Pinned main `68b7893b`, explicit A plus conflicting environment B | Real GET to B, HTTP 401, selected-profile `auth-rejected` and `refreshFailed`; static rows remain visible |
| Candidate, same admitted configuration | Real GET to A at the preserved prefix, HTTP 200, selected-profile `ready`, MiniMax-M3 available |
| Whitespace/trailing slash and both OpenAI base shapes | Correct normalized path; Bearer for OpenAI, X-Api-Key for Anthropic, no alternate auth header |
| Absent/blank base and unchanged Global default | Expected environment/default request and ready catalog, including real verified TLS at the default URL |
| Portal API key and persisted OAuth | Correct selected material/profile and respective X-Api-Key/Bearer request; OAuth imported through public Doctor |
| Cached read, replace mode and arbitrary-host exclusion | No extra discovery request; intended authored inventory preserved |

The actual candidate runtime is CI merge `6dec9527`, containing contributor head `3fed41a1`; it is not relabeled as an exact build of the contributor head. Complete build/source inspection and independent equivalence review qualify the unchanged MiniMax repair for this public flow. The original setup failures and all corrected captures remain retained.

Native formatting passed. The focused native run passed 212 cases; seven unchanged music-fixture cases failed an ambient-DNS guard and a representative case failed identically on pinned main. A separate isolated 22-test file run passed, but this is not a claim of an unconditionally green 219-test native run. Those unrelated failures were source-traced and retained rather than changing this PR's scope. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34579529265) without an exception.

Earlier contributor evidence remains part of the history: 219 local MiniMax tests and real CN registered-catalog HTTP 200 results were reported; its full local changed-path gate stopped at a dependency minimum-release-age bootstrap refusal. No security policy was disabled. The new Gateway acceptance uses synthetic credentials and does not claim real vendor credential acceptance, inference success, universal auth repair or Control UI visual validation.

Thanks @vantang for the report, implementation and correction of the earlier compatibility finding.
