### PR TITLE
test: restore unavailable FTS ranking coverage

### DIFF
--- a/extensions/memory-core/src/memory/manager-temporal-ranking.test.ts
+++ b/extensions/memory-core/src/memory/manager-temporal-ranking.test.ts
@@ -147,10 +147,12 @@ describe("memory source temporal ranking", () => {
       });
       if (ftsUnavailable) {
         await manager.close();
+        // An empty read-only view rejects FTS backfill while leaving canonical chunks intact.
         openOpenClawAgentDatabase({ agentId: "main" }).db.exec(`
           DROP TABLE memory_index_chunks_fts;
           CREATE VIEW memory_index_chunks_fts AS
-            SELECT text, id, path, source, model, start_line, end_line FROM memory_index_chunks;
+            SELECT text, id, path, source, model, start_line, end_line
+            FROM memory_index_chunks WHERE 0;
         `);
         manager = await fixture.getFreshManager(cfg, "cli");
         expect(manager.status().fts).toMatchObject({ enabled: true, available: false });


### PR DESCRIPTION
## What Problem This Solves

The memory temporal-ranking test no longer exercised its unavailable-FTS path after #144641 began rebuilding derived indexes only when their row counts differ. Its read-only view had the same count as the canonical chunks, so initialization succeeded and CI failed the existing availability assertion.

## Why This Change Was Made

Make the fixture's existing read-only view empty. The required backfill then encounters SQLite's real write error while the canonical chunks remain intact. Every availability, ranking, recency, provenance, embedding-count, and public-tool assertion stays unchanged.

## User Impact

This restores regression coverage for memory ranking when FTS is unavailable. Production behavior and storage code are unchanged.

## Evidence

The unchanged test reproduced five passes and one failure on the exact CI merge. An in-memory comparison of the previous and current schema owners isolated the count-trigger change and confirmed that the real partial-index repair still works.

The repair passes all six temporal-ranking cases, ten FTS reconciliation controls, and 19 changed-file checks. Independent review through P2 found no actionable findings. Proof uses synthetic local SQLite/session fixtures and mocked embeddings.
