### PR TITLE
fix(agents): show ask_user options on the question card

### DIFF
--- a/src/agents/tool-display-common.test.ts
+++ b/src/agents/tool-display-common.test.ts
@@ -191,3 +191,81 @@ describe("progress card tool display", () => {
     },
   );
 });
+
+describe("ask_user tool display", () => {
+  it("shows ask_user options with numbers and reply guidance", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "ask_user",
+        args: {
+          questions: [
+            {
+              question: "Lunch plans?",
+              options: [{ label: "Noodles" }, { label: "Rice" }],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(detail).toBe("Lunch plans? 1. Noodles 2. Rice (reply with the number or option text)");
+  });
+
+  it("keeps a distinct ask_user header alongside the question", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "ask_user",
+        args: {
+          questions: [
+            {
+              header: "Target",
+              question: "Where should this deploy?",
+              options: [{ label: "Staging" }, { label: "Production" }],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(detail).toBe(
+      "Target: Where should this deploy? 1. Staging 2. Production (reply with the number or option text)",
+    );
+  });
+
+  it("numbers multiple ask_user questions and truncates beyond three", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "ask_user",
+        args: {
+          questions: [
+            { question: "Pick a color", options: [{ label: "Red" }, { label: "Blue" }] },
+            { question: "Name the file?" },
+            { question: "Any notes?" },
+            { question: "This one is truncated" },
+          ],
+        },
+      }),
+    );
+
+    const joined = "1) Pick a color 1. Red 2. Blue | 2) Name the file? | 3) Any notes? | …";
+    expect(detail).toBe(`${joined} (reply with the number or option text)`);
+  });
+
+  it("guides free-text ask_user questions to reply with an answer", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "ask_user",
+        args: { questions: [{ question: "Describe the bug" }] },
+      }),
+    );
+
+    expect(detail).toBe("Describe the bug (reply with your answer)");
+  });
+
+  it("returns no detail for ask_user args without questions", () => {
+    expect(formatToolDetail(resolveToolDisplay({ name: "ask_user", args: {} }))).toBeUndefined();
+    expect(
+      formatToolDetail(resolveToolDisplay({ name: "ask_user", args: { questions: [] } })),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -657,6 +657,32 @@ function resolveDetailFromKeys(
   return parts.join(", ");
 }
 
+/** Resolves the compact ask_user summary: numbered options plus reply guidance. */
+function resolveAskUserDetail(args: unknown): string | undefined {
+  const record = asRecord(args);
+  const questions: unknown[] = record && Array.isArray(record.questions) ? record.questions : [];
+  let hasOptions = false;
+  const parts = questions.slice(0, 3).map((raw, index) => {
+    const entry = asRecord(raw) ?? {};
+    const header = normalizeOptionalString(entry.header) ?? "";
+    const text = normalizeOptionalString(entry.question) ?? header;
+    const options = (Array.isArray(entry.options) ? entry.options : [])
+      .slice(0, 4)
+      .map((option, optionIndex) => {
+        const label = normalizeOptionalString(asRecord(option)?.label) ?? "";
+        return label ? `${optionIndex + 1}. ${label}` : "";
+      })
+      .filter(Boolean);
+    hasOptions ||= options.length > 0;
+    const merged = text && header && header !== text ? `${header}: ${text}` : text;
+    const segment = [merged, options.join(" ")].filter(Boolean).join(" ");
+    return segment ? `${questions.length > 1 ? `${index + 1}) ` : ""}${segment}` : "";
+  });
+  const joined = parts.filter(Boolean).join(" | ") + (questions.length > 3 ? " | …" : "");
+  const hint = hasOptions ? "reply with the number or option text" : "reply with your answer";
+  return joined ? `${joined} (${hint})` : undefined;
+}
+
 /** Resolve display verb/detail from tool args and optional display metadata. */
 export function resolveToolVerbAndDetailForArgs(params: {
   toolKey: string;
@@ -716,6 +742,9 @@ export function resolveToolVerbAndDetailForArgs(params: {
   }
   if (!detail && toolKey === "tool_search_code") {
     detail = resolveToolSearchCodeDetail(args);
+  }
+  if (!detail && toolKey === "ask_user") {
+    detail = resolveAskUserDetail(args);
   }
 
   const detailKeys = actionSpec?.detailKeys ?? spec?.detailKeys ?? fallbackDetailKeys ?? [];

--- a/src/tui/components/tool-execution.test.ts
+++ b/src/tui/components/tool-execution.test.ts
@@ -303,4 +303,14 @@ describe("ToolExecutionComponent", () => {
     expect(linkedRtl?.indexOf("\u2067")).toBeLessThan(linkedRtl?.indexOf("\x1b]8;;") ?? -1);
     expect(linkedRtl?.indexOf("\u2069")).toBeGreaterThan(linkedRtl?.lastIndexOf("\x1b]8;;") ?? -1);
   });
+
+  it("omits empty recovered tool arguments instead of rendering braces", () => {
+    const recovered = new ToolExecutionComponent("read", {});
+    recovered.setResult({ content: [{ type: "text", text: "done" }] });
+    expect(normalizeTestText(recovered.render(80).join("\n"))).not.toContain("{}");
+
+    const hydrated = new ToolExecutionComponent("read", { path: "src/index.ts" });
+    hydrated.setResult({ content: [{ type: "text", text: "done" }] });
+    expect(normalizeTestText(hydrated.render(80).join("\n"))).toContain("src/index.ts");
+  });
 });

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -87,7 +87,8 @@ function formatArgs(detail: string | undefined, args: unknown): string {
   if (detail) {
     return tuiFormatters.sanitizeRenderableText(detail);
   }
-  if (!args || typeof args !== "object") {
+  // Recovered tool calls can carry empty args; render nothing rather than "{}".
+  if (!args || typeof args !== "object" || Object.keys(args).length === 0) {
     return "";
   }
   try {


### PR DESCRIPTION
Related: #137978

## What Problem This Solves

Fixes an issue where users cannot see the available choices when the assistant asks a question with the `ask_user` tool: the question card renders only the bare question text (for example `Lunch today?`) with no numbered options and no hint of how to reply, so users have to guess what to type.

Fixes an issue where reopening a session that contains a completed `ask_user` call renders a stray `{}` line on the card instead of clean output.

## Why This Change Was Made

The shared tool-display detail resolver had no case for `ask_user`'s argument shape (`questions[].options`), so its compact summary fell back to the bare question. Separately, the tui formatter stringified an empty restored args object as `"{}"`. This adds a dedicated resolver that mirrors the tool's own reply phrasing, and a one-line empty-args guard.

## User Impact

- Question cards now show numbered options plus reply guidance, e.g. `Lunch: Lunch today? 1. Noodles 2. Rice (reply with the number or option text)`.
- Questions without options fall back to `(reply with your answer)`.
- Reopened sessions no longer show a stray `{}` on completed cards.
- No behavior change for other tools.

## Evidence

Captured from real tui sessions against a local gateway on Windows.

Options rendering, before:

![options before](https://raw.githubusercontent.com/mengyuyuan/openclaw/ask-user-card-evidence/ask_user-options-before.png)

Options rendering, after:

![options after](https://raw.githubusercontent.com/mengyuyuan/openclaw/ask-user-card-evidence/ask_user-options-after.png)

Restored session rendering, before:

![restore before](https://raw.githubusercontent.com/mengyuyuan/openclaw/ask-user-card-evidence/ask_user-restore-before.png)

Restored session rendering, after:

![restore after](https://raw.githubusercontent.com/mengyuyuan/openclaw/ask-user-card-evidence/ask_user-restore-after.png)

New regression tests fail on the pristine sources (84/88 for the tool-display suites, 35/36 for the tui suite) and pass with the fix (88/88 and 36/36). Formatting and line-budget checks pass.
