### PR TITLE
refactor(hooks): await native relay persistence and drainage

### DIFF
--- a/docs/plugins/codex-harness-runtime/hooks.md
+++ b/docs/plugins/codex-harness-runtime/hooks.md
@@ -61,6 +61,14 @@ plugin behavior. For the native tool and permission bridge, OpenClaw injects
 per-thread Codex config for `PreToolUse`, `PostToolUse`, `PermissionRequest`,
 and `Stop`.
 
+Before starting or resuming a thread, OpenClaw waits for the native relay's
+SQLite locator to be published. Renewal extends the visible expiry only after
+the stored locator is updated. Unregistering invalidates foreground access
+immediately. Cleanup drains accepted locator writes and, once the relay is
+retired, listener closure. Existing grace windows for late hooks and direct
+children retained after a successful yield are preserved; draining pending
+storage work does not close those children.
+
 When Codex app-server approvals are enabled (`approvalPolicy` is not
 `"never"`), the default injected native hook config omits `PermissionRequest`
 so Codex's app-server reviewer and OpenClaw's approval bridge handle real

--- a/docs/plugins/codex-harness-runtime/hooks.md
+++ b/docs/plugins/codex-harness-runtime/hooks.md
@@ -62,8 +62,11 @@ per-thread Codex config for `PreToolUse`, `PostToolUse`, `PermissionRequest`,
 and `Stop`.
 
 Before starting or resuming a thread, OpenClaw waits for the native relay's
-SQLite locator to be published. Renewal extends the visible expiry only after
-the stored locator is updated. Unregistering invalidates foreground access
+direct publication attempt and rechecks the current run's authority. If the
+listener or SQLite locator is unavailable, hook commands can use the existing
+Gateway fallback. A relay without a listening direct bridge can still renew its
+logical expiry; a listening bridge updates its stored locator before extending
+the visible expiry. Unregistering invalidates foreground access
 immediately. Cleanup drains accepted locator writes and, once the relay is
 retired, listener closure. Existing grace windows for late hooks and direct
 children retained after a successful yield are preserved; draining pending

--- a/extensions/codex/src/app-server/native-hook-relay-state.ts
+++ b/extensions/codex/src/app-server/native-hook-relay-state.ts
@@ -4,6 +4,7 @@ type PendingUnregister = {
 };
 
 const pending = new Set<PendingUnregister>();
+const closing = new Set<Promise<void>>();
 
 /** Owns delayed hook-relay cleanup across runtime scheduling and test teardown. */
 export const nativeHookRelayUnregisterQueue = {
@@ -13,20 +14,33 @@ export const nativeHookRelayUnregisterQueue = {
   delete(entry: PendingUnregister): boolean {
     return pending.delete(entry);
   },
-  flush(): void {
+  track(operation: Promise<void>): void {
+    closing.add(operation);
+    void operation.then(
+      () => closing.delete(operation),
+      () => closing.delete(operation),
+    );
+  },
+  async flush(): Promise<void> {
     while (pending.size > 0) {
       const entry = pending.values().next().value;
       if (!entry) {
-        return;
+        break;
       }
       clearTimeout(entry.timeout);
       entry.unregister();
     }
+    while (closing.size > 0) {
+      await Promise.allSettled(closing);
+    }
   },
-  clear(): void {
+  async clear(): Promise<void> {
     for (const entry of pending) {
       clearTimeout(entry.timeout);
     }
     pending.clear();
+    while (closing.size > 0) {
+      await Promise.allSettled(closing);
+    }
   },
 };

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -7,12 +7,11 @@ import type {
   BeforeToolCallFailureDisposition,
   EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
   NativeHookRelayEvent,
-  NativeHookRelayRegistrationHandle,
   registerNativeHookRelay,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import { registerRetainedNativeHookRelayForBundledRuntime } from "openclaw/plugin-sdk/native-hook-relay-runtime";
+import { registerNativeHookRelayForBundledRuntime } from "openclaw/plugin-sdk/native-hook-relay-runtime";
 import type { NativeHookRelayCommandPlan } from "openclaw/plugin-sdk/native-hook-relay-runtime";
 import {
   addTimerTimeoutGraceMs,
@@ -63,7 +62,7 @@ export type CodexNativePreToolUseFailure = {
   durationMs: number;
 };
 
-export type CodexNativeHookRelay = NativeHookRelayRegistrationHandle & {
+export type CodexNativeHookRelay = ReturnType<typeof registerNativeHookRelayForBundledRuntime> & {
   authorizeRetentionAfterSuccessfulYield: () => void;
   hasClaimedDirectChild: () => boolean;
   claimDirectChild: (threadId: string) => () => void;
@@ -116,7 +115,7 @@ export async function assertCodexNativeHookRelayAllowed(
 
 /** Defers relay unregister so late native hook subprocesses can still resolve. */
 export function scheduleCodexNativeHookRelayUnregister(params: {
-  relay: NativeHookRelayRegistrationHandle;
+  relay: ReturnType<typeof registerNativeHookRelayForBundledRuntime>;
   hookTimeoutSec?: number;
 }): void {
   let pending: { timeout: ReturnType<typeof setTimeout>; unregister: () => void } | undefined;
@@ -130,6 +129,7 @@ export function scheduleCodexNativeHookRelayUnregister(params: {
       return;
     }
     params.relay.unregister();
+    nativeHookRelayUnregisterQueue.track(params.relay.drain());
   };
   const timeout = setTimeout(
     unregister,
@@ -235,7 +235,7 @@ export function createCodexNativeHookRelay(params: {
     }
     pendingDirectChildAdmissions.clear();
   };
-  const relay = registerRetainedNativeHookRelayForBundledRuntime({
+  const relay = registerNativeHookRelayForBundledRuntime({
     provider: "codex",
     relayId: buildCodexNativeHookRelayId({
       agentId: params.agentId,
@@ -362,6 +362,7 @@ export function createCodexNativeHookRelay(params: {
         directChildClaims.delete(threadId);
         if (foregroundClosed && directChildClaims.size === 0) {
           relay.unregister();
+          nativeHookRelayUnregisterQueue.track(relay.drain());
         }
       };
     },

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -205,7 +205,7 @@ export async function cleanupCodexAttempt(
     );
     const nativeHookRelay = resourceState.nativeHookRelay;
     resourceState.nativeHookRelay = undefined;
-    await runCleanupStep("codex-native-hook-relay-release", () => {
+    await runCleanupStep("codex-native-hook-relay-release", async () => {
       if (!nativeHookRelay) {
         return;
       }
@@ -218,6 +218,7 @@ export async function cleanupCodexAttempt(
       } else {
         nativeHookRelay.unregister();
       }
+      await nativeHookRelay.drain();
     });
     await runCleanupStep("codex-sandbox-release", releaseSandboxExecEnvironment);
     await runCleanupStep("codex-abort-listener-remove", () => {

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -269,10 +269,13 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
   });
   const requesterChannel = params.messageChannel ?? params.messageProvider;
   const requester = buildCodexHookRequester(params);
-  const buildNativeHookRelayFinalConfigPatch = (
+  const buildNativeHookRelayFinalConfigPatch = async (
     decision: { action: "resume"; binding: CodexAppServerThreadBinding } | { action: "start" },
   ) => {
-    state.nativeHookRelay?.unregister();
+    const previousRelay = state.nativeHookRelay;
+    previousRelay?.unregister();
+    await previousRelay?.drain();
+    connection.assertCurrent();
     if (params.pluginHarnessToolPolicyRestricted === true) {
       state.nativeHookRelay = undefined;
       return {
@@ -324,6 +327,8 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
         }
       },
     });
+    await state.nativeHookRelay?.ready;
+    connection.assertCurrent();
     return {
       configPatch: state.nativeHookRelay
         ? buildCodexNativeHookRelayConfig({

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -327,7 +327,7 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
         }
       },
     });
-    await state.nativeHookRelay?.ready;
+    await state.nativeHookRelay?.prepareInvocation();
     connection.assertCurrent();
     return {
       configPatch: state.nativeHookRelay

--- a/extensions/codex/src/app-server/run-attempt-route.ts
+++ b/extensions/codex/src/app-server/run-attempt-route.ts
@@ -1,4 +1,8 @@
-import { embeddedAgentLog, formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  embeddedAgentLog,
+  formatErrorMessage,
+  runAgentCleanupStep,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { CodexAttemptNotificationController } from "./run-attempt-notification-controller.js";
 import type { CodexAttemptResources } from "./run-attempt-resources.js";
 import type { createCodexAttemptServerRequestController } from "./run-attempt-server-requests.js";
@@ -98,7 +102,17 @@ export async function prepareCodexAttemptRoute(
   } catch (error) {
     activateNativePreToolUseFailureFallback();
     releaseCurrentRoute();
-    resourceState.nativeHookRelay?.unregister();
+    const relay = resourceState.nativeHookRelay;
+    relay?.unregister();
+    await runAgentCleanupStep({
+      runId: connection.params.runId,
+      sessionId: connection.params.sessionId,
+      step: "codex-route-failure-native-hook-relay",
+      log: embeddedAgentLog,
+      cleanup: async () => {
+        await relay?.drain();
+      },
+    });
     await releaseSandboxExecEnvironment();
     releaseSharedClientLeaseOnce();
     throw error;

--- a/extensions/codex/src/app-server/run-attempt-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-start.ts
@@ -240,9 +240,10 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
     await runCleanupStep("codex-start-failure-route-release", releaseCurrentRoute);
     const nativeHookRelay = state.nativeHookRelay;
     state.nativeHookRelay = undefined;
-    await runCleanupStep("codex-start-failure-native-hook-relay", () =>
-      nativeHookRelay?.unregister(),
-    );
+    await runCleanupStep("codex-start-failure-native-hook-relay", async () => {
+      nativeHookRelay?.unregister();
+      await nativeHookRelay?.drain();
+    });
     await runCleanupStep("codex-start-failure-sandbox-release", releaseSandboxExecEnvironment);
     await runCleanupStep(
       "codex-start-failure-shared-client-release",

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -728,8 +728,8 @@ export function setupRunAttemptTestHooks(): void {
     clearRuntimeAuthProfileStoreSnapshots();
     dynamicToolBuildState.openClawCodingToolsFactory = undefined;
     codexWorkspaceDirCache.clear();
-    nativeHookRelayUnregisterQueue.clear();
-    nativeHookRelayTesting.clearNativeHookRelaysForTests();
+    await nativeHookRelayUnregisterQueue.clear();
+    await nativeHookRelayTesting.clearNativeHookRelaysForTests();
     clearMemoryPluginState();
     clearPluginCommands();
     resetAgentEventsForTest();

--- a/extensions/codex/src/app-server/run-attempt-turn-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-start.ts
@@ -265,7 +265,17 @@ export async function startCodexAttemptTurn(
       }
       releaseCurrentRoute();
       activateNativePreToolUseFailureFallback();
-      resourceState.nativeHookRelay?.unregister();
+      const relay = resourceState.nativeHookRelay;
+      relay?.unregister();
+      await runAgentCleanupStep({
+        runId: params.runId,
+        sessionId: params.sessionId,
+        step: "codex-turn-start-failure-native-hook-relay",
+        log: embeddedAgentLog,
+        cleanup: async () => {
+          await relay?.drain();
+        },
+      });
       await releaseSandboxExecEnvironment();
       await runAgentCleanupStep({
         runId: params.runId,

--- a/extensions/codex/src/app-server/run-attempt-turn-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-state.ts
@@ -109,8 +109,13 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
     }
     return completed;
   };
+  let pendingNativeHookRenewal: Promise<void> | undefined;
   const renewNativeHookRelayForTurnProgress = () => {
-    if (!resourceState.nativeHookRelay || options.nativeHookRelay?.ttlMs !== undefined) {
+    if (
+      !resourceState.nativeHookRelay ||
+      options.nativeHookRelay?.ttlMs !== undefined ||
+      pendingNativeHookRenewal
+    ) {
       return;
     }
     const now = Date.now();
@@ -121,14 +126,27 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
     if (renewsRecently && !expiresSoon) {
       return;
     }
-    state.nativeHookRelayLastRenewedAt = now;
-    resourceState.nativeHookRelay.renew(
+    const relay = resourceState.nativeHookRelay;
+    relay.renew(
       resolveCodexNativeHookRelayTtlMs({
         explicitTtlMs: undefined,
         attemptTimeoutMs: params.timeoutMs,
         startupTimeoutMs,
         turnStartTimeoutMs: params.timeoutMs,
       }),
+    );
+    pendingNativeHookRenewal = relay.drain();
+    void pendingNativeHookRenewal.then(
+      () => {
+        pendingNativeHookRenewal = undefined;
+        if (resourceState.nativeHookRelay === relay) {
+          state.nativeHookRelayLastRenewedAt = now;
+        }
+      },
+      (error: unknown) => {
+        pendingNativeHookRenewal = undefined;
+        embeddedAgentLog.debug("native hook relay renewal did not drain", { error });
+      },
     );
   };
   const noteProgress = (reason: string) => {

--- a/extensions/codex/src/app-server/run-attempt.native-hook-fallback.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-fallback.test.ts
@@ -1,0 +1,123 @@
+import { Server } from "node:http";
+import path from "node:path";
+import {
+  invokeNativeHookRelay,
+  nativeHookRelayTesting,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import {
+  createEmptyPluginRegistry,
+  createMockPluginRegistry,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { nativeHookRelayUnregisterQueue } from "./native-hook-relay-state.js";
+import {
+  bindProductionHarnessHostCapabilitiesForTest,
+  createParams,
+  createStartedThreadHarness,
+  extractGenerationFromThreadRequest,
+  extractRelayIdFromThreadRequest,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+  threadStartResult,
+} from "./run-attempt-test-harness.js";
+import { writeCodexAppServerBinding } from "./session-binding.test-helpers.js";
+
+setupRunAttemptTestHooks();
+afterEach(() => setActivePluginRegistry(createEmptyPluginRegistry()));
+
+describe("Codex native hook Gateway fallback", () => {
+  it.each(["fresh", "resumed"] as const)(
+    "keeps %s native hook policy available when the direct listener fails",
+    async (selection) => {
+      const sessionFile = path.join(tempDir, "listener-unavailable.jsonl");
+      const workspaceDir = path.join(tempDir, "listener-unavailable-workspace");
+      if (selection === "resumed") {
+        await writeCodexAppServerBinding(sessionFile, {
+          threadId: "thread-existing",
+          cwd: workspaceDir,
+          model: "gpt-5.4-codex",
+          modelProvider: "openai",
+          dynamicToolsFingerprint: "[]",
+          webSearchThreadConfigFingerprint: JSON.stringify({
+            "features.standalone_web_search": false,
+            web_search: "disabled",
+          }),
+        });
+      }
+      const started = createDeferred<void>();
+      const harness = createStartedThreadHarness(
+        async (method) => {
+          if (method === "thread/resume") {
+            return threadStartResult("thread-existing");
+          }
+          if (method === "turn/start") {
+            started.resolve();
+          }
+          return undefined;
+        },
+        { persistedThreads: selection === "resumed" ? ["thread-existing"] : [] },
+      );
+      const beforeToolCall = vi.fn(() => ({ block: true, blockReason: "fixture policy denial" }));
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+      );
+      const params = createParams(sessionFile, workspaceDir);
+      params.config = { tools: { loopDetection: { enabled: true } } };
+      const closeHost = await bindProductionHarnessHostCapabilitiesForTest(params);
+      const abort = new AbortController();
+      params.abortSignal = abort.signal;
+      vi.spyOn(Server.prototype, "listen").mockImplementationOnce(function (this: Server) {
+        queueMicrotask(() =>
+          this.emit(
+            "error",
+            Object.assign(new Error("fixture listener unavailable"), { code: "EADDRNOTAVAIL" }),
+          ),
+        );
+        return this;
+      });
+      const run = runCodexAppServerAttempt(params, {
+        nativeHookRelay: { enabled: true, events: ["pre_tool_use"] },
+      });
+      try {
+        await Promise.race([started.promise, run.then(() => undefined)]);
+        const request = harness.requests.find(
+          ({ method }) => method === (selection === "resumed" ? "thread/resume" : "thread/start"),
+        );
+        const relayId = extractRelayIdFromThreadRequest(request?.params);
+        const generation = extractGenerationFromThreadRequest(request?.params);
+        const response = await invokeNativeHookRelay({
+          provider: "codex",
+          relayId,
+          generation,
+          requireGeneration: true,
+          event: "pre_tool_use",
+          rawPayload: {
+            hook_event_name: "PreToolUse",
+            tool_name: "Bash",
+            tool_use_id: "listener-unavailable-tool",
+            tool_input: { command: "pwd" },
+          },
+        });
+        expect(response.stdout).toContain("fixture policy denial");
+        expect(beforeToolCall).toHaveBeenCalledTimes(1);
+        await harness.completeTurn({
+          threadId: selection === "resumed" ? "thread-existing" : "thread-1",
+          turnId: "turn-1",
+        });
+        await run;
+        await nativeHookRelayUnregisterQueue.flush();
+        expect(
+          nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId),
+        ).toBeUndefined();
+      } finally {
+        abort.abort("test cleanup");
+        await Promise.allSettled([run]);
+        closeHost();
+      }
+    },
+  );
+});

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts
@@ -359,7 +359,7 @@ describe("runCodexAppServerAttempt native hook relay retention", () => {
           },
         } as CodexServerNotification;
         await harness.notify(childTerminal);
-        nativeHookRelayUnregisterQueue.flush();
+        await nativeHookRelayUnregisterQueue.flush();
         expect(
           nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId),
         ).toBeUndefined();

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -246,7 +246,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect(preToolUseState?.trusted_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeDefined();
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -347,7 +347,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -417,7 +417,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
     closeHostCapabilities();
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
   });
 
   it("fails a defensive unattended yolo approval immediately when the hook requires review", async () => {
@@ -479,7 +479,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
     closeHostCapabilities();
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
   });
 
   it.each([
@@ -519,7 +519,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -582,7 +582,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -615,7 +615,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -649,7 +649,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -691,7 +691,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
       completed = true;
       await run;
-      nativeHookRelayUnregisterQueue.flush();
+      await nativeHookRelayUnregisterQueue.flush();
       expect(
         nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId),
       ).toBeUndefined();
@@ -786,7 +786,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
         nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId)?.runId,
       ).toBe(sameExecutionSession ? "run-2" : "run-1");
 
-      nativeHookRelayUnregisterQueue.flush();
+      await nativeHookRelayUnregisterQueue.flush();
       expect(
         nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(secondRelayId)?.runId,
       ).toBe("run-2");
@@ -796,7 +796,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       expect(
         nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(secondRelayId)?.runId,
       ).toBe("run-2");
-      nativeHookRelayUnregisterQueue.flush();
+      await nativeHookRelayUnregisterQueue.flush();
       expect(
         nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(secondRelayId),
       ).toBeUndefined();
@@ -863,7 +863,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
       currentGeneration,
     );
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
   });
 
   it("rotates native hook relay generations when an existing binding starts a fresh thread", async () => {
@@ -912,7 +912,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
       currentGeneration,
     );
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
   });
 
   it("rotates native hook relay generations when resume fails over to a fresh thread", async () => {
@@ -971,7 +971,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
       currentGeneration,
     );
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
   });
 
   it("sends clearing Codex native hook config when the relay is disabled", async () => {
@@ -1081,7 +1081,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
         },
       }),
     ).rejects.toThrow("native hook relay not found");
-    nativeHookRelayUnregisterQueue.flush();
+    await nativeHookRelayUnregisterQueue.flush();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 });

--- a/extensions/codex/src/app-server/run-attempt.settlement.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.settlement.test.ts
@@ -572,6 +572,8 @@ describe("Codex app-server terminal settlement", () => {
           expect(result.contextEngineTerminalAnchor).toBeUndefined();
         }
         if (boundary === "final" && release === "after cutoff") {
+          // Successor I/O and relay retirement must outlive the completed deadline simulation.
+          vi.useRealTimers();
           const nextHarness = createStartedThreadHarness(
             async (method) => {
               if (method === "thread/resume") {

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -39,12 +39,6 @@ import {
   threadStartResult,
   turnStartResult,
 } from "./run-attempt-test-harness.js";
-
-const testing = {
-  flushPendingCodexNativeHookRelayUnregistersForTests(): void {
-    nativeHookRelayUnregisterQueue.flush();
-  },
-};
 import {
   readCodexAppServerBinding,
   writeCodexAppServerBinding as writeRawCodexAppServerBinding,
@@ -1300,7 +1294,7 @@ describe("runCodexAppServerAttempt native lifecycle", () => {
         },
       }),
     ).rejects.toThrow("native hook relay not found");
-    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+    await nativeHookRelayUnregisterQueue.flush();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -1330,7 +1324,7 @@ describe("runCodexAppServerAttempt native lifecycle", () => {
         },
       }),
     ).rejects.toThrow("native hook relay not found");
-    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+    await nativeHookRelayUnregisterQueue.flush();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -57,6 +57,7 @@ import {
   resolveManagedCodexNativeCommand,
 } from "./managed-binary.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
+import { nativeHookRelayUnregisterQueue } from "./native-hook-relay-state.js";
 import {
   closeRetiredSharedClientEntry,
   closeRetiredSharedClientEntryIfIdle,
@@ -1482,6 +1483,7 @@ export async function clearSharedCodexAppServerClientAndWait(options?: {
       await Promise.allSettled(lifetime.pending);
     }
     await closing;
+    await nativeHookRelayUnregisterQueue.flush();
   } finally {
     if (state.startup === lifetime) {
       state.startup = createCodexAppServerStartupLifetime();

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -573,8 +573,8 @@ async function runSideQuestionWithManagedWebSearchCall(
 describe("runCodexAppServerSideQuestion", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-  beforeEach(() => {
-    nativeHookRelayTesting.clearNativeHookRelaysForTests();
+  beforeEach(async () => {
+    await nativeHookRelayTesting.clearNativeHookRelaysForTests();
     readCodexAppServerBindingMock.mockReset();
     isCodexAppServerNativeAuthProfileMock.mockReset();
     getSharedCodexAppServerClientMock.mockReset();
@@ -633,8 +633,8 @@ describe("runCodexAppServerSideQuestion", () => {
     });
   });
 
-  afterEach(() => {
-    nativeHookRelayTesting.clearNativeHookRelaysForTests();
+  afterEach(async () => {
+    await nativeHookRelayTesting.clearNativeHookRelaysForTests();
     resetDiagnosticEventsForTest();
     resetGlobalHookRunner();
     vi.unstubAllGlobals();

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1,3 +1,4 @@
+import { Server } from "node:http";
 // Codex tests cover side question plugin behavior.
 import path from "node:path";
 import {
@@ -16,6 +17,7 @@ import {
   resetGlobalHookRunner,
 } from "openclaw/plugin-sdk/hook-runtime";
 import {
+  createAdmittedHostCapabilityTestFixture,
   createMockPluginRegistry,
   loadWebFetchToolFactoryForTest,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
@@ -2241,7 +2243,21 @@ describe("runCodexAppServerSideQuestion", () => {
     },
   );
 
-  it("installs native hook relay config for opted-in side threads", async () => {
+  it.each([false, true])("keeps side hooks after listener failure: %s", async (failed) => {
+    if (failed) {
+      vi.spyOn(Server.prototype, "listen").mockImplementationOnce(function (this: Server) {
+        queueMicrotask(() => this.emit("error", new Error("fixture side listener unavailable")));
+        return this;
+      });
+    }
+    const beforeToolCall = vi.fn(() => ({
+      block: true,
+      blockReason: "fixture side policy denial",
+    }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const host = await createAdmittedHostCapabilityTestFixture({ runId: "run-side-1" });
     const client = createFakeClient();
     let relayIdDuringFork: string | undefined;
     client.request.mockImplementation(async (method: string, requestParams: unknown) => {
@@ -2258,6 +2274,23 @@ describe("runCodexAppServerSideQuestion", () => {
           channelId: "voice-room",
           allowedEvents: ["pre_tool_use", "post_tool_use", "before_agent_finalize"],
         });
+        const generation = codexHookCommand(config, "hooks.PreToolUse")?.command?.match(
+          /--generation ([^ ]+)/,
+        )?.[1];
+        const response = await invokeNativeHookRelay({
+          provider: "codex",
+          relayId: relayIdDuringFork,
+          generation,
+          requireGeneration: true,
+          event: "pre_tool_use",
+          rawPayload: {
+            hook_event_name: "PreToolUse",
+            tool_name: "Bash",
+            tool_use_id: "side-listener-unavailable-tool",
+            tool_input: { command: "pwd" },
+          },
+        });
+        expect(response.stdout).toContain("fixture side policy denial");
         return threadResult("side-thread");
       }
       if (method === "thread/inject_items") {
@@ -2280,6 +2313,7 @@ describe("runCodexAppServerSideQuestion", () => {
     await expect(
       runCodexAppServerSideQuestion(
         sideLoopRelayParams({
+          hostCapabilities: host.hostCapabilities,
           sessionKey: "agent:main:session-1",
           sessionEntry: {
             sessionId: "session-1",
@@ -2293,7 +2327,10 @@ describe("runCodexAppServerSideQuestion", () => {
           opts: { runId: "run-side-1" },
         }),
         { nativeHookRelay: { enabled: true, hookTimeoutSec: 9 } },
-      ),
+      ).finally(() => {
+        host.closeHost();
+        host.closeAdmission();
+      }),
     ).resolves.toEqual({ text: "Side answer." });
 
     const forkParams = mockCall(client.request)[1] as Record<string, unknown> | undefined;
@@ -2320,6 +2357,7 @@ describe("runCodexAppServerSideQuestion", () => {
     const turnStartCall = client.request.mock.calls.find(([method]) => method === "turn/start");
     expect(turnStartCall?.[1]).not.toHaveProperty("config");
     expect(relayIdDuringFork).toBeDefined();
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
     expect(createOpenClawCodingToolsMock).toHaveBeenCalledWith(
       expect.objectContaining({ runId: "run-side-1" }),
     );

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -8,14 +8,14 @@ import {
   resolveAttemptSpawnWorkspaceDir,
   resolveModelAuthMode,
   resolveSandboxContext,
-  registerNativeHookRelay,
+  runAgentCleanupStep,
   supportsModelTools,
   type AnyAgentTool,
   type AgentHarnessSideQuestionParamsV2,
   type AgentHarnessSideQuestionResult,
   type EmbeddedRunAttemptParamsV2,
   type NativeHookRelayEvent,
-  type NativeHookRelayRegistrationHandle,
+  type registerNativeHookRelay,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveSessionAgentIdsStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
@@ -24,6 +24,7 @@ import {
   resolveCodexMcpToolOverridesForAgent,
 } from "openclaw/plugin-sdk/codex-mcp-projection";
 import { loadExecApprovals } from "openclaw/plugin-sdk/exec-approvals-runtime";
+import { registerNativeHookRelayForBundledRuntime } from "openclaw/plugin-sdk/native-hook-relay-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -468,7 +469,7 @@ export async function runCodexAppServerSideQuestion(
   let sandboxEnvironment: CodexSandboxExecEnvironment | undefined;
   let sandboxDisconnectError: Error | undefined;
   let sandboxEnvironmentClient: CodexAppServerClient | undefined;
-  let nativeHookRelay: NativeHookRelayRegistrationHandle | undefined;
+  let nativeHookRelay: ReturnType<typeof registerNativeHookRelayForBundledRuntime> | undefined;
   const activeDynamicToolCalls = new Set<Promise<unknown>>();
   const releaseSandboxEnvironment = async () => {
     if (!sandboxEnvironment) {
@@ -717,6 +718,8 @@ export async function runCodexAppServerSideQuestion(
           },
         })
       : undefined;
+    await nativeHookRelay?.ready;
+    assertCurrent();
     const nativeHookRelayConfig = nativeHookRelay
       ? buildCodexNativeHookRelayConfig({
           relay: nativeHookRelay,
@@ -1044,6 +1047,15 @@ export async function runCodexAppServerSideQuestion(
       } finally {
         releaseCodexAppServerClientLease(clientLease);
         nativeHookRelay?.unregister();
+        await runAgentCleanupStep({
+          runId: sideRunParams.runId,
+          sessionId: sideRunParams.sessionId,
+          step: "codex-side-native-hook-relay-release",
+          log: embeddedAgentLog,
+          cleanup: async () => {
+            await nativeHookRelay?.drain();
+          },
+        });
       }
     }
   }
@@ -1083,11 +1095,11 @@ function registerCodexSideNativeHookRelay(params: {
   hostCapabilities: EmbeddedRunAttemptParamsV2["hostCapabilities"];
   assertCurrent: () => void;
   onPreToolUseFailure: (failure: CodexNativePreToolUseFailure) => void;
-}): NativeHookRelayRegistrationHandle | undefined {
+}): ReturnType<typeof registerNativeHookRelayForBundledRuntime> | undefined {
   if (params.options.enabled === false) {
     return undefined;
   }
-  return registerNativeHookRelay({
+  return registerNativeHookRelayForBundledRuntime({
     provider: "codex",
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionId: params.sessionId,

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -718,7 +718,7 @@ export async function runCodexAppServerSideQuestion(
           },
         })
       : undefined;
-    await nativeHookRelay?.ready;
+    await nativeHookRelay?.prepareInvocation();
     assertCurrent();
     const nativeHookRelayConfig = nativeHookRelay
       ? buildCodexNativeHookRelayConfig({

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -112,10 +112,10 @@ export async function resumeExistingCodexThread(
         ? undefined
         : (params.params.authProfileId ?? resumeBinding.authProfileId);
     const finalConfigPatch = context.prebuiltFinalConfigPatch ??
-      params.buildFinalConfigPatch?.({
+      (await params.buildFinalConfigPatch?.({
         action: "resume",
         binding: resumeBinding,
-      }) ?? {
+      })) ?? {
         configPatch: params.finalConfigPatch,
         nativeHookRelayGeneration: params.nativeHookRelayGeneration,
       };
@@ -458,7 +458,7 @@ export async function startFreshCodexThread(
         params.pluginThreadConfig?.build(),
       )))
     : undefined;
-  const finalConfigPatch = params.buildFinalConfigPatch?.({ action: "start" }) ?? {
+  const finalConfigPatch = (await params.buildFinalConfigPatch?.({ action: "start" })) ?? {
     configPatch: params.finalConfigPatch,
     nativeHookRelayGeneration: params.nativeHookRelayGeneration,
   };

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -162,7 +162,7 @@ export async function startOrResumeThread(
             params.pluginThreadConfig?.build(),
           )
         : undefined;
-      const finalConfigPatch = params.buildFinalConfigPatch?.({ action: "start" }) ?? {
+      const finalConfigPatch = (await params.buildFinalConfigPatch?.({ action: "start" })) ?? {
         configPatch: params.finalConfigPatch,
         nativeHookRelayGeneration: params.nativeHookRelayGeneration,
       };

--- a/extensions/codex/src/app-server/thread-lifecycle-types.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-types.ts
@@ -82,7 +82,7 @@ export type CodexStartOrResumeThreadParams = {
   finalConfigPatch?: JsonObject;
   buildFinalConfigPatch?: (
     decision: CodexThreadFinalConfigPatchDecision,
-  ) => CodexThreadFinalConfigPatchResult;
+  ) => CodexThreadFinalConfigPatchResult | Promise<CodexThreadFinalConfigPatchResult>;
   nativeHookRelayGeneration?: string;
   /** Session-layer PreToolUse hooks must survive authoritative managed hook requirements. */
   nativeHookRelayRequired?: boolean;

--- a/extensions/codex/src/app-server/thread-lifecycle-warm.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-warm.ts
@@ -195,7 +195,7 @@ export async function tryReuseCodexLiveThread(
       ((await options.buildLoadedPluginThreadConfig(binding))?.fingerprint ??
         binding.pluginAppsFingerprint) === binding.pluginAppsFingerprint
     ) {
-      params.buildFinalConfigPatch?.({ action: "resume", binding });
+      await params.buildFinalConfigPatch?.({ action: "resume", binding });
       throwIfAborted();
       return { kind: "ready", binding: { ...binding, lifecycle: { action: "resumed" } } };
     }
@@ -248,10 +248,10 @@ export async function tryReuseCodexLiveThread(
     // Engine identity, projection epoch, and policy were checked by the owner
     // before this call; compatible bootstrap threads must keep their session.
 
-    const prebuiltFinalConfigPatch = params.buildFinalConfigPatch?.({
+    const prebuiltFinalConfigPatch = (await params.buildFinalConfigPatch?.({
       action: "resume",
       binding,
-    }) ?? {
+    })) ?? {
       configPatch: params.finalConfigPatch,
       nativeHookRelayGeneration: params.nativeHookRelayGeneration,
     };

--- a/src/agents/harness/native-hook-relay-bridge.ts
+++ b/src/agents/harness/native-hook-relay-bridge.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { hasErrnoCode } from "../../infra/errno.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { isPidDefinitelyDead } from "../../shared/pid-alive.js";
 import {
   isNativeHookRelayBridgeStaleRegistrationError,
@@ -38,11 +40,13 @@ export {
   NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
 } from "./native-hook-relay-client.js";
 
-const { relays, relayBridges } = nativeHookRelayState;
+const { relays, relayBridges, pendingBridgeOperations } = nativeHookRelayState;
 
 type InvokeNativeHookRelay = (
   params: InvokeNativeHookRelayParams,
 ) => Promise<NativeHookRelayProcessResponse>;
+
+type NativeHookRelayBridgeRenewalResult = "renewed" | "unavailable" | "ownership-changed";
 
 type NativeHookRelayBridgeRequestAuth = {
   provider: NativeHookRelayProvider;
@@ -57,34 +61,21 @@ export function registerNativeHookRelayBridge(
   registration: ActiveNativeHookRelayRegistration,
   stateDbPath: string,
   invokeRelay: InvokeNativeHookRelay,
-): void {
-  // Liveness checks stay outside the write transaction. The store rereads each
-  // authoritative row before deletion so renewal or replacement wins the race.
-  try {
-    const pruned = pruneNativeHookRelayBridgeRecords({
-      currentPid: process.pid,
-      isPidDead: isPidDefinitelyDead,
-      stateDbPath,
-    });
-    for (const row of pruned) {
-      log.debug("pruned stale native hook relay bridge record", {
-        relayId: row.relayId,
-        stalePid: row.pid,
-        currentPid: process.pid,
-        reason: row.reason,
-      });
-    }
-  } catch (error) {
-    log.debug("native hook relay bridge record prune skipped", { error });
-  }
-  unregisterNativeHookRelayBridge(registration.relayId);
+): NativeHookRelayBridgeRegistration {
   const token = randomUUID();
   const server = createServer();
+  const listening = createDeferredCore();
+  server.once("listening", listening.resolve);
+  server.once("error", listening.reject);
   const bridge: NativeHookRelayBridgeRegistration = {
     relayId: registration.relayId,
     stateDbPath,
     token,
     server,
+    ready: listening.promise,
+    pending: listening.promise,
+    cancelStartup: () =>
+      listening.reject(new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR)),
   };
   server.on("request", (req, res) => {
     void handleNativeHookRelayBridgeRequest(req, res, {
@@ -100,31 +91,90 @@ export function registerNativeHookRelayBridge(
   server.on("error", (error) => {
     log.debug("native hook relay bridge server error", { error, relayId: registration.relayId });
   });
-  server.listen(0, "127.0.0.1", () => {
-    if (relayBridges.get(registration.relayId) !== bridge) {
-      return;
+  bridge.ready = listening.promise.then(async () => {
+    assertNativeHookRelayBridgeCurrent(registration, bridge);
+    await pruneNativeHookRelayBridges(stateDbPath);
+    assertNativeHookRelayBridgeCurrent(registration, bridge);
+    const record = resolveNativeHookRelayBridgeRecord(registration, bridge);
+    if (!record) {
+      throw new Error("native hook relay bridge server address unavailable");
     }
-    try {
-      writeNativeHookRelayBridgeRecordForRegistration(registration, bridge);
-    } catch (error) {
-      log.debug("failed to publish native hook relay bridge record", {
-        error,
-        relayId: registration.relayId,
-      });
-    }
+    await writeNativeHookRelayBridgeRecord({
+      record,
+      stateDbPath,
+      assertCurrent: () => assertNativeHookRelayBridgeCurrent(registration, bridge),
+    });
   });
+  bridge.pending = bridge.ready;
+  retainNativeHookRelayBridgeOperation(bridge, bridge.ready);
+  server.listen(0, "127.0.0.1");
   server.unref();
+  return bridge;
 }
 
-function writeNativeHookRelayBridgeRecordForRegistration(
+function retainNativeHookRelayBridgeOperation(
+  bridge: NativeHookRelayBridgeRegistration,
+  operation: Promise<void>,
+): void {
+  pendingBridgeOperations.add(operation);
+  void operation.then(
+    () => pendingBridgeOperations.delete(operation),
+    (error: unknown) => {
+      pendingBridgeOperations.delete(operation);
+      log.debug("native hook relay bridge operation failed", { error, relayId: bridge.relayId });
+    },
+  );
+}
+
+export async function drainNativeHookRelayBridge(bridge: NativeHookRelayBridgeRegistration) {
+  let pending: Promise<void>;
+  let failure: { error: unknown } | undefined;
+  do {
+    pending = bridge.pending;
+    try {
+      await pending;
+    } catch (error) {
+      failure ??= { error };
+    }
+  } while (pending !== bridge.pending);
+  if (failure) {
+    throw failure.error;
+  }
+}
+
+function assertNativeHookRelayBridgeCurrent(
   registration: ActiveNativeHookRelayRegistration,
   bridge: NativeHookRelayBridgeRegistration,
 ): void {
-  const record = resolveNativeHookRelayBridgeRecord(registration, bridge);
-  if (!record) {
-    return;
+  if (
+    relays.get(registration.relayId) !== registration ||
+    relayBridges.get(registration.relayId) !== bridge ||
+    bridge.closing
+  ) {
+    throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
   }
-  writeNativeHookRelayBridgeRecord({ record, stateDbPath: bridge.stateDbPath });
+}
+
+async function pruneNativeHookRelayBridges(stateDbPath: string): Promise<void> {
+  // Liveness checks stay outside the write transaction. The store rereads each
+  // authoritative row before deletion so renewal or replacement wins the race.
+  try {
+    const pruned = await pruneNativeHookRelayBridgeRecords({
+      currentPid: process.pid,
+      isPidDead: isPidDefinitelyDead,
+      stateDbPath,
+    });
+    for (const row of pruned) {
+      log.debug("pruned stale native hook relay bridge record", {
+        relayId: row.relayId,
+        stalePid: row.pid,
+        currentPid: process.pid,
+        reason: row.reason,
+      });
+    }
+  } catch (error) {
+    log.debug("native hook relay bridge record prune skipped", { error });
+  }
 }
 
 function resolveNativeHookRelayBridgeRecord(
@@ -149,21 +199,31 @@ function resolveNativeHookRelayBridgeRecord(
   };
 }
 
-export function renewNativeHookRelayBridgeRecord(
+export async function renewNativeHookRelayBridgeRecord(
   registration: ActiveNativeHookRelayRegistration,
   bridge: NativeHookRelayBridgeRegistration,
   expiresAtMs: number,
-): "renewed" | "unavailable" | "ownership-changed" {
-  const record = resolveNativeHookRelayBridgeRecord(registration, bridge, expiresAtMs);
-  if (!record) {
-    return "unavailable";
-  }
-  return renewOrRestoreNativeHookRelayBridgeRecord({
-    record,
-    stateDbPath: bridge.stateDbPath,
-  })
-    ? "renewed"
-    : "ownership-changed";
+): Promise<NativeHookRelayBridgeRenewalResult> {
+  // Keep each rejection observable without poisoning a later eligible renewal.
+  const renewal = bridge.pending
+    .catch(() => undefined)
+    .then<NativeHookRelayBridgeRenewalResult>(async () => {
+      assertNativeHookRelayBridgeCurrent(registration, bridge);
+      const record = resolveNativeHookRelayBridgeRecord(registration, bridge, expiresAtMs);
+      if (!record) {
+        return "unavailable";
+      }
+      return (await renewOrRestoreNativeHookRelayBridgeRecord({
+        record,
+        stateDbPath: bridge.stateDbPath,
+        assertCurrent: () => assertNativeHookRelayBridgeCurrent(registration, bridge),
+      }))
+        ? "renewed"
+        : "ownership-changed";
+    });
+  bridge.pending = renewal.then(() => undefined);
+  retainNativeHookRelayBridgeOperation(bridge, bridge.pending);
+  return await renewal;
 }
 
 export function unregisterNativeHookRelayBridge(
@@ -172,31 +232,49 @@ export function unregisterNativeHookRelayBridge(
     deferListenerCloseMs?: number;
     expectedBridge?: NativeHookRelayBridgeRegistration;
   },
-): void {
+): Promise<void> | undefined {
   const bridge = options?.expectedBridge ?? relayBridges.get(relayId);
   if (!bridge) {
-    return;
+    return undefined;
+  }
+  if (bridge.closing) {
+    return bridge.closing;
   }
   if (relayBridges.get(relayId) === bridge) {
     relayBridges.delete(relayId);
   }
+  if (!bridge.server.listening) {
+    bridge.cancelStartup();
+  }
   // Stop advertising the retired endpoint before its listener can close.
   // Token-scoped removal cannot delete an already-published successor.
-  try {
-    deleteNativeHookRelayBridgeRecordIfOwned({ ...bridge, pid: process.pid });
-  } catch (error) {
-    log.debug("failed to remove native hook relay bridge record", { error, relayId });
-  }
-  const closeListener = () => bridge.server.close();
-  const deferListenerCloseMs = normalizePositiveInteger(options?.deferListenerCloseMs, 0);
-  if (deferListenerCloseMs > 0) {
-    // Readers that already captured the old locator still receive a stale-owner
-    // rejection. New lookups wait for the successor's listener publication.
-    const timeout = setTimeout(closeListener, deferListenerCloseMs);
-    timeout.unref();
-    return;
-  }
-  closeListener();
+  bridge.closing = bridge.pending
+    .catch(() => undefined)
+    .then(async () => {
+      try {
+        await deleteNativeHookRelayBridgeRecordIfOwned({ ...bridge, pid: process.pid });
+      } finally {
+        const deferListenerCloseMs = normalizePositiveInteger(options?.deferListenerCloseMs, 0);
+        if (deferListenerCloseMs > 0) {
+          // Captured old locators keep receiving stale-owner rejection during replacement.
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, deferListenerCloseMs).unref();
+          });
+        }
+        await new Promise<void>((resolve, reject) => {
+          bridge.server.close((error?: Error) => {
+            if (error && !hasErrnoCode(error, "ERR_SERVER_NOT_RUNNING")) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        });
+      }
+    });
+  bridge.pending = bridge.closing;
+  retainNativeHookRelayBridgeOperation(bridge, bridge.closing);
+  return bridge.closing;
 }
 
 async function handleNativeHookRelayBridgeRequest(
@@ -293,21 +371,24 @@ function writeNativeHookRelayBridgeJson(
   res.end(body);
 }
 
-export function readNativeHookRelayBridgeRecordIfExists(
+export async function readNativeHookRelayBridgeRecordIfExists(
   relayId: string,
   stateDbPath?: string,
-): NativeHookRelayBridgeRecord | undefined {
+): Promise<NativeHookRelayBridgeRecord | undefined> {
   try {
-    return readNativeHookRelayBridgeRecordFromStore({ relayId, stateDbPath });
+    return await readNativeHookRelayBridgeRecordFromStore({ relayId, stateDbPath });
   } catch (error) {
     log.debug("failed to read native hook relay bridge record", { error, relayId });
   }
   return undefined;
 }
 
-export function clearNativeHookRelayBridgesForTests(): void {
+export async function clearNativeHookRelayBridgesForTests(): Promise<void> {
   for (const relayId of relayBridges.keys()) {
-    unregisterNativeHookRelayBridge(relayId);
+    void unregisterNativeHookRelayBridge(relayId);
   }
-  clearNativeHookRelayBridgeRecordsForTests();
+  while (pendingBridgeOperations.size > 0) {
+    await Promise.allSettled(pendingBridgeOperations);
+  }
+  await clearNativeHookRelayBridgeRecordsForTests();
 }

--- a/src/agents/harness/native-hook-relay-client-store.ts
+++ b/src/agents/harness/native-hook-relay-client-store.ts
@@ -17,10 +17,10 @@ import {
 type NativeHookRelayBridgeDatabase = Pick<OpenClawStateKyselyDatabase, "native_hook_relay_bridges">;
 
 /** Read one native relay locator without loading the shared-state writer lifecycle. */
-export function readNativeHookRelayClientBridgeRecord(params: {
+export async function readNativeHookRelayClientBridgeRecord(params: {
   relayId: string;
   stateDbPath?: string;
-}): NativeHookRelayBridgeRecord | undefined {
+}): Promise<NativeHookRelayBridgeRecord | undefined> {
   const pathname = path.resolve(params.stateDbPath ?? resolveOpenClawStateSqlitePath());
   const db = openNodeSqliteDatabase(pathname, { readOnly: true });
   try {

--- a/src/agents/harness/native-hook-relay-client.ts
+++ b/src/agents/harness/native-hook-relay-client.ts
@@ -35,7 +35,7 @@ export async function invokeNativeHookRelayBridge(
   let lastError: unknown = new Error("native hook relay bridge not found");
   while (Date.now() - startedAt < timeoutMs) {
     try {
-      const record = readNativeHookRelayClientBridgeRecord({
+      const record = await readNativeHookRelayClientBridgeRecord({
         relayId,
         stateDbPath: params.stateDbPath,
       });
@@ -50,9 +50,13 @@ export async function invokeNativeHookRelayBridge(
       if (Date.now() > record.expiresAtMs) {
         throw new Error("native hook relay bridge expired");
       }
+      const remainingMs = timeoutMs - (Date.now() - startedAt);
+      if (remainingMs <= 0) {
+        throw new Error("native hook relay bridge timed out");
+      }
       return await postNativeHookRelayBridgeRecord({
         record,
-        timeoutMs: Math.max(1, timeoutMs - (Date.now() - startedAt)),
+        timeoutMs: remainingMs,
         payload: {
           provider,
           relayId,

--- a/src/agents/harness/native-hook-relay-state.ts
+++ b/src/agents/harness/native-hook-relay-state.ts
@@ -10,6 +10,7 @@ function getNativeHookRelaySharedState(): NativeHookRelaySharedState {
   globalRecord[NATIVE_HOOK_RELAY_STATE_SYMBOL] ??= {
     relays: new Map(),
     relayBridges: new Map(),
+    pendingBridgeOperations: new Set(),
     invocations: [],
     pendingPermissionApprovals: new Map(),
     pendingPreToolUseApprovals: new Map(),

--- a/src/agents/harness/native-hook-relay-store.test.ts
+++ b/src/agents/harness/native-hook-relay-store.test.ts
@@ -43,7 +43,7 @@ function bridgeRecord(
 }
 
 describe("native hook relay store", () => {
-  it("upserts and reads bridge records", () => {
+  it("upserts and reads bridge records", async () => {
     const first = bridgeRecord("relay-upsert");
     const replacement = bridgeRecord("relay-upsert", {
       pid: 101,
@@ -52,104 +52,104 @@ describe("native hook relay store", () => {
       expiresAtMs: 30_000,
     });
 
-    writeNativeHookRelayBridgeRecord({
+    await writeNativeHookRelayBridgeRecord({
       record: first,
       updatedAtMs: 1_000,
       stateDbPath: primaryStateDbPath,
     });
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: first.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toStrictEqual(first);
 
-    writeNativeHookRelayBridgeRecord({
+    await writeNativeHookRelayBridgeRecord({
       record: replacement,
       updatedAtMs: 2_000,
       stateDbPath: primaryStateDbPath,
     });
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: replacement.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toStrictEqual(replacement);
   });
 
-  it("requires matching token and pid to renew or delete a bridge", () => {
+  it("requires matching token and pid to renew or delete a bridge", async () => {
     const record = bridgeRecord("relay-owned");
-    writeNativeHookRelayBridgeRecord({
+    await writeNativeHookRelayBridgeRecord({
       record,
       updatedAtMs: 1_000,
       stateDbPath: primaryStateDbPath,
     });
 
     expect(
-      renewOrRestoreNativeHookRelayBridgeRecord({
+      await renewOrRestoreNativeHookRelayBridgeRecord({
         record: { ...record, pid: record.pid + 1, expiresAtMs: 30_000 },
         stateDbPath: primaryStateDbPath,
       }),
     ).toBe(false);
     expect(
-      renewOrRestoreNativeHookRelayBridgeRecord({
+      await renewOrRestoreNativeHookRelayBridgeRecord({
         record: { ...record, token: "decoy-token", expiresAtMs: 30_000 },
         stateDbPath: primaryStateDbPath,
       }),
     ).toBe(false);
     expect(
-      renewOrRestoreNativeHookRelayBridgeRecord({
+      await renewOrRestoreNativeHookRelayBridgeRecord({
         record: { ...record, expiresAtMs: 30_000 },
         updatedAtMs: 2_000,
         stateDbPath: primaryStateDbPath,
       }),
     ).toBe(true);
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: record.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toStrictEqual({ ...record, expiresAtMs: 30_000 });
 
     expect(
-      deleteNativeHookRelayBridgeRecordIfOwned({
+      await deleteNativeHookRelayBridgeRecordIfOwned({
         ...record,
         pid: record.pid + 1,
         stateDbPath: primaryStateDbPath,
       }),
     ).toBe(false);
     expect(
-      deleteNativeHookRelayBridgeRecordIfOwned({
+      await deleteNativeHookRelayBridgeRecordIfOwned({
         ...record,
         token: "decoy-token",
         stateDbPath: primaryStateDbPath,
       }),
     ).toBe(false);
     expect(
-      deleteNativeHookRelayBridgeRecordIfOwned({
+      await deleteNativeHookRelayBridgeRecordIfOwned({
         ...record,
         stateDbPath: primaryStateDbPath,
       }),
     ).toBe(true);
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: record.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toBeUndefined();
   });
 
-  it("restores a missing record without overwriting another owner", () => {
+  it("restores a missing record without overwriting another owner", async () => {
     const record = bridgeRecord("relay-restored");
     expect(
-      renewOrRestoreNativeHookRelayBridgeRecord({
+      await renewOrRestoreNativeHookRelayBridgeRecord({
         record,
         updatedAtMs: 1_000,
         stateDbPath: primaryStateDbPath,
       }),
     ).toBe(true);
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: record.relayId,
         stateDbPath: primaryStateDbPath,
       }),
@@ -159,27 +159,27 @@ describe("native hook relay store", () => {
       pid: record.pid + 1,
       token: "test-auth-token",
     });
-    writeNativeHookRelayBridgeRecord({
+    await writeNativeHookRelayBridgeRecord({
       record: otherOwner,
       updatedAtMs: 2_000,
       stateDbPath: primaryStateDbPath,
     });
     expect(
-      renewOrRestoreNativeHookRelayBridgeRecord({
+      await renewOrRestoreNativeHookRelayBridgeRecord({
         record,
         updatedAtMs: 3_000,
         stateDbPath: primaryStateDbPath,
       }),
     ).toBe(false);
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: record.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toStrictEqual(otherOwner);
   });
 
-  it("does not let an old owner delete its replacement", () => {
+  it("does not let an old owner delete its replacement", async () => {
     const oldOwner = bridgeRecord("relay-replaced", {
       pid: 100,
       token: "secret-token",
@@ -190,38 +190,38 @@ describe("native hook relay store", () => {
       token: "test-auth-token",
       expiresAtMs: 30_000,
     });
-    writeNativeHookRelayBridgeRecord({
+    await writeNativeHookRelayBridgeRecord({
       record: oldOwner,
       updatedAtMs: 1_000,
       stateDbPath: primaryStateDbPath,
     });
-    writeNativeHookRelayBridgeRecord({
+    await writeNativeHookRelayBridgeRecord({
       record: replacement,
       updatedAtMs: 2_000,
       stateDbPath: primaryStateDbPath,
     });
 
     expect(
-      deleteNativeHookRelayBridgeRecordIfOwned({
+      await deleteNativeHookRelayBridgeRecordIfOwned({
         ...oldOwner,
         stateDbPath: primaryStateDbPath,
       }),
     ).toBe(false);
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: replacement.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toStrictEqual(replacement);
   });
 
-  it("prunes expired and dead bridges while preserving live and unknown pids", () => {
+  it("prunes expired and dead bridges while preserving live and unknown pids", async () => {
     const expired = bridgeRecord("relay-expired", { pid: 200, expiresAtMs: 9_999 });
     const dead = bridgeRecord("relay-dead", { pid: 201 });
     const live = bridgeRecord("relay-live", { pid: 202 });
     const unknown = bridgeRecord("relay-unknown", { pid: 203 });
     for (const [index, record] of [expired, dead, live, unknown].entries()) {
-      writeNativeHookRelayBridgeRecord({
+      await writeNativeHookRelayBridgeRecord({
         record,
         updatedAtMs: 1_000 + index,
         stateDbPath: primaryStateDbPath,
@@ -229,7 +229,7 @@ describe("native hook relay store", () => {
     }
     const isPidDead = vi.fn((pid: number) => pid === dead.pid);
 
-    const pruned = pruneNativeHookRelayBridgeRecords({
+    const pruned = await pruneNativeHookRelayBridgeRecords({
       currentPid: 100,
       isPidDead,
       nowMs: 10_000,
@@ -247,32 +247,32 @@ describe("native hook relay store", () => {
       new Set([dead.pid, live.pid, unknown.pid]),
     );
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: expired.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toBeUndefined();
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: dead.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toBeUndefined();
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: live.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toStrictEqual(live);
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: unknown.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toStrictEqual(unknown);
   });
 
-  it("preserves a replacement published during dead-pid planning", () => {
+  it("preserves a replacement published during dead-pid planning", async () => {
     const stale = bridgeRecord("relay-prune-race", {
       pid: 201,
       token: "secret-token",
@@ -283,17 +283,17 @@ describe("native hook relay store", () => {
       token: "test-auth-token",
       expiresAtMs: 30_000,
     });
-    writeNativeHookRelayBridgeRecord({
+    await writeNativeHookRelayBridgeRecord({
       record: stale,
       updatedAtMs: 1_000,
       stateDbPath: primaryStateDbPath,
     });
 
-    const pruned = pruneNativeHookRelayBridgeRecords({
+    const pruned = await pruneNativeHookRelayBridgeRecords({
       currentPid: 100,
-      isPidDead: (pid) => {
+      isPidDead: async (pid) => {
         expect(pid).toBe(stale.pid);
-        writeNativeHookRelayBridgeRecord({
+        await writeNativeHookRelayBridgeRecord({
           record: replacement,
           updatedAtMs: 2_000,
           stateDbPath: primaryStateDbPath,
@@ -306,14 +306,14 @@ describe("native hook relay store", () => {
 
     expect(pruned).toStrictEqual([]);
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: replacement.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toStrictEqual(replacement);
   });
 
-  it("isolates records by the exact state database path", () => {
+  it("isolates records by the exact state database path", async () => {
     const primary = bridgeRecord("relay-isolated", {
       pid: 100,
       token: "config-token",
@@ -323,11 +323,11 @@ describe("native hook relay store", () => {
       port: 18_790,
       token: "gateway-token",
     });
-    writeNativeHookRelayBridgeRecord({
+    await writeNativeHookRelayBridgeRecord({
       record: primary,
       stateDbPath: primaryStateDbPath,
     });
-    writeNativeHookRelayBridgeRecord({
+    await writeNativeHookRelayBridgeRecord({
       record: secondary,
       stateDbPath: secondaryStateDbPath,
     });
@@ -335,13 +335,13 @@ describe("native hook relay store", () => {
     expect(fs.existsSync(primaryStateDbPath)).toBe(true);
     expect(fs.existsSync(secondaryStateDbPath)).toBe(true);
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: primary.relayId,
         stateDbPath: primaryStateDbPath,
       }),
     ).toStrictEqual(primary);
     expect(
-      readNativeHookRelayBridgeRecord({
+      await readNativeHookRelayBridgeRecord({
         relayId: secondary.relayId,
         stateDbPath: secondaryStateDbPath,
       }),

--- a/src/agents/harness/native-hook-relay-store.ts
+++ b/src/agents/harness/native-hook-relay-store.ts
@@ -82,9 +82,9 @@ function sameNativeHookRelayBridgeSnapshot(
   );
 }
 
-export function readNativeHookRelayBridgeRecord(
+export async function readNativeHookRelayBridgeRecord(
   params: { relayId: string } & NativeHookRelayBridgeStoreOptions,
-): NativeHookRelayBridgeRecord | undefined {
+): Promise<NativeHookRelayBridgeRecord | undefined> {
   return withOpenClawStateDatabaseReadOnly(
     (database) =>
       readNativeHookRelayBridgeSnapshotFromDatabase({
@@ -95,17 +95,19 @@ export function readNativeHookRelayBridgeRecord(
   );
 }
 
-export function writeNativeHookRelayBridgeRecord(
+export async function writeNativeHookRelayBridgeRecord(
   params: {
     record: NativeHookRelayBridgeRecord;
     updatedAtMs?: number;
+    assertCurrent?: () => void;
   } & NativeHookRelayBridgeStoreOptions,
-): void {
+): Promise<void> {
   const updatedAtMs = params.updatedAtMs ?? Date.now();
   const record = params.record;
   const { token } = record;
   runOpenClawStateWriteTransaction(
     (database) => {
+      params.assertCurrent?.();
       const db = getNodeSqliteKysely<NativeHookRelayBridgeDatabase>(database.db);
       executeSqliteQuerySync(
         database.db,
@@ -136,17 +138,19 @@ export function writeNativeHookRelayBridgeRecord(
   );
 }
 
-export function renewOrRestoreNativeHookRelayBridgeRecord(
+export async function renewOrRestoreNativeHookRelayBridgeRecord(
   params: {
     record: NativeHookRelayBridgeRecord;
     updatedAtMs?: number;
+    assertCurrent?: () => void;
   } & NativeHookRelayBridgeStoreOptions,
-): boolean {
+): Promise<boolean> {
   const { record } = params;
   const { token } = record;
   const updatedAtMs = params.updatedAtMs ?? Date.now();
   return runOpenClawStateWriteTransaction(
     (database) => {
+      params.assertCurrent?.();
       const db = getNodeSqliteKysely<NativeHookRelayBridgeDatabase>(database.db);
       const current = readNativeHookRelayBridgeSnapshotFromDatabase({
         database,
@@ -194,12 +198,12 @@ export function renewOrRestoreNativeHookRelayBridgeRecord(
   );
 }
 
-export function deleteNativeHookRelayBridgeRecordIfOwned(params: {
+export async function deleteNativeHookRelayBridgeRecordIfOwned(params: {
   relayId: string;
   pid: number;
   token: string;
   stateDbPath?: string;
-}): boolean {
+}): Promise<boolean> {
   return runOpenClawStateWriteTransaction(
     (database) => {
       const current = readNativeHookRelayBridgeSnapshotFromDatabase({
@@ -225,12 +229,12 @@ export function deleteNativeHookRelayBridgeRecordIfOwned(params: {
   );
 }
 
-export function pruneNativeHookRelayBridgeRecords(params: {
+export async function pruneNativeHookRelayBridgeRecords(params: {
   currentPid: number;
-  isPidDead: (pid: number) => boolean;
+  isPidDead: (pid: number) => boolean | Promise<boolean>;
   nowMs?: number;
   stateDbPath?: string;
-}): NativeHookRelayBridgePruneResult[] {
+}): Promise<NativeHookRelayBridgePruneResult[]> {
   const nowMs = params.nowMs ?? Date.now();
   const database = openOpenClawStateDatabase({ path: params.stateDbPath });
   const db = getNodeSqliteKysely<NativeHookRelayBridgeDatabase>(database.db);
@@ -247,7 +251,10 @@ export function pruneNativeHookRelayBridgeRecords(params: {
       candidates.push({ snapshot, reason: "expired" });
       continue;
     }
-    if (snapshot.record.pid !== params.currentPid && params.isPidDead(snapshot.record.pid)) {
+    if (
+      snapshot.record.pid !== params.currentPid &&
+      (await params.isPidDead(snapshot.record.pid))
+    ) {
       candidates.push({ snapshot, reason: "dead-pid" });
     }
   }
@@ -293,9 +300,9 @@ export function pruneNativeHookRelayBridgeRecords(params: {
   );
 }
 
-export function clearNativeHookRelayBridgeRecordsForTests(
+export async function clearNativeHookRelayBridgeRecordsForTests(
   options: NativeHookRelayBridgeStoreOptions = {},
-): void {
+): Promise<void> {
   runOpenClawStateWriteTransaction(
     (database) => {
       const db = getNodeSqliteKysely<NativeHookRelayBridgeDatabase>(database.db);

--- a/src/agents/harness/native-hook-relay-types.ts
+++ b/src/agents/harness/native-hook-relay-types.ts
@@ -212,6 +212,12 @@ export type ActiveNativeHookRelayRegistrationHandle = NativeHookRelayRegistratio
   generation: string;
 };
 
+export type OwnedNativeHookRelayRegistrationHandle = ActiveNativeHookRelayRegistrationHandle & {
+  ready: Promise<void>;
+  /** Joins accepted publication, renewal and cleanup without retiring retained children. */
+  drain: () => Promise<void>;
+};
+
 export type NativeHookRelayPermissionApprovalRequest = {
   provider: NativeHookRelayProvider;
   agentId?: string;
@@ -253,11 +259,16 @@ export type NativeHookRelayBridgeRegistration = {
   stateDbPath: string;
   token: string;
   server: Server;
+  ready: Promise<void>;
+  pending: Promise<void>;
+  cancelStartup: () => void;
+  closing?: Promise<void>;
 };
 
 export type NativeHookRelaySharedState = {
   relays: Map<string, ActiveNativeHookRelayRegistration>;
   relayBridges: Map<string, NativeHookRelayBridgeRegistration>;
+  pendingBridgeOperations: Set<Promise<unknown>>;
   invocations: NativeHookRelayInvocation[];
   pendingPermissionApprovals: Map<string, Promise<NativeHookRelayPermissionApprovalResult>>;
   pendingPreToolUseApprovals: Map<string, NativeHookRelayPreToolUseApproval>;

--- a/src/agents/harness/native-hook-relay-types.ts
+++ b/src/agents/harness/native-hook-relay-types.ts
@@ -213,7 +213,10 @@ export type ActiveNativeHookRelayRegistrationHandle = NativeHookRelayRegistratio
 };
 
 export type OwnedNativeHookRelayRegistrationHandle = ActiveNativeHookRelayRegistrationHandle & {
+  /** Strict direct-listener and locator publication result. */
   ready: Promise<void>;
+  /** Requires current foreground authority; direct publication may use the Gateway fallback. */
+  prepareInvocation: () => Promise<void>;
   /** Joins accepted publication, renewal and cleanup without retiring retained children. */
   drain: () => Promise<void>;
 };

--- a/src/agents/harness/native-hook-relay-work.ts
+++ b/src/agents/harness/native-hook-relay-work.ts
@@ -1,0 +1,27 @@
+import { drainNativeHookRelayBridge } from "./native-hook-relay-bridge.js";
+import type { NativeHookRelayBridgeRegistration } from "./native-hook-relay-types.js";
+
+/** Preserve the first failure while joining work admitted during a pending drain. */
+export async function drainNativeHookRelayWork(params: {
+  bridge: NativeHookRelayBridgeRegistration;
+  readRenewal: () => Promise<void>;
+}): Promise<void> {
+  let renewal: Promise<void>;
+  let failure: { error: unknown } | undefined;
+  do {
+    renewal = params.readRenewal();
+    try {
+      await renewal;
+    } catch (error) {
+      failure ??= { error };
+    }
+    try {
+      await drainNativeHookRelayBridge(params.bridge);
+    } catch (error) {
+      failure ??= { error };
+    }
+  } while (renewal !== params.readRenewal());
+  if (failure) {
+    throw failure.error;
+  }
+}

--- a/src/agents/harness/native-hook-relay.approval-binding.test.ts
+++ b/src/agents/harness/native-hook-relay.approval-binding.test.ts
@@ -13,11 +13,11 @@ vi.mock("../tools/gateway.js", async (importOriginal) => ({
 
 const mockCallGatewayTool = vi.mocked(callGatewayTool);
 
-afterEach(() => {
+afterEach(async () => {
   // restoreAllMocks does not clear call history on module-mock vi.fn()s.
   mockCallGatewayTool.mockReset();
   vi.restoreAllMocks();
-  testing.clearNativeHookRelaysForTests();
+  await testing.clearNativeHookRelaysForTests();
 });
 
 function mockGatewayApproval(waitResult: { id?: string; decision?: string | null }) {

--- a/src/agents/harness/native-hook-relay.approval-wait.test.ts
+++ b/src/agents/harness/native-hook-relay.approval-wait.test.ts
@@ -17,10 +17,10 @@ beforeEach(() => {
   approvalMocks.loadExecApprovalsReadOnly.mockReset().mockReturnValue({ version: 1, agents: {} });
 });
 
-afterEach(() => {
+afterEach(async () => {
   vi.restoreAllMocks();
   mockCallGatewayTool.mockReset();
-  testing.clearNativeHookRelaysForTests();
+  await testing.clearNativeHookRelaysForTests();
 });
 
 describe("native hook relay approval wait handling", () => {

--- a/src/agents/harness/native-hook-relay.lifecycle.test.ts
+++ b/src/agents/harness/native-hook-relay.lifecycle.test.ts
@@ -1,0 +1,377 @@
+import { Agent, Server } from "node:http";
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import * as relayBridge from "./native-hook-relay-bridge.js";
+import * as clientStore from "./native-hook-relay-client-store.js";
+import { invokeNativeHookRelayBridge } from "./native-hook-relay-client.js";
+import * as store from "./native-hook-relay-store.js";
+import {
+  registerNativeHookRelay,
+  registerOwnedNativeHookRelay,
+  testing,
+} from "./native-hook-relay.js";
+
+afterEach(async () => {
+  await testing.clearNativeHookRelaysForTests();
+  vi.restoreAllMocks();
+});
+
+it("keeps command preparation synchronous while readiness waits for locator publication", async () => {
+  await withOpenClawTestState({ label: "relay-ready-publication" }, async () => {
+    const entered = createDeferredCore();
+    const resume = createDeferredCore();
+    const write = store.writeNativeHookRelayBridgeRecord;
+    vi.spyOn(store, "writeNativeHookRelayBridgeRecord").mockImplementation(async (params) => {
+      entered.resolve();
+      await resume.promise;
+      await write(params);
+    });
+    const relay = registerOwnedNativeHookRelay({
+      provider: "codex",
+      sessionId: "ready-publication",
+      runId: "ready-publication",
+    });
+    let ready = false;
+    const readiness = relay.ready.then(() => {
+      ready = true;
+    });
+    try {
+      expect(typeof relay.commandForEvent("post_tool_use")).toBe("string");
+      await entered.promise;
+      expect(ready).toBe(false);
+      expect(Boolean(await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId }))).toBe(
+        false,
+      );
+      resume.resolve();
+      await readiness;
+      expect(Boolean(await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId }))).toBe(
+        true,
+      );
+    } finally {
+      resume.resolve();
+      await readiness;
+      relay.unregister();
+      await relay.drain();
+    }
+  });
+});
+
+it("joins unregister when listener startup has not completed", async () => {
+  await withOpenClawTestState({ label: "relay-close-startup" }, async () => {
+    vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server) {
+      return this;
+    });
+    const relay = registerOwnedNativeHookRelay({
+      provider: "codex",
+      sessionId: "close-startup",
+      runId: "close-startup",
+    });
+    relay.unregister();
+    await relay.drain();
+    await expect(relay.ready).rejects.toThrow("stale registration");
+    expect(Boolean(await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId }))).toBe(
+      false,
+    );
+  });
+});
+
+it("preserves a listener startup error while draining its cleanup", async () => {
+  await withOpenClawTestState({ label: "relay-listener-failure" }, async () => {
+    const failure = new Error("fixture listener failed");
+    vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server) {
+      queueMicrotask(() => this.emit("error", failure));
+      return this;
+    });
+    const relay = registerOwnedNativeHookRelay({
+      provider: "codex",
+      sessionId: "listener-failure",
+      runId: "listener-failure",
+    });
+    try {
+      await expect(relay.ready).rejects.toBe(failure);
+    } finally {
+      relay.unregister();
+      await relay.drain();
+    }
+  });
+});
+
+it("does not start transport when locator lookup consumes the caller deadline", async () => {
+  await withOpenClawTestState({ label: "relay-lookup-deadline" }, async () => {
+    const relay = registerOwnedNativeHookRelay({
+      provider: "codex",
+      sessionId: "lookup-deadline",
+      runId: "lookup-deadline",
+    });
+    await relay.ready;
+    const entered = createDeferredCore();
+    const resume = createDeferredCore();
+    const read = clientStore.readNativeHookRelayClientBridgeRecord;
+    vi.spyOn(clientStore, "readNativeHookRelayClientBridgeRecord").mockImplementation(
+      async (params) => {
+        const record = await read(params);
+        entered.resolve();
+        await resume.promise;
+        return record;
+      },
+    );
+    const startedAt = Date.now();
+    const invocation = invokeNativeHookRelayBridge({
+      provider: "codex",
+      relayId: relay.relayId,
+      generation: relay.generation,
+      event: "post_tool_use",
+      rawPayload: { hook_event_name: "PostToolUse", tool_name: "fixture", tool_response: {} },
+      timeoutMs: 100,
+    });
+    void invocation.catch(() => undefined);
+    await entered.promise;
+    const connect = vi.spyOn(Agent.prototype, "createConnection");
+    const clock = vi.spyOn(Date, "now").mockReturnValue(startedAt + 101);
+    try {
+      resume.resolve();
+      await expect(invocation).rejects.toThrow("timed out");
+      expect(connect.mock.calls.length).toBe(0);
+    } finally {
+      clock.mockRestore();
+      resume.resolve();
+      await Promise.allSettled([invocation]);
+      relay.unregister();
+      await relay.drain();
+    }
+  });
+});
+
+it("allows a later renewal after one storage renewal fails", async () => {
+  await withOpenClawTestState({ label: "relay-renewal-recovery" }, async () => {
+    const relay = registerOwnedNativeHookRelay({
+      provider: "codex",
+      sessionId: "renewal-recovery",
+      runId: "renewal-recovery",
+      ttlMs: 60_000,
+    });
+    await relay.ready;
+    vi.spyOn(store, "renewOrRestoreNativeHookRelayBridgeRecord").mockRejectedValueOnce(
+      new Error("fixture renewal failed"),
+    );
+    const expiresAtMs = relay.expiresAtMs;
+    try {
+      relay.renew(120_000);
+      await expect(relay.drain()).rejects.toThrow("fixture renewal failed");
+      expect(relay.expiresAtMs).toBe(expiresAtMs);
+
+      relay.renew(180_000);
+      await relay.drain();
+      const renewed = await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId });
+      expect(renewed?.expiresAtMs).toBe(relay.expiresAtMs);
+      expect(relay.expiresAtMs).toBeGreaterThan(expiresAtMs);
+    } finally {
+      relay.unregister();
+      await relay.drain();
+    }
+  });
+});
+
+it("joins a renewal accepted while an earlier drain reports failure", async () => {
+  await withOpenClawTestState({ label: "relay-drain-renewal-race" }, async () => {
+    const relay = registerOwnedNativeHookRelay({
+      provider: "codex",
+      sessionId: "drain-renewal-race",
+      runId: "drain-renewal-race",
+      ttlMs: 60_000,
+    });
+    await relay.ready;
+    const failure = new Error("fixture first renewal failed");
+    const entered = createDeferredCore();
+    const resume = createDeferredCore();
+    const renew = store.renewOrRestoreNativeHookRelayBridgeRecord;
+    vi.spyOn(store, "renewOrRestoreNativeHookRelayBridgeRecord")
+      .mockRejectedValueOnce(failure)
+      .mockImplementationOnce(async (params) => {
+        entered.resolve();
+        await resume.promise;
+        return await renew(params);
+      });
+    const drain = relayBridge.drainNativeHookRelayBridge;
+    vi.spyOn(relayBridge, "drainNativeHookRelayBridge").mockImplementationOnce(async (bridge) => {
+      try {
+        await drain(bridge);
+      } catch (error) {
+        relay.renew(180_000);
+        throw error;
+      }
+    });
+    const expiresAtMs = relay.expiresAtMs;
+    relay.renew(120_000);
+    const draining = relay.drain();
+    let settled = false;
+    void draining.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    try {
+      await entered.promise;
+      expect(settled).toBe(false);
+      resume.resolve();
+      await expect(draining).rejects.toBe(failure);
+      expect(relay.expiresAtMs).toBeGreaterThan(expiresAtMs);
+    } finally {
+      resume.resolve();
+      await Promise.allSettled([draining]);
+      relay.unregister();
+      await relay.drain();
+    }
+  });
+});
+
+it("removes the locator after an admitted publication finishes during unregister", async () => {
+  await withOpenClawTestState({ label: "relay-publication-close" }, async () => {
+    const entered = createDeferredCore();
+    const resume = createDeferredCore();
+    const published = createDeferredCore();
+    const deleted = createDeferredCore();
+    const write = store.writeNativeHookRelayBridgeRecord;
+    const remove = store.deleteNativeHookRelayBridgeRecordIfOwned;
+    vi.spyOn(store, "writeNativeHookRelayBridgeRecord").mockImplementation(async (params) => {
+      entered.resolve();
+      await resume.promise;
+      try {
+        await write(params);
+      } finally {
+        published.resolve();
+      }
+    });
+    vi.spyOn(store, "deleteNativeHookRelayBridgeRecordIfOwned").mockImplementation(
+      async (params) => {
+        try {
+          return await remove(params);
+        } finally {
+          deleted.resolve();
+        }
+      },
+    );
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "publication-close",
+      runId: "publication-close",
+    });
+    try {
+      await entered.promise;
+      relay.unregister();
+      expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeUndefined();
+      resume.resolve();
+      await published.promise;
+      await deleted.promise;
+      expect(Boolean(await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId }))).toBe(
+        false,
+      );
+    } finally {
+      resume.resolve();
+      await published.promise;
+      relay.unregister();
+      await testing.clearNativeHookRelaysForTests();
+    }
+  });
+});
+
+it("does not restore an old locator when renewal finishes after unregister", async () => {
+  await withOpenClawTestState({ label: "relay-renewal-close" }, async () => {
+    const entered = createDeferredCore();
+    const resume = createDeferredCore();
+    const renewed = createDeferredCore();
+    const deleted = createDeferredCore();
+    const renew = store.renewOrRestoreNativeHookRelayBridgeRecord;
+    const remove = store.deleteNativeHookRelayBridgeRecordIfOwned;
+    vi.spyOn(store, "renewOrRestoreNativeHookRelayBridgeRecord").mockImplementation(
+      async (params) => {
+        entered.resolve();
+        await resume.promise;
+        try {
+          return await renew(params);
+        } finally {
+          renewed.resolve();
+        }
+      },
+    );
+    vi.spyOn(store, "deleteNativeHookRelayBridgeRecordIfOwned").mockImplementation(
+      async (params) => {
+        try {
+          return await remove(params);
+        } finally {
+          deleted.resolve();
+        }
+      },
+    );
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "renewal-close",
+      runId: "renewal-close",
+    });
+    try {
+      await vi.waitFor(async () => {
+        expect(
+          Boolean(await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId })),
+        ).toBe(true);
+      });
+      relay.renew(60_000);
+      await entered.promise;
+      relay.unregister();
+      resume.resolve();
+      await renewed.promise;
+      await deleted.promise;
+      expect(Boolean(await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId }))).toBe(
+        false,
+      );
+    } finally {
+      resume.resolve();
+      relay.unregister();
+      await testing.clearNativeHookRelaysForTests();
+    }
+  });
+});
+
+it("does not publish renewal expiry before the durable renewal succeeds", async () => {
+  await withOpenClawTestState({ label: "relay-renewal-expiry" }, async () => {
+    const entered = createDeferredCore();
+    const resume = createDeferredCore();
+    const renewed = createDeferredCore();
+    const renew = store.renewOrRestoreNativeHookRelayBridgeRecord;
+    vi.spyOn(store, "renewOrRestoreNativeHookRelayBridgeRecord").mockImplementation(
+      async (params) => {
+        entered.resolve();
+        await resume.promise;
+        try {
+          return await renew(params);
+        } finally {
+          renewed.resolve();
+        }
+      },
+    );
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "renewal-expiry",
+      runId: "renewal-expiry",
+    });
+    try {
+      await vi.waitFor(async () => {
+        expect(
+          Boolean(await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId })),
+        ).toBe(true);
+      });
+      const expiresAtMs = relay.expiresAtMs;
+      relay.renew(60_000);
+      await entered.promise;
+      expect(relay.expiresAtMs).toBe(expiresAtMs);
+    } finally {
+      resume.resolve();
+      await renewed.promise;
+      relay.unregister();
+      await testing.clearNativeHookRelaysForTests();
+    }
+  });
+});

--- a/src/agents/harness/native-hook-relay.lifecycle.test.ts
+++ b/src/agents/harness/native-hook-relay.lifecycle.test.ts
@@ -1,12 +1,19 @@
 import { Agent, Server } from "node:http";
 import { afterEach, expect, it, vi } from "vitest";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../../plugins/hooks.test-fixtures.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createAdmittedHostCapabilityTestFixture } from "./host-capability.test-support.js";
 import * as relayBridge from "./native-hook-relay-bridge.js";
 import * as clientStore from "./native-hook-relay-client-store.js";
 import { invokeNativeHookRelayBridge } from "./native-hook-relay-client.js";
 import * as store from "./native-hook-relay-store.js";
 import {
+  invokeNativeHookRelay,
   registerNativeHookRelay,
   registerOwnedNativeHookRelay,
   testing,
@@ -14,6 +21,7 @@ import {
 
 afterEach(async () => {
   await testing.clearNativeHookRelaysForTests();
+  resetGlobalHookRunner();
   vi.restoreAllMocks();
 });
 
@@ -76,26 +84,220 @@ it("joins unregister when listener startup has not completed", async () => {
   });
 });
 
-it("preserves a listener startup error while draining its cleanup", async () => {
-  await withOpenClawTestState({ label: "relay-listener-failure" }, async () => {
+it.each(["listener", "publication"] as const)(
+  "preserves the exact %s error while admitting logical hook policy",
+  async (stage) => {
+    await withOpenClawTestState({ label: `relay-${stage}-failure` }, async () => {
+      await store.clearNativeHookRelayBridgeRecordsForTests();
+      const failure = new Error(`fixture ${stage} failed`);
+      if (stage === "listener") {
+        vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server) {
+          queueMicrotask(() => this.emit("error", failure));
+          return this;
+        });
+      } else {
+        vi.spyOn(store, "writeNativeHookRelayBridgeRecord").mockRejectedValueOnce(failure);
+      }
+      const policy = vi.fn(async () => ({
+        kind: "veto" as const,
+        blocked: true as const,
+        reason: "fixture policy denied",
+      }));
+      const relay = registerOwnedNativeHookRelay({
+        provider: "codex",
+        sessionId: `${stage}-failure`,
+        runId: `${stage}-failure`,
+        allowedEvents: ["pre_tool_use"],
+        runBeforeToolCall: policy,
+      });
+      try {
+        await expect(relay.ready).rejects.toBe(failure);
+        await relay.prepareInvocation();
+        const response = await invokeNativeHookRelay({
+          provider: "codex",
+          relayId: relay.relayId,
+          generation: relay.generation,
+          requireGeneration: true,
+          event: "pre_tool_use",
+          rawPayload: {
+            tool_name: "Bash",
+            tool_input: { command: "echo synthetic" },
+          },
+        });
+        expect(JSON.parse(response.stdout)).toMatchObject({
+          hookSpecificOutput: {
+            permissionDecision: "deny",
+            permissionDecisionReason: "fixture policy denied",
+          },
+        });
+        expect(policy).toHaveBeenCalledOnce();
+        expect(
+          await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId }),
+        ).toBeUndefined();
+      } finally {
+        relay.unregister();
+        await relay.drain();
+      }
+    });
+  },
+);
+
+it("renews logical invocation beyond its original expiry when the listener is unavailable", async () => {
+  await withOpenClawTestState({ label: "relay-logical-renewal" }, async () => {
+    await store.clearNativeHookRelayBridgeRecordsForTests();
     const failure = new Error("fixture listener failed");
     vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server) {
       queueMicrotask(() => this.emit("error", failure));
       return this;
     });
+    const policy = vi.fn(async () => ({
+      kind: "veto" as const,
+      blocked: true as const,
+      reason: "renewed policy denied",
+    }));
     const relay = registerOwnedNativeHookRelay({
       provider: "codex",
-      sessionId: "listener-failure",
-      runId: "listener-failure",
+      sessionId: "logical-renewal",
+      runId: "logical-renewal",
+      ttlMs: 60_000,
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: policy,
     });
+    await expect(relay.ready).rejects.toBe(failure);
+    const originalExpiry = relay.expiresAtMs;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(originalExpiry - 1);
     try {
-      await expect(relay.ready).rejects.toBe(failure);
+      relay.renew(60_000);
+      // A known transport failure may still be reported by the strict resource drain.
+      await relay.drain().catch((error: unknown) => expect(error).toBe(failure));
+      clock.mockReturnValue(originalExpiry + 1);
+      const response = await invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        generation: relay.generation,
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: { tool_name: "Bash", tool_input: { command: "echo synthetic" } },
+      });
+      expect(JSON.parse(response.stdout)).toMatchObject({
+        hookSpecificOutput: {
+          permissionDecision: "deny",
+          permissionDecisionReason: "renewed policy denied",
+        },
+      });
+      expect(policy).toHaveBeenCalledOnce();
+      expect(relay.expiresAtMs).toBeGreaterThan(originalExpiry + 1);
+      expect(
+        await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId }),
+      ).toBeUndefined();
     } finally {
+      clock.mockRestore();
       relay.unregister();
       await relay.drain();
     }
   });
 });
+
+it.each(["cancellation", "replacement", "foreground retirement"] as const)(
+  "rejects logical preparation after %s while publication is held",
+  async (retirement) => {
+    await withOpenClawTestState({ label: "relay-prepare-retirement" }, async () => {
+      const entered = createDeferredCore();
+      const resume = createDeferredCore();
+      const write = store.writeNativeHookRelayBridgeRecord;
+      vi.spyOn(store, "writeNativeHookRelayBridgeRecord").mockImplementationOnce(async (params) => {
+        entered.resolve();
+        await resume.promise;
+        await write(params);
+      });
+      const policy = vi.fn(() => ({ block: true, blockReason: "retired policy must not run" }));
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([{ hookName: "before_tool_call", handler: policy }]),
+      );
+      const host = await createAdmittedHostCapabilityTestFixture({ runId: "prepare-retirement" });
+      const abort = new AbortController();
+      const relay = registerOwnedNativeHookRelay({
+        provider: "codex",
+        relayId: "prepare-retirement",
+        sessionId: "prepare-retirement",
+        runId: "prepare-retirement",
+        signal: abort.signal,
+        allowedEvents: ["pre_tool_use"],
+        runBeforeToolCall: host.hostCapabilities.runBeforeToolCall,
+        assertActive: host.hostCapabilities.assertActive,
+        retention: {
+          readClaim: () => undefined,
+          shouldRetainAfterForegroundClose: () => retirement === "foreground retirement",
+          allowPreToolUse: () => false,
+          onDispose: () => {},
+        },
+      });
+      let successor: ReturnType<typeof registerOwnedNativeHookRelay> | undefined;
+      let preparation: Promise<void> | undefined;
+      let settled = false;
+      try {
+        preparation = relay.prepareInvocation();
+        void preparation.then(
+          () => {
+            settled = true;
+          },
+          () => {
+            settled = true;
+          },
+        );
+        await entered.promise;
+        expect(settled).toBe(false);
+        if (retirement === "cancellation") {
+          abort.abort();
+        } else if (retirement === "replacement") {
+          successor = registerOwnedNativeHookRelay({
+            provider: "codex",
+            relayId: relay.relayId,
+            sessionId: "prepare-retirement",
+            runId: "prepare-successor",
+          });
+        } else {
+          relay.unregister();
+          expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeDefined();
+        }
+        resume.resolve();
+        await expect(preparation).rejects.toThrow(/inactive|foreground|abort/i);
+        await expect(
+          invokeNativeHookRelay({
+            provider: "codex",
+            relayId: relay.relayId,
+            generation: relay.generation,
+            requireGeneration: true,
+            event: "pre_tool_use",
+            rawPayload: { tool_name: "Bash", tool_input: { command: "echo synthetic" } },
+          }),
+        ).rejects.toThrow();
+        expect(policy).not.toHaveBeenCalled();
+        if (successor) {
+          await successor.ready;
+          expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)?.runId).toBe(
+            "prepare-successor",
+          );
+          expect(
+            await store.readNativeHookRelayBridgeRecord({ relayId: relay.relayId }),
+          ).toBeDefined();
+        }
+      } finally {
+        resume.resolve();
+        abort.abort();
+        successor?.unregister();
+        await Promise.allSettled([
+          preparation,
+          relay.drain(),
+          ...(successor ? [successor.drain()] : []),
+        ]);
+        host.closeHost();
+        host.closeAdmission();
+        resetGlobalHookRunner();
+      }
+    });
+  },
+);
 
 it("does not start transport when locator lookup consumes the caller deadline", async () => {
   await withOpenClawTestState({ label: "relay-lookup-deadline" }, async () => {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -27,6 +27,7 @@ import { createMockPluginRegistry } from "../../plugins/hooks.test-fixtures.js";
 import { patchPluginSessionExtension } from "../../plugins/host-hook-state.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { splitShellArgs } from "../../utils/shell-argv.js";
 import {
@@ -36,14 +37,10 @@ import {
 import { createAdmittedHostCapabilityTestFixture } from "./host-capability.test-support.js";
 import * as nativeHookRelayBridge from "./native-hook-relay-bridge.js";
 import { invokeNativeHookRelayBridge } from "./native-hook-relay-client.js";
+import * as nativeHookRelayStore from "./native-hook-relay-store.js";
+import type { NativeHookRelayBridgeRecord } from "./native-hook-relay-store.js";
 import {
-  deleteNativeHookRelayBridgeRecordIfOwned,
-  readNativeHookRelayBridgeRecord,
-  writeNativeHookRelayBridgeRecord,
-  type NativeHookRelayBridgeRecord,
-} from "./native-hook-relay-store.js";
-import {
-  registerRetainedNativeHookRelay,
+  registerOwnedNativeHookRelay,
   testing,
   buildNativeHookRelayCommand,
   hasNativeHookRelayInvocation,
@@ -61,12 +58,12 @@ function readTestNativeAgentId(rawPayload: unknown): string | undefined {
   return rawPayload.agent_id.trim() || undefined;
 }
 
-afterEach(() => {
+afterEach(async () => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   resetGlobalHookRunner();
   setActivePluginRegistry(createEmptyPluginRegistry());
-  testing.clearNativeHookRelaysForTests();
+  await testing.clearNativeHookRelaysForTests();
 });
 
 const requireRecord = createRequireRecord("record", "expected-label-object-capitalized");
@@ -104,8 +101,8 @@ async function waitForNativeHookRelayBridgeRecord(
   relayId: string,
 ): Promise<NativeHookRelayBridgeRecord> {
   let record: NativeHookRelayBridgeRecord | undefined;
-  await vi.waitFor(() => {
-    record = readNativeHookRelayBridgeRecord({ relayId });
+  await vi.waitFor(async () => {
+    record = await nativeHookRelayStore.readNativeHookRelayBridgeRecord({ relayId });
     expect(record?.relayId).toBe(relayId);
   });
   if (!record) {
@@ -121,7 +118,7 @@ async function writeForeignNativeHookRelayBridgeRecordForTests(
     expiresAtMs: number;
   },
 ): Promise<string> {
-  writeNativeHookRelayBridgeRecord({
+  await nativeHookRelayStore.writeNativeHookRelayBridgeRecord({
     record: {
       relayId,
       pid: record.pid,
@@ -426,7 +423,7 @@ describe("native hook relay registry", () => {
         },
       ]),
     );
-    const relay = registerRetainedNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: "codex-root-foreground-close",
       sessionId: "session-1",
@@ -456,6 +453,7 @@ describe("native hook relay registry", () => {
       expect(resolvePolicy).toBeTypeOf("function");
     });
     relay.unregister();
+    await relay.drain();
     resolvePolicy?.(undefined);
 
     await expect(invocation).rejects.toThrow("foreground invocation not allowed");
@@ -479,7 +477,7 @@ describe("native hook relay registry", () => {
     const approvalRequester = vi.fn(async () => "allow" as const);
     testing.setNativeHookRelayPermissionApprovalRequesterForTests(approvalRequester);
     let retainChild = true;
-    const relay = registerRetainedNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: "codex-retained-direct-child",
       sessionId: "session-1",
@@ -641,7 +639,7 @@ describe("native hook relay registry", () => {
         throw new Error("Expected admitted delegated authority");
       }
       const controller = new AbortController();
-      const relay = registerRetainedNativeHookRelay({
+      const relay = registerOwnedNativeHookRelay({
         provider: "codex",
         relayId: uniqueNativeHookRelayIdForTests(`retained-${cause}`),
         sessionId: "session-1",
@@ -676,7 +674,7 @@ describe("native hook relay registry", () => {
         await vi.advanceTimersByTimeAsync(6);
       }
       expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeUndefined();
-      expect(testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
+      expect(await testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
       await expect(
         invokeNativeHookRelay({
           provider: "codex",
@@ -701,7 +699,7 @@ describe("native hook relay registry", () => {
       runBeforeToolCall: hostCapabilities.runBeforeToolCall,
       assertActive: hostCapabilities.assertActive,
     });
-    const retaining = registerRetainedNativeHookRelay({
+    const retaining = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: uniqueNativeHookRelayIdForTests("retaining-same-host"),
       sessionId: "session-1",
@@ -775,7 +773,7 @@ describe("native hook relay registry", () => {
       }
       const controller = new AbortController();
       const relayId = uniqueNativeHookRelayIdForTests("throwing-unregister");
-      const relay = registerRetainedNativeHookRelay({
+      const relay = registerOwnedNativeHookRelay({
         provider: "codex",
         relayId,
         sessionId: "session-1",
@@ -815,14 +813,14 @@ describe("native hook relay registry", () => {
         expect(testing.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
       }
       if (mode !== "replacement") {
-        expect(testing.getNativeHookRelayBridgeRecordForTests(relayId)).toBeUndefined();
+        expect(await testing.getNativeHookRelayBridgeRecordForTests(relayId)).toBeUndefined();
       }
     },
   );
 
   it("fails closed when a retained relay predicate throws", () => {
     const relayId = uniqueNativeHookRelayIdForTests("throwing-retain-predicate");
-    const relay = registerRetainedNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId,
       sessionId: "session-1",
@@ -843,7 +841,7 @@ describe("native hook relay registry", () => {
 
   it("keeps a reentrant same-id successor after old teardown completes", () => {
     const relayId = uniqueNativeHookRelayIdForTests("reentrant-successor");
-    const first = registerRetainedNativeHookRelay({
+    const first = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId,
       sessionId: "session-1",
@@ -870,7 +868,7 @@ describe("native hook relay registry", () => {
   it("keeps the callback-created successor after replacement teardown", async () => {
     const relayId = uniqueNativeHookRelayIdForTests("replacement-reentrant-successor");
     let callbackSuccessor: ReturnType<typeof registerNativeHookRelay> | undefined;
-    const first = registerRetainedNativeHookRelay({
+    const first = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId,
       sessionId: "session-1",
@@ -892,7 +890,7 @@ describe("native hook relay registry", () => {
       },
     });
     const replacementUnregistered = vi.fn();
-    registerRetainedNativeHookRelay({
+    registerOwnedNativeHookRelay({
       provider: "codex",
       relayId,
       sessionId: "session-1",
@@ -925,10 +923,10 @@ describe("native hook relay registry", () => {
     callbackSuccessor?.unregister();
   });
 
-  it("delivers old replacement callback when the successor signal is already aborted", () => {
+  it("delivers old replacement callback when the successor signal is already aborted", async () => {
     const relayId = uniqueNativeHookRelayIdForTests("replacement-preaborted");
     const oldUnregistered = vi.fn();
-    registerRetainedNativeHookRelay({
+    registerOwnedNativeHookRelay({
       provider: "codex",
       relayId,
       sessionId: "session-1",
@@ -955,7 +953,7 @@ describe("native hook relay registry", () => {
 
     expect(oldUnregistered).toHaveBeenCalledOnce();
     expect(testing.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
-    expect(testing.getNativeHookRelayBridgeRecordForTests(relayId)).toBeUndefined();
+    expect(await testing.getNativeHookRelayBridgeRecordForTests(relayId)).toBeUndefined();
   });
 
   it("cleans a partial retained relay when bridge setup throws", async () => {
@@ -970,7 +968,7 @@ describe("native hook relay registry", () => {
       });
 
     expect(() =>
-      registerRetainedNativeHookRelay({
+      registerOwnedNativeHookRelay({
         provider: "codex",
         relayId,
         sessionId: "session-1",
@@ -986,7 +984,7 @@ describe("native hook relay registry", () => {
       }),
     ).toThrow("bridge setup failed");
     expect(testing.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
-    expect(testing.getNativeHookRelayBridgeRecordForTests(relayId)).toBeUndefined();
+    expect(await testing.getNativeHookRelayBridgeRecordForTests(relayId)).toBeUndefined();
     expect(getAdmittedRunDelegatedAuthority(admittedRunContext)).toBeDefined();
 
     bridgeFailure.mockRestore();
@@ -1215,7 +1213,7 @@ describe("native hook relay registry", () => {
   });
 
   it("invokes the successor when retirement expires before its listener publishes", async () => {
-    const first = registerNativeHookRelay({
+    const first = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: uniqueNativeHookRelayIdForTests("replacement-publication"),
       sessionId: "session-1",
@@ -1232,6 +1230,27 @@ describe("native hook relay registry", () => {
       }
       return originalEmit.call(this, event, ...args);
     });
+    const remove = nativeHookRelayStore.deleteNativeHookRelayBridgeRecordIfOwned;
+    const removed = createDeferredCore();
+    vi.spyOn(nativeHookRelayStore, "deleteNativeHookRelayBridgeRecordIfOwned").mockImplementation(
+      async (params) => {
+        const result = await remove(params);
+        removed.resolve();
+        return result;
+      },
+    );
+    // oxlint-disable-next-line typescript/unbound-method -- replayed with the captured server receiver.
+    const originalListen = Server.prototype.listen;
+    let startSuccessor: (() => void) | undefined;
+    const listen = vi.spyOn(Server.prototype, "listen").mockImplementation(function (
+      this: Server,
+      ...args
+    ) {
+      startSuccessor = () => {
+        Reflect.apply(originalListen, this, args);
+      };
+      return this;
+    });
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     try {
       const successor = registerNativeHookRelay({
@@ -1241,6 +1260,11 @@ describe("native hook relay registry", () => {
         runId: "run-successor",
         allowedEvents: ["post_tool_use"],
       });
+      // The grace begins after durable removal, while successor publication is held explicitly.
+      await removed.promise;
+      await vi.advanceTimersByTimeAsync(250);
+      await first.drain();
+      vi.useRealTimers();
       const result = expect(
         invokeNativeHookRelayBridge({
           provider: "codex",
@@ -1251,13 +1275,13 @@ describe("native hook relay registry", () => {
           rawPayload: { hook_event_name: "PostToolUse", tool_name: "Bash", tool_response: {} },
         }),
       ).resolves.toMatchObject({ exitCode: 0 });
-      // Let retirement win before Node delivers listening/connect callbacks.
-      vi.advanceTimersByTime(250);
-      await vi.advanceTimersByTimeAsync(25);
+      expect(startSuccessor).toBeTypeOf("function");
+      startSuccessor?.();
       await result;
       expect(connectionErrors).toEqual([]);
       expect(getOnlyNativeHookRelayInvocation()).toMatchObject({ runId: "run-successor" });
     } finally {
+      listen.mockRestore();
       vi.useRealTimers();
     }
   });
@@ -1947,7 +1971,7 @@ describe("native hook relay registry", () => {
   });
 
   it("renews relay ttl without rotating the direct hook bridge", async () => {
-    const relay = registerNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: "codex-renewed-bridge-session",
       sessionId: "session-1",
@@ -1957,10 +1981,8 @@ describe("native hook relay registry", () => {
     });
     const before = await waitForNativeHookRelayBridgeRecord(relay.relayId);
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 5);
-    });
     relay.renew(20_000);
+    await relay.drain();
 
     const after = await waitForNativeHookRelayBridgeRecord(relay.relayId);
     expect(after.port).toBe(before.port);
@@ -1994,12 +2016,12 @@ describe("native hook relay registry", () => {
     });
     const before = await waitForNativeHookRelayBridgeRecord(relay.relayId);
     expect(
-      deleteNativeHookRelayBridgeRecordIfOwned({
+      await nativeHookRelayStore.deleteNativeHookRelayBridgeRecordIfOwned({
         ...before,
         stateDbPath: resolveOpenClawStateSqlitePath(),
       }),
     ).toBe(true);
-    expect(testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
+    expect(await testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
 
     relay.renew(20_000);
 
@@ -2024,16 +2046,17 @@ describe("native hook relay registry", () => {
       return true;
     });
 
-    registerNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: "codex-prune-dead-foreign-bridge-session",
       sessionId: "session-1",
       runId: "run-1",
       allowedEvents: ["pre_tool_use"],
     });
+    await relay.ready;
 
     expect(kill).toHaveBeenCalledWith(9_999_991, 0);
-    expect(testing.getNativeHookRelayBridgeRecordForTests(staleRelayId)).toBeUndefined();
+    expect(await testing.getNativeHookRelayBridgeRecordForTests(staleRelayId)).toBeUndefined();
   });
 
   it("prunes expired foreign direct bridge records even when their pid is alive", async () => {
@@ -2058,18 +2081,21 @@ describe("native hook relay registry", () => {
       return true;
     });
 
-    registerNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: "codex-prune-expired-foreign-bridge-session",
       sessionId: "session-1",
       runId: "run-1",
       allowedEvents: ["pre_tool_use"],
     });
+    await relay.ready;
 
     expect(kill).toHaveBeenCalledWith(9_999_994, 0);
     expect(kill).not.toHaveBeenCalledWith(9_999_992, 0);
-    expect(testing.getNativeHookRelayBridgeRecordForTests(staleRelayId)).toBeUndefined();
-    expect(testing.getNativeHookRelayBridgeRecordForTests(unrelatedLiveRelayId)).toBeDefined();
+    expect(await testing.getNativeHookRelayBridgeRecordForTests(staleRelayId)).toBeUndefined();
+    expect(
+      await testing.getNativeHookRelayBridgeRecordForTests(unrelatedLiveRelayId),
+    ).toBeDefined();
   });
 
   it("preserves live unexpired foreign direct bridge records during registration", async () => {
@@ -2087,16 +2113,17 @@ describe("native hook relay registry", () => {
       return true;
     });
 
-    registerNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: "codex-preserve-live-foreign-bridge-session",
       sessionId: "session-1",
       runId: "run-1",
       allowedEvents: ["pre_tool_use"],
     });
+    await relay.ready;
 
     expect(kill).toHaveBeenCalledWith(9_999_993, 0);
-    expect(testing.getNativeHookRelayBridgeRecordForTests(liveRelayId)).toBeDefined();
+    expect(await testing.getNativeHookRelayBridgeRecordForTests(liveRelayId)).toBeDefined();
   });
 
   it("preserves foreign direct bridge records when liveness is unknown", async () => {
@@ -2114,16 +2141,17 @@ describe("native hook relay registry", () => {
       return true;
     });
 
-    registerNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: "codex-preserve-unknown-liveness-foreign-bridge-session",
       sessionId: "session-1",
       runId: "run-1",
       allowedEvents: ["pre_tool_use"],
     });
+    await relay.ready;
 
     expect(kill).toHaveBeenCalledWith(9_999_994, 0);
-    expect(testing.getNativeHookRelayBridgeRecordForTests(liveRelayId)).toBeDefined();
+    expect(await testing.getNativeHookRelayBridgeRecordForTests(liveRelayId)).toBeDefined();
   });
 
   it("treats direct bridge records with a dead owning pid as absent", async () => {
@@ -2168,7 +2196,7 @@ describe("native hook relay registry", () => {
     });
 
     const record = await waitForNativeHookRelayBridgeRecord(relay.relayId);
-    writeNativeHookRelayBridgeRecord({
+    await nativeHookRelayStore.writeNativeHookRelayBridgeRecord({
       // Simulate a hostile/corrupt database row outside the typed store contract.
       record: {
         ...record,
@@ -2212,7 +2240,7 @@ describe("native hook relay registry", () => {
 
     const firstRecord = await waitForNativeHookRelayBridgeRecord(first.relayId);
     await waitForNativeHookRelayBridgeRecord(second.relayId);
-    writeNativeHookRelayBridgeRecord({
+    await nativeHookRelayStore.writeNativeHookRelayBridgeRecord({
       record: {
         ...firstRecord,
         relayId: second.relayId,
@@ -2258,7 +2286,7 @@ describe("native hook relay registry", () => {
       if (!address || typeof address === "string") {
         throw new Error("test bridge server address unavailable");
       }
-      writeNativeHookRelayBridgeRecord({
+      await nativeHookRelayStore.writeNativeHookRelayBridgeRecord({
         record: {
           ...record,
           port: address.port,
@@ -2666,9 +2694,9 @@ describe("native hook relay registry", () => {
       }),
     ).rejects.toThrow("expired");
     expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeUndefined();
-    expect(testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
+    expect(await testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
     relay.unregister();
-    expect(testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
+    expect(await testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
   });
 
   it("rearms relay expiry beyond the maximum timer chunk and physically releases at deadline", async () => {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -11,6 +11,7 @@ import { resolveProjectedMcpCodexToolApprovalMode } from "../mcp-codex-tool-appr
 import { retainBeforeToolCallForNativeHookRelay } from "./host-private-capabilities.js";
 import {
   clearNativeHookRelayBridgesForTests,
+  drainNativeHookRelayBridge,
   NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
   NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
   readNativeHookRelayBridgeRecordIfExists,
@@ -53,6 +54,7 @@ import type {
   NativeHookRelayPermissionApprovalRequester,
   NativeHookRelayProcessResponse,
   NativeHookRelayRegistration,
+  OwnedNativeHookRelayRegistrationHandle,
   RegisterNativeHookRelayParams,
 } from "./native-hook-relay-types.js";
 import { NATIVE_HOOK_RELAY_EVENTS } from "./native-hook-relay-types.js";
@@ -97,8 +99,8 @@ export type NativeHookRelayRetention = Readonly<{
   onDispose: () => void;
 }>;
 
-type RetainedNativeHookRelayParams = RegisterNativeHookRelayParams & {
-  retention: NativeHookRelayRetention;
+type OwnedNativeHookRelayParams = RegisterNativeHookRelayParams & {
+  retention?: NativeHookRelayRetention;
 };
 
 function readRelayLifetime(
@@ -157,9 +159,9 @@ export function registerNativeHookRelay(
 }
 
 /** Private-local bundled runtime entrypoint; not exported through the public SDK. */
-export function registerRetainedNativeHookRelay(
-  params: RetainedNativeHookRelayParams,
-): ActiveNativeHookRelayRegistrationHandle {
+export function registerOwnedNativeHookRelay(
+  params: OwnedNativeHookRelayParams,
+): OwnedNativeHookRelayRegistrationHandle {
   const { retention, ...registrationParams } = params;
   return registerNativeHookRelayInternal(registrationParams, retention);
 }
@@ -167,7 +169,7 @@ export function registerRetainedNativeHookRelay(
 function registerNativeHookRelayInternal(
   params: RegisterNativeHookRelayParams,
   retention: NativeHookRelayRetention | undefined,
-): ActiveNativeHookRelayRegistrationHandle {
+): OwnedNativeHookRelayRegistrationHandle {
   pruneExpiredNativeHookRelays();
   pruneNativeHookRelayPermissionAllowAlways();
   const relayId = normalizeRelayKey(params.relayId, "id") ?? randomUUID();
@@ -245,11 +247,33 @@ function registerNativeHookRelayInternal(
         throw new Error("native hook relay registration aborted");
       }
     }
-    registerNativeHookRelayBridge(registration, stateDbPath, invokeNativeHookRelay);
+    const bridge = registerNativeHookRelayBridge(registration, stateDbPath, invokeNativeHookRelay);
     scheduleNativeHookRelayExpiry(relayId, registration);
-    const handle: ActiveNativeHookRelayRegistrationHandle = {
+    let pendingRenewal = Promise.resolve();
+    const handle: OwnedNativeHookRelayRegistrationHandle = {
       ...registration,
       ...buildNativeHookRelayCommandPlan({ ...params, relayId, generation }),
+      ready: bridge.ready,
+      drain: async () => {
+        let renewal: Promise<void>;
+        let failure: { error: unknown } | undefined;
+        do {
+          renewal = pendingRenewal;
+          try {
+            await renewal;
+          } catch (error) {
+            failure ??= { error };
+          }
+          try {
+            await drainNativeHookRelayBridge(bridge);
+          } catch (error) {
+            failure ??= { error };
+          }
+        } while (renewal !== pendingRenewal);
+        if (failure) {
+          throw failure.error;
+        }
+      },
       renew: (ttlMs) => {
         const current = relays.get(relayId);
         if (current !== registration) {
@@ -259,10 +283,16 @@ function registerNativeHookRelayInternal(
         if (renewedExpiresAtMs === undefined) {
           return;
         }
-        const bridge = relayBridges.get(relayId);
-        if (bridge && bridge.server.listening) {
+        pendingRenewal = pendingRenewal.then(async () => {
+          if (relays.get(relayId) !== current) {
+            return;
+          }
           try {
-            const renewal = renewNativeHookRelayBridgeRecord(current, bridge, renewedExpiresAtMs);
+            const renewal = await renewNativeHookRelayBridgeRecord(
+              current,
+              bridge,
+              renewedExpiresAtMs,
+            );
             if (renewal === "unavailable") {
               return;
             }
@@ -275,10 +305,13 @@ function registerNativeHookRelayInternal(
             log.debug("failed to renew native hook relay bridge record", { error, relayId });
             return;
           }
-        }
-        current.expiresAtMs = renewedExpiresAtMs;
-        handle.expiresAtMs = renewedExpiresAtMs;
-        scheduleNativeHookRelayExpiry(relayId, current);
+          if (relays.get(relayId) !== current) {
+            return;
+          }
+          current.expiresAtMs = renewedExpiresAtMs;
+          handle.expiresAtMs = renewedExpiresAtMs;
+          scheduleNativeHookRelayExpiry(relayId, current);
+        });
       },
       unregister: () => deactivateNativeHookRelayForeground(relayId, registration),
     };
@@ -325,7 +358,7 @@ function unregisterNativeHookRelay(
   delete (registration as ActiveNativeHookRelayRegistration & { [RELAY_LIFETIME]?: RelayLifetime })[
     RELAY_LIFETIME
   ];
-  unregisterNativeHookRelayBridge(relayId, {
+  void unregisterNativeHookRelayBridge(relayId, {
     ...options,
     ...(bridge ? { expectedBridge: bridge } : {}),
   });
@@ -650,11 +683,11 @@ function normalizeAllowedEvents(
 }
 
 export const testing = {
-  clearNativeHookRelaysForTests(): void {
+  async clearNativeHookRelaysForTests(): Promise<void> {
     for (const [relayId, registration] of relays) {
       unregisterNativeHookRelay(relayId, registration);
     }
-    clearNativeHookRelayBridgesForTests();
+    await clearNativeHookRelayBridgesForTests();
     invocations.length = 0;
     clearNativeHookRelayPermissionsForTests();
   },
@@ -671,8 +704,10 @@ export const testing = {
     void relayId;
     throw new Error("native hook relay bridge files were retired");
   },
-  getNativeHookRelayBridgeRecordForTests(relayId: string): Record<string, unknown> | undefined {
-    const record = readNativeHookRelayBridgeRecordIfExists(relayId);
+  async getNativeHookRelayBridgeRecordForTests(
+    relayId: string,
+  ): Promise<Record<string, unknown> | undefined> {
+    const record = await readNativeHookRelayBridgeRecordIfExists(relayId);
     return record ? { ...record } : undefined;
   },
   isNativeHookRelayBridgeLookupRetryableForTests(error: unknown, elapsedMs = 0): boolean {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -11,7 +11,6 @@ import { resolveProjectedMcpCodexToolApprovalMode } from "../mcp-codex-tool-appr
 import { retainBeforeToolCallForNativeHookRelay } from "./host-private-capabilities.js";
 import {
   clearNativeHookRelayBridgesForTests,
-  drainNativeHookRelayBridge,
   NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
   NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
   readNativeHookRelayBridgeRecordIfExists,
@@ -66,6 +65,7 @@ import {
   readNonEmptyString,
   snapshotNativeHookRelayPayload,
 } from "./native-hook-relay-utils.js";
+import { drainNativeHookRelayWork } from "./native-hook-relay-work.js";
 export { buildNativeHookRelayCommand } from "./native-hook-relay-command.js";
 export { resolveNativeHookRelayDeferredToolApproval } from "./native-hook-relay-permissions.js";
 export type {
@@ -254,26 +254,19 @@ function registerNativeHookRelayInternal(
       ...registration,
       ...buildNativeHookRelayCommandPlan({ ...params, relayId, generation }),
       ready: bridge.ready,
-      drain: async () => {
-        let renewal: Promise<void>;
-        let failure: { error: unknown } | undefined;
-        do {
-          renewal = pendingRenewal;
-          try {
-            await renewal;
-          } catch (error) {
-            failure ??= { error };
-          }
-          try {
-            await drainNativeHookRelayBridge(bridge);
-          } catch (error) {
-            failure ??= { error };
-          }
-        } while (renewal !== pendingRenewal);
-        if (failure) {
-          throw failure.error;
+      prepareInvocation: async () => {
+        const lifetime = readRelayLifetime(registration);
+        if (!lifetime) {
+          throw new Error("native hook relay registration is inactive");
         }
+        const foregroundToken = lifetime.foregroundToken;
+        assertNativeHookRelayForegroundCurrent(registration, lifetime, foregroundToken);
+        // A failed direct locator can still use the CLI's Gateway route. Keep
+        // its strict result on ready and revalidate admission after it settles.
+        await bridge.ready.catch(() => undefined);
+        assertNativeHookRelayForegroundCurrent(registration, lifetime, foregroundToken);
       },
+      drain: () => drainNativeHookRelayWork({ bridge, readRenewal: () => pendingRenewal }),
       renew: (ttlMs) => {
         const current = relays.get(relayId);
         if (current !== registration) {
@@ -287,23 +280,25 @@ function registerNativeHookRelayInternal(
           if (relays.get(relayId) !== current) {
             return;
           }
-          try {
-            const renewal = await renewNativeHookRelayBridgeRecord(
-              current,
-              bridge,
-              renewedExpiresAtMs,
-            );
-            if (renewal === "unavailable") {
+          if (bridge.server.listening) {
+            try {
+              const renewal = await renewNativeHookRelayBridgeRecord(
+                current,
+                bridge,
+                renewedExpiresAtMs,
+              );
+              if (renewal === "unavailable") {
+                return;
+              }
+              if (renewal === "ownership-changed") {
+                log.debug("native hook relay bridge record ownership changed", { relayId });
+                unregisterNativeHookRelay(relayId, current);
+                return;
+              }
+            } catch (error) {
+              log.debug("failed to renew native hook relay bridge record", { error, relayId });
               return;
             }
-            if (renewal === "ownership-changed") {
-              log.debug("native hook relay bridge record ownership changed", { relayId });
-              unregisterNativeHookRelay(relayId, current);
-              return;
-            }
-          } catch (error) {
-            log.debug("failed to renew native hook relay bridge record", { error, relayId });
-            return;
           }
           if (relays.get(relayId) !== current) {
             return;
@@ -463,20 +458,24 @@ async function resolveNativeHookRelayInvocationBinding(
     throw new Error("native hook relay foreground invocation not allowed");
   }
   const foregroundToken = lifetime.foregroundToken;
-  const assertActive = () => {
-    if (
-      relays.get(registration.relayId) !== registration ||
-      Date.now() > registration.expiresAtMs
-    ) {
-      throw new Error("native hook relay registration is inactive");
-    }
-    registration.signal?.throwIfAborted();
-    registration.assertActive?.();
-    if (!lifetime.foregroundOpen || lifetime.foregroundToken !== foregroundToken) {
-      throw new Error("native hook relay foreground invocation not allowed");
-    }
-  };
+  const assertActive = () =>
+    assertNativeHookRelayForegroundCurrent(registration, lifetime, foregroundToken);
   return { ...registration, assertActive };
+}
+
+function assertNativeHookRelayForegroundCurrent(
+  registration: ActiveNativeHookRelayRegistration,
+  lifetime: RelayLifetime,
+  foregroundToken: symbol,
+): void {
+  if (relays.get(registration.relayId) !== registration || Date.now() > registration.expiresAtMs) {
+    throw new Error("native hook relay registration is inactive");
+  }
+  registration.signal?.throwIfAborted();
+  registration.assertActive?.();
+  if (!lifetime.foregroundOpen || lifetime.foregroundToken !== foregroundToken) {
+    throw new Error("native hook relay foreground invocation not allowed");
+  }
 }
 
 function normalizeRelayKey(

--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -23,7 +23,7 @@ const exitAfterOutputTimeoutMs = 30_000;
 const exitOnlyTimeoutMs = 60_000;
 
 afterEach(async () => {
-  nativeHookRelayTesting.clearNativeHookRelaysForTests();
+  await nativeHookRelayTesting.clearNativeHookRelaysForTests();
   await Promise.all(Array.from(activeChildren, terminateChild));
 });
 
@@ -398,7 +398,10 @@ describe("hooks CLI process lifecycle", () => {
         allowedEvents: ["post_tool_use"],
       });
       await expect
-        .poll(() => nativeHookRelayTesting.getNativeHookRelayBridgeRecordForTests(relay.relayId))
+        .poll(
+          async () =>
+            await nativeHookRelayTesting.getNativeHookRelayBridgeRecordForTests(relay.relayId),
+        )
         .toBeDefined();
 
       const fixture = await createRelayPreloadFixture();

--- a/src/gateway/server-methods/native-hook-relay.test.ts
+++ b/src/gateway/server-methods/native-hook-relay.test.ts
@@ -13,8 +13,8 @@ const POST_TOOL_USE_PAYLOAD = {
   tool_response: { output: "ok" },
 };
 
-afterEach(() => {
-  testing.clearNativeHookRelaysForTests();
+afterEach(async () => {
+  await testing.clearNativeHookRelaysForTests();
 });
 
 describe("native hook relay gateway method", () => {

--- a/src/plugin-sdk/native-hook-relay-runtime.ts
+++ b/src/plugin-sdk/native-hook-relay-runtime.ts
@@ -1,7 +1,7 @@
 import type { RegisterNativeHookRelayParams } from "../agents/harness/native-hook-relay-types.js";
 // Private retained native-hook relay capability for bundled runtime owners.
 import {
-  registerRetainedNativeHookRelay,
+  registerOwnedNativeHookRelay,
   type NativeHookRelayRetention,
 } from "../agents/harness/native-hook-relay.js";
 
@@ -10,13 +10,11 @@ export {
   type NativeHookRelayCommandPlan,
 } from "../agents/harness/native-hook-relay-plan.js";
 
-export type RetainedNativeHookRelayParams = RegisterNativeHookRelayParams & {
-  retention: NativeHookRelayRetention;
+export type OwnedNativeHookRelayParams = RegisterNativeHookRelayParams & {
+  retention?: NativeHookRelayRetention;
 };
 
-/** Registers a bundled-only relay that may retain host policy for direct children. */
-export function registerRetainedNativeHookRelayForBundledRuntime(
-  params: RetainedNativeHookRelayParams,
-) {
-  return registerRetainedNativeHookRelay(params);
+/** Bundled owners join publication and cleanup while preserving optional direct-child retention. */
+export function registerNativeHookRelayForBundledRuntime(params: OwnedNativeHookRelayParams) {
+  return registerOwnedNativeHookRelay(params);
 }

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -20,6 +20,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.generation-finalization.test.ts",
       "extensions/codex/src/app-server/run-attempt.hooks.test.ts",
       "extensions/codex/src/app-server/run-attempt.media-lifetime.test.ts",
+      "extensions/codex/src/app-server/run-attempt.native-hook-fallback.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts",
       "extensions/codex/src/app-server/run-attempt.notification-burst.test.ts",


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Native-hook startup and cleanup assume SQLite locator operations finish synchronously. Delayed publication or renewal can start a thread before its relay is discoverable, expose an expiry before it is stored, or leave an old locator after unregistering. Lookup delays can also initiate transport after the caller deadline.

## Why This Change Was Made

The relay owner retains publication, serialized renewal, conditional deletion and listener closure. Bundled Codex startup waits for the direct publication attempt and revalidates current foreground authority; if direct publication fails, the generated command keeps its existing Gateway route. Strict publication errors remain observable separately. Non-listening relays retain logical renewal; listening relays publish durable expiry before exposing it.

Cleanup joins accepted work while preserving successful-yield children and existing late-hook grace. The shipped synchronous registration handle and command getters remain compatible; readiness, preparation and drainage are private bundled capabilities. Schema, hook payloads and approval policy stay unchanged.

## User Impact

Native hooks preserve their command, fallback and approval behavior while startup, renewal and cleanup gain explicit completion boundaries. Cancellation, replacement and foreground retirement still reject stale invocation. An exhausted lookup deadline cannot start transport.

## Evidence

- Delayed real-SQLite tests reproduce publication, renewal and cleanup ordering failures, deadline overrun and drain/retry races. The original 178 native/Gateway cases and 170 bundled lifecycle cases passed.
- The final fallback repair reproduces fresh/resumed/side-thread startup failure and logical TTL expiry on the prior code. All 297 relevant cases passed; final layout rechecks passed 138 owner cases, 93 side-question cases and 2 fresh/resume cases.
- Full selected checks, fresh independent Codex P2 review and a normal build passed. The original CI teardown hang was repaired by returning to real timers after deadline assertions; the exact 12-file cohort passed all 134 cases without changing product timeouts.
- On the unchanged emitted build, a real isolated Gateway handled cold generated CLI commands after actual listener and SQLite publication failures. Both returned the real policy denial; retirement produced the Gateway's specific not-found rejection without another policy call. Both listeners drained, SQLite closed and reopened with integrity intact, and no locators remained.
- Final isolated proof took 10.77 seconds; listener-failure and publication-failure CLI calls took approximately 875 ms and 673 ms. These are descriptive probe timings, not performance comparisons. Source and artifact inventories were unchanged.

This is lifecycle/API groundwork. Native SQLite still runs on the calling thread until the canonical worker cutover. The compiled proof exercises real Gateway, CLI and SQLite behavior; native Codex binary execution and model inference were not run.
