### PR TITLE
feat(sqlite): run Team Reports storage in owned workers

### DIFF
--- a/docs/plugins/sdk-overview/infrastructure.md
+++ b/docs/plugins/sdk-overview/infrastructure.md
@@ -68,6 +68,63 @@ Admission retries use the connection's existing `busy_timeout`; this is not a
 total deadline for preparation or transaction execution. `options` supplies the
 same transaction diagnostics as `runSqliteImmediateTransactionSync`. Keep the
 database handle and its owning operation alive until the returned promise settles.
+The callback and SQLite calls still run synchronously on the caller's thread.
+
+### SQLite worker stores
+
+Use `openSqliteWorkerStore<Operations>` from
+`openclaw/plugin-sdk/sqlite-runtime` to move a feature's SQLite lifecycle off the
+application event loop. Call it from the main application thread with
+`{ moduleUrl, databasePath, input }`. `Operations` maps each domain operation to
+its `{ input, output }` types; `store.execute({ type, input }, { signal }?)`
+returns the corresponding output promise. The host currently rejects calls from
+other application workers, which need a shared host-broker connection.
+
+This first host supports filesystem-backed databases only. Empty paths, SQLite
+URIs, `:memory:`, and OpenClaw's reserved incognito database basename are refused
+before normalization or worker admission. In-memory and incognito ownership
+remain pending; these locators must never become disk filenames.
+
+The static local `moduleUrl` identifies a trusted feature module exporting
+`createSqliteWorkerBackend(input, { databasePath })`. Its factory owns database
+opening and schema setup; its synchronous `execute(command)` owns queries and
+transactions. `close()` may await cleanup outside transactions; the host retains
+the actor until that cleanup settles. Keep native handles, WAL maintenance, and
+prepared statements inside that backend. Send serializable domain commands and
+results across the boundary, never SQL strings, callbacks, or Kysely builders.
+Declare private build entries with
+[`openclaw.build.workerEntries`](/plugins/dependency-resolution#native-imports-from-a-standalone-source-build)
+and derive their locations from the loader's `api.runtimeSource` fact.
+
+Abort signals remove operations that are still queued. Once dispatched, an
+operation retains its result or failure; cancellation does not prove rollback.
+`close()` rejects new work and drains that client's accepted operations. The
+last client also closes its database backend; the last backend releases its
+worker. Worker loss or failure to serialize a completed operation's result can
+reject with `code: "outcome-unknown"`. The operation may have committed: inspect
+authoritative state before deciding what to do next. The host never
+automatically retries a write.
+
+An asynchronous `execute` return violates the command contract. The host retires
+and joins that worker before reporting `outcome-unknown`; it does the same when
+a completed reply cannot be decoded. Failed cleanup retains its original error
+while the worker is drained.
+
+The process-wide host starts lazily and permits at most four workers, 64 opening
+or live store clients (including clients sharing a database), 128 outstanding
+operations, and 64 MiB of queued input. Each input message is limited to 32 MiB
+and each result to 64 MiB; capacity exhaustion rejects with
+`code: "overloaded"`. Operations for one database share its connection owner
+and execute in order. There are no reader replicas or worker-pool configuration
+options.
+
+File identities are admission facts, not native-handle attestations. Close and
+drain a database's clients before replacing or relocating its file. The host
+refuses observed identity changes and collisions with an existing owner; path
+checks cannot protect against an uncoordinated filesystem replacement.
+Each client retains its admitted lexical and canonical pathnames through
+drainage and close. The backend's opening paths remain pinned for its native
+lifetime; released secondary aliases do not accumulate while other clients live.
 
 ### Webhook body rejection
 

--- a/extensions/team-reports/README.md
+++ b/extensions/team-reports/README.md
@@ -17,6 +17,9 @@ openclaw team-reports list --json
 
 Reports use UTC windows, remain in the plugin-owned SQLite store, and are
 served behind Gateway authentication at `/plugins/team-reports/` by default.
+Database operations run in a worker so SQLite lock waits do not block the
+Gateway event loop. Plugin shutdown drains admitted database work before closing
+the connection.
 The Control UI tab opens at `/reports` (prefixed by the Control UI base path).
 Model summary calls are optional; set `summaries.enabled: false` for deterministic text.
 

--- a/extensions/team-reports/index.test.ts
+++ b/extensions/team-reports/index.test.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type {
   OpenClawConfig,
@@ -31,7 +33,7 @@ const config: OpenClawConfig = {
   plugins: { entries: { "team-reports": { enabled: true, config: pluginConfig } } },
 };
 
-function captureReports() {
+function captureReports(runtimeSource = fileURLToPath(new URL("./index.ts", import.meta.url))) {
   const services: OpenClawPluginService[] = [];
   const routes: Array<Parameters<OpenClawPluginApi["registerHttpRoute"]>[0]> = [];
   const methods: Array<Parameters<OpenClawPluginApi["registerGatewayMethod"]>> = [];
@@ -42,6 +44,7 @@ function captureReports() {
     register(api) {
       plugin.register({
         ...api,
+        runtimeSource,
         pluginConfig: api.config.plugins?.entries?.["team-reports"]?.config,
         registerService(service) {
           services.push(service);
@@ -65,11 +68,48 @@ beforeEach(() => vi.clearAllMocks());
 afterEach(() => vi.restoreAllMocks());
 
 describe("Team Reports registration", () => {
+  it.each([
+    ["source", "extensions/team-reports/index.ts", "extensions/team-reports/src/store.worker.ts"],
+    [
+      "standalone",
+      "plugins/team-reports/dist/index.js",
+      "plugins/team-reports/dist/src/store.worker.js",
+    ],
+    [
+      "bundled",
+      "dist/extensions/team-reports/index.js",
+      "dist/extensions/team-reports/src/store.worker.js",
+    ],
+  ] as const)(
+    "locates its %s worker from the selected runtime entry",
+    async (_layout, entry, worker) => {
+      const runtimeSource = path.resolve(entry);
+      const { services } = captureReports(runtimeSource);
+      const parsed = configRuntime.parseTeamReportsConfig(pluginConfig);
+      vi.spyOn(configRuntime, "resolveTeamReportsConfig").mockResolvedValue({
+        github: { ...parsed.github, token: "fixture-github-token", ignoreCommentPatterns: [] },
+        people: [],
+      });
+      const stopBeforeOpening = new Error("worker location captured");
+      vi.mocked(createTeamReportsStore).mockRejectedValueOnce(stopBeforeOpening);
+      await expect(
+        services[0]!.start({ config, stateDir: "/unused", logger: console }),
+      ).rejects.toBe(stopBeforeOpening);
+      expect(createTeamReportsStore).toHaveBeenCalledWith({
+        stateDir: "/unused",
+        workerModuleUrl: pathToFileURL(path.resolve(worker)),
+      });
+    },
+  );
+
   it("drains storage that opens after retirement without publishing the service", async () => {
     const directory = tempDirs.make("team-reports-retired-open-");
     const { createTeamReportsStore: openStore } =
       await vi.importActual<typeof import("./src/store.js")>("./src/store.js");
-    const store = await openStore({ stateDir: directory });
+    const store = await openStore({
+      stateDir: directory,
+      workerModuleUrl: new URL("./src/store.worker.ts", import.meta.url),
+    });
     const opened = createDeferred<void>();
     const releaseOpen = createDeferred<void>();
     const releaseClose = createDeferred<void>();

--- a/extensions/team-reports/index.ts
+++ b/extensions/team-reports/index.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { parseTeamReportsConfig, resolveTeamReportsConfig } from "./src/config.js";
 import { registerTeamReportsGatewayMethods } from "./src/gateway-methods.js";
@@ -77,7 +77,18 @@ export default definePluginEntry({
           delete summaryOptions.model;
         }
         startingStore = (async () => {
-          const nextStore = await createTeamReportsStore({ stateDir: ctx.stateDir });
+          if (!api.runtimeSource) {
+            throw new Error(
+              "Team Reports requires an OpenClaw host with runtime entrypoint metadata",
+            );
+          }
+          const nextStore = await createTeamReportsStore({
+            stateDir: ctx.stateDir,
+            workerModuleUrl: new URL(
+              `./src/store.worker${path.extname(api.runtimeSource)}`,
+              pathToFileURL(api.runtimeSource),
+            ),
+          });
           if (retired || currentGeneration !== generation) {
             await nextStore.close();
             return;

--- a/extensions/team-reports/package.json
+++ b/extensions/team-reports/package.json
@@ -38,6 +38,9 @@
     "build": {
       "openclawVersion": "2026.9.3",
       "bundledDist": false,
+      "workerEntries": [
+        "./src/store.worker.ts"
+      ],
       "staticAssets": [
         {
           "source": "./assets/crab.avif",

--- a/extensions/team-reports/src/http.test.ts
+++ b/extensions/team-reports/src/http.test.ts
@@ -117,7 +117,10 @@ function fetchPath(
 
 beforeAll(async () => {
   directory = fs.mkdtempSync(path.join(os.tmpdir(), "team-reports-http-"));
-  store = await createTeamReportsStore({ stateDir: directory });
+  store = await createTeamReportsStore({
+    stateDir: directory,
+    workerModuleUrl: new URL("./store.worker.ts", import.meta.url),
+  });
   const avatarReport = report("day", "2026-08-19");
   avatarReport.members = avatarPeople.map((person) => ({
     login: person.github[0] ?? "",
@@ -464,7 +467,10 @@ describe("Team Reports HTTP responses", () => {
   });
 
   it("reads current overview organizations and prefers the displayed report's organizations", async () => {
-    const emptyStore = await createTeamReportsStore({ stateDir: path.join(directory, "empty") });
+    const emptyStore = await createTeamReportsStore({
+      stateDir: path.join(directory, "empty"),
+      workerModuleUrl: new URL("./store.worker.ts", import.meta.url),
+    });
     try {
       for (const name of ["first-organization", "new <organization>"]) {
         currentOrgs = [name];

--- a/extensions/team-reports/src/scheduler.test.ts
+++ b/extensions/team-reports/src/scheduler.test.ts
@@ -65,7 +65,10 @@ async function setup(
   };
   const directory =
     options.stateDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "team-reports-scheduler-"));
-  const store = await createTeamReportsStore({ stateDir: directory });
+  const store = await createTeamReportsStore({
+    stateDir: directory,
+    workerModuleUrl: new URL("./store.worker.ts", import.meta.url),
+  });
   if (options.caughtUp !== false) {
     const yesterday = describePeriod("day", Date.now() - 86_400_000);
     await store.startRun({
@@ -116,9 +119,15 @@ async function setup(
     return { github, discord };
   };
   const complete = vi.fn<Complete>().mockRejectedValue(new Error("Unexpected model request"));
+  const completions: Array<ReturnType<typeof createDeferred<void>>> = [];
+  let published = 0;
+  let consumed = 0;
+  const completionAt = (index: number) => (completions[index] ??= createDeferred<void>());
+  const runSettled = () => completionAt(published++).resolve();
+  const nextRun = () => completionAt(consumed++).promise;
   const context = {
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    serviceHealth: { reportFailure: vi.fn(), clearFailure: vi.fn() },
+    serviceHealth: { reportFailure: vi.fn(runSettled), clearFailure: vi.fn(runSettled) },
   };
   const scheduler = new TeamReportsScheduler({
     config,
@@ -129,7 +138,18 @@ async function setup(
     sources,
   });
   resources.push({ directory, store, scheduler });
-  return { scheduler, store, directory, config, github, discord, complete, context, runtimes };
+  return {
+    scheduler,
+    store,
+    directory,
+    config,
+    github,
+    discord,
+    complete,
+    context,
+    runtimes,
+    nextRun,
+  };
 }
 
 function modelResponse(): Awaited<ReturnType<Complete>> {
@@ -211,11 +231,12 @@ describe("Team Reports schedule boundaries", () => {
   it("does not schedule another closed-day run today when the next jitter sample is larger", async () => {
     vi.setSystemTime(new Date("2026-08-20T00:04:00Z"));
     vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValue(1);
-    const { scheduler, store } = await setup({
+    const { scheduler, store, nextRun } = await setup({
       schedule: { closedDayUtc: "00:05", jitterMinutes: 5 },
     });
     await scheduler.start();
     await vi.advanceTimersByTimeAsync(60_000);
+    await nextRun();
     expect((await store.listRuns()).filter((run) => run.id !== "previous-closed-day")).toHaveLength(
       1,
     );
@@ -255,14 +276,14 @@ describe("Team Reports scheduler lifecycle", () => {
   });
 
   it("rejects failed admission without collecting and releases the run for another request", async () => {
-    const { scheduler, store, github } = await setup();
+    const { scheduler, nextRun, store, github } = await setup();
     await scheduler.start();
     vi.spyOn(store, "startRun").mockRejectedValueOnce(new Error("database unavailable"));
     await expect(scheduler.generate()).rejects.toThrow("database unavailable");
     expect(github.loadRoster).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     const id = await scheduler.generate();
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("ok");
   });
 
@@ -290,7 +311,10 @@ describe("Team Reports scheduler lifecycle", () => {
       await stopped;
     }
     expect(close).toHaveBeenCalledOnce();
-    const reopened = await createTeamReportsStore({ stateDir: directory });
+    const reopened = await createTeamReportsStore({
+      stateDir: directory,
+      workerModuleUrl: new URL("./store.worker.ts", import.meta.url),
+    });
     try {
       expect((await reopened.getPeriod("day", "2026-08-19"))?.report.totals.github.total).toBe(1);
       expect((await reopened.listRuns()).find((run) => run.id === id)).toMatchObject({
@@ -337,7 +361,7 @@ describe("Team Reports scheduler lifecycle", () => {
   });
 
   it("reports the earliest due time and last completed run while another run is active", async () => {
-    const { scheduler, github } = await setup({
+    const { scheduler, github, nextRun } = await setup({
       caughtUp: false,
       schedule: { intradayEveryHours: 4 },
     });
@@ -348,8 +372,12 @@ describe("Team Reports scheduler lifecycle", () => {
       nextDueMs: Date.parse("2026-08-20T12:01:00Z"),
       warnings: 0,
     });
+    const firstCollection = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
+    github.collect.mockImplementationOnce(() => firstCollection.promise);
     await scheduler.generate();
     expect((await scheduler.health()).lastRun).toBeUndefined();
+    firstCollection.resolve({ items: [], status: healthy });
+    await nextRun();
     await vi.advanceTimersByTimeAsync(60_000);
     expect(await scheduler.health()).toEqual({
       running: true,
@@ -367,19 +395,20 @@ describe("Team Reports scheduler lifecycle", () => {
       finishedAtMs: Date.parse("2026-08-20T12:00:00Z"),
     });
     blocked.resolve({ items: [], status: healthy });
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     expect((await scheduler.health()).lastRun?.finishedAtMs).toBe(
       Date.parse("2026-08-20T12:01:00Z"),
     );
   });
 
   it("catches up yesterday once after the startup delay and also publishes today's partial", async () => {
-    const { scheduler, store, github } = await setup({ caughtUp: false });
+    const { scheduler, store, github, nextRun } = await setup({ caughtUp: false });
     await scheduler.start();
     expect((await scheduler.status()).nextDue.catchUp).toBe(Date.now() + 60_000);
     await vi.advanceTimersByTimeAsync(59_999);
     expect(github.collect).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
+    await nextRun();
     expect(await store.listRuns()).toMatchObject([{ kind: "closed-day", status: "ok" }]);
     expect(await store.listPeriods()).toMatchObject([
       { period: "day", key: "2026-08-20", status: "partial" },
@@ -427,6 +456,7 @@ describe("Team Reports scheduler lifecycle", () => {
         await first.scheduler.generate({ intraday: true });
       }
       await vi.advanceTimersByTimeAsync(60_000);
+      await first.nextRun();
       expect((await first.store.listRuns())[0]).toMatchObject({
         kind,
         status: "ok",
@@ -440,6 +470,7 @@ describe("Team Reports scheduler lifecycle", () => {
       await restarted.scheduler.start();
       expect((await restarted.scheduler.status()).nextDue.catchUp).toBe(Date.now() + 60_000);
       await vi.advanceTimersByTimeAsync(60_000);
+      await restarted.nextRun();
       expect(restarted.github.collect).toHaveBeenCalledTimes(2);
       expect(restarted.github.collect.mock.calls[0]?.[1]).toEqual({
         sinceMs: Date.parse("2026-08-20T00:00:00Z"),
@@ -450,16 +481,21 @@ describe("Team Reports scheduler lifecycle", () => {
   );
 
   it("skips deferred catch-up after a manual run completes yesterday", async () => {
-    const { scheduler, store, github } = await setup({ caughtUp: false });
+    const { scheduler, nextRun, store, github } = await setup({ caughtUp: false });
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
-    github.collect.mockImplementationOnce(() => blocked.promise);
+    const collecting = createDeferred<void>();
+    github.collect.mockImplementationOnce(() => {
+      collecting.resolve();
+      return blocked.promise;
+    });
     await scheduler.start();
     const id = await scheduler.generate({ date: "2026-08-19" });
+    await collecting.promise;
     await vi.advanceTimersByTimeAsync(19 * 60_000);
     expect(github.collect).toHaveBeenCalledOnce();
     expect(await store.listRuns()).toMatchObject([{ id, kind: "manual", status: "running" }]);
     blocked.resolve({ items: [], status: healthy });
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     expect(await store.listRuns()).toMatchObject([{ id, kind: "manual", status: "ok" }]);
     await vi.advanceTimersByTimeAsync(60_000);
     expect(github.collect).toHaveBeenCalledOnce();
@@ -468,7 +504,9 @@ describe("Team Reports scheduler lifecycle", () => {
 
   it("rejects a concurrent manual run and defers an intraday tick without overlapping collectors", async () => {
     vi.setSystemTime(new Date("2026-08-20T03:59:00Z"));
-    const { scheduler, store, github } = await setup({ schedule: { intradayEveryHours: 4 } });
+    const { scheduler, store, github, nextRun } = await setup({
+      schedule: { intradayEveryHours: 4 },
+    });
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
     github.collect.mockImplementationOnce(() => blocked.promise);
     await scheduler.start();
@@ -479,9 +517,10 @@ describe("Team Reports scheduler lifecycle", () => {
     expect(github.collect).toHaveBeenCalledOnce();
     expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("running");
     blocked.resolve({ items: [], status: healthy });
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("ok");
     await vi.advanceTimersByTimeAsync(60_000);
+    await nextRun();
     expect(github.collect).toHaveBeenCalledTimes(2);
     expect(
       (await store.listRuns()).some((run) => run.kind === "intraday" && run.status === "ok"),
@@ -506,7 +545,10 @@ describe("Team Reports scheduler lifecycle", () => {
     blocked.resolve({ items: [], status: healthy });
     await stopped;
     expect(finished).toBe(true);
-    const reopened = await createTeamReportsStore({ stateDir: directory });
+    const reopened = await createTeamReportsStore({
+      stateDir: directory,
+      workerModuleUrl: new URL("./store.worker.ts", import.meta.url),
+    });
     try {
       expect((await reopened.listRuns()).find((run) => run.id === id)?.status).toBe("ok");
       expect((await reopened.getPeriod("day", "2026-08-19"))?.report.status).toBe("closed");
@@ -530,7 +572,10 @@ describe("Team Reports scheduler lifecycle", () => {
     expect(runtimes[0]?.signal?.aborted).toBe(true);
     blocked.resolve({ items: [], status: healthy });
     await vi.advanceTimersByTimeAsync(0);
-    const reopened = await createTeamReportsStore({ stateDir: directory });
+    const reopened = await createTeamReportsStore({
+      stateDir: directory,
+      workerModuleUrl: new URL("./store.worker.ts", import.meta.url),
+    });
     try {
       expect((await reopened.listRuns()).find((run) => run.id === id)).toMatchObject({
         status: "error",
@@ -543,7 +588,7 @@ describe("Team Reports scheduler lifecycle", () => {
   });
 
   it("passes the 45-minute deadline abort to sources and records a failed run without late writes", async () => {
-    const { scheduler, github, runtimes, store, context } = await setup();
+    const { scheduler, github, runtimes, store, context, nextRun } = await setup();
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
     github.collect.mockImplementationOnce(() => blocked.promise);
     await scheduler.start();
@@ -552,6 +597,7 @@ describe("Team Reports scheduler lifecycle", () => {
     expect(runtimes[0]?.signal?.aborted).toBe(false);
     await vi.advanceTimersByTimeAsync(1);
     expect(runtimes[0]?.signal?.aborted).toBe(true);
+    await nextRun();
     expect((await store.listRuns()).find((run) => run.id === id)).toMatchObject({
       status: "error",
       error: expect.stringContaining("45-minute"),
@@ -563,24 +609,30 @@ describe("Team Reports scheduler lifecycle", () => {
   });
 
   it("makes collected evidence readable while model summaries are still pending", async () => {
-    const { scheduler, store, complete } = await setup({ summaries: true });
+    const { scheduler, store, complete, nextRun } = await setup({ summaries: true });
     const blocked = createDeferred<Awaited<ReturnType<Complete>>>();
-    complete.mockImplementation(() => blocked.promise);
+    const summarizing = createDeferred<void>();
+    complete.mockImplementation(() => {
+      summarizing.resolve();
+      return blocked.promise;
+    });
     await scheduler.start();
     const id = await scheduler.generate();
-    await vi.advanceTimersByTimeAsync(0);
+    await summarizing.promise;
     const before = await store.getPeriod("day", "2026-08-19");
     expect(before?.report.totals.github.total).toBe(1);
     expect(before?.summary?.source).toBe("fallback");
     expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("running");
     blocked.resolve(modelResponse());
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     expect((await store.getPeriod("day", "2026-08-19"))?.summary?.source).toBe("model");
     expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("ok");
   });
 
   it("surfaces the latest day's model fallback in status, storage, Markdown, and logs", async () => {
-    const { scheduler, store, context, complete, github } = await setup({ summaries: true });
+    const { scheduler, nextRun, store, context, complete, github } = await setup({
+      summaries: true,
+    });
     github.loadRoster.mockResolvedValue({
       people: [{ github: ["alex"] }],
       status: { ...healthy, warnings: ["Roster coverage warning"] },
@@ -588,7 +640,7 @@ describe("Team Reports scheduler lifecycle", () => {
     complete.mockRejectedValue(new Error("private-provider-error-marker"));
     await scheduler.start();
     await scheduler.generate();
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     const reason = "Model summary unavailable: completion failed";
     const stored = await store.getPeriod("day", "2026-08-19");
     expect(stored?.summary?.warnings).toEqual([reason]);
@@ -598,17 +650,17 @@ describe("Team Reports scheduler lifecycle", () => {
     expect(context.logger.warn.mock.calls).toEqual([[reason]]);
     complete.mockResolvedValue(modelResponse());
     await scheduler.generate({ intraday: true });
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     expect((await scheduler.status()).sourceWarnings).toEqual(["Roster coverage warning"]);
     expect((await scheduler.health()).warnings).toBe(1);
   });
 
   it("reports source failures with redacted errors and clears health on the next successful run", async () => {
-    const { scheduler, store, github, context } = await setup();
+    const { scheduler, nextRun, store, github, context } = await setup();
     github.collect.mockRejectedValueOnce(new Error("Access failed for fixture-github-token"));
     await scheduler.start();
     const failed = await scheduler.generate();
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     expect((await store.listRuns()).find((run) => run.id === failed)).toMatchObject({
       status: "error",
       error: "Access failed for [redacted]",
@@ -621,16 +673,16 @@ describe("Team Reports scheduler lifecycle", () => {
     });
     expect(JSON.stringify(context.logger.error.mock.calls)).not.toContain("fixture-github-token");
     const succeeded = await scheduler.generate();
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     expect((await store.listRuns()).find((run) => run.id === succeeded)?.status).toBe("ok");
     expect(context.serviceHealth.clearFailure).toHaveBeenCalledOnce();
   });
 
   it.each([false, true])("collects Discord only when configured (enabled: %s)", async (enabled) => {
-    const { scheduler, discord, store, complete } = await setup({ discord: enabled });
+    const { scheduler, nextRun, discord, store, complete } = await setup({ discord: enabled });
     await scheduler.start();
     await scheduler.generate();
-    await vi.advanceTimersByTimeAsync(0);
+    await nextRun();
     expect(discord.collect).toHaveBeenCalledTimes(enabled ? 1 : 0);
     const generated = await store.getPeriod("day", "2026-08-19");
     expect(generated?.report.totals.discord.messages).toBe(enabled ? 1 : 0);
@@ -640,12 +692,13 @@ describe("Team Reports scheduler lifecycle", () => {
 
   it("closes the prior week and month while opening the current periods at calendar rollover", async () => {
     vi.setSystemTime(new Date("2026-06-01T00:04:00Z"));
-    const { scheduler, store, github } = await setup({
+    const { scheduler, store, github, nextRun } = await setup({
       caughtUp: "manual",
       schedule: { closedDayUtc: "00:05", weekly: true, monthly: true },
     });
     await scheduler.start();
     await vi.advanceTimersByTimeAsync(60_000);
+    await nextRun();
     expect(github.collect).toHaveBeenCalledTimes(2);
     expect(await store.listPeriods()).toEqual(
       expect.arrayContaining([

--- a/extensions/team-reports/src/scheduler.test.ts
+++ b/extensions/team-reports/src/scheduler.test.ts
@@ -508,11 +508,15 @@ describe("Team Reports scheduler lifecycle", () => {
       schedule: { intradayEveryHours: 4 },
     });
     const blocked = createDeferred<Awaited<ReturnType<GithubSource["collect"]>>>();
-    github.collect.mockImplementationOnce(() => blocked.promise);
+    const collecting = createDeferred<void>();
+    github.collect.mockImplementationOnce(() => {
+      collecting.resolve();
+      return blocked.promise;
+    });
     await scheduler.start();
     const id = await scheduler.generate({ intraday: true });
-    await vi.advanceTimersByTimeAsync(0);
     await expect(scheduler.generate()).rejects.toThrow("already in progress");
+    await collecting.promise;
     await vi.advanceTimersByTimeAsync(60_000);
     expect(github.collect).toHaveBeenCalledOnce();
     expect((await store.listRuns()).find((run) => run.id === id)?.status).toBe("running");

--- a/extensions/team-reports/src/store-contract.ts
+++ b/extensions/team-reports/src/store-contract.ts
@@ -1,0 +1,90 @@
+import type { Period, ReportDocument, SummaryDocument } from "./types.js";
+
+export type StoredPeriod = {
+  report: ReportDocument;
+  summary: SummaryDocument | null;
+  markdown: string;
+};
+export type PeriodListEntry = {
+  period: Period;
+  key: string;
+  sinceMs: number;
+  untilMs: number;
+  status: "partial" | "closed";
+  generatedAtMs: number;
+  activeMembers: number;
+  memberCount: number;
+  githubTotal: number;
+  discordMessages: number;
+  commits: number;
+  prsOpened: number;
+  prsMerged: number;
+  securityAdvisories: number;
+};
+export type PersonDay = {
+  dayKey: string;
+  login: string;
+  githubTotal: number;
+  commits: number;
+  prsOpened: number;
+  prsMerged: number;
+  prsClosed: number;
+  issuesOpened: number;
+  issuesClosed: number;
+  issueComments: number;
+  reviewComments: number;
+  discordMessages: number;
+};
+export type RunPeriod = { period: Period; key: string };
+export type ReportRun = {
+  id: string;
+  kind: "closed-day" | "intraday" | "manual";
+  startedAtMs: number;
+  finishedAtMs: number | null;
+  status: "running" | "ok" | "error";
+  periods: RunPeriod[];
+  stats: Record<string, unknown> | null;
+  error: string | null;
+};
+
+export type TeamReportsOperations = {
+  upsertPeriod: {
+    input: Omit<StoredPeriod, "summary"> & { summary?: SummaryDocument | null };
+    output: void;
+  };
+  getPeriod: { input: { period: Period; key: string }; output: StoredPeriod | undefined };
+  listPeriods: {
+    input: { period?: Period; status?: "partial" | "closed"; limit?: number };
+    output: PeriodListEntry[];
+  };
+  getDayReports: { input: { sinceMs: number; untilMs: number }; output: ReportDocument[] };
+  listPersonDays: {
+    input: { login: string; options: { since?: string; until?: string; limit?: number } };
+    output: PersonDay[];
+  };
+  listPersonDaysSince: { input: string; output: PersonDay[] };
+  startRun: {
+    input: { id: string; kind: ReportRun["kind"]; startedAtMs: number; periods: RunPeriod[] };
+    output: void;
+  };
+  finishRun: {
+    input: {
+      id: string;
+      result: {
+        finishedAtMs: number;
+        status: "ok" | "error";
+        stats?: Record<string, unknown>;
+        error?: string;
+      };
+    };
+    output: void;
+  };
+  listRuns: {
+    input: { limit: number; filter: { kind?: ReportRun["kind"]; status?: ReportRun["status"] } };
+    output: ReportRun[];
+  };
+  prune: {
+    input: { retentionDays: number; nowMs: number };
+    output: { periods: number; personDays: number; runs: number };
+  };
+};

--- a/extensions/team-reports/src/store.test.ts
+++ b/extensions/team-reports/src/store.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,11 +9,12 @@ import { createTeamReportsStore, type TeamReportsStore } from "./store.js";
 import type { PeriodDescriptor, ReportDocument, SummaryDocument } from "./types.js";
 
 const DAY_MS = 86_400_000;
+const workerModuleUrl = new URL("./store.worker.ts", import.meta.url);
 const resources: Array<{ store: TeamReportsStore; directory: string }> = [];
 
 async function openStore() {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "team-reports-store-"));
-  const store = await createTeamReportsStore({ stateDir: directory });
+  const store = await createTeamReportsStore({ stateDir: directory, workerModuleUrl });
   resources.push({ directory, store });
   return { store, dbPath: path.join(directory, "plugins", "team-reports", "team-reports.sqlite") };
 }
@@ -85,7 +87,7 @@ describe("Team Reports storage", () => {
       database.close();
     }
     await store.close();
-    const reopened = await createTeamReportsStore({ dbPath });
+    const reopened = await createTeamReportsStore({ dbPath, workerModuleUrl });
     try {
       expect(await reopened.getPeriod("day", "2026-08-20")).toEqual({
         report: report(),
@@ -96,6 +98,40 @@ describe("Team Reports storage", () => {
       await reopened.close();
     }
     await expect(store.listPeriods()).rejects.toThrow("store is closed");
+  });
+
+  it("keeps timers responsive during lock contention and drains admitted writes before closing", async () => {
+    const { store, dbPath } = await openStore();
+    const retained = await createTeamReportsStore({ dbPath, workerModuleUrl });
+    const blocker = openNodeSqliteDatabase(dbPath);
+    let released = false;
+    blocker.exec("BEGIN IMMEDIATE");
+    const release = setTimeout(() => {
+      blocker.exec("ROLLBACK");
+      released = true;
+    }, 20);
+    try {
+      const write = store.upsertPeriod({ report: report(), markdown: "drained before close" });
+      const closing = store.close().then(() => expect(released).toBe(true));
+      await expect(store.listPeriods()).rejects.toThrow("store is closed");
+      await Promise.all([write, closing]);
+      expect(released).toBe(true);
+    } finally {
+      clearTimeout(release);
+      if (!released) {
+        blocker.exec("ROLLBACK");
+      }
+      blocker.close();
+      await retained.close();
+    }
+    const reopened = await createTeamReportsStore({ dbPath, workerModuleUrl });
+    try {
+      expect((await reopened.getPeriod("day", "2026-08-20"))?.markdown).toBe(
+        "drained before close",
+      );
+    } finally {
+      await reopened.close();
+    }
   });
 
   it("replaces the document, summary, markdown, and person-day counts as one unit", async () => {
@@ -218,6 +254,35 @@ describe("Team Reports storage", () => {
       discordMessages: 2,
     });
     expect(await store.listPersonDaysSince("2026-08-21")).toEqual([]);
+  });
+
+  it("reads a complete month of individually valid reports across the worker boundary", async () => {
+    const { store } = await openStore();
+    const titlePrefix = "x".repeat(1_100_000);
+    const expected: Array<{ key: string; titleLength: number; titleHash: string }> = [];
+    for (let day = 1; day <= 31; day++) {
+      const key = `2026-08-${String(day).padStart(2, "0")}`;
+      const document = report(key);
+      document.period.title = `${titlePrefix}:${key}`;
+      expected.push({
+        key,
+        titleLength: document.period.title.length,
+        titleHash: createHash("sha256").update(document.period.title).digest("hex"),
+      });
+      await store.upsertPeriod({ report: document, markdown: key });
+    }
+    const days = await store.getDayReports(
+      Date.parse("2026-08-01T00:00:00Z"),
+      Date.parse("2026-09-01T00:00:00Z"),
+    );
+    expect(days).toHaveLength(31);
+    expect(
+      days.map(({ period }) => ({
+        key: period.key,
+        titleLength: period.title.length,
+        titleHash: createHash("sha256").update(period.title).digest("hex"),
+      })),
+    ).toEqual(expected);
   });
 
   it("reads half-open day ranges and indexes newest first without projecting week rows onto people", async () => {

--- a/extensions/team-reports/src/store.ts
+++ b/extensions/team-reports/src/store.ts
@@ -1,473 +1,81 @@
-import fs from "node:fs";
 import path from "node:path";
-import type { DatabaseSync } from "node:sqlite";
-import {
-  configureSqliteConnectionPragmas,
-  migrateSqliteSchemaToStrict,
-} from "openclaw/plugin-sdk/plugin-state-runtime";
-import {
-  executeSqliteQuerySync,
-  executeSqliteQueryTakeFirstSync,
-  getNodeSqliteKysely,
-  openNodeSqliteDatabase,
-  runSqliteImmediateTransactionSync,
-} from "openclaw/plugin-sdk/sqlite-runtime";
+import { openSqliteWorkerStore, type SqliteWorkerStore } from "openclaw/plugin-sdk/sqlite-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
-import { MAX_REPORT_BYTES } from "./limits.js";
-import { DAY_MS } from "./periods.js";
-import {
-  reportDocumentSchema,
-  runPeriodsSchema,
-  runStatsSchema,
-  summaryDocumentSchema,
-  TEAM_REPORTS_SCHEMA_SQL,
-} from "./store-schema.js";
-import type { Period, ReportDocument, SummaryDocument } from "./types.js";
+import type { TeamReportsOperations } from "./store-contract.js";
+import type { Period } from "./types.js";
 
-type StoredPeriod = {
-  report: ReportDocument;
-  summary: SummaryDocument | null;
-  markdown: string;
-};
-export type PeriodListEntry = {
-  period: Period;
-  key: string;
-  sinceMs: number;
-  untilMs: number;
-  status: "partial" | "closed";
-  generatedAtMs: number;
-  activeMembers: number;
-  memberCount: number;
-  githubTotal: number;
-  discordMessages: number;
-  commits: number;
-  prsOpened: number;
-  prsMerged: number;
-  securityAdvisories: number;
-};
-export type PersonDay = {
-  dayKey: string;
-  login: string;
-  githubTotal: number;
-  commits: number;
-  prsOpened: number;
-  prsMerged: number;
-  prsClosed: number;
-  issuesOpened: number;
-  issuesClosed: number;
-  issueComments: number;
-  reviewComments: number;
-  discordMessages: number;
-};
-type RunPeriod = { period: Period; key: string };
-type ReportRun = {
-  id: string;
-  kind: "closed-day" | "intraday" | "manual";
-  startedAtMs: number;
-  finishedAtMs: number | null;
-  status: "running" | "ok" | "error";
-  periods: RunPeriod[];
-  stats: Record<string, unknown> | null;
-  error: string | null;
-};
-
-type PeriodRow = {
-  period: Period;
-  period_key: string;
-  since_ms: number;
-  until_ms: number;
-  status: "partial" | "closed";
-  generated_at_ms: number;
-  data_json: string;
-  summary_json: string | null;
-  markdown: string;
-};
-type PersonDayRow = {
-  day_key: string;
-  login: string;
-  github_total: number;
-  commits: number;
-  prs_opened: number;
-  prs_merged: number;
-  prs_closed: number;
-  issues_opened: number;
-  issues_closed: number;
-  issue_comments: number;
-  review_comments: number;
-  discord_messages: number;
-};
-type RunRow = {
-  id: string;
-  kind: ReportRun["kind"];
-  started_at_ms: number;
-  finished_at_ms: number | null;
-  status: ReportRun["status"];
-  periods_json: string;
-  stats_json: string | null;
-  error: string | null;
-};
-type ReportsDatabase = {
-  team_reports_schema_migrations: { id: string; applied_at: number };
-  team_reports_periods: PeriodRow;
-  team_reports_person_days: PersonDayRow;
-  team_reports_runs: RunRow;
-};
-
-function readPeriod(row: PeriodRow): StoredPeriod {
-  return {
-    report: reportDocumentSchema.parse(JSON.parse(row.data_json)),
-    summary:
-      row.summary_json === null ? null : summaryDocumentSchema.parse(JSON.parse(row.summary_json)),
-    markdown: row.markdown,
-  };
-}
-
-function chmodIfExists(file: string): void {
-  try {
-    fs.chmodSync(file, 0o600);
-  } catch (error) {
-    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
-      throw error;
-    }
-  }
-}
+export type { PeriodListEntry, PersonDay } from "./store-contract.js";
 
 export class TeamReportsStore {
   private closed = false;
-  private readonly query;
 
-  constructor(
-    private readonly db: DatabaseSync,
-    private readonly maintenance: ReturnType<typeof configureSqliteConnectionPragmas>,
-  ) {
-    this.query = getNodeSqliteKysely<ReportsDatabase>(db);
-  }
+  constructor(private readonly worker: SqliteWorkerStore<TeamReportsOperations>) {}
 
-  private assertOpen(): void {
+  private async execute<K extends keyof TeamReportsOperations>(
+    type: K,
+    input: TeamReportsOperations[K]["input"],
+  ): Promise<TeamReportsOperations[K]["output"]> {
     if (this.closed) {
       throw new Error("Team Reports store is closed.");
     }
+    return this.worker.execute({ type, input });
   }
 
-  async upsertPeriod(
-    value: Omit<StoredPeriod, "summary"> & { summary?: SummaryDocument | null },
-  ): Promise<void> {
-    this.assertOpen();
-    const { report } = value;
-    const dataJson = JSON.stringify(report);
-    if (Buffer.byteLength(dataJson, "utf8") > MAX_REPORT_BYTES) {
-      throw new Error("Team Reports document exceeds the 2 MiB storage limit.");
-    }
-    const row: PeriodRow = {
-      period: report.period.period,
-      period_key: report.period.key,
-      since_ms: report.period.sinceMs,
-      until_ms: report.period.untilMs,
-      status: report.status,
-      generated_at_ms: report.generatedAtMs,
-      data_json: dataJson,
-      summary_json: value.summary ? JSON.stringify(value.summary) : null,
-      markdown: value.markdown,
-    };
-    const people: PersonDayRow[] = report.members.map((member) => ({
-      day_key: report.period.key,
-      login: member.login.toLowerCase(),
-      github_total: member.github.total,
-      commits: member.github.commits,
-      prs_opened: member.github.prsOpened,
-      prs_merged: member.github.prsMerged,
-      prs_closed: member.github.prsClosed,
-      issues_opened: member.github.issuesOpened,
-      issues_closed: member.github.issuesClosed,
-      issue_comments: member.github.issueComments,
-      review_comments: member.github.reviewComments,
-      discord_messages: member.discord.total,
-    }));
-    runSqliteImmediateTransactionSync(this.db, () => {
-      executeSqliteQuerySync(
-        this.db,
-        this.query
-          .insertInto("team_reports_periods")
-          .values(row)
-          .onConflict((conflict) => conflict.columns(["period", "period_key"]).doUpdateSet(row)),
-      );
-      if (report.period.period === "day") {
-        // Replacing the whole day also removes people excluded by a refreshed roster.
-        executeSqliteQuerySync(
-          this.db,
-          this.query
-            .deleteFrom("team_reports_person_days")
-            .where("day_key", "=", report.period.key),
-        );
-        for (const person of people) {
-          executeSqliteQuerySync(
-            this.db,
-            this.query.insertInto("team_reports_person_days").values(person),
-          );
-        }
-      }
-    });
+  upsertPeriod(value: TeamReportsOperations["upsertPeriod"]["input"]) {
+    return this.execute("upsertPeriod", value);
   }
 
-  async getPeriod(period: Period, key: string): Promise<StoredPeriod | undefined> {
-    this.assertOpen();
-    const row = executeSqliteQueryTakeFirstSync(
-      this.db,
-      this.query
-        .selectFrom("team_reports_periods")
-        .selectAll()
-        .where("period", "=", period)
-        .where("period_key", "=", key),
-    );
-    return row ? readPeriod(row) : undefined;
+  getPeriod(period: Period, key: string) {
+    return this.execute("getPeriod", { period, key });
   }
 
-  async listPeriods(
-    options: {
-      period?: Period;
-      status?: "partial" | "closed";
-      limit?: number;
-    } = {},
-  ): Promise<PeriodListEntry[]> {
-    this.assertOpen();
-    let query = this.query
-      .selectFrom("team_reports_periods")
-      .select([
-        "period",
-        "period_key as key",
-        "since_ms as sinceMs",
-        "until_ms as untilMs",
-        "status",
-        "generated_at_ms as generatedAtMs",
-      ])
-      // SQLite extracts only the chart totals instead of materializing every report in JavaScript.
-      .select((eb) => [
-        eb.fn<number>("json_extract", ["data_json", eb.val("$.activeMembers")]).as("activeMembers"),
-        eb.fn<number>("json_extract", ["data_json", eb.val("$.memberCount")]).as("memberCount"),
-        eb
-          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.total")])
-          .as("githubTotal"),
-        eb
-          .fn<number>("json_extract", ["data_json", eb.val("$.totals.discord.messages")])
-          .as("discordMessages"),
-        eb
-          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.commits")])
-          .as("commits"),
-        eb
-          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.prsOpened")])
-          .as("prsOpened"),
-        eb
-          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.prsMerged")])
-          .as("prsMerged"),
-        eb
-          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.securityAdvisories")])
-          .as("securityAdvisories"),
-      ])
-      .orderBy("since_ms", "desc")
-      .orderBy("period", "asc");
-    if (options.period) {
-      query = query.where("period", "=", options.period);
-    }
-    if (options.status) {
-      query = query.where("status", "=", options.status);
-    }
-    return executeSqliteQuerySync(this.db, query.limit(options.limit ?? 180)).rows;
+  listPeriods(options: TeamReportsOperations["listPeriods"]["input"] = {}) {
+    return this.execute("listPeriods", options);
   }
 
-  async getDayReports(sinceMs: number, untilMs: number): Promise<ReportDocument[]> {
-    this.assertOpen();
-    return executeSqliteQuerySync(
-      this.db,
-      this.query
-        .selectFrom("team_reports_periods")
-        .select("data_json")
-        .where("period", "=", "day")
-        .where("since_ms", ">=", sinceMs)
-        .where("since_ms", "<", untilMs)
-        .orderBy("since_ms", "asc"),
-    ).rows.map((row) => reportDocumentSchema.parse(JSON.parse(row.data_json)));
+  getDayReports(sinceMs: number, untilMs: number) {
+    return this.execute("getDayReports", { sinceMs, untilMs });
   }
 
-  async listPersonDays(
+  listPersonDays(
     login: string,
-    options: { since?: string; until?: string; limit?: number } = {},
-  ): Promise<PersonDay[]> {
-    this.assertOpen();
-    let query = this.selectPersonDays()
-      .where("login", "=", login.toLowerCase())
-      .orderBy("day_key", "desc");
-    if (options.since) {
-      query = query.where("day_key", ">=", options.since);
-    }
-    if (options.until) {
-      query = query.where("day_key", "<", options.until);
-    }
-    return executeSqliteQuerySync(this.db, query.limit(options.limit ?? 28)).rows;
+    options: TeamReportsOperations["listPersonDays"]["input"]["options"] = {},
+  ) {
+    return this.execute("listPersonDays", { login, options });
   }
 
-  async listPersonDaysSince(since: string): Promise<PersonDay[]> {
-    this.assertOpen();
-    return executeSqliteQuerySync(
-      this.db,
-      this.selectPersonDays()
-        .where("day_key", ">=", since)
-        .orderBy("day_key", "desc")
-        .orderBy("login", "asc"),
-    ).rows;
+  listPersonDaysSince(since: string) {
+    return this.execute("listPersonDaysSince", since);
   }
 
-  private selectPersonDays() {
-    return this.query
-      .selectFrom("team_reports_person_days")
-      .select([
-        "day_key as dayKey",
-        "login",
-        "github_total as githubTotal",
-        "commits",
-        "prs_opened as prsOpened",
-        "prs_merged as prsMerged",
-        "prs_closed as prsClosed",
-        "issues_opened as issuesOpened",
-        "issues_closed as issuesClosed",
-        "issue_comments as issueComments",
-        "review_comments as reviewComments",
-        "discord_messages as discordMessages",
-      ]);
+  startRun(run: TeamReportsOperations["startRun"]["input"]) {
+    return this.execute("startRun", run);
   }
 
-  async startRun(run: {
-    id: string;
-    kind: ReportRun["kind"];
-    startedAtMs: number;
-    periods: RunPeriod[];
-  }): Promise<void> {
-    this.assertOpen();
-    executeSqliteQuerySync(
-      this.db,
-      this.query.insertInto("team_reports_runs").values({
-        id: run.id,
-        kind: run.kind,
-        started_at_ms: run.startedAtMs,
-        finished_at_ms: null,
-        status: "running",
-        periods_json: JSON.stringify(run.periods),
-        stats_json: null,
-        error: null,
-      }),
-    );
+  finishRun(id: string, result: TeamReportsOperations["finishRun"]["input"]["result"]) {
+    return this.execute("finishRun", { id, result });
   }
 
-  async finishRun(
-    id: string,
-    result: {
-      finishedAtMs: number;
-      status: "ok" | "error";
-      stats?: Record<string, unknown>;
-      error?: string;
-    },
-  ): Promise<void> {
-    this.assertOpen();
-    const updated = executeSqliteQuerySync(
-      this.db,
-      this.query
-        .updateTable("team_reports_runs")
-        .set({
-          finished_at_ms: result.finishedAtMs,
-          status: result.status,
-          stats_json: result.stats ? JSON.stringify(result.stats) : null,
-          error: result.error?.slice(0, 2000) ?? null,
-        })
-        .where("id", "=", id)
-        .where("status", "=", "running"),
-    );
-    if (updated.numAffectedRows !== 1n) {
-      throw new Error(`Team Reports run ${id} is not running.`);
-    }
+  listRuns(limit = 20, filter: TeamReportsOperations["listRuns"]["input"]["filter"] = {}) {
+    return this.execute("listRuns", { limit, filter });
   }
 
-  async listRuns(
-    limit = 20,
-    filter: { kind?: ReportRun["kind"]; status?: ReportRun["status"] } = {},
-  ): Promise<ReportRun[]> {
-    this.assertOpen();
-    let query = this.query.selectFrom("team_reports_runs").selectAll();
-    if (filter.kind) {
-      query = query.where("kind", "=", filter.kind);
-    }
-    if (filter.status) {
-      query = query.where("status", "=", filter.status);
-    }
-    return executeSqliteQuerySync(
-      this.db,
-      query.orderBy("started_at_ms", "desc").orderBy("id", "asc").limit(limit),
-    ).rows.map((row) => ({
-      id: row.id,
-      kind: row.kind,
-      startedAtMs: row.started_at_ms,
-      finishedAtMs: row.finished_at_ms,
-      status: row.status,
-      periods: runPeriodsSchema.parse(JSON.parse(row.periods_json)),
-      stats: row.stats_json === null ? null : runStatsSchema.parse(JSON.parse(row.stats_json)),
-      error: row.error,
-    }));
+  prune(retentionDays: number, nowMs = Date.now()) {
+    return this.execute("prune", { retentionDays, nowMs });
   }
 
-  async prune(
-    retentionDays: number,
-    nowMs = Date.now(),
-  ): Promise<{ periods: number; personDays: number; runs: number }> {
-    this.assertOpen();
-    if (!Number.isSafeInteger(retentionDays) || retentionDays < 0) {
-      throw new Error("Team Reports retention days must be a nonnegative integer.");
-    }
-    if (retentionDays === 0) {
-      return { periods: 0, personDays: 0, runs: 0 };
-    }
-    const cutoffMs = Math.floor(nowMs / DAY_MS) * DAY_MS - retentionDays * DAY_MS;
-    const cutoffDay = new Date(cutoffMs).toISOString().slice(0, 10);
-    return runSqliteImmediateTransactionSync(this.db, () => ({
-      // Preserve week/month reports that overlap the retained window.
-      periods: Number(
-        executeSqliteQuerySync(
-          this.db,
-          this.query.deleteFrom("team_reports_periods").where("until_ms", "<=", cutoffMs),
-        ).numAffectedRows ?? 0n,
-      ),
-      personDays: Number(
-        executeSqliteQuerySync(
-          this.db,
-          this.query.deleteFrom("team_reports_person_days").where("day_key", "<", cutoffDay),
-        ).numAffectedRows ?? 0n,
-      ),
-      runs: Number(
-        executeSqliteQuerySync(
-          this.db,
-          this.query
-            .deleteFrom("team_reports_runs")
-            .where("started_at_ms", "<", cutoffMs)
-            .where("status", "!=", "running"),
-        ).numAffectedRows ?? 0n,
-      ),
-    }));
-  }
-
-  async close(): Promise<void> {
-    if (this.closed) {
-      return;
-    }
+  close(): Promise<void> {
     this.closed = true;
-    try {
-      this.maintenance.close();
-    } finally {
-      this.db.close();
-    }
+    return this.worker.close();
   }
 }
 
-export async function createTeamReportsStore(
-  options: { stateDir?: string; dbPath?: string } = {},
-): Promise<TeamReportsStore> {
-  const dbPath =
+export async function createTeamReportsStore(options: {
+  workerModuleUrl: URL;
+  stateDir?: string;
+  dbPath?: string;
+}): Promise<TeamReportsStore> {
+  const databasePath =
     options.dbPath ??
     path.join(
       options.stateDir ?? resolveStateDir(),
@@ -475,50 +83,10 @@ export async function createTeamReportsStore(
       "team-reports",
       "team-reports.sqlite",
     );
-  fs.mkdirSync(path.dirname(dbPath), { recursive: true, mode: 0o700 });
-  fs.chmodSync(path.dirname(dbPath), 0o700);
-  if (!fs.existsSync(dbPath)) {
-    fs.closeSync(fs.openSync(dbPath, "a", 0o600));
-  }
-  const db = openNodeSqliteDatabase(dbPath);
-  let maintenance: ReturnType<typeof configureSqliteConnectionPragmas> | undefined;
-  try {
-    maintenance = configureSqliteConnectionPragmas(db, {
-      busyTimeoutMs: 5000,
-      checkpointIntervalMs: 0,
-      databaseLabel: "team-reports database",
-      databasePath: dbPath,
-      foreignKeys: true,
-      synchronous: "NORMAL",
-    });
-    db.exec(TEAM_REPORTS_SCHEMA_SQL);
-    const query = getNodeSqliteKysely<ReportsDatabase>(db);
-    const migration = executeSqliteQueryTakeFirstSync(
-      db,
-      query.selectFrom("team_reports_schema_migrations").select("id").where("id", "=", "schema-1"),
-    );
-    if (!migration) {
-      migrateSqliteSchemaToStrict(db, TEAM_REPORTS_SCHEMA_SQL, {
-        databaseLabel: "team-reports database",
-      });
-      executeSqliteQuerySync(
-        db,
-        query
-          .insertInto("team_reports_schema_migrations")
-          .values({ id: "schema-1", applied_at: Date.now() })
-          .onConflict((conflict) => conflict.column("id").doNothing()),
-      );
-    }
-    for (const file of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`, `${dbPath}-journal`]) {
-      chmodIfExists(file);
-    }
-    return new TeamReportsStore(db, maintenance);
-  } catch (error) {
-    try {
-      maintenance?.close();
-    } finally {
-      db.close();
-    }
-    throw error;
-  }
+  const worker = await openSqliteWorkerStore<TeamReportsOperations>({
+    moduleUrl: options.workerModuleUrl,
+    databasePath,
+    input: undefined,
+  });
+  return new TeamReportsStore(worker);
 }

--- a/extensions/team-reports/src/store.worker.ts
+++ b/extensions/team-reports/src/store.worker.ts
@@ -1,0 +1,485 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  configureSqliteConnectionPragmas,
+  migrateSqliteSchemaToStrict,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  enableNodeSqliteKyselyStatementCache,
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+  openNodeSqliteDatabase,
+  runSqliteImmediateTransactionSync,
+  type SqliteWorkerCommand,
+} from "openclaw/plugin-sdk/sqlite-runtime";
+import { MAX_REPORT_BYTES } from "./limits.js";
+import { DAY_MS } from "./periods.js";
+import type {
+  PeriodListEntry,
+  PersonDay,
+  ReportRun,
+  RunPeriod,
+  StoredPeriod,
+  TeamReportsOperations,
+} from "./store-contract.js";
+import {
+  reportDocumentSchema,
+  runPeriodsSchema,
+  runStatsSchema,
+  summaryDocumentSchema,
+  TEAM_REPORTS_SCHEMA_SQL,
+} from "./store-schema.js";
+import type { Period, ReportDocument, SummaryDocument } from "./types.js";
+
+type PeriodRow = {
+  period: Period;
+  period_key: string;
+  since_ms: number;
+  until_ms: number;
+  status: "partial" | "closed";
+  generated_at_ms: number;
+  data_json: string;
+  summary_json: string | null;
+  markdown: string;
+};
+type PersonDayRow = {
+  day_key: string;
+  login: string;
+  github_total: number;
+  commits: number;
+  prs_opened: number;
+  prs_merged: number;
+  prs_closed: number;
+  issues_opened: number;
+  issues_closed: number;
+  issue_comments: number;
+  review_comments: number;
+  discord_messages: number;
+};
+type RunRow = {
+  id: string;
+  kind: ReportRun["kind"];
+  started_at_ms: number;
+  finished_at_ms: number | null;
+  status: ReportRun["status"];
+  periods_json: string;
+  stats_json: string | null;
+  error: string | null;
+};
+type ReportsDatabase = {
+  team_reports_schema_migrations: { id: string; applied_at: number };
+  team_reports_periods: PeriodRow;
+  team_reports_person_days: PersonDayRow;
+  team_reports_runs: RunRow;
+};
+
+function readPeriod(row: PeriodRow): StoredPeriod {
+  return {
+    report: reportDocumentSchema.parse(JSON.parse(row.data_json)),
+    summary:
+      row.summary_json === null ? null : summaryDocumentSchema.parse(JSON.parse(row.summary_json)),
+    markdown: row.markdown,
+  };
+}
+
+function chmodIfExists(file: string): void {
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+}
+
+class TeamReportsDatabase {
+  private readonly query;
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly maintenance: ReturnType<typeof configureSqliteConnectionPragmas>,
+  ) {
+    this.query = getNodeSqliteKysely<ReportsDatabase>(db);
+  }
+
+  upsertPeriod(value: Omit<StoredPeriod, "summary"> & { summary?: SummaryDocument | null }): void {
+    const { report } = value;
+    const dataJson = JSON.stringify(report);
+    if (Buffer.byteLength(dataJson, "utf8") > MAX_REPORT_BYTES) {
+      throw new Error("Team Reports document exceeds the 2 MiB storage limit.");
+    }
+    const row: PeriodRow = {
+      period: report.period.period,
+      period_key: report.period.key,
+      since_ms: report.period.sinceMs,
+      until_ms: report.period.untilMs,
+      status: report.status,
+      generated_at_ms: report.generatedAtMs,
+      data_json: dataJson,
+      summary_json: value.summary ? JSON.stringify(value.summary) : null,
+      markdown: value.markdown,
+    };
+    const people: PersonDayRow[] = report.members.map((member) => ({
+      day_key: report.period.key,
+      login: member.login.toLowerCase(),
+      github_total: member.github.total,
+      commits: member.github.commits,
+      prs_opened: member.github.prsOpened,
+      prs_merged: member.github.prsMerged,
+      prs_closed: member.github.prsClosed,
+      issues_opened: member.github.issuesOpened,
+      issues_closed: member.github.issuesClosed,
+      issue_comments: member.github.issueComments,
+      review_comments: member.github.reviewComments,
+      discord_messages: member.discord.total,
+    }));
+    runSqliteImmediateTransactionSync(this.db, () => {
+      executeSqliteQuerySync(
+        this.db,
+        this.query
+          .insertInto("team_reports_periods")
+          .values(row)
+          .onConflict((conflict) => conflict.columns(["period", "period_key"]).doUpdateSet(row)),
+      );
+      if (report.period.period === "day") {
+        // Replacing the whole day also removes people excluded by a refreshed roster.
+        executeSqliteQuerySync(
+          this.db,
+          this.query
+            .deleteFrom("team_reports_person_days")
+            .where("day_key", "=", report.period.key),
+        );
+        for (const person of people) {
+          executeSqliteQuerySync(
+            this.db,
+            this.query.insertInto("team_reports_person_days").values(person),
+          );
+        }
+      }
+    });
+  }
+
+  getPeriod(period: Period, key: string): StoredPeriod | undefined {
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.query
+        .selectFrom("team_reports_periods")
+        .selectAll()
+        .where("period", "=", period)
+        .where("period_key", "=", key),
+    );
+    return row ? readPeriod(row) : undefined;
+  }
+
+  listPeriods(
+    options: {
+      period?: Period;
+      status?: "partial" | "closed";
+      limit?: number;
+    } = {},
+  ): PeriodListEntry[] {
+    let query = this.query
+      .selectFrom("team_reports_periods")
+      .select([
+        "period",
+        "period_key as key",
+        "since_ms as sinceMs",
+        "until_ms as untilMs",
+        "status",
+        "generated_at_ms as generatedAtMs",
+      ])
+      // SQLite extracts only the chart totals instead of materializing every report in JavaScript.
+      .select((eb) => [
+        eb.fn<number>("json_extract", ["data_json", eb.val("$.activeMembers")]).as("activeMembers"),
+        eb.fn<number>("json_extract", ["data_json", eb.val("$.memberCount")]).as("memberCount"),
+        eb
+          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.total")])
+          .as("githubTotal"),
+        eb
+          .fn<number>("json_extract", ["data_json", eb.val("$.totals.discord.messages")])
+          .as("discordMessages"),
+        eb
+          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.commits")])
+          .as("commits"),
+        eb
+          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.prsOpened")])
+          .as("prsOpened"),
+        eb
+          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.prsMerged")])
+          .as("prsMerged"),
+        eb
+          .fn<number>("json_extract", ["data_json", eb.val("$.totals.github.securityAdvisories")])
+          .as("securityAdvisories"),
+      ])
+      .orderBy("since_ms", "desc")
+      .orderBy("period", "asc");
+    if (options.period) {
+      query = query.where("period", "=", options.period);
+    }
+    if (options.status) {
+      query = query.where("status", "=", options.status);
+    }
+    return executeSqliteQuerySync(this.db, query.limit(options.limit ?? 180)).rows;
+  }
+
+  getDayReports(sinceMs: number, untilMs: number): ReportDocument[] {
+    return executeSqliteQuerySync(
+      this.db,
+      this.query
+        .selectFrom("team_reports_periods")
+        .select("data_json")
+        .where("period", "=", "day")
+        .where("since_ms", ">=", sinceMs)
+        .where("since_ms", "<", untilMs)
+        .orderBy("since_ms", "asc"),
+    ).rows.map((row) => reportDocumentSchema.parse(JSON.parse(row.data_json)));
+  }
+
+  listPersonDays(
+    login: string,
+    options: { since?: string; until?: string; limit?: number } = {},
+  ): PersonDay[] {
+    let query = this.selectPersonDays()
+      .where("login", "=", login.toLowerCase())
+      .orderBy("day_key", "desc");
+    if (options.since) {
+      query = query.where("day_key", ">=", options.since);
+    }
+    if (options.until) {
+      query = query.where("day_key", "<", options.until);
+    }
+    return executeSqliteQuerySync(this.db, query.limit(options.limit ?? 28)).rows;
+  }
+
+  listPersonDaysSince(since: string): PersonDay[] {
+    return executeSqliteQuerySync(
+      this.db,
+      this.selectPersonDays()
+        .where("day_key", ">=", since)
+        .orderBy("day_key", "desc")
+        .orderBy("login", "asc"),
+    ).rows;
+  }
+
+  private selectPersonDays() {
+    return this.query
+      .selectFrom("team_reports_person_days")
+      .select([
+        "day_key as dayKey",
+        "login",
+        "github_total as githubTotal",
+        "commits",
+        "prs_opened as prsOpened",
+        "prs_merged as prsMerged",
+        "prs_closed as prsClosed",
+        "issues_opened as issuesOpened",
+        "issues_closed as issuesClosed",
+        "issue_comments as issueComments",
+        "review_comments as reviewComments",
+        "discord_messages as discordMessages",
+      ]);
+  }
+
+  startRun(run: {
+    id: string;
+    kind: ReportRun["kind"];
+    startedAtMs: number;
+    periods: RunPeriod[];
+  }): void {
+    executeSqliteQuerySync(
+      this.db,
+      this.query.insertInto("team_reports_runs").values({
+        id: run.id,
+        kind: run.kind,
+        started_at_ms: run.startedAtMs,
+        finished_at_ms: null,
+        status: "running",
+        periods_json: JSON.stringify(run.periods),
+        stats_json: null,
+        error: null,
+      }),
+    );
+  }
+
+  finishRun(
+    id: string,
+    result: {
+      finishedAtMs: number;
+      status: "ok" | "error";
+      stats?: Record<string, unknown>;
+      error?: string;
+    },
+  ): void {
+    const updated = executeSqliteQuerySync(
+      this.db,
+      this.query
+        .updateTable("team_reports_runs")
+        .set({
+          finished_at_ms: result.finishedAtMs,
+          status: result.status,
+          stats_json: result.stats ? JSON.stringify(result.stats) : null,
+          error: result.error?.slice(0, 2000) ?? null,
+        })
+        .where("id", "=", id)
+        .where("status", "=", "running"),
+    );
+    if (updated.numAffectedRows !== 1n) {
+      throw new Error(`Team Reports run ${id} is not running.`);
+    }
+  }
+
+  listRuns(
+    limit = 20,
+    filter: { kind?: ReportRun["kind"]; status?: ReportRun["status"] } = {},
+  ): ReportRun[] {
+    let query = this.query.selectFrom("team_reports_runs").selectAll();
+    if (filter.kind) {
+      query = query.where("kind", "=", filter.kind);
+    }
+    if (filter.status) {
+      query = query.where("status", "=", filter.status);
+    }
+    return executeSqliteQuerySync(
+      this.db,
+      query.orderBy("started_at_ms", "desc").orderBy("id", "asc").limit(limit),
+    ).rows.map((row) => ({
+      id: row.id,
+      kind: row.kind,
+      startedAtMs: row.started_at_ms,
+      finishedAtMs: row.finished_at_ms,
+      status: row.status,
+      periods: runPeriodsSchema.parse(JSON.parse(row.periods_json)),
+      stats: row.stats_json === null ? null : runStatsSchema.parse(JSON.parse(row.stats_json)),
+      error: row.error,
+    }));
+  }
+
+  prune(
+    retentionDays: number,
+    nowMs = Date.now(),
+  ): { periods: number; personDays: number; runs: number } {
+    if (!Number.isSafeInteger(retentionDays) || retentionDays < 0) {
+      throw new Error("Team Reports retention days must be a nonnegative integer.");
+    }
+    if (retentionDays === 0) {
+      return { periods: 0, personDays: 0, runs: 0 };
+    }
+    const cutoffMs = Math.floor(nowMs / DAY_MS) * DAY_MS - retentionDays * DAY_MS;
+    const cutoffDay = new Date(cutoffMs).toISOString().slice(0, 10);
+    return runSqliteImmediateTransactionSync(this.db, () => ({
+      // Preserve week/month reports that overlap the retained window.
+      periods: Number(
+        executeSqliteQuerySync(
+          this.db,
+          this.query.deleteFrom("team_reports_periods").where("until_ms", "<=", cutoffMs),
+        ).numAffectedRows ?? 0n,
+      ),
+      personDays: Number(
+        executeSqliteQuerySync(
+          this.db,
+          this.query.deleteFrom("team_reports_person_days").where("day_key", "<", cutoffDay),
+        ).numAffectedRows ?? 0n,
+      ),
+      runs: Number(
+        executeSqliteQuerySync(
+          this.db,
+          this.query
+            .deleteFrom("team_reports_runs")
+            .where("started_at_ms", "<", cutoffMs)
+            .where("status", "!=", "running"),
+        ).numAffectedRows ?? 0n,
+      ),
+    }));
+  }
+
+  close(): void {
+    try {
+      this.maintenance.close();
+    } finally {
+      this.db.close();
+    }
+  }
+}
+
+function openTeamReportsDatabase(dbPath: string): TeamReportsDatabase {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true, mode: 0o700 });
+  fs.chmodSync(path.dirname(dbPath), 0o700);
+  if (!fs.existsSync(dbPath)) {
+    fs.closeSync(fs.openSync(dbPath, "a", 0o600));
+  }
+  const db = openNodeSqliteDatabase(dbPath);
+  let maintenance: ReturnType<typeof configureSqliteConnectionPragmas> | undefined;
+  try {
+    enableNodeSqliteKyselyStatementCache(db);
+    maintenance = configureSqliteConnectionPragmas(db, {
+      busyTimeoutMs: 5000,
+      checkpointIntervalMs: 0,
+      databaseLabel: "team-reports database",
+      databasePath: dbPath,
+      foreignKeys: true,
+      synchronous: "NORMAL",
+    });
+    db.exec(TEAM_REPORTS_SCHEMA_SQL);
+    const query = getNodeSqliteKysely<ReportsDatabase>(db);
+    const migration = executeSqliteQueryTakeFirstSync(
+      db,
+      query.selectFrom("team_reports_schema_migrations").select("id").where("id", "=", "schema-1"),
+    );
+    if (!migration) {
+      migrateSqliteSchemaToStrict(db, TEAM_REPORTS_SCHEMA_SQL, {
+        databaseLabel: "team-reports database",
+      });
+      executeSqliteQuerySync(
+        db,
+        query
+          .insertInto("team_reports_schema_migrations")
+          .values({ id: "schema-1", applied_at: Date.now() })
+          .onConflict((conflict) => conflict.column("id").doNothing()),
+      );
+    }
+    for (const file of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`, `${dbPath}-journal`]) {
+      chmodIfExists(file);
+    }
+    return new TeamReportsDatabase(db, maintenance);
+  } catch (error) {
+    try {
+      maintenance?.close();
+    } finally {
+      db.close();
+    }
+    throw error;
+  }
+}
+
+export function createSqliteWorkerBackend(_input: undefined, context: { databasePath: string }) {
+  const database = openTeamReportsDatabase(context.databasePath);
+  return {
+    execute(command: SqliteWorkerCommand<TeamReportsOperations>) {
+      switch (command.type) {
+        case "upsertPeriod":
+          return database.upsertPeriod(command.input);
+        case "getPeriod":
+          return database.getPeriod(command.input.period, command.input.key);
+        case "listPeriods":
+          return database.listPeriods(command.input);
+        case "getDayReports":
+          return database.getDayReports(command.input.sinceMs, command.input.untilMs);
+        case "listPersonDays":
+          return database.listPersonDays(command.input.login, command.input.options);
+        case "listPersonDaysSince":
+          return database.listPersonDaysSince(command.input);
+        case "startRun":
+          return database.startRun(command.input);
+        case "finishRun":
+          return database.finishRun(command.input.id, command.input.result);
+        case "listRuns":
+          return database.listRuns(command.input.limit, command.input.filter);
+        case "prune":
+          return database.prune(command.input.retentionDays, command.input.nowMs);
+      }
+    },
+    close: () => database.close(),
+  };
+}

--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -22,6 +22,7 @@ import {
   isProviderOpenAiExtensionRoot,
 } from "../../test/vitest/vitest.extension-provider-paths.mjs";
 import { isQaExtensionRoot } from "../../test/vitest/vitest.extension-qa-paths.mjs";
+import { isTeamReportsExtensionRoot } from "../../test/vitest/vitest.extension-team-reports-paths.mjs";
 import { isTelegramExtensionRoot } from "../../test/vitest/vitest.extension-telegram-paths.mjs";
 import { isVoiceCallExtensionRoot } from "../../test/vitest/vitest.extension-voice-call-paths.mjs";
 import { isWhatsAppExtensionRoot } from "../../test/vitest/vitest.extension-whatsapp-paths.mjs";
@@ -145,6 +146,7 @@ const EXTENSION_TEST_CONFIG_ROUTES: Array<[(root: string) => boolean, string]> =
   [isMiscExtensionRoot, "test/vitest/vitest.extension-misc.config.ts"],
   [isMsTeamsExtensionRoot, "test/vitest/vitest.extension-msteams.config.ts"],
   [isQaExtensionRoot, "test/vitest/vitest.extension-qa.config.ts"],
+  [isTeamReportsExtensionRoot, "test/vitest/vitest.extension-team-reports.config.ts"],
   [isTelegramExtensionRoot, "test/vitest/vitest.extension-telegram.config.ts"],
   [isVoiceCallExtensionRoot, "test/vitest/vitest.extension-voice-call.config.ts"],
   [isWhatsAppExtensionRoot, "test/vitest/vitest.extension-whatsapp.config.ts"],

--- a/scripts/pr-lib/wrapper-components.txt
+++ b/scripts/pr-lib/wrapper-components.txt
@@ -62,6 +62,7 @@ test/vitest/vitest.extension-misc-paths.mjs
 test/vitest/vitest.extension-msteams-paths.mjs
 test/vitest/vitest.extension-provider-paths.mjs
 test/vitest/vitest.extension-qa-paths.mjs
+test/vitest/vitest.extension-team-reports-paths.mjs
 test/vitest/vitest.extension-telegram-paths.mjs
 test/vitest/vitest.extension-voice-call-paths.mjs
 test/vitest/vitest.extension-whatsapp-paths.mjs

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -249,6 +249,7 @@ const EXTENSION_PROVIDERS_VITEST_CONFIG = "test/vitest/vitest.extension-provider
 const EXTENSION_QA_VITEST_CONFIG = "test/vitest/vitest.extension-qa.config.ts";
 const EXTENSION_SIGNAL_VITEST_CONFIG = "test/vitest/vitest.extension-signal.config.ts";
 const EXTENSION_SLACK_VITEST_CONFIG = "test/vitest/vitest.extension-slack.config.ts";
+const EXTENSION_TEAM_REPORTS_VITEST_CONFIG = "test/vitest/vitest.extension-team-reports.config.ts";
 const EXTENSION_TELEGRAM_VITEST_CONFIG = "test/vitest/vitest.extension-telegram.config.ts";
 const EXTENSION_VOICE_CALL_VITEST_CONFIG = "test/vitest/vitest.extension-voice-call.config.ts";
 const EXTENSION_WHATSAPP_VITEST_CONFIG = "test/vitest/vitest.extension-whatsapp.config.ts";
@@ -538,6 +539,7 @@ const VITEST_CONFIG_BY_KIND: Record<string, string> = {
   extensionIrc: EXTENSION_IRC_VITEST_CONFIG,
   extensionLine: EXTENSION_LINE_VITEST_CONFIG,
   extensionMattermost: EXTENSION_MATTERMOST_VITEST_CONFIG,
+  extensionTeamReports: EXTENSION_TEAM_REPORTS_VITEST_CONFIG,
   extensionTelegram: EXTENSION_TELEGRAM_VITEST_CONFIG,
   extensionVoiceCall: EXTENSION_VOICE_CALL_VITEST_CONFIG,
   extensionWhatsApp: EXTENSION_WHATSAPP_VITEST_CONFIG,

--- a/src/infra/runtime-process-entrypoints.ts
+++ b/src/infra/runtime-process-entrypoints.ts
@@ -4,6 +4,11 @@ const currentModuleUrl = import.meta.url;
 export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
 
 export const runtimeProcessEntrypoints = {
+  sqliteStore: {
+    currentModuleUrl,
+    sourceWorkerName: "sqlite-store.worker",
+    distWorkerPath: "infra/sqlite-store.worker.js",
+  },
   stateMigrationSnapshot: {
     currentModuleUrl,
     sourceWorkerName: "state-migrations.snapshot.worker",

--- a/src/infra/sqlite-store.worker.ts
+++ b/src/infra/sqlite-store.worker.ts
@@ -1,0 +1,98 @@
+import { isPromise } from "node:util/types";
+import { deserialize, serialize } from "node:v8";
+import { parentPort } from "node:worker_threads";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  SQLITE_WORKER_MAX_RESULT_BYTES,
+  type SqliteWorkerBackend,
+  type SqliteWorkerOperations,
+  type SqliteWorkerReply,
+  type SqliteWorkerRequest,
+} from "./sqlite-worker-contract.js";
+
+const port = parentPort;
+if (!port) {
+  throw new Error("SQLite store worker requires its host port");
+}
+const actors = new Map<number, SqliteWorkerBackend<SqliteWorkerOperations>>();
+let sourceLoaderRegistered = false;
+
+async function receive(request: SqliteWorkerRequest): Promise<void> {
+  let reply: SqliteWorkerReply;
+  let executed = false;
+  let retire = false;
+  try {
+    let value: unknown;
+    if (request.type === "open") {
+      if (actors.has(request.actor)) {
+        throw new Error("SQLite worker actor is already open");
+      }
+      if (!sourceLoaderRegistered && request.sourceLoaderUrl) {
+        const loader: unknown = await import(request.sourceLoaderUrl);
+        if (!isRecord(loader) || typeof loader.register !== "function") {
+          throw new Error("SQLite source worker loader is unavailable");
+        }
+        loader.register();
+        sourceLoaderRegistered = true;
+      }
+      const module: unknown = await import(request.moduleUrl);
+      if (!isRecord(module) || typeof module.createSqliteWorkerBackend !== "function") {
+        throw new Error("SQLite worker module must export createSqliteWorkerBackend");
+      }
+      const backend: unknown = await module.createSqliteWorkerBackend(deserialize(request.input), {
+        databasePath: request.databasePath,
+      });
+      if (
+        !isRecord(backend) ||
+        typeof backend.execute !== "function" ||
+        typeof backend.close !== "function"
+      ) {
+        throw new Error("SQLite worker module returned an invalid backend");
+      }
+      // SAFETY: The validated backend and its typed client own the private command contract.
+      actors.set(request.actor, backend as SqliteWorkerBackend<SqliteWorkerOperations>);
+    } else {
+      const backend = actors.get(request.actor);
+      if (!backend) {
+        throw new Error("SQLite worker actor is closed");
+      }
+      if (request.type === "close") {
+        await backend.close();
+        actors.delete(request.actor);
+      } else {
+        value = backend.execute(deserialize(request.input));
+        executed = true;
+        if (isPromise(value) || (isRecord(value) && typeof value.then === "function")) {
+          retire = true;
+          if (isPromise(value)) {
+            // Retirement owns the failure; consume rejection while native exit is joined.
+            void value.catch(() => {});
+          }
+          throw new Error("SQLite worker operations must remain synchronous");
+        }
+      }
+    }
+    const serialized = serialize(value);
+    if (serialized.byteLength > SQLITE_WORKER_MAX_RESULT_BYTES) {
+      throw new Error("SQLite worker result exceeds the transport byte limit");
+    }
+    reply = { id: request.id, ok: true, value: serialized };
+  } catch (error) {
+    const failure = error instanceof Error ? error : new Error(String(error));
+    const code = executed ? "outcome-unknown" : "code" in failure ? failure.code : undefined;
+    reply = {
+      id: request.id,
+      ok: false,
+      ...(retire ? { retire: true } : {}),
+      error: {
+        name: executed ? "SqliteWorkerError" : failure.name,
+        message: failure.message,
+        ...(typeof code === "string" || typeof code === "number" ? { code } : {}),
+      },
+    };
+  }
+  port!.postMessage(reply, []);
+}
+
+// The broker sends one request at a time, including module initialization.
+port.on("message", (request: SqliteWorkerRequest) => void receive(request));

--- a/src/infra/sqlite-worker-contract.ts
+++ b/src/infra/sqlite-worker-contract.ts
@@ -1,0 +1,43 @@
+export type SqliteWorkerOperations = Record<string, { input: unknown; output: unknown }>;
+export type SqliteWorkerCommand<Operations extends SqliteWorkerOperations> = {
+  [Key in keyof Operations]: { type: Key; input: Operations[Key]["input"] };
+}[keyof Operations];
+
+export type SqliteWorkerBackend<Operations extends SqliteWorkerOperations> = {
+  execute(command: SqliteWorkerCommand<Operations>): Operations[keyof Operations]["output"];
+  close(): void | Promise<void>;
+};
+
+export type SqliteWorkerStore<Operations extends SqliteWorkerOperations> = {
+  execute<Key extends keyof Operations>(
+    command: { type: Key; input: Operations[Key]["input"] },
+    options?: { signal?: AbortSignal },
+  ): Promise<Operations[Key]["output"]>;
+  close(): Promise<void>;
+};
+
+export type SqliteWorkerRequest = {
+  id: number;
+  actor: number;
+} & (
+  | {
+      type: "open";
+      moduleUrl: string;
+      sourceLoaderUrl?: string;
+      databasePath: string;
+      input: Uint8Array;
+    }
+  | { type: "execute"; input: Uint8Array }
+  | { type: "close" }
+);
+
+export type SqliteWorkerReply = {
+  id: number;
+} & (
+  | { ok: true; value: Uint8Array }
+  | { ok: false; retire?: true; error: { name: string; message: string; code?: string | number } }
+);
+
+export const SQLITE_WORKER_MAX_MESSAGE_BYTES = 32 * 1024 * 1024;
+// Complete multi-record reads can exceed a single admitted write payload.
+export const SQLITE_WORKER_MAX_RESULT_BYTES = 64 * 1024 * 1024;

--- a/src/infra/sqlite-worker-store.test-support.ts
+++ b/src/infra/sqlite-worker-store.test-support.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, linkSync, renameSync, watch, writeFileSync } from "node:fs";
+import path from "node:path";
+import { parentPort, threadId } from "node:worker_threads";
+import type { Generated } from "kysely";
+import { clearNodeSqliteKyselyCacheForDatabase } from "./kysely-sync-cache-state.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
+import type { SqliteWorkerBackend } from "./sqlite-worker-contract.js";
+
+let pendingCloses = 0;
+if (parentPort) {
+  const postMessage = parentPort.postMessage.bind(parentPort);
+  parentPort.postMessage = (...args) => {
+    if (pendingCloses > 0) {
+      throw new Error("Fixture close acknowledgement preceded native cleanup");
+    }
+    Reflect.apply(postMessage, undefined, args);
+  };
+}
+
+export type FixtureOpenInput =
+  | { type: "link"; existingPath: string }
+  | { type: "replace"; backupPath: string };
+
+type Receipt = { actor: string; writes: number; threadId: number };
+export type FixtureOperations = {
+  append: { input: { value: string }; output: Receipt };
+  read: { input: undefined; output: string[] };
+  commitThenExit: { input: { value: string }; output: never };
+  commitUnserializable: { input: { value: string }; output: symbol };
+  failClose: { input: undefined; output: undefined };
+  delayClose: { input: { markerPath: string; reject: boolean }; output: undefined };
+  illegalAsync: {
+    input: { value: string; gatePath: string; reject: boolean };
+    output: Promise<Receipt>;
+  };
+};
+
+function waitForFile(file: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const watcher = watch(path.dirname(file), () => {
+      if (existsSync(file)) {
+        watcher.close();
+        resolve();
+      }
+    });
+    watcher.once("error", reject);
+    if (existsSync(file)) {
+      watcher.close();
+      resolve();
+    }
+  });
+}
+
+export function createSqliteWorkerBackend(
+  input: FixtureOpenInput | undefined,
+  { databasePath }: { databasePath: string },
+): SqliteWorkerBackend<FixtureOperations> {
+  if (input?.type === "link") {
+    linkSync(input.existingPath, databasePath);
+  } else if (input?.type === "replace") {
+    renameSync(databasePath, input.backupPath);
+  }
+  const db = openNodeSqliteDatabase(databasePath);
+  db.exec("CREATE TABLE IF NOT EXISTS entries (id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+  const query = getNodeSqliteKysely<{ entries: { id: Generated<number>; value: string } }>(db);
+  const actor = randomUUID();
+  let writes = 0;
+  let failClose = false;
+  let delayedClose: { markerPath: string; reject: boolean } | undefined;
+  function append(value: string): Receipt {
+    runSqliteImmediateTransactionSync(db, () => {
+      executeSqliteQuerySync(db, query.insertInto("entries").values({ value }));
+    });
+    writes += 1;
+    return { actor, writes, threadId };
+  }
+  function closeNative(): void {
+    clearNodeSqliteKyselyCacheForDatabase(db);
+    db.close();
+    if (failClose) {
+      throw new Error("Fixture native database closed with a cleanup failure");
+    }
+  }
+  return {
+    execute(command) {
+      if (command.type === "delayClose") {
+        delayedClose = command.input;
+        return undefined;
+      }
+      if (command.type === "illegalAsync") {
+        if (command.input.reject) {
+          return Promise.reject(new Error("Fixture async operation rejected"));
+        }
+        return waitForFile(command.input.gatePath).then(() => append(command.input.value));
+      }
+      if (command.type === "failClose") {
+        failClose = true;
+        return undefined;
+      }
+      if (command.type === "read") {
+        return executeSqliteQuerySync(
+          db,
+          query.selectFrom("entries").select("value").orderBy("id"),
+        ).rows.map((row) => row.value);
+      }
+      const receipt = append(command.input.value);
+      if (command.type === "commitThenExit") {
+        // Leave an outstanding native lock as well as a committed write when the worker exits.
+        db.exec("BEGIN IMMEDIATE");
+        process.exit(17);
+      }
+      if (command.type === "commitUnserializable") {
+        return Symbol("unserializable committed receipt");
+      }
+      return receipt;
+    },
+    close() {
+      if (delayedClose) {
+        const { markerPath, reject } = delayedClose;
+        pendingCloses += 1;
+        return (async () => {
+          try {
+            await Promise.resolve();
+            closeNative();
+            writeFileSync(markerPath, "native database closed");
+            if (reject) {
+              throw Object.assign(new Error("Fixture delayed cleanup rejected"), {
+                name: "FixtureCleanupError",
+                code: "FIXTURE_CLEANUP_FAILED",
+              });
+            }
+          } finally {
+            pendingCloses -= 1;
+          }
+        })();
+      }
+      return closeNative();
+    },
+  };
+}

--- a/src/infra/sqlite-worker-store.test.ts
+++ b/src/infra/sqlite-worker-store.test.ts
@@ -1,0 +1,614 @@
+import {
+  link,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
+import type { SqliteWorkerReply } from "./sqlite-worker-contract.js";
+import { openSqliteWorkerStore, type SqliteWorkerStore } from "./sqlite-worker-store.js";
+import type { FixtureOpenInput, FixtureOperations } from "./sqlite-worker-store.test-support.js";
+
+const stores = new Set<SqliteWorkerStore<FixtureOperations>>();
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    try {
+      await Promise.all([...stores].map((store) => store.close()));
+    } finally {
+      stores.clear();
+      cleanup();
+    }
+  }),
+);
+
+function databasePath(): string {
+  return path.join(tempDirs.make("openclaw-sqlite-worker-store-"), "store.sqlite");
+}
+
+async function open(file: string, input?: FixtureOpenInput) {
+  const store = await openSqliteWorkerStore<FixtureOperations>({
+    moduleUrl: new URL("./sqlite-worker-store.test-support.ts", import.meta.url),
+    databasePath: file,
+    input,
+  });
+  stores.add(store);
+  return store;
+}
+
+async function expectRejectedOpen(
+  file: string,
+  input?: FixtureOpenInput,
+  code?: string,
+): Promise<void> {
+  const [result] = await Promise.allSettled([open(file, input)]);
+  if (result.status === "fulfilled") {
+    await result.value.close();
+    stores.delete(result.value);
+  }
+  expect(result.status).toBe("rejected");
+  if (code) {
+    expect(result).toMatchObject({ reason: { code } });
+  }
+}
+
+function append(store: SqliteWorkerStore<FixtureOperations>, value: string) {
+  return store.execute({ type: "append", input: { value } });
+}
+
+function read(store: SqliteWorkerStore<FixtureOperations>) {
+  return store.execute({ type: "read", input: undefined });
+}
+
+describe("SQLite worker store", () => {
+  it.each(["memory", "absolute memory", "memory URI", "incognito", "empty"] as const)(
+    "rejects a %s locator before creating a file or dispatching a worker request",
+    async (kind) => {
+      const directory = tempDirs.make("openclaw-sqlite-worker-locator-");
+      const incognito = resolveIncognitoOpenClawAgentSqlitePath({
+        agentId: "fixture",
+        env: { OPENCLAW_STATE_DIR: directory },
+      });
+      await mkdir(path.dirname(incognito), { recursive: true });
+      const locators = {
+        memory: ":memory:",
+        "absolute memory": path.join(directory, ":memory:"),
+        "memory URI": "file:memory-test?mode=memory&cache=shared",
+        incognito,
+        empty: "",
+      };
+      const contents = (await readdir(directory, { recursive: true })).toSorted();
+      const originalCwd = process.cwd();
+      const originalTsconfigPath = process.env.TSX_TSCONFIG_PATH;
+      const requests = vi.spyOn(Worker.prototype, "postMessage");
+      try {
+        // An unfixed broker may resolve a memory locator into a real file; contain it in this test.
+        process.env.TSX_TSCONFIG_PATH = path.join(originalCwd, "tsconfig.json");
+        process.chdir(directory);
+        const [result] = await Promise.allSettled([open(locators[kind])]);
+        if (result.status === "fulfilled") {
+          await result.value.close();
+          stores.delete(result.value);
+        }
+        expect(result).toMatchObject({
+          status: "rejected",
+          reason: expect.objectContaining({
+            message: expect.stringMatching(/file-backed|memory|incognito/i),
+          }),
+        });
+        expect(requests).not.toHaveBeenCalled();
+        expect((await readdir(directory, { recursive: true })).toSorted()).toEqual(contents);
+      } finally {
+        process.chdir(originalCwd);
+        if (originalTsconfigPath === undefined) {
+          delete process.env.TSX_TSCONFIG_PATH;
+        } else {
+          process.env.TSX_TSCONFIG_PATH = originalTsconfigPath;
+        }
+        requests.mockRestore();
+      }
+    },
+  );
+
+  it("shares one native actor across physical file aliases", async () => {
+    const file = databasePath();
+    const first = await open(file);
+    const alias = path.join(path.dirname(file), "alias.sqlite");
+    await link(file, alias);
+    const second = await open(alias);
+
+    const firstReceipt = await append(first, "first");
+    const secondReceipt = await append(second, "second");
+    expect(firstReceipt.threadId).toBeGreaterThan(0);
+    expect(secondReceipt).toEqual({ ...firstReceipt, writes: 2 });
+    expect(await read(first)).toEqual(["first", "second"]);
+  });
+
+  describe.skipIf(process.platform === "win32")("replaced admitted aliases", () => {
+    it.each(["hardlink", "symlink"] as const)(
+      "holds a replaced %s alias until both alias clients drain and close",
+      async (kind) => {
+        const file = databasePath();
+        const aliasPath = path.join(path.dirname(file), "alias.sqlite");
+        const original = await open(file);
+        const originalReceipt = await append(original, "original data");
+        if (kind === "hardlink") {
+          await link(file, aliasPath);
+        } else {
+          await symlink(file, aliasPath);
+        }
+        const firstAlias = await open(aliasPath);
+        const secondAlias = await open(aliasPath);
+        await unlink(aliasPath);
+        if (kind === "hardlink") {
+          await writeFile(aliasPath, "");
+        } else {
+          const replacementTarget = path.join(path.dirname(file), "replacement.sqlite");
+          await writeFile(replacementTarget, "");
+          await symlink(replacementTarget, aliasPath);
+        }
+        await expectRejectedOpen(aliasPath);
+        await firstAlias.close();
+        await expectRejectedOpen(aliasPath);
+
+        const ahead = append(original, "ahead of alias write");
+        let drained = false;
+        const queued = append(secondAlias, "last alias write").then((receipt) => {
+          drained = true;
+          return receipt;
+        });
+        await secondAlias.close();
+        expect(drained).toBe(true);
+        await Promise.all([ahead, queued]);
+
+        const replacement = await open(aliasPath);
+        expect(await read(replacement)).toEqual([]);
+        const replacementReceipt = await append(replacement, "replacement data");
+        expect(replacementReceipt.actor).not.toBe(originalReceipt.actor);
+        expect(replacementReceipt.writes).toBe(1);
+        expect(await append(original, "original still usable")).toEqual({
+          ...originalReceipt,
+          writes: 4,
+        });
+        expect(await read(original)).toEqual([
+          "original data",
+          "ahead of alias write",
+          "last alias write",
+          "original still usable",
+        ]);
+        expect(await read(replacement)).toEqual(["replacement data"]);
+      },
+    );
+
+    it("pins the canonical target of the first symlink open until its native actor closes", async () => {
+      const canonicalPath = databasePath();
+      const aliasPath = path.join(path.dirname(canonicalPath), "first-open.sqlite");
+      const displacedPath = path.join(path.dirname(canonicalPath), "displaced.sqlite");
+      await writeFile(canonicalPath, "");
+      await symlink(canonicalPath, aliasPath);
+      const original = await open(aliasPath);
+      await append(original, "original data");
+      await rename(canonicalPath, displacedPath);
+      await writeFile(canonicalPath, "");
+      await expectRejectedOpen(canonicalPath);
+      await original.close();
+
+      const replacement = await open(canonicalPath);
+      expect(await read(replacement)).toEqual([]);
+      await expect(append(replacement, "replacement data")).resolves.toMatchObject({ writes: 1 });
+      expect(await read(await open(displacedPath))).toEqual(["original data"]);
+    });
+  });
+
+  it("rejects a factory-created physical collision without replacing the existing owner", async () => {
+    const file = databasePath();
+    const first = await open(file);
+    const receipt = await append(first, "original");
+    const alias = path.join(path.dirname(file), "created-during-open.sqlite");
+    await expectRejectedOpen(alias, { type: "link", existingPath: file });
+
+    expect(await append(first, "still owned")).toEqual({ ...receipt, writes: 2 });
+    const shared = await open(alias);
+    expect(await append(shared, "alias after refusal")).toEqual({ ...receipt, writes: 3 });
+    expect(await read(first)).toEqual(["original", "still owned", "alias after refusal"]);
+  });
+
+  it("rejects an existing file whose identity changes inside the backend factory", async () => {
+    const file = databasePath();
+    const backupPath = path.join(path.dirname(file), "before-replacement.sqlite");
+    const seeded = await open(file);
+    await append(seeded, "original data");
+    await seeded.close();
+    await expectRejectedOpen(file, { type: "replace", backupPath });
+
+    expect(await read(await open(backupPath))).toEqual(["original data"]);
+    const replacement = await open(file);
+    expect(await read(replacement)).toEqual([]);
+    await expect(append(replacement, "explicit recovery")).resolves.toMatchObject({ writes: 1 });
+  });
+
+  // Windows prevents replacing SQLite's open database file at this boundary.
+  it.skipIf(process.platform === "win32")(
+    "refuses a replaced active pathname until its original client closes",
+    async () => {
+      const file = databasePath();
+      const displacedPath = path.join(path.dirname(file), "displaced.sqlite");
+      const original = await open(file);
+      await append(original, "original data");
+      await rename(file, displacedPath);
+      await writeFile(file, "");
+      await expectRejectedOpen(file);
+      await original.close();
+
+      const replacement = await open(file);
+      expect(await read(replacement)).toEqual([]);
+      await expect(append(replacement, "replacement data")).resolves.toMatchObject({ writes: 1 });
+      expect(await read(await open(displacedPath))).toEqual(["original data"]);
+    },
+  );
+
+  it("drains a closing client's writes and preserves the remaining client's connection", async () => {
+    const file = databasePath();
+    const first = await open(file);
+    const second = await open(file);
+    let committedSettled = false;
+    const committed = append(first, "before close").then((receipt) => {
+      committedSettled = true;
+      return receipt;
+    });
+    const closed = first.close();
+    await expect(append(first, "after close")).rejects.toMatchObject({ code: "closed" });
+    await closed;
+    expect(committedSettled).toBe(true);
+
+    const receipt = await committed;
+    expect(await append(second, "still open")).toEqual({ ...receipt, writes: 2 });
+    await second.close();
+    expect(await read(await open(file))).toEqual(["before close", "still open"]);
+  });
+
+  it("keeps a newly admitted database usable while another worker retires at capacity", async () => {
+    const first = await open(databasePath());
+    // Fill the documented four-worker budget before retiring an otherwise idle worker.
+    for (let index = 0; index < 3; index += 1) {
+      await open(databasePath());
+    }
+    const retiring = createDeferredCore();
+    const release = createDeferredCore();
+    const spy = vi
+      .spyOn(Worker.prototype, "terminate")
+      .mockImplementationOnce(async function (this: Worker) {
+        retiring.resolve();
+        await release.promise;
+        spy.mockRestore();
+        return this.terminate();
+      });
+    const closed = first.close();
+    let replacement: SqliteWorkerStore<FixtureOperations> | undefined;
+    try {
+      await retiring.promise;
+      replacement = await open(databasePath());
+      release.resolve();
+      await closed;
+      await expect(append(replacement, "survives retirement")).resolves.toMatchObject({
+        writes: 1,
+      });
+      expect(await read(replacement)).toEqual(["survives retirement"]);
+    } finally {
+      release.resolve();
+      spy.mockRestore();
+      await closed;
+      if (replacement) {
+        // The regressed broker loses this actor too; join its cleanup without masking the assertion.
+        await Promise.allSettled([replacement.close()]);
+        stores.delete(replacement);
+      }
+    }
+  });
+
+  it("snapshots command input before a queued caller can mutate it", async () => {
+    const store = await open(databasePath());
+    const first = append(store, "first");
+    const command = { type: "append" as const, input: { value: "admitted" } };
+    const queued = store.execute(command);
+    command.input.value = "mutated";
+    await Promise.all([first, queued]);
+    expect(await read(store)).toEqual(["first", "admitted"]);
+  });
+
+  it("cancels queued work but retains a dispatched write until its outcome is known", async () => {
+    const store = await open(databasePath());
+    const dispatched = new AbortController();
+    const queued = new AbortController();
+    const committed = store.execute(
+      { type: "append", input: { value: "dispatched" } },
+      { signal: dispatched.signal },
+    );
+    const canceled = store.execute(
+      { type: "append", input: { value: "queued" } },
+      { signal: queued.signal },
+    );
+    const reason = new Error("owner retired");
+    dispatched.abort(reason);
+    queued.abort(reason);
+    await expect(canceled).rejects.toBe(reason);
+    await expect(committed).resolves.toMatchObject({ writes: 1 });
+    expect(await read(store)).toEqual(["dispatched"]);
+  });
+
+  it("bounds reserved and live clients sharing one actor until close or failed admission drains", async () => {
+    const file = databasePath();
+    const retiring = await open(file);
+    const survivor = await open(file);
+    for (let index = 2; index < 64; index += 1) {
+      await open(file);
+    }
+    await expectRejectedOpen(file, undefined, "overloaded");
+
+    const replyReady = createDeferredCore();
+    let publish: (() => void) | undefined;
+    const messages = vi.spyOn(Worker.prototype, "emit").mockImplementationOnce(function (
+      this: Worker,
+      event: string | symbol,
+      reply: SqliteWorkerReply,
+    ) {
+      messages.mockRestore();
+      publish = () => this.emit(event, reply);
+      replyReady.resolve();
+      return true;
+    });
+    const write = append(retiring, "write before close");
+    const closed = retiring.close();
+    try {
+      await replyReady.promise;
+      await expectRejectedOpen(file, undefined, "overloaded");
+      publish?.();
+      publish = undefined;
+      await closed;
+      await write;
+    } finally {
+      messages.mockRestore();
+      publish?.();
+      await Promise.allSettled([write, closed]);
+    }
+    expect(await read(survivor)).toEqual(["write before close"]);
+
+    const missing = path.join(path.dirname(file), "missing.sqlite");
+    const failed = open(missing, {
+      type: "replace",
+      backupPath: path.join(path.dirname(file), "unused-backup.sqlite"),
+    });
+    // The failing factory owns the last reservation before its asynchronous admission settles.
+    const overflow = expectRejectedOpen(file, undefined, "overloaded");
+    await Promise.all([expect(failed).rejects.toThrow(), overflow]);
+    const recovered = await open(file);
+    expect(await append(recovered, "after failed admission")).toMatchObject({ writes: 2 });
+    await expectRejectedOpen(file, undefined, "overloaded");
+    expect(await read(survivor)).toEqual(["write before close", "after failed admission"]);
+  });
+
+  it("rejects an overloaded actor admission without retiring healthy shared workers or writes", async () => {
+    const active: SqliteWorkerStore<FixtureOperations>[] = [];
+    for (let index = 0; index < 4; index += 1) {
+      active.push(await open(databasePath()));
+    }
+    const repliesReady = createDeferredCore();
+    const replies: (() => void)[] = [];
+    const messages = vi.spyOn(Worker.prototype, "emit").mockImplementation(function (
+      this: Worker,
+      event: string | symbol,
+      reply: SqliteWorkerReply,
+    ) {
+      replies.push(() => this.emit(event, reply));
+      if (replies.length === active.length) {
+        messages.mockRestore();
+        repliesReady.resolve();
+      }
+      return true;
+    });
+    function releaseReplies(): void {
+      messages.mockRestore();
+      for (const publish of replies.splice(0)) {
+        publish();
+      }
+    }
+    const writes: ReturnType<typeof append>[] = [];
+    for (let round = 0; round < 32; round += 1) {
+      for (const [index, store] of active.entries()) {
+        writes.push(append(store, `${index}:${round}`));
+      }
+    }
+    const outcomes = Promise.allSettled(writes);
+    try {
+      await repliesReady.promise;
+      const pendingFile = databasePath();
+      await expectRejectedOpen(pendingFile, undefined, "overloaded");
+      releaseReplies();
+      const results = await outcomes;
+      expect(results.find((result) => result.status === "rejected")).toBeUndefined();
+      for (const [index, store] of active.entries()) {
+        expect(await read(store)).toEqual(
+          Array.from({ length: 32 }, (_, round) => `${index}:${round}`),
+        );
+      }
+      const admitted = await open(pendingFile);
+      await expect(append(admitted, "after queue drainage")).resolves.toMatchObject({ writes: 1 });
+      expect(await read(admitted)).toEqual(["after queue drainage"]);
+    } finally {
+      releaseReplies();
+      await outcomes;
+      // A regressed admission can lose a shared worker; preserve the write failure as the assertion.
+      await Promise.allSettled(active.map((store) => store.close()));
+      for (const store of active) {
+        stores.delete(store);
+      }
+    }
+  });
+
+  it("bounds outstanding requests and accepts work again after the queue drains", async () => {
+    const store = await open(databasePath());
+    // The burst is admitted in one main-thread turn, before worker replies can drain it.
+    const accepted = Array.from({ length: 128 }, (_, index) => append(store, String(index)));
+    await expect(append(store, "overflow")).rejects.toMatchObject({ code: "overloaded" });
+    await Promise.all(accepted);
+    expect(await append(store, "after drain")).toMatchObject({ writes: 129 });
+    expect(await read(store)).toEqual([
+      ...Array.from({ length: 128 }, (_, i) => String(i)),
+      "after drain",
+    ]);
+  });
+
+  it("surfaces native-close cleanup failure and permits explicit recovery of committed data", async () => {
+    const file = databasePath();
+    const store = await open(file);
+    const receipt = await append(store, "preserved");
+    await store.execute({ type: "failClose", input: undefined });
+    const closed = store.close();
+    stores.delete(store);
+    await expect(closed).rejects.toThrow("Fixture native database closed with a cleanup failure");
+
+    const recovered = await open(file);
+    expect(await read(recovered)).toEqual(["preserved"]);
+    const recoveredReceipt = await append(recovered, "after recovery");
+    expect(recoveredReceipt.actor).not.toBe(receipt.actor);
+    expect(recoveredReceipt.writes).toBe(1);
+    expect(await read(recovered)).toEqual(["preserved", "after recovery"]);
+  });
+
+  it.each([false, true])(
+    "awaits delayed native cleanup before close settles (reject: %s)",
+    async (reject) => {
+      const file = databasePath();
+      const markerPath = path.join(path.dirname(file), "closed");
+      const store = await open(file);
+      await append(store, "preserved");
+      await store.execute({ type: "delayClose", input: { markerPath, reject } });
+      stores.delete(store);
+      const events = vi.spyOn(Worker.prototype, "emit");
+      try {
+        const [result] = await Promise.allSettled([store.close()]);
+        expect(events.mock.calls.filter(([event]) => event === "error")).toEqual([]);
+        expect(await readFile(markerPath, "utf8")).toBe("native database closed");
+        if (reject) {
+          expect(result).toEqual({
+            status: "rejected",
+            reason: expect.objectContaining({
+              name: "FixtureCleanupError",
+              code: "FIXTURE_CLEANUP_FAILED",
+              message: "Fixture delayed cleanup rejected",
+            }),
+          });
+        } else {
+          expect(result).toEqual({ status: "fulfilled", value: undefined });
+        }
+      } finally {
+        events.mockRestore();
+      }
+      const recovered = await open(file);
+      expect(await read(recovered)).toEqual(["preserved"]);
+      await expect(append(recovered, "recovered")).resolves.toMatchObject({ writes: 1 });
+    },
+  );
+
+  it.each([false, true])(
+    "retires an illegal async operation before reporting uncertainty (reject: %s)",
+    async (reject) => {
+      const file = databasePath();
+      const gatePath = path.join(path.dirname(file), "release-operation");
+      const store = await open(file);
+      await append(store, "before");
+      const events = vi.spyOn(Worker.prototype, "emit");
+      try {
+        const operation = store.execute({
+          type: "illegalAsync",
+          input: { value: "late write", gatePath, reject },
+        });
+        const queued = append(store, "queued write");
+        const outcomes = await Promise.allSettled([operation, queued]);
+        expect(outcomes).toEqual([
+          { status: "rejected", reason: expect.objectContaining({ code: "outcome-unknown" }) },
+          { status: "rejected", reason: expect.objectContaining({ code: "unavailable" }) },
+        ]);
+        expect(events.mock.calls.filter(([event]) => event === "error")).toEqual([]);
+        await writeFile(gatePath, "released after operation settled");
+      } finally {
+        events.mockRestore();
+        await writeFile(gatePath, "released for cleanup");
+        await Promise.allSettled([store.close()]);
+        stores.delete(store);
+      }
+      const recovered = await open(file);
+      expect(await read(recovered)).toEqual(["before"]);
+      await expect(append(recovered, "after recovery")).resolves.toMatchObject({ writes: 1 });
+    },
+  );
+
+  it("retires a worker after a committed result cannot be deserialized without dispatching queued writes", async () => {
+    const file = databasePath();
+    const store = await open(file);
+    const messages = vi.spyOn(Worker.prototype, "emit").mockImplementationOnce(function (
+      this: Worker,
+      event: string | symbol,
+      reply: SqliteWorkerReply,
+    ) {
+      messages.mockRestore();
+      expect(event).toBe("message");
+      expect(reply.ok).toBe(true);
+      return this.emit(event, { ...reply, value: new Uint8Array([0]) });
+    });
+    try {
+      const committed = append(store, "committed once");
+      const queued = append(store, "never dispatched");
+      expect(await Promise.allSettled([committed, queued])).toEqual([
+        { status: "rejected", reason: expect.objectContaining({ code: "outcome-unknown" }) },
+        { status: "rejected", reason: expect.objectContaining({ code: "unavailable" }) },
+      ]);
+    } finally {
+      messages.mockRestore();
+      await Promise.allSettled([store.close()]);
+      stores.delete(store);
+    }
+    const recovered = await open(file);
+    expect(await read(recovered)).toEqual(["committed once"]);
+    await expect(append(recovered, "after recovery")).resolves.toMatchObject({ writes: 1 });
+  });
+
+  it("reports an uncertain result when serialization fails after commit without replaying the write", async () => {
+    const file = databasePath();
+    const store = await open(file);
+    await expect(
+      store.execute({ type: "commitUnserializable", input: { value: "committed once" } }),
+    ).rejects.toMatchObject({ code: "outcome-unknown" });
+    expect(await read(store)).toEqual(["committed once"]);
+    expect(await append(store, "next write")).toMatchObject({ writes: 2 });
+    await store.close();
+    expect(await read(await open(file))).toEqual(["committed once", "next write"]);
+  });
+
+  it("reports a lost write outcome without replay and releases native locks before recovery", async () => {
+    const file = databasePath();
+    const store = await open(file);
+    const lost = store.execute({ type: "commitThenExit", input: { value: "committed" } });
+    const queued = append(store, "never dispatched");
+    const results = await Promise.allSettled([lost, queued]);
+    expect(results).toEqual([
+      { status: "rejected", reason: expect.objectContaining({ code: "outcome-unknown" }) },
+      { status: "rejected", reason: expect.objectContaining({ code: "unavailable" }) },
+    ]);
+    await expect(store.close()).rejects.toMatchObject({ code: "unavailable" });
+    stores.delete(store);
+
+    const recovered = await open(file);
+    expect(await read(recovered)).toEqual(["committed"]);
+    expect(await append(recovered, "explicit recovery")).toMatchObject({ writes: 1 });
+    expect(await read(recovered)).toEqual(["committed", "explicit recovery"]);
+  });
+});

--- a/src/infra/sqlite-worker-store.ts
+++ b/src/infra/sqlite-worker-store.ts
@@ -1,0 +1,679 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash } from "node:crypto";
+import { realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { deserialize, serialize } from "node:v8";
+import { isMainThread, Worker } from "node:worker_threads";
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
+import { createDeferredCore } from "../shared/deferred.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { INCOGNITO_AGENT_SQLITE_BASENAME } from "../state/openclaw-agent-db.paths.js";
+import { hasErrnoCode } from "./errno.js";
+import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
+import { resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+import {
+  SQLITE_WORKER_MAX_MESSAGE_BYTES,
+  type SqliteWorkerOperations,
+  type SqliteWorkerReply,
+  type SqliteWorkerRequest,
+  type SqliteWorkerStore,
+} from "./sqlite-worker-contract.js";
+
+export type {
+  SqliteWorkerBackend,
+  SqliteWorkerCommand,
+  SqliteWorkerOperations,
+  SqliteWorkerStore,
+} from "./sqlite-worker-contract.js";
+
+const MAX_WORKERS = 4;
+const MAX_STORES = 64;
+const MAX_REQUESTS = 128;
+const MAX_QUEUED_BYTES = 64 * 1024 * 1024;
+const runOutsideCaller = AsyncLocalStorage.snapshot();
+
+type RequestBody = SqliteWorkerRequest extends infer Request
+  ? Request extends SqliteWorkerRequest
+    ? Omit<Request, "id">
+    : never
+  : never;
+type DispatchState = { dispatched: boolean };
+type Job = {
+  dispatchState?: DispatchState;
+  request: SqliteWorkerRequest;
+  bytes: number;
+  resolve(value: unknown): void;
+  reject(error: unknown): void;
+  detach(): void;
+};
+type Slot = {
+  worker: Worker;
+  actors: Set<Actor>;
+  queue: Job[];
+  current?: Job;
+  failed?: Error;
+  retiring?: Promise<void>;
+  exit: Promise<void>;
+  pendingOpens: number;
+};
+type Actor = {
+  id: number;
+  key: string;
+  pathReferences: Map<string, number>;
+  moduleUrl: string;
+  inputHash: string;
+  slot: Slot;
+  references: number;
+  opened: Promise<unknown>;
+  openDispatch: DispatchState;
+  initialized: boolean;
+  closing?: Promise<void>;
+};
+
+export class SqliteWorkerError extends Error {
+  constructor(
+    message: string,
+    readonly code: "closed" | "overloaded" | "unavailable" | "outcome-unknown",
+  ) {
+    super(message);
+    this.name = "SqliteWorkerError";
+  }
+}
+
+async function readDatabasePathIdentity(databasePath: string): Promise<{
+  key: string;
+  canonicalPath: string;
+}> {
+  const file = await stat(databasePath, { bigint: true }).catch((error: unknown) => {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return undefined;
+    }
+    throw error;
+  });
+  if (file) {
+    if (!file.isFile()) {
+      throw new Error("SQLite worker database path must identify a regular file");
+    }
+    const canonicalPath = await realpath(databasePath);
+    const canonicalFile = await stat(canonicalPath, { bigint: true });
+    if (file.dev !== canonicalFile.dev || file.ino !== canonicalFile.ino) {
+      throw new Error("SQLite database pathname changed during admission");
+    }
+    return { key: `file:${file.dev}:${file.ino}`, canonicalPath };
+  }
+  // Resolve the existing ancestor before a first open so directory aliases share admission.
+  const missing: string[] = [];
+  let ancestor = databasePath;
+  while (true) {
+    try {
+      const canonicalPath = path.join(await realpath(ancestor), ...missing);
+      return { key: `path:${canonicalPath}`, canonicalPath };
+    } catch (error) {
+      if (!hasErrnoCode(error, "ENOENT")) {
+        throw error;
+      }
+      missing.unshift(path.basename(ancestor));
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) {
+        throw error;
+      }
+      ancestor = parent;
+    }
+  }
+}
+
+class SqliteWorkerBroker {
+  private readonly actors = new Map<string, Actor>();
+  private readonly slots = new Set<Slot>();
+  private readonly clients = new Set<object>();
+  private nextActor = 0;
+  private nextRequest = 0;
+  private requests = 0;
+  private bytes = 0;
+  private admissionBytes = 0;
+  private admissionTail: Promise<void> = Promise.resolve();
+  private draining?: Promise<void>;
+
+  open<Operations extends SqliteWorkerOperations>(options: {
+    moduleUrl: URL;
+    databasePath: string;
+    input: unknown;
+  }): Promise<SqliteWorkerStore<Operations>> {
+    const basename = path.basename(options.databasePath);
+    if (
+      !options.databasePath ||
+      options.databasePath.startsWith("file:") ||
+      basename === ":memory:" ||
+      basename === INCOGNITO_AGENT_SQLITE_BASENAME
+    ) {
+      return Promise.reject(
+        new Error(
+          "SQLite worker stores require a file-backed filesystem path; in-memory and incognito databases are not supported",
+        ),
+      );
+    }
+    if (this.draining) {
+      return Promise.reject(new SqliteWorkerError("SQLite worker host is closing", "closed"));
+    }
+    if (this.clients.size >= MAX_STORES) {
+      return Promise.reject(
+        new SqliteWorkerError("SQLite worker store capacity reached", "overloaded"),
+      );
+    }
+    const client = {};
+    this.clients.add(client);
+    let snapshot: { moduleUrl: URL; databasePath: string; input: Buffer };
+    try {
+      snapshot = {
+        moduleUrl: new URL(options.moduleUrl),
+        databasePath: path.resolve(options.databasePath),
+        input: serialize(options.input),
+      };
+    } catch (error) {
+      this.clients.delete(client);
+      return Promise.reject(toErrorObject(error, "SQLite worker input could not be serialized"));
+    }
+    const { input } = snapshot;
+    if (
+      input.byteLength > SQLITE_WORKER_MAX_MESSAGE_BYTES ||
+      this.bytes + this.admissionBytes + input.byteLength > MAX_QUEUED_BYTES
+    ) {
+      this.clients.delete(client);
+      return Promise.reject(
+        new SqliteWorkerError("SQLite worker open input capacity reached", "overloaded"),
+      );
+    }
+    const previous = this.admissionTail;
+    const released = createDeferredCore();
+    this.admissionTail = released.promise;
+    this.admissionBytes += input.byteLength;
+    // Opening can create the physical file. Publish its identity before admitting any alias.
+    return previous
+      .then(() => this.openAdmitted<Operations>(snapshot, client))
+      .catch((error: unknown) => {
+        this.clients.delete(client);
+        throw error;
+      })
+      .finally(() => {
+        this.admissionBytes -= input.byteLength;
+        released.resolve();
+      });
+  }
+
+  private async openAdmitted<Operations extends SqliteWorkerOperations>(
+    options: {
+      moduleUrl: URL;
+      databasePath: string;
+      input: Buffer;
+    },
+    client: object,
+  ): Promise<SqliteWorkerStore<Operations>> {
+    if (
+      options.moduleUrl.protocol !== "file:" ||
+      options.moduleUrl.search ||
+      options.moduleUrl.hash
+    ) {
+      throw new Error("SQLite worker backend must be a static local module URL");
+    }
+    const databasePath = path.resolve(options.databasePath);
+    const input = options.input;
+    const inputHash = createHash("sha256").update(input).digest("hex");
+    const [identity, modulePath] = await Promise.all([
+      readDatabasePathIdentity(databasePath),
+      realpath(fileURLToPath(options.moduleUrl)),
+    ]);
+    const { key, canonicalPath } = identity;
+    const admittedPaths = new Set([databasePath, canonicalPath]);
+    const moduleUrl = pathToFileURL(modulePath).href;
+    if (!/\.[cm]?[jt]s$/.test(modulePath) || !(await stat(modulePath)).isFile()) {
+      throw new Error("SQLite worker backend must identify a JavaScript or TypeScript file");
+    }
+    if (
+      [...this.actors.values()].some(
+        (entry) =>
+          entry.key !== key &&
+          [...admittedPaths].some((pathname) => entry.pathReferences.has(pathname)),
+      )
+    ) {
+      throw new Error(
+        "SQLite database pathname changed while its worker owner is active; close the existing store first",
+      );
+    }
+    let actor = this.actors.get(key);
+    if (actor?.closing) {
+      await actor.closing;
+      return this.openAdmitted(options, client);
+    }
+    if (actor) {
+      if (actor.slot.failed) {
+        throw actor.slot.failed;
+      }
+      if (actor.moduleUrl !== moduleUrl || actor.inputHash !== inputHash) {
+        throw new Error("SQLite database already belongs to another worker backend");
+      }
+      actor.references += 1;
+    } else {
+      const slot = await this.acquireSlot();
+      actor = {
+        id: ++this.nextActor,
+        key,
+        // Native ownership pins its opening paths even after the first client closes.
+        pathReferences: new Map([...admittedPaths].map((pathname) => [pathname, 1])),
+        moduleUrl,
+        inputHash,
+        slot,
+        references: 1,
+        opened: Promise.resolve(),
+        openDispatch: { dispatched: false },
+        initialized: false,
+      };
+      this.actors.set(key, actor);
+      slot.actors.add(actor);
+      slot.pendingOpens -= 1;
+      const opening = actor;
+      opening.opened = this.enqueue(
+        slot,
+        {
+          type: "open",
+          actor: actor.id,
+          moduleUrl,
+          databasePath,
+          input,
+          ...(/\.[cm]?ts$/.test(modulePath)
+            ? { sourceLoaderUrl: import.meta.resolve("tsx/esm/api") }
+            : {}),
+        },
+        input.byteLength,
+        undefined,
+        opening.openDispatch,
+      ).then(async () => {
+        opening.initialized = true;
+        const openedIdentity = await readDatabasePathIdentity(databasePath);
+        const physical = openedIdentity.key;
+        if (openedIdentity.canonicalPath !== canonicalPath) {
+          throw new Error("SQLite database canonical pathname changed during open");
+        }
+        if (!physical.startsWith("file:")) {
+          throw new Error("SQLite worker backend did not establish its database file");
+        }
+        const existing = this.actors.get(physical);
+        if (existing && existing !== opening) {
+          throw new Error(
+            "SQLite database identity collided with an existing worker owner during open",
+          );
+        }
+        if (key.startsWith("file:") && physical !== key) {
+          throw new Error("SQLite database file identity changed during open");
+        }
+        if (physical !== key) {
+          this.actors.delete(key);
+          opening.key = physical;
+          this.actors.set(physical, opening);
+        }
+      });
+    }
+    try {
+      await actor.opened;
+      if (actor.slot.failed) {
+        throw actor.slot.failed;
+      }
+    } catch (error) {
+      actor.references -= 1;
+      if (!actor.references) {
+        if (actor.initialized) {
+          let cleanupFailure: { error: unknown } | undefined;
+          try {
+            await this.closeActor(actor);
+          } catch (cleanupError) {
+            cleanupFailure = { error: cleanupError };
+          }
+          if (cleanupFailure) {
+            throw new AggregateError(
+              [error, cleanupFailure.error],
+              "SQLite worker admission and cleanup failed",
+              { cause: error },
+            );
+          }
+        } else {
+          if (actor.openDispatch.dispatched) {
+            // A throwing factory cannot prove that all partially opened native handles closed.
+            this.fail(actor.slot, error);
+            await actor.slot.exit;
+          }
+          this.forget(actor);
+          await this.retireEmpty(actor.slot);
+        }
+      }
+      throw error;
+    }
+    const owned = actor;
+    for (const pathname of admittedPaths) {
+      owned.pathReferences.set(pathname, (owned.pathReferences.get(pathname) ?? 0) + 1);
+    }
+    let closed: Promise<void> | undefined;
+    const pending = new Set<Promise<unknown>>();
+    return {
+      execute: (command, operationOptions = {}) => {
+        if (closed) {
+          return Promise.reject(new SqliteWorkerError("SQLite worker store is closed", "closed"));
+        }
+        if (operationOptions.signal?.aborted) {
+          return Promise.reject(
+            toErrorObject(operationOptions.signal.reason, "SQLite worker operation canceled"),
+          );
+        }
+        let payload: Buffer;
+        try {
+          // Snapshot at admission, before a queued caller can mutate its input.
+          payload = serialize(command);
+        } catch (error) {
+          return Promise.reject(
+            toErrorObject(error, "SQLite worker command could not be serialized"),
+          );
+        }
+        const operation = this.enqueue(
+          owned.slot,
+          { type: "execute", actor: owned.id, input: payload },
+          payload.byteLength,
+          operationOptions.signal,
+        ) as Promise<Operations[typeof command.type]["output"]>; // SAFETY: The typed backend owns this result.
+        pending.add(operation);
+        void operation.then(
+          () => pending.delete(operation),
+          () => pending.delete(operation),
+        );
+        return operation;
+      },
+      close: () => {
+        if (!closed) {
+          closed = (async () => {
+            await Promise.allSettled(pending);
+            owned.references -= 1;
+            try {
+              if (!owned.references) {
+                await this.closeActor(owned);
+              }
+            } finally {
+              this.clients.delete(client);
+              for (const pathname of admittedPaths) {
+                const references = owned.pathReferences.get(pathname) ?? 0;
+                if (references > 1) {
+                  owned.pathReferences.set(pathname, references - 1);
+                } else {
+                  owned.pathReferences.delete(pathname);
+                }
+              }
+            }
+          })();
+        }
+        return closed;
+      },
+    };
+  }
+
+  private async acquireSlot(): Promise<Slot> {
+    const available = [...this.slots].filter((slot) => !slot.failed && !slot.retiring);
+    if (this.slots.size >= MAX_WORKERS) {
+      if (!available.length) {
+        await Promise.race([...this.slots].map((slot) => slot.exit));
+        return this.acquireSlot();
+      }
+      const selected = available.reduce((left, right) =>
+        left.actors.size <= right.actors.size ? left : right,
+      );
+      selected.pendingOpens += 1;
+      return selected;
+    }
+    const url = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteStore);
+    const worker = runOutsideCaller(
+      () =>
+        new Worker(url, {
+          execArgv: url.pathname.endsWith(".ts")
+            ? ["--import", import.meta.resolve("tsx/esm")]
+            : [],
+        }),
+    );
+    const exited = createDeferredCore();
+    const slot: Slot = {
+      worker,
+      actors: new Set(),
+      queue: [],
+      exit: exited.promise,
+      pendingOpens: 1,
+    };
+    this.slots.add(slot);
+    worker.on("message", (reply: SqliteWorkerReply) => {
+      const job = slot.current;
+      if (!job || reply.id !== job.request.id) {
+        this.fail(slot, new Error("SQLite worker returned an unexpected response"));
+        return;
+      }
+      if (!reply.ok) {
+        const error = Object.assign(new Error(reply.error.message), {
+          name: reply.error.name,
+          ...(reply.error.code === undefined ? {} : { code: reply.error.code }),
+        });
+        if (job.request.type !== "execute" || reply.retire) {
+          this.fail(slot, error, job.request.type !== "execute" ? error : undefined);
+          return;
+        }
+        slot.current = undefined;
+        this.finish(job, error);
+        this.dispatch(slot);
+        return;
+      }
+      let value: unknown;
+      try {
+        value = deserialize(reply.value);
+      } catch (error) {
+        this.fail(slot, error);
+        return;
+      }
+      slot.current = undefined;
+      this.finish(job, undefined, value);
+      this.dispatch(slot);
+    });
+    worker.on("error", (error) => this.fail(slot, error));
+    worker.on("messageerror", (error) => this.fail(slot, error));
+    worker.once("exit", (code) => {
+      this.fail(slot, new Error(`SQLite worker exited with code ${code}`));
+      this.slots.delete(slot);
+      exited.resolve();
+    });
+    worker.unref();
+    return slot;
+  }
+
+  private enqueue(
+    slot: Slot,
+    body: RequestBody,
+    bytes: number,
+    signal?: AbortSignal,
+    dispatchState?: DispatchState,
+  ): Promise<unknown> {
+    if (this.draining && body.type !== "close") {
+      return Promise.reject(new SqliteWorkerError("SQLite worker host is closing", "closed"));
+    }
+    if (slot.failed) {
+      return Promise.reject(slot.failed);
+    }
+    if (
+      body.type !== "close" &&
+      (bytes > SQLITE_WORKER_MAX_MESSAGE_BYTES ||
+        this.requests >= MAX_REQUESTS ||
+        this.bytes + this.admissionBytes + bytes > MAX_QUEUED_BYTES)
+    ) {
+      return Promise.reject(
+        new SqliteWorkerError("SQLite worker queue capacity reached", "overloaded"),
+      );
+    }
+    const result = createDeferredCore<unknown>();
+    const job: Job = {
+      dispatchState,
+      request: { ...body, id: ++this.nextRequest },
+      bytes,
+      resolve: result.resolve,
+      reject: result.reject,
+      detach: () => signal?.removeEventListener("abort", abort),
+    };
+    const abort = () => {
+      const index = slot.queue.indexOf(job);
+      if (index >= 0) {
+        slot.queue.splice(index, 1);
+        this.finish(job, signal?.reason ?? new Error("SQLite worker operation canceled"));
+      }
+      // Once dispatched, retain the Promise until the database outcome is known.
+    };
+    this.requests += 1;
+    this.bytes += bytes;
+    slot.queue.push(job);
+    signal?.addEventListener("abort", abort, { once: true });
+    if (signal?.aborted) {
+      abort();
+    }
+    this.dispatch(slot);
+    return result.promise;
+  }
+
+  private dispatch(slot: Slot): void {
+    if (slot.current || slot.failed) {
+      return;
+    }
+    const job = slot.queue.shift();
+    if (!job) {
+      slot.worker.unref();
+      return;
+    }
+    slot.current = job;
+    job.detach();
+    slot.worker.ref();
+    try {
+      slot.worker.postMessage(job.request, []);
+      if (job.dispatchState) {
+        job.dispatchState.dispatched = true;
+      }
+    } catch (error) {
+      slot.current = undefined;
+      this.finish(job, error);
+      this.dispatch(slot);
+    }
+  }
+
+  private finish(job: Job, error?: unknown, value?: unknown): void {
+    job.detach();
+    this.requests -= 1;
+    this.bytes -= job.bytes;
+    if (error !== undefined) {
+      job.reject(error);
+    } else {
+      job.resolve(value);
+    }
+  }
+
+  private fail(slot: Slot, reason: unknown, currentError?: Error): void {
+    if (slot.failed) {
+      return;
+    }
+    const error = toErrorObject(reason, "SQLite worker failed");
+    slot.failed = new SqliteWorkerError(error.message, "unavailable");
+    const current = slot.current;
+    slot.current = undefined;
+    const queued = slot.queue.splice(0);
+    // Join native exit before releasing any operation that might have touched SQLite.
+    void this.retire(slot).then(() => {
+      if (current) {
+        this.finish(
+          current,
+          currentError ??
+            new SqliteWorkerError(
+              `SQLite worker stopped before its result was received: ${error.message}`,
+              current.request.type === "execute" ? "outcome-unknown" : "unavailable",
+            ),
+        );
+      }
+      for (const job of queued) {
+        this.finish(job, slot.failed);
+      }
+    });
+  }
+
+  private closeActor(actor: Actor): Promise<void> {
+    if (actor.closing) {
+      return actor.closing;
+    }
+    actor.closing = (async () => {
+      try {
+        await this.enqueue(actor.slot, { type: "close", actor: actor.id }, 0);
+      } catch (error) {
+        this.fail(actor.slot, error instanceof Error ? error : new Error(String(error)));
+        await actor.slot.exit;
+        throw error;
+      } finally {
+        this.forget(actor);
+        await this.retireEmpty(actor.slot);
+      }
+    })();
+    return actor.closing;
+  }
+
+  private forget(actor: Actor): void {
+    if (this.actors.get(actor.key) === actor) {
+      this.actors.delete(actor.key);
+    }
+    actor.slot.actors.delete(actor);
+  }
+
+  private async retireEmpty(slot: Slot): Promise<void> {
+    if (!slot.actors.size && !slot.pendingOpens) {
+      await this.retire(slot);
+    }
+  }
+
+  private retire(slot: Slot): Promise<void> {
+    slot.retiring ??= (async () => {
+      await slot.worker.terminate();
+      await slot.exit;
+    })();
+    return slot.retiring;
+  }
+
+  close(): Promise<void> {
+    this.draining ??= (async () => {
+      await this.admissionTail;
+      const results = await Promise.allSettled(
+        [...this.actors.values()].map((actor) => this.closeActor(actor)),
+      );
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (errors.length) {
+        throw new AggregateError(errors, "SQLite worker host cleanup failed");
+      }
+    })().finally(() => {
+      this.clients.clear();
+      this.draining = undefined;
+    });
+    return this.draining;
+  }
+}
+
+export function openSqliteWorkerStore<Operations extends SqliteWorkerOperations>(options: {
+  moduleUrl: URL;
+  databasePath: string;
+  input: unknown;
+}): Promise<SqliteWorkerStore<Operations>> {
+  if (!isMainThread) {
+    return Promise.reject(
+      new SqliteWorkerError(
+        "SQLite stores in application workers require the host broker connection",
+        "unavailable",
+      ),
+    );
+  }
+  return resolveGlobalSingleton(
+    Symbol.for("openclaw.sqliteWorkerBroker"),
+    () => new SqliteWorkerBroker(),
+    (broker) => broker.close(),
+  ).open(options);
+}

--- a/src/plugin-sdk/sqlite-runtime.ts
+++ b/src/plugin-sdk/sqlite-runtime.ts
@@ -1,6 +1,14 @@
 // Narrow SQLite schema, path, and transaction helpers for first-party runtime.
 
 export type { Generated, Selectable } from "kysely";
+export {
+  openSqliteWorkerStore,
+  SqliteWorkerError,
+  type SqliteWorkerBackend,
+  type SqliteWorkerCommand,
+  type SqliteWorkerOperations,
+  type SqliteWorkerStore,
+} from "../infra/sqlite-worker-store.js";
 
 export {
   borrowOpenClawAgentDatabase,
@@ -13,6 +21,7 @@ export { assertOpenClawAgentDatabaseForMaintenance } from "../state/openclaw-age
 export { ensureOpenClawAgentStandingIntentsSchema } from "../state/openclaw-agent-standing-intents-schema.js";
 export {
   compileSqliteQueryBindings,
+  enableNodeSqliteKyselyStatementCache,
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,

--- a/src/state/openclaw-agent-db.paths.ts
+++ b/src/state/openclaw-agent-db.paths.ts
@@ -16,7 +16,7 @@ type OpenClawAgentSqlitePathOptions = {
   path?: string;
 };
 
-const INCOGNITO_AGENT_SQLITE_BASENAME = "incognito-openclaw-agent.sqlite";
+export const INCOGNITO_AGENT_SQLITE_BASENAME = "incognito-openclaw-agent.sqlite";
 
 /** Resolve the SQLite file for one normalized agent id. */
 export function resolveOpenClawAgentSqlitePath(options: OpenClawAgentSqlitePathOptions): string {

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -1,5 +1,7 @@
 // Vitest project config tests validate aggregate Vitest project wiring.
 import { afterEach, describe, expect, it } from "vitest";
+import { resolveExtensionTestConfig } from "../scripts/lib/extension-test-plan.mts";
+import { buildVitestRunPlans } from "../scripts/test-projects.test-support.mts";
 import { spawnNodeEvalSync } from "../src/test-utils/node-process.js";
 import { createPatternFileHelper } from "./helpers/pattern-file.js";
 import { normalizeConfigPath, normalizeConfigPaths } from "./helpers/vitest-config-paths.js";
@@ -30,6 +32,8 @@ import {
   createContractsVitestConfig,
   pluginContractPatterns,
 } from "./vitest/vitest.contracts-shared.ts";
+import { createExtensionTeamReportsVitestConfig } from "./vitest/vitest.extension-team-reports.config.ts";
+import { createExtensionsVitestConfig } from "./vitest/vitest.extensions.config.ts";
 import { createGatewayMethodsIsolatedVitestConfig } from "./vitest/vitest.gateway-methods-isolated.config.ts";
 import { createGatewayMethodsVitestConfig } from "./vitest/vitest.gateway-methods.config.ts";
 import { createGatewayServerIsolatedVitestConfig } from "./vitest/vitest.gateway-server-isolated.config.ts";
@@ -489,6 +493,25 @@ describe("projects vitest config", () => {
     expect(testConfig.fileParallelism).toBe(false);
     expect(testConfig.maxWorkers).toBe(1);
     expect(testConfig.sequence).toMatchObject({ groupOrder: 1 });
+  });
+
+  it("runs Team Reports database owners in main-thread hosts across focused and full suites", () => {
+    const project = "test/vitest/vitest.extension-team-reports.config.ts";
+    const testConfig = requireTestConfig(createExtensionTeamReportsVitestConfig({}));
+    expect(resolveExtensionTestConfig("extensions/team-reports")).toBe(project);
+    expect(
+      buildVitestRunPlans(["extensions/team-reports/src/store.test.ts"]).map((plan) => plan.config),
+    ).toEqual([project]);
+    expect(rootVitestProjects).toContain(project);
+    expect(fullSuiteVitestShards.find((shard) => shard.name === "extensions")?.projects).toContain(
+      project,
+    );
+    expect(testConfig.pool).toBe("forks");
+    expect(testConfig.isolate).toBe(true);
+    expect(testConfig.include).toEqual(["team-reports/**/*.test.ts"]);
+    expect(requireTestConfig(createExtensionsVitestConfig({})).exclude).toContain(
+      "team-reports/**",
+    );
   });
 
   it("keeps the bundled lane on thread workers with the non-isolated runner", () => {

--- a/test/vitest/vitest.config.ts
+++ b/test/vitest/vitest.config.ts
@@ -71,6 +71,7 @@ const rootVitestProjects = [
   "test/vitest/vitest.extension-providers.config.ts",
   "test/vitest/vitest.extension-signal.config.ts",
   "test/vitest/vitest.extension-slack.config.ts",
+  "test/vitest/vitest.extension-team-reports.config.ts",
   "test/vitest/vitest.extension-telegram.config.ts",
   "test/vitest/vitest.extension-voice-call.config.ts",
   "test/vitest/vitest.extension-whatsapp.config.ts",

--- a/test/vitest/vitest.extension-team-reports-paths.d.mts
+++ b/test/vitest/vitest.extension-team-reports-paths.d.mts
@@ -1,0 +1,2 @@
+export const teamReportsExtensionTestRoots: string[];
+export function isTeamReportsExtensionRoot(root: string): boolean;

--- a/test/vitest/vitest.extension-team-reports-paths.mjs
+++ b/test/vitest/vitest.extension-team-reports-paths.mjs
@@ -1,0 +1,5 @@
+export const teamReportsExtensionTestRoots = ["extensions/team-reports"];
+
+export function isTeamReportsExtensionRoot(root) {
+  return teamReportsExtensionTestRoots.includes(root);
+}

--- a/test/vitest/vitest.extension-team-reports.config.ts
+++ b/test/vitest/vitest.extension-team-reports.config.ts
@@ -1,0 +1,24 @@
+import { teamReportsExtensionTestRoots } from "./vitest.extension-team-reports-paths.mjs";
+import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
+import { pluginControlUiPathGlob } from "./vitest.ui-paths.mjs";
+
+export function createExtensionTeamReportsVitestConfig(
+  env: Record<string, string | undefined> = process.env,
+) {
+  return createScopedVitestConfig(
+    teamReportsExtensionTestRoots.map((root) => `${root}/**/*.test.ts`),
+    {
+      dir: "extensions",
+      env,
+      name: "extension-team-reports",
+      // The database broker runs in the application main thread and owns its SQLite workers.
+      pool: "forks",
+      isolate: true,
+      passWithNoTests: true,
+      setupFiles: ["test/setup.extensions.ts"],
+      exclude: [pluginControlUiPathGlob],
+    },
+  );
+}
+
+export default createExtensionTeamReportsVitestConfig();

--- a/test/vitest/vitest.extensions.config.ts
+++ b/test/vitest/vitest.extensions.config.ts
@@ -20,6 +20,7 @@ import {
   providerOpenAiExtensionTestRoots,
 } from "./vitest.extension-provider-paths.mjs";
 import { qaExtensionTestRoots } from "./vitest.extension-qa-paths.mjs";
+import { teamReportsExtensionTestRoots } from "./vitest.extension-team-reports-paths.mjs";
 import { telegramExtensionTestRoots } from "./vitest.extension-telegram-paths.mjs";
 import { voiceCallExtensionTestRoots } from "./vitest.extension-voice-call-paths.mjs";
 import { whatsAppExtensionTestRoots } from "./vitest.extension-whatsapp-paths.mjs";
@@ -45,6 +46,7 @@ export const extensionCatchAllExcludedTestRoots = [
   providerOpenAiExtensionTestRoots,
   providerExtensionTestRoots,
   qaExtensionTestRoots,
+  teamReportsExtensionTestRoots,
   telegramExtensionTestRoots,
   voiceCallExtensionTestRoots,
   whatsAppExtensionTestRoots,

--- a/test/vitest/vitest.scoped-config.ts
+++ b/test/vitest/vitest.scoped-config.ts
@@ -110,6 +110,7 @@ const SCOPED_PROJECT_GROUP_ORDER_BY_NAME = new Map(
     "extension-providers",
     "extension-signal",
     "extension-slack",
+    "extension-team-reports",
     "extension-telegram",
     "extension-voice-call",
     "extension-whatsapp",

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -165,6 +165,7 @@ export const fullSuiteVitestShards = [
       "test/vitest/vitest.extension-providers.config.ts",
       "test/vitest/vitest.extension-signal.config.ts",
       "test/vitest/vitest.extension-slack.config.ts",
+      "test/vitest/vitest.extension-team-reports.config.ts",
       "test/vitest/vitest.extension-telegram.config.ts",
       "test/vitest/vitest.extension-voice-call.config.ts",
       "test/vitest/vitest.extension-whatsapp.config.ts",


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Awaiting Node SQLite calls does not move their work off the application thread. Team Reports can still block timers and requests during database operations or lock contention even though its store methods return promises.

## Why This Change Was Made

Move Team Reports opening, schema work, prepared queries, complete transactions, WAL maintenance and close into a long-lived worker owned by a bounded shared broker. The plugin sends typed domain commands to a static private backend and locates it from the loader-selected runtime entry. Its existing service lifetime retains admitted work through shutdown.

The broker allows four lazy workers, 64 opening/live store clients, 128 requests and a bounded input queue. Physical aliases share an owner; admitted pathnames remain protected through client drainage. Queued cancellation removes unstarted work; dispatched operations retain their settlement. Worker loss or an undecodable committed result reports an uncertain outcome without automatically replaying writes. Local overload before dispatch does not retire a healthy shared worker.

This first consumer supports file-backed stores from the application main thread. Incognito, shared canonical databases and callers hosted in other application workers remain separate campaign work. Native synchronous SQLite primitives stay entirely inside the worker; no main-thread blocking RPC bridge is introduced.

## User Impact

Team Reports preserves its schema, report formats, UTF-8 limits, retention and HTTP behavior while SQLite work stops blocking its host event loop. Existing connection and prepared-statement ownership stays with the database worker.

Release context: publish this Team Reports change with the first host release containing the worker SDK and selected-runtime-entry capability. The regular release workflow must synchronize its plugin API compatibility floor; this PR does not publish or guess a future version.

## Evidence

- 296 focused tests passed on current main: 27 broker cases, 243 Team Reports cases and 26 test-routing checks. Full selected checks and both root-bundled and standalone builds passed.
- Fresh independent Codex review through P2 passed. The final 29-file remainder exactly matches that reviewed source after the two prerequisite PRs landed.
- Strict native instrumentation observed zero SQLite calls on the main thread for source execution and both plain-Node 24 compiled package layouts, including opening, HTTP reads/writes, drainage, close and fresh reopening. Compiled proofs imported no TypeScript/source fallback.
- A 751.386 ms external writer lock allowed 128 main-thread timer ticks; the largest gap was 6.665 ms and event-loop p99 was 6.480 ms. All 25 queued writes drained before close. Four actual HTTP routes returned 200, and report/Unicode data survived service restart and fresh-process reopening.
- Thirty warm source samples observed read median/p95 of 0.312/0.580 ms and write median/p95 of 0.408/0.610 ms. These are descriptive timings, not a paired throughput improvement claim.
- Regressions reproduce alias replacement, premature close, uncertain result decoding, invalid async backend execution, leaked client capacity and overload that previously disrupted unrelated writes.
- Proof uses synthetic reports and an isolated registered-service/HTTP harness; it does not claim a production Gateway deployment or completion of all SQLite migrations.

The exact CI wrapper failure is repaired by including the worker-path module in the canonical extracted dependency closure; all 70 wrapper regressions pass. The scheduler fixture waits for actual collector entry while retaining its immediate concurrent-run rejection and no-overlap assertions; all 31 scheduler cases and the original delayed-read reproduction pass. Full candidate checks and fresh P2 review passed for these two fixes.
