### PR TITLE
refactor(copilot): deduplicate transcript user text

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -252,9 +252,9 @@ extensions/copilot-proxy/index.ts	1
 extensions/copilot/harness.ts	8
 extensions/copilot/src/attempt-config.ts	16
 extensions/copilot/src/attempt-execution.ts	4
-extensions/copilot/src/attempt-finalize.ts	5
+extensions/copilot/src/attempt-finalize.ts	4
 extensions/copilot/src/attempt-prepare.ts	4
-extensions/copilot/src/attempt-transcript-journal.ts	25
+extensions/copilot/src/attempt-transcript-journal.ts	24
 extensions/copilot/src/byok-proxy.ts	1
 extensions/copilot/src/event-bridge-transcript.ts	4
 extensions/copilot/src/event-bridge.ts	3

--- a/extensions/copilot/src/attempt-finalize.ts
+++ b/extensions/copilot/src/attempt-finalize.ts
@@ -6,6 +6,7 @@ import {
 import { finalizeCopilotAttempt } from "./attempt-cleanup.js";
 import { createResult } from "./attempt-config.js";
 import type { AttemptTranscriptJournal } from "./attempt-transcript-journal.js";
+import { userText } from "./attempt-transcript-replay.js";
 import { withPromptFailure } from "./attempt-types.js";
 import type {
   AgentHarnessAttemptResult,
@@ -237,17 +238,4 @@ function isSamePreparedUser(
     candidate.timestamp === prepared.timestamp &&
     userText(candidate.content) === userText(prepared.content)
   );
-}
-
-function userText(content: unknown): string {
-  if (typeof content === "string") {
-    return content;
-  }
-  if (Array.isArray(content) && content.length === 1) {
-    const part = content[0] as { text?: unknown; type?: unknown };
-    if (part?.type === "text" && typeof part.text === "string") {
-      return part.text;
-    }
-  }
-  return JSON.stringify(content) ?? "";
 }

--- a/extensions/copilot/src/attempt-transcript-journal.ts
+++ b/extensions/copilot/src/attempt-transcript-journal.ts
@@ -19,6 +19,7 @@ import {
   isCompatibleSingletonRewrite,
   isCompleteToolGroup,
   projectReplayPayload,
+  userText,
   type AttemptTranscriptMessage as TranscriptMessage,
 } from "./attempt-transcript-replay.js";
 import type { AttemptParamsLike } from "./attempt-types.js";
@@ -696,17 +697,4 @@ function isSameUserTurn(
     candidate.timestamp === current.timestamp &&
     userText(candidate.content) === userText(current.content)
   );
-}
-
-function userText(content: unknown): string {
-  if (typeof content === "string") {
-    return content;
-  }
-  if (Array.isArray(content) && content.length === 1) {
-    const part = content[0] as { text?: unknown; type?: unknown };
-    if (part?.type === "text" && typeof part.text === "string") {
-      return part.text;
-    }
-  }
-  return JSON.stringify(content) ?? "";
 }

--- a/extensions/copilot/src/attempt-transcript-replay.ts
+++ b/extensions/copilot/src/attempt-transcript-replay.ts
@@ -6,6 +6,20 @@ export type AttemptTranscriptMessage =
   | NonNullable<TranscriptRecorder["message"]>
   | Extract<AgentMessage, { role: "assistant" | "toolResult" }>;
 
+export function userText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content) && content.length === 1) {
+    // SAFETY: Fields stay unknown until checked below; retain primitive access and repeated getter reads.
+    const part = content[0] as { text?: unknown; type?: unknown };
+    if (part?.type === "text" && typeof part.text === "string") {
+      return part.text;
+    }
+  }
+  return JSON.stringify(content) ?? "";
+}
+
 function readAssistantToolCallIds(message: AttemptTranscriptMessage): string[] {
   return message.role === "assistant"
     ? message.content.flatMap((part) => (part.type === "toolCall" ? [part.id] : []))


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

The head branch is in `openclaw/openclaw`.

</details>

## What Problem This Solves

Maintainer-requested consolidation of duplicated user-text comparison logic in Copilot transcript finalization and journaling. Keeping these paths aligned matters when replacing the active user message without collapsing distinct historical turns.

## Why This Change Was Made

Move the identical `userText` implementations into the existing replay module as a plugin-internal export and reuse it at all six existing call positions. Document the retained field-access assertion and shrink only the two allowances for assertions removed from their original files.

The separate identity predicates, getter-read order, string/text-block handling, JSON serialization and exceptions, and unkeyed pre-journal fallback remain unchanged. No SDK, dependency, configuration option, persistence, or provider behavior changes.

## User Impact

No intended user-visible change. The same transcript behavior now has one implementation to maintain.

## Evidence

- The same 191 existing cases passed before and after extraction, including the eight reviewed boundary cases and unkeyed pre-journal fallback. No new tests or regression-failure claim.
- All 26 selected check components are covered by 28 command results, including types, formatting, lint, import cycles, six Doctor cases, and three zero-finding dead-export scans.
- The initial aggregate remains a failed run: its 600-second administrative budget expired during database-first checking without a code diagnostic. Only the four unfinished guards ran in a fresh, unchanged budget and passed; earlier successful checks were reused.
- Independent review found no actionable issues. Local proof is controlled validation, not live Copilot/provider or a full current-main build. Hosted CI [run 34594819959](https://github.com/openclaw/openclaw/actions/runs/34594819959) succeeded for exact head `768b9cf972e6ab4da4f8475d37a943dc5b90dde7`.
