### PR TITLE
fix(ui): show Error instead of custom on failure notices

### DIFF
--- a/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
+++ b/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
@@ -270,7 +270,9 @@ suite.define(() => {
           await page.reload();
           await notice.waitFor({ timeout: 10_000 });
           expect(await notice.count()).toBe(1);
+          expect(await notice.locator(".chat-sender-name").textContent()).toBe("Error");
           await gateway.waitForRequest("chat.startup");
+          await notice.hover();
           await capture(page, `04-${customType}-history.png`);
         },
       );

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5211,6 +5211,7 @@ export const en: TranslationMap & {
       tooLargeToDisplay: "This message is too large to display here.",
       unknownDate: "Unknown date",
       toolSender: "Tool",
+      errorSender: "Error",
       forwardedFrom: "From",
       forwardedFromAgent: "Forwarded from {agentId}",
       forwardedMessage: "Forwarded message",

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing } from "lit";
 import { resolveLocalUserName } from "../../../app/user-identity.ts";
 import type { BrowserTabSelection } from "../../../components/browser/browser-target.ts";
@@ -303,6 +304,20 @@ export function resolveMessageGroupSenderLabel(
   opts: Pick<RenderMessageGroupOptions, "assistantName" | "userId" | "userName" | "userAvatar">,
 ): string {
   const normalizedRole = normalizeRoleForGrouping(group.role);
+  if (normalizedRole === "custom") {
+    const isError = group.messages.every(({ message }) => {
+      const customType = asNullableRecord(message)?.customType;
+      return (
+        customType === "run-failed-before-reply" || customType === "cloud-workspace-recovery-failed"
+      );
+    });
+    if (isError) {
+      return t("chat.messages.errorSender");
+    }
+    return group.messages.every(({ message }) => workspaceResultConflictFromTranscript(message))
+      ? t("chat.workspaceConflict.eventSender")
+      : t("common.system");
+  }
   const assistantName = opts.assistantName ?? "Assistant";
   const resolvedUserName = resolveLocalUserName({
     name: opts.userName ?? null,
@@ -319,11 +334,7 @@ export function resolveMessageGroupSenderLabel(
       ? (userLabel ?? assistantName)
       : normalizedRole === "tool"
         ? t("chat.messages.toolSender")
-        : group.messages.every((item) =>
-              Boolean(workspaceResultConflictFromTranscript(item.message)),
-            )
-          ? t("chat.workspaceConflict.eventSender")
-          : normalizedRole;
+        : normalizedRole;
 }
 
 function isActivityMessageGroup(group: MessageGroup): boolean {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -705,6 +705,27 @@ afterEach(() => {
 });
 
 describe("grouped chat rendering", () => {
+  it.each([
+    { customType: "run-failed-before-reply", label: "Error" },
+    { customType: "cloud-workspace-recovery-failed", label: "Error" },
+    { customType: "system-notice", label: "System" },
+  ])("labels $customType notices as $label", ({ customType, label }) => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        role: "custom",
+        customType,
+        content: "Notice details",
+        display: true,
+        timestamp: Date.now(),
+      },
+      "custom",
+    );
+    expect(container.querySelector(".chat-sender-name")?.textContent).toBe(label);
+    expect(container.textContent).toContain("Notice details");
+  });
+
   it("preserves paragraph breaks around assistant attachments in rendered markdown", () => {
     const container = document.createElement("div");
 


### PR DESCRIPTION
## What Problem This Solves

Failed-turn notices in the Control UI currently show the internal sender label `custom`, which is confusing and leaks an implementation detail into the transcript.

## Why This Change Was Made

The shared sender-label renderer now uses the recorded notice subtype:

- failed-before-reply and cloud-workspace recovery failures display **Error**
- other custom notices display **System**
- structured workspace conflicts retain **Cloud workspace**
- mixed informational/error groups remain **System** so informational messages are not mislabeled

This is presentation-only. It does not change transcript roles, persistence, grouping, or the runtime failure itself.

## User Impact

Failure footers read **Error** followed by the timestamp, including after history reload. This fixes the confusing label shown alongside the stale-install failure; it does not prevent that failure.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts`: 236 passed
- focused Chromium history/reload coverage: 2 passed
- `node scripts/check-changed.mjs`: passed on the rebased patch
- rebased onto current main and removed an unrelated historical CI-cleanup commit from this branch

AI-assisted with Codex.
