### PR TITLE
fix(ui): preserve useful automatic-build failure diagnostics

### DIFF
--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -200,6 +200,85 @@ describe("control UI assets helpers", () => {
     }
   });
 
+  it.each([
+    {
+      name: "plain multiline context",
+      stderr: "Could not load configuration\nCheck the configured entry point.\n",
+      summary: "Could not load configuration Check the configured entry point.",
+    },
+    {
+      name: "a visible error header after warnings",
+      stderr:
+        "warning: error reporting is enabled\r\n\u001b[31m\u0007[build] TypeError: invalid entry\r\nDetails:\tentry is missing\u001b[0m\r\n",
+      summary: "[build] TypeError: invalid entry Details:\\tentry is missing",
+    },
+    { name: "empty terminal output", stderr: "\u001b[0m\n\u0007\r\n", summary: "exit 1" },
+  ])("preserves $name in build failures", async ({ stderr, summary }) => {
+    const root = abs("fixtures/build-diagnostic");
+    setFile(path.join(root, "ui", "vite.config.ts"));
+    setFile(path.join(root, "scripts", "ui.js"));
+    state.runCommandWithTimeout.mockResolvedValueOnce({
+      stdout: "unrelated standard output",
+      stderr,
+      code: 1,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    await expect(ensureControlUiAssetsBuilt(undefined, { root })).resolves.toEqual({
+      ok: false,
+      built: false,
+      message: `Control UI build failed: ${summary}`,
+    });
+  });
+
+  it.each([1, 0])("reports the real build process outcome for exit %i", async (code) => {
+    const root = abs("fixtures/build-process");
+    const diagnostic = 'Error: Cannot resolve package entry "example-package/missing"';
+    const stderr = [
+      ...Array.from({ length: 15 }, () => "warning: error reporting is enabled"),
+      "\u001b[31merror during build:",
+      diagnostic,
+      ...Array.from({ length: 20 }, (_, index) => `    at loadModule (build.js:${index + 1}:1)`),
+      "  {",
+      "    code: 'ERR_MODULE_NOT_FOUND',",
+      "    plugin: 'example-plugin'",
+      "  }\u001b[0m",
+    ].join("\r\n");
+    setFile(path.join(root, "package.json"), '{"type":"commonjs"}');
+    setFile(path.join(root, "ui", "vite.config.ts"));
+    setFile(
+      path.join(root, "scripts", "ui.js"),
+      `const fs = require("node:fs");
+process.stderr.write(${JSON.stringify(stderr)});
+process.exitCode = ${code};
+if (process.exitCode === 0) {
+  fs.mkdirSync("dist/control-ui", { recursive: true });
+  fs.writeFileSync("dist/control-ui/index.html", "<html></html>");
+}
+`,
+    );
+    const { runCommandWithTimeout } =
+      await vi.importActual<typeof import("../process/exec.js")>("../process/exec.js");
+    state.runCommandWithTimeout.mockImplementationOnce(runCommandWithTimeout);
+
+    const result = await ensureControlUiAssetsBuilt(undefined, { root });
+
+    expect(result.ok).toBe(code === 0);
+    if (result.ok) {
+      expect(result).toMatchObject({ ok: true, built: true });
+      expect(result).not.toHaveProperty("message");
+    } else {
+      expect(result).toMatchObject({ ok: false, built: false });
+      expect(result.message).toMatch(`Control UI build failed: error during build: ${diagnostic}`);
+      const summary = result.message.slice("Control UI build failed: ".length);
+      expect(summary).toHaveLength(240);
+      expect(summary.endsWith("…")).toBe(true);
+      expect(summary).not.toMatch(/warning|\p{Cc}/u);
+    }
+  });
+
   it.each(["ready", "stale", "incomplete"])(
     "checks %s macOS Resources ahead of a healthy unused dist root",
     async (kind) => {
@@ -392,7 +471,7 @@ describe("control UI assets helpers", () => {
     await expect(ensureControlUiAssetsBuilt(undefined, { root })).resolves.toEqual({
       ok: false,
       built: false,
-      message: "Control UI build failed: spawn ENOENT",
+      message: "Control UI build failed: details spawn ENOENT",
     });
   });
 

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { quoteCliArg, quotePowerShellArg } from "../cli/quote-cli-arg.js";
 import { CONTROL_UI_BUILD_ID_ATTRIBUTE } from "../gateway/control-ui-root-assets.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -345,15 +347,20 @@ export function inspectControlUiRootAssets(
 }
 
 function summarizeCommandOutput(text: string): string | undefined {
-  const lines = normalizeStringEntries(text.split(/\r?\n/g));
+  const lines = normalizeStringEntries(
+    stripAnsi(text)
+      .split(/\r?\n/g)
+      .map((line) => sanitizeTerminalText(line.trim())),
+  );
   if (!lines.length) {
     return undefined;
   }
-  const last = lines.at(-1);
-  if (!last) {
-    return undefined;
-  }
-  return last.length > 240 ? `${truncateUtf16Safe(last, 239)}…` : last;
+  // Keep the error and its context, not a warning preamble or a stack/object tail.
+  const errorIndex = lines.findIndex((line) =>
+    /^(?:\[[^\]]+\]\s*)?(?:\w*error|fatal)\b/iu.test(line),
+  );
+  const summary = lines.slice(Math.max(0, errorIndex)).join(" ");
+  return summary.length > 240 ? `${truncateUtf16Safe(summary, 239)}…` : summary;
 }
 
 export async function ensureControlUiAssetsBuilt(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where automatic Control UI build failures could leave Gateway and Doctor users with only `Control UI build failed: }`, hiding the useful error above a stack trace or metadata object.

## Why This Change Was Made

The automatic-build owner now selects a generic error header and its following context, normalizes terminal output, and keeps the existing 240-UTF-16-unit diagnostic cap. Cancellation, timeouts, exit handling, and successful builds are unchanged. The surrogate-safe truncation introduced in https://github.com/openclaw/openclaw/pull/101591 is preserved.

## User Impact

Source-checkout users get an actionable build diagnostic instead of a trailing brace or ANSI escape. Build execution, dependencies, configuration, and protocol contracts are unchanged.

## Evidence

- A real spawned-child regression reproduced the old closing-brace diagnostic; the repaired path retains the package-resolution error within the cap. An exit-zero child emitting the same stderr still succeeds.
- 71 unique focused tests passed on Linux/Node 24.19.0 across asset preparation, Gateway lifecycle, and Doctor before the final lint-only test regex correction. The 41 asset tests were rerun on the final bytes locally on Node 26.7.0 and passed.
- Core production and test type graphs and the early classified guards passed before that one-literal test correction; this successful proof was reused. Production code was unchanged.
- The final exact candidate passed scoped typed lint and all eight previously unreached guards in a targeted Linux/Node 24.19.0 run. Formatting and `git diff --check` also passed. This is targeted proof across staged runs, not a claim of one clean full-suite run or normal PR CI.
- Fresh scoped autoreview on the final bytes found no P0-P2 findings.
