### PR TITLE
refactor(boards): await storage and retain current authority

### DIFF
--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -38,6 +38,19 @@ admission. Publish live session changes and other dependent effects only after
 the durable write succeeds. A future network-backed owner must preserve that
 ordering while awaiting its driver.
 
+Board operations, board inventory reads, and widget document reads expose asynchronous
+contracts. Gateway callers await persistence before publishing board changes or replies.
+Writes carry the caller's current-authority assertion into the synchronous SQLite
+transaction. HTML widget capability actions and protected publication run in the store's immediate
+continuation after its authoritative read and current ticket, session, and grant checks.
+Database ownership is released before awaiting external work; no Promise handoff separates
+the final authorization from its use. SQLite execution remains synchronous inside the
+store, with existing revision, grant, and transaction semantics.
+
+MCP App pinning retains its existing source-interaction checks. A delayed adapter must
+revalidate that source authority at its actual write admission; checking view registration
+alone cannot replace the supported asynchronous interaction policy.
+
 Explicit session deletion, lifecycle-artifact cleanup, and history disk-budget
 eviction prepare their plans inside the session writer queue. When the parent database handle is cold, its
 existing asynchronous admission owner runs the full integrity and foreign-key

--- a/src/boards/board-generated-identity.test.ts
+++ b/src/boards/board-generated-identity.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { BoardStore } from "./board-store.js";
-import { createTestBoardStore } from "./board-store.test-support.js";
+import { readBoardHtml, createTestBoardStore } from "./board-store.test-support.js";
 import { SqliteBoardStore } from "./sqlite-board-store.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -39,9 +39,9 @@ afterEach(() => {
 
 describe("generated BoardStore identity", () => {
   const createStore = createSqliteStore;
-  it("keeps colliding titles distinct and canonical spellings stable", () => {
+  it("keeps colliding titles distinct and canonical spellings stable", async () => {
     const store = createStore();
-    const composed = store.putWidget({
+    const composed = await store.putWidget({
       sessionKey: "agent:main:board",
       name: "cafe-menu",
       title: "Café Menu",
@@ -50,7 +50,7 @@ describe("generated BoardStore identity", () => {
     });
     expect(composed.resolvedWidgetName).toBe("cafe-menu");
 
-    const decomposed = store.putWidget({
+    const decomposed = await store.putWidget({
       sessionKey: "agent:main:board",
       name: "cafe-menu",
       title: "Cafe\u0301 Menu",
@@ -62,7 +62,7 @@ describe("generated BoardStore identity", () => {
       widgets: [{ name: "cafe-menu", revision: 2 }],
     });
 
-    const plain = store.putWidget({
+    const plain = await store.putWidget({
       sessionKey: "agent:main:board",
       name: "cafe-menu",
       title: "Cafe Menu",
@@ -71,11 +71,11 @@ describe("generated BoardStore identity", () => {
     });
     expect(plain.resolvedWidgetName).toBe("cafe-menu-bbbbbbbb");
     expect(plain.widgets.map((widget) => widget.name)).toEqual(["cafe-menu", "cafe-menu-bbbbbbbb"]);
-    expect(store.readWidgetHtml({ sessionKey: "agent:main:board" }, "cafe-menu")?.html).toContain(
-      "accented revised",
-    );
+    expect(
+      (await readBoardHtml(store, { sessionKey: "agent:main:board" }, "cafe-menu"))?.html,
+    ).toContain("accented revised");
 
-    const plainUpdate = store.putWidget({
+    const plainUpdate = await store.putWidget({
       sessionKey: "agent:main:board",
       name: "cafe-menu",
       title: "Cafe Menu",
@@ -91,22 +91,22 @@ describe("generated BoardStore identity", () => {
     });
   });
 
-  it("keeps same-title explicit takeovers distinct from later generated pins", () => {
+  it("keeps same-title explicit takeovers distinct from later generated pins", async () => {
     const store = createStore();
-    store.putWidget({
+    await store.putWidget({
       sessionKey: "agent:main:board",
       name: "release-status",
       title: "Release Status",
       content: { kind: "html", html: "<p>generated</p>" },
       generatedIdentity: generatedIdentity("c", "release-status-cccccccc"),
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey: "agent:main:board",
       name: "release-status",
       title: "Release Status",
       content: { kind: "html", html: "<p>manual</p>" },
     });
-    const generatedAfterTakeover = store.putWidget({
+    const generatedAfterTakeover = await store.putWidget({
       sessionKey: "agent:main:board",
       name: "release-status",
       title: "Release Status",
@@ -116,26 +116,26 @@ describe("generated BoardStore identity", () => {
     expect(generatedAfterTakeover.resolvedWidgetName).toBe("release-status-cccccccc");
     expect(generatedAfterTakeover.widgets).toHaveLength(2);
     expect(
-      store.readWidgetHtml({ sessionKey: "agent:main:board" }, "release-status")?.html,
+      (await readBoardHtml(store, { sessionKey: "agent:main:board" }, "release-status"))?.html,
     ).toContain("manual");
   });
 
-  it("fails closed instead of overwriting an occupied deterministic fallback", () => {
+  it("fails closed instead of overwriting an occupied deterministic fallback", async () => {
     const store = createStore();
-    store.putWidget({
+    await store.putWidget({
       sessionKey: "agent:main:board",
       name: "status",
       title: "Manual",
       content: { kind: "html", html: "manual" },
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey: "agent:main:board",
       name: "status-dddddddd",
       title: "Reserved",
       content: { kind: "html", html: "reserved" },
     });
 
-    expect(() =>
+    await expect(
       store.putWidget({
         sessionKey: "agent:main:board",
         name: "status",
@@ -143,13 +143,13 @@ describe("generated BoardStore identity", () => {
         content: { kind: "html", html: "generated" },
         generatedIdentity: generatedIdentity("d", "status-dddddddd"),
       }),
-    ).toThrow("generated widget fallback name is already in use");
-    expect(store.getSnapshot({ sessionKey: "agent:main:board" }).widgets).toHaveLength(2);
+    ).rejects.toThrow("generated widget fallback name is already in use");
+    expect((await store.getSnapshot({ sessionKey: "agent:main:board" })).widgets).toHaveLength(2);
   });
 
-  it("rejects a fallback that is not distinct even on an empty board", () => {
+  it("rejects a fallback that is not distinct even on an empty board", async () => {
     const store = createStore();
-    expect(() =>
+    await expect(
       store.putWidget({
         sessionKey: "agent:main:board",
         name: "status",
@@ -157,11 +157,11 @@ describe("generated BoardStore identity", () => {
         content: { kind: "html", html: "generated" },
         generatedIdentity: generatedIdentity("f", "status"),
       }),
-    ).toThrow("generated widget fallback name must differ from its preferred name");
+    ).rejects.toThrow("generated widget fallback name must differ from its preferred name");
   });
 });
 
-it("preserves a beta.5-format unmarked explicit row and reuses the generated fallback", () => {
+it("preserves a beta.5-format unmarked explicit row and reuses the generated fallback", async () => {
   const env = { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-board-beta5-identity-") };
   const sessionKey = "agent:main:beta5-identity";
   seedSession(env, sessionKey);
@@ -170,27 +170,27 @@ it("preserves a beta.5-format unmarked explicit row and reuses the generated fal
     env,
   };
   const store = new SqliteBoardStore(options);
-  store.putWidget({
+  await store.putWidget({
     sessionKey,
     name: "anchor",
     title: "Anchor",
     content: { kind: "html", html: "<p>anchor</p>" },
   });
-  const legacy = store.putWidget({
+  const legacy = await store.putWidget({
     sessionKey,
     name: "cafe-menu",
     title: "Café Menu",
     content: { kind: "html", html: "<p>approved</p>" },
     declared: { tools: ["menu.refresh"] },
   });
-  store.grant(
+  await store.grant(
     { sessionKey },
     "cafe-menu",
     "granted",
     1,
     legacy.widgets.find((widget) => widget.name === "cafe-menu")?.instanceId,
   );
-  store.applyOps({ sessionKey }, [
+  await store.applyOps({ sessionKey }, [
     { kind: "widget_resize", name: "cafe-menu", sizeW: 8, sizeH: 6 },
   ]);
   const seededDatabase = openOpenClawAgentDatabase({ agentId: "main", env });
@@ -204,7 +204,7 @@ it("preserves a beta.5-format unmarked explicit row and reuses the generated fal
   closeOpenClawStateDatabaseForTest();
 
   const reopened = new SqliteBoardStore(options);
-  const generated = reopened.putWidget({
+  const generated = await reopened.putWidget({
     sessionKey,
     name: "cafe-menu",
     title: "Cafe\u0301 Menu",
@@ -220,13 +220,13 @@ it("preserves a beta.5-format unmarked explicit row and reuses the generated fal
     sizeH: 6,
     position: 1,
   });
-  expect(reopened.readWidgetHtml({ sessionKey }, "cafe-menu")?.html).toContain("approved");
+  expect((await readBoardHtml(reopened, { sessionKey }, "cafe-menu"))?.html).toContain("approved");
 
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
 
   const durable = new SqliteBoardStore(options);
-  const reused = durable.putWidget({
+  const reused = await durable.putWidget({
     sessionKey,
     name: "cafe-menu",
     title: "Café Menu",
@@ -237,13 +237,13 @@ it("preserves a beta.5-format unmarked explicit row and reuses the generated fal
   expect(reused.widgets.find((widget) => widget.name === "cafe-menu-eeeeeeee")).toMatchObject({
     revision: 2,
   });
-  expect(durable.readWidgetHtml({ sessionKey }, "cafe-menu")?.html).toContain("approved");
+  expect((await readBoardHtml(durable, { sessionKey }, "cafe-menu"))?.html).toContain("approved");
   closeOpenClawAgentDatabasesForTest();
 
   expect(
-    new SqliteBoardStore(options)
-      .getSnapshot({ sessionKey })
-      .widgets.find((widget) => widget.name === "cafe-menu"),
+    (await new SqliteBoardStore(options).getSnapshot({ sessionKey })).widgets.find(
+      (widget) => widget.name === "cafe-menu",
+    ),
   ).toMatchObject({
     name: "cafe-menu",
     revision: 1,
@@ -261,7 +261,7 @@ it("preserves a beta.5-format unmarked explicit row and reuses the generated fal
   });
 });
 
-it("does not infer generated ownership from a canonical unmarked title match", () => {
+it("does not infer generated ownership from a canonical unmarked title match", async () => {
   const env = { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-board-canonical-legacy-") };
   const sessionKey = "agent:main:canonical-legacy";
   seedSession(env, sessionKey);
@@ -270,7 +270,7 @@ it("does not infer generated ownership from a canonical unmarked title match", (
     env,
   };
   const store = new SqliteBoardStore(options);
-  store.putWidget({
+  await store.putWidget({
     sessionKey,
     name: "widget-e3b21956",
     title: "が",
@@ -285,7 +285,7 @@ it("does not infer generated ownership from a canonical unmarked title match", (
   closeOpenClawAgentDatabasesForTest();
 
   const reopened = new SqliteBoardStore(options);
-  const generated = reopened.putWidget({
+  const generated = await reopened.putWidget({
     sessionKey,
     name: "widget-f62b28f7",
     title: "が",
@@ -294,10 +294,12 @@ it("does not infer generated ownership from a canonical unmarked title match", (
   });
   expect(generated.resolvedWidgetName).toBe("widget-f62b28f7");
   expect(generated.widgets).toHaveLength(2);
-  expect(reopened.readWidgetHtml({ sessionKey }, "widget-e3b21956")?.html).toContain("legacy");
+  expect((await readBoardHtml(reopened, { sessionKey }, "widget-e3b21956"))?.html).toContain(
+    "legacy",
+  );
 });
 
-it("preserves unmarked rows whose absent or capped titles are ambiguous", () => {
+it("preserves unmarked rows whose absent or capped titles are ambiguous", async () => {
   const env = { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-board-ambiguous-legacy-") };
   const sessionKey = "agent:main:ambiguous-legacy";
   seedSession(env, sessionKey);
@@ -307,12 +309,12 @@ it("preserves unmarked rows whose absent or capped titles are ambiguous", () => 
   };
   const store = new SqliteBoardStore(options);
   const cappedTitle = `${"!".repeat(79)}a`;
-  store.putWidget({
+  await store.putWidget({
     sessionKey,
     name: "status",
     content: { kind: "html", html: "<p>manual untitled</p>" },
   });
-  store.putWidget({
+  await store.putWidget({
     sessionKey,
     name: "report",
     title: cappedTitle,
@@ -327,13 +329,13 @@ it("preserves unmarked rows whose absent or capped titles are ambiguous", () => 
   closeOpenClawAgentDatabasesForTest();
 
   const reopened = new SqliteBoardStore(options);
-  const untitled = reopened.putWidget({
+  const untitled = await reopened.putWidget({
     sessionKey,
     name: "status",
     content: { kind: "html", html: "<p>generated untitled</p>" },
     generatedIdentity: generatedIdentity("b", "status-bbbbbbbb"),
   });
-  const long = reopened.putWidget({
+  const long = await reopened.putWidget({
     sessionKey,
     name: "report",
     title: cappedTitle,
@@ -343,11 +345,13 @@ it("preserves unmarked rows whose absent or capped titles are ambiguous", () => 
 
   expect(untitled.resolvedWidgetName).toBe("status-bbbbbbbb");
   expect(long.resolvedWidgetName).toBe("report-cccccccc");
-  expect(reopened.readWidgetHtml({ sessionKey }, "status")?.html).toContain("manual untitled");
-  expect(reopened.readWidgetHtml({ sessionKey }, "report")?.html).toContain("legacy long");
+  expect((await readBoardHtml(reopened, { sessionKey }, "status"))?.html).toContain(
+    "manual untitled",
+  );
+  expect((await readBoardHtml(reopened, { sessionKey }, "report"))?.html).toContain("legacy long");
 });
 
-it("persists explicit ownership across restart", () => {
+it("persists explicit ownership across restart", async () => {
   const env = { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-board-explicit-owner-") };
   const sessionKey = "agent:main:explicit-owner";
   seedSession(env, sessionKey);
@@ -355,7 +359,7 @@ it("persists explicit ownership across restart", () => {
     resolveSession: () => ({ agentId: "main", sessionKey }),
     env,
   };
-  new SqliteBoardStore(options).putWidget({
+  await new SqliteBoardStore(options).putWidget({
     sessionKey,
     name: "status",
     title: "Status",
@@ -364,7 +368,7 @@ it("persists explicit ownership across restart", () => {
   closeOpenClawAgentDatabasesForTest();
 
   const reopened = new SqliteBoardStore(options);
-  const generated = reopened.putWidget({
+  const generated = await reopened.putWidget({
     sessionKey,
     name: "status",
     title: "Status",
@@ -372,5 +376,5 @@ it("persists explicit ownership across restart", () => {
     generatedIdentity: generatedIdentity("d", "status-dddddddd"),
   });
   expect(generated.resolvedWidgetName).toBe("status-dddddddd");
-  expect(reopened.readWidgetHtml({ sessionKey }, "status")?.html).toContain("manual");
+  expect((await readBoardHtml(reopened, { sessionKey }, "status"))?.html).toContain("manual");
 });

--- a/src/boards/board-store.parity.test.ts
+++ b/src/boards/board-store.parity.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { replaceSessionEntrySync } from "../config/sessions/session-accessor.entry.js";
 import { deleteSessionEntryLifecycle } from "../config/sessions/session-accessor.js";
@@ -11,8 +11,7 @@ import {
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import type { BoardStore } from "./board-store.js";
-import { createTestBoardStore } from "./board-store.test-support.js";
+import { readBoardHtml, createTestBoardStore } from "./board-store.test-support.js";
 import { SqliteBoardStore } from "./sqlite-board-store.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -27,50 +26,17 @@ function seedSession(env: NodeJS.ProcessEnv, agentId: string, sessionKey: string
   return database.path;
 }
 
-function createSqliteStore(): BoardStore {
-  return createTestBoardStore();
-}
-
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
 });
 
-it("does not select the HTML BLOB when preparing board view metadata", () => {
-  const stateDir = tempDirs.make("openclaw-board-projection-");
-  const env = { OPENCLAW_STATE_DIR: stateDir };
-  const sessionKey = "agent:main:projection";
-  seedSession(env, "main", sessionKey);
-  const database = openOpenClawAgentDatabase({ agentId: "main", env });
-  const store = new SqliteBoardStore({
-    resolveSession: () => ({ agentId: "main", sessionKey }),
-    env,
-  });
-  store.putWidget({
-    sessionKey,
-    name: "status",
-    content: { kind: "html", html: "x".repeat(256 * 1024) },
-  });
-  const prepare = vi.spyOn(database.db, "prepare");
-
-  const prepared = store.getSnapshotWithHtmlViewMetadata({ sessionKey });
-
-  const widgetSelects = prepare.mock.calls
-    .map(([sql]) => sql)
-    .filter((sql) => /select .* from "board_widgets"/iu.test(sql));
-  expect(widgetSelects).toHaveLength(1);
-  expect(widgetSelects[0]).toContain('"sha256"');
-  expect(widgetSelects[0]).not.toContain('"html"');
-  expect(prepared.htmlViewMetadata.get("status")).not.toHaveProperty("html");
-  prepare.mockRestore();
-});
-
 describe("SqliteBoardStore behavior", () => {
-  const createStore = createSqliteStore;
+  const createStore = createTestBoardStore;
   const boardSession = { sessionKey: "agent:main:board" };
-  it("persists revisions, layout, bytes, and declared summaries", () => {
+  it("persists revisions, layout, bytes, and declared summaries", async () => {
     const store = createStore();
-    const first = store.putWidget({
+    const first = await store.putWidget({
       ...boardSession,
       name: "weather",
       content: { kind: "html", html: "<p>one</p>" },
@@ -102,12 +68,12 @@ describe("SqliteBoardStore behavior", () => {
         },
       ],
     });
-    expect(store.readWidgetHtml(boardSession, "weather")).toMatchObject({
+    expect(await readBoardHtml(store, boardSession, "weather")).toMatchObject({
       html: "<p>one</p>",
       revision: 1,
       sha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
     });
-    const preparedView = store.getSnapshotWithHtmlViewMetadata(boardSession);
+    const preparedView = await store.getSnapshotWithHtmlViewMetadata(boardSession);
     expect(preparedView).toMatchObject({
       snapshot: { revision: 1 },
       htmlViewMetadata: new Map([
@@ -123,7 +89,7 @@ describe("SqliteBoardStore behavior", () => {
     expect(preparedView.htmlViewMetadata.get("weather")).not.toHaveProperty("html");
 
     // Legacy clients omit heightMode on resize; explicit user sizing must pin.
-    const resized = store.applyOps(boardSession, [
+    const resized = await store.applyOps(boardSession, [
       { kind: "widget_resize", name: "weather", sizeW: 8, sizeH: 6 },
     ]);
     expect(resized).toMatchObject({
@@ -139,13 +105,13 @@ describe("SqliteBoardStore behavior", () => {
       ],
     });
     expect(
-      store.grant(boardSession, "weather", "granted", 1, first.widgets[0]?.instanceId),
+      await store.grant(boardSession, "weather", "granted", 1, first.widgets[0]?.instanceId),
     ).toMatchObject({
       revision: 3,
       widgets: [{ grantState: "granted" }],
     });
 
-    const updated = store.putWidget({
+    const updated = await store.putWidget({
       ...boardSession,
       name: "weather",
       content: { kind: "html", html: "<p>two</p>" },
@@ -164,22 +130,24 @@ describe("SqliteBoardStore behavior", () => {
       ],
     });
     expect(updated.widgets[0]).not.toHaveProperty("declaredSummary");
-    expect(store.getSnapshot(boardSession).widgets[0]).not.toHaveProperty("declaredSummary");
+    expect((await store.getSnapshot(boardSession)).widgets[0]).not.toHaveProperty(
+      "declaredSummary",
+    );
     expect(updated.widgets[0]).not.toHaveProperty("declared");
   });
 
-  it("keeps content-kind semantics and normalized ordering", () => {
+  it("keeps content-kind semantics and normalized ordering", async () => {
     const store = createStore();
-    store.applyOps(boardSession, [
+    await store.applyOps(boardSession, [
       { kind: "tab_create", tabId: "main", title: "Main" },
       { kind: "tab_create", tabId: "notes", title: "Notes" },
     ]);
-    store.putWidget({
+    await store.putWidget({
       ...boardSession,
       name: "first",
       content: { kind: "html", html: "first" },
     });
-    store.putWidget({
+    await store.putWidget({
       ...boardSession,
       name: "app",
       content: {
@@ -194,12 +162,12 @@ describe("SqliteBoardStore behavior", () => {
       },
       placement: { tabId: "notes" },
     });
-    expect(store.getSnapshot(boardSession).widgets).toEqual([
+    expect((await store.getSnapshot(boardSession)).widgets).toEqual([
       expect.objectContaining({ name: "first", tabId: "main", position: 0 }),
       expect.objectContaining({ name: "app", tabId: "notes", position: 0 }),
     ]);
-    expect(store.readWidgetHtml(boardSession, "app")).toBeUndefined();
-    expect(store.readWidgetMcpApp(boardSession, "app")).toMatchObject({
+    expect(await readBoardHtml(store, boardSession, "app")).toBeUndefined();
+    expect(await store.readWidgetMcpApp(boardSession, "app")).toMatchObject({
       descriptor: {
         serverName: "server",
         toolName: "tool",
@@ -210,12 +178,14 @@ describe("SqliteBoardStore behavior", () => {
       instanceId: expect.stringMatching(/^[a-f0-9]{32}$/u),
       interactive: true,
     });
-    expect(store.getSnapshot(boardSession).widgets[1]?.instanceId).toMatch(/^[a-f0-9]{32}$/u);
+    expect((await store.getSnapshot(boardSession)).widgets[1]?.instanceId).toMatch(
+      /^[a-f0-9]{32}$/u,
+    );
   });
 
-  it("replaces omitted plugin props without changing unrelated layout state", () => {
+  it("replaces omitted plugin props without changing unrelated layout state", async () => {
     const store = createStore();
-    const initial = store.putWidget({
+    const initial = await store.putWidget({
       ...boardSession,
       name: "work-item",
       content: {
@@ -224,12 +194,12 @@ describe("SqliteBoardStore behavior", () => {
         props: { cardId: "card-123", compact: true },
       },
     });
-    store.putWidget({
+    await store.putWidget({
       ...boardSession,
       name: "left",
       content: { kind: "plugin", pluginKind: "workboard:card", props: { side: "left" } },
     });
-    store.putWidget({
+    await store.putWidget({
       ...boardSession,
       name: "right",
       content: { kind: "plugin", pluginKind: "workboard:card", props: { side: "right" } },
@@ -243,17 +213,17 @@ describe("SqliteBoardStore behavior", () => {
       grantState: "none",
     });
     expect(initial.widgets[0]).not.toHaveProperty("instanceId");
-    expect(store.readWidgetHtml(boardSession, "work-item")).toBeUndefined();
-    expect(store.readWidgetMcpApp(boardSession, "work-item")).toBeUndefined();
+    expect(await readBoardHtml(store, boardSession, "work-item")).toBeUndefined();
+    expect(await store.readWidgetMcpApp(boardSession, "work-item")).toBeUndefined();
 
-    const moved = store.applyOps(boardSession, [
+    const moved = await store.applyOps(boardSession, [
       { kind: "widget_move", name: "work-item", after: "right" },
     ]);
     expect(moved.widgets.map((widget) => widget.name)).toEqual(["left", "right", "work-item"]);
     expect(moved.widgets[2]?.props).toEqual({ cardId: "card-123", compact: true });
     const [left, right] = moved.widgets;
 
-    const put = store.putWidget({
+    const put = await store.putWidget({
       ...boardSession,
       name: "work-item",
       content: { kind: "plugin", pluginKind: "workboard:card" },
@@ -265,9 +235,9 @@ describe("SqliteBoardStore behavior", () => {
     expect(put.widgets[2]).not.toHaveProperty("props");
     const { resolvedWidgetName: putName, ...putSnapshot } = put;
     expect(putName).toBe("work-item");
-    expect(store.getSnapshot(boardSession)).toEqual(putSnapshot);
+    expect(await store.getSnapshot(boardSession)).toEqual(putSnapshot);
 
-    const placed = store.putWidget({
+    const placed = await store.putWidget({
       ...boardSession,
       name: "work-item",
       content: { kind: "plugin", pluginKind: "workboard:card" },
@@ -279,12 +249,12 @@ describe("SqliteBoardStore behavior", () => {
     expect(placed.widgets[2]).toEqual({ ...right, position: 2 });
     const { resolvedWidgetName: placedName, ...placedSnapshot } = placed;
     expect(placedName).toBe("work-item");
-    expect(store.getSnapshot(boardSession)).toEqual(placedSnapshot);
+    expect(await store.getSnapshot(boardSession)).toEqual(placedSnapshot);
   });
 
-  it("rejects oversized plugin props and capability declarations", () => {
+  it("rejects oversized plugin props and capability declarations", async () => {
     const store = createStore();
-    expect(() =>
+    await expect(
       store.putWidget({
         ...boardSession,
         name: "too-large",
@@ -294,20 +264,20 @@ describe("SqliteBoardStore behavior", () => {
           props: { value: "x".repeat(8 * 1024) },
         },
       }),
-    ).toThrow("props exceed 8192 UTF-8 bytes");
-    expect(() =>
+    ).rejects.toThrow("props exceed 8192 UTF-8 bytes");
+    await expect(
       store.putWidget({
         ...boardSession,
         name: "declared",
         content: { kind: "plugin", pluginKind: "workboard:card" },
         declared: { tools: ["workboard.cards.move"] },
       }),
-    ).toThrow("do not accept sandbox capability declarations");
+    ).rejects.toThrow("do not accept sandbox capability declarations");
   });
 
-  it("preserves grants only for unchanged bytes with equal or narrower declarations", () => {
+  it("preserves grants only for unchanged bytes with equal or narrower declarations", async () => {
     const store = createStore();
-    const first = store.putWidget({
+    const first = await store.putWidget({
       ...boardSession,
       name: "scoped",
       content: { kind: "html", html: "one" },
@@ -316,9 +286,9 @@ describe("SqliteBoardStore behavior", () => {
         tools: ["weather.read", "weather.refresh"],
       },
     });
-    store.grant(boardSession, "scoped", "granted", 1, first.widgets[0]?.instanceId);
+    await store.grant(boardSession, "scoped", "granted", 1, first.widgets[0]?.instanceId);
 
-    const equal = store.putWidget({
+    const equal = await store.putWidget({
       ...boardSession,
       name: "scoped",
       content: { kind: "html", html: "one" },
@@ -328,12 +298,12 @@ describe("SqliteBoardStore behavior", () => {
       },
     });
     expect(equal.widgets[0]).toMatchObject({ revision: 2, grantState: "granted" });
-    expect(store.readWidgetHtml(boardSession, "scoped")).toMatchObject({
+    expect(await readBoardHtml(store, boardSession, "scoped")).toMatchObject({
       html: "one",
       grantState: "granted",
     });
 
-    const narrower = store.putWidget({
+    const narrower = await store.putWidget({
       ...boardSession,
       name: "scoped",
       content: { kind: "html", html: "one" },
@@ -344,7 +314,7 @@ describe("SqliteBoardStore behavior", () => {
     });
     expect(narrower.widgets[0]).toMatchObject({ revision: 3, grantState: "granted" });
 
-    const changed = store.putWidget({
+    const changed = await store.putWidget({
       ...boardSession,
       name: "scoped",
       content: { kind: "html", html: "two" },
@@ -354,13 +324,13 @@ describe("SqliteBoardStore behavior", () => {
       },
     });
     expect(changed.widgets[0]).toMatchObject({ revision: 4, grantState: "pending" });
-    expect(store.readWidgetHtml(boardSession, "scoped")).toMatchObject({
+    expect(await readBoardHtml(store, boardSession, "scoped")).toMatchObject({
       html: "two",
       grantState: "pending",
     });
-    store.grant(boardSession, "scoped", "granted", 4, changed.widgets[0]?.instanceId);
+    await store.grant(boardSession, "scoped", "granted", 4, changed.widgets[0]?.instanceId);
 
-    const wider = store.putWidget({
+    const wider = await store.putWidget({
       ...boardSession,
       name: "scoped",
       content: { kind: "html", html: "two" },
@@ -372,7 +342,7 @@ describe("SqliteBoardStore behavior", () => {
     expect(wider.widgets[0]).toMatchObject({ revision: 5, grantState: "pending" });
   });
 
-  it("requires a fresh grant when an MCP app widget changes servers", () => {
+  it("requires a fresh grant when an MCP app widget changes servers", async () => {
     const store = createStore();
     const descriptor = {
       serverName: "server-a",
@@ -380,15 +350,15 @@ describe("SqliteBoardStore behavior", () => {
       uiResourceUri: "ui://weather",
       toolCallId: "call-a",
     };
-    const first = store.putWidget({
+    const first = await store.putWidget({
       ...boardSession,
       name: "weather",
       content: { kind: "mcp-app", descriptor, interactive: true },
       declared: { tools: ["refresh"] },
     });
-    store.grant(boardSession, "weather", "granted", 1, first.widgets[0]?.instanceId);
+    await store.grant(boardSession, "weather", "granted", 1, first.widgets[0]?.instanceId);
 
-    const differentServer = store.putWidget({
+    const differentServer = await store.putWidget({
       ...boardSession,
       name: "weather",
       content: {
@@ -400,8 +370,14 @@ describe("SqliteBoardStore behavior", () => {
     });
     expect(differentServer.widgets[0]).toMatchObject({ revision: 2, grantState: "pending" });
 
-    store.grant(boardSession, "weather", "granted", 2, differentServer.widgets[0]?.instanceId);
-    const sameServer = store.putWidget({
+    await store.grant(
+      boardSession,
+      "weather",
+      "granted",
+      2,
+      differentServer.widgets[0]?.instanceId,
+    );
+    const sameServer = await store.putWidget({
       ...boardSession,
       name: "weather",
       content: {
@@ -414,10 +390,10 @@ describe("SqliteBoardStore behavior", () => {
     expect(sameServer.widgets[0]).toMatchObject({ revision: 3, grantState: "granted" });
   });
 
-  it("rejects a delayed MCP App grant after remove and same-name replacement", () => {
+  it("rejects a delayed MCP App grant after remove and same-name replacement", async () => {
     const store = createStore();
-    const putApp = (serverName: string) =>
-      store.putWidget({
+    const putApp = async (serverName: string) =>
+      await store.putWidget({
         ...boardSession,
         name: "app",
         content: {
@@ -432,66 +408,72 @@ describe("SqliteBoardStore behavior", () => {
         },
         declared: { tools: ["refresh"] },
       });
-    const original = putApp("server-a");
-    store.applyOps(boardSession, [{ kind: "widget_remove", name: "app" }]);
-    const replacement = putApp("server-b");
+    const original = await putApp("server-a");
+    await store.applyOps(boardSession, [{ kind: "widget_remove", name: "app" }]);
+    const replacement = await putApp("server-b");
 
     expect(replacement.widgets[0]).toMatchObject({ revision: 1, grantState: "pending" });
     expect(replacement.widgets[0]?.instanceId).not.toBe(original.widgets[0]?.instanceId);
-    expect(() =>
+    await expect(
       store.grant(boardSession, "app", "granted", 1, original.widgets[0]?.instanceId),
-    ).toThrow("instance changed");
+    ).rejects.toThrow("instance changed");
     expect(
-      store.grant(boardSession, "app", "granted", 1, replacement.widgets[0]?.instanceId).widgets[0],
+      (await store.grant(boardSession, "app", "granted", 1, replacement.widgets[0]?.instanceId))
+        .widgets[0],
     ).toMatchObject({ grantState: "granted" });
   });
 
-  it("rejects a delayed HTML grant after remove and same-name replacement", () => {
+  it("rejects a delayed HTML grant after remove and same-name replacement", async () => {
     const store = createStore();
-    const putHtml = (html: string) =>
-      store.putWidget({
+    const putHtml = async (html: string) =>
+      await store.putWidget({
         ...boardSession,
         name: "app",
         content: { kind: "html", html },
         declared: { tools: ["refresh"] },
       });
-    const original = putHtml("original");
-    store.applyOps(boardSession, [{ kind: "widget_remove", name: "app" }]);
-    const replacement = putHtml("replacement");
+    const original = await putHtml("original");
+    await store.applyOps(boardSession, [{ kind: "widget_remove", name: "app" }]);
+    const replacement = await putHtml("replacement");
 
     expect(replacement.widgets[0]).toMatchObject({ revision: 1, grantState: "pending" });
     expect(replacement.widgets[0]?.instanceId).not.toBe(original.widgets[0]?.instanceId);
-    expect(() =>
+    await expect(
       store.grant(boardSession, "app", "granted", 1, original.widgets[0]?.instanceId),
-    ).toThrow("instance changed");
+    ).rejects.toThrow("instance changed");
   });
 
-  it("rejects stale grant revisions before accepting the current one", () => {
+  it("rejects stale grant revisions before accepting the current one", async () => {
     const store = createStore();
-    const first = store.putWidget({
+    const first = await store.putWidget({
       ...boardSession,
       name: "scoped",
       content: { kind: "html", html: "one" },
       declared: { tools: ["weather.read"] },
     });
-    expect(() => store.grant(boardSession, "scoped", "granted", 2)).toThrow("revision changed");
+    await expect(store.grant(boardSession, "scoped", "granted", 2)).rejects.toThrow(
+      "revision changed",
+    );
     expect(
-      store.grant(boardSession, "scoped", "granted", 1, first.widgets[0]?.instanceId).widgets[0],
+      (await store.grant(boardSession, "scoped", "granted", 1, first.widgets[0]?.instanceId))
+        .widgets[0],
     ).toMatchObject({
       revision: 1,
       grantState: "granted",
     });
   });
 
-  it("drops an empty board after its last tab is deleted", () => {
+  it("drops an empty board after its last tab is deleted", async () => {
     const store = createStore();
-    store.applyOps(boardSession, [{ kind: "tab_create", tabId: "main", title: "Main" }]);
-    expect(store.applyOps(boardSession, [{ kind: "tab_delete", tabId: "main" }])).toMatchObject({
+    await store.applyOps(boardSession, [{ kind: "tab_create", tabId: "main", title: "Main" }]);
+    expect(
+      await store.applyOps(boardSession, [{ kind: "tab_delete", tabId: "main" }]),
+    ).toMatchObject({
       revision: 2,
       tabs: [],
       widgets: [],
     });
-    expect(store.getSnapshot(boardSession)).toMatchObject({
+    expect(await store.getSnapshot(boardSession)).toMatchObject({
       revision: 0,
       tabs: [],
       widgets: [],
@@ -500,7 +482,7 @@ describe("SqliteBoardStore behavior", () => {
 });
 
 describe("SqliteBoardStore persistence", () => {
-  it("round-trips widget frame preferences through the manifest", () => {
+  it("round-trips widget frame preferences through the manifest", async () => {
     const stateDir = tempDirs.make("openclaw-board-widget-frame-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sessionKey = "agent:main:widget-frame";
@@ -509,18 +491,18 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey,
       name: "status",
       content: { kind: "html", html: "status" },
       presentation: "card",
       heightMode: "auto",
     });
-    store.applyOps({ sessionKey }, [
+    await store.applyOps({ sessionKey }, [
       { kind: "widget_resize", name: "status", sizeW: 8, sizeH: 7, heightMode: "fixed" },
     ]);
 
-    expect(store.getSnapshot({ sessionKey }).widgets[0]).toMatchObject({
+    expect((await store.getSnapshot({ sessionKey })).widgets[0]).toMatchObject({
       presentation: "card",
       heightMode: "fixed",
       sizeW: 8,
@@ -538,19 +520,25 @@ describe("SqliteBoardStore persistence", () => {
     expect(readManifest()).toMatchObject({ presentation: "card", heightMode: "fixed" });
 
     // A content re-pin that omits frame options must keep the persisted ones.
-    store.putWidget({ sessionKey, name: "status", content: { kind: "html", html: "status v2" } });
+    await store.putWidget({
+      sessionKey,
+      name: "status",
+      content: { kind: "html", html: "status v2" },
+    });
     expect(readManifest()).toMatchObject({ presentation: "card", heightMode: "fixed" });
 
     // Legacy resize ops without heightMode still pin persisted height.
-    store.applyOps({ sessionKey }, [
+    await store.applyOps({ sessionKey }, [
       { kind: "widget_resize", name: "status", sizeW: 8, sizeH: 7, heightMode: "auto" },
     ]);
     expect(readManifest()).toMatchObject({ heightMode: "auto" });
-    store.applyOps({ sessionKey }, [{ kind: "widget_resize", name: "status", sizeW: 6, sizeH: 4 }]);
+    await store.applyOps({ sessionKey }, [
+      { kind: "widget_resize", name: "status", sizeW: 6, sizeH: 4 },
+    ]);
     expect(readManifest()).toMatchObject({ presentation: "card", heightMode: "fixed" });
   });
 
-  it("drops MCP App rows without canonical authority provenance", () => {
+  it("drops MCP App rows without canonical authority provenance", async () => {
     const stateDir = tempDirs.make("openclaw-board-noncanonical-app-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sessionKey = "agent:main:board";
@@ -559,7 +547,7 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey,
       name: "legacy-app",
       content: {
@@ -580,8 +568,8 @@ describe("SqliteBoardStore persistence", () => {
       .prepare("UPDATE board_widgets SET manifest = '{}' WHERE session_key = ? AND name = ?")
       .run(sessionKey, "legacy-app");
 
-    expect(store.getSnapshot({ sessionKey }).widgets).toEqual([]);
-    expect(store.readWidgetMcpApp({ sessionKey }, "legacy-app")).toBeUndefined();
+    expect((await store.getSnapshot({ sessionKey })).widgets).toEqual([]);
+    expect(await store.readWidgetMcpApp({ sessionKey }, "legacy-app")).toBeUndefined();
   });
 
   it("migrates board tables into an existing v14 database", async () => {
@@ -618,17 +606,21 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    expect(store.getSnapshot({ sessionKey })).toMatchObject({ revision: 0, tabs: [], widgets: [] });
-    expect(store.readWidgetHtml({ sessionKey }, "status")).toBeUndefined();
-    expect(() =>
+    expect(await store.getSnapshot({ sessionKey })).toMatchObject({
+      revision: 0,
+      tabs: [],
+      widgets: [],
+    });
+    expect(await readBoardHtml(store, { sessionKey }, "status")).toBeUndefined();
+    await expect(
       store.putWidget({
         sessionKey,
         name: "broken",
         content: { kind: "html", html: "broken" },
         placement: { tabId: "missing" },
       }),
-    ).toThrow("board tab not found");
-    store.putWidget({
+    ).rejects.toThrow("board tab not found");
+    await store.putWidget({
       sessionKey,
       name: "status",
       content: { kind: "html", html: "ok" },
@@ -663,7 +655,7 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey,
       name: "existing",
       content: { kind: "html", html: "preserved" },
@@ -709,17 +701,19 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    expect(upgradedStore.getSnapshot({ sessionKey }).widgets).toEqual([
+    expect((await upgradedStore.getSnapshot({ sessionKey })).widgets).toEqual([
       expect.objectContaining({ name: "existing", contentKind: "html" }),
     ]);
-    upgradedStore.putWidget({
+    await upgradedStore.putWidget({
       sessionKey,
       name: "plugin",
       content: { kind: "plugin", pluginKind: "workboard:card", props: { cardId: "123" } },
     });
 
-    expect(upgradedStore.readWidgetHtml({ sessionKey }, "existing")?.html).toBe("preserved");
-    expect(upgradedStore.getSnapshot({ sessionKey }).widgets).toEqual(
+    expect((await readBoardHtml(upgradedStore, { sessionKey }, "existing"))?.html).toBe(
+      "preserved",
+    );
+    expect((await upgradedStore.getSnapshot({ sessionKey })).widgets).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "existing", contentKind: "html" }),
         expect.objectContaining({
@@ -732,7 +726,7 @@ describe("SqliteBoardStore persistence", () => {
     );
   });
 
-  it("does not create an unregistered agent database during widget byte lookup", () => {
+  it("does not create an unregistered agent database during widget byte lookup", async () => {
     const stateDir = tempDirs.make("openclaw-board-no-create-");
     const store = new SqliteBoardStore({
       resolveSession: () => ({
@@ -742,22 +736,22 @@ describe("SqliteBoardStore persistence", () => {
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
 
-    expect(store.getSnapshot({ sessionKey: "agent:attacker-selected:main" })).toEqual({
+    expect(await store.getSnapshot({ sessionKey: "agent:attacker-selected:main" })).toEqual({
       sessionKey: "agent:attacker-selected:main",
       revision: 0,
       tabs: [],
       widgets: [],
     });
     expect(
-      store.readWidgetHtml({ sessionKey: "agent:attacker-selected:main" }, "missing"),
+      await readBoardHtml(store, { sessionKey: "agent:attacker-selected:main" }, "missing"),
     ).toBeUndefined();
-    expect(() =>
+    await expect(
       store.putWidget({
         sessionKey: "agent:attacker-selected:main",
         name: "missing",
         content: { kind: "html", html: "no" },
       }),
-    ).toThrow("board session not found");
+    ).rejects.toThrow("board session not found");
     expect(
       existsSync(
         path.join(stateDir, "agents", "attacker-selected", "agent", "openclaw-agent.sqlite"),
@@ -766,7 +760,7 @@ describe("SqliteBoardStore persistence", () => {
     expect(existsSync(path.join(stateDir, "agents", "attacker-selected"))).toBe(false);
   });
 
-  it("rejects board writes for transcript-only placeholder nodes", () => {
+  it("rejects board writes for transcript-only placeholder nodes", async () => {
     const stateDir = tempDirs.make("openclaw-board-transcript-only-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sessionKey = "agent:main:transcript-only";
@@ -790,16 +784,16 @@ describe("SqliteBoardStore persistence", () => {
       env,
     });
 
-    expect(() =>
+    await expect(
       store.putWidget({
         sessionKey,
         name: "status",
         content: { kind: "html", html: "no" },
       }),
-    ).toThrow("board session not found");
+    ).rejects.toThrow("board session not found");
   });
 
-  it("canonicalizes aliases before reading and writing board rows", () => {
+  it("canonicalizes aliases before reading and writing board rows", async () => {
     const stateDir = tempDirs.make("openclaw-board-alias-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const canonicalSessionKey = "agent:main:main";
@@ -812,28 +806,28 @@ describe("SqliteBoardStore persistence", () => {
       env,
     });
 
-    store.putWidget({
+    await store.putWidget({
       sessionKey: "main",
       name: "status",
       content: { kind: "html", html: "one" },
     });
-    expect(store.getSnapshot({ sessionKey: canonicalSessionKey })).toMatchObject({
+    expect(await store.getSnapshot({ sessionKey: canonicalSessionKey })).toMatchObject({
       sessionKey: canonicalSessionKey,
       widgets: [{ name: "status", revision: 1 }],
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey: canonicalSessionKey,
       name: "status",
       content: { kind: "html", html: "two" },
     });
-    expect(store.getSnapshot({ sessionKey: "main" })).toMatchObject({
+    expect(await store.getSnapshot({ sessionKey: "main" })).toMatchObject({
       sessionKey: canonicalSessionKey,
       widgets: [{ name: "status", revision: 2 }],
     });
-    expect(store.readWidgetHtml({ sessionKey: "main" }, "status")?.html).toBe("two");
+    expect((await readBoardHtml(store, { sessionKey: "main" }, "status"))?.html).toBe("two");
   });
 
-  it("fails closed when reading a persisted unsafe capability manifest", () => {
+  it("fails closed when reading a persisted unsafe capability manifest", async () => {
     const stateDir = tempDirs.make("openclaw-board-unsafe-manifest-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sessionKey = "agent:main:unsafe-manifest";
@@ -842,7 +836,7 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey,
       name: "status",
       content: { kind: "html", html: "ok" },
@@ -858,33 +852,33 @@ describe("SqliteBoardStore persistence", () => {
         sessionKey,
       );
 
-    expect(store.getSnapshot({ sessionKey }).widgets[0]).toMatchObject({
+    expect((await store.getSnapshot({ sessionKey })).widgets[0]).toMatchObject({
       name: "status",
       grantState: "none",
     });
-    expect(store.getSnapshot({ sessionKey }).widgets[0]).not.toHaveProperty("declared");
-    expect(store.readWidgetHtml({ sessionKey }, "status")).toMatchObject({
+    expect((await store.getSnapshot({ sessionKey })).widgets[0]).not.toHaveProperty("declared");
+    expect(await readBoardHtml(store, { sessionKey }, "status")).toMatchObject({
       html: "ok",
       grantState: "none",
     });
-    expect(store.readWidgetHtml({ sessionKey }, "status")).not.toHaveProperty("declared");
+    expect(await readBoardHtml(store, { sessionKey }, "status")).not.toHaveProperty("declared");
 
     database.db
       .prepare(
         "UPDATE board_widgets SET grant_state = 'rejected' WHERE session_key = ? AND name = 'status'",
       )
       .run(sessionKey);
-    expect(store.getSnapshot({ sessionKey }).widgets[0]).toMatchObject({
+    expect((await store.getSnapshot({ sessionKey })).widgets[0]).toMatchObject({
       name: "status",
       grantState: "rejected",
     });
-    expect(store.readWidgetHtml({ sessionKey }, "status")).toMatchObject({
+    expect(await readBoardHtml(store, { sessionKey }, "status")).toMatchObject({
       html: "ok",
       grantState: "rejected",
     });
   });
 
-  it("reads widget bytes only from the canonical per-agent database", () => {
+  it("reads widget bytes only from the canonical per-agent database", async () => {
     const stateDir = tempDirs.make("openclaw-board-canonical-bytes-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentId = "worker-1";
@@ -894,7 +888,7 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId, sessionKey }),
       env,
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey,
       name: "status",
       content: { kind: "html", html: "canonical" },
@@ -920,7 +914,9 @@ describe("SqliteBoardStore persistence", () => {
       )
       .run(sessionKey, Buffer.from("relocated"), "a".repeat(64), "b".repeat(32));
 
-    expect(store.readWidgetHtml({ sessionKey }, "status")).toMatchObject({ html: "canonical" });
+    expect(await readBoardHtml(store, { sessionKey }, "status")).toMatchObject({
+      html: "canonical",
+    });
   });
 
   it("purges board rows through the shared session deletion lifecycle", async () => {
@@ -932,7 +928,7 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey,
       name: "status",
       content: { kind: "html", html: "ok" },
@@ -955,7 +951,7 @@ describe("SqliteBoardStore persistence", () => {
     });
   });
 
-  it("clears a frozen grant when the widget digest changes", () => {
+  it("clears a frozen grant when the widget digest changes", async () => {
     const stateDir = tempDirs.make("openclaw-board-granted-digest-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sessionKey = "agent:main:grant-digest";
@@ -964,14 +960,14 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    const first = store.putWidget({
+    const first = await store.putWidget({
       sessionKey,
       name: "status",
       content: { kind: "html", html: "one" },
       declared: { tools: ["status.read", "status.refresh"] },
     });
-    store.grant({ sessionKey }, "status", "granted", 1, first.widgets[0]?.instanceId);
-    store.putWidget({
+    await store.grant({ sessionKey }, "status", "granted", 1, first.widgets[0]?.instanceId);
+    await store.putWidget({
       sessionKey,
       name: "status",
       content: { kind: "html", html: "two" },
@@ -992,7 +988,7 @@ describe("SqliteBoardStore persistence", () => {
     });
   });
 
-  it("requires reapproval for grants stored before byte-frozen semantics", () => {
+  it("requires reapproval for grants stored before byte-frozen semantics", async () => {
     const stateDir = tempDirs.make("openclaw-board-legacy-grant-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sessionKey = "agent:main:legacy-grant";
@@ -1001,29 +997,29 @@ describe("SqliteBoardStore persistence", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    const current = store.putWidget({
+    const current = await store.putWidget({
       sessionKey,
       name: "status",
       content: { kind: "html", html: "approved" },
       declared: { tools: ["health"] },
     });
-    store.grant({ sessionKey }, "status", "granted", 1, current.widgets[0]?.instanceId);
+    await store.grant({ sessionKey }, "status", "granted", 1, current.widgets[0]?.instanceId);
 
     const database = openOpenClawAgentDatabase({ agentId: "main", env });
     database.db
       .prepare("UPDATE board_widgets SET manifest = ? WHERE session_key = ? AND name = 'status'")
       .run(JSON.stringify({ tools: ["health"] }), sessionKey);
 
-    expect(store.getSnapshot({ sessionKey }).widgets[0]).toMatchObject({
+    expect((await store.getSnapshot({ sessionKey })).widgets[0]).toMatchObject({
       grantState: "pending",
       declared: { tools: ["health"] },
     });
-    expect(store.readWidgetHtml({ sessionKey }, "status")).toMatchObject({
+    expect(await readBoardHtml(store, { sessionKey }, "status")).toMatchObject({
       grantState: "pending",
       declared: { tools: ["health"] },
     });
     expect(
-      store.grant({ sessionKey }, "status", "granted", 1, current.widgets[0]?.instanceId)
+      (await store.grant({ sessionKey }, "status", "granted", 1, current.widgets[0]?.instanceId))
         .widgets[0],
     ).toMatchObject({ grantState: "granted" });
     expect(
@@ -1037,7 +1033,7 @@ describe("SqliteBoardStore persistence", () => {
     ).toEqual({ contentOwner: "html", tools: ["health"], grantSemanticsVersion: 2 });
   });
 
-  it("reopens durable boards and isolates owning agent databases", () => {
+  it("reopens durable boards and isolates owning agent databases", async () => {
     const stateDir = tempDirs.make("openclaw-board-durable-");
     const options = {
       resolveSession: ({ sessionKey }: { sessionKey: string }) => ({
@@ -1049,12 +1045,12 @@ describe("SqliteBoardStore persistence", () => {
     seedSession(options.env, "alpha", "agent:alpha:board");
     seedSession(options.env, "beta", "agent:beta:board");
     const store = new SqliteBoardStore(options);
-    store.putWidget({
+    await store.putWidget({
       sessionKey: "agent:alpha:board",
       name: "alpha",
       content: { kind: "html", html: "alpha" },
     });
-    store.putWidget({
+    await store.putWidget({
       sessionKey: "agent:beta:board",
       name: "beta",
       content: { kind: "html", html: "beta" },
@@ -1064,10 +1060,10 @@ describe("SqliteBoardStore persistence", () => {
     closeOpenClawStateDatabaseForTest();
 
     const reopened = new SqliteBoardStore(options);
-    expect(reopened.getSnapshot({ sessionKey: "agent:alpha:board" }).widgets).toEqual([
+    expect((await reopened.getSnapshot({ sessionKey: "agent:alpha:board" })).widgets).toEqual([
       expect.objectContaining({ name: "alpha", revision: 1 }),
     ]);
-    expect(reopened.getSnapshot({ sessionKey: "agent:beta:board" }).widgets).toEqual([
+    expect((await reopened.getSnapshot({ sessionKey: "agent:beta:board" })).widgets).toEqual([
       expect.objectContaining({ name: "beta", revision: 1 }),
     ]);
   });

--- a/src/boards/board-store.test-support.ts
+++ b/src/boards/board-store.test-support.ts
@@ -9,6 +9,7 @@ import {
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import type { BoardStore, BoardSessionTarget } from "./board-store.js";
 import { SqliteBoardStore } from "./sqlite-board-store.js";
 
 export function createTestBoardStore(options: { stateDir?: string } = {}): SqliteBoardStore {
@@ -47,4 +48,20 @@ export function createTestBoardStore(options: { stateDir?: string } = {}): Sqlit
     },
     env,
   });
+}
+
+export async function readBoardHtml(store: BoardStore, target: BoardSessionTarget, name: string) {
+  return await store.useWidgetDocument(target, name, (document) =>
+    document && "html" in document ? document : undefined,
+  );
+}
+
+export async function readBoardRegistered(
+  store: BoardStore,
+  target: BoardSessionTarget,
+  name: string,
+) {
+  return await store.useWidgetDocument(target, name, (document) =>
+    document && "source" in document ? document : undefined,
+  );
 }

--- a/src/boards/board-store.test.ts
+++ b/src/boards/board-store.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BoardWidgetMaterializedPutParams } from "../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -8,7 +9,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { BoardValidationError } from "./board-layout.js";
 import { createBoardWidgetPutSnapshot, type BoardStore } from "./board-store.js";
-import { createTestBoardStore } from "./board-store.test-support.js";
+import { readBoardHtml, createTestBoardStore } from "./board-store.test-support.js";
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
@@ -16,8 +17,8 @@ afterEach(() => {
 });
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-function putHtml(store: BoardStore, sessionKey: string, name: string, html = "<p>one</p>") {
-  return store.putWidget({ sessionKey, name, content: { kind: "html", html } });
+async function putHtml(store: BoardStore, sessionKey: string, name: string, html = "<p>one</p>") {
+  return await store.putWidget({ sessionKey, name, content: { kind: "html", html } });
 }
 
 const widgetContents = [
@@ -42,10 +43,39 @@ const widgetContents = [
 ] satisfies BoardWidgetMaterializedPutParams["content"][];
 
 describe("board store", () => {
-  it("creates the implicit main tab and bumps board and widget revisions", () => {
+  it("releases SQLite before awaiting a widget consumer's external work", async () => {
+    const stateDir = tempDirs.make("openclaw-board-consume-");
+    const store = createTestBoardStore({ stateDir });
+    const target = { sessionKey: "agent:main:consume" };
+    await putHtml(store, target.sessionKey, "status", "original");
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const started = createDeferred();
+    const release = createDeferred();
+    const consumed = store.useWidgetDocument(target, "status", async (document) => {
+      expect(database.db.isTransaction).toBe(false);
+      started.resolve();
+      await release.promise;
+      return document;
+    });
+    try {
+      await started.promise;
+      await putHtml(store, target.sessionKey, "status", "replacement");
+    } finally {
+      release.resolve();
+    }
+    expect(await consumed).toMatchObject({ html: "original" });
+    expect(await readBoardHtml(store, target, "status")).toMatchObject({
+      html: "replacement",
+    });
+  });
+
+  it("creates the implicit main tab and bumps board and widget revisions", async () => {
     const store = createTestBoardStore();
-    const first = putHtml(store, "agent:main:main", "status");
-    const second = putHtml(store, "agent:main:main", "status", "<p>two</p>");
+    const first = await putHtml(store, "agent:main:main", "status");
+    const second = await putHtml(store, "agent:main:main", "status", "<p>two</p>");
     expect(first).toMatchObject({
       revision: 1,
       tabs: [{ tabId: "main", title: "Main", position: 0 }],
@@ -57,10 +87,10 @@ describe("board store", () => {
 
   it.each(widgetContents)(
     "preserves $kind widget ownership across same-name updates",
-    (content) => {
+    async (content) => {
       const store = createTestBoardStore();
       const name = `${content.kind}-status`;
-      const created = store.putWidget({ sessionKey: "session", name, content });
+      const created = await store.putWidget({ sessionKey: "session", name, content });
 
       expect(created.widgets[0]).toMatchObject({
         contentOwner: content.kind,
@@ -70,43 +100,43 @@ describe("board store", () => {
       for (const replacement of widgetContents.filter(
         (candidate) => candidate.kind !== content.kind,
       )) {
-        expect(() =>
+        await expect(
           store.putWidget({ sessionKey: "session", name, content: replacement }),
-        ).toThrow(
+        ).rejects.toThrow(
           expect.objectContaining({
             code: "invalid_operation",
             message: expect.stringMatching(/same content kind.*remove/i),
           }),
         );
-        expect(store.getSnapshot({ sessionKey: "session" })).toMatchObject({
+        expect(await store.getSnapshot({ sessionKey: "session" })).toMatchObject({
           revision: created.revision,
           widgets: created.widgets,
         });
       }
 
       if (content.kind === "plugin" || content.kind === "registered") {
-        expect(() =>
+        await expect(
           store.putWidget({
             sessionKey: "session",
             name,
             content: { ...content, pluginKind: "other:replacement" },
           }),
-        ).toThrow(expect.objectContaining({ code: "invalid_operation" }));
-        expect(store.getSnapshot({ sessionKey: "session" })).toMatchObject({
+        ).rejects.toThrow(expect.objectContaining({ code: "invalid_operation" }));
+        expect(await store.getSnapshot({ sessionKey: "session" })).toMatchObject({
           revision: created.revision,
           widgets: created.widgets,
         });
       }
 
       if (content.kind === "registered") {
-        expect(() =>
+        await expect(
           store.putWidget({
             sessionKey: "session",
             name,
             content: { ...content, contentKind: "alternate" },
           }),
-        ).toThrow(expect.objectContaining({ code: "invalid_operation" }));
-        expect(store.getSnapshot({ sessionKey: "session" })).toMatchObject({
+        ).rejects.toThrow(expect.objectContaining({ code: "invalid_operation" }));
+        expect(await store.getSnapshot({ sessionKey: "session" })).toMatchObject({
           revision: created.revision,
           widgets: created.widgets,
         });
@@ -126,15 +156,17 @@ describe("board store", () => {
         ).toMatchObject({ contentOwner: "plugin", revision: 2 });
       }
 
-      expect(store.putWidget({ sessionKey: "session", name, content }).widgets[0]).toMatchObject({
+      expect(
+        (await store.putWidget({ sessionKey: "session", name, content })).widgets[0],
+      ).toMatchObject({
         name,
         revision: 2,
       });
 
-      store.applyOps({ sessionKey: "session" }, [{ kind: "widget_remove", name }]);
+      await store.applyOps({ sessionKey: "session" }, [{ kind: "widget_remove", name }]);
       const replacement = widgetContents.find((candidate) => candidate.kind !== content.kind)!;
       expect(
-        store.putWidget({ sessionKey: "session", name, content: replacement }).widgets[0],
+        (await store.putWidget({ sessionKey: "session", name, content: replacement })).widgets[0],
       ).toMatchObject({
         contentKind: replacement.kind === "registered" ? "plugin" : replacement.kind,
         contentOwner: replacement.kind,
@@ -143,7 +175,7 @@ describe("board store", () => {
     },
   );
 
-  it("upgrades registered ownership from its exact legacy descriptor and preserves it", () => {
+  it("upgrades registered ownership from its exact legacy descriptor and preserves it", async () => {
     const stateDir = tempDirs.make("openclaw-board-legacy-registered-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sessionKey = "agent:main:legacy-registered";
@@ -154,45 +186,45 @@ describe("board store", () => {
       pluginKind: "diagram:diagram",
       source: "diagram:first",
     };
-    store.putWidget({ sessionKey, name: "status", content, declared: { tools: ["health"] } });
+    await store.putWidget({ sessionKey, name: "status", content, declared: { tools: ["health"] } });
     const database = openOpenClawAgentDatabase({ agentId: "main", env });
     database.db
       .prepare(
         "UPDATE board_widgets SET manifest = json_set(manifest, '$.registeredContentKind', 'other') WHERE session_key = ? AND name = 'status'",
       )
       .run(sessionKey);
-    expect(() => store.getSnapshot({ sessionKey })).toThrow(/content ownership/i);
+    await expect(store.getSnapshot({ sessionKey })).rejects.toThrow(/content ownership/i);
     database.db
       .prepare(
         "UPDATE board_widgets SET manifest = json_remove(manifest, '$.contentOwner', '$.registeredContentKind', '$.registeredInstanceId') WHERE session_key = ? AND name = 'status'",
       )
       .run(sessionKey);
 
-    const legacy = store.getSnapshot({ sessionKey }).widgets[0]!;
+    const legacy = (await store.getSnapshot({ sessionKey })).widgets[0]!;
     expect(legacy).toMatchObject({ contentOwner: "registered", registeredContentKind: "diagram" });
     expect(legacy).not.toHaveProperty("instanceId");
-    expect(() =>
+    await expect(
       store.putWidget({
         sessionKey,
         name: "status",
         content: { kind: "plugin", pluginKind: "diagram:diagram" },
       }),
-    ).toThrow(/same content kind.*remove/i);
-    expect(() =>
+    ).rejects.toThrow(/same content kind.*remove/i);
+    await expect(
       store.putWidget({
         sessionKey,
         name: "status",
         content: { ...content, contentKind: "other" },
       }),
-    ).toThrow(/same content kind.*remove/i);
+    ).rejects.toThrow(/same content kind.*remove/i);
 
-    const refreshed = store.putWidget({
+    const refreshed = await store.putWidget({
       sessionKey,
       name: "status",
       content: { ...content, source: "diagram:refreshed" },
       declared: { tools: ["health"] },
     });
-    store.grant({ sessionKey }, "status", "granted", 2, refreshed.widgets[0]?.instanceId);
+    await store.grant({ sessionKey }, "status", "granted", 2, refreshed.widgets[0]?.instanceId);
     const row = database.db
       .prepare("SELECT manifest FROM board_widgets WHERE session_key = ? AND name = 'status'")
       .get(sessionKey) as { manifest: string };
@@ -203,16 +235,20 @@ describe("board store", () => {
     });
   });
 
-  it("returns immutable snapshots and isolates session boards", () => {
+  it("returns immutable snapshots and isolates session boards", async () => {
     const store = createTestBoardStore();
-    putHtml(store, "session-b", "b");
-    putHtml(store, "session-a", "a");
-    const snapshot = store.getSnapshot({ sessionKey: "session-a" });
+    await putHtml(store, "session-b", "b");
+    await putHtml(store, "session-a", "a");
+    const snapshot = await store.getSnapshot({ sessionKey: "session-a" });
     snapshot.tabs[0]!.title = "Changed";
-    expect(store.getSnapshot({ sessionKey: "session-a" }).tabs[0]!.title).toBe("Main");
-    expect(store.getSnapshot({ sessionKey: "session-a" }).widgets).toMatchObject([{ name: "a" }]);
-    expect(store.getSnapshot({ sessionKey: "session-b" }).widgets).toMatchObject([{ name: "b" }]);
-    expect(store.getSnapshot({ sessionKey: "missing" })).toEqual({
+    expect((await store.getSnapshot({ sessionKey: "session-a" })).tabs[0]!.title).toBe("Main");
+    expect((await store.getSnapshot({ sessionKey: "session-a" })).widgets).toMatchObject([
+      { name: "a" },
+    ]);
+    expect((await store.getSnapshot({ sessionKey: "session-b" })).widgets).toMatchObject([
+      { name: "b" },
+    ]);
+    expect(await store.getSnapshot({ sessionKey: "missing" })).toEqual({
       sessionKey: "agent:main:missing",
       revision: 0,
       tabs: [],
@@ -220,10 +256,10 @@ describe("board store", () => {
     });
   });
 
-  it("stores HTML bytes with digest and keeps MCP descriptors non-HTML", () => {
+  it("stores HTML bytes with digest and keeps MCP descriptors non-HTML", async () => {
     const store = createTestBoardStore();
-    putHtml(store, "session", "html", "<main>ok</main>");
-    store.putWidget({
+    await putHtml(store, "session", "html", "<main>ok</main>");
+    await store.putWidget({
       sessionKey: "session",
       name: "app",
       content: {
@@ -237,13 +273,13 @@ describe("board store", () => {
         interactive: false,
       },
     });
-    expect(store.readWidgetHtml({ sessionKey: "session" }, "html")).toMatchObject({
+    expect(await readBoardHtml(store, { sessionKey: "session" }, "html")).toMatchObject({
       html: "<main>ok</main>",
       revision: 1,
       sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
     });
-    expect(store.readWidgetHtml({ sessionKey: "session" }, "app")).toBeUndefined();
-    expect(store.readWidgetMcpApp({ sessionKey: "session" }, "app")).toMatchObject({
+    expect(await readBoardHtml(store, { sessionKey: "session" }, "app")).toBeUndefined();
+    expect(await store.readWidgetMcpApp({ sessionKey: "session" }, "app")).toMatchObject({
       descriptor: {
         serverName: "server",
         toolName: "tool",
@@ -254,12 +290,12 @@ describe("board store", () => {
       instanceId: expect.stringMatching(/^[a-f0-9]{32}$/u),
       interactive: false,
     });
-    expect(store.readWidgetHtml({ sessionKey: "session" }, "unknown")).toBeUndefined();
+    expect(await readBoardHtml(store, { sessionKey: "session" }, "unknown")).toBeUndefined();
   });
 
-  it("transitions declared widgets through pending grants", () => {
+  it("transitions declared widgets through pending grants", async () => {
     const store = createTestBoardStore();
-    const pending = store.putWidget({
+    const pending = await store.putWidget({
       sessionKey: "session",
       name: "networked",
       content: { kind: "html", html: "<p>ok</p>" },
@@ -267,15 +303,17 @@ describe("board store", () => {
     });
     expect(pending.widgets[0]!.grantState).toBe("pending");
     expect(
-      store.grant(
-        { sessionKey: "session" },
-        "networked",
-        "granted",
-        1,
-        pending.widgets[0]?.instanceId,
+      (
+        await store.grant(
+          { sessionKey: "session" },
+          "networked",
+          "granted",
+          1,
+          pending.widgets[0]?.instanceId,
+        )
       ).widgets[0]!.grantState,
     ).toBe("granted");
-    expect(() =>
+    await expect(
       store.grant(
         { sessionKey: "session" },
         "networked",
@@ -283,26 +321,26 @@ describe("board store", () => {
         1,
         pending.widgets[0]?.instanceId,
       ),
-    ).toThrow("not pending");
+    ).rejects.toThrow("not pending");
   });
 
-  it("survives reset/new boundaries", () => {
+  it("survives reset/new boundaries", async () => {
     const store = createTestBoardStore();
-    putHtml(store, "session", "status");
+    await putHtml(store, "session", "status");
     // Session reset has no BoardStore call; the stable session key remains authoritative.
-    expect(store.getSnapshot({ sessionKey: "session" }).widgets).toHaveLength(1);
+    expect((await store.getSnapshot({ sessionKey: "session" })).widgets).toHaveLength(1);
   });
 
-  it("rejects stale grant revisions and accepts the current revision", () => {
+  it("rejects stale grant revisions and accepts the current revision", async () => {
     const store = createTestBoardStore();
-    const pending = store.putWidget({
+    const pending = await store.putWidget({
       sessionKey: "session",
       name: "networked",
       content: { kind: "html", html: "ok" },
       declared: { tools: ["weather.refresh"] },
     });
     try {
-      store.grant({ sessionKey: "session" }, "networked", "granted", 2);
+      await store.grant({ sessionKey: "session" }, "networked", "granted", 2);
       throw new Error("expected stale grant to fail");
     } catch (error) {
       expect(error).toBeInstanceOf(BoardValidationError);
@@ -310,12 +348,14 @@ describe("board store", () => {
       expect((error as Error).message).toContain("revision changed");
     }
     expect(
-      store.grant(
-        { sessionKey: "session" },
-        "networked",
-        "granted",
-        1,
-        pending.widgets[0]?.instanceId,
+      (
+        await store.grant(
+          { sessionKey: "session" },
+          "networked",
+          "granted",
+          1,
+          pending.widgets[0]?.instanceId,
+        )
       ).widgets[0],
     ).toMatchObject({
       grantState: "granted",
@@ -323,54 +363,81 @@ describe("board store", () => {
     });
   });
 
-  it("enforces the board widget count and UTF-8 HTML byte limits", () => {
+  it("enforces the board widget count and UTF-8 HTML byte limits", async () => {
     const store = createTestBoardStore();
     for (let index = 0; index < 48; index += 1) {
-      putHtml(store, "session", `widget-${index}`, "ok");
+      await putHtml(store, "session", `widget-${index}`, "ok");
     }
     try {
-      putHtml(store, "session", "widget-48", "ok");
+      await putHtml(store, "session", "widget-48", "ok");
       throw new Error("expected widget cap to fail");
     } catch (error) {
       expect(error).toBeInstanceOf(BoardValidationError);
       expect(error).toMatchObject({ code: "invalid_operation" });
       expect((error as Error).message).toContain("more than 48 widgets");
     }
-    expect(() => putHtml(createTestBoardStore(), "session", "large", "é".repeat(131_073))).toThrow(
-      "262144 UTF-8 bytes",
-    );
+    await expect(
+      putHtml(createTestBoardStore(), "session", "large", "é".repeat(131_073)),
+    ).rejects.toThrow("262144 UTF-8 bytes");
   });
 
-  it("bumps once per applyOps transaction and removes widget bytes", () => {
+  it("bumps once per applyOps transaction and removes widget bytes", async () => {
     const store = createTestBoardStore();
-    putHtml(store, "session", "status");
-    const snapshot = store.applyOps({ sessionKey: "session" }, [
+    await putHtml(store, "session", "status");
+    const snapshot = await store.applyOps({ sessionKey: "session" }, [
       { kind: "widget_resize", name: "status", sizeW: 3, sizeH: 3 },
       { kind: "widget_remove", name: "status" },
     ]);
     expect(snapshot.revision).toBe(2);
     expect(snapshot.widgets).toEqual([]);
-    expect(store.readWidgetHtml({ sessionKey: "session" }, "status")).toBeUndefined();
+    expect(await readBoardHtml(store, { sessionKey: "session" }, "status")).toBeUndefined();
   });
 
-  it("preserves position on content updates and honors explicit after placement", () => {
+  it("preserves position on content updates and honors explicit after placement", async () => {
     const store = createTestBoardStore();
-    putHtml(store, "session", "first");
-    putHtml(store, "session", "second");
-    putHtml(store, "session", "third");
+    await putHtml(store, "session", "first");
+    await putHtml(store, "session", "second");
+    await putHtml(store, "session", "third");
 
     expect(
-      putHtml(store, "session", "first", "<p>updated</p>").widgets.map((widget) => widget.name),
+      (await putHtml(store, "session", "first", "<p>updated</p>")).widgets.map(
+        (widget) => widget.name,
+      ),
     ).toEqual(["first", "second", "third"]);
     expect(
-      store
-        .putWidget({
+      (
+        await store.putWidget({
           sessionKey: "session",
           name: "first",
           content: { kind: "html", html: "<p>moved</p>" },
           placement: { after: "third" },
         })
-        .widgets.map((widget) => widget.name),
+      ).widgets.map((widget) => widget.name),
     ).toEqual(["second", "third", "first"]);
   });
+});
+
+it("does not select the HTML BLOB when preparing board view metadata", async () => {
+  const stateDir = tempDirs.make("openclaw-board-projection-");
+  const env = { OPENCLAW_STATE_DIR: stateDir };
+  const sessionKey = "agent:main:projection";
+  const database = openOpenClawAgentDatabase({ agentId: "main", env });
+  const store = createTestBoardStore({ stateDir });
+  await store.putWidget({
+    sessionKey,
+    name: "status",
+    content: { kind: "html", html: "x".repeat(256 * 1024) },
+  });
+  const prepare = vi.spyOn(database.db, "prepare");
+
+  const prepared = await store.getSnapshotWithHtmlViewMetadata({ sessionKey });
+
+  const widgetSelects = prepare.mock.calls
+    .map(([sql]) => sql)
+    .filter((sql) => /select .* from "board_widgets"/iu.test(sql));
+  expect(widgetSelects).toHaveLength(1);
+  expect(widgetSelects[0]).toContain('"sha256"');
+  expect(widgetSelects[0]).not.toContain('"html"');
+  expect(prepared.htmlViewMetadata.get("status")).not.toHaveProperty("html");
+  prepare.mockRestore();
 });

--- a/src/boards/board-store.ts
+++ b/src/boards/board-store.ts
@@ -59,24 +59,48 @@ export type BoardSnapshotWithHtmlViewMetadata = {
 
 export type BoardSessionTarget = { sessionKey: string; agentId?: string };
 
+export type BoardWriteOptions = {
+  /** Recheck the caller after write admission, inside the synchronous mutation. */
+  assertCurrent?: () => void;
+};
+
 export interface BoardStore {
-  getSnapshot(target: BoardSessionTarget): BoardSnapshot;
-  getSnapshotWithHtmlViewMetadata(target: BoardSessionTarget): BoardSnapshotWithHtmlViewMetadata;
-  applyOps(target: BoardSessionTarget, ops: readonly BoardOp[]): BoardSnapshot;
-  putWidget(params: BoardWidgetMaterializedPutParams): BoardWidgetPutResult;
+  /** Start consumption in the authoritative read turn; release the database before awaiting its result. */
+  useSnapshot<T>(
+    target: BoardSessionTarget,
+    consume: (snapshot: BoardSnapshot) => T,
+  ): Promise<Awaited<T>>;
+  useWidgetDocument<T>(
+    target: BoardSessionTarget,
+    name: string,
+    consume: (document: BoardWidgetDocument | undefined) => T,
+  ): Promise<Awaited<T>>;
+
+  getSnapshot(target: BoardSessionTarget): Promise<BoardSnapshot>;
+  getSnapshotWithHtmlViewMetadata(
+    target: BoardSessionTarget,
+  ): Promise<BoardSnapshotWithHtmlViewMetadata>;
+  applyOps(
+    target: BoardSessionTarget,
+    ops: readonly BoardOp[],
+    options?: BoardWriteOptions,
+  ): Promise<BoardSnapshot>;
+  putWidget(
+    params: BoardWidgetMaterializedPutParams,
+    options?: BoardWriteOptions,
+  ): Promise<BoardWidgetPutResult>;
   grant(
     target: BoardSessionTarget,
     name: string,
     decision: "granted" | "rejected",
     revision: number,
     instanceId?: string,
-  ): BoardSnapshot;
-  readWidgetHtml(target: BoardSessionTarget, name: string): BoardWidgetHtmlDocument | undefined;
-  readWidgetRegistered(
+    options?: BoardWriteOptions,
+  ): Promise<BoardSnapshot>;
+  readWidgetMcpApp(
     target: BoardSessionTarget,
     name: string,
-  ): BoardWidgetRegisteredDocument | undefined;
-  readWidgetMcpApp(target: BoardSessionTarget, name: string): BoardWidgetMcpAppDocument | undefined;
+  ): Promise<BoardWidgetMcpAppDocument | undefined>;
 }
 
 const BOARD_MAX_WIDGETS = 48;

--- a/src/boards/sqlite-board-codec.ts
+++ b/src/boards/sqlite-board-codec.ts
@@ -18,6 +18,8 @@ import {
   createBoardDeclaredSummary,
   resolveBoardWidgetPutParams,
   type BoardWidgetHtmlViewMetadata,
+  type BoardWidgetHtmlDocument,
+  type BoardWidgetDocument,
   type BoardWidgetNameIdentityMarker,
   type BoardWidgetRegisteredDocument,
 } from "./board-store.js";
@@ -357,7 +359,7 @@ export function updateManifestHeightMode(
   return JSON.stringify({ ...parsed, heightMode });
 }
 
-export function effectiveGrantState(
+function effectiveGrantState(
   storedGrantState: string,
   manifest: ParsedBoardManifest,
 ): BoardWidget["grantState"] {
@@ -401,7 +403,65 @@ export function parsePluginContent(value: string): ParsedPluginContent {
       };
 }
 
-export function rowToRegisteredDocument(
+function rowToHtmlDocument(
+  row: Pick<
+    SelectedBoardWidgetRow,
+    "content_kind" | "html" | "revision" | "sha256" | "view_generation" | "grant_state" | "manifest"
+  >,
+): BoardWidgetHtmlDocument | undefined {
+  if (row.content_kind !== "html" || row.html === null || row.view_generation === null) {
+    return undefined;
+  }
+  const manifest = parseManifest(row.manifest);
+  const declared = manifest.declared;
+  return {
+    html: Buffer.from(row.html).toString("utf8"),
+    revision: row.revision,
+    sha256: row.sha256,
+    viewGeneration: row.view_generation,
+    grantState: effectiveGrantState(row.grant_state, manifest),
+    ...(declared ? { declared } : {}),
+  };
+}
+
+export function rowToBoardWidgetDocument(
+  row: Pick<
+    SelectedBoardWidgetRow,
+    | "content_kind"
+    | "html"
+    | "descriptor_json"
+    | "title"
+    | "revision"
+    | "sha256"
+    | "view_generation"
+    | "grant_state"
+    | "manifest"
+  >,
+): BoardWidgetDocument | undefined {
+  if (row.content_kind === "html") {
+    return rowToHtmlDocument(row);
+  }
+  if (row.content_kind === "plugin") {
+    return rowToRegisteredDocument(row);
+  }
+  if (row.descriptor_json === null) {
+    return undefined;
+  }
+  const manifest = parseManifest(row.manifest);
+  if (manifest.mcpAppInteractive === undefined || manifest.mcpAppInstanceId === undefined) {
+    return undefined;
+  }
+  return {
+    descriptor: parseDescriptor(row.descriptor_json),
+    revision: row.revision,
+    instanceId: manifest.mcpAppInstanceId,
+    grantState: effectiveGrantState(row.grant_state, manifest),
+    declaredTools: manifest.declared?.tools ?? [],
+    interactive: manifest.mcpAppInteractive,
+  };
+}
+
+function rowToRegisteredDocument(
   row: Pick<
     SelectedBoardWidgetRow,
     | "content_kind"

--- a/src/boards/sqlite-board-store.ts
+++ b/src/boards/sqlite-board-store.ts
@@ -27,28 +27,26 @@ import {
   normalizeBoardWidgetPutParams,
   type BoardSessionTarget,
   type BoardStore,
+  type BoardWriteOptions,
+  type BoardWidgetDocument,
   type BoardSnapshotWithHtmlViewMetadata,
-  type BoardWidgetHtmlDocument,
   type BoardWidgetHtmlViewMetadata,
   type BoardWidgetMcpAppDocument,
-  type BoardWidgetRegisteredDocument,
 } from "./board-store.js";
 import {
   BOARD_WIDGET_SNAPSHOT_COLUMNS,
   createBoardWidgetContentFields,
-  effectiveGrantState,
   parseDescriptor,
   parseManifest,
   parsePluginContent,
   resolveSqliteBoardWidgetPutParams,
-  rowToRegisteredDocument,
+  rowToBoardWidgetDocument,
   rowToTab,
   rowToHtmlViewMetadata,
   rowToWidget,
   serializeManifest,
   updateManifestHeightMode,
   type SelectedBoardTabRow,
-  type SelectedBoardWidgetRow,
   type SelectedBoardWidgetSnapshotRow,
 } from "./sqlite-board-codec.js";
 
@@ -85,11 +83,11 @@ function boardTablesPresent(database: Pick<OpenClawAgentDatabase, "db">): boolea
   return true;
 }
 
-export function listBoardSessionKeysReadOnly(params: {
+export async function listBoardSessionKeysReadOnly(params: {
   agentId: string;
   path: string;
   env?: NodeJS.ProcessEnv;
-}): ReadonlySet<string> {
+}): Promise<ReadonlySet<string>> {
   const result = withOpenClawAgentDatabaseReadOnly((database) => {
     if (!boardTablesPresent(database)) {
       return [];
@@ -198,27 +196,6 @@ function readStoredBoard(database: BoardDatabaseHandle, sessionKey: string): Sto
     },
     { databaseLabel: database.path, operationLabel: "board.read" },
   );
-}
-
-function rowToHtmlDocument(
-  row: Pick<
-    SelectedBoardWidgetRow,
-    "content_kind" | "html" | "revision" | "sha256" | "view_generation" | "grant_state" | "manifest"
-  >,
-): BoardWidgetHtmlDocument | undefined {
-  if (row.content_kind !== "html" || row.html === null || row.view_generation === null) {
-    return undefined;
-  }
-  const manifest = parseManifest(row.manifest);
-  const declared = manifest.declared;
-  return {
-    html: Buffer.from(row.html).toString("utf8"),
-    revision: row.revision,
-    sha256: row.sha256,
-    viewGeneration: row.view_generation,
-    grantState: effectiveGrantState(row.grant_state, manifest),
-    ...(declared ? { declared } : {}),
-  };
 }
 
 function upsertTabs(
@@ -421,25 +398,34 @@ export class SqliteBoardStore implements BoardStore {
     return { database, resolved };
   }
 
-  getSnapshot(target: BoardSessionTarget): BoardSnapshot {
-    const resolved = this.resolve(target);
-    const result = withOpenClawAgentDatabaseReadOnly(
-      (database) =>
-        hasSession(database, resolved.sessionKey) && boardTablesPresent(database)
-          ? readStoredBoard(database, resolved.sessionKey).snapshot
-          : undefined,
-      {
-        agentId: resolved.agentId,
-        ...(resolved.path ? { path: resolved.path } : {}),
-        env: this.options.env,
-      },
-    );
-    return cloneBoardSnapshot(
-      result.found && result.value ? result.value : emptyBoardSnapshot(resolved.sessionKey),
-    );
+  async getSnapshot(target: BoardSessionTarget): Promise<BoardSnapshot> {
+    return this.readSnapshotWithHtmlViewMetadata(target).snapshot;
   }
 
-  getSnapshotWithHtmlViewMetadata(target: BoardSessionTarget): BoardSnapshotWithHtmlViewMetadata {
+  async getSnapshotWithHtmlViewMetadata(
+    target: BoardSessionTarget,
+  ): Promise<BoardSnapshotWithHtmlViewMetadata> {
+    return this.readSnapshotWithHtmlViewMetadata(target);
+  }
+
+  async useSnapshot<T>(
+    target: BoardSessionTarget,
+    consume: (snapshot: BoardSnapshot) => T,
+  ): Promise<Awaited<T>> {
+    return await consume(this.readSnapshotWithHtmlViewMetadata(target).snapshot);
+  }
+
+  async useWidgetDocument<T>(
+    target: BoardSessionTarget,
+    name: string,
+    consume: (document: BoardWidgetDocument | undefined) => T,
+  ): Promise<Awaited<T>> {
+    return await consume(this.readWidgetDocument(target, name));
+  }
+
+  private readSnapshotWithHtmlViewMetadata(
+    target: BoardSessionTarget,
+  ): BoardSnapshotWithHtmlViewMetadata {
     const resolved = this.resolve(target);
     const result = withOpenClawAgentDatabaseReadOnly(
       (database) =>
@@ -459,13 +445,19 @@ export class SqliteBoardStore implements BoardStore {
     };
   }
 
-  applyOps(target: BoardSessionTarget, ops: readonly BoardOp[]): BoardSnapshot {
+  async applyOps(
+    target: BoardSessionTarget,
+    ops: readonly BoardOp[],
+    options?: BoardWriteOptions,
+  ): Promise<BoardSnapshot> {
     if (ops.length === 0) {
       return this.getSnapshot(target);
     }
+    options?.assertCurrent?.();
     const { database, resolved } = this.prepareWrite(target);
     return runOpenClawAgentWriteTransaction(
       (transactionDatabase) => {
+        options?.assertCurrent?.();
         if (!hasSession(transactionDatabase, resolved.sessionKey)) {
           throw new BoardValidationError(
             "not_found",
@@ -492,12 +484,14 @@ export class SqliteBoardStore implements BoardStore {
     );
   }
 
-  putWidget(params: BoardWidgetMaterializedPutParams) {
+  async putWidget(params: BoardWidgetMaterializedPutParams, options?: BoardWriteOptions) {
+    options?.assertCurrent?.();
     const { database, resolved } = this.prepareWrite(params);
     const canonicalInput = normalizeBoardWidgetPutParams(params, resolved.sessionKey);
     const viewGeneration = randomBytes(16).toString("hex");
     return runOpenClawAgentWriteTransaction(
       (transactionDatabase) => {
+        options?.assertCurrent?.();
         if (!hasSession(transactionDatabase, resolved.sessionKey)) {
           throw new BoardValidationError(
             "not_found",
@@ -577,16 +571,19 @@ export class SqliteBoardStore implements BoardStore {
     );
   }
 
-  grant(
+  async grant(
     target: BoardSessionTarget,
     name: string,
     decision: "granted" | "rejected",
     revision: number,
     instanceId?: string,
-  ): BoardSnapshot {
+    options?: BoardWriteOptions,
+  ): Promise<BoardSnapshot> {
+    options?.assertCurrent?.();
     const { database, resolved } = this.prepareWrite(target);
     return runOpenClawAgentWriteTransaction(
       (transactionDatabase) => {
+        options?.assertCurrent?.();
         if (!hasSession(transactionDatabase, resolved.sessionKey)) {
           throw new BoardValidationError(
             "not_found",
@@ -694,38 +691,22 @@ export class SqliteBoardStore implements BoardStore {
     return result.found ? result.value : undefined;
   }
 
-  readWidgetHtml(target: BoardSessionTarget, name: string): BoardWidgetHtmlDocument | undefined {
-    const row = this.readWidgetRow(target, name);
-    return row ? rowToHtmlDocument(row) : undefined;
-  }
-
-  readWidgetMcpApp(
+  private readWidgetDocument(
     target: BoardSessionTarget,
     name: string,
-  ): BoardWidgetMcpAppDocument | undefined {
+    contentKind?: "mcp-app",
+  ): BoardWidgetDocument | undefined {
     const row = this.readWidgetRow(target, name);
-    if (!row || row.content_kind !== "mcp-app" || row.descriptor_json === null) {
-      return undefined;
-    }
-    const manifest = parseManifest(row.manifest);
-    if (manifest.mcpAppInteractive === undefined || manifest.mcpAppInstanceId === undefined) {
-      return undefined;
-    }
-    return {
-      descriptor: parseDescriptor(row.descriptor_json),
-      revision: row.revision,
-      instanceId: manifest.mcpAppInstanceId,
-      grantState: effectiveGrantState(row.grant_state, manifest),
-      declaredTools: manifest.declared?.tools ?? [],
-      interactive: manifest.mcpAppInteractive,
-    };
+    return row && (!contentKind || row.content_kind === contentKind)
+      ? rowToBoardWidgetDocument(row)
+      : undefined;
   }
 
-  readWidgetRegistered(
+  async readWidgetMcpApp(
     target: BoardSessionTarget,
     name: string,
-  ): BoardWidgetRegisteredDocument | undefined {
-    const row = this.readWidgetRow(target, name);
-    return row ? rowToRegisteredDocument(row) : undefined;
+  ): Promise<BoardWidgetMcpAppDocument | undefined> {
+    const document = this.readWidgetDocument(target, name, "mcp-app");
+    return document && "descriptor" in document ? document : undefined;
   }
 }

--- a/src/canvas/widget-tool.report.test.ts
+++ b/src/canvas/widget-tool.report.test.ts
@@ -4,7 +4,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createDashboardTool } from "../agents/tools/dashboard-tool.js";
 import type { InProcessGatewayCaller } from "../agents/tools/in-process-gateway.js";
 import type { BoardReport } from "../boards/board-report.js";
-import { createTestBoardStore } from "../boards/board-store.test-support.js";
+import { readBoardHtml, createTestBoardStore } from "../boards/board-store.test-support.js";
 import { createBoardHarness } from "../gateway/server-methods/board.test-support.js";
 import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -84,7 +84,7 @@ describe("native report authoring", () => {
         sessionKey: "global",
         agentId: target.agentId === "main" ? "research" : "main",
       };
-      const siblingBefore = store.getSnapshot(sibling);
+      const siblingBefore = await store.getSnapshot(sibling);
       const { invoke } = createBoardHarness(undefined, {}, store, {
         getRuntimeConfig: () => ({
           agents: { ownership: "explicit", entries: { main: {}, research: {} } },
@@ -117,7 +117,7 @@ describe("native report authoring", () => {
         status: "pinned",
         boardWidgetName: "community-pulse",
       });
-      expect(store.getSnapshot(target).widgets[0]).toMatchObject({
+      expect((await store.getSnapshot(target)).widgets[0]).toMatchObject({
         name: "community-pulse",
         contentKind: "plugin",
         contentOwner: "plugin",
@@ -138,15 +138,18 @@ describe("native report authoring", () => {
         props: updated,
       });
       closeOpenClawAgentDatabasesForTest();
-      expect(store.getSnapshot(target).widgets[0]).toMatchObject({ props: updated, revision: 2 });
+      expect((await store.getSnapshot(target)).widgets[0]).toMatchObject({
+        props: updated,
+        revision: 2,
+      });
       const view = await invoke("board.get", target);
       expect(view.mock.calls[0]?.[0]).toBe(true);
       const snapshot = view.mock.calls[0]?.[1] as { widgets: Array<Record<string, unknown>> };
       expect(snapshot.widgets[0]).toMatchObject({ pluginKind: "session:report", props: updated });
       expect(snapshot.widgets[0]).not.toHaveProperty("frameUrl");
       expect(snapshot.widgets[0]).not.toHaveProperty("viewTicket");
-      expect(store.readWidgetHtml(target, "community-pulse")).toBeUndefined();
-      expect(store.getSnapshot(sibling)).toEqual(siblingBefore);
+      expect(await readBoardHtml(store, target, "community-pulse")).toBeUndefined();
+      expect(await store.getSnapshot(sibling)).toEqual(siblingBefore);
       await expect(access(resolveCanvasDocumentsDir(stateDir))).rejects.toThrow();
     },
   );
@@ -184,16 +187,17 @@ describe("native report authoring", () => {
         blocks: Array.from({ length: 3 }, () => ({ type: "text", text: "é".repeat(2_000) })),
       },
     },
-  ])("rejects $label at the storage owner without changing the saved report", ({ props }) => {
+  ])("rejects $label at the storage owner without changing the saved report", async ({ props }) => {
     const store = createTestBoardStore();
     const target = { sessionKey: "agent:main:report" };
     const content = { kind: "plugin" as const, pluginKind: "session:report", props: report };
-    store.putWidget({ ...target, name: "report", content });
-    const before = store.getSnapshot(target);
-    expect(() =>
-      store.putWidget({ ...target, name: "report", content: { ...content, props } }),
-    ).toThrow();
-    expect(store.getSnapshot(target)).toEqual(before);
+    await store.putWidget({ ...target, name: "report", content });
+    const before = await store.getSnapshot(target);
+    await expect(
+      (async () =>
+        await store.putWidget({ ...target, name: "report", content: { ...content, props } }))(),
+    ).rejects.toThrow();
+    expect(await store.getSnapshot(target)).toEqual(before);
   });
 
   it.each([

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { InProcessGatewayCaller } from "../agents/tools/in-process-gateway.js";
-import { createTestBoardStore } from "../boards/board-store.test-support.js";
+import { readBoardHtml, createTestBoardStore } from "../boards/board-store.test-support.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { createBoardHandlers } from "../gateway/server-methods/board.js";
@@ -662,7 +662,7 @@ describe("show_widget", () => {
       const broadcast = vi.fn();
       const target = { sessionKey, agentId };
       const sibling = { sessionKey: "global", agentId: agentId === "main" ? "research" : "main" };
-      const siblingBefore = store.getSnapshot(sibling);
+      const siblingBefore = await store.getSnapshot(sibling);
       const boardBroadcastScope = { sessionKeys: [sessionKey], agentId };
       const eventSessionKey = sessionKey === "global" ? `agent:${agentId}:global` : sessionKey;
       const cfg: OpenClawConfig = {
@@ -718,12 +718,12 @@ describe("show_widget", () => {
       const result = await pinWidget("<p>ready</p>", true);
       const pinnedTitle = Array.from(title).slice(0, 80).join("");
 
-      expect(store.readWidgetHtml(target, "release-status")).toMatchObject({
+      expect(await readBoardHtml(store, target, "release-status")).toMatchObject({
         html: buildWidgetDocument(pinnedTitle, "<p>ready</p>"),
         revision: 1,
       });
-      expect(store.getSnapshot(target).widgets[0]?.title).toBe(pinnedTitle);
-      expect(store.getSnapshot(target).widgets[0]?.presentation).toBe("frameless");
+      expect((await store.getSnapshot(target)).widgets[0]?.title).toBe(pinnedTitle);
+      expect((await store.getSnapshot(target)).widgets[0]?.presentation).toBe("frameless");
       expect(result.resultText).toContain("pinned to dashboard tab main as release-status (lg)");
       expect(result.boardWidgetName).toBe("release-status");
       expect(broadcast).toHaveBeenCalledWith(
@@ -739,11 +739,11 @@ describe("show_widget", () => {
           content: { kind: "plugin", pluginKind: "workboard:card" },
         }),
       ).rejects.toThrow(/same content kind.*remove/i);
-      expect(store.readWidgetHtml(target, "release-status")?.revision).toBe(1);
+      expect((await readBoardHtml(store, target, "release-status"))?.revision).toBe(1);
 
       const refreshed = await pinWidget("<p>refreshed</p>");
 
-      expect(store.readWidgetHtml(target, "release-status")).toMatchObject({
+      expect(await readBoardHtml(store, target, "release-status")).toMatchObject({
         html: buildWidgetDocument(pinnedTitle, "<p>refreshed</p>"),
         revision: 2,
       });
@@ -753,7 +753,7 @@ describe("show_widget", () => {
         { sessionKey: eventSessionKey, revision: 2, widget: "release-status" },
         boardBroadcastScope,
       );
-      expect(store.getSnapshot(sibling)).toEqual(siblingBefore);
+      expect(await store.getSnapshot(sibling)).toEqual(siblingBefore);
     },
   );
 
@@ -803,7 +803,7 @@ describe("show_widget", () => {
       path.join(resolveCanvasDocumentDir(stateDir, result.viewId), "index.html"),
       "utf8",
     );
-    const pinned = store.readWidgetHtml({ sessionKey: "agent:main:weather" }, "weather");
+    const pinned = await readBoardHtml(store, { sessionKey: "agent:main:weather" }, "weather");
 
     expect(inlineHtml).toContain("connect-src 'none'");
     expect(pinned).toMatchObject({
@@ -935,7 +935,7 @@ describe("show_widget", () => {
       }),
     ]);
     expect(new Set([slash.boardWidgetName, plus.boardWidgetName]).size).toBe(2);
-    expect(store.getSnapshot({ sessionKey }).widgets).toHaveLength(2);
+    expect((await store.getSnapshot({ sessionKey })).widgets).toHaveLength(2);
 
     const composed = await executeWidget({
       stateDir,
@@ -954,7 +954,9 @@ describe("show_widget", () => {
       callGateway,
     });
     expect(decomposed.boardWidgetName).toBe(composed.boardWidgetName);
-    expect(store.readWidgetHtml({ sessionKey }, composed.boardWidgetName ?? "")).toMatchObject({
+    expect(
+      await readBoardHtml(store, { sessionKey }, composed.boardWidgetName ?? ""),
+    ).toMatchObject({
       revision: 2,
     });
   });

--- a/src/config/sessions/session-accessor.reset-progress.test.ts
+++ b/src/config/sessions/session-accessor.reset-progress.test.ts
@@ -1,6 +1,7 @@
 /** A fresh conversation must not inherit the prior task's progress card. */
 import path from "node:path";
 import { expect, it } from "vitest";
+import { readBoardHtml } from "../../boards/board-store.test-support.js";
 import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
 import {
   readSessionProgressCard,
@@ -53,12 +54,12 @@ it.each(
       const boards = new SqliteBoardStore({
         resolveSession: () => ({ agentId: "main", path: database.path, sessionKey }),
       });
-      boards.putWidget({
+      await boards.putWidget({
         sessionKey,
         name: "retained-widget",
         content: { kind: "html", html: "<p>Keep this dashboard</p>" },
       });
-      const boardBefore = boards.getSnapshot({ sessionKey });
+      const boardBefore = await boards.getSnapshot({ sessionKey });
       const historyBefore = await loadTranscriptEvents(scope);
       const entryBefore = loadSessionEntry(scope);
       const input =
@@ -122,8 +123,8 @@ it.each(
       expect(readSessionProgressCard(database.path, sessionKey)).toEqual(
         context === "clear" && !rollback ? null : before,
       );
-      expect(boards.getSnapshot({ sessionKey })).toEqual(boardBefore);
-      expect(boards.readWidgetHtml({ sessionKey }, "retained-widget")?.html).toBe(
+      expect(await boards.getSnapshot({ sessionKey })).toEqual(boardBefore);
+      expect((await readBoardHtml(boards, { sessionKey }, "retained-widget"))?.html).toBe(
         "<p>Keep this dashboard</p>",
       );
       if (context === "clear" && !rollback) {

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -186,6 +186,7 @@ test.each(
       }),
     });
     const appends: unknown[] = [];
+    const boardAppends: Promise<void>[] = [];
     const appendErrors: unknown[] = [];
     let commitChecks = 0;
     let commitRequested = false;
@@ -206,12 +207,21 @@ test.each(
             }
             if (operation === "board") {
               // First use enters the board's schema transaction before its canonical writer.
-              appends.push(
-                board.putWidget({
-                  sessionKey: scope.sessionKey,
-                  name: "writer-proof",
-                  content: { kind: "html", html: "<p>committed</p>" },
-                }).revision,
+              boardAppends.push(
+                board
+                  .putWidget({
+                    sessionKey: scope.sessionKey,
+                    name: "writer-proof",
+                    content: { kind: "html", html: "<p>committed</p>" },
+                  })
+                  .then(
+                    (snapshot) => {
+                      appends.push(snapshot.revision);
+                    },
+                    (error: unknown) => {
+                      appendErrors.push(error);
+                    },
+                  ),
               );
               continue;
             }
@@ -253,6 +263,7 @@ test.each(
     } finally {
       process.off("worker", observeWorker);
     }
+    await Promise.all(boardAppends);
     expect(workers).toHaveLength(1);
     expect(workers[0]?.id).toBeGreaterThan(0);
     expect(diagnostics).toEqual({ kind: "history-eviction", workerThreadId: workers[0]?.id });
@@ -277,7 +288,7 @@ test.each(
         continue;
       }
       if (operation === "board") {
-        expect(board.getSnapshot({ sessionKey: scope.sessionKey }).widgets).toMatchObject([
+        expect((await board.getSnapshot({ sessionKey: scope.sessionKey })).widgets).toMatchObject([
           { name: "writer-proof", revision: 1 },
         ]);
         continue;

--- a/src/gateway/board-host-tools.ts
+++ b/src/gateway/board-host-tools.ts
@@ -24,8 +24,10 @@ import { isGatewaySubordinateWorkAdmissionClosed } from "../process/gateway-work
 import {
   BoardGatewayUnavailableError,
   type BoardViewTicketAuthorityInput,
+  verifyBoardViewTicket,
+  requireBoardViewTicketAuthority,
 } from "./board-view-ticket.js";
-import { resolveAuthorizedBoardWidgetView } from "./board-widget-view.js";
+import { withAuthorizedBoardWidgetView } from "./board-widget-view.js";
 import { agentsHandlers } from "./server-methods/agents.js";
 import { cronHandlers } from "./server-methods/cron.js";
 import { healthHandlers } from "./server-methods/health.js";
@@ -46,7 +48,21 @@ export type BoardRequestAuthority = {
 
 export type BoardCapabilityAuthority = BoardRequestAuthority & {
   boardSession: Required<BoardSessionTarget>;
+  /** Validate the stored grant and start work together; assertActive only checks request liveness. */
+  useCurrent: <T>(start: () => T) => Promise<Awaited<T>>;
 };
+
+export function assertBoardCapabilityParamsSize(
+  params: Record<string, unknown>,
+  capability: "action" | "data binding",
+): void {
+  if (Buffer.byteLength(JSON.stringify(params), "utf8") > 8 * 1024) {
+    throw new BoardValidationError(
+      "invalid_operation",
+      `board widget ${capability} params exceed 8192 UTF-8 bytes`,
+    );
+  }
+}
 
 export function boardDataBindingCapability(
   bindingId: string,
@@ -65,50 +81,61 @@ export function captureBoardCapabilityAuthority(
   capability: string,
 ): BoardCapabilityAuthority {
   const authority = captureBoardRequestAuthority(invocation);
-  const resolveSession = () => {
+  const claims = verifyBoardViewTicket(ticket);
+  if (!claims) {
+    throw new BoardValidationError("invalid_operation", "board widget view ticket is invalid");
+  }
+  requireBoardViewTicketAuthority(claims, invocation.context);
+  const resolveSession = (target: BoardSessionTarget) => {
     authority.assertActive();
-    const view = resolveAuthorizedBoardWidgetView(store, ticket, {
-      gatewayContext: invocation.context,
-    });
     const cfg = invocation.context.getRuntimeConfig();
-    const selected = resolveRequestedSessionAgentId(cfg, view.sessionKey, view.agentId);
+    const selected = resolveRequestedSessionAgentId(cfg, target.sessionKey, target.agentId);
     if (
       !selected.ok ||
       resolveSessionStoreKey({
         cfg,
-        sessionKey: view.sessionKey,
+        sessionKey: target.sessionKey,
         storeAgentId: selected.agentId,
-      }) !== view.sessionKey
+      }) !== target.sessionKey
     ) {
       throw new BoardValidationError(
         "invalid_operation",
         "board widget session identity changed; reload the dashboard",
       );
     }
-    if (!boardWidgetHasGrantedTool(view.document.declared, view.document.grantState, capability)) {
-      throw new BoardValidationError(
-        "invalid_operation",
-        `board widget tool is not granted: ${capability}`,
-      );
-    }
-    return { sessionKey: view.sessionKey, agentId: selected.agentId };
+    return { sessionKey: target.sessionKey, agentId: selected.agentId };
   };
-  const boardSession = resolveSession();
+  const boardSession = resolveSession(claims);
   return {
     ...authority,
     boardSession,
-    assertActive: () => {
-      const current = resolveSession();
-      if (
-        current.agentId !== boardSession.agentId ||
-        current.sessionKey !== boardSession.sessionKey
-      ) {
-        throw new BoardValidationError(
-          "invalid_operation",
-          "board widget session identity changed; reload the dashboard",
-        );
-      }
-    },
+    useCurrent: async <T>(start: () => T): Promise<Awaited<T>> =>
+      await withAuthorizedBoardWidgetView(
+        store,
+        ticket,
+        (view) => {
+          const current = resolveSession(view);
+          if (
+            current.agentId !== boardSession.agentId ||
+            current.sessionKey !== boardSession.sessionKey
+          ) {
+            throw new BoardValidationError(
+              "invalid_operation",
+              "board widget session identity changed; reload the dashboard",
+            );
+          }
+          if (
+            !boardWidgetHasGrantedTool(view.document.declared, view.document.grantState, capability)
+          ) {
+            throw new BoardValidationError(
+              "invalid_operation",
+              `board widget tool is not granted: ${capability}`,
+            );
+          }
+          return start();
+        },
+        { gatewayContext: invocation.context },
+      ),
   };
 }
 
@@ -197,41 +224,46 @@ async function invokeGatewayHandler(
   method: string,
   params: Record<string, unknown>,
   invocation: GatewayHandlerInvocation,
-  authority: BoardRequestAuthority,
-): Promise<unknown> {
-  let didRespond = false;
-  let succeeded = false;
-  let payload: unknown;
-  let responseError: ErrorShape | undefined;
-  authority.assertActive();
-  await handler({
-    ...invocation,
-    req: { ...invocation.req, method, params },
-    params,
-    respond: (ok, value, error) => {
-      if (didRespond) {
-        return;
-      }
-      didRespond = true;
-      if (ok) {
-        succeeded = true;
-        payload = value;
-      } else {
-        responseError = error;
-      }
-    },
+  authority: BoardCapabilityAuthority,
+  publish: GatewayHandlerInvocation["respond"],
+): Promise<void> {
+  let outcome:
+    | { kind: "reply"; ok: boolean; payload: unknown; error: ErrorShape | undefined }
+    | { kind: "thrown"; error: unknown }
+    | undefined;
+  await authority.useCurrent(async () => {
+    try {
+      await handler({
+        ...invocation,
+        req: { ...invocation.req, method, params },
+        params,
+        respond: (ok, payload, error) => {
+          outcome ??= { kind: "reply", ok, payload, error };
+        },
+      });
+    } catch (error) {
+      outcome = { kind: "thrown", error };
+    }
   });
-  authority.assertActive();
-  if (!didRespond) {
-    throw new BoardValidationError("invalid_operation", `${method} did not return a result`);
-  }
-  if (!succeeded) {
-    throw new BoardValidationError(
-      "invalid_operation",
-      responseError?.message || `${method} failed`,
-    );
-  }
-  return payload;
+  await authority.useCurrent(() => {
+    if (!outcome) {
+      publish(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `${method} did not return a result`),
+      );
+    } else if (outcome.kind === "thrown") {
+      respondBoardError(outcome.error, publish);
+    } else if (!outcome.ok) {
+      publish(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, outcome.error?.message || `${method} failed`),
+      );
+    } else {
+      publish(true, outcome.payload);
+    }
+  });
 }
 
 export async function readBoardDataBinding(
@@ -239,11 +271,11 @@ export async function readBoardDataBinding(
   params: Record<string, unknown>,
   invocation: GatewayHandlerInvocation,
   authority: BoardCapabilityAuthority,
-): Promise<unknown> {
+  publish: GatewayHandlerInvocation["respond"],
+): Promise<void> {
   if (bindingId === GITHUB_ACTIONS_BINDING_ID) {
     const { readBoardGitHubActions } = await import("./github-actions-read.js");
-    authority.assertActive();
-    return await readBoardGitHubActions(params, invocation.context, authority);
+    return await readBoardGitHubActions(params, invocation.context, authority, publish);
   }
   if (isBoardDataBindingId(bindingId)) {
     return await invokeGatewayHandler(
@@ -252,6 +284,7 @@ export async function readBoardDataBinding(
       params,
       invocation,
       authority,
+      publish,
     );
   }
   const registration = authority.pluginRegistry?.dashboardDataBindings.get(bindingId);
@@ -267,6 +300,7 @@ export async function readBoardDataBinding(
     params,
     invocation,
     authority,
+    publish,
   );
 }
 
@@ -275,7 +309,8 @@ export async function runBoardActionVerb(
   params: Record<string, unknown>,
   invocation: GatewayHandlerInvocation,
   authority: BoardCapabilityAuthority,
-): Promise<unknown> {
+  publish: GatewayHandlerInvocation["respond"],
+): Promise<void> {
   const registration = authority.pluginRegistry?.dashboardActionVerbs.get(actionId);
   if (!registration) {
     throw new BoardValidationError(
@@ -302,6 +337,7 @@ export async function runBoardActionVerb(
     params,
     invocation,
     authority,
+    publish,
   );
 }
 
@@ -309,12 +345,14 @@ export async function triggerBoardCronJob(
   jobId: string,
   invocation: GatewayHandlerInvocation,
   authority: BoardCapabilityAuthority,
-): Promise<unknown> {
+  publish: GatewayHandlerInvocation["respond"],
+): Promise<void> {
   return await invokeGatewayHandler(
     cronHandlers["cron.run"]!,
     "cron.run",
     { id: jobId, mode: "force" },
     invocation,
     authority,
+    publish,
   );
 }

--- a/src/gateway/board-http.test.ts
+++ b/src/gateway/board-http.test.ts
@@ -4,7 +4,8 @@ import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { createTestBoardStore } from "../boards/board-store.test-support.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { readBoardHtml, createTestBoardStore } from "../boards/board-store.test-support.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { handleBoardHttpRequest } from "./board-http.js";
@@ -40,31 +41,31 @@ const gatewayBAuthority = {
 };
 
 beforeAll(async () => {
-  store.putWidget({
+  await store.putWidget({
     sessionKey: "agent:main:main",
     name: "status",
     content: { kind: "html", html: statusHtml },
   });
-  store.putWidget({
+  await store.putWidget({
     sessionKey: "agent:main:main",
     name: "pending",
     content: { kind: "html", html: "pending" },
     declared: { tools: ["pending.read"] },
   });
-  const rejected = store.putWidget({
+  const rejected = await store.putWidget({
     sessionKey: "agent:main:main",
     name: "rejected",
     content: { kind: "html", html: "rejected" },
     declared: { tools: ["rejected.read"] },
   });
-  store.grant(
+  await store.grant(
     mainSession,
     "rejected",
     "rejected",
     1,
     rejected.widgets.find((widget) => widget.name === "rejected")?.instanceId,
   );
-  store.putWidget({
+  await store.putWidget({
     sessionKey: "agent:main:main",
     name: "mcp",
     content: {
@@ -78,29 +79,32 @@ beforeAll(async () => {
       interactive: false,
     },
   });
-  store.putWidget({
+  await store.putWidget({
     sessionKey: "agent:main:main",
     name: "revisioned",
     content: { kind: "html", html: "<p>one</p>" },
   });
-  store.putWidget({
+  await store.putWidget({
     sessionKey: "agent:main:main",
     name: "grantable",
     content: { kind: "html", html: "<script>pending()</script>" },
     declared: { netOrigins: ["https://example.com"] },
   });
   server = createServer((req, res) => {
-    const handled = handleBoardHttpRequest(req, res, {
+    void handleBoardHttpRequest(req, res, {
       store,
       nowMs,
       resolveGatewayContext: () => requestGatewayContext,
-    } as Parameters<typeof handleBoardHttpRequest>[2] & {
-      resolveGatewayContext: () => GatewayRequestContext | undefined;
-    });
-    if (!handled) {
-      res.statusCode = 404;
-      res.end("unhandled");
-    }
+    }).then(
+      (handled) => {
+        if (!handled) {
+          res.statusCode = 404;
+          res.end("unhandled");
+        }
+      },
+      (error: unknown) =>
+        res.destroy(new Error("Board HTTP test request failed", { cause: error })),
+    );
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -124,8 +128,8 @@ afterAll(async () => {
   rmSync(stateDir, { recursive: true, force: true });
 });
 
-function ticketFor(name: string, revision = 1, issuedAtMs = nowMs): string {
-  const document = store.readWidgetHtml(mainSession, name);
+async function ticketFor(name: string, revision = 1, issuedAtMs = nowMs): Promise<string> {
+  const document = await readBoardHtml(store, mainSession, name);
   if (!document) {
     throw new Error(`missing HTML widget: ${name}`);
   }
@@ -162,7 +166,7 @@ function request(
 describe("board widget HTTP", () => {
   it("binds global widget tickets to their canonical session and selected owner", async () => {
     for (const agentId of ["main", "work"]) {
-      store.putWidget({
+      await store.putWidget({
         sessionKey: "global",
         agentId,
         name: "global-status",
@@ -171,7 +175,7 @@ describe("board widget HTTP", () => {
     }
     for (const agentId of ["main", "work"]) {
       const target = { sessionKey: "global", agentId };
-      const document = store.readWidgetHtml(target, "global-status")!;
+      const document = (await readBoardHtml(store, target, "global-status"))!;
       const { ticket } = issueTicket({
         ...target,
         name: "global-status",
@@ -193,12 +197,12 @@ describe("board widget HTTP", () => {
   it("serves a ticket only through its issuing live Gateway", async () => {
     gatewayAActive = true;
     requestGatewayContext = gatewayA;
-    const ticket = ticketFor("status");
+    const ticket = await ticketFor("status");
     expect((await request("status", { ticket })).status).toBe(200);
 
     requestGatewayContext = gatewayB;
     expect((await request("status", { ticket })).status).toBe(503);
-    const document = store.readWidgetHtml(mainSession, "status");
+    const document = await readBoardHtml(store, mainSession, "status");
     if (!document) {
       throw new Error("missing status widget");
     }
@@ -220,8 +224,8 @@ describe("board widget HTTP", () => {
     gatewayAActive = true;
   });
 
-  it("round-trips self-contained claims covered by a two-minute HMAC ticket", () => {
-    const document = store.readWidgetHtml(mainSession, "status");
+  it("round-trips self-contained claims covered by a two-minute HMAC ticket", async () => {
+    const document = await readBoardHtml(store, mainSession, "status");
     if (!document || !("html" in document)) {
       throw new Error("missing status widget");
     }
@@ -250,7 +254,7 @@ describe("board widget HTTP", () => {
     {
       label: "authorized multibyte HTML",
       name: "status",
-      ticket: () => ticketFor("status"),
+      ticket: async () => await ticketFor("status"),
       status: 200,
       body: statusHtml,
       contentType: "text/html; charset=utf-8",
@@ -273,7 +277,7 @@ describe("board widget HTTP", () => {
     for (const method of ["GET", "HEAD"] as const) {
       const response = await request(testCase.name, {
         method,
-        ticket: testCase.ticket?.(),
+        ticket: await testCase.ticket?.(),
       });
       const body = Buffer.from(await response.arrayBuffer());
 
@@ -295,16 +299,16 @@ describe("board widget HTTP", () => {
 
   it("does not require or inspect an operator token", async () => {
     const response = await request("status", {
-      ticket: ticketFor("status"),
+      ticket: await ticketFor("status"),
       headers: { Authorization: "Bearer test-token" },
     });
     expect(response.status).toBe(200);
   });
 
   it("rejects garbage and expired tickets before reading the store", async () => {
-    const expired = ticketFor("status", 1, nowMs - BOARD_VIEW_TICKET_TTL_MS - 1);
-    const valid = ticketFor("status");
-    const readSpy = vi.spyOn(store, "readWidgetHtml");
+    const expired = await ticketFor("status", 1, nowMs - BOARD_VIEW_TICKET_TTL_MS - 1);
+    const valid = await ticketFor("status");
+    const readSpy = vi.spyOn(store, "useWidgetDocument");
     expect((await request("status")).status).toBe(401);
     const garbage = await request("status", { ticket: "garbage" });
     expect(garbage.status).toBe(401);
@@ -315,16 +319,80 @@ describe("board widget HTTP", () => {
     readSpy.mockRestore();
   });
 
+  it("withholds delayed HTML when the serving Gateway retires during its read", async () => {
+    const ticket = await ticketFor("status");
+    const started = createDeferred();
+    const release = createDeferred();
+    const read = store.useWidgetDocument.bind(store);
+    const readSpy = vi.spyOn(store, "useWidgetDocument").mockImplementationOnce(async (...args) => {
+      started.resolve();
+      await release.promise;
+      return await read(...args);
+    });
+    const pending = request("status", { ticket });
+    try {
+      await started.promise;
+      gatewayAActive = false;
+      release.resolve();
+      const response = await pending;
+      expect(response.status).toBe(503);
+      expect(await response.text()).toBe("Service Unavailable");
+    } finally {
+      release.resolve();
+      await pending;
+      gatewayAActive = true;
+      readSpy.mockRestore();
+    }
+  });
+
+  it("sends widget HTML in the authorized read turn before a queued removal", async () => {
+    await store.putWidget({
+      ...mainSession,
+      name: "handoff",
+      content: { kind: "html", html: "handoff" },
+    });
+    const ticket = await ticketFor("handoff");
+    const order: string[] = [];
+    const removed = createDeferred();
+    server.prependOnceListener("request", (_req, res) => {
+      res.once("finish", () => order.push("sent"));
+    });
+    const read = store.useWidgetDocument.bind(store);
+    const readSpy = vi
+      .spyOn(store, "useWidgetDocument")
+      .mockImplementationOnce((target, name, consume) =>
+        read(target, name, (document) => {
+          queueMicrotask(() => {
+            order.push("removal");
+            void store
+              .applyOps(target, [{ kind: "widget_remove", name }])
+              .then(() => removed.resolve(), removed.reject);
+          });
+          return consume(document);
+        }),
+      );
+    try {
+      const response = await request("handoff", { ticket });
+      await removed.promise;
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("handoff");
+      expect(order).toEqual(["sent", "removal"]);
+      expect(await readBoardHtml(store, mainSession, "handoff")).toBeUndefined();
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
   it("withholds declared widget bytes until the operator grants them", async () => {
-    const ticket = ticketFor("grantable");
+    const ticket = await ticketFor("grantable");
     expect((await request("grantable", { ticket })).status).toBe(401);
 
-    store.grant(
+    await store.grant(
       mainSession,
       "grantable",
       "granted",
       1,
-      store.getSnapshot(mainSession).widgets.find((widget) => widget.name === "grantable")
+      (await store.getSnapshot(mainSession)).widgets.find((widget) => widget.name === "grantable")
         ?.instanceId,
     );
     const response = await request("grantable", { ticket });
@@ -336,34 +404,34 @@ describe("board widget HTTP", () => {
   });
 
   it("rejects a ticket after the widget revision changes", async () => {
-    const stale = ticketFor("revisioned");
-    store.putWidget({
+    const stale = await ticketFor("revisioned");
+    await store.putWidget({
       sessionKey: "agent:main:main",
       name: "revisioned",
       content: { kind: "html", html: "<p>two</p>" },
     });
     expect((await request("revisioned", { ticket: stale })).status).toBe(401);
-    const current = await request("revisioned", { ticket: ticketFor("revisioned", 2) });
+    const current = await request("revisioned", { ticket: await ticketFor("revisioned", 2) });
     expect(current.status).toBe(200);
     await expect(current.text()).resolves.toBe("<p>two</p>");
   });
 
   it("rejects a stale ticket when a widget name and revision are reused", async () => {
-    store.putWidget({
+    await store.putWidget({
       sessionKey: "agent:main:main",
       name: "recreated",
       content: { kind: "html", html: "<p>old</p>" },
     });
-    const stale = ticketFor("recreated");
-    store.applyOps(mainSession, [{ kind: "widget_remove", name: "recreated" }]);
-    store.putWidget({
+    const stale = await ticketFor("recreated");
+    await store.applyOps(mainSession, [{ kind: "widget_remove", name: "recreated" }]);
+    await store.putWidget({
       sessionKey: "agent:main:main",
       name: "recreated",
       content: { kind: "html", html: "<p>old</p>" },
     });
 
     expect((await request("recreated", { ticket: stale })).status).toBe(401);
-    expect((await request("recreated", { ticket: ticketFor("recreated") })).status).toBe(200);
+    expect((await request("recreated", { ticket: await ticketFor("recreated") })).status).toBe(200);
   });
 
   it("rejects a ticket with a stale view generation", async () => {
@@ -378,17 +446,18 @@ describe("board widget HTTP", () => {
   });
 
   it("refuses pending and rejected widgets even with valid tickets", async () => {
-    expect((await request("pending", { ticket: ticketFor("pending") })).status).toBe(401);
-    expect((await request("rejected", { ticket: ticketFor("rejected") })).status).toBe(401);
+    expect((await request("pending", { ticket: await ticketFor("pending") })).status).toBe(401);
+    expect((await request("rejected", { ticket: await ticketFor("rejected") })).status).toBe(401);
   });
 
   it("serves an encoded slash as part of an opaque session key", async () => {
-    store.putWidget({
+    await store.putWidget({
       sessionKey: "session/with/slash",
       name: "slash-key",
       content: { kind: "html", html: "slash" },
     });
-    const document = store.readWidgetHtml(
+    const document = await readBoardHtml(
+      store,
       { sessionKey: "session/with/slash", agentId: "main" },
       "slash-key",
     );
@@ -429,7 +498,7 @@ describe("board widget HTTP", () => {
   });
 
   it("allows GET and HEAD only", async () => {
-    const response = await request("status", { method: "POST", ticket: ticketFor("status") });
+    const response = await request("status", { method: "POST", ticket: await ticketFor("status") });
     expect(response.status).toBe(405);
     expect(response.headers.get("allow")).toBe("GET, HEAD");
   });

--- a/src/gateway/board-http.ts
+++ b/src/gateway/board-http.ts
@@ -3,7 +3,7 @@ import type { BoardStore } from "../boards/board-store.js";
 import { buildBoardWidgetContentSecurityPolicy } from "./board-sandbox.js";
 import { boardStore } from "./board-store.js";
 import { BoardGatewayUnavailableError, BOARD_HTTP_PATH_PREFIX } from "./board-view-ticket.js";
-import { resolveAuthorizedBoardWidgetView } from "./board-widget-view.js";
+import { withAuthorizedBoardWidgetView } from "./board-widget-view.js";
 import { isReadHttpMethod, respondNotFound, respondPlainText } from "./control-ui-http-utils.js";
 import { sendMethodNotAllowed } from "./http-common.js";
 import type { GatewayContextResolver } from "./server-methods/types.js";
@@ -34,11 +34,11 @@ function parseBoardWidgetPath(pathname: string): { sessionKey: string; name: str
   }
 }
 
-export function handleBoardHttpRequest(
+export async function handleBoardHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
   opts: BoardHttpOptions = {},
-): boolean {
+): Promise<boolean> {
   const url = new URL(req.url ?? "/", "http://localhost");
   const pathname = url.pathname;
   if (!pathname.startsWith(BOARD_HTTP_PATH_PREFIX)) {
@@ -61,12 +61,36 @@ export function handleBoardHttpRequest(
     respondPlainText(res, 401, "Unauthorized");
     return true;
   }
-  let authorized;
   try {
-    authorized = resolveAuthorizedBoardWidgetView(opts.store ?? boardStore, ticket, {
-      gatewayContext: opts.resolveGatewayContext?.(),
-      nowMs: opts.nowMs,
-    });
+    return await withAuthorizedBoardWidgetView(
+      opts.store ?? boardStore,
+      ticket,
+      (authorized) => {
+        // Ticket claims address stored rows; owned frame routes carry observer identity.
+        const routeSessionKey = authorized.agentId
+          ? sessionObserverScopeKey(authorized.sessionKey, authorized.agentId)
+          : authorized.sessionKey;
+        if (routeSessionKey !== path.sessionKey || authorized.name !== path.name) {
+          respondPlainText(res, 401, "Unauthorized");
+          return true;
+        }
+        const html = authorized.document.html;
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.setHeader("Content-Length", String(Buffer.byteLength(html)));
+        res.setHeader(
+          "Content-Security-Policy",
+          buildBoardWidgetContentSecurityPolicy(authorized.document),
+        );
+        res.setHeader("Cache-Control", "no-cache");
+        res.end(req.method === "HEAD" ? undefined : html);
+        return true;
+      },
+      {
+        gatewayContext: opts.resolveGatewayContext?.(),
+        nowMs: opts.nowMs,
+      },
+    );
   } catch (error) {
     if (error instanceof BoardGatewayUnavailableError) {
       respondPlainText(res, 503, "Service Unavailable");
@@ -75,23 +99,4 @@ export function handleBoardHttpRequest(
     respondPlainText(res, 401, "Unauthorized");
     return true;
   }
-  // Ticket claims address stored rows; owned frame routes carry observer identity.
-  const routeSessionKey = authorized.agentId
-    ? sessionObserverScopeKey(authorized.sessionKey, authorized.agentId)
-    : authorized.sessionKey;
-  if (routeSessionKey !== path.sessionKey || authorized.name !== path.name) {
-    respondPlainText(res, 401, "Unauthorized");
-    return true;
-  }
-  const html = authorized.document.html;
-  res.statusCode = 200;
-  res.setHeader("Content-Type", "text/html; charset=utf-8");
-  res.setHeader("Content-Length", String(Buffer.byteLength(html)));
-  res.setHeader(
-    "Content-Security-Policy",
-    buildBoardWidgetContentSecurityPolicy(authorized.document),
-  );
-  res.setHeader("Cache-Control", "no-cache");
-  res.end(req.method === "HEAD" ? undefined : html);
-  return true;
 }

--- a/src/gateway/board-store.test.ts
+++ b/src/gateway/board-store.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { readBoardHtml } from "../boards/board-store.test-support.js";
 import { buildWidgetDocument } from "../canvas/wrap.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/io.js";
 import { replaceSessionEntrySync } from "../config/sessions/session-accessor.entry.js";
@@ -81,11 +82,11 @@ it("keeps global boards and progress under each owner's canonical row across reo
   for (const agentId of ["main", "work"]) {
     const target = { sessionKey: "global", agentId };
     for (const params of [target, { sessionKey: `agent:${agentId}:main` }]) {
-      expect(boardStore.getSnapshot(params)).toMatchObject({
+      expect(await boardStore.getSnapshot(params)).toMatchObject({
         sessionKey: "global",
         widgets: [{ name: "status", revision: 1 }],
       });
-      expect(boardStore.readWidgetHtml(params, "status")?.html).toBe(
+      expect((await readBoardHtml(boardStore, params, "status"))?.html).toBe(
         buildWidgetDocument("status", `<p>${agentId}</p>`),
       );
       const snapshot = await invoke("board.get", params);
@@ -228,7 +229,7 @@ it("reopens separate boards and progress cards in a shared database owned by ano
       { agentId, sessionKey, storePath },
       { sessionId: `session-${agentId}`, updatedAt: Date.now() },
     );
-    boardStore.putWidget({
+    await boardStore.putWidget({
       sessionKey,
       name: agentId,
       content: { kind: "html", html: `<p>${agentId}</p>` },
@@ -240,7 +241,7 @@ it("reopens separate boards and progress cards in a shared database owned by ano
 
   for (const agentId of ["alpha", "beta"]) {
     const sessionKey = `agent:${agentId}:main`;
-    expect(boardStore.getSnapshot({ sessionKey }).widgets).toEqual([
+    expect((await boardStore.getSnapshot({ sessionKey })).widgets).toEqual([
       expect.objectContaining({ name: agentId, revision: 1 }),
     ]);
     expect(await progressCardStore.get(sessionKey)).toMatchObject({

--- a/src/gateway/board-widget-view.ts
+++ b/src/gateway/board-widget-view.ts
@@ -13,71 +13,77 @@ type AuthorizedBoardWidgetView = BoardSessionTarget & {
   document: Extract<BoardWidgetDocument, { html: string }>;
 };
 
-export function resolveAuthorizedBoardWidgetView(
+export async function withAuthorizedBoardWidgetView<T>(
   store: BoardStore,
   ticket: string,
+  consume: (view: AuthorizedBoardWidgetView) => T,
   options: { gatewayContext?: GatewayRequestContext; nowMs?: number } = {},
-): AuthorizedBoardWidgetView {
+): Promise<Awaited<T>> {
   const claims = verifyBoardViewTicket(ticket, options);
   if (!claims) {
     throw new BoardValidationError("invalid_operation", "board widget view ticket is invalid");
   }
-  const authority = requireBoardViewTicketAuthority(claims, options.gatewayContext);
+  requireBoardViewTicketAuthority(claims, options.gatewayContext);
   const session = { sessionKey: claims.sessionKey, agentId: claims.agentId };
-  const document = claims.pluginFrame
-    ? store.readWidgetRegistered(session, claims.name)
-    : store.readWidgetHtml(session, claims.name);
-  if (
-    !document ||
-    (document.grantState !== "none" && document.grantState !== "granted") ||
-    document.revision !== claims.revision ||
-    document.viewGeneration !== claims.viewGeneration
-  ) {
-    throw new BoardValidationError("invalid_operation", "board widget view ticket is stale");
-  }
-  if (claims.pluginFrame) {
-    if (!("source" in document) || document.pluginKind !== claims.pluginFrame.pluginKind) {
+  return await store.useWidgetDocument(session, claims.name, (document) => {
+    const authority = requireBoardViewTicketAuthority(claims, options.gatewayContext);
+    if (claims.expiresAtMs <= (options.nowMs ?? Date.now())) {
+      throw new BoardValidationError("invalid_operation", "board widget view ticket is expired");
+    }
+    if (
+      !document ||
+      !("viewGeneration" in document) ||
+      (document.grantState !== "none" && document.grantState !== "granted") ||
+      document.revision !== claims.revision ||
+      document.viewGeneration !== claims.viewGeneration
+    ) {
       throw new BoardValidationError("invalid_operation", "board widget view ticket is stale");
     }
-    const registration = resolveBoardWidgetContentKindByPluginKind(
-      authority.pluginRegistry,
-      document.pluginKind,
-    );
-    const resourceUrls = registration
-      ? resolveBoardWidgetContentKindResourceUrls(registration, claims.pluginFrame.scopedHostUrl)
-      : undefined;
-    if (!registration || !resourceUrls) {
-      throw new BoardValidationError(
-        "invalid_operation",
-        "board widget content kind is unavailable",
+    if (claims.pluginFrame) {
+      if (!("source" in document) || document.pluginKind !== claims.pluginFrame.pluginKind) {
+        throw new BoardValidationError("invalid_operation", "board widget view ticket is stale");
+      }
+      const registration = resolveBoardWidgetContentKindByPluginKind(
+        authority.pluginRegistry,
+        document.pluginKind,
       );
+      const resourceUrls = registration
+        ? resolveBoardWidgetContentKindResourceUrls(registration, claims.pluginFrame.scopedHostUrl)
+        : undefined;
+      if (!registration || !resourceUrls) {
+        throw new BoardValidationError(
+          "invalid_operation",
+          "board widget content kind is unavailable",
+        );
+      }
+      const resourceOrigins = [
+        ...new Set(Object.values(resourceUrls).map((url) => new URL(url).origin)),
+      ];
+      const body = registration.definition.composeDocument({
+        source: document.source,
+        title: document.title ?? claims.name,
+        resourceUrls,
+        promptGranted:
+          document.grantState === "granted" &&
+          document.declared?.tools?.includes("prompt") === true,
+      });
+      const composed = {
+        html: buildWidgetDocument(document.title ?? claims.name, body, {
+          connectOrigins: document.declared?.netOrigins,
+          scriptOrigins: resourceOrigins,
+        }),
+        revision: document.revision,
+        sha256: document.sha256,
+        viewGeneration: document.viewGeneration,
+        grantState: document.grantState,
+        ...(document.declared ? { declared: document.declared } : {}),
+        resourceOrigins,
+      };
+      return consume({ ...session, name: claims.name, document: composed });
     }
-    const resourceOrigins = [
-      ...new Set(Object.values(resourceUrls).map((url) => new URL(url).origin)),
-    ];
-    const body = registration.definition.composeDocument({
-      source: document.source,
-      title: document.title ?? claims.name,
-      resourceUrls,
-      promptGranted:
-        document.grantState === "granted" && document.declared?.tools?.includes("prompt") === true,
-    });
-    const composed = {
-      html: buildWidgetDocument(document.title ?? claims.name, body, {
-        connectOrigins: document.declared?.netOrigins,
-        scriptOrigins: resourceOrigins,
-      }),
-      revision: document.revision,
-      sha256: document.sha256,
-      viewGeneration: document.viewGeneration,
-      grantState: document.grantState,
-      ...(document.declared ? { declared: document.declared } : {}),
-      resourceOrigins,
-    };
-    return { ...session, name: claims.name, document: composed };
-  }
-  if (!("html" in document)) {
-    throw new BoardValidationError("invalid_operation", "board widget view ticket is stale");
-  }
-  return { ...session, name: claims.name, document };
+    if (!("html" in document)) {
+      throw new BoardValidationError("invalid_operation", "board widget view ticket is stale");
+    }
+    return consume({ ...session, name: claims.name, document });
+  });
 }

--- a/src/gateway/github-actions-read.ts
+++ b/src/gateway/github-actions-read.ts
@@ -13,7 +13,7 @@ import {
   readGitHubJsonResponse,
 } from "./control-ui-github-api.js";
 import { requestCurrentGitHubOAuthRefresh } from "./github-oauth-lifecycle.js";
-import type { GatewayRequestContext } from "./server-methods/types.js";
+import type { GatewayRequestContext, RespondFn } from "./server-methods/types.js";
 
 const CACHE_TTL_MS = 30_000;
 const CACHE_LIMIT = 32;
@@ -85,7 +85,8 @@ function actionsFailure(error: unknown): Error {
 /** Pinning and reads share the same source-config scrub, refresh, and current credential check. */
 export async function prepareBoardGitHubIdentity(
   context: GatewayRequestContext,
-  authority: Pick<BoardCapabilityAuthority, "boardSession" | "assertActive">,
+  authority: Pick<BoardCapabilityAuthority, "boardSession" | "assertActive"> &
+    Partial<Pick<BoardCapabilityAuthority, "useCurrent">>,
 ) {
   try {
     const config = context.getRuntimeConfig();
@@ -95,9 +96,9 @@ export async function prepareBoardGitHubIdentity(
       agentId: authority.boardSession.agentId,
       getCurrentConfig: () => context.getRuntimeConfig(),
       assertActive: authority.assertActive,
+      startActive: authority.useCurrent,
       refresh: () => requestCurrentGitHubOAuthRefresh(authority.boardSession.agentId),
     });
-    await identity.revalidate();
     return identity;
   } catch (error) {
     if (
@@ -115,74 +116,76 @@ export async function readBoardGitHubActions(
   params: Record<string, unknown>,
   context: GatewayRequestContext,
   authority: BoardCapabilityAuthority,
-): Promise<ActionsResult> {
+  publish: RespondFn,
+): Promise<void> {
   const request = resolveGitHubActionsRequest(params);
-  authority.assertActive();
-  const cache: ActionsCache = gatewayCaches.get(context) ?? {
-    active: 0,
-    values: new Map(),
-    pending: new Map(),
-  };
-  gatewayCaches.set(context, cache);
-  if (cache.active >= MAX_CONCURRENT_READS) {
-    throw new Error("GitHub Actions reads are busy; retry shortly.");
-  }
-  cache.active += 1;
+  const cache = await authority.useCurrent(() => {
+    const admitted: ActionsCache = gatewayCaches.get(context) ?? {
+      active: 0,
+      values: new Map(),
+      pending: new Map(),
+    };
+    gatewayCaches.set(context, admitted);
+    if (admitted.active >= MAX_CONCURRENT_READS) {
+      throw new Error("GitHub Actions reads are busy; retry shortly.");
+    }
+    admitted.active += 1;
+    return admitted;
+  });
   try {
     const identity = await prepareBoardGitHubIdentity(context, authority);
-    identity.assertSelected();
     const key = JSON.stringify([authority.boardSession, identity.cacheScope, request.url]);
-    const cached = cache.values.get(key);
-    if (cached && cached.expiresAt > Date.now()) {
-      return structuredClone(cached.value);
-    }
-    cache.values.delete(key);
-    // Creation is synchronous, so the checked caller admits the fetch. Shared transport
-    // must not inherit that widget's lifetime; every caller gates delivery below.
-    const result = await getOrCreatePromise(
-      cache.pending,
-      key,
-      async () => {
-        const response = await fetchGitHubApi(request.url, fetch, identity.token, async () => {
-          // A redirect is a new target, not authority to read another repository or operation.
-          throw new BoardValidationError(
-            "invalid_operation",
-            "GitHub Actions redirected the request; verify the repository/workflow, update the widget grant if needed, and retry.",
-          );
-        });
-        const raw = await readGitHubJsonResponse(response, ACTIONS_MAX_RESPONSE_BYTES);
-        const parsed = runsSchema.safeParse(raw);
-        if (
-          !parsed.success ||
-          parsed.data.workflow_runs.length > request.perPage ||
-          JSON.stringify(parsed.data).includes(identity.token)
-        ) {
-          throw new Error("Invalid Actions response");
-        }
-        for (const run of parsed.data.workflow_runs) {
-          const url = new URL(run.html_url);
+    const result = await identity.start(() => {
+      const cached = cache.values.get(key);
+      if (cached && cached.expiresAt > Date.now()) {
+        return structuredClone(cached.value);
+      }
+      cache.values.delete(key);
+      // Creation is synchronous, so the checked caller admits the fetch. Shared transport
+      // must not inherit that widget's lifetime; every caller gates delivery below.
+      return getOrCreatePromise(
+        cache.pending,
+        key,
+        async () => {
+          const response = await fetchGitHubApi(request.url, fetch, identity.token, async () => {
+            // A redirect is a new target, not authority to read another repository or operation.
+            throw new BoardValidationError(
+              "invalid_operation",
+              "GitHub Actions redirected the request; verify the repository/workflow, update the widget grant if needed, and retry.",
+            );
+          });
+          const raw = await readGitHubJsonResponse(response, ACTIONS_MAX_RESPONSE_BYTES);
+          const parsed = runsSchema.safeParse(raw);
           if (
-            url.origin !== "https://github.com" ||
-            url.username ||
-            url.password ||
-            url.search ||
-            url.hash ||
-            url.pathname.toLowerCase() !== `/${request.repository}/actions/runs/${run.id}`
+            !parsed.success ||
+            parsed.data.workflow_runs.length > request.perPage ||
+            JSON.stringify(parsed.data).includes(identity.token)
           ) {
-            throw new Error("Invalid Actions run URL");
+            throw new Error("Invalid Actions response");
           }
-        }
-        // Internal, credential-scoped cache population is not delivery. No widget owns
-        // this transport result; every caller must validate its own authority below.
-        cache.values.set(key, { value: parsed.data, expiresAt: Date.now() + CACHE_TTL_MS });
-        pruneMapToMaxSize(cache.values, CACHE_LIMIT);
-        return parsed.data;
-      },
-      { evictOnSettled: true },
-    );
-    await identity.revalidate();
-    identity.assertSelected();
-    return structuredClone(result);
+          for (const run of parsed.data.workflow_runs) {
+            const url = new URL(run.html_url);
+            if (
+              url.origin !== "https://github.com" ||
+              url.username ||
+              url.password ||
+              url.search ||
+              url.hash ||
+              url.pathname.toLowerCase() !== `/${request.repository}/actions/runs/${run.id}`
+            ) {
+              throw new Error("Invalid Actions run URL");
+            }
+          }
+          // Internal, credential-scoped cache population is not delivery. No widget owns
+          // this transport result; every caller must validate its own authority below.
+          cache.values.set(key, { value: parsed.data, expiresAt: Date.now() + CACHE_TTL_MS });
+          pruneMapToMaxSize(cache.values, CACHE_LIMIT);
+          return parsed.data;
+        },
+        { evictOnSettled: true },
+      );
+    });
+    await identity.start(() => publish(true, structuredClone(result)));
   } catch (error) {
     throw actionsFailure(error);
   } finally {

--- a/src/gateway/server-broadcast.board.test.ts
+++ b/src/gateway/server-broadcast.board.test.ts
@@ -314,7 +314,7 @@ describe("board and progress event session ownership", () => {
           content: { kind: "html", html: "<p>Working</p>" },
           declared: { tools: ["status.refresh"] },
         });
-        const widget = boardStore.getSnapshot(target).widgets[0]!;
+        const widget = (await boardStore.getSnapshot(target)).widgets[0]!;
         const rawGrant = await invoke("board.widget.grant", {
           ...target,
           name: "status",
@@ -332,7 +332,7 @@ describe("board and progress event session ownership", () => {
           agentId: "main",
           ops: [{ kind: "tab_create", tabId: "main-notes", title: "Main notes" }],
         });
-        expect(boardStore.getSnapshot(target)).toMatchObject({
+        expect(await boardStore.getSnapshot(target)).toMatchObject({
           sessionKey: "global",
           revision: 3,
           widgets: [{ name: "status", grantState: "granted" }],

--- a/src/gateway/server-methods/board.content-kinds.test.ts
+++ b/src/gateway/server-methods/board.content-kinds.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
+import { readBoardRegistered } from "../../boards/board-store.test-support.js";
 import { createPluginBoardWidgetContentKindRegistrar } from "../../plugins/board-widget-content-kinds.js";
 import { createPluginRecord } from "../../plugins/loader-records.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
@@ -8,7 +9,7 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../../plugins/runtime.js";
-import { resolveAuthorizedBoardWidgetView } from "../board-widget-view.js";
+import { withAuthorizedBoardWidgetView } from "../board-widget-view.js";
 import { createBoardHarness } from "./board.test-support.js";
 
 function registeredWidgetRegistry() {
@@ -94,7 +95,7 @@ describe("board registered widget content kinds", () => {
         ],
       });
       expect(
-        store.readWidgetRegistered({ sessionKey: "session", agentId: "main" }, "status"),
+        await readBoardRegistered(store, { sessionKey: "session", agentId: "main" }, "status"),
       ).toMatchObject({
         source: "diagram:second",
         pluginKind: "diagram:diagram",
@@ -114,12 +115,16 @@ describe("board registered widget content kinds", () => {
         frameUrl: expect.stringContaining("/__openclaw__/board/"),
         sandboxUrl: expect.stringContaining("/mcp-app-sandbox"),
       });
-      const authorized = resolveAuthorizedBoardWidgetView(store, widget.viewTicket!, {
-        gatewayContext: context,
-      });
-      expect(authorized.document.html).toContain("<main>diagram:second</main>");
-      expect(authorized.document.html).toContain(
-        "https://gateway.test/__openclaw__/cap/diagram-token/__openclaw__/diagram/app.js",
+      await withAuthorizedBoardWidgetView(
+        store,
+        widget.viewTicket!,
+        (authorized) => {
+          expect(authorized.document.html).toContain("<main>diagram:second</main>");
+          expect(authorized.document.html).toContain(
+            "https://gateway.test/__openclaw__/cap/diagram-token/__openclaw__/diagram/app.js",
+          );
+        },
+        { gatewayContext: context },
       );
       expect(composeDocument).toHaveBeenCalledOnce();
     } finally {
@@ -197,7 +202,7 @@ describe("board registered widget content kinds", () => {
       }
       const widget = (snapshot as BoardSnapshot).widgets[0]!;
 
-      resolveAuthorizedBoardWidgetView(store, widget.viewTicket!, {
+      await withAuthorizedBoardWidgetView(store, widget.viewTicket!, () => {}, {
         gatewayContext: context,
       });
 

--- a/src/gateway/server-methods/board.github-actions.test.ts
+++ b/src/gateway/server-methods/board.github-actions.test.ts
@@ -8,7 +8,7 @@ import type {
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { clearGitHubCredentialVerificationCache } from "../../agents/github-oauth-client.js";
 import { resolveManagedGitHubProfileDir } from "../../agents/github-tool-identity.js";
-import { createTestBoardStore } from "../../boards/board-store.test-support.js";
+import { readBoardHtml, createTestBoardStore } from "../../boards/board-store.test-support.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createPluginBoardWidgetContentKindRegistrar } from "../../plugins/board-widget-content-kinds.js";
 import { createPluginRecord } from "../../plugins/loader-records.js";
@@ -184,7 +184,7 @@ describe("board authenticated GitHub Actions", () => {
         name: "runs",
         content: { kind: "html", html: "original" },
       });
-      const before = store.getSnapshot(target);
+      const before = await store.getSnapshot(target);
       broadcast.mockClear();
       if (unavailable === "missing native" || unavailable === "native failure") {
         delete config.tools!.github;
@@ -210,8 +210,8 @@ describe("board authenticated GitHub Actions", () => {
       expect(response.mock.calls[0]?.[0]).toBe(false);
       expect(response.mock.calls[0]?.[2]?.message).toMatch(/reconnect|retry/);
       expect(JSON.stringify(response.mock.calls)).not.toContain(token);
-      expect(store.getSnapshot(target)).toEqual(before);
-      expect(store.readWidgetHtml(target, "runs")?.html).toContain("original");
+      expect(await store.getSnapshot(target)).toEqual(before);
+      expect((await readBoardHtml(store, target, "runs"))?.html).toContain("original");
       expect(broadcast).not.toHaveBeenCalled();
       expect(http).not.toHaveBeenCalled();
       if (unavailable === "missing managed" || unavailable === "invalid managed") {
@@ -263,10 +263,10 @@ describe("board authenticated GitHub Actions", () => {
       expect(account).toHaveBeenCalledOnce();
       expect(native).not.toHaveBeenCalled();
       expect(actionCalls()).toHaveLength(0);
-      expect(store.getSnapshot(target).widgets[0]?.declared?.tools).toEqual([
+      expect((await store.getSnapshot(target)).widgets[0]?.declared?.tools).toEqual([
         "github.actions.runs:owner/repo",
       ]);
-      const before = store.getSnapshot(target);
+      const before = await store.getSnapshot(target);
       broadcast.mockClear();
       // Verified credentials are reused within their TTL; expire the entry so the
       // next pin must prove the credential again.
@@ -276,7 +276,7 @@ describe("board authenticated GitHub Actions", () => {
       expect(denied.mock.calls[0]?.[0]).toBe(false);
       expect(denied.mock.calls[0]?.[2]?.message).toMatch(/reconnect|retry/);
       expect(JSON.stringify(denied.mock.calls)).not.toContain(token);
-      expect(store.getSnapshot(target)).toEqual(before);
+      expect(await store.getSnapshot(target)).toEqual(before);
       expect(broadcast).not.toHaveBeenCalled();
     },
   );
@@ -327,8 +327,12 @@ describe("board authenticated GitHub Actions", () => {
       expect(response.mock.calls[0]?.[0]).toBe(true);
       if (kind === "mcp-app") {
         expect(
-          store.readWidgetMcpApp({ sessionKey: "agent:main:runs", agentId: "main" }, "other")
-            ?.declaredTools,
+          (
+            await store.readWidgetMcpApp(
+              { sessionKey: "agent:main:runs", agentId: "main" },
+              "other",
+            )
+          )?.declaredTools,
         ).toEqual(["github.actions.runs:owner/repo"]);
       }
       expect(native).not.toHaveBeenCalled();
@@ -350,7 +354,7 @@ describe("board authenticated GitHub Actions", () => {
     async (changed) => {
       const { handlers, context, store, broadcast } = createGitHubBoardHarness();
       const target = { sessionKey: "agent:main:runs", agentId: "main" };
-      const before = store.getSnapshot(target);
+      const before = await store.getSnapshot(target);
       const controller = new AbortController();
       let current = true;
       const assertCurrent = () => {
@@ -402,7 +406,7 @@ describe("board authenticated GitHub Actions", () => {
       });
       await handlers["board.widget.put"]!(invocation);
       expect(respond.mock.calls[0]?.[0]).toBe(false);
-      expect(store.getSnapshot(target)).toEqual(before);
+      expect(await store.getSnapshot(target)).toEqual(before);
       expect(broadcast).not.toHaveBeenCalled();
       expect(actionCalls()).toHaveLength(0);
     },
@@ -598,6 +602,31 @@ describe("board authenticated GitHub Actions", () => {
     const unavailable = await read();
     expect(unavailable.mock.calls[0]?.[2]?.message).toContain("reconnect");
     expect(actionCalls()).toHaveLength(1);
+  });
+
+  it("does not start an Actions read after its widget is removed during credential preparation", async () => {
+    delete config.tools!.github;
+    native.mockImplementation(async () => commandResult(token));
+    const { read, invoke } = await reader();
+    const started = createDeferred();
+    const release = createDeferred();
+    native.mockImplementationOnce(async () => {
+      started.resolve();
+      await release.promise;
+      return commandResult(token);
+    });
+    const pending = read();
+    try {
+      await started.promise;
+      await invoke("board.update", {
+        sessionKey: "agent:main:runs",
+        ops: [{ kind: "widget_remove", name: "runs" }],
+      });
+    } finally {
+      release.resolve();
+    }
+    expect((await pending).mock.calls[0]?.[0]).toBe(false);
+    expect(actionCalls()).toHaveLength(0);
   });
 
   it("coalesces successful reads and scopes cache entries to filters and current credentials", async () => {

--- a/src/gateway/server-methods/board.plugin-capabilities.test.ts
+++ b/src/gateway/server-methods/board.plugin-capabilities.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  errorShape,
+  ErrorCodes,
+  type BoardSnapshot,
+} from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { registerPluginDashboardCapabilities } from "../../plugins/dashboard-capabilities.js";
 import { createPluginRecord } from "../../plugins/loader-records.js";
@@ -11,7 +15,7 @@ import {
 } from "../../plugins/runtime.js";
 import { createPluginGatewayMethodDescriptor } from "../methods/descriptor.js";
 import { createBoardHarness } from "./board.test-support.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 function createWorkboardCapabilityRegistry(params: {
   readHandler: GatewayRequestHandlers[string];
@@ -69,16 +73,117 @@ function createWorkboardCapabilityRegistry(params: {
 }
 
 describe("board plugin capabilities", () => {
-  it.each(["read", "action"] as const)(
-    "rejects an awaited plugin %s after its widget is removed or replaced",
-    async (operation) => {
+  it.each([
+    { operation: "read", phase: "start" },
+    { operation: "action", phase: "start" },
+    { operation: "read", phase: "publish" },
+    { operation: "action", phase: "publish" },
+  ] as const)(
+    "keeps $operation $phase in the authorized read turn",
+    async ({ operation, phase }) => {
+      const previousRegistry = getActivePluginRegistry();
+      const order: string[] = [];
+      let started = false;
+      const handler: GatewayRequestHandlers[string] = ({ respond }) => {
+        started = true;
+        order.push("started");
+        respond(true, { ok: true });
+      };
+      setActivePluginRegistry(
+        createWorkboardCapabilityRegistry({ readHandler: handler, actionHandler: handler }),
+      );
+      try {
+        const { invoke, store, handlers, context } = createBoardHarness(undefined, {}, undefined, {
+          getRuntimeConfig: () => ({
+            agents: { list: [{ id: "main" }] },
+            tools: { exec: { mode: "full" } },
+          }),
+        });
+        await invoke("board.widget.put", {
+          sessionKey: "session",
+          name: "handoff",
+          content: { kind: "html", html: "handoff" },
+          declared: { tools: ["workboard.cards.list", "workboard.dispatch"] },
+        });
+        const board = await invoke("board.get", { sessionKey: "session" });
+        const ticket = (board.mock.calls[0]![1] as BoardSnapshot).widgets[0]!.viewTicket;
+        const removed = createDeferred();
+        let removalScheduled = false;
+        const read = store.useWidgetDocument.bind(store);
+        vi.spyOn(store, "useWidgetDocument").mockImplementation((target, name, consume) =>
+          read(target, name, (document) => {
+            if (!removalScheduled && (phase === "start" || started)) {
+              removalScheduled = true;
+              queueMicrotask(() => {
+                order.push("removal");
+                void store
+                  .applyOps(target, [{ kind: "widget_remove", name }])
+                  .then(() => removed.resolve(), removed.reject);
+              });
+            }
+            return consume(document);
+          }),
+        );
+        const method = operation === "read" ? "board.data.read" : "board.action";
+        const params =
+          operation === "read"
+            ? { ticket, bindingId: "workboard.cards.list" }
+            : { ticket, action: "workboard.dispatch", params: { force: true } };
+        const respond = vi.fn<RespondFn>((ok) => {
+          if (ok) {
+            order.push("published");
+          }
+        });
+        await handlers[method]!({
+          req: { type: "req", id: "handoff", method, params },
+          params,
+          respond,
+          context,
+          client: null,
+          isWebchatConnect: () => false,
+        });
+        expect(removalScheduled).toBe(true);
+        await removed.promise;
+        expect(order).toEqual(
+          phase === "start" ? ["started", "removal"] : ["started", "published", "removal"],
+        );
+        expect(respond.mock.calls[0]?.[0]).toBe(phase === "publish");
+      } finally {
+        resetPluginRuntimeStateForTest();
+        if (previousRegistry) {
+          setActivePluginRegistry(previousRegistry);
+        }
+      }
+    },
+  );
+
+  it.each([
+    { operation: "read", outcome: "success", scope: "retired" },
+    { operation: "read", outcome: "failure", scope: "retired" },
+    { operation: "read", outcome: "throw", scope: "retired" },
+    { operation: "action", outcome: "success", scope: "retired" },
+    { operation: "action", outcome: "failure", scope: "retired" },
+    { operation: "action", outcome: "throw", scope: "retired" },
+    { operation: "read", outcome: "failure", scope: "current" },
+    { operation: "action", outcome: "throw", scope: "current" },
+  ] as const)(
+    "$scope widget authority controls plugin $operation $outcome publication",
+    async ({ operation, outcome, scope }) => {
       const previousRegistry = getActivePluginRegistry();
       const started = createDeferred();
       const release = createDeferred();
+      const privateDetail = "private plugin result detail";
       const handler: GatewayRequestHandlers[string] = async ({ respond }) => {
         started.resolve();
         await release.promise;
-        respond(true, { ok: true });
+        if (outcome === "throw") {
+          throw new Error(privateDetail);
+        }
+        if (outcome === "failure") {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, privateDetail));
+        } else {
+          respond(true, { detail: privateDetail });
+        }
       };
       setActivePluginRegistry(
         createWorkboardCapabilityRegistry({ readHandler: handler, actionHandler: handler }),
@@ -108,19 +213,28 @@ describe("board plugin capabilities", () => {
                 params: { force: true },
               });
         await started.promise;
-        if (operation === "read") {
+        if (scope === "retired" && operation === "read") {
           await invoke("board.widget.put", {
             ...widget,
             content: { kind: "html", html: "replacement" },
           });
-        } else {
+        } else if (scope === "retired") {
           await invoke("board.update", {
             sessionKey: "session",
             ops: [{ kind: "widget_remove", name: "plugin-widget" }],
           });
         }
         release.resolve();
-        expect((await pending).mock.calls[0]?.[0]).toBe(false);
+        const response = await pending;
+        expect(response.mock.calls[0]?.[0]).toBe(false);
+        if (scope === "retired") {
+          expect(JSON.stringify(response.mock.calls)).not.toContain(privateDetail);
+        } else {
+          expect(response.mock.calls[0]?.[2]).toMatchObject({
+            code: outcome === "throw" ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
+            message: expect.stringContaining(privateDetail),
+          });
+        }
       } finally {
         release.resolve();
         if (previousRegistry) {
@@ -165,7 +279,7 @@ describe("board plugin capabilities", () => {
         name: "plugin-widget",
         decision: "granted",
         revision: 1,
-        instanceId: store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets[0]
+        instanceId: (await store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets[0]
           ?.instanceId,
       });
       const board = await invoke("board.get", { sessionKey: "session" });

--- a/src/gateway/server-methods/board.runtime-boundaries.test.ts
+++ b/src/gateway/server-methods/board.runtime-boundaries.test.ts
@@ -27,6 +27,7 @@ import {
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resolveCoreOperatorGatewayMethodScope } from "../methods/core-descriptors.js";
 import {
   createCoreGatewayMethodDescriptors,
   createGatewayMethodRegistry,
@@ -40,6 +41,14 @@ import { sessionMutationHandlers } from "./sessions-mutations.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 const reviewWidgetApproval = vi.hoisted(() => vi.fn());
+const sessionList = vi.hoisted(() => vi.fn());
+const cronRun = vi.hoisted(() => vi.fn());
+
+vi.mock("./sessions-read.js", () => ({
+  sessionReadHandlers: { "sessions.list": sessionList },
+  sessionsListHandler: sessionList,
+}));
+vi.mock("./cron.js", () => ({ cronHandlers: { "cron.run": cronRun } }));
 
 vi.mock("../../agents/exec-auto-reviewer.js", () => ({
   createModelExecAutoReviewer: vi.fn(() => reviewWidgetApproval),
@@ -62,6 +71,8 @@ describe("board gateway runtime boundaries", () => {
     resetBoardEventNoticeStateForTest();
     resetSystemEventsForTest();
     reviewWidgetApproval.mockReset();
+    sessionList.mockReset();
+    cronRun.mockReset();
   });
 
   afterEach(() => {
@@ -70,9 +81,114 @@ describe("board gateway runtime boundaries", () => {
     closeOpenClawStateDatabaseForTest();
   });
 
+  it("registers every contract method with its required scope", () => {
+    expect(
+      Object.fromEntries(
+        [
+          "board.get",
+          "board.update",
+          "board.widget.put",
+          "board.widget.grant",
+          "board.widget.appView",
+          "board.event",
+          "board.prompt.authorize",
+          "board.data.read",
+          "board.action",
+        ].map((method) => [method, resolveCoreOperatorGatewayMethodScope(method)]),
+      ),
+    ).toEqual({
+      "board.get": "operator.read",
+      "board.update": "operator.write",
+      "board.widget.put": "operator.write",
+      "board.widget.grant": "operator.approvals",
+      "board.widget.appView": "operator.read",
+      "board.event": "operator.write",
+      "board.prompt.authorize": "operator.read",
+      "board.data.read": "operator.read",
+      "board.action": "operator.write",
+    });
+  });
+
+  it.each(["commit", "failure", "retired"] as const)(
+    "waits for board persistence before publishing a %s result",
+    async (outcome) => {
+      const harness = createHarness();
+      const started = createDeferred();
+      const release = createDeferred();
+      const applyOps = harness.store.applyOps.bind(harness.store);
+      vi.spyOn(harness.store, "applyOps").mockImplementationOnce(async (...args) => {
+        started.resolve();
+        await release.promise;
+        if (outcome === "failure") {
+          throw new Error("board write failed");
+        }
+        return await applyOps(...args);
+      });
+      let responded = false;
+      const pending = harness
+        .invoke("board.update", {
+          sessionKey: "session",
+          ops: [{ kind: "tab_create", tabId: "work", title: "Work" }],
+        })
+        .then((response) => {
+          responded = true;
+          return response;
+        });
+      await started.promise;
+      expect(responded).toBe(false);
+      expect(harness.broadcast).not.toHaveBeenCalled();
+      if (outcome === "retired") {
+        harness.context.resolveGatewayContext = () => undefined;
+      }
+      release.resolve();
+      const response = await pending;
+      const snapshot = await harness.store.getSnapshot({ sessionKey: "session", agentId: "main" });
+      expect(response.mock.calls[0]?.[0]).toBe(outcome === "commit");
+      expect(snapshot.tabs).toHaveLength(outcome === "commit" ? 1 : 0);
+      if (outcome === "commit") {
+        expect(harness.broadcast).toHaveBeenCalledWith(
+          "board.changed",
+          { sessionKey: "agent:main:session", revision: snapshot.revision },
+          { sessionKeys: ["agent:main:session"], agentId: "main" },
+        );
+      } else {
+        expect(harness.broadcast).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("waits for a board snapshot and rejects publication after its Gateway retires", async () => {
+    const harness = createHarness();
+    const started = createDeferred();
+    const release = createDeferred();
+    const read = harness.store.getSnapshotWithHtmlViewMetadata.bind(harness.store);
+    vi.spyOn(harness.store, "getSnapshotWithHtmlViewMetadata").mockImplementationOnce(
+      async (...args) => {
+        const snapshot = await read(...args);
+        started.resolve();
+        await release.promise;
+        return snapshot;
+      },
+    );
+    let responded = false;
+    const pending = harness.invoke("board.get", { sessionKey: "session" }).then((response) => {
+      responded = true;
+      return response;
+    });
+    await started.promise;
+    expect(responded).toBe(false);
+    harness.context.resolveGatewayContext = () => undefined;
+    release.resolve();
+    const response = await pending;
+    expect(response.mock.calls[0]?.[0]).toBe(false);
+    expect(response.mock.calls[0]?.[2]).toMatchObject({ code: "UNAVAILABLE" });
+  });
+
   it("enforces data bindings against the granted tool set", async () => {
-    const readDataBinding = vi.fn(async () => ({ sessions: ["one"] }));
-    const { invoke, store } = createHarness(undefined, { readDataBinding });
+    sessionList.mockImplementation(async ({ respond }: { respond: RespondFn }) =>
+      respond(true, { sessions: ["one"] }),
+    );
+    const { invoke, store } = createHarness();
     await invoke("board.widget.put", {
       sessionKey: "session",
       name: "reader",
@@ -86,7 +202,7 @@ describe("board gateway runtime boundaries", () => {
       params: { limit: 2 },
     });
     expect(denied.mock.calls[0]?.[0]).toBe(false);
-    expect(readDataBinding).not.toHaveBeenCalled();
+    expect(sessionList).not.toHaveBeenCalled();
 
     await invoke("board.widget.put", {
       sessionKey: "session",
@@ -99,7 +215,7 @@ describe("board gateway runtime boundaries", () => {
       name: "reader",
       decision: "granted",
       revision: 2,
-      instanceId: store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets[0]
+      instanceId: (await store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets[0]
         ?.instanceId,
     });
     board = await invoke("board.get", { sessionKey: "session" });
@@ -110,12 +226,7 @@ describe("board gateway runtime boundaries", () => {
       params: { limit: 2 },
     });
     expect(allowed.mock.calls[0]?.[1]).toEqual({ sessions: ["one"] });
-    expect(readDataBinding).toHaveBeenCalledWith(
-      "sessions.list",
-      { limit: 2 },
-      expect.objectContaining({ params: expect.any(Object) }),
-      expect.objectContaining({ assertActive: expect.any(Function) }),
-    );
+    expect(sessionList).toHaveBeenCalledWith(expect.objectContaining({ params: { limit: 2 } }));
   });
 
   it("fences awaited board mutation through Gateway dispatch when its root retires", async () => {
@@ -257,9 +368,9 @@ describe("board gateway runtime boundaries", () => {
       const { error } = await requestOutcome;
       expect(error).toBeInstanceOf(Error);
       expect(String(error)).toContain("dashboard unavailable");
-      expect(harness.store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets).toEqual(
-        [],
-      );
+      expect(
+        (await harness.store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets,
+      ).toEqual([]);
       expect(events).not.toContain("board.changed");
 
       await client.request("board.widget.put", {
@@ -268,7 +379,7 @@ describe("board gateway runtime boundaries", () => {
         content: { kind: "canvas-doc", docId: "live-canvas-doc" },
       });
       expect(
-        harness.store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets,
+        (await harness.store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets,
       ).toMatchObject([{ name: "live" }]);
       expect(events).toContain("board.changed");
     } finally {
@@ -322,9 +433,9 @@ describe("board gateway runtime boundaries", () => {
         });
         return {
           response,
-          verify: () =>
+          verify: async () =>
             expect(
-              harness.store.getSnapshot({ sessionKey: "session", agentId: "main" }).tabs,
+              (await harness.store.getSnapshot({ sessionKey: "session", agentId: "main" })).tabs,
             ).toEqual([]),
         };
       },
@@ -363,9 +474,9 @@ describe("board gateway runtime boundaries", () => {
         );
         return {
           response,
-          verify: () =>
+          verify: async () =>
             expect(
-              harness.store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets,
+              (await harness.store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets,
             ).toMatchObject([{ name: "approval", grantState: "pending" }]),
         };
       },
@@ -398,9 +509,9 @@ describe("board gateway runtime boundaries", () => {
         });
         return {
           response,
-          verify: () =>
+          verify: async () =>
             expect(
-              harness.store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets,
+              (await harness.store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets,
             ).toMatchObject([{ name: "grant", grantState: "pending" }]),
         };
       },
@@ -425,7 +536,7 @@ describe("board gateway runtime boundaries", () => {
         });
         return {
           response,
-          verify: () => expect(peekSystemEvents("agent:main:session")).toEqual([]),
+          verify: async () => expect(peekSystemEvents("agent:main:session")).toEqual([]),
         };
       },
     },
@@ -434,7 +545,7 @@ describe("board gateway runtime boundaries", () => {
 
     expect(response.mock.calls[0]?.[0]).toBe(false);
     expect(response.mock.calls[0]?.[2]).toMatchObject({ code: "UNAVAILABLE" });
-    verify();
+    await verify();
   });
 
   it("rejects unknown data bindings inside the gateway allowlist boundary", async () => {
@@ -450,7 +561,7 @@ describe("board gateway runtime boundaries", () => {
       name: "reader",
       decision: "granted",
       revision: 1,
-      instanceId: store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets[0]
+      instanceId: (await store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets[0]
         ?.instanceId,
     });
     const board = await invoke("board.get", { sessionKey: "session" });
@@ -467,8 +578,11 @@ describe("board gateway runtime boundaries", () => {
   });
 
   it("runs only the exact granted cron job capability", async () => {
-    const triggerCronJob = vi.fn(async (jobId: string) => ({ ok: true, jobId }));
-    const { invoke, store } = createHarness(undefined, { triggerCronJob });
+    cronRun.mockImplementation(
+      async ({ params, respond }: { params: { id: string }; respond: RespondFn }) =>
+        respond(true, { ok: true, jobId: params.id }),
+    );
+    const { invoke, store } = createHarness();
     await invoke("board.widget.put", {
       sessionKey: "session",
       name: "runner",
@@ -480,7 +594,7 @@ describe("board gateway runtime boundaries", () => {
       name: "runner",
       decision: "granted",
       revision: 1,
-      instanceId: store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets[0]
+      instanceId: (await store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets[0]
         ?.instanceId,
     });
     const board = await invoke("board.get", { sessionKey: "session" });
@@ -493,7 +607,7 @@ describe("board gateway runtime boundaries", () => {
       jobId: "job-2",
     });
     expect(denied.mock.calls[0]?.[0]).toBe(false);
-    expect(triggerCronJob).not.toHaveBeenCalled();
+    expect(cronRun).not.toHaveBeenCalled();
 
     const allowed = await invoke("board.action", {
       ticket,
@@ -501,10 +615,8 @@ describe("board gateway runtime boundaries", () => {
       jobId: "job-1",
     });
     expect(allowed.mock.calls[0]?.[1]).toEqual({ ok: true, jobId: "job-1" });
-    expect(triggerCronJob).toHaveBeenCalledWith(
-      "job-1",
-      expect.any(Object),
-      expect.objectContaining({ assertActive: expect.any(Function) }),
+    expect(cronRun).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { id: "job-1", mode: "force" } }),
     );
   });
 
@@ -550,7 +662,7 @@ describe("board gateway runtime boundaries", () => {
       resolveSession: () => ({ agentId: "main", sessionKey }),
       env,
     });
-    boardStore.putWidget({
+    await boardStore.putWidget({
       sessionKey,
       name: "status",
       content: { kind: "html", html: "ok" },
@@ -568,7 +680,7 @@ describe("board gateway runtime boundaries", () => {
       } as unknown as GatewayRequestContext,
     });
     expect(respond.mock.calls[0]?.[0]).toBe(true);
-    expect(boardStore.getSnapshot({ sessionKey }).widgets).toHaveLength(1);
+    expect((await boardStore.getSnapshot({ sessionKey })).widgets).toHaveLength(1);
   });
 
   it("replaces a dashboard widget through Gateway while preserving layout patches", async () => {

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { readBoardHtml } from "../../boards/board-store.test-support.js";
 import { resetPluginRuntimeStateForTest } from "../../plugins/runtime.js";
-import { resolveCoreOperatorGatewayMethodScope } from "../methods/core-descriptors.js";
 import {
   boardWidgetContentPermissionCases,
   createBoardHarness as createHarness,
@@ -31,34 +31,6 @@ describe("board gateway methods", () => {
     return () => resetPluginRuntimeStateForTest();
   });
 
-  it("registers every contract method with its required scope", () => {
-    expect(
-      Object.fromEntries(
-        [
-          "board.get",
-          "board.update",
-          "board.widget.put",
-          "board.widget.grant",
-          "board.widget.appView",
-          "board.event",
-          "board.prompt.authorize",
-          "board.data.read",
-          "board.action",
-        ].map((method) => [method, resolveCoreOperatorGatewayMethodScope(method)]),
-      ),
-    ).toEqual({
-      "board.get": "operator.read",
-      "board.update": "operator.write",
-      "board.widget.put": "operator.write",
-      "board.widget.grant": "operator.approvals",
-      "board.widget.appView": "operator.read",
-      "board.event": "operator.write",
-      "board.prompt.authorize": "operator.read",
-      "board.data.read": "operator.read",
-      "board.action": "operator.write",
-    });
-  });
-
   it("rejects malformed params before touching the store", async () => {
     const { invoke, store } = createHarness();
     const response = await invoke("board.widget.put", {
@@ -71,7 +43,7 @@ describe("board gateway methods", () => {
       undefined,
       expect.objectContaining({ code: "INVALID_REQUEST" }),
     );
-    expect(store.getSnapshot({ sessionKey: "session", agentId: "main" })).toMatchObject({
+    expect(await store.getSnapshot({ sessionKey: "session", agentId: "main" })).toMatchObject({
       revision: 0,
       tabs: [],
       widgets: [],
@@ -94,7 +66,7 @@ describe("board gateway methods", () => {
       true,
       expect.objectContaining({ sessionKey: "agent:work:global" }),
     );
-    expect(store.getSnapshot({ sessionKey: "global", agentId: "work" })).toMatchObject({
+    expect(await store.getSnapshot({ sessionKey: "global", agentId: "work" })).toMatchObject({
       sessionKey: "global",
       revision: 1,
       widgets: [{ name: "owner" }],
@@ -105,7 +77,9 @@ describe("board gateway methods", () => {
       true,
       expect.objectContaining({ sessionKey: "agent:main:global", revision: 0 }),
     );
-    expect(store.getSnapshot({ sessionKey: "global", agentId: "main" }).widgets).toEqual([]);
+    expect((await store.getSnapshot({ sessionKey: "global", agentId: "main" })).widgets).toEqual(
+      [],
+    );
 
     const ambiguous = await invoke("board.get", { sessionKey: "global" });
     expect(ambiguous).toHaveBeenCalledWith(
@@ -161,9 +135,9 @@ describe("board gateway methods", () => {
       name: "rejected",
       decision: "rejected",
       revision: 1,
-      instanceId: store
-        .getSnapshot({ sessionKey: "agent:main:main" })
-        .widgets.find((widget) => widget.name === "rejected")?.instanceId,
+      instanceId: (await store.getSnapshot({ sessionKey: "agent:main:main" })).widgets.find(
+        (widget) => widget.name === "rejected",
+      )?.instanceId,
     });
 
     const firstResponse = await invoke("board.get", { sessionKey: "agent:main:main" });
@@ -244,7 +218,7 @@ describe("board gateway methods", () => {
       content: { kind: "html", html: "<p>second</p>" },
     });
     const preparedRead = vi.spyOn(store, "getSnapshotWithHtmlViewMetadata");
-    const documentRead = vi.spyOn(store, "readWidgetHtml");
+    const documentRead = vi.spyOn(store, "useWidgetDocument");
 
     await invoke("board.get", { sessionKey: "agent:main:main" });
 
@@ -366,8 +340,8 @@ describe("board gateway methods", () => {
       );
       const stored =
         contentKind === "html"
-          ? store.readWidgetHtml({ sessionKey: "agent:main:session" }, "weather")
-          : store.readWidgetMcpApp({ sessionKey: "agent:main:session" }, "weather");
+          ? await readBoardHtml(store, { sessionKey: "agent:main:session" }, "weather")
+          : await store.readWidgetMcpApp({ sessionKey: "agent:main:session" }, "weather");
       expect(stored?.grantState).toBe(grantState);
       const reviewed = permissionMode === "workspace" || mode === "auto";
       expect(reviewWidgetApproval).toHaveBeenCalledTimes(reviewed ? 1 : 0);
@@ -430,7 +404,9 @@ describe("board gateway methods", () => {
     expect(mcpApp.resolveActiveView).toHaveBeenCalledWith(
       expect.objectContaining({ sessionKey: "agent:main:main", viewId: "mcp-app-source" }),
     );
-    expect(store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "server-app")).toMatchObject({
+    expect(
+      await store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "server-app"),
+    ).toMatchObject({
       descriptor: {
         serverName: "server",
         toolName: "tool",
@@ -470,7 +446,7 @@ describe("board gateway methods", () => {
         widgets: [{ name: "message-app", grantState }],
       });
       expect(
-        store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "message-app"),
+        await store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "message-app"),
       ).toMatchObject({
         grantState,
         interactive: true,
@@ -511,7 +487,9 @@ describe("board gateway methods", () => {
     const widget = snapshot.widgets[0]!;
 
     expect(widget.grantState).toBe("none");
-    expect(store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "restored")).toMatchObject({
+    expect(
+      await store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "restored"),
+    ).toMatchObject({
       interactive: false,
       declaredTools: [],
     });
@@ -559,7 +537,9 @@ describe("board gateway methods", () => {
     const snapshot = put.mock.calls[0]?.[1] as BoardSnapshot;
     expect(snapshot.widgets[0]?.grantState).toBe("none");
     expect(mcpApp.resolveAllowedToolNames).not.toHaveBeenCalled();
-    expect(store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "revoked")).toMatchObject({
+    expect(
+      await store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "revoked"),
+    ).toMatchObject({
       interactive: false,
       declaredTools: [],
     });
@@ -611,7 +591,7 @@ describe("board gateway methods", () => {
       ],
     });
     expect(
-      store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "revoked-during-resolution"),
+      await store.readWidgetMcpApp({ sessionKey: "agent:main:main" }, "revoked-during-resolution"),
     ).toMatchObject({
       interactive: false,
       declaredTools: [],
@@ -634,7 +614,7 @@ describe("board gateway methods", () => {
       code: "UNAVAILABLE",
       message: "Error: catalog failed",
     });
-    expect(store.getSnapshot({ sessionKey: "agent:main:main" }).widgets).toEqual([]);
+    expect((await store.getSnapshot({ sessionKey: "agent:main:main" })).widgets).toEqual([]);
   });
 
   it("keeps zero-tool MCP Apps read-only until an explicit grant", async () => {
@@ -713,7 +693,7 @@ describe("board gateway methods", () => {
     expect(mcpApp.resolveActiveView).toHaveBeenCalledWith(
       expect.objectContaining({ ...target, viewId: "mcp-app-source" }),
     );
-    const originalInstanceId = store.getSnapshot(target).widgets[0]?.instanceId;
+    const originalInstanceId = (await store.getSnapshot(target)).widgets[0]?.instanceId;
     expect(originalInstanceId).toMatch(/^[a-f0-9]{32}$/u);
 
     const readOnly = await invoke("board.widget.appView", {
@@ -776,7 +756,7 @@ describe("board gateway methods", () => {
       name: "server-app",
       content,
     });
-    const replacementInstanceId = store.getSnapshot(target).widgets[0]?.instanceId;
+    const replacementInstanceId = (await store.getSnapshot(target)).widgets[0]?.instanceId;
     const staleGrant = await invoke("board.widget.grant", {
       ...target,
       name: "server-app",
@@ -814,7 +794,9 @@ describe("board gateway methods", () => {
     });
     expect(response.mock.calls[0]?.[0]).toBe(false);
     expect(mcpApp.mintFromTranscript).not.toHaveBeenCalled();
-    expect(store.getSnapshot({ sessionKey: "agent:main:main" }).widgets[0]?.revision).toBe(1);
+    expect((await store.getSnapshot({ sessionKey: "agent:main:main" })).widgets[0]?.revision).toBe(
+      1,
+    );
   });
 
   it("materializes canvas document sources before storing and broadcasting", async () => {
@@ -832,7 +814,8 @@ describe("board gateway methods", () => {
     });
 
     expect(readCanvasDocument).toHaveBeenCalledWith("cv_123");
-    const stored = store.readWidgetHtml(
+    const stored = await readBoardHtml(
+      store,
       { sessionKey: "session", agentId: "main" },
       "canvas-widget",
     );
@@ -870,7 +853,8 @@ describe("board gateway methods", () => {
     });
 
     expect(response.mock.calls[0]?.[0]).toBe(true);
-    const stored = store.readWidgetHtml(
+    const stored = await readBoardHtml(
+      store,
       { sessionKey: "session", agentId: "main" },
       "complete-document",
     );
@@ -898,10 +882,14 @@ describe("board gateway methods", () => {
       name: "canonical",
       decision: "granted",
       revision: 1,
-      instanceId: store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets[0]
+      instanceId: (await store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets[0]
         ?.instanceId,
     });
-    const granted = store.readWidgetHtml({ sessionKey: "session", agentId: "main" }, "canonical");
+    const granted = await readBoardHtml(
+      store,
+      { sessionKey: "session", agentId: "main" },
+      "canonical",
+    );
 
     const updated = await invoke("board.widget.put", {
       sessionKey: "session",
@@ -928,7 +916,7 @@ describe("board gateway methods", () => {
       }),
     );
     expect(
-      store.readWidgetHtml({ sessionKey: "session", agentId: "main" }, "canonical"),
+      await readBoardHtml(store, { sessionKey: "session", agentId: "main" }, "canonical"),
     ).toMatchObject({
       sha256: granted && "sha256" in granted ? granted.sha256 : "missing",
       grantState: "granted",
@@ -950,7 +938,9 @@ describe("board gateway methods", () => {
       undefined,
       expect.objectContaining({ code: "INVALID_REQUEST" }),
     );
-    expect(store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets).toEqual([]);
+    expect((await store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets).toEqual(
+      [],
+    );
     expect(broadcast).not.toHaveBeenCalled();
   });
 
@@ -972,7 +962,9 @@ describe("board gateway methods", () => {
       undefined,
       expect.objectContaining({ code: "INVALID_REQUEST" }),
     );
-    expect(store.getSnapshot({ sessionKey: "session", agentId: "main" }).widgets).toEqual([]);
+    expect((await store.getSnapshot({ sessionKey: "session", agentId: "main" })).widgets).toEqual(
+      [],
+    );
     expect(broadcast).not.toHaveBeenCalled();
   });
 
@@ -1055,9 +1047,9 @@ describe("board gateway methods", () => {
       name: "approved",
       decision: "granted",
       revision: 1,
-      instanceId: store
-        .getSnapshot({ sessionKey: "session", agentId: "main" })
-        .widgets.find((widget) => widget.name === "approved")?.instanceId,
+      instanceId: (
+        await store.getSnapshot({ sessionKey: "session", agentId: "main" })
+      ).widgets.find((widget) => widget.name === "approved")?.instanceId,
     });
     board = await invoke("board.get", { sessionKey: "session" });
     snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;

--- a/src/gateway/server-methods/board.ts
+++ b/src/gateway/server-methods/board.ts
@@ -30,6 +30,7 @@ import {
 import {
   boardDataBindingCapability,
   captureBoardCapabilityAuthority,
+  assertBoardCapabilityParamsSize,
   captureBoardRequestAuthority,
   readBoardDataBinding,
   respondBoardError,
@@ -44,7 +45,7 @@ import {
   createBoardViewTicket,
 } from "../board-view-ticket.js";
 import { resolveBoardWidgetApproval } from "../board-widget-approval.js";
-import { resolveAuthorizedBoardWidgetView } from "../board-widget-view.js";
+import { withAuthorizedBoardWidgetView } from "../board-widget-view.js";
 import {
   requireMcpAppInteraction,
   resolveMcpAppActiveView,
@@ -64,20 +65,7 @@ type McpAppDependencies = {
   resolveAllowedToolNames: typeof resolveMcpAppAllowedToolNames;
   mintFromTranscript: typeof mintMcpAppViewFromTranscript;
 };
-type BoardDataReader = typeof readBoardDataBinding;
-type BoardActionVerbRunner = typeof runBoardActionVerb;
-type BoardCronTrigger = typeof triggerBoardCronJob;
-type BoardHandlerDependencies = Partial<McpAppDependencies> & {
-  readDataBinding?: BoardDataReader;
-  runActionVerb?: BoardActionVerbRunner;
-  triggerCronJob?: BoardCronTrigger;
-};
-
-const defaultMcpAppDependencies: McpAppDependencies = {
-  resolveActiveView: resolveMcpAppActiveView,
-  resolveAllowedToolNames: resolveMcpAppAllowedToolNames,
-  mintFromTranscript: mintMcpAppViewFromTranscript,
-};
+type BoardHandlerDependencies = Partial<McpAppDependencies>;
 
 function resolveBoardSession(
   params: { sessionKey: string; agentId?: string | undefined },
@@ -103,34 +91,16 @@ function projectBoardSnapshot<T extends BoardSnapshot>(snapshot: T, agentId: str
   return { ...snapshot, sessionKey: sessionObserverScopeKey(snapshot.sessionKey, agentId) };
 }
 
-function assertCapabilityParamsSize(
-  params: Record<string, unknown>,
-  capability: "action" | "data binding",
-): void {
-  if (Buffer.byteLength(JSON.stringify(params), "utf8") > 8 * 1024) {
-    throw new BoardValidationError(
-      "invalid_operation",
-      `board widget ${capability} params exceed 8192 UTF-8 bytes`,
-    );
-  }
-}
-
 export function createBoardHandlers(
   store: BoardStore,
   readCanvasDocument: CanvasDocumentReader = readCanvasDocumentHtmlSource,
   dependencies: BoardHandlerDependencies = {},
 ): GatewayRequestHandlers {
   const mcpApp: McpAppDependencies = {
-    resolveActiveView:
-      dependencies.resolveActiveView ?? defaultMcpAppDependencies.resolveActiveView,
-    resolveAllowedToolNames:
-      dependencies.resolveAllowedToolNames ?? defaultMcpAppDependencies.resolveAllowedToolNames,
-    mintFromTranscript:
-      dependencies.mintFromTranscript ?? defaultMcpAppDependencies.mintFromTranscript,
+    resolveActiveView: dependencies.resolveActiveView ?? resolveMcpAppActiveView,
+    resolveAllowedToolNames: dependencies.resolveAllowedToolNames ?? resolveMcpAppAllowedToolNames,
+    mintFromTranscript: dependencies.mintFromTranscript ?? mintMcpAppViewFromTranscript,
   };
-  const readDataBinding = dependencies.readDataBinding ?? readBoardDataBinding;
-  const runActionVerb = dependencies.runActionVerb ?? runBoardActionVerb;
-  const triggerCronJob = dependencies.triggerCronJob ?? triggerBoardCronJob;
   return {
     "board.get": defineValidatedGatewayMethod(
       "board.get",
@@ -144,7 +114,8 @@ export function createBoardHandlers(
             return;
           }
           const { snapshot, htmlViewMetadata } =
-            store.getSnapshotWithHtmlViewMetadata(boardSession);
+            await store.getSnapshotWithHtmlViewMetadata(boardSession);
+          authority.assertActive();
           let sandboxPort = context.getMcpAppSandboxPort?.();
           let sandboxOrigin: string | undefined;
           let sandboxOriginResolved = false;
@@ -236,7 +207,7 @@ export function createBoardHandlers(
     "board.update": defineValidatedGatewayMethod(
       "board.update",
       validateBoardUpdateParams,
-      (invocation) => {
+      async (invocation) => {
         const { params: boardParams, respond, context } = invocation;
         try {
           const authority = captureBoardRequestAuthority(invocation);
@@ -246,9 +217,12 @@ export function createBoardHandlers(
           }
           authority.assertActive();
           const snapshot = projectBoardSnapshot(
-            store.applyOps(boardSession, boardParams.ops),
+            await store.applyOps(boardSession, boardParams.ops, {
+              assertCurrent: authority.assertActive,
+            }),
             boardSession.agentId,
           );
+          authority.assertActive();
           if (boardParams.ops.length > 0) {
             emitSessionsChanged(context, {
               sessionKey: boardSession.sessionKey,
@@ -407,27 +381,49 @@ export function createBoardHandlers(
             content: materializedContent,
             ...(declared ? { declared } : {}),
           };
+          let identity:
+            | Awaited<
+                ReturnType<typeof import("../github-actions-read.js").prepareBoardGitHubIdentity>
+              >
+            | undefined;
           if (
             (content.kind === "html" || content.kind === "registered") &&
             declared?.tools?.some((tool) => tool.startsWith(GITHUB_ACTIONS_GRANT_PREFIX))
           ) {
             const { prepareBoardGitHubIdentity } = await import("../github-actions-read.js");
-            const identity = await prepareBoardGitHubIdentity(context, {
+            identity = await prepareBoardGitHubIdentity(context, {
               ...authority,
               boardSession,
             });
-            identity.assertSelected();
-            // Credential selection alone cannot detect a retired agent or changed board routing.
-            const currentSession = resolveBoardSession(boardSession, context, respond);
-            if (!currentSession) {
-              return;
-            }
-            if (currentSession.sessionKey !== boardSession.sessionKey) {
-              throw new BoardValidationError("invalid_operation", "board session changed; retry");
-            }
           }
+          const putWidget = () =>
+            store.putWidget(boardParams, {
+              assertCurrent: () => {
+                authority.assertActive();
+                identity?.assertSelected();
+                const cfg = context.getRuntimeConfig();
+                const current = resolveRequestedSessionAgentId(
+                  cfg,
+                  boardSession.sessionKey,
+                  boardSession.agentId,
+                );
+                if (
+                  !current.ok ||
+                  resolveSessionStoreKey({
+                    cfg,
+                    sessionKey: boardSession.sessionKey,
+                    storeAgentId: current.agentId,
+                  }) !== boardSession.sessionKey
+                ) {
+                  throw new BoardValidationError(
+                    "invalid_operation",
+                    "board session changed; retry",
+                  );
+                }
+              },
+            });
+          let snapshot = identity ? await identity.start(putWidget) : await putWidget();
           authority.assertActive();
-          let snapshot = store.putWidget(boardParams);
           const widget = snapshot.widgets.find(
             (candidate) => candidate.name === snapshot.resolvedWidgetName,
           );
@@ -441,17 +437,19 @@ export function createBoardHandlers(
             authority.assertActive();
             if (decision) {
               snapshot = {
-                ...store.grant(
+                ...(await store.grant(
                   boardSession,
                   snapshot.resolvedWidgetName,
                   decision,
                   widget.revision,
                   widget.instanceId,
-                ),
+                  { assertCurrent: authority.assertActive },
+                )),
                 resolvedWidgetName: snapshot.resolvedWidgetName,
               };
             }
           }
+          authority.assertActive();
           snapshot = projectBoardSnapshot(snapshot, boardSession.agentId);
           emitSessionsChanged(context, {
             sessionKey: boardSession.sessionKey,
@@ -476,7 +474,7 @@ export function createBoardHandlers(
     "board.widget.grant": defineValidatedGatewayMethod(
       "board.widget.grant",
       validateBoardWidgetGrantParams,
-      (invocation) => {
+      async (invocation) => {
         const { params: boardParams, respond, context } = invocation;
         try {
           const authority = captureBoardRequestAuthority(invocation);
@@ -486,15 +484,17 @@ export function createBoardHandlers(
           }
           authority.assertActive();
           const snapshot = projectBoardSnapshot(
-            store.grant(
+            await store.grant(
               boardSession,
               boardParams.name,
               boardParams.decision,
               boardParams.revision,
               boardParams.instanceId,
+              { assertCurrent: authority.assertActive },
             ),
             boardSession.agentId,
           );
+          authority.assertActive();
           context.broadcast(
             "board.changed",
             {
@@ -512,15 +512,18 @@ export function createBoardHandlers(
     "board.widget.appView": defineValidatedGatewayMethod(
       "board.widget.appView",
       validateBoardWidgetAppViewParams,
-      async ({ params: boardParams, respond, context }) => {
+      async (invocation) => {
+        const { params: boardParams, respond, context } = invocation;
         try {
+          const authority = captureBoardRequestAuthority(invocation);
           const boardSession = resolveBoardSession(boardParams, context, respond);
           if (!boardSession) {
             return;
           }
-          const snapshot = store.getSnapshot(boardSession);
+          const snapshot = await store.getSnapshot(boardSession);
           const widget = snapshot.widgets.find((candidate) => candidate.name === boardParams.name);
-          const document = store.readWidgetMcpApp(boardSession, boardParams.name);
+          const document = await store.readWidgetMcpApp(boardSession, boardParams.name);
+          authority.assertActive();
           if (
             !widget ||
             widget.contentKind !== "mcp-app" ||
@@ -537,8 +540,8 @@ export function createBoardHandlers(
           }
           const interactive = document.interactive && document.grantState === "granted";
           const authorizeAppInteraction = interactive
-            ? () => {
-                const current = store.readWidgetMcpApp(boardSession, boardParams.name);
+            ? async () => {
+                const current = await store.readWidgetMcpApp(boardSession, boardParams.name);
                 return (
                   current?.interactive === true &&
                   current.grantState === "granted" &&
@@ -555,6 +558,7 @@ export function createBoardHandlers(
             ...(authorizeAppInteraction ? { authorizeAppInteraction } : {}),
             readOnly: !interactive,
           });
+          authority.assertActive();
           if (!minted) {
             throw new Error("Pinned MCP App source is no longer available");
           }
@@ -570,43 +574,39 @@ export function createBoardHandlers(
     "board.event": defineValidatedGatewayMethod(
       "board.event",
       validateBoardEventParams,
-      (invocation) => {
+      async (invocation) => {
         const { params: boardParams, respond, context } = invocation;
         try {
           const authority = captureBoardRequestAuthority(invocation);
-          const identity =
-            "ticket" in boardParams
-              ? resolveAuthorizedBoardWidgetView(store, boardParams.ticket, {
-                  gatewayContext: context,
-                })
-              : (() => {
-                  const boardSession = resolveBoardSession(boardParams, context, respond);
-                  if (!boardSession) {
-                    return undefined;
-                  }
-                  const snapshot = store.getSnapshot(boardSession);
-                  const widget = snapshot.widgets.some(
-                    (candidate) => candidate.name === boardParams.widget,
-                  );
-                  if (!widget) {
-                    throw new BoardValidationError(
-                      "not_found",
-                      `board widget not found: ${boardParams.widget}`,
-                    );
-                  }
-                  return { ...boardSession, name: boardParams.widget };
-                })();
-          if (!identity) {
-            return;
+          const publish = (identity: BoardSessionTarget & { name: string }) => {
+            authority.assertActive();
+            const appended = appendBoardEventNotice({
+              sessionKey: identity.sessionKey,
+              agentId: identity.agentId,
+              widget: identity.name,
+              payload: boardParams.payload,
+            });
+            respond(true, { ok: true, appended });
+          };
+          if ("ticket" in boardParams) {
+            await withAuthorizedBoardWidgetView(store, boardParams.ticket, publish, {
+              gatewayContext: context,
+            });
+          } else {
+            const boardSession = resolveBoardSession(boardParams, context, respond);
+            if (!boardSession) {
+              return;
+            }
+            await store.useSnapshot(boardSession, (snapshot) => {
+              if (!snapshot.widgets.some((candidate) => candidate.name === boardParams.widget)) {
+                throw new BoardValidationError(
+                  "not_found",
+                  `board widget not found: ${boardParams.widget}`,
+                );
+              }
+              publish({ ...boardSession, name: boardParams.widget });
+            });
           }
-          authority.assertActive();
-          const appended = appendBoardEventNotice({
-            sessionKey: identity.sessionKey,
-            agentId: identity.agentId,
-            widget: identity.name,
-            payload: boardParams.payload,
-          });
-          respond(true, { ok: true, appended });
         } catch (error) {
           respondBoardError(error, respond);
         }
@@ -615,21 +615,25 @@ export function createBoardHandlers(
     "board.prompt.authorize": defineValidatedGatewayMethod(
       "board.prompt.authorize",
       validateBoardPromptAuthorizeParams,
-      (invocation) => {
+      async (invocation) => {
         const { params: boardParams, respond, context } = invocation;
         try {
           const authority = captureBoardRequestAuthority(invocation);
-          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket, {
-            gatewayContext: context,
-          });
-          authority.assertActive();
-          respond(true, {
-            confirmationRequired: !boardWidgetHasGrantedTool(
-              document.declared,
-              document.grantState,
-              "prompt",
-            ),
-          });
+          await withAuthorizedBoardWidgetView(
+            store,
+            boardParams.ticket,
+            ({ document }) => {
+              authority.assertActive();
+              respond(true, {
+                confirmationRequired: !boardWidgetHasGrantedTool(
+                  document.declared,
+                  document.grantState,
+                  "prompt",
+                ),
+              });
+            },
+            { gatewayContext: context },
+          );
         } catch (error) {
           respondBoardError(error, respond);
         }
@@ -642,21 +646,20 @@ export function createBoardHandlers(
         const { params: boardParams, respond } = invocation;
         try {
           const bindingParams = boardParams.params ?? {};
-          assertCapabilityParamsSize(bindingParams, "data binding");
+          assertBoardCapabilityParamsSize(bindingParams, "data binding");
           const authority = captureBoardCapabilityAuthority(
             store,
             boardParams.ticket,
             invocation,
             boardDataBindingCapability(boardParams.bindingId, bindingParams),
           );
-          const result = await readDataBinding(
+          await readBoardDataBinding(
             boardParams.bindingId,
             bindingParams,
             invocation,
             authority,
+            respond,
           );
-          authority.assertActive();
-          respond(true, result);
         } catch (error) {
           respondBoardError(error, respond);
         }
@@ -677,21 +680,18 @@ export function createBoardHandlers(
             capability,
           );
           if ("jobId" in boardParams) {
-            const result = await triggerCronJob(boardParams.jobId, invocation, authority);
-            authority.assertActive();
-            respond(true, result);
+            await triggerBoardCronJob(boardParams.jobId, invocation, authority, respond);
             return;
           }
           const actionParams = boardParams.params ?? {};
-          assertCapabilityParamsSize(actionParams, "action");
-          const result = await runActionVerb(
+          assertBoardCapabilityParamsSize(actionParams, "action");
+          await runBoardActionVerb(
             boardParams.action,
             actionParams,
             invocation,
             authority,
+            respond,
           );
-          authority.assertActive();
-          respond(true, result);
         } catch (error) {
           respondBoardError(error, respond);
         }

--- a/src/gateway/server-methods/sessions-board-inventory.ts
+++ b/src/gateway/server-methods/sessions-board-inventory.ts
@@ -1,17 +1,16 @@
-import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
 import { listBoardSessionKeysReadOnly } from "../../boards/sqlite-board-store.js";
-import type { SessionEntry } from "../../config/sessions.js";
 import type { GatewayStoredSessionTargets } from "../../config/sessions/combined-store-gateway.js";
-import { prepareSessionSharing } from "../session-sharing.js";
 
-function listBoardSessionKeys(targets: GatewayStoredSessionTargets): ReadonlySet<string> {
+export async function listBoardSessionKeys(
+  targets: GatewayStoredSessionTargets,
+): Promise<ReadonlySet<string>> {
   const inventories = new Map<string, ReadonlySet<string>>();
   const keys = new Set<string>();
   for (const [key, { storeKey, storeTarget }] of targets) {
     const identity = `${storeTarget.agentId}\0${storeTarget.storePath}`;
     let inventory = inventories.get(identity);
     if (!inventory) {
-      inventory = listBoardSessionKeysReadOnly({
+      inventory = await listBoardSessionKeysReadOnly({
         agentId: storeTarget.agentId,
         path: storeTarget.storePath,
       });
@@ -23,28 +22,4 @@ function listBoardSessionKeys(targets: GatewayStoredSessionTargets): ReadonlySet
     }
   }
   return keys;
-}
-
-export function listFilter(input: {
-  cfg: Parameters<typeof prepareSessionSharing>[0]["cfg"];
-  client: Parameters<typeof prepareSessionSharing>[0]["client"];
-  loaded: { targetsBySessionKey: GatewayStoredSessionTargets };
-  options: { excludedKeys?: ReadonlySet<string> };
-  p: SessionsListParams;
-}): ((key: string, entry: SessionEntry) => boolean) | undefined {
-  const { loaded, p: params } = input;
-  const visibilityFilter = prepareSessionSharing({
-    client: input.client,
-    cfg: input.cfg,
-  }).entryFilter;
-  const excludedKeys = input.options.excludedKeys;
-  const boardSessionKeys =
-    params.hasBoard === undefined ? undefined : listBoardSessionKeys(loaded.targetsBySessionKey);
-  if (!visibilityFilter && !boardSessionKeys && !excludedKeys?.size) {
-    return undefined;
-  }
-  return (key, entry) =>
-    !excludedKeys?.has(key) &&
-    (visibilityFilter?.(key, entry) ?? true) &&
-    (params.hasBoard === undefined || boardSessionKeys?.has(key) === params.hasBoard);
 }

--- a/src/gateway/server-methods/sessions-read-active.test.ts
+++ b/src/gateway/server-methods/sessions-read-active.test.ts
@@ -311,7 +311,7 @@ it.each(["global", "unknown"] as const)(
         sessionId: literalSessionId,
         agentId: "ops",
       } as never);
-      new SqliteBoardStore({
+      await new SqliteBoardStore({
         resolveSession: () => ({ agentId: "ops", path: storePathFor("ops"), sessionKey: sentinel }),
       }).applyOps({ sessionKey: sentinel }, [{ kind: "tab_create", tabId: "main", title: "Ops" }]);
       const normal = await listSessions({

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -69,7 +69,7 @@ import { createVisibleActiveSessionRunProjector } from "./session-active-runs.js
 import { emitSessionsChanged } from "./session-change-event.js";
 import { resolveGatewayModelSelectionPolicy } from "./session-model-selection-policy.js";
 import { createSessionPlacementBatchProjector } from "./session-placement-read-projection.js";
-import { listFilter } from "./sessions-board-inventory.js";
+import { listBoardSessionKeys } from "./sessions-board-inventory.js";
 import { respondWithCachedSessionList } from "./sessions-list-cache.js";
 import { withSessionListDiagnostics } from "./sessions-list-diagnostics.js";
 import { sessionByKeyReadHandlers } from "./sessions-read-by-key.js";
@@ -283,7 +283,17 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           }
           const { targetsBySessionKey, durableStorePath, modelCatalogByAgent, storePath } = loaded;
           diagnostics?.mark("filterSetup");
-          const visibleEntryFilter = listFilter({ p, loaded, client, cfg, options });
+          const boardSessionKeys =
+            p.hasBoard === undefined ? undefined : await listBoardSessionKeys(targetsBySessionKey);
+          const visibilityFilter = prepareSessionSharing({ client, cfg }).entryFilter;
+          const excludedSessionKeys = options.excludedKeys;
+          const visibleEntryFilter =
+            !visibilityFilter && !boardSessionKeys && !excludedSessionKeys?.size
+              ? undefined
+              : (key: string, entry: SessionEntry) =>
+                  !excludedSessionKeys?.has(key) &&
+                  (visibilityFilter?.(key, entry) ?? true) &&
+                  (p.hasBoard === undefined || boardSessionKeys?.has(key) === p.hasBoard);
           const selectionRuns =
             p.activeOnly === true || p.search?.trim()
               ? createVisibleActiveSessionRunProjector(context)

--- a/src/gateway/server.sessions.delete-state-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-state-lifecycle.test.ts
@@ -182,7 +182,7 @@ test("sessions.delete removes the session board from its agent database", async 
     }),
     env: process.env,
   });
-  store.putWidget({
+  await store.putWidget({
     sessionKey,
     name: "status",
     content: { kind: "html", html: "ok" },
@@ -194,7 +194,7 @@ test("sessions.delete removes the session board from its agent database", async 
 
   expect(deleted.ok).toBe(true);
   expect(deleted.payload?.deleted).toBe(true);
-  expect(store.getSnapshot({ sessionKey })).toEqual({
+  expect(await store.getSnapshot({ sessionKey })).toEqual({
     sessionKey,
     revision: 0,
     tabs: [],

--- a/src/gateway/server.sessions.face.test.ts
+++ b/src/gateway/server.sessions.face.test.ts
@@ -111,7 +111,7 @@ test("sessions.list filters dashboard sessions by board existence instead of sav
       },
     },
   });
-  boardStore.applyOps({ sessionKey: "agent:main:board" }, [
+  await boardStore.applyOps({ sessionKey: "agent:main:board" }, [
     { kind: "tab_create", tabId: "main", title: "Dashboard" },
   ]);
 
@@ -152,7 +152,7 @@ test("sessions.list includes boards stored with incognito sessions", async () =>
   const incognitoBoardStore = new SqliteBoardStore({
     resolveSession: () => ({ agentId: "main", path: incognitoPath, sessionKey }),
   });
-  incognitoBoardStore.applyOps({ sessionKey }, [
+  await incognitoBoardStore.applyOps({ sessionKey }, [
     { kind: "tab_create", tabId: "main", title: "Incognito dashboard" },
   ]);
   expect(listOpenIncognitoAgentDatabases()).toContainEqual({
@@ -204,7 +204,7 @@ test.each(["first", "later"] as const)(
           sessionKey: "unknown",
         }),
       });
-      boards.applyOps({ sessionKey: "unknown" }, [
+      await boards.applyOps({ sessionKey: "unknown" }, [
         { kind: "tab_create", tabId: "main", title: "Selected-store dashboard" },
       ]);
       testState.agentsConfig = { list: [{ id: "main", default: true }] };


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Board reads, edits, grants and session inventory use synchronous persistence contracts. Moving storage work off the application thread requires their callers to await results while retaining current request and widget authority.

## Why This Change Was Made

Convert the Board store and actual Gateway, HTTP, widget and session-list callers together. Keep current-state consumption inside the store owner, propagate request authority to mutation admission, and revalidate widget authority when publishing successful or failed capability results. Session inventory returns Board keys; visibility selection is prepared after that awaited read.

Existing SQLite schema, native synchronous transactions, grant policy, revision checks and MCP interaction contract remain intact. Native execution moves to workers in a subsequent change under the umbrella issue.

## User Impact

Board routes and response shapes stay compatible. Pending storage work is awaited, and retired requests or stale widget grants cannot publish capability results through newly introduced asynchronous gaps.

## Evidence

- Focused Board, Gateway, session inventory and authority cohorts passed; the final 114-test cohort covers the final error-publication and inventory changes.
- Full selected changed checks, full build and fresh independent Codex review through P2 passed. Rebase onto the landed identity prerequisite is patch-identical.
- An isolated built Gateway with synthetic data exercised CRUD, grants, layout, HTTP GET/HEAD, hasBoard true/false, process restart with revision 23 retained, and stale-ticket refusal.
- Twenty warm samples observed write/read medians of 1.427 ms/0.789 ms. No performance improvement is claimed.
- This is awaited API and lifecycle groundwork; it does not yet establish zero main-thread SQLite calls.
