### PR TITLE
fix(channels): honor pinned accounts in Mattermost model menus

### DIFF
--- a/extensions/discord/src/monitor/native-command.options.ts
+++ b/extensions/discord/src/monitor/native-command.options.ts
@@ -144,7 +144,7 @@ export function buildDiscordCommandOptions(params: {
             provider: context?.provider,
             model: context?.model,
             agentRuntime: context?.agentRuntime,
-            ...(choiceCatalog?.length ? { catalog: choiceCatalog } : {}),
+            catalog: choiceCatalog,
           });
           const filtered = focusValue
             ? choices.filter((choice) =>

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -583,7 +583,7 @@ async function dispatchDiscordCommandInteraction(params: {
           provider: menuModelContext?.provider,
           model: menuModelContext?.model,
           agentRuntime: menuModelContext?.agentRuntime,
-          ...(menuModelCatalog?.length ? { catalog: menuModelCatalog } : {}),
+          catalog: menuModelCatalog,
         });
   if (menu) {
     const menuPayload = buildDiscordCommandArgMenu({

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.ts
@@ -1,4 +1,5 @@
 // Mattermost plugin module owns native model-picker interactions.
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import type { MattermostPost } from "./client.js";
 import type { MattermostInteractionResponse } from "./interactions.js";
@@ -203,7 +204,14 @@ export function createMattermostModelPickerInteractionHandler(
       agentId: eventPlan.route.agentId,
       sessionKey: eventPlan.thread.sessionKey,
     };
-    const data = await buildPreparedModelsProviderData(cfg, eventPlan.route.agentId);
+    const sessionEntry = getSessionEntry({
+      storePath: resolveStorePath(cfg.session?.store, { agentId: modelSessionRoute.agentId }),
+      sessionKey: modelSessionRoute.sessionKey,
+      readConsistency: "latest",
+    });
+    const data = await buildPreparedModelsProviderData(cfg, eventPlan.route.agentId, {
+      sessionEntry,
+    });
     if (data.providers.length === 0) {
       return await updatePickerPost("No models available.");
     }

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -2,8 +2,10 @@
 import { ServerResponse, type IncomingMessage } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import { upsertSessionEntry, type SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 
 type BuildPreparedModelsProviderData =
@@ -295,7 +297,23 @@ describe("slash-http cfg threading", () => {
       text: "replacement provider picker",
     },
   ] as const)("sends recovered data for $commandText initial render", async (testCase) => {
-    const cfg = {} as OpenClawConfig;
+    const state = await createOpenClawTestState({ label: "mattermost-menu-pin", applyEnv: false });
+    onTestFinished(() => state.cleanup());
+    const storePath = state.path("sessions.json");
+    const cfg: OpenClawConfig = { session: { store: storePath } };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      providerOverride: "openai",
+      authProfileOverride: "openai:previous",
+      authProfileOverrideSource: "user",
+      agentRuntimeOverride: "openclaw",
+    };
+    await upsertSessionEntry({
+      storePath,
+      sessionKey: "mattermost:session:1",
+      entry: sessionEntry,
+    });
     const buttons = [{ text: "OpenAI", value: "openai" }];
     mockState.resolveCommandText.mockReturnValueOnce(testCase.commandText);
     mockState.resolveMattermostModelPickerEntry.mockReturnValueOnce(testCase.entry);
@@ -328,6 +346,12 @@ describe("slash-http cfg threading", () => {
     });
     const response = createResponse();
 
+    await upsertSessionEntry({
+      storePath,
+      sessionKey: "mattermost:session:1",
+      entry: { ...sessionEntry, authProfileOverride: "openai:current", updatedAt: 2 },
+    });
+
     await handler(createRequest(), response.res);
 
     expect(response.res.statusCode).toBe(200);
@@ -335,6 +359,14 @@ describe("slash-http cfg threading", () => {
     expect(mockState.buildPreparedModelsProviderData).toHaveBeenCalledExactlyOnceWith(
       cfg,
       "agent-1",
+      {
+        sessionEntry: expect.objectContaining({
+          providerOverride: "openai",
+          authProfileOverride: "openai:current",
+          authProfileOverrideSource: "user",
+          agentRuntimeOverride: "openclaw",
+        }),
+      },
     );
     expect(mockState.sendMessageMattermost).toHaveBeenCalledExactlyOnceWith(
       "channel:chan-1",

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ResolvedMattermostAccount } from "../mattermost/accounts.js";
@@ -788,7 +789,12 @@ async function handleSlashCommandAsync(params: {
   const to = kind === "direct" ? `user:${senderId}` : `channel:${channelId}`;
   const pickerEntry = resolveMattermostModelPickerEntry(commandText);
   if (pickerEntry) {
-    const data = await buildPreparedModelsProviderData(cfg, route.agentId);
+    const sessionEntry = getSessionEntry({
+      storePath: resolveStorePath(cfg.session?.store, { agentId: route.agentId }),
+      sessionKey: route.sessionKey,
+      readConsistency: "latest",
+    });
+    const data = await buildPreparedModelsProviderData(cfg, route.agentId, { sessionEntry });
     if (data.providers.length === 0) {
       await sendMessageMattermost(`channel:${channelId}`, "No models available.", {
         cfg,

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -726,7 +726,7 @@ export function createSlackCommandHandler(params: {
           cfg,
           session: menuRoute,
           ...menuModelContext,
-          ...(menuModelCatalog?.length ? { catalog: menuModelCatalog } : {}),
+          catalog: menuModelCatalog,
         });
         if (menu) {
           const commandLabel = commandDefinition.nativeName ?? commandDefinition.key;

--- a/extensions/telegram/src/bot-native-command-builtins.ts
+++ b/extensions/telegram/src/bot-native-command-builtins.ts
@@ -342,7 +342,7 @@ export async function executeTelegramBuiltinCommand(
         cfg: dispatch.runtimeCfg,
         session: { agentId: dispatch.route.agentId, sessionKey: dispatch.targetSessionKey },
         ...menuModelContext,
-        ...(menuModelCatalog?.length ? { catalog: menuModelCatalog } : {}),
+        catalog: menuModelCatalog,
       })
     : null;
   if (menu && commandDefinition) {


### PR DESCRIPTION
## What Problem This Solves

Channel model menus could show learned choices from a shared account after the session pinned a different, expired account. Slash and thread-picker requests omitted session context.

## Why This Change Was Made

Both affected channel entry points read the latest session and pass it to the shared menu builder; thread interactions use the thread session. Other thinking-menu callers now preserve an explicitly empty catalog.

## User Impact

Model choices honor the session account pin. Existing native thinking controls remain available. No configuration or protocol change is required.

## Evidence

A real Gateway with a controlled channel transport exercised registered slash and thread callbacks. Healthy → expired → healthy → expired pins correctly removed and restored account-only choices after the fix; the baseline retained them. No inference was sent. Telegram Test Server /think retained all seven buttons with an empty provider list. Focused channel suites passed 13, 21, and 71 cases.

Related: #136257.
