### PR TITLE
fix(gateway): post-ack webhook work fails with "Async work scope is closed"

### DIFF
--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -365,4 +365,35 @@ describe("runDetachedWebhookWork", () => {
 
     await expect(inherited).rejects.toThrow("Gateway is draining");
   });
+
+  it("keeps tracked work accepted after the caller's async work scope closes", async () => {
+    const { runWithGatewayHttpWorkAdmission } =
+      await import("../gateway/server/http-work-admission.js");
+    const { AsyncWorkScope, captureAsyncWorkTracker } =
+      await import("../shared/async-work-scope.js");
+
+    const parentScope = new AsyncWorkScope();
+    let detached: Promise<string> | undefined;
+    await runWithGatewayHttpWorkAdmission(
+      new ServerResponse(new IncomingMessage(new Socket())),
+      async () =>
+        // Deferred post-ack work starts under the request's async work scope; that
+        // scope closes once the triggering turn settles, but the detached callback
+        // must still be able to run and track embedded work afterwards.
+        await parentScope.track(async () => {
+          detached = runDetachedWebhookWork(async () => {
+            const trackOwner = captureAsyncWorkTracker();
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, 25);
+            });
+            return await trackOwner(async () => "tracked-after-close");
+          });
+          return true;
+        }),
+    );
+
+    parentScope.beginClose();
+    await parentScope.drain();
+    await expect(detached).resolves.toBe("tracked-after-close");
+  });
 });

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -15,7 +15,7 @@ import {
   waitForHttpRequestRejection,
 } from "../infra/http-request-lifecycle.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
-import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
+import { runWithGatewayDetachedWorkContinuation } from "../process/gateway-work-admission.js";
 import type { FixedWindowRateLimiter } from "./webhook-memory-guards.js";
 
 export { resolveAcceptedBrowserOrigin } from "../gateway/origin-check.js";
@@ -306,7 +306,8 @@ export function beginWebhookRequestPipelineOrReject(params: {
 }
 
 /**
- * Run post-ack webhook processing on its own admitted gateway work root.
+ * Run post-ack webhook processing on its own admitted gateway work root with
+ * an independently owned async work scope.
  *
  * Ack-first handlers respond before processing events, so the continued work
  * outlives the HTTP request admission it inherited; once that admission is
@@ -314,9 +315,12 @@ export function beginWebhookRequestPipelineOrReject(params: {
  * gateway were draining. Call this synchronously from the request handler
  * (while the request is still admitted): it reserves an independent root that
  * keeps the detached processing accepted and lets a restart drain wait for it.
+ * The callback also runs inside a fresh detached async work scope, so work
+ * started here (for example deferred embedded-agent runs) keeps tracking even
+ * after the caller's own scope closes.
  */
 export function runDetachedWebhookWork<T>(run: () => Promise<T>): Promise<T> {
-  return runWithGatewayIndependentRootWorkContinuation(async () => {
+  return runWithGatewayDetachedWorkContinuation(async () => {
     // Reserve the root now, but let the request handler write its acknowledgement
     // before any synchronous prefix in the detached callback can run.
     await Promise.resolve();

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -26,6 +26,7 @@ import {
   resetGatewayWorkAdmission,
   rollbackGatewayRestartSignalFence,
   runWithGatewayDetachedWorkAdmission,
+  runWithGatewayDetachedWorkContinuation,
   runWithGatewayIndependentRootWorkAdmission,
   runWithGatewayIndependentRootWorkContinuation,
   runWithRetainedGatewayRootWork,
@@ -361,6 +362,52 @@ it("retains detached work through descendant cleanup after its requester closes"
     await nextTurn();
   }
   expect(backgroundSignal?.aborted).toBe(true);
+  await expect(track?.(() => {})).rejects.toThrow("Async work scope is closed");
+  expect(getActiveGatewayRootWorkCount()).toBe(0);
+});
+
+it("keeps a detached continuation's reservation while it owns its async lifetime", async () => {
+  const foreground = new AsyncWorkScope();
+  const root = tryBeginGatewayRootWorkAdmission("ws:agent")!;
+  const releaseChild = createDeferredCore();
+  const handlerReturned = createDeferredCore();
+  let child: Promise<string> | undefined;
+  let track: ReturnType<typeof captureAsyncWorkTracker> | undefined;
+  let continuationSignal: AbortSignal | undefined;
+  let settled = false;
+  const run = async () => {
+    track = captureAsyncWorkTracker();
+    continuationSignal = getAsyncWorkSignal();
+    child = trackAsyncWork(async () => {
+      await releaseChild.promise;
+      return "tracked-after-close";
+    });
+    handlerReturned.resolve();
+    return "completed";
+  };
+  const continuation = root.run(async () =>
+    foreground.run(() => runWithGatewayDetachedWorkContinuation(run, "webhook:detached")),
+  );
+  void continuation.then(() => {
+    settled = true;
+  });
+  await handlerReturned.promise;
+  root.release();
+  const foregroundClosed = foreground.drain();
+  try {
+    await nextTurn();
+    expect(settled).toBe(true);
+    expect(continuationSignal).toBeDefined();
+    expect(continuationSignal).not.toBe(foreground.signal);
+    expect(continuationSignal?.aborted).toBe(false);
+    expect(getActiveGatewayRootWorkHolders()).toEqual(["webhook:detached"]);
+  } finally {
+    releaseChild.resolve();
+    await expect(child).resolves.toBe("tracked-after-close");
+    await continuation;
+    await foregroundClosed;
+    await nextTurn();
+  }
   await expect(track?.(() => {})).rejects.toThrow("Async work scope is closed");
   expect(getActiveGatewayRootWorkCount()).toBe(0);
 });

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -499,11 +499,35 @@ export function runWithGatewayIndependentRootWorkContinuation<T>(
   run: () => Promise<T>,
   origin = "independent",
 ): Promise<T> {
+  return runWithGatewayRootWorkContinuation(run, origin, false);
+}
+
+/**
+ * Detached continuations own their async lifetime: like the independent
+ * continuation, a live parent synchronously reserves a tracked root even
+ * across closed admission fences, but the callback runs inside a fresh
+ * detached async work scope so deferred work survives the caller's scope
+ * closing instead of inheriting it.
+ */
+export function runWithGatewayDetachedWorkContinuation<T>(
+  run: () => Promise<T>,
+  origin = "independent",
+): Promise<T> {
+  return runWithGatewayRootWorkContinuation(run, origin, true);
+}
+
+function runWithGatewayRootWorkContinuation<T>(
+  run: () => Promise<T>,
+  origin: string,
+  detachedWork: boolean,
+): Promise<T> {
   const parent = GATEWAY_WORK_ADMISSION_STATE.currentRootWork.getStore();
   if (!parent || parent.released) {
-    return runWithGatewayIndependentRootWorkAdmission(run, origin);
+    return detachedWork
+      ? runWithGatewayDetachedWorkAdmission(run, origin)
+      : runWithGatewayIndependentRootWorkAdmission(run, origin);
   }
-  const admission = createGatewayRootWorkAdmission(origin);
+  const admission = createGatewayRootWorkAdmission(origin, detachedWork);
   return admission.run(run).finally(admission.release);
 }
 


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #144788

## What Problem This Solves

- Fixes a regression where plugins that defer work through the public `runDetachedWebhookWork` helper after a turn ends (for example the memory-tencentdb plugin's post-agent_end L1/L2/L3 extraction) always fail with `Error: Async work scope is closed`, so no higher-level memories are ever generated.
- Affected any plugin running embedded-agent or other tracked work asynchronously after acknowledging a webhook/agent_end trigger, on 2026.9.4 and current main.
- **Related:** #144788; the 2026.9.4 admission rework added detached async-work roots for delayed event dispatch (#143866) but left the webhook helper on the non-detached continuation path.

## Why This Change Was Made

- **Intended outcome:** `runDetachedWebhookWork` now routes its post-ack callback through a detached work continuation: a live parent still synchronously reserves a tracked root (the fence-crossing continuation behavior that #143866 deliberately preserved for delayed producers), but the callback runs inside a fresh `AsyncWorkScope` instead of inheriting the caller's scope, so work tracked from it stays accepted after that scope closes.
- **Out of scope:** No changes to other callers of `runWithGatewayIndependentRootWorkContinuation`; no new public plugin-sdk surface (the existing helper's documented contract — "its own tracked admission root" with post-ack ordering — is simply honored again).
- **Highest-risk area:** admission/root reservation semantics in `src/process/gateway-work-admission.ts`.
- **How is that risk mitigated?** The detached flag only flows into the existing `runWithDetachedAsyncWork` machinery introduced by #143866 (already used by session-event wakes and skill review); acknowledgement ordering is unchanged (the callback still starts in the next microtask), and the full gateway-work-admission test file (35 tests) passes unchanged.

## User Impact

- **Success criteria:** Work started via `runDetachedWebhookWork` after agent_end (memory extraction, webhook event processing) completes instead of rejecting with "Async work scope is closed"; restart/suspension drains still wait for it, and the request handler's acknowledgement is still written before processing starts.
- **What should reviewers focus on?** `src/process/gateway-work-admission.ts` (`runWithGatewayDetachedWorkContinuation`), `src/plugin-sdk/webhook-request-guards.ts`; regression tests `keeps tracked work accepted after the caller's async work scope closes` (webhook-request-guards.test.ts) and `keeps a detached continuation's reservation while it owns its async lifetime` (gateway-work-admission.test.ts).

## Evidence

- **Real environment tested:** repository worktree at `aispace/worktrees/issue-144788` (upstream main 0b52dc467b3 + this patch; initially developed against e7ebacf626d and rebased without conflicts — upstream did not touch the four changed files), Node v26.7.0. Zero-mock real-runtime proof of the exact agent_end webhook lifecycle: a real `node:http` server on a real socket, requests admitted through the real `runWithGatewayHttpWorkAdmission` chain, a real `AsyncWorkScope` as the triggering turn's scope, and the public `runDetachedWebhookWork` helper deferring embedded-agent-style tracked work (ambient tracker capture, then a tracked L1-extraction run) past the acknowledgement and past the triggering scope's close. No mocks anywhere on the exercised path.
- **Exact steps or commands run after this patch:**
  ```bash
  # real-runtime before/after proof (zero mocks; same script both runs)
  # before: git checkout origin/main -- src/plugin-sdk/webhook-request-guards.ts src/process/gateway-work-admission.ts
  # after:  git checkout HEAD --  <same two files>
  node --import ./scripts/tsx.mjs webhook-agent-end-runtime-proof.mts
  # focused regression shards (rebased head, all green)
  node scripts/run-vitest.mjs run src/plugin-sdk/webhook-request-guards.test.ts src/process/gateway-work-admission.test.ts
  skills/fix-pr/scripts/validate.sh src/plugin-sdk/webhook-request-guards.ts src/plugin-sdk/webhook-request-guards.test.ts src/process/gateway-work-admission.ts src/process/gateway-work-admission.test.ts
  ```
- **Evidence after fix:** (first: unpatched origin/main, same real-HTTP agent_end flow — the deferred plugin callback's tracked L1 extraction is rejected with the reporter's exact error; second: this patch, same flow — deferred tracked work completes after the triggering scope closed and the gateway reservation is released afterwards)
  ```text
  # BEFORE (origin/main):
  [2026-09-11T09:36:19.806Z] server: POST /webhook/agent-end received
  [2026-09-11T09:36:19.808Z] handler: acknowledgement written (200 OK)
  [2026-09-11T09:36:19.809Z] plugin callback: started (after ack)
  [2026-09-11T09:36:19.809Z] handler: triggering turn settled (its async work scope closed)
  [2026-09-11T09:36:19.815Z] handler: gateway root work holders while deferred work pending: ["http:request","webhook:detached"]
  [2026-09-11T09:36:19.826Z] client: ack response 200 {"ok":true}
  [2026-09-11T09:36:19.861Z] plugin callback: invoking tracked L1 extraction
  [2026-09-11T09:36:19.878Z] RESULT: FAIL - deferred tracked work rejected: Async work scope is closed
  ```
  ```text
  # AFTER (this patch):
  [2026-09-11T09:36:30.487Z] server: POST /webhook/agent-end received
  [2026-09-11T09:36:30.489Z] handler: acknowledgement written (200 OK)
  [2026-09-11T09:36:30.490Z] plugin callback: started (after ack)
  [2026-09-11T09:36:30.490Z] handler: triggering turn settled (its async work scope closed)
  [2026-09-11T09:36:30.492Z] handler: gateway root work holders while deferred work pending: ["http:request","webhook:detached"]
  [2026-09-11T09:36:30.499Z] client: ack response 200 {"ok":true}
  [2026-09-11T09:36:30.541Z] plugin callback: invoking tracked L1 extraction
  [2026-09-11T09:36:30.572Z] plugin callback: tracked work COMPLETED -> L1 extraction: extracted=1, stored=1
  [2026-09-11T09:36:30.575Z] RESULT: PASS - deferred tracked work completed after the triggering scope closed: L1 extraction: extracted=1, stored=1
  [2026-09-11T09:36:30.575Z] RESULT: gateway root work count after deferred completion: 0
  ```
- **Observed result after fix:** in the real-HTTP agent_end flow the request is still acknowledged first (200 `{"ok":true}` before any processing), the `webhook:detached` admission root stays reserved while the deferred work is pending, the triggering turn's async work scope closes while the deferred callback is still running, and the deferred tracked work then completes (`L1 extraction: extracted=1, stored=1`) instead of rejecting with "Async work scope is closed"; after completion the gateway root work count returns to 0, i.e. the reservation is released once deferred work and cleanup finish. Focused vitest shards on the rebased head are green — webhook-request-guards (incl. the new regression test) and gateway-work-admission 35/35 — and `validate.sh` (oxfmt + oxlint + same-directory tests + `tsgo:core`) is fully green. The before-run on unpatched origin/main reproduces the exact reporter failure (`run() failed: Error: Async work scope is closed`) through the same helper chain.
- **What was not tested:** no live memory-tencentdb plugin install / real TencentDB + tencent-maas provider turn was exercised (needs external TencentDB and model credentials); the real-runtime proof above drives the exact public helper + admission + async-work-scope chain the plugin hits — real socket, real HTTP admission, real scopes, real timers — with a plugin-shaped deferred callback, per the issue's source-level analysis.
- **Proof tier:** L2 (real-runtime before/after on a real socket through the real admission chain, deterministic terminal output, plus deterministic boundary regression tests).
- **Proof limitations:** end-to-end plugin memory generation with a real TencentDB/model provider was not tested. The available CI receipt does not establish that external integration behavior.
- **Review state:** Exact-head CI is green; native maintainer preparation and a fresh ClawSweeper review are in progress.

### Maintainer acceptance and landing scope (2026-09-13)

Accepted the cancellation-lifetime tradeoff identified in the latest review: `runDetachedWebhookWork` explicitly promises work that survives the HTTP handler returning. Its callback needs a fresh async-work scope as well as its reserved Gateway root. Inheriting the handler's cancellation scope violates that documented post-ack contract. Independent cancellation is intentional here; ordinary independent continuations retain their existing cancellation behavior.

The new detached continuation preserves live-parent reservation across admission fences, descendant drain, Gateway affinity, and existing authorization/capability closures. It does not revive retired host capabilities or broaden tool policy. The current Google Chat non-turn webhook and Mattermost model-picker callers already use this post-return contract. Public contract: [post-ack webhook work](https://docs.openclaw.ai/plugins/sdk-overview/infrastructure).

Reviewed exact head `6f6370415df781bc784380706969c076e81d22c4` against current main and the async-work/admission owners. The contributor's recorded real HTTP/admission/scope trace and added regressions cover this PR's boundary; they are not a live TencentDB, external-provider, or channel-delivery claim. Production delta is +33/-5 lines; the growth introduces one explicit resource-lifetime owner while preserving the ordinary continuation path. Tests add 78 lines.

Land this contributor PR intact, then use its helper in a separate `sessions_send` announcement fix. The latter has independent real Gateway/MCP evidence and remains a separate caller change. Release-note context: fix post-ack webhook work failing with `Async work scope is closed` after the request finishes.
