### PR TITLE
fix(qa): isolate Matrix progress scenario events

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-event-scope.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-event-scope.ts
@@ -1,0 +1,11 @@
+import type { MatrixQaObservedEvent } from "../substrate/events.js";
+
+export function createCurrentScenarioEventPredicate(
+  observedEvents: readonly MatrixQaObservedEvent[],
+  startObservedIndex: number,
+) {
+  const preexistingEventIds = new Set(
+    observedEvents.slice(0, startObservedIndex).map((event) => event.eventId),
+  );
+  return (event: MatrixQaObservedEvent) => !preexistingEventIds.has(event.eventId);
+}

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
@@ -2,6 +2,8 @@ import { readdir, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
+import type { MatrixQaObservedEvent } from "../substrate/events.js";
+import { createCurrentScenarioEventPredicate } from "./scenario-runtime-event-scope.js";
 import {
   MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY,
   type MatrixQaScenarioContext,
@@ -10,6 +12,22 @@ import { prepareMatrixMentionProgressGate } from "./scenario-runtime-tool-progre
 import { runToolProgressMentionSafetyScenario } from "./scenario-runtime-tool-progress.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+it("does not reuse events observed before the current progress scenario", () => {
+  const event = (eventId: string): MatrixQaObservedEvent => ({
+    kind: "message",
+    roomId: "!room:example.test",
+    eventId,
+    type: "m.room.message",
+  });
+  const stale = event("$stale");
+  const observedEvents = [stale, event("$current")];
+  const isCurrentScenarioEvent = createCurrentScenarioEventPredicate(observedEvents, 1);
+
+  expect(isCurrentScenarioEvent(stale)).toBe(false);
+  expect(isCurrentScenarioEvent(event("$stale"))).toBe(false);
+  expect(isCurrentScenarioEvent(event("$current"))).toBe(true);
+});
 
 it("skips the release-directory-backed mention progress scenario on Windows", async () => {
   const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.ts
@@ -3,6 +3,7 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { QaSuiteScenarioSkipError } from "../../../errors.js";
 import type { MatrixQaObservedEvent } from "../substrate/events.js";
+import { createCurrentScenarioEventPredicate } from "./scenario-runtime-event-scope.js";
 import {
   advanceMatrixQaActorCursor,
   buildMatrixQaToken,
@@ -58,6 +59,10 @@ async function runMatrixToolProgressScenario(
   const allowTopLevelFinalWithProgress = allowsMatrixQaTopLevelFinalAfterProgress(params);
   const { client, startSince } = await primeMatrixQaDriverScenarioClient(context);
   const startObservedIndex = context.observedEvents.length;
+  const isCurrentScenarioEvent = createCurrentScenarioEventPredicate(
+    context.observedEvents,
+    startObservedIndex,
+  );
   await writeMatrixToolProgressTaskFile(context, params.finalText);
   await using mentionProgressGate = params.mentionSafety
     ? await prepareMatrixMentionProgressGate(context)
@@ -74,6 +79,7 @@ async function runMatrixToolProgressScenario(
   const getPreviewRootEventId = (event: MatrixQaObservedEvent) =>
     event.replacesEventId ?? event.eventId;
   const isFinalReply = (event: MatrixQaObservedEvent) =>
+    isCurrentScenarioEvent(event) &&
     event.roomId === context.roomId &&
     event.sender === context.sutUserId &&
     event.type === "m.room.message" &&
@@ -87,12 +93,14 @@ async function runMatrixToolProgressScenario(
       isMatrixQaMessageLikeKind(event.kind) &&
       matchesExpectedProgress(event.body));
   const isProgressEvent = (event: MatrixQaObservedEvent) =>
+    isCurrentScenarioEvent(event) &&
     event.roomId === context.roomId &&
     event.sender === context.sutUserId &&
     isExpectedProgressKind(event) &&
     (matchesExpectedProgress(event.body) ||
       (event.replacesEventId === undefined && event.relatesTo === undefined));
   const isProgressProofEvent = (event: MatrixQaObservedEvent) =>
+    isCurrentScenarioEvent(event) &&
     event.roomId === context.roomId &&
     event.sender === context.sutUserId &&
     isExpectedProgressKind(event) &&


### PR DESCRIPTION
## Summary

- exclude Matrix events already observed before the current tool-progress mention scenario
- apply the same scenario-local identity boundary to preview, final, and cleanup predicates
- retain current-scenario events even when sync replay duplicates an older event body

## Validation

- 7 focused Matrix progress tests
- `pnpm check:test-types`
- `pnpm lint`
- scoped `oxfmt --check`
- `git diff --check`

The Full Validation retry showed the mention-safety assertion consuming an event ID from the immediately preceding scenario even though the current progress and final events were present. This fixes the cursor identity boundary without weakening the mention-safety assertions.
