### PR TITLE
fix(matrix): preserve unrelated files when migration fails

### DIFF
--- a/docs/channels/matrix-migration.md
+++ b/docs/channels/matrix-migration.md
@@ -110,8 +110,8 @@ The previous public Matrix plugin did **not** automatically create Matrix room-k
 
 `Failed migrating legacy Matrix client storage: ...`
 
-- Meaning: the Matrix client-side fallback found file-based sidecar state, but the import into SQLite failed. OpenClaw rolls back completed moves and aborts that fallback instead of silently starting with a fresh store.
-- What to do: inspect filesystem permissions or conflicts, keep the old state intact, and retry after fixing the error.
+- Meaning: the Matrix client-side fallback failed while importing file-based sidecar state into SQLite. Startup stops. Completed SQLite imports and already archived sidecars remain in place; files not yet archived remain available for retry.
+- What to do: inspect filesystem permissions or conflicts, keep the SQLite state and source or `.migrated` files intact, and retry after fixing the error.
 
 `Matrix is installed from a custom path: ...`
 

--- a/extensions/matrix/src/matrix/client/storage.test.ts
+++ b/extensions/matrix/src/matrix/client/storage.test.ts
@@ -9,6 +9,11 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMatrixAccountStorageRoot } from "../../storage-paths.js";
 import { installMatrixTestRuntime } from "../../test-runtime.js";
+import {
+  MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
+  openMatrixLegacyCryptoMigrationStoreOptions,
+  readMatrixRecoveryKeyStateForPath,
+} from "../crypto-state-store.js";
 import { SqliteBackedMatrixSyncStore } from "./file-sync-store.js";
 import { openMatrixStorageMetaStoreOptions } from "./storage-metadata.js";
 import {
@@ -385,6 +390,106 @@ describe("matrix client storage paths", () => {
 
     expect(fs.readFileSync(storagePaths.storagePath, "utf8")).toBe('{"new":true}');
   });
+
+  it.each([
+    { name: "without an unrelated sibling", withSentinel: false },
+    { name: "with an unrelated sibling", withSentinel: true },
+  ])(
+    "preserves completed imports and retries a later archive failure $name",
+    async ({ withSentinel }) => {
+      const stateDir = setupStateDir();
+      const storagePaths = resolveDefaultStoragePaths();
+      fs.mkdirSync(storagePaths.rootDir, { recursive: true });
+      fs.writeFileSync(storagePaths.storagePath, legacySyncCacheBody("retry-token"));
+      const recoveryKey = {
+        version: 1,
+        createdAt: "2026-09-01T00:00:00.000Z",
+        keyId: "synthetic-key",
+        privateKeyBase64: Buffer.alloc(32, 7).toString("base64"),
+      };
+      const migrationState = {
+        version: 1,
+        accountId: "default",
+        roomKeyCounts: null,
+        restoreStatus: "pending",
+      };
+      writeJson(storagePaths.rootDir, "recovery-key.json", recoveryKey);
+      writeJson(storagePaths.rootDir, MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME, migrationState);
+      const migrationPath = path.join(
+        storagePaths.rootDir,
+        MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
+      );
+      const sentinelPath = `${storagePaths.rootDir} SQLite recovery key state`;
+      const sentinel = "unrelated file must remain at its original path";
+      if (withSentinel) {
+        fs.writeFileSync(sentinelPath, sentinel);
+      }
+      const renameSync = fs.renameSync;
+      const rename = vi.spyOn(fs, "renameSync").mockImplementation((source, destination) => {
+        if (String(source) === migrationPath) {
+          throw Object.assign(new Error("synthetic migration archive denied"), { code: "EACCES" });
+        }
+        renameSync(source, destination);
+      });
+      const env = createMigrationEnv(stateDir);
+
+      await expect(maybeMigrateLegacyStorage({ storagePaths, env })).rejects.toThrow(
+        "synthetic migration archive denied",
+      );
+      rename.mockRestore();
+      resetPluginStateStoreForTests();
+
+      const expectPreservedState = () => {
+        expect(readMatrixRecoveryKeyStateForPath(storagePaths.recoveryKeyPath)).toEqual(
+          recoveryKey,
+        );
+        expect(
+          JSON.parse(fs.readFileSync(`${storagePaths.recoveryKeyPath}.migrated`, "utf8")),
+        ).toEqual(recoveryKey);
+        expect(
+          createPluginStateSyncKeyedStoreForTests(
+            "matrix",
+            openMatrixLegacyCryptoMigrationStoreOptions(storagePaths.rootDir),
+          ).lookup("current"),
+        ).toEqual(migrationState);
+        expect
+          .soft({
+            recoverySource: fs.existsSync(storagePaths.recoveryKeyPath)
+              ? fs.readFileSync(storagePaths.recoveryKeyPath, "utf8")
+              : null,
+            unrelatedFile: fs.existsSync(sentinelPath)
+              ? fs.readFileSync(sentinelPath, "utf8")
+              : null,
+          })
+          .toEqual({
+            recoverySource: null,
+            unrelatedFile: withSentinel ? sentinel : null,
+          });
+      };
+      expectPreservedState();
+      expect(fs.existsSync(storagePaths.storagePath)).toBe(true);
+      expect(fs.existsSync(migrationPath)).toBe(true);
+      expect(fs.existsSync(`${migrationPath}.migrated`)).toBe(false);
+      await expect(
+        new SqliteBackedMatrixSyncStore(storagePaths.rootDir).getSavedSyncToken(),
+      ).resolves.toBe("retry-token");
+
+      resetPluginStateStoreForTests();
+      await maybeMigrateLegacyStorage({ storagePaths, env });
+      resetPluginStateStoreForTests();
+
+      expectPreservedState();
+      expect(fs.existsSync(storagePaths.storagePath)).toBe(false);
+      expect(fs.existsSync(`${storagePaths.storagePath}.migrated`)).toBe(true);
+      expect(fs.existsSync(migrationPath)).toBe(false);
+      expect(JSON.parse(fs.readFileSync(`${migrationPath}.migrated`, "utf8"))).toEqual(
+        migrationState,
+      );
+      await expect(
+        new SqliteBackedMatrixSyncStore(storagePaths.rootDir).getSavedSyncToken(),
+      ).resolves.toBe("retry-token");
+    },
+  );
 
   it("keeps the canonical current-token storage root when deviceId is still unknown", () => {
     const stateDir = setupStateDir();

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -29,9 +29,9 @@ import type { MatrixAuth, MatrixStoragePaths } from "./types.js";
 const DEFAULT_ACCOUNT_KEY = "default";
 const STORAGE_META_FILENAME = "storage-meta.json";
 const THREAD_BINDINGS_FILENAME = "thread-bindings.json";
-type LegacyMoveRecord = {
+type LegacyMigrationRecord = {
   sourcePath: string;
-  targetPath: string;
+  targetDescription: string;
   label: string;
 };
 
@@ -361,7 +361,7 @@ export async function maybeMigrateLegacyStorage(params: {
 
   const logger = getMatrixRuntime().logging.getChildLogger({ module: "matrix-storage" });
   fs.mkdirSync(params.storagePaths.rootDir, { recursive: true });
-  const moved: LegacyMoveRecord[] = [];
+  const migrations: LegacyMigrationRecord[] = [];
   const pendingArchives: LegacyArchiveRecord[] = [];
   const skippedExistingTargets: string[] = [];
   try {
@@ -371,34 +371,30 @@ export async function maybeMigrateLegacyStorage(params: {
         sourcePath: params.storagePaths.storagePath,
         targetRootDir: params.storagePaths.rootDir,
         label: "account sync cache",
-        moved,
+        migrations,
         pendingArchives,
       });
     }
     if (hasAccountScopedRecoveryKey) {
       migrateLegacyMatrixRecoveryKeyFileToStore(params.storagePaths.rootDir);
-      moved.push({
+      migrations.push({
         sourcePath: params.storagePaths.recoveryKeyPath,
-        targetPath: `${params.storagePaths.rootDir} SQLite recovery key state`,
+        targetDescription: `${params.storagePaths.rootDir} SQLite recovery key state`,
         label: "recovery key",
       });
     }
     if (hasAccountScopedLegacyCryptoMigration) {
       migrateLegacyMatrixLegacyCryptoMigrationFileToStore(params.storagePaths.rootDir);
-      moved.push({
+      migrations.push({
         sourcePath: path.join(params.storagePaths.rootDir, MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME),
-        targetPath: `${params.storagePaths.rootDir} SQLite legacy crypto migration state`,
+        targetDescription: `${params.storagePaths.rootDir} SQLite legacy crypto migration state`,
         label: "legacy crypto migration",
       });
     }
   } catch (err) {
-    const rollbackError = rollbackLegacyMoves(moved);
-    throw new Error(
-      rollbackError
-        ? `Failed migrating legacy Matrix client storage: ${String(err)}. Rollback also failed: ${rollbackError}`
-        : `Failed migrating legacy Matrix client storage: ${String(err)}`,
-      { cause: err },
-    );
+    throw new Error(`Failed migrating legacy Matrix client storage: ${String(err)}`, {
+      cause: err,
+    });
   }
   for (const archive of pendingArchives) {
     archiveLegacyStoragePath({
@@ -406,10 +402,10 @@ export async function maybeMigrateLegacyStorage(params: {
       skippedExistingTargets,
     });
   }
-  if (moved.length > 0) {
+  if (migrations.length > 0) {
     logger.info(
-      `matrix: migrated legacy client storage into ${params.storagePaths.rootDir}\n${moved
-        .map((entry) => `- ${entry.label}: ${entry.sourcePath} -> ${entry.targetPath}`)
+      `matrix: migrated legacy client storage into ${params.storagePaths.rootDir}\n${migrations
+        .map((entry) => `- ${entry.label}: ${entry.sourcePath} -> ${entry.targetDescription}`)
         .join("\n")}`,
     );
   }
@@ -425,7 +421,7 @@ async function migrateLegacySyncCacheToSqlite(params: {
   sourcePath: string;
   targetRootDir: string;
   label: string;
-  moved: LegacyMoveRecord[];
+  migrations: LegacyMigrationRecord[];
   pendingArchives: LegacyArchiveRecord[];
 }): Promise<void> {
   const syncCache = await import("./sync-cache-state.js");
@@ -450,9 +446,9 @@ async function migrateLegacySyncCacheToSqlite(params: {
     claimCurrentTokenStorageState({
       rootDir: params.targetRootDir,
     });
-    params.moved.push({
+    params.migrations.push({
       sourcePath: params.sourcePath,
-      targetPath: `${params.targetRootDir} SQLite sync cache`,
+      targetDescription: `${params.targetRootDir} SQLite sync cache`,
       label: params.label,
     });
   }
@@ -475,20 +471,6 @@ function archiveLegacyStoragePath(params: {
     return;
   }
   fs.renameSync(params.sourcePath, archivedLegacyStoragePath);
-}
-
-function rollbackLegacyMoves(moved: LegacyMoveRecord[]): string | null {
-  for (const entry of moved.toReversed()) {
-    try {
-      if (!fs.existsSync(entry.targetPath) || fs.existsSync(entry.sourcePath)) {
-        continue;
-      }
-      fs.renameSync(entry.targetPath, entry.sourcePath);
-    } catch (err) {
-      return `${entry.label} (${entry.targetPath} -> ${entry.sourcePath}): ${String(err)}`;
-    }
-  }
-  return null;
 }
 
 function writeStoredRootMetadata(


### PR DESCRIPTION
Closes #144882

## What Problem This Solves

Fixes an issue where a failed Matrix sidecar migration could move an unrelated sibling file into `recovery-key.json` when its name matched a human-readable SQLite destination label. Retrying left the file misplaced.

## Why This Change Was Made

Remove filesystem compensation over those display labels and name the remaining records as migration descriptions. Preserve the actual SQLite owners, import and archive order, canonical-value precedence, successful logs, and original error prefix/cause. Correct the stale documentation to describe the already-shipped per-file import and retry behavior.

## User Impact

A failed import preserves unrelated files, committed SQLite state, actual archives, and remaining inputs for retry. No schema, transaction, retention, account, or lease behavior changes.

## Evidence

A real SQLite/temp-file regression passed without the sentinel and failed on original code by moving its exact bytes into the legacy recovery filename, both before and after closed-handle retry. After the repair, all 66 tests across storage, sync-cache, recovery-key, and Doctor migration suites passed. The changed-code gate and fresh review also passed; five underlying persistence/client owners remain byte-identical.

Complete change: −17 production code lines, +100 test code lines, and unchanged documentation line count, for **+83 code lines overall**. This is a correctness fix, with no net-reduction claim. No live Matrix service or real credentials were used.
