### PR TITLE
fix(ci): recover generated PR push timeouts

### DIFF
--- a/.github/actions/publish-generated-pr/policy.py
+++ b/.github/actions/publish-generated-pr/policy.py
@@ -146,6 +146,41 @@ def push_generated_branch(expected_head):
     return code
 
 
+def push_generated_branch_with_timeout_recovery(expected_head):
+    code = push_generated_branch(expected_head)
+    if code != 124:
+        return code
+    published_commit = git("rev-parse", "HEAD", capture=True).rstrip("\n")
+    current_remote_head = read_remote_head()
+    if current_remote_head == published_commit:
+        print(
+            "::notice::Generated branch push timed out after the remote accepted the exact commit.",
+            flush=True,
+        )
+        return 0
+    if current_remote_head != expected_head:
+        print(
+            "::error::Generated branch moved while a timed-out push was being reconciled.",
+            flush=True,
+        )
+        return code
+    print(
+        "::notice::Generated branch push timed out before the remote moved; "
+        "retrying once under the same lease.",
+        flush=True,
+    )
+    code = push_generated_branch(expected_head)
+    if code == 0:
+        return code
+    if read_remote_head() == published_commit:
+        print(
+            "::notice::Generated branch reached the exact commit while its bounded retry was resolving.",
+            flush=True,
+        )
+        return 0
+    return code
+
+
 def report_push_failure():
     text = push_log.read_text(errors="surrogateescape")
     if re.search(r"GH013|repository rule violations|required status check", text, re.I):
@@ -271,7 +306,7 @@ def publish():
         return
     remote_head = read_remote_head()
     gh("ensure_auto_merge_compatible", remote_head)
-    code = push_generated_branch(remote_head)
+    code = push_generated_branch_with_timeout_recovery(remote_head)
     if code:
         current_remote_head = read_remote_head()
         branch_was_deleted = bool(remote_head) and not current_remote_head

--- a/test/scripts/ci-git-owner.test.ts
+++ b/test/scripts/ci-git-owner.test.ts
@@ -1302,25 +1302,38 @@ posixIt.each([124, 125, 143])(
     const report = await publisherRun({
       gitFault: { match: "^push ", code, output: "GH013 repository rule violations\n" },
     });
-    expect(report.code, report.output).toBe(code);
-    expect(report.pushes).toHaveLength(1);
-    expect(report.commands.filter(({ args }) => args[0] === "ls-remote")).toHaveLength(2);
-    expect(report.output).toContain("refusing a doomed retry");
-    expect(report.pushLog).toBe("GH013 repository rule violations\n");
+    expect(report.code, report.output).toBe(code === 124 ? 0 : code);
+    expect(report.pushes).toHaveLength(code === 124 ? 2 : 1);
+    expect(report.commands.filter(({ args }) => args[0] === "ls-remote")).toHaveLength(
+      code === 124 ? 3 : 2,
+    );
+    if (code === 124) {
+      expect(report.output).toContain("retrying once under the same lease");
+      expect(report.githubSummary).toContain("Generated pull request:");
+    } else {
+      expect(report.output).toContain("refusing a doomed retry");
+      expect(report.pushLog).toBe("GH013 repository rule violations\n");
+    }
     expect(report.authHeaderPresent).toBe(false);
-    expect(report.githubSummary).toBe("");
+    if (code !== 124) {
+      expect(report.githubSummary).toBe("");
+    }
   },
   55_000,
 );
 
 posixIt.each(["fetch", "ls-remote", "push"])(
-  "generated publisher %s timeout has one attempt and no general retry",
+  "generated publisher %s timeout has bounded recovery",
   async (operation) => {
     const report = await publisherRun({ gitFault: { match: `^${operation} `, code: "hang" } });
-    expect(report.code, report.output).toBe(124);
+    expect(report.code, report.output).toBe(operation === "push" ? 0 : 124);
     expect(report.fetches).toHaveLength(1);
-    expect(report.pushes).toHaveLength(operation === "push" ? 1 : 0);
-    expect(report.githubSummary).toBe("");
+    expect(report.pushes).toHaveLength(operation === "push" ? 2 : 0);
+    expect(report.githubSummary).toBe(
+      operation === "push"
+        ? "Generated pull request: https://github.com/openclaw/openclaw/pull/1\n"
+        : "",
+    );
     expect(report.authHeaderPresent).toBe(false);
   },
   55_000,
@@ -1395,6 +1408,22 @@ posixIt.each([0, 2, 23, 125, 143, "hang", "cleanup-failure", "cancel"] as const)
         expect(report.output).not.toContain("Unable to determine");
       }
     }
+  },
+  55_000,
+);
+
+posixIt(
+  "generated publisher retries one timed-out push under the unchanged lease",
+  async () => {
+    const report = await publisherRun({
+      gitFault: { match: "^push ", occurrence: 1, code: "hang" },
+    });
+    expect(report.code, report.output).toBe(0);
+    expect(report.pushes).toHaveLength(2);
+    expect(report.pushes[0]?.args).toEqual(report.pushes[1]?.args);
+    expect(report.publication?.generatedA).toBe("desired-a");
+    expect(report.githubSummary).toContain("Generated pull request:");
+    expect(report.output).toContain("retrying once under the same lease");
   },
   55_000,
 );


### PR DESCRIPTION
## Summary

- reconcile the generated branch after a timed-out push
- accept success when the remote already contains the exact local commit
- retry once under the unchanged force-with-lease when the remote has not moved
- recheck the remote after retry races before reporting failure

## Failure evidence

Maturity run [34465387094](https://github.com/openclaw/openclaw/actions/runs/34465387094) completed QA and generated the scorecard, but the first push of its generated branch hit the publisher's 60-second timeout. The workflow exited 124 without checking whether the server accepted the ref and without a bounded lease-safe retry, so no PR was created.

## Test plan

- focused generated-publisher lifecycle suite: 7/7
- `pnpm check:changed`
- local P0-P2 autoreview: clean after timeout/lease race review
