### PR TITLE
fix(config): avoid false model changes when saving settings

### DIFF
--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -274,6 +274,85 @@ beforeEach(() => {
   mockLoadPluginManifestRegistry.mockReset().mockReturnValue({ diagnostics: [], plugins: [] });
 });
 
+describe("validateConfigObjectWithPlugins model metadata", () => {
+  it("does not discover plugins when materialization needs no metadata", () => {
+    expect(validateConfigObjectWithPlugins({ gateway: { mode: "local" } }).ok).toBe(true);
+    expect(mockLoadPluginManifestRegistry).not.toHaveBeenCalled();
+  });
+
+  it.each(["full", "skip"] as const)(
+    "loads catalog defaults before materialization with %s plugin validation",
+    (pluginValidation) => {
+      const source = {
+        plugins: { enabled: true },
+        models: {
+          providers: {
+            fixture: {
+              baseUrl: "https://models.example/v1",
+              models: [{ id: "vision-model", name: "Authored model", contextWindow: 64_000 }],
+            },
+          },
+        },
+      };
+      const original = structuredClone(source);
+      const cost = { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 };
+      mockLoadPluginManifestRegistry.mockReturnValue({
+        diagnostics: [],
+        plugins: [
+          createPluginManifestRecord({
+            id: "fixture",
+            providers: ["fixture"],
+            modelCatalog: {
+              providers: {
+                fixture: {
+                  models: [
+                    {
+                      id: "vision-model",
+                      name: "Catalog model",
+                      reasoning: true,
+                      input: ["text", "image"],
+                      cost,
+                      contextWindow: 128_000,
+                      maxTokens: 16_000,
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+        ],
+      });
+
+      const result = validateConfigObjectWithPlugins(source, { pluginValidation });
+
+      expect(result).toMatchObject({
+        ok: true,
+        config: {
+          models: {
+            providers: {
+              fixture: {
+                models: [
+                  {
+                    id: "vision-model",
+                    name: "Authored model",
+                    reasoning: true,
+                    input: ["text", "image"],
+                    cost,
+                    contextWindow: 64_000,
+                    maxTokens: 16_000,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+      expect(source).toEqual(original);
+      expect(mockLoadPluginManifestRegistry).toHaveBeenCalledOnce();
+    },
+  );
+});
+
 describe("validateConfigObjectWithPlugins channel metadata (applyDefaults: true)", () => {
   it("applies bundled channel defaults from plugin-owned schema metadata", () => {
     setupTelegramSchemaWithDefault();

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -222,6 +222,17 @@ function validateConfigObjectWithPluginsBase(
   let registryInfo: RegistryInfo | null = opts.pluginMetadataSnapshot
     ? rememberRegistry(opts.pluginMetadataSnapshot.manifestRegistry)
     : null;
+  const ensureLoadedRegistryInfo = (): RegistryInfo => {
+    registryInfo ??= rememberRegistry(
+      opts.loadPluginMetadataSnapshot?.(parsedConfig)?.manifestRegistry ??
+        resolveConfigWidePluginManifestRegistry({
+          config: parsedConfig,
+          env: opts.env ?? process.env,
+        }),
+    );
+    return registryInfo;
+  };
+
   if (opts.applyDefaults && !registryInfo && opts.pluginValidation !== "core-only") {
     const pluginMetadataSnapshot = opts.loadPluginMetadataSnapshot?.(parsedConfig);
     if (pluginMetadataSnapshot) {
@@ -235,6 +246,12 @@ function validateConfigObjectWithPluginsBase(
         manifestRegistry:
           registryInfo?.registry ??
           (opts.pluginValidation === "core-only" ? { plugins: [] } : undefined),
+        // Catalog defaults must use the same metadata as later plugin validation;
+        // generic defaults erase omitted fields and create false runtime diffs.
+        loadManifestRegistry:
+          opts.pluginValidation === "core-only"
+            ? undefined
+            : () => ensureLoadedRegistryInfo().registry,
       })
     : parsedConfig;
   if (opts.pluginValidation === "skip" || opts.pluginValidation === "core-only") {
@@ -280,22 +297,6 @@ function validateConfigObjectWithPluginsBase(
     }
   };
 
-  const loadValidationRegistry = (): RegistryInfo => {
-    const pluginMetadataSnapshot = opts.loadPluginMetadataSnapshot?.(config);
-    if (pluginMetadataSnapshot) {
-      registryInfo = rememberRegistry(pluginMetadataSnapshot.manifestRegistry);
-      return registryInfo;
-    }
-    const registry = resolveConfigWidePluginManifestRegistry({
-      config,
-      env: opts.env ?? process.env,
-    });
-    registryInfo = rememberRegistry(registry);
-    return registryInfo;
-  };
-
-  const ensureLoadedRegistryInfo = (): RegistryInfo => registryInfo ?? loadValidationRegistry();
-
   const ensureCompatPluginIds = (): ReadonlySet<string> => {
     if (compatPluginIds) {
       return compatPluginIds;
@@ -305,7 +306,7 @@ function validateConfigObjectWithPluginsBase(
       compatPluginIds = new Set<string>();
       return compatPluginIds;
     }
-    const { registry } = registryInfo ?? loadValidationRegistry();
+    const { registry } = ensureLoadedRegistryInfo();
     const overriddenBundledPluginIds = ensureOverriddenPluginIds();
     compatPluginIds = new Set(
       registry.plugins


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators saving unrelated settings would see configured models listed as changed when those model entries omit catalog metadata.

## Why This Change Was Made

Configuration validation now resolves plugin metadata before catalog-backed defaults need it, then reuses that registry for later validation. Discovery stays lazy, authored model overrides remain authoritative, and raw/core-only validation keeps its existing behavior.

## User Impact

Configuration writes compare consistent runtime model metadata, avoiding spurious model-change reports without changing the persisted configuration format.

## Evidence

- The new full/skip regression failed on the original code: sparse model entries acquired generic text-only, non-reasoning, zero-cost defaults instead of catalog values.
- On the final candidate, `node scripts/run-vitest.mjs src/config/validation.channel-metadata.test.ts src/config/config.model-ref-validation.test.ts --reporter=dot` passed: 2 files, 54 tests. Coverage includes catalog fields, explicit overrides, unchanged authored source, one registry load, lazy discovery, and the existing core-only/injected-metadata cases.
- Targeted Oxlint, `tsgo:core`, the config-cli test typecheck graph, and relevant configuration guards passed on the final source bytes.
- Independent autoreview found no actionable findings through P2 on those same bytes.
- The focused regressions prove the validation owner; a targeted repaired Gateway settings-save E2E run was not performed.
- Exact-head [hosted CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/34584072166/attempts/2) passed after one retry of the failed jobs. Attempt 1 had 189 passing jobs and 6 skips, with a Gateway cleanup failure and Windows subprocess fixture failures; both retry jobs passed without source changes.
- The [current ClawSweeper review](https://github.com/openclaw/openclaw/pull/144807#issuecomment-5632400901) found no actionable finding or remaining Rank-up move on this head.
- The later [normal PR CI run](https://github.com/openclaw/openclaw/actions/runs/34588558082/attempts/1) also passed on the unchanged head, on its first attempt.
