### PR TITLE
fix(codex): deliver generated dynamic tool images

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -26,6 +26,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
   createCodexDynamicToolBridge,
+  shouldTreatDynamicToolMediaAsHostOwned,
 } from "./dynamic-tools.js";
 import type { CodexDynamicToolFunctionSpec, CodexDynamicToolSpec, JsonValue } from "./protocol.js";
 
@@ -178,6 +179,56 @@ afterEach(() => {
 });
 
 describe("createCodexDynamicToolBridge", () => {
+  it("limits host-owned dynamic media to the concrete core image tool", () => {
+    expect(
+      shouldTreatDynamicToolMediaAsHostOwned({
+        toolName: "image_generate",
+        pluginOwned: false,
+        channelOwned: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldTreatDynamicToolMediaAsHostOwned({
+        toolName: "image_generate",
+        pluginOwned: true,
+        channelOwned: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTreatDynamicToolMediaAsHostOwned({
+        toolName: "image_generate",
+        pluginOwned: false,
+        channelOwned: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTreatDynamicToolMediaAsHostOwned({
+        toolName: "video_generate",
+        pluginOwned: false,
+        channelOwned: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("records core image generation media as host-owned", async () => {
+    const bridge = createBridgeWithToolResult(
+      "image_generate",
+      mediaResult("/tmp/generated-image.png"),
+    );
+
+    await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "image_generate",
+      arguments: { prompt: "lighthouse" },
+    });
+
+    expect(bridge.telemetry.toolMediaUrls).toEqual(["/tmp/generated-image.png"]);
+    expect(bridge.telemetry.hostOwnedToolMediaUrls).toEqual(["/tmp/generated-image.png"]);
+  });
+
   it("keeps OpenClaw control-path tools direct while deferring broad tools", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -351,6 +351,7 @@ export type CodexDynamicToolBridge = {
     messagingToolSourceReplyPayloads: MessagingToolSourceReplyPayload[];
     heartbeatToolResponse?: HeartbeatToolResponse;
     toolMediaUrls: string[];
+    hostOwnedToolMediaUrls: string[];
     toolAudioAsVoice: boolean;
     successfulCronAdds?: number;
     quarantinedTools: CodexDynamicToolSchemaQuarantine[];
@@ -422,6 +423,7 @@ export function createCodexDynamicToolBridge(params: {
     messagingToolSentTargets: [],
     messagingToolSourceReplyPayloads: [],
     toolMediaUrls: [],
+    hostOwnedToolMediaUrls: [],
     toolAudioAsVoice: false,
     quarantinedTools,
   };
@@ -602,6 +604,11 @@ export function createCodexDynamicToolBridge(params: {
           telemetry,
           isError: resultIsError,
           messagingTarget: confirmedMessagingTarget,
+          hostOwnsToolMedia: shouldTreatDynamicToolMediaAsHostOwned({
+            toolName,
+            pluginOwned: getPluginToolMeta(toolEntry.tool) !== undefined,
+            channelOwned: getChannelAgentToolMeta(toolEntry.tool as never) !== undefined,
+          }),
         });
         const terminalType =
           resultFailureKind === "blocked" ? "blocked" : resultIsError ? "error" : "completed";
@@ -1078,6 +1085,7 @@ function collectToolTelemetry(params: {
   telemetry: CodexDynamicToolBridge["telemetry"];
   isError: boolean;
   messagingTarget?: MessagingToolSend;
+  hostOwnsToolMedia?: boolean;
 }): void {
   if (params.isError) {
     return;
@@ -1104,6 +1112,12 @@ function collectToolTelemetry(params: {
         if (!seen.has(mediaUrl)) {
           seen.add(mediaUrl);
           params.telemetry.toolMediaUrls.push(mediaUrl);
+        }
+        if (
+          params.hostOwnsToolMedia === true &&
+          !params.telemetry.hostOwnedToolMediaUrls.includes(mediaUrl)
+        ) {
+          params.telemetry.hostOwnedToolMediaUrls.push(mediaUrl);
         }
       }
       if (media.audioAsVoice) {
@@ -1153,6 +1167,14 @@ function collectToolTelemetry(params: {
     ...(text ? { text } : {}),
     ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
   });
+}
+
+export function shouldTreatDynamicToolMediaAsHostOwned(params: {
+  toolName: string;
+  pluginOwned: boolean;
+  channelOwned: boolean;
+}): boolean {
+  return params.toolName === "image_generate" && !params.pluginOwned && !params.channelOwned;
 }
 
 function extractInternalSourceReplyPayload(

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -834,6 +834,20 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.toolMediaUrls).toStrictEqual([]);
   });
 
+  it("projects host-owned dynamic tool media into the terminal result", async () => {
+    const projector = await createProjector();
+    const mediaUrl = "/tmp/generated-image.png";
+
+    const result = projector.buildResult({
+      ...buildEmptyToolTelemetry(),
+      toolMediaUrls: [mediaUrl],
+      hostOwnedToolMediaUrls: [mediaUrl],
+    });
+
+    expect(result.toolMediaUrls).toEqual([mediaUrl]);
+    expect(result.hostOwnedToolMediaUrls).toEqual([mediaUrl]);
+  });
+
   it("propagates message-tool-only source reply delivery telemetry", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -65,6 +65,7 @@ export type CodexAppServerToolTelemetry = {
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
   heartbeatToolResponse?: HeartbeatToolResponse;
   toolMediaUrls?: string[];
+  hostOwnedToolMediaUrls?: string[];
   toolAudioAsVoice?: boolean;
   successfulCronAdds?: number;
 };
@@ -1620,7 +1621,13 @@ export class CodexAppServerEventProjector {
       return undefined;
     }
     const mediaUrls = [...this.nativeGeneratedMediaUrlsByItemId.values()];
-    return mediaUrls.length > 0 ? mediaUrls : undefined;
+    for (const mediaUrl of toolTelemetry.hostOwnedToolMediaUrls ?? []) {
+      const normalized = mediaUrl.trim();
+      if (normalized) {
+        mediaUrls.push(normalized);
+      }
+    }
+    return mediaUrls.length > 0 ? [...new Set(mediaUrls)] : undefined;
   }
 
   private async maybeEndReasoning(): Promise<void> {


### PR DESCRIPTION
## Summary

- mark concrete built-in `image_generate` results as host-owned media in the Codex dynamic-tool bridge
- carry that provenance through the app-server event projector
- preserve plugin/channel-owned name collisions and ordinary tool-media suppression

## Validation

- 218 focused Codex app-server tests
- `pnpm check:test-types`
- `pnpm lint`
- scoped `oxfmt --check` on all four changed files
- `git diff --check`

Backport for the 2026.7.33 release candidate. The Full Validation Matrix catalog invoked `image_generate` successfully but emitted no `m.image`; this closes the missing provenance boundary without importing broader current-main media changes.
