### PR TITLE
fix(ollama): preserve hosted subdomain model context

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -245,8 +245,6 @@ const rootEntries = [
   "scripts/e2e/*.{js,mjs,ts}!",
   "scripts/e2e/lib/**/{assertions,probe,mock-server}.{js,mjs,ts}!",
   "src/agents/prepared-model-catalog.worker.ts!",
-  // Loaded by URL from setup-inference-detection.ts; no static import edge exists.
-  "src/system-agent/setup-inference-detection.worker.ts!",
   // Split runtime loaded through a path assembled in subagent-registry.ts.
   "src/agents/subagents/registry/subagent-registry.runtime.ts!",
   // Loaded lazily by the sweeper only when a receipt-bearing or interrupted row is found.

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -819,6 +819,10 @@ describe("ollama plugin", () => {
   it.each([
     { baseUrl: "http://127.0.0.1:11434", contextTokens: 32_768 },
     { baseUrl: "https://ollama.com", contextTokens: undefined },
+    { baseUrl: "https://api.ollama.com", contextTokens: undefined },
+    { baseUrl: "https://models.ollama.com/v1", contextTokens: undefined },
+    { baseUrl: "http://api.ollama.com:11434", contextTokens: undefined },
+    { baseUrl: "https://ollama.com.example/v1", contextTokens: 32_768 },
   ])(
     "prepares the exact configured idle model at $baseUrl with its runtime context",
     async ({ baseUrl, contextTokens }) => {

--- a/extensions/ollama/src/defaults.ts
+++ b/extensions/ollama/src/defaults.ts
@@ -9,6 +9,11 @@ export function isOllamaCloudOrigin(baseUrl: string | undefined): boolean {
   return baseUrl !== undefined && URL.parse(baseUrl)?.origin === OLLAMA_CLOUD_BASE_URL;
 }
 
+export function isHostedOllamaCloud(baseUrl: string | undefined | null): boolean {
+  const host = baseUrl ? URL.parse(baseUrl)?.hostname.toLowerCase() : undefined;
+  return host !== undefined && (host === "ollama.com" || host.endsWith(".ollama.com"));
+}
+
 export const OLLAMA_CLOUD_PROVIDER_ID = "ollama-cloud";
 export const OLLAMA_GLM52_CLOUD_MODEL_ID = "glm-5.2";
 /**

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -9,7 +9,11 @@ import type {
 import { coerceSecretRef } from "openclaw/plugin-sdk/secret-input-runtime";
 import { isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { OLLAMA_DEFAULT_API_KEY, OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
+import {
+  isHostedOllamaCloud,
+  OLLAMA_DEFAULT_API_KEY,
+  OLLAMA_DEFAULT_BASE_URL,
+} from "./defaults.js";
 import { readProviderBaseUrl } from "./provider-base-url.js";
 import { resolveOllamaApiBase } from "./provider-models.js";
 
@@ -158,22 +162,6 @@ export function isLocalOllamaBaseUrl(baseUrl: string | undefined | null): boolea
     isIpv6LocalRange(host) ||
     (!host.includes(".") && !host.includes(":"))
   );
-}
-
-const HOSTED_OLLAMA_CLOUD_HOSTNAMES = new Set(["ollama.com", "api.ollama.com"]);
-
-function isHostedOllamaCloud(baseUrl: string | undefined | null): boolean {
-  if (!baseUrl) {
-    return false;
-  }
-  let parsed: URL;
-  try {
-    parsed = new URL(baseUrl);
-  } catch {
-    return false;
-  }
-  const host = parsed.hostname.toLowerCase();
-  return HOSTED_OLLAMA_CLOUD_HOSTNAMES.has(host) || host.endsWith(".ollama.com");
 }
 
 function isLoopbackOllamaBaseUrl(baseUrl: string | undefined | null): boolean {

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -10,7 +10,7 @@ import {
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-onboard";
 import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
-  isOllamaCloudOrigin,
+  isHostedOllamaCloud,
   OLLAMA_CLOUD_DEFAULT_MODELS,
   OLLAMA_DEFAULT_BASE_URL,
   OLLAMA_DEFAULT_CONTEXT_WINDOW,
@@ -453,7 +453,7 @@ export function capLocalOllamaModelContext(
 ): ModelDefinitionConfig {
   // Direct hosted routes use bare model IDs; their context is not a local KV allocation.
   if (
-    isOllamaCloudOrigin(baseUrl) ||
+    isHostedOllamaCloud(baseUrl) ||
     isOllamaCloudModel(model.id) ||
     typeof model.contextWindow !== "number"
   ) {

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -2979,7 +2979,6 @@ const SEMANTIC_TOOLING_TARGET_PATTERNS: Array<[RegExp, string[]]> = [
       "src/system-agent/system-agent.test.ts",
       "src/system-agent/operations.test.ts",
       "src/system-agent/overview.test.ts",
-      "src/system-agent/setup-inference.test.ts",
       "src/system-agent/audit.test.ts",
     ],
   ],

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2417,7 +2417,6 @@ describe("scripts/test-projects changed-target routing", () => {
       "src/system-agent/system-agent.test.ts",
       "src/system-agent/operations.test.ts",
       "src/system-agent/overview.test.ts",
-      "src/system-agent/setup-inference.test.ts",
       "src/system-agent/audit.test.ts",
       "src/system-agent/rescue-policy.test.ts",
       "src/system-agent/rescue-message.test.ts",

--- a/test/vitest/vitest.commands-light-paths.mjs
+++ b/test/vitest/vitest.commands-light-paths.mjs
@@ -47,8 +47,6 @@ const commandsLightEntries = [
     test: "src/commands/gateway-status/helpers.test.ts",
   },
   { test: "src/commands/models/auth.test.ts" },
-  { test: "src/commands/models/list.auth-index.test.ts" },
-  { test: "src/commands/models/list.list-command.forward-compat.test.ts" },
   {
     source: "src/commands/models/list.status-command.ts",
     test: "src/commands/models/list.status.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Onboarding a bare model name through a hosted service subdomain could save the local 32,768-token cap even when discovery reported a larger context.

## Why This Change Was Made

Discovery and context preparation now share the hosted-hostname classifier. Transport policy keeps its separate HTTPS-origin checks. Obsolete test-routing references are removed.

## User Impact

Hosted aliases preserve their advertised context; local models retain their existing cap. No configuration keys or migration change.

## Evidence

Real noninteractive onboarding against a controlled endpoint reported 262,144 tokens. Before the fix, the hosted alias saved a 32,768-token cap; afterward it saved no local cap. The local control retained the cap. Focused provider and routing tests passed 400 and 480 cases. All 17 sanitized configs reached Gateway readiness with documented repairs and an exposure override. Live hosted inference and graceful shutdown were not established.

Related: #136257.
