### PR TITLE
fix: resolve the documented Fireworks model alias

### DIFF
--- a/extensions/fireworks/openclaw.plugin.json
+++ b/extensions/fireworks/openclaw.plugin.json
@@ -31,6 +31,12 @@
     }
   ],
   "modelCatalog": {
+    "aliases": {
+      "fireworks-ai": {
+        "provider": "fireworks",
+        "api": "openai-completions"
+      }
+    },
     "modelsDev": {
       "fireworks": "fireworks-ai"
     },

--- a/src/agents/embedded-agent-runner/model.static-catalog.provider-alias.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.provider-alias.test.ts
@@ -1,6 +1,4 @@
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const manifestMocks = vi.hoisted(() => ({
   getCurrentPluginMetadataSnapshot: vi.fn(),
@@ -17,17 +15,8 @@ vi.mock("../../plugins/manifest-registry.js", async (importOriginal) => ({
   loadPluginManifestRegistryCore: manifestMocks.loadPluginManifestRegistryCore,
 }));
 
-import { loadPluginManifest } from "../../plugins/manifest.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
-import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
-import { resolveOwningPluginIdsForProviderRef } from "../../plugins/providers.js";
-import { resolveBundledPluginPublicModulePath } from "../../test-utils/bundled-plugin-public-surface.js";
-import { resolveRuntimeHooks } from "./model.provider-hooks.js";
-import { resolveModelWithRegistry } from "./model.registry-resolution.js";
-import {
-  resolveBundledStaticCatalogModel,
-  resolveManifestModelCatalogProviderAliasMetadata,
-} from "./model.static-catalog.js";
+import { resolveManifestModelCatalogProviderAliasMetadata } from "./model.static-catalog.js";
 
 const canonicalizeManifestModelCatalogProviderAlias = (
   params: Parameters<typeof resolveManifestModelCatalogProviderAliasMetadata>[0],
@@ -107,122 +96,6 @@ beforeEach(() => {
   manifestMocks.loadPluginManifestRegistryCore.mockReset();
   manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(undefined);
   manifestMocks.loadPluginManifestRegistryCore.mockReturnValue({ plugins: [] });
-});
-
-describe("Fireworks manifest provider alias", () => {
-  const modelId = "accounts/fireworks/routers/glm-5p2-fast";
-  const providerBaseUrl = "https://fireworks-proxy.example/v1";
-  const modelBaseUrl = "https://fireworks-proxy.example/model";
-
-  beforeEach(() => {
-    const rootDir = path.dirname(
-      resolveBundledPluginPublicModulePath({
-        pluginId: "fireworks",
-        artifactBasename: "openclaw.plugin.json",
-      }),
-    );
-    const loaded = loadPluginManifest(rootDir);
-    if (!loaded.ok) {
-      throw new Error(loaded.error);
-    }
-    const snapshot = createPluginMetadataSnapshotFixture({
-      plugins: [{ ...loaded.manifest, origin: "bundled", rootDir }],
-    });
-    manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(snapshot);
-    manifestMocks.loadPluginManifestRegistryCore.mockReturnValue(snapshot.manifestRegistry);
-  });
-
-  function resolveFireworksGlm(provider: string, cfg?: OpenClawConfig) {
-    const catalogModel = resolveBundledStaticCatalogModel({
-      provider: "fireworks",
-      modelId,
-      includeRuntimeDiscovery: true,
-    });
-    if (!catalogModel) {
-      throw new Error("Missing Fireworks GLM catalog model");
-    }
-    return resolveModelWithRegistry({
-      provider,
-      modelId,
-      cfg,
-      modelRegistry: {
-        getAll: () => [catalogModel],
-        getAvailable: () => [],
-        hasConfiguredAuth: () => false,
-        find: (candidateProvider, candidateId) =>
-          candidateProvider === catalogModel.provider && candidateId === catalogModel.id
-            ? catalogModel
-            : undefined,
-      },
-      runtimeHooks: resolveRuntimeHooks({ skipProviderRuntimeHooks: true }),
-      authProfileMode: "api_key",
-    });
-  }
-
-  it("finds the alias owner before runtime loading and resolves the canonical catalog model", () => {
-    expect(resolveOwningPluginIdsForProviderRef({ provider: "fireworks-ai" })).toEqual([
-      "fireworks",
-    ]);
-    const canonical = resolveFireworksGlm("fireworks");
-    expect(canonical).toMatchObject({
-      provider: "fireworks",
-      id: modelId,
-      api: "openai-completions",
-      baseUrl: "https://api.fireworks.ai/inference/v1",
-    });
-    expect(resolveFireworksGlm("fireworks-ai")).toEqual(canonical);
-  });
-
-  it.each([
-    ["omitted API", undefined, undefined, undefined, "openai-completions"],
-    ["provider API", "openai-responses", undefined, undefined, "openai-responses"],
-    [
-      "model API and URL",
-      "openai-responses",
-      "anthropic-messages",
-      modelBaseUrl,
-      "anthropic-messages",
-    ],
-  ] as const)(
-    "preserves explicit alias configuration with %s",
-    (_name, providerApi, modelApi, configuredModelBaseUrl, expectedApi) => {
-      const cfg: OpenClawConfig = {
-        models: {
-          providers: {
-            "fireworks-ai": {
-              baseUrl: providerBaseUrl,
-              api: providerApi,
-              headers: { "X-Fireworks-Route": "custom" },
-              models: [
-                {
-                  id: modelId,
-                  name: "Configured GLM",
-                  api: modelApi,
-                  baseUrl: configuredModelBaseUrl,
-                  reasoning: false,
-                  input: ["text", "image"],
-                  contextWindow: 4096,
-                  maxTokens: 512,
-                },
-              ],
-            },
-          },
-        },
-      };
-
-      expect(resolveFireworksGlm("fireworks-ai", cfg)).toMatchObject({
-        provider: "fireworks-ai",
-        id: modelId,
-        api: expectedApi,
-        baseUrl: configuredModelBaseUrl ?? providerBaseUrl,
-        headers: { "X-Fireworks-Route": "custom" },
-        reasoning: false,
-        input: ["text", "image"],
-        contextWindow: 4096,
-        maxTokens: 512,
-      });
-    },
-  );
 });
 
 describe("canonicalizeManifestModelCatalogProviderAlias", () => {

--- a/src/agents/embedded-agent-runner/model.static-catalog.provider-alias.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.provider-alias.test.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const manifestMocks = vi.hoisted(() => ({
   getCurrentPluginMetadataSnapshot: vi.fn(),
@@ -15,8 +17,17 @@ vi.mock("../../plugins/manifest-registry.js", async (importOriginal) => ({
   loadPluginManifestRegistryCore: manifestMocks.loadPluginManifestRegistryCore,
 }));
 
+import { loadPluginManifest } from "../../plugins/manifest.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
-import { resolveManifestModelCatalogProviderAliasMetadata } from "./model.static-catalog.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { resolveOwningPluginIdsForProviderRef } from "../../plugins/providers.js";
+import { resolveBundledPluginPublicModulePath } from "../../test-utils/bundled-plugin-public-surface.js";
+import { resolveRuntimeHooks } from "./model.provider-hooks.js";
+import { resolveModelWithRegistry } from "./model.registry-resolution.js";
+import {
+  resolveBundledStaticCatalogModel,
+  resolveManifestModelCatalogProviderAliasMetadata,
+} from "./model.static-catalog.js";
 
 const canonicalizeManifestModelCatalogProviderAlias = (
   params: Parameters<typeof resolveManifestModelCatalogProviderAliasMetadata>[0],
@@ -96,6 +107,122 @@ beforeEach(() => {
   manifestMocks.loadPluginManifestRegistryCore.mockReset();
   manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(undefined);
   manifestMocks.loadPluginManifestRegistryCore.mockReturnValue({ plugins: [] });
+});
+
+describe("Fireworks manifest provider alias", () => {
+  const modelId = "accounts/fireworks/routers/glm-5p2-fast";
+  const providerBaseUrl = "https://fireworks-proxy.example/v1";
+  const modelBaseUrl = "https://fireworks-proxy.example/model";
+
+  beforeEach(() => {
+    const rootDir = path.dirname(
+      resolveBundledPluginPublicModulePath({
+        pluginId: "fireworks",
+        artifactBasename: "openclaw.plugin.json",
+      }),
+    );
+    const loaded = loadPluginManifest(rootDir);
+    if (!loaded.ok) {
+      throw new Error(loaded.error);
+    }
+    const snapshot = createPluginMetadataSnapshotFixture({
+      plugins: [{ ...loaded.manifest, origin: "bundled", rootDir }],
+    });
+    manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(snapshot);
+    manifestMocks.loadPluginManifestRegistryCore.mockReturnValue(snapshot.manifestRegistry);
+  });
+
+  function resolveFireworksGlm(provider: string, cfg?: OpenClawConfig) {
+    const catalogModel = resolveBundledStaticCatalogModel({
+      provider: "fireworks",
+      modelId,
+      includeRuntimeDiscovery: true,
+    });
+    if (!catalogModel) {
+      throw new Error("Missing Fireworks GLM catalog model");
+    }
+    return resolveModelWithRegistry({
+      provider,
+      modelId,
+      cfg,
+      modelRegistry: {
+        getAll: () => [catalogModel],
+        getAvailable: () => [],
+        hasConfiguredAuth: () => false,
+        find: (candidateProvider, candidateId) =>
+          candidateProvider === catalogModel.provider && candidateId === catalogModel.id
+            ? catalogModel
+            : undefined,
+      },
+      runtimeHooks: resolveRuntimeHooks({ skipProviderRuntimeHooks: true }),
+      authProfileMode: "api_key",
+    });
+  }
+
+  it("finds the alias owner before runtime loading and resolves the canonical catalog model", () => {
+    expect(resolveOwningPluginIdsForProviderRef({ provider: "fireworks-ai" })).toEqual([
+      "fireworks",
+    ]);
+    const canonical = resolveFireworksGlm("fireworks");
+    expect(canonical).toMatchObject({
+      provider: "fireworks",
+      id: modelId,
+      api: "openai-completions",
+      baseUrl: "https://api.fireworks.ai/inference/v1",
+    });
+    expect(resolveFireworksGlm("fireworks-ai")).toEqual(canonical);
+  });
+
+  it.each([
+    ["omitted API", undefined, undefined, undefined, "openai-completions"],
+    ["provider API", "openai-responses", undefined, undefined, "openai-responses"],
+    [
+      "model API and URL",
+      "openai-responses",
+      "anthropic-messages",
+      modelBaseUrl,
+      "anthropic-messages",
+    ],
+  ] as const)(
+    "preserves explicit alias configuration with %s",
+    (_name, providerApi, modelApi, configuredModelBaseUrl, expectedApi) => {
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            "fireworks-ai": {
+              baseUrl: providerBaseUrl,
+              api: providerApi,
+              headers: { "X-Fireworks-Route": "custom" },
+              models: [
+                {
+                  id: modelId,
+                  name: "Configured GLM",
+                  api: modelApi,
+                  baseUrl: configuredModelBaseUrl,
+                  reasoning: false,
+                  input: ["text", "image"],
+                  contextWindow: 4096,
+                  maxTokens: 512,
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      expect(resolveFireworksGlm("fireworks-ai", cfg)).toMatchObject({
+        provider: "fireworks-ai",
+        id: modelId,
+        api: expectedApi,
+        baseUrl: configuredModelBaseUrl ?? providerBaseUrl,
+        headers: { "X-Fireworks-Route": "custom" },
+        reasoning: false,
+        input: ["text", "image"],
+        contextWindow: 4096,
+        maxTokens: 512,
+      });
+    },
+  );
 });
 
 describe("canonicalizeManifestModelCatalogProviderAlias", () => {

--- a/test/plugins/fireworks-model-alias.test.ts
+++ b/test/plugins/fireworks-model-alias.test.ts
@@ -1,0 +1,152 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+
+const manifestMocks = vi.hoisted(() => ({
+  getCurrentPluginMetadataSnapshot: vi.fn(),
+  loadPluginManifestRegistryCore: vi.fn(),
+}));
+
+vi.mock("../../src/plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../src/plugins/current-plugin-metadata-snapshot.js")
+  >()),
+  getCurrentPluginMetadataSnapshot: manifestMocks.getCurrentPluginMetadataSnapshot,
+}));
+
+vi.mock("../../src/plugins/manifest-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/plugins/manifest-registry.js")>()),
+  loadPluginManifestRegistryCore: manifestMocks.loadPluginManifestRegistryCore,
+}));
+
+import { resolveRuntimeHooks } from "../../src/agents/embedded-agent-runner/model.provider-hooks.js";
+import { resolveModelWithRegistry } from "../../src/agents/embedded-agent-runner/model.registry-resolution.js";
+import { resolveBundledStaticCatalogModel } from "../../src/agents/embedded-agent-runner/model.static-catalog.js";
+import { loadPluginManifest } from "../../src/plugins/manifest.js";
+import { clearPluginMetadataLifecycleCaches } from "../../src/plugins/plugin-metadata-lifecycle.js";
+import { createPluginMetadataSnapshotFixture } from "../../src/plugins/plugin-metadata.test-support.js";
+import { resolveOwningPluginIdsForProviderRef } from "../../src/plugins/providers.js";
+import { resolveBundledPluginPublicModulePath } from "../../src/test-utils/bundled-plugin-public-surface.js";
+
+beforeEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  manifestMocks.getCurrentPluginMetadataSnapshot.mockReset();
+  manifestMocks.loadPluginManifestRegistryCore.mockReset();
+});
+
+describe("Fireworks manifest provider alias", () => {
+  const modelId = "accounts/fireworks/routers/glm-5p2-fast";
+  const providerBaseUrl = "https://fireworks-proxy.example/v1";
+  const modelBaseUrl = "https://fireworks-proxy.example/model";
+
+  beforeEach(() => {
+    const rootDir = path.dirname(
+      resolveBundledPluginPublicModulePath({
+        pluginId: "fireworks",
+        artifactBasename: "openclaw.plugin.json",
+      }),
+    );
+    const loaded = loadPluginManifest(rootDir);
+    if (!loaded.ok) {
+      throw new Error(loaded.error);
+    }
+    const snapshot = createPluginMetadataSnapshotFixture({
+      plugins: [{ ...loaded.manifest, origin: "bundled", rootDir }],
+    });
+    manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(snapshot);
+    manifestMocks.loadPluginManifestRegistryCore.mockReturnValue(snapshot.manifestRegistry);
+  });
+
+  function resolveFireworksGlm(provider: string, cfg?: OpenClawConfig) {
+    const catalogModel = resolveBundledStaticCatalogModel({
+      provider: "fireworks",
+      modelId,
+      includeRuntimeDiscovery: true,
+    });
+    if (!catalogModel) {
+      throw new Error("Missing Fireworks GLM catalog model");
+    }
+    return resolveModelWithRegistry({
+      provider,
+      modelId,
+      cfg,
+      modelRegistry: {
+        getAll: () => [catalogModel],
+        getAvailable: () => [],
+        hasConfiguredAuth: () => false,
+        find: (candidateProvider, candidateId) =>
+          candidateProvider === catalogModel.provider && candidateId === catalogModel.id
+            ? catalogModel
+            : undefined,
+      },
+      runtimeHooks: resolveRuntimeHooks({ skipProviderRuntimeHooks: true }),
+      authProfileMode: "api_key",
+    });
+  }
+
+  it("finds the alias owner before runtime loading and resolves the canonical catalog model", () => {
+    expect(resolveOwningPluginIdsForProviderRef({ provider: "fireworks-ai" })).toEqual([
+      "fireworks",
+    ]);
+    const canonical = resolveFireworksGlm("fireworks");
+    expect(canonical).toMatchObject({
+      provider: "fireworks",
+      id: modelId,
+      api: "openai-completions",
+      baseUrl: "https://api.fireworks.ai/inference/v1",
+    });
+    expect(resolveFireworksGlm("fireworks-ai")).toEqual(canonical);
+  });
+
+  it.each([
+    ["omitted API", undefined, undefined, undefined, "openai-completions"],
+    ["provider API", "openai-responses", undefined, undefined, "openai-responses"],
+    [
+      "model API and URL",
+      "openai-responses",
+      "anthropic-messages",
+      modelBaseUrl,
+      "anthropic-messages",
+    ],
+  ] as const)(
+    "preserves explicit alias configuration with %s",
+    (_name, providerApi, modelApi, configuredModelBaseUrl, expectedApi) => {
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            "fireworks-ai": {
+              baseUrl: providerBaseUrl,
+              api: providerApi,
+              headers: { "X-Fireworks-Route": "custom" },
+              models: [
+                {
+                  id: modelId,
+                  name: "Configured GLM",
+                  api: modelApi,
+                  baseUrl: configuredModelBaseUrl,
+                  reasoning: false,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 4096,
+                  maxTokens: 512,
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      expect(resolveFireworksGlm("fireworks-ai", cfg)).toMatchObject({
+        provider: "fireworks-ai",
+        id: modelId,
+        api: expectedApi,
+        baseUrl: configuredModelBaseUrl ?? providerBaseUrl,
+        headers: { "X-Fireworks-Route": "custom" },
+        reasoning: false,
+        input: ["text", "image"],
+        contextWindow: 4096,
+        maxTokens: 512,
+      });
+    },
+  );
+});


### PR DESCRIPTION
Fixes #144857

## What Problem This Solves

Fixes an issue where users selecting `fireworks-ai/accounts/fireworks/routers/glm-5p2-fast` through `openclaw config set` receive an unknown-model error even though the documented `fireworks-ai` alias is registered by the Fireworks plugin.

## Why This Change Was Made

Declare the alias in Fireworks' model-catalog metadata so provider ownership and model normalization can resolve it before the plugin runtime loads. The `openai-completions` transport declaration preserves explicit alias-owned endpoints and configuration; a plain alias would discard those overrides during canonicalization.

## User Impact

Users can select Fireworks models through the documented alias while retaining custom endpoints, headers, API overrides, capabilities, and model limits.

## Evidence

- Four Fireworks contract tests, all 11 generic alias tests, the extension test boundary suite, and nine affected owner/caller/plugin test files passed on Blacksmith Testbox. The original manifest fails the ownership regression; an alias without transport metadata fails all three custom-routing controls.
- Build and runtime validation passed with 32 observations covering both provider spellings, all three curated models plus a forward model ID, primary/fallback validation, cold/warm resolution, and explicit routing overrides.
- Fresh CLI processes saved, read back, and resolved clean canonical and alias configurations without explicit plugin enablement. Existing custom alias settings also survived save/readback, including omitted API and per-model API/URL overrides; headers, capabilities, and limits remained intact.
- The full affected `check:changed` gate passed at the final revision, including extension/root test types, lint, metadata checks, and import boundaries. Independent review found no actionable issues through P2. [CI passed](https://github.com/openclaw/openclaw/actions/runs/34599975269).
- Runtime proof used isolated synthetic state, verified its cleanup, and made no paid inference requests.
