### PR TITLE
fix(e2e): qualify rich Telegram scenario by source

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -346,6 +346,7 @@ jobs:
             qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml
             qa/scenarios/channels/telegram-progress-tool-visibility.yaml
             qa/scenarios/channels/telegram-queue-invalid-mode.yaml
+            qa/scenarios/channels/telegram-rich-inline-composition.yaml
             src/agents/embedded-agent-subscribe.ts
 
       - name: Resolve frozen package Telegram scenarios

--- a/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
+++ b/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
@@ -8,6 +8,7 @@ const SETTLED_EMPTY_RESPONSE_SCENARIO = "telegram-empty-response-after-write-rec
 const PROGRESS_TOOL_VISIBILITY_SCENARIO = "telegram-progress-tool-visibility";
 const PROVIDER_FAILURE_BEFORE_OUTPUT_SCENARIO = "telegram-provider-failure-before-output";
 const QUEUE_INVALID_MODE_SCENARIO = "telegram-queue-invalid-mode";
+const RICH_INLINE_COMPOSITION_SCENARIO = "telegram-rich-inline-composition";
 
 function readSource(sourceRoot: string, relativePath: string): string | undefined {
   try {
@@ -59,6 +60,13 @@ export function isPreQueueInvalidModeTarget(sourceRoot: string): boolean {
   );
 }
 
+export function isPreRichInlineCompositionTarget(sourceRoot: string): boolean {
+  return (
+    readSource(sourceRoot, "qa/scenarios/channels/telegram-rich-inline-composition.yaml") ===
+    undefined
+  );
+}
+
 export function resolveFrozenTelegramScenarioOmissions(sourceRoot: string): string[] {
   return [
     ...(isPrePartialFailureRecoveryTarget(sourceRoot) ? [PARTIAL_FAILURE_RECOVERY_SCENARIO] : []),
@@ -68,6 +76,7 @@ export function resolveFrozenTelegramScenarioOmissions(sourceRoot: string): stri
       ? [PROVIDER_FAILURE_BEFORE_OUTPUT_SCENARIO]
       : []),
     ...(isPreQueueInvalidModeTarget(sourceRoot) ? [QUEUE_INVALID_MODE_SCENARIO] : []),
+    ...(isPreRichInlineCompositionTarget(sourceRoot) ? [RICH_INLINE_COMPOSITION_SCENARIO] : []),
   ];
 }
 

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -10,6 +10,7 @@ import {
   isPreProgressToolVisibilityTarget,
   isPreProviderFailureBeforeOutputTarget,
   isPreQueueInvalidModeTarget,
+  isPreRichInlineCompositionTarget,
   isPreSettledEmptyResponseTarget,
   resolveFrozenTelegramScenarioOmissions,
 } from "../../scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts";
@@ -486,6 +487,16 @@ describe("package Telegram live Docker E2E", () => {
     expect(isPreQueueInvalidModeTarget(root)).toBe(false);
   });
 
+  it("omits rich inline composition until the frozen source owns its scenario", () => {
+    const root = mkTempRoot();
+    const scenario = path.join(root, "qa/scenarios/channels/telegram-rich-inline-composition.yaml");
+
+    expect(isPreRichInlineCompositionTarget(root)).toBe(true);
+    mkdirSync(path.dirname(scenario), { recursive: true });
+    writeFileSync(scenario, "id: telegram-rich-inline-composition\n");
+    expect(isPreRichInlineCompositionTarget(root)).toBe(false);
+  });
+
   it("combines only the unsupported frozen Telegram scenario contracts", () => {
     const root = mkTempRoot();
     const writeOwner = (relativePath: string, source: string) => {
@@ -506,6 +517,7 @@ describe("package Telegram live Docker E2E", () => {
       "telegram-progress-tool-visibility",
       "telegram-provider-failure-before-output",
       "telegram-queue-invalid-mode",
+      "telegram-rich-inline-composition",
     ]);
     writeOwner("extensions/telegram/src/draft-stream.ts", "waitForInFlight();");
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
@@ -513,6 +525,7 @@ describe("package Telegram live Docker E2E", () => {
       "telegram-progress-tool-visibility",
       "telegram-provider-failure-before-output",
       "telegram-queue-invalid-mode",
+      "telegram-rich-inline-composition",
     ]);
     writeOwner(
       "qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml",
@@ -522,6 +535,7 @@ describe("package Telegram live Docker E2E", () => {
       "telegram-progress-tool-visibility",
       "telegram-provider-failure-before-output",
       "telegram-queue-invalid-mode",
+      "telegram-rich-inline-composition",
     ]);
     writeOwner(
       "qa/scenarios/channels/telegram-progress-tool-visibility.yaml",
@@ -530,15 +544,26 @@ describe("package Telegram live Docker E2E", () => {
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
       "telegram-provider-failure-before-output",
       "telegram-queue-invalid-mode",
+      "telegram-rich-inline-composition",
     ]);
     writeOwner(
       "qa/scenarios/channels/telegram-provider-failure-before-output.yaml",
       "id: telegram-provider-failure-before-output\n",
     );
-    expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual(["telegram-queue-invalid-mode"]);
+    expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
+      "telegram-queue-invalid-mode",
+      "telegram-rich-inline-composition",
+    ]);
     writeOwner(
       "qa/scenarios/channels/telegram-queue-invalid-mode.yaml",
       "id: telegram-queue-invalid-mode\n",
+    );
+    expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
+      "telegram-rich-inline-composition",
+    ]);
+    writeOwner(
+      "qa/scenarios/channels/telegram-rich-inline-composition.yaml",
+      "id: telegram-rich-inline-composition\n",
     );
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([]);
   });


### PR DESCRIPTION
## Summary

- omit the rich inline composition scenario when a frozen target does not own its source contract
- sparse-checkout the scenario source before resolving target support
- cover direct and combined frozen-scenario qualification

## Validation

- `pnpm exec vitest run test/scripts/npm-telegram-live.test.ts --config vitest.config.ts`
- `pnpm check:test-types`
- `pnpm lint`
- `pnpm format:check`

Release validation root: `telegram-rich-inline-composition` was added after 2026.7.33, but the trusted package harness selected it for that frozen candidate.
