### PR TITLE
fix(secrets): trust configured CAs for protected egress

### DIFF
--- a/src/secrets/egress-proxy/proxy-server.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.test.ts
@@ -4,7 +4,7 @@ import { createServer as createHttpsServer } from "node:https";
 import net, { type Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
-import tls from "node:tls";
+import tls, { getCACertificates, rootCertificates } from "node:tls";
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { generateLocalProxyLeaf } from "../../proxy-capture/ca.js";
@@ -306,6 +306,13 @@ describe("secret egress proxy", () => {
 
   it("activates Node environment proxy support for registered Gateway runs", () => {
     expect(proxyEnv.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
+  it("preserves Node's configured default CAs in the generated trust bundle", () => {
+    const trustBundle = fs.readFileSync(path.join(caDir, "trust-bundle.pem"), "utf8");
+    for (const certificate of [...rootCertificates, ...getCACertificates("default")]) {
+      expect(trustBundle).toContain(certificate);
+    }
   });
 
   it("survives a client that resets a refused tunnel instead of crashing the Gateway", async () => {

--- a/src/secrets/egress-proxy/proxy-server.ts
+++ b/src/secrets/egress-proxy/proxy-server.ts
@@ -10,7 +10,7 @@ import { Agent as HttpsAgent, createServer as createHttpsServer } from "node:htt
 import net, { type Socket } from "node:net";
 import path from "node:path";
 import type { Duplex, Readable, Writable } from "node:stream";
-import { rootCertificates } from "node:tls";
+import { getCACertificates, rootCertificates } from "node:tls";
 import { URL } from "node:url";
 import { normalizeExactAllowedHost as normalizeHostname } from "../exact-hostname.js";
 import {
@@ -241,10 +241,15 @@ export async function startSecretEgressProxyServer(params: {
 }): Promise<SecretEgressProxyHandle> {
   const certificates = await createSecretEgressCertificates(params.caDir);
   const { caPem } = certificates;
+  const defaultCaCertificates = [
+    ...new Set([...rootCertificates, ...getCACertificates("default")]),
+  ];
   const trustBundlePath = path.join(params.caDir, "trust-bundle.pem");
-  fs.writeFileSync(trustBundlePath, `${rootCertificates.join("\n")}\n${caPem}`, { mode: 0o644 });
+  fs.writeFileSync(trustBundlePath, `${defaultCaCertificates.join("\n")}\n${caPem}`, {
+    mode: 0o644,
+  });
   const upstreamTlsAgent = new HttpsAgent({
-    ca: [...rootCertificates, caPem],
+    ca: [...defaultCaCertificates, caPem],
   });
   const bypassHosts = new Set((params.bypassHosts ?? []).map(normalizeHostname));
   const allowedHosts =


### PR DESCRIPTION
Closes #144830

## What Problem This Solves

Fixes an issue where protected secret-egress requests could not reach HTTPS services whose certificate was trusted through Node's configured CA sources, including `NODE_EXTRA_CA_CERTS`.

## Why This Change Was Made

Build both egress trust paths from a deduplicated union of Node's bundled roots and configured default certificates, then append the proxy's private CA. Bundled roots remain available when OpenSSL CA mode does not enumerate its lookup store.

## User Impact

Operators can use protected-secret substitution with internally trusted HTTPS services while retaining normal public HTTPS trust.

## Evidence

- Regression reproduced before the fix: the generated bundle omitted a configured default CA.
- Focused secret-egress suite: 21 tests passed after the fix.
- Formatting, type-aware lint, `git diff --check`, and automated review passed.
- Automated review identified the OpenSSL-CA fallback risk; the final union preserves bundled roots.