### PR TITLE
refactor(android): share discovery TXT boolean parsing

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -282,7 +282,7 @@ class GatewayDiscovery(
     val lanHost = txt(resolved, "lanHost")
     val tailnetDns = txt(resolved, "tailnetDns")
     val gatewayPort = txtInt(resolved, "gatewayPort")
-    val tlsEnabled = txtBool(resolved, "gatewayTls")
+    val tlsEnabled = parseTxtBool(txt(resolved, "gatewayTls"))
     val tlsFingerprint = txt(resolved, "gatewayTlsSha256")
     val id = stableId(serviceName, "local.")
     // Local NSD gives the socket host/port; TXT ports are retained as gateway metadata only.
@@ -346,11 +346,8 @@ class GatewayDiscovery(
     key: String,
   ): Int? = txt(info, key)?.toIntOrNull()
 
-  private fun txtBool(
-    info: NsdServiceInfo,
-    key: String,
-  ): Boolean {
-    val raw = txt(info, key)?.trim()?.lowercase() ?: return false
+  private fun parseTxtBool(value: String?): Boolean {
+    val raw = value?.trim()?.lowercase() ?: return false
     return raw == "1" || raw == "true" || raw == "yes"
   }
 
@@ -396,7 +393,7 @@ class GatewayDiscovery(
       val lanHost = txtValue(txt, "lanHost")
       val tailnetDns = txtValue(txt, "tailnetDns")
       val gatewayPort = txtIntValue(txt, "gatewayPort")
-      val tlsEnabled = txtBoolValue(txt, "gatewayTls")
+      val tlsEnabled = parseTxtBool(txtValue(txt, "gatewayTls"))
       val tlsFingerprint = txtValue(txt, "gatewayTlsSha256")
       val id = stableId(instanceName, domain)
       next[id] =
@@ -648,14 +645,6 @@ class GatewayDiscovery(
     records: List<TXTRecord>,
     key: String,
   ): Int? = txtValue(records, key)?.toIntOrNull()
-
-  private fun txtBoolValue(
-    records: List<TXTRecord>,
-    key: String,
-  ): Boolean {
-    val raw = txtValue(records, key)?.trim()?.lowercase() ?: return false
-    return raw == "1" || raw == "true" || raw == "yes"
-  }
 
   private fun decodeDnsTxtString(raw: String): String {
     // dnsjava treats TXT as opaque bytes and decodes as ISO-8859-1 to preserve bytes.


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Android's local NSD and DNS discovery paths separately implement the same interpretation of the `gatewayTls` TXT flag. This requested refactor gives that boolean parsing one owner while preserving the distinct discovery readers.

## Why This Change Was Made

Use one private nullable-string parser after the existing NSD and DNS TXT readers. Preserve trimming, case normalization, accepted `1`/`true`/`yes` values, false for missing or other values, and one read at each existing call site.

## User Impact

No intended behavior change. Discovery results, TLS hints, and certificate trust/pinning policy remain unchanged. No configuration, dependency, or public API changes.

## Evidence

- Original and candidate each passed 32 characterization cases: 31 owner/NSD cases and one controlled DNS case. This is PASS/PASS coverage, not a reproduced-bug RED/GREEN result.
- Selected checks and the native schema guard passed. All four selected `ktlintCheck` tasks passed. Oxfmt matched no Kotlin files and is not claimed as Kotlin formatting proof.
- Independent P2 review was accepted with no findings.

Proof uses controlled local fixtures. It does not establish real-device behavior, external/live DNS, a TLS handshake, full-suite qualification, or whole-current-main qualification. Hosted CI passed for exact head `f553bf0998b3b564c8afee13195da048575b5f00`: https://github.com/openclaw/openclaw/actions/runs/34584555687, including the required `openclaw/ci-gate`.
