### PR TITLE
fix(memory): restore FTS fallback for same-name view collisions

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-schema-fts-reconcile.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts-reconcile.test.ts
@@ -99,10 +99,12 @@ describe("memory FTS schema reconciliation", () => {
     }
   });
 
-  it("repairs malformed derived tables without changing canonical rows", () => {
+  it.each(["fts5", "ordinary"])("repairs malformed %s derived tables", (kind) => {
     const db = new DatabaseSync(":memory:");
     try {
       ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      const tableDefinition = kind === "fts5" ? "VIRTUAL TABLE" : "TABLE";
+      const columns = kind === "fts5" ? "USING fts5(wrong)" : "(wrong TEXT)";
       db.exec(`
         INSERT INTO memory_index_sources (path, source, hash, mtime, size)
         VALUES ('memory/kept.md', 'memory', 'source-hash', 1, 1);
@@ -110,8 +112,8 @@ describe("memory FTS schema reconciliation", () => {
           (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
         VALUES
           ('kept', 'memory/kept.md', 'memory', 1, 1, 'chunk-hash', 'model', 'kept body', '[]', 1);
-        CREATE VIRTUAL TABLE memory_index_chunks_fts USING fts5(wrong);
-        CREATE VIRTUAL TABLE memory_index_paths_fts USING fts5(wrong);
+        CREATE ${tableDefinition} memory_index_chunks_fts ${columns};
+        CREATE ${tableDefinition} memory_index_paths_fts ${columns};
         CREATE TRIGGER memory_index_paths_fts_after_insert
         AFTER INSERT ON memory_index_sources BEGIN SELECT 1; END;
       `);
@@ -139,6 +141,53 @@ describe("memory FTS schema reconciliation", () => {
       db.close();
     }
   });
+
+  it.each(["memory_index_chunks_fts", "memory_index_paths_fts", "custom_memory_fts"])(
+    "rejects a colliding view at %s without changing it or canonical rows",
+    (viewName) => {
+      const db = new DatabaseSync(":memory:");
+      try {
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+        db.exec(`
+          INSERT INTO memory_index_sources (path, source, hash, mtime, size)
+          VALUES ('memory/kept.md', 'memory', 'source-hash', 1, 1);
+          INSERT INTO memory_index_chunks
+            (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+          VALUES
+            ('kept', 'memory/kept.md', 'memory', 1, 1, 'chunk-hash', 'model', 'kept body', '[]', 1);
+          CREATE VIEW ${viewName} AS SELECT ${
+            viewName === "memory_index_paths_fts"
+              ? "path, source FROM memory_index_sources"
+              : "text, id, path, source, model, start_line, end_line FROM memory_index_chunks"
+          };
+        `);
+        const readView = () =>
+          db.prepare("SELECT type, sql FROM sqlite_schema WHERE name = ?").get(viewName);
+        const viewBefore = readView();
+        const rowsBefore = db.prepare(`SELECT * FROM ${viewName}`).all();
+
+        expect(
+          ensureMemoryIndexSchema({
+            db,
+            cacheEnabled: false,
+            ftsEnabled: true,
+            ...(viewName === "custom_memory_fts" ? { ftsTable: viewName } : {}),
+          }).ftsAvailable,
+        ).toBe(false);
+
+        expect(readView()).toEqual(viewBefore);
+        expect(db.prepare(`SELECT * FROM ${viewName}`).all()).toEqual(rowsBefore);
+        expect(db.prepare("SELECT id, text FROM memory_index_chunks").all()).toEqual([
+          { id: "kept", text: "kept body" },
+        ]);
+        expect(db.prepare("SELECT path, source FROM memory_index_sources").all()).toEqual([
+          { path: "memory/kept.md", source: "memory" },
+        ]);
+      } finally {
+        db.close();
+      }
+    },
+  );
 
   it.each([
     {

--- a/packages/memory-host-sdk/src/host/memory-schema-fts.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts.ts
@@ -16,8 +16,13 @@ function ftsTableMatchesSchema(params: {
   tokenizeClause: string;
 }): FtsTableSchemaStatus {
   const table = params.db
-    .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ? COLLATE NOCASE")
-    .get(params.tableName) as { sql?: unknown } | undefined;
+    .prepare(
+      "SELECT type, sql FROM sqlite_schema WHERE type IN ('table', 'view') AND name = ? COLLATE NOCASE",
+    )
+    .get(params.tableName) as { type?: unknown; sql?: unknown } | undefined;
+  if (table?.type === "view") {
+    throw new Error(`Memory FTS table "${params.tableName}" collides with a view`);
+  }
   if (typeof table?.sql !== "string") {
     return "missing";
   }

--- a/packages/memory-host-sdk/src/host/memory-schema-fts.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts.ts
@@ -21,7 +21,7 @@ function ftsTableMatchesSchema(params: {
     )
     .get(params.tableName) as { type?: unknown; sql?: unknown } | undefined;
   if (table?.type === "view") {
-    throw new Error(`Memory FTS table "${params.tableName}" collides with a view`);
+    throw new Error(`cannot modify ${params.tableName} because it is a view`);
   }
   if (typeof table?.sql !== "string") {
     return "missing";


### PR DESCRIPTION
Related: #144641, #144761

## What Problem This Solves

Fixes an issue where memory searches could report full-text search as available when a SQLite view occupied the body index name, bypassing the intended unavailable-FTS fallback. The fixture repair in #144761 restored CI coverage but left this production detection bug unchanged.

## Why This Change Was Made

The row-count optimization in #144641 exposed a table-only schema lookup: a same-name view could remain in place with matching row counts. The existing FTS schema owner now detects views and rejects the collision before reconciliation, preserving the view and canonical memory rows. It retains SQLite's existing view-collision diagnostic, including the expectation added in #144761. Ordinary derived-table repairs remain unchanged.

## User Impact

Memory search can use its existing fallback when a view shadows the canonical or custom body FTS index. No schema migration or configuration change is required.

## Evidence

- Reproduced the original body-view detection failures before the guard, then reproduced the diagnostic mismatch against the exact merged #144761 fixture before preserving SQLite's wording.
- Passed 53 focused tests across five files on Node 24.20.0, including view preservation, ordinary-table repair, 31 canonical/legacy-schema cases, and all six temporal-ranking modes with the exact merged #144761 fixture. Its assertions were not changed.
- Compatibility proof: schema definitions, versions, configuration, transactions, and recovery rules are unchanged. The canonical/legacy-schema tests exercise existing upgrade paths, and the exact-main fixture passes with the guard. The change introduces no migration.
- The full changed gate passed for the original guard, including production/test typechecks, dead-export scans, lint, and architecture/storage guards. The subsequent message-only adjustment passed the focused suites, formatting, and whitespace checks.
- The original P2 review identified a pre-existing path-trigger recovery limitation; paired original/candidate SQLite proof confirmed it is unchanged by this patch. A separate P2 review of the one-line diagnostic adjustment found no actionable issues. Recovery after externally replacing a live path index remains a separate follow-up.
