### PR TITLE
fix(qa): stabilize Matrix voice preflight

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -4667,6 +4667,32 @@ describe("qa mock openai server", () => {
     });
   });
 
+  it("serves deterministic Matrix voice preflight transcription for the request prompt", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/audio/transcriptions`, {
+      method: "POST",
+      headers: {
+        "content-type": "multipart/form-data; boundary=qa",
+      },
+      body:
+        '--qa\r\ncontent-disposition: form-data; name="file"; filename="audio.wav"\r\n\r\n' +
+        'fixture audio\r\n--qa\r\ncontent-disposition: form-data; name="prompt"\r\n\r\n' +
+        "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER\r\n--qa--\r\n",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      text: "C3PLQA reply with only these words Matrix QA voice pre-flight OK.",
+    });
+  });
+
   it("dispatches an Anthropic /v1/messages read tool call for source discovery prompts", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -213,6 +213,9 @@ const QA_AUDIO_TRANSCRIPTION_TEXT =
 const QA_GROUP_AUDIO_TRANSCRIPTION_TEXT =
   "openclawqa reply with only this exact marker after group audio preflight: WHATSAPP_QA_GROUP_AUDIO_TRANSCRIPT_OK";
 const QA_GROUP_AUDIO_TRIGGER_SENTINEL = "OPENCLAW_QA_GROUP_AUDIO_TRIGGER";
+const QA_MATRIX_VOICE_TRANSCRIPTION_TRIGGER = "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER";
+const QA_MATRIX_VOICE_TRANSCRIPTION_TEXT =
+  "C3PLQA reply with only these words Matrix QA voice pre-flight OK.";
 const QA_MCP_CODE_MODE_API_FILE_PROMPT_RE = /mcp code mode api file qa check/i;
 
 type MockScenarioState = {
@@ -274,6 +277,9 @@ function writeOpenAiMalformedJsonError(res: ServerResponse, label: string) {
 }
 
 function transcriptionTextForAudioRequest(rawBody: string) {
+  if (rawBody.includes(QA_MATRIX_VOICE_TRANSCRIPTION_TRIGGER)) {
+    return QA_MATRIX_VOICE_TRANSCRIPTION_TEXT;
+  }
   if (rawBody.includes(QA_GROUP_AUDIO_TRIGGER_SENTINEL)) {
     return QA_GROUP_AUDIO_TRANSCRIPTION_TEXT;
   }

--- a/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
@@ -444,11 +444,15 @@ export const MATRIX_QA_SCENARIOS: MatrixQaScenarioDefinition[] = [
     configOverrides: {
       audio: {
         enabled: true,
+        echoTranscript: true,
+        models: [{ provider: "openai", model: "gpt-4o-transcribe" }],
+        prompt: "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER",
       },
-      groupMentionPatterns: ["\\S"],
+      groupMentionPatterns: ["matrix\\W+qa\\W+voice\\W+pre[ -]?flight\\W+ok(?:ay)?"],
+      requiredPluginIds: ["openai"],
     },
-    providerMode: "live-frontier",
-    timeoutMs: 180_000,
+    providerMode: "mock-openai",
+    timeoutMs: 90_000,
     title: "Matrix voice notes can trigger mention gating through transcription",
     topology: MATRIX_QA_MEDIA_ROOM_TOPOLOGY,
   },

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-media.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-media.ts
@@ -67,14 +67,13 @@ function buildMatrixQaMediaTypeCoveragePrompt(params: {
 }
 
 function normalizeMatrixQaVoiceReply(value: string | undefined) {
-  return (value ?? "")
-    .toUpperCase()
-    .replace(/[^A-Z0-9]+/g, " ")
-    .trim();
+  return (value ?? "").toUpperCase().replace(/[^A-Z0-9]+/g, "");
 }
 
 function hasMatrixQaVoicePreflightReply(body: string | undefined) {
-  return normalizeMatrixQaVoiceReply(body).includes(MATRIX_QA_VOICE_PREFLIGHT_REPLY_MARKER);
+  return normalizeMatrixQaVoiceReply(body).includes(
+    normalizeMatrixQaVoiceReply(MATRIX_QA_VOICE_PREFLIGHT_REPLY_MARKER),
+  );
 }
 
 export async function runImageUnderstandingAttachmentScenario(context: MatrixQaScenarioContext) {

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -4068,7 +4068,7 @@ describe("matrix live qa scenarios", () => {
           eventId: "$voice-reply",
           sender: "@sut:matrix-qa.test",
           type: "m.room.message",
-          body: `Sure: ${MATRIX_QA_VOICE_PREFLIGHT_REPLY_MARKER}.`,
+          body: '📝 "C3PLQA reply with only these words Matrix QA voice pre-flight OK."',
         },
         since: "driver-sync-reply",
       };
@@ -4081,8 +4081,18 @@ describe("matrix live qa scenarios", () => {
     });
 
     const scenario = requireMatrixQaScenario("matrix-voice-preflight-mention");
-    expect(scenario.configOverrides?.audio?.enabled).toBe(true);
-    expect(scenario.configOverrides?.groupMentionPatterns).toEqual(["\\S"]);
+    expect(scenario.providerMode).toBe("mock-openai");
+    expect(scenario.timeoutMs).toBe(90_000);
+    expect(scenario.configOverrides).toMatchObject({
+      audio: {
+        enabled: true,
+        echoTranscript: true,
+        models: [{ provider: "openai", model: "gpt-4o-transcribe" }],
+        prompt: "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER",
+      },
+      groupMentionPatterns: ["matrix\\W+qa\\W+voice\\W+pre[ -]?flight\\W+ok(?:ay)?"],
+      requiredPluginIds: ["openai"],
+    });
 
     const result = await runMatrixQaScenario(scenario, {
       baseUrl: "http://127.0.0.1:28008/",
@@ -4146,7 +4156,7 @@ describe("matrix live qa scenarios", () => {
         eventId: "$voice-reply",
         sender: "@sut:matrix-qa.test",
         type: "m.room.message",
-        body: ` ${MATRIX_QA_VOICE_PREFLIGHT_REPLY_MARKER.toLowerCase()}!\n`,
+        body: '📝 "C3PLQA reply with only these words Matrix QA voice pre-flight OK."',
       }),
     ).toBe(true);
 


### PR DESCRIPTION
## Summary

- run the frozen Matrix voice maturity scenario against deterministic mock OpenAI transcription
- configure the exact transcription model, prompt, plugin, and mention pattern required by the scenario
- add mock-server and scenario-contract regressions

## Validation

- 197 focused tests passed
- stable core and extension test type graphs passed
- repository lint passed
- exact changed-file formatting and git diff checks passed

## Release validation root

Full Validation 34540886759 and unchanged retry 34541072222 timed out matrix-voice-preflight-mention because the 7.33 catalog still pinned live-frontier audio. This backports the reviewed deterministic transcription contract from later release tooling without changing product behavior.