### PR TITLE
fix: killed subagent without a captured reply retriggers requester-settle forever

### DIFF
--- a/src/agents/subagents/completion/subagent-completion-admission.store.test.ts
+++ b/src/agents/subagents/completion/subagent-completion-admission.store.test.ts
@@ -191,6 +191,37 @@ describe("atomic subagent completion admission store", () => {
     },
   );
 
+  it("durably settles a killed child that never captured completion text", async () => {
+    useDefaultDatabase();
+    const input = failedRecords("cancelled", { status: "error", error: "killed" });
+    input.subagent.completion = { required: true };
+    input.subagent.suppressAnnounceReason = "killed";
+    input.subagent.killReconciliation = {
+      killedAt: input.subagent.execution.endedAt ?? Date.now(),
+      taskCancellationAccepted: true,
+    };
+    persistOwner(input);
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+      expect(driver.warn).not.toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.any(Object),
+      );
+      expect(input.subagent.requesterSettleWake).toBeUndefined();
+      expect(input.subagent.delivery).toMatchObject({
+        status: "failed",
+        lastError: "requester unavailable",
+      });
+      expect(getTaskById(input.task.taskId)).toMatchObject({
+        status: "cancelled",
+        deliveryStatus: "failed",
+      });
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
   it.each(["successful generation", "successful task run", "cancelled delivered"] as const)(
     "rejects a stale %s requester-settle owner without changing durable records",
     async (change) => {

--- a/src/agents/subagents/registry/subagent-registry-completion.ts
+++ b/src/agents/subagents/registry/subagent-registry-completion.ts
@@ -25,26 +25,28 @@ import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const log = createSubsystemLogger("agents/subagent-registry-completion");
 
-/** Returns the complete task projection only after completion capture has settled. */
+/** Returns the complete task projection after completion capture, or immediately for a killed run. */
 export function resolveFinalizedSubagentTaskState(
   entry: SubagentRunRecord,
 ): DetachedTaskTerminalState | undefined {
   const endedAt = entry.execution.endedAt;
   const outcome = entry.execution.outcome;
   const completion = entry.completion;
+  const killedTerminal =
+    entry.endedReason === SUBAGENT_ENDED_REASON_KILLED &&
+    entry.suppressAnnounceReason !== "steer-restart";
   if (
     typeof endedAt !== "number" ||
     !outcome ||
     entry.pauseReason === "sessions_yield" ||
-    (completion?.resultText === undefined && typeof completion?.capturedAt !== "number")
+    (!killedTerminal &&
+      completion?.resultText === undefined &&
+      typeof completion?.capturedAt !== "number")
   ) {
     return undefined;
   }
   const progressSummary = resolveSubagentCompletionResultText(entry);
-  if (
-    entry.endedReason === SUBAGENT_ENDED_REASON_KILLED &&
-    entry.suppressAnnounceReason !== "steer-restart"
-  ) {
+  if (killedTerminal) {
     return {
       status: "cancelled",
       endedAt,


### PR DESCRIPTION
Related: #137332. This PR owns the remaining killed-without-completion-capture residual after #137344. Other requester-settle leftovers mentioned on that issue (multi-agent routing / missing requester identity) stay there.

## What Problem This Solves

Fixes an issue where operators with a killed child that never captured a completion reply would see the same requester-settle batch retry forever — `subagent completion owner changed before settlement` — even after the #137344 non-success settlement path.

## Why This Change Was Made

A killed child is already terminal. The finalized-state gate no longer waits for completion capture on that path, so the existing cancelled settlement can clear the wake. Successful children still require capture. No new config, no new delivery policy.

Non-goals: this does not change announce routing, requester-agent selection, or other settlement leftovers on #137332.

## User Impact

A killed / cancelled child that never produced a completion reply no longer leaves the gateway retrying its requester-settle wake every minute after restart.

## Evidence

- Pre-fail at `d9ad56cbe319ac6ba1c106a27ab547c4d50c7f05`: `node scripts/run-vitest.mjs src/agents/subagents/completion/subagent-completion-admission.store.test.ts -t 'durably settles a killed child that never captured completion text'` failed with `subagent completion owner changed before settlement: completion-run`.
- Post-fix at `6fab055f2f4b356243372aaa11968e5363355739`: the same file, 28 passed / 28.
- Production LOC: +8/-6. Tests: +31/-0.


Made with [Cursor](https://cursor.com)