### PR TITLE
fix(update): let candidate restarts finish first-hop startup

### DIFF
--- a/docs/cli/gateway/restart-and-supervision.md
+++ b/docs/cli/gateway/restart-and-supervision.md
@@ -33,6 +33,14 @@ Gateway state without starting a schema migration while the old Gateway is still
 running. If no state database exists, it logs that intent recording was skipped
 and continues the restart.
 
+When an updater invokes the installed `gateway restart` command, its existing
+update marker enables the five-minute startup watchdog after the managed process
+is observed running. This lets an older updater complete a slow first-hop startup
+without passing a new option. The watchdog includes migration, listener, and health
+phases; phase changes cannot extend its cap. Explicit readiness budgets supplied
+by newer update callers take precedence. Ordinary standalone restarts keep their
+existing deadlines. See [Restart recovery](/gateway/restart-recovery).
+
 On Windows, a plain restart launched from a Gateway service process, including an agent's shell command, automatically uses the safe restart path. The running Gateway owns the deferred Scheduled Task handoff, so stopping its process tree cannot kill the caller before relaunch. This requires a reachable Gateway; the command acknowledges the restart request, not successor health. Use `openclaw gateway status` afterward to verify recovery.
 
 On macOS, when `openclaw gateway restart`, `stop`, `install`, or `uninstall` runs inside the managed LaunchAgent's process tree, including an agent's shell command, OpenClaw detects that from launchd's service environment or, when a hand-written plist omits those variables, from process ancestry against the PID launchd reports for the job. Restart hands off to a detached helper so `kickstart -k` cannot kill the caller. Stop, install, and uninstall refuse and ask you to run the command from an external shell.

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -195,6 +195,12 @@ After activation, the updater verifies that the managed service is running and
 owns its port, the Gateway hello handshake matches the expected version/build
 identity, a 12-probe health settle passes, plugins and channels are healthy, and
 `/readyz` returns HTTP 200. Update verification does not use model inference.
+Startup receives the update's existing per-step `--timeout` budget (1800 seconds
+by default), including migration and listener initialization, followed by the
+12-probe settle window. A slow startup does not trigger another restart at the
+ordinary restart command's 60-second deadline. The budget remains finite even
+while migration activity continues; an exhausted wait reports the last observed
+startup phase. Standalone restart deadlines are unchanged.
 Verification facts and measured downtime are retained in the
 [update run report](/cli/update#run-history-and-reports).
 

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -197,10 +197,14 @@ identity, a 12-probe health settle passes, plugins and channels are healthy, and
 `/readyz` returns HTTP 200. Update verification does not use model inference.
 Startup receives the update's existing per-step `--timeout` budget (1800 seconds
 by default), including migration and listener initialization, followed by the
-12-probe settle window. A slow startup does not trigger another restart at the
-ordinary restart command's 60-second deadline. The budget remains finite even
-while migration activity continues; an exhausted wait reports the last observed
-startup phase. Standalone restart deadlines are unchanged.
+12-probe settle window. On the first update from an older release, the old updater
+invokes the newly installed CLI but does not pass that readiness budget. The
+candidate recognizes the existing update marker and, once the managed process is
+running, uses the five-minute startup watchdog instead of the standalone
+60-second deadline. Migration, listener, and health transitions do not reset this
+bound. The old updater's subprocess timeout also remains in force. An exhausted
+wait reports the last observed startup phase. Standalone restart deadlines are
+unchanged.
 Verification facts and measured downtime are retained in the
 [update run report](/cli/update#run-history-and-reports).
 

--- a/src/cli/daemon-cli/lifecycle-context.ts
+++ b/src/cli/daemon-cli/lifecycle-context.ts
@@ -44,6 +44,7 @@ export async function resolveGatewayConfigPorts() {
 export async function waitForGatewayUpdateRecovery(
   expectedVersion: string,
   expectedBuildId?: string,
+  timeoutMs?: number,
 ) {
   if (!expectedVersion?.trim()) {
     throw new Error("Recovery Gateway version is unavailable.");
@@ -56,6 +57,7 @@ export async function waitForGatewayUpdateRecovery(
     env,
     expectedVersion,
     expectedBuildId,
+    timeoutMs,
     requireRunningService: true,
     settle: { probes: 12 },
   });

--- a/src/cli/daemon-cli/restart-health-diagnostics.ts
+++ b/src/cli/daemon-cli/restart-health-diagnostics.ts
@@ -19,6 +19,11 @@ function renderPortUsageDiagnostics(snapshot: GatewayPortHealthSnapshot): string
 
 export function renderRestartDiagnostics(snapshot: GatewayRestartSnapshot): string[] {
   const lines: string[] = [];
+  if (snapshot.waitOutcome === "timeout" && snapshot.startupPhase) {
+    lines.push(
+      `Readiness budget exhausted after ${Math.round((snapshot.elapsedMs ?? 0) / 1000)}s. Last observed startup phase: ${snapshot.startupPhase}.`,
+    );
+  }
   if (snapshot.versionMismatch) {
     const actual = snapshot.versionMismatch.actual ?? "unavailable";
     lines.push(

--- a/src/cli/daemon-cli/restart-health-wait.test.ts
+++ b/src/cli/daemon-cli/restart-health-wait.test.ts
@@ -19,6 +19,112 @@ describe("restart health", () => {
 
   it.each([
     {
+      name: "waits for a slow update child",
+      marker: "1",
+      readyAtMs: 90_000,
+      outcome: "healthy",
+      elapsedMs: 90_000,
+    },
+    {
+      name: "keeps the standalone deadline",
+      marker: undefined,
+      readyAtMs: 90_000,
+      outcome: "timeout",
+      elapsedMs: 60_000,
+    },
+    {
+      name: "honors a cleared update marker",
+      marker: "0",
+      readyAtMs: 90_000,
+      outcome: "timeout",
+      elapsedMs: 60_000,
+    },
+    {
+      name: "bounds a live but unready update child",
+      marker: "1",
+      readyAtMs: Infinity,
+      outcome: "timeout",
+      elapsedMs: 300_000,
+    },
+    {
+      name: "honors an explicit shorter budget",
+      marker: "1",
+      readyAtMs: Infinity,
+      timeoutMs: 30_000,
+      outcome: "timeout",
+      elapsedMs: 30_000,
+    },
+    {
+      name: "does not reset the bound when a listener appears",
+      marker: "1",
+      readyAtMs: Infinity,
+      boundAtMs: 150_000,
+      outcome: "timeout",
+      elapsedMs: 300_000,
+      phase: "waiting for Gateway health and identity",
+    },
+    {
+      name: "does not reset the bound after migration",
+      marker: "1",
+      readyAtMs: Infinity,
+      migrationUntilMs: 290_000,
+      outcome: "timeout",
+      elapsedMs: 300_000,
+    },
+    {
+      name: "requires observed startup progress",
+      marker: "1",
+      readyAtMs: Infinity,
+      running: false,
+      outcome: "timeout",
+      elapsedMs: 60_000,
+    },
+  ])(
+    "$name",
+    async ({
+      marker,
+      readyAtMs,
+      timeoutMs,
+      boundAtMs,
+      migrationUntilMs,
+      running,
+      outcome,
+      elapsedMs,
+      phase,
+    }) => {
+      inspectPortUsage.mockImplementation(async (port) => ({
+        port,
+        status: monotonicClock.nowMs < (boundAtMs ?? readyAtMs) ? "free" : "busy",
+        listeners: monotonicClock.nowMs < (boundAtMs ?? readyAtMs) ? [] : [{ pid: 8000 }],
+        hints: [],
+      }));
+      const service = makeGatewayService({ status: "running", pid: 8000 });
+      if (running === false) {
+        vi.mocked(service.readRuntime).mockResolvedValue({ status: "unknown" });
+      }
+      const { waitForGatewayHealthyRestart, renderRestartDiagnostics } =
+        await import("./restart-health.js");
+      const snapshot = await waitForGatewayHealthyRestart({
+        service,
+        port: 18789,
+        env: { OPENCLAW_UPDATE_IN_PROGRESS: marker },
+        timeoutMs,
+        expectedVersion: boundAtMs === undefined ? undefined : "2026.9.4",
+        isStartupMigrationActive: () => monotonicClock.nowMs < (migrationUntilMs ?? 0),
+      });
+      expect(snapshot.waitOutcome).toBe(outcome);
+      expect(snapshot.healthy).toBe(outcome === "healthy");
+      expect(snapshot.elapsedMs).toBe(elapsedMs);
+      if (outcome === "timeout") {
+        expect(renderRestartDiagnostics(snapshot)).toContain(
+          `Readiness budget exhausted after ${elapsedMs / 1000}s. Last observed startup phase: ${phase ?? (running === false ? "waiting for managed service" : "waiting for Gateway listener")}.`,
+        );
+      }
+    },
+  );
+
+  it.each([
+    {
       name: "waits for consecutive healthy probes",
       pids: [8000, 8000, 8000],
       reachable: [true, true, true],

--- a/src/cli/daemon-cli/restart-health-wait.test.ts
+++ b/src/cli/daemon-cli/restart-health-wait.test.ts
@@ -314,6 +314,28 @@ describe("restart health", () => {
     expect(isStartupMigrationActive).toHaveBeenCalledTimes(7);
   });
 
+  it.each([false, true])(
+    "bounds an explicit readiness budget (migration=%s)",
+    async (migration) => {
+      const { waitForGatewayHealthyRestart, renderRestartDiagnostics } =
+        await import("./restart-health.js");
+      const snapshot = await waitForGatewayHealthyRestart({
+        service: makeGatewayService({ status: "running", pid: 8000 }),
+        port: 18789,
+        timeoutMs: 120_000,
+        isStartupMigrationActive: () => migration,
+      });
+      expect(snapshot).toMatchObject({
+        healthy: false,
+        waitOutcome: "timeout",
+        elapsedMs: 120_000,
+      });
+      expect(renderRestartDiagnostics(snapshot)).toContain(
+        `Readiness budget exhausted after 120s. Last observed startup phase: ${migration ? "startup migration" : "waiting for Gateway listener"}.`,
+      );
+    },
+  );
+
   it("bounds a startup migration that never reaches readiness", async () => {
     inspectPortUsage.mockResolvedValue({
       port: 18789,

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -297,6 +297,7 @@ export async function waitForGatewayHealthyRestart(params: {
   port: number;
   attempts?: number;
   delayMs?: number;
+  timeoutMs?: number;
   settle?: { probes: number };
   env?: NodeJS.ProcessEnv;
   expectedVersion?: string | null;
@@ -314,7 +315,7 @@ export async function waitForGatewayHealthyRestart(params: {
   const delayMs = params.delayMs ?? DEFAULT_RESTART_HEALTH_DELAY_MS;
   const settleProbes = Math.max(1, params.settle?.probes ?? 1);
   const settleDurationMs = (settleProbes - 1) * delayMs;
-  const standardDeadlineMs = attempts * delayMs;
+  const standardDeadlineMs = params.timeoutMs ?? attempts * delayMs;
 
   const probeContext = await resolveGatewayRestartProbeContext(params.env).catch(() => ({
     auth: undefined,
@@ -364,6 +365,13 @@ export async function waitForGatewayHealthyRestart(params: {
       (!params.requireRunningService ||
         (snapshot.runtime.status === "running" &&
           (process.platform === "win32" || typeof snapshot.runtime.pid === "number")));
+    snapshot.startupPhase = healthy
+      ? "settling healthy Gateway"
+      : snapshot.runtime.status !== "running"
+        ? "waiting for managed service"
+        : snapshot.portUsage.status === "free"
+          ? "waiting for Gateway listener"
+          : "waiting for Gateway health and identity";
     if (healthy) {
       if (healthyStreak && isSameGatewayRestartGeneration(healthyStreak.snapshot, snapshot)) {
         healthyStreak.probes += 1;
@@ -432,11 +440,19 @@ export async function waitForGatewayHealthyRestart(params: {
       }
     }
 
+    if (migrationActive) {
+      snapshot.startupPhase = "startup migration";
+    }
     if (elapsedMs >= standardDeadlineMs || migrationDeadlineMs !== undefined) {
       // Settling gets its own readiness time, but cannot extend an active migration's watchdog.
-      const deadlineMs = migrationActive
-        ? migrationDeadlineMs
-        : (postMigrationDeadlineMs ?? standardDeadlineMs) + settleDurationMs;
+      // An update supplies its complete readiness budget, including migration progress.
+      // Standalone restarts retain their migration watchdog and post-migration window.
+      const deadlineMs =
+        params.timeoutMs !== undefined
+          ? standardDeadlineMs + settleDurationMs
+          : migrationActive
+            ? migrationDeadlineMs
+            : (postMigrationDeadlineMs ?? standardDeadlineMs) + settleDurationMs;
       if (deadlineMs === undefined || elapsedMs >= deadlineMs) {
         return withWaitContext(snapshot, "timeout", elapsedMs);
       }

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -316,6 +316,7 @@ export async function waitForGatewayHealthyRestart(params: {
   const settleProbes = Math.max(1, params.settle?.probes ?? 1);
   const settleDurationMs = (settleProbes - 1) * delayMs;
   const standardDeadlineMs = params.timeoutMs ?? attempts * delayMs;
+  const updateInProgress = (params.env ?? process.env).OPENCLAW_UPDATE_IN_PROGRESS === "1";
 
   const probeContext = await resolveGatewayRestartProbeContext(params.env).catch(() => ({
     auth: undefined,
@@ -352,12 +353,19 @@ export async function waitForGatewayHealthyRestart(params: {
   let migrationActive = false;
   let nextMigrationActivityPollMs = 0;
   let healthyStreak: { snapshot: GatewayRestartSnapshot; probes: number } | undefined;
+  let updateStartupDeadlineMs: number | undefined;
 
   for (let attempt = 0; ; attempt += 1) {
     params.signal?.throwIfAborted();
     // Health probes and state-DB reads are part of the operator-visible wait. A monotonic clock
     // keeps both the normal deadline and migration watchdog bounded when those operations stall.
     const elapsedMs = Math.max(0, performance.now() - startedAtMs);
+    if (updateInProgress && snapshot.runtime.status === "running") {
+      // Old updaters invoke the candidate CLI without forwarding their budget. A live
+      // process earns the startup watchdog; later phases never reset its finite cap.
+      updateStartupDeadlineMs ??= Math.max(standardDeadlineMs, STARTUP_MIGRATION_LEASE_TTL_MS);
+    }
+    const boundedDeadlineMs = params.timeoutMs ?? updateStartupDeadlineMs;
     // A managed settle streak needs a concrete process identity. Scheduled Tasks can
     // report running without exposing a PID, so Windows retains status-only proof.
     const healthy =
@@ -372,6 +380,9 @@ export async function waitForGatewayHealthyRestart(params: {
         : snapshot.portUsage.status === "free"
           ? "waiting for Gateway listener"
           : "waiting for Gateway health and identity";
+    if (boundedDeadlineMs !== undefined && elapsedMs > boundedDeadlineMs + settleDurationMs) {
+      return withWaitContext({ ...snapshot, healthy: false }, "timeout", elapsedMs);
+    }
     if (healthy) {
       if (healthyStreak && isSameGatewayRestartGeneration(healthyStreak.snapshot, snapshot)) {
         healthyStreak.probes += 1;
@@ -444,12 +455,11 @@ export async function waitForGatewayHealthyRestart(params: {
       snapshot.startupPhase = "startup migration";
     }
     if (elapsedMs >= standardDeadlineMs || migrationDeadlineMs !== undefined) {
-      // Settling gets its own readiness time, but cannot extend an active migration's watchdog.
-      // An update supplies its complete readiness budget, including migration progress.
-      // Standalone restarts retain their migration watchdog and post-migration window.
+      // Explicit update budgets win. Older update children use the startup watchdog;
+      // standalone restarts retain their migration and post-migration windows.
       const deadlineMs =
-        params.timeoutMs !== undefined
-          ? standardDeadlineMs + settleDurationMs
+        boundedDeadlineMs !== undefined
+          ? boundedDeadlineMs + settleDurationMs
           : migrationActive
             ? migrationDeadlineMs
             : (postMigrationDeadlineMs ?? standardDeadlineMs) + settleDurationMs;

--- a/src/cli/daemon-cli/restart-health.types.ts
+++ b/src/cli/daemon-cli/restart-health.types.ts
@@ -35,6 +35,7 @@ export type GatewayRestartSnapshot = {
   };
   waitOutcome?: GatewayRestartWaitOutcome;
   elapsedMs?: number;
+  startupPhase?: string;
 };
 
 export type GatewayPortHealthSnapshot = {

--- a/src/cli/update-cli/update-command-repair-service.ts
+++ b/src/cli/update-cli/update-command-repair-service.ts
@@ -83,6 +83,7 @@ export async function repairUpdateService(params: {
           opts: params.opts,
           serviceEnv: params.env,
           gatewayPort: params.gatewayPort,
+          timeoutMs: params.timeoutMs,
           nodeRunner: params.nodeRunner,
           expectedVersion: params.result.after?.version ?? undefined,
           expectedBuildId: params.result.after?.buildId ?? undefined,

--- a/src/cli/update-cli/update-command-service-recovery.test-support.ts
+++ b/src/cli/update-cli/update-command-service-recovery.test-support.ts
@@ -113,7 +113,7 @@ export function registerRecoveryTests(params: {
 }): void {
   it.each([
     { startup: "fast", readyAfterMs: 0, needsRecovery: false },
-    { startup: "slow", readyAfterMs: 20_000, needsRecovery: false },
+    { startup: "slow", readyAfterMs: 20_000, needsRecovery: true },
     { startup: "unready", readyAfterMs: Infinity, needsRecovery: true },
     { startup: "wrong version", readyAfterMs: 0, needsRecovery: true },
   ])(
@@ -220,8 +220,8 @@ export function registerRecoveryTests(params: {
       ]);
       expect(mocks.script).not.toHaveBeenCalled();
       expect(mocks.restart).not.toHaveBeenCalled();
-      if (startup === "unready") {
-        expect(healthResults[0]?.elapsedMs).toBeGreaterThanOrEqual(60_000);
+      if (startup === "unready" || startup === "slow") {
+        expect(healthResults[0]?.elapsedMs).toBe(6_500);
       } else if (!needsRecovery) {
         expect(nowMs).toBeGreaterThanOrEqual(readyAfterMs + 5_500);
       }

--- a/src/cli/update-cli/update-command-service-recovery.ts
+++ b/src/cli/update-cli/update-command-service-recovery.ts
@@ -45,6 +45,7 @@ export async function recoverLaunchAgentAndRecheckGatewayHealth(params: {
   health: GatewayRestartSnapshot;
   service: GatewayService;
   port: number;
+  timeoutMs?: number;
   expectedVersion?: string;
   expectedBuildId?: string;
   env?: NodeJS.ProcessEnv;
@@ -111,6 +112,7 @@ export async function recoverLaunchAgentAndRecheckGatewayHealth(params: {
   const health = await waitForHealthy({
     service: params.service,
     port: params.port,
+    timeoutMs: params.timeoutMs,
     expectedVersion: params.expectedVersion,
     ...(params.expectedBuildId ? { expectedBuildId: params.expectedBuildId } : {}),
     env: params.env,
@@ -241,6 +243,7 @@ export async function maybeRestartServiceAfterFailedMutableUpdate(params: {
       service,
       port,
       env: current.env,
+      timeoutMs: params.timeoutMs,
       expectedVersion: params.recovery.version,
       expectedBuildId: params.recovery.buildId,
       requireRunningService: true,

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -278,6 +278,7 @@ export async function maybeRestartService(params: {
     return "ok";
   }
   let activationAccepted = false;
+  let childReadinessPending = false;
   let updatedInstallRestartNeedsServiceRootProof = false;
   const verifyRestartedGateway = async (
     expectedGatewayVersion: string | undefined,
@@ -290,6 +291,7 @@ export async function maybeRestartService(params: {
       opts: activation.opts,
       serviceEnv: activation.serviceEnv,
       gatewayPort: activation.gatewayPort,
+      timeoutMs: activation.timeoutMs,
       nodeRunner: activation.nodeRunner,
       expectedVersion: expectedGatewayVersion,
       expectedBuildId: expectedGatewayBuildId,
@@ -299,6 +301,9 @@ export async function maybeRestartService(params: {
       assertCurrent,
       recoverHealth: async (initialHealth, reinspect) => {
         assertCurrent();
+        if (childReadinessPending) {
+          return { health: initialHealth, launchAgentRecovery: null };
+        }
         let health = initialHealth;
         if (!health.healthy && health.staleGatewayPids.length > 0) {
           if (!activation.opts.json) {
@@ -324,6 +329,7 @@ export async function maybeRestartService(params: {
           health,
           service: resolveGatewayService(),
           port: activation.gatewayPort,
+          timeoutMs: activation.timeoutMs,
           expectedVersion: expectedGatewayVersion,
           ...(expectedGatewayBuildId ? { expectedBuildId: expectedGatewayBuildId } : {}),
           env: activation.serviceEnv,
@@ -390,6 +396,7 @@ export async function maybeRestartService(params: {
             const health = await waitForGatewayHealthyRestart({
               service,
               port: activation.gatewayPort,
+              timeoutMs: activation.timeoutMs,
               expectedVersion: expectedGatewayVersion,
               ...(expectedGatewayBuildId ? { expectedBuildId: expectedGatewayBuildId } : {}),
               env: activation.serviceEnv,
@@ -503,7 +510,17 @@ export async function maybeRestartService(params: {
           activation,
           "restart",
           preserveDefinition,
-        );
+        ).catch((error: unknown) => {
+          if (!(error instanceof GatewayRestartHealthError)) {
+            throw error;
+          }
+          // Activation succeeded; the update verifier owns the longer readiness budget.
+          childReadinessPending = true;
+          defaultRuntime.error(
+            "Gateway is not ready yet; continuing update readiness verification.",
+          );
+          return "accepted" as const;
+        });
         restarted = true;
         activationAccepted = restart === "accepted";
         if (

--- a/src/cli/update-cli/update-command-verification.test.ts
+++ b/src/cli/update-cli/update-command-verification.test.ts
@@ -6,14 +6,21 @@ import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import * as gatewayService from "../../daemon/service.js";
 import { gatewayHealthResponse } from "../../gateway/health-response.test-support.js";
 import { recordUpdateRunVerification } from "../../infra/update-run-ledger.js";
+import { defaultRuntime } from "../../runtime.js";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
 import {
   callGateway,
   inspectPortUsage,
   makeGatewayService,
+  monotonicClock,
   resetRestartHealthMocks,
   restoreRestartHealthMocks,
 } from "../daemon-cli/restart-health.test-helpers.js";
+import {
+  GatewayRestartHealthError,
+  runUpdatedInstallGatewayCommand,
+} from "./update-command-service-command.js";
+import { maybeRestartService } from "./update-command-service.js";
 import { verifyUpdatedGateway } from "./update-command-verification.js";
 
 vi.mock("../../infra/update-run-ledger.js", async (importOriginal) => ({
@@ -23,6 +30,18 @@ vi.mock("../../infra/update-run-ledger.js", async (importOriginal) => ({
 }));
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: { log: vi.fn(), error: vi.fn() },
+}));
+vi.mock("./restart-helper.js", () => ({ runRestartScript: vi.fn(async () => true) }));
+vi.mock("../../infra/gateway-supervision.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/gateway-supervision.js")>()),
+  assertGatewayServiceMutationAllowed: vi.fn(),
+}));
+vi.mock("./update-command-config-snapshot.js", () => ({
+  createUpdateConfigSnapshot: vi.fn(async () => undefined),
+}));
+vi.mock("./update-command-service-command.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./update-command-service-command.js")>()),
+  runUpdatedInstallGatewayCommand: vi.fn(async () => "accepted"),
 }));
 
 let server: Server;
@@ -47,6 +66,65 @@ afterEach(async () => {
 });
 
 describe("update readiness generation", () => {
+  it.each(["restart script", "service refresh", "child readiness timeout"])(
+    "lets a 90-second startup finish within the update budget (%s)",
+    async (activation) => {
+      const refreshServiceEnv = activation === "service refresh";
+      const childTimeout = activation === "child readiness timeout";
+      if (childTimeout) {
+        vi.mocked(runUpdatedInstallGatewayCommand).mockImplementationOnce(async () => {
+          monotonicClock.nowMs = 60_000;
+          throw new GatewayRestartHealthError(
+            "Gateway restart timed out after 60s waiting for health checks.",
+          );
+        });
+      }
+      mockProcessPlatform("linux");
+      const service = makeGatewayService({ status: "running", pid: 8000 });
+      vi.spyOn(gatewayService, "resolveGatewayService").mockReturnValue(service);
+      inspectPortUsage.mockImplementation(async (port) => ({
+        port,
+        status: monotonicClock.nowMs < 90_000 ? "free" : "busy",
+        listeners: monotonicClock.nowMs < 90_000 ? [] : [{ pid: 8000 }],
+        hints: [],
+      }));
+      callGateway.mockImplementation(
+        gatewayHealthResponse({
+          server: { version: "2026.9.4", buildId: "candidate-build", bootId: "slow-boot" },
+        }),
+      );
+      server = createServer((_req, res) => res.writeHead(200).end());
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("missing loopback listener");
+      }
+      const result = await maybeRestartService({
+        shouldRestart: true,
+        result: {
+          status: "ok",
+          mode: "npm",
+          steps: [],
+          durationMs: 0,
+          after: { version: "2026.9.4", buildId: "candidate-build" },
+        },
+        opts: { json: true },
+        refreshServiceEnv,
+        serviceEnv: { HOME: "/synthetic-home" },
+        gatewayPort: address.port,
+        restartScriptPath: childTimeout ? undefined : "/synthetic-restart.sh",
+        requireRunningServiceAfterRestart: true,
+        timeoutMs: 120_000,
+      });
+      expect(result, JSON.stringify(vi.mocked(defaultRuntime.error).mock.calls)).toBe("ok");
+      expect(monotonicClock.nowMs).toBe(95_500);
+      expect(callGateway).toHaveBeenCalledTimes(14);
+      const { runRestartScript } = await import("./restart-helper.js");
+      expect(runRestartScript).toHaveBeenCalledTimes(refreshServiceEnv || childTimeout ? 0 : 1);
+    },
+  );
+
   it.each([
     { transition: "unchanged", supplied: false },
     { transition: "replacement", supplied: false },

--- a/src/cli/update-cli/update-command-verification.test.ts
+++ b/src/cli/update-cli/update-command-verification.test.ts
@@ -66,7 +66,7 @@ afterEach(async () => {
 });
 
 describe("update readiness generation", () => {
-  it.each(["restart script", "service refresh", "child readiness timeout"])(
+  it.each(["restart script", "service refresh", "child readiness timeout", "legacy update marker"])(
     "lets a 90-second startup finish within the update budget (%s)",
     async (activation) => {
       const refreshServiceEnv = activation === "service refresh";
@@ -100,28 +100,45 @@ describe("update readiness generation", () => {
       if (!address || typeof address === "string") {
         throw new Error("missing loopback listener");
       }
-      const result = await maybeRestartService({
-        shouldRestart: true,
-        result: {
-          status: "ok",
-          mode: "npm",
-          steps: [],
-          durationMs: 0,
-          after: { version: "2026.9.4", buildId: "candidate-build" },
-        },
-        opts: { json: true },
-        refreshServiceEnv,
-        serviceEnv: { HOME: "/synthetic-home" },
-        gatewayPort: address.port,
-        restartScriptPath: childTimeout ? undefined : "/synthetic-restart.sh",
-        requireRunningServiceAfterRestart: true,
-        timeoutMs: 120_000,
-      });
+      const result =
+        activation === "legacy update marker"
+          ? (
+              await verifyUpdatedGateway({
+                result: { status: "ok", mode: "npm", steps: [], durationMs: 0 },
+                opts: { json: true },
+                serviceEnv: { HOME: "/synthetic-home", OPENCLAW_UPDATE_IN_PROGRESS: "1" },
+                gatewayPort: address.port,
+                expectedVersion: "2026.9.4",
+                expectedBuildId: "candidate-build",
+                requireRunningService: true,
+              })
+            ).ok
+            ? "ok"
+            : "restart-health-failed"
+          : await maybeRestartService({
+              shouldRestart: true,
+              result: {
+                status: "ok",
+                mode: "npm",
+                steps: [],
+                durationMs: 0,
+                after: { version: "2026.9.4", buildId: "candidate-build" },
+              },
+              opts: { json: true },
+              refreshServiceEnv,
+              serviceEnv: { HOME: "/synthetic-home" },
+              gatewayPort: address.port,
+              restartScriptPath: childTimeout ? undefined : "/synthetic-restart.sh",
+              requireRunningServiceAfterRestart: true,
+              timeoutMs: 120_000,
+            });
       expect(result, JSON.stringify(vi.mocked(defaultRuntime.error).mock.calls)).toBe("ok");
       expect(monotonicClock.nowMs).toBe(95_500);
       expect(callGateway).toHaveBeenCalledTimes(14);
       const { runRestartScript } = await import("./restart-helper.js");
-      expect(runRestartScript).toHaveBeenCalledTimes(refreshServiceEnv || childTimeout ? 0 : 1);
+      expect(runRestartScript).toHaveBeenCalledTimes(
+        refreshServiceEnv || childTimeout || activation === "legacy update marker" ? 0 : 1,
+      );
     },
   );
 

--- a/src/cli/update-cli/update-command-verification.ts
+++ b/src/cli/update-cli/update-command-verification.ts
@@ -61,6 +61,7 @@ export async function verifyUpdatedGateway(params: {
   opts: UpdateCommandOptions;
   serviceEnv: NodeJS.ProcessEnv;
   gatewayPort: number;
+  timeoutMs?: number;
   nodeRunner?: string;
   expectedVersion?: string;
   expectedBuildId?: string;
@@ -121,6 +122,7 @@ export async function verifyUpdatedGateway(params: {
     assertCurrent();
     const health = await waitForGatewayHealthyRestart({
       ...probeParams,
+      timeoutMs: params.timeoutMs,
       requireRunningService: params.requireRunningService,
       settle: { probes: 12 },
       supervisorKeepsAlive,

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -1039,7 +1039,7 @@ async function restoreGatewayService(reason, decision = params.recovery, childSt
     try {
       const { waitForGatewayUpdateRecovery } = await import(pathToFileURL(params.recoveryModulePath).href);
       if (!ownsRecovery()) throw new Error("managed update recovery ownership was lost");
-      const health = await waitForGatewayUpdateRecovery(expectedVersion, expectedBuildId);
+      const health = await waitForGatewayUpdateRecovery(expectedVersion, expectedBuildId, params.recoveryTimeoutMs);
       restored = ownsRecovery() && health.healthy === true &&
         health.runtime?.status === "running" && health.gatewayVersion === expectedVersion &&
         (!expectedBuildId || health.gatewayBuildId === expectedBuildId);


### PR DESCRIPTION
Fixes #144859

## What Problem This Solves

Fixes an issue where users updating a managed Gateway from a published release could have a still-starting candidate rejected after 60 seconds, then stopped and rolled back despite a larger update timeout.

## Why This Change Was Made

The published updater can remain in memory while launching `gateway restart` from the newly activated package. The candidate's shared restart-health owner now recognizes the existing update marker. Once the managed process is observed running, a child without an explicit readiness budget receives the five-minute startup watchdog; migration, listener, and health transitions cannot reset its finite cap. Standalone restart deadlines stay unchanged. An explicit timeout supplied by a newer caller takes precedence, and the older driver's subprocess watchdog remains in force.

The updater-side timeout forwarding remains in place for service refresh, verification, repair, and managed-handoff recovery. An accepted child restart that exhausts its own wait can continue through the newer updater's verification without repeating native recovery. Expected process, version/build, plugin/channel health, HTTP readiness, and settling checks remain required. Exhausted waits name the last observed startup phase. No new configuration, environment variable, or schema is introduced.

## User Impact

The candidate supplies the first-hop fix, so users do not need a fixed updater installed before beginning the update. Thanks @Baumus for the original report and measured startup evidence.

## Evidence

- The new marker-based 90-second startup and update-verification regressions failed before the candidate-side change. They now pass; unmarked or cleared-marker calls retain the 60-second deadline.
- Tests cover finite exhaustion, explicit shorter budgets, listener and migration transitions that cannot reset the cap, and missing process-start evidence. The 90-second update case settles and verifies at 95.5 simulated seconds.
- 119 focused tests passed across restart health, update verification, daemon lifecycle, and update service tests. `node scripts/check-changed.mjs`, `git diff --check`, the canonical package build/integrity checks, and independent local plus full-branch Codex P0/P1 reviews passed.
- **Live first hop passed:** published 2026.9.4 driver → unchanged candidate artifact built from `de7f22ecda621c9645dc7f3d195915c853996bb7`, using the existing L47 systemd fixture and isolated synthetic state. Cached baseline installation took 20.663 seconds. With `--timeout 600`, the candidate completed a 120.016-second injected startup delay and reached `/readyz` HTTP 200 in **125.015 seconds**. The update returned `status: ok`, exit 0, and the durable run finished `succeeded` with matching version/build, service running, no plugin errors, channels ready, HTTP readiness, and settling verified. No rollback or additional service start/stop/restart occurred during candidate initialization.
- The actual spawn observation captured the candidate's installed `dist/index.js`, its exact commit/build ID, `/usr/local/bin/node`, and `OPENCLAW_UPDATE_IN_PROGRESS=1`. All seven confirmation oracles passed. Both owned proof containers were removed. The first product run also succeeded at 125.2 seconds; its extra identity recorder missed the child, so the recorder was repaired without changing the product or its assertions, and the complete cell was repeated successfully.
- A separate read-only probe on this same candidate used an explicit 1000 ms readiness budget and returned `timeout`, phase `waiting for Gateway listener`, after 6.877 seconds including the 12-probe settling allowance. Unit regressions also cover exhaustion of the full five-minute fallback.
- **Unrelated CI blocker:** [exact-head CI run 34605178905](https://github.com/openclaw/openclaw/actions/runs/34605178905) completed with failure in [checks-node-compact-small-30](https://github.com/openclaw/openclaw/actions/runs/34605178905/job/103282136066): `keeps hosted tooling within the GitHub job cap when its inventory grows` planned 81 jobs against the existing 80-job cap. The dependent `openclaw/ci-gate` failed; 131 checks succeeded, 42 skipped, and one was neutral, with none pending. The tested merge `b286e775f8b7d11ca335a5c2f343f3d64cadeb42` and its main parent `c94dbef6c914c3433a1c6678996ffa99674c1ea2` have identical CI planner/test/configuration/timing sources and identical tracked-path inventory. This PR changes none of those inputs, and the focused planner test passes on the branch itself. CI policy was left unchanged for its owner.
