### PR TITLE
fix(update): install explicit same-version artifacts

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6068,6 +6068,30 @@ describe("update-cli", () => {
     expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
   });
 
+  it("previews a same-version package override as an explicit artifact update", async () => {
+    await mockPackageInstallAtCaseDir("openclaw-same-version-override-preview");
+    readPackageVersion.mockResolvedValue("1.0.0");
+    primeNpmChannelTag("latest", "1.0.0");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({ target: "1.0.0", version: "1.0.0" }),
+    );
+    const packageSpec = "file:/owned/openclaw-current.tgz";
+
+    await withEnvAsync({ OPENCLAW_UPDATE_PACKAGE_SPEC: packageSpec }, async () => {
+      await updateCommand({ dryRun: true, json: true, restart: false });
+    });
+
+    expect(lastWriteJsonCall()).toMatchObject({
+      dryRun: true,
+      currentVersion: "1.0.0",
+      targetVersion: "1.0.0",
+      tag: packageSpec,
+      actions: expect.arrayContaining([
+        `Run global package manager update with spec ${packageSpec}`,
+      ]),
+    });
+  });
+
   it("previews the resolved package owner without probing for another manager", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-dry-run-owner"));
     resolveGlobalManager.mockResolvedValueOnce("npm").mockResolvedValue("bun");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -18,6 +18,7 @@ import {
 import {
   canResolveRegistryVersionForPackageTarget,
   createGlobalInstallEnv,
+  isPackageTargetAlreadyCurrent,
   resolveGlobalInstallSpec,
   resolveGlobalInstallTarget,
   resolveNpmLifecyclePolicyGate,
@@ -365,22 +366,24 @@ async function updateCommandInternal(
     }
     const cmp =
       currentVersion && targetVersion ? compareSemverStrings(currentVersion, targetVersion) : null;
-    packageAlreadyCurrent =
-      updateInstallKind === "package" &&
-      !switchToPackage &&
-      currentVersion != null &&
-      targetVersion != null &&
-      currentVersion === targetVersion;
-    downgradeRisk =
-      canResolveRegistryVersionForPackageTarget(tag) &&
-      !fallbackToLatest &&
-      currentVersion != null &&
-      (targetVersion == null ? tag !== "latest" : cmp != null && cmp > 0);
     packageInstallSpec ??= resolveGlobalInstallSpec({
       packageName: DEFAULT_PACKAGE_NAME,
       tag,
       env: packageInstallEnv,
     });
+    packageAlreadyCurrent =
+      updateInstallKind === "package" &&
+      !switchToPackage &&
+      isPackageTargetAlreadyCurrent({
+        currentVersion,
+        targetVersion,
+        target: packageInstallSpec,
+      });
+    downgradeRisk =
+      canResolveRegistryVersionForPackageTarget(tag) &&
+      !fallbackToLatest &&
+      currentVersion != null &&
+      (targetVersion == null ? tag !== "latest" : cmp != null && cmp > 0);
     if (targetVersion) {
       const targetMetadata = await fetchNpmPackageTargetStatus({
         target: targetVersion,

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -26,6 +26,7 @@ import {
   createGlobalInstallEnv,
   globalInstallArgs,
   globalInstallFallbackArgs,
+  isPackageTargetAlreadyCurrent,
   resolveExpectedInstalledVersionFromSpec,
   resolveGlobalInstallTarget,
   resolveGlobalInstallSpec,
@@ -177,6 +178,37 @@ describe("update global helpers", () => {
     expect(canResolveRegistryVersionForPackageTarget("main")).toBe(false);
     expect(canResolveRegistryVersionForPackageTarget("github:openclaw/openclaw#main")).toBe(false);
     expect(canResolveRegistryVersionForPackageTarget("/tmp/openclaw.tgz")).toBe(false);
+  });
+
+  it.each([
+    { target: "latest", currentVersion: "1.0.0", targetVersion: "1.0.0", expected: true },
+    {
+      target: "/tmp/openclaw-current.tgz",
+      currentVersion: "1.0.0",
+      targetVersion: "1.0.0",
+      expected: false,
+    },
+    {
+      target: "file:/tmp/openclaw-current.tgz",
+      currentVersion: "1.0.0",
+      targetVersion: "1.0.0",
+      expected: false,
+    },
+    {
+      target: "openclaw@file:/tmp/openclaw-current.tgz",
+      currentVersion: "1.0.0",
+      targetVersion: "1.0.0",
+      expected: false,
+    },
+    {
+      target: "openclaw@1.0.0",
+      currentVersion: "1.0.0",
+      targetVersion: "1.0.0",
+      expected: true,
+    },
+    { target: "latest", currentVersion: "1.0.0", targetVersion: "1.0.1", expected: false },
+  ])("classifies same-version package target $target", (testCase) => {
+    expect(isPackageTargetAlreadyCurrent(testCase)).toBe(testCase.expected);
   });
 
   it.each([

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -530,6 +530,20 @@ export function canResolveRegistryVersionForPackageTarget(value: string): boolea
   return !isMainPackageTarget(trimmed) && !isExplicitPackageInstallSpec(trimmed);
 }
 
+/** Same-version registry targets are no-ops; explicit artifacts still require validation/install. */
+export function isPackageTargetAlreadyCurrent(params: {
+  currentVersion: string | null;
+  targetVersion: string | null;
+  target: string;
+}): boolean {
+  return (
+    params.currentVersion !== null &&
+    params.targetVersion !== null &&
+    params.currentVersion === params.targetVersion &&
+    canResolveRegistryVersionForPackageTarget(params.target)
+  );
+}
+
 async function resolvePortableGitPathPrepend(): Promise<string[]> {
   if (process.platform !== "win32") {
     return [];


### PR DESCRIPTION
## Summary

- distinguish registry version targets from explicit file and path artifacts
- retain the same-version no-op for registry-resolvable targets
- install explicit same-version artifacts so Docker upgrade probes can validate a distinct candidate

## Failure evidence

Maturity run 34465387094 short-circuited docker-update-migration and docker-update-restart-auth before installing the explicit local candidate because its package version matched the installed version.

## Test plan

- focused update tests: 75 passed
- pnpm check:changed
- local P0-P2 autoreview: clean