### PR TITLE
refactor(memory): await journal operations and allocate sequences atomically

### DIFF
--- a/src/memory-host-sdk/event-store.ts
+++ b/src/memory-host-sdk/event-store.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import {
   pluginStateEntriesInKeyRange,
-  registerPluginStateSyncSequencedJournalEntry,
+  registerPluginStateSequencedJournalEntry,
 } from "../plugin-state/plugin-state-store.js";
 import type { MemoryHostEventRecord } from "./event-types.js";
 
@@ -144,13 +144,6 @@ function eventKeyPrefix(workspaceDir: string): string {
 
 function eventKeyRangeEnd(workspaceDir: string): string {
   return `${memoryHostWorkspacePrefix(workspaceDir)}:event;`;
-}
-
-function memoryHostEventStorageKey(workspaceDir: string, sequence: number): string {
-  if (!Number.isSafeInteger(sequence)) {
-    throw new Error("Memory host event sequence must be a safe integer");
-  }
-  return `${eventKeyPrefix(workspaceDir)}1:${sequence.toString().padStart(16, "0")}`;
 }
 
 function cursorKey(workspaceDir: string): string {
@@ -296,25 +289,18 @@ export function normalizeMemoryHostEventRecordForStorage(
   return null;
 }
 
-export function registerMemoryHostEvent(params: {
+export async function registerMemoryHostEvent(params: {
   workspaceDir: string;
   event: MemoryHostEventRecord;
   env?: NodeJS.ProcessEnv;
-}): void {
+}): Promise<void> {
   const event = normalizeMemoryHostEventRecordForStorage(params.event);
   if (!event) {
     throw new TypeError("Memory host event is invalid");
   }
-  const initialSequence = Math.max(
-    0,
-    listStoredMemoryHostEvents({
-      workspaceDir: params.workspaceDir,
-      limit: 1,
-      ...(params.env ? { env: params.env } : {}),
-    }).at(-1)?.value.sequence ?? 0,
-  );
+  const keyStartInclusive = eventKeyPrefix(params.workspaceDir);
   const recordedAt = Date.now();
-  registerPluginStateSyncSequencedJournalEntry({
+  await registerPluginStateSequencedJournalEntry({
     pluginId: MEMORY_HOST_EVENTS_PLUGIN_ID,
     cursorOptions: {
       namespace: MEMORY_HOST_EVENT_CURSORS_NAMESPACE,
@@ -327,17 +313,21 @@ export function registerMemoryHostEvent(params: {
       maxEntries: maxMemoryHostEventsForTests ?? MAX_MEMORY_HOST_EVENTS,
       ...(params.env ? { env: params.env } : {}),
     },
-    initialSequence,
-    journalKey: (sequence) => memoryHostEventStorageKey(params.workspaceDir, sequence),
+    journalKeyPrefix: `${keyStartInclusive}1:`,
+    journalKeyRange: {
+      keyStartInclusive,
+      keyEndExclusive: eventKeyRangeEnd(params.workspaceDir),
+      valueKind: "event",
+    },
     journalValue: (sequence) => ({ kind: "event", event, recordedAt, sequence }),
   });
 }
 
-export function listStoredMemoryHostEvents(params: {
+export async function listStoredMemoryHostEvents(params: {
   workspaceDir: string;
   limit?: number;
   env?: NodeJS.ProcessEnv;
-}): PersistedMemoryHostEvent[] {
+}): Promise<PersistedMemoryHostEvent[]> {
   const limit = Number.isFinite(params.limit)
     ? Math.max(
         1,

--- a/src/memory-host-sdk/events.ts
+++ b/src/memory-host-sdk/events.ts
@@ -23,7 +23,7 @@ export async function appendMemoryHostEvent(
   event: MemoryHostEventRecord,
   options: { env?: NodeJS.ProcessEnv } = {},
 ): Promise<void> {
-  registerMemoryHostEvent({
+  await registerMemoryHostEvent({
     workspaceDir,
     event,
     ...(options.env ? { env: options.env } : {}),
@@ -35,7 +35,7 @@ async function readMemoryHostEventRecordsRaw(params: {
   limit?: number;
   env?: NodeJS.ProcessEnv;
 }): Promise<MemoryHostEventRecord[]> {
-  const events = listStoredMemoryHostEvents(params).map((entry) => entry.value.event);
+  const events = (await listStoredMemoryHostEvents(params)).map((entry) => entry.value.event);
   return applyMemoryHostEventLimit(events, params.limit);
 }
 

--- a/src/plugin-sdk/memory-host-core.ts
+++ b/src/plugin-sdk/memory-host-core.ts
@@ -267,7 +267,7 @@ async function materializeMemoryHostEventExport(params: {
   return memoryHostEventExportQueue.enqueue(owner.queueKey, async () => {
     const absolutePath = path.join(workspaceKey, ...owner.relativePath.split("/"));
     return await withFileLock(owner.lockTarget, MEMORY_HOST_EVENT_EXPORT_LOCK_OPTIONS, async () => {
-      const storedEvents = listStoredMemoryHostEvents({
+      const storedEvents = await listStoredMemoryHostEvents({
         workspaceDir: workspaceKey,
         limit: MAX_MEMORY_HOST_PUBLIC_EXPORT_EVENTS,
       });

--- a/src/plugin-sdk/memory-host-event-export.test.ts
+++ b/src/plugin-sdk/memory-host-event-export.test.ts
@@ -3,7 +3,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { root as createFsSafeRoot } from "../infra/fs-safe.js";
+import * as eventStore from "../memory-host-sdk/event-store.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
 import { clearMemoryPluginState } from "../plugins/memory-state.test-fixtures.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -21,6 +23,70 @@ describe("memory host event export recovery", () => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
+
+  it.each([false, true])(
+    "waits for journal reads before replacing an export (read fails: %s)",
+    async (readFails) => {
+      const state = await createOpenClawTestState({
+        layout: "state-only",
+        prefix: "memory-host-delayed-export-",
+      });
+      const { workspaceDir } = state;
+      const cfg = { agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] } };
+      const event = {
+        type: "memory.recall.recorded" as const,
+        timestamp: "2026-09-10T12:00:00.000Z",
+        query: "first",
+        resultCount: 0,
+        results: [],
+      };
+      const entered = createDeferred();
+      const release = createDeferred();
+      try {
+        await appendMemoryHostEvent(workspaceDir, event);
+        const artifact = (await listMemoryHostPublicArtifacts({ cfg })).find(
+          (entry) => entry.kind === "event-log",
+        );
+        if (!artifact) {
+          throw new Error("expected initial event export");
+        }
+        const before = await fs.readFile(artifact.absolutePath, "utf8");
+        await appendMemoryHostEvent(workspaceDir, { ...event, query: "second" });
+        const failure = new Error("journal read failed");
+        const list = eventStore.listStoredMemoryHostEvents;
+        vi.spyOn(eventStore, "listStoredMemoryHostEvents").mockImplementationOnce(
+          async (params) => {
+            entered.resolve();
+            await release.promise;
+            if (readFails) {
+              throw failure;
+            }
+            return await list(params);
+          },
+        );
+        const result = listMemoryHostPublicArtifacts({ cfg }).catch((error: unknown) => error);
+        try {
+          await entered.promise;
+          expect(await fs.readFile(artifact.absolutePath, "utf8")).toBe(before);
+        } finally {
+          release.resolve();
+          await result;
+        }
+        if (readFails) {
+          expect(await result).toBe(failure);
+          expect(await fs.readFile(artifact.absolutePath, "utf8")).toBe(before);
+        } else {
+          expect(await result).toEqual(
+            expect.arrayContaining([expect.objectContaining({ kind: "event-log" })]),
+          );
+          expect(await fs.readFile(artifact.absolutePath, "utf8")).toContain('"query":"second"');
+        }
+      } finally {
+        release.resolve();
+        await state.cleanup();
+      }
+    },
+  );
 
   it("does not finalize an initial export changed through the published inode", async () => {
     const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-publish-race-"));

--- a/src/plugin-sdk/memory-host-events.test.ts
+++ b/src/plugin-sdk/memory-host-events.test.ts
@@ -4,12 +4,16 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import * as eventStore from "../memory-host-sdk/event-store.js";
 import {
   listStoredMemoryHostEvents,
   normalizeMemoryHostEventRecordForStorage,
   setMaxMemoryHostEventsForTests,
 } from "../memory-host-sdk/event-store.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
+import * as pluginStateStore from "../plugin-state/plugin-state-store.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   appendMemoryHostEvent,
   readMemoryHostEventRecords,
@@ -43,6 +47,248 @@ afterEach(() => {
 });
 
 describe("memory host event journal helpers", () => {
+  it("uses the retained tail when a cursor retires during a delayed append", async () => {
+    const workspaceDir = await createTempDir("memory-host-events-retired-cursor-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: workspaceDir };
+    const append = (query: string) =>
+      appendMemoryHostEvent(
+        workspaceDir,
+        {
+          type: "memory.recall.recorded",
+          timestamp: "2026-09-10T12:00:00.000Z",
+          query,
+          resultCount: 0,
+          results: [],
+        },
+        { env },
+      );
+    for (let index = 1; index <= 9; index++) {
+      await append(`event-${index}`);
+    }
+    const entered = createDeferred();
+    const release = createDeferred();
+    const register = pluginStateStore.registerPluginStateSequencedJournalEntry;
+    vi.spyOn(pluginStateStore, "registerPluginStateSequencedJournalEntry").mockImplementationOnce(
+      async (params) => {
+        entered.resolve();
+        await release.promise;
+        return await register(params);
+      },
+    );
+    const pending = append("delayed").catch((error: unknown) => error);
+    try {
+      await entered.promise;
+      await append("intervening");
+      const cursors = pluginStateStore.createPluginStateKeyedStore("memory-core", {
+        namespace: "memory-host.event-cursors",
+        maxEntries: 1_000,
+        env,
+      });
+      expect(await cursors.entries()).toMatchObject([{ value: { lastSequence: 10 } }]);
+      await cursors.clear();
+    } finally {
+      release.resolve();
+      await pending;
+    }
+    expect(await pending).toBeUndefined();
+    expect(
+      (await listStoredMemoryHostEvents({ workspaceDir, env })).map(
+        (entry) => entry.value.sequence,
+      ),
+    ).toEqual(Array.from({ length: 11 }, (_, index) => index + 1));
+  });
+
+  it("waits for the journal commit before completing an append", async () => {
+    const workspaceDir = await createTempDir("memory-host-events-delayed-commit-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: workspaceDir };
+    const entered = createDeferred();
+    const release = createDeferred();
+    const register = pluginStateStore.registerPluginStateSequencedJournalEntry;
+    vi.spyOn(pluginStateStore, "registerPluginStateSequencedJournalEntry").mockImplementationOnce(
+      async (params) => {
+        entered.resolve();
+        await release.promise;
+        return await register(params);
+      },
+    );
+    const completed = vi.fn();
+    const pending = appendMemoryHostEvent(
+      workspaceDir,
+      {
+        type: "memory.recall.recorded",
+        timestamp: "2026-09-10T12:00:00.000Z",
+        query: "delayed commit",
+        resultCount: 0,
+        results: [],
+      },
+      { env },
+    ).then(completed);
+    try {
+      await entered.promise;
+      expect(completed).not.toHaveBeenCalled();
+      expect(await readMemoryHostEventRecords({ workspaceDir, env })).toEqual([]);
+    } finally {
+      release.resolve();
+      await pending;
+    }
+    expect(await readMemoryHostEventRecords({ workspaceDir, env })).toMatchObject([
+      { query: "delayed commit" },
+    ]);
+  });
+
+  it.each([
+    { name: "fractional sequence", value: { kind: "event", sequence: 1.5 }, next: undefined },
+    {
+      name: "unsafe sequence",
+      value: { kind: "event", sequence: Number.MAX_SAFE_INTEGER + 1 },
+      next: undefined,
+    },
+    { name: "null record", value: null, next: undefined },
+    { name: "other record kind", value: { kind: "other", sequence: "invalid" }, next: 2 },
+    { name: "numeric string", value: { kind: "event", sequence: "2" }, next: 3 },
+  ])("preserves retained-tail decoding for $name", async ({ value, next }) => {
+    const workspaceDir = await createTempDir("memory-host-events-tail-decoding-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: workspaceDir };
+    const append = () =>
+      appendMemoryHostEvent(
+        workspaceDir,
+        {
+          type: "memory.recall.recorded",
+          timestamp: "2026-09-10T12:00:00.000Z",
+          query: "valid event",
+          resultCount: 0,
+          results: [],
+        },
+        { env },
+      );
+    await append();
+    const entry = (await listStoredMemoryHostEvents({ workspaceDir, env }))[0];
+    if (!entry) {
+      throw new Error("expected initial journal entry");
+    }
+    const journal = pluginStateStore.createPluginStateKeyedStore("memory-core", {
+      namespace: "memory-host.events",
+      maxEntries: 10_000,
+      env,
+    });
+    const cursors = pluginStateStore.createPluginStateKeyedStore("memory-core", {
+      namespace: "memory-host.event-cursors",
+      maxEntries: 1_000,
+      env,
+    });
+    await journal.register(entry.key, value);
+    const cursorBefore = await cursors.entries();
+    if (next === undefined) {
+      await expect(append()).rejects.toThrow();
+      expect(await cursors.entries()).toEqual(cursorBefore);
+      expect(await journal.entries()).toHaveLength(1);
+    } else {
+      await append();
+      expect(await cursors.entries()).toMatchObject([{ value: { lastSequence: next } }]);
+    }
+  });
+
+  it("awaits event reads and propagates read rejection through the public helpers", async () => {
+    const workspaceDir = await createTempDir("memory-host-events-delayed-read-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: workspaceDir };
+    await appendMemoryHostEvent(
+      workspaceDir,
+      {
+        type: "memory.recall.recorded",
+        timestamp: "2026-09-10T12:00:00.000Z",
+        query: "delayed read",
+        resultCount: 0,
+        results: [],
+      },
+      { env },
+    );
+    const entered = createDeferred();
+    const release = createDeferred();
+    const list = eventStore.listStoredMemoryHostEvents;
+    const reader = vi
+      .spyOn(eventStore, "listStoredMemoryHostEvents")
+      .mockImplementationOnce(async (params) => {
+        entered.resolve();
+        await release.promise;
+        return await list(params);
+      });
+    const completed = vi.fn();
+    const pending = readMemoryHostEventRecords({ workspaceDir, env }).then(completed);
+    try {
+      await entered.promise;
+      expect(completed).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await pending;
+    }
+    expect(completed).toHaveBeenCalledWith([expect.objectContaining({ query: "delayed read" })]);
+    const failure = new Error("journal read failed");
+    reader.mockRejectedValueOnce(failure);
+    await expect(readMemoryHostEvents({ workspaceDir, env })).rejects.toBe(failure);
+  });
+
+  it("allocates unique sequences for concurrent appends and continues after reopen", async () => {
+    const workspaceDir = await createTempDir("memory-host-events-concurrent-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: workspaceDir };
+    const append = (index: number) =>
+      appendMemoryHostEvent(
+        workspaceDir,
+        {
+          type: "memory.recall.recorded",
+          timestamp: "2026-09-10T12:00:00.000Z",
+          query: `event-${index}`,
+          resultCount: 0,
+          results: [],
+        },
+        { env },
+      );
+    await Promise.all(Array.from({ length: 24 }, (_, index) => append(index + 1)));
+    resetPluginStateStoreForTests();
+    const stored = await listStoredMemoryHostEvents({ workspaceDir, env });
+    expect(stored.map((entry) => entry.value.sequence)).toEqual(
+      Array.from({ length: 24 }, (_, index) => index + 1),
+    );
+    expect(new Set(stored.map((entry) => entry.key)).size).toBe(24);
+    await append(25);
+    expect(
+      (await listStoredMemoryHostEvents({ workspaceDir, env, limit: 1 }))[0]?.value.sequence,
+    ).toBe(25);
+  });
+
+  it("rolls back cursor allocation and retention when journal insertion fails", async () => {
+    const workspaceDir = await createTempDir("memory-host-events-rollback-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: workspaceDir };
+    setMaxMemoryHostEventsForTests(1);
+    const append = (query: string) =>
+      appendMemoryHostEvent(
+        workspaceDir,
+        {
+          type: "memory.recall.recorded",
+          timestamp: "2026-09-10T12:00:00.000Z",
+          query,
+          resultCount: 0,
+          results: [],
+        },
+        { env },
+      );
+    await append("retained");
+    const before = await listStoredMemoryHostEvents({ workspaceDir, env });
+    const { db } = openOpenClawStateDatabase({ env });
+    db.exec(`CREATE TEMP TRIGGER fail_memory_journal BEFORE INSERT ON plugin_state_entries
+      WHEN NEW.namespace = 'memory-host.events'
+      BEGIN SELECT RAISE(ABORT, 'injected journal write failure'); END`);
+    try {
+      await expect(append("refused")).rejects.toMatchObject({ code: "PLUGIN_STATE_WRITE_FAILED" });
+      expect(await listStoredMemoryHostEvents({ workspaceDir, env })).toEqual(before);
+    } finally {
+      db.exec("DROP TRIGGER fail_memory_journal");
+    }
+    await append("accepted");
+    expect(await listStoredMemoryHostEvents({ workspaceDir, env })).toMatchObject([
+      { value: { sequence: 2, event: { query: "accepted" } } },
+    ]);
+  });
+
   it("appends and reads typed workspace events", async () => {
     const workspaceDir = await createTempDir("memory-host-events-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: workspaceDir };
@@ -116,7 +362,7 @@ describe("memory host event journal helpers", () => {
     }
 
     expect(
-      listStoredMemoryHostEvents({ workspaceDir, env }).map((entry) => entry.createdAt),
+      (await listStoredMemoryHostEvents({ workspaceDir, env })).map((entry) => entry.createdAt),
     ).toEqual([now, now + 1]);
   });
 

--- a/src/plugin-state/plugin-state-store.retention.test.ts
+++ b/src/plugin-state/plugin-state-store.retention.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../test-utils/openclaw-test-state.js";
 import {
   createPluginStateKeyedStore,
-  registerPluginStateSyncSequencedJournalEntry,
+  registerPluginStateSequencedJournalEntry,
   resetPluginStateStoreForTests,
   sweepExpiredPluginStateEntries,
 } from "./plugin-state-store.js";
@@ -238,27 +238,27 @@ describe("plugin state keyed store", () => {
                 pluginId: "memory-core",
                 namespace: "memory-host.event-cursors",
                 key: "workspace",
-                value: { kind: "cursor", lastSequence: 1 },
+                value: { kind: "cursor", lastSequence: 9 },
               },
             ]
           : [
               {
                 pluginId: "memory-core",
                 namespace: "memory-host.events",
-                key: "event-2",
-                value: { sequence: 2 },
+                key: "event-0000000000000010",
+                value: { sequence: 10 },
               },
             ]),
         {
           pluginId: "memory-core",
           namespace: "memory-host.events",
-          key: "event-1",
-          value: { sequence: 1 },
+          key: "event-0000000000000009",
+          value: { sequence: 9 },
         },
       ]);
 
       expect(
-        registerPluginStateSyncSequencedJournalEntry({
+        await registerPluginStateSequencedJournalEntry({
           pluginId: "memory-core",
           cursorOptions: {
             namespace: "memory-host.event-cursors",
@@ -266,11 +266,11 @@ describe("plugin state keyed store", () => {
           },
           cursorKey: "workspace",
           journalOptions: { namespace: "memory-host.events", maxEntries: 10_000 },
-          initialSequence: existingCursor ? 0 : 2,
-          journalKey: (sequence) => `event-${sequence}`,
+          journalKeyPrefix: "event-",
+          journalKeyRange: { keyStartInclusive: "event-", keyEndExclusive: "event." },
           journalValue: (sequence) => ({ sequence }),
         }),
-      ).toBe(existingCursor ? 2 : 3);
+      ).toBe(existingCursor ? 10 : 11);
 
       const durable = createPluginStateKeyedStore("memory-core", {
         namespace: "durable-state",
@@ -293,16 +293,16 @@ describe("plugin state keyed store", () => {
       await expect(checkpoints.lookup("generation")).resolves.toEqual({
         kind: "raw-checkpoint",
       });
-      await expect(journal.lookup("event-1")).resolves.toBeUndefined();
+      await expect(journal.lookup("event-0000000000000009")).resolves.toBeUndefined();
       if (existingCursor) {
-        await expect(journal.lookup("event-2")).resolves.toEqual({ sequence: 2 });
+        await expect(journal.lookup("event-0000000000000010")).resolves.toEqual({ sequence: 10 });
       } else {
-        await expect(journal.lookup("event-2")).resolves.toBeUndefined();
-        await expect(journal.lookup("event-3")).resolves.toEqual({ sequence: 3 });
+        await expect(journal.lookup("event-0000000000000010")).resolves.toBeUndefined();
+        await expect(journal.lookup("event-0000000000000011")).resolves.toEqual({ sequence: 11 });
       }
       await expect(cursor.lookup("workspace")).resolves.toEqual({
         kind: "cursor",
-        lastSequence: existingCursor ? 2 : 3,
+        lastSequence: existingCursor ? 10 : 11,
       });
     },
   );

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -860,7 +860,11 @@ export function pluginStateRegisterSequencedJournalEntry(params: {
   cursorMaxEntries: number;
   journalNamespace: string;
   journalMaxEntries: number;
-  initialSequence: number;
+  journalKeyRange: {
+    keyStartInclusive: string;
+    keyEndExclusive: string;
+    valueKind?: string;
+  };
   readCursorSequence: (valueJson: string) => number | undefined;
   prepareEntry: (sequence: number) => {
     cursorValueJson: string;
@@ -889,12 +893,52 @@ export function pluginStateRegisterSequencedJournalEntry(params: {
           now,
         });
         const cursorSequence = cursor ? params.readCursorSequence(cursor.value_json) : undefined;
-        const lastSequence = Math.max(params.initialSequence, cursorSequence ?? 0);
+        // Cursor eviction must not let an admitted append reuse a retained sequence.
+        const tail = selectPluginStateEntriesInKeyRange(store.db, {
+          pluginId: params.pluginId,
+          namespace: params.journalNamespace,
+          ...params.journalKeyRange,
+          limit: 1,
+          order: "desc",
+          now,
+        })[0];
+        let retainedSequence = 0;
+        if (tail) {
+          const value = parseStoredJson(tail.value_json, "entries", store.path);
+          if (value === null) {
+            throw new TypeError("Plugin state journal tail must not be null.");
+          }
+          if (
+            typeof value === "object" &&
+            (params.journalKeyRange.valueKind === undefined ||
+              ("kind" in value && value.kind === params.journalKeyRange.valueKind))
+          ) {
+            retainedSequence = Math.max(0, Number("sequence" in value ? (value.sequence ?? 0) : 0));
+            if (!Number.isSafeInteger(retainedSequence)) {
+              throw createPluginStateError({
+                code: "PLUGIN_STATE_INVALID_INPUT",
+                operation: "register",
+                message: "Plugin state journal sequence must be a safe non-negative integer.",
+              });
+            }
+          }
+        }
+        const lastSequence = Math.max(retainedSequence, cursorSequence ?? 0);
         const sequence = lastSequence + 1;
         if (!Number.isSafeInteger(sequence)) {
           throw new RangeError("Plugin state journal sequence exhausted safe integer range");
         }
         const prepared = params.prepareEntry(sequence);
+        if (
+          prepared.journalKey < params.journalKeyRange.keyStartInclusive ||
+          prepared.journalKey >= params.journalKeyRange.keyEndExclusive
+        ) {
+          throw createPluginStateError({
+            code: "PLUGIN_STATE_INVALID_INPUT",
+            operation: "register",
+            message: "Plugin state journal key must be inside its retained key range.",
+          });
+        }
         const existingJournalEntry = selectPluginStateEntry(store.db, {
           pluginId: params.pluginId,
           namespace: params.journalNamespace,

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -380,20 +380,26 @@ export function createPluginStateSyncKeyedStore<T>(
 }
 
 /** Atomically allocates a workspace sequence and appends one journal entry. */
-export function registerPluginStateSyncSequencedJournalEntry(params: {
+export async function registerPluginStateSequencedJournalEntry(params: {
   pluginId: string;
   cursorOptions: OpenKeyedStoreOptions;
   cursorKey: string;
   journalOptions: OpenKeyedStoreOptions;
-  initialSequence: number;
-  journalKey: (sequence: number) => string;
+  /** This owner adds a fixed-width sequence suffix so key order matches append order. */
+  journalKeyPrefix: string;
+  journalKeyRange: {
+    keyStartInclusive: string;
+    keyEndExclusive: string;
+    valueKind?: string;
+  };
   journalValue: (sequence: number) => unknown;
-}): number {
+}): Promise<number> {
   if (params.pluginId.startsWith("core:")) {
     throw invalidInput("Plugin ids starting with 'core:' are reserved for core consumers.", "open");
   }
-  if (!Number.isSafeInteger(params.initialSequence) || params.initialSequence < 0) {
-    throw invalidInput("plugin state initial journal sequence must be a safe non-negative integer");
+  const journalKeyPrefix = validateKey(params.journalKeyPrefix);
+  if (params.journalKeyRange.keyStartInclusive >= params.journalKeyRange.keyEndExclusive) {
+    throw invalidInput("Plugin state key range must have an increasing exclusive upper bound.");
   }
   const cursorNamespace = validateNamespace(params.cursorOptions.namespace);
   const cursorMaxEntries = validateMaxEntries(params.cursorOptions.maxEntries);
@@ -436,7 +442,7 @@ export function registerPluginStateSyncSequencedJournalEntry(params: {
     cursorMaxEntries,
     journalNamespace,
     journalMaxEntries,
-    initialSequence: params.initialSequence,
+    journalKeyRange: params.journalKeyRange,
     readCursorSequence(valueJson) {
       try {
         const value = JSON.parse(valueJson) as { kind?: unknown; lastSequence?: unknown };
@@ -450,7 +456,7 @@ export function registerPluginStateSyncSequencedJournalEntry(params: {
     prepareEntry(sequence) {
       const cursor = prepareRegisterParams(cursorKey, { kind: "cursor", lastSequence: sequence });
       const journal = prepareRegisterParams(
-        params.journalKey(sequence),
+        `${journalKeyPrefix}${sequence.toString().padStart(16, "0")}`,
         params.journalValue(sequence),
       );
       return {


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Memory-host event operations still expose synchronous storage contracts. Introducing awaited append admission also exposes a race if a cursor is evicted after an earlier tail read: a later append can reuse a retained sequence.

## Why This Change Was Made

Await journal registration and reads throughout the memory-host API. Move retained-tail selection into the existing append transaction so sequence allocation considers both the cursor and authoritative retained events at commit. Carry the journal key prefix and range as data, preserving the existing fixed-width storage keys.

## User Impact

Event ordering and export formats remain compatible. Appends cannot overwrite a retained event because a cursor disappears during an asynchronous handoff. Existing schema, retention limits and synchronous native transaction callbacks are preserved.

## Evidence

- 65 focused tests and full selected changed checks passed.
- Fresh independent Codex review through P2 passed with full append-owner and caller context.
- Fingerprinted real-SQLite smoke appended 32 records, removed the derived cursor, reopened in a fresh process and allocated/exported sequence 33 successfully.
- Delayed append coverage exercises the cursor/tail interleaving, and export coverage preserves ordering and limits.
- This prepares the complete journal operation for worker execution; native SQLite still runs on the calling thread in this prerequisite.
