### PR TITLE
fix: keep discovered models when sign-in tokens renew

### DIFF
--- a/src/agents/prepared-model-runtime-auth.ts
+++ b/src/agents/prepared-model-runtime-auth.ts
@@ -1,4 +1,8 @@
+import { isDeepStrictEqual } from "node:util";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes.js";
+import { isOAuthRefreshFence } from "./auth-profiles/oauth-refresh-marker.js";
+import { hasOAuthIdentity } from "./auth-profiles/oauth-shared.js";
 import type { RuntimeAuthMaterialization } from "./auth-profiles/runtime-materializations.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import type { ModelCatalogAuthLabels } from "./model-catalog-auth-labels.js";
@@ -20,6 +24,68 @@ export type PreparedModelRuntimeAuthScope = Readonly<{
   providerIds: readonly string[];
   profileIds?: readonly string[];
 }>;
+
+/** Inventory follows identified accounts; credential use still follows the current auth owner. */
+export function hasSamePreparedModelCatalogAuth(
+  previous: Pick<PreparedModelCatalogAuth, "authStore" | "credentials"> | undefined,
+  next: Pick<PreparedModelCatalogAuth, "authStore" | "credentials">,
+  includesProvider: (provider: string) => boolean = () => true,
+): boolean {
+  if (!previous?.credentials || !next.credentials) {
+    return false;
+  }
+  const identity = (authStore: AuthProfileStore, credentials: Readonly<AuthStorageData>) => {
+    const profiles = Object.entries(authStore.profiles).filter(([, profile]) =>
+      includesProvider(profile.provider),
+    );
+    const identifiedOAuth = profiles.filter(
+      ([, profile]) =>
+        profile.type === "oauth" && hasOAuthIdentity(profile) && !isOAuthRefreshFence(profile),
+    );
+    return {
+      profiles: Object.fromEntries(
+        profiles.map(([id, profile]) => {
+          if (profile.type !== "oauth" || !identifiedOAuth.some(([key]) => key === id)) {
+            return [id, profile];
+          }
+          const {
+            access: _access,
+            refresh: _refresh,
+            expires: _expires,
+            idToken: _idToken,
+            ...account
+          } = profile;
+          return [id, account];
+        }),
+      ),
+      credentials: Object.fromEntries(
+        Object.entries(credentials)
+          .filter(([provider]) => includesProvider(provider))
+          .map(([provider, credential]) => {
+            if (credential.type !== "oauth") {
+              return [provider, credential];
+            }
+            const profileIds = identifiedOAuth
+              .flatMap(([id, profile]) =>
+                profile.type === "oauth" &&
+                normalizeProviderId(profile.provider) === normalizeProviderId(provider) &&
+                profile.access === credential.access &&
+                profile.refresh === credential.refresh &&
+                profile.expires === credential.expires
+                  ? [id]
+                  : [],
+              )
+              .toSorted();
+            return [provider, profileIds.length ? { profileIds } : credential];
+          }),
+      ),
+    };
+  };
+  return isDeepStrictEqual(
+    identity(previous.authStore, previous.credentials),
+    identity(next.authStore, next.credentials),
+  );
+}
 
 /** Private auth facts owned by an immutable prepared model generation. */
 const authStoreBySnapshot = new WeakMap<object, AuthProfileStore>();

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -1,6 +1,5 @@
 import { performance } from "node:perf_hooks";
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
-import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import pLimit from "p-limit";
@@ -19,6 +18,7 @@ import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
 import { createPreparedModelCatalogWorker } from "./prepared-model-catalog-worker.js";
 import {
   getPreparedModelFullCatalogAuth,
+  hasSamePreparedModelCatalogAuth,
   setPreparedModelFullCatalogAuth,
   type PreparedModelRuntimeAuth,
 } from "./prepared-model-runtime-auth.js";
@@ -196,6 +196,8 @@ function createFullModelCatalogAccess(params: {
     params.agentFacts.env,
   );
   const previousInventory = params.inventoryOwner.catalogInventory;
+  const previousAuth =
+    previousInventory && getPreparedModelFullCatalogAuth(previousInventory.catalog);
   const pluginFingerprint = resolveInstalledManifestRegistryIndexFingerprint(
     params.pluginGeneration.pluginMetadataSnapshot.index,
   );
@@ -207,12 +209,17 @@ function createFullModelCatalogAccess(params: {
   let inventory =
     previousInventory?.key === inventoryKey &&
     previousInventory.pluginFingerprint === pluginFingerprint &&
-    isDeepStrictEqual(
-      getPreparedModelFullCatalogAuth(previousInventory.catalog)?.credentials,
-      params.agentFacts.credentials,
-    )
-      ? previousInventory
+    hasSamePreparedModelCatalogAuth(previousAuth, params.agentFacts)
+      ? { ...previousInventory, catalog: { ...previousInventory.catalog } }
       : undefined;
+  if (inventory && previousAuth) {
+    setPreparedModelFullCatalogAuth(inventory.catalog, {
+      ...previousAuth,
+      authStore: params.agentFacts.authStore,
+      credentials: params.agentFacts.credentials,
+      authModes: resolveUsableAgentCredentialModes(params.agentFacts.credentials),
+    });
+  }
   let fullCatalog = inventory ? project(inventory.catalog) : undefined;
   if (fullCatalog) {
     if (

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -26,10 +26,7 @@ import {
   discoverModelsFromCapturedSources,
 } from "./agent-model-discovery.js";
 import { withAgentRosterFactsBatch } from "./agent-scope-config.js";
-import {
-  getPreparedRuntimeAuthProfileStoreSnapshotCore,
-  getRuntimeAuthProfileStoreCredentialsRevision,
-} from "./auth-profiles/runtime-snapshots.js";
+import { getPreparedRuntimeAuthProfileStoreSnapshotCore } from "./auth-profiles/runtime-snapshots.js";
 import { buildInlineProviderModels } from "./embedded-agent-runner/model.inline-provider.js";
 import {
   createBundledStaticCatalogModelResolver,
@@ -554,7 +551,6 @@ export function preparedModelInventoryKey(input: PreparedModelRuntimeInput): str
     config: { models, auth, env, plugins },
     env: input.env ?? process.env,
     runtimePluginSelections: undefined,
-    credentials: getRuntimeAuthProfileStoreCredentialsRevision(),
     order:
       getPreparedRuntimeAuthProfileStoreSnapshotCore(input.agentDir, input.inheritedAuthDir)
         ?.order ?? {},

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -1,4 +1,3 @@
-import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { Model } from "../llm/types.js";
 import { resolvePreparedProviderStaticConfigs } from "../plugins/provider-discovery.js";
@@ -16,6 +15,7 @@ import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
 import {
   getPreparedModelFullCatalogAuth,
+  hasSamePreparedModelCatalogAuth,
   setPreparedModelFullCatalogAuth,
   setPreparedModelRuntimeAuthMaterializations,
   setPreparedModelRuntimeAuthLoader,
@@ -173,23 +173,11 @@ export function prepareModelCatalogPublication(
       ) {
         return [];
       }
-      const providerProfiles = (value: PreparedModelCatalogAuth) =>
-        Object.fromEntries(
-          Object.entries(value.authStore.profiles).filter(
-            ([, profile]) => normalizeProvider(profile.provider) === provider,
-          ),
-        );
-      const providerCredentials = (
-        credentials: NonNullable<PreparedModelCatalogAuth["credentials"]>,
-      ) =>
-        Object.entries(credentials)
-          .filter(([candidate]) => normalizeProvider(candidate) === provider)
-          .map(([, credential]) => credential);
-      return isDeepStrictEqual(providerProfiles(previousAuth), providerProfiles(auth)) &&
-        isDeepStrictEqual(
-          providerCredentials(previousAuth.credentials),
-          providerCredentials(auth.credentials),
-        )
+      return hasSamePreparedModelCatalogAuth(
+        previousAuth,
+        auth,
+        (candidate) => normalizeProvider(candidate) === provider,
+      )
         ? [provider]
         : [];
     }),

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -404,6 +404,14 @@ describe("prepared model runtime scoped refresh", () => {
     "carries completed discovery across hot reload without rediscovery (scope: %j)",
     async (agentIds) => {
       mocks.configuredAgentIds = ["pro"];
+      const credential = { type: "api_key" as const, key: "discovered-provider-key" };
+      mocks.preparedAuthStore = {
+        version: 1,
+        profiles: {
+          "discovered-provider:default": { ...credential, provider: "discovered-provider" },
+        },
+      };
+      mocks.authStorage.getAll.mockReturnValue({ "discovered-provider": credential });
       const config: OpenClawConfig = {
         agents: { entries: { pro: {} } },
         plugins: { entries: { fixture: { enabled: true } } },
@@ -420,7 +428,7 @@ describe("prepared model runtime scoped refresh", () => {
       const auth = {
         authModes: { "discovered-provider": "api_key" as const },
         providerAuthLabels: new Map(),
-        authStore: { version: 1 as const, profiles: {} },
+        authStore: mocks.preparedAuthStore,
         credentials: mocks.authStorage.getAll(),
       };
       setPreparedModelFullCatalogAuth(catalog, auth);
@@ -478,7 +486,8 @@ describe("prepared model runtime scoped refresh", () => {
       expect(refreshedCatalog).toMatchObject(refreshed);
       expect(replacement.readFullModelCatalog!()).toBe(refreshedCatalog);
       expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(2);
-      mocks.credentialsRevision += 1;
+      mocks.preparedAuthStore = { version: 1, profiles: {} };
+      mocks.authStorage.getAll.mockReturnValue({});
       mocks.mutationListener?.({ agentDir: input.agentDir, affectsInheritedStores: false });
       const afterAuth = await loadPreparedGatewayModelCatalogSnapshot({
         agentId: "pro",
@@ -689,6 +698,12 @@ describe("prepared model runtime scoped refresh", () => {
 
   it("reprojects retained discovery when a runtime override is added and removed", async () => {
     mocks.configuredAgentIds = ["pro"];
+    mocks.preparedAuthStore = {
+      version: 1,
+      profiles: {
+        "custom:default": { type: "api_key", provider: "custom", key: "test-key" },
+      },
+    };
     mocks.resolveStaticCatalogModel.mockImplementation(({ provider, modelId }) => ({
       provider,
       id: modelId,
@@ -715,7 +730,7 @@ describe("prepared model runtime scoped refresh", () => {
     setPreparedModelFullCatalogAuth(catalog, {
       authModes: { custom: "api_key" },
       providerAuthLabels: new Map(),
-      authStore: { version: 1, profiles: {} },
+      authStore: mocks.preparedAuthStore,
       credentials: mocks.authStorage.getAll(),
     });
     mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(catalog);
@@ -748,7 +763,7 @@ describe("prepared model runtime scoped refresh", () => {
         setPreparedModelFullCatalogAuth(failed, {
           authModes: { custom: "api_key" },
           providerAuthLabels: new Map(),
-          authStore: { version: 1, profiles: {} },
+          authStore: mocks.preparedAuthStore,
           credentials: mocks.authStorage.getAll(),
         });
         mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(failed);

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { resolveUsableAgentCredentialModes } from "./agent-auth-credentials.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
   getPreparedModelFullCatalogAuth,
@@ -127,9 +128,9 @@ vi.mock("./prepared-model-catalog-worker.js", () => ({
           catalog,
           getPreparedModelFullCatalogAuth(catalog) ?? {
             providerAuthLabels: new Map(),
-            authStore: preparedModelRuntimeMocks.preparedAuthStore ?? { version: 1, profiles: {} },
-            authModes: {},
-            credentials: preparedModelRuntimeMocks.authStorage.getAll(),
+            authStore: factoryArgs[0].agentFacts.authStore,
+            authModes: resolveUsableAgentCredentialModes(factoryArgs[0].agentFacts.credentials),
+            credentials: factoryArgs[0].agentFacts.credentials,
           },
         );
         return {

--- a/src/gateway/server-methods/models-auth-refresh.catalog.integration.test.ts
+++ b/src/gateway/server-methods/models-auth-refresh.catalog.integration.test.ts
@@ -1,0 +1,176 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { describe, expect, it } from "vitest";
+import type { ModelsListResult } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "../test-helpers.e2e.js";
+
+describe("models.authRefresh learned catalog", () => {
+  it("retains discovery on same-account renewal and replaces it for another account", async () => {
+    const state = await createOpenClawTestState({
+      label: "models-auth-refresh-catalog",
+      env: {
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      },
+    });
+    const provider = "renewal-fixture";
+    const requests: string[] = [];
+    const accounts = new Map([
+      ["Bearer account-one-original", "account-one"],
+      ["Bearer account-one-renewed", "account-one"],
+      ["Bearer account-two-original", "account-two"],
+    ]);
+    const discovery = createServer((request, response) => {
+      const authorization = request.headers.authorization ?? "";
+      requests.push(authorization);
+      const account = accounts.get(authorization);
+      if (request.url !== "/models" || !account) {
+        response.writeHead(401).end();
+        return;
+      }
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify([{ id: `${account}-learned`, name: `${account} learned` }]));
+    });
+    const saveAccount = async (accountId: string, access: string) => {
+      const store: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          [`${provider}:primary`]: {
+            type: "oauth",
+            provider,
+            accountId,
+            email: `${accountId}@example.invalid`,
+            access,
+            refresh: `${access}-refresh`,
+            expires: Date.now() + 3_600_000,
+          },
+        },
+      };
+      await state.writeAuthProfiles(store);
+    };
+    try {
+      discovery.listen(0, "127.0.0.1");
+      await once(discovery, "listening");
+      const address = discovery.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Discovery fixture did not bind a TCP port");
+      }
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+      await state.writeJson("catalog-plugin/openclaw.plugin.json", {
+        id: provider,
+        providers: [provider],
+        configSchema: { type: "object", additionalProperties: false },
+      });
+      const pluginPath = await state.writeText(
+        "catalog-plugin/index.cjs",
+        `module.exports = {
+          id: ${JSON.stringify(provider)},
+          register(api) {
+            api.registerProvider({
+              id: ${JSON.stringify(provider)}, label: "Renewal fixture", auth: [],
+              formatApiKey: (credential) => credential.access,
+              catalog: {
+                order: "profile",
+                async run(ctx) {
+                  const auth = ctx.resolveProviderAuth(${JSON.stringify(provider)});
+                  if (!auth.discoveryApiKey) return null;
+                  const response = await fetch(${JSON.stringify(`${baseUrl}/models`)}, {
+                    headers: { Authorization: "Bearer " + auth.discoveryApiKey },
+                  });
+                  if (!response.ok) throw new Error("Fixture discovery rejected credentials");
+                  const rows = await response.json();
+                  return { provider: {
+                    baseUrl: ${JSON.stringify(baseUrl)}, api: "openai-completions",
+                    models: rows.map((row) => ({
+                      ...row, reasoning: false, input: ["text"],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 32768, maxTokens: 4096,
+                    })),
+                  } };
+                },
+              },
+            });
+          },
+        };`,
+      );
+      const token = "catalog-renewal-gateway-token";
+      const cfg = {
+        agents: {
+          defaults: { modelPolicy: { allow: [`${provider}/*`] } },
+          list: [{ id: "main", workspace: state.workspaceDir }],
+        },
+        plugins: {
+          allow: [provider],
+          load: { paths: [pluginPath] },
+          slots: { memory: "none" },
+        },
+        gateway: { mode: "local", auth: { mode: "token", token } },
+      };
+      await state.writeConfig(cfg);
+      await saveAccount("account-one", "account-one-original");
+      const { client, server } = await startGatewayWithClient({
+        cfg,
+        configPath: state.configPath,
+        token,
+        scopes: ["operator.admin"],
+      });
+      try {
+        await server.startupSettled;
+        const list = async (refresh = false) => {
+          const result = await client.request<ModelsListResult>("models.list", {
+            agentId: "main",
+            view: "all",
+            refresh,
+          });
+          return result.models.filter((model) => model.provider === provider);
+        };
+        const original = await list(true);
+        expect(original.map((model) => model.id)).toEqual(["account-one-learned"]);
+        expect(requests.length).toBeGreaterThan(0);
+        expect(
+          requests.every((authorization) => authorization === "Bearer account-one-original"),
+        ).toBe(true);
+        const initialRequests = requests.length;
+
+        await saveAccount("account-one", "account-one-renewed");
+        await expect(
+          client.request("models.authRefresh", { agentId: "main", operation: "update" }),
+        ).resolves.toEqual({ refreshed: true });
+        expect((await list()).map((model) => model.id)).toEqual(["account-one-learned"]);
+        expect(requests).toHaveLength(initialRequests);
+
+        // An explicit refresh proves that the renewed bearer is now used.
+        await list(true);
+        expect(requests.slice(initialRequests)).toEqual(["Bearer account-one-renewed"]);
+        const renewedRequests = requests.length;
+        await saveAccount("account-two", "account-two-original");
+        await client.request("models.authRefresh", { agentId: "main", operation: "login" });
+        expect((await list()).map((model) => model.id)).not.toContain("account-one-learned");
+        expect(requests).toHaveLength(renewedRequests);
+        expect((await list(true)).map((model) => model.id)).toEqual(["account-two-learned"]);
+        expect(requests.slice(renewedRequests)).toEqual(["Bearer account-two-original"]);
+
+        await state.writeAuthProfiles({ version: 1, profiles: {} });
+        await client.request("models.authRefresh", { agentId: "main", operation: "logout" });
+        expect((await list()).filter((model) => model.available)).toEqual([]);
+      } finally {
+        await disconnectGatewayClient(client);
+        await server.close();
+      }
+    } finally {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          discovery.close((error) => (error ? reject(error) : resolve()));
+        });
+      } finally {
+        await state.cleanup();
+      }
+    }
+  });
+});


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

Fixes an issue where token renewal for the same account cleared learned model choices until another discovery request completed.

## Why This Change Was Made

Retain inventory by captured account identity and selected credentials rather than the global credential revision. Retained catalogs adopt current authentication facts; replacement accounts, logout and changed keys still invalidate them.

## User Impact

Token renewal keeps learned choices available without extra discovery. Switching accounts removes the previous account’s rows.

## Evidence

The real Gateway regression failed before the fix and passed afterward with no additional discovery request. Controls covered the renewed credential, account replacement, rediscovery and logout. Fifty-nine focused tests and 58 configuration/state tests passed; all 17 sanitized configurations reached Gateway readiness.
