### PR TITLE
refactor(sessions): await discovery and config readiness

### DIFF
--- a/src/agents/workspace-state-dirs.ts
+++ b/src/agents/workspace-state-dirs.ts
@@ -15,12 +15,12 @@ import { assertWorkspaceStateMigrationReady } from "./workspace-legacy-state.js"
 import { readWorkspaceStateSnapshot } from "./workspace-state-store.js";
 
 /** Select configured workspaces and active sandbox copies for migration and readiness. */
-export function listWorkspaceStateDirs(params: {
+export async function listWorkspaceStateDirs(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   homedir: () => string;
   stateDir: string;
-}): string[] {
+}): Promise<string[]> {
   const dirs = new Set(listAgentWorkspaceDirs(params.cfg, params.env));
 
   for (const agentId of listAgentIds(params.cfg)) {
@@ -53,7 +53,7 @@ export function listWorkspaceStateDirs(params: {
 
     // Sandbox containers may be pruned while their workspace survives. The
     // agent-owned session store remains the durable authority for that copy.
-    const sessionKeys = listSessionEntryKeysReadOnly({
+    const sessionKeys = await listSessionEntryKeysReadOnly({
       agentId,
       env: params.env,
       storePath: resolveSessionStorePathCore(params.cfg.session?.store, {
@@ -83,34 +83,24 @@ export function listWorkspaceStateDirs(params: {
   return [...dirs];
 }
 
-type ConfiguredWorkspaceStateParams = {
+/** Refuse completion before channels accept work that a workspace cannot execute. */
+export async function assertConfiguredWorkspaceStateReady(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
-};
-
-function configuredWorkspaceStateScope(params: ConfiguredWorkspaceStateParams) {
+  operation?: "doctor";
+}): Promise<void> {
   const env = params.env ?? process.env;
   const homedir = os.homedir;
-  const workspaceDirs = listWorkspaceStateDirs({
+  const workspaceDirs = await listWorkspaceStateDirs({
     cfg: params.cfg,
     env,
     homedir,
     stateDir: resolveStateDir(env, homedir),
   });
-  return { ...params, workspaceDirs, env, homedir };
-}
-
-/** Refuse completion before channels accept work that a workspace cannot execute. */
-export function assertConfiguredWorkspaceStateReady(params: ConfiguredWorkspaceStateParams): void {
-  assertWorkspaceStateMigrationReady(configuredWorkspaceStateScope(params));
-}
-
-export async function assertConfiguredWorkspaceStateReadyForDoctor(
-  params: ConfiguredWorkspaceStateParams,
-): Promise<void> {
-  const scope = configuredWorkspaceStateScope(params);
-  for (const workspaceDir of scope.workspaceDirs) {
-    await readWorkspaceStateSnapshot(workspaceDir, { env: scope.env, readOnly: true });
+  if (params.operation === "doctor") {
+    for (const workspaceDir of workspaceDirs) {
+      await readWorkspaceStateSnapshot(workspaceDir, { env, readOnly: true });
+    }
   }
-  assertWorkspaceStateMigrationReady({ ...scope, operation: "doctor" });
+  assertWorkspaceStateMigrationReady({ ...params, workspaceDirs, env, homedir });
 }

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -154,7 +154,7 @@ async function assertStartupStateMigrationReady(params: {
   });
   assertSessionStoreMigrationComplete({ ...params, targets });
   const { assertConfiguredWorkspaceStateReady } = await import("../agents/workspace-state-dirs.js");
-  assertConfiguredWorkspaceStateReady(params);
+  await assertConfiguredWorkspaceStateReady(params);
 }
 
 type MigrationCheckpoint = {
@@ -303,10 +303,10 @@ export async function assertDoctorPreflightMigrationsComplete(params: {
     if (error instanceof DoctorStateMigrationRefusalError) {
       // A refused owner stops all later repairs. Still diagnose canonical
       // workspace state read-only before final completion becomes unreachable.
-      const { assertConfiguredWorkspaceStateReadyForDoctor } =
+      const { assertConfiguredWorkspaceStateReady } =
         await import("../agents/workspace-state-dirs.js");
       try {
-        await assertConfiguredWorkspaceStateReadyForDoctor({ cfg: params.cfg });
+        await assertConfiguredWorkspaceStateReady({ cfg: params.cfg, operation: "doctor" });
       } catch (workspaceError) {
         params.report({ changes: [], warnings: [String(workspaceError)] });
       }

--- a/src/commands/doctor-session-delivery-state.test.ts
+++ b/src/commands/doctor-session-delivery-state.test.ts
@@ -265,7 +265,7 @@ describe("doctor canonical session delivery state", () => {
     expect(repaired).not.toHaveProperty("lastAccountId");
   });
 
-  it("publishes cross-agent incognito parent rewrites to each existing SQLite connection", () => {
+  it("publishes cross-agent incognito parent rewrites to each existing SQLite connection", async () => {
     const stateDir = fs.realpathSync(tempDirs.make("openclaw-incognito-warm-cache-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     const oldParentKey = "agent:main:dashboard:incognito-warm-cache";
@@ -291,7 +291,7 @@ describe("doctor canonical session delivery state", () => {
       updatedAt: 20,
       parentSessionKey: oldParentKey,
     });
-    expect(repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
+    expect(await repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
       found: 1,
       repaired: 1,
     });

--- a/src/commands/doctor-session-incognito-key-repair.test.ts
+++ b/src/commands/doctor-session-incognito-key-repair.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 });
 
 describe("doctor reserved incognito session key repair", () => {
-  it("renames durable collisions and every key-bearing linkage idempotently", () => {
+  it("renames durable collisions and every key-bearing linkage idempotently", async () => {
     const stateDir = fs.realpathSync(tempDirs.make("openclaw-doctor-incognito-key-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     const sqlitePath = resolveOpenClawAgentSqlitePath({ agentId: "main", env });
@@ -139,11 +139,11 @@ describe("doctor reserved incognito session key repair", () => {
         oldKey,
       );
 
-      expect(repairReservedIncognitoSessionKeys({ apply: false, cfg: {}, env })).toEqual({
+      expect(await repairReservedIncognitoSessionKeys({ apply: false, cfg: {}, env })).toEqual({
         found: 1,
         repaired: 0,
       });
-      expect(repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
+      expect(await repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
         found: 1,
         repaired: 1,
       });
@@ -246,7 +246,7 @@ describe("doctor reserved incognito session key repair", () => {
           entry: { sessionId: "session-work", updatedAt: 1 },
         },
       ]);
-      expect(repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
+      expect(await repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
         found: 0,
         repaired: 0,
       });
@@ -262,7 +262,7 @@ describe("doctor reserved incognito session key repair", () => {
 
   it.each([false, true])(
     "resumes an interrupted repair from its journal (shared owner: %s)",
-    (shared) => {
+    async (shared) => {
       const stateDir = fs.realpathSync(tempDirs.make("openclaw-doctor-incognito-resume-"));
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
       const sqlitePath = shared
@@ -316,11 +316,11 @@ describe("doctor reserved incognito session key repair", () => {
         )
         .run(resumedKey);
 
-      expect(repairReservedIncognitoSessionKeys({ apply: false, cfg, env })).toEqual({
+      expect(await repairReservedIncognitoSessionKeys({ apply: false, cfg, env })).toEqual({
         found: 2,
         repaired: 0,
       });
-      expect(repairReservedIncognitoSessionKeys({ apply: true, cfg, env })).toEqual({
+      expect(await repairReservedIncognitoSessionKeys({ apply: true, cfg, env })).toEqual({
         found: 2,
         repaired: 2,
       });
@@ -338,7 +338,7 @@ describe("doctor reserved incognito session key repair", () => {
     },
   );
 
-  it("rewrites dense incognito references in bounded batches without changing payloads", () => {
+  it("rewrites dense incognito references in bounded batches without changing payloads", async () => {
     const stateDir = fs.realpathSync(tempDirs.make("openclaw-doctor-incognito-density-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     const database = openOpenClawAgentDatabase({ agentId: "main", env });
@@ -390,7 +390,7 @@ describe("doctor reserved incognito session key repair", () => {
       return originalExec(sql);
     });
 
-    expect(repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
+    expect(await repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
       found: 1,
       repaired: 1,
     });

--- a/src/commands/doctor-session-incognito-key-repair.ts
+++ b/src/commands/doctor-session-incognito-key-repair.ts
@@ -43,11 +43,11 @@ export type ReservedIncognitoKeyRepairReport = {
   repaired: number;
 };
 
-export function repairReservedIncognitoSessionKeys(params: {
+export async function repairReservedIncognitoSessionKeys(params: {
   apply: boolean;
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
-}): ReservedIncognitoKeyRepairReport {
+}): Promise<ReservedIncognitoKeyRepairReport> {
   const targets = listExistingAgentDatabaseTargets(params.cfg, params.env).map((target) => ({
     target,
     databaseOptions: resolveTargetSqliteOptions(target, params.env),
@@ -134,7 +134,7 @@ export function repairReservedIncognitoSessionKeys(params: {
       );
       rewriteDoctorSessionEntries({
         scope: { agentId: target.agentId, env: params.env, storePath: target.storePath },
-        sessionKeys: listSessionEntryKeysReadOnly({
+        sessionKeys: await listSessionEntryKeysReadOnly({
           agentId: target.agentId,
           env: params.env,
           storePath: target.storePath,

--- a/src/commands/doctor-session-transcripts.ts
+++ b/src/commands/doctor-session-transcripts.ts
@@ -278,7 +278,7 @@ async function noteSessionSqliteMigrationHealth(params: {
     // Canonical-key ties compare complete entry JSON, so select their winner before stripping it.
     resolvedSkillsReport = repairCanonicalSessionResolvedSkills(repairParams);
     // Import may create the first durable SQLite row for a colliding legacy key.
-    reservedKeyReport = repairReservedIncognitoSessionKeys(repairParams);
+    reservedKeyReport = await repairReservedIncognitoSessionKeys(repairParams);
     deliveryReport = repairCanonicalSessionDeliveryStates(repairParams);
     repairLegacySessionExecPolicy(repairParams);
     if (params.postSessionPluginMigrationPlanBound && !params.postSessionPluginMigration) {

--- a/src/commands/doctor-skill-workshop-collection-backups.test.ts
+++ b/src/commands/doctor-skill-workshop-collection-backups.test.ts
@@ -717,7 +717,7 @@ describe("doctor Skill Workshop collection backup migration", () => {
     ).resolves.toBe(sourceManifest);
     await expect(fs.access(fixture.destinationBackupDir)).rejects.toMatchObject({ code: "ENOENT" });
     const workspaceMigration = await migrateLegacyWorkspaceState({
-      detected: detectLegacyWorkspaceState({
+      detected: await detectLegacyWorkspaceState({
         cfg: fixture.config,
         stateDir: testState.stateDir,
         env: testState.env,

--- a/src/commands/doctor-state-integrity.transcripts.test.ts
+++ b/src/commands/doctor-state-integrity.transcripts.test.ts
@@ -168,7 +168,7 @@ describe("doctor transcript and heartbeat session repairs", () => {
 
     await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
 
-    const keys = listSessionEntryKeysReadOnly({ agentId: "ops", storePath });
+    const keys = await listSessionEntryKeysReadOnly({ agentId: "ops", storePath });
     const recoveredKey = keys.find((key) => key.startsWith("agent:ops:heartbeat-recovered-"));
     expect(keys).not.toContain(mainKey);
     if (!recoveredKey) {
@@ -206,7 +206,7 @@ describe("doctor transcript and heartbeat session repairs", () => {
 
     await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
 
-    const keys = listSessionEntryKeysReadOnly({ agentId: "ops", storePath });
+    const keys = await listSessionEntryKeysReadOnly({ agentId: "ops", storePath });
     expect(keys).toEqual([mainKey]);
     expect(keys.filter((key) => key.startsWith("agent:ops:heartbeat-recovered-"))).toStrictEqual(
       [],
@@ -259,7 +259,7 @@ describe("doctor transcript and heartbeat session repairs", () => {
 
     await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
 
-    const keys = listSessionEntryKeysReadOnly({ agentId: "ops", storePath });
+    const keys = await listSessionEntryKeysReadOnly({ agentId: "ops", storePath });
     const recoveredKeys = keys.filter((key) => key.startsWith("agent:ops:heartbeat-recovered-"));
     expect(keys).not.toContain(mainKey);
     expect(recoveredKeys).toHaveLength(1);

--- a/src/commands/doctor-workspace-alias.test.ts
+++ b/src/commands/doctor-workspace-alias.test.ts
@@ -130,7 +130,7 @@ describe("doctor workspace alias repair", () => {
   it("reports a repointed alias as a warning finding", async () => {
     const { alias } = await repointAlias({ seedAttestedFile: false });
 
-    const findings = collectRepointedWorkspaceAliasFindings(buildAliasCfg(alias));
+    const findings = await collectRepointedWorkspaceAliasFindings(buildAliasCfg(alias));
 
     expect(findings).toHaveLength(1);
     expect(findings[0]).toMatchObject({
@@ -144,7 +144,7 @@ describe("doctor workspace alias repair", () => {
     const dir = testState!.workspaceDir;
     await mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
 
-    expect(collectRepointedWorkspaceAliasFindings(buildAliasCfg(dir))).toHaveLength(0);
+    expect(await collectRepointedWorkspaceAliasFindings(buildAliasCfg(dir))).toHaveLength(0);
   });
 
   it("requires explicit confirmation even when generated hashes match", async () => {

--- a/src/commands/doctor-workspace-alias.ts
+++ b/src/commands/doctor-workspace-alias.ts
@@ -16,7 +16,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { shortenHomePath } from "../utils.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
-function configuredWorkspaceDirs(cfg: OpenClawConfig): string[] {
+async function configuredWorkspaceDirs(cfg: OpenClawConfig): Promise<string[]> {
   return listWorkspaceStateDirs({
     cfg,
     env: process.env,
@@ -54,11 +54,11 @@ const REBIND_MESSAGES: Record<Exclude<WorkspaceAliasRebindOutcome, "rebound">, s
 };
 
 /** Read-only findings include failed inspection so health cannot report a false success. */
-export function collectRepointedWorkspaceAliasFindings(
+export async function collectRepointedWorkspaceAliasFindings(
   cfg: OpenClawConfig,
-): WorkspaceAliasFinding[] {
+): Promise<WorkspaceAliasFinding[]> {
   const findings: WorkspaceAliasFinding[] = [];
-  for (const workspaceDir of configuredWorkspaceDirs(cfg)) {
+  for (const workspaceDir of await configuredWorkspaceDirs(cfg)) {
     let message: string;
     try {
       const facts = detectRepointedWorkspaceAlias(workspaceDir);
@@ -87,7 +87,7 @@ async function maybeRepairRepointedWorkspaceAliases(params: {
   if (!params.prompter.shouldRepair) {
     return;
   }
-  const workspaceDirs = configuredWorkspaceDirs(params.cfg);
+  const workspaceDirs = await configuredWorkspaceDirs(params.cfg);
   const configuration = await readConfigFileSnapshot();
   const verifyConfiguration = async () => {
     const current = await readConfigFileSnapshot();
@@ -155,12 +155,12 @@ export function createWorkspaceAliasMigrationRepair(
     return undefined;
   }
   return async (cfg) => {
-    if (collectRepointedWorkspaceAliasFindings(cfg).length === 0) {
+    if ((await collectRepointedWorkspaceAliasFindings(cfg)).length === 0) {
       return;
     }
     beforePrompt();
     await maybeRepairRepointedWorkspaceAliases({ cfg, prompter });
-    const unresolved = collectRepointedWorkspaceAliasFindings(cfg);
+    const unresolved = await collectRepointedWorkspaceAliasFindings(cfg);
     if (unresolved.length > 0) {
       throw new Error(
         unresolved.map((finding) => `${finding.message} ${finding.fixHint}`).join("\n"),

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -172,9 +172,9 @@ export function loadSessionEntryReadOnly(scope: SessionAccessScope): SessionEntr
 }
 
 /** Lists persisted session keys without materializing their entry JSON. */
-export function listSessionEntryKeysReadOnly(
+export async function listSessionEntryKeysReadOnly(
   scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
-): string[] {
+): Promise<string[]> {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const result = withOpenClawAgentDatabaseReadOnly((database) => {
     const db = getSessionKysely(database.db);

--- a/src/flows/doctor-health-contribution-runners.workspace.ts
+++ b/src/flows/doctor-health-contribution-runners.workspace.ts
@@ -132,7 +132,7 @@ export async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Pr
 export async function runWorkspaceAliasHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { collectRepointedWorkspaceAliasFindings } =
     await import("../commands/doctor-workspace-alias.js");
-  const findings = collectRepointedWorkspaceAliasFindings(ctx.cfg);
+  const findings = await collectRepointedWorkspaceAliasFindings(ctx.cfg);
   if (findings.length > 0) {
     const { note } = await import("../../packages/terminal-core/src/note.js");
     note(

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -234,7 +234,7 @@ describe("runDoctorHealthFlow", () => {
           const result = await migrateLegacyWorkspaceState({
             stateDir: state.stateDir,
             env: state.env,
-            detected: detectLegacyWorkspaceState({
+            detected: await detectLegacyWorkspaceState({
               cfg: ctx.cfg,
               stateDir: state.stateDir,
               env: state.env,
@@ -482,7 +482,7 @@ describe("runDoctorHealthFlow", () => {
             const migration = await migrateLegacyWorkspaceState({
               stateDir: state.stateDir,
               env: state.env,
-              detected: detectLegacyWorkspaceState({
+              detected: await detectLegacyWorkspaceState({
                 cfg: ctx.cfg,
                 stateDir: state.stateDir,
                 env: state.env,
@@ -951,7 +951,7 @@ describe("runDoctorHealthFlow", () => {
           const result = await migrateLegacyWorkspaceState({
             stateDir: state.stateDir,
             env: state.env,
-            detected: detectLegacyWorkspaceState({
+            detected: await detectLegacyWorkspaceState({
               cfg: ctx.cfg,
               stateDir: state.stateDir,
               env: state.env,

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -211,9 +211,9 @@ async function runDoctorHealthFlowWithResult(
           env: process.env,
         }),
       });
-      const { assertConfiguredWorkspaceStateReadyForDoctor } =
+      const { assertConfiguredWorkspaceStateReady } =
         await import("../agents/workspace-state-dirs.js");
-      await assertConfiguredWorkspaceStateReadyForDoctor({ cfg: ctx.cfg });
+      await assertConfiguredWorkspaceStateReady({ cfg: ctx.cfg, operation: "doctor" });
       const { assertNoPendingLegacyExecApprovals } =
         await import("../infra/exec-approvals-migration-gate.js");
       assertNoPendingLegacyExecApprovals({ operation: "doctor" });

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1628,11 +1628,11 @@ function createReloaderHarness(
       runtimeConfig: OpenClawConfig;
       sourceConfig: OpenClawConfig;
       previousSourceConfig: OpenClawConfig;
-    }) => {
+    }) => Promise<{
       runtimeConfig: OpenClawConfig;
       compareConfig: OpenClawConfig;
       runtimeEnv?: ReturnType<typeof prepareConfigRuntimeEnv>;
-    };
+    }>;
     initialInternalWriteHash?: string | null;
     promoteSnapshot?: (snapshot: ConfigFileSnapshot, reason: string) => Promise<boolean>;
     initialPluginInstallRecords?: Record<string, PluginInstallRecord>;
@@ -1858,6 +1858,7 @@ describe("startGatewayConfigReloader include files", () => {
       log: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
       watchPath: configPath,
     });
+    await reloader.ready;
 
     try {
       expect(initialSnapshot.includedPaths).toEqual(
@@ -1933,6 +1934,114 @@ describe("startGatewayConfigReloader", () => {
     vi.restoreAllMocks();
   });
 
+  it("captures writes while initial candidate preparation is pending", async () => {
+    const gate = createDeferred();
+    const write = makeZeroDebounceHookWrite("during-initialization");
+    let initial = true;
+    const harness = createReloaderHarness(
+      async () =>
+        makeSnapshot({
+          config: write.runtimeConfig,
+          sourceConfig: write.sourceConfig,
+          hash: write.persistedHash,
+        }),
+      {
+        prepareConfigCandidate: async ({ runtimeConfig, sourceConfig }) => {
+          if (initial) {
+            initial = false;
+            await gate.promise;
+          }
+          return { runtimeConfig, compareConfig: sourceConfig };
+        },
+      },
+    );
+    try {
+      expect(harness.reloader.isReady()).toBe(false);
+      expect(harness.reloader.hotReloadStatus()).toBeUndefined();
+      harness.emitWrite(write);
+      await vi.runAllTimersAsync();
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      expect(chokidar.watch).not.toHaveBeenCalled();
+      gate.resolve();
+      await harness.reloader.ready;
+      await vi.runAllTimersAsync();
+      expect(getOnlyHotReloadCall(harness)[1]).toEqual(write.runtimeConfig);
+      expect(harness.reloader.isReady()).toBe(true);
+      expect(
+        configAuditMocks.upsertSnapshot.mock.calls.map(([snapshot]) => snapshot.rawHash),
+      ).not.toContain("initial-raw-hash");
+    } finally {
+      gate.resolve();
+      await harness.reloader.stop();
+    }
+  });
+
+  it("reconciles disk changes made during initial candidate preparation", async () => {
+    const gate = createDeferred();
+    let initial = true;
+    let disk = makeSnapshot({ config: { gateway: { reload: {} } }, hash: "initial-raw-hash" });
+    const harness = createReloaderHarness(async () => disk, {
+      prepareConfigCandidate: async ({ runtimeConfig, sourceConfig }) => {
+        if (initial) {
+          initial = false;
+          await gate.promise;
+        }
+        return { runtimeConfig, compareConfig: sourceConfig };
+      },
+    });
+    try {
+      const nextConfig = { gateway: { reload: {} }, hooks: { enabled: true } };
+      disk = makeSnapshot({ config: nextConfig, hash: "written-during-preparation" });
+      gate.resolve();
+      await harness.reloader.ready;
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      harness.watcher.emit("ready");
+      await vi.runAllTimersAsync();
+      expect(getOnlyHotReloadCall(harness)[1]).toEqual(nextConfig);
+    } finally {
+      gate.resolve();
+      await harness.reloader.stop();
+    }
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "owns shutdown while initial candidate preparation is pending: %s",
+    async (settlement) => {
+      const gate = createDeferred();
+      const failure = new Error("candidate load failed");
+      const harness = createReloaderHarness(vi.fn(), {
+        prepareConfigCandidate: async ({ runtimeConfig, sourceConfig }) => {
+          await gate.promise;
+          if (settlement === "reject") {
+            throw failure;
+          }
+          return { runtimeConfig, compareConfig: sourceConfig };
+        },
+      });
+      let stopFinished = false;
+      const stopping = harness.reloader.stop().then(() => {
+        stopFinished = true;
+      });
+      try {
+        await Promise.resolve();
+        expect(stopFinished).toBe(false);
+        harness.emitWrite(makeZeroDebounceHookWrite("after-stop"));
+        gate.resolve();
+        await expect(harness.reloader.ready).rejects.toThrow(
+          settlement === "reject" ? failure : GatewayConfigReloadSupersededError,
+        );
+        await stopping;
+        await vi.runAllTimersAsync();
+        expect(chokidar.watch).not.toHaveBeenCalled();
+        expect(harness.onHotReload).not.toHaveBeenCalled();
+        expect(configAuditMocks.upsertSnapshot).not.toHaveBeenCalled();
+      } finally {
+        gate.resolve();
+        await stopping;
+      }
+    },
+  );
+
   it("watches resolved includes and reconciles them after an accepted reload", async () => {
     const initialConfig = makeGatewayPortConfig(18789);
     const nextConfig = makeGatewayPortConfig(18790);
@@ -1953,6 +2062,7 @@ describe("startGatewayConfigReloader", () => {
         initialIncludedPaths: [initialIncludePath, retainedIncludePath],
       },
     );
+    await harness.reloader.ready;
 
     expect(chokidar.watch).toHaveBeenCalledWith(
       ["/tmp/openclaw.json", initialIncludePath, retainedIncludePath],
@@ -1996,6 +2106,7 @@ describe("startGatewayConfigReloader", () => {
     const harness = createReloaderHarness(readSnapshot, {
       initialIncludedPaths: [acceptedIncludePath],
     });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
     expect(harness.watcher.close).toHaveBeenCalledOnce();
@@ -2026,6 +2137,7 @@ describe("startGatewayConfigReloader", () => {
     const harness = createReloaderHarness(readSnapshot, {
       initialIncludedPaths: [rejectedIncludeDir],
     });
+    await harness.reloader.ready;
 
     expect(chokidar.watch).toHaveBeenCalledWith(
       ["/tmp/openclaw.json", rejectedIncludeDir],
@@ -2049,6 +2161,7 @@ describe("startGatewayConfigReloader", () => {
       makeSnapshot({ config: nextConfig, parsed: nextConfig, hash: "next-raw-hash" }),
     );
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -2081,6 +2194,7 @@ describe("startGatewayConfigReloader", () => {
       ),
       { initialConfig },
     );
+    await harness.reloader.ready;
     configAuditMocks.readSnapshot.mockReturnValue({
       configPath: "/tmp/openclaw.json",
       rawHash: "other-write",
@@ -2112,6 +2226,7 @@ describe("startGatewayConfigReloader", () => {
       vi.fn(async () => invalid),
       { initialConfig },
     );
+    await harness.reloader.ready;
     configAuditMocks.upsertSnapshot.mockClear();
 
     await flushWatcherChange(harness);
@@ -2141,6 +2256,7 @@ describe("startGatewayConfigReloader", () => {
     });
     let activeSnapshot = firstInvalid;
     const harness = createReloaderHarness(vi.fn(async () => activeSnapshot));
+    await harness.reloader.ready;
     configAuditMocks.append.mockClear();
 
     await flushWatcherChange(harness);
@@ -2173,6 +2289,7 @@ describe("startGatewayConfigReloader", () => {
       vi.fn(async () => activeSnapshot),
       { initialConfig },
     );
+    await harness.reloader.ready;
     configAuditMocks.append.mockClear();
 
     await flushWatcherChange(harness);
@@ -2205,6 +2322,7 @@ describe("startGatewayConfigReloader", () => {
       vi.fn(async () => activeSnapshot),
       { initialConfig },
     );
+    await harness.reloader.ready;
     configAuditMocks.append.mockClear();
 
     await flushWatcherChange(harness);
@@ -2248,6 +2366,7 @@ describe("startGatewayConfigReloader", () => {
         initialSnapshotValid: false,
       },
     );
+    await harness.reloader.ready;
     configAuditMocks.append.mockClear();
 
     await flushWatcherChange(harness);
@@ -2280,6 +2399,7 @@ describe("startGatewayConfigReloader", () => {
       initialSnapshotRawHash: "current-raw-hash",
       initialAuthoredConfig: initialConfig,
     });
+    await harness.reloader.ready;
 
     expect(configAuditMocks.append.mock.calls[0]?.[0]?.record).toMatchObject({
       event: "config.external",
@@ -2312,6 +2432,7 @@ describe("startGatewayConfigReloader", () => {
       initialSnapshotValid: false,
       initialSnapshotIssues: [{ path: "gateway.port", message: "expected number" }],
     });
+    await harness.reloader.ready;
 
     expect(configAuditMocks.append.mock.calls[0]?.[0]?.record).toMatchObject({
       event: "config.external",
@@ -2344,6 +2465,7 @@ describe("startGatewayConfigReloader", () => {
       initialSnapshotRawHash: "current-raw-hash",
       initialAuthoredConfig: initialConfig,
     });
+    await harness.reloader.ready;
 
     expect(configAuditMocks.append.mock.calls[0]?.[0]?.record).toMatchObject({
       event: "config.external",
@@ -2366,6 +2488,7 @@ describe("startGatewayConfigReloader", () => {
       initialSnapshotRawHash: null,
       initialAuthoredConfig: {},
     });
+    await harness.reloader.ready;
 
     expect(configAuditMocks.append).toHaveBeenCalledOnce();
     expect(configAuditMocks.append.mock.calls[0]?.[0]?.record).toMatchObject({
@@ -2400,6 +2523,7 @@ describe("startGatewayConfigReloader", () => {
       initialSnapshotRawHash: "path-b-raw-hash",
       initialAuthoredConfig: initialConfig,
     });
+    await harness.reloader.ready;
 
     expect(configAuditMocks.append).not.toHaveBeenCalled();
     expect(configAuditMocks.upsertSnapshot).toHaveBeenCalledWith(
@@ -2417,6 +2541,7 @@ describe("startGatewayConfigReloader", () => {
     const harness = createReloaderHarness(
       vi.fn(async () => makeZeroDebounceHookSnapshot("internal-write")),
     );
+    await harness.reloader.ready;
     configAuditMocks.append.mockClear();
 
     harness.emitWrite(makeZeroDebounceHookWrite("internal-write"));
@@ -2457,6 +2582,7 @@ describe("startGatewayConfigReloader", () => {
         },
         onRestart: finishReload,
       });
+      await harness.reloader.ready;
       const settled = vi.fn();
       void application.result.then(settled);
       const write = makeZeroDebounceHookWrite("application-settlement");
@@ -2569,6 +2695,7 @@ describe("startGatewayConfigReloader", () => {
           log,
           watchPath: configPath,
         });
+        await reloader.ready;
 
         try {
           const request = tryBeginGatewayRootWorkAdmission();
@@ -2619,6 +2746,7 @@ describe("startGatewayConfigReloader", () => {
       initialAuthoredConfig: {},
       onHotReload: async () => "applied-restart-required",
     });
+    await harness.reloader.ready;
 
     harness.emitWrite(
       attachRuntimeConfigWriteApplication(
@@ -2639,6 +2767,7 @@ describe("startGatewayConfigReloader", () => {
       initialSnapshotRawHash: null,
       initialAuthoredConfig: {},
     });
+    await harness.reloader.ready;
 
     harness.emitWrite(
       attachRuntimeConfigWriteApplication(
@@ -2670,6 +2799,7 @@ describe("startGatewayConfigReloader", () => {
         initialAuthoredConfig: snapshot.parsed,
       },
     );
+    await harness.reloader.ready;
     configAuditMocks.append.mockClear();
 
     await flushWatcherChange(harness);
@@ -2694,6 +2824,7 @@ describe("startGatewayConfigReloader", () => {
         initialAuthoredConfig: initialConfig,
       },
     );
+    await harness.reloader.ready;
     configAuditMocks.append.mockClear();
 
     await flushWatcherChange(harness);
@@ -2726,6 +2857,7 @@ describe("startGatewayConfigReloader", () => {
       const onConfigCandidateObserved = vi.fn();
       const readSnapshot = vi.fn(async () => snapshot);
       const harness = createReloaderHarness(readSnapshot, { onConfigCandidateObserved });
+      await harness.reloader.ready;
 
       harness.watcher.emit("change");
 
@@ -2752,6 +2884,7 @@ describe("startGatewayConfigReloader", () => {
       makeSnapshot({ config: nextConfig, hash: "external-prefs-write" }),
     );
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -2781,6 +2914,7 @@ describe("startGatewayConfigReloader", () => {
       makeSnapshot({ config: nextConfig, hash: "mode-off-write" }),
     );
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -2796,6 +2930,7 @@ describe("startGatewayConfigReloader", () => {
       makeSnapshot({ config: initialConfig, hash: "reverted-restart-edit" }),
     );
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -2822,6 +2957,7 @@ describe("startGatewayConfigReloader", () => {
       initialInternalWriteHash: "accepted-write",
       onConfigCandidateObserved,
     });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -2872,6 +3008,7 @@ describe("startGatewayConfigReloader", () => {
       initialCompareConfig: initialConfig,
       onRestart,
     });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -2943,6 +3080,7 @@ describe("startGatewayConfigReloader", () => {
         terminalPolicy.acceptConfig({ retireRejectedRestart: false });
       },
     });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -2999,6 +3137,7 @@ describe("startGatewayConfigReloader", () => {
           onConfigApplied: () => terminalPolicy.commitConfig(),
         },
       );
+      await harness.reloader.ready;
 
       harness.emitWrite({
         configPath: "/tmp/openclaw.json",
@@ -3073,6 +3212,7 @@ describe("startGatewayConfigReloader", () => {
         terminalPolicy.acceptConfig({ retireRejectedRestart: false });
       },
     });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -3106,6 +3246,7 @@ describe("startGatewayConfigReloader", () => {
       initialConfig,
       initialInternalWriteHash: "accepted-write",
     });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -3168,6 +3309,7 @@ describe("startGatewayConfigReloader", () => {
         initialConfig,
         ...(kind === "noop" ? { onNoopConfigCommit: publishA } : { onHotReload: hotReloadA }),
       });
+      await harness.reloader.ready;
 
       harness.watcher.emit("change");
       await vi.advanceTimersByTimeAsync(0);
@@ -3232,6 +3374,7 @@ describe("startGatewayConfigReloader", () => {
       onHotReload,
       promoteSnapshot,
     });
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.advanceTimersByTimeAsync(0);
@@ -3277,7 +3420,7 @@ describe("startGatewayConfigReloader", () => {
     const preparedEnvValues: Array<string | undefined> = [];
     const harness = createReloaderHarness(vi.fn(), {
       initialConfig,
-      prepareConfigCandidate: ({ runtimeConfig, sourceConfig, previousSourceConfig }) => ({
+      prepareConfigCandidate: async ({ runtimeConfig, sourceConfig, previousSourceConfig }) => ({
         runtimeConfig,
         compareConfig: { ...sourceConfig, env: initialConfig.env },
         runtimeEnv: prepareConfigRuntimeEnv({
@@ -3299,6 +3442,7 @@ describe("startGatewayConfigReloader", () => {
         return "applied";
       },
     });
+    await harness.reloader.ready;
     const emitWrite = (config: OpenClawConfig, hash: string, revision: number) => {
       harness.emitWrite({
         configPath: "/tmp/openclaw.json",
@@ -3339,6 +3483,7 @@ describe("startGatewayConfigReloader", () => {
       }),
     );
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -3420,6 +3565,7 @@ describe("startGatewayConfigReloader", () => {
         restartRequests.push(nextConfig);
       },
     });
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.advanceTimersByTimeAsync(0);
@@ -3481,6 +3627,7 @@ describe("startGatewayConfigReloader", () => {
         return "applied";
       },
     });
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.advanceTimersByTimeAsync(0);
@@ -3542,6 +3689,7 @@ describe("startGatewayConfigReloader", () => {
         pausedRestartDebt = false;
       },
     });
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.advanceTimersByTimeAsync(0);
@@ -3573,6 +3721,7 @@ describe("startGatewayConfigReloader", () => {
       makeSnapshot({ config: nextConfig, hash: "active-reload" }),
     );
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
     const { promise: reloadStarted, resolve: markReloadStarted } = createDeferred();
     const { promise: reloadBlocked, resolve: finishReload } = createDeferred();
     harness.onHotReload.mockImplementationOnce(async () => {
@@ -3614,6 +3763,7 @@ describe("startGatewayConfigReloader", () => {
     };
     const readSnapshot = vi.fn(async () => makeSnapshot({ config: nextConfig, hash: "sandbox" }));
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -3641,6 +3791,7 @@ describe("startGatewayConfigReloader", () => {
       makeSnapshot({ config: nextConfig, hash: "visible-replies" }),
     );
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -3692,6 +3843,7 @@ describe("startGatewayConfigReloader", () => {
       vi.fn(async () => makeSnapshot({ config: nextConfig, hash: "account-reload" })),
       { initialConfig },
     );
+    await harness.reloader.ready;
 
     setActivePluginRegistry(channelRegistry);
     try {
@@ -3713,7 +3865,7 @@ describe("startGatewayConfigReloader", () => {
       messages: { visibleReplies: "automatic" },
     };
     let visibleRepliesOverride: "message_tool" | undefined;
-    const prepareConfigCandidate = vi.fn(({ runtimeConfig, sourceConfig }) => {
+    const prepareConfigCandidate = vi.fn(async ({ runtimeConfig, sourceConfig }) => {
       const override = visibleRepliesOverride;
       const applyCapturedOverride = (config: OpenClawConfig): OpenClawConfig =>
         override
@@ -3729,6 +3881,7 @@ describe("startGatewayConfigReloader", () => {
       initialConfig,
       prepareConfigCandidate,
     });
+    await harness.reloader.ready;
     const makeOverrideWrite = (
       config: OpenClawConfig,
       persistedHash: string,
@@ -3788,6 +3941,7 @@ describe("startGatewayConfigReloader", () => {
     };
     const readSnapshot = vi.fn(async () => makeSnapshot({ config: nextConfig, hash: "hot" }));
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -3816,6 +3970,7 @@ describe("startGatewayConfigReloader", () => {
         makeSnapshot({ config: nextConfig, hash: "terminal" }),
       );
       const harness = createReloaderHarness(readSnapshot, { initialConfig });
+      await harness.reloader.ready;
 
       await flushWatcherChange(harness);
       await Promise.resolve();
@@ -3857,6 +4012,7 @@ describe("startGatewayConfigReloader", () => {
         },
       },
     );
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
@@ -3877,6 +4033,7 @@ describe("startGatewayConfigReloader", () => {
     };
     const readSnapshot = vi.fn(async () => makeSnapshot({ config: nextConfig, hash: "off" }));
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -3895,6 +4052,7 @@ describe("startGatewayConfigReloader", () => {
     };
     const readSnapshot = vi.fn(async () => makeSnapshot({ config: nextConfig, hash: "hot" }));
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
 
@@ -3918,6 +4076,7 @@ describe("startGatewayConfigReloader", () => {
         }),
       );
     const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot);
+    await reloader.ready;
 
     watcher.emit("unlink");
     await vi.runOnlyPendingTimersAsync();
@@ -3937,6 +4096,7 @@ describe("startGatewayConfigReloader", () => {
       .fn<() => Promise<ConfigFileSnapshot>>()
       .mockResolvedValue(makeSnapshot({ exists: false, raw: null, hash: "missing" }));
     const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot);
+    await reloader.ready;
 
     watcher.emit("unlink");
     await vi.runAllTimersAsync();
@@ -3964,6 +4124,7 @@ describe("startGatewayConfigReloader", () => {
     const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot, {
       promoteSnapshot,
     });
+    await reloader.ready;
     onRestart.mockRejectedValueOnce(new Error("restart-check failed"));
     onRestart.mockResolvedValueOnce(undefined);
 
@@ -4006,6 +4167,7 @@ describe("startGatewayConfigReloader", () => {
     });
     const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValue(snapshot);
     const { watcher, onRestart, log, reloader } = createReloaderHarness(readSnapshot);
+    await reloader.ready;
     onRestart.mockRejectedValueOnce(new GatewayConfigReloadSupersededError());
 
     watcher.emit("change");
@@ -4035,6 +4197,7 @@ describe("startGatewayConfigReloader", () => {
     const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot, {
       promoteSnapshot,
     });
+    await reloader.ready;
 
     watcher.emit("change");
     await vi.runAllTimersAsync();
@@ -4097,6 +4260,7 @@ describe("startGatewayConfigReloader", () => {
       initialCompareConfig: previousConfig,
       promoteSnapshot,
     });
+    await reloader.ready;
 
     watcher.emit("change");
     await vi.runAllTimersAsync();
@@ -4131,6 +4295,7 @@ describe("startGatewayConfigReloader", () => {
     const { watcher, onHotReload, reloader } = createReloaderHarness(readSnapshot, {
       promoteSnapshot,
     });
+    await reloader.ready;
 
     watcher.emit("change");
     await vi.runAllTimersAsync();
@@ -4157,6 +4322,7 @@ describe("startGatewayConfigReloader", () => {
       readSnapshot,
       { promoteSnapshot },
     );
+    await reloader.ready;
     onHotReload.mockRejectedValueOnce(new Error("reload refused"));
 
     watcher.emit("change");
@@ -4174,6 +4340,7 @@ describe("startGatewayConfigReloader", () => {
     const snapshot = makeZeroDebounceHookSnapshot("external-retry-1");
     const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValue(snapshot);
     const { watcher, onConfigApplied, onHotReload, reloader } = createReloaderHarness(readSnapshot);
+    await reloader.ready;
     onHotReload.mockRejectedValueOnce(new Error("reload refused"));
 
     watcher.emit("change");
@@ -4190,6 +4357,7 @@ describe("startGatewayConfigReloader", () => {
     const snapshot = makeZeroDebounceHookSnapshot("internal-retry-1");
     const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValue(snapshot);
     const harness = createReloaderHarness(readSnapshot);
+    await harness.reloader.ready;
     harness.onHotReload.mockRejectedValueOnce(new Error("reload refused"));
 
     harness.emitWrite(makeZeroDebounceHookWrite("internal-retry-1"));
@@ -4218,6 +4386,7 @@ describe("startGatewayConfigReloader", () => {
     const { watcher, onHotReload, log, reloader } = createReloaderHarness(readSnapshot, {
       promoteSnapshot,
     });
+    await reloader.ready;
 
     watcher.emit("change");
     await vi.runAllTimersAsync();
@@ -4252,6 +4421,7 @@ describe("startGatewayConfigReloader", () => {
       );
     const promoteSnapshot = vi.fn(async (_snapshot: ConfigFileSnapshot, _reason: string) => true);
     const harness = createReloaderHarness(readSnapshot, { promoteSnapshot });
+    await harness.reloader.ready;
 
     harness.emitWrite(makeZeroDebounceHookWrite("internal-1"));
     await vi.runOnlyPendingTimersAsync();
@@ -4285,6 +4455,7 @@ describe("startGatewayConfigReloader", () => {
       .mockResolvedValueOnce(makeZeroDebounceHookSnapshot("internal-none"));
     const promoteSnapshot = vi.fn(async (_snapshot: ConfigFileSnapshot, _reason: string) => true);
     const harness = createReloaderHarness(readSnapshot, { promoteSnapshot });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("internal-none"),
@@ -4340,6 +4511,7 @@ describe("startGatewayConfigReloader", () => {
         previousOwnedEnv: { [envKey]: "old" },
       });
       const harness = createReloaderHarness(vi.fn(), { initialConfig });
+      await harness.reloader.ready;
 
       harness.emitWrite({
         configPath: "/tmp/openclaw.json",
@@ -4398,6 +4570,7 @@ describe("startGatewayConfigReloader", () => {
         throw new Error("hot reload failed");
       },
     });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -4442,6 +4615,7 @@ describe("startGatewayConfigReloader", () => {
         onRestart: async () => await restartGate,
       },
     );
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -4491,7 +4665,7 @@ describe("startGatewayConfigReloader", () => {
     );
     const harness = createReloaderHarness(readSnapshot, {
       initialConfig: configA,
-      prepareConfigCandidate: ({ runtimeConfig, sourceConfig, previousSourceConfig }) => ({
+      prepareConfigCandidate: async ({ runtimeConfig, sourceConfig, previousSourceConfig }) => ({
         runtimeConfig,
         compareConfig: sourceConfig,
         runtimeEnv: prepareConfigRuntimeEnv({
@@ -4504,6 +4678,7 @@ describe("startGatewayConfigReloader", () => {
         }),
       }),
     });
+    await harness.reloader.ready;
 
     await flushWatcherChange(harness);
     expect(targetEnv[envKey]).toBe("c");
@@ -4534,6 +4709,7 @@ describe("startGatewayConfigReloader", () => {
       .fn<() => Promise<ConfigFileSnapshot>>()
       .mockResolvedValueOnce(makeZeroDebounceHookSnapshot("internal-restart"));
     const harness = createReloaderHarness(readSnapshot);
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("internal-restart"),
@@ -4577,6 +4753,7 @@ describe("startGatewayConfigReloader", () => {
       promoteSnapshot,
       readPluginInstallRecords,
     });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite(hash),
@@ -4627,6 +4804,7 @@ describe("startGatewayConfigReloader", () => {
       initialConfig,
       readPluginInstallRecords,
     });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("slow-restart-a"),
@@ -4662,6 +4840,7 @@ describe("startGatewayConfigReloader", () => {
       }),
     );
     const harness = createReloaderHarness(readSnapshot);
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("same-root-hash"),
@@ -4711,6 +4890,7 @@ describe("startGatewayConfigReloader", () => {
       }),
     );
     const harness = createReloaderHarness(readSnapshot);
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -4750,6 +4930,7 @@ describe("startGatewayConfigReloader", () => {
       logging: { level: "debug" as const },
     } satisfies OpenClawConfig;
     const harness = createReloaderHarness(vi.fn(), { initialConfig });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -4793,6 +4974,7 @@ describe("startGatewayConfigReloader", () => {
         throw new Error("restart debt admission failed");
       },
     });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -4855,6 +5037,7 @@ describe("startGatewayConfigReloader", () => {
         },
       },
     );
+    await harness.reloader.ready;
     emitSupersedingChange = () => {
       emitSupersedingChange = () => {};
       harness.watcher.emit("change");
@@ -4896,6 +5079,7 @@ describe("startGatewayConfigReloader", () => {
     });
     const readSnapshot = vi.fn(async () => makeZeroDebounceHookSnapshot("overlay-echo"));
     const harness = createReloaderHarness(readSnapshot);
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("overlay-echo"),
@@ -4923,6 +5107,7 @@ describe("startGatewayConfigReloader", () => {
     });
     const readSnapshot = vi.fn(async () => makeZeroDebounceHookSnapshot("source-only-echo"));
     const harness = createReloaderHarness(readSnapshot);
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("source-only-echo"),
@@ -4970,6 +5155,7 @@ describe("startGatewayConfigReloader", () => {
       },
     } satisfies OpenClawConfig;
     const harness = createReloaderHarness(vi.fn());
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -5025,6 +5211,7 @@ describe("startGatewayConfigReloader", () => {
       }),
     );
     const harness = createReloaderHarness(readSnapshot, { readPluginInstallRecords });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -5058,6 +5245,7 @@ describe("startGatewayConfigReloader", () => {
       }),
     );
     const harness = createReloaderHarness(readSnapshot);
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("same-invalid-root-hash"),
@@ -5082,6 +5270,7 @@ describe("startGatewayConfigReloader", () => {
     });
     const readSnapshot = vi.fn(async () => makeZeroDebounceHookSnapshot("newer-b"));
     const harness = createReloaderHarness(readSnapshot, { readPluginInstallRecords });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("older-a"),
@@ -5122,6 +5311,7 @@ describe("startGatewayConfigReloader", () => {
     });
     const readSnapshot = vi.fn(async () => makeZeroDebounceHookSnapshot("latest-c"));
     const harness = createReloaderHarness(readSnapshot, { readPluginInstallRecords });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("active-a"),
@@ -5200,6 +5390,7 @@ describe("startGatewayConfigReloader", () => {
     });
     const readSnapshot = vi.fn(async () => makeSnapshot({ exists: false, valid: false }));
     const harness = createReloaderHarness(readSnapshot, { readPluginInstallRecords });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("active-a"),
@@ -5243,6 +5434,7 @@ describe("startGatewayConfigReloader", () => {
       .mockResolvedValueOnce(makeSnapshot({ exists: false, valid: false }))
       .mockResolvedValueOnce(makeZeroDebounceHookSnapshot("missing-retry"));
     const harness = createReloaderHarness(readSnapshot);
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("missing-retry"),
@@ -5265,6 +5457,7 @@ describe("startGatewayConfigReloader", () => {
   it("retries failed watcher-replayed intent with the same persisted hash", async () => {
     const readSnapshot = vi.fn(async () => makeZeroDebounceHookSnapshot("replay-retry"));
     const harness = createReloaderHarness(readSnapshot);
+    await harness.reloader.ready;
     harness.onRestart.mockRejectedValueOnce(new Error("restart admission failed"));
 
     harness.emitWrite({
@@ -5288,6 +5481,7 @@ describe("startGatewayConfigReloader", () => {
     const harness = createReloaderHarness(readSnapshot, {
       runTransaction: runWithGatewayIndependentRootWorkAdmission,
     });
+    await harness.reloader.ready;
     harness.onRestart.mockRejectedValueOnce(new Error("restart admission failed"));
     const request = tryBeginGatewayRootWorkAdmission();
     if (!request) {
@@ -5360,6 +5554,7 @@ describe("startGatewayConfigReloader", () => {
       }),
     );
     const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: sourceConfig });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -5448,6 +5643,7 @@ describe("startGatewayConfigReloader", () => {
       }),
     );
     const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: sourceConfig });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
@@ -5508,6 +5704,7 @@ describe("startGatewayConfigReloader", () => {
       initialPluginInstallRecords: {},
       readPluginInstallRecords,
     });
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
@@ -5548,6 +5745,7 @@ describe("startGatewayConfigReloader", () => {
       initialPluginInstallRecords: {},
       readPluginInstallRecords,
     });
+    await harness.reloader.ready;
 
     harness.reloader.notifyPluginMetadataChanged();
     await vi.runOnlyPendingTimersAsync();
@@ -5590,6 +5788,7 @@ describe("startGatewayConfigReloader", () => {
         initialPluginInstallRecords: installRecords,
         readPluginInstallRecords,
       });
+      await harness.reloader.ready;
       const startupMetadata = { plugins: [] };
       setCurrentPluginMetadataSnapshotState(startupMetadata, "startup-metadata");
 
@@ -5663,6 +5862,7 @@ describe("startGatewayConfigReloader", () => {
       initialPluginInstallRecords: installRecords,
       readPluginInstallRecords,
     });
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
@@ -5715,6 +5915,7 @@ describe("startGatewayConfigReloader", () => {
       initialPluginInstallRecords: {},
       readPluginInstallRecords,
     });
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
@@ -5749,6 +5950,7 @@ describe("startGatewayConfigReloader", () => {
     );
     const promoteSnapshot = vi.fn(async () => true);
     const harness = createReloaderHarness(readSnapshot, { promoteSnapshot });
+    await harness.reloader.ready;
 
     harness.emitWrite(makeZeroDebounceHookWrite("internal-1"));
     await vi.runOnlyPendingTimersAsync();
@@ -5785,6 +5987,7 @@ describe("startGatewayConfigReloader", () => {
       initialConfig: startupConfig,
       initialInternalWriteHash: "startup-internal-1",
     });
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
@@ -5807,6 +6010,7 @@ describe("startGatewayConfigReloader", () => {
     const harness = createReloaderHarness(readSnapshot, {
       initialInternalWriteHash: "startup-internal-1",
     });
+    await harness.reloader.ready;
 
     harness.emitWrite({
       ...makeZeroDebounceHookWrite("startup-internal-1"),
@@ -5834,6 +6038,7 @@ describe("startGatewayConfigReloader", () => {
     const harness = createReloaderHarness(readSnapshot, {
       initialInternalWriteHash: null,
     });
+    await harness.reloader.ready;
 
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
@@ -5859,7 +6064,7 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     vi.restoreAllMocks();
   });
 
-  function startReloaderWithWatchers(watchers: ReturnType<typeof createWatcherMock>[]) {
+  async function startReloaderWithWatchers(watchers: ReturnType<typeof createWatcherMock>[]) {
     const watchSpy = vi.spyOn(chokidar, "watch");
     let watcherIndex = 0;
     watchSpy.mockImplementation((_path, options) => {
@@ -5887,13 +6092,17 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
       log,
       watchPath: "/tmp/openclaw.json",
     });
+    await reloader.ready;
     return { watchSpy, readSnapshot, log, reloader };
   }
 
   it("re-creates the watcher with backoff and reconciles after it is ready", async () => {
     const first = createWatcherMock();
     const second = createWatcherMock();
-    const { watchSpy, readSnapshot, log, reloader } = startReloaderWithWatchers([first, second]);
+    const { watchSpy, readSnapshot, log, reloader } = await startReloaderWithWatchers([
+      first,
+      second,
+    ]);
 
     expect(watchSpy).toHaveBeenCalledTimes(1);
     first.emit("ready");
@@ -5925,7 +6134,7 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     const first = createWatcherMock();
     const failedReplacement = createWatcherMock();
     const recoveredReplacement = createWatcherMock();
-    const { readSnapshot, reloader } = startReloaderWithWatchers([
+    const { readSnapshot, reloader } = await startReloaderWithWatchers([
       first,
       failedReplacement,
       recoveredReplacement,
@@ -5951,11 +6160,11 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
     delete process.env.VITEST;
     delete process.env.CHOKIDAR_USEPOLLING;
-    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    let reloader: ReturnType<typeof startGatewayConfigReloader> | undefined;
     try {
       // One initial watcher plus one re-create per error/recovery round.
       const watchers = Array.from({ length: 5 }, () => createWatcherMock());
-      const started = startReloaderWithWatchers(watchers);
+      const started = await startReloaderWithWatchers(watchers);
       const { watchSpy, log } = started;
       reloader = started.reloader;
       const watchOptions = (index: number) =>
@@ -6008,12 +6217,12 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
     delete process.env.VITEST;
     delete process.env.CHOKIDAR_USEPOLLING;
-    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    let reloader: ReturnType<typeof startGatewayConfigReloader> | undefined;
     try {
       // Native phase: initial watcher + 3 re-creates = 4 watchers.
       // Polling phase: 1 polling re-create + 3 re-creates = 4 watchers.
       const watchers = Array.from({ length: 8 }, () => createWatcherMock());
-      const started = startReloaderWithWatchers(watchers);
+      const started = await startReloaderWithWatchers(watchers);
       const { watchSpy, readSnapshot, log } = started;
       reloader = started.reloader;
       const watchOptions = (index: number) =>
@@ -6089,10 +6298,10 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
     delete process.env.VITEST;
     process.env.CHOKIDAR_USEPOLLING = "1";
-    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    let reloader: ReturnType<typeof startGatewayConfigReloader> | undefined;
     try {
       const watchers = Array.from({ length: 4 }, () => createWatcherMock());
-      const started = startReloaderWithWatchers(watchers);
+      const started = await startReloaderWithWatchers(watchers);
       const { watchSpy, log } = started;
       reloader = started.reloader;
       const watchOptions = (index: number) =>
@@ -6139,10 +6348,10 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
     delete process.env.VITEST;
     delete process.env.CHOKIDAR_USEPOLLING;
-    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    let reloader: ReturnType<typeof startGatewayConfigReloader> | undefined;
     try {
       const watchers = Array.from({ length: 4 }, () => createWatcherMock(true));
-      const started = startReloaderWithWatchers(watchers);
+      const started = await startReloaderWithWatchers(watchers);
       const { log } = started;
       reloader = started.reloader;
       const backoffs = [500, 2000, 5000] as const;
@@ -6178,10 +6387,10 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
     delete process.env.VITEST;
     process.env.CHOKIDAR_USEPOLLING = "0";
-    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    let reloader: ReturnType<typeof startGatewayConfigReloader> | undefined;
     try {
       const watchers = Array.from({ length: 4 }, () => createWatcherMock());
-      const started = startReloaderWithWatchers(watchers);
+      const started = await startReloaderWithWatchers(watchers);
       const { watchSpy, log } = started;
       reloader = started.reloader;
       const watchOptions = (index: number) =>
@@ -6248,6 +6457,7 @@ describe("startGatewayConfigReloader skills invalidation", () => {
       }),
     );
     const { watcher, log, reloader } = createReloaderHarness(readSnapshot);
+    await reloader.ready;
 
     watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
@@ -6272,6 +6482,7 @@ describe("startGatewayConfigReloader skills invalidation", () => {
       }),
     );
     const { watcher, reloader } = createReloaderHarness(readSnapshot);
+    await reloader.ready;
 
     watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1976,33 +1976,168 @@ describe("startGatewayConfigReloader", () => {
     }
   });
 
-  it("reconciles disk changes made during initial candidate preparation", async () => {
-    const gate = createDeferred();
-    let initial = true;
-    let disk = makeSnapshot({ config: { gateway: { reload: {} } }, hash: "initial-raw-hash" });
-    const harness = createReloaderHarness(async () => disk, {
-      prepareConfigCandidate: async ({ runtimeConfig, sourceConfig }) => {
-        if (initial) {
-          initial = false;
-          await gate.promise;
-        }
-        return { runtimeConfig, compareConfig: sourceConfig };
+  it.each([true, false])(
+    "keeps unchanged initial watch scans out of config candidate ownership (exists: %s)",
+    async (exists) => {
+      const gate = createDeferred<ConfigFileSnapshot>();
+      const observed = vi.fn();
+      const harness = createReloaderHarness(() => gate.promise, {
+        initialSnapshotRawHash: exists ? "initial-raw-hash" : null,
+        prepareConfigCandidate: async ({ runtimeConfig, sourceConfig }) => ({
+          runtimeConfig,
+          compareConfig: sourceConfig,
+        }),
+        onConfigCandidateObserved: observed,
+      });
+      try {
+        await harness.reloader.ready;
+        harness.watcher.emit("ready");
+        expect(observed).not.toHaveBeenCalled();
+        gate.resolve(makeSnapshot({ exists, hash: exists ? "initial-raw-hash" : undefined }));
+        await vi.runAllTimersAsync();
+        expect(observed).not.toHaveBeenCalled();
+        expect(harness.onConfigAccepted).not.toHaveBeenCalled();
+        expect(harness.onRestart).not.toHaveBeenCalled();
+      } finally {
+        gate.resolve(makeSnapshot());
+        await harness.reloader.stop();
+      }
+    },
+  );
+
+  it.each(["root", "include", "created root"] as const)(
+    "reconciles %s changes made during initial candidate preparation",
+    async (changedFile) => {
+      const gate = createDeferred();
+      let initial = true;
+      let disk = makeSnapshot({ config: { gateway: { reload: {} } }, hash: "initial-raw-hash" });
+      const includedPaths = changedFile === "include" ? ["/tmp/hooks.json5"] : [];
+      const harness = createReloaderHarness(async () => disk, {
+        initialSnapshotRawHash: changedFile === "created root" ? null : "initial-raw-hash",
+        initialIncludedPaths: includedPaths,
+        prepareConfigCandidate: async ({ runtimeConfig, sourceConfig }) => {
+          if (initial) {
+            initial = false;
+            await gate.promise;
+          }
+          return { runtimeConfig, compareConfig: sourceConfig };
+        },
+      });
+      try {
+        const nextConfig = { gateway: { reload: {} }, hooks: { enabled: true } };
+        disk = makeSnapshot({
+          config: nextConfig,
+          hash: changedFile === "include" ? "initial-raw-hash" : "written-during-preparation",
+          includedPaths,
+        });
+        gate.resolve();
+        await harness.reloader.ready;
+        expect(harness.onHotReload).not.toHaveBeenCalled();
+        harness.watcher.emit("ready");
+        await vi.runAllTimersAsync();
+        expect(getOnlyHotReloadCall(harness)[1]).toEqual(nextConfig);
+      } finally {
+        gate.resolve();
+        await harness.reloader.stop();
+      }
+    },
+  );
+
+  it("updates watch dependencies when an initial include resolves to unchanged config", async () => {
+    const config = { gateway: { reload: {} } };
+    const harness = createReloaderHarness(
+      async () =>
+        makeSnapshot({ config, hash: "initial-raw-hash", includedPaths: ["/tmp/new.json5"] }),
+      {
+        initialIncludedPaths: ["/tmp/old.json5"],
+        prepareConfigCandidate: async ({ runtimeConfig, sourceConfig }) => ({
+          runtimeConfig,
+          compareConfig: sourceConfig,
+        }),
       },
-    });
+    );
     try {
-      const nextConfig = { gateway: { reload: {} }, hooks: { enabled: true } };
-      disk = makeSnapshot({ config: nextConfig, hash: "written-during-preparation" });
-      gate.resolve();
       await harness.reloader.ready;
-      expect(harness.onHotReload).not.toHaveBeenCalled();
       harness.watcher.emit("ready");
       await vi.runAllTimersAsync();
-      expect(getOnlyHotReloadCall(harness)[1]).toEqual(nextConfig);
+      expect(chokidar.watch).toHaveBeenLastCalledWith(
+        ["/tmp/openclaw.json", "/tmp/new.json5"],
+        expect.any(Object),
+      );
+      expect(harness.onConfigAccepted).toHaveBeenCalledTimes(1);
     } finally {
-      gate.resolve();
       await harness.reloader.stop();
     }
   });
+
+  it("reconciles through the reload owner after an initial watch read rejects", async () => {
+    const nextConfig = { gateway: { reload: {} }, hooks: { enabled: true } };
+    const readSnapshot = vi
+      .fn(async () => makeSnapshot({ config: nextConfig, hash: "new-disk-config" }))
+      .mockRejectedValueOnce(new Error("initial read failed"));
+    const harness = createReloaderHarness(readSnapshot, {
+      prepareConfigCandidate: async ({ runtimeConfig, sourceConfig }) => ({
+        runtimeConfig,
+        compareConfig: sourceConfig,
+      }),
+    });
+    try {
+      await harness.reloader.ready;
+      harness.watcher.emit("ready");
+      await vi.runAllTimersAsync();
+      expect(getOnlyHotReloadCall(harness)[1]).toEqual(nextConfig);
+      expect(harness.log.warn).toHaveBeenCalledWith(expect.stringContaining("initial read failed"));
+    } finally {
+      await harness.reloader.stop();
+    }
+  });
+
+  it.each(["write", "stop", "replace"] as const)(
+    "discards an initial watch read superseded by %s",
+    async (supersededBy) => {
+      const gate = createDeferred<ConfigFileSnapshot>();
+      const observed = vi.fn();
+      const harness = createReloaderHarness(() => gate.promise, {
+        prepareConfigCandidate: async ({ runtimeConfig, sourceConfig }) => ({
+          runtimeConfig,
+          compareConfig: sourceConfig,
+        }),
+        onConfigCandidateObserved: observed,
+      });
+      let stopFinished = false;
+      let stopping: Promise<void> | undefined;
+      try {
+        await harness.reloader.ready;
+        harness.watcher.emit("ready");
+        expect(observed).not.toHaveBeenCalled();
+        if (supersededBy === "write") {
+          harness.emitWrite(makeZeroDebounceHookWrite("newer-write"));
+          await vi.runAllTimersAsync();
+          expect(getOnlyHotReloadCall(harness)[1].hooks?.enabled).toBe(true);
+        } else if (supersededBy === "stop") {
+          stopping = harness.reloader.stop().then(() => {
+            stopFinished = true;
+          });
+          await Promise.resolve();
+          expect(stopFinished).toBe(false);
+        } else {
+          harness.watcher.emit("error", new Error("watch failed"));
+        }
+        observed.mockClear();
+        gate.resolve(makeSnapshot({ config: { hooks: { enabled: false } }, hash: "stale-read" }));
+        await stopping;
+        await vi.advanceTimersByTimeAsync(0);
+        expect(observed).not.toHaveBeenCalled();
+        expect(harness.onRestart).not.toHaveBeenCalled();
+        if (supersededBy === "stop") {
+          expect(stopFinished).toBe(true);
+        }
+      } finally {
+        gate.resolve(makeSnapshot());
+        await harness.reloader.stop();
+      }
+    },
+  );
 
   it.each(["resolve", "reject"] as const)(
     "owns shutdown while initial candidate preparation is pending: %s",

--- a/src/gateway/config-reload.transcripts.test.ts
+++ b/src/gateway/config-reload.transcripts.test.ts
@@ -327,6 +327,7 @@ it.each([false, true])(
             onConfigApplied: applied,
             log: logger,
           });
+          await reloader.ready;
           try {
             service.start();
             await vi.waitFor(async () =>

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -31,7 +31,6 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
   loadInstalledPluginIndexInstallRecords,
-  loadInstalledPluginIndexInstallRecordsSync,
 } from "../plugins/installed-plugin-index-records.js";
 import { bumpSkillsSnapshotVersion } from "../skills/runtime/refresh-state.js";
 import { createConfigAppliedRevisionTracker } from "./config-applied-revision.js";
@@ -78,8 +77,11 @@ function resolveChokidarUsePolling(degradedToPolling: boolean): boolean {
 }
 
 type GatewayConfigReloader = {
+  /** Candidate validation and watcher creation; stop owns this work immediately. */
+  ready: Promise<void>;
+  isReady: () => boolean;
   stop: () => Promise<void>;
-  hotReloadStatus: () => GatewayHotReloadStatus;
+  hotReloadStatus: () => GatewayHotReloadStatus | undefined;
   notifyPluginMetadataChanged: () => void;
 };
 
@@ -139,7 +141,7 @@ export function startGatewayConfigReloader(opts: {
     runtimeConfig: OpenClawConfig;
     sourceConfig: OpenClawConfig;
     previousSourceConfig: OpenClawConfig;
-  }) => PreparedGatewayConfigCandidate;
+  }) => Promise<PreparedGatewayConfigCandidate>;
   initialInternalWriteHash?: string | null;
   readSnapshot: (activeSourceConfig: OpenClawConfig) => Promise<ConfigFileSnapshot>;
   /** Pauses restart emission synchronously when a matching disk candidate is observed. */
@@ -216,13 +218,8 @@ export function startGatewayConfigReloader(opts: {
   watchPath: string;
 }): GatewayConfigReloader {
   const initialSourceConfig = opts.initialCompareConfig ?? opts.initialConfig;
-  const initialCandidate = opts.prepareConfigCandidate?.({
-    runtimeConfig: opts.initialConfig,
-    sourceConfig: initialSourceConfig,
-    previousSourceConfig: initialSourceConfig,
-  });
-  let currentConfig = initialCandidate?.runtimeConfig ?? opts.initialConfig;
-  let currentCompareConfig = initialCandidate?.compareConfig ?? initialSourceConfig;
+  let currentConfig = opts.initialConfig;
+  let currentCompareConfig = initialSourceConfig;
   let currentSourceConfig = initialSourceConfig;
   let currentRawHash = opts.initialSnapshotRawHash;
   let lastObservedRawHash = opts.initialSnapshotRawHash;
@@ -231,8 +228,7 @@ export function startGatewayConfigReloader(opts: {
     { env: process.env, homedir },
   );
   let currentRuntimeEnvSourceConfig = initialSourceConfig;
-  let currentReapplyRuntimeOverlays =
-    initialCandidate?.reapplyRuntimeOverlays ?? ((config: OpenClawConfig) => config);
+  let currentReapplyRuntimeOverlays = (config: OpenClawConfig) => config;
   let currentRuntimeRefresh: RuntimeConfigSnapshotRefreshOptions | undefined;
   const resolveSettings = (config: OpenClawConfig) => {
     const resolved = resolveGatewayReloadSettings(config);
@@ -245,6 +241,7 @@ export function startGatewayConfigReloader(opts: {
   let pending = false;
   let running = false;
   let stopped = false;
+  let initialized = false;
   const activeReloads = new Set<Promise<void>>();
   let missingConfigRetries = 0;
   let configWriteEpoch = 0;
@@ -291,7 +288,7 @@ export function startGatewayConfigReloader(opts: {
   // CAS token is the unfiltered slot: a slot owned by another config path must
   // still be the expected value so this path can take the slot over. Only a
   // path-matched slot may seed reconcile baselines.
-  let currentSnapshotSlot = readLatestConfigSnapshotAuditRecord();
+  let currentSnapshotSlot: ReturnType<typeof readLatestConfigSnapshotAuditRecord> = null;
 
   const updateAcceptedSnapshot = (rawHash: string, authoredConfig: unknown) => {
     currentRawHash = rawHash;
@@ -316,54 +313,7 @@ export function startGatewayConfigReloader(opts: {
     }
   };
 
-  const priorSnapshot = configSnapshotAuditRecordMatchesPath(currentSnapshotSlot, opts.watchPath)
-    ? currentSnapshotSlot
-    : null;
-  if (priorSnapshot && opts.initialSnapshotRawHash === null) {
-    currentRawHash = priorSnapshot.rawHash;
-    currentFingerprintedAuthoredConfig = priorSnapshot.fingerprintedAuthoredConfig;
-    appendExternalAudit({
-      detectedBy: "startup",
-      previousHash: priorSnapshot.rawHash,
-      nextHash: null,
-      valid: false,
-      issues: capConfigAuditIssues(["config file missing"]),
-    });
-  } else if (priorSnapshot && priorSnapshot.rawHash !== opts.initialSnapshotRawHash) {
-    if (!opts.initialSnapshotValid) {
-      currentRawHash = priorSnapshot.rawHash;
-      currentFingerprintedAuthoredConfig = priorSnapshot.fingerprintedAuthoredConfig;
-    }
-    const startupChangedPaths = opts.initialSnapshotValid
-      ? diffConfigPaths(
-          priorSnapshot.fingerprintedAuthoredConfig,
-          fingerprintConfigSnapshotAuthoredConfig(opts.initialAuthoredConfig, {
-            env: process.env,
-            homedir,
-          }),
-        )
-      : [];
-    appendExternalAudit({
-      detectedBy: "startup",
-      previousHash: priorSnapshot.rawHash,
-      nextHash: opts.initialSnapshotRawHash,
-      valid: opts.initialSnapshotValid,
-      ...(!opts.initialSnapshotValid
-        ? {
-            issues: capConfigAuditIssues(
-              formatConfigIssueLines(opts.initialSnapshotIssues, "", { normalizeRoot: true }),
-            ),
-          }
-        : startupChangedPaths.length > 0
-          ? { changedPaths: capConfigAuditPaths(startupChangedPaths) }
-          : { opaqueChange: true }),
-    });
-  }
-  if (opts.initialSnapshotRawHash !== null && opts.initialSnapshotValid) {
-    updateAcceptedSnapshot(opts.initialSnapshotRawHash, opts.initialAuthoredConfig);
-  }
-  let currentPluginInstallRecords =
-    opts.initialPluginInstallRecords ?? loadInstalledPluginIndexInstallRecordsSync();
+  let currentPluginInstallRecords: PluginInstallRecords = {};
   const readPluginInstallRecords =
     opts.readPluginInstallRecords ?? loadInstalledPluginIndexInstallRecords;
   const appliedRevision = createConfigAppliedRevisionTracker({
@@ -372,7 +322,7 @@ export function startGatewayConfigReloader(opts: {
   });
 
   const scheduleAfter = (wait: number) => {
-    if (stopped) {
+    if (stopped || !initialized) {
       return;
     }
     // Coalesce filesystem/write-listener bursts into one reload pass. Config
@@ -443,14 +393,25 @@ export function startGatewayConfigReloader(opts: {
         opts.hasOutstandingGatewayRestart?.() ? "applied-restart-required" : status,
       );
     };
+    const isCurrent = () => configWriteEpoch === transactionEpoch;
+    const assertCurrent = () => {
+      if (!isCurrent()) {
+        throw new GatewayConfigReloadSupersededError();
+      }
+    };
     // Reprepare against the current accepted env owner. A managed write can
     // finish preflight while another watcher transaction accepts first.
-    const preparedCandidate =
-      opts.prepareConfigCandidate?.({
-        runtimeConfig: candidateRuntimeConfig,
-        sourceConfig: nextSourceConfig,
-        previousSourceConfig: currentRuntimeEnvSourceConfig,
-      }) ?? preflightCandidate;
+    const preparedCandidate = opts.prepareConfigCandidate
+      ? await opts.prepareConfigCandidate({
+          runtimeConfig: candidateRuntimeConfig,
+          sourceConfig: nextSourceConfig,
+          previousSourceConfig: currentRuntimeEnvSourceConfig,
+        })
+      : preflightCandidate;
+    assertCurrent();
+    if (stopped) {
+      throw new GatewayConfigReloadSupersededError();
+    }
     const nextConfig = preparedCandidate?.runtimeConfig ?? candidateRuntimeConfig;
     const nextCompareConfig = preparedCandidate?.compareConfig ?? nextSourceConfig;
     const nextConfigRevisionHash = hashRuntimeConfigValue(nextSourceConfig);
@@ -459,12 +420,6 @@ export function startGatewayConfigReloader(opts: {
     let publishedRuntimeEnv: ConfigRuntimeEnvPublication | undefined;
     let runtimeEnvCommitted = false;
     const nextSettings = resolveSettings(nextConfig);
-    const isCurrent = () => configWriteEpoch === transactionEpoch;
-    const assertCurrent = () => {
-      if (!isCurrent()) {
-        throw new GatewayConfigReloadSupersededError();
-      }
-    };
     const commitPublishedRuntimeEnv = () => {
       runtimeEnvCommitted = true;
       publishedRuntimeEnv?.commit();
@@ -798,7 +753,7 @@ export function startGatewayConfigReloader(opts: {
   };
 
   const runReload = async () => {
-    if (stopped) {
+    if (stopped || !initialized) {
       return;
     }
     if (running) {
@@ -1289,9 +1244,91 @@ export function startGatewayConfigReloader(opts: {
     await reconcileWatchedPaths([...acceptedIncludedPaths]);
   };
 
-  createWatcher();
+  const ready = (async () => {
+    const initialCandidate = opts.prepareConfigCandidate
+      ? await opts.prepareConfigCandidate({
+          runtimeConfig: opts.initialConfig,
+          sourceConfig: initialSourceConfig,
+          previousSourceConfig: initialSourceConfig,
+        })
+      : undefined;
+    const initialPluginInstallRecords =
+      opts.initialPluginInstallRecords ?? (await loadInstalledPluginIndexInstallRecords());
+    if (stopped) {
+      throw new GatewayConfigReloadSupersededError();
+    }
+    currentConfig = initialCandidate?.runtimeConfig ?? opts.initialConfig;
+    currentCompareConfig = initialCandidate?.compareConfig ?? initialSourceConfig;
+    currentReapplyRuntimeOverlays =
+      initialCandidate?.reapplyRuntimeOverlays ?? ((config) => config);
+    settings = resolveSettings(currentConfig);
+    currentSnapshotSlot = readLatestConfigSnapshotAuditRecord();
+    // A write captured during validation owns the newer audit baseline.
+    if (configWriteEpoch === 0) {
+      const priorSnapshot = configSnapshotAuditRecordMatchesPath(
+        currentSnapshotSlot,
+        opts.watchPath,
+      )
+        ? currentSnapshotSlot
+        : null;
+      if (priorSnapshot && opts.initialSnapshotRawHash === null) {
+        currentRawHash = priorSnapshot.rawHash;
+        currentFingerprintedAuthoredConfig = priorSnapshot.fingerprintedAuthoredConfig;
+        appendExternalAudit({
+          detectedBy: "startup",
+          previousHash: priorSnapshot.rawHash,
+          nextHash: null,
+          valid: false,
+          issues: capConfigAuditIssues(["config file missing"]),
+        });
+      } else if (priorSnapshot && priorSnapshot.rawHash !== opts.initialSnapshotRawHash) {
+        if (!opts.initialSnapshotValid) {
+          currentRawHash = priorSnapshot.rawHash;
+          currentFingerprintedAuthoredConfig = priorSnapshot.fingerprintedAuthoredConfig;
+        }
+        const startupChangedPaths = opts.initialSnapshotValid
+          ? diffConfigPaths(
+              priorSnapshot.fingerprintedAuthoredConfig,
+              fingerprintConfigSnapshotAuthoredConfig(opts.initialAuthoredConfig, {
+                env: process.env,
+                homedir,
+              }),
+            )
+          : [];
+        appendExternalAudit({
+          detectedBy: "startup",
+          previousHash: priorSnapshot.rawHash,
+          nextHash: opts.initialSnapshotRawHash,
+          valid: opts.initialSnapshotValid,
+          ...(!opts.initialSnapshotValid
+            ? {
+                issues: capConfigAuditIssues(
+                  formatConfigIssueLines(opts.initialSnapshotIssues, "", { normalizeRoot: true }),
+                ),
+              }
+            : startupChangedPaths.length > 0
+              ? { changedPaths: capConfigAuditPaths(startupChangedPaths) }
+              : { opaqueChange: true }),
+        });
+      }
+      if (opts.initialSnapshotRawHash !== null && opts.initialSnapshotValid) {
+        updateAcceptedSnapshot(opts.initialSnapshotRawHash, opts.initialAuthoredConfig);
+      }
+    }
+    currentPluginInstallRecords = initialPluginInstallRecords;
+    // Async preparation can outlive disk changes before the initial watch scan.
+    createWatcher(
+      opts.prepareConfigCandidate !== undefined || opts.initialPluginInstallRecords === undefined,
+    );
+    initialized = true;
+    if (pendingInProcessConfig || pluginMetadataRefreshRequests > pluginMetadataRefreshApplied) {
+      scheduleAfter(0);
+    }
+  })();
 
   return {
+    ready,
+    isReady: () => initialized,
     notifyPluginMetadataChanged: () => {
       // Keep the running inventory intact; only the next Gateway startup may
       // discover changed plugin artifacts. Refresh install records for restart planning.
@@ -1315,13 +1352,14 @@ export function startGatewayConfigReloader(opts: {
         watcherRecreateTimer = null;
       }
       unsubscribeFromWrites();
+      await ready.catch(() => {});
       const active = watcher;
       watcher = null;
       await active?.close().catch(() => {});
       // Timer callbacks detach runReload; shutdown owns their full transaction unwind.
       await Promise.all(activeReloads);
     },
-    hotReloadStatus: () => hotReloadStatus,
+    hotReloadStatus: () => (initialized ? hotReloadStatus : undefined),
   };
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -331,7 +331,7 @@ export function startGatewayConfigReloader(opts: {
       clearTimeout(debounceTimer);
     }
     debounceTimer = setTimeout(() => {
-      startTrackedReload();
+      trackReload(runReload());
     }, wait);
   };
   const schedule = () => {
@@ -1018,8 +1018,7 @@ export function startGatewayConfigReloader(opts: {
     }
   };
 
-  function startTrackedReload(): void {
-    const reload = runReload();
+  function trackReload(reload: Promise<void>): void {
     activeReloads.add(reload);
     // A quick invocation can only set `pending` and finish while the owner run
     // remains active. Track every promise so it cannot replace that owner.
@@ -1113,7 +1112,43 @@ export function startGatewayConfigReloader(opts: {
   let degradedToPolling = false;
   let watcherUsesPolling = false;
 
-  const createWatcher = (reconcileAfterReady = false) => {
+  const reconcileInitialWatch = async (source: NonNullable<typeof watcher>) => {
+    const epoch = configWriteEpoch;
+    const isCurrent = () => !stopped && watcher === source && configWriteEpoch === epoch;
+    try {
+      const snapshot = await opts.readSnapshot(currentRuntimeEnvSourceConfig);
+      if (!isCurrent()) {
+        return;
+      }
+      const includedPaths = snapshot.includedPaths ?? [];
+      const hasIncludes = acceptedIncludedPaths.size > 0 || includedPaths.length > 0;
+      const sameIncludedPaths =
+        acceptedIncludedPaths.size === includedPaths.length &&
+        includedPaths.every((path) => acceptedIncludedPaths.has(path));
+      const sameRoot = snapshot.exists
+        ? typeof snapshot.hash === "string" && snapshot.hash === currentRawHash
+        : currentRawHash === null;
+      // Without includes, equal authored bytes prove the initial scan found no disk edit.
+      // Included files can change without changing the root file hash.
+      if (
+        snapshot.valid &&
+        sameRoot &&
+        (!hasIncludes ||
+          (sameIncludedPaths &&
+            diffConfigPaths(currentSourceConfig, snapshot.sourceConfig).length === 0))
+      ) {
+        return;
+      }
+    } catch (err) {
+      if (!isCurrent()) {
+        return;
+      }
+      opts.log.warn(`config reload initial watch check failed: ${String(err)}`);
+    }
+    scheduleExternalRefresh();
+  };
+
+  const createWatcher = (reconcileAfterReady?: "initial" | "replacement") => {
     if (stopped) {
       return;
     }
@@ -1142,10 +1177,14 @@ export function startGatewayConfigReloader(opts: {
     next.on("ready", () => {
       opts.onWatcherReady?.();
       if (reconcileAfterReady) {
-        // Replacement watchers suppress their initial add event. Reconcile only after the
-        // scan completes, and ignore a watcher that failed again before reaching ready.
+        // Initial add events are suppressed. Reconcile after the scan, ignoring a
+        // watcher that was replaced or stopped before reaching ready.
         if (!stopped && watcher === next) {
-          scheduleExternalRefresh();
+          if (reconcileAfterReady === "initial") {
+            trackReload(reconcileInitialWatch(next));
+          } else {
+            scheduleExternalRefresh();
+          }
         }
       }
     });
@@ -1175,7 +1214,7 @@ export function startGatewayConfigReloader(opts: {
         );
         watcherRecreateTimer = setTimeout(() => {
           watcherRecreateTimer = null;
-          createWatcher(true);
+          createWatcher("replacement");
         }, WATCHER_RECREATE_BACKOFF_MS[0] ?? 500);
         return;
       }
@@ -1196,7 +1235,7 @@ export function startGatewayConfigReloader(opts: {
     );
     watcherRecreateTimer = setTimeout(() => {
       watcherRecreateTimer = null;
-      createWatcher(true);
+      createWatcher("replacement");
     }, backoff);
   };
 
@@ -1227,7 +1266,7 @@ export function startGatewayConfigReloader(opts: {
     }
     watcher = null;
     watcherUsesPolling = false;
-    createWatcher(true);
+    createWatcher("replacement");
   };
 
   const observeCandidateWatchedPaths = async (includedPaths: readonly string[]) => {
@@ -1318,7 +1357,9 @@ export function startGatewayConfigReloader(opts: {
     currentPluginInstallRecords = initialPluginInstallRecords;
     // Async preparation can outlive disk changes before the initial watch scan.
     createWatcher(
-      opts.prepareConfigCandidate !== undefined || opts.initialPluginInstallRecords === undefined,
+      opts.prepareConfigCandidate !== undefined || opts.initialPluginInstallRecords === undefined
+        ? "initial"
+        : undefined,
     );
     initialized = true;
     if (pendingInProcessConfig || pluginMetadataRefreshRequests > pluginMetadataRefreshApplied) {

--- a/src/gateway/server-reload-contracts.ts
+++ b/src/gateway/server-reload-contracts.ts
@@ -1,5 +1,6 @@
 import type { CliDeps } from "../cli/deps.types.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { GatewayRestartEmitter } from "../infra/restart.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
@@ -186,6 +187,7 @@ export type ManagedGatewayConfigReloaderParams = Omit<
   configRevisionProjector: import("./config-revision-token.js").GatewayConfigRevisionProjector;
   minimalTestGateway: boolean;
   initialConfig: OpenClawConfig;
+  initialPluginInstallRecords?: Record<string, PluginInstallRecord>;
   initialCompareConfig?: OpenClawConfig;
   initialSnapshotRawHash: string | null;
   initialAuthoredConfig: unknown;
@@ -206,12 +208,12 @@ export type ManagedGatewayConfigReloaderParams = Omit<
   prepareConfigCandidate?: (params: {
     runtimeConfig: OpenClawConfig;
     sourceConfig: OpenClawConfig;
-  }) => {
+  }) => Promise<{
     runtimeConfig: OpenClawConfig;
     compareConfig: OpenClawConfig;
     reapplyRuntimeOverlays?: (config: OpenClawConfig) => OpenClawConfig;
     reapplyCompareOverlays?: (config: OpenClawConfig) => OpenClawConfig;
-  };
+  }>;
   /** Reapplies fixed process-lifetime overlays before secrets preparation. */
   applyRuntimeConfigOverrides?: (config: OpenClawConfig) => OpenClawConfig;
   resolveSharedGatewaySessionGenerationForConfig: (config: OpenClawConfig) => string | undefined;
@@ -227,4 +229,6 @@ export type ManagedGatewayConfigReloaderParams = Omit<
   acceptTerminalConfig: (options: { retireRejectedRestart: boolean }) => void;
 };
 
-export type ManagedGatewayConfigReloaderHandle = GatewayConfigReloaderHandle;
+export type ManagedGatewayConfigReloaderHandle = GatewayConfigReloaderHandle & {
+  ready: Promise<void>;
+};

--- a/src/gateway/server-reload-handlers.hot-reload-status.test.ts
+++ b/src/gateway/server-reload-handlers.hot-reload-status.test.ts
@@ -55,6 +55,8 @@ vi.mock("./config-reload.js", async () => {
         hoisted.onConfigCandidateCommitted = options.onConfigCandidateCommitted;
         hoisted.onRuntimeConfigCommitted = options.onRuntimeConfigCommitted;
         return {
+          ready: Promise.resolve(),
+          isReady: () => true,
           stop: hoisted.stop,
           hotReloadStatus: () => hoisted.hotReloadStatus.current,
           notifyPluginMetadataChanged: hoisted.notifyPluginMetadataChanged,
@@ -138,6 +140,7 @@ describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
       acceptTerminalConfig: vi.fn(),
       clients: [],
     });
+    await reloader.ready;
 
     expect(reloader.hotReloadStatus).toBeTypeOf("function");
     expect(reloader.hotReloadStatus?.()).toBe("active");

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -227,6 +227,7 @@ function startManagedGatewayConfigReloader(params: ManagedReloaderTestParams) {
   return startManagedGatewayConfigReloaderImpl({
     getPluginRegistry: requireActivePluginChannelRegistry,
     minimalTestGateway: false,
+    initialPluginInstallRecords: {},
     initialCompareConfig: params.initialConfig,
     initialInternalWriteHash: null,
     watchPath: "/tmp/openclaw.json",
@@ -794,7 +795,7 @@ function createReloadHandlersForTest(
   };
 }
 
-function createManagedRestartSequenceHarness(
+async function createManagedRestartSequenceHarness(
   options: { invalidateGenerationOnReconcile?: boolean } = {},
 ) {
   const initialConfig = {
@@ -950,6 +951,7 @@ function createManagedRestartSequenceHarness(
     sharedGatewaySessionGenerationState,
     requestRecoveryRestart,
   });
+  await reloader.ready;
   const writeConfig = (
     config: OpenClawConfig,
     hash: string,
@@ -1200,6 +1202,7 @@ async function runManagedOwnershipScenario(params: {
     acceptTerminalConfig,
     requestRecoveryRestart,
   });
+  await reloader.ready;
   writeListenerRef.current?.(
     createConfigWriteNotification(configA, "hash-a", 1, "runtime-a", "source-a"),
   );
@@ -1415,6 +1418,7 @@ async function withManagedChannelSecretFixture(
     commitRuntimePolicy,
     requestRecoveryRestart,
   });
+  await reloader.ready;
   try {
     await run({
       initialSource,
@@ -3025,6 +3029,7 @@ describe("gateway targeted service reload", () => {
       subscribeToWrites: captureConfigWriteListener(listener),
       reloadPluginServices,
     });
+    await reloader.ready;
     try {
       const application = createRuntimeConfigWriteApplication();
       if (!listener.current) {
@@ -5014,6 +5019,7 @@ describe("gateway Gmail hot reload handlers", () => {
       commitRuntimePolicy,
       acceptTerminalConfig,
     });
+    await reloader.ready;
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
@@ -5164,14 +5170,18 @@ describe("gateway Gmail hot reload handlers", () => {
         ],
       }),
     );
+    let persistedSourceConfig = initialSourceConfig;
+    let persistedHash = "initial-source";
+    const watch = vi.spyOn(chokidar, "watch");
     const reloader = startManagedGatewayConfigReloader({
       initialConfig: runtimeConfig,
+      initialCompareConfig: initialSourceConfig,
       readSnapshot: vi.fn(async () => ({
         path: "/tmp/openclaw.json",
         exists: true,
-        raw: "{}",
-        parsed: nextSourceConfig,
-        sourceConfig: nextSourceConfig,
+        raw: JSON.stringify(persistedSourceConfig),
+        parsed: persistedSourceConfig,
+        sourceConfig: persistedSourceConfig,
         resolved: runtimeConfig,
         valid: true,
         runtimeConfig,
@@ -5179,26 +5189,41 @@ describe("gateway Gmail hot reload handlers", () => {
         issues: [],
         warnings: [],
         legacyIssues: [],
-        hash: "same-runtime-next-source",
+        hash: persistedHash,
       })) as never,
       subscribeToWrites: captureConfigWriteListener(writeListenerRef),
-      prepareConfigCandidate: ({ runtimeConfig: candidateRuntime }) => ({
+      prepareConfigCandidate: async ({ runtimeConfig: candidateRuntime }) => ({
         runtimeConfig: candidateRuntime,
         compareConfig: candidateRuntime,
       }),
       activateRuntimeSecrets: activateRuntimeSecrets as never,
     });
+    await reloader.ready;
 
     try {
       const listener = writeListenerRef.current;
       if (!listener) {
         throw new Error("Expected config write listener to be registered");
       }
+      const publishSourceWrite = (notification: ConfigWriteNotification) => {
+        persistedSourceConfig = notification.sourceConfig;
+        persistedHash = notification.persistedHash;
+        listener(notification);
+      };
+      const watcher = watch.mock.results[0]?.value;
+      if (!watcher) {
+        throw new Error("Expected config watcher to be registered");
+      }
+      watcher.emit("change", "/tmp/openclaw.json");
+      await vi.advanceTimersByTimeAsync(300);
+      await waitForFast(() => expect(reloader.isConfigReloadSettled()).toBe(true));
+      expect(activateRuntimeSecrets).not.toHaveBeenCalled();
+
       const unrelatedSourceConfig = {
         ...initialSourceConfig,
         logging: { level: "info" as const },
       };
-      listener(
+      publishSourceWrite(
         createConfigWriteNotification(
           unrelatedSourceConfig,
           "same-secrets-new-source",
@@ -5208,7 +5233,8 @@ describe("gateway Gmail hot reload handlers", () => {
           { runtimeConfig },
         ),
       );
-      await vi.runAllTimersAsync();
+      // Flush the write without advancing the database's recurring WAL maintenance.
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(activateRuntimeSecrets).not.toHaveBeenCalled();
       expect(getActiveSecretsRuntimeSnapshot()?.sourceConfig).toEqual(unrelatedSourceConfig);
@@ -5227,7 +5253,7 @@ describe("gateway Gmail hot reload handlers", () => {
         },
       ]);
 
-      listener(
+      publishSourceWrite(
         createConfigWriteNotification(
           nextSourceConfig,
           "same-runtime-next-source",
@@ -5237,7 +5263,7 @@ describe("gateway Gmail hot reload handlers", () => {
           { runtimeConfig },
         ),
       );
-      await vi.runAllTimersAsync();
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(activateRuntimeSecrets.mock.calls[0]?.[1]).toMatchObject({
         activate: false,
@@ -5287,7 +5313,7 @@ describe("gateway Gmail hot reload handlers", () => {
           ],
         }),
       );
-      listener(
+      publishSourceWrite(
         createConfigWriteNotification(
           sourceConfig(thirdRef),
           "changed-second-resolution",
@@ -5297,7 +5323,7 @@ describe("gateway Gmail hot reload handlers", () => {
           { runtimeConfig },
         ),
       );
-      await vi.runAllTimersAsync();
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(getActiveSecretsRuntimeSnapshot()?.secretOwners).toEqual([
         {
@@ -5330,7 +5356,7 @@ describe("gateway Gmail hot reload handlers", () => {
           ],
         });
       });
-      listener(
+      publishSourceWrite(
         createConfigWriteNotification(
           sourceConfig(thirdRef),
           "superseded-source-owner",
@@ -5344,6 +5370,8 @@ describe("gateway Gmail hot reload handlers", () => {
       await preparationStarted;
 
       const concurrentSourceConfig = sourceConfig(fourthRef);
+      persistedSourceConfig = concurrentSourceConfig;
+      persistedHash = "concurrent-source-owner";
       activateSecretsRuntimeSnapshot(
         makePreparedSecretsSnapshot(concurrentSourceConfig, {
           config: runtimeConfig,
@@ -5357,7 +5385,7 @@ describe("gateway Gmail hot reload handlers", () => {
         }),
       );
       releasePreparation();
-      await vi.runAllTimersAsync();
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(getActiveSecretsRuntimeSnapshot()?.sourceConfig).toEqual(concurrentSourceConfig);
       expect(getActiveSecretsRuntimeSnapshot()?.secretOwners).toEqual([
@@ -5371,6 +5399,7 @@ describe("gateway Gmail hot reload handlers", () => {
       expect(hoisted.applyLoggingConfig).not.toHaveBeenCalled();
     } finally {
       await reloader.stop();
+      watch.mockRestore();
     }
   });
 
@@ -5419,6 +5448,7 @@ describe("gateway Gmail hot reload handlers", () => {
       acceptTerminalConfig: terminalPolicy.acceptConfig,
       restartRecoveryAvailable: false,
     });
+    await reloader.ready;
     let revision = 0;
     const writeConfig = (config: OpenClawConfig, hash: string) => {
       const listener = writeListenerRef.current;
@@ -5575,6 +5605,7 @@ describe("gateway Gmail hot reload handlers", () => {
         acceptTerminalConfig: policy.acceptConfig,
         requestRecoveryRestart,
       });
+      await reloader.ready;
       const writeConfig = (config: OpenClawConfig, revision: number) => {
         const application = createRuntimeConfigWriteApplication();
         if (!writeListenerRef.current) {
@@ -5709,6 +5740,7 @@ describe("gateway Gmail hot reload handlers", () => {
       acceptTerminalConfig,
       requestRecoveryRestart,
     });
+    await reloader.ready;
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
@@ -5751,7 +5783,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("does not emit a restart after shared-generation ownership rejects the candidate", async () => {
     vi.useFakeTimers();
-    const harness = createManagedRestartSequenceHarness({
+    const harness = await createManagedRestartSequenceHarness({
       invalidateGenerationOnReconcile: true,
     });
 
@@ -5775,7 +5807,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("cancels a deferred restart when a newer config fails required SecretRef preflight", async () => {
     vi.useFakeTimers();
-    const harness = createManagedRestartSequenceHarness();
+    const harness = await createManagedRestartSequenceHarness();
     hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "restart-sequence-blocker" }));
 
     try {
@@ -5853,7 +5885,7 @@ describe("gateway Gmail hot reload handlers", () => {
     vi.useFakeTimers();
     const watcher = new chokidar.FSWatcher();
     const watch = vi.spyOn(chokidar, "watch").mockReturnValue(watcher);
-    const harness = createManagedRestartSequenceHarness();
+    const harness = await createManagedRestartSequenceHarness();
     hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "metadata-restart-blocker" }));
 
     try {
@@ -5889,7 +5921,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("stops managed config reload while its Gateway admission is suspended", async () => {
     vi.useFakeTimers();
-    const harness = createManagedRestartSequenceHarness();
+    const harness = await createManagedRestartSequenceHarness();
     const suspension = tryBeginGatewaySuspendAdmission(() => {});
     expect(suspension).not.toBeNull();
     let stopping: Promise<void> | undefined;
@@ -5922,7 +5954,7 @@ describe("gateway Gmail hot reload handlers", () => {
     "joins admitted config restart %s after managed shutdown starts",
     async (outcome) => {
       vi.useFakeTimers();
-      const harness = createManagedRestartSequenceHarness();
+      const harness = await createManagedRestartSequenceHarness();
       const { promise: preflightStarted, resolve: markPreflightStarted } = createDeferred();
       const { promise: preflightBlocked, resolve: releasePreflight } = createDeferred();
       harness.activateRuntimeSecrets.mockImplementationOnce(async (config: OpenClawConfig) => {
@@ -5976,18 +6008,19 @@ describe("gateway Gmail hot reload handlers", () => {
   it.each([
     [
       "hot",
-      (harness: ReturnType<typeof createManagedRestartSequenceHarness>) => harness.invalidHotConfig,
+      (harness: Awaited<ReturnType<typeof createManagedRestartSequenceHarness>>) =>
+        harness.invalidHotConfig,
     ],
     [
       "noop",
-      (harness: ReturnType<typeof createManagedRestartSequenceHarness>) =>
+      (harness: Awaited<ReturnType<typeof createManagedRestartSequenceHarness>>) =>
         harness.invalidNoopConfig,
     ],
   ] as const)(
     "pauses deferred restart A before external %s config B fails required SecretRef preflight",
     async (_kind, selectInvalidConfig) => {
       vi.useFakeTimers();
-      const harness = createManagedRestartSequenceHarness();
+      const harness = await createManagedRestartSequenceHarness();
       const invalidConfig = selectInvalidConfig(harness);
       const invalidPlan = buildGatewayReloadPlan(
         diffConfigPaths(harness.deferredConfig, invalidConfig),
@@ -6032,7 +6065,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("revalidates canonical SecretRefs instead of trusting direct-write runtime literals", async () => {
     vi.useFakeTimers();
-    const harness = createManagedRestartSequenceHarness();
+    const harness = await createManagedRestartSequenceHarness();
     const resolvedRuntimeConfig = {
       ...harness.deferredConfig,
       logging: { level: "info" },
@@ -6076,7 +6109,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("revalidates deferred restart SecretRefs again before emission and retry", async () => {
     vi.useFakeTimers();
-    const harness = createManagedRestartSequenceHarness();
+    const harness = await createManagedRestartSequenceHarness();
     hoisted.activeTaskBlockers.push(
       makeActiveTaskBlocker({ taskId: "restart-emission-preflight-blocker" }),
     );
@@ -6109,7 +6142,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("supersedes a blocked emission preflight without marking sessions or signaling", async () => {
     vi.useFakeTimers();
-    const harness = createManagedRestartSequenceHarness();
+    const harness = await createManagedRestartSequenceHarness();
     const { promise: emissionPreflightStarted, resolve: recordEmissionPreflightStarted } =
       createDeferred();
     const { promise: emissionPreflightGate, resolve: releaseEmissionPreflight } = createDeferred();
@@ -6158,7 +6191,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("revalidates paused restart secrets before rearming an exact config revert", async () => {
     vi.useFakeTimers();
-    const harness = createManagedRestartSequenceHarness();
+    const harness = await createManagedRestartSequenceHarness();
     hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "restart-sequence-blocker" }));
 
     try {
@@ -6203,7 +6236,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("lets a newer valid restart config replace the deferred restart owner", async () => {
     vi.useFakeTimers();
-    const harness = createManagedRestartSequenceHarness();
+    const harness = await createManagedRestartSequenceHarness();
     hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "restart-sequence-blocker" }));
 
     try {
@@ -6316,6 +6349,7 @@ describe("gateway Gmail hot reload handlers", () => {
       activateRuntimeSecrets: activateRuntimeSecrets as never,
       commitRuntimePolicy,
     });
+    await reloader.ready;
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
@@ -6377,6 +6411,7 @@ describe("gateway Gmail hot reload handlers", () => {
       subscribeToWrites: captureConfigWriteListener(writeListenerRef),
       logReload,
     });
+    await reloader.ready;
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
@@ -6420,6 +6455,7 @@ describe("gateway Gmail hot reload handlers", () => {
         subscribeToWrites: captureConfigWriteListener(writeListenerRef),
         logReload,
       });
+      await reloader.ready;
       try {
         const registeredWriteListener = writeListenerRef.current;
         if (!registeredWriteListener) {
@@ -6466,6 +6502,7 @@ describe("gateway Gmail hot reload handlers", () => {
         return makePreparedSecretsSnapshot(config, { webTools: {} as never });
       }) as never,
     });
+    await reloader.ready;
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
@@ -6687,6 +6724,7 @@ describe("gateway plugin hot reload handlers", () => {
       }),
       reloadPlugins,
     });
+    await reloader.ready;
     try {
       const listener = writeListenerRef.current;
       if (!listener) {
@@ -7678,7 +7716,7 @@ describe("deferred channel reload abort generation", () => {
     channels: any,
     options?: Pick<
       Partial<ReloadHandlerParams>,
-      "reloadPlugins" | "requestRecoveryRestart" | "releaseChannelRouteHandoffs"
+      "reloadPlugins" | "requestRecoveryRestart" | "releaseChannelRouteHandoffs" | "logReload"
     >,
   ) =>
     createGatewayReloadHandlers({
@@ -7884,6 +7922,9 @@ describe("deferred channel reload abort generation", () => {
     "settles active-work deferral (runtime committed: %s, cancellation: %s)",
     async (committed, cancellationKind) => {
       const logChannels = { info: vi.fn(), error: vi.fn() };
+      const deferralStarted = createDeferred();
+      const logReload = createInfoWarnErrorLogger();
+      logReload.warn.mockImplementation(() => deferralStarted.resolve());
       const channels = {
         start: vi.fn(async () => new Map()),
         stop: vi.fn(async () => {}),
@@ -7897,7 +7938,7 @@ describe("deferred channel reload abort generation", () => {
       const { applyHotReload, getDeferredChannelReloads } = createTestHandlers(
         logChannels,
         channels,
-        { reloadPlugins },
+        { reloadPlugins, logReload },
       );
       hoisted.activeTaskBlockers.push(
         makeActiveTaskBlocker({ taskId: "task-blocking-superseded-reload" }),
@@ -7924,6 +7965,7 @@ describe("deferred channel reload abort generation", () => {
           (error: unknown) => error,
         );
         await vi.advanceTimersByTimeAsync(10);
+        await deferralStarted.promise;
         expect(getDeferredChannelReloads?.()).toEqual([
           { channel: "whatsapp", publicationPending: !committed },
         ]);
@@ -8024,7 +8066,9 @@ describe("deferred channel reload abort generation", () => {
       const application = createRuntimeConfigWriteApplication();
       const settled = vi.fn();
       void application.result.then(settled);
+      const deferralStarted = createDeferred();
       const logReload = createInfoWarnErrorLogger();
+      logReload.warn.mockImplementation(() => deferralStarted.resolve());
       const watch = vi.spyOn(chokidar, "watch");
       setActivePluginRegistry(registry);
       const reloader = startManagedGatewayConfigReloader({
@@ -8038,6 +8082,7 @@ describe("deferred channel reload abort generation", () => {
         stopChannel,
         reloadPlugins,
       });
+      await reloader.ready;
       const registeredWriteListener = writeListenerRef.current;
       if (!registeredWriteListener) {
         throw new Error("Expected config write listener to be registered");
@@ -8056,6 +8101,7 @@ describe("deferred channel reload abort generation", () => {
           ),
         );
         await vi.advanceTimersByTimeAsync(10);
+        await deferralStarted.promise;
         expect(logReload.warn).toHaveBeenCalledWith(
           expect.stringContaining("deferring until 1 gateway request(s) complete"),
         );
@@ -8209,6 +8255,7 @@ describe("deferred channel reload abort generation", () => {
         logReload,
         requestRecoveryRestart,
       });
+      await reloader.ready;
       if (successor === "prepared refresh failure") {
         hoisted.refreshPreparedModelRuntimeSnapshots.mockRejectedValueOnce(
           new Error("prepared runtime refresh failed"),

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -58,6 +58,7 @@ export function startManagedGatewayConfigReloader(
   const lifecycle = new AbortController();
   if (params.minimalTestGateway) {
     return {
+      ready: Promise.resolve(),
       stop: async () => {
         lifecycle.abort(new GatewayConfigReloadSupersededError());
       },
@@ -327,6 +328,7 @@ export function startManagedGatewayConfigReloader(
     initialIncludedPaths: params.initialIncludedPaths ?? [],
     initialSnapshotValid: params.initialSnapshotValid,
     initialSnapshotIssues: params.initialSnapshotIssues,
+    initialPluginInstallRecords: params.initialPluginInstallRecords,
     // Single notification point for every persisted config change — gateway
     // RPC writes, agent/CLI config_set, doctor, and hand edits all land here
     // once the candidate is accepted. Hash-only; clients refresh via config.get.
@@ -522,6 +524,7 @@ export function startManagedGatewayConfigReloader(
     watchPath: params.watchPath,
   });
   return {
+    ready: configReloader.ready,
     stop: async () => {
       lifecycle.abort(new GatewayConfigReloadSupersededError());
       stopRestartRetries();
@@ -535,6 +538,9 @@ export function startManagedGatewayConfigReloader(
     notifyPluginMetadataChanged: configReloader.notifyPluginMetadataChanged,
     // Equal config revisions can still owe a plugin/runtime restart.
     isConfigReloadSettled: () =>
-      !lifecycle.signal.aborted && !hasConfigCandidatePending() && !hasOutstandingGatewayRestart(),
+      configReloader.isReady() &&
+      !lifecycle.signal.aborted &&
+      !hasConfigCandidatePending() &&
+      !hasOutstandingGatewayRestart(),
   };
 }

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -23,7 +23,7 @@ import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach
 // active" instead of guessing.
 export type GatewayConfigReloaderHandle = {
   stop: () => Promise<void>;
-  hotReloadStatus?: () => GatewayHotReloadStatus;
+  hotReloadStatus?: () => GatewayHotReloadStatus | undefined;
   getDeferredChannelReloads?: () => readonly GatewayDeferredChannelReload[];
   notifyPluginMetadataChanged: () => void;
   isConfigReloadSettled: () => boolean;

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -120,7 +120,7 @@ export async function prepareGatewayServerBootstrap(input: {
           measure: (name, run) => startupTrace.measure(name, run),
         }),
       ));
-    assertConfiguredWorkspaceStateReady({
+    await assertConfiguredWorkspaceStateReady({
       cfg: captureConfigOverrideApplier()(read.snapshot.config),
     });
     return read;
@@ -437,7 +437,7 @@ export async function prepareGatewayServerBootstrap(input: {
     ]);
     return next;
   };
-  const prepareReloadCandidate = (params: {
+  const prepareReloadCandidate = async (params: {
     runtimeConfig: OpenClawConfig;
     sourceConfig: OpenClawConfig;
     previousSourceConfig?: OpenClawConfig;
@@ -477,7 +477,7 @@ export async function prepareGatewayServerBootstrap(input: {
     const runtimeConfig = reapplyRuntimeOverlays(params.runtimeConfig);
     // Both managed writes and watcher reloads must reject unmigrated workspaces
     // before persistence or publication, using the candidate's final config and env.
-    assertConfiguredWorkspaceStateReady({ cfg: runtimeConfig, env: runtimeEnv.env });
+    await assertConfiguredWorkspaceStateReady({ cfg: runtimeConfig, env: runtimeEnv.env });
     return {
       runtimeConfig,
       compareConfig: reapplyCompareOverlays(params.sourceConfig),

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -386,6 +386,7 @@ export async function finishGatewayStartup(params: {
     resolveGatewayContext: resolvePluginGatewayContext,
     minimalTestGateway,
     initialConfig: cfgAtStart,
+    initialPluginInstallRecords: pluginMetadataSnapshot?.index.installRecords,
     initialCompareConfig: startupLastGoodSnapshot.sourceConfig,
     initialSnapshotRawHash: startupLastGoodSnapshot.exists
       ? (startupLastGoodSnapshot.hash ?? null)
@@ -402,7 +403,7 @@ export async function finishGatewayStartup(params: {
       registerConfigWriteListener(listener, {
         ownsRuntimeActivationFor: configSnapshot.path,
         preCommitRuntimePreflight: async (sourceConfig, runtimeRefresh) => {
-          const candidate = prepareReloadCandidate({
+          const candidate = await prepareReloadCandidate({
             runtimeConfig: sourceConfig,
             sourceConfig,
           });
@@ -507,7 +508,15 @@ export async function finishGatewayStartup(params: {
     ...(opts.hotReloadRecovery ? { requestRecoveryRestart: opts.hotReloadRecovery } : {}),
     restartRecoveryAvailable: opts.hotReloadRecovery !== undefined,
   };
-  kernel.setConfigReloaderHandle(startManagedGatewayConfigReloader(configReloaderParams));
+  if (lifecycle.closePreludeStarted) {
+    return { startupSettled: postAttachHandles.startupSettled };
+  }
+  const configReloader = startManagedGatewayConfigReloader(configReloaderParams);
+  kernel.setConfigReloaderHandle(configReloader);
+  await configReloader.ready;
+  if (lifecycle.closePreludeStarted) {
+    return { startupSettled: postAttachHandles.startupSettled };
+  }
   await promoteConfigSnapshotToLastKnownGood(startupLastGoodSnapshot).catch((err: unknown) => {
     log.warn(`gateway: failed to promote config last-known-good backup: ${String(err)}`);
   });

--- a/src/gateway/server-startup-workspace-readiness.test.ts
+++ b/src/gateway/server-startup-workspace-readiness.test.ts
@@ -120,7 +120,7 @@ describe("Gateway workspace migration readiness", () => {
 
       const migration = await migrateLegacyWorkspaceState({
         stateDir,
-        detected: detectLegacyWorkspaceState({
+        detected: await detectLegacyWorkspaceState({
           cfg,
           stateDir,
           homedir: os.homedir,
@@ -213,7 +213,7 @@ describe("Gateway workspace migration readiness", () => {
       server = undefined;
       const migration = await migrateLegacyWorkspaceState({
         stateDir: state.stateDir,
-        detected: detectLegacyWorkspaceState({
+        detected: await detectLegacyWorkspaceState({
           cfg: nextConfig,
           stateDir: state.stateDir,
           doctorOnlyStateMigrations: true,

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -558,7 +558,7 @@ export async function detectLegacyStateMigrations(params: {
     artifactPreservingReadOnly: params.artifactPreservingReadOnly,
   });
   const restartSentinel = detectLegacyRestartSentinel({ stateDir });
-  const workspace = detectLegacyWorkspaceState({
+  const workspace = await detectLegacyWorkspaceState({
     cfg: params.cfg,
     stateDir,
     env,

--- a/src/infra/state-migrations.workspace-move-order.test.ts
+++ b/src/infra/state-migrations.workspace-move-order.test.ts
@@ -45,7 +45,7 @@ describe("Doctor workspace move ordering", () => {
     const raw = JSON.stringify(milestones);
     const sourceName = "openclaw-workspace-state.json";
     fs.writeFileSync(path.join(context.workspaceDir, sourceName), raw);
-    const source = detect(configured).sources.find((entry) => entry.kind === "setup")!;
+    const source = (await detect(configured)).sources.find((entry) => entry.kind === "setup")!;
     expect((await migrate(configured)).warnings).toEqual([]);
     expect(readReceipt(source, context.env)?.removedSource).toBe(true);
 

--- a/src/infra/state-migrations.workspace-move.test.ts
+++ b/src/infra/state-migrations.workspace-move.test.ts
@@ -53,7 +53,7 @@ describe("workspace move migration recovery", () => {
       const raw = JSON.stringify(milestones);
       const sourcePath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
       fs.writeFileSync(sourcePath, raw);
-      const detected = detect(configured);
+      const detected = await detect(configured);
       const source = detected.sources.find((entry) => entry.kind === "setup")!;
       const imported = await migrateLegacyWorkspaceState({
         detected,

--- a/src/infra/state-migrations.workspace-setup-sandbox.test.ts
+++ b/src/infra/state-migrations.workspace-setup-sandbox.test.ts
@@ -2,17 +2,20 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { removeRegistryEntry, updateRegistry } from "../agents/sandbox/registry.js";
 import { resolveSandboxWorkspaceLayoutPaths } from "../agents/sandbox/shared.js";
+import { assertConfiguredWorkspaceStateReady } from "../agents/workspace-state-dirs.js";
 import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
 import {
   listSessionEntryKeysReadOnly,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import {
@@ -76,10 +79,10 @@ describe("sandbox workspace Doctor migration", () => {
     });
   }
 
-  it("does not create an agent database when no sandbox sessions are persisted", () => {
+  it("does not create an agent database when no sandbox sessions are persisted", async () => {
     const context = setup();
 
-    expect(listSessionEntryKeysReadOnly({ agentId: "main", env: context.env })).toEqual([]);
+    expect(await listSessionEntryKeysReadOnly({ agentId: "main", env: context.env })).toEqual([]);
     expect(
       fs.existsSync(resolveOpenClawAgentSqlitePath({ agentId: "main", env: context.env })),
     ).toBe(false);
@@ -93,10 +96,84 @@ describe("sandbox workspace Doctor migration", () => {
     await registerSandboxRuntimeScope("agent:main");
     await registerSandboxRuntimeScope("shared");
 
-    expect(listSessionEntryKeysReadOnly({ agentId: "main", env: context.env }).toSorted()).toEqual(
-      [sessionKey, "global"].toSorted(),
-    );
+    expect(
+      (await listSessionEntryKeysReadOnly({ agentId: "main", env: context.env })).toSorted(),
+    ).toEqual([sessionKey, "global"].toSorted());
   });
+
+  it.each(["discovered workspace", "read failure"] as const)(
+    "awaits persisted session keys before reporting readiness: %s",
+    async (outcome) => {
+      const context = setup();
+      const sandboxRoot = path.join(context.homeDir, "sandboxes");
+      const cfg = {
+        agents: {
+          defaults: {
+            workspace: context.workspaceDir,
+            sandbox: {
+              mode: "all",
+              scope: "session",
+              workspaceAccess: "ro",
+              workspaceRoot: sandboxRoot,
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+      const sessionKey = "agent:main:telegram:direct:delayed-discovery";
+      const layout = resolveSandboxWorkspaceLayoutPaths({
+        cfg: { scope: "session", workspaceAccess: "ro", workspaceRoot: sandboxRoot },
+        agentId: "main",
+        rawSessionKey: sessionKey,
+        workspaceDir: context.workspaceDir,
+      });
+      const legacyPath = path.join(layout.sandboxWorkspaceDir, "openclaw-workspace-state.json");
+      const entered = createDeferred();
+      const release = createDeferred();
+      const unavailable = new Error("Session key storage is unavailable");
+      const readKeys = sessionAccessor.listSessionEntryKeysReadOnly;
+      const read = vi
+        .spyOn(sessionAccessor, "listSessionEntryKeysReadOnly")
+        .mockImplementation(async (...args) => {
+          entered.resolve();
+          await release.promise;
+          if (outcome === "read failure") {
+            throw unavailable;
+          }
+          return readKeys(...args);
+        });
+      let settled = false;
+      const readiness = assertConfiguredWorkspaceStateReady({ cfg, env: context.env });
+      void readiness.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      try {
+        await withTestTimeout(entered.promise, 5_000, "Session-key discovery was not reached");
+        expect(settled).toBe(false);
+        await registerSandboxSession(sessionKey);
+        fs.mkdirSync(layout.sandboxWorkspaceDir, { recursive: true });
+        fs.writeFileSync(legacyPath, JSON.stringify({ version: 1 }));
+        release.resolve();
+        if (outcome === "read failure") {
+          await expect(readiness).rejects.toBe(unavailable);
+        } else {
+          await expect(readiness).rejects.toThrow(
+            "Legacy workspace setup state requires migration",
+          );
+        }
+        expect(fs.existsSync(legacyPath)).toBe(true);
+        expect(await readKeys({ agentId: "main", env: context.env })).toEqual([sessionKey]);
+      } finally {
+        release.resolve();
+        await Promise.allSettled([readiness]);
+        read.mockRestore();
+      }
+    },
+  );
 
   it("detects and removes legacy setup state in reused sandbox workspace copies", async () => {
     const context = setup();
@@ -133,7 +210,7 @@ describe("sandbox workspace Doctor migration", () => {
       "utf8",
     );
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: context.stateDir,
       env,
@@ -206,7 +283,7 @@ describe("sandbox workspace Doctor migration", () => {
         "utf8",
       );
 
-      const detected = detectLegacyWorkspaceState({
+      const detected = await detectLegacyWorkspaceState({
         cfg,
         stateDir: context.stateDir,
         env: context.env,
@@ -276,7 +353,7 @@ describe("sandbox workspace Doctor migration", () => {
     const sessionHash = createHash("sha256").update(sessionKey).digest("hex").slice(0, 12);
     await removeRegistryEntry(`workspace-migration-proof-${sessionHash}`);
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: context.stateDir,
       env: context.env,
@@ -336,7 +413,7 @@ describe("sandbox workspace Doctor migration", () => {
       await fsp.mkdir(sandboxLayout.sandboxWorkspaceDir, { recursive: true });
       await fsp.writeFile(setupPath, JSON.stringify({ version: 1 }), "utf8");
 
-      const detected = detectLegacyWorkspaceState({
+      const detected = await detectLegacyWorkspaceState({
         cfg,
         stateDir: context.stateDir,
         env: context.env,
@@ -422,7 +499,7 @@ describe("sandbox workspace Doctor migration", () => {
     await registerSandboxRuntimeScope("agent:main");
     await registerSandboxRuntimeScope("shared");
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: context.stateDir,
       env: context.env,
@@ -494,7 +571,7 @@ describe("sandbox workspace Doctor migration", () => {
     await registerSandboxSession("agent:main:telegram:direct:doctor-proof");
     await registerSandboxSession("agent:main-telegram:signal:direct:doctor-proof");
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: context.stateDir,
       env: context.env,
@@ -561,7 +638,7 @@ describe("sandbox workspace Doctor migration", () => {
     await registerSandboxSession(sessionKey);
     setTestEnvValue("OPENCLAW_STATE_DIR", context.stateDir);
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: requestedStateDir,
       env: requestedEnv,
@@ -629,14 +706,14 @@ describe("sandbox workspace Doctor migration", () => {
     setTestEnvValue("OPENCLAW_STATE_DIR", context.stateDir);
     await registerSandboxSession(ambientSession);
 
-    expect(listSessionEntryKeysReadOnly({ agentId: "main", env: requestedEnv })).toEqual([
+    expect(await listSessionEntryKeysReadOnly({ agentId: "main", env: requestedEnv })).toEqual([
       requestedSession,
     ]);
-    expect(listSessionEntryKeysReadOnly({ agentId: "main", env: context.env })).toEqual([
+    expect(await listSessionEntryKeysReadOnly({ agentId: "main", env: context.env })).toEqual([
       ambientSession,
     ]);
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: requestedStateDir,
       env: requestedEnv,
@@ -700,7 +777,7 @@ describe("sandbox workspace Doctor migration", () => {
     }
     await registerSandboxSession("agent:main:telegram:direct:doctor-proof");
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: context.stateDir,
       env: context.env,
@@ -758,7 +835,7 @@ describe("sandbox workspace Doctor migration", () => {
     );
     await registerSandboxSession("global");
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: context.stateDir,
       env: context.env,
@@ -824,7 +901,7 @@ describe("sandbox workspace Doctor migration", () => {
     await registerSandboxSession("agent:main:main");
     await registerSandboxSession("agent:main:telegram:direct:doctor-proof");
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: context.stateDir,
       env: context.env,
@@ -887,7 +964,7 @@ describe("sandbox workspace Doctor migration", () => {
       "utf8",
     );
 
-    const detected = detectLegacyWorkspaceState({
+    const detected = await detectLegacyWorkspaceState({
       cfg,
       stateDir: context.stateDir,
       env,

--- a/src/infra/state-migrations.workspace-setup-shared-root.test.ts
+++ b/src/infra/state-migrations.workspace-setup-shared-root.test.ts
@@ -62,9 +62,11 @@ describe("shared-root workspace Doctor migration", () => {
           ["main", "other"].map((id) => path.join(context.workspaceDir, id)),
         );
         // An unused shared root is a Doctor source, not a runtime admission requirement.
-        expect(() => assertConfiguredWorkspaceStateReady({ cfg, env: context.env })).not.toThrow();
+        await expect(
+          assertConfiguredWorkspaceStateReady({ cfg, env: context.env }),
+        ).resolves.toBeUndefined();
       }
-      const detected = detect({ ...context, cfg });
+      const detected = await detect({ ...context, cfg });
       expect(
         detected.sources
           .filter((source) => source.kind === "setup")
@@ -92,7 +94,7 @@ describe("shared-root workspace Doctor migration", () => {
           originalCorpus[index],
         );
       }
-      expect(detect({ ...context, cfg })).toEqual({ sources: [], hasLegacy: false });
+      expect(await detect({ ...context, cfg })).toEqual({ sources: [], hasLegacy: false });
       expect(await migrate({ ...context, cfg })).toEqual({ changes: [], warnings: [] });
     },
   );

--- a/src/infra/state-migrations.workspace-setup.test-support.ts
+++ b/src/infra/state-migrations.workspace-setup.test-support.ts
@@ -59,7 +59,7 @@ export function useWorkspaceMigrationTestFixture() {
 
   async function migrate(context: Parameters<typeof detect>[0]) {
     return await migrateLegacyWorkspaceState({
-      detected: detect(context),
+      detected: await detect(context),
       env: context.env,
       stateDir: context.stateDir,
     });

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -60,14 +60,14 @@ describe("legacy workspace Doctor migration", () => {
     );
 
     expect(
-      detectLegacyWorkspaceState({
+      await detectLegacyWorkspaceState({
         cfg: context.cfg,
         stateDir: context.stateDir,
         env: context.env,
         homedir: () => context.homeDir,
       }),
     ).toEqual({ sources: [], hasLegacy: false });
-    expect(detect(context)).toMatchObject({
+    expect(await detect(context)).toMatchObject({
       hasLegacy: true,
       sources: expect.arrayContaining([
         expect.objectContaining({ kind: "setup", sourcePath: canonicalSetupPath }),
@@ -159,7 +159,7 @@ describe("legacy workspace Doctor migration", () => {
     const attestedAt = new Date("2026-07-15T11:00:00.000Z");
     await fsp.utimes(attestationPath, attestedAt, attestedAt);
 
-    const detected = detect(aliasContext);
+    const detected = await detect(aliasContext);
     expect(detected.sources.find((source) => source.sourcePath === attestationPath)).toMatchObject({
       workspaceDir: identity.workspacePath,
       workspaceAliasPath: path.resolve(workspaceAlias),
@@ -266,7 +266,7 @@ describe("legacy workspace Doctor migration", () => {
       "openclaw-workspace-attestation:v1\n2026-07-15T11:00:00.000Z\n",
       "utf8",
     );
-    const detected = detect(aliasContext);
+    const detected = await detect(aliasContext);
 
     const result = await migrateLegacyWorkspaceState({
       detected,
@@ -495,7 +495,7 @@ describe("legacy workspace Doctor migration", () => {
         await fsp.writeFile(attestationPath, content, "utf8");
       }
 
-      expect(detect(context).hasLegacy).toBe(true);
+      expect((await detect(context)).hasLegacy).toBe(true);
       const result = await migrate(context);
 
       expect(result.warnings[0]).toMatch(/legacy workspace/i);
@@ -572,7 +572,7 @@ describe("legacy workspace Doctor migration", () => {
       ).toThrow(/requires migration/);
       await fsp.rename(sourcePath, retainedPath);
       expect(await fsp.readFile(retainedPath)).toEqual(original);
-      expect(detect(context).hasLegacy).toBe(false);
+      expect((await detect(context)).hasLegacy).toBe(false);
       expect(await migrate(context)).toEqual({ changes: [], warnings: [] });
       expect(() =>
         assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
@@ -585,7 +585,7 @@ describe("legacy workspace Doctor migration", () => {
     const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
     const attestationPath = await writeEmptyReservedAttestation(context);
 
-    expect(detect(context).hasLegacy).toBe(true);
+    expect((await detect(context)).hasLegacy).toBe(true);
     expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir })).toThrow(
       /requires migration/,
     );
@@ -596,7 +596,7 @@ describe("legacy workspace Doctor migration", () => {
     expect(result.changes[0]).toContain(attestationPath);
     expect(fs.existsSync(attestationPath)).toBe(false);
     expect(fs.existsSync(`${attestationPath}.doctor-importing`)).toBe(false);
-    expect(detect(context).hasLegacy).toBe(false);
+    expect((await detect(context)).hasLegacy).toBe(false);
     expect(() =>
       assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
     ).not.toThrow();
@@ -616,7 +616,7 @@ describe("legacy workspace Doctor migration", () => {
     const originalInode = fs.statSync(attestationPath).ino;
 
     const result = await migrateLegacyWorkspaceState({
-      detected: detect(context),
+      detected: await detect(context),
       env: context.env,
       stateDir: context.stateDir,
       beforeClaim: (source) => {
@@ -644,7 +644,7 @@ describe("legacy workspace Doctor migration", () => {
     expect(result.warnings).toEqual([]);
     expect(fs.existsSync(attestationPath)).toBe(false);
     expect(fs.existsSync(claimPath)).toBe(false);
-    expect(detect(context).hasLegacy).toBe(false);
+    expect((await detect(context)).hasLegacy).toBe(false);
     expect(() =>
       assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
     ).not.toThrow();
@@ -655,7 +655,7 @@ describe("legacy workspace Doctor migration", () => {
     const siblingPath = `${context.workspaceDir}.attested`;
     await fsp.writeFile(siblingPath, "", "utf8");
 
-    expect(detect(context).hasLegacy).toBe(false);
+    expect((await detect(context)).hasLegacy).toBe(false);
     const result = await migrate(context);
 
     expect(result.warnings).toEqual([]);
@@ -673,7 +673,7 @@ describe("legacy workspace Doctor migration", () => {
     await fsp.writeFile(externalSource, JSON.stringify({ version: 1 }), "utf8");
     await fsp.symlink(externalDir, path.join(context.workspaceDir, ".openclaw"));
 
-    expect(detect(context).hasLegacy).toBe(true);
+    expect((await detect(context)).hasLegacy).toBe(true);
     const result = await migrate(context);
 
     expect(result.warnings[0]).toMatch(/legacy workspace/i);
@@ -703,7 +703,7 @@ describe("legacy workspace Doctor migration", () => {
     await fsp.mkdir(context.stateDir, { recursive: true });
     await fsp.symlink(externalDir, path.join(context.stateDir, "workspace-attestations"));
 
-    expect(detect(context).hasLegacy).toBe(true);
+    expect((await detect(context)).hasLegacy).toBe(true);
     const result = await migrate(context);
 
     expect(result.warnings[0]).toMatch(/legacy workspace/i);
@@ -724,7 +724,7 @@ describe("legacy workspace Doctor migration", () => {
     await fsp.writeFile(setupPath, JSON.stringify({ version: 1 }), "utf8");
 
     const result = await migrateLegacyWorkspaceState({
-      detected: detect(context),
+      detected: await detect(context),
       env: context.env,
       stateDir: context.stateDir,
       beforeClaim: () => {
@@ -819,7 +819,7 @@ describe("legacy workspace Doctor migration", () => {
       expect(() =>
         assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
       ).not.toThrow();
-      expect(detect(context).hasLegacy).toBe(false);
+      expect((await detect(context)).hasLegacy).toBe(false);
       expect(await migrate(context)).toEqual({ changes: [], warnings: [] });
       expect(
         db
@@ -852,7 +852,7 @@ describe("legacy workspace Doctor migration", () => {
       }
       await fsp.writeFile(setupPath, setupSource, "utf8");
       const first = await migrateLegacyWorkspaceState({
-        detected: detect(context),
+        detected: await detect(context),
         env: context.env,
         stateDir: context.stateDir,
         removeSource: () => {
@@ -939,7 +939,7 @@ describe("legacy workspace Doctor migration", () => {
       "utf8",
     );
     const first = await migrateLegacyWorkspaceState({
-      detected: detect(context),
+      detected: await detect(context),
       env: context.env,
       stateDir: context.stateDir,
       removeSource: () => {
@@ -972,7 +972,7 @@ describe("legacy workspace Doctor migration", () => {
     const originalMtime = new Date("2026-07-15T11:01:00.000Z");
     await fsp.utimes(attestationPath, originalMtime, originalMtime);
     const first = await migrateLegacyWorkspaceState({
-      detected: detect(context),
+      detected: await detect(context),
       env: context.env,
       stateDir: context.stateDir,
       removeSource: () => {

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -299,13 +299,13 @@ function addLegacyWorkspaceSources(params: {
 }
 
 /** Detect retired workspace files only when an explicit Doctor flow opts in. */
-export function detectLegacyWorkspaceState(params: {
+export async function detectLegacyWorkspaceState(params: {
   cfg: OpenClawConfig;
   stateDir: string;
   env?: NodeJS.ProcessEnv;
   homedir?: () => string;
   doctorOnlyStateMigrations?: boolean;
-}): LegacyWorkspaceStateDetection {
+}): Promise<LegacyWorkspaceStateDetection> {
   if (params.doctorOnlyStateMigrations !== true) {
     return { sources: [], hasLegacy: false };
   }
@@ -327,7 +327,7 @@ export function detectLegacyWorkspaceState(params: {
   };
 
   const workspaceDirs = new Set(
-    listWorkspaceStateDirs({
+    await listWorkspaceStateDirs({
       cfg: params.cfg,
       env,
       homedir,


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Workspace discovery and config readiness still assume session-key reads finish synchronously. Once those reads are awaited, startup must retain validation and shutdown must own it immediately, including writes arriving before the watcher starts.

## Why This Change Was Made

Await session-key discovery, workspace/Doctor readiness and their actual startup/repair callers. The config reloader returns its stop handle immediately with an explicit readiness promise, captures writes during preparation, and checks the current transaction before publishing prepared config. Shutdown joins preparation and admitted reloads; startup publishes the handle before awaiting it.

## User Impact

Startup waits for configured workspace readiness before completing. Config changes during asynchronous validation are retained, superseded candidates cannot publish, and shutdown cannot leave a late watcher behind. Existing read-only and Doctor migration authority remains intact.

## Evidence

- Gateway and Doctor/discovery cohorts passed (500 and 239 cases), plus full selected checks and real SQLite/Chokidar/reopen proof with six workspace directories and a change during preparation.
- After contextual fixture repair, all 16 focused cases and all 278 reload-handler tests pass; selected checks and fresh full-candidate Codex P2 review pass.
- Fixture repair uses the source/hash actually present at each write, waits for observed deferral, and avoids exhausting a recurring SQLite WAL timer. Existing assertions and timeouts are preserved.
- Rebase onto the landed workspace prerequisite is patch-identical.
- Native SQLite remains synchronous inside its owner until the shared worker cutover; this is awaited discovery and readiness groundwork.

Initial watcher catch-up rereads before admitting a config candidate, avoiding spurious restart/pending state for unchanged or absent configs. Real include changes, supersession and stop remain covered. Both original CI lifecycle failures were reproduced and fixed; all 776 Gateway owner/sibling tests, full selected checks and fresh P2 review pass.
