### PR TITLE
fix(e2e): avoid suspicious ClawHub install candidates

### DIFF
--- a/scripts/e2e/lib/skills/clawhub-install-proof.sh
+++ b/scripts/e2e/lib/skills/clawhub-install-proof.sh
@@ -79,6 +79,9 @@ const [searchPath, resolvePath, requestedSlug, preferredSlug] = process.argv.sli
 const payload = JSON.parse(fs.readFileSync(searchPath, "utf8"));
 const results = Array.isArray(payload) ? payload : Array.isArray(payload.results) ? payload.results : [];
 const slugs = results.map((entry) => String(entry.slug ?? "")).filter(Boolean);
+const hasExplicitRisk = (entry) =>
+  String(entry?.trust?.clawHubVerdict ?? "").toLowerCase() === "suspicious" ||
+  entry?.native?.skill?.isSuspicious === true;
 let chosen;
 if (requestedSlug) {
   chosen = results.find((entry) => entry.slug === requestedSlug);
@@ -86,24 +89,27 @@ if (requestedSlug) {
     throw new Error(`Requested skill slug ${requestedSlug} not found. Search returned: ${slugs.join(", ") || "(none)"}`);
   }
 } else {
+  const safeResults = results.filter((entry) => !hasExplicitRisk(entry));
   chosen =
-    results.find((entry) => entry.slug === preferredSlug) ??
-    results.find((entry) => String(entry.slug ?? "").includes("homeassistant")) ??
-    results[0];
+    safeResults.find((entry) => entry.slug === preferredSlug) ??
+    safeResults.find((entry) => String(entry.slug ?? "").includes("homeassistant")) ??
+    safeResults[0];
 }
 if (!chosen?.slug) {
-  throw new Error(`No installable skill slug found. Search returned: ${slugs.join(", ") || "(none)"}`);
+  throw new Error(`No non-suspicious skill slug found. Search returned: ${slugs.join(", ") || "(none)"}`);
 }
 fs.writeFileSync(resolvePath, `${JSON.stringify({
   slug: chosen.slug,
+  installRef: chosen.installRef ?? chosen.slug,
   version: chosen.version ?? null,
   displayName: chosen.displayName ?? chosen.name ?? chosen.slug,
 })}\n`);
 NODE
 
 slug="$(node -e 'process.stdout.write(JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).slug)' "$resolve_json")"
+install_ref="$(node -e 'process.stdout.write(JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).installRef)' "$resolve_json")"
 echo "Installing live ClawHub skill: $slug"
-if ! "${OPENCLAW_CMD[@]}" skills install "$slug" --force >"$install_log" 2>&1; then
+if ! "${OPENCLAW_CMD[@]}" skills install "$install_ref" --force >"$install_log" 2>&1; then
   echo "Skill install failed" >&2
   openclaw_e2e_dump_logs /tmp/openclaw-skill-install-npm.log "$search_json" "$resolve_json" "$install_log"
   exit 1

--- a/test/scripts/e2e-shell-tempfiles.test.ts
+++ b/test/scripts/e2e-shell-tempfiles.test.ts
@@ -40,6 +40,22 @@ async function extractClawhubSkillInstallVerifier(): Promise<string> {
   return script.slice(verifierStart, verifierEnd);
 }
 
+async function extractClawhubSkillInstallSelector(): Promise<string> {
+  const script = await readFile("scripts/e2e/lib/skills/clawhub-install-proof.sh", "utf8");
+  const marker =
+    'node --input-type=module - "$search_json" "$resolve_json" "$requested_slug" "$preferred_slug" <<\'NODE\'\n';
+  const start = script.indexOf(marker);
+  if (start === -1) {
+    throw new Error("ClawHub skill install selector heredoc was not found");
+  }
+  const selectorStart = start + marker.length;
+  const selectorEnd = script.indexOf("\nNODE", selectorStart);
+  if (selectorEnd === -1) {
+    throw new Error("ClawHub skill install selector heredoc was not terminated");
+  }
+  return script.slice(selectorStart, selectorEnd);
+}
+
 describe("e2e shell tempfile hygiene", () => {
   it("does not allocate FIFO paths with mktemp -u", async () => {
     const offenders: string[] = [];
@@ -303,6 +319,58 @@ exit 42
       expect(
         scratchEntries.filter((entry) => entry.startsWith("openclaw-skill-install-home.")),
       ).toEqual([]);
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("selects a non-suspicious ClawHub search result without weakening explicit requests", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "openclaw-clawhub-select-test-"));
+    const searchPath = path.join(tempRoot, "search.json");
+    const resolvePath = path.join(tempRoot, "resolved.json");
+    const selector = await extractClawhubSkillInstallSelector();
+    await writeFile(
+      searchPath,
+      `${JSON.stringify({
+        results: [
+          {
+            installRef: "@owner/risky",
+            native: { skill: { isSuspicious: true } },
+            slug: "preferred",
+            trust: { clawHubVerdict: "suspicious" },
+          },
+          {
+            installRef: "@owner/safe",
+            native: { skill: { isSuspicious: false } },
+            slug: "homeassistant-safe",
+            trust: { clawHubVerdict: null, installability: "installable" },
+          },
+        ],
+      })}\n`,
+    );
+
+    try {
+      const defaultResult = spawnSync(
+        process.execPath,
+        ["--input-type=module", "-", searchPath, resolvePath, "", "preferred"],
+        { encoding: "utf8", input: selector },
+      );
+      expect(defaultResult.status, defaultResult.stderr).toBe(0);
+      expect(JSON.parse(await readFile(resolvePath, "utf8"))).toMatchObject({
+        installRef: "@owner/safe",
+        slug: "homeassistant-safe",
+      });
+
+      const explicitResult = spawnSync(
+        process.execPath,
+        ["--input-type=module", "-", searchPath, resolvePath, "preferred", "preferred"],
+        { encoding: "utf8", input: selector },
+      );
+      expect(explicitResult.status, explicitResult.stderr).toBe(0);
+      expect(JSON.parse(await readFile(resolvePath, "utf8"))).toMatchObject({
+        installRef: "@owner/risky",
+        slug: "preferred",
+      });
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary

- reject ClawHub search candidates explicitly marked suspicious by either trust surface
- preserve explicit requested-slug behavior while choosing a safe default candidate
- install the exact search result reference and cover moving-verdict selection

## Validation

- `pnpm exec vitest run test/scripts/e2e-shell-tempfiles.test.ts --config vitest.config.ts`
- `pnpm test:docker:skill-install`
- `pnpm check:test-types`
- `pnpm lint`
- `pnpm format:check`

Release validation root: the unattended Docker skill-install proof selected `homeassistant-skill` after its ClawHub verdict moved to suspicious, so the production installer correctly refused it.
