### PR TITLE
test(qa): align kitchen sink diagnostics contract

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
@@ -185,6 +185,15 @@ describe("qa scenario catalog", () => {
     expect(config?.allowedAdversarialDiagnostics).toContain(
       "memory prompt preparation registration missing prepare function",
     );
+    expect(config?.allowedAdversarialDiagnostics).toContain(
+      "MCP server connection resolver registration missing serverName or resolve",
+    );
+    expect(config?.allowedAdversarialDiagnostics).toContain(
+      "invalid widget presenter registration",
+    );
+    expect(config?.allowedAdversarialDiagnostics).toContain(
+      "worker provider registration missing method: resolveAllocation",
+    );
     expect(
       config?.requiredAdversarialDiagnostics?.every((entry) => typeof entry === "string"),
     ).toBe(true);

--- a/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
+++ b/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
@@ -102,11 +102,14 @@ scenario:
         - memory prompt preparation registration missing prepare function
         - memory prompt supplement registration missing builder
         - model catalog provider registration missing provider
+        - MCP server connection resolver registration missing serverName or resolve
         - node invoke policy registration missing commands
         - session extension registration requires namespace and description
         - session scheduler job registration requires unique id, sessionKey, and kind
         - "plugin must declare contracts.tools for: kitchen-sink-tool"
         - tool metadata registration missing toolName
+        - invalid widget presenter registration
+        - "worker provider registration missing method: resolveAllocation"
       requiredAdversarialDiagnostics:
         - agent tool result middleware must be a function
         - agent harness "kitchen-sink-agent-harness" registration missing required runtime methods


### PR DESCRIPTION
## Summary

- align the Kitchen Sink maturity scenario with the current registration diagnostics
- keep every diagnostic explicit and asserted in the QA catalog contract

## Failure evidence

Run [34465387094](https://github.com/openclaw/openclaw/actions/runs/34465387094) emitted three intentional validation diagnostics that were not yet in the scenario allowlist: missing MCP resolver metadata, invalid widget presenter registration, and a worker provider missing `resolveAllocation`.

## Test plan

- `pnpm exec vitest run --config test/vitest/vitest.extension-qa.config.ts extensions/qa-lab/src/scenario-catalog.openai-live.test.ts --reporter=dot` (5/5)
- `pnpm check:changed`
- local P0-P2 autoreview: clean
