### PR TITLE
fix(update): resolve compatibility bridges within the runtime graph

### DIFF
--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -370,7 +370,10 @@ The recorder scans emitted lazy imports in the updater, service, and CLI cleanup
 regions and records required export origins. The wizard entry is excluded
 because it starts before replacement. `runtime-postbuild` generates hashed
 compatibility files by re-exporting the candidate's corresponding symbols;
-missing or ambiguous mappings fail the build. Stable entrypoints are checked
+multiple exports of one declaration resolve to its own chunk, with sorted paths
+and export names breaking alias ties. Missing mappings or distinct declaration
+bindings for the same source origin fail the build. The isolated `config-doctor`
+graph cannot supply updater bridges. Stable entrypoints are checked
 without replacement. The package carries the inventory in
 `dist/update-compat-inventory.json`, so negative and future fixtures remove that
 candidate's bridges. Existing older compatibility aliases remain separately

--- a/scripts/lib/update-compat-chunks.mts
+++ b/scripts/lib/update-compat-chunks.mts
@@ -259,11 +259,11 @@ class ModuleGraph {
     return [...matches.values()];
   }
 
-  private sourceOrigin(
+  private singleBinding(
     file: string,
     symbol: string,
     bindings: ModuleBinding[],
-  ): UpdateCompatibilityOrigin | undefined {
+  ): ModuleBinding | undefined {
     if (bindings.length > 1) {
       throw new Error(
         `Ambiguous export ${file}:${symbol}; conflicting sources: ${bindings
@@ -272,15 +272,19 @@ class ModuleGraph {
           .join(", ")}`,
       );
     }
-    return bindings[0]?.origin;
+    return bindings[0];
+  }
+
+  binding(file: string, symbol: string): ModuleBinding | undefined {
+    return this.singleBinding(file, symbol, this.resolveExport(file, symbol));
   }
 
   origin(file: string, symbol: string): UpdateCompatibilityOrigin | undefined {
-    return this.sourceOrigin(file, symbol, this.resolveExport(file, symbol));
+    return this.binding(file, symbol)?.origin;
   }
 
   localOrigin(file: string, symbol: string): UpdateCompatibilityOrigin | undefined {
-    return this.sourceOrigin(file, symbol, this.resolveLocal(file, symbol, new Set()));
+    return this.singleBinding(file, symbol, this.resolveLocal(file, symbol, new Set()))?.origin;
   }
 }
 
@@ -618,10 +622,15 @@ export function writeUpdateCompatibilityChunks(params: {
     }
   }
   const ownerModules = new Set([...origins.values()].map((origin) => origin.module));
-  const candidates = new Map<string, Array<{ file: string; exported: string }>>();
+  const candidates = new Map<string, Map<string, { file: string; exported: string }>>();
   for (const file of moduleFiles(distDir)) {
     const relative = portable(path.relative(distDir, file));
-    if (relative.startsWith("extensions/") || relative.startsWith("plugin-sdk/")) {
+    // Retained config repairs are built separately from the updater's runtime graph.
+    if (
+      relative.startsWith("extensions/") ||
+      relative.startsWith("plugin-sdk/") ||
+      relative.startsWith("config-doctor/")
+    ) {
       continue;
     }
     const source = fs.readFileSync(file, "utf8");
@@ -634,13 +643,19 @@ export function writeUpdateCompatibilityChunks(params: {
       continue;
     }
     for (const exported of graph.names(file)) {
-      const origin = graph.origin(file, exported);
-      if (!origin) {
+      const binding = graph.binding(file, exported);
+      const origin = binding?.origin;
+      if (!binding || !origin) {
         continue;
       }
       const key = `${origin.module}:${origin.symbol}`;
-      const matches = candidates.get(key) ?? [];
-      matches.push({ file: relative, exported });
+      const matches = candidates.get(key) ?? new Map<string, { file: string; exported: string }>();
+      const bindingKey = `${binding.file}:${binding.symbol}`;
+      const previous = matches.get(bindingKey);
+      // Prefer the declaration's own export; sorted files/names break alias ties.
+      if (!previous || (file === binding.file && previous.file !== relative)) {
+        matches.set(bindingKey, { file: relative, exported });
+      }
       candidates.set(key, matches);
     }
   }
@@ -678,7 +693,7 @@ export function writeUpdateCompatibilityChunks(params: {
     const lines = [UPDATE_COMPATIBILITY_CHUNK_HEADER];
     for (const entry of chunk.exports) {
       const origin = origins.get(`${entry.origin.module}:${entry.origin.symbol}`)!;
-      const matches = candidates.get(`${origin.module}:${origin.symbol}`) ?? [];
+      const matches = [...(candidates.get(`${origin.module}:${origin.symbol}`)?.values() ?? [])];
       const match = matches[0];
       if (matches.length !== 1 || !match) {
         throw new Error(

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -1759,6 +1759,59 @@ describe("previous release update compatibility", () => {
     expect(loaded.mode()).toBe("npm");
   });
 
+  it.each([
+    'import { y as mode } from "../current.mjs"; export { mode as forwarded };',
+    'export { y as forwarded } from "../current.mjs";',
+    'export * from "../current.mjs";',
+  ])("bridges shared declaration bindings through %s", async (forwarding) => {
+    const inventory = recordFixture();
+    const root = createTempDir("update-compat-shared-binding-");
+    candidate(root);
+    fsSync.appendFileSync(path.join(root, "dist/current.mjs"), "\nexport { resolveMode as z };\n");
+    write(
+      root,
+      "dist/a-facade/forward.mjs",
+      `//#region src/cli/update-cli/mode.ts\n${forwarding}\n`,
+    );
+    const options = { distDir: path.join(root, "dist"), sourceDir: root, inventory };
+    writeUpdateCompatibilityChunks(options);
+    const bridge = path.join(root, "dist/service-abcdefgh.js");
+    const contents = fsSync.readFileSync(bridge, "utf8");
+    expect(contents).toContain('export { y as mode } from "./current.mjs";');
+    writeUpdateCompatibilityChunks(options);
+    expect(fsSync.readFileSync(bridge, "utf8")).toBe(contents);
+    const loaded = await import(pathToFileURL(bridge).href);
+    const current = await import(pathToFileURL(path.join(root, "dist/current.mjs")).href);
+    expect(loaded.mode).toBe(current.y);
+    expect(loaded.mode()).toBe("npm");
+    expect(loaded.runner).toBe(current.x);
+  });
+
+  it.each(["present", "missing"])(
+    "excludes the isolated config-doctor graph when the runtime binding is %s",
+    async (runtime) => {
+      const inventory = recordFixture();
+      const root = createTempDir("update-compat-isolated-graph-");
+      candidate(root);
+      const current = path.join(root, "dist/current.mjs");
+      write(root, "dist/config-doctor/inspect.mjs", fsSync.readFileSync(current, "utf8"));
+      const options = { distDir: path.join(root, "dist"), sourceDir: root, inventory };
+      if (runtime === "missing") {
+        fsSync.unlinkSync(current);
+        expect(() => writeUpdateCompatibilityChunks(options)).toThrow(
+          /no equivalent current export/,
+        );
+        expect(fsSync.existsSync(path.join(root, "dist/service-abcdefgh.js"))).toBe(false);
+        return;
+      }
+      writeUpdateCompatibilityChunks(options);
+      const bridge = await import(pathToFileURL(path.join(root, "dist/service-abcdefgh.js")).href);
+      const declaration = await import(pathToFileURL(current).href);
+      expect(bridge.mode).toBe(declaration.y);
+      expect(bridge.runner).toBe(declaration.x);
+    },
+  );
+
   it.each(["missing", "ambiguous"])(
     "refuses %s required implementations before writing bridges",
     (failure) => {


### PR DESCRIPTION
Refs #142195

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled through this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where building an update-compatible package can fail with `ambiguous current exports` when multiple chunk exports identify the same declaration, or an isolated config-doctor build also emits an updater dependency. The reported failure involved `findSystemGatewayServices` during canonical Docker packaging.

## Why This Change Was Made

Preserve the module graph's resolved declaration identity when selecting bridges. Aliases of one declaration choose its own chunk, with sorted paths and export names breaking ties. Distinct declarations within the runtime graph still fail before any bridge is written.

Exclude `dist/config-doctor` from bridge candidates because its retained configuration repairs have an explicitly separate build graph in `tsdown.config.ts`. Its copies must neither compete with the updater's runtime nor substitute for a missing runtime implementation. The release guide documents this boundary.

## User Impact

Package builds can preserve old updater imports across harmless alias layouts without redirecting them into isolated configuration-repair artifacts. Runtime behavior, the compatibility inventory, and the supported upgrade window are unchanged.

## Evidence

- Five new regression cases fail against the original owner code at base `47918f787d845c1901887626e3cff14c245253e0`: imported/exported/star-forwarded shared bindings, an isolated config-doctor duplicate, and a missing runtime binding that previously selected the isolated copy.
- `node scripts/run-vitest.mjs test/scripts/runtime-postbuild.test.ts test/scripts/update-first-hop-package-fixtures.test.ts test/scripts/upgrade-survivor-first-hop.test.ts test/scripts/openclaw-live-updater.test.ts test/vitest-ui-e2e-prebuilt.test.ts`: **203 passed**, including existing distinct-binding rejection and first-hop fixture coverage.
- Canonical packaging of git archives of that base plus this change passed on **Node 24.20.0** and **Node 26.8.1**:
  ```sh
  node scripts/package-openclaw-for-docker.mjs --source-dir "$SOURCE" --output-dir "$OUTPUT" --allow-unreleased-changelog
  ```
  Both runs finished with `OpenClaw package tarball integrity passed.`, including emitted import-graph validation.
- `node scripts/check-changed.mjs` and `git diff --check` passed. Independent Codex reviews before commit and on the committed branch were both clean through P1. Exact-head CI passed for `0d08a7e019e81d5caff198264090fff93abf32e2`: [run 34587228646](https://github.com/openclaw/openclaw/actions/runs/34587228646). `node scripts/watch-pr-ci.mjs 144831 0d08a7e019e81d5caff198264090fff93abf32e2` finished `GREEN` with zero pending checks.

The unmodified current-main archive also packaged successfully on this host. The intermittent full-build layout from the reported failures was **not reproduced**; the new fixtures reproduce the resolver defects directly. A build of reported commit `8ac24c73da8` likewise emitted only the root inspection definition here.

Main CI already reaches the canonical packager indirectly through `docker-seed-e2e` / `published-upgrade-survivor` (`ci.yml`, `scripts/test-docker-all.mts`). Install smoke and release E2E workflows also invoke it directly. The ordinary artifact build uses a different compiler profile. A matching ambiguous layout should fail the packaging lane; this change does not claim the path was absent from CI. No live Gateway update was performed.

### ClawSweeper compatibility-proof follow-up

The September 11 10:22 UTC review reports no correctness findings and requests data-model compatibility proof. Schema migration proof is skipped as inapplicable: this patch changes only build-time bridge candidate selection, with no database schema, inventory format, persistent-store retention/recovery, or supported upgrade-window change. Existing upgrade compatibility proof is the five failing-before/passing-after resolver regressions, the 203 passing compatibility/first-hop tests, and canonical package construction on Node 24.20.0 and 26.8.1, including import-graph and tarball integrity validation. The intermittent full-build layout and a live Gateway update remain unproven as disclosed above.
