### PR TITLE
refactor(web-fetch): remove private runtime cache reset

### DIFF
--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -103,17 +103,14 @@ function requireResolvedWebFetch(
 
 describe("web fetch runtime", () => {
   let resolveWebFetchDefinition: typeof import("./runtime.js").resolveWebFetchDefinition;
-  let clearWebFetchRuntimeCachesForTest: typeof import("./runtime.js").clearWebFetchRuntimeCachesForTest;
   let clearSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").clearSecretsRuntimeSnapshot;
 
   beforeAll(async () => {
-    ({ clearWebFetchRuntimeCachesForTest, resolveWebFetchDefinition } =
-      await import("./runtime.js"));
+    ({ resolveWebFetchDefinition } = await import("./runtime.js"));
     ({ clearSecretsRuntimeSnapshot } = await import("../secrets/runtime.js"));
   });
 
   beforeEach(() => {
-    clearWebFetchRuntimeCachesForTest();
     getActivePluginRegistryVersionMock.mockReset();
     getActivePluginRegistryVersionMock.mockReturnValue(1);
     resolvePluginWebFetchProvidersMock.mockReset();
@@ -124,7 +121,6 @@ describe("web fetch runtime", () => {
 
   afterEach(() => {
     clearSecretsRuntimeSnapshot();
-    clearWebFetchRuntimeCachesForTest();
   });
 
   it("does not auto-detect providers from plugin-owned env SecretRefs without runtime metadata", () => {

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -47,7 +47,7 @@ type WebFetchProviderCacheEntry = {
   providers: PluginWebFetchProviderEntry[];
 };
 
-let webFetchProviderCache = new WeakMap<OpenClawConfig, WebFetchProviderCacheEntry>();
+const webFetchProviderCache = new WeakMap<OpenClawConfig, WebFetchProviderCacheEntry>();
 
 function resolveFetchConfig(config: OpenClawConfig | undefined): WebFetchConfig | undefined {
   return resolveWebProviderConfig(config, "fetch") as NonNullable<WebFetchConfig> | undefined;
@@ -201,10 +201,6 @@ function resolveCachedWebFetchProviders(params: {
     });
   }
   return loaded;
-}
-
-export function clearWebFetchRuntimeCachesForTest(): void {
-  webFetchProviderCache = new WeakMap();
 }
 
 function resolveWebFetchProvidersForOptions(


### PR DESCRIPTION
## What Problem This Solves

The web-fetch provider cache exposes a private reset used only by its own tests, even though those tests already create independent config keys.

## Why This Change Was Made

Remove that reset, make the existing WeakMap binding const, and remove the test-only reset calls. All case bodies and runtime cache invalidation rules remain unchanged. Production and test code each shrink by four lines (+1/-5 each).

The reset shipped internally in v2026.8.2; this changes the internal module export set. Contract inspection found no supported package/SDK route or production caller for it. The change preserves the legacy alias source and the three production exports: isWebFetchProviderConfigured, listWebFetchProviders, and resolveWebFetchDefinition. Unsupported external dist imports were not exhaustively audited.

## User Impact

No intended change to provider selection, cache behavior, config activation, or supported public APIs. The current config-writer authority checks remain untouched.

## Evidence

All 41 cases passed before and after with identical inventories and statuses: 19 owner-cache cases, ten cold-import contracts, and 12 public-tool fallback cases. All 29 selected changed checks passed, and independent review found no actionable P0-P2 issue. The fallback suite mocks provider-definition resolution and includes an existing local loopback cleanup check; it is not external-provider proof.

The normal full build passed all 16 phases, including declarations, SDK export checks, runtime postbuild, and UI budgets. A credential-free process with an isolated HOME imported both built runtime paths: all three executable exports remain functions with identical alias bindings, and the private reset is absent. No provider was invoked. Source and dependency fingerprints stayed unchanged through proof.
