### PR TITLE
refactor(ui): reuse canonical model provider test helpers

### DIFF
--- a/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
@@ -2,6 +2,7 @@
 
 import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
 import type { ModelCatalogResult } from "../../api/types.ts";
 import type { SelectPicker } from "../../components/select-picker.ts";
 import { updatePickers } from "../../test-helpers/select-picker.ts";
@@ -10,7 +11,6 @@ import { EMPTY_MODEL_PROVIDERS_DATA } from "./load.ts";
 import {
   appendPage,
   createHarness,
-  deferred,
   type ModelProvidersPageTestElement,
 } from "./model-providers-page.test-support.ts";
 

--- a/ui/src/pages/model-providers/model-providers-page.login.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.login.test.ts
@@ -6,13 +6,13 @@ import type {
   WizardNextParams,
 } from "../../../../packages/gateway-protocol/src/schema/wizard.ts";
 import { WizardSession } from "../../../../src/wizard/session.js";
+import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { ModelAuthStatusResult, WizardNextResult } from "../../api/types.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   appendPage,
   createHarness,
-  deferred,
   type ModelProvidersPageTestElement,
 } from "./model-providers-page.test-support.ts";
 
@@ -187,7 +187,7 @@ describe("Models provider login", () => {
     const initialAuth = await client.request<ModelAuthStatusResult>("models.authStatus");
     const originalRequest = request.getMockImplementation()!;
     const cancelled = deferred<{ status: "running" }>();
-    const cancelReceived = deferred<void>();
+    const cancelReceived = deferred();
     const sessions = new Map<string, WizardSession>();
     const profiles = new Set<string>();
     request.mockImplementation(

--- a/ui/src/pages/model-providers/model-providers-page.order.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.order.test.ts
@@ -5,6 +5,7 @@ import type {
   ModelsAuthLogoutParams,
   ModelsAuthOrderSetParams,
 } from "../../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
+import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
 import type { ModelAuthStatusProfile } from "../../api/types.ts";
 import {
   getRenderedModalDialog,
@@ -17,7 +18,6 @@ import {
   appendPage,
   createAuthStatus,
   createHarness,
-  deferred,
   requestCount,
 } from "./model-providers-page.test-support.ts";
 
@@ -331,7 +331,7 @@ describe("ModelProvidersPage profile actions", () => {
       auth: { role: "operator", scopes: ["operator.admin"] },
     };
     const originalRequest = request.getMockImplementation()!;
-    const logout = deferred<void>();
+    const logout = deferred();
     let failLogout = true;
     let profiles: ModelAuthStatusProfile[] = [
       {

--- a/ui/src/pages/model-providers/model-providers-page.test-support.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test-support.ts
@@ -10,6 +10,7 @@ import type {
   RuntimeConfigExternalMutationOptions,
   RuntimeConfigExternalMutationResult,
 } from "../../lib/config/config-gateway-operations.ts";
+import { createApplicationGateway } from "../../test-helpers/application-context.ts";
 import type { ModelBehaviorConfig } from "./config-mutation.ts";
 import type { DefaultModelSelection } from "./data.ts";
 import { EMPTY_MODEL_PROVIDERS_DATA, type ModelProvidersData } from "./load.ts";
@@ -89,16 +90,6 @@ export async function saveKey(page: ModelProvidersPageTestElement, value: string
   page.querySelector<HTMLButtonElement>(".model-providers__inline-form button")!.click();
 }
 
-export function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
-
 export function createHarness(initialScopeId: string) {
   let pendingAuthStatus: Promise<void> | null = null;
   let releaseAuthStatus: (() => void) | null = null;
@@ -152,7 +143,7 @@ export function createHarness(initialScopeId: string) {
     lastError: null,
     lastErrorCode: null,
   };
-  const gatewaySource = publishableGateway(snapshot);
+  const gatewaySource = createApplicationGateway(snapshot);
   let selectionListener: (() => void) | undefined;
   const agentSelection = {
     state: {
@@ -270,28 +261,6 @@ export function createHarness(initialScopeId: string) {
     },
     failUsageStatus: () => {
       usageStatusRejects = true;
-    },
-  };
-}
-
-export function publishableGateway(initial: ApplicationGatewaySnapshot) {
-  let current = initial;
-  const listeners = new Set<(value: ApplicationGatewaySnapshot) => void>();
-  return {
-    gateway: {
-      get snapshot() {
-        return current;
-      },
-      subscribe(listener: (value: ApplicationGatewaySnapshot) => void) {
-        listeners.add(listener);
-        return () => listeners.delete(listener);
-      },
-    },
-    publish(next: ApplicationGatewaySnapshot) {
-      current = next;
-      for (const listener of listeners) {
-        listener(next);
-      }
     },
   };
 }

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -1,8 +1,10 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
 import type { ModelsProbeResult } from "../../api/types.ts";
 import type { SelectPicker } from "../../components/select-picker.ts";
+import { createApplicationGateway } from "../../test-helpers/application-context.ts";
 import { choosePickerValue, updatePickers } from "../../test-helpers/select-picker.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { DefaultModelSelection } from "./data.ts";
@@ -13,8 +15,6 @@ import {
   createAuthStatus,
   createEmptyModelProvidersRouteData,
   createHarness,
-  deferred,
-  publishableGateway,
   requestCount,
   saveKey,
   type AgentSelectElement,
@@ -122,7 +122,7 @@ describe("ModelProvidersPage agent scope", () => {
 
   it("recovers a failed provider usage result after a same-client reconnect", async () => {
     const { context, request, snapshot } = createHarness("main");
-    const source = publishableGateway(snapshot);
+    const source = createApplicationGateway(snapshot);
     (context as { gateway: unknown }).gateway = source.gateway;
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
@@ -147,7 +147,7 @@ describe("ModelProvidersPage agent scope", () => {
 
   it("defers failed provider usage recovery while hidden until page activation", async () => {
     const { context, request, snapshot } = createHarness("main");
-    const source = publishableGateway(snapshot);
+    const source = createApplicationGateway(snapshot);
     (context as { gateway: unknown }).gateway = source.gateway;
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     const visibility = vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
@@ -176,7 +176,7 @@ describe("ModelProvidersPage agent scope", () => {
 
   it("supersedes a hung load on disconnect so reconnect can replace it", async () => {
     const { context, request, snapshot, deferNextAuthStatus } = createHarness("main");
-    const source = publishableGateway(snapshot);
+    const source = createApplicationGateway(snapshot);
     (context as { gateway: unknown }).gateway = source.gateway;
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
@@ -195,7 +195,7 @@ describe("ModelProvidersPage agent scope", () => {
 
   it("keeps direct data visible while a same-client reconnect replaces it", async () => {
     const { context, deferNextAuthStatus, request, snapshot } = createHarness("main");
-    const source = publishableGateway(snapshot);
+    const source = createApplicationGateway(snapshot);
     (context as { gateway: unknown }).gateway = source.gateway;
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
@@ -558,7 +558,7 @@ describe("ModelProvidersPage agent scope", () => {
 
   it("keeps a replacement agent's default-model draft after a global model write", async () => {
     const { agentSelection, context, notifySelection, runtimeConfig } = createHarness("main");
-    const gate = deferred<void>();
+    const gate = deferred();
     runtimeConfig.ensureLoaded.mockImplementationOnce(async () => gate.promise);
     const page = appendPage(context);
     await waitForFast(() => expect(page.data?.config).toEqual({}));
@@ -586,7 +586,7 @@ describe("ModelProvidersPage agent scope", () => {
   it("cancels a queued key save when the selected agent changes", async () => {
     const { agentSelection, context, notifySelection, runtimeConfig, request } =
       createHarness("main");
-    const gate = deferred<void>();
+    const gate = deferred();
     runtimeConfig.beforeExternalDispatch.mockImplementationOnce(() => gate.promise);
     const page = appendPage(context);
     await waitForFast(() => expect(page.data?.config).toEqual({}));

--- a/ui/src/pages/model-providers/model-providers-page.usage.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.usage.test.ts
@@ -1,13 +1,13 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
 import { EMPTY_MODEL_PROVIDERS_DATA } from "./load.ts";
 import {
   advanceUsageRetries,
   appendPage,
   createHarness,
   createAuthStatus,
-  deferred,
   focusDocument,
   requestCount,
   type ModelProvidersPageTestElement,


### PR DESCRIPTION
## What Problem This Solves

Model Providers tests duplicate deferred-promise and Gateway publication helpers that already have canonical test owners.

## Why This Change Was Made

Use `createDeferred as deferred` and `createApplicationGateway` directly in the existing consumers. Preserve the harness's manual auth-status gate, configuration closure, fixtures, assertions, cleanup, and all cases, including quota persistence/page refresh. Publication equivalence is limited to these non-recursive callers.

## User Impact

Test-support cleanup only: six files, 31 net lines removed, no cases removed, no production or dependency changes.

## Evidence

- Local cohort: 80 cases passed; five observer cases never executed because the existing installation lacked `markdown-it-cjk-friendly`. The command exited 1. Four later default-type-argument removals preserve emitted JavaScript.
- Local guards: 16 passed; lint initially failed those four redundant type arguments, then the exact amended lint passed. The known blocked core-type command remained unrun. Formatting/diff checks passed. This is not a full local gate pass.
- Fresh scoped review of the final source: no findings.
- CI34583414403, attempt1: all85 named cases passed across the three normal UI shards, including all five observer cases. Actual unit metadata confirms threads, three workers, and isolation disabled. This is shard-union proof, not identical local file packing.
- All17 canonical core compiler graphs passed through the five-stripe union. All six proof jobs completed normal frozen dependency setup with cache hits.
- Actual tested/workflow checkout `425d82209d9f2ecc105f21913a88860fcde7ee4d` is the synthetic merge of the reviewed head into main. Its first-parent patch is exact; bound source, compiler, workflow, and dependency inputs match the reviewed candidate. No whole-repository or environment-equivalence claim.

No live API, browser-appearance, or performance proof is claimed.

Related: https://github.com/openclaw/openclaw/issues/139428
