### PR TITLE
test(slack): recognize native exec progress headers

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -738,7 +738,7 @@ describe("Slack live QA runtime helpers", () => {
                         ? commentaryMarker
                         : `🛠️ Exec ${toolMarker}`,
                 ...(testCase.id === "slack-progress-commentary-omitted"
-                  ? { blockText: [`• *Exec* — sleep 5`] }
+                  ? { blockText: [`🛠️ *Exec* — sleep 5`] }
                   : {}),
                 ts: testCase.toolProgress === "draft" ? "1.500000" : "1.750000",
               },

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -115,7 +115,9 @@ function hasSlackExecHeader(message: { blockText?: string[]; text: string }) {
   // fallback text remains a generic status headline. Command-derived suffixes
   // can be truncated, so identify the row by its stable native label.
   return (message.blockText ?? []).some((text) =>
-    text.split(/\r?\n/u).some((line) => /^• \*Exec\* — \S/u.test(line.trim())),
+    text
+      .split(/\r?\n/u)
+      .some((line) => /^(?:•|🛠️|:hammer_and_wrench:) \*Exec\* — \S/u.test(line.trim())),
   );
 }
 


### PR DESCRIPTION
## Summary

- accept the native Slack tool-progress header emitted by the current renderer
- keep compatibility with the legacy bullet and emoji alias forms
- exercise the verifier with the actual native Exec surface

## Failure evidence

Maturity run 34465387094 failed slack-progress-commentary-omitted because delivery emitted the native wrench header while the verifier only recognized the legacy bullet prefix.

## Test plan

- focused Slack live transport tests
- pnpm check:changed
- local P0-P2 autoreview: clean