### PR TITLE
refactor(auth): await Copilot cache persistence

### DIFF
--- a/src/plugin-sdk/provider-auth-copilot-cache.test.ts
+++ b/src/plugin-sdk/provider-auth-copilot-cache.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { COPILOT_INTEGRATION_ID } from "../agents/copilot-dynamic-headers.js";
+import * as pluginState from "../plugin-state/plugin-state-store.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import {
+  fingerprintCopilotSourceCredential,
+  resolveCopilotTokenCache,
+} from "./provider-auth-copilot-cache.js";
+import { resolveCopilotApiToken } from "./provider-auth.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  pluginState.resetPluginStateStoreForTests();
+});
+
+describe("Copilot cache completion", () => {
+  it.each(
+    (["load", "save"] as const).flatMap((operation) =>
+      (["resolve", "reject"] as const).map((outcome) => ({ operation, outcome })),
+    ),
+  )("awaits cache $operation through $outcome", async ({ operation, outcome }) => {
+    await withStateDirEnv("openclaw-copilot-async-", async ({ tempRoot }) => {
+      const env = { OPENCLAW_STATE_DIR: tempRoot, COPILOT_GITHUB_DOMAIN: "github.com" };
+      const githubToken = "synthetic-github-credential";
+      const cache = await resolveCopilotTokenCache({
+        env,
+        domain: "github.com",
+        sourceCredentialFingerprint: fingerprintCopilotSourceCredential(githubToken),
+      });
+      if (operation === "load") {
+        await cache.save({
+          token: "synthetic-cached-token",
+          expiresAt: Date.now() + 3_600_000,
+          updatedAt: Date.now(),
+          integrationId: COPILOT_INTEGRATION_ID,
+          sourceCredentialFingerprint: fingerprintCopilotSourceCredential(githubToken),
+          domain: "github.com",
+        });
+      }
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      const createStore = pluginState.createCorePluginStateKeyedStore;
+      vi.spyOn(pluginState, "createCorePluginStateKeyedStore").mockImplementation((options) => {
+        const store = createStore(options);
+        return {
+          ...store,
+          lookup: async (...args) => {
+            if (operation === "load") {
+              entered.resolve();
+              await release.promise;
+            }
+            return store.lookup(...args);
+          },
+          register: async (...args) => {
+            if (operation === "save") {
+              entered.resolve();
+              await release.promise;
+            }
+            return store.register(...args);
+          },
+        };
+      });
+      const fetchImpl = vi.fn<typeof fetch>(
+        async () =>
+          new Response(
+            JSON.stringify({
+              token: "synthetic-exchanged-token",
+              expires_at: Math.floor(Date.now() / 1_000) + 3_600,
+            }),
+          ),
+      );
+      const pending = resolveCopilotApiToken({ env, githubToken, fetchImpl });
+      let completed = false;
+      const settle = () => {
+        completed = true;
+        return "settled";
+      };
+      const settled = pending.then(settle, settle);
+      try {
+        expect(await Promise.race([entered.promise.then(() => "waiting"), settled])).toBe(
+          "waiting",
+        );
+        expect(completed).toBe(false);
+        expect(fetchImpl).toHaveBeenCalledTimes(operation === "load" ? 0 : 1);
+        if (outcome === "reject") {
+          const error = new Error("synthetic cache rejection");
+          release.reject(error);
+          await expect(pending).rejects.toBe(error);
+        } else {
+          release.resolve();
+          await expect(pending).resolves.toMatchObject({
+            token: operation === "load" ? "synthetic-cached-token" : "synthetic-exchanged-token",
+          });
+          pluginState.closePluginStateDatabase();
+          await expect(cache.load()).resolves.toMatchObject({
+            token: operation === "load" ? "synthetic-cached-token" : "synthetic-exchanged-token",
+          });
+        }
+      } finally {
+        release.resolve();
+        await settled;
+      }
+    });
+  });
+});

--- a/src/plugin-sdk/provider-auth-copilot-cache.ts
+++ b/src/plugin-sdk/provider-auth-copilot-cache.ts
@@ -63,8 +63,8 @@ export function isCopilotTokenUsable(params: {
 
 type CopilotTokenCache = {
   path: string;
-  load(): CachedCopilotToken | undefined;
-  save(value: CachedCopilotToken): void;
+  load(): Promise<CachedCopilotToken | undefined>;
+  save(value: CachedCopilotToken): Promise<void>;
 };
 
 export async function resolveCopilotTokenCache(params: {
@@ -87,14 +87,13 @@ export async function resolveCopilotTokenCache(params: {
     const saveJsonFileFn = params.saveJsonFileImpl ?? writeJsonTarget;
     return {
       path: cachePath,
-      load: () => loadJsonFileFn(cachePath) as CachedCopilotToken | undefined,
-      save: (value) => saveJsonFileFn(cachePath, value),
+      load: async () => loadJsonFileFn(cachePath) as CachedCopilotToken | undefined,
+      save: async (value) => saveJsonFileFn(cachePath, value),
     };
   }
 
-  const { createCorePluginStateSyncKeyedStore } =
-    await import("../plugin-state/plugin-state-store.js");
-  const store = createCorePluginStateSyncKeyedStore<CachedCopilotToken>({
+  const { createCorePluginStateKeyedStore } = await import("../plugin-state/plugin-state-store.js");
+  const store = createCorePluginStateKeyedStore<CachedCopilotToken>({
     ownerId: "core:provider-auth",
     namespace: COPILOT_CACHE_NAMESPACE,
     maxEntries: COPILOT_TOKEN_CACHE_MAX_ENTRIES,

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -313,7 +313,7 @@ export async function resolveCopilotApiToken(params: {
     ...(params.saveJsonFileImpl ? { saveJsonFileImpl: params.saveJsonFileImpl } : {}),
   });
   const cachePath = cache.path;
-  const cached = cache.load();
+  const cached = await cache.load();
   if (cached && typeof cached.token === "string" && typeof cached.expiresAt === "number") {
     // Token cache entries are scoped to the current Copilot integration id and
     // GitHub host so stale tokens from older editor identities or a different
@@ -368,7 +368,7 @@ export async function resolveCopilotApiToken(params: {
     sourceCredentialFingerprint,
     domain,
   };
-  cache.save(payload);
+  await cache.save(payload);
 
   return {
     token: payload.token,


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Copilot token resolution still reads and writes its SQLite cache through synchronous persistence contracts. It needs to retain the cache operation before returning a token when persistence becomes asynchronous.

## Why This Change Was Made

Use the existing asynchronous core keyed store and await both cache lookup and save. Preserve the shipped explicit cache-file and injected JSON callback options, credential scoping, expiry checks, and token exchange behavior.

## User Impact

Authentication behavior and stored data stay compatible. A cache save finishes before token resolution returns. This is API groundwork; moving native SQLite execution into workers remains tracked by the umbrella issue.

## Evidence

- 30 focused tests and the full selected changed checks passed.
- Fresh independent Codex review through P2 passed. The rebase onto the landed core-store prerequisite is patch-identical.
- Synthetic loopback token exchange with real SQLite persistence and a second process verified cache reuse: the first exchange took 146.46 ms with one HTTP request; reopening took 5.02 ms with zero HTTP requests. These measure different paths and are not a speedup comparison.
- Existing synchronous injected JSON callbacks remain supported. No real provider credentials were used.
