### PR TITLE
fix(qa-channel): preserve final replies after preview cleanup

### DIFF
--- a/extensions/qa-channel/src/inbound.preview-terminal.test.ts
+++ b/extensions/qa-channel/src/inbound.preview-terminal.test.ts
@@ -1,0 +1,152 @@
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setQaChannelRuntime } from "../api.js";
+import { deleteQaBusMessage, editQaBusMessage, sendQaBusMessage } from "./bus-client.js";
+import { handleQaInbound } from "./inbound.js";
+import { createQaInboundParams, firstRunAssembledParams } from "./inbound.test-harness.js";
+
+vi.mock("./bus-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./bus-client.js")>()),
+  deleteQaBusMessage: vi.fn(async () => ({ message: {} })),
+  editQaBusMessage: vi.fn(async () => ({ message: {} })),
+  sendQaBusMessage: vi.fn(async () => ({ message: { id: "preview-1" } })),
+}));
+
+async function assembledTurn() {
+  const runtime = createPluginRuntimeMock();
+  setQaChannelRuntime(runtime);
+  await handleQaInbound(createQaInboundParams());
+  return firstRunAssembledParams(runtime);
+}
+
+describe("QA preview terminal ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("cannot edit a promoted final from a late partial", async () => {
+    const turn = await assembledTurn();
+    await turn.replyOptions?.onPartialReply?.({ text: "draft" });
+    await turn.delivery.deliver({ text: "answer" }, { kind: "final" });
+    await turn.replyOptions?.onPartialReply?.({ text: "late draft" });
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+    expect(editQaBusMessage).toHaveBeenCalledOnce();
+    expect(editQaBusMessage).toHaveBeenCalledWith(expect.objectContaining({ text: "answer" }));
+    expect(deleteQaBusMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not delete a promoted answer during later error cleanup", async () => {
+    const turn = await assembledTurn();
+    await turn.replyOptions?.onPartialReply?.({ text: "draft" });
+    await turn.delivery.deliver({ text: "answer" }, { kind: "final" });
+    turn.delivery.onError?.(new Error("later dispatch failure"), { kind: "final" });
+    // This queued callback drains the same lock after the cleanup callback.
+    await turn.replyOptions?.onPartialReply?.({ text: "late draft" });
+    expect(deleteQaBusMessage).not.toHaveBeenCalled();
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+  });
+
+  it("does not create a preview after a final without an earlier preview", async () => {
+    const turn = await assembledTurn();
+    await turn.delivery.deliver({ text: "answer" }, { kind: "final" });
+    await turn.replyOptions?.onPartialReply?.({ text: "late draft" });
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+    expect(editQaBusMessage).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges a repeated promoted final without a duplicate message", async () => {
+    const turn = await assembledTurn();
+    await turn.replyOptions?.onPartialReply?.({ text: "draft" });
+    await turn.delivery.deliver({ text: "answer" }, { kind: "final" });
+    await turn.delivery.deliver({ text: "answer" }, { kind: "final" });
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+    expect(editQaBusMessage).toHaveBeenCalledOnce();
+    expect(deleteQaBusMessage).not.toHaveBeenCalled();
+  });
+
+  it("retains distinct final chunks rather than dropping all later delivery", async () => {
+    const turn = await assembledTurn();
+    await turn.replyOptions?.onPartialReply?.({ text: "draft" });
+    await turn.delivery.deliver({ text: "answer one" }, { kind: "final" });
+    await turn.delivery.deliver({ text: "answer two" }, { kind: "final" });
+    expect(editQaBusMessage).toHaveBeenCalledOnce();
+    expect(sendQaBusMessage).toHaveBeenCalledTimes(2);
+    expect(sendQaBusMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ text: "answer two" }),
+    );
+    expect(deleteQaBusMessage).not.toHaveBeenCalled();
+  });
+
+  it("still permits previews after a nonterminal block", async () => {
+    const turn = await assembledTurn();
+    await turn.delivery.deliver({ text: "block" }, { kind: "block" });
+    await turn.replyOptions?.onPartialReply?.({ text: "next draft" });
+    expect(sendQaBusMessage).toHaveBeenCalledTimes(2);
+    expect(sendQaBusMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ text: "next draft" }),
+    );
+  });
+
+  it("removes an unfinished preview on an empty final and rejects later partials", async () => {
+    const turn = await assembledTurn();
+    await turn.replyOptions?.onPartialReply?.({ text: "unfinished" });
+    await turn.delivery.deliver({ text: "" }, { kind: "final" });
+    await turn.replyOptions?.onPartialReply?.({ text: "late" });
+    expect(deleteQaBusMessage).toHaveBeenCalledOnce();
+    expect(editQaBusMessage).not.toHaveBeenCalled();
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+  });
+
+  it("does not close previews for an empty nonterminal block", async () => {
+    const turn = await assembledTurn();
+    await turn.delivery.deliver({ text: "" }, { kind: "block" });
+    await turn.replyOptions?.onPartialReply?.({ text: "draft" });
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+    expect(deleteQaBusMessage).not.toHaveBeenCalled();
+  });
+
+  it("stops partials queued while the final edit is still in flight", async () => {
+    const turn = await assembledTurn();
+    await turn.replyOptions?.onPartialReply?.({ text: "draft" });
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    vi.mocked(editQaBusMessage).mockImplementationOnce(async () => {
+      entered.resolve();
+      await release.promise;
+      return { message: {} } as Awaited<ReturnType<typeof editQaBusMessage>>;
+    });
+    const final = turn.delivery.deliver({ text: "answer" }, { kind: "final" });
+    await entered.promise;
+    const late = turn.replyOptions?.onPartialReply?.({ text: "late draft" });
+    release.resolve();
+    await Promise.all([final, late]);
+    expect(editQaBusMessage).toHaveBeenCalledOnce();
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+  });
+
+  it("keeps cleanup ownership when the final edit failed", async () => {
+    const turn = await assembledTurn();
+    await turn.replyOptions?.onPartialReply?.({ text: "draft" });
+    vi.mocked(editQaBusMessage).mockRejectedValueOnce(new Error("final edit failed"));
+    await expect(turn.delivery.deliver({ text: "answer" }, { kind: "final" })).rejects.toThrow(
+      "final edit failed",
+    );
+    turn.delivery.onError?.(new Error("dispatch failed"), { kind: "final" });
+    await turn.replyOptions?.onPartialReply?.({ text: "late" });
+    expect(deleteQaBusMessage).toHaveBeenCalledOnce();
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+  });
+
+  it("does not revive a preview after cleanup of a failed turn", async () => {
+    const turn = await assembledTurn();
+    await turn.replyOptions?.onPartialReply?.({ text: "draft" });
+    turn.delivery.onError?.(new Error("dispatch failed"), { kind: "final" });
+    await turn.replyOptions?.onPartialReply?.({ text: "late" });
+    expect(deleteQaBusMessage).toHaveBeenCalledOnce();
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+    expect(editQaBusMessage).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -166,6 +166,7 @@ function createQaReplyPreview(params: {
 }) {
   let messageId: string | null = null;
   let currentText = "";
+  let previewStopped = false;
   let lastDurableText = "";
   let lastDurableToolCallSnapshot = "[]";
   // Partials run concurrently with delivery callbacks. Keep edits, deletion,
@@ -245,9 +246,17 @@ function createQaReplyPreview(params: {
   };
 
   return {
-    clear: () => withPreviewLock(clear),
-    deliver: (text: string, kind: string, isError?: boolean, mediaUrls: string[] = []) =>
-      withPreviewLock(async () => {
+    clear: () => {
+      previewStopped = true;
+      return withPreviewLock(clear);
+    },
+    deliver: (text: string, kind: string, isError?: boolean, mediaUrls: string[] = []) => {
+      // Stop queued partials at final admission, not after an awaited send.
+      // Durable callbacks may still contain several final chunks or attachments.
+      if (kind === "final") {
+        previewStopped = true;
+      }
+      return withPreviewLock(async () => {
         if (mediaUrls.length > 0) {
           // Tool/block callbacks acknowledge real delivery, not a preview. A new
           // attachment must survive even when its caption matches an earlier send.
@@ -276,12 +285,23 @@ function createQaReplyPreview(params: {
         }
         if (kind === "final" && messageId && params.toolCalls.length === 0) {
           await write(text);
+          // The edited message is now durable; preview cleanup no longer owns it.
+          messageId = null;
+          currentText = "";
+          lastDurableText = text;
+          lastDurableToolCallSnapshot = "[]";
           return;
         }
         await clear();
         await sendDurable(text);
+      });
+    },
+    update: (text: string) =>
+      withPreviewLock(async () => {
+        if (!previewStopped) {
+          await write(text);
+        }
       }),
-    update: (text: string) => withPreviewLock(() => write(text)),
   };
 }
 
@@ -485,6 +505,9 @@ export async function handleQaInbound(params: {
           ),
         );
         if (!text.trim() && mediaUrls.length === 0) {
+          if ((info?.kind ?? "final") === "final") {
+            await preview.clear();
+          }
           return;
         }
         await preview.deliver(text, info?.kind ?? "final", reply?.isError, mediaUrls);


### PR DESCRIPTION
Closes #144851.

## What Problem This Solves

QA Channel's registered reply callbacks can overwrite a completed answer with a late preview or delete an answer promoted from a preview during later error cleanup. An empty final can also leave an unfinished preview visible.

## Why This Change Was Made

Close preview admission when a final or failure cleanup is admitted, and release the preview's cleanup handle only after a successful final edit. Continue using the existing serialized queue. Distinct final chunks, attachments, existing tool-trace deduplication, routing, and nonterminal blocks retain their delivery paths.

## User Impact

QA runs retain completed answers and do not revive stale previews. A failed final edit still permits cleanup of its unfinished preview. Empty nonterminal blocks do not close preview admission. No new timer, queue, configuration, protocol, or persistence contract is added.

## Evidence

### Exact-head real-behavior receipt

- Product head SHA: `ac314528c3a62cfc818fcbcbc081fd99a159db78`
- Runtime: Node `v24.16.0`
- Production entry: real `handleQaInbound` registration in `extensions/qa-channel/src/inbound.ts`
- Canonical owner exercised: the production per-turn preview state and serialized preview lock
- Runtime boundary: real QA Channel account resolution and inbound admission -> production reply callbacks -> production QA bus HTTP client -> real in-process QA bus HTTP server/state -> HTTP readback
- Controlled boundary: only deterministic model dispatch was substituted to drive the actual registered callbacks. No bus, HTTP, storage, preview-owner, routing, or admission mock was used.
- Fault control: one final-edit case deliberately used a wrong synthetic account for one real HTTP edit; the server returned HTTP 400, ownership was restored, and real HTTP cleanup deleted the unfinished preview.
- Cleanup: the HTTP server was stopped and reports `serverListening=false`; the bus was closed. No production account, channel, credential, or persistent state was touched.

Inspectable exact-head observations:

```text
PASS promoted-final: final "answer" retained; late preview rejected; deleted=false
PASS failed-final-edit: HTTP edit=400; unfinished preview then deleted=true
PASS empty-final: unfinished preview deleted=true
PASS distinct-final-chunks: "answer one" and "answer two" retained; deleted=false
PASS distinct-attachments: stale draft deleted; both distinct attachment finals retained
HTTP receipt: edit 200 x2; edit 400 x1; delete 200 x3; readback 200 x8; total requests x33
Cleanup: serverListening=false; busClosed=true
Result: PASS
```

The same exact-head harness was run twice; both executions passed all five scenarios. The readbacks confirmed final text, deletion state, and decoded attachment bytes.

### Tests and controls

- Acceptance-red on unchanged `f0e841aed3145b29fc6a2cad0abd85917d169cc7`: 8 target lifecycle cases failed while 35 adjacent inbound cases passed; the visible sequence `draft -> answer -> late draft` ended as `late draft`.
- Acceptance-green: focused run passed 43/43; `pnpm test:extension qa-channel` passed 12 files and 131 tests.
- Legal controls: a partial queued during a final edit cannot overwrite it; successful promotion releases cleanup ownership; failed promotion retains cleanup ownership; repeated final is deduplicated; distinct final chunks and attachments remain deliverable; empty nonterminal blocks keep preview admission open.
- Formatting, extension production/test typechecks, coercion/deprecation guards, and `git diff --check` passed.
- Exact-head hosted CI: required CI is green.
- Independent autoreview: pass, no actionable P0-P2 findings, correctness 0.89.

Production LOC: +27/-4. Tests: +152/-0. Positive production growth is the lifecycle ownership repair and explicit terminal cleanup, with no parallel queue or fallback path. Existing-solutions preflight: this is owner-local callback state; no plugin, library, or external platform can repair the existing QA Channel lifecycle.

No config, default, protocol, schema, security policy, migration, persistence, or upgrade surface changes. The proof exercises the real production entry and real HTTP recorder/readback boundary; it does not claim a live external provider or model call.

AI-assisted. No credentials or production data were used.