### PR TITLE
refactor(infra): share device pairing list projection

### DIFF
--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -24,6 +24,7 @@ import {
   loadPairedDevicePairingStoreRecord,
   persistDevicePairingStoreState,
   updatePairedDevicePresenceInTransaction,
+  type DevicePairingStoreState,
 } from "./device-pairing-store.js";
 import type {
   DeviceAuthToken,
@@ -397,8 +398,7 @@ function buildPendingDevicePairingRequest(params: {
   };
 }
 
-export async function listDevicePairing(baseDir?: string): Promise<DevicePairingList> {
-  const state = await loadDevicePairingState(baseDir);
+function toDevicePairingList(state: DevicePairingStoreState): DevicePairingList {
   const pending = Object.values(state.pendingById)
     .map(toPublicPendingDevicePairingRequest)
     .toSorted((a, b) => b.ts - a.ts);
@@ -408,16 +408,13 @@ export async function listDevicePairing(baseDir?: string): Promise<DevicePairing
   return { pending, paired };
 }
 
+export async function listDevicePairing(baseDir?: string): Promise<DevicePairingList> {
+  return toDevicePairingList(await loadDevicePairingState(baseDir));
+}
+
 /** List pairing state without creating or migrating shared state. */
 export async function listDevicePairingReadOnly(baseDir?: string): Promise<DevicePairingList> {
-  const state = await loadDevicePairingStateReadOnly(baseDir);
-  const pending = Object.values(state.pendingById)
-    .map(toPublicPendingDevicePairingRequest)
-    .toSorted((a, b) => b.ts - a.ts);
-  const paired = Object.values(state.pairedByDeviceId).toSorted(
-    (a, b) => b.approvedAtMs - a.approvedAtMs,
-  );
-  return { pending, paired };
+  return toDevicePairingList(await loadDevicePairingStateReadOnly(baseDir));
 }
 
 /** Return one paired device by normalized device id. */


### PR DESCRIPTION
## What Problem This Solves

Device-pairing list maintenance currently requires updating equivalent assembly logic in both ordinary and read-only listing.

## User Impact

No user-visible behavior change is intended. Ordering, pending-field stripping, returned values, and error propagation remain unchanged. There are no API, SDK, configuration, dependency, approval, authorization, schema, migration, or storage-semantics changes.

## Why This Change Was Made

Both entrypoints reuse one private synchronous projection with the existing store-state type. Each still awaits its original loader, preserving the read-only path's existing no-create behavior.

## Evidence

- Before and after: 83 existing owner tests, one selected Doctor/no-create case, two aged-node durability cases, and two private real-store entrypoint characterizations passed per version. Skipped cases are excluded. This is PASS/PASS characterization, not RED/GREEN defect evidence.
- All 28 selected check components passed, including core production/test typechecks, formatting, lint, storage/auth guards, and three dead-code scopes with zero entries.
- Independent review completed with no actionable findings; the signed commit preserves the reviewed one-file diff.
- Hosted CI succeeded for exact head `793e65ab0b15b1b7fe7563a91b6492f5affd3174`: [run 34589023984](https://github.com/openclaw/openclaw/actions/runs/34589023984), including the [required CI gate](https://github.com/openclaw/openclaw/actions/runs/34589023984/job/103233115002).
- Local proof remains tied to the recorded frozen baseline. This does not claim a current-main runtime or full-suite pass, live Gateway validation, or Crabbox proof.

## Main Alignment

- Later CI on that original head [failed in run 34754926877](https://github.com/openclaw/openclaw/actions/runs/34754926877). The Android onboarding test used an older synchronization pattern already corrected on main. A separate pnpm-download bootstrap `Parser.finish` assertion also failed; its underlying trigger remains unconfirmed.
- Signed merge `e1b4a1f2324a00e99818d094ff0cafad571df9a0` incorporates captured main `4aff70f27016f9acf62d0acc19c8bd3592993e4c`, retaining original head `793e65ab0b15b1b7fe7563a91b6492f5affd3174` as first parent. The one-file PR patch and reviewed owner blob are unchanged.
- Exact-head [CI run 34757669529](https://github.com/openclaw/openclaw/actions/runs/34757669529) completed **FAILURE**: `check-test-types-core-2` reported three diagnostics, and `checks-node-compact-small-1` failed with empty `outcomes` plus a worker-lease cleanup `ENOENT` (58 passed, 1 failed, 1 unhandled error). The aggregate CI gate also failed.
- The [canonical ClawSweeper review](https://github.com/openclaw/openclaw/pull/144847#issuecomment-5633124368) completed for exact head `e1b4a1f2324a00e99818d094ff0cafad571df9a0` on September 13, 2026 at 12:48:56.464 UTC, with no actionable findings. That review did not clear the failed CI and does not qualify the new head.
- Existing [PR147028](https://github.com/openclaw/openclaw/pull/147028), authored by steipete, landed as `d4d3d6cda5d5325e3047f5ad58a6577e428d372a`. Captured main also includes the later writer-context correction; this is source verification, not a claim that all prior failures are resolved.
- Signed merge `737a1c210d59597bf11b35700a96bbb1fc90bbf6` incorporates captured main `201f11afefdb19a9c75e9d3542bf7425c80df7a7`, with published `e1b4a1f2324a00e99818d094ff0cafad571df9a0` as first parent. Native publication preserved that ancestry, the reviewed owner blob, and the exact one-file +7/-10 PR patch.
- Automatic exact-new-head [CI run 34773499501](https://github.com/openclaw/openclaw/actions/runs/34773499501) completed **SUCCESS**. The previously failing `check-test-types-core-2` and `checks-node-compact-small-1` both passed on this head.
- The [canonical ClawSweeper review](https://github.com/openclaw/openclaw/pull/144847#issuecomment-5633124368) completed for exact head `737a1c210d59597bf11b35700a96bbb1fc90bbf6` on September 13, 2026 at 18:12:18.099 UTC: Findings None, Security None, Before merge None.
- Historical failures remain preserved. The new hosted result qualifies its exact head, not a full current-main or live Gateway run; no local proof was rerun.
