### PR TITLE
refactor(matrix): share draft fallback delivery

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -179,6 +179,20 @@ export function createMatrixReplyDispatcher(config: {
           );
         }
 
+        const deliverFallback = async () =>
+          await deliverMatrixReplies({
+            cfg,
+            replies: [fallbackPayload],
+            roomId,
+            client,
+            runtime,
+            replyToMode,
+            hasRepliedRef,
+            threadId: threadTarget,
+            replyToId: threadTarget ?? replyToEventId ?? undefined,
+            accountId,
+            mediaLocalRoots,
+          });
         const payloadReplyMismatch =
           ((!threadTarget && replyToMode !== "off") ||
             payload.replyToTag ||
@@ -292,20 +306,7 @@ export function createMatrixReplyDispatcher(config: {
               fallbackResult = await settleDraftReplacement({
                 draftEventId,
                 draftContent: draftStream.content() ?? preparedFinalPreviewContent,
-                deliver: async () =>
-                  await deliverMatrixReplies({
-                    cfg,
-                    replies: [fallbackPayload],
-                    roomId,
-                    client,
-                    runtime,
-                    replyToMode,
-                    hasRepliedRef,
-                    threadId: threadTarget,
-                    replyToId: threadTarget ?? replyToEventId ?? undefined,
-                    accountId,
-                    mediaLocalRoots,
-                  }),
+                deliver: deliverFallback,
               });
               return fallbackResult.visibleReplySent;
             },
@@ -434,20 +435,6 @@ export function createMatrixReplyDispatcher(config: {
             payloadReplyMismatch ||
             mustDeliverFinalNormally ||
             draftFinalTextNeedsNormalMentionDelivery);
-        const deliverFallback = async () =>
-          await deliverMatrixReplies({
-            cfg,
-            replies: [fallbackPayload],
-            roomId,
-            client,
-            runtime,
-            replyToMode,
-            hasRepliedRef,
-            threadId: threadTarget,
-            replyToId: threadTarget ?? replyToEventId ?? undefined,
-            accountId,
-            mediaLocalRoots,
-          });
         const draftContent = draftStream.content();
         if (shouldRedactDraft && draftEventId && draftContent) {
           return await completeDelivery(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Maintainer-requested cleanup of Matrix streamed reply delivery. Draft replacement and final delivery need consistent fallback behavior; maintaining equivalent delivery callbacks separately makes future fixes easier to apply unevenly. This is preventive maintenance, not a claim of an observed user-facing defect.

## Why This Change Was Made

Move the existing private async `deliverFallback` callback immediately after the inactive-draft early return and reuse it for draft replacement. Its body, captured values, awaited delivery, and existing completion path stay unchanged.

The change is confined to one dispatcher file. No API, SDK, import/export, configuration, dependency, authentication, or encryption-policy changes are included.

## User Impact

No user-visible behavior change is intended. Matrix reply routing, thread and reply targets, media handling, and delivery sequencing retain their existing behavior. The shared callback reduces maintenance duplication without introducing another abstraction.

## Evidence

- The same four existing test partitions passed before and after: 89 handler-streaming, 22 reply, four delivery-trace, and one selected sender case, totaling 116 executed cases per version. Skipped cases are not counted. This is PASS/PASS characterization, not RED/GREEN bug evidence.
- All 24 selected check components passed, including six Doctor contract cases, production/test typechecks, formatting, lint, boundaries, and three dead-code scopes with zero entries.
- Independent review completed with no actionable findings; the signed commit preserves the reviewed one-file diff.
- Proof is controlled local testing at the recorded checkpoint, not a full-suite or current-main build. Live Matrix/E2EE and unsupported scripted trace faults were not run. Hosted CI passed for exact head `cfed65f9d4e66b72c1e3ff04ad01139207005118`: https://github.com/openclaw/openclaw/actions/runs/34588133139, including the required `openclaw/ci-gate`.
