### PR TITLE
fix(doctor): explain Codex plugin health failures

### DIFF
--- a/src/flows/bundled-health-checks.test.ts
+++ b/src/flows/bundled-health-checks.test.ts
@@ -583,11 +583,13 @@ describe("registerBundledHealthChecks", () => {
       writeFileSync(join(workspaceDir, "api.js"), 'throw new Error("selected artifact failed");');
     }
     expect(() => registerBundledHealthChecks({ cfg: codexConfig, cwd: workspaceDir })).toThrow(
-      state === "broken-api"
-        ? "selected artifact failed"
-        : state === "missing-export"
-          ? TypeError
-          : MissingPublicSurfaceError,
+      state === "missing"
+        ? "The configured Codex plugin was not found. Install it with openclaw plugins install @openclaw/codex."
+        : state.startsWith("untrusted")
+          ? "The selected Codex plugin is not a bundled or verified official installation. Run openclaw plugins inspect codex --runtime --json to inspect its source; install the official plugin with openclaw plugins install @openclaw/codex."
+          : state === "missing-export"
+            ? "The selected Codex plugin's Doctor health checks are incomplete. Run openclaw plugins inspect codex --runtime --json for details, or openclaw triage for repair help."
+            : "The selected Codex plugin declares Doctor health checks but its health API could not be loaded. Run openclaw plugins inspect codex --runtime --json for details, or openclaw triage for repair help.",
     );
     expect(getHealthCheck("codex/managed-app-server")).toBeUndefined();
     expect(mocks.registerCodexManagedAppServerDoctorChecks).not.toHaveBeenCalled();

--- a/src/flows/bundled-health-checks.ts
+++ b/src/flows/bundled-health-checks.ts
@@ -193,21 +193,43 @@ function registerCodexHealthChecks(
     const owner = registry.plugins.find((plugin) => plugin.id === "codex");
     // Doctor must inspect the selected runtime's artifact, including official external installs.
     // A bundled-first lookup can inspect a different version or bypass the selected owner's trust.
-    if (!owner || (owner.origin !== "bundled" && owner.trustedOfficialInstall !== true)) {
+    if (!owner) {
       throw new MissingPublicSurfaceError(
-        "Unable to resolve Codex doctor health API: install the official Codex plugin with openclaw plugins install @openclaw/codex",
+        "The configured Codex plugin was not found. Install it with openclaw plugins install @openclaw/codex.",
+      );
+    }
+    if (owner.origin !== "bundled" && owner.trustedOfficialInstall !== true) {
+      throw new MissingPublicSurfaceError(
+        "The selected Codex plugin is not a bundled or verified official installation. Run openclaw plugins inspect codex --runtime --json to inspect its source; install the official plugin with openclaw plugins install @openclaw/codex.",
       );
     }
     // Retained stable plugins can predate health APIs while an upgrade awaits capability consent.
     // Only load an advertised surface; a broken declaration must still fail visibly.
     if (owner.doctorHealthChecks === true) {
-      loadPluginPublicArtifactModuleSync<
-        Required<Pick<BundledHealthApi, "registerCodexManagedAppServerDoctorChecks">>
-      >({
-        pluginRoot: owner.rootDir,
-        artifactBasename: "api.js",
-        origin: owner.origin === "bundled" ? "bundled" : "global",
-      }).registerCodexManagedAppServerDoctorChecks({
+      let api: Pick<BundledHealthApi, "registerCodexManagedAppServerDoctorChecks">;
+      try {
+        api = loadPluginPublicArtifactModuleSync({
+          pluginRoot: owner.rootDir,
+          artifactBasename: "api.js",
+          origin: owner.origin === "bundled" ? "bundled" : "global",
+        });
+      } catch (cause) {
+        throw new MissingPublicSurfaceError(
+          "The selected Codex plugin declares Doctor health checks but its health API could not be loaded. Run openclaw plugins inspect codex --runtime --json for details, or openclaw triage for repair help.",
+          { cause },
+        );
+      }
+      if (typeof api.registerCodexManagedAppServerDoctorChecks !== "function") {
+        throw new MissingPublicSurfaceError(
+          "The selected Codex plugin's Doctor health checks are incomplete. Run openclaw plugins inspect codex --runtime --json for details, or openclaw triage for repair help.",
+          {
+            cause: new TypeError(
+              "Codex health API must export registerCodexManagedAppServerDoctorChecks",
+            ),
+          },
+        );
+      }
+      api.registerCodexManagedAppServerDoctorChecks({
         getHealthCheck,
         registerHealthCheck: registerCheck,
       });

--- a/src/infra/update-candidate-plugin-tree.ts
+++ b/src/infra/update-candidate-plugin-tree.ts
@@ -81,7 +81,7 @@ export async function copyUpdateCandidatePluginTrees(params: {
   }
   function assertSource(source: string) {
     if (isPathInside(source, privateRoot) || isPathInside(privateRoot, source)) {
-      throw new Error("Plugin copy source overlaps candidate state");
+      throw new Error("Plugin copy source overlaps update state");
     }
   }
   async function discoverHoistedDependencies(directory: string): Promise<void> {
@@ -338,7 +338,7 @@ export async function copyUpdateCandidatePluginTrees(params: {
   for (const [source, target] of copies) {
     const destination = resolvePathViaExistingAncestorSync(target);
     if (!isPathInside(privateRoot, destination)) {
-      throw new Error("Plugin copy destination escapes candidate state");
+      throw new Error("Plugin copy destination escapes update state");
     }
     for (const [other] of copies) {
       if (isPathInside(other, destination) || isPathInside(destination, other)) {
@@ -360,7 +360,7 @@ export async function copyUpdateCandidatePluginTrees(params: {
   // literal node_modules directory and cannot bind a relocated module owner.
   for (const link of hostLinks) {
     if (!isPathInside(privateRoot, resolvePathViaExistingAncestorSync(path.dirname(link)))) {
-      throw new Error("Plugin host link escapes candidate state");
+      throw new Error("Plugin host link escapes update state");
     }
     await fs.mkdir(path.dirname(link), { recursive: true });
     const existing = await fs.lstat(link).catch((error: unknown) => {
@@ -374,7 +374,7 @@ export async function copyUpdateCandidatePluginTrees(params: {
         !existing.isSymbolicLink() ||
         path.resolve(path.dirname(link), await fs.readlink(link)) !== candidateRoot
       ) {
-        throw new Error("Plugin host link conflicts with its candidate owner");
+        throw new Error("Plugin host link conflicts with its update owner");
       }
     } else {
       await fs.symlink(candidateRoot, link, process.platform === "win32" ? "junction" : "dir");
@@ -388,7 +388,7 @@ export async function copyUpdateCandidatePluginTrees(params: {
       : params.project(source);
     const target = projected(real);
     if (!isPathInside(privateRoot, resolvePathViaExistingAncestorSync(path.dirname(alias)))) {
-      throw new Error("Plugin module alias escapes candidate state");
+      throw new Error("Plugin module alias escapes update state");
     }
     const existing = await fs.lstat(alias).catch((error: unknown) => {
       if (hasNodeErrorCode(error, "ENOENT")) {
@@ -413,7 +413,7 @@ export async function copyUpdateCandidatePluginTrees(params: {
         !stat.isSymbolicLink() ||
         path.resolve(path.dirname(file), await fs.readlink(file)) !== candidateRoot
       ) {
-        throw new Error("Copied plugin host link does not target the candidate");
+        throw new Error("Copied plugin host link does not target the update");
       }
       return;
     }
@@ -425,7 +425,7 @@ export async function copyUpdateCandidatePluginTrees(params: {
         !isPathInside(privateRoot, target) &&
         !(isHostLauncher(file) && isPathInside(candidateRoot, target))
       ) {
-        throw new Error("Copied plugin symlink escapes candidate state");
+        throw new Error("Copied plugin symlink escapes update state");
       }
       return;
     }

--- a/src/infra/update-candidate-rehearsal.ts
+++ b/src/infra/update-candidate-rehearsal.ts
@@ -54,7 +54,7 @@ function isolatedConfig(
   const projectPluginPath = (value: string) => {
     const projected = pluginPaths[resolveUserPath(value, sourceEnv)];
     if (!projected) {
-      throw new Error("Plugin locator was not included in the candidate snapshot");
+      throw new Error("Plugin locator was not included in the update snapshot");
     }
     return projected;
   };
@@ -134,7 +134,7 @@ export async function prepareUpdateCandidateRehearsal(params: {
     params.signal?.throwIfAborted();
     const milliseconds = deadline - Date.now();
     if (milliseconds <= 0) {
-      throw new Error("Candidate snapshot deadline exceeded");
+      throw new Error("Update snapshot deadline exceeded");
     }
     return milliseconds;
   };
@@ -247,7 +247,7 @@ export async function prepareUpdateCandidateRehearsal(params: {
     );
     if (snapshot.code !== 0) {
       throw new Error(
-        `Candidate state snapshot failed (${snapshot.termination}): ${redactSupportString(snapshot.stderr.toString("utf8"), { env: sourceEnv, stateDir: params.stateDir }, { maxLength: 20_000 })}`,
+        `Update state snapshot failed (${snapshot.termination}): ${redactSupportString(snapshot.stderr.toString("utf8"), { env: sourceEnv, stateDir: params.stateDir }, { maxLength: 20_000 })}`,
       );
     }
     const { pluginPaths } = UpdateCandidateStateSnapshotSchema.parse(
@@ -282,7 +282,7 @@ export async function prepareUpdateCandidateRehearsal(params: {
       changedConfigKeys: async () => {
         const current: unknown = JSON5.parse(await fs.readFile(configPath, "utf8"));
         if (!isRecord(current)) {
-          throw new Error("Rehearsal config is not an object.");
+          throw new Error("Update validation config is not an object.");
         }
         // Compare against the same live config projection: private paths, the
         // canary token and disabled background services are isolation, not repairs.


### PR DESCRIPTION
## What Problem This Solves

Codex Doctor reported the same installation command when the plugin was missing or its selected source was untrusted. Broken health APIs could instead expose an implementation error.

## Why This Change Was Made

Distinguish missing plugins, unverified sources, unloadable health APIs, and incomplete health checks. Each failure gives an appropriate installation or inspection command and repair guidance. Preserve trust enforcement and underlying causes. Update snapshot failures also use plain update terminology.

The reported old-updater failure was reproduced against `853d0c0`: its snapshot projector changed bundled plugin ownership to an untrusted global copy and selected the old payload. The producer fix is already on main in #143190, including the reported target `6aab56d5`; this PR improves diagnosis without adding another projection path.

## User Impact

Doctor explains why the selected Codex plugin cannot provide health checks, instead of incorrectly treating every failure as a missing installation.

## Evidence

- Six diagnostic regression cases failed before this change.
- 117 focused tests passed across health registration, Doctor, and snapshot/provenance behavior.
- Full build, changed checks including typechecks, targeted infrastructure lint, and `git diff --check` passed.
- Independent P1 review: no findings.

Related: #144808 preserves public package names; #144811 surfaces the health error once in update output.
