### PR TITLE
refactor(e2e): deduplicate release file assertions

### DIFF
--- a/scripts/e2e/lib/release-assertion-files.mjs
+++ b/scripts/e2e/lib/release-assertion-files.mjs
@@ -4,7 +4,7 @@ import { readTextFileTail } from "./text-file-utils.mjs";
 
 const SCAN_CHUNK_BYTES = 64 * 1024;
 const SCAN_CARRY_CHARS = 256;
-export const ERROR_DETAIL_TAIL_BYTES = 16 * 1024;
+const ERROR_DETAIL_TAIL_BYTES = 16 * 1024;
 const JSON_ARTIFACT_MAX_BYTES = 2 * 1024 * 1024;
 
 export function readJson(file, maxBytes = JSON_ARTIFACT_MAX_BYTES) {
@@ -66,4 +66,11 @@ export function fileContainsText(file, needle) {
   } finally {
     fs.closeSync(fd);
   }
+}
+
+export function assertFileContainsText(file, needle, callerAssert) {
+  callerAssert(
+    fileContainsText(file, needle),
+    `${file} did not contain ${needle}. Output tail: ${readTextFileTail(file, ERROR_DETAIL_TAIL_BYTES)}`,
+  );
 }

--- a/scripts/e2e/lib/release-scenarios/assertions.mjs
+++ b/scripts/e2e/lib/release-scenarios/assertions.mjs
@@ -16,12 +16,7 @@ import {
 } from "../fixtures/mock-openai-config.mjs";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
 import { hasExpectedPluginUninstallConfigState } from "../plugin-uninstall-assertions.mjs";
-import {
-  ERROR_DETAIL_TAIL_BYTES,
-  fileContainsText,
-  readJson,
-} from "../release-assertion-files.mjs";
-import { readTextFileTail } from "../text-file-utils.mjs";
+import { assertFileContainsText, fileContainsText, readJson } from "../release-assertion-files.mjs";
 
 const command = process.argv[2];
 
@@ -149,10 +144,7 @@ function assertAgentTurn() {
 function assertFileContains() {
   const file = process.argv[3];
   const needle = process.argv[4];
-  assert(
-    fileContainsText(file, needle),
-    `${file} did not contain ${needle}. Output tail: ${readTextFileTail(file, ERROR_DETAIL_TAIL_BYTES)}`,
-  );
+  assertFileContainsText(file, needle, assert);
 }
 
 function assertPackageVersion() {

--- a/scripts/e2e/lib/release-user-journey/assertions.mjs
+++ b/scripts/e2e/lib/release-user-journey/assertions.mjs
@@ -16,12 +16,7 @@ import {
 } from "../fixtures/mock-openai-config.mjs";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
 import { hasExpectedPluginUninstallConfigState } from "../plugin-uninstall-assertions.mjs";
-import {
-  ERROR_DETAIL_TAIL_BYTES,
-  fileContainsText,
-  readJson,
-} from "../release-assertion-files.mjs";
-import { readTextFileTail } from "../text-file-utils.mjs";
+import { assertFileContainsText, readJson } from "../release-assertion-files.mjs";
 
 function clickClackHttpTimeoutMs() {
   return readPositiveInt(
@@ -173,10 +168,7 @@ function assertAgentTurn() {
 function assertFileContains() {
   const file = process.argv[3];
   const needle = process.argv[4];
-  assert(
-    fileContainsText(file, needle),
-    `${file} did not contain ${needle}. Output tail: ${readTextFileTail(file, ERROR_DETAIL_TAIL_BYTES)}`,
-  );
+  assertFileContainsText(file, needle, assert);
 }
 
 function rememberPluginInstallPath() {

--- a/test/scripts/release-scenarios-assertions.test.ts
+++ b/test/scripts/release-scenarios-assertions.test.ts
@@ -90,27 +90,41 @@ describe("release scenario assertions", () => {
     }
   });
 
-  it("bounds release output text assertion diagnostics", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
-    const outputPath = path.join(root, "output.log");
+  it.each(["large output", "missing path", "empty file", "directory"])(
+    "bounds release output text assertion diagnostics for %s",
+    (kind) => {
+      const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
+      const outputPath = path.join(root, "output.log");
 
-    try {
-      writeFileSync(
-        outputPath,
-        `DO_NOT_DUMP_OLD_OUTPUT${"x".repeat(70 * 1024)}\nrecent output tail\n`,
-        "utf8",
-      );
+      try {
+        if (kind === "large output") {
+          writeFileSync(
+            outputPath,
+            `DO_NOT_DUMP_OLD_OUTPUT${"x".repeat(70 * 1024)}\nrecent output tail\n`,
+            "utf8",
+          );
+        } else if (kind === "empty file") {
+          writeFileSync(outputPath, "", "utf8");
+        } else if (kind === "directory") {
+          mkdirSync(outputPath);
+        }
 
-      const result = runAssertion(["assert-file-contains", outputPath, "missing"]);
+        const result = runAssertion(["assert-file-contains", outputPath, "missing"]);
+        const message = `${outputPath} did not contain missing. Output tail: `;
 
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain("Output tail:");
-      expect(result.stderr).toContain("recent output tail");
-      expect(result.stderr).not.toContain("DO_NOT_DUMP_OLD_OUTPUT");
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(message);
+        if (kind === "large output") {
+          expect(result.stderr).toContain("recent output tail");
+          expect(result.stderr).not.toContain("DO_NOT_DUMP_OLD_OUTPUT");
+        } else {
+          expect(result.stderr).toContain(`${message}\n`);
+        }
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
 
   it("reports bounded onboarding hook diagnostics without leaking unrelated config", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));

--- a/test/scripts/release-user-journey-assertions.test.ts
+++ b/test/scripts/release-user-journey-assertions.test.ts
@@ -67,7 +67,9 @@ async function waitUntil(matches: () => boolean | Promise<boolean>, label: strin
 
 async function reserveTcpPort(): Promise<number> {
   const server = createServer();
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
   const port = (server.address() as AddressInfo).port;
   await new Promise<void>((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));
@@ -166,26 +168,73 @@ describe("release user journey assertions", () => {
     }
   });
 
-  it("bounds release user journey output assertion diagnostics", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-user-assertions-"));
-    const home = path.join(root, "home");
-    const outputPath = path.join(root, "output.log");
+  it.each(["large output", "missing path", "empty file", "directory"])(
+    "bounds release user journey output assertion diagnostics for %s",
+    (kind) => {
+      const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-user-assertions-"));
+      const home = path.join(root, "home");
+      const outputPath = path.join(root, "output.log");
+
+      try {
+        if (kind === "large output") {
+          writeFileSync(
+            outputPath,
+            `DO_NOT_DUMP_OLD_OUTPUT${"x".repeat(70 * 1024)}\nrecent output tail\n`,
+            "utf8",
+          );
+        } else if (kind === "empty file") {
+          writeFileSync(outputPath, "", "utf8");
+        } else if (kind === "directory") {
+          mkdirSync(outputPath);
+        }
+
+        const result = runAssertion(home, ["assert-file-contains", outputPath, "missing"]);
+        const message = `${outputPath} did not contain missing. Output tail: `;
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(message);
+        if (kind === "large output") {
+          expect(result.stderr).toContain("recent output tail");
+          expect(result.stderr).not.toContain("DO_NOT_DUMP_OLD_OUTPUT");
+        } else {
+          expect(result.stderr).toContain(`${message}\n`);
+        }
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
+
+  it("uses each file and needle and restores argv after successful and failed dispatch", async () => {
+    const root = tempDirs.make("openclaw-release-user-assertions-");
+    const fileA = path.join(root, "a.log");
+    const fileB = path.join(root, "b.log");
+    writeFileSync(fileA, "first marker\n", "utf8");
+    writeFileSync(fileB, "second marker\n", "utf8");
+    const previousArgv = process.argv;
+    const previousArgs = [...previousArgv];
 
     try {
-      writeFileSync(
-        outputPath,
-        `DO_NOT_DUMP_OLD_OUTPUT${"x".repeat(70 * 1024)}\nrecent output tail\n`,
-        "utf8",
-      );
-
-      const result = runAssertion(home, ["assert-file-contains", outputPath, "missing"]);
-
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain("Output tail:");
-      expect(result.stderr).toContain("recent output tail");
-      expect(result.stderr).not.toContain("DO_NOT_DUMP_OLD_OUTPUT");
+      for (const [file, needle, shouldReject] of [
+        [fileA, "first marker", false],
+        [fileB, "second marker", false],
+        [fileB, "first marker", true],
+        [fileA, "first marker", false],
+      ] as const) {
+        const assertion = runReleaseUserJourneyAssertion("assert-file-contains", [file, needle]);
+        if (shouldReject) {
+          await expect(assertion).rejects.toThrow(
+            `${file} did not contain ${needle}. Output tail: `,
+          );
+        } else {
+          await expect(assertion).resolves.toBeUndefined();
+        }
+        expect(process.argv).toBe(previousArgv);
+        expect(process.argv).toEqual(previousArgs);
+      }
     } finally {
-      rmSync(root, { force: true, recursive: true });
+      process.argv = previousArgv;
+      previousArgv.splice(0, previousArgv.length, ...previousArgs);
     }
   });
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

The head branch is in openclaw/openclaw.

</details>

## What Problem This Solves

Maintainer-requested refactor of release validation tooling. Scenario and user-journey checks duplicate the same file-content assertion and bounded diagnostic, making those parallel paths harder to keep aligned.

## Why This Change Was Made

Share the assertion in the existing release file helper, with explicit file, needle, and caller-owned assertion arguments. Preserve scanning, eager best-effort 16 KiB tail collection even on success, error text, and callback order. The zero-argument CLI adapters, scenario image checks, and distinct dispatch lifecycles remain unchanged.

## User Impact

No intended user-visible behavior change. Both release workflows retain the same file matching and bounded failure diagnostics. No scanner, decoder, dependency, configuration, or concurrency changes.

## Evidence

- Both complete assertion suites passed on unchanged production plus characterization tests, then on the extraction: **40/40 cases per run** (17 scenario, 23 journey), with identical case sets. Added coverage includes missing paths, empty files, directories, and sequential dispatch with argument restoration.
- **18/18 selected check components pass**, scoped from the explicit reviewed base. Formatting and diff checks pass.
- Initial Knip failures identified an orphaned constant export; targeted lint identified an existing Promise-executor return in the touched test file. Both were fixed within scope and the failed checks passed afterward; the original failures were retained.
- The paired behavioral results were retained after the two mechanical cleanups: removing the unused export keyword and discarding an already-ignored executor return. Exact byte comparisons bound those changes; behavioral suites and already-passing checks were not repeated solely for them.
- **P2 review is scoped-clean**: the full refactor review was retained and the final mechanical delta was reviewed separately.

Hosted CI [run 34597546156](https://github.com/openclaw/openclaw/actions/runs/34597546156) succeeded for exact head `6f1305b177a43728e3c1d6d9a211eb5977da07b0`. No live-service, mounted release harness, or whole-current-main qualification is claimed.
