### PR TITLE
test(matrix): isolate progress config mutation

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -296,9 +296,14 @@ describe("qa scenario catalog channel contracts", () => {
   it("isolates scenarios that own asynchronous transport state", () => {
     const channelBaseline = requireFlowScenario(readQaScenarioById("channel-chat-baseline"));
     const subagentFanout = requireFlowScenario(readQaScenarioById("subagent-fanout-synthesis"));
+    const matrixProgress = requireFlowScenario(
+      readQaScenarioById("matrix-room-tool-progress-mention-safety"),
+    );
 
     expect(channelBaseline.execution.suiteIsolation).toBe("isolated");
     expect(subagentFanout.execution.suiteIsolation).toBe("isolated");
+    expect(matrixProgress.execution.suiteIsolation).toBe("isolated");
+    expect(matrixProgress.execution.isolationReason).toContain("streaming progress configuration");
   });
 
   it("uses public parent history and durable task records before accepting fanout", () => {

--- a/qa/scenarios/channels/matrix-room-tool-progress-mention-safety.yaml
+++ b/qa/scenarios/channels/matrix-room-tool-progress-mention-safety.yaml
@@ -10,6 +10,8 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
+    suiteIsolation: isolated
+    isolationReason: Changes Matrix streaming progress configuration and must not race an active shared-worker turn during channel reload.
     config:
       matrixConfigOverrides:
         streaming:


### PR DESCRIPTION
## Summary

- run the Matrix progress scenario in an isolated suite worker
- document that the scenario mutates live Gateway configuration
- guard the isolation contract in the channel scenario catalog

## Failure evidence

Maturity run 34465387094 completed the Matrix delivery, then its next config patch raced one lingering Gateway request and background task and timed out during the valid deferred reload path.

## Test plan

- focused QA channel catalog tests: 80 passed
- pnpm check:changed
- local P0-P2 autoreview: clean