### PR TITLE
fix(qa): enable Telegram compaction progress evidence

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -288,6 +288,7 @@ describe("qa scenario catalog channel contracts", () => {
     );
     expect(semanticFlow).not.toContain("received.at(-1)?.botApiMessageId");
     expect(compactionFlow).toContain('"minimumPreviewEvents":2');
+    expect(compactionFlow).toContain("progress: { commentary: true, toolProgress: true }");
     expect(compactionFlow).toContain("config.commentaryOne");
     expect(compactionFlow).toContain("config.commentaryTwo");
     expect(compactionFlow).toContain("Compacting context");

--- a/qa/scenarios/channels/telegram-claude-cli-compaction-final-priority.yaml
+++ b/qa/scenarios/channels/telegram-claude-cli-compaction-final-priority.yaml
@@ -145,7 +145,7 @@ flow:
                     const telegram = cfg.channels.telegram.accounts?.[transport.accountId] ?? cfg.channels.telegram;
                     telegram.streaming = {
                       mode: "progress",
-                      progress: { commentary: true },
+                      progress: { commentary: true, toolProgress: true },
                     };
                     await fs.writeFile(ctx.configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
                   })()


### PR DESCRIPTION
## Summary

- enable Telegram tool-progress previews in the Claude compaction scenario
- retain commentary progress alongside tool progress
- guard the exact scenario streaming configuration in the catalog

## Failure evidence

Maturity run 34465387094 observed commentary previews but no compaction notice because the fixture enabled commentary only; compaction notices use the rolling tool-progress lane.

## Test plan

- focused Telegram and QA catalog tests: 30 passed on the rebased head
- pnpm check:changed
- local P0-P2 autoreview: clean

## Compatibility

Not applicable: this PR changes only one ephemeral QA scenario configuration and its catalog assertion. It does not change persisted state, a data model, the configuration schema, migrations, or production serialization. The toolProgress field is an existing optional production setting; this fixture now enables it for the scenario that asserts compaction progress.