### PR TITLE
fix(update): reviewed failure reports omit the facts that triage node-runtime-preflight

### DIFF
--- a/src/cli/update-cli/update-command-report.ts
+++ b/src/cli/update-cli/update-command-report.ts
@@ -39,6 +39,7 @@ export async function runInteractiveUpdateFailureAction(params: {
   attemptId: string;
   env: NodeJS.ProcessEnv;
   error?: string;
+  errorDetails?: Record<string, string>;
   result?: UpdateRunResult;
   rollbackCompleted?: boolean;
   runtime: Pick<RuntimeEnv, "error" | "log">;
@@ -74,6 +75,7 @@ export async function runInteractiveUpdateFailureAction(params: {
         {
           attemptId: params.attemptId,
           ...(params.error ? { error: params.error } : {}),
+          ...(params.errorDetails ? { errorDetails: params.errorDetails } : {}),
           result,
           ...(result.after?.upstreamRef ? { target: result.after.upstreamRef } : {}),
         },

--- a/src/cli/update-cli/update-command-result.ts
+++ b/src/cli/update-cli/update-command-result.ts
@@ -95,16 +95,22 @@ export async function withUpdateAdmissionReporting<T>(
 /** Unwind update ownership before diagnostics or an interactive agent can run. */
 export class UpdateCommandFailure extends Error {
   readonly automaticTriage?: TriageFailureContext;
+  /** Refusal-time scalar facts that the failure report can render verbatim-safe. */
+  readonly errorDetails?: Record<string, string>;
 
   constructor(
     readonly result: UpdateRunResult,
     readonly exitCode = 1,
     readonly detail?: string,
-    options?: ErrorOptions & { automaticTriage?: TriageFailureContext },
+    options?: ErrorOptions & {
+      automaticTriage?: TriageFailureContext;
+      errorDetails?: Record<string, string>;
+    },
   ) {
     super(detail ?? result.reason ?? "Update failed", options);
     this.name = "UpdateCommandFailure";
     this.automaticTriage = options?.automaticTriage;
+    this.errorDetails = options?.errorDetails;
   }
 }
 

--- a/src/cli/update-cli/update-command-terminal.ts
+++ b/src/cli/update-cli/update-command-terminal.ts
@@ -189,6 +189,7 @@ export async function reportPreMutationUpdateFailure(params: {
   installKind: "git" | "package" | "unknown";
   reason: string;
   message?: string;
+  errorDetails?: Record<string, string>;
   opts: UpdateCommandOptions;
   controlPlaneUpdateSentinelMeta: ControlPlaneUpdateSentinelMetaFile["meta"] | null;
 }): Promise<never> {
@@ -235,6 +236,7 @@ export async function reportPreMutationUpdateFailure(params: {
     result,
     resolveManagedServiceUpdateFailureExitCode(result),
     params.message,
+    params.errorDetails ? { errorDetails: params.errorDetails } : undefined,
   );
 }
 

--- a/src/cli/update-cli/update-command-triage.ts
+++ b/src/cli/update-cli/update-command-triage.ts
@@ -119,6 +119,9 @@ export async function withUpdateFailureTriage(
               attemptId: updateAttemptId,
               env: opts.run?.env ?? target.env,
               ...(failure.error ? { error: failure.error } : {}),
+              ...(reportedFailure && error.errorDetails
+                ? { errorDetails: error.errorDetails }
+                : {}),
               ...(failure.result ? { result: failure.result } : {}),
               ...(rollbackCompleted ? { rollbackCompleted: true } : {}),
               runtime: defaultRuntime,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,4 +1,5 @@
 // Main update orchestration for source checkouts and package installs.
+import { minVersion } from "semver";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { disableCurrentOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
@@ -180,12 +181,13 @@ async function updateCommandInternal(
 
   let root = discoveredRoot;
   let updateInstallKind = installKind;
-  const refuseUpdate = (reason: string, message?: string) =>
+  const refuseUpdate = (reason: string, message?: string, errorDetails?: Record<string, string>) =>
     reportPreMutationUpdateFailure({
       root,
       installKind: updateInstallKind,
       reason,
       message,
+      errorDetails,
       opts,
       controlPlaneUpdateSentinelMeta,
     });
@@ -549,7 +551,24 @@ async function updateCommandInternal(
       fallbackNodeRunner: canRefreshManagedServiceNode ? resolveNodeRunner() : undefined,
     });
     if (!runtimePreflight.ok) {
-      await refuseUpdate("node-runtime-preflight", runtimePreflight.error);
+      // Free-form refusal prose is redacted from the public report, so the
+      // diagnostic facts a maintainer needs travel as sanitized scalars:
+      // the exact target build and the engine floor it requires.
+      const engineFloor = (() => {
+        const engine = packageRuntimeTarget?.nodeEngine;
+        if (!engine) {
+          return "unspecified";
+        }
+        try {
+          return minVersion(engine)?.version ?? "unspecified";
+        } catch {
+          return "unspecified";
+        }
+      })();
+      await refuseUpdate("node-runtime-preflight", runtimePreflight.error, {
+        "Target package": `openclaw@${packageRuntimeTarget?.version ?? "unknown"}`,
+        "Minimum Node engine": engineFloor,
+      });
       return;
     }
     const runtimeSelection = runtimePreflight.value;

--- a/src/infra/update-failure-report-prepare.test.ts
+++ b/src/infra/update-failure-report-prepare.test.ts
@@ -158,4 +158,49 @@ describe("update report diagnostic command boundary", () => {
     expect(report.body).toContain("- Failed phase: doctor-failed\n");
     expect(report.body).not.toContain("openclaw doctor");
   });
+
+  it("renders structured error facts in bounded diagnostics", async () => {
+    const report = await prepareUpdateFailureReport(
+      {
+        attemptId: "preflight-details",
+        errorDetails: {
+          "Target package": "openclaw@2026.9.4",
+          "Minimum Node engine": "26.0.0",
+        },
+        result: {
+          mode: "unknown",
+          status: "error",
+          reason: "node-runtime-preflight",
+          steps: [],
+          durationMs: 1,
+        },
+      },
+      context,
+    );
+    expect(report.body).toContain("- Target package: openclaw@2026.9.4\n");
+    expect(report.body).toContain("- Minimum Node engine: 26.0.0\n");
+  });
+
+  it("redacts private paths and commands inside structured error facts", async () => {
+    const report = await prepareUpdateFailureReport(
+      {
+        attemptId: "redacted-details",
+        errorDetails: {
+          "Private path": "/Users/private-customer-text/openclaw",
+          "Plain fact": "build",
+        },
+        result: { mode: "npm", status: "error", reason: "build-failed", steps: [], durationMs: 1 },
+      },
+      context,
+    );
+    expect(report.body).not.toContain("private-customer-text");
+    expect(report.body).toContain("- Private path: [redacted-path]\n");
+    expect(report.body).toContain("- Plain fact: build\n");
+  });
+
+  it("omits structured error facts when none are supplied", async () => {
+    const report = await prepareDiagnosticReport("node-runtime-preflight");
+    expect(report.body).not.toContain("- Target package:");
+    expect(report.body).not.toContain("- Minimum Node engine:");
+  });
 });

--- a/src/infra/update-failure-report-prepare.ts
+++ b/src/infra/update-failure-report-prepare.ts
@@ -28,6 +28,8 @@ export type PreparedUpdateFailureReport = PreparedGithubIssue & {
 export type UpdateFailureReportInput = {
   attemptId: string;
   error?: string;
+  /** Refusal-time scalar facts (versions, engine bounds) that survive redaction. */
+  errorDetails?: Record<string, string>;
   result: UpdateRunResult;
   target?: string;
 };
@@ -151,6 +153,15 @@ function renderBoundedDiagnostics(
     `Update mode: ${sanitizeReportField(input.result.mode, context)}`,
     `Reason code: ${sanitizeReportField(input.result.reason ?? "unknown", context)}`,
   ];
+  // Refusal sites supply scalar facts (versions, engine bounds) because free-form
+  // prose is redacted below; labels are code constants, values still pass the
+  // same sanitization as every other diagnostic field.
+  for (const [label, value] of Object.entries(input.errorDetails ?? {})) {
+    if (typeof value !== "string" || !value.trim()) {
+      continue;
+    }
+    diagnostics.push(`${label}: ${sanitizeReportField(value, context)}`);
+  }
   if (input.result.reason === LEGACY_UPDATE_RUN_EXPIRED_REASON) {
     diagnostics.push(`Advisory: ${LEGACY_UPDATE_RUN_ADVISORY}`);
   }


### PR DESCRIPTION
Closes #144718

## What Problem This Solves

Fixes an issue where a user whose `openclaw update` fails at the node-runtime-preflight phase submits a reviewed failure report that a maintainer cannot act on. The #144718 report shows `Reason code: node-runtime-preflight` with `Update target: exact target unavailable`, so nothing in the issue says which build was targeted, which Node engine it requires, or which runtime the updater probed. A P0 release-blocker report arrives undiagnosable, and every future preflight refusal would produce the same blind spot.

## Why This Change Was Made

The refusal site already holds the diagnosable facts: the exact inspected target version and its `engines.node` requirement. The refusal message itself cannot be published as-is, because the report pipeline intentionally redacts any line that looks like prose, a command, or a filesystem path. So the pre-mutation refusal now attaches those facts as scalars to the thrown failure, the existing catch chain forwards them into the report flow, and the report renderer emits them inside the bounded diagnostics block right after the reason code.

Every value still passes the same sanitization as all other report fields: private paths and command-shaped text inside a value are redacted as before, free-form refusal prose never reaches the public body, and reports produced without refusal facts keep their previous shape. The engine requirement is rendered through semver `minVersion` as a plain version scalar, because range syntax such as `>=26.0.0` would otherwise be redacted as command-shaped text. Terminal output, JSON output, the run ledger, and the restart sentinel are untouched; the gateway sentinel path still supplies no refusal prose, which is unchanged scope.

## User Impact

The next reviewed report for a node-runtime-preflight refusal tells the maintainer the target build and the engine floor it requires, next to the Node version the report already records. That is enough to distinguish a user-side runtime problem from an updater defect without asking the user to re-run anything. Redaction guarantees are unchanged: the report stays safe to publish, and nothing new is collected.

## Evidence

Focused rendering tests cover fact rendering, redaction of private paths inside fact values, and the unchanged shape when no facts are supplied. The rendering suite and every touched report, triage, and result sibling pass together:

    node scripts/run-vitest.mjs run --config vitest.config.ts \
      src/infra/update-failure-report-prepare.test.ts \
      src/cli/update-cli/update-command-runtime.test.ts \
      src/cli/update-cli/update-command-report.test.ts \
      src/cli/update-cli/update-command-result-diagnostics.test.ts \
      src/cli/update-cli/update-command-rollback-report.test.ts \
      src/cli/update-cli/update-command-terminal-outcome.test.ts \
      src/cli/update-cli/update-command-terminal-triage.test.ts \
      src/cli/update-cli/update-command-triage.test.ts \
      src/commands/triage-failure-process.test.ts \
      src/gateway/server-methods/update-report.test.ts

     Test Files  10 passed (10)
          Tests  148 passed (148)

A recorded proof renders the real reviewed report for a preflight refusal, first against the unmodified renderer and then against the change. Before the fix:

    [FAIL] report names the exact target build :: - Target package: openclaw@2026.9.4
    [FAIL] report states the engine floor as a sanitized scalar :: - Minimum Node engine: 26.0.0
    [PASS] refusal prose stays out of the public body
    [PASS] reason code stays visible for the reviewer
    [PASS] reports without refusal facts keep the old shape
    RUNTIME PROOF FAILED (2)

After the fix:

    [PASS] report names the exact target build :: - Target package: openclaw@2026.9.4
    [PASS] report states the engine floor as a sanitized scalar :: - Minimum Node engine: 26.0.0
    [PASS] refusal prose stays out of the public body
    [PASS] reason code stays visible for the reviewer
    [PASS] reports without refusal facts keep the old shape
    RUNTIME PROOF PASSED

The repository changed-file gate passes over the touched files, including typecheck, scoped lint, the dead-export scan, and the import and boundary guards.
