### PR TITLE
fix: preserve async scope for detached webhook work

### DIFF
--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -322,33 +322,62 @@ describe("runDetachedWebhookWork", () => {
   it("keeps tracked descendants alive after the requester scope closes", async () => {
     const { runWithGatewayHttpWorkAdmission } =
       await import("../gateway/server/http-work-admission.js");
-    const { AsyncWorkScope, trackAsyncWork } = await import("../shared/async-work-scope.js");
+    const { AsyncWorkScope, captureAsyncWorkTracker } =
+      await import("../shared/async-work-scope.js");
 
-    let detached: Promise<number> | null = null;
-    let releaseCallback!: () => void;
-    const callbackGate = new Promise<void>((resolve) => {
-      releaseCallback = resolve;
-    });
     const requester = new AsyncWorkScope();
+    let detached: Promise<string> | undefined;
+    await runWithGatewayHttpWorkAdmission(
+      new ServerResponse(new IncomingMessage(new Socket())),
+      async () =>
+        await requester.track(async () => {
+          detached = runDetachedWebhookWork(async () => {
+            const trackOwner = captureAsyncWorkTracker();
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, 25);
+            });
+            return await trackOwner(async () => "tracked-after-close");
+          });
+          return true;
+        }),
+    );
+
+    requester.beginClose();
+    await requester.drain();
+    await expect(detached).resolves.toBe("tracked-after-close");
+  });
+
+  it("reserves post-ack work across a closed suspension fence", async () => {
+    const { runWithGatewayHttpWorkAdmission } =
+      await import("../gateway/server/http-work-admission.js");
+    const { getActiveGatewayRootWorkHolders, tryBeginGatewaySuspendAdmission } =
+      await import("../process/gateway-work-admission.js");
+
+    let releaseWork!: () => void;
+    const workGate = new Promise<void>((resolve) => {
+      releaseWork = resolve;
+    });
+    let rollbackSuspension: (() => boolean) | undefined;
+    let detached: Promise<string> | undefined;
     await runWithGatewayHttpWorkAdmission(
       new ServerResponse(new IncomingMessage(new Socket())),
       async () => {
-        requester.run(() => {
-          detached = runDetachedWebhookWork(async () => {
-            await callbackGate;
-            return await trackAsyncWork(async () => 42);
-          });
+        const suspension = tryBeginGatewaySuspendAdmission(() => {});
+        expect(suspension).not.toBeNull();
+        rollbackSuspension = suspension?.rollback;
+        detached = runDetachedWebhookWork(async () => {
+          await workGate;
+          return "completed-across-fence";
         });
-        await requester.drain();
-        releaseCallback();
+        expect(getActiveGatewayRootWorkHolders()).toEqual(["http:request", "webhook:detached"]);
         return true;
       },
     );
 
-    if (!detached) {
-      throw new Error("detached webhook work was not started");
-    }
-    await expect(detached).resolves.toBe(42);
+    expect(getActiveGatewayRootWorkHolders()).toEqual(["webhook:detached"]);
+    expect(rollbackSuspension?.()).toBe(true);
+    releaseWork();
+    await expect(detached).resolves.toBe("completed-across-fence");
   });
 
   it("keeps post-ack processing admitted after the request admission is released", async () => {

--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -324,6 +324,8 @@ describe("runDetachedWebhookWork", () => {
       await import("../gateway/server/http-work-admission.js");
     const { AsyncWorkScope, captureAsyncWorkTracker } =
       await import("../shared/async-work-scope.js");
+    const { getActiveGatewayRootWorkHolders } =
+      await import("../process/gateway-work-admission.js");
 
     const requester = new AsyncWorkScope();
     let detached: Promise<string> | undefined;
@@ -344,6 +346,7 @@ describe("runDetachedWebhookWork", () => {
 
     requester.beginClose();
     await requester.drain();
+    expect(getActiveGatewayRootWorkHolders()).toEqual(["webhook:detached"]);
     await expect(detached).resolves.toBe("tracked-after-close");
   });
 

--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -319,6 +319,38 @@ describe("runDetachedWebhookWork", () => {
     expect(order).toEqual(["ack", "work"]);
   });
 
+  it("keeps tracked descendants alive after the requester scope closes", async () => {
+    const { runWithGatewayHttpWorkAdmission } =
+      await import("../gateway/server/http-work-admission.js");
+    const { AsyncWorkScope, trackAsyncWork } = await import("../shared/async-work-scope.js");
+
+    let detached: Promise<number> | null = null;
+    let releaseCallback!: () => void;
+    const callbackGate = new Promise<void>((resolve) => {
+      releaseCallback = resolve;
+    });
+    const requester = new AsyncWorkScope();
+    await runWithGatewayHttpWorkAdmission(
+      new ServerResponse(new IncomingMessage(new Socket())),
+      async () => {
+        requester.run(() => {
+          detached = runDetachedWebhookWork(async () => {
+            await callbackGate;
+            return await trackAsyncWork(async () => 42);
+          });
+        });
+        await requester.drain();
+        releaseCallback();
+        return true;
+      },
+    );
+
+    if (!detached) {
+      throw new Error("detached webhook work was not started");
+    }
+    await expect(detached).resolves.toBe(42);
+  });
+
   it("keeps post-ack processing admitted after the request admission is released", async () => {
     const { runWithGatewayHttpWorkAdmission } =
       await import("../gateway/server/http-work-admission.js");

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -15,7 +15,7 @@ import {
   waitForHttpRequestRejection,
 } from "../infra/http-request-lifecycle.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
-import { runWithGatewayDetachedWorkAdmission } from "../process/gateway-work-admission.js";
+import { runWithGatewayDetachedWorkContinuation } from "../process/gateway-work-admission.js";
 import type { FixedWindowRateLimiter } from "./webhook-memory-guards.js";
 
 export { resolveAcceptedBrowserOrigin } from "../gateway/origin-check.js";
@@ -306,7 +306,8 @@ export function beginWebhookRequestPipelineOrReject(params: {
 }
 
 /**
- * Run post-ack webhook processing on its own admitted gateway work root.
+ * Run post-ack webhook processing on its own admitted gateway work root with
+ * an independently owned async work scope.
  *
  * Ack-first handlers respond before processing events, so the continued work
  * outlives the HTTP request admission it inherited; once that admission is
@@ -314,9 +315,12 @@ export function beginWebhookRequestPipelineOrReject(params: {
  * gateway were draining. Call this synchronously from the request handler
  * (while the request is still admitted): it reserves an independent root that
  * keeps the detached processing accepted and lets a restart drain wait for it.
+ * The callback also runs inside a fresh detached async work scope, so work
+ * started here (for example deferred embedded-agent runs) keeps tracking even
+ * after the caller's own scope closes.
  */
 export function runDetachedWebhookWork<T>(run: () => Promise<T>): Promise<T> {
-  return runWithGatewayDetachedWorkAdmission(async () => {
+  return runWithGatewayDetachedWorkContinuation(async () => {
     // Reserve the root now, but let the request handler write its acknowledgement
     // before any synchronous prefix in the detached callback can run.
     await Promise.resolve();

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -15,7 +15,7 @@ import {
   waitForHttpRequestRejection,
 } from "../infra/http-request-lifecycle.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
-import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
+import { runWithGatewayDetachedWorkAdmission } from "../process/gateway-work-admission.js";
 import type { FixedWindowRateLimiter } from "./webhook-memory-guards.js";
 
 export { resolveAcceptedBrowserOrigin } from "../gateway/origin-check.js";
@@ -316,7 +316,7 @@ export function beginWebhookRequestPipelineOrReject(params: {
  * keeps the detached processing accepted and lets a restart drain wait for it.
  */
 export function runDetachedWebhookWork<T>(run: () => Promise<T>): Promise<T> {
-  return runWithGatewayIndependentRootWorkContinuation(async () => {
+  return runWithGatewayDetachedWorkAdmission(async () => {
     // Reserve the root now, but let the request handler write its acknowledgement
     // before any synchronous prefix in the detached callback can run.
     await Promise.resolve();

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -499,11 +499,35 @@ export function runWithGatewayIndependentRootWorkContinuation<T>(
   run: () => Promise<T>,
   origin = "independent",
 ): Promise<T> {
+  return runWithGatewayRootWorkContinuation(run, origin, false);
+}
+
+/**
+ * Detached continuations own their async lifetime: like the independent
+ * continuation, a live parent synchronously reserves a tracked root even
+ * across closed admission fences, but the callback runs inside a fresh
+ * detached async work scope so deferred work survives the caller's scope
+ * closing instead of inheriting it.
+ */
+export function runWithGatewayDetachedWorkContinuation<T>(
+  run: () => Promise<T>,
+  origin = "independent",
+): Promise<T> {
+  return runWithGatewayRootWorkContinuation(run, origin, true);
+}
+
+function runWithGatewayRootWorkContinuation<T>(
+  run: () => Promise<T>,
+  origin: string,
+  detachedWork: boolean,
+): Promise<T> {
   const parent = GATEWAY_WORK_ADMISSION_STATE.currentRootWork.getStore();
   if (!parent || parent.released) {
-    return runWithGatewayIndependentRootWorkAdmission(run, origin);
+    return detachedWork
+      ? runWithGatewayDetachedWorkAdmission(run, origin)
+      : runWithGatewayIndependentRootWorkAdmission(run, origin);
   }
-  const admission = createGatewayRootWorkAdmission(origin);
+  const admission = createGatewayRootWorkAdmission(origin, detachedWork);
   return admission.run(run).finally(admission.release);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugins that schedule post-ack webhook work could fail with `Async work scope is closed` after the triggering request scope closed.

Fixes #144788

## Why This Change Was Made

`runDetachedWebhookWork` now uses a detached continuation: it reserves the root synchronously from the live parent, including across a closed suspension fence, while executing the callback in a fresh async work scope. This preserves acknowledgement ordering and drain accounting.

## User Impact

Deferred webhook/plugin work can complete after the triggering request scope closes without becoming untracked or rejected.

## Evidence

- Real call-chain loopback proof: `node --import ./scripts/tsx.mjs webhook-agent-end-runtime-proof.mts` started a real TCP/HTTP server and exercised `runWithGatewayHttpWorkAdmission` through the public `runDetachedWebhookWork` helper. No external credentials or private data were used.
- The same script and input on pinned base `227e7ae2` reproduced `Async work scope is closed` (exit 1); on this head it completed successfully (exit 0).
- The `webhook:detached` root remained reserved while the triggering scope was closed and was released after tracked work completed. The unchanged inherited-admission negative control still rejects with `Gateway is draining`.

```text
$ node --import ./scripts/tsx.mjs webhook-agent-end-runtime-proof.mts
base 227e7ae26af4e4f3f8a256c4fa808c7b046f4c88 (exit 1): result: rejected: Error: Async work scope is closed
head e9d92f7a5d758f019b1f42fd31ad83f13708169d (exit 0):
ack written (200 OK)
plugin callback started (after ack)
triggering turn settled (async work scope closed)
gateway holders while deferred work pending: ["http:request","webhook:detached"]
client received ack 200 {"ok":true}
tracked L1 extraction completed
result: L1 extraction: extracted=1, stored=1
gateway root work count after completion: 0
```

<details>
<summary>webhook-agent-end-runtime-proof.mts</summary>

```typescript
import { createServer, request } from "node:http";
import { setTimeout as delay } from "node:timers/promises";
import { AsyncWorkScope, captureAsyncWorkTracker } from "./src/shared/async-work-scope.js";
import { runWithGatewayHttpWorkAdmission } from "./src/gateway/server/http-work-admission.js";
import {
  getActiveGatewayRootWorkCount,
  getActiveGatewayRootWorkHolders,
  resetGatewayWorkAdmission,
} from "./src/process/gateway-work-admission.js";
import { runDetachedWebhookWork } from "./src/plugin-sdk/webhook-request-guards.js";

const events: string[] = [];
let releaseProcessing!: () => void;
const processingGate = new Promise<void>((resolve) => {
  releaseProcessing = resolve;
});
let resolvePending!: () => void;
const pendingReady = new Promise<void>((resolve) => {
  resolvePending = resolve;
});
let detached: Promise<string> | undefined;

const server = createServer((_req, res) => {
  void (async () => {
    const triggeringScope = new AsyncWorkScope();
    await runWithGatewayHttpWorkAdmission(res, async () => {
      await triggeringScope.track(async () => {
        detached = runDetachedWebhookWork(async () => {
          events.push("plugin callback started (after ack)");
          const trackOwner = captureAsyncWorkTracker();
          await delay(25);
          await processingGate;
          return await trackOwner(async () => {
            events.push("tracked L1 extraction completed");
            return "L1 extraction: extracted=1, stored=1";
          });
        });
        res.statusCode = 200;
        res.setHeader("Content-Type", "application/json");
        res.end(JSON.stringify({ ok: true }));
        events.push("ack written (200 OK)");
        return true;
      });
      await triggeringScope.drain();
      events.push("triggering turn settled (async work scope closed)");
      events.push(
        `gateway holders while deferred work pending: ${JSON.stringify(getActiveGatewayRootWorkHolders())}`,
      );
      resolvePending();
      return true;
    });
  })().catch((error: unknown) => {
    events.push(`server error: ${String(error)}`);
  });
});

const listen = (): Promise<number> =>
  new Promise((resolve, reject) => {
    server.once("error", reject);
    server.listen(0, "127.0.0.1", () => {
      const address = server.address();
      if (!address || typeof address === "string") {
        reject(new Error("server did not bind to a TCP port"));
        return;
      }
      resolve(address.port);
    });
  });

const readResponse = (port: number): Promise<{ statusCode: number; body: string }> =>
  new Promise((resolve, reject) => {
    const client = request(
      {
        hostname: "127.0.0.1",
        port,
        method: "POST",
        path: "/webhook/agent-end",
        headers: { "Content-Type": "application/json" },
      },
      (res) => {
        const chunks: Buffer[] = [];
        res.on("data", (chunk: Buffer) => chunks.push(chunk));
        res.on("end", () =>
          resolve({
            statusCode: res.statusCode ?? 0,
            body: Buffer.concat(chunks).toString("utf8"),
          }),
        );
      },
    );
    client.on("error", reject);
    client.end(JSON.stringify({ event: "agent_end" }));
  });

let failure: unknown;
resetGatewayWorkAdmission();
try {
  const port = await listen();
  const response = await readResponse(port);
  await pendingReady;
  events.push(`client received ack ${response.statusCode} ${response.body}`);
  releaseProcessing();
  const result = await detached;
  events.push(`result: ${result}`);
  events.push(`gateway root work count after completion: ${getActiveGatewayRootWorkCount()}`);
} catch (error: unknown) {
  failure = error;
  events.push(`result: rejected: ${String(error)}`);
} finally {
  await new Promise<void>((resolve) => server.close(() => resolve()));
  resetGatewayWorkAdmission();
}
for (const event of events) {
  console.log(event);
}
if (failure) {
  throw failure;
}
```

</details>

AI-assisted: built with Codex
