### PR TITLE
fix(bonjour): silence transient ENODEV mdns socket warnings

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -38,7 +38,6 @@ extensions/anthropic/stream-wrappers.ts	5
 extensions/baseten/models.ts	3
 extensions/beam/src/mirror.ts	3
 extensions/beam/src/types.ts	2
-extensions/bonjour/src/advertiser.ts	2
 extensions/brave/src/brave-web-search-provider.shared.ts	1
 extensions/browser/plugin-registration.ts	1
 extensions/browser/src/browser-node-fallback.ts	1

--- a/docs/gateway/bonjour.md
+++ b/docs/gateway/bonjour.md
@@ -116,7 +116,7 @@ The gateway writes a rolling log file (printed on startup as `gateway log file: 
 - `bonjour: suppressing ciao netmask assertion ...`
 - `bonjour: ... name conflict resolved` / `hostname conflict resolved`
 
-OpenClaw starts each Bonjour service once and leaves probing, retry, name-conflict resolution, and interface-change republishing to the mDNS responder. This avoids overlapping publish attempts during normal network churn. Repeated internal self-probe messages are suppressed so they cannot flood the gateway log.
+OpenClaw starts each Bonjour service once and leaves probing, retry, name-conflict resolution, and interface-change republishing to the mDNS responder. This avoids overlapping publish attempts during normal network churn. Repeated internal self-probe messages are suppressed so they cannot flood the gateway log, as are transient `ENODEV` MDNS socket warnings that occur when a network interface (for example a short-lived Docker bridge) is removed between the responder's interface polls.
 
 When multiple OpenClaw gateways advertise from the same host, Bonjour may append suffixes such as `(2)` or `(3)` to keep service instance names unique. Those suffixes are normal conflict resolution.
 

--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -455,6 +455,39 @@ describe("gateway bonjour advertiser", () => {
     }
   });
 
+  it("suppresses transient ciao ENODEV MDNS socket warnings while advertising", async () => {
+    enableAdvertiserUnitMode();
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const originalConsoleWarn = console.warn;
+    const baseConsoleWarn = vi.fn();
+    console.warn = baseConsoleWarn as typeof console.warn;
+
+    try {
+      const started = await startAdvertiser({
+        gatewayPort: 18789,
+        sshPort: 2222,
+      });
+
+      // A Docker bridge disappears between ciao's interface polls; the send to
+      // the removed interface fails with ENODEV, which ciao does not silence.
+      console.warn(
+        "Encountered MDNS socket error on socket 'br-abcdef123456': Error: send ENODEV 224.0.0.251:5353\n    at ...",
+      );
+      console.warn("ordinary warning line");
+
+      expect(baseConsoleWarn).toHaveBeenCalledTimes(1);
+      expect(baseConsoleWarn).toHaveBeenCalledWith("ordinary warning line");
+
+      await started.stop();
+    } finally {
+      console.warn = originalConsoleWarn;
+    }
+  });
+
   it("does not monkey-patch responder methods during shutdown", async () => {
     enableAdvertiserUnitMode();
 

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -26,7 +26,6 @@ type GatewayBonjourAdvertiseOpts = {
 
 type BonjourServices = Array<{ label: string; svc: CiaoService }>;
 
-type ConsoleLogFn = (...args: unknown[]) => void;
 type UncaughtExceptionHandler = (error: unknown) => boolean;
 type UnhandledRejectionHandler = (reason: unknown) => boolean;
 
@@ -185,20 +184,20 @@ function shouldSuppressCiaoConsoleWarn(args: unknown[]): boolean {
 }
 
 function installCiaoConsoleNoiseFilter(): () => void {
-  const previousConsoleLog = console.log as ConsoleLogFn;
-  const previousConsoleWarn = console.warn as ConsoleLogFn;
-  const logWrapper = ((...args: unknown[]) => {
+  const previousConsoleLog = console.log;
+  const previousConsoleWarn = console.warn;
+  const logWrapper = (...args: unknown[]) => {
     if (shouldSuppressCiaoConsoleLog(args)) {
       return;
     }
     previousConsoleLog(...args);
-  }) as ConsoleLogFn;
-  const warnWrapper = ((...args: unknown[]) => {
+  };
+  const warnWrapper = (...args: unknown[]) => {
     if (shouldSuppressCiaoConsoleWarn(args)) {
       return;
     }
     previousConsoleWarn(...args);
-  }) as ConsoleLogFn;
+  };
   console.log = logWrapper;
   console.warn = warnWrapper;
   return () => {

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -39,6 +39,13 @@ type BonjourAdvertiserDeps = {
 const CIAO_SELF_PROBE_RETRY_FRAGMENT =
   "failed probing with reason: Error: Can't probe for a service which is announced already.";
 
+// Ciao already treats EADDRNOTAVAIL / EHOSTDOWN / ENETUNREACH / EHOSTUNREACH /
+// EPERM / EINVAL as transient socket errors and keeps the socket valid, but
+// ENODEV (device gone — a short-lived Docker bridge removed between interface
+// polls) is not in that set, so ciao logs a full warning stack trace per send.
+const CIAO_MDNS_SOCKET_ERROR_FRAGMENT = "Encountered MDNS socket error on socket";
+const CIAO_ENODEV_SOCKET_ERROR_FRAGMENT = "send ENODEV";
+
 const defaultLogger = {
   info: (_msg: string) => {},
   warn: (_msg: string) => {},
@@ -168,18 +175,38 @@ function shouldSuppressCiaoConsoleLog(args: unknown[]): boolean {
   );
 }
 
+function shouldSuppressCiaoConsoleWarn(args: unknown[]): boolean {
+  return args.some(
+    (arg) =>
+      typeof arg === "string" &&
+      arg.includes(CIAO_MDNS_SOCKET_ERROR_FRAGMENT) &&
+      arg.includes(CIAO_ENODEV_SOCKET_ERROR_FRAGMENT),
+  );
+}
+
 function installCiaoConsoleNoiseFilter(): () => void {
   const previousConsoleLog = console.log as ConsoleLogFn;
-  const wrapper = ((...args: unknown[]) => {
+  const previousConsoleWarn = console.warn as ConsoleLogFn;
+  const logWrapper = ((...args: unknown[]) => {
     if (shouldSuppressCiaoConsoleLog(args)) {
       return;
     }
     previousConsoleLog(...args);
   }) as ConsoleLogFn;
-  console.log = wrapper;
+  const warnWrapper = ((...args: unknown[]) => {
+    if (shouldSuppressCiaoConsoleWarn(args)) {
+      return;
+    }
+    previousConsoleWarn(...args);
+  }) as ConsoleLogFn;
+  console.log = logWrapper;
+  console.warn = warnWrapper;
   return () => {
-    if (console.log === wrapper) {
+    if (console.log === logWrapper) {
       console.log = previousConsoleLog;
+    }
+    if (console.warn === warnWrapper) {
+      console.warn = previousConsoleWarn;
     }
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Ciao can retain a multicast socket after its network interface disappears. When a later send fails with `ENODEV`, its repeated warning stacks bypass OpenClaw's existing console noise filter and flood Gateway logs.

## Solution

Extend the existing Bonjour diagnostic filter to suppress Ciao's `send ENODEV` socket warning. Other warnings and argument forms still pass through. Shutdown and startup failure restore only this advertiser's own wrapper, preserving any wrapper installed later. Ciao retains ownership of probing, retries, and interface changes. The wrappers use inferred types, and the old Bonjour type-assertion allowance is removed.

Fixes #144796.

## Evidence

Real Linux network proof used the built Gateway, Ciao 1.3.12, separate stable/transient network segments, an independent DNS observer, and kernel syscall traces. The baseline is `b5907743200dc657c7c8916888c64d30c0adf7a2`; the network-tested candidate tree is `99fc0fd5ffa3e922eba6799c1e4b3d48a698ba43` at signed commit `9301b91feb0c9c90839f4cca1f4eb0de7b15f57b`. Current signed head `a96f3bf0bfda221bf9820c3faec0212affc70253` removes erased type assertions and shrinks the validation baseline. Fresh review of the complete source and emitted JavaScript confirms unchanged behavior; original build and capture identities are retained.

| Observation | Baseline | Candidate |
| --- | --- | --- |
| Actual Gateway `sendmsg` failures with `ENODEV` | 38 in one cycle | 55 across two cycles |
| Matching Ciao warning stacks | 38 | 0 |
| Fresh stable PTR/SRV/TXT/address discovery | Passed | Passed through both cycles and recreation |
| Gateway health | Passed | Passed |

The baseline sequence was observed at the kernel boundary: transient PTR receipt at `12:11:49.642541 UTC`, an independent interface lookup returning absent at `.668017`, and the original Ciao socket's queued `sendmsg` returning `ENODEV` at `.730455`. The matching warning followed at `.740`. The independent lookup error and Gateway send error are separate observations.

The candidate repeats the same address-migration/removal sequence twice in one Gateway process, with fresh interface identities and real discovery after recreation. The two cycles and restoration windows recorded 574 successful health responses. During the first recreation, one of 40 stable browse rounds had no PTR response; the next round resolved. The recreated transient interfaces appeared after about 14.65 and 8.44 seconds. Warning discrimination and wrapper restoration were also checked against real Ciao; all three controls passed. All 34 Bonjour tests, the three console controls, formatting, the assertion ratchet, and focused syntax/boundary lint passed after that cleanup. Full type-aware checks run in hosted CI.

**Scope:** simple interface deletion on this kernel produced the already-silenced `ENETUNREACH`. To reach `ENODEV`, the fixture retained the source address on the stable interface after Ciao bound its transient socket, then removed the transient interface. This is a real address-migration case, not injected errno or a manually emitted warning as the primary proof. It does not establish the reporter's exact network topology. Discovery continuity is sampled; this does not claim zero packet loss, physical-LAN reliability, or outage recovery. Full private traces, failed attempts, fixture sources, and independent acceptance evidence are retained for review.
