### PR TITLE
fix(telegram): preserve mixed text order and pending stop

### DIFF
--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -51,6 +51,7 @@ Rapid consecutive text messages from the same sender can be batched into one age
 
 - Debounce applies to text-only messages; media/attachments flush immediately.
 - Control commands (stop/abort/status, etc.) bypass debouncing so they dispatch immediately.
+- For non-forwarded Telegram text, a near-limit fragment starts a separate batch and flushes earlier ordinary text from the same sender and conversation. This preserves order without merging the two batches.
 - Disabled by default: `messages.inbound.debounceMs` has no built-in default, so debouncing only activates once you set it (globally or per channel).
 - iMessage follows the same generic debounce policy. `imsg` 0.13.1 and newer coalesces Apple URL-preview split-sends before OpenClaw receives them, so no iMessage-specific debounce setting is needed.
 

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -32,7 +32,7 @@ import { getOrCreateAccountThrottler } from "./account-throttler.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
-import { registerTelegramHandlers } from "./bot-handlers.runtime.js";
+import { createTelegramHandlers } from "./bot-handlers.runtime.js";
 import {
   createTelegramMessageProcessor,
   resolveTelegramMessageTurnSettings,
@@ -408,26 +408,7 @@ export function createTelegramBotCore(
     telegramDeps,
   });
 
-  const nativeCommandCallbackDispatcher = registerTelegramNativeCommands({
-    bot,
-    cfg,
-    runtime,
-    accountId: account.accountId,
-    telegramCfg,
-    mediaMaxBytes,
-    nativeEnabled,
-    nativeSkillsEnabled,
-    resolveGroupPolicy,
-    resolveTelegramGroupConfig,
-    shouldSkipUpdate,
-    opts: runtimeOpts,
-    telegramDeps: {
-      ...telegramDeps,
-      sendMessageTelegram: defaultTelegramNativeCommandDeps.sendMessageTelegram,
-    },
-  });
-
-  registerTelegramHandlers({
+  const handlers = createTelegramHandlers({
     cfg,
     accountId: account.accountId,
     ownerAgentId,
@@ -464,8 +445,29 @@ export function createTelegramBotCore(
       ),
     logger,
     telegramDeps,
-    nativeCommandCallbackDispatcher,
   });
+
+  const nativeCommandCallbackDispatcher = registerTelegramNativeCommands({
+    cancelPendingInbound: handlers.cancelPending,
+    bot,
+    cfg,
+    runtime,
+    accountId: account.accountId,
+    telegramCfg,
+    mediaMaxBytes,
+    nativeEnabled,
+    nativeSkillsEnabled,
+    resolveGroupPolicy,
+    resolveTelegramGroupConfig,
+    shouldSkipUpdate,
+    opts: runtimeOpts,
+    telegramDeps: {
+      ...telegramDeps,
+      sendMessageTelegram: defaultTelegramNativeCommandDeps.sendMessageTelegram,
+    },
+  });
+
+  handlers.register(nativeCommandCallbackDispatcher);
 
   const originalStop = bot.stop.bind(bot);
   bot.stop = ((...args: Parameters<typeof originalStop>) => {

--- a/extensions/telegram/src/bot-handlers.inbound-buffer.provenance.test.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-buffer.provenance.test.ts
@@ -43,6 +43,7 @@ describe("Telegram inbound provenance buffering", () => {
       } as unknown as TelegramMessagePipeline;
       const { inboundDebouncer } = createTelegramInboundBuffers({
         params: {
+          accountId: "default",
           cfg,
           bot: { api: { sendMessage: vi.fn() } } as never,
           runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },

--- a/extensions/telegram/src/bot-handlers.inbound-buffer.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-buffer.ts
@@ -12,7 +12,10 @@ import {
   buildTelegramInboundDebounceKey,
 } from "./bot-handlers.debounce-key.js";
 import type { TelegramMessagePipeline } from "./bot-handlers.message-pipeline.js";
-import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
+import type {
+  RegisterTelegramHandlerParams,
+  TelegramPendingInboundTarget,
+} from "./bot-handlers.types.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type {
   TelegramAmbientTranscriptWatermark,
@@ -76,12 +79,6 @@ type TelegramTextFragmentInput = {
   promptContextAmbientWatermark?: TelegramAmbientTranscriptWatermark;
   dispatchDedupeClaims: TelegramMessageDispatchReplayClaim[];
   channelIngressResolver: TelegramChannelIngressResolver;
-};
-
-export type TelegramPendingInboundTarget = {
-  chatId: number;
-  threadSpec: TelegramThreadSpec;
-  senderId: string;
 };
 
 interface TelegramInboundBuffers {

--- a/extensions/telegram/src/bot-handlers.inbound-buffer.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-buffer.ts
@@ -72,14 +72,20 @@ type TelegramTextFragmentInput = {
   threadSpec: TelegramThreadSpec;
   storeAllowFrom: string[];
   isAbortControlMessage: boolean;
-  isAuthorizedAbortControlMessage: () => Promise<boolean>;
   promptContextMinTimestampMs?: number;
   promptContextAmbientWatermark?: TelegramAmbientTranscriptWatermark;
   dispatchDedupeClaims: TelegramMessageDispatchReplayClaim[];
   channelIngressResolver: TelegramChannelIngressResolver;
 };
 
+export type TelegramPendingInboundTarget = {
+  chatId: number;
+  threadSpec: TelegramThreadSpec;
+  senderId: string;
+};
+
 interface TelegramInboundBuffers {
+  cancelPending: (target: TelegramPendingInboundTarget) => void;
   inboundDebouncer: {
     enqueue: (entry: TelegramDebounceEntry) => Promise<void>;
     flushKey: (key: string) => Promise<void>;
@@ -423,6 +429,21 @@ export function createTelegramInboundBuffers({
     }
     entry.timer = setTimeout(() => releaseTextFragments(entry), maxGapMs);
   };
+  const cancelPending = ({ chatId, threadSpec, senderId }: TelegramPendingInboundTarget) => {
+    if (!senderId) {
+      return;
+    }
+    const key = `text:${chatId}:${threadSpec.scope}:${threadSpec.id ?? "main"}:${senderId}`;
+    for (const entry of pendingTextFragments.get(key) ?? []) {
+      cancelTextFragments(entry);
+    }
+    const conversationKey = buildTelegramInboundDebounceConversationKey({ chatId, threadSpec });
+    for (const debounceLane of ["default", "forward"] as const) {
+      inboundDebouncer.cancelKey(
+        buildTelegramInboundDebounceKey({ accountId, conversationKey, senderId, debounceLane }),
+      );
+    }
+  };
   const handleTextFragment = async (params: TelegramTextFragmentInput): Promise<boolean> => {
     const text = typeof params.msg.text === "string" ? params.msg.text : undefined;
     const isCommand = getTelegramTextParts(params.msg).entities.some(
@@ -533,19 +554,12 @@ export function createTelegramInboundBuffers({
           });
         return true;
       }
-    } else if (
-      text &&
-      params.isAbortControlMessage &&
-      (await params.isAuthorizedAbortControlMessage())
-    ) {
-      for (const entry of pendingTextFragments.get(key) ?? []) {
-        cancelTextFragments(entry);
-      }
     }
     return false;
   };
 
   return {
+    cancelPending,
     inboundDebouncer,
     resolveTelegramDebounceEntryMs,
     shouldDebounceTelegramEntry,

--- a/extensions/telegram/src/bot-handlers.inbound-buffer.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-buffer.ts
@@ -5,9 +5,12 @@ import {
   resolveInboundDebounceMs,
 } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { createRuntimeConfigReader } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import {
+  buildTelegramInboundDebounceConversationKey,
+  buildTelegramInboundDebounceKey,
+} from "./bot-handlers.debounce-key.js";
 import type { TelegramMessagePipeline } from "./bot-handlers.message-pipeline.js";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
@@ -42,6 +45,7 @@ export type TelegramDebounceEntry = {
   dispatchDedupeClaims: TelegramMessageDispatchReplayClaim[];
   spooledReplayParticipant?: TelegramSpooledReplayDeferredParticipant;
   channelIngressResolvers: readonly TelegramChannelIngressResolver[];
+  textFragment?: TextFragmentEntry;
 };
 
 type TextFragmentEntry = {
@@ -54,7 +58,11 @@ type TextFragmentEntry = {
   dispatchDedupeClaims: TelegramMessageDispatchReplayClaim[];
   spooledReplayParticipants: TelegramSpooledReplayDeferredParticipant[];
   channelIngressResolvers: TelegramChannelIngressResolver[];
-  timer: ReturnType<typeof setTimeout>;
+  timer: ReturnType<typeof setTimeout> | null;
+  ready: Promise<void>;
+  releaseReady: () => void;
+  completion: Promise<void>;
+  canceled: boolean;
 };
 
 type TelegramTextFragmentInput = {
@@ -85,10 +93,10 @@ interface TelegramInboundBuffers {
 }
 
 export function createTelegramInboundBuffers({
-  params: { cfg, bot, runtime, opts },
+  params: { cfg, accountId, bot, runtime, opts },
   message,
 }: {
-  params: Pick<RegisterTelegramHandlerParams, "cfg" | "bot" | "runtime" | "opts">;
+  params: Pick<RegisterTelegramHandlerParams, "cfg" | "accountId" | "bot" | "runtime" | "opts">;
   message: TelegramMessagePipeline;
 }): TelegramInboundBuffers {
   const {
@@ -113,6 +121,9 @@ export function createTelegramInboundBuffers({
   const resolveTelegramDebounceEntryMs = (entry: TelegramDebounceEntry): number =>
     entry.debounceLane === "forward" ? FORWARD_BURST_DEBOUNCE_MS : resolveDebounceMs();
   const shouldDebounceTelegramEntry = (entry: TelegramDebounceEntry): boolean => {
+    if (entry.textFragment) {
+      return false;
+    }
     const hasDebounceableText = shouldDebounceTextInbound({
       text: getTelegramTextParts(entry.msg).text,
       cfg,
@@ -146,6 +157,16 @@ export function createTelegramInboundBuffers({
     buildKey: (entry) => entry.debounceKey,
     shouldDebounce: shouldDebounceTelegramEntry,
     onFlush: (entries) => {
+      const fragment = entries[0]?.textFragment;
+      if (fragment) {
+        const completion = (async () => {
+          await fragment.ready;
+          if (!fragment.canceled) {
+            await flushTextFragments(fragment);
+          }
+        })();
+        return { admission: completion, completion };
+      }
       const completion = (async () => {
         const participants = entries
           .map((entry) => entry.spooledReplayParticipant)
@@ -245,6 +266,11 @@ export function createTelegramInboundBuffers({
       return { admission: completion, completion };
     },
     onError: (error, items) => {
+      const fragment = items[0]?.textFragment;
+      if (fragment) {
+        failTextFragments(fragment, error);
+        return;
+      }
       const participants = items
         .map((item) => item.spooledReplayParticipant)
         .filter(
@@ -271,6 +297,11 @@ export function createTelegramInboundBuffers({
       }
     },
     onCancel: (items) => {
+      const fragment = items[0]?.textFragment;
+      if (fragment) {
+        cancelTextFragments(fragment);
+        return;
+      }
       releaseDispatchDedupeClaims(
         mergeDispatchDedupeClaims(...items.map((item) => item.dispatchDedupeClaims)),
       );
@@ -292,9 +323,50 @@ export function createTelegramInboundBuffers({
       ? Math.max(10, Math.floor(opts.testTimings.textFragmentGapMs))
       : 1500;
   const textBuffer = new Map<string, TextFragmentEntry>();
-  const textQueue = new KeyedAsyncQueue();
+  const pendingTextFragments = new Map<string, Set<TextFragmentEntry>>();
+
+  const untrackTextFragments = (entry: TextFragmentEntry) => {
+    const pending = pendingTextFragments.get(entry.key);
+    pending?.delete(entry);
+    if (pending?.size === 0) {
+      pendingTextFragments.delete(entry.key);
+    }
+  };
+
+  const releaseTextFragments = (entry: TextFragmentEntry) => {
+    if (textBuffer.get(entry.key) === entry) {
+      textBuffer.delete(entry.key);
+    }
+    if (entry.timer) {
+      clearTimeout(entry.timer);
+      entry.timer = null;
+    }
+    entry.releaseReady();
+  };
+  const cancelTextFragments = (entry: TextFragmentEntry) => {
+    if (entry.canceled) {
+      return;
+    }
+    entry.canceled = true;
+    untrackTextFragments(entry);
+    releaseTextFragments(entry);
+    releaseDispatchDedupeClaims(entry.dispatchDedupeClaims);
+    settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
+  };
+  const failTextFragments = (entry: TextFragmentEntry, error: unknown) => {
+    untrackTextFragments(entry);
+    releaseTextFragments(entry);
+    releaseDispatchDedupeClaims(entry.dispatchDedupeClaims, error);
+    settleSpooledReplayParticipants(
+      entry.spooledReplayParticipants,
+      buildFailedProcessingResult(error),
+    );
+    runtime.error?.(danger(`text fragment handler failed: ${String(error)}`));
+  };
 
   const flushTextFragments = async (entry: TextFragmentEntry) => {
+    // Timer expiry seals collection; only processing releases cancellation ownership.
+    untrackTextFragments(entry);
     try {
       entry.messages.sort((a, b) => a.msg.message_id - b.msg.message_id);
       const bufferedMessages = entry.messages.map((bufferedMessage) => bufferedMessage.msg);
@@ -342,26 +414,14 @@ export function createTelegramInboundBuffers({
       });
       settleSpooledReplayParticipants(entry.spooledReplayParticipants, result);
     } catch (error) {
-      releaseDispatchDedupeClaims(entry.dispatchDedupeClaims, error);
-      settleSpooledReplayParticipants(
-        entry.spooledReplayParticipants,
-        buildFailedProcessingResult(error),
-      );
-      runtime.error?.(danger(`text fragment handler failed: ${String(error)}`));
+      failTextFragments(entry, error);
     }
   };
-  const queueTextFlush = async (entry: TextFragmentEntry) => {
-    await textQueue.enqueue(entry.key, async () => {
-      await flushTextFragments(entry).catch(() => undefined);
-    });
-  };
-  const runTextFlush = async (entry: TextFragmentEntry) => {
-    textBuffer.delete(entry.key);
-    await queueTextFlush(entry);
-  };
   const scheduleTextFlush = (entry: TextFragmentEntry) => {
-    clearTimeout(entry.timer);
-    entry.timer = setTimeout(() => void runTextFlush(entry), maxGapMs);
+    if (entry.timer) {
+      clearTimeout(entry.timer);
+    }
+    entry.timer = setTimeout(() => releaseTextFragments(entry), maxGapMs);
   };
   const handleTextFragment = async (params: TelegramTextFragmentInput): Promise<boolean> => {
     const text = typeof params.msg.text === "string" ? params.msg.text : undefined;
@@ -407,14 +467,21 @@ export function createTelegramInboundBuffers({
           scheduleTextFlush(existing);
           return true;
         }
-        clearTimeout(existing.timer);
-        textBuffer.delete(key);
-        await queueTextFlush(existing);
+        releaseTextFragments(existing);
+        await existing.completion;
       }
       if (text.length >= 4000) {
         const participant = createSpooledReplayParticipantForBufferedWork(
           `text-fragment:${key}:${params.msg.message_id}`,
         );
+        let releaseReady!: () => void;
+        const ready = new Promise<void>((resolve) => {
+          releaseReady = resolve;
+        });
+        let resolveCompletion!: () => void;
+        const completion = new Promise<void>((resolve) => {
+          resolveCompletion = resolve;
+        });
         const entry: TextFragmentEntry = {
           key,
           storeAllowFrom: params.storeAllowFrom,
@@ -427,10 +494,43 @@ export function createTelegramInboundBuffers({
             params.promptContextMinTimestampMs,
             params.promptContextAmbientWatermark,
           ),
-          timer: setTimeout(() => {}, maxGapMs),
+          timer: null,
+          ready,
+          releaseReady,
+          completion,
+          canceled: false,
         };
         textBuffer.set(key, entry);
+        const pending = pendingTextFragments.get(key) ?? new Set<TextFragmentEntry>();
+        pending.add(entry);
+        pendingTextFragments.set(key, pending);
         scheduleTextFlush(entry);
+        const debounceLane = resolveTelegramDebounceLane(params.msg);
+        // Reserve on the first fragment, while later updates can still append.
+        // The existing immediate boundary seals earlier ordinary text separately.
+        void inboundDebouncer
+          .enqueue({
+            ctx: params.ctx,
+            msg: params.msg,
+            allMedia: [],
+            storeAllowFrom: params.storeAllowFrom,
+            receivedAtMs: nowMs,
+            debounceKey: buildTelegramInboundDebounceKey({
+              accountId,
+              conversationKey: buildTelegramInboundDebounceConversationKey(params),
+              senderId,
+              debounceLane,
+            }),
+            debounceLane,
+            threadSpec: params.threadSpec,
+            dispatchDedupeClaims: params.dispatchDedupeClaims,
+            channelIngressResolvers: [params.channelIngressResolver],
+            textFragment: entry,
+          })
+          .then(resolveCompletion, (error: unknown) => {
+            failTextFragments(entry, error);
+            resolveCompletion();
+          });
         return true;
       }
     } else if (
@@ -438,12 +538,8 @@ export function createTelegramInboundBuffers({
       params.isAbortControlMessage &&
       (await params.isAuthorizedAbortControlMessage())
     ) {
-      const existing = textBuffer.get(key);
-      if (existing) {
-        clearTimeout(existing.timer);
-        textBuffer.delete(key);
-        releaseDispatchDedupeClaims(existing.dispatchDedupeClaims);
-        settleSpooledReplayParticipants(existing.spooledReplayParticipants, { kind: "skipped" });
+      for (const entry of pendingTextFragments.get(key) ?? []) {
+        cancelTextFragments(entry);
       }
     }
     return false;

--- a/extensions/telegram/src/bot-handlers.inbound-pipeline.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-pipeline.ts
@@ -397,13 +397,10 @@ export function createTelegramInboundPipeline({
   message: TelegramMessagePipeline;
   authorization: TelegramHandlerAuthorization;
 }): TelegramInboundPipeline {
-  const handlers = createTelegramInboundHandlers(
-    params,
-    message,
-    authorization,
-    createTelegramInboundProcessing({ params, message }),
-  );
+  const processing = createTelegramInboundProcessing({ params, message });
+  const handlers = createTelegramInboundHandlers(params, message, authorization, processing);
   return {
+    cancelPending: processing.cancelPending,
     handle: async (ctx) => {
       if (ctx.message) {
         return await handlers.handleMessage(ctx);
@@ -427,7 +424,7 @@ export function registerTelegramInboundHandlers({
   pipeline,
 }: {
   bot: RegisterTelegramHandlerParams["bot"];
-  pipeline: TelegramInboundPipeline;
+  pipeline: Pick<TelegramInboundPipeline, "handle">;
 }): void {
   bot.on("message", pipeline.handle);
   bot.on("edited_message", pipeline.handle);

--- a/extensions/telegram/src/bot-handlers.inbound-processing.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.ts
@@ -15,6 +15,7 @@ import {
 import {
   createTelegramInboundBuffers,
   type TelegramDebounceEntry,
+  type TelegramPendingInboundTarget,
 } from "./bot-handlers.inbound-buffer.js";
 import { createTelegramInboundMedia } from "./bot-handlers.inbound-media.js";
 import {
@@ -48,6 +49,7 @@ import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
 
 export interface TelegramInboundProcessing {
+  cancelPending: (target: TelegramPendingInboundTarget) => void;
   processInboundMessage: (params: TelegramInboundMessage) => Promise<TelegramInboundDisposition>;
 }
 
@@ -99,6 +101,7 @@ export function createTelegramInboundProcessing({
     createSpooledReplayParticipantForBufferedWork,
   } = message;
   const {
+    cancelPending,
     inboundDebouncer,
     resolveTelegramDebounceEntryMs,
     shouldDebounceTelegramEntry,
@@ -177,6 +180,10 @@ export function createTelegramInboundProcessing({
       return abortControlAuthorized;
     };
 
+    if (await isAuthorizedAbortControlMessage()) {
+      cancelPending({ chatId, threadSpec, senderId });
+    }
+
     if (
       await handleTextFragment({
         ctx,
@@ -185,7 +192,6 @@ export function createTelegramInboundProcessing({
         threadSpec,
         storeAllowFrom,
         isAbortControlMessage,
-        isAuthorizedAbortControlMessage,
         promptContextMinTimestampMs,
         promptContextAmbientWatermark,
         dispatchDedupeClaims,
@@ -342,18 +348,6 @@ export function createTelegramInboundProcessing({
           debounceLane,
         })
       : null;
-    if (senderId && (await isAuthorizedAbortControlMessage())) {
-      for (const lane of ["default", "forward"] as const) {
-        inboundDebouncer.cancelKey(
-          buildTelegramInboundDebounceKey({
-            accountId,
-            conversationKey,
-            senderId,
-            debounceLane: lane,
-          }),
-        );
-      }
-    }
     const debounceEntry: TelegramDebounceEntry = {
       ctx,
       msg,
@@ -382,5 +376,5 @@ export function createTelegramInboundProcessing({
     return shouldBufferDebounce ? { kind: "buffered", buffer: "debounce" } : { kind: "processed" };
   };
 
-  return { processInboundMessage };
+  return { processInboundMessage, cancelPending };
 }

--- a/extensions/telegram/src/bot-handlers.inbound-processing.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.ts
@@ -104,7 +104,7 @@ export function createTelegramInboundProcessing({
     shouldDebounceTelegramEntry,
     resolveTelegramDebounceLane,
     handleTextFragment,
-  } = createTelegramInboundBuffers({ params: { cfg, bot, runtime, opts }, message });
+  } = createTelegramInboundBuffers({ params: { cfg, accountId, bot, runtime, opts }, message });
 
   const { handleMediaGroup, resolveUnaddressedGroupMediaDisposition } = createTelegramInboundMedia({
     params: {

--- a/extensions/telegram/src/bot-handlers.inbound-processing.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.ts
@@ -15,7 +15,6 @@ import {
 import {
   createTelegramInboundBuffers,
   type TelegramDebounceEntry,
-  type TelegramPendingInboundTarget,
 } from "./bot-handlers.inbound-buffer.js";
 import { createTelegramInboundMedia } from "./bot-handlers.inbound-media.js";
 import {
@@ -27,6 +26,7 @@ import type { TelegramMessagePipeline } from "./bot-handlers.message-pipeline.js
 import type {
   RegisterTelegramHandlerParams,
   TelegramInboundDisposition,
+  TelegramPendingInboundTarget,
 } from "./bot-handlers.types.js";
 import type {
   TelegramAmbientTranscriptWatermark,

--- a/extensions/telegram/src/bot-handlers.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.test.ts
@@ -3,10 +3,10 @@ import { Bot } from "grammy";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import { describe, expect, it, vi } from "vitest";
 import { defaultTelegramBotDeps } from "./bot-deps.js";
-import { registerTelegramHandlers } from "./bot-handlers.runtime.js";
+import { createTelegramHandlers } from "./bot-handlers.runtime.js";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
 
-describe("registerTelegramHandlers", () => {
+describe("createTelegramHandlers", () => {
   it("registers middleware in transport order", () => {
     const bot = new Bot("123456:handler-registration-test");
     const on = vi.spyOn(bot, "on");
@@ -29,7 +29,7 @@ describe("registerTelegramHandlers", () => {
       logger: getChildLogger({ module: "telegram/handler-registration-test" }),
     };
 
-    registerTelegramHandlers(params);
+    createTelegramHandlers(params).register();
 
     expect(on.mock.calls.map(([trigger]) => trigger)).toEqual([
       "my_chat_member",

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -6,27 +6,40 @@ import {
   registerTelegramInboundHandlers,
 } from "./bot-handlers.inbound-pipeline.js";
 import { createTelegramMessagePipeline } from "./bot-handlers.message-pipeline.js";
-import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
+import type {
+  RegisterTelegramHandlerParams,
+  TelegramNativeCommandCallbackDispatcher,
+} from "./bot-handlers.types.js";
 
-export const registerTelegramHandlers = (params: RegisterTelegramHandlerParams) => {
+export const createTelegramHandlers = (
+  params: Omit<RegisterTelegramHandlerParams, "nativeCommandCallbackDispatcher">,
+) => {
   const message = createTelegramMessagePipeline(params);
   const authorization = createTelegramHandlerAuthorization(params);
   const inboundPipeline = createTelegramInboundPipeline({ params, message, authorization });
-  const callbackRouter = createTelegramCallbackRouter({ params, message, authorization });
-  const eventBindings = createTelegramEventBindings({
-    params,
-    message,
-    authorization,
-    registerMessages: () =>
-      registerTelegramInboundHandlers({ bot: params.bot, pipeline: inboundPipeline }),
-  });
-
-  eventBindings.registerChatMembership();
-  eventBindings.registerReaction();
-  eventBindings.registerPolls();
-  params.bot.on("callback_query", async (ctx) => {
-    await callbackRouter.route(ctx);
-  });
-  eventBindings.registerMigration();
-  eventBindings.registerMessages();
+  return {
+    cancelPending: inboundPipeline.cancelPending,
+    register(nativeCommandCallbackDispatcher?: TelegramNativeCommandCallbackDispatcher) {
+      const callbackRouter = createTelegramCallbackRouter({
+        params: { ...params, nativeCommandCallbackDispatcher },
+        message,
+        authorization,
+      });
+      const eventBindings = createTelegramEventBindings({
+        params,
+        message,
+        authorization,
+        registerMessages: () =>
+          registerTelegramInboundHandlers({ bot: params.bot, pipeline: inboundPipeline }),
+      });
+      eventBindings.registerChatMembership();
+      eventBindings.registerReaction();
+      eventBindings.registerPolls();
+      params.bot.on("callback_query", async (ctx) => {
+        await callbackRouter.route(ctx);
+      });
+      eventBindings.registerMigration();
+      eventBindings.registerMessages();
+    },
+  };
 };

--- a/extensions/telegram/src/bot-handlers.types.ts
+++ b/extensions/telegram/src/bot-handlers.types.ts
@@ -9,7 +9,6 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramBotDeps } from "./bot-deps.js";
-import type { TelegramPendingInboundTarget } from "./bot-handlers.inbound-buffer.js";
 import type {
   TelegramMediaRef,
   TelegramMessageContextOptions,
@@ -24,6 +23,13 @@ import type { TelegramBotOptions } from "./bot.types.js";
 import type { TelegramContext } from "./bot/types.js";
 import type { TelegramTransport } from "./fetch.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
+import type { TelegramThreadSpec } from "./thread-spec.js";
+
+export type TelegramPendingInboundTarget = {
+  chatId: number;
+  threadSpec: TelegramThreadSpec;
+  senderId: string;
+};
 
 export type TelegramMessageProcessorTurnContext = {
   cfg: OpenClawConfig;

--- a/extensions/telegram/src/bot-handlers.types.ts
+++ b/extensions/telegram/src/bot-handlers.types.ts
@@ -9,6 +9,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramBotDeps } from "./bot-deps.js";
+import type { TelegramPendingInboundTarget } from "./bot-handlers.inbound-buffer.js";
 import type {
   TelegramMediaRef,
   TelegramMessageContextOptions,
@@ -106,6 +107,7 @@ export type TelegramInboundDisposition =
   | { kind: "processed" };
 
 export interface TelegramInboundPipeline {
+  cancelPending: (target: TelegramPendingInboundTarget) => void;
   handle: (ctx: Context) => Promise<TelegramInboundDisposition>;
 }
 

--- a/extensions/telegram/src/bot-native-command-builtins.ts
+++ b/extensions/telegram/src/bot-native-command-builtins.ts
@@ -28,7 +28,7 @@ import {
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
-import type { TelegramPendingInboundTarget } from "./bot-handlers.inbound-buffer.js";
+import type { TelegramPendingInboundTarget } from "./bot-handlers.types.js";
 import {
   dispatchTelegramBuiltinTurn,
   prepareTelegramCommandDispatch,

--- a/extensions/telegram/src/bot-native-command-builtins.ts
+++ b/extensions/telegram/src/bot-native-command-builtins.ts
@@ -18,6 +18,7 @@ import {
   resolveStoredModelOverride,
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth-native";
+import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
@@ -27,6 +28,7 @@ import {
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
+import type { TelegramPendingInboundTarget } from "./bot-handlers.inbound-buffer.js";
 import {
   dispatchTelegramBuiltinTurn,
   prepareTelegramCommandDispatch,
@@ -248,12 +250,11 @@ function formatTelegramCommandArgMenuTitle(params: {
 }
 
 export async function executeTelegramBuiltinCommand(
-  params: TelegramCommandExecutorParams & { commandName: string },
+  params: TelegramCommandExecutorParams & {
+    commandName: string;
+    cancelPendingInbound: (target: TelegramPendingInboundTarget) => void;
+  },
 ): Promise<boolean> {
-  const dispatch = await prepareTelegramCommandDispatch({ ...params, requireAuth: true });
-  if (!dispatch) {
-    return false;
-  }
   // Loaded-registry lookup only: Telegram defines no resolveNativeCommandName
   // hook, and the bundled fallback would jiti-load the plugin source in dev/test.
   const commandDefinition = findCommandByNativeName(params.commandName, "telegram", {
@@ -269,6 +270,13 @@ export async function executeTelegramBuiltinCommand(
     : params.rawText
       ? `/${params.commandName} ${params.rawText}`
       : `/${params.commandName}`;
+  const dispatch = await prepareTelegramCommandDispatch(
+    { ...params, requireAuth: true },
+    isAbortRequestText(prompt) ? params.cancelPendingInbound : undefined,
+  );
+  if (!dispatch) {
+    return false;
+  }
   if (commandDefinition?.key === "login") {
     const { executeTelegramLoginCommand } = await loadTelegramLoginCommandExecutor();
     const currentProvider =

--- a/extensions/telegram/src/bot-native-command-dispatch.ts
+++ b/extensions/telegram/src/bot-native-command-dispatch.ts
@@ -21,7 +21,6 @@ import { resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { normalizeDmAllowFromWithStore, resolveTelegramEffectiveDmPolicy } from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
-import type { TelegramPendingInboundTarget } from "./bot-handlers.inbound-buffer.js";
 import type { TelegramResolvedGroupConfig } from "./bot-handlers.types.js";
 import { resolveTelegramMessageTurnSettings } from "./bot-message.js";
 import {
@@ -363,7 +362,7 @@ async function resolveTelegramCommandAuth(params: {
 
 export async function prepareTelegramCommandDispatch(
   params: TelegramCommandExecutorParams & { requireAuth: boolean },
-  onAuthorized?: (target: TelegramPendingInboundTarget) => void,
+  onAuthorized?: (target: TelegramCommandAuthResult) => void,
 ): Promise<TelegramCommandDispatch | null> {
   const telegramDeps = params.telegramDeps ?? defaultTelegramNativeCommandDeps;
   const runtimeCfg = telegramDeps.getRuntimeConfig();

--- a/extensions/telegram/src/bot-native-command-dispatch.ts
+++ b/extensions/telegram/src/bot-native-command-dispatch.ts
@@ -21,6 +21,7 @@ import { resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { normalizeDmAllowFromWithStore, resolveTelegramEffectiveDmPolicy } from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
+import type { TelegramPendingInboundTarget } from "./bot-handlers.inbound-buffer.js";
 import type { TelegramResolvedGroupConfig } from "./bot-handlers.types.js";
 import { resolveTelegramMessageTurnSettings } from "./bot-message.js";
 import {
@@ -362,6 +363,7 @@ async function resolveTelegramCommandAuth(params: {
 
 export async function prepareTelegramCommandDispatch(
   params: TelegramCommandExecutorParams & { requireAuth: boolean },
+  onAuthorized?: (target: TelegramPendingInboundTarget) => void,
 ): Promise<TelegramCommandDispatch | null> {
   const telegramDeps = params.telegramDeps ?? defaultTelegramNativeCommandDeps;
   const runtimeCfg = telegramDeps.getRuntimeConfig();
@@ -391,6 +393,7 @@ export async function prepareTelegramCommandDispatch(
   if (!auth) {
     return null;
   }
+  onAuthorized?.(auth);
   const { route, bindingMode } = resolveTelegramConversationRoute({
     cfg: runtimeCfg,
     accountId: params.accountId,

--- a/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
@@ -17,6 +17,7 @@ export function createNativeCommandTestParams(
 ): RegisterTelegramNativeCommandsParams {
   const log = vi.fn();
   return {
+    cancelPendingInbound: params.cancelPendingInbound ?? vi.fn(),
     bot:
       params.bot ??
       ({

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -199,6 +199,7 @@ export function createNativeCommandsHarness(params?: {
   } as unknown as RegisterTelegramNativeCommandsParams["bot"];
 
   registerTelegramNativeCommands({
+    cancelPendingInbound: vi.fn(),
     bot,
     cfg,
     runtime: params?.runtime ?? ({ log } as unknown as RuntimeEnv),

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -14,6 +14,7 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { createPluginCommandRuntime } from "openclaw/plugin-sdk/plugin-command-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import type { TelegramPendingInboundTarget } from "./bot-handlers.inbound-buffer.js";
 import type {
   TelegramNativeCommandCallbackDispatcher,
   TelegramResolvedGroupConfig,
@@ -46,6 +47,7 @@ const loadTelegramPluginCommandExecutor = createLazyRuntimeModule(
 type TelegramNativeCommandContext = Context & { match?: string };
 
 type RegisterTelegramNativeCommandsParams = {
+  cancelPendingInbound: (target: TelegramPendingInboundTarget) => void;
   bot: Bot;
   cfg: OpenClawConfig;
   runtime: RuntimeEnv;
@@ -76,6 +78,7 @@ type RegisterTelegramNativeCommandsParams = {
 };
 
 export const registerTelegramNativeCommands = ({
+  cancelPendingInbound,
   bot,
   cfg,
   runtime,
@@ -266,6 +269,7 @@ export const registerTelegramNativeCommands = ({
       return await executeTelegramBuiltinCommand({
         ...buildExecutorParams({ botUser, msg, rawText }),
         commandName: command.name,
+        cancelPendingInbound,
       });
     };
     if (nativeEnabled) {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -14,9 +14,9 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { createPluginCommandRuntime } from "openclaw/plugin-sdk/plugin-command-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import type { TelegramPendingInboundTarget } from "./bot-handlers.inbound-buffer.js";
 import type {
   TelegramNativeCommandCallbackDispatcher,
+  TelegramPendingInboundTarget,
   TelegramResolvedGroupConfig,
 } from "./bot-handlers.types.js";
 import {

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -75,7 +75,7 @@ const TELEGRAM_TEST_TIMINGS = {
   mediaGroupFlushMs: 20,
   textFragmentGapMs: 30,
 } as const;
-const TEXT_FRAGMENT_COALESCE_TEST_GAP_MS = 5_000;
+const FRAGMENT_TEST_GAP_MS = 5_000;
 const TELEGRAM_TEST_TOPIC = "-100456:topic:42";
 
 async function withTelegramSpooledReplayUpdate<T>(
@@ -474,7 +474,7 @@ describe("createTelegramBot channel_post media", () => {
     try {
       const handler = getChannelPostHandler({
         ...TELEGRAM_TEST_TIMINGS,
-        textFragmentGapMs: TEXT_FRAGMENT_COALESCE_TEST_GAP_MS,
+        textFragmentGapMs: FRAGMENT_TEST_GAP_MS,
       });
 
       const part1 = "A".repeat(4050);
@@ -503,12 +503,13 @@ describe("createTelegramBot channel_post media", () => {
       });
 
       expect(replySpy).not.toHaveBeenCalled();
-      await flushChannelPostMediaGroup(setTimeoutSpy, 1_075, TEXT_FRAGMENT_COALESCE_TEST_GAP_MS);
-
-      expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = replyPayload() as { RawBody?: string };
-      expect(payload.RawBody).toContain(part1.slice(0, 32));
-      expect(payload.RawBody).toContain(part2.slice(0, 32));
+      const flush = resolveFlushTimerForDelay(setTimeoutSpy, FRAGMENT_TEST_GAP_MS);
+      expect(flush).toBeTypeOf("function");
+      flush?.();
+      await vi.waitFor(() => expect(replySpy).toHaveBeenCalledOnce(), { timeout: 1_075 });
+      const payload = replyPayload();
+      expect(payload.RawBody).toBe(part1 + part2);
+      expect(payload.MessageSid).toBe("302");
     } finally {
       setTimeoutSpy.mockRestore();
     }

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1148,6 +1148,148 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("preserves mixed short and fragment admission order with complete source text", async () => {
+    loadConfig.mockReturnValue({
+      agents: { defaults: { envelopeTimezone: "utc" } },
+      messages: { inbound: { byChannel: { telegram: 3000 } } },
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    vi.setSystemTime(1736380800000);
+    replySpy.mockResolvedValue(undefined);
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getMessageHandler();
+      const short = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 301,
+        messageId: 301,
+        text: "A".repeat(611),
+        replayUpdate: "full",
+      });
+      await vi.advanceTimersByTimeAsync(283);
+      const long = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 302,
+        messageId: 302,
+        text: "B".repeat(4065),
+        date: 1736380801,
+        replayUpdate: "full",
+      });
+      await vi.advanceTimersByTimeAsync(14);
+      const continuation = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 303,
+        messageId: 303,
+        text: "C".repeat(3354),
+        date: 1736380802,
+        replayUpdate: "full",
+      });
+
+      await vi.advanceTimersByTimeAsync(2703);
+      await expect(
+        Promise.all([
+          requireValue(short.deferredWork, "short source participant").task,
+          requireValue(long.deferredWork, "long source participant").task,
+          requireValue(continuation.deferredWork, "continuation source participant").task,
+        ]),
+      ).resolves.toEqual([{ kind: "completed" }, { kind: "completed" }, { kind: "completed" }]);
+
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual([
+        "A".repeat(611),
+        "B".repeat(4065) + "C".repeat(3354),
+      ]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["301", "303"]);
+      expect(
+        replySpy.mock.calls.map(([ctx]) => ctx.SessionTranscriptContext?.beforeTimestampMs),
+      ).toEqual([1736380800000, 1736380800283]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.Timestamp)).toEqual([
+        1736380800000, 1736380802000,
+      ]);
+
+      const next = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 304,
+        messageId: 304,
+        text: "next independent message",
+        replayUpdate: "full",
+      });
+      await vi.advanceTimersByTimeAsync(3000);
+      await expect(
+        requireValue(next.deferredWork, "next source participant").task,
+      ).resolves.toEqual({
+        kind: "completed",
+      });
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual([
+        "A".repeat(611),
+        "B".repeat(4065) + "C".repeat(3354),
+        "next independent message",
+      ]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["301", "303", "304"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels an expired fragment behind an earlier active message before releasing that message", async () => {
+    configureOpenDm({ debounceMs: 3000, timezone: "envelopeTimezone" });
+    installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const earlierStarted = createDeferred<void>();
+    const releaseEarlier = createDeferred<void>();
+    let earlierWork: Promise<unknown> | undefined;
+    replySpy.mockImplementation(async (ctx: MsgContext) => {
+      if (ctx.RawBody === "earlier message") {
+        earlierStarted.resolve();
+        await releaseEarlier.promise;
+      }
+      return undefined;
+    });
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getMessageHandler();
+      const earlier = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 311,
+        messageId: 311,
+        text: "earlier message",
+        replayUpdate: "full",
+      });
+      earlierWork = requireValue(earlier.deferredWork, "earlier source participant").task;
+      await vi.advanceTimersByTimeAsync(3000);
+      await earlierStarted.promise;
+      const fragment = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 312,
+        messageId: 312,
+        text: "B".repeat(4065),
+        replayUpdate: "full",
+      });
+      const fragmentParticipant = requireValue(
+        fragment.deferredWork,
+        "fragment source participant",
+      );
+      await vi.advanceTimersByTimeAsync(1500);
+      await dispatchPrivateText(messageHandler, {
+        updateId: 313,
+        messageId: 313,
+        text: "stop",
+      });
+
+      expect(fragmentParticipant.isSettled()).toBe(true);
+      await expect(fragmentParticipant.task).resolves.toEqual({ kind: "skipped" });
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(["earlier message", "stop"]);
+
+      releaseEarlier.resolve();
+      await expect(earlierWork).resolves.toEqual({
+        kind: "completed",
+      });
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(["earlier message", "stop"]);
+    } finally {
+      releaseEarlier.resolve();
+      await earlierWork;
+      vi.useRealTimers();
+    }
+  });
+
   it.each(["stop", "/stop@openclaw_bot"] as const)(
     "lets %s bypass and cancel pending same-chat inbound debounce",
     async (stopText) => {
@@ -1235,32 +1377,120 @@ describe("createTelegramBot", () => {
     }
   });
 
-  it("settles spooled replay participants when stop cancels pending text fragments", async () => {
-    configureOpenDm({ timezone: "envelopeTimezone" });
-
+  it("settles a fragment waiting for continuation on stop and allows same-key reuse", async () => {
+    configureOpenDm({ debounceMs: 3000, timezone: "envelopeTimezone" });
     installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    replySpy.mockResolvedValue(undefined);
 
-    createTelegramBot({ token: "tok" });
-    const messageHandler = getMessageHandler();
-    const replay = await dispatchSpooledPrivateText(messageHandler, {
-      updateId: 211,
-      messageId: 211,
-      text: "A".repeat(4050),
-    });
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getMessageHandler();
+      const replay = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 211,
+        messageId: 211,
+        text: "A".repeat(4065),
+        replayUpdate: "full",
+      });
+      const participant = requireValue(replay.deferredWork, "fragment source participant");
+      await vi.advanceTimersByTimeAsync(100);
+      await dispatchPrivateText(messageHandler, {
+        updateId: 212,
+        messageId: 212,
+        text: "stop",
+      });
+      expect(participant.isSettled()).toBe(true);
+      await expect(participant.task).resolves.toEqual({ kind: "skipped" });
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(["stop"]);
 
-    const deferredWork = replay.deferredWork;
-    expect(deferredWork).toBeDefined();
-    if (!deferredWork) {
-      throw new Error("Expected spooled replay deferred work");
+      const next = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 213,
+        messageId: 213,
+        text: "message after stop",
+        replayUpdate: "full",
+      });
+      await vi.advanceTimersByTimeAsync(3000);
+      await expect(
+        requireValue(next.deferredWork, "next source participant").task,
+      ).resolves.toEqual({
+        kind: "completed",
+      });
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual([
+        "stop",
+        "message after stop",
+      ]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["212", "213"]);
+    } finally {
+      vi.useRealTimers();
     }
-    await dispatchPrivateText(messageHandler, {
-      updateId: 212,
-      messageId: 212,
-      text: "stop",
-      date: 1736380801,
+  });
+
+  it("waits for a forced fragment flush before admitting the triggering forwarded message", async () => {
+    configureOpenDm({ debounceMs: 3000, timezone: "envelopeTimezone" });
+    installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const fragmentStarted = createDeferred<void>();
+    const releaseFragment = createDeferred<void>();
+    let fragmentWork: Promise<unknown> | undefined;
+    let forwardDispatch: ReturnType<typeof dispatchSpooledPrivateText> | undefined;
+    let forwardHandlerCompleted = false;
+    replySpy.mockImplementation(async (ctx: MsgContext) => {
+      if (ctx.MessageSid === "321") {
+        fragmentStarted.resolve();
+        await releaseFragment.promise;
+      }
+      return undefined;
     });
 
-    await expect(deferredWork.task).resolves.toEqual({ kind: "skipped" });
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getMessageHandler();
+      const fragment = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 321,
+        messageId: 321,
+        text: "B".repeat(4065),
+        replayUpdate: "full",
+      });
+      fragmentWork = requireValue(fragment.deferredWork, "fragment source participant").task;
+      await vi.advanceTimersByTimeAsync(100);
+      forwardDispatch = dispatchSpooledPrivateText(messageHandler, {
+        updateId: 322,
+        messageId: 323,
+        text: "forwarded message",
+        message: { forward_date: 1736380700 },
+        replayUpdate: "full",
+      }).then((result) => {
+        forwardHandlerCompleted = true;
+        return result;
+      });
+
+      await fragmentStarted.promise;
+      await vi.advanceTimersByTimeAsync(80);
+      expect(forwardHandlerCompleted).toBe(false);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(["B".repeat(4065)]);
+
+      releaseFragment.resolve();
+      const forwarded = await forwardDispatch;
+      await vi.advanceTimersByTimeAsync(80);
+      await expect(
+        Promise.all([
+          fragmentWork,
+          requireValue(forwarded.deferredWork, "forwarded source participant").task,
+        ]),
+      ).resolves.toEqual([{ kind: "completed" }, { kind: "completed" }]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual([
+        "B".repeat(4065),
+        "forwarded message",
+      ]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["321", "323"]);
+    } finally {
+      releaseFragment.resolve();
+      await fragmentWork;
+      const forwarded = await forwardDispatch;
+      await vi.advanceTimersByTimeAsync(80);
+      await forwarded?.deferredWork?.task;
+      vi.useRealTimers();
+    }
   });
 
   it("keeps forced text-fragment flush settlement isolated from the triggering replay", async () => {
@@ -1760,85 +1990,83 @@ describe("createTelegramBot", () => {
     }
   });
 
-  it("does not let unauthorized group stop cancel pending same-sender inbound debounce", async () => {
-    const chatId = nextForumCacheChatId();
-    loadConfig.mockReturnValue({
-      agents: {
-        defaults: {
-          envelopeTimezone: "utc",
-        },
-      },
-      messages: {
-        inbound: {
-          debounceMs: INBOUND_DEBOUNCE_MS,
-        },
-      },
-      channels: {
-        telegram: {
-          dmPolicy: "pairing",
-          groupPolicy: "open",
-          groups: { "*": { requireMention: false } },
-        },
-      },
-    });
-
-    installPerKeySequentializer();
-
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    const startedBodies: string[] = [];
-    replySpy.mockImplementation(async (ctx: MsgContext, opts?: GetReplyOptions) => {
-      await opts?.onReplyStart?.();
-      const body = ctx.Body ?? "";
-      startedBodies.push(body);
-      return { text: `reply:${body}` };
-    });
-
-    try {
-      createTelegramBot({ token: "tok" });
-      const messageHandler = getMessageHandler();
-
-      await runTelegramMiddlewareChain({
-        ctx: {
-          update: { update_id: 104 },
-          message: {
-            chat: { id: chatId, type: "supergroup", title: "OpenClaw Ops" },
-            text: "first",
-            date: 1736380804,
-            message_id: 104,
-            from: { id: 42, first_name: "Ada" },
+  it.each([
+    { buffer: "inbound debounce", text: "first", delayMs: INBOUND_DEBOUNCE_MS },
+    { buffer: "text fragments", text: "B".repeat(4065), delayMs: 1500 },
+  ])(
+    "does not let unauthorized group stop cancel pending same-sender $buffer",
+    async ({ text, delayMs }) => {
+      const chatId = nextForumCacheChatId();
+      loadConfig.mockReturnValue({
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
           },
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({}),
         },
-        finalHandler: messageHandler,
-      });
-
-      const flushFirst = takeLatestTimerCallback(INBOUND_DEBOUNCE_MS);
-
-      await runTelegramMiddlewareChain({
-        ctx: {
-          update: { update_id: 105 },
-          message: {
-            chat: { id: chatId, type: "supergroup", title: "OpenClaw Ops" },
-            text: "stop",
-            date: 1736380805,
-            message_id: 105,
-            from: { id: 42, first_name: "Ada" },
+        messages: {
+          inbound: {
+            debounceMs: INBOUND_DEBOUNCE_MS,
           },
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({}),
         },
-        finalHandler: messageHandler,
+        channels: {
+          telegram: {
+            dmPolicy: "pairing",
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
       });
 
-      flushFirst();
-      await vi.waitFor(() => {
-        expect(startedBodies.some((body) => body.includes("first"))).toBe(true);
-      });
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
-  });
+      installPerKeySequentializer();
+
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      replySpy.mockResolvedValue(undefined);
+
+      try {
+        createTelegramBot({ token: "tok" });
+        const messageHandler = getMessageHandler();
+
+        await runTelegramMiddlewareChain({
+          ctx: {
+            update: { update_id: 104 },
+            message: {
+              chat: { id: chatId, type: "supergroup", title: "OpenClaw Ops" },
+              text,
+              date: 1736380804,
+              message_id: 104,
+              from: { id: 42, first_name: "Ada" },
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({}),
+          },
+          finalHandler: messageHandler,
+        });
+
+        await runTelegramMiddlewareChain({
+          ctx: {
+            update: { update_id: 105 },
+            message: {
+              chat: { id: chatId, type: "supergroup", title: "OpenClaw Ops" },
+              text: "stop",
+              date: 1736380805,
+              message_id: 105,
+              from: { id: 42, first_name: "Ada" },
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({}),
+          },
+          finalHandler: messageHandler,
+        });
+
+        await vi.advanceTimersByTimeAsync(delayMs);
+        await vi.waitFor(() => {
+          expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toContain(text);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("routes generic callback_query payloads as callback_data messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { escapeRegExp, formatEnvelopeTimestamp } from "openclaw/plugin-sdk/channel-test-helpers";
-import type { TelegramGroupConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenClawConfig, TelegramGroupConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   buildPluginBindingApprovalCustomId,
   resolvePluginConversationBindingApproval,
@@ -19,6 +19,10 @@ import type {
   PluginStateSyncKeyedStore,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { createRequireRecord, sanitizeTerminalText } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1194,6 +1198,147 @@ describe("createTelegramBot", () => {
       expect(sentBodies[1]).toContain("second");
     } finally {
       setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it.each([0, 500, 1000, 3000])(
+    "preserves ordinary short-pair behavior with Telegram debounce %i ms",
+    async (debounceMs) => {
+      loadConfig.mockReturnValue({
+        messages: { inbound: { debounceMs: 9999, byChannel: { telegram: debounceMs } } },
+        channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+      });
+      installPerKeySequentializer();
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      replySpy.mockResolvedValue(undefined);
+      const sourceWork: Promise<unknown>[] = [];
+
+      try {
+        createTelegramBot({ token: "tok" });
+        const messageHandler = getMessageHandler();
+        const first = await dispatchSpooledPrivateText(messageHandler, {
+          updateId: 501,
+          messageId: 501,
+          text: "first short message",
+          replayUpdate: "full",
+        });
+        if (first.deferredWork) {
+          sourceWork.push(first.deferredWork.task);
+        }
+        expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(
+          debounceMs === 0 ? ["first short message"] : [],
+        );
+        await vi.advanceTimersByTimeAsync(100);
+        const second = await dispatchSpooledPrivateText(messageHandler, {
+          updateId: 502,
+          messageId: 502,
+          text: "second short message",
+          replayUpdate: "full",
+        });
+        if (second.deferredWork) {
+          sourceWork.push(second.deferredWork.task);
+        }
+
+        if (debounceMs > 0) {
+          expect(first.deferredWork).toBeDefined();
+          expect(second.deferredWork).toBeDefined();
+          await vi.advanceTimersByTimeAsync(debounceMs - 1);
+          expect(replySpy).not.toHaveBeenCalled();
+          await vi.advanceTimersByTimeAsync(1);
+        }
+        expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(
+          debounceMs === 0
+            ? ["first short message", "second short message"]
+            : ["first short message\nsecond short message"],
+        );
+        expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(
+          debounceMs === 0 ? ["501", "502"] : ["502"],
+        );
+        await Promise.all(sourceWork);
+      } finally {
+        await vi.advanceTimersByTimeAsync(10_000);
+        await Promise.all(sourceWork);
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("applies committed Telegram debounce changes only when new input arrives", async () => {
+    const initialConfig: OpenClawConfig = {
+      messages: { inbound: { byChannel: { telegram: 1000 } } },
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    };
+    loadConfig.mockReturnValue(initialConfig);
+    setRuntimeConfigSnapshot(initialConfig, initialConfig);
+    installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    replySpy.mockResolvedValue(undefined);
+    const sourceWork: Promise<unknown>[] = [];
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getMessageHandler();
+      const first = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 511,
+        messageId: 511,
+        text: "before delay change",
+        replayUpdate: "full",
+      });
+      const firstParticipant = requireValue(first.deferredWork, "first source participant");
+      sourceWork.push(firstParticipant.task);
+      await vi.advanceTimersByTimeAsync(100);
+      const shorterConfig: OpenClawConfig = {
+        ...initialConfig,
+        messages: { inbound: { byChannel: { telegram: 500 } } },
+      };
+      loadConfig.mockReturnValue(shorterConfig);
+      setRuntimeConfigSnapshot(shorterConfig, shorterConfig);
+      await vi.advanceTimersByTimeAsync(899);
+      expect(replySpy).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(["before delay change"]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["511"]);
+      await expect(firstParticipant.task).resolves.toEqual({ kind: "completed" });
+
+      const second = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 512,
+        messageId: 512,
+        text: "new batch",
+        replayUpdate: "full",
+      });
+      sourceWork.push(requireValue(second.deferredWork, "second source participant").task);
+      await vi.advanceTimersByTimeAsync(100);
+      const longerConfig: OpenClawConfig = {
+        ...initialConfig,
+        messages: { inbound: { byChannel: { telegram: 1500 } } },
+      };
+      loadConfig.mockReturnValue(longerConfig);
+      setRuntimeConfigSnapshot(longerConfig, longerConfig);
+      const third = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 513,
+        messageId: 513,
+        text: "extends batch",
+        replayUpdate: "full",
+      });
+      sourceWork.push(requireValue(third.deferredWork, "third source participant").task);
+      await vi.advanceTimersByTimeAsync(1499);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(["before delay change"]);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual([
+        "before delay change",
+        "new batch\nextends batch",
+      ]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["511", "513"]);
+      await expect(Promise.all(sourceWork)).resolves.toEqual([
+        { kind: "completed" },
+        { kind: "completed" },
+        { kind: "completed" },
+      ]);
+    } finally {
+      await vi.advanceTimersByTimeAsync(3000);
+      await Promise.all(sourceWork);
+      vi.useRealTimers();
+      clearRuntimeConfigSnapshot();
     }
   });
 

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1,5 +1,5 @@
 // Telegram tests cover bot.create telegram bot plugin behavior.
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -22,6 +22,10 @@ import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runt
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { createRequireRecord, sanitizeTerminalText } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createConfiguredAcpTopicBinding,
+  createConfiguredBindingRoute,
+} from "./bot-native-command-dispatch.test-support.js";
 import {
   createTelegramNativeCommandTestDeps,
   telegramBotInfoForTest,
@@ -48,6 +52,8 @@ const harness = await import("./bot.create-telegram-bot.test-harness.js");
 const pluginStateTestRuntime = await import("openclaw/plugin-sdk/plugin-state-test-runtime");
 const configMutation = await import("openclaw/plugin-sdk/config-mutation");
 const modelSessionRuntime = await import("openclaw/plugin-sdk/model-session-runtime");
+const conversationRuntime = await import("openclaw/plugin-sdk/conversation-runtime");
+const telegramMediaResolver = await import("./bot/delivery.resolve-media.js");
 const EYES_EMOJI = "\u{1F440}";
 const tempStateDirs: string[] = [];
 let previousStateDir: string | undefined;
@@ -102,8 +108,11 @@ const {
 } = await import("./bot-processing-outcome.js");
 const { TELEGRAM_RICH_TEXT_LIMIT } = await import("./rich-message.js");
 const { resolveTelegramConversationRoute } = await import("./conversation-route.js");
-const { clearTelegramRuntimeForTest, resetTelegramAccountThrottlersForTest } =
-  await import("./runtime.test-support.js");
+const {
+  clearTelegramRuntimeForTest,
+  resetTelegramAccountThrottlersForTest,
+  resetTelegramTopicNameCacheForTest,
+} = await import("./runtime.test-support.js");
 const { setTelegramRuntime } = await import("./runtime.js");
 const {
   buildTelegramGroupFrom,
@@ -292,6 +301,46 @@ async function dispatchSpooledPrivateText(
   return await runWithTelegramSpooledReplayUpdate(replayUpdate, async () => {
     await runTelegramMiddlewareChain({ ctx, finalHandler: messageHandler });
   });
+}
+
+function installTelegramTopicStateForTest(): void {
+  resetTelegramTopicNameCacheForTest();
+  const openKeyedStore: TelegramRuntime["state"]["openKeyedStore"] = <T>(
+    options: Parameters<TelegramRuntime["state"]["openKeyedStore"]>[0],
+  ) => pluginStateTestRuntime.createPluginStateKeyedStoreForTests<T>("telegram", options);
+  const openSyncKeyedStore: TelegramRuntime["state"]["openSyncKeyedStore"] = <T>(
+    options: Parameters<TelegramRuntime["state"]["openSyncKeyedStore"]>[0],
+  ) => pluginStateTestRuntime.createPluginStateSyncKeyedStoreForTests<T>("telegram", options);
+  setTelegramRuntime({
+    state: { openKeyedStore, openSyncKeyedStore },
+    channel: {},
+  } as TelegramRuntime);
+}
+
+async function dispatchSpooledNativeStop(
+  params: Omit<Parameters<typeof dispatchSpooledPrivateText>[1], "text" | "replayUpdate"> & {
+    match?: string;
+  },
+) {
+  const { match = "", ...messageParams } = params;
+  const stopHandler = requireValue(
+    commandSpy.mock.calls.find((call) => call[0] === "stop")?.[1] as
+      | TelegramMessageHandler
+      | undefined,
+    "registered native stop handler",
+  );
+  return await dispatchSpooledPrivateText(
+    async (ctx) => await stopHandler({ ...ctx, me: telegramBotInfoForTest, match }),
+    {
+      ...messageParams,
+      text: match ? `/stop ${match}` : "/stop",
+      replayUpdate: "full",
+      message: {
+        ...messageParams.message,
+        entities: [{ type: "bot_command", offset: 0, length: 5 }],
+      },
+    },
+  );
 }
 
 function setupUpdateOffsetTracker(params: {
@@ -1422,6 +1471,407 @@ describe("createTelegramBot", () => {
       expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["212", "213"]);
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { buffer: "ordinary text", text: "A".repeat(611) },
+    { buffer: "text fragments", text: "B".repeat(4065) },
+  ])("native stop cancels pending $buffer and permits same-key reuse", async ({ text }) => {
+    loadConfig.mockReturnValue({
+      commands: { native: true, allowFrom: { telegram: ["42"] } },
+      messages: { inbound: { byChannel: { telegram: 3000 } } },
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    replySpy.mockResolvedValue(undefined);
+    const sourceWork: Promise<unknown>[] = [];
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getMessageHandler();
+      const pending = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 401,
+        messageId: 401,
+        text,
+        replayUpdate: "full",
+      });
+      const participant = requireValue(pending.deferredWork, "pending source participant");
+      sourceWork.push(participant.task);
+      await vi.advanceTimersByTimeAsync(100);
+
+      await dispatchSpooledNativeStop({ updateId: 402, messageId: 402 });
+
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        CommandSource: "native",
+        CommandBody: "/stop",
+        CommandAuthorized: true,
+        MessageSid: "402",
+      });
+      expect(participant.isSettled()).toBe(true);
+      await expect(participant.task).resolves.toEqual({ kind: "skipped" });
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(["/stop"]);
+
+      const next = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 403,
+        messageId: 403,
+        text: "message after native stop",
+        replayUpdate: "full",
+      });
+      const nextParticipant = requireValue(next.deferredWork, "next source participant");
+      sourceWork.push(nextParticipant.task);
+      await vi.advanceTimersByTimeAsync(3000);
+      await expect(nextParticipant.task).resolves.toEqual({ kind: "completed" });
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual([
+        "/stop",
+        "message after native stop",
+      ]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["402", "403"]);
+    } finally {
+      await vi.advanceTimersByTimeAsync(3000);
+      await Promise.all(sourceWork);
+      vi.useRealTimers();
+    }
+  });
+
+  it("unauthorized native group stop leaves the sender's pending fragment intact", async () => {
+    installTelegramTopicStateForTest();
+    const chatId = nextForumCacheChatId();
+    const topic = {
+      chat: { id: chatId, type: "supergroup", title: "OpenClaw Ops", is_forum: true },
+      message_thread_id: 99,
+      is_topic_message: true,
+    };
+    loadConfig.mockReturnValue({
+      commands: { native: true, allowFrom: { telegram: ["99"] } },
+      messages: { inbound: { byChannel: { telegram: 3000 } } },
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+    installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    replySpy.mockResolvedValue(undefined);
+    let sourceWork: Promise<unknown> | undefined;
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const pending = await dispatchSpooledPrivateText(getMessageHandler(), {
+        updateId: 411,
+        messageId: 411,
+        text: "U".repeat(4065),
+        message: topic,
+        replayUpdate: "full",
+      });
+      const participant = requireValue(pending.deferredWork, "pending source participant");
+      sourceWork = participant.task;
+      await vi.advanceTimersByTimeAsync(100);
+
+      await dispatchSpooledNativeStop({ updateId: 412, messageId: 412, message: topic });
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        chatId,
+        "You are not authorized to use this command.",
+        { message_thread_id: 99 },
+      );
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(participant.isSettled()).toBe(false);
+      await vi.advanceTimersByTimeAsync(3000);
+      await expect(participant.task).resolves.toEqual({ kind: "completed" });
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(["U".repeat(4065)]);
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        MessageSid: "411",
+        SenderId: "42",
+        MessageThreadId: 99,
+      });
+    } finally {
+      await vi.advanceTimersByTimeAsync(3000);
+      await sourceWork;
+      vi.useRealTimers();
+      clearTelegramRuntimeForTest();
+      resetTelegramTopicNameCacheForTest();
+    }
+  });
+
+  it.each([
+    { scope: "another sender", senderId: 43, threadId: 99 },
+    { scope: "another topic", senderId: 42, threadId: 100 },
+  ])("native stop preserves a pending fragment from $scope", async ({ senderId, threadId }) => {
+    installTelegramTopicStateForTest();
+    const chatId = nextForumCacheChatId();
+    const chat = { id: chatId, type: "supergroup", title: "OpenClaw Ops", is_forum: true };
+    loadConfig.mockReturnValue({
+      commands: { native: true, allowFrom: { telegram: ["42"] } },
+      messages: { inbound: { byChannel: { telegram: 3000 } } },
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+    installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    replySpy.mockResolvedValue(undefined);
+    const sourceWork: Promise<unknown>[] = [];
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const target = await dispatchSpooledPrivateText(getMessageHandler(), {
+        updateId: 419,
+        messageId: 419,
+        text: "T".repeat(4065),
+        message: { chat, message_thread_id: 99, is_topic_message: true },
+        replayUpdate: "full",
+      });
+      const targetParticipant = requireValue(target.deferredWork, "stop target participant");
+      sourceWork.push(targetParticipant.task);
+      const pending = await dispatchSpooledPrivateText(getMessageHandler(), {
+        updateId: 421,
+        messageId: 421,
+        from: { id: senderId, first_name: "Pending sender" },
+        text: "P".repeat(4065),
+        message: { chat, message_thread_id: threadId, is_topic_message: true },
+        replayUpdate: "full",
+      });
+      const participant = requireValue(pending.deferredWork, "other source participant");
+      sourceWork.push(participant.task);
+      await vi.advanceTimersByTimeAsync(100);
+
+      await dispatchSpooledNativeStop({
+        updateId: 422,
+        messageId: 422,
+        message: { chat, message_thread_id: 99, is_topic_message: true },
+      });
+
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        CommandSource: "native",
+        CommandAuthorized: true,
+        MessageSid: "422",
+        SenderId: "42",
+        MessageThreadId: 99,
+      });
+      expect(targetParticipant.isSettled()).toBe(true);
+      await expect(targetParticipant.task).resolves.toEqual({ kind: "skipped" });
+      expect(participant.isSettled()).toBe(false);
+      await vi.advanceTimersByTimeAsync(3000);
+      await expect(participant.task).resolves.toEqual({ kind: "completed" });
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual(["/stop", "P".repeat(4065)]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["422", "421"]);
+      expect(replySpy.mock.calls[1]?.[0]).toMatchObject({
+        SenderId: String(senderId),
+        MessageThreadId: threadId,
+      });
+    } finally {
+      await vi.advanceTimersByTimeAsync(3000);
+      await Promise.all(sourceWork);
+      vi.useRealTimers();
+      clearTelegramRuntimeForTest();
+      resetTelegramTopicNameCacheForTest();
+    }
+  });
+
+  it("native stop with unsupported arguments leaves pending input intact", async () => {
+    loadConfig.mockReturnValue({
+      commands: { native: true, allowFrom: { telegram: ["42"] } },
+      messages: { inbound: { byChannel: { telegram: 3000 } } },
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    replySpy.mockResolvedValue(undefined);
+    let sourceWork: Promise<unknown> | undefined;
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const pending = await dispatchSpooledPrivateText(getMessageHandler(), {
+        updateId: 431,
+        messageId: 431,
+        text: "Q".repeat(4065),
+        replayUpdate: "full",
+      });
+      const participant = requireValue(pending.deferredWork, "pending source participant");
+      sourceWork = participant.task;
+      await vi.advanceTimersByTimeAsync(100);
+
+      await dispatchSpooledNativeStop({ updateId: 432, messageId: 432, match: "later" });
+
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        CommandSource: "native",
+        CommandAuthorized: true,
+        CommandBody: "/stop later",
+        MessageSid: "432",
+      });
+      expect(participant.isSettled()).toBe(false);
+      await vi.advanceTimersByTimeAsync(3000);
+      await expect(participant.task).resolves.toEqual({ kind: "completed" });
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.RawBody)).toEqual([
+        "/stop later",
+        "Q".repeat(4065),
+      ]);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["432", "431"]);
+    } finally {
+      await vi.advanceTimersByTimeAsync(3000);
+      await sourceWork;
+      vi.useRealTimers();
+    }
+  });
+
+  it("authorized stop caption cancels pending ordinary and forwarded text", async () => {
+    configureOpenDm({ debounceMs: 3000, timezone: "envelopeTimezone" });
+    installPerKeySequentializer();
+    const attachmentPath = path.join(
+      requireValue(process.env.OPENCLAW_STATE_DIR, "test state directory"),
+      "caption.txt",
+    );
+    writeFileSync(attachmentPath, "attachment");
+    const resolveMedia = vi.spyOn(telegramMediaResolver, "resolveMedia");
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    replySpy.mockResolvedValue(undefined);
+    const sourceWork: Promise<unknown>[] = [];
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getMessageHandler();
+      const ordinary = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 441,
+        messageId: 441,
+        text: "A".repeat(611),
+        replayUpdate: "full",
+      });
+      const ordinaryParticipant = requireValue(
+        ordinary.deferredWork,
+        "ordinary source participant",
+      );
+      sourceWork.push(ordinaryParticipant.task);
+      const forwarded = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 442,
+        messageId: 442,
+        text: "F".repeat(611),
+        message: { forward_date: 1736380700 },
+        replayUpdate: "full",
+      });
+      const forwardedParticipant = requireValue(
+        forwarded.deferredWork,
+        "forwarded source participant",
+      );
+      sourceWork.push(forwardedParticipant.task);
+
+      resolveMedia.mockResolvedValueOnce({
+        id: "caption-fixture",
+        fileUniqueId: "caption-document-unique",
+        path: attachmentPath,
+        size: 10,
+        contentType: "text/plain",
+        kind: "document",
+        savedAt: 1736380800000,
+      });
+      await dispatchPrivateText(messageHandler, {
+        updateId: 443,
+        messageId: 443,
+        text: "",
+        message: {
+          text: undefined,
+          caption: "stop",
+          document: {
+            file_id: "caption-document",
+            file_unique_id: "caption-document-unique",
+            file_name: "caption.txt",
+            mime_type: "text/plain",
+          },
+        },
+      });
+
+      expect(ordinaryParticipant.isSettled()).toBe(true);
+      expect(forwardedParticipant.isSettled()).toBe(true);
+      await expect(Promise.all(sourceWork)).resolves.toEqual([
+        { kind: "skipped" },
+        { kind: "skipped" },
+      ]);
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(replySpy.mock.calls.map(([ctx]) => ctx.MessageSid)).toEqual(["443"]);
+    } finally {
+      await vi.advanceTimersByTimeAsync(3000);
+      await Promise.all(sourceWork);
+      vi.useRealTimers();
+      resolveMedia.mockRestore();
+    }
+  });
+
+  it("native stop cancels pending input before configured binding preparation finishes", async () => {
+    installTelegramTopicStateForTest();
+    const topic = {
+      chat: { id: -1001234567890, type: "supergroup", title: "Bound topic", is_forum: true },
+      message_thread_id: 42,
+      is_topic_message: true,
+    };
+    loadConfig.mockReturnValue({
+      commands: { native: true, allowFrom: { telegram: ["42"] } },
+      messages: { inbound: { byChannel: { telegram: 3000 } } },
+      channels: { telegram: { groupPolicy: "open", groups: { "*": { requireMention: false } } } },
+    });
+    installPerKeySequentializer();
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    replySpy.mockResolvedValue(undefined);
+    const preparationStarted = createDeferred<void>();
+    const releasePreparation = createDeferred<void>();
+    let sourceWork: Promise<unknown> | undefined;
+    let stopDispatch: ReturnType<typeof dispatchSpooledNativeStop> | undefined;
+    const bindingRoute = vi.spyOn(conversationRuntime, "resolveConfiguredBindingRoute");
+    const bindingReady = vi.spyOn(conversationRuntime, "ensureConfiguredBindingRouteReady");
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const pending = await dispatchSpooledPrivateText(getMessageHandler(), {
+        updateId: 451,
+        messageId: 451,
+        text: "H".repeat(4065),
+        message: topic,
+        replayUpdate: "full",
+      });
+      const participant = requireValue(pending.deferredWork, "pending source participant");
+      sourceWork = participant.task;
+      bindingRoute.mockImplementationOnce(({ route }) =>
+        createConfiguredBindingRoute(
+          route,
+          createConfiguredAcpTopicBinding("agent:main:acp:binding:telegram:default:held"),
+        ),
+      );
+      bindingReady.mockImplementationOnce(async () => {
+        preparationStarted.resolve();
+        await releasePreparation.promise;
+        return { ok: false, error: "binding unavailable" };
+      });
+
+      stopDispatch = dispatchSpooledNativeStop({ updateId: 452, messageId: 452, message: topic });
+      await preparationStarted.promise;
+
+      expect(participant.isSettled()).toBe(true);
+      await expect(participant.task).resolves.toEqual({ kind: "skipped" });
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(replySpy).not.toHaveBeenCalled();
+      releasePreparation.resolve();
+      await stopDispatch;
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        -1001234567890,
+        "Configured ACP binding is unavailable right now. Please try again.",
+        { message_thread_id: 42 },
+      );
+    } finally {
+      releasePreparation.resolve();
+      await stopDispatch;
+      bindingRoute.mockRestore();
+      bindingReady.mockRestore();
+      await vi.advanceTimersByTimeAsync(3000);
+      await sourceWork;
+      vi.useRealTimers();
+      clearTelegramRuntimeForTest();
+      resetTelegramTopicNameCacheForTest();
     }
   });
 


### PR DESCRIPTION
Thanks @xilopaint for the detailed reproduction.

Fixes #144722.

## What Problem This Solves

Fixes an issue where a short Telegram message could be processed after a later long message and its continuation when inbound debounce was enabled. Native stop could also leave a buffered fragment pending.

## Why This Change Was Made

Reserve fragment work in the existing inbound debounce queue on arrival, so both text paths share processing order. Authorized native stop now cancels through the same pending-buffer operation. Fragment thresholds and source metadata remain unchanged.

## User Impact

Earlier text is processed first, canceled fragments do not reach the provider, and fresh messages work after cancellation. Ordinary-only debounce retains its behavior.

## Evidence

Real Telegram direct messages reproduced both bugs. Seven acceptance cases passed, covering mixed order, ordinary/long pairs, thresholds, pending stop and reuse. Seven provider requests matched eight visible messages, including the stop acknowledgement; canceled input was absent. The ordinary debounce timing matrix and focused handler tests passed.
