### PR TITLE
fix(logging): preserve OpenClaw package references in diagnostics

### DIFF
--- a/src/logging/diagnostic-support-redaction.test.ts
+++ b/src/logging/diagnostic-support-redaction.test.ts
@@ -161,6 +161,9 @@ describe("diagnostic support redaction", () => {
       ["event $OPENCLAW_STATE_DIR1", "event <redacted-matrix-event>"],
       ["event $PREFIX_OPENCLAW_STATE_DIR", "event <redacted-matrix-event>"],
       ["notify @support_bot now", "notify <redacted-handle> now"],
+      ["notify @openclaw now", "notify <redacted-handle> now"],
+      ["package @private_team/codex", "package <redacted-handle>/codex"],
+      ["package @openclaw_private/codex", "package <redacted-handle>/codex"],
       ["phone 15555551212", "phone <redacted-id>"],
       [
         `config password = ${["support", "password", "1234567890"].join("-")}`,
@@ -190,6 +193,27 @@ describe("diagnostic support redaction", () => {
       expect(redactTextForSupport(input)).toBe(expected);
     }
   });
+
+  it.each(["@openclaw/codex", "@openclaw/codex@latest", "@openclaw/codex@2026.9.3"])(
+    "preserves install guidance for %s beside private diagnostics across support handoffs",
+    (packageSpec) => {
+      const redaction = { env: {}, stateDir: tempDir };
+      const command = `openclaw plugins install ${packageSpec}`;
+      const input =
+        `Unable to resolve Codex doctor health API: install the official Codex plugin with ${command}\n` +
+        `Config: ${tempDir}/openclaw.json; contact @support_bot or alice@example.com\n` +
+        "Endpoint: https://gateway.example/ws?token=synthetic-secret&ok=1";
+      const expected =
+        `Unable to resolve Codex doctor health API: install the official Codex plugin with ${command}\n` +
+        "Config: $OPENCLAW_STATE_DIR/openclaw.json; contact <redacted-handle> or <redacted-email>\n" +
+        "Endpoint: https://gateway.example/ws?token=<redacted>&ok=1";
+
+      const sanitized = redactSupportString(input, redaction);
+
+      expect(sanitized).toBe(expected);
+      expect(redactSupportString(sanitized, redaction)).toBe(expected);
+    },
+  );
 
   it("preserves canonical state path markers across repeated support handoffs", () => {
     const redaction = { env: {}, stateDir: tempDir };

--- a/src/logging/diagnostic-support-redaction.ts
+++ b/src/logging/diagnostic-support-redaction.ts
@@ -32,7 +32,8 @@ const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu;
 const MATRIX_USER_ID_RE = /@[A-Za-z0-9._=-]+:[A-Za-z0-9.-]+/gu;
 const MATRIX_ROOM_ID_RE = /![A-Za-z0-9._=-]+:[A-Za-z0-9.-]+/gu;
 const MATRIX_EVENT_ID_RE = /\$[A-Za-z0-9_-]{16,}/gu;
-const HANDLE_RE = /(^|[^\w:/])@[A-Za-z0-9_]{5,}\b(?!\.)/gu;
+// Public OpenClaw package references must remain usable in repair commands.
+const HANDLE_RE = /(^|[^\w:/])@(?!openclaw\/[a-z0-9])[A-Za-z0-9_]{5,}\b(?!\.)/gu;
 const LONG_DECIMAL_ID_RE = /\b\d{9,}\b/gu;
 const MAX_SUPPORT_STRING_LENGTH = 2000;
 const MAX_SUPPORT_SNAPSHOT_DEPTH = 10;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw update` received a broken repair command: diagnostic redaction changed `@openclaw/codex` into `<redacted-handle>/codex`.

## Why This Change Was Made

Preserve public `@openclaw/` npm package references when scrubbing contact handles. Standalone handles, private scopes, paths, email addresses, and credentials retain their existing redaction.

## User Impact

Plugin installation commands remain copyable in update errors and support reports, including after repeated redaction.

## Evidence

- Three mixed-data regressions failed before the fix and passed afterward, covering unversioned, tagged, and versioned package references.
- All nine diagnostic-support-redaction tests pass.
- Independent P1 review: no findings.

- Full changed-file checks passed, including production/test typechecks and repository guards.
