### PR TITLE
feat(notifications): identify completed sessions by explicit labels

### DIFF
--- a/docs/web/notifications.md
+++ b/docs/web/notifications.md
@@ -57,6 +57,14 @@ The detail levels are:
 - **Names only** — may include a sanitized person, session, device, agent, task, or automation label.
 - **Detailed** — currently uses the same bounded, sanitized producer-owned labels. Message excerpts, raw prompts, command arguments, output, environment values, and errors never enter the push payload.
 
+For browser **Agent finished** alerts, **Names only** and **Detailed** include the
+current explicit session label when the event has exactly one authoritative
+session target and the browser can read it. The label is sanitized and bounded
+by the existing notification-label policy. Unnamed sessions, multiple targets,
+and unavailable label metadata retain the agent-only fallback. Raw session keys,
+generated titles, and message text are never used as label fallbacks. **Private**
+remains generic. This does not change native macOS or mobile notifications.
+
 On iPhone and iPad, Web Push is available only after two steps. First, install the Control UI with **Share → Add to Home Screen**. Then open that installed app. A normal Safari tab remains usable for the Control UI. In that tab, the Notifications page reports the install requirement. It does not attempt to dereference an unavailable `PushManager`.
 
 **Send test** asks the Gateway to push a test message to every registered browser subscription. Tests intentionally check transport only. Approval requests are targeted to authorized device bindings. **Unsubscribe** removes the current browser's endpoint from the Gateway only when its paired device and user profile still own the subscription. It then unsubscribes locally. Reconnecting under another profile can transfer the browser subscription only with its existing subscription keys. Knowing an endpoint alone cannot change its owner or remove it.

--- a/src/gateway/event-web-push.test.ts
+++ b/src/gateway/event-web-push.test.ts
@@ -17,6 +17,7 @@ const {
   getUserPreferencesMock,
   resolveOperatorRolePolicyForProfileMock,
   canReceiveSessionEventMock,
+  resolveSessionSharingTargetMock,
   mentionCurrentMock,
   webPushWarnMock,
 } = vi.hoisted(() => ({
@@ -28,6 +29,7 @@ const {
   getUserPreferencesMock: vi.fn(),
   resolveOperatorRolePolicyForProfileMock: vi.fn(),
   canReceiveSessionEventMock: vi.fn(),
+  resolveSessionSharingTargetMock: vi.fn(),
   mentionCurrentMock: vi.fn(),
   webPushWarnMock: vi.fn(),
 }));
@@ -80,6 +82,7 @@ vi.mock("./operator-role-policy.js", async (importOriginal) => ({
 vi.mock("./session-sharing.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./session-sharing.js")>()),
   canReceiveSessionEvent: canReceiveSessionEventMock,
+  resolveSessionSharingTarget: resolveSessionSharingTargetMock,
 }));
 
 const { createEventWebPushDelivery } = await import("./event-web-push.js");
@@ -151,6 +154,7 @@ describe("event Web Push classification", () => {
     getUserPreferencesMock.mockReturnValue({});
     resolveOperatorRolePolicyForProfileMock.mockReturnValue(undefined);
     canReceiveSessionEventMock.mockReturnValue(true);
+    resolveSessionSharingTargetMock.mockReturnValue({ entry: { label: "Deployment review" } });
     mentionCurrentMock.mockReturnValue(true);
   });
 
@@ -780,6 +784,203 @@ describe("event Web Push classification", () => {
 
       await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
       expect(order).toEqual(["current", "send", "next-microtask"]);
+    });
+  });
+
+  describe("completion labels", () => {
+    const scope = { agentId: "research", sessionKeys: ["agent:research:thread.1"] };
+    const completion = { state: "final", runId: "run-1" };
+
+    function emitCompletion(opts = scope, payload: Record<string, unknown> = completion): void {
+      createEventWebPushDelivery({ getRuntimeConfig: () => ({}) }).handleEvent(
+        "chat",
+        payload,
+        opts,
+      );
+    }
+
+    function expectCompletionBody(body: string): void {
+      expect(preparedWebPushSendMock).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: expect.objectContaining({ body }) }),
+      );
+    }
+
+    it.each(["identified", "detailed"] as const)(
+      "uses an explicit session label for %s copy",
+      async (detailLevel) => {
+        const subscription = boundSubscription("browser-device");
+        subscription.devicePreferences.detailLevel = detailLevel;
+        listBoundWebPushSubscriptionsMock.mockReturnValue([subscription]);
+        emitCompletion();
+
+        await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+        expectCompletionBody("Deployment review: An agent completed its response.");
+        expect(resolveSessionSharingTargetMock).toHaveBeenCalledOnce();
+        expect(resolveSessionSharingTargetMock).toHaveBeenCalledWith({
+          cfg: {},
+          agentId: "research",
+          sessionKey: "agent:research:thread.1",
+        });
+      },
+    );
+
+    it("keeps private copy generic without looking up label metadata", async () => {
+      const subscription = boundSubscription("browser-device");
+      subscription.devicePreferences.detailLevel = "private";
+      listBoundWebPushSubscriptionsMock.mockReturnValue([subscription]);
+      emitCompletion();
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+      expectCompletionBody("An agent completed its response.");
+      expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
+    });
+
+    it.each([undefined, "", "   "])(
+      "keeps the agent fallback for an absent or blank explicit label: %s",
+      async (label) => {
+        resolveSessionSharingTargetMock.mockReturnValue({
+          entry: { label, displayName: "Generated title", subject: "Conversation content" },
+        });
+        emitCompletion();
+
+        await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+        expectCompletionBody("research: An agent completed its response.");
+      },
+    );
+
+    it("ignores payload-provided labels and message text", async () => {
+      resolveSessionSharingTargetMock.mockReturnValue(null);
+      emitCompletion(scope, {
+        ...completion,
+        label: "Untrusted label",
+        title: "Untrusted title",
+        message: { role: "assistant", content: [{ type: "text", text: "Synthetic message" }] },
+      });
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+      expectCompletionBody("research: An agent completed its response.");
+    });
+
+    it("does not use a payload-only routing key as a label source", async () => {
+      emitCompletion(
+        { agentId: "research", sessionKeys: [] },
+        { ...completion, sessionKey: scope.sessionKeys[0] },
+      );
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+      expectCompletionBody("research: An agent completed its response.");
+      expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
+    });
+
+    it("does not choose an arbitrary label from multiple authoritative sessions", async () => {
+      emitCompletion({
+        ...scope,
+        sessionKeys: [...scope.sessionKeys, "agent:research:thread.2"],
+      });
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+      expectCompletionBody("research: An agent completed its response.");
+      expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
+    });
+
+    it("does not read metadata for a reader rejected by the existing access check", async () => {
+      canReceiveSessionEventMock.mockReturnValue(false);
+      emitCompletion();
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(preparedWebPushSendMock).not.toHaveBeenCalled();
+      expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
+    });
+
+    it("keeps disabled subscriptions outside metadata lookup", async () => {
+      const subscription = boundSubscription("browser-device");
+      subscription.devicePreferences.enabled = false;
+      listBoundWebPushSubscriptionsMock.mockReturnValue([subscription]);
+      emitCompletion();
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(preparedWebPushSendMock).not.toHaveBeenCalled();
+      expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
+    });
+
+    it("reads the label once per fanout while preserving private grouping", async () => {
+      const identified = boundSubscription("browser-device");
+      const detailed = boundSubscription("phone-device");
+      detailed.devicePreferences.detailLevel = "detailed";
+      const privateSubscription = boundSubscription("tablet-device");
+      privateSubscription.devicePreferences.detailLevel = "private";
+      listBoundWebPushSubscriptionsMock.mockReturnValue([
+        identified,
+        detailed,
+        privateSubscription,
+      ]);
+      listDevicePairingMock.mockReturnValue({
+        paired: [
+          pairedOperator("browser-device"),
+          pairedOperator("phone-device"),
+          pairedOperator("tablet-device"),
+        ],
+      });
+      emitCompletion();
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledTimes(2));
+      expect(resolveSessionSharingTargetMock).toHaveBeenCalledOnce();
+      expectCompletionBody("Deployment review: An agent completed its response.");
+      expectCompletionBody("An agent completed its response.");
+    });
+
+    it("does not retain label metadata across separate events", async () => {
+      const delivery = createEventWebPushDelivery({ getRuntimeConfig: () => ({}) });
+      delivery.handleEvent("chat", completion, scope);
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+      resolveSessionSharingTargetMock.mockReturnValue({ entry: { label: "Renamed session" } });
+
+      delivery.handleEvent("chat", { ...completion, runId: "run-2" }, scope);
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledTimes(2));
+      expectCompletionBody("Renamed session: An agent completed its response.");
+      expect(resolveSessionSharingTargetMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back without publishing a metadata exception", async () => {
+      resolveSessionSharingTargetMock.mockImplementation(() => {
+        throw new Error("synthetic private storage path");
+      });
+      emitCompletion();
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+      expectCompletionBody("research: An agent completed its response.");
+    });
+
+    it("uses the existing 80-character label bound", async () => {
+      resolveSessionSharingTargetMock.mockReturnValue({ entry: { label: "x".repeat(81) } });
+      emitCompletion();
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+      expectCompletionBody(`${"x".repeat(80)}: An agent completed its response.`);
+    });
+
+    it("does not change the background-task notification label", async () => {
+      createEventWebPushDelivery({ getRuntimeConfig: () => ({}) }).handleEvent(
+        "task",
+        {
+          action: "upserted",
+          task: { id: "task-1", title: "Task label", runtime: "subagent", status: "failed" },
+        },
+        scope,
+      );
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+      expectCompletionBody("Task label needs attention.");
+      expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
+    });
+
+    it("does not resolve a completion label for a yielding parent", async () => {
+      emitCompletion(scope, { ...completion, yielded: true });
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(preparedWebPushSendMock).not.toHaveBeenCalled();
+      expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/gateway/event-web-push.test.ts
+++ b/src/gateway/event-web-push.test.ts
@@ -887,7 +887,9 @@ describe("event Web Push classification", () => {
       canReceiveSessionEventMock.mockReturnValue(false);
       emitCompletion();
 
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(preparedWebPushSendMock).not.toHaveBeenCalled();
       expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
     });
@@ -898,7 +900,9 @@ describe("event Web Push classification", () => {
       listBoundWebPushSubscriptionsMock.mockReturnValue([subscription]);
       emitCompletion();
 
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(preparedWebPushSendMock).not.toHaveBeenCalled();
       expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
     });
@@ -978,7 +982,9 @@ describe("event Web Push classification", () => {
     it("does not resolve a completion label for a yielding parent", async () => {
       emitCompletion(scope, { ...completion, yielded: true });
 
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(preparedWebPushSendMock).not.toHaveBeenCalled();
       expect(resolveSessionSharingTargetMock).not.toHaveBeenCalled();
     });

--- a/src/gateway/event-web-push.ts
+++ b/src/gateway/event-web-push.ts
@@ -26,7 +26,7 @@ import { resolveControlUiWebPushUrl } from "./control-ui-shared.js";
 import { QUESTIONS_SCOPE } from "./method-scopes.js";
 import { ADMIN_SCOPE, READ_SCOPE } from "./operator-scopes.js";
 import type { GatewayBroadcastOpts } from "./server-broadcast-types.js";
-import { canReceiveSessionEvent } from "./session-sharing.js";
+import { canReceiveSessionEvent, resolveSessionSharingTarget } from "./session-sharing.js";
 import {
   listCurrentWebPushTargets,
   webPushTargetClient,
@@ -203,6 +203,7 @@ export function createEventWebPushDelivery(params: {
         stateDir: params.stateDir,
       });
       const agentLabel = normalizeWebPushDisplayLabel(agentId);
+      let completionLabel: string | null | undefined;
       const groups = new Map<
         string,
         { title: string; body: string; subscriptions: BoundWebPushSubscription[] }
@@ -236,12 +237,34 @@ export function createEventWebPushDelivery(params: {
           // Multi-user events without an authoritative session owner are not broadcast offline.
           continue;
         }
+        let identifiedBody = notification.identifiedBody;
+        if (
+          notification.category === "agent-finished" &&
+          preferences.detailLevel !== "private" &&
+          sessionKeys.length === 1 &&
+          sessionKey
+        ) {
+          // Only explicit metadata from the authorized target is displayable.
+          // Never derive a lock-screen label from route keys or message content.
+          if (completionLabel === undefined) {
+            try {
+              const session = resolveSessionSharingTarget({ cfg, sessionKey, agentId });
+              completionLabel = normalizeWebPushDisplayLabel(session?.entry.label) ?? null;
+            } catch {
+              // Optional metadata must not turn an otherwise valid alert into a failure.
+              completionLabel = null;
+            }
+          }
+          if (completionLabel) {
+            identifiedBody = `${completionLabel}: ${notification.body}`;
+          }
+        }
         const prefix = preferences.label ? `${preferences.label} · ` : "";
         const title = `${prefix}${notification.title}`;
         const body =
           preferences.detailLevel === "private"
             ? notification.body
-            : (notification.identifiedBody ??
+            : (identifiedBody ??
               (agentLabel ? `${agentLabel}: ${notification.body}` : notification.body));
         const key = JSON.stringify({ title, body });
         const group = groups.get(key) ?? { title, body, subscriptions: [] };


### PR DESCRIPTION
Closes #143946. Coordinates with notification consolidation #133164; this change stays within the existing event Web Push owner and does not add another presentation owner.

## What Problem This Solves

Users following several conversations under one agent receive indistinguishable browser completion notifications. An explicit session label can identify which conversation completed without including its prompt or response.

## Why This Change Was Made

For Names only and Detailed, resolve only the current explicit `entry.label` of one authoritative session target, and only after the existing recipient admission check. Reuse the existing notification sanitizer and 80-character label bound. Private notifications and all existing fallback text remain unchanged.

## User Impact

Eligible browser completion alerts can display the explicitly labeled conversation. Unnamed sessions, ambiguous multi-session events, unavailable metadata, and metadata errors retain the agent-only fallback. Raw routing keys, payload titles, generated display names, subjects, message text, and errors are not alternate label sources. Native macOS and mobile delivery are unchanged.

## Evidence

### September 14 integration refresh

Current head: `3047b7a9ba5e34ebb3cc482be4a71f9c1a3bf728`. Original branch head `19c397243ee4f3ef2450a510f82a0bed7fc1b0bd` and pinned main `8b917bc499607eb94bb77358ddd69f6494d26c65` are both preserved as parents; no force-push. Refresh the existing accepted patch onto pinned main to remove stale integration inputs and obtain new-head CI. No new feature or unrelated failure workaround is added. The resulting tree exactly matches the conflict-free git merge-tree result; there are no manual source or test edits.

Validation on Linux / Node 26.1.0 with frozen-lockfile dependencies: No new local runtime test is claimed for this mechanical integration; existing proof keeps its original revision and exact-head hosted CI is required.. The native staged-content/format guard, main-relative diff check, and one fresh independent P0-P2 source review passed. No full build or full type-aware check was rerun locally; new-head CI is tracked separately. Earlier runtime proof below retains its recorded SHA; it is not relabeled as a new execution.


Product head remains `19c397243ee4f3ef2450a510f82a0bed7fc1b0bd`. No new product or test commit was needed for this evidence update.

### Gateway-to-browser behavior proof — September 12, 2026

- **Environment:** isolated temporary local state and browser profile, exact PR source, Node 24.21.0, headed Chromium 151.0.7922.34. No production account or data used.
- **Production entry:** `createGatewayConnectionState(...).broadcast("chat", finalEvent, sessionScope)` through the existing `onBroadcast` wiring in `src/gateway/server-connection-state.ts`. This is the same connection-state factory called by `src/gateway/server-runtime-state-prepare.ts`; the proof did not start the full Gateway HTTP/WebSocket listener or a model run.
- **Authoritative state:** real pairing approval and SQLite-backed subscription/device preferences; an explicit session label written through `upsertSessionEntryCore` and read back through `resolveSessionSharingTarget`. Session lookup, authorization, preference handling, and sender were not mocked.
- **Delivery:** the production `web-push` transport generated VAPID-authenticated `aes128gcm` HTTPS requests. A controlled temporary TLS receiver decrypted and asserted the payload; the label/body was absent from ciphertext plaintext.
- **Browser readback:** the unchanged `ui/public/sw.js` was registered in real Chromium. The receiver passed the decrypted wire payload through CDP `ServiceWorker.deliverPushMessage`; the production service-worker push handler called real `registration.showNotification`. Bounded awaited polling of actual `registration.getNotifications` asserted title, body, tag, and `renotify` fields. No notification or service-worker implementation was mocked. Observed at `2026-09-12T08:34:12.219Z`:

| Case | Actual browser notification body | Result |
| --- | --- | --- |
| Names only | `Release planning: An agent completed its response.` | Passed |
| Detailed | `Release planning: An agent completed its response.` | Passed |
| Private | `An agent completed its response.` | Passed |
| Private, no stored session metadata | `An agent completed its response.` | Passed |
| Device pairing revoked before event | No HTTPS delivery in the bounded 750 ms observation; no browser notification | Passed control |

The Private no-metadata case proves delivery without a stored label; the prior focused unit case separately verifies that Private does not call metadata lookup.

**Proof boundary:** this uses the real Gateway connection-state/broadcast owner, SQLite state, encrypted HTTPS sender, and browser notification registry. It does not start the full Gateway HTTP/WebSocket listener or a model run; CDP bridges the controlled HTTPS receiver to the browser instead of an external Web Push service. No OS-banner screenshot is claimed. The screenshot is a view of the actual notification-registry receipt. Headed Chromium was used after a browser-only control showed headless Chromium denying notification display despite permission overrides; headed direct display and push controls both passed before the integrated proof.

Service-worker SHA-256: `945cfe16dbcae8c6d63b5b6f20715e41bc2d360e03b1aff7fc550d96d1f32e72`. The notification bodies above are authoritative browser readback, not expected text rendered by the harness.

### Existing focused validation on this head

- Acceptance-red on unchanged `f0e841aed3145b29fc6a2cad0abd85917d169cc7`: 5 explicit-label assertions failed; 56 adjacent assertions passed.
- Acceptance-green: `node scripts/run-vitest.mjs run src/gateway/event-web-push.test.ts src/infra/push-web-preferences.test.ts` — 61 gateway tests and 4 preference tests passed.
- Controls cover Private without metadata lookup, denied readers, disabled subscriptions, multiple authoritative sessions, payload-only keys, other notification categories, and yielding parents.
- Previously recorded docs checks, repository boundary guard, targeted type-aware oxlint, and independent exact-head autoreview passed. No redundant autoreview or test suite was run for this unchanged-head evidence update.
- Fresh `git diff --check` passed; worktree remained clean.

Production LOC: +25/-2. Tests: +207/-0. Docs: +8/-0. The positive production delta is the bounded user-visible capability plus its privacy/authorization boundary. Existing-solutions preflight found no plugin or external platform that can change this core browser notification payload at the owning delivery seam.

No config, default, protocol, schema, security policy, migration, persistence, or upgrade surface changes. Temporary proof processes were closed and their generated state, TLS keys, and browser profiles removed. AI-assisted. No production credentials or data were used.
