### PR TITLE
refactor(i18n): share Apple catalog reader

### DIFF
--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -724,26 +724,18 @@ async function readNativeTranslations(): Promise<NativeTranslationArtifact[]> {
   );
 }
 
-async function readIosCatalogBuild(): Promise<AppleCatalogBuild> {
+async function readAppleCatalogBuild(
+  catalogPath: string,
+  buildCatalog: typeof buildIosCatalog,
+): Promise<AppleCatalogBuild> {
   const existingCatalog = JSON.parse(
-    await readFile(path.join(ROOT, IOS_CATALOG_PATH), "utf8"),
+    await readFile(path.join(ROOT, catalogPath), "utf8"),
   ) as Catalog;
   const nativeSource = JSON.parse(
     await readFile(path.join(ROOT, NATIVE_SOURCE_PATH), "utf8"),
   ) as NativeSourceArtifact;
   const translations = await readNativeTranslations();
-  return buildIosCatalog(existingCatalog, nativeSource, translations);
-}
-
-async function readMacosCatalogBuild(): Promise<AppleCatalogBuild> {
-  const existingCatalog = JSON.parse(
-    await readFile(path.join(ROOT, MACOS_CATALOG_PATH), "utf8"),
-  ) as Catalog;
-  const nativeSource = JSON.parse(
-    await readFile(path.join(ROOT, NATIVE_SOURCE_PATH), "utf8"),
-  ) as NativeSourceArtifact;
-  const translations = await readNativeTranslations();
-  return buildMacosCatalog(existingCatalog, nativeSource, translations);
+  return buildCatalog(existingCatalog, nativeSource, translations);
 }
 
 function validateCatalog(pathName: string, catalog: Catalog): number {
@@ -822,7 +814,7 @@ async function syncIosInfoPlist(write: boolean): Promise<number> {
 }
 
 export async function syncIosCatalog(write: boolean): Promise<AppleCatalogBuild> {
-  const build = await readIosCatalogBuild();
+  const build = await readAppleCatalogBuild(IOS_CATALOG_PATH, buildIosCatalog);
   const catalogPath = path.join(ROOT, IOS_CATALOG_PATH);
   const expected = serializeAppleCatalog(build.catalog);
   const actual = await readFile(catalogPath, "utf8");
@@ -838,7 +830,7 @@ export async function syncIosCatalog(write: boolean): Promise<AppleCatalogBuild>
 }
 
 export async function syncMacosCatalog(write: boolean): Promise<AppleCatalogBuild> {
-  const build = await readMacosCatalogBuild();
+  const build = await readAppleCatalogBuild(MACOS_CATALOG_PATH, buildMacosCatalog);
   const catalogPath = path.join(ROOT, MACOS_CATALOG_PATH);
   const expected = serializeAppleCatalog(build.catalog);
   const actual = await readFile(catalogPath, "utf8");
@@ -896,7 +888,7 @@ export async function verifyAppleAppI18n() {
     }
   }
 
-  const macosBuild = await readMacosCatalogBuild();
+  const macosBuild = await readAppleCatalogBuild(MACOS_CATALOG_PATH, buildMacosCatalog);
   const macosKeys = validateCatalog(MACOS_CATALOG_PATH, macosBuild.catalog);
 
   process.stdout.write(`apple-app-i18n: sourceMacosKeys=${macosKeys}\n`);
@@ -930,7 +922,7 @@ export async function compileMacosLocalizations(outputDir: string) {
   // post-merge refresh. Package from the derived catalog so source changes
   // cannot ship stale localization coverage before that refresh lands.
   await verifyAppleAppI18n();
-  const catalog = (await readMacosCatalogBuild()).catalog;
+  const catalog = (await readAppleCatalogBuild(MACOS_CATALOG_PATH, buildMacosCatalog)).catalog;
   if (!catalog.strings) {
     throw new Error(`invalid Apple string catalog: ${MACOS_CATALOG_PATH}`);
   }


### PR DESCRIPTION
The head branch is in openclaw/openclaw.

## What Problem This Solves

Apple localization tooling maintains the same catalog-reading flow separately for iOS and macOS. This maintainer-requested refactor removes that duplication while preserving the platform-specific builders.

## Why This Change Was Made

One private reader takes an explicit catalog path and existing builder. All four callers preserve platform pairings, sequential reads and parsing, error propagation, and verification followed by an independent reread. No caching is introduced.

## User Impact

No user-facing behavior change is intended. Exported builders, serialization, locale policy, and native app code are unchanged.

This reader-only refactor changes neither catalog format nor persistent state, so migration proof is not applicable.

## Evidence

Paired CLI proof uses frozen candidate source/data at `5ea54a9889e76bbbb1724f20c96858e81b78f00d`, restoring only the original reader from parent `0a4447ecc53e24449cbc2b8c2f9725faeee1213a` for the baseline.

- Existing focused tests: the same two files passed 54/54 tests before and after the refactor.
- Actual local CLI: `compile-macos` followed by `sync-ios --write` in each isolated copy; all four commands exited successfully. Each variant produced 43 compiled files, and all 86 sync targets matched in membership, modes, hashes, and bytes. Sync was idempotent, not a stale-catalog rewrite exercise. Source and dependencies stayed unchanged; child processes joined and scratch was removed.
- Selected check components passed, including the targeted typecheck and deadcode checks after dependency-ownership/resolution repairs. The original aggregate failure remains recorded, not relabeled as a passing rerun. Scoped P2 code review and independent CLI-proof review found no actionable issues.
- This is frozen-source local Node/filesystem proof, not Linux/Testbox, native Apple build/app/device, current-main catalog-data, or hosted CI proof. The separate remote-allocation hold remains unchanged.
