### PR TITLE
fix(qa): fence Matrix progress scenarios by event

### DIFF
--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
@@ -553,6 +553,11 @@ async function runMatrixToolProgressScenario(
 ) {
   const { client, startSince } = await primeMatrixQaDriverScenarioClient(context);
   const startObservedIndex = context.observedEvents.length;
+  const preexistingEventIds = new Set(
+    context.observedEvents.slice(0, startObservedIndex).map((event) => event.eventId),
+  );
+  const isCurrentScenarioEvent = (event: MatrixQaObservedEvent) =>
+    !preexistingEventIds.has(event.eventId);
   await writeMatrixToolProgressTaskFile(context, params.finalText);
   const triggerBody = params.triggerBodyBuilder(context.sutUserId, params.finalText);
   const driverEventId = await client.sendTextMessage({
@@ -566,6 +571,7 @@ async function runMatrixToolProgressScenario(
   const getPreviewRootEventId = (event: MatrixQaObservedEvent) =>
     event.replacesEventId ?? event.eventId;
   const isFinalReply = (event: MatrixQaObservedEvent) =>
+    isCurrentScenarioEvent(event) &&
     event.roomId === context.roomId &&
     event.sender === context.sutUserId &&
     event.type === "m.room.message" &&
@@ -578,11 +584,14 @@ async function runMatrixToolProgressScenario(
       isMatrixQaMessageLikeKind(event.kind) &&
       matchesExpectedProgress(event.body));
   const isProgressEvent = (event: MatrixQaObservedEvent) =>
+    isCurrentScenarioEvent(event) &&
     event.roomId === context.roomId &&
     event.sender === context.sutUserId &&
     isExpectedProgressKind(event) &&
-    (matchesExpectedProgress(event.body) || event.relatesTo === undefined);
+    (matchesExpectedProgress(event.body) ||
+      (event.relatesTo === undefined && hasMatrixQaToolProgressPreviewLine(event.body)));
   const isProgressProofEvent = (event: MatrixQaObservedEvent) =>
+    isCurrentScenarioEvent(event) &&
     event.roomId === context.roomId &&
     event.sender === context.sutUserId &&
     isExpectedProgressKind(event) &&

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -3515,6 +3515,53 @@ describe("matrix live qa scenarios", () => {
     );
   });
 
+  it("ignores late top-level finals from earlier Matrix progress scenarios", async () => {
+    const context = matrixQaScenarioContext();
+    const primeRoom = vi.fn().mockResolvedValue("driver-sync-start");
+    const sendTextMessage = vi.fn().mockResolvedValue("$tool-progress-mention-late-trigger");
+    const waitForRoomEvent = vi
+      .fn()
+      .mockImplementationOnce(
+        async (params: { predicate: (event: MatrixQaObservedEvent) => boolean }) => {
+          const staleFinal = matrixQaMessageEvent({
+            kind: "message",
+            eventId: "$tool-progress-prior-final",
+            body: "MATRIX_QA_TOOL_PROGRESS_OPTOUT_PRIOR",
+          });
+          expect(params.predicate(staleFinal)).toBe(false);
+          const currentFinal = matrixQaMessageEvent({
+            kind: "message",
+            eventId: "$tool-progress-mention-late-final",
+            body: readMatrixQaReplyDirective(
+              mockMessageBody(sendTextMessage, "sendTextMessage"),
+              "MATRIX_QA_TOOL_PROGRESS_MENTION_SAFE_FIXED",
+            ),
+          });
+          return { event: currentFinal, since: "driver-sync-final" };
+        },
+      )
+      .mockImplementationOnce(async () => ({
+        event: matrixQaMessageEvent({
+          kind: "message",
+          eventId: "$tool-progress-mention-late-progress",
+          body: "Working...\n- `read matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt failed`",
+          formattedBody:
+            "Working...<br><ul><li><code>read matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt failed</code></li></ul>",
+          mentions: {},
+        }),
+        since: "driver-sync-progress",
+      }));
+    createMatrixQaClient.mockReturnValue({ primeRoom, sendTextMessage, waitForRoomEvent });
+
+    const scenario = requireMatrixQaScenario("matrix-room-tool-progress-mention-safety");
+    const result = await runMatrixQaScenario(scenario, context);
+
+    expect((result.artifacts as { previewEventId?: unknown }).previewEventId).toBe(
+      "$tool-progress-mention-late-progress",
+    );
+    expect(waitForRoomEvent).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps Matrix-looking top-level tool errors inert after final-first replies", async () => {
     mockMatrixQaRoomClient({
       driverEventId: "$tool-progress-mention-top-level-trigger",


### PR DESCRIPTION
## Summary

- fence Matrix progress scenario predicates to events observed during the current scenario
- require a real progress-preview line before accepting an unthreaded top-level fallback
- regress delayed finals from an earlier opt-out scenario

## Validation

- focused Matrix scenario regressions pass
- full OpenClaw test typecheck passes
- repository lint passes
- exact changed-file formatting and diff checks pass
- ordered seven-scenario Docker-backed Matrix gate passes together on a disposable homeserver (11/11 checks)

This is the frozen 7.33 harness counterpart to the current trusted-tooling event-scope repair.
