### PR TITLE
build(plugins): emit declared private worker entries

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -3,6 +3,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { collectPluginSourceEntries } from "../scripts/lib/bundled-plugin-build-entries.mjs";
 import { createManagedHandoffBuildConfig } from "../scripts/lib/managed-handoff-build-config.mts";
 import { runtimeProcessBuildEntries } from "../scripts/lib/runtime-process-build-entries.mts";
 import { controlUiSource } from "../src/plugins/package-manifest.js";
@@ -949,22 +950,29 @@ const config = {
 } as const;
 
 const configuredWorkspaces = new Map(Object.entries(config.workspaces));
-// Browser roots come from authoring metadata; the runtime manifest names only
-// compiled assets. Keep each plugin's remaining files subject to reachability.
-const browserWorkspaces = Object.fromEntries(
+// Declared runtime, setup, worker, and browser roots need no static import edge.
+// Keep each plugin's remaining files subject to reachability.
+const artifactWorkspaces = Object.fromEntries(
   fs
     .globSync(`${BUNDLED_PLUGIN_ROOT_DIR}/*/package.json`)
     .toSorted()
     .flatMap((manifestPath) => {
-      const source = controlUiSource(JSON.parse(fs.readFileSync(manifestPath, "utf8")));
-      if (!source) {
-        return [];
-      }
+      const packageJson = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      const browserSource = controlUiSource(packageJson);
+      const sources = [
+        ...(browserSource ? [browserSource] : []),
+        ...collectPluginSourceEntries(packageJson),
+      ];
       const workspace = path.dirname(manifestPath).replaceAll("\\", "/");
       const settings =
         configuredWorkspaces.get(workspace) ?? config.workspaces[`${BUNDLED_PLUGIN_ROOT_DIR}/*`];
-      return [[workspace, { ...settings, entry: [...settings.entry, `${source}!`] }]];
+      return [
+        [
+          workspace,
+          { ...settings, entry: [...settings.entry, ...sources.map((source) => `${source}!`)] },
+        ],
+      ];
     }),
 );
 
-export default { ...config, workspaces: { ...config.workspaces, ...browserWorkspaces } };
+export default { ...config, workspaces: { ...config.workspaces, ...artifactWorkspaces } };

--- a/docs/plugins/dependency-resolution.md
+++ b/docs/plugins/dependency-resolution.md
@@ -277,6 +277,14 @@ it first with `node scripts/lib/plugin-npm-runtime-build.mjs extensions/<package
 The standalone build runs the selected package's asset build command and copies
 its declared `openclaw.build.staticAssets` into `dist`, including for new packages
 that are not yet tracked by Git. Missing declared source files fail the build.
+
+Declare private worker source files in `openclaw.build.workerEntries`, using
+package-relative paths such as `./src/store.worker.ts`. The standalone build
+emits them at matching paths under `dist`, such as `dist/src/store.worker.js`
+(`.cjs` for CommonJS packages). These entries are also included when the plugin
+is selected for the root bundled build. Declaring a worker does not register it
+as a plugin entrypoint or add a public package export.
+
 The preparation command does not rebuild either output or execute plugin code.
 It only links the checkout as `node_modules/openclaw` for a real immediate
 source package that declares `openclaw` in `peerDependencies` or `dependencies`.

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -150,6 +150,11 @@ export function collectPluginSourceEntries(packageJson, manifest = {}) {
       ...CATALOG_ENTRY_FIELDS.map((field) => manifest[field]).filter(
         (entry) => typeof entry === "string" && entry.trim().length > 0,
       ),
+      ...(Array.isArray(packageJson?.openclaw?.build?.workerEntries)
+        ? packageJson.openclaw.build.workerEntries.filter(
+            (entry) => typeof entry === "string" && entry.trim().length > 0,
+          )
+        : []),
     ]),
   ];
 }

--- a/scripts/lib/plugin-npm-runtime-build.mts
+++ b/scripts/lib/plugin-npm-runtime-build.mts
@@ -23,7 +23,12 @@ export type PluginPackageJson = JsonRecord & {
   dependencies?: JsonRecord;
   openclaw?: {
     assetScripts?: { build?: unknown };
-    build?: { bundledDist?: unknown; openclawVersion?: unknown; runtimeFormat?: unknown };
+    build?: {
+      bundledDist?: unknown;
+      openclawVersion?: unknown;
+      runtimeFormat?: unknown;
+      workerEntries?: unknown;
+    };
     compat?: { pluginApi?: unknown };
     release?: {
       bundleRuntimeDependencies?: unknown;

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildPluginNpmRuntime,
@@ -37,6 +38,46 @@ function expectPluginNpmRuntimeBuildPlan(
 }
 
 describe("plugin npm runtime build planning", () => {
+  it("builds a private worker without registering it as a plugin entry", async () => {
+    const packageDir = tempDirs.make("openclaw-plugin-runtime-worker-");
+    mkdirSync(path.join(packageDir, "src"));
+    writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/worker-fixture",
+        version: "1.0.0",
+        type: "module",
+        openclaw: {
+          extensions: ["./index.ts"],
+          compat: { pluginApi: "1.0.0" },
+          build: { workerEntries: ["./src/store.worker.ts"] },
+        },
+      }),
+    );
+    writeFileSync(path.join(packageDir, "index.ts"), 'export default { id: "worker-fixture" };\n');
+    writeFileSync(
+      path.join(packageDir, "src/store.worker.ts"),
+      'import { parentPort, isMainThread } from "node:worker_threads";\n' +
+        "const value: number = 42; parentPort!.postMessage({ value, isMainThread });\n",
+    );
+
+    const plan = expectPluginNpmRuntimeBuildPlan(
+      await buildPluginNpmRuntime({ repoRoot, packageDir, logLevel: "silent" }),
+    );
+    expect(plan.runtimeExtensions).toEqual(["./dist/index.js"]);
+    const worker = new Worker(path.join(packageDir, "dist/src/store.worker.js"));
+    try {
+      const result = await new Promise((resolve, reject) => {
+        worker.once("message", resolve);
+        worker.once("error", reject);
+        worker.once("exit", (code) => reject(new Error(`Worker exited before replying: ${code}`)));
+      });
+      expect(result).toEqual({ value: 42, isMainThread: false });
+    } finally {
+      await worker.terminate();
+    }
+  });
+
   it.each(["index.tsx", "src/index.tsx"])(
     "builds an executable %s package entry",
     async (entry) => {


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Private worker modules need to be emitted with their plugin in both standalone packages and root bundled builds. They are runtime artifacts without a static import from the registration entry.

## Why This Change Was Made

Collect package-relative `openclaw.build.workerEntries` through the existing source-entry owner. Standalone and root builds include them, and dead-code analysis recognizes declared entry roots. Workers do not become registration entrypoints or public package exports.

## User Impact

Plugin authors can package private workers alongside their selected runtime entry. This supplies packaging support for the upcoming SQLite worker consumer; no plugin switches execution in this prerequisite.

## Evidence

- All 15 runtime-build tests and 84 additional build/package tests passed.
- Native ESM and CommonJS smoke executed the emitted worker and confirmed it ran off the main thread. Root entries and package artifacts include it; registration metadata and public exports remain unchanged.
- Full selected changed checks and fresh isolated Codex review through P2 passed.
- One broader ClawHub packaging test fails with missing `consumer/pack-metadata.json` identically on the candidate and clean pinned main 8ac24c73. It declares no worker entries; recorded as an inherited failure rather than changing unrelated packaging behavior.
