### PR TITLE
fix: keep widget cards beside their progress messages

### DIFF
--- a/ui/src/e2e/chat-widget-order.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-order.e2e.test.ts
@@ -17,6 +17,132 @@ const suite = createControlUiE2eSuite({
 
 suite.define(() => {
   const canvasView = useCanvasSandboxFixture();
+  it.each(["forwarded", "projected", "mixed"] as const)(
+    "preserves %s assistant embeds through history reload",
+    async (representation) => {
+      await suite.withPage(
+        { viewport: { width: 1280, height: 1000 }, colorScheme: "light", locale: "en-US" },
+        async ({ page }) => {
+          const startedAt = Date.now();
+          const result = {
+            role: "toolResult",
+            toolName: "show_widget",
+            toolCallId: "review-widget-one",
+            timestamp: startedAt + 10,
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  kind: "canvas",
+                  view: {
+                    backend: "canvas",
+                    id: "cv_review_one",
+                    title: "Widget one",
+                    url: "/__openclaw__/canvas/documents/cv_review_one/index.html",
+                  },
+                  presentation: { target: "assistant_message" },
+                }),
+              },
+            ],
+          };
+          const siblingId = representation === "mixed" ? "cv_review_two" : "cv_review_one";
+          const siblingTitle = representation === "mixed" ? "Widget two" : "Widget one";
+          const historyMessages = [
+            { role: "user", content: "Show the report.", timestamp: startedAt },
+            result,
+            ...(representation === "mixed"
+              ? []
+              : [
+                  {
+                    role: "assistant",
+                    content: "Another turn: show that report again.",
+                    timestamp: startedAt + 20,
+                    ...(representation === "forwarded"
+                      ? { provenance: { kind: "inter_session", sourceTool: "sessions_send" } }
+                      : { __openclaw: { id: "review-new-turn", turnBoundary: true } }),
+                  },
+                ]),
+            {
+              role: "assistant",
+              timestamp: startedAt + 30,
+              content: [
+                ...(representation === "mixed"
+                  ? [
+                      {
+                        type: "text",
+                        text: '[embed ref="cv_review_one" /][embed ref="cv_review_two" /]',
+                      },
+                    ]
+                  : []),
+                {
+                  type: "canvas",
+                  preview: {
+                    kind: "canvas",
+                    surface: "assistant_message",
+                    render: "url",
+                    viewId: siblingId,
+                    title: siblingTitle,
+                    url: `/__openclaw__/canvas/documents/${siblingId}/index.html`,
+                    sandbox: "scripts",
+                  },
+                },
+              ],
+            },
+          ];
+          await installMockGateway(page, {
+            historyMessages,
+            methodResponses: {
+              "canvas.document.view": {
+                cases: ["one", "two"].map((suffix) => ({
+                  match: { docId: `cv_review_${suffix}` },
+                  response: canvasView(
+                    buildWidgetDocument(
+                      `Widget ${suffix}`,
+                      `<section style="padding:16px"><h2>Widget ${suffix}</h2><p>Report contents preserved.</p></section>`,
+                    ),
+                  ),
+                })),
+              },
+            },
+          });
+          await page.goto(`${suite.server.baseUrl}chat`);
+          for (const stage of ["history", "reload"]) {
+            if (stage === "reload") {
+              await page.reload();
+            }
+            const widgets = page.locator(".chat-tool-card__preview-frame");
+            await expect.poll(() => widgets.count()).toBe(2);
+            expect(
+              await widgets.evaluateAll((frames) =>
+                frames.map((frame) => frame.getAttribute("title")),
+              ),
+            ).toEqual(["Widget one", siblingTitle]);
+            for (let index = 0; index < 2; index++) {
+              await widgets
+                .nth(index)
+                .contentFrame()
+                .frameLocator("iframe")
+                .getByRole("heading", { name: index === 0 ? "Widget one" : siblingTitle })
+                .waitFor();
+            }
+            if (representation !== "mixed") {
+              const boundary = await page
+                .getByText("Another turn: show that report again.", { exact: true })
+                .boundingBox();
+              const first = await widgets.nth(0).boundingBox();
+              const second = await widgets.nth(1).boundingBox();
+              expect(first!.y).toBeLessThan(boundary!.y);
+              expect(boundary!.y).toBeLessThan(second!.y);
+            }
+            await page.screenshot({
+              path: path.join(suite.artifactDir, `${representation}-${stage}.png`),
+            });
+          }
+        },
+      );
+    },
+  );
+
   it("keeps progress and widgets in order through final and history reload", async () => {
     await suite.withPage(
       { viewport: { width: 1280, height: 1100 }, colorScheme: "light", locale: "en-US" },

--- a/ui/src/e2e/chat-widget-order.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-order.e2e.test.ts
@@ -17,8 +17,8 @@ const suite = createControlUiE2eSuite({
 
 suite.define(() => {
   const canvasView = useCanvasSandboxFixture();
-  it.each(["forwarded", "projected", "mixed"] as const)(
-    "preserves %s assistant embeds through history reload",
+  it.each(["forwarded", "projected", "mixed", "repeated-text"] as const)(
+    "preserves %s transcript content through history reload",
     async (representation) => {
       await suite.withPage(
         { viewport: { width: 1280, height: 1000 }, colorScheme: "light", locale: "en-US" },
@@ -47,12 +47,19 @@ suite.define(() => {
           };
           const siblingId = representation === "mixed" ? "cv_review_two" : "cv_review_one";
           const siblingTitle = representation === "mixed" ? "Widget two" : "Widget one";
+          const hasBoundary = representation === "forwarded" || representation === "projected";
           const historyMessages = [
             { role: "user", content: "Show the report.", timestamp: startedAt },
+            ...(representation === "repeated-text"
+              ? [1, 2].map((offset) => ({
+                  role: "assistant",
+                  content: "Preparing the report.",
+                  timestamp: startedAt + offset,
+                }))
+              : []),
             result,
-            ...(representation === "mixed"
-              ? []
-              : [
+            ...(hasBoundary
+              ? [
                   {
                     role: "assistant",
                     content: "Another turn: show that report again.",
@@ -61,11 +68,15 @@ suite.define(() => {
                       ? { provenance: { kind: "inter_session", sourceTool: "sessions_send" } }
                       : { __openclaw: { id: "review-new-turn", turnBoundary: true } }),
                   },
-                ]),
+                ]
+              : []),
             {
-              role: "assistant",
+              role: representation === "repeated-text" ? "Assistant" : "assistant",
               timestamp: startedAt + 30,
               content: [
+                ...(representation === "repeated-text"
+                  ? [{ type: "text", text: "Report ready." }]
+                  : []),
                 ...(representation === "mixed"
                   ? [
                       {
@@ -111,21 +122,23 @@ suite.define(() => {
               await page.reload();
             }
             const widgets = page.locator(".chat-tool-card__preview-frame");
-            await expect.poll(() => widgets.count()).toBe(2);
+            const expectedTitles =
+              representation === "repeated-text" ? ["Widget one"] : ["Widget one", siblingTitle];
+            await expect.poll(() => widgets.count()).toBe(expectedTitles.length);
             expect(
               await widgets.evaluateAll((frames) =>
                 frames.map((frame) => frame.getAttribute("title")),
               ),
-            ).toEqual(["Widget one", siblingTitle]);
-            for (let index = 0; index < 2; index++) {
+            ).toEqual(expectedTitles);
+            for (const [index, title] of expectedTitles.entries()) {
               await widgets
                 .nth(index)
                 .contentFrame()
                 .frameLocator("iframe")
-                .getByRole("heading", { name: index === 0 ? "Widget one" : siblingTitle })
+                .getByRole("heading", { name: title })
                 .waitFor();
             }
-            if (representation !== "mixed") {
+            if (hasBoundary) {
               const boundary = await page
                 .getByText("Another turn: show that report again.", { exact: true })
                 .boundingBox();
@@ -137,6 +150,15 @@ suite.define(() => {
             await page.screenshot({
               path: path.join(suite.artifactDir, `${representation}-${stage}.png`),
             });
+            if (representation === "repeated-text") {
+              expect(await page.getByText("Report ready.", { exact: true }).count()).toBe(1);
+              const badges = page.locator(".chat-duplicate-count");
+              expect(await badges.count()).toBe(1);
+              expect(await badges.textContent()).toBe("×2");
+              expect(await badges.getAttribute("aria-label")).toBe(
+                "2 consecutive identical messages collapsed",
+              );
+            }
           }
         },
       );

--- a/ui/src/e2e/chat-widget-order.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-order.e2e.test.ts
@@ -1,0 +1,215 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
+import {
+  appendChatCanvasBlocksToMessage,
+  augmentChatHistoryWithCanvasBlocks,
+  extractChatToolResultCanvasPreview,
+} from "../../../src/gateway/chat-display-projection.canvas.js";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { useCanvasSandboxFixture } from "./canvas-sandbox.test-support.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI interleaved widget order",
+  startServerBeforeBrowser: true,
+});
+
+suite.define(() => {
+  const canvasView = useCanvasSandboxFixture();
+  it("keeps progress and widgets in order through final and history reload", async () => {
+    await suite.withPage(
+      { viewport: { width: 1280, height: 1100 }, colorScheme: "light", locale: "en-US" },
+      async ({ page: livePage, context }) => {
+        let page = livePage;
+        const runId = "run-widget-order";
+        const startedAt = Date.now();
+        const titles = ["Widget one", "Widget two"];
+        const progress = ["Step one: collect readings.", "Step two: compare readings."];
+        const user = {
+          role: "user",
+          content: "Show two visual steps, with a progress message before each widget.",
+          timestamp: startedAt,
+          __openclaw: { id: "widget-order-user", idempotencyKey: runId, seq: 1 },
+        };
+        const results = titles.map((title, index) => ({
+          role: "toolResult",
+          runId,
+          toolName: "show_widget",
+          toolCallId: `widget-order-${index}`,
+          timestamp: startedAt + 20 + index * 20,
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                kind: "canvas",
+                view: {
+                  backend: "canvas",
+                  id: `cv_order_${index}`,
+                  title,
+                  url: `/__openclaw__/canvas/documents/cv_order_${index}/index.html`,
+                  preferred_height: 140,
+                },
+                presentation: { target: "assistant_message", sandbox: "scripts" },
+              }),
+            },
+          ],
+        }));
+        const scenario = {
+          historyMessages: [user],
+          inFlightRun: { runId, startedAt, text: "" },
+          methodResponses: {
+            "canvas.document.view": {
+              cases: titles.map((title, index) => ({
+                match: { docId: `cv_order_${index}` },
+                response: canvasView(
+                  buildWidgetDocument(
+                    title,
+                    `<section style="padding:16px;background:${index === 0 ? "#e8f2ff" : "#eaf8ed"};border-radius:12px"><h2 style="margin:0 0 8px">${title}</h2><p style="margin:0">${index === 0 ? "Readings collected" : "Comparison complete"}</p></section>`,
+                  ),
+                ),
+              })),
+            },
+          },
+        };
+        const gateway = await installMockGateway(page, scenario);
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await page.getByText(user.content, { exact: true }).waitFor();
+        let seq = 0;
+        for (const [index, result] of results.entries()) {
+          await gateway.emitGatewayEvent("agent", {
+            runId,
+            sessionKey: "main",
+            stream: "item",
+            seq: ++seq,
+            ts: startedAt + 10 + index * 20,
+            data: { kind: "preamble", itemId: `progress-${index}`, progressText: progress[index] },
+          });
+          await page.getByText(progress[index]!, { exact: true }).waitFor();
+          await gateway.emitGatewayEvent("agent", {
+            runId,
+            sessionKey: "main",
+            stream: "tool",
+            seq: ++seq,
+            ts: result.timestamp - 1,
+            data: {
+              phase: "start",
+              name: "show_widget",
+              toolCallId: result.toolCallId,
+              args: { title: titles[index] },
+            },
+          });
+          await gateway.emitGatewayEvent("agent", {
+            runId,
+            sessionKey: "main",
+            stream: "tool",
+            seq: ++seq,
+            ts: result.timestamp,
+            data: {
+              phase: "result",
+              name: "show_widget",
+              toolCallId: result.toolCallId,
+              result: result.content[0]!.text,
+            },
+          });
+          await page
+            .locator(`.chat-tool-card__preview-frame[title="${titles[index]}"]`)
+            .contentFrame()
+            .frameLocator("iframe")
+            .getByRole("heading", { name: titles[index] })
+            .waitFor();
+        }
+        const inspectOrder = async (stage: string) => {
+          const widgets = page.locator(".chat-tool-card__preview-frame");
+          await expect.poll(() => widgets.count()).toBeGreaterThanOrEqual(2);
+          const positions = await Promise.all(
+            [
+              page.getByText(progress[0]!, { exact: true }),
+              page.locator(`.chat-tool-card__preview-frame[title="${titles[0]}"]`),
+              page.getByText(progress[1]!, { exact: true }),
+              page.locator(`.chat-tool-card__preview-frame[title="${titles[1]}"]`),
+            ].map(async (locator, index) => ({
+              index,
+              y: (await locator.first().boundingBox())?.y ?? -1,
+            })),
+          );
+          await page.screenshot({ path: path.join(suite.artifactDir, `${stage}.png`) });
+          expect.soft(await widgets.count(), stage).toBe(2);
+          expect
+            .soft(
+              positions.map(({ y }) => y),
+              stage,
+            )
+            .not.toContain(-1);
+          expect
+            .soft(
+              positions.toSorted((a, b) => a.y - b.y).map(({ index }) => index),
+              stage,
+            )
+            .toEqual([0, 1, 2, 3]);
+        };
+        await inspectOrder("01-streaming");
+        const final = appendChatCanvasBlocksToMessage(
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Both steps are complete." }],
+            timestamp: startedAt + 50,
+          },
+          results.flatMap((result) => extractChatToolResultCanvasPreview(result) ?? []),
+        );
+        const history = augmentChatHistoryWithCanvasBlocks([
+          user,
+          ...results.flatMap((result, index) => [
+            {
+              role: "assistant",
+              phase: "commentary",
+              content: [{ type: "text", text: progress[index] }],
+              timestamp: startedAt + 10 + index * 20,
+              __openclaw: { id: `progress-${index}`, runId, seq: 2 + index * 2 },
+            },
+            result,
+          ]),
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Both steps are complete." }],
+            timestamp: startedAt + 50,
+          },
+        ]);
+        await gateway.setHistoryMessages(history);
+        await gateway.emitGatewayEvent("chat", {
+          runId,
+          sessionKey: "main",
+          seq: seq + 1,
+          state: "final",
+          message: final,
+        });
+        await page
+          .getByRole("paragraph")
+          .filter({ hasText: /^Both steps are complete\.$/u })
+          .waitFor();
+        await inspectOrder("02-final");
+        // The mock's initial history is immutable across navigations. A fresh
+        // page receives the now-durable snapshot, without retaining live state.
+        await page.close();
+        page = await context.newPage();
+        await installMockGateway(page, {
+          ...scenario,
+          historyMessages: history,
+          inFlightRun: null,
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await page
+          .getByRole("paragraph")
+          .filter({ hasText: /^Both steps are complete\.$/u })
+          .waitFor();
+        await inspectOrder("03-history");
+        await page.reload();
+        await page
+          .getByRole("paragraph")
+          .filter({ hasText: /^Both steps are complete\.$/u })
+          .waitFor();
+        await inspectOrder("04-reload");
+      },
+    );
+  });
+});

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -53,7 +53,7 @@ import {
   messageMatchesSearchQuery,
   queuedSendThreadMessage,
   rawMessageTimestamp,
-  removeCanvasPreviewFromAssistantMessage,
+  reconcileCanvasDisplayCopies,
   insertChatItemsByTimestamp,
   sanitizeStreamText,
   timestampAfterVisibleItems,
@@ -72,7 +72,7 @@ import {
   resolveRunInsertionBounds,
 } from "./chat-thread-run-identity.ts";
 import { coalesceToolActivityMessages } from "./chat-tool-activity-coalesce.ts";
-import { chatItemStartsUserTurn, safeNormalizeMessage } from "./chat-turn-boundary.ts";
+import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
 import { selectChatInputDisplay } from "./history-merge.ts";
 import { resolveSystemNoticeKind } from "./system-notice-kinds.ts";
 import { isLiveTerminalForRun } from "./terminal-message-identity.ts";
@@ -141,7 +141,10 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   );
   const searchFiltering = props.searchOpen === true && Boolean(props.searchQuery?.trim());
   const persistedCanvasIdentities = new Set<string>();
-  const toolOwnedCanvasPreviews = new Map<string, CanvasToolPreview>();
+  const toolOwnedCanvasSources = new Map<
+    string,
+    NonNullable<ReturnType<typeof extractChatMessagePreview>>
+  >();
   const normalizedHistory = history.map(safeNormalizeMessage);
   const historyItems = buildMessageItems(history);
   let canvasTurn: {
@@ -151,8 +154,8 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     previews: [],
     lastMatchingAssistantIndex: -1,
   };
-  // Rows in one turn share these facts so a tool result can see the assistant
-  // projection that follows it, without consuming a view from another turn.
+  // Search keeps its existing assistant-centric projection. Non-search display
+  // copies are reconciled only after all live/history rows have been placed.
   const canvasTurns = historyItems.map((item, index) => {
     const message = normalizedHistory[index];
     const role = message && normalizeRoleForGrouping(message.role);
@@ -238,25 +241,13 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         persistedCanvasSource.text,
       );
     }
-    if (persistedCanvasSource && !searchFiltering) {
-      for (const { preview, item: assistantItem } of canvasTurns[i]!.previews) {
-        if (!canvasPreviewsMatch(preview, persistedCanvasSource.preview)) {
-          continue;
-        }
-        persistedCanvasSource.preview = { ...persistedCanvasSource.preview, ...preview };
-        assistantItem.message = removeCanvasPreviewFromAssistantMessage(
-          assistantItem.message,
-          preview,
-        );
-      }
-    }
     const renderPersistedPreview =
       persistedCanvasSource != null &&
       (!matchingCanvas || !searchFiltering) &&
       (!searchFiltering || canvasTurns[i]!.lastMatchingAssistantIndex > i);
     if (persistedCanvasSource && renderPersistedPreview) {
       const key = canvasAssistantItemKey(msg, persistedCanvasSource, itemKey);
-      toolOwnedCanvasPreviews.set(key, persistedCanvasSource.preview);
+      toolOwnedCanvasSources.set(key, persistedCanvasSource);
       items.push({
         kind: "message",
         key,
@@ -427,22 +418,6 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       }
       continue;
     }
-    for (let index = canvasMinimumIndex; index < canvasMaximumIndex; index += 1) {
-      const item = items[index];
-      if (item?.kind !== "message" || toolOwnedCanvasPreviews.has(item.key)) {
-        continue;
-      }
-      const normalized = safeNormalizeMessage(item.message);
-      if (normalized?.role !== "assistant") {
-        continue;
-      }
-      for (const block of normalized.content) {
-        if (block.type === "canvas" && canvasPreviewsMatch(block.preview, preview.preview)) {
-          preview.preview = { ...preview.preview, ...block.preview };
-          item.message = removeCanvasPreviewFromAssistantMessage(item.message, block.preview);
-        }
-      }
-    }
     // The tool owns the preview's position. Attaching it to a nearby assistant
     // collapses intervening live commentary and moves widgets again at final.
     const canvas: ChatProjection = {
@@ -453,7 +428,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       },
       bounds: canvasBounds ?? undefined,
     };
-    toolOwnedCanvasPreviews.set(canvas.item.key, preview.preview);
+    toolOwnedCanvasSources.set(canvas.item.key, preview);
     canvasProjections.push({ canvas, tool: projection });
     projections.push(canvas);
   }
@@ -698,46 +673,12 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     appendQueuedSend(queued);
   }
 
-  const grouped = groupMessages(coalesceToolActivityMessages(items));
+  const coalesced = coalesceToolActivityMessages(items);
+  const grouped = groupMessages(coalesced);
   if (searchFiltering) {
     return grouped;
   }
-  // Grouping owns projected and forwarded turn boundaries as well as user
-  // messages. Keep replay deduplication inside those established boundaries.
-  let turnPreviews: CanvasToolPreview[] = [];
-  const duplicateCanvasMessages = new Set<unknown>();
-  for (const item of grouped) {
-    if (item.kind !== "group") {
-      if (chatItemStartsUserTurn(item) || item.kind === "divider") {
-        turnPreviews = [];
-      }
-      continue;
-    }
-    for (const entry of item.messages) {
-      // A forwarded input can share a same-role group with earlier output.
-      // Apply the canonical boundary predicate at the exact message position.
-      if (chatItemStartsUserTurn({ ...item, messages: [entry] })) {
-        turnPreviews = [];
-      }
-      const preview = toolOwnedCanvasPreviews.get(entry.key);
-      if (!preview) {
-        continue;
-      }
-      if (turnPreviews.some((existing) => canvasPreviewsMatch(existing, preview))) {
-        duplicateCanvasMessages.add(entry.message);
-      } else {
-        turnPreviews.push(preview);
-      }
-    }
-  }
-  if (duplicateCanvasMessages.size === 0) {
-    return grouped;
-  }
-  // Rebuild only when a replay was removed so group keys and visible-content
-  // classification still describe the surviving messages.
-  return groupMessages(
-    coalesceToolActivityMessages(
-      items.filter((item) => item.kind !== "message" || !duplicateCanvasMessages.has(item.message)),
-    ),
-  );
+  const reconciled = reconcileCanvasDisplayCopies(coalesced, grouped, toolOwnedCanvasSources);
+  // Rebuild only changed projections so group keys and content facts stay current.
+  return reconciled === coalesced ? grouped : groupMessages(reconciled);
 }

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -46,7 +46,6 @@ import {
   canvasPreviewBaseIdentity,
   createCanvasAssistantMessage,
   extractChatMessagePreview,
-  findCanvasInsertionIndex,
   findNearestAssistantMessage,
   hasRenderableNormalizedMessage,
   insertionIndexesForBounds,
@@ -54,6 +53,7 @@ import {
   messageMatchesSearchQuery,
   queuedSendThreadMessage,
   rawMessageTimestamp,
+  removeCanvasPreviewFromAssistantMessage,
   insertChatItemsByTimestamp,
   sanitizeStreamText,
   timestampAfterVisibleItems,
@@ -72,7 +72,7 @@ import {
   resolveRunInsertionBounds,
 } from "./chat-thread-run-identity.ts";
 import { coalesceToolActivityMessages } from "./chat-tool-activity-coalesce.ts";
-import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
+import { chatItemStartsUserTurn, safeNormalizeMessage } from "./chat-turn-boundary.ts";
 import { selectChatInputDisplay } from "./history-merge.ts";
 import { resolveSystemNoticeKind } from "./system-notice-kinds.ts";
 import { isLiveTerminalForRun } from "./terminal-message-identity.ts";
@@ -141,6 +141,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   );
   const searchFiltering = props.searchOpen === true && Boolean(props.searchQuery?.trim());
   const persistedCanvasIdentities = new Set<string>();
+  const toolOwnedCanvasPreviews = new Map<string, CanvasToolPreview>();
   const normalizedHistory = history.map(safeNormalizeMessage);
   const historyItems = buildMessageItems(history);
   let canvasTurn: {
@@ -228,7 +229,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       canvasTurns[i]!.previews.find(({ preview }) =>
         canvasPreviewsMatch(preview, persistedCanvasSource.preview),
       );
-    if (persistedCanvasSource && matchingCanvas) {
+    if (persistedCanvasSource && matchingCanvas && searchFiltering) {
       // Enrich the owned display row, including a later assistant shortcode,
       // without changing transcript input or introducing a second widget card.
       matchingCanvas.item.message = appendCanvasBlockToAssistantMessage(
@@ -237,14 +238,28 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         persistedCanvasSource.text,
       );
     }
+    if (persistedCanvasSource && !searchFiltering) {
+      for (const { preview, item: assistantItem } of canvasTurns[i]!.previews) {
+        if (!canvasPreviewsMatch(preview, persistedCanvasSource.preview)) {
+          continue;
+        }
+        persistedCanvasSource.preview = { ...persistedCanvasSource.preview, ...preview };
+        assistantItem.message = removeCanvasPreviewFromAssistantMessage(
+          assistantItem.message,
+          preview,
+        );
+      }
+    }
     const renderPersistedPreview =
       persistedCanvasSource != null &&
-      !matchingCanvas &&
+      (!matchingCanvas || !searchFiltering) &&
       (!searchFiltering || canvasTurns[i]!.lastMatchingAssistantIndex > i);
     if (persistedCanvasSource && renderPersistedPreview) {
+      const key = canvasAssistantItemKey(msg, persistedCanvasSource, itemKey);
+      toolOwnedCanvasPreviews.set(key, persistedCanvasSource.preview);
       items.push({
         kind: "message",
-        key: canvasAssistantItemKey(msg, persistedCanvasSource, itemKey),
+        key,
         message: createCanvasAssistantMessage(
           persistedCanvasSource,
           persistedCanvasSource.timestamp ?? transcriptPositionTimestamp(history, i),
@@ -310,11 +325,6 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   const futureQueuedSends = threadQueuedSends.filter(
     (queued) => !currentRunQueuedSends.includes(queued),
   );
-  const futureQueuedTimestamp = futureQueuedSends.reduce<number | null>(
-    (earliest, queued) =>
-      earliest == null ? queued.createdAt : Math.min(earliest, queued.createdAt),
-    null,
-  );
   // Transient projections merge into stable history + queued-send rows by timestamp.
   // Stable rows keep their relative order despite client and Gateway clock skew.
   const projections: ChatProjection[] = buildPendingInputItems(
@@ -379,6 +389,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   }
   const currentTurnBounds = findCurrentTurnBounds(items);
   const canvasRunBounds = createRunTurnLookup(items);
+  const canvasProjections: Array<{ canvas: ChatProjection; tool: ChatProjection }> = [];
   for (const { projection, preview } of toolItems) {
     if (!preview) {
       continue;
@@ -397,53 +408,54 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       items,
       canvasBounds ?? undefined,
     );
-    const assistant = findNearestAssistantMessage(
-      items,
-      preview.timestamp,
-      canvasMinimumIndex,
-      canvasMaximumIndex,
-    );
-    if (assistant) {
-      items[assistant.index] = {
-        ...assistant.item,
-        message: appendCanvasBlockToAssistantMessage(
-          assistant.item.message,
-          preview.preview,
-          preview.text,
-        ),
-      };
-      continue;
-    }
     if (searchFiltering) {
+      const assistant = findNearestAssistantMessage(
+        items,
+        preview.timestamp,
+        canvasMinimumIndex,
+        canvasMaximumIndex,
+      );
+      if (assistant) {
+        items[assistant.index] = {
+          ...assistant.item,
+          message: appendCanvasBlockToAssistantMessage(
+            assistant.item.message,
+            preview.preview,
+            preview.text,
+          ),
+        };
+      }
       continue;
     }
-    const insertionIndex = findCanvasInsertionIndex(
-      items,
-      preview.timestamp,
-      canvasMinimumIndex,
-      canvasMaximumIndex,
-    );
-    const nextItem = items[insertionIndex];
-    const nextTimestamp =
-      nextItem?.kind === "message" ? rawMessageTimestamp(nextItem.message) : null;
-    const boundaryTimestamp =
-      nextTimestamp == null
-        ? futureQueuedTimestamp
-        : futureQueuedTimestamp == null
-          ? nextTimestamp
-          : Math.min(nextTimestamp, futureQueuedTimestamp);
-    const timestamp =
-      preview.timestamp != null && boundaryTimestamp != null
-        ? Math.min(preview.timestamp, boundaryTimestamp)
-        : preview.timestamp;
-    // Canvas previews are positioned relative to the queued-send tail that
-    // existed when they were lifted, so they stay in the stable row order
-    // rather than being re-sorted with live stream/tool cards.
-    items.splice(insertionIndex, 0, {
-      kind: "message",
-      key: canvasAssistantItemKey(projection.item.message, preview, projection.item.key),
-      message: createCanvasAssistantMessage(preview, timestamp),
-    });
+    for (let index = canvasMinimumIndex; index < canvasMaximumIndex; index += 1) {
+      const item = items[index];
+      if (item?.kind !== "message" || toolOwnedCanvasPreviews.has(item.key)) {
+        continue;
+      }
+      const normalized = safeNormalizeMessage(item.message);
+      if (normalized?.role !== "assistant") {
+        continue;
+      }
+      for (const block of normalized.content) {
+        if (block.type === "canvas" && canvasPreviewsMatch(block.preview, preview.preview)) {
+          preview.preview = { ...preview.preview, ...block.preview };
+          item.message = removeCanvasPreviewFromAssistantMessage(item.message, block.preview);
+        }
+      }
+    }
+    // The tool owns the preview's position. Attaching it to a nearby assistant
+    // collapses intervening live commentary and moves widgets again at final.
+    const canvas: ChatProjection = {
+      item: {
+        kind: "message",
+        key: canvasAssistantItemKey(projection.item.message, preview, projection.item.key),
+        message: createCanvasAssistantMessage(preview),
+      },
+      bounds: canvasBounds ?? undefined,
+    };
+    toolOwnedCanvasPreviews.set(canvas.item.key, preview.preview);
+    canvasProjections.push({ canvas, tool: projection });
+    projections.push(canvas);
   }
   items = items.filter(
     (item) => item.kind !== "message" || hasRenderableNormalizedMessage(item.message),
@@ -607,6 +619,10 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     items,
     toolItems.map((tool) => tool.projection),
   );
+  for (const { canvas, tool } of canvasProjections) {
+    canvas.bounds = tool.bounds ?? canvas.bounds;
+    canvas.predecessorKey = tool.predecessorKey;
+  }
   insertChatItemsByTimestamp(items, projections);
 
   // The active claw is telemetry, not a placeholder: it stays through visible
@@ -682,5 +698,46 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     appendQueuedSend(queued);
   }
 
-  return groupMessages(coalesceToolActivityMessages(items));
+  const grouped = groupMessages(coalesceToolActivityMessages(items));
+  if (searchFiltering) {
+    return grouped;
+  }
+  // Grouping owns projected and forwarded turn boundaries as well as user
+  // messages. Keep replay deduplication inside those established boundaries.
+  let turnPreviews: CanvasToolPreview[] = [];
+  const duplicateCanvasMessages = new Set<unknown>();
+  for (const item of grouped) {
+    if (item.kind !== "group") {
+      if (chatItemStartsUserTurn(item) || item.kind === "divider") {
+        turnPreviews = [];
+      }
+      continue;
+    }
+    for (const entry of item.messages) {
+      // A forwarded input can share a same-role group with earlier output.
+      // Apply the canonical boundary predicate at the exact message position.
+      if (chatItemStartsUserTurn({ ...item, messages: [entry] })) {
+        turnPreviews = [];
+      }
+      const preview = toolOwnedCanvasPreviews.get(entry.key);
+      if (!preview) {
+        continue;
+      }
+      if (turnPreviews.some((existing) => canvasPreviewsMatch(existing, preview))) {
+        duplicateCanvasMessages.add(entry.message);
+      } else {
+        turnPreviews.push(preview);
+      }
+    }
+  }
+  if (duplicateCanvasMessages.size === 0) {
+    return grouped;
+  }
+  // Rebuild only when a replay was removed so group keys and visible-content
+  // classification still describe the surviving messages.
+  return groupMessages(
+    coalesceToolActivityMessages(
+      items.filter((item) => item.kind !== "message" || !duplicateCanvasMessages.has(item.message)),
+    ),
+  );
 }

--- a/ui/src/pages/chat/chat-thread-canvas-order.test.ts
+++ b/ui/src/pages/chat/chat-thread-canvas-order.test.ts
@@ -139,6 +139,138 @@ describe("interleaved widget transcript order", () => {
     ]);
   });
 
+  it("removes a display copy from a coalesced assistant tool invocation", () => {
+    // The canonical activity row owns the replayed call. Coalescing leaves a
+    // new assistant object for its earlier prose and Canvas display copy.
+    const result = widgetResult(1);
+    const mixed = appendChatCanvasBlocksToMessage(
+      {
+        role: "assistant",
+        timestamp: 3_000,
+        content: [
+          { type: "text", text: "Keep going" },
+          { type: "toolCall", id: "call-read", name: "read", arguments: { path: "report.txt" } },
+        ],
+      },
+      [result].flatMap((value) => extractChatToolResultCanvasPreview(value) ?? []),
+    );
+    expect(
+      visibleOrder({
+        showToolCalls: true,
+        messages: [
+          { role: "user", content: "Show the widget", timestamp: 500 },
+          result,
+          mixed,
+          {
+            role: "assistant",
+            timestamp: 3_500,
+            __openclaw: {
+              transcriptPosition: {
+                source: "test-history",
+                rawSeq: 4,
+                activity: { afterRawSeq: 3, scopeId: runId, startOrder: 0 },
+              },
+            },
+            content: [
+              {
+                type: "toolCall",
+                id: "call-read",
+                name: "read",
+                arguments: { path: "report.txt" },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual(["Widget one", "Keep going"]);
+  });
+
+  describe.each(["history", "live"] as const)("%s display-copy ownership", (source) => {
+    it.each([
+      { provenance: { kind: "inter_session", sourceTool: "sessions_send" } },
+      { __openclaw: { id: "projected-embed-turn", turnBoundary: true } },
+    ])("preserves a later turn's embed without another tool result: %j", (metadata) => {
+      const result = widgetResult(1);
+      const messages = [
+        { role: "user", content: "Show the widget", timestamp: 500 },
+        ...(source === "history" ? [result] : []),
+        { role: "assistant", content: "Another turn", timestamp: 3_000, ...metadata },
+        {
+          role: "assistant",
+          content: '[embed ref="cv_interleaved_1" title="Widget one" /]',
+          timestamp: 4_000,
+        },
+      ];
+      const original = structuredClone(messages);
+      expect(visibleOrder({ messages, toolMessages: source === "live" ? [result] : [] })).toEqual([
+        "Widget one",
+        "Another turn",
+        "Widget one",
+      ]);
+      expect(messages).toEqual(original);
+    });
+
+    it("does not materialize an unrelated shortcode over its structured sibling", () => {
+      const result = widgetResult(1);
+      const sibling = {
+        type: "canvas",
+        preview: {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          viewId: "cv_interleaved_2",
+          title: "Widget two",
+          url: "/__openclaw__/canvas/documents/cv_interleaved_2/index.html",
+          sandbox: "scripts",
+          preferredHeight: 480,
+        },
+      };
+      const messages = [
+        { role: "user", content: "Show the widget", timestamp: 500 },
+        ...(source === "history" ? [result] : []),
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: '[embed ref="cv_interleaved_1" /][embed ref="cv_interleaved_2" /]',
+            },
+            sibling,
+          ],
+          timestamp: 3_000,
+        },
+      ];
+      const original = structuredClone(messages);
+      expect(visibleOrder({ messages, toolMessages: source === "live" ? [result] : [] })).toEqual([
+        "Widget one",
+        "Widget two",
+      ]);
+      const items = buildCachedChatItems({
+        paneId: "mixed-embed-metadata",
+        sessionKey: "main",
+        messages,
+        toolMessages: source === "live" ? [result] : [],
+        streamSegments: [],
+        stream: null,
+        streamStartedAt: null,
+        showToolCalls: false,
+      });
+      const previews = items.flatMap((item) =>
+        item.kind === "group"
+          ? item.messages.flatMap(({ message }) =>
+              normalizeMessage(message).content.flatMap((block) =>
+                block.type === "canvas" && block.preview.viewId === sibling.preview.viewId
+                  ? [block.preview]
+                  : [],
+              ),
+            )
+          : [],
+      );
+      expect(previews).toEqual([sibling.preview]);
+      expect(messages).toEqual(original);
+    });
+  });
+
   it.each(["streaming", "terminal", "terminal-with-widgets", "history"] as const)(
     "keeps each widget between its surrounding progress messages at %s",
     (stage) => {

--- a/ui/src/pages/chat/chat-thread-canvas-order.test.ts
+++ b/ui/src/pages/chat/chat-thread-canvas-order.test.ts
@@ -67,6 +67,52 @@ function visibleOrder(props: Partial<Parameters<typeof buildCachedChatItems>[0]>
 }
 
 describe("interleaved widget transcript order", () => {
+  it.each([
+    { copies: 2, showToolCalls: false },
+    { copies: 2, showToolCalls: true },
+    { copies: 3, showToolCalls: false },
+    { copies: 3, showToolCalls: true },
+  ])("keeps $copies text copies counted once with widgets and tools=$showToolCalls", (options) => {
+    const result = widgetResult(1);
+    const messages = [
+      { role: "user", content: "Show a visual step", timestamp: 500 },
+      ...Array.from({ length: options.copies }, (_, index) => ({
+        role: "assistant",
+        content: "Step one",
+        timestamp: 1_000 + index,
+      })),
+      result,
+      appendChatCanvasBlocksToMessage(
+        { role: "assistant", content: "", timestamp: 3_000 },
+        [result].flatMap((value) => extractChatToolResultCanvasPreview(value) ?? []),
+      ),
+    ];
+    const original = structuredClone(messages);
+    const items = buildCachedChatItems({
+      paneId: `widget-repeat-count-${options.copies}-${options.showToolCalls}`,
+      sessionKey: "main",
+      messages,
+      toolMessages: [],
+      streamSegments: [],
+      stream: null,
+      streamStartedAt: null,
+      showToolCalls: options.showToolCalls,
+    });
+    const entries = items.flatMap((item) => (item.kind === "group" ? item.messages : []));
+    const repeated = entries.filter(({ message }) =>
+      normalizeMessage(message).content.some(
+        (block) => block.type === "text" && block.text === "Step one",
+      ),
+    );
+    expect(repeated).toHaveLength(1);
+    expect(repeated[0]?.duplicateCount).toBe(options.copies);
+    expect(visibleOrder({ messages, showToolCalls: options.showToolCalls })).toEqual([
+      "Step one",
+      "Widget one",
+    ]);
+    expect(messages).toEqual(original);
+  });
+
   it.each(["streaming", "history", "overlap"] as const)(
     "renders a repeated widget once within its turn at %s",
     (stage) => {
@@ -186,6 +232,26 @@ describe("interleaved widget transcript order", () => {
   });
 
   describe.each(["history", "live"] as const)("%s display-copy ownership", (source) => {
+    it.each(["assistant", "Assistant", "ASSISTANT"])(
+      "reconciles structured display copies for normalized role %s without losing prose",
+      (role) => {
+        const result = widgetResult(1);
+        const messages = [
+          { role: "user", content: "Show the widget", timestamp: 500 },
+          ...(source === "history" ? [result] : []),
+          appendChatCanvasBlocksToMessage(
+            { role, content: "Keep this explanation.", timestamp: 3_000 },
+            [result].flatMap((value) => extractChatToolResultCanvasPreview(value) ?? []),
+          ),
+        ];
+        const original = structuredClone(messages);
+        expect(visibleOrder({ messages, toolMessages: source === "live" ? [result] : [] })).toEqual(
+          ["Widget one", "Keep this explanation."],
+        );
+        expect(messages).toEqual(original);
+      },
+    );
+
     it.each([
       { provenance: { kind: "inter_session", sourceTool: "sessions_send" } },
       { __openclaw: { id: "projected-embed-turn", turnBoundary: true } },

--- a/ui/src/pages/chat/chat-thread-canvas-order.test.ts
+++ b/ui/src/pages/chat/chat-thread-canvas-order.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  appendChatCanvasBlocksToMessage,
+  augmentChatHistoryWithCanvasBlocks,
+  extractChatToolResultCanvasPreview,
+} from "../../../../src/gateway/chat-display-projection.canvas.js";
+import type { ChatStreamSegment } from "../../lib/chat/chat-types.ts";
+import { normalizeMessage } from "../../lib/chat/message-normalizer.ts";
+import { buildCachedChatItems } from "./chat-thread.ts";
+import { materializeVisibleStreamState } from "./stream-reconciliation.ts";
+
+const runId = "run-interleaved-widgets";
+const expectedOrder = ["Step one", "Widget one", "Step two", "Widget two"];
+
+function widgetResult(index: number) {
+  return {
+    role: "toolResult",
+    runId,
+    toolCallId: `call-widget-${index}`,
+    toolName: "show_widget",
+    timestamp: index * 2_000,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          kind: "canvas",
+          view: {
+            backend: "canvas",
+            id: `cv_interleaved_${index}`,
+            url: `/__openclaw__/canvas/documents/cv_interleaved_${index}/index.html`,
+            title: index === 1 ? "Widget one" : "Widget two",
+            preferred_height: 160,
+          },
+          presentation: { target: "assistant_message" },
+        }),
+      },
+    ],
+  };
+}
+
+function visibleOrder(props: Partial<Parameters<typeof buildCachedChatItems>[0]>) {
+  return buildCachedChatItems({
+    paneId: "interleaved-widgets",
+    sessionKey: "main",
+    runId,
+    messages: [],
+    toolMessages: [],
+    streamSegments: [],
+    stream: null,
+    streamStartedAt: null,
+    showToolCalls: false,
+    ...props,
+  }).flatMap((item) => {
+    if (item.kind === "stream") {
+      return [item.text];
+    }
+    if (item.kind !== "group" || item.role !== "assistant") {
+      return [];
+    }
+    return item.messages.flatMap(({ message }) =>
+      normalizeMessage(message).content.flatMap((block) =>
+        block.type === "canvas" ? [block.preview.title] : block.type === "text" ? [block.text] : [],
+      ),
+    );
+  });
+}
+
+describe("interleaved widget transcript order", () => {
+  it.each(["streaming", "history", "overlap"] as const)(
+    "renders a repeated widget once within its turn at %s",
+    (stage) => {
+      const user = { role: "user", content: "Show a visual step", timestamp: 500 };
+      const progress = { role: "assistant", content: "Step one", timestamp: 1_000 };
+      const result = widgetResult(1);
+      const replay = { ...result, toolCallId: "call-widget-replay", timestamp: 3_000 };
+      expect(
+        visibleOrder({
+          messages:
+            stage === "overlap"
+              ? [user, progress, result]
+              : stage === "history"
+                ? augmentChatHistoryWithCanvasBlocks([user, progress, result, replay])
+                : [user, progress],
+          toolMessages:
+            stage === "history" ? [] : stage === "overlap" ? [replay] : [result, replay],
+        }),
+      ).toEqual(["Step one", "Widget one"]);
+    },
+  );
+
+  it("does not deduplicate the same widget across user turns", () => {
+    const result = widgetResult(1);
+    expect(
+      visibleOrder({
+        messages: [
+          { role: "user", content: "Show the widget", timestamp: 500 },
+          result,
+          { role: "user", content: "Show it again", timestamp: 3_000 },
+          { ...result, toolCallId: "call-later-turn", timestamp: 4_000 },
+        ],
+      }),
+    ).toEqual(["Widget one", "Widget one"]);
+  });
+
+  it.each([
+    { provenance: { kind: "inter_session", sourceTool: "sessions_send" } },
+    { __openclaw: { id: "projected-turn", turnBoundary: true } },
+  ])("keeps a repeated widget after assistant-side turn boundary %j", (metadata) => {
+    const result = widgetResult(1);
+    expect(
+      visibleOrder({
+        messages: [
+          { role: "user", content: "Show the widget", timestamp: 500 },
+          result,
+          { role: "assistant", content: "Another turn", timestamp: 3_000, ...metadata },
+          { ...result, toolCallId: "call-forwarded-turn", timestamp: 4_000 },
+        ],
+      }),
+    ).toEqual(["Widget one", "Another turn", "Widget one"]);
+  });
+
+  it("allows adjacent widgets to share a message group", () => {
+    const items = buildCachedChatItems({
+      paneId: "adjacent-widgets",
+      sessionKey: "main",
+      messages: [],
+      toolMessages: [widgetResult(1), widgetResult(2)],
+      streamSegments: [],
+      stream: null,
+      streamStartedAt: null,
+      showToolCalls: false,
+    });
+    const assistants = items.filter((item) => item.kind === "group" && item.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(visibleOrder({ toolMessages: [widgetResult(1), widgetResult(2)] })).toEqual([
+      "Widget one",
+      "Widget two",
+    ]);
+  });
+
+  it.each(["streaming", "terminal", "terminal-with-widgets", "history"] as const)(
+    "keeps each widget between its surrounding progress messages at %s",
+    (stage) => {
+      const user = { role: "user", content: "Show two visual steps", timestamp: 500 };
+      const results = [widgetResult(1), widgetResult(2)];
+      const streamSegments: ChatStreamSegment[] = [
+        { text: "Step one", ts: 1_000, itemId: "progress-one", runId },
+        { text: "Step two", ts: 3_000, itemId: "progress-two", runId },
+      ];
+      const terminalMessages = materializeVisibleStreamState(
+        [user],
+        {
+          chatMessages: [user],
+          chatRunId: runId,
+          chatStream: null,
+          chatStreamStartedAt: null,
+          chatStreamSegments: streamSegments,
+        },
+        {
+          persistCommentary: true,
+          isHiddenAssistantMessage: () => false,
+          isHiddenStreamText: () => false,
+        },
+      );
+      const savedProgress = streamSegments.map((segment) => ({
+        role: "assistant",
+        content: [{ type: "text", text: segment.text }],
+        timestamp: segment.ts,
+        phase: "commentary",
+      }));
+      const history = augmentChatHistoryWithCanvasBlocks([
+        user,
+        savedProgress[0],
+        results[0],
+        savedProgress[1],
+        results[1],
+      ]);
+      if (stage === "terminal-with-widgets") {
+        terminalMessages.push(
+          appendChatCanvasBlocksToMessage(
+            { role: "assistant", content: [], timestamp: 5_000 },
+            results.flatMap((result) => extractChatToolResultCanvasPreview(result) ?? []),
+          ),
+        );
+      }
+
+      expect(
+        visibleOrder({
+          messages:
+            stage === "streaming"
+              ? [user]
+              : stage.startsWith("terminal")
+                ? terminalMessages
+                : history,
+          toolMessages: stage === "history" ? [] : results,
+          streamSegments: stage === "streaming" ? streamSegments : [],
+          runWorking: stage === "streaming",
+        }),
+      ).toEqual(expectedOrder);
+    },
+  );
+});

--- a/ui/src/pages/chat/chat-thread-duplicates.ts
+++ b/ui/src/pages/chat/chat-thread-duplicates.ts
@@ -145,7 +145,11 @@ export function prepareMessagesForGrouping(items: ChatItem[]): PreparedChatItem[
     ) {
       const signature = collapseDuplicateDisplaySignature(parts);
       if (signature && signature === collapseDuplicateDisplaySignature(previousParts)) {
-        previous.item.duplicateCount = (previous.item.duplicateCount ?? 1) + 1;
+        // Counts belong to this projection, not the source items reused by regrouping.
+        previous.item = {
+          ...previous.item,
+          duplicateCount: (previous.item.duplicateCount ?? 1) + 1,
+        };
         continue;
       }
     }

--- a/ui/src/pages/chat/chat-thread-grouping.test.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.test.ts
@@ -33,6 +33,24 @@ function cachedGroups(messages: unknown[]) {
   }).filter((item) => item.kind === "group");
 }
 
+describe("duplicate count projection", () => {
+  it.each([2, 3])("groups %i repeated messages without mutating or recounting inputs", (copies) => {
+    const items: ChatItem[] = Array.from({ length: copies }, (_, index) => ({
+      kind: "message",
+      key: `repeat:${index}`,
+      message: { role: "assistant", content: "Still working", timestamp: 1_000 + index },
+    }));
+    const original = structuredClone(items);
+    const first = groupMessages(items);
+    expect(first).toMatchObject([
+      { kind: "group", messages: [{ key: "repeat:0", duplicateCount: copies }] },
+    ]);
+    expect(items).toEqual(original);
+    expect(groupMessages(items)).toEqual(first);
+    expect(items).toEqual(original);
+  });
+});
+
 describe("reasoning activity boundaries", () => {
   it.each([
     { type: "text", text: "Visible answer" },

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -3,6 +3,7 @@ import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
+import { extractCanvasShortcodes } from "../../../../src/chat/canvas-render.js";
 import { resolveToolUseId } from "../../../../src/chat/tool-content.js";
 import type { ChatItem, ChatQueueItem, ToolCard } from "../../lib/chat/chat-types.ts";
 import { extractTextCached, readTranscriptMediaEntries } from "../../lib/chat/message-extract.ts";
@@ -51,6 +52,55 @@ export function appendCanvasBlockToAssistantMessage(
       },
     ],
   };
+}
+
+/** Remove a tool-owned display copy without rewriting other message content. */
+export function removeCanvasPreviewFromAssistantMessage(
+  message: unknown,
+  preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>,
+): unknown {
+  const raw = asRecord(message);
+  if (!raw || raw.role !== "assistant") {
+    return message;
+  }
+  const content = Array.isArray(raw.content)
+    ? raw.content
+    : typeof raw.content === "string"
+      ? [{ type: "text", text: raw.content }]
+      : typeof raw.text === "string"
+        ? [{ type: "text", text: raw.text }]
+        : [];
+  let changed = false;
+  const nextContent: unknown[] = [];
+  for (const value of content) {
+    const existing = readCanvasContentPreview(value);
+    if (existing && canvasPreviewsMatch(existing, preview)) {
+      changed = true;
+      continue;
+    }
+    const block = asRecord(value);
+    if (
+      !block ||
+      !["text", "input_text", "output_text"].includes(String(block.type)) ||
+      typeof block.text !== "string"
+    ) {
+      nextContent.push(value);
+      continue;
+    }
+    const extracted = extractCanvasShortcodes(block.text);
+    if (!extracted.previews.some((candidate) => canvasPreviewsMatch(candidate, preview))) {
+      nextContent.push(value);
+      continue;
+    }
+    changed = true;
+    nextContent.push({ ...block, text: extracted.text });
+    for (const candidate of extracted.previews) {
+      if (!canvasPreviewsMatch(candidate, preview)) {
+        nextContent.push({ type: "canvas", preview: candidate });
+      }
+    }
+  }
+  return changed ? { ...raw, content: nextContent } : message;
 }
 
 export function messageMatchesSearchQuery(message: unknown, query: string): boolean {
@@ -205,33 +255,6 @@ export function findNearestAssistantMessage(
       : last;
   }
   return previous?.anchor ?? last;
-}
-
-export function findCanvasInsertionIndex(
-  items: ChatItem[],
-  toolTimestamp: number | null,
-  minimumIndex = 0,
-  maximumIndex = items.length,
-): number {
-  if (toolTimestamp == null) {
-    return maximumIndex;
-  }
-  for (let index = minimumIndex; index < maximumIndex; index += 1) {
-    const item = items[index];
-    if (item?.kind !== "message") {
-      continue;
-    }
-    const normalized = safeNormalizeMessage(item.message);
-    if (
-      normalized &&
-      normalizeRoleForGrouping(normalized.role).toLowerCase() === "user" &&
-      normalized.timestamp != null &&
-      normalized.timestamp > toolTimestamp
-    ) {
-      return index;
-    }
-  }
-  return maximumIndex;
 }
 
 function resolveMessageToolUseId(message: Record<string, unknown>): string | undefined {

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -54,13 +54,13 @@ export function appendCanvasBlockToAssistantMessage(
   };
 }
 
-/** Remove a tool-owned display copy without rewriting other message content. */
+/** The caller selects normalized assistant groups; preserve their other content. */
 function removeCanvasPreviewFromAssistantMessage(
   message: unknown,
   preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>,
 ): unknown {
   const raw = asRecord(message);
-  if (!raw || raw.role !== "assistant") {
+  if (!raw) {
     return message;
   }
   const content = Array.isArray(raw.content)

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -5,7 +5,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { extractCanvasShortcodes } from "../../../../src/chat/canvas-render.js";
 import { resolveToolUseId } from "../../../../src/chat/tool-content.js";
-import type { ChatItem, ChatQueueItem, ToolCard } from "../../lib/chat/chat-types.ts";
+import type { ChatItem, ChatQueueItem, MessageGroup, ToolCard } from "../../lib/chat/chat-types.ts";
 import { extractTextCached, readTranscriptMediaEntries } from "../../lib/chat/message-extract.ts";
 import {
   canvasPreviewsMatch,
@@ -55,7 +55,7 @@ export function appendCanvasBlockToAssistantMessage(
 }
 
 /** Remove a tool-owned display copy without rewriting other message content. */
-export function removeCanvasPreviewFromAssistantMessage(
+function removeCanvasPreviewFromAssistantMessage(
   message: unknown,
   preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>,
 ): unknown {
@@ -72,6 +72,7 @@ export function removeCanvasPreviewFromAssistantMessage(
         : [];
   let changed = false;
   const nextContent: unknown[] = [];
+  const structuredPreviews = content.flatMap((value) => readCanvasContentPreview(value) ?? []);
   for (const value of content) {
     const existing = readCanvasContentPreview(value);
     if (existing && canvasPreviewsMatch(existing, preview)) {
@@ -95,12 +96,110 @@ export function removeCanvasPreviewFromAssistantMessage(
     changed = true;
     nextContent.push({ ...block, text: extracted.text });
     for (const candidate of extracted.previews) {
-      if (!canvasPreviewsMatch(candidate, preview)) {
+      if (
+        !canvasPreviewsMatch(candidate, preview) &&
+        !structuredPreviews.some((structured) => canvasPreviewsMatch(candidate, structured))
+      ) {
         nextContent.push({ type: "canvas", preview: candidate });
       }
     }
   }
   return changed ? { ...raw, content: nextContent } : message;
+}
+
+export function reconcileCanvasDisplayCopies(
+  items: ChatItem[],
+  grouped: Array<ChatItem | MessageGroup>,
+  toolOwnedCanvasSources: ReadonlyMap<string, ChatMessagePreview>,
+): ChatItem[] {
+  // All history and live projections now have their actual positions. Resolve
+  // display-copy ownership only here, using the same forwarded/projected/user
+  // boundaries as grouping; earlier removal cannot restore a later turn's embed.
+  let turnMessages: MessageGroup["messages"] = [];
+  const replacements = new Map<unknown, unknown>();
+  const duplicateCanvasMessages = new Set<unknown>();
+  const finishCanvasTurn = () => {
+    const owners: {
+      message: unknown;
+      source: ChatMessagePreview;
+    }[] = [];
+    for (const entry of turnMessages) {
+      const source = toolOwnedCanvasSources.get(entry.key);
+      if (!source) {
+        continue;
+      }
+      if (owners.some((owner) => canvasPreviewsMatch(owner.source.preview, source.preview))) {
+        duplicateCanvasMessages.add(entry.message);
+      } else {
+        owners.push({ message: entry.message, source });
+      }
+    }
+    for (const entry of turnMessages) {
+      if (toolOwnedCanvasSources.has(entry.key)) {
+        continue;
+      }
+      for (const block of safeNormalizeMessage(entry.message)?.content ?? []) {
+        if (block.type !== "canvas") {
+          continue;
+        }
+        const owner = owners.find(({ source }) =>
+          canvasPreviewsMatch(source.preview, block.preview),
+        );
+        if (!owner) {
+          continue;
+        }
+        owner.source = { ...owner.source, preview: { ...owner.source.preview, ...block.preview } };
+        replacements.set(
+          entry.message,
+          removeCanvasPreviewFromAssistantMessage(
+            replacements.get(entry.message) ?? entry.message,
+            block.preview,
+          ),
+        );
+        replacements.set(
+          owner.message,
+          createCanvasAssistantMessage(owner.source, rawMessageTimestamp(owner.message)),
+        );
+      }
+    }
+    turnMessages = [];
+  };
+  for (const item of grouped) {
+    if (item.kind !== "group") {
+      if (chatItemStartsUserTurn(item) || item.kind === "divider") {
+        finishCanvasTurn();
+      }
+      continue;
+    }
+    for (const entry of item.messages) {
+      // A forwarded input can share a same-role group with earlier output.
+      // Apply the canonical boundary predicate at the exact message position.
+      if (chatItemStartsUserTurn({ ...item, messages: [entry] })) {
+        finishCanvasTurn();
+      }
+      if (item.role === "assistant") {
+        turnMessages.push(entry);
+      }
+    }
+  }
+  finishCanvasTurn();
+  if (duplicateCanvasMessages.size === 0 && replacements.size === 0) {
+    return items;
+  }
+  return items.flatMap<ChatItem>((item) => {
+    if (item.kind !== "message") {
+      return [item];
+    }
+    if (duplicateCanvasMessages.has(item.message)) {
+      return [];
+    }
+    const message = replacements.get(item.message);
+    return message === undefined
+      ? [item]
+      : hasRenderableNormalizedMessage(message)
+        ? [{ ...item, message }]
+        : [];
+  });
 }
 
 export function messageMatchesSearchQuery(message: unknown, query: string): boolean {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -4430,7 +4430,7 @@ describe("buildCachedChatItems", () => {
     ]);
   });
 
-  it("attaches lifted canvas previews to the nearest assistant turn", () => {
+  it("keeps a lifted canvas preview before the later unrelated reply", () => {
     const groups = messageGroups({
       messages: [
         assistantMessage([{ type: "text", text: "First reply." }], 1_000, {
@@ -4451,7 +4451,7 @@ describe("buildCachedChatItems", () => {
       ],
     });
 
-    expect(canvasBlocksIn(groupAt(groups, 0))).toHaveLength(1);
+    expect(canvasBlocksAcross(groupAt(groups, 0))).toHaveLength(1);
     expect(canvasBlocksIn(groupAt(groups, 1))).toStrictEqual([]);
   });
 


### PR DESCRIPTION
Closes #144812

## What Problem This Solves

Fixes an issue where users following several visual steps in Control UI see widget cards move away from their progress messages while a reply is running or when it finishes. A sequence of `progress one → widget one → progress two → widget two` can become `progress one → widget one → widget two → progress two`; finalization can also leave duplicate display copies.

This concerns a widget's position in the conversation, not whether every widget should have its own message bubble. Existing refresh deduplication does not by itself preserve that position.

## Why This Change Was Made

Place each preview at its existing tool projection position, using the established run bounds and predecessor relationship, instead of attaching it to a nearby assistant before stream segments have been merged.

The review repair removes the two early assistant-copy removal passes. After all live/history projections are placed, a single turn-scoped pass uses the existing `groupMessages` / `chatItemStartsUserTurn` boundaries to remove matching display copies, preserve richer widget metadata, and deduplicate repeated tool-owned views. This also preserves intentional assistant embeds after forwarded or projected boundaries when there is no second tool result to recreate them.

When removing a matching shortcode, unrelated shortcodes honor the normalizer's existing structured-sibling priority: removing A must not materialize another B when a richer structured B already exists.

The second review identified a separate repeat-count defect: widget reconciliation may regroup the same projected items, while duplicate preparation mutated their counters in place. The duplicate owner now creates a grouping-local item copy when incrementing the count. Repeated passes derive the same count from unchanged source items. A subsequent isolated review caught a redundant raw-role check in display-copy removal; the helper now consumes its caller's canonical assistant-group selection, so supported `Assistant`/`ASSISTANT` role variants also retain their prose without duplicating the card.

The production change remains limited to three Control UI projection files. It does not change Gateway payloads, widget HTML/CSS, plugins, approvals, or the global bubble-grouping policy. Adjacent distinct widgets can still share a bubble. Existing search placement is retained.

## User Impact

Progress stays beside its corresponding visual step across streaming, finalization, and history reconstruction. Users do not have to refresh to recover a readable sequence. A later turn can intentionally show the same view, and mixed shortcode/structured replies do not gain extra cards or lose rich metadata. Repeated text retains an accurate collapsed-message count, including when widget reconciliation rebuilds the groups.

## Evidence

Compared with official baseline `68b7893b3ca977a238af165717f7bc2a40e1a8f0`, using synthetic content only:

- **Original RED:** focused live projection puts the second widget before its progress message. A separate canonical-history fixture without message IDs puts both progress messages before the widgets.
- **Original browser RED:** the built Control UI shows the live ordering defect and four preview elements at finalization instead of two. The fixture's ID-bearing history/reload path already passes on baseline; those stages are compatibility coverage, not a claim that every reload path is broken.
- **Review RED:** six new `buildCachedChatItems` cases fail on reviewed head `d39b9082cc4f8d084095232d7ba24a2a71a23ddb`: forwarded/projected boundaries lose the next turn's embed in both history and live input, and mixed A/B shortcodes plus structured B duplicate B in both sources. Boundary regressions deliberately have **no second tool result**.
- **Sibling RED/GREEN:** canonical tool coalescing can allocate a new assistant message for leftover prose and Canvas content. An additional regression exposed reconciliation applying replacements to the older list, leaving a duplicate. Grouping and reconciliation now consume the same coalesced list; the regression passes without changing coalescing policy.
- **Revision 2 RED:** six new tests fail on `080718e0b5`: the real `buildCachedChatItems` entry point reports 3 for two identical text rows and 5 for three, with tool details both shown and hidden. Direct grouping also mutates its source items. The cases combine repeated text, a widget tool result, and its assistant display copy.
- **Role-boundary RED:** history/live tests with `Assistant` and `ASSISTANT` each retain a duplicate widget before the raw-role guard is removed (four failures); lowercase controls pass. All six now pass, preserving prose and unmodified input messages.
- **Review GREEN:** all 475 tests across `chat-thread.test.ts`, `chat-thread-canvas-order.test.ts`, `chat-thread-grouping.test.ts`, `chat-agent-run-grouping.test.ts`, `stream-reconciliation.test.ts`, and `message-normalizer.test.ts` pass. The new cases verify exact counts, retained widget order, unmodified inputs, stable repeated grouping, and canonical assistant-role handling.
- **Browser GREEN:** five built Control UI Chromium cases pass: original streaming/final/cold-history/reload ordering; forwarded-boundary reuse; projected-boundary reuse; mixed shortcode/structured content; repeated text with widget-copy reconciliation. The new count case includes an `Assistant`-role structured display copy with explanation text; it displays exactly one widget, the explanation once, and `×2` (also `2 consecutive identical messages collapsed` in its accessible label) on initial history load and reload. Current captures were personally inspected and retained locally. This uses the real built UI with synthetic Gateway transport, not a live model/provider.
- The full changed-file gate passes against the explicit official baseline (core-test and UI types, formatting, ratchets, i18n, coercion/dead-export guards, and lint), as does `git diff --check`.
- Fresh isolated `autoreview` of the complete final candidate against the official baseline returned **scoped-clean at P0–P2** after the role-boundary repair. This is independent local review evidence, not maintainer approval or an all-CI-green claim.
- No full-repository runtime test or live-provider claim is made.

### Failure-mode sweep

| Surface | Repair / retained contract |
| --- | --- |
| History assistant-copy removal | Early removal deleted; canonical turn boundaries apply after placement. |
| Live assistant-copy removal | Early removal deleted; shares the same turn-scoped pass as history. |
| Repeated tool previews and rich copies | Reconciled within canonical user/forwarded/projected/reset boundaries; unrelated embeds remain. |
| Mixed shortcode / structured content | Existing structured sibling wins; B's count and metadata are preserved when A is removed. |
| Coalesced tool activity | Replacements apply to the same coalesced message objects used by canonical grouping. |
| Duplicate-count lifetime | The sole presentation count writer uses a grouping-local item copy. Two grouping passes no longer count the same source row twice; matching and relay/native rules are unchanged. |
| Assistant role selection | The private removal helper consumes the caller's canonical assistant groups rather than imposing a conflicting raw-role check. |
| Search and bubble grouping | Existing behavior retained; not replaced with global Canvas splitting. |

### Original ordering screenshots

These previously attached captures show the central ordering scenario; the latest candidate reruns that same scenario plus the three representation cases and the repeated-text/count case. These are prior attached captures, not newly uploaded screenshots from the latest head.

Before, during streaming: widget two appears before its progress message.

![Before: both widgets above the second progress message](https://github.com/user-attachments/assets/fce805cd-737a-4ef2-9e2e-c94534c083d8)

After, during streaming: each progress message precedes its own widget.

![After: progress and widgets remain interleaved](https://github.com/user-attachments/assets/6c2f7fd7-4076-4aba-b558-016eaef6e3dc)

The same sequence after [finalization](https://github.com/user-attachments/assets/d6d920ca-0c98-4b2e-9d26-fbb97fe6dbbc) and [reload](https://github.com/user-attachments/assets/f09060cf-8bfc-4f4b-849b-3c49259f67a4).

### Reproduction

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/chat-thread-canvas-order.test.ts ui/src/pages/chat/chat-thread-grouping.test.ts ui/src/pages/chat/chat-agent-run-grouping.test.ts ui/src/pages/chat/stream-reconciliation.test.ts ui/src/lib/chat/message-normalizer.test.ts --reporter=dot
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-widget-order.e2e.test.ts --reporter=dot
node scripts/check-changed.mjs --base 68b7893b3ca977a238af165717f7bc2a40e1a8f0 -- ui/src/pages/chat/chat-thread-build.ts ui/src/pages/chat/chat-thread-items.ts ui/src/pages/chat/chat-thread-duplicates.ts ui/src/pages/chat/chat-thread-grouping.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/chat-thread-canvas-order.test.ts ui/src/e2e/chat-widget-order.e2e.test.ts
git diff --check
```

### Separate CI readiness failure

The earlier [real-Gateway CI failure](https://github.com/openclaw/openclaw/actions/runs/34590169290/job/103233705656) is the model-picker test retaining `with-effort` instead of switching to `no-effort`. The [same failure occurred independently](https://github.com/openclaw/openclaw/actions/runs/34600233825/job/103265660688) on a tree whose two card-production files and failing test were byte-identical to this PR's unpatched baseline. Official [add8f2a](https://github.com/openclaw/openclaw/commit/add8f2a59e430a1c4abd42dc13ced20ec1d644c1) waits for the Send control to be enabled before pressing Enter; its [corresponding job passed](https://github.com/openclaw/openclaw/actions/runs/34603321083/job/103276061721), and the repair landed in [#144226](https://github.com/openclaw/openclaw/pull/144226).

That unrelated test repair is not mixed into this card patch. The exact baseline job was skipped, not green; this evidence is independent reproduction and upstream repair, not a claim that every CI check passed.

The subsequent CI run on `080718e0b5` also had a [Doctor ledger failure](https://github.com/openclaw/openclaw/actions/runs/34633441320/job/103375817985): `doctor-update.ledger.test.ts` expected `ExitError(1)` but received `Doctor child did not settle normally`. That test has the identical blob in main parent `24a8205e9afb` and CI merge `0a18dcbec2a1`; causation is not established by that comparison alone. No Doctor code/test changes are included. New-head CI must be evaluated separately; the targeted local results above are not an all-CI-green claim.

Allow edits from maintainers is enabled.
