### PR TITLE
fix(mcp): accept already-terminated HTTP sessions

### DIFF
--- a/src/agents/mcp-http-transport.test.ts
+++ b/src/agents/mcp-http-transport.test.ts
@@ -521,24 +521,30 @@ describe("OpenClaw MCP HTTP lifecycle adapters", () => {
     },
   );
 
-  it("accepts unsupported session DELETE without sending it again", async () => {
-    const onDelete = vi.fn(() => new Response(null, { status: 405 }));
-    const fetchMock = initializedFetch({
-      onGet: () => new Response(null, { status: 405 }),
-      onDelete,
-    });
-    const transport = new OpenClawStreamableHTTPClientTransport(new URL("http://mcp.invalid/mcp"), {
-      fetch: fetchMock,
-    });
-    const client = new Client({ name: "test", version: "1" });
-    await client.connect(transport);
-    await transport.terminateSession();
-    await transport.terminateSession();
-    await expect(
-      disposeMcpClient({ client, transport, transportType: "streamable-http" }),
-    ).resolves.toBe("closed");
-    expect(onDelete).toHaveBeenCalledOnce();
-  });
+  it.each([404, 405])(
+    "accepts terminal session DELETE status %s without sending it again",
+    async (status) => {
+      const onDelete = vi.fn(() => new Response(null, { status }));
+      const fetchMock = initializedFetch({
+        onGet: () => new Response(null, { status: 405 }),
+        onDelete,
+      });
+      const transport = new OpenClawStreamableHTTPClientTransport(
+        new URL("http://mcp.invalid/mcp"),
+        {
+          fetch: fetchMock,
+        },
+      );
+      const client = new Client({ name: "test", version: "1" });
+      await client.connect(transport);
+      await transport.terminateSession();
+      await transport.terminateSession();
+      await expect(
+        disposeMcpClient({ client, transport, transportType: "streamable-http" }),
+      ).resolves.toBe("closed");
+      expect(onDelete).toHaveBeenCalledOnce();
+    },
+  );
 
   it("does not record a rejected DELETE as successful termination", async () => {
     const onDelete = vi.fn(() => new Response("refused", { status: 500, statusText: "Rejected" }));

--- a/src/agents/mcp-http-transport.ts
+++ b/src/agents/mcp-http-transport.ts
@@ -377,7 +377,7 @@ export class OpenClawStreamableHTTPClientTransport extends OpenClawMcpHttpTransp
       signal: AbortSignal.timeout(SESSION_TERMINATION_TIMEOUT_MS),
     });
     void response.body?.cancel().catch(() => undefined);
-    if (!response.ok && response.status !== 405) {
+    if (!response.ok && response.status !== 404 && response.status !== 405) {
       throw new StreamableHTTPError(
         response.status,
         `Failed to terminate session: ${response.statusText}`,


### PR DESCRIPTION
Closes #144860

## What Problem This Solves

Fixes an issue where MCP cleanup was reported as failed when a Streamable HTTP server returned 404 because the session was already terminated.

## Why This Change Was Made

Treat DELETE responses 404 and 405 as terminal cleanup outcomes while preserving errors and retries for authentication failures and server failures.

## User Impact

MCP clients no longer surface a false cleanup failure when the remote session has already disappeared, and repeated termination remains idempotent.

## Evidence

- Focused MCP HTTP lifecycle suite: 19 tests passed.
- Regression coverage verifies both 404 and 405 are accepted once.
- Existing rejected-DELETE retry coverage remains green.
- Formatting, direct type-aware lint, and `git diff --check` passed.