### PR TITLE
fix(cli): reject blank message channel selectors

### DIFF
--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -73,6 +73,10 @@ An explicitly empty or whitespace-only `--account` value is rejected. Omit the
 option to use the existing default or bound account, including when a shell
 variable is empty. Nonblank account values keep their existing selection rules.
 
+An explicitly empty or whitespace-only `--channel` value is also rejected. Omit
+the option to select the sole configured channel, or use a channel-prefixed
+target when supported.
+
 Discord message bodies, captions, poll context, and component text retain
 leading indentation. Existing empty-message validation still applies.
 Ordinary message and caption delivery still trims trailing whitespace.

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -229,24 +229,13 @@ describe("runMessageAction", () => {
   it.each(["", "   "])(
     "rejects an explicitly blank message channel before command startup (%j)",
     async (channel) => {
-      const program = new Command()
-        .exitOverride()
-        .configureOutput({ writeErr: () => undefined });
+      const program = new Command().exitOverride().configureOutput({ writeErr: () => undefined });
       const message = program.command("message");
       registerMessageSendCommand(message, createMessageCliHelpers("discord"));
 
       await expect(
         program.parseAsync(
-          [
-            "message",
-            "send",
-            "--channel",
-            channel,
-            "--target",
-            "channel:123",
-            "--message",
-            "hi",
-          ],
+          ["message", "send", "--channel", channel, "--target", "channel:123", "--message", "hi"],
           { from: "user" },
         ),
       ).rejects.toThrow("--channel must not be blank");

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -226,6 +226,36 @@ describe("runMessageAction", () => {
     },
   );
 
+  it.each(["", "   "])(
+    "rejects an explicitly blank message channel before command startup (%j)",
+    async (channel) => {
+      const program = new Command()
+        .exitOverride()
+        .configureOutput({ writeErr: () => undefined });
+      const message = program.command("message");
+      registerMessageSendCommand(message, createMessageCliHelpers("discord"));
+
+      await expect(
+        program.parseAsync(
+          [
+            "message",
+            "send",
+            "--channel",
+            channel,
+            "--target",
+            "channel:123",
+            "--message",
+            "hi",
+          ],
+          { from: "user" },
+        ),
+      ).rejects.toThrow("--channel must not be blank");
+
+      expect(loadPluginRegistryHandleMock).not.toHaveBeenCalled();
+      expect(messageCommandMock).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     ["disabled reaction", "react", { ok: false, hint: "Reactions are disabled." }, 1],
     ["rejected added reaction", "react", { ok: false, warning: "Unavailable", added: "✅" }, 1],

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -67,6 +67,13 @@ function normalizeMessageOptions(opts: Record<string, unknown>): Record<string, 
   };
 }
 
+function parseMessageChannelSelector(channel: string): string {
+  if (!channel.trim()) {
+    throw new Error("--channel must not be blank");
+  }
+  return channel;
+}
+
 function validateMessageNumericOptions(opts: Record<string, unknown>): void {
   for (const [key, flag] of STRICT_POSITIVE_INTEGER_OPTIONS) {
     if (opts[key] === undefined) {
@@ -150,7 +157,11 @@ export function createMessageCliHelpers(messageChannelOptions: string): MessageC
   return {
     withMessageBase: (command) =>
       command
-        .option("--channel <channel>", `Channel: ${messageChannelOptions}`)
+        .option(
+          "--channel <channel>",
+          `Channel: ${messageChannelOptions}`,
+          parseMessageChannelSelector,
+        )
         .option("--account <id>", "Channel account id (accountId)", parseAccountSelector)
         .option("--json", "Output result as JSON", false)
         .option("--dry-run", "Print payload and skip sending", false)


### PR DESCRIPTION
Closes #144795

## What Problem This Solves

An explicit empty or whitespace-only `--channel` value was treated as omission. A shell command such as `openclaw message send --channel "$CHANNEL" ...` could therefore select the sole configured channel when the variable was empty.

## Why This Change Was Made

The shared message option rejects blanks during argument parsing, before message-specific plugin loading and action startup. Omitted and nonblank selectors keep their existing routing. Shared programmatic optional-channel semantics are unchanged. Generic CLI bootstrap can still read configuration.

## User Impact

Explicit blanks now fail with `--channel must not be blank`. Scripts that want automatic selection must omit the option. Maintainer scope accepts this documented malformed-input correction and the omission migration; the earlier compatibility review is preserved as history.

## Evidence

Real compiled CLI proof used isolated normal setup, synthetic Discord/Slack configuration, numeric targets, and `--dry-run --json`.

| Input | Baseline | Candidate |
| --- | --- | --- |
| `--channel ""` | Exit 0; unintended Discord selection | Exit 1; blank-selector diagnostic |
| `--channel "   "` | Exit 0; unintended Discord selection | Exit 1; blank-selector diagnostic |
| Omitted selector, sole Discord | Exit 0; intended Discord target | Same |
| `discord` or surrounding whitespace | Exit 0; intended Discord target | Same |
| Omission with no channels | Normal no-channel error | Same |
| Omission with Discord and Slack | Normal ambiguity error | Same |
| Supported Discord user-prefixed target | Inferred Discord dry-run | Preserved; explicit blanks reject |

- Baseline: `d9ad56cbe319ac6ba1c106a27ab547c4d50c7f05`.
- Candidate runtime: CI merge `8a9feadbfd230b706daf99318d5a67e8a551d9fb`, containing reviewed contributor head `fc9d2efaaf02a8eefa91907c2b94db239d0c23b6`. Independent source/artifact review verified the exercised message behavior and dependency contracts; the merge build is not relabeled as a contributor-head build.
- Fresh independent behavior validation retained full argv, exits, stdout and stderr. It covers fresh/configured blank rejection, routing controls, strict accounts, help/required errors, and edit/delete/react/poll/pin/broadcast/administrative sibling commands. All observable clauses pass.
- Focused candidate tests: **200 passed across 3 files** (`helpers.test.ts`, `register.message.test.ts`, `account-selector-boundary.test.ts`). The exact two new regression cases fail on baseline for the intended missing-parser reason, then pass on candidate.
- Changed-file formatting, syntax lint, boundary guards, line/assertion ratchets, documentation syntax, conflict and whitespace checks pass. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34582757126) is green; full type checks remain hosted.
- Contributor proof is retained: [run 34583269047](https://github.com/ly85206559/openclaw/actions/runs/34583269047), [job 103211516544](https://github.com/ly85206559/openclaw/actions/runs/34583269047/job/103211516544).

Dry-run proves routing and validation, not delivery. Send output does not echo message text; complete input preserves it. Broadcast retains an unrelated aggregate `dryRun: false` reporting inconsistency on both builds while child results are dry runs; the selector change does not alter that path. Earlier review judgments and the contributor’s report of a superseded non-required Auto response HTTP 500 failure remain preserved as history; the current exact-head CI result was independently verified.

Original implementation and tests by @ly85206559. Maintainer validation was AI-assisted.
