### PR TITLE
test(qa): stabilize remote log tail limit proof

### DIFF
--- a/test/e2e/qa-lab/runtime/remote-log-tailing-runtime.test.ts
+++ b/test/e2e/qa-lab/runtime/remote-log-tailing-runtime.test.ts
@@ -3,7 +3,7 @@ import { once } from "node:events";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { withOwnedFollowChild } from "./remote-log-tailing-runtime.js";
+import { assertInitialTailBound, withOwnedFollowChild } from "./remote-log-tailing-runtime.js";
 
 describe("remote log tailing scenario", () => {
   it("declares packaged CLI, RPC bounds, cursor, follow, and owned SIGINT proof", () => {
@@ -32,5 +32,23 @@ describe("remote log tailing scenario", () => {
     ).rejects.toThrow("forced follow failure");
 
     expect(child.signalCode).not.toBeNull();
+  });
+
+  it("accepts a bounded initial tail when concurrent gateway logs replace fixture markers", () => {
+    expect(() =>
+      assertInitialTailBound({
+        lines: ["background cron log", "background websocket log"],
+        truncated: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an initial tail that exceeds the requested bound", () => {
+    expect(() =>
+      assertInitialTailBound({
+        lines: ["one", "two", "three"],
+        truncated: true,
+      }),
+    ).toThrow("logs.tail did not honor limit");
   });
 });

--- a/test/e2e/qa-lab/runtime/remote-log-tailing-runtime.ts
+++ b/test/e2e/qa-lab/runtime/remote-log-tailing-runtime.ts
@@ -73,6 +73,12 @@ export async function withOwnedFollowChild<T>(
   }
 }
 
+export function assertInitialTailBound(result: { lines: string[]; truncated: boolean }): void {
+  if (result.lines.length !== 2 || !result.truncated) {
+    throw new Error(`logs.tail did not honor limit: ${JSON.stringify(result)}`);
+  }
+}
+
 export async function runRemoteLogTailing(repoRoot: string, outputRoot: string) {
   const logPath = path.join(outputRoot, "gateway.jsonl");
   await mkdir(outputRoot, { recursive: true });
@@ -102,13 +108,7 @@ export async function runRemoteLogTailing(repoRoot: string, outputRoot: string) 
       lines: string[];
       truncated: boolean;
     };
-    if (
-      first.lines.length !== 2 ||
-      !first.lines.some((line) => line.includes("qa-line-three")) ||
-      !first.truncated
-    ) {
-      throw new Error(`logs.tail did not honor limit: ${JSON.stringify(first)}`);
-    }
+    assertInitialTailBound(first);
     const bounded = (await gateway.call("logs.tail", { limit: 20, maxBytes: 96 })) as {
       cursor: number;
       lines: string[];


### PR DESCRIPTION
## Summary

- keep the remote log-tail maturity proof focused on the public `limit` and `truncated` contract
- allow concurrent Gateway/cron records to occupy the bounded initial tail
- retain the later cursor and marker checks that prove ordered incremental delivery

## Failure evidence

Run [34465387094](https://github.com/openclaw/openclaw/actions/runs/34465387094) returned exactly two initial records with `truncated: true`, but unrelated concurrent Gateway logs displaced the fixture marker from that two-record window.

## Test plan

- `pnpm exec vitest run --config test/vitest/vitest.tooling.config.ts test/e2e/qa-lab/runtime/remote-log-tailing-runtime.test.ts --reporter=dot` (4/4)
- `pnpm check:changed`
- local P0-P2 autoreview: clean
