### PR TITLE
test(qa): normalize Telegram semantic fixtures

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -287,6 +287,11 @@ describe("qa scenario catalog channel contracts", () => {
       "received.some((message) => String(message.botApiMessageId) === String(receipt.messageId))",
     );
     expect(semanticFlow).not.toContain("received.at(-1)?.botApiMessageId");
+    expect(semanticFlow).toContain('"set":"expectedNormalized"');
+    expect(semanticFlow).toContain("JSON.stringify(actual) === JSON.stringify(expectedNormalized)");
+    expect(semanticFlow).not.toContain(
+      "JSON.stringify(actual) === JSON.stringify(fixture.expectedChunks)",
+    );
     expect(compactionFlow).toContain('"minimumPreviewEvents":2');
     expect(compactionFlow).toContain("config.commentaryOne");
     expect(compactionFlow).toContain("config.commentaryTwo");

--- a/qa/scenarios/channels/telegram-semantic-formatting-boundaries.yaml
+++ b/qa/scenarios/channels/telegram-semantic-formatting-boundaries.yaml
@@ -152,8 +152,11 @@ flow:
               - set: actual
                 value:
                   expr: "received.map(({ contentType, text, entities }) => ({ contentType, text, entities: entities.map(({ offset, length, type }) => ({ offset, length, type: { '@type': type['@type'], ...(type['@type'] === 'textEntityTypeTextUrl' ? { url: type.url } : {}), ...(type['@type'] === 'textEntityTypePreCode' ? { language: type.language } : {}) } })) }))"
+              - set: expectedNormalized
+                value:
+                  expr: "fixture.expectedChunks.map(({ contentType, text, entities }) => ({ contentType, text, entities: entities.map(({ offset, length, type }) => ({ offset, length, type: { '@type': type['@type'], ...(type['@type'] === 'textEntityTypeTextUrl' ? { url: type.url } : {}), ...(type['@type'] === 'textEntityTypePreCode' ? { language: type.language } : {}) } })) }))"
               - assert:
-                  expr: "received.some((message) => String(message.botApiMessageId) === String(receipt.messageId)) && JSON.stringify(actual) === JSON.stringify(fixture.expectedChunks)"
+                  expr: "received.some((message) => String(message.botApiMessageId) === String(receipt.messageId)) && JSON.stringify(actual) === JSON.stringify(expectedNormalized)"
                   message:
                     expr: "JSON.stringify({ case: fixture.id, expected: fixture.expectedChunks, observed: actual.map((message, index) => ({ contentType: message.contentType, text: message.text === fixture.expectedChunks[index]?.text ? message.text : message.text.replace(/\\S/gu, '?'), nonWhitespaceRedacted: message.text !== fixture.expectedChunks[index]?.text, entities: message.entities.map((entity) => ({ offset: entity.offset, length: entity.length, type: entity.type['@type'], expectedTypePayload: JSON.stringify(entity.type) === JSON.stringify(fixture.expectedChunks[index]?.entities.find((expected) => expected.offset === entity.offset && expected.length === entity.length)?.type) })) })) })"
               - set: proofs


### PR DESCRIPTION
## Summary

- normalize Telegram semantic-formatting fixture entities through the same canonical projection as received messages
- compare only the contract-owned entity fields while retaining exact text, offsets, lengths, and type payloads
- guard the comparison shape in the QA catalog test

## Failure evidence

Run [34465387094](https://github.com/openclaw/openclaw/actions/runs/34465387094) reported semantically identical expected/observed chunks while the raw JSON comparison still failed because fixture objects had a different serialization shape.

## Test plan

- `pnpm exec vitest run --config test/vitest/vitest.extension-qa.config.ts extensions/qa-lab/src/scenario-catalog-channels.test.ts -t 'keeps Telegram semantic receipts' --reporter=dot`
- `pnpm check:changed`
- local P0-P2 autoreview: clean
