### PR TITLE
docs(slack): document reactionNotifications reaction mode

### DIFF
--- a/docs/channels/slack/messaging.md
+++ b/docs/channels/slack/messaging.md
@@ -179,6 +179,13 @@ Notes:
 - Slack expects shortcodes (for example `"hourglass_flowing_sand"`).
 - The reaction is best-effort and cleanup is attempted automatically after the reply or failure path completes.
 
+## Reaction notifications
+
+`reactionNotifications` controls whether the agent is notified of reactions that others add to messages. It is unrelated to `ackReaction` and `typingReaction`, which are reactions the agent sends on inbound messages while processing.
+
+- `channels.slack.reactionNotifications`: `off | own | all | allowlist` (default `own`). `off` ignores all reactions from others; `own` notifies only on reactions to the agent's own messages; `all` notifies on reactions to any message; `allowlist` notifies only on reactions from senders listed in `reactionAllowlist`.
+- `channels.slack.reactionAllowlist`: senders whose reactions notify the agent when `reactionNotifications: "allowlist"`. Enterprise Grid org installs require stable Slack user entries here.
+
 ## Commands and slash behavior
 
 Slash commands appear in Slack as either a single configured command or multiple native commands. Configure `channels.slack.slashCommand` to change command defaults:


### PR DESCRIPTION
## What Problem This Solves

The Slack messaging docs documented `ackReaction` and `typingReaction` (reactions the agent sends) but never documented `reactionNotifications`, the option that controls whether the agent is *notified of reactions from others*. The field is defined in the Slack config schema, consumed at runtime, and already documented for sibling channels (Signal, Telegram, Matrix, Discord, Feishu). Users configuring Slack via the docs could not discover this capability or its `allowlist` gating.

- Problem: `docs/channels/slack/messaging.md` (and the rest of the Slack docs tree) had no mention of `reactionNotifications` anywhere. `ackReaction`, `typingReaction`, and `reactionAllowlist` (Enterprise Grid only) were documented, but the notification-mode switch itself was missing.
- Solution: Add a `## Reaction notifications` section after the `## Typing reaction fallback` section, matching the sibling-channel wording (Signal).
- What changed: `docs/channels/slack/messaging.md` (+7 lines).
- What did NOT change: No code or behavior changes. Documentation only.

## Why This Change Was Made

Slack's reaction shape is built via `buildChannelReactionShape({ notificationModes: ["off", "own", "all", "allowlist"], ... })` at `extensions/slack/src/config-schema.ts:116`, which produces a `reactionNotifications: z.enum(["off","own","all","allowlist"]).optional()` field (see `src/config/zod-schema.channel-messaging-common.ts:213-223`). At runtime, `extensions/slack/src/monitor/provider.ts:387` resolves it as `slackCfg.reactionNotifications ?? "own"` (default `"own"`), and `extensions/slack/src/monitor/enterprise-install.ts:149` enforces that `reactionAllowlist` holds stable Slack user entries when the mode is `"allowlist"`. The implementation and command contract are unchanged; this is a documentation discoverability fix.

## User Impact

Users can now discover the `reactionNotifications` reaction-notification mode (`off | own | all | allowlist`; default `own`) and its `reactionAllowlist` companion from the Slack messaging docs, matching the existing wording in the Signal docs (`docs/channels/signal.md:501-502`). No runtime behavior changes.

## Evidence

**Schema source** (`extensions/slack/src/config-schema.ts:116`)
```typescript
...buildChannelReactionShape({
  notificationModes: ["off", "own", "all", "allowlist"],
  reactionAllowlist: true,
  ackReaction: z.string().optional(),
}),
```

**Type / enum leaf** (`src/config/zod-schema.channel-messaging-common.ts:213-223`)
```typescript
notificationModes?: readonly [string, string, ...string[]];
...
...(options.notificationModes
  ? { reactionNotifications: z.enum(options.notificationModes).optional() }
```
`z.enum(options.notificationModes)` resolves to `z.enum(["off","own","all","allowlist"])`.

**Runtime default** (`extensions/slack/src/monitor/provider.ts:387`)
```typescript
const reactionMode = slackCfg.reactionNotifications ?? "own";
```

**Runtime consumer** (`extensions/slack/src/monitor/enterprise-install.ts:149`)
```typescript
if (config.reactionNotifications === "allowlist") {
  assertStableEntries({
    values: config.reactionAllowlist,
    ...
```

**Test** (`extensions/slack/src/monitor/enterprise-install.test.ts:140,183`)
```typescript
reactionNotifications: "allowlist",
...
["reaction allowlist", { reactionNotifications: "allowlist", reactionAllowlist: ["ursula"] }],
```

**Sibling docs** — already documented for Signal (`docs/channels/signal.md:501-502`): "`channels.signal.reactionNotifications`: `off | own | all | allowlist` (default `own`) - when the agent is notified of incoming reactions from others." and "`channels.signal.reactionAllowlist`: senders whose reactions notify the agent when `reactionNotifications: "allowlist"`." Also present for Telegram, Matrix, Discord, Feishu.

**Documentation checks**
- `pnpm docs:list --headings` — new `H2: Reaction notifications` indexed correctly, placed between `Typing reaction fallback` and `Commands and slash behavior`.
- `docs/docs_map.md` is a source stub; the map is generated at publish time from all headings, so no manual sync is needed in the source checkout.
- `git diff --check` — no whitespace issues.

**Proof boundary**: this is a documentation discoverability fix; the Slack implementation is unchanged. No runtime behavior proof applies.

Public documentation: https://docs.openclaw.ai/channels/slack/messaging

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: glm-5.2 <noreply@anthropic.com>
- **Human confirmed understanding**: Yes — verified 5-layer evidence (Schema → Type/enum leaf → Default → Consumer → Test), confirmed the gap still exists on the latest `origin/main` (f50d4ce71e3), confirmed runtime consumption before writing (not a dead schema field), and matched the sibling-channel (Signal) wording for the enum values and default.
