### PR TITLE
fix(models): keep catalog refresh consistent without delaying startup

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -406,7 +406,6 @@ src/auto-reply/reply/agent-runner-payloads.test.ts
 src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
 src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
 src/auto-reply/reply/commands-acp.test.ts
-src/auto-reply/reply/commands-models.ts
 src/auto-reply/reply/commands-status.test.ts
 src/auto-reply/reply/directive-handling.model.test.ts
 src/auto-reply/reply/dispatch-acp.test.ts

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -142,6 +142,10 @@ agent on that Gateway. Provider filtering, model visibility and availability use
 the Gateway's captured config and auth facts. The command does not resolve local
 model-provider secrets for that request.
 
+Gateway startup initializes the same provider inventory used by `--refresh`
+before accepting agent requests. Both paths include admitted stored accounts and
+native CLI logins. Ordinary list requests reuse that published inventory.
+
 A selected Gateway must advertise `published-model-catalog`. If it does not,
 update or restart it and retry. Connection, authorization and capability errors
 are reported directly; they do not switch the command to a different local list.

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -142,9 +142,10 @@ agent on that Gateway. Provider filtering, model visibility and availability use
 the Gateway's captured config and auth facts. The command does not resolve local
 model-provider secrets for that request.
 
-Gateway startup initializes the same provider inventory used by `--refresh`
-before accepting agent requests. Both paths include admitted stored accounts and
-native CLI logins. Ordinary list requests reuse that published inventory.
+Gateway startup publishes admitted static models and stored account data before
+accepting agent requests. Live discovery and native CLI sync run after readiness
+and update the same published inventory used by `--refresh`. Ordinary list
+requests reuse that inventory.
 
 A selected Gateway must advertise `published-model-catalog`. If it does not,
 update or restart it and retry. Connection, authorization and capability errors

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -21,45 +21,65 @@ per reader job. Open the page that matches your task.
 
 ## When credentials enable a provider
 
-OpenClaw checks whether a provider is enabled for use before resolving credentials
-for model requests or authenticated model discovery:
+OpenClaw checks a provider's binding before resolving credentials for model
+requests or authenticated model discovery:
 
 - An explicit `models.providers.<id>` entry permits that provider to use its
   supported credentials.
 - Stored auth profiles and native CLI accounts remain bound to their provider.
-- An environment variable alone enables a provider only when exactly one distinct
-  provider ID directly declares it in the plugin manifest's
-  `setup.providers[].envVars`. IDs are compared after trimming and lowercasing;
-  auth aliases do not transfer this permission to another provider.
-- A key shared by multiple declared providers requires an explicit provider entry
-  or a stored profile for the intended provider. This includes OpenCode Zen/Go
-  keys, `MINIMAX_API_KEY`, `KIMI_API_KEY`, `KIMICODE_API_KEY`, `OLLAMA_API_KEY`,
-  `OPENROUTER_API_KEY`, `STEPFUN_API_KEY`, and Qwen's `QWEN_API_KEY`,
-  `DASHSCOPE_API_KEY`, and `MODELSTUDIO_API_KEY`.
+  A selected family route can use an existing account through the provider's
+  authentication alias.
+- A provider-specific environment variable works without a `models.providers`
+  entry when one model-serving plugin owns its declaration. That plugin can
+  bind each of its model-provider IDs that directly names the variable.
+  Kimi, MiniMax, Ollama, and StepFun can therefore use their own declared family
+  keys without extra provider entries. Non-model plugins do not claim chat keys.
+- A variable claimed by different model plugins, such as the shared OpenCode
+  Zen/Go variables, needs an explicit binding for the intended provider.
+  Borrowing another provider's key also requires an explicit provider entry.
 - Generic credentials such as `GH_TOKEN`, `GITHUB_TOKEN`, `MODEL_API_KEY`, the AWS
   credential chain, and Google Application Default Credentials do not enable a
   provider by themselves.
 
-Unique provider keys such as `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and
-`OPENAI_API_KEY` still work without a `models.providers` entry. Selecting a model
-or setting `discovery.enabled: true` does not grant credential use. Discovery
-settings only control catalog discovery; public catalogs remain browsable.
+Provider keys such as `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`,
+and `OPENROUTER_API_KEY` still work without a provider entry. If another enabled
+model plugin claims the same variable, Doctor reports the ownership conflict;
+bind the intended provider explicitly. An explicitly disabled plugin does not
+claim the variable.
 
-On upgrade, Gateway startup and `openclaw doctor --fix` use the same one-time
-repair for existing shared-key selections. The repair adds an env SecretRef for
-a provider selected as a primary, fallback, or user-pinned session model only
-when no saved account for that provider or its family exists in any auth scope.
-Saved accounts keep their credential and ordered fallback through the provider's
-authentication alias for the selected route. The repair names conflicting
-profiles so the operator can bind them explicitly; it never writes an env
-reference over a saved account. Notices name variables and providers, never key
-values. Unselected siblings and generic credentials are excluded. Later
-environment-key selections need their own explicit binding.
+For automatic, unpinned selection, an independently bound environment key can
+cover an expired or otherwise unusable saved account. An explicit profile pin
+does not switch accounts this way. An ambiguous or borrowed key is not an
+independently bound fallback.
 
-If Doctor cannot see a selected provider's shared-key variable, it leaves the
-upgrade open and names the missing variable. Rerun Doctor from the service
-environment or with that variable set. A later Gateway startup can finish the
-same repair using the service's environment.
+If a key is present but its model provider is reported as unbound, setting the
+same variable again will not repair the binding. Use `openclaw doctor --fix` for
+an eligible existing selection, or add an explicit provider entry.
+
+`discovery.enabled` controls catalog discovery, not permission to use credentials.
+Public catalogs remain browsable without authentication. Auxiliary capabilities
+such as media, speech, search, and embeddings retain their own authentication
+and selection rules.
+
+On upgrade, Gateway startup and `openclaw doctor --fix` use the same transform
+to preserve existing selected routes. **Startup applies provider bindings only
+in memory: it does not write the config or complete the upgrade receipt.**
+This lets a Gateway with managed or read-only config keep serving an eligible
+route while reporting the exact entry its operator must add.
+
+To persist these upgrades, run `openclaw doctor --fix`. Doctor records completion
+after a successful write. It writes a credential-only env SecretRef for an
+eligible shared-key selection, or a minimal provider declaration for a selected
+cloud credential-chain route. Any saved account for that provider or its family,
+in shared or agent-local storage, blocks a generated env binding. Notices name
+providers, variables, and conflicting profiles, never credential values.
+
+If Doctor cannot see a required variable or cannot write managed config, it
+leaves the upgrade open. Run it from the service environment, or add the reported
+entry to the managed config. A later startup can use the same approved binding
+in memory; it still leaves persistence to Doctor. See
+[Provider upgrade migrations](/gateway/doctor/config-migrations) for selection
+coverage, conflict handling, and examples.
 
 ## Where each section moved
 

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -19,6 +19,32 @@ per reader job. Open the page that matches your task.
 | [Official provider plugins](/concepts/model-providers/official-provider-plugins)  | You are setting up a bundled provider, or need its id, auth env, example model, and quirks.                         |
 | [Custom providers and local runtimes](/concepts/model-providers/custom-providers) | You are configuring a provider through `models.providers`, a custom base URL, a proxy, or a local inference server. |
 
+## When credentials enable a provider
+
+OpenClaw checks whether a provider is enabled for use before resolving credentials
+for model requests or authenticated model discovery:
+
+- An explicit `models.providers.<id>` entry permits that provider to use its
+  supported credentials.
+- Stored auth profiles and native CLI accounts remain bound to their provider.
+- An environment variable alone enables a provider only when exactly one distinct
+  provider ID directly declares it in the plugin manifest's
+  `setup.providers[].envVars`. IDs are compared after trimming and lowercasing;
+  auth aliases do not transfer this permission to another provider.
+- A key shared by multiple declared providers requires an explicit provider entry
+  or a stored profile for the intended provider. This includes OpenCode Zen/Go
+  keys, `MINIMAX_API_KEY`, `KIMI_API_KEY`, `KIMICODE_API_KEY`, `OLLAMA_API_KEY`,
+  `OPENROUTER_API_KEY`, `STEPFUN_API_KEY`, and Qwen's `QWEN_API_KEY`,
+  `DASHSCOPE_API_KEY`, and `MODELSTUDIO_API_KEY`.
+- Generic credentials such as `GH_TOKEN`, `GITHUB_TOKEN`, `MODEL_API_KEY`, the AWS
+  credential chain, and Google Application Default Credentials do not enable a
+  provider by themselves.
+
+Unique provider keys such as `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and
+`OPENAI_API_KEY` still work without a `models.providers` entry. Selecting a model
+or setting `discovery.enabled: true` does not grant credential use. Discovery
+settings only control catalog discovery; public catalogs remain browsable.
+
 ## Where each section moved
 
 Every section heading from the previous single-page version keeps its anchor

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -45,6 +45,12 @@ Unique provider keys such as `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and
 or setting `discovery.enabled: true` does not grant credential use. Discovery
 settings only control catalog discovery; public catalogs remain browsable.
 
+When upgrading, run `openclaw doctor --fix` once to preserve existing shared-key
+selections. Doctor adds an env SecretRef for a provider selected as a primary,
+fallback, or user-pinned session model. It names the variable and provider in its
+notice, never the key value. It does not enroll unselected siblings or use generic
+credentials. Later selections need their own explicit binding.
+
 ## Where each section moved
 
 Every section heading from the previous single-page version keeps its anchor

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -45,11 +45,21 @@ Unique provider keys such as `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and
 or setting `discovery.enabled: true` does not grant credential use. Discovery
 settings only control catalog discovery; public catalogs remain browsable.
 
-When upgrading, run `openclaw doctor --fix` once to preserve existing shared-key
-selections. Doctor adds an env SecretRef for a provider selected as a primary,
-fallback, or user-pinned session model. It names the variable and provider in its
-notice, never the key value. It does not enroll unselected siblings or use generic
-credentials. Later selections need their own explicit binding.
+On upgrade, Gateway startup and `openclaw doctor --fix` use the same one-time
+repair for existing shared-key selections. The repair adds an env SecretRef for
+a provider selected as a primary, fallback, or user-pinned session model only
+when no saved account for that provider or its family exists in any auth scope.
+Saved accounts keep their credential and ordered fallback through the provider's
+authentication alias for the selected route. The repair names conflicting
+profiles so the operator can bind them explicitly; it never writes an env
+reference over a saved account. Notices name variables and providers, never key
+values. Unselected siblings and generic credentials are excluded. Later
+environment-key selections need their own explicit binding.
+
+If Doctor cannot see a selected provider's shared-key variable, it leaves the
+upgrade open and names the missing variable. Rerun Doctor from the service
+environment or with that variable set. A later Gateway startup can finish the
+same repair using the service's environment.
 
 ## Where each section moved
 

--- a/docs/concepts/model-providers/custom-providers.md
+++ b/docs/concepts/model-providers/custom-providers.md
@@ -111,9 +111,9 @@ Volcano Engine (火山引擎) provides access to Doubao and other models in Chin
 Onboarding defaults to the coding surface, but the general `volcengine/*` catalog is registered at the same time.
 
 `VOLCANO_ENGINE_API_KEY` alone binds only `volcengine`. Onboarding explicitly
-declares `volcengine-plan`. Gateway startup and `openclaw doctor --fix` share the
-[one-time upgrade repair](/concepts/model-providers), which preserves selected
-coding models without replacing saved accounts.
+declares `volcengine-plan`. The [upgrade repair](/concepts/model-providers)
+preserves eligible existing coding selections without replacing saved accounts.
+Startup applies it only in memory; `openclaw doctor --fix` persists the binding.
 
 In onboarding/configure model pickers, the Volcengine auth choice prefers both `volcengine/*` and `volcengine-plan/*` rows. If those models are not loaded yet, OpenClaw falls back to the unfiltered catalog instead of showing an empty provider-scoped picker.
 
@@ -161,9 +161,9 @@ openclaw gateway restart
 Onboarding defaults to the coding surface, but the general `byteplus/*` catalog is registered at the same time.
 
 `BYTEPLUS_API_KEY` alone binds only `byteplus`. Onboarding explicitly declares
-`byteplus-plan`. Gateway startup and `openclaw doctor --fix` share the
-[one-time upgrade repair](/concepts/model-providers), which preserves selected
-coding models without replacing saved accounts.
+`byteplus-plan`. The [upgrade repair](/concepts/model-providers) preserves
+eligible existing coding selections without replacing saved accounts. Startup
+applies it only in memory; `openclaw doctor --fix` persists the binding.
 
 In onboarding/configure model pickers, the BytePlus auth choice prefers both `byteplus/*` and `byteplus-plan/*` rows. If those models are not loaded yet, OpenClaw falls back to the unfiltered catalog instead of showing an empty provider-scoped picker.
 

--- a/docs/concepts/model-providers/custom-providers.md
+++ b/docs/concepts/model-providers/custom-providers.md
@@ -74,6 +74,9 @@ Kimi Coding uses Moonshot AI's Anthropic-compatible endpoint:
 ```json5
 {
   env: { vars: { KIMI_API_KEY: "sk-..." } },
+  models: {
+    providers: { kimi: { baseUrl: "https://api.kimi.com/coding/", models: [] } },
+  },
   agents: {
     defaults: { model: { primary: "kimi/kimi-for-coding" } },
   },

--- a/docs/concepts/model-providers/custom-providers.md
+++ b/docs/concepts/model-providers/custom-providers.md
@@ -111,8 +111,9 @@ Volcano Engine (火山引擎) provides access to Doubao and other models in Chin
 Onboarding defaults to the coding surface, but the general `volcengine/*` catalog is registered at the same time.
 
 `VOLCANO_ENGINE_API_KEY` alone binds only `volcengine`. Onboarding explicitly
-declares `volcengine-plan`. To retain an existing selected coding model during
-upgrade, run `openclaw doctor --fix` once.
+declares `volcengine-plan`. Gateway startup and `openclaw doctor --fix` share the
+[one-time upgrade repair](/concepts/model-providers), which preserves selected
+coding models without replacing saved accounts.
 
 In onboarding/configure model pickers, the Volcengine auth choice prefers both `volcengine/*` and `volcengine-plan/*` rows. If those models are not loaded yet, OpenClaw falls back to the unfiltered catalog instead of showing an empty provider-scoped picker.
 
@@ -160,8 +161,9 @@ openclaw gateway restart
 Onboarding defaults to the coding surface, but the general `byteplus/*` catalog is registered at the same time.
 
 `BYTEPLUS_API_KEY` alone binds only `byteplus`. Onboarding explicitly declares
-`byteplus-plan`. To retain an existing selected coding model during upgrade, run
-`openclaw doctor --fix` once.
+`byteplus-plan`. Gateway startup and `openclaw doctor --fix` share the
+[one-time upgrade repair](/concepts/model-providers), which preserves selected
+coding models without replacing saved accounts.
 
 In onboarding/configure model pickers, the BytePlus auth choice prefers both `byteplus/*` and `byteplus-plan/*` rows. If those models are not loaded yet, OpenClaw falls back to the unfiltered catalog instead of showing an empty provider-scoped picker.
 

--- a/docs/concepts/model-providers/custom-providers.md
+++ b/docs/concepts/model-providers/custom-providers.md
@@ -110,6 +110,10 @@ Volcano Engine (火山引擎) provides access to Doubao and other models in Chin
 
 Onboarding defaults to the coding surface, but the general `volcengine/*` catalog is registered at the same time.
 
+`VOLCANO_ENGINE_API_KEY` alone binds only `volcengine`. Onboarding explicitly
+declares `volcengine-plan`. To retain an existing selected coding model during
+upgrade, run `openclaw doctor --fix` once.
+
 In onboarding/configure model pickers, the Volcengine auth choice prefers both `volcengine/*` and `volcengine-plan/*` rows. If those models are not loaded yet, OpenClaw falls back to the unfiltered catalog instead of showing an empty provider-scoped picker.
 
 <Tabs>
@@ -154,6 +158,10 @@ openclaw gateway restart
 ```
 
 Onboarding defaults to the coding surface, but the general `byteplus/*` catalog is registered at the same time.
+
+`BYTEPLUS_API_KEY` alone binds only `byteplus`. Onboarding explicitly declares
+`byteplus-plan`. To retain an existing selected coding model during upgrade, run
+`openclaw doctor --fix` once.
 
 In onboarding/configure model pickers, the BytePlus auth choice prefers both `byteplus/*` and `byteplus-plan/*` rows. If those models are not loaded yet, OpenClaw falls back to the unfiltered catalog instead of showing an empty provider-scoped picker.
 

--- a/docs/concepts/model-providers/official-provider-plugins.md
+++ b/docs/concepts/model-providers/official-provider-plugins.md
@@ -183,6 +183,10 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
 
 ### Other bundled provider plugins
 
+The auth variables below are credential sources. Shared keys and generic
+credentials still require provider setup or an explicit provider entry; see
+[When credentials enable a provider](/concepts/model-providers#when-credentials-enable-a-provider).
+
 | Provider                                | Id                               | Auth env                                       | Example model                                          |
 | --------------------------------------- | -------------------------------- | ---------------------------------------------- | ------------------------------------------------------ |
 | [Arcee](/providers/arcee)               | `arcee`                          | `ARCEEAI_API_KEY` or `OPENROUTER_API_KEY`      | `arcee/trinity-large-thinking`                         |

--- a/docs/concepts/model-providers/official-provider-plugins.md
+++ b/docs/concepts/model-providers/official-provider-plugins.md
@@ -183,8 +183,9 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
 
 ### Other bundled provider plugins
 
-The auth variables below are credential sources. Shared keys and generic
-credentials still require provider setup or an explicit provider entry; see
+The auth variables below are credential sources. A plugin's directly declared
+family keys can bind its own model providers. Keys shared across different model
+plugins, borrowed keys, and generic credentials require provider setup or an explicit entry; see
 [When credentials enable a provider](/concepts/model-providers#when-credentials-enable-a-provider).
 
 | Provider                                | Id                               | Auth env                                       | Example model                                          |

--- a/docs/gateway/config-tools/provider-examples.md
+++ b/docs/gateway/config-tools/provider-examples.md
@@ -51,6 +51,10 @@ Worked `models.providers` configurations. For what each field means, see [Custom
 
   </Accordion>
   <Accordion title="Kimi Coding">
+    `KIMI_API_KEY` and `KIMICODE_API_KEY` are declared by the Kimi Coding plugin
+    for its own `kimi` and `kimi-coding` providers. They need no provider entry
+    for those model requests and do not authenticate Moonshot API models.
+
     ```json5
     {
       env: { vars: { KIMI_API_KEY: "sk-..." } },
@@ -108,6 +112,10 @@ Worked `models.providers` configurations. For what each field means, see [Custom
     See [Local Models](/gateway/local-models). TL;DR: run a large local model via LM Studio Responses API on serious hardware; keep hosted models merged for fallback.
   </Accordion>
   <Accordion title="MiniMax M3 (direct)">
+    `MINIMAX_API_KEY` already binds the MiniMax plugin's declaring providers.
+    The explicit entry below also shows how to override its transport and model
+    metadata; it is not required for default environment-key authentication.
+
     ```json5
     {
       agents: {
@@ -185,6 +193,9 @@ Worked `models.providers` configurations. For what each field means, see [Custom
 
   </Accordion>
   <Accordion title="OpenCode">
+    Zen and Go are separate plugin owners. Bind the catalog you intend to use;
+    the shared environment variable alone does not choose between them.
+
     ```json5
     {
       agents: {
@@ -193,10 +204,21 @@ Worked `models.providers` configurations. For what each field means, see [Custom
           models: { "opencode/claude-opus-4-6": { alias: "Opus" } },
         },
       },
+      models: {
+        providers: {
+          opencode: {
+            apiKey: { source: "env", provider: "default", id: "OPENCODE_API_KEY" },
+          },
+        },
+      },
     }
     ```
 
-    Set `OPENCODE_API_KEY` (or `OPENCODE_ZEN_API_KEY`). Use `opencode/...` refs for the Zen catalog or `opencode-go/...` refs for the Go catalog. Shortcut: `openclaw onboard --auth-choice opencode-zen` or `openclaw onboard --auth-choice opencode-go`.
+    Set `OPENCODE_API_KEY`, or change the SecretRef `id` to `OPENCODE_ZEN_API_KEY`
+    and set that variable. For Go, use `opencode-go` in both the provider entry
+    and model refs. Onboarding writes the selected binding:
+    `openclaw onboard --auth-choice opencode-zen` or
+    `openclaw onboard --auth-choice opencode-go`.
 
   </Accordion>
   <Accordion title="Synthetic (Anthropic-compatible)">

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -61,6 +61,13 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
 
 > JSON5 lets you use comments and trailing commas. Regular JSON works too.
 
+The provider-specific OpenRouter and Groq variables below work without extra
+provider entries. A key claimed by different model plugins, such as an OpenCode
+Zen/Go key, needs an explicit binding for the selected provider. An existing
+route may receive an in-memory upgrade binding at startup; only
+`openclaw doctor --fix` persists that repair. See
+[Model provider bindings](/concepts/model-providers#when-credentials-enable-a-provider).
+
 ```json5
 {
   // Environment + shell

--- a/docs/gateway/doctor/config-migrations.md
+++ b/docs/gateway/doctor/config-migrations.md
@@ -82,7 +82,20 @@ beyond the grace period.
       precedence. Unselected siblings and generic credentials are excluded. A
       receipt closes this one-time upgrade after a successful Doctor pass; later
       model selections need an explicit binding. Unreadable upgrade state leaves
-      config unchanged and asks for another Doctor run.
+      config unchanged and asks for another Doctor run. The provider overlay contains
+      only the credential reference; bundled catalog defaults stay with the provider:
+
+      ```json5
+      {
+        models: {
+          providers: {
+            "byteplus-plan": {
+              apiKey: { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" },
+            },
+          },
+        },
+      }
+      ```
 
     | Legacy key                                                                                    | Current key                                                                 |
     | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |

--- a/docs/gateway/doctor/config-migrations.md
+++ b/docs/gateway/doctor/config-migrations.md
@@ -75,17 +75,25 @@ beyond the grace period.
 
     Active migrations:
 
-    - Shared model-provider credentials: Doctor preserves only providers selected
+    - Shared model-provider credentials: Doctor and Gateway startup preserve only providers selected
       by a primary model, configured fallback, or persisted user session pin. It
       writes an env SecretRef under `models.providers.<id>` when a shared-family
-      key previously supplied that unbound identity. Existing bound accounts take
-      precedence. Unselected siblings and generic credentials are excluded. A
-      receipt closes this one-time upgrade after a successful Doctor pass; later
+      key previously supplied that unbound identity. Any saved account for that
+      provider or its family, in shared or agent-local storage, blocks an env
+      binding. The notice names the provider and saved profiles so the operator
+      can bind the account explicitly. Selected routes keep their existing saved
+      account through the provider's authentication alias. Unselected siblings
+      and generic credentials are excluded. A
+      receipt closes this one-time upgrade after successful persistence; later
       model selections need an explicit binding. Unreadable upgrade state leaves
       config unchanged and asks for another Doctor run. If a global binding would
       replace another agent's account, Doctor preserves that account, warns which
       agent still needs authentication, and leaves the upgrade open. Independent
-      safe bindings still proceed. The provider overlay contains
+      safe bindings still proceed. A missing shared-key variable also leaves
+      the upgrade open. The warning names the variable and asks you to rerun
+      Doctor from the service environment or with that variable set. Gateway
+      startup can finish the same repair using its service environment.
+      The provider overlay contains
       only the credential reference; bundled catalog defaults stay with the provider:
 
       ```json5

--- a/docs/gateway/doctor/config-migrations.md
+++ b/docs/gateway/doctor/config-migrations.md
@@ -75,6 +75,15 @@ beyond the grace period.
 
     Active migrations:
 
+    - Shared model-provider credentials: Doctor preserves only providers selected
+      by a primary model, configured fallback, or persisted user session pin. It
+      writes an env SecretRef under `models.providers.<id>` when a shared-family
+      key previously supplied that unbound identity. Existing bound accounts take
+      precedence. Unselected siblings and generic credentials are excluded. A
+      receipt closes this one-time upgrade after a successful Doctor pass; later
+      model selections need an explicit binding. Unreadable upgrade state leaves
+      config unchanged and asks for another Doctor run.
+
     | Legacy key                                                                                    | Current key                                                                 |
     | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
     | `routing.allowFrom`                                                                              | `channels.whatsapp.allowFrom`                                                |

--- a/docs/gateway/doctor/config-migrations.md
+++ b/docs/gateway/doctor/config-migrations.md
@@ -93,6 +93,11 @@ beyond the grace period.
       the upgrade open. The warning names the variable and asks you to rerun
       Doctor from the service environment or with that variable set. Gateway
       startup can finish the same repair using its service environment.
+      If an account is saved while Doctor prepares the config write, Doctor
+      defers the new shared-key bindings, keeps the upgrade open, and saves
+      independent config repairs. It never writes a generated binding over the
+      saved account. If a binding requires a guarded write to an included config
+      file, Doctor leaves it pending and asks you to edit that file explicitly.
       The provider overlay contains
       only the credential reference; bundled catalog defaults stay with the provider:
 

--- a/docs/gateway/doctor/config-migrations.md
+++ b/docs/gateway/doctor/config-migrations.md
@@ -82,7 +82,10 @@ beyond the grace period.
       precedence. Unselected siblings and generic credentials are excluded. A
       receipt closes this one-time upgrade after a successful Doctor pass; later
       model selections need an explicit binding. Unreadable upgrade state leaves
-      config unchanged and asks for another Doctor run. The provider overlay contains
+      config unchanged and asks for another Doctor run. If a global binding would
+      replace another agent's account, Doctor preserves that account, warns which
+      agent still needs authentication, and leaves the upgrade open. Independent
+      safe bindings still proceed. The provider overlay contains
       only the credential reference; bundled catalog defaults stay with the provider:
 
       ```json5

--- a/docs/gateway/doctor/config-migrations.md
+++ b/docs/gateway/doctor/config-migrations.md
@@ -51,6 +51,9 @@ beyond the grace period.
   <Accordion title="2. Legacy config key migrations">
     Gateway startup automatically applies deterministic, prompt-free legacy config migrations when an otherwise invalid single-file config can be fully migrated. It uses the same migration transforms as `openclaw doctor --fix`, validates the complete result including plugin config before writing, and reports the applied changes. The write runs under the startup migration lease and preserves the previous config in the five-slot `openclaw.json.bak` / `.bak.1` through `.bak.4` backup ring.
 
+    The provider-binding upgrade described below is separate: startup applies
+    those bindings only in memory. Doctor owns their persistent write and receipt.
+
     Startup does not migrate configs using `$include`, configs in Nix mode, or configs last written by a newer OpenClaw version. It also skips automatic config migration while an update is in progress and plugin validation is deferred; the post-update doctor run owns that repair. If any validation or legacy-key issue remains after migration, startup leaves the config unchanged, refuses to start, and prints the `openclaw doctor --fix` hint. An interactive terminal can still offer to run doctor and retry once for configs that need other repairs; headless services stop with the hint.
 
     Other commands that encounter legacy keys still ask you to run `openclaw doctor`. Doctor explains the issues, shows its migrations, and rewrites `~/.openclaw/openclaw.json` with the updated schema. Cron job store migrations are also handled by `openclaw doctor --fix`; automatic config-key migration does not import legacy session stores or repair services.
@@ -75,31 +78,46 @@ beyond the grace period.
 
     Active migrations:
 
-    - Shared model-provider credentials: Doctor and Gateway startup preserve only providers selected
-      by a primary model, configured fallback, or persisted user session pin. It
-      writes an env SecretRef under `models.providers.<id>` when a shared-family
-      key previously supplied that unbound identity. Any saved account for that
-      provider or its family, in shared or agent-local storage, blocks an env
-      binding. The notice names the provider and saved profiles so the operator
-      can bind the account explicitly. Selected routes keep their existing saved
-      account through the provider's authentication alias. Unselected siblings
-      and generic credentials are excluded. A
-      receipt closes this one-time upgrade after successful persistence; later
-      model selections need an explicit binding. Unreadable upgrade state leaves
-      config unchanged and asks for another Doctor run. If a global binding would
-      replace another agent's account, Doctor preserves that account, warns which
-      agent still needs authentication, and leaves the upgrade open. Independent
-      safe bindings still proceed. A missing shared-key variable also leaves
-      the upgrade open. The warning names the variable and asks you to rerun
-      Doctor from the service environment or with that variable set. Gateway
-      startup can finish the same repair using its service environment.
-      If an account is saved while Doctor prepares the config write, Doctor
-      defers the new shared-key bindings, keeps the upgrade open, and saves
-      independent config repairs. It never writes a generated binding over the
-      saved account. If a binding requires a guarded write to an included config
-      file, Doctor leaves it pending and asks you to edit that file explicitly.
-      The provider overlay contains
-      only the credential reference; bundled catalog defaults stay with the provider:
+    - Model-provider bindings: Gateway startup applies the approved upgrade
+      transform **in memory only**. It does not write provider bindings to
+      `openclaw.json` or complete their upgrade receipt. `openclaw doctor --fix`
+      owns persistent changes and keeps the normal config backup.
+      A managed or read-only config remains unchanged; startup can serve an
+      eligible selected route and reports the exact entry to add to that config.
+
+      The upgrade inspects configured model selections, including primary and
+      fallback models, subagent and utility models, image/PDF/voice/media model
+      references, heartbeat, compaction and memory-flush models, exec reviewers,
+      channel overrides, cron model overrides, and persisted user session pins.
+      Doctor revisits completion records from the earlier primary/fallback-only
+      selection pass. Auxiliary capability selection and authentication are
+      otherwise unchanged.
+
+      A key owned by one chat plugin already binds that plugin's directly
+      declaring family providers and needs no migration. For other eligible
+      existing shared-key selections, the transform proposes an env SecretRef.
+      For an unambiguous selected cloud credential-chain provider, it proposes
+      a minimal `models.providers.<id>: {}` declaration. Generic credentials
+      alone never select a provider.
+
+      Any saved account for the provider or its family, in any auth scope,
+      blocks a generated env binding. The notice names the provider and saved
+      profiles so the operator can bind that account explicitly. A missing
+      variable, account conflict, unreadable upgrade state, or unwritable config
+      leaves completion open. Independent safe repairs can still proceed.
+      Doctor reports conflicting model-plugin claims to a variable rather than
+      advising the operator to set a key that is already present.
+
+      If an account appears while Doctor prepares a write, the final publication
+      check defers generated bindings and preserves independent repairs. If a
+      binding belongs in an included file, Doctor leaves it pending and names
+      that file. Only successful Doctor persistence closes the upgrade.
+      Later model selections need their own binding when their key is ambiguous
+      or borrowed.
+
+      An auth-only overlay is not a catalog override. Doctor does not recommend
+      removing it to restore catalog defaults. The env overlay contains only
+      its credential reference; bundled defaults stay with the provider:
 
       ```json5
       {

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -142,6 +142,14 @@ The config `env.vars` block accepts literal string values only. It does not expa
 `file:...` values. For example, `XAI_API_KEY: "file:secrets/xai-api-key.txt"`
 is passed to providers as that exact string.
 
+For model requests, a variable directly declared by one model plugin binds that
+plugin's declaring provider IDs. This includes the OpenRouter key above and
+same-plugin family keys such as `MINIMAX_API_KEY`. Non-model plugins do not
+claim chat-key ownership. Variables shared across different model plugins and
+generic credentials such as `GITHUB_TOKEN` still require an explicit provider
+binding. The environment source does not change this rule. See
+[Model provider bindings](/concepts/model-providers#when-credentials-enable-a-provider).
+
 For file-backed provider keys, use a SecretRef on the credential field that
 supports it:
 

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -64,6 +64,12 @@ export ANTHROPIC_API_KEY="..."
 
 The script creates a Kubernetes Secret with the API key and an auto-generated gateway token, then deploys. If the Secret already exists, it preserves the current gateway token and any provider keys not being changed.
 
+Provider-specific keys such as `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
+`OPENAI_API_KEY`, and `OPENROUTER_API_KEY` need no extra provider entry.
+Keys shared across different model plugins, borrowed keys, and cloud credential
+chains need a binding for the intended provider. See
+[Provider bindings](/concepts/model-providers#when-credentials-enable-a-provider).
+
 **Option B: create the secret separately**
 
 ```bash
@@ -118,6 +124,12 @@ kubectl rollout restart -n openclaw deploy/openclaw
 ```
 
 Deployments created from the previous template applied ConfigMap edits on every pod start (and discarded any config changes made through OpenClaw). If you relied on that flow, use the reseed commands above after ConfigMap edits.
+
+If you mount the config directly from a read-only ConfigMap instead, keep
+`OPENCLAW_STATE_DIR` on writable storage. Provider-binding upgrades at startup
+apply only in memory and do not modify the ConfigMap or mark the upgrade complete.
+Add the exact provider entry reported by Doctor to your managed config and
+redeploy. `openclaw doctor --fix` persists a binding only when its config is writable.
 
 ### Add providers
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -11,6 +11,11 @@ Anthropic builds the **Claude** model family. OpenClaw supports two auth routes:
 - **API key** - direct Anthropic API access with usage-based billing (`anthropic/*` models)
 - **Claude CLI** - reuse an existing Claude Code login through the installed executable on the same host
 
+For Claude on Google Vertex AI, explicitly declare
+`models.providers["anthropic-vertex"]`. Google Application Default Credentials
+alone do not enable that provider for model requests or authenticated discovery.
+See the [Anthropic Vertex plugin reference](/plugins/reference/anthropic-vertex).
+
 ## Usage and cost tracking
 
 OpenClaw detects the available Anthropic credential and selects the matching usage surface:

--- a/docs/providers/arcee.md
+++ b/docs/providers/arcee.md
@@ -10,6 +10,11 @@ read_when:
 
 Access Arcee models directly through the Arcee platform or through [OpenRouter](/providers/openrouter).
 
+`ARCEEAI_API_KEY` can enable direct Arcee use without a provider entry.
+To use `OPENROUTER_API_KEY` through the `arcee` provider, first run the OpenRouter
+onboarding path below or configure `models.providers.arcee` with the OpenRouter
+base URL. An OpenRouter environment key alone does not enable Arcee.
+
 | Property | Value                                                                                 |
 | -------- | ------------------------------------------------------------------------------------- |
 | Provider | `arcee`                                                                               |

--- a/docs/providers/bedrock-mantle.md
+++ b/docs/providers/bedrock-mantle.md
@@ -33,6 +33,13 @@ openclaw config set models.providers.amazon-bedrock-mantle '{}'
 AWS credentials, including `AWS_BEARER_TOKEN_BEDROCK`, do not enable Mantle by
 themselves. A standard Bedrock provider entry does not enable Mantle either.
 
+An existing selected Mantle route can receive this minimal declaration through
+the provider-binding upgrade. Startup applies it only in memory and leaves
+config and the upgrade receipt unchanged. `openclaw doctor --fix` persists an
+unambiguous selected declaration when no saved-account conflict exists. For
+managed config, add the command's entry to its source instead. See
+[Provider upgrade migrations](/gateway/doctor/config-migrations).
+
 <Tabs>
   <Tab title="Explicit bearer token">
     **Best for:** environments where you already have a Mantle bearer token.

--- a/docs/providers/bedrock-mantle.md
+++ b/docs/providers/bedrock-mantle.md
@@ -24,6 +24,15 @@ exposes Anthropic Claude models through an Anthropic Messages route.
 
 Choose your preferred auth method and follow the setup steps.
 
+First declare the Mantle provider:
+
+```bash
+openclaw config set models.providers.amazon-bedrock-mantle '{}'
+```
+
+AWS credentials, including `AWS_BEARER_TOKEN_BEDROCK`, do not enable Mantle by
+themselves. A standard Bedrock provider entry does not enable Mantle either.
+
 <Tabs>
   <Tab title="Explicit bearer token">
     **Best for:** environments where you already have a Mantle bearer token.
@@ -45,8 +54,7 @@ Choose your preferred auth method and follow the setup steps.
         openclaw models list
         ```
 
-        Discovered models appear under the `amazon-bedrock-mantle` provider. No
-        additional config is required unless you want to override defaults.
+        Discovered models appear under the configured `amazon-bedrock-mantle` provider.
       </Step>
     </Steps>
 
@@ -82,7 +90,7 @@ Choose your preferred auth method and follow the setup steps.
 
 ## Automatic model discovery
 
-When `AWS_BEARER_TOKEN_BEDROCK` is set, OpenClaw uses it directly. Otherwise,
+After provider setup, OpenClaw uses `AWS_BEARER_TOKEN_BEDROCK` when set. Otherwise,
 OpenClaw attempts to generate a Mantle bearer token from the AWS default
 credential chain. It then discovers available Mantle models by querying the
 region's `/v1/models` endpoint.
@@ -122,7 +130,7 @@ The bearer token is the same `AWS_BEARER_TOKEN_BEDROCK` used by the standard [Am
 
 ## Manual configuration
 
-If you prefer explicit config instead of auto-discovery:
+To override the configured provider's automatic catalog:
 
 ```json5
 {

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -20,6 +20,8 @@ not an API key.
 ## Getting started
 
 Choose your preferred auth method and follow the setup steps.
+Both methods require an explicit `models.providers["amazon-bedrock"]` entry.
+AWS credentials and discovery settings alone do not enable Bedrock use.
 
 <Tabs>
   <Tab title="Access keys / env vars">
@@ -79,7 +81,8 @@ Choose your preferred auth method and follow the setup steps.
     </Steps>
 
     <Tip>
-    With env-marker auth (`AWS_ACCESS_KEY_ID`, `AWS_PROFILE`, or `AWS_BEARER_TOKEN_BEDROCK`), OpenClaw auto-enables the implicit Bedrock provider for model discovery without extra config.
+    After you configure the provider, OpenClaw can use AWS credentials for
+    model requests and discovery. You do not need to copy them into `apiKey`.
     </Tip>
 
   </Tab>
@@ -88,23 +91,17 @@ Choose your preferred auth method and follow the setup steps.
     **Best for:** EC2 instances with an IAM role attached, using the instance metadata service for authentication.
 
     <Steps>
-      <Step title="Enable discovery explicitly">
-        When using IMDS, OpenClaw cannot detect AWS auth from env markers alone, so you must opt in:
+      <Step title="Configure the Bedrock provider">
+        Add the `models.providers["amazon-bedrock"]` entry shown in the access-key
+        example, including `auth: "aws-sdk"`. The AWS credential chain uses the
+        instance role without access-key environment variables.
+      </Step>
+      <Step title="Choose the discovery region">
+        Discovery runs by default after provider setup. Choose its region:
 
         ```bash
-        openclaw config set plugins.entries.amazon-bedrock.config.discovery.enabled true
         openclaw config set plugins.entries.amazon-bedrock.config.discovery.region us-east-1
         ```
-      </Step>
-      <Step title="Optionally add an env marker for auto mode">
-        If you also want the env-marker auto-detection path to work (for example, for `openclaw status` surfaces):
-
-        ```bash
-        export AWS_PROFILE=default
-        export AWS_REGION=us-east-1
-        ```
-
-        You do **not** need a fake API key.
       </Step>
       <Step title="Verify models are discovered">
         ```bash
@@ -125,7 +122,8 @@ Choose your preferred auth method and follow the setup steps.
     </Warning>
 
     <Note>
-    You only need `AWS_PROFILE=default` if you specifically want an env marker for auto mode or status surfaces. The actual Bedrock runtime auth path uses the AWS SDK default chain, so IMDS instance-role auth works even without env markers.
+    `AWS_PROFILE` is optional when you use an instance role. Setting it does not
+    replace the explicit Bedrock provider entry.
     </Note>
 
   </Tab>
@@ -151,18 +149,14 @@ defaults from v2026.9.2. Pass `discoveryMode: "strict"` to propagate acquisition
 failures and retain successful empty provider results, as the bundled catalog
 hooks do. Advisory partial results are not cached as complete inventory.
 
-How the implicit provider is enabled:
+Discovery requires the configured Bedrock provider:
 
-- If `plugins.entries.amazon-bedrock.config.discovery.enabled` is `true`,
-  OpenClaw will try discovery even when no AWS env marker is present.
-- If `plugins.entries.amazon-bedrock.config.discovery.enabled` is unset,
-  OpenClaw only auto-adds the
-  implicit Bedrock provider when it sees one of these AWS auth markers:
-  `AWS_BEARER_TOKEN_BEDROCK`, `AWS_ACCESS_KEY_ID` +
-  `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`.
-- The actual Bedrock runtime auth path still uses the AWS SDK default chain, so
-  shared config, SSO, and IMDS instance-role auth can work even when discovery
-  needed `enabled: true` to opt in.
+- Discovery runs by default for the configured provider, including with
+  instance-role credentials and no AWS environment markers.
+- `discovery.enabled: false` disables discovery while keeping explicitly
+  configured models usable.
+- The AWS credential chain supplies credentials after provider setup. Neither
+  AWS environment variables nor `discovery.enabled: true` replace that setup.
 
 <Note>
 For explicit `models.providers["amazon-bedrock"]` entries, OpenClaw can still resolve Bedrock env-marker auth early from AWS env markers such as `AWS_BEARER_TOKEN_BEDROCK` without forcing full runtime auth loading. The actual model-call auth path still uses the AWS SDK default chain.
@@ -195,7 +189,7 @@ For explicit `models.providers["amazon-bedrock"]` entries, OpenClaw can still re
 
     | Option | Default | Description |
     | ------ | ------- | ----------- |
-    | `enabled` | auto | In auto mode, OpenClaw only enables the implicit Bedrock provider when it sees a supported AWS env marker. Set `true` to force discovery. |
+    | `enabled` | enabled after provider setup | Set `false` to skip discovery. Default credential-chain auth needs no environment markers. |
     | `region` | `AWS_REGION` / `AWS_DEFAULT_REGION` / `us-east-1` | AWS region used for discovery API calls. |
     | `providerFilter` | (all) | Matches Bedrock provider names (for example `anthropic`, `amazon`). |
     | `refreshInterval` | `3600` | Cache duration in seconds. Set to `0` to disable caching. |
@@ -250,16 +244,11 @@ aws ec2 associate-iam-instance-profile \
   --instance-id i-xxxxx \
   --iam-instance-profile Name=EC2-Bedrock-Access
 
-# 3. On the EC2 instance, enable discovery explicitly
-openclaw config set plugins.entries.amazon-bedrock.config.discovery.enabled true
+# 3. On the EC2 instance, configure the provider and discovery
+openclaw config set models.providers.amazon-bedrock '{"baseUrl":"https://bedrock-runtime.us-east-1.amazonaws.com","api":"bedrock-converse-stream","auth":"aws-sdk","models":[]}'
 openclaw config set plugins.entries.amazon-bedrock.config.discovery.region us-east-1
 
-# 4. Optional: add an env marker if you want auto mode without explicit enable
-echo 'export AWS_PROFILE=default' >> ~/.bashrc
-echo 'export AWS_REGION=us-east-1' >> ~/.bashrc
-source ~/.bashrc
-
-# 5. Verify models are discovered
+# 4. Verify models are discovered
 openclaw models list
 ```
 
@@ -477,9 +466,8 @@ openclaw models list
     - Bedrock requires **model access** enabled in your AWS account/region.
     - Automatic discovery needs the `bedrock:ListFoundationModels` and
       `bedrock:ListInferenceProfiles` permissions.
-    - If you rely on auto mode, set one of the supported AWS auth env markers on the
-      gateway host. If you prefer IMDS/shared-config auth without env markers, set
-      `plugins.entries.amazon-bedrock.config.discovery.enabled: true`.
+    - Configure `models.providers["amazon-bedrock"]` first. Discovery then uses
+      the default credential chain unless `discovery.enabled` is `false`.
     - OpenClaw surfaces the credential source in this order: `AWS_BEARER_TOKEN_BEDROCK`,
       then `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, then `AWS_PROFILE`, then the
       default AWS SDK chain.

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -20,8 +20,18 @@ not an API key.
 ## Getting started
 
 Choose your preferred auth method and follow the setup steps.
-Both methods require an explicit `models.providers["amazon-bedrock"]` entry.
+For a new setup, declare the Bedrock provider:
+
+```bash
+openclaw config set models.providers.amazon-bedrock '{}'
+```
+
 AWS credentials and discovery settings alone do not enable Bedrock use.
+For an existing selected Bedrock route, the provider-binding upgrade can supply
+this minimal declaration in memory at startup. Startup does not write config or
+complete the upgrade. `openclaw doctor --fix` persists it when the selection is
+unambiguous and no saved-account conflict exists. Managed config receives the
+exact declaration to add. See [Provider upgrade migrations](/gateway/doctor/config-migrations).
 
 <Tabs>
   <Tab title="Access keys / env vars">
@@ -157,6 +167,13 @@ Discovery requires the configured Bedrock provider:
   configured models usable.
 - The AWS credential chain supplies credentials after provider setup. Neither
   AWS environment variables nor `discovery.enabled: true` replace that setup.
+
+This changes discovery for configured instance-role installs that have no AWS
+environment markers: they now call `ListFoundationModels` and
+`ListInferenceProfiles` by default. A narrow IAM policy must permit those calls,
+or set `plugins.entries.amazon-bedrock.config.discovery.enabled` to `false` and
+keep an explicit model list. The same applies to a selected route admitted by
+the in-memory upgrade.
 
 <Note>
 For explicit `models.providers["amazon-bedrock"]` entries, OpenClaw can still resolve Bedrock env-marker auth early from AWS env markers such as `AWS_BEARER_TOKEN_BEDROCK` without forcing full runtime auth loading. The actual model-call auth path still uses the AWS SDK default chain.

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -19,6 +19,10 @@ The Google plugin provides access to Gemini models through Google AI Studio, plu
 For most installations, use a Google AI Studio API key. Use `google-vertex` when
 the Gateway already runs inside a managed Google Cloud environment.
 
+For Vertex with Application Default Credentials, explicitly configure
+`models.providers["google-vertex"]`. Cloud credentials alone do not enable model
+requests. The provider-specific `GOOGLE_CLOUD_API_KEY` can enable Vertex directly.
+
 <Tabs>
   <Tab title="AI Studio API key">
     **Recommended for:** standard Gemini API access.

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -23,6 +23,17 @@ For Vertex with Application Default Credentials, explicitly configure
 `models.providers["google-vertex"]`. Cloud credentials alone do not enable model
 requests. The provider-specific `GOOGLE_CLOUD_API_KEY` can enable Vertex directly.
 
+```bash
+openclaw config set models.providers.google-vertex '{}'
+```
+
+For an existing selected Vertex route, the provider-binding upgrade can supply
+that minimal declaration in memory at startup, without changing config or
+completing the upgrade receipt. `openclaw doctor --fix` persists an unambiguous
+selected declaration when no saved-account conflict exists. For read-only
+config, add the reported entry to your deployment source. See
+[Provider upgrade migrations](/gateway/doctor/config-migrations).
+
 <Tabs>
   <Tab title="AI Studio API key">
     **Recommended for:** standard Gemini API access.

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -34,8 +34,9 @@ Model refs follow the auth path: `minimax/<model>` for API-key setups, `minimax-
 `MINIMAX_API_KEY` is declared for both providers. To use it for model requests,
 run onboarding or explicitly configure the intended `models.providers` entry.
 The environment key alone does not select a provider.
-For an existing selected model, `openclaw doctor --fix` preserves the binding
-during the one-time [shared-key upgrade](/concepts/model-providers).
+For an existing selected model, Gateway startup and `openclaw doctor --fix` use
+the same one-time [shared-key upgrade](/concepts/model-providers), which preserves
+saved accounts.
 
 ## Getting started
 

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -31,6 +31,10 @@ Referral link for MiniMax Coding Plan (10% off): [MiniMax Coding Plan](https://p
 
 Model refs follow the auth path: `minimax/<model>` for API-key setups, `minimax-portal/<model>` for OAuth setups.
 
+`MINIMAX_API_KEY` is declared for both providers. To use it for model requests,
+run onboarding or explicitly configure the intended `models.providers` entry.
+The environment key alone does not select a provider.
+
 ## Getting started
 
 <Tabs>

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -34,6 +34,8 @@ Model refs follow the auth path: `minimax/<model>` for API-key setups, `minimax-
 `MINIMAX_API_KEY` is declared for both providers. To use it for model requests,
 run onboarding or explicitly configure the intended `models.providers` entry.
 The environment key alone does not select a provider.
+For an existing selected model, `openclaw doctor --fix` preserves the binding
+during the one-time [shared-key upgrade](/concepts/model-providers).
 
 ## Getting started
 

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -31,12 +31,15 @@ Referral link for MiniMax Coding Plan (10% off): [MiniMax Coding Plan](https://p
 
 Model refs follow the auth path: `minimax/<model>` for API-key setups, `minimax-portal/<model>` for OAuth setups.
 
-`MINIMAX_API_KEY` is declared for both providers. To use it for model requests,
-run onboarding or explicitly configure the intended `models.providers` entry.
-The environment key alone does not select a provider.
-For an existing selected model, Gateway startup and `openclaw doctor --fix` use
-the same one-time [shared-key upgrade](/concepts/model-providers), which preserves
-saved accounts.
+`MINIMAX_API_KEY` is declared by the MiniMax plugin for both providers, so it
+binds those model identities without extra `models.providers` entries. Choose
+the model ref and account type that match your MiniMax access. Onboarding remains
+the supported way to save an account and region settings.
+
+For automatic, unpinned model selection, an independently bound environment key
+can cover an unusable saved account. Explicit profile pins do not switch accounts.
+See [Provider bindings](/concepts/model-providers) for shared-key upgrade rules;
+startup applies any needed upgrade only in memory, and Doctor owns persistence.
 
 ## Getting started
 
@@ -364,6 +367,9 @@ See [MiniMax Search](/tools/minimax-search) for full web search configuration an
 
   <Accordion title="Fallback example">
     **Best for:** keep your strongest latest-generation model as primary, fail over to MiniMax M2.7. Example below uses Opus as a concrete primary; swap to your preferred latest-gen primary model.
+
+    `MINIMAX_API_KEY` is a direct MiniMax-plugin binding, so this fallback needs
+    no extra provider entry. Configure a separate credential for the primary.
 
     ```json5
     {

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -15,6 +15,11 @@ separate Kimi Coding provider.
 Moonshot and Kimi Coding are **separate providers**, each shipped as a separate external plugin. Keys are not interchangeable, endpoints differ, and model refs differ (`moonshot/...` vs `kimi/...`).
 </Warning>
 
+`MOONSHOT_API_KEY` can enable Moonshot without a provider entry. `KIMI_API_KEY`
+is shared across the Moonshot and Kimi manifest declarations, and
+`KIMICODE_API_KEY` is shared across Kimi declarations. For these shared keys,
+run onboarding or explicitly configure the intended `models.providers` entry.
+
 ## Built-in model catalog
 
 Moonshot and Kimi Coding setup save connection settings and aliases without copying generated catalog rows into your config.
@@ -248,6 +253,9 @@ onboarding.
     ```json5
     {
       env: { vars: { KIMI_API_KEY: "sk-..." } },
+      models: {
+        providers: { kimi: { baseUrl: "https://api.kimi.com/coding/", models: [] } },
+      },
       agents: {
         defaults: {
           model: { primary: "kimi/kimi-for-coding" },

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -15,10 +15,10 @@ separate Kimi Coding provider.
 Moonshot and Kimi Coding are **separate providers**, each shipped as a separate external plugin. Keys are not interchangeable, endpoints differ, and model refs differ (`moonshot/...` vs `kimi/...`).
 </Warning>
 
-`MOONSHOT_API_KEY` can enable Moonshot without a provider entry. `KIMI_API_KEY`
-is shared across the Moonshot and Kimi manifest declarations, and
-`KIMICODE_API_KEY` is shared across Kimi declarations. For these shared keys,
-run onboarding or explicitly configure the intended `models.providers` entry.
+`MOONSHOT_API_KEY` enables Moonshot without a provider entry. `KIMI_API_KEY`
+and `KIMICODE_API_KEY` belong to the Kimi Coding plugin's declaring providers,
+including `kimi` and `kimi-coding`. They do not enable or authenticate Moonshot
+API model requests.
 
 ## Built-in model catalog
 

--- a/docs/providers/ollama-cloud.md
+++ b/docs/providers/ollama-cloud.md
@@ -24,7 +24,7 @@ Follow [Ollama's API key instructions](https://docs.ollama.com/api/authenticatio
 openclaw onboard --auth-choice ollama-cloud
 ```
 
-Or set the key and explicitly declare the cloud provider:
+For an explicit configuration, set the key and declare the cloud provider:
 
 ```bash
 export OLLAMA_API_KEY="<your-ollama-cloud-api-key>" # pragma: allowlist secret
@@ -39,9 +39,9 @@ openclaw onboard --auth-choice ollama-cloud --ollama-cloud-api-key "<key>"
 
 Onboarding sets the default model to `ollama-cloud/minimax-m2.7`.
 
-`OLLAMA_API_KEY` is shared with the local `ollama` provider. The environment key
-alone does not enable cloud model requests; use onboarding or the provider
-entry above.
+The Ollama plugin declares `OLLAMA_API_KEY` for both `ollama` and `ollama-cloud`.
+The environment key therefore enables those model identities without the
+explicit entry above. Keep an entry when you need to override provider settings.
 
 ## Defaults
 

--- a/docs/providers/ollama-cloud.md
+++ b/docs/providers/ollama-cloud.md
@@ -24,10 +24,11 @@ Follow [Ollama's API key instructions](https://docs.ollama.com/api/authenticatio
 openclaw onboard --auth-choice ollama-cloud
 ```
 
-Or set:
+Or set the key and explicitly declare the cloud provider:
 
 ```bash
 export OLLAMA_API_KEY="<your-ollama-cloud-api-key>" # pragma: allowlist secret
+openclaw config set models.providers.ollama-cloud '{"baseUrl":"https://ollama.com","api":"ollama","models":[]}'
 ```
 
 Non-interactive onboarding accepts the key directly:
@@ -37,6 +38,10 @@ openclaw onboard --auth-choice ollama-cloud --ollama-cloud-api-key "<key>"
 ```
 
 Onboarding sets the default model to `ollama-cloud/minimax-m2.7`.
+
+`OLLAMA_API_KEY` is shared with the local `ollama` provider. The environment key
+alone does not enable cloud model requests; use onboarding or the provider
+entry above.
 
 ## Defaults
 
@@ -62,8 +67,8 @@ semantics or provider-specific OpenAI-style features.
 
 ## Models
 
-The provider requires an API key; without one it stays inactive. With a key,
-OpenClaw discovers Ollama Cloud models live from the hosted catalog:
+After provider setup, OpenClaw uses the API key to discover Ollama Cloud models
+live from the hosted catalog:
 
 ```bash
 openclaw models list --provider ollama-cloud

--- a/docs/providers/ollama/configuration.md
+++ b/docs/providers/ollama/configuration.md
@@ -16,10 +16,10 @@ sidebarTitle: "Configuration"
     ```
 
     <Tip>
-    Local connections do not need a key. `OLLAMA_API_KEY` is shared with Ollama Cloud,
-    so the environment variable alone does not select a provider. For an existing
-    selected model, Gateway startup and `openclaw doctor --fix` share the
-    [one-time repair](/concepts/model-providers) without replacing saved accounts.
+    Local connections do not need a key. The Ollama plugin declares
+    `OLLAMA_API_KEY` for both local and cloud model identities, so that variable
+    can bind both without extra provider entries. The entry above explicitly
+    selects a local host when no key is needed.
     </Tip>
 
   </Tab>

--- a/docs/providers/ollama/configuration.md
+++ b/docs/providers/ollama/configuration.md
@@ -18,7 +18,8 @@ sidebarTitle: "Configuration"
     <Tip>
     Local connections do not need a key. `OLLAMA_API_KEY` is shared with Ollama Cloud,
     so the environment variable alone does not select a provider. For an existing
-    selected model, `openclaw doctor --fix` can preserve its shared-key binding once.
+    selected model, Gateway startup and `openclaw doctor --fix` share the
+    [one-time repair](/concepts/model-providers) without replacing saved accounts.
     </Tip>
 
   </Tab>

--- a/docs/providers/ollama/configuration.md
+++ b/docs/providers/ollama/configuration.md
@@ -12,11 +12,13 @@ sidebarTitle: "Configuration"
 <Tabs>
   <Tab title="Basic (implicit discovery)">
     ```bash
-    export OLLAMA_API_KEY="ollama-local"
+    openclaw config set models.providers.ollama.baseUrl "http://127.0.0.1:11434"
     ```
 
     <Tip>
-    If `OLLAMA_API_KEY` is set, you can omit `apiKey` in the provider entry; OpenClaw fills it in for availability checks.
+    Local connections do not need a key. `OLLAMA_API_KEY` is shared with Ollama Cloud,
+    so the environment variable alone does not select a provider. For an existing
+    selected model, `openclaw doctor --fix` can preserve its shared-key binding once.
     </Tip>
 
   </Tab>

--- a/docs/providers/ollama/model-discovery.md
+++ b/docs/providers/ollama/model-discovery.md
@@ -10,9 +10,10 @@ sidebarTitle: "Model discovery"
 
 ## Model discovery (implicit provider)
 
-When `OLLAMA_API_KEY` (or an auth profile) is set and neither
-`models.providers.ollama` nor another custom provider with `api: "ollama"` is
-defined, OpenClaw discovers models from `http://127.0.0.1:11434`:
+Declare `models.providers.ollama` or use an Ollama-bound auth profile before
+discovery. `OLLAMA_API_KEY` alone does not select between Ollama and Ollama Cloud.
+The default local endpoint is `http://127.0.0.1:11434`; an explicit self-hosted
+`baseUrl` selects that host instead:
 
 | Behavior             | Detail                                                                                                                                                                                                                                                                                        |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/providers/ollama/recipes.md
+++ b/docs/providers/ollama/recipes.md
@@ -19,13 +19,12 @@ Replace model IDs with exact names from `ollama list` or
     ```bash
     ollama serve
     ollama pull gemma4
-    export OLLAMA_API_KEY="ollama-local"
+    openclaw config set models.providers.ollama.baseUrl "http://127.0.0.1:11434"
     openclaw models list --provider ollama
     openclaw models set ollama/gemma4
     ```
 
-    Leave `models.providers.ollama` unset to use the default local endpoint, or
-    configure a self-hosted endpoint with `models: []` to keep discovery eligible.
+    Leave the provider's `models` list unset or empty to keep automatic discovery.
 
   </Accordion>
 

--- a/docs/providers/ollama/setup.md
+++ b/docs/providers/ollama/setup.md
@@ -98,17 +98,18 @@ sidebarTitle: "Setup"
 
         For hybrid cloud access, run `ollama signin` on the same host.
       </Step>
-      <Step title="Set a credential">
-        For a local or LAN host, any value works:
+      <Step title="Declare the connection">
+        For a local or LAN host, configure its endpoint:
 
         ```bash
-        export OLLAMA_API_KEY="ollama-local"
+        openclaw config set models.providers.ollama.baseUrl "http://127.0.0.1:11434"
         ```
 
-        For `https://ollama.com`, use the real key instead:
+        For `https://ollama.com`, configure the hosted endpoint and a real key:
 
         ```bash
         export OLLAMA_API_KEY="your-real-key"
+        openclaw config set models.providers.ollama.baseUrl "https://ollama.com"
         ```
 
         Or in config: `openclaw config set models.providers.ollama.apiKey "OLLAMA_API_KEY"`.

--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -67,6 +67,11 @@ interactive onboarding or pass the shared OpenCode API key directly.
 ```json5
 {
   env: { vars: { OPENCODE_API_KEY: "YOUR_API_KEY_HERE" } }, // pragma: allowlist secret
+  models: {
+    providers: {
+      "opencode-go": { baseUrl: "https://opencode.ai/zen/go/v1", models: [] },
+    },
+  },
   agents: { defaults: { model: { primary: "opencode-go/kimi-k3" } } },
 }
 ```
@@ -103,8 +108,9 @@ model, because provider policy can change independently of OpenClaw.
 
 <AccordionGroup>
   <Accordion title="Routing behavior">
-    OpenClaw routes any `opencode-go/...` model ref automatically. No extra
-    provider config is required.
+    OpenClaw routes `opencode-go/...` model refs after Go has a stored auth
+    profile or an explicit `models.providers["opencode-go"]` entry. The shared
+    OpenCode environment key alone does not enable Go.
   </Accordion>
 
   <Accordion title="Runtime ref convention">

--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -10,6 +10,8 @@ OpenCode Go is a separate paid subscription inside [OpenCode](/providers/opencod
 It uses the same `OPENCODE_API_KEY` credential infrastructure as Zen, but a Zen
 key does not automatically include Go entitlement. Go keeps its own runtime
 provider id (`opencode-go`) so upstream per-model routing stays correct.
+After an upgrade, run `openclaw doctor --fix` to preserve an existing selected Go
+model with an explicit env SecretRef. See [provider bindings](/concepts/model-providers).
 OpenCode Go is bundled in the OpenClaw package, so onboarding
 and configuration are sufficient; no separate plugin install is required.
 

--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -10,8 +10,9 @@ OpenCode Go is a separate paid subscription inside [OpenCode](/providers/opencod
 It uses the same `OPENCODE_API_KEY` credential infrastructure as Zen, but a Zen
 key does not automatically include Go entitlement. Go keeps its own runtime
 provider id (`opencode-go`) so upstream per-model routing stays correct.
-On upgrade, Gateway startup and `openclaw doctor --fix` preserve eligible
-existing Go selections without replacing saved accounts. See
+On upgrade, Gateway startup preserves eligible existing Go selections in memory
+without replacing saved accounts or writing config. `openclaw doctor --fix`
+persists the approved binding and records completion. See
 [provider bindings](/concepts/model-providers).
 OpenCode Go is bundled in the OpenClaw package, so onboarding
 and configuration are sufficient; no separate plugin install is required.

--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -10,8 +10,9 @@ OpenCode Go is a separate paid subscription inside [OpenCode](/providers/opencod
 It uses the same `OPENCODE_API_KEY` credential infrastructure as Zen, but a Zen
 key does not automatically include Go entitlement. Go keeps its own runtime
 provider id (`opencode-go`) so upstream per-model routing stays correct.
-After an upgrade, run `openclaw doctor --fix` to preserve an existing selected Go
-model with an explicit env SecretRef. See [provider bindings](/concepts/model-providers).
+On upgrade, Gateway startup and `openclaw doctor --fix` preserve eligible
+existing Go selections without replacing saved accounts. See
+[provider bindings](/concepts/model-providers).
 OpenCode Go is bundled in the OpenClaw package, so onboarding
 and configuration are sufficient; no separate plugin install is required.
 

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -18,6 +18,11 @@ alias `OPENCODE_ZEN_API_KEY`). Go still requires its own paid subscription;
 having a Zen key does not by itself grant Go access. OpenClaw keeps the runtime
 provider ids split so upstream per-model routing stays correct.
 
+Both provider manifests declare these environment keys, so an environment key
+alone does not enable either catalog for model requests. Use onboarding to save
+provider-bound credentials, or declare each intended provider under
+`models.providers`. Selecting a Zen or Go model alone is not sufficient.
+
 OpenClaw sends a stable `x-opencode-session` conversation header on requests to
 `https://opencode.ai` across the Anthropic, Gemini, OpenAI Chat Completions, and
 OpenAI Responses transports. This header remains enabled when prompt caching is
@@ -104,6 +109,11 @@ or caller routing headers are preserved regardless of header name casing.
 ```json5
 {
   env: { vars: { OPENCODE_API_KEY: "sk-..." } },
+  models: {
+    providers: {
+      opencode: { baseUrl: "https://opencode.ai/zen/v1", models: [] },
+    },
+  },
   agents: { defaults: { model: { primary: "opencode/gpt-5.6-sol" } } },
 }
 ```

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -84,9 +84,17 @@ completion so browsers outside the tailnet can still finish setup.
 
 ## Config example
 
+`OPENROUTER_API_KEY` is also declared by the Perplexity plugin. For model
+requests, save an OpenRouter auth profile or explicitly configure
+`models.providers.openrouter` as below. Selecting a model alone does not enable
+credential use.
+
 ```json5
 {
   env: { vars: { OPENROUTER_API_KEY: "sk-or-..." } },
+  models: {
+    providers: { openrouter: { baseUrl: "https://openrouter.ai/api/v1", models: [] } },
+  },
   agents: {
     defaults: {
       model: { primary: "openrouter/auto" },
@@ -282,6 +290,9 @@ omit the `env.vars.OPENROUTER_API_KEY` line below.
 ```json5
 {
   env: { vars: { OPENROUTER_API_KEY: "sk-or-..." } },
+  models: {
+    providers: { openrouter: { baseUrl: "https://openrouter.ai/api/v1", models: [] } },
+  },
   agents: {
     defaults: {
       model: { primary: "openrouter/openrouter/fusion" },

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -84,10 +84,10 @@ completion so browsers outside the tailnet can still finish setup.
 
 ## Config example
 
-`OPENROUTER_API_KEY` is also declared by the Perplexity plugin. For model
-requests, save an OpenRouter auth profile or explicitly configure
-`models.providers.openrouter` as below. Selecting a model alone does not enable
-credential use.
+`OPENROUTER_API_KEY` enables OpenRouter model requests without a provider entry.
+Perplexity's use of that key for web search does not claim chat-provider
+ownership. The explicit entry below remains useful when you want to set
+provider options yourself.
 
 ```json5
 {

--- a/docs/providers/stepfun.md
+++ b/docs/providers/stepfun.md
@@ -31,6 +31,11 @@ openclaw gateway restart
 
 Auth env var: `STEPFUN_API_KEY`
 
+This variable is shared by StepFun provider identities. Run onboarding or declare
+the intended `models.providers` entry before making model requests. For existing
+selections, `openclaw doctor --fix` applies the one-time
+[shared-key upgrade](/concepts/model-providers).
+
 ## Built-in catalog
 
 Setup saves connection settings and aliases without copying generated catalog rows into your config.

--- a/docs/providers/stepfun.md
+++ b/docs/providers/stepfun.md
@@ -31,10 +31,10 @@ openclaw gateway restart
 
 Auth env var: `STEPFUN_API_KEY`
 
-This variable is shared by StepFun provider identities. Run onboarding or declare
-the intended `models.providers` entry before making model requests. For existing
-selections, Gateway startup and `openclaw doctor --fix` apply the same one-time
-[shared-key upgrade](/concepts/model-providers).
+The StepFun plugin declares this variable for both `stepfun` and `stepfun-plan`,
+so it binds both model identities without extra provider entries. Choose the
+model ref and regional endpoint that match your account. Onboarding saves those
+settings; a binding does not grant additional upstream entitlements.
 
 ## Built-in catalog
 

--- a/docs/providers/stepfun.md
+++ b/docs/providers/stepfun.md
@@ -33,7 +33,7 @@ Auth env var: `STEPFUN_API_KEY`
 
 This variable is shared by StepFun provider identities. Run onboarding or declare
 the intended `models.providers` entry before making model requests. For existing
-selections, `openclaw doctor --fix` applies the one-time
+selections, Gateway startup and `openclaw doctor --fix` apply the same one-time
 [shared-key upgrade](/concepts/model-providers).
 
 ## Built-in catalog

--- a/docs/providers/volcengine.md
+++ b/docs/providers/volcengine.md
@@ -18,8 +18,9 @@ The Volcengine provider gives access to Doubao models and third-party models hos
 
 ## Getting started
 
-For an existing selected coding model, run `openclaw doctor --fix` once to
-preserve its shared-key binding. New setup uses onboarding below.
+Gateway startup and `openclaw doctor --fix` share the
+[one-time upgrade repair](/concepts/model-providers) for existing selected coding
+models. Saved accounts are preserved. New setup uses onboarding below.
 
 <Steps>
   <Step title="Install the plugin">

--- a/docs/providers/volcengine.md
+++ b/docs/providers/volcengine.md
@@ -18,6 +18,9 @@ The Volcengine provider gives access to Doubao models and third-party models hos
 
 ## Getting started
 
+For an existing selected coding model, run `openclaw doctor --fix` once to
+preserve its shared-key binding. New setup uses onboarding below.
+
 <Steps>
   <Step title="Install the plugin">
     ```bash
@@ -32,7 +35,9 @@ The Volcengine provider gives access to Doubao models and third-party models hos
     openclaw onboard --auth-choice volcengine-api-key
     ```
 
-    This registers both the general (`volcengine`) and coding (`volcengine-plan`) providers from a single API key.
+    This stores the general provider credential and explicitly declares the selected
+    coding provider (`volcengine-plan`). Setting `VOLCANO_ENGINE_API_KEY` alone
+    enables only `volcengine`.
 
   </Step>
   <Step title="Set a default model">

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -296,7 +296,10 @@ on a different release.
     when you want an xAI Console API key instead of subscription OAuth.
   </Accordion>
   <Accordion title="OpenCode">
-    Prompts for `OPENCODE_API_KEY` (or `OPENCODE_ZEN_API_KEY`) and lets you choose the Zen or Go catalog (one API key covers both).
+    Prompts for `OPENCODE_API_KEY` (or `OPENCODE_ZEN_API_KEY`) and lets you choose
+    the Zen or Go catalog. Setup binds the selected provider explicitly. The
+    plugins share variable names; this does not grant access to both catalogs
+    or their separate entitlements.
     Setup URL: [opencode.ai/auth](https://opencode.ai/auth).
   </Accordion>
   <Accordion title="API key (generic)">

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -671,19 +671,29 @@ describe("bedrock discovery", () => {
     expect(destroyMock).toHaveBeenCalledTimes(3);
   });
 
-  it.each([false, undefined])(
-    "keeps non-attempt discovery null when enabled is %s",
-    async (enabled) => {
-      await expect(
-        resolveImplicitBedrockProvider({
-          pluginConfig: { discovery: { enabled } },
-          env: {},
-          clientFactory,
-        }),
-      ).resolves.toBeNull();
-      expect(sendMock).not.toHaveBeenCalled();
-    },
-  );
+  it("skips explicitly disabled discovery", async () => {
+    await expect(
+      resolveImplicitBedrockProvider({
+        pluginConfig: { discovery: { enabled: false } },
+        env: {},
+        clientFactory,
+      }),
+    ).resolves.toBeNull();
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("discovers an admitted provider through the default AWS chain without env markers", async () => {
+    mockBedrockDiscovery([baseActiveAnthropicSummary]);
+    const provider = await resolveImplicitBedrockProvider({
+      env: {},
+      pluginConfig: { discovery: { refreshInterval: 0 } },
+      clientFactory,
+    });
+    expect(provider?.models).toContainEqual(
+      expect.objectContaining({ id: baseActiveAnthropicSummary.modelId }),
+    );
+    expect(provider?.auth).toBe("aws-sdk");
+  });
 
   it("keeps matching inference profiles when provider filters are enabled", async () => {
     mockBedrockDiscovery(

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -37,7 +37,6 @@ import {
   runBedrockControlPlaneRequest,
   type BedrockControlPlaneSdk,
 } from "./control-plane.js";
-import { resolveBedrockConfigApiKey } from "./discovery-shared.js";
 import { resolveBedrockNativeThinkingLevelMap } from "./thinking-policy.js";
 
 const DEFAULT_REFRESH_INTERVAL_SECONDS = 3600;
@@ -634,11 +633,7 @@ export async function resolveImplicitBedrockProvider(params: {
   const env = params.env ?? process.env;
   const discoveryConfig = params.pluginConfig?.discovery;
   const enabled = discoveryConfig?.enabled;
-  const hasAwsCreds = resolveBedrockConfigApiKey(env) !== undefined;
   if (enabled === false) {
-    return null;
-  }
-  if (enabled !== true && !hasAwsCreds) {
     return null;
   }
 

--- a/extensions/byteplus/index.ts
+++ b/extensions/byteplus/index.ts
@@ -4,8 +4,12 @@
 import { buildOpenAICompatibleProviderFamilyCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { readManifestProviderDefaultModelRef } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
-import { ensureModelAllowlistEntry } from "openclaw/plugin-sdk/provider-onboard";
-import { BYTEPLUS_PROVIDER_CATALOG } from "./models.js";
+import { applyProviderConnectionConfig } from "openclaw/plugin-sdk/provider-onboard";
+import {
+  BYTEPLUS_PROVIDER_CATALOG,
+  BYTEPLUS_CODING_BASE_URL,
+  BYTEPLUS_CODING_MODEL_CATALOG,
+} from "./models.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { buildBytePlusVideoGenerationProvider } from "./video-generation-provider.js";
 
@@ -23,7 +27,13 @@ export default defineSingleProviderPluginEntry({
     manifestAuth: {
       defaultModel: BYTEPLUS_DEFAULT_MODEL_REF,
       applyConfig: (cfg) =>
-        ensureModelAllowlistEntry({ cfg, modelRef: BYTEPLUS_DEFAULT_MODEL_REF }),
+        applyProviderConnectionConfig(cfg, {
+          providerId: "byteplus-plan",
+          api: "openai-completions",
+          baseUrl: BYTEPLUS_CODING_BASE_URL,
+          catalogModels: BYTEPLUS_CODING_MODEL_CATALOG,
+          aliases: [BYTEPLUS_DEFAULT_MODEL_REF],
+        }),
     },
     ...buildOpenAICompatibleProviderFamilyCatalog({
       discoveryMode: "strict",

--- a/extensions/byteplus/index.ts
+++ b/extensions/byteplus/index.ts
@@ -27,7 +27,6 @@ export default defineSingleProviderPluginEntry({
     },
     ...buildOpenAICompatibleProviderFamilyCatalog({
       discoveryMode: "strict",
-      credentialProviderId: PROVIDER_ID,
       entries: BYTEPLUS_PROVIDER_CATALOG.entries,
       staticCatalog: BYTEPLUS_PROVIDER_CATALOG.staticCatalog,
       augmentModelCatalog: BYTEPLUS_PROVIDER_CATALOG.augmentModelCatalog,

--- a/extensions/moonshot/index.test.ts
+++ b/extensions/moonshot/index.test.ts
@@ -89,14 +89,16 @@ describe("moonshot provider plugin", () => {
     },
   );
 
-  it("mirrors Kimi web-search env credentials in manifest metadata", () => {
+  it("keeps Moonshot chat credentials distinct from Kimi web-search credentials", () => {
     const manifestEnvVars =
       readManifest().setup?.providers?.find((provider) => provider.id === "moonshot")?.envVars ??
       [];
 
-    expect([...manifestEnvVars].toSorted()).toStrictEqual(
-      [...createKimiWebSearchProvider().envVars].toSorted(),
-    );
+    expect(manifestEnvVars).toStrictEqual(["MOONSHOT_API_KEY"]);
+    expect([...createKimiWebSearchProvider().envVars].toSorted()).toStrictEqual([
+      "KIMI_API_KEY",
+      "MOONSHOT_API_KEY",
+    ]);
   });
 
   it("declares shipped Moonshot provider aliases in runtime and manifest metadata", async () => {

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -141,8 +141,7 @@
       {
         "id": "moonshot",
         "envVars": [
-          "MOONSHOT_API_KEY",
-          "KIMI_API_KEY"
+          "MOONSHOT_API_KEY"
         ]
       }
     ]

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -524,7 +524,9 @@ async function handleTelegramModelCallback(params: {
       senderId,
       runtimeCfg,
     });
-    const providerData = await telegramDeps.buildModelsProviderData(runtimeCfg, session.agentId);
+    const providerData = await telegramDeps.buildModelsProviderData(runtimeCfg, session.agentId, {
+      sessionEntry: session.sessionEntry,
+    });
     return { sessionState: session, modelData: providerData };
   });
   const { byProvider, providers, modelNames, resolvedDefault: activeResolvedDefault } = modelData;

--- a/extensions/volcengine/index.ts
+++ b/extensions/volcengine/index.ts
@@ -30,7 +30,6 @@ export default defineSingleProviderPluginEntry({
     },
     ...buildOpenAICompatibleProviderFamilyCatalog({
       discoveryMode: "strict",
-      credentialProviderId: PROVIDER_ID,
       entries: VOLCENGINE_PROVIDER_CATALOG.entries,
       staticCatalog: VOLCENGINE_PROVIDER_CATALOG.staticCatalog,
       augmentModelCatalog: VOLCENGINE_PROVIDER_CATALOG.augmentModelCatalog,

--- a/extensions/volcengine/index.ts
+++ b/extensions/volcengine/index.ts
@@ -2,9 +2,13 @@
 import { buildOpenAICompatibleProviderFamilyCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { readManifestProviderDefaultModelRef } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
-import { ensureModelAllowlistEntry } from "openclaw/plugin-sdk/provider-onboard";
+import { applyProviderConnectionConfig } from "openclaw/plugin-sdk/provider-onboard";
 import { applyVolcengineToolSchemaCompat } from "./api.js";
-import { VOLCENGINE_PROVIDER_CATALOG } from "./models.js";
+import {
+  VOLCENGINE_PROVIDER_CATALOG,
+  DOUBAO_CODING_BASE_URL,
+  DOUBAO_CODING_MODEL_CATALOG,
+} from "./models.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { buildVolcengineSpeechProvider } from "./speech-provider.js";
 
@@ -26,7 +30,13 @@ export default defineSingleProviderPluginEntry({
     manifestAuth: {
       defaultModel: VOLCENGINE_DEFAULT_MODEL_REF,
       applyConfig: (cfg) =>
-        ensureModelAllowlistEntry({ cfg, modelRef: VOLCENGINE_DEFAULT_MODEL_REF }),
+        applyProviderConnectionConfig(cfg, {
+          providerId: "volcengine-plan",
+          api: "openai-completions",
+          baseUrl: DOUBAO_CODING_BASE_URL,
+          catalogModels: DOUBAO_CODING_MODEL_CATALOG,
+          aliases: [VOLCENGINE_DEFAULT_MODEL_REF],
+        }),
     },
     ...buildOpenAICompatibleProviderFamilyCatalog({
       discoveryMode: "strict",

--- a/src/agents/agent-auth-discovery-core.ts
+++ b/src/agents/agent-auth-discovery-core.ts
@@ -1,11 +1,10 @@
 /** Env/config-backed credential discovery shared by agent auth discovery modes. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import type { AgentCredentialMap } from "./agent-auth-credentials.js";
-import {
-  listProviderEnvAuthLookupKeys,
-  resolveProviderEnvAuthLookupMaps,
-} from "./model-auth-env-vars.js";
+import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
 import { resolveEnvApiKey } from "./model-auth-env.js";
+import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
 
 /** Options for discovering env-backed credentials during agent auth discovery. */
 export type AgentDiscoveryAuthLookupOptions = {
@@ -28,22 +27,22 @@ export function addEnvBackedAgentCredentials(
   const lookupMaps = resolveProviderEnvAuthLookupMaps(lookupParams);
   const { aliasMap, envCandidateMap: candidateMap, authEvidenceMap } = lookupMaps;
   const next = { ...credentials };
-  // session runtime hides providers from its registry when auth storage lacks
-  // a matching credential entry. Mirror env-backed provider auth here so
-  // live/model discovery sees the same providers runtime auth can use.
-  for (const provider of listProviderEnvAuthLookupKeys({
-    envCandidateMap: candidateMap,
-    authEvidenceMap,
-  })) {
+  const admitted = resolveProviderUseAdmission({
+    config: options.config,
+    env,
+    providerEnvVars: resolveProviderBindingEnvVarCandidates(lookupParams),
+  });
+  for (const [provider, binding] of admitted) {
     if (next[provider]) {
       continue;
     }
     const resolved = resolveEnvApiKey(provider, env, {
       config: options.config,
       workspaceDir: options.workspaceDir,
-      aliasMap,
-      candidateMap,
-      authEvidenceMap,
+      aliasMap: binding.kind === "environment" ? {} : aliasMap,
+      candidateMap:
+        binding.kind === "environment" ? { [provider]: [binding.envVar] } : candidateMap,
+      authEvidenceMap: binding.kind === "environment" ? {} : authEvidenceMap,
     });
     if (!resolved?.apiKey) {
       continue;

--- a/src/agents/agent-auth-discovery.external-cli.test.ts
+++ b/src/agents/agent-auth-discovery.external-cli.test.ts
@@ -45,6 +45,20 @@ import {
 import { externalCliDiscoveryForProviders } from "./auth-profiles/external-cli-discovery.js";
 
 describe("resolveAgentDiscoveryAuthFacts external CLI scoping", () => {
+  it("retains a native CLI account through its declared runtime owner", () => {
+    const credentials = resolveAmbientAgentCredentialsForDiscovery({
+      config: {},
+      env: {},
+      authoritativeSyntheticAuthProviderRefs: ["claude-cli"],
+      syntheticAuthProviderRefs: ["claude-cli"],
+      resolveSyntheticAuth: () => ({ apiKey: "native-account-marker", mode: "oauth" }),
+    });
+    expect(credentials["claude-cli"]).toEqual({
+      type: "api_key",
+      key: "native-account-marker",
+      nativeAuth: { runtime: "claude-cli", mode: "oauth" },
+    });
+  });
   beforeEach(() => {
     vi.clearAllMocks();
     credentialMocks.resolveAgentCredentialMapFromStore.mockReturnValue({});

--- a/src/agents/agent-auth-discovery.ts
+++ b/src/agents/agent-auth-discovery.ts
@@ -5,6 +5,7 @@ import {
   resolveProviderSyntheticAuthWithPlugin,
 } from "../plugins/provider-runtime.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
+import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import {
   resolveAgentCredentialMapFromStore,
   type AgentCredentialMap,
@@ -20,6 +21,10 @@ import {
   ensureAuthProfileStoreWithoutExternalProfiles,
 } from "./auth-profiles/store-runtime.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import {
+  resolveProviderUseAdmission,
+  type ProviderUseBinding,
+} from "./provider-model-auth-source-plan.js";
 
 /** Options for discovering credentials without prompting for secret material. */
 export type DiscoverAuthStorageOptions = {
@@ -36,6 +41,7 @@ export type DiscoverAuthStorageOptions = {
 type SyntheticAuth =
   | {
       apiKey?: string;
+      mode?: "api-key" | "oauth" | "token";
       nativeAuth?: { runtime: string; mode: "api-key" | "oauth" | "token" };
     }
   | undefined;
@@ -82,7 +88,17 @@ function resolveAmbientCredentialInputs(
     }
     providers.push(provider);
   }
-  return { credentials, providers };
+  const admitted = resolveProviderUseAdmission({
+    config: options.config,
+    env: options.env,
+    providerEnvVars: resolveProviderBindingEnvVarCandidates(options),
+  });
+  return {
+    credentials,
+    providers,
+    admitted,
+    nativeProviders: authoritativeSyntheticAuthProviderRefs,
+  };
 }
 
 function syntheticAuthParams(options: AgentDiscoveryAuthLookupOptions, provider: string) {
@@ -103,13 +119,23 @@ function addSyntheticCredential(
   credentials: AgentCredentialMap,
   provider: string,
   resolved: SyntheticAuth,
+  admitted: ReadonlyMap<string, ProviderUseBinding>,
+  nativeProviders: ReadonlySet<string>,
 ) {
+  const nativeAuth =
+    resolved?.nativeAuth ??
+    (nativeProviders.has(normalizeProviderId(provider)) && resolved?.mode
+      ? { runtime: provider, mode: resolved.mode }
+      : undefined);
+  if (!nativeAuth && !admitted.has(normalizeProviderId(provider))) {
+    return;
+  }
   const apiKey = resolved?.apiKey?.trim();
   if (apiKey) {
     credentials[normalizeProviderId(provider) || provider] = {
       type: "api_key",
       key: apiKey,
-      ...(resolved?.nativeAuth ? { nativeAuth: resolved.nativeAuth } : {}),
+      ...(nativeAuth ? { nativeAuth } : {}),
     };
   }
 }
@@ -118,7 +144,8 @@ function addSyntheticCredential(
 export function resolveAmbientAgentCredentialsForDiscovery(
   options: AmbientAgentCredentialOptions = {},
 ): AgentCredentialMap {
-  const { credentials, providers } = resolveAmbientCredentialInputs(options);
+  const { credentials, providers, admitted, nativeProviders } =
+    resolveAmbientCredentialInputs(options);
   for (const provider of providers) {
     addSyntheticCredential(
       credentials,
@@ -126,6 +153,8 @@ export function resolveAmbientAgentCredentialsForDiscovery(
       options.resolveSyntheticAuth
         ? options.resolveSyntheticAuth(provider)
         : resolveProviderSyntheticAuthWithPlugin(syntheticAuthParams(options, provider)),
+      admitted,
+      nativeProviders,
     );
   }
   return credentials;
@@ -138,7 +167,8 @@ export async function prepareAmbientAgentCredentialsForDiscovery(
     signal?: AbortSignal;
   } = {},
 ): Promise<AgentCredentialMap> {
-  const { credentials, providers } = resolveAmbientCredentialInputs(options);
+  const { credentials, providers, admitted, nativeProviders } =
+    resolveAmbientCredentialInputs(options);
   for (const provider of providers) {
     options.signal?.throwIfAborted();
     const resolved = options.resolveSyntheticAuth
@@ -148,7 +178,7 @@ export async function prepareAmbientAgentCredentialsForDiscovery(
           signal: options.signal,
         });
     options.signal?.throwIfAborted();
-    addSyntheticCredential(credentials, provider, resolved);
+    addSyntheticCredential(credentials, provider, resolved, admitted, nativeProviders);
   }
   return credentials;
 }

--- a/src/agents/agent-model-discovery.auth.test.ts
+++ b/src/agents/agent-model-discovery.auth.test.ts
@@ -401,6 +401,13 @@ describe("discoverAuthStorage", () => {
     const credentials = addEnvBackedAgentCredentials(
       {},
       {
+        config: {
+          models: {
+            providers: {
+              "workspace-cloud": { baseUrl: "https://workspace-cloud.example.test", models: [] },
+            },
+          },
+        },
         env: {},
         workspaceDir: "/tmp/workspace",
       },

--- a/src/agents/agent-model-discovery.synthetic-auth.test.ts
+++ b/src/agents/agent-model-discovery.synthetic-auth.test.ts
@@ -38,6 +38,7 @@ vi.mock("./agent-auth-discovery-core.js", () => ({
 }));
 
 let resolveAgentDiscoveryAuthFacts: typeof import("./agent-auth-discovery.js").resolveAgentDiscoveryAuthFacts;
+let resolveAmbientAgentCredentialsForDiscovery: typeof import("./agent-auth-discovery.js").resolveAmbientAgentCredentialsForDiscovery;
 
 async function withAgentDir(run: (agentDir: string) => Promise<void>): Promise<void> {
   const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-synthetic-auth-"));
@@ -50,7 +51,8 @@ async function withAgentDir(run: (agentDir: string) => Promise<void>): Promise<v
 
 describe("agent model discovery synthetic auth", () => {
   beforeAll(async () => {
-    ({ resolveAgentDiscoveryAuthFacts } = await import("./agent-auth-discovery.js"));
+    ({ resolveAgentDiscoveryAuthFacts, resolveAmbientAgentCredentialsForDiscovery } =
+      await import("./agent-auth-discovery.js"));
   });
 
   beforeEach(() => {
@@ -66,7 +68,13 @@ describe("agent model discovery synthetic auth", () => {
 
   it("mirrors plugin-owned synthetic cli auth into credential discovery", async () => {
     await withAgentDir(async (agentDir) => {
-      const { credentials } = resolveAgentDiscoveryAuthFacts(agentDir, { readOnly: true });
+      const ambientCredentials = resolveAmbientAgentCredentialsForDiscovery({
+        authoritativeSyntheticAuthProviderRefs: ["claude-cli"],
+      });
+      const { credentials } = resolveAgentDiscoveryAuthFacts(agentDir, {
+        readOnly: true,
+        ambientCredentials,
+      });
 
       expect(resolveRuntimeSyntheticAuthProviderRefs).toHaveBeenCalledTimes(1);
       expect(resolveRuntimeSyntheticAuthProviderRefs).toHaveBeenCalledWith();
@@ -85,6 +93,7 @@ describe("agent model discovery synthetic auth", () => {
       expect(credentials["claude-cli"]).toEqual({
         type: "api_key",
         key: "claude-cli-access-token",
+        nativeAuth: { runtime: "claude-cli", mode: "oauth" },
       });
     });
   });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -4,7 +4,10 @@ import {
   normalizeOptionalString,
   resolvePrimaryStringValue,
 } from "@openclaw/normalization-core/string-coerce";
-import { resolveAgentModelFallbackValues } from "../config/model-input.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveSelectedModelFallbacksOverride,
+} from "../config/model-input.js";
 import {
   resolveCollapsedSessionAuthPinSource,
   resolveSessionAuthProfileOverrideSource,
@@ -487,22 +490,6 @@ export function resolveAgentModelFallbacksOverride(
   agentId: string,
 ): string[] | undefined {
   return resolveSelectedModelFallbacksOverride(resolveAgentConfig(cfg, agentId)?.model);
-}
-
-function resolveSelectedModelFallbacksOverride(
-  raw: AgentModelConfig | undefined,
-): string[] | undefined {
-  if (!raw) {
-    return undefined;
-  }
-  if (typeof raw === "string") {
-    return resolvePrimaryStringValue(raw) ? [] : undefined;
-  }
-  // Important: treat an explicitly provided empty array as an override to disable global fallbacks.
-  if (!Object.hasOwn(raw, "fallbacks")) {
-    return Object.hasOwn(raw, "primary") && resolvePrimaryStringValue(raw) ? [] : undefined;
-  }
-  return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
 }
 
 function resolveFirstModelFallbacksOverride(

--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -336,7 +336,7 @@ describe("buildAuthHealthSummary", () => {
     expect(summary.providers.find((entry) => entry.provider === "zai")?.status).toBe("missing");
   });
 
-  it("uses runtime provider credentials for profile health", () => {
+  it("preserves the stored account type and expiry for a CLI provider", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     const store = {
       version: 1,
@@ -354,22 +354,15 @@ describe("buildAuthHealthSummary", () => {
     const summary = buildAuthHealthSummary({
       store,
       warnAfterMs: DEFAULT_OAUTH_WARN_MS,
-      runtimeCredentialsByProvider: new Map([
-        [
-          "claude-cli",
-          {
-            type: "token",
-            provider: "claude-cli",
-            token: "fresh-cli-access",
-            expires: now + DEFAULT_OAUTH_WARN_MS + 60_000,
-          },
-        ],
-      ]),
     });
 
     const profile = summary.profiles.find((entry) => entry.profileId === "anthropic:claude-cli");
-    expect(profile?.status).toBe("ok");
-    expect(profile?.expiresAt).toBe(now + DEFAULT_OAUTH_WARN_MS + 60_000);
+    expect(profile).toMatchObject({
+      type: "oauth",
+      status: "expired",
+      expiresAt: now - 10_000,
+      remainingMs: -10_000,
+    });
   });
 
   it("does not let fresh .codex state override expired canonical health", () => {

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -1,6 +1,6 @@
 /**
  * Auth profile health summarization.
- * Classifies stored and runtime credentials into profile/provider rollups for
+ * Classifies stored credentials into profile/provider rollups for
  * status commands and doctor output without prompting keychain access.
  */
 import {
@@ -122,27 +122,16 @@ function resolveOAuthStatus(
 function buildProfileHealth(params: {
   profileId: string;
   credential: AuthProfileCredential;
-  runtimeCredential?: AuthProfileCredential;
   store: AuthProfileStore;
   cfg?: OpenClawConfig;
   now: number;
   warnAfterMs: number;
   allowKeychainPrompt?: boolean;
 }): AuthProfileHealth {
-  const {
-    profileId,
-    credential,
-    runtimeCredential,
-    store,
-    cfg,
-    now,
-    warnAfterMs,
-    allowKeychainPrompt,
-  } = params;
+  const { profileId, credential, store, cfg, now, warnAfterMs, allowKeychainPrompt } = params;
   const label = resolveAuthProfileDisplayLabel({ cfg, store, profileId });
   const source: AuthProfileSource = "store";
-  const healthCredential = runtimeCredential ?? credential;
-  const provider = normalizeProviderId(healthCredential.provider);
+  const provider = normalizeProviderId(credential.provider);
 
   if (credential.setup?.replacement) {
     return {
@@ -156,9 +145,9 @@ function buildProfileHealth(params: {
     };
   }
 
-  if (healthCredential.type === "api_key") {
+  if (credential.type === "api_key") {
     const eligibility = evaluateStoredCredentialEligibility({
-      credential: healthCredential,
+      credential,
       now,
     });
     if (!eligibility.eligible) {
@@ -182,9 +171,9 @@ function buildProfileHealth(params: {
     };
   }
 
-  if (healthCredential.type === "token") {
+  if (credential.type === "token") {
     const eligibility = evaluateStoredCredentialEligibility({
-      credential: healthCredential,
+      credential,
       now,
     });
     if (!eligibility.eligible) {
@@ -200,8 +189,8 @@ function buildProfileHealth(params: {
         label,
       };
     }
-    const expiryState = resolveTokenExpiryState(healthCredential.expires, now);
-    const expiresAt = expiryState === "valid" ? healthCredential.expires : undefined;
+    const expiryState = resolveTokenExpiryState(credential.expires, now);
+    const expiresAt = expiryState === "valid" ? credential.expires : undefined;
     if (!expiresAt) {
       return {
         profileId,
@@ -231,7 +220,7 @@ function buildProfileHealth(params: {
   }
 
   const storedEligibility = evaluateStoredCredentialEligibility({
-    credential: healthCredential,
+    credential,
     now,
   });
   if (!storedEligibility.eligible && storedEligibility.reasonCode === "unresolved_ref") {
@@ -249,7 +238,7 @@ function buildProfileHealth(params: {
   const effectiveCredential = resolveEffectiveOAuthCredential({
     store,
     profileId,
-    credential: healthCredential,
+    credential,
     allowKeychainPrompt,
   });
   const eligibility = evaluateStoredCredentialEligibility({
@@ -292,7 +281,6 @@ export function buildAuthHealthSummary(params: {
   cfg?: OpenClawConfig;
   warnAfterMs?: number;
   providers?: string[];
-  runtimeCredentialsByProvider?: ReadonlyMap<string, AuthProfileCredential>;
   allowKeychainPrompt?: boolean;
   /** Exact prepared metadata for request paths that must not rediscover plugin aliases. */
   authAliasLookupParams?: ProviderAuthAliasLookupParams;
@@ -311,9 +299,6 @@ export function buildAuthHealthSummary(params: {
       buildProfileHealth({
         profileId,
         credential,
-        runtimeCredential: params.runtimeCredentialsByProvider?.get(
-          normalizeProviderId(credential.provider),
-        ),
         store: params.store,
         cfg: params.cfg,
         now,

--- a/src/agents/auth-profiles/candidate-store-update.ts
+++ b/src/agents/auth-profiles/candidate-store-update.ts
@@ -1,0 +1,54 @@
+import { runOpenClawAgentWriteTransaction } from "../../state/openclaw-agent-db.js";
+import type { CandidateAuthProfileStore } from "./candidate-stores.js";
+import { AUTH_STORE_VERSION } from "./constants.js";
+import { loadPersistedAuthProfileStore } from "./persisted.js";
+import { resolveAuthProfileStoreOwner } from "./sqlite.js";
+import { saveAuthProfileStoreWithPreparedOwner } from "./store-runtime.js";
+import type { AuthProfileStore } from "./types.js";
+
+/**
+ * Update one exact candidate database in a single synchronous SQLite
+ * transaction. Callers serialize candidates externally; this never holds two
+ * database transactions at once. Keep runtime writers outside read-only discovery.
+ */
+export function updateCandidateAuthProfileStore(params: {
+  candidate: CandidateAuthProfileStore;
+  preserveProfileState?: boolean;
+  profileId: string;
+  updater: (store: AuthProfileStore) => boolean;
+}): { changed: boolean; store: AuthProfileStore } {
+  return runOpenClawAgentWriteTransaction(
+    (database) => {
+      const store = loadPersistedAuthProfileStore(params.candidate.agentDir, { database }) ?? {
+        version: AUTH_STORE_VERSION,
+        profiles: {},
+      };
+      const changed = params.updater(store);
+      if (changed) {
+        const profileIds = [params.profileId];
+        saveAuthProfileStoreWithPreparedOwner(
+          store,
+          params.candidate.agentDir,
+          {
+            filterExternalAuthProfiles: false,
+            syncExternalCli: false,
+            ...(params.preserveProfileState
+              ? {
+                  preserveOrderProfileIds: profileIds,
+                  preserveStateProfileIds: profileIds,
+                }
+              : {}),
+          },
+          database,
+          resolveAuthProfileStoreOwner(database, params.candidate.env),
+        );
+      }
+      return { changed, store };
+    },
+    {
+      agentId: params.candidate.agentId,
+      env: params.candidate.env,
+      path: params.candidate.databasePath,
+    },
+  );
+}

--- a/src/agents/auth-profiles/candidate-stores.test.ts
+++ b/src/agents/auth-profiles/candidate-stores.test.ts
@@ -31,7 +31,7 @@ describe("candidate auth profile stores", () => {
     ).toThrow(error);
   });
 
-  it("dedupes configured, state-root, and registered custom database paths", async () => {
+  it("dedupes configured, state-root, and registered custom database paths", () => {
     const tempRoot = tempDirs.make("openclaw-auth-candidates-");
     const stateDir = path.join(tempRoot, "state");
     const configuredAgentDir = path.join(tempRoot, "configured-agent");
@@ -55,7 +55,7 @@ describe("candidate auth profile stores", () => {
         env,
       });
 
-      const candidates = await listCandidateAuthProfileStores({
+      const candidates = listCandidateAuthProfileStores({
         cfg: {
           agents: {
             list: [{ id: "configured", agentDir: configuredAgentDir }],

--- a/src/agents/auth-profiles/candidate-stores.test.ts
+++ b/src/agents/auth-profiles/candidate-stores.test.ts
@@ -8,10 +8,10 @@ import {
 } from "../../state/openclaw-agent-db-registry.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { updateCandidateAuthProfileStore } from "./candidate-store-update.js";
 import {
   listCandidateAuthProfileStores,
   loadCandidateAuthProfileStore,
-  updateCandidateAuthProfileStore,
 } from "./candidate-stores.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);

--- a/src/agents/auth-profiles/candidate-stores.test.ts
+++ b/src/agents/auth-profiles/candidate-stores.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
@@ -18,16 +17,18 @@ import {
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("candidate auth profile stores", () => {
-  it("fails closed when the state-root agent inventory cannot be read", async () => {
+  it("fails closed when the state-root agent inventory cannot be read", () => {
     const error = Object.assign(new Error("permission denied"), { code: "EACCES" });
-    vi.spyOn(fsPromises, "readdir").mockRejectedValueOnce(error);
+    vi.spyOn(fs, "readdirSync").mockImplementationOnce(() => {
+      throw error;
+    });
 
-    await expect(
+    expect(() =>
       listCandidateAuthProfileStores({
         cfg: {},
         env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-auth-candidates-denied-") },
       }),
-    ).rejects.toBe(error);
+    ).toThrow(error);
   });
 
   it("dedupes configured, state-root, and registered custom database paths", async () => {

--- a/src/agents/auth-profiles/candidate-stores.ts
+++ b/src/agents/auth-profiles/candidate-stores.ts
@@ -6,15 +6,9 @@ import { resolvePathViaExistingAncestorSync } from "../../infra/boundary-path.js
 import { isErrno } from "../../infra/errno.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { listOpenClawRegisteredAgentDatabases } from "../../state/openclaw-agent-db-registry-listing.js";
-import { runOpenClawAgentWriteTransaction } from "../../state/openclaw-agent-db.js";
 import { listAgentEntries, resolveAgentDir } from "../agent-scope.js";
-import { AUTH_STORE_VERSION } from "./constants.js";
-import {
-  loadPersistedAuthProfileStore,
-  loadPersistedAuthProfileStoreAtDatabasePath,
-} from "./persisted.js";
-import { resolveAuthProfileDatabasePath, resolveAuthProfileStoreOwner } from "./sqlite.js";
-import { saveAuthProfileStoreWithPreparedOwner } from "./store-runtime.js";
+import { loadPersistedAuthProfileStoreAtDatabasePath } from "./persisted.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 import type { AuthProfileStore } from "./types.js";
 
 export type CandidateAuthProfileStore = {
@@ -113,51 +107,4 @@ export function loadCandidateAuthProfileStore(
   candidate: CandidateAuthProfileStore,
 ): AuthProfileStore | null {
   return loadPersistedAuthProfileStoreAtDatabasePath(candidate.databasePath, "agent");
-}
-
-/**
- * Update one exact candidate database in a single synchronous SQLite
- * transaction. Callers serialize candidates externally; this never holds two
- * database transactions at once.
- */
-export function updateCandidateAuthProfileStore(params: {
-  candidate: CandidateAuthProfileStore;
-  preserveProfileState?: boolean;
-  profileId: string;
-  updater: (store: AuthProfileStore) => boolean;
-}): { changed: boolean; store: AuthProfileStore } {
-  return runOpenClawAgentWriteTransaction(
-    (database) => {
-      const store = loadPersistedAuthProfileStore(params.candidate.agentDir, { database }) ?? {
-        version: AUTH_STORE_VERSION,
-        profiles: {},
-      };
-      const changed = params.updater(store);
-      if (changed) {
-        const profileIds = [params.profileId];
-        saveAuthProfileStoreWithPreparedOwner(
-          store,
-          params.candidate.agentDir,
-          {
-            filterExternalAuthProfiles: false,
-            syncExternalCli: false,
-            ...(params.preserveProfileState
-              ? {
-                  preserveOrderProfileIds: profileIds,
-                  preserveStateProfileIds: profileIds,
-                }
-              : {}),
-          },
-          database,
-          resolveAuthProfileStoreOwner(database, params.candidate.env),
-        );
-      }
-      return { changed, store };
-    },
-    {
-      agentId: params.candidate.agentId,
-      env: params.candidate.env,
-      path: params.candidate.databasePath,
-    },
-  );
 }

--- a/src/agents/auth-profiles/candidate-stores.ts
+++ b/src/agents/auth-profiles/candidate-stores.ts
@@ -1,5 +1,4 @@
-import type { Dirent } from "node:fs";
-import fs from "node:fs/promises";
+import fs, { type Dirent } from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -14,8 +13,8 @@ import {
   loadPersistedAuthProfileStore,
   loadPersistedAuthProfileStoreAtDatabasePath,
 } from "./persisted.js";
-import { resolveAuthProfileDatabasePath } from "./sqlite.js";
-import { saveAuthProfileStore } from "./store-runtime.js";
+import { resolveAuthProfileDatabasePath, resolveAuthProfileStoreOwner } from "./sqlite.js";
+import { saveAuthProfileStoreWithPreparedOwner } from "./store-runtime.js";
 import type { AuthProfileStore } from "./types.js";
 
 export type CandidateAuthProfileStore = {
@@ -35,11 +34,11 @@ function canonicalizeDatabasePath(databasePath: string): string {
   return resolvePathViaExistingAncestorSync(path.resolve(databasePath));
 }
 
-async function collectStateRootCandidates(env: NodeJS.ProcessEnv): Promise<CandidateSource[]> {
+function collectStateRootCandidates(env: NodeJS.ProcessEnv): CandidateSource[] {
   const agentsRoot = path.join(resolveStateDir(env), "agents");
   let entries: Dirent[];
   try {
-    entries = await fs.readdir(agentsRoot, { withFileTypes: true });
+    entries = fs.readdirSync(agentsRoot, { withFileTypes: true });
   } catch (error) {
     if (isErrno(error) && error.code === "ENOENT") {
       return [];
@@ -64,10 +63,10 @@ async function collectStateRootCandidates(env: NodeJS.ProcessEnv): Promise<Candi
  * identity. Registered paths cover custom database locations that cannot be
  * reconstructed from an agent directory.
  */
-export async function listCandidateAuthProfileStores(params: {
+export function listCandidateAuthProfileStores(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
-}): Promise<CandidateAuthProfileStore[]> {
+}): CandidateAuthProfileStore[] {
   const env = params.env ?? process.env;
   const sources: CandidateSource[] = [];
   for (const entry of listAgentEntries(params.cfg)) {
@@ -83,7 +82,7 @@ export async function listCandidateAuthProfileStores(params: {
       databasePath: resolveAuthProfileDatabasePath(agentDir),
     });
   }
-  sources.push(...(await collectStateRootCandidates(env)));
+  sources.push(...collectStateRootCandidates(env));
   for (const registered of listOpenClawRegisteredAgentDatabases({ env })) {
     sources.push({
       agentId: normalizeAgentId(registered.agentId),
@@ -136,7 +135,7 @@ export function updateCandidateAuthProfileStore(params: {
       const changed = params.updater(store);
       if (changed) {
         const profileIds = [params.profileId];
-        saveAuthProfileStore(
+        saveAuthProfileStoreWithPreparedOwner(
           store,
           params.candidate.agentDir,
           {
@@ -150,6 +149,7 @@ export function updateCandidateAuthProfileStore(params: {
               : {}),
           },
           database,
+          resolveAuthProfileStoreOwner(database, params.candidate.env),
         );
       }
       return { changed, store };

--- a/src/agents/auth-profiles/oauth-refresh-peers.ts
+++ b/src/agents/auth-profiles/oauth-refresh-peers.ts
@@ -2,10 +2,10 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolvePathViaExistingAncestorSync } from "../../infra/boundary-path.js";
 import { toErrorObject } from "../../infra/errors.js";
 import { isUserModelAuthProfileId } from "../../state/user-model-account-id.js";
+import { updateCandidateAuthProfileStore } from "./candidate-store-update.js";
 import {
   listCandidateAuthProfileStores,
   loadCandidateAuthProfileStore,
-  updateCandidateAuthProfileStore,
   type CandidateAuthProfileStore,
 } from "./candidate-stores.js";
 import { hasUsableOAuthCredential } from "./credential-state.js";

--- a/src/agents/auth-profiles/oauth-refresh-peers.ts
+++ b/src/agents/auth-profiles/oauth-refresh-peers.ts
@@ -121,7 +121,7 @@ async function listPeerCandidates(params: {
   ownerDatabasePath: string;
 }): Promise<CandidateAuthProfileStore[]> {
   const ownerDatabasePath = canonicalDatabasePath(params.ownerDatabasePath);
-  return (await listCandidateAuthProfileStores(params)).filter(
+  return listCandidateAuthProfileStores(params).filter(
     (candidate) => candidate.databasePath !== ownerDatabasePath,
   );
 }

--- a/src/agents/auth-profiles/publication.ts
+++ b/src/agents/auth-profiles/publication.ts
@@ -25,7 +25,8 @@ export function withAuthProfilePublicationLock<T>(env: NodeJS.ProcessEnv, publis
 }
 
 function acquireAuthProfilePublicationLock(env: NodeJS.ProcessEnv): () => void {
-  const directory = path.join(captureAuthProfileOwnerScope(env).stateDir, "locks");
+  // Keep the lock in the owner root so release leaves no staged migration artifacts.
+  const directory = captureAuthProfileOwnerScope(env).stateDir;
   fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
   const lockPath = path.join(fs.realpathSync(directory), "auth-profile-publication");
   const pending = pendingPublicationLockReleases.get(lockPath);

--- a/src/agents/auth-profiles/publication.ts
+++ b/src/agents/auth-profiles/publication.ts
@@ -1,0 +1,75 @@
+/** Publication locks shared by credential transactions and config binding commits. */
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { acquireFileLockSyncWithRetry } from "../../infra/file-lock-sync.js";
+import { stageSqliteTransactionState } from "../../infra/sqlite-post-commit.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import { captureAuthProfileOwnerScope } from "./path-resolve.js";
+
+const publicationLog = createSubsystemLogger("auth/profile-publication");
+const pendingPublicationLockReleases = resolveGlobalSingleton(
+  Symbol.for("openclaw.authProfilePublicationLockReleases"),
+  () => new Map<string, Set<() => void>>(),
+);
+
+/** Serialize config bindings and credential publication across a stable state owner. */
+export function withAuthProfilePublicationLock<T>(env: NodeJS.ProcessEnv, publish: () => T): T {
+  const release = acquireAuthProfilePublicationLock(env);
+  try {
+    return publish();
+  } finally {
+    release();
+  }
+}
+
+function acquireAuthProfilePublicationLock(env: NodeJS.ProcessEnv): () => void {
+  const directory = path.join(captureAuthProfileOwnerScope(env).stateDir, "locks");
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const lockPath = path.join(fs.realpathSync(directory), "auth-profile-publication");
+  const pending = pendingPublicationLockReleases.get(lockPath);
+  for (const release of pending ?? []) {
+    // A previous durable write succeeded. Cleanup must succeed before a new writer enters.
+    release();
+    pending?.delete(release);
+  }
+  pendingPublicationLockReleases.delete(lockPath);
+  const release = acquireFileLockSyncWithRetry(lockPath, "auth-profile-publication");
+  return () => {
+    try {
+      release();
+    } catch (error) {
+      const retained = pendingPublicationLockReleases.get(lockPath) ?? new Set<() => void>();
+      retained.add(release);
+      pendingPublicationLockReleases.set(lockPath, retained);
+      publicationLog.warn(
+        `Auth publication lock cleanup failed; retained for retry: ${String(error)}`,
+      );
+    }
+  };
+}
+
+export function withAuthProfileStorePublication(
+  database: DatabaseSync,
+  env: NodeJS.ProcessEnv,
+  write: () => void,
+): void {
+  const release = acquireAuthProfilePublicationLock(env);
+  // Keep the fence through outer COMMIT/ROLLBACK, including a supplied agent transaction.
+  const deferred = stageSqliteTransactionState(database, {
+    stage: () => {},
+    commit: release,
+    rollback: release,
+  });
+  try {
+    if (database.isTransaction && !deferred) {
+      throw new Error("Auth publication requires the managed transaction lifecycle.");
+    }
+    write();
+  } finally {
+    if (!deferred) {
+      release();
+    }
+  }
+}

--- a/src/agents/auth-profiles/setup-access.ts
+++ b/src/agents/auth-profiles/setup-access.ts
@@ -9,6 +9,11 @@ type SetupCredentialAccess = {
 
 const setupCredentialAccess = new AsyncLocalStorage<SetupCredentialAccess>();
 
+/** An explicit setup probe must not verify its candidate through an ambient account. */
+export function isSetupCredentialAccessActive(): boolean {
+  return setupCredentialAccess.getStore()?.isActive() === true;
+}
+
 export function isSetupCredentialAccessible(params: {
   profileId: string;
   credential: Pick<AuthProfileCredential, "setup">;

--- a/src/agents/auth-profiles/setup-access.ts
+++ b/src/agents/auth-profiles/setup-access.ts
@@ -11,7 +11,7 @@ const setupCredentialAccess = new AsyncLocalStorage<SetupCredentialAccess>();
 
 export function isSetupCredentialAccessible(params: {
   profileId: string;
-  credential: AuthProfileCredential;
+  credential: Pick<AuthProfileCredential, "setup">;
   agentDir?: string;
 }): boolean {
   if (!params.credential.setup?.replacement) {

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -36,6 +36,7 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { resolveOpenClawStateDirForDatabasePath } from "../../state/openclaw-state-db.paths.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveRegisteredAgentIdForDir } from "../agent-dir-registry.js";
 import {
@@ -43,6 +44,7 @@ import {
   resolveSharedAuthStorePath,
   type SharedAuthStoreOwnership,
 } from "./path-resolve.js";
+import { withAuthProfileStorePublication } from "./publication.js";
 import { prepareFreshSharedAuthStoreWrite } from "./shared-store-bootstrap.js";
 
 type AgentAuthProfileDatabase = Pick<
@@ -64,7 +66,7 @@ export type PreparedAuthProfileStoreOwner = AuthProfileStoreOwner & { env: NodeJ
 export function resolveAuthProfileStoreOwner(
   database: AuthProfileDatabase,
   env: NodeJS.ProcessEnv = process.env,
-): AuthProfileStoreOwner | PreparedAuthProfileStoreOwner {
+): PreparedAuthProfileStoreOwner {
   const prepared = authProfileTransactions.get(database)?.owner;
   if (prepared) {
     return prepared;
@@ -72,7 +74,12 @@ export function resolveAuthProfileStoreOwner(
   // A supplied shared connection already names its owner; ambient discovery can
   // select another database (or fail on it) before this connection is ever used.
   if (!("agentId" in database)) {
-    return { databasePath: database.path, sharedDatabasePath: database.path, location: "state-db" };
+    return {
+      databasePath: database.path,
+      sharedDatabasePath: database.path,
+      location: "state-db",
+      env: { ...env, OPENCLAW_STATE_DIR: resolveOpenClawStateDirForDatabasePath(database.path) },
+    };
   }
   return {
     ...prepareAuthProfileSharedOwner(env),
@@ -568,6 +575,7 @@ export function writePersistedAuthProfileStoreRaw(
   payload: unknown,
   agentDir?: string,
   database?: AuthProfileDatabase,
+  owner?: PreparedAuthProfileStoreOwner,
 ): void {
   const databaseKind = resolveAuthProfileDatabaseKind(agentDir, database);
   const write = (target: AuthProfileDatabase) => {
@@ -593,16 +601,23 @@ export function writePersistedAuthProfileStoreRaw(
     );
   };
   if (database) {
-    write(database);
+    withAuthProfileStorePublication(
+      database.db,
+      (owner ?? resolveAuthProfileStoreOwner(database)).env,
+      () => write(database),
+    );
     return;
   }
-  runAuthProfileWriteTransaction(agentDir, write);
+  runAuthProfileWriteTransaction(agentDir, (target, preparedOwner) =>
+    withAuthProfileStorePublication(target.db, preparedOwner.env, () => write(target)),
+  );
 }
 
 /** Deletes the persisted secrets-store row while leaving runtime state intact. */
 export function deletePersistedAuthProfileStoreRaw(
   agentDir?: string,
   database?: AuthProfileDatabase,
+  owner?: PreparedAuthProfileStoreOwner,
 ): void {
   const databaseKind = resolveAuthProfileDatabaseKind(agentDir, database);
   const remove = (target: AuthProfileDatabase) => {
@@ -618,10 +633,16 @@ export function deletePersistedAuthProfileStoreRaw(
     );
   };
   if (database) {
-    remove(database);
+    withAuthProfileStorePublication(
+      database.db,
+      (owner ?? resolveAuthProfileStoreOwner(database)).env,
+      () => remove(database),
+    );
     return;
   }
-  runAuthProfileWriteTransaction(agentDir, remove);
+  runAuthProfileWriteTransaction(agentDir, (target, preparedOwner) =>
+    withAuthProfileStorePublication(target.db, preparedOwner.env, () => remove(target)),
+  );
 }
 
 /** Writes or deletes the persisted runtime-state payload. */

--- a/src/agents/auth-profiles/store-owner-publication.test.ts
+++ b/src/agents/auth-profiles/store-owner-publication.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { prepareSecretsRuntimeFastPathSnapshot } from "../../secrets/runtime-fast-path.js";
 import { activateSecretsRuntimeSnapshotState } from "../../secrets/runtime-state.js";
+import { runOpenClawAgentWriteTransaction } from "../../state/openclaw-agent-db.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { withEnv } from "../../test-utils/env.js";
 import {
@@ -16,12 +17,14 @@ import {
 } from "./mutation-lineage.js";
 import { createOAuthRefreshFence } from "./oauth-refresh-marker.js";
 import { loadPersistedAuthProfileStore, loadPersistedSharedAuthProfileStore } from "./persisted.js";
+import { withAuthProfilePublicationLock } from "./publication.js";
 import {
   replaceRuntimeAuthProfileStoreSnapshots,
   setRuntimeAuthProfileStoreSnapshot,
 } from "./runtime-snapshots.js";
 import {
   resolveAuthProfileDatabasePath,
+  resolveAuthProfileStoreOwner,
   runAuthProfileWriteTransaction,
   writePersistedAuthProfileStoreRaw,
 } from "./sqlite.js";
@@ -29,6 +32,7 @@ import {
   ensureAuthProfileStoreWithoutExternalProfiles,
   loadAuthProfileStoreWithoutExternalProfiles,
   saveAuthProfileStore,
+  saveAuthProfileStoreWithPreparedOwner,
   saveAuthProfileStoreIfPersistenceSnapshotMatches,
   updateAuthProfileStoreWithLock,
 } from "./store-runtime.js";
@@ -45,6 +49,85 @@ const { tempDirs, saveOptions, apiKey, store, snapshotAt, unreadableOuter, seedR
   createAuthOwnerTestFixtures();
 
 describe("auth publication owner receipts", () => {
+  it("holds a supplied agent's publication fence until rollback under its captured state root", async () => {
+    const root = await seedRoot("original");
+    const outer = await seedRoot("unrelated");
+    const agentId = runAuthProfileWriteTransaction(
+      root.agentDir,
+      (database) => {
+        if (!("agentId" in database)) {
+          throw new Error("Fixture requires an agent-owned database");
+        }
+        return database.agentId;
+      },
+      { env: root.env },
+    );
+    const lockPath = path.join(root.stateDir, "locks", "auth-profile-publication.lock");
+    const outerLockPath = path.join(outer.stateDir, "locks", "auth-profile-publication.lock");
+    expect(() =>
+      withEnv(outer.env, () =>
+        runOpenClawAgentWriteTransaction(
+          (database) => {
+            saveAuthProfileStoreWithPreparedOwner(
+              store("replacement"),
+              root.agentDir,
+              saveOptions,
+              database,
+              resolveAuthProfileStoreOwner(database, root.env),
+            );
+            expect(fs.existsSync(lockPath)).toBe(true);
+            expect(fs.existsSync(outerLockPath)).toBe(false);
+            throw new Error("rollback publication");
+          },
+          { agentId, path: root.agentPath, env: root.env },
+        ),
+      ),
+    ).toThrow("rollback publication");
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(loadPersistedAuthProfileStore(root.agentDir)?.profiles.local).toEqual(
+      apiKey("original-local"),
+    );
+  });
+
+  it("preserves successful publication when lock cleanup fails and blocks the next write until cleanup succeeds", async () => {
+    const root = await seedRoot("original");
+    const lockPath = path.join(
+      fs.realpathSync(root.stateDir),
+      "locks",
+      "auth-profile-publication.lock",
+    );
+    const remove = fs.rmSync;
+    const failure = Object.assign(new Error("publication lock cleanup denied"), { code: "EACCES" });
+    const mock = vi.spyOn(fs, "rmSync").mockImplementation((target, options) => {
+      if (target === lockPath) {
+        throw failure;
+      }
+      return remove(target, options);
+    });
+    let publications = 0;
+    try {
+      expect(() =>
+        withAuthProfilePublicationLock(root.env, () => {
+          publications += 1;
+        }),
+      ).not.toThrow();
+      expect(publications).toBe(1);
+      expect(() =>
+        withAuthProfilePublicationLock(root.env, () => {
+          publications += 1;
+        }),
+      ).toThrow(failure);
+      expect(publications).toBe(1);
+    } finally {
+      mock.mockRestore();
+      withAuthProfilePublicationLock(root.env, () => {
+        publications += 1;
+      });
+    }
+    expect(publications).toBe(2);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
   it.each(["prepare", "activate"] as const)(
     "requires a recorded migration diagnosis discovered at %s before empty-owner activation",
     async (discoveredAt) => {

--- a/src/agents/auth-profiles/store-owner-publication.test.ts
+++ b/src/agents/auth-profiles/store-owner-publication.test.ts
@@ -62,8 +62,8 @@ describe("auth publication owner receipts", () => {
       },
       { env: root.env },
     );
-    const lockPath = path.join(root.stateDir, "locks", "auth-profile-publication.lock");
-    const outerLockPath = path.join(outer.stateDir, "locks", "auth-profile-publication.lock");
+    const lockPath = path.join(root.stateDir, "auth-profile-publication.lock");
+    const outerLockPath = path.join(outer.stateDir, "auth-profile-publication.lock");
     expect(() =>
       withEnv(outer.env, () =>
         runOpenClawAgentWriteTransaction(
@@ -89,13 +89,10 @@ describe("auth publication owner receipts", () => {
     );
   });
 
-  it("preserves successful publication when lock cleanup fails and blocks the next write until cleanup succeeds", async () => {
-    const root = await seedRoot("original");
-    const lockPath = path.join(
-      fs.realpathSync(root.stateDir),
-      "locks",
-      "auth-profile-publication.lock",
-    );
+  it("preserves successful publication when lock cleanup fails and blocks the next write until cleanup succeeds", () => {
+    const stateDir = tempDirs.make("openclaw-auth-publication-cleanup-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const lockPath = path.join(fs.realpathSync(stateDir), "auth-profile-publication.lock");
     const remove = fs.rmSync;
     const failure = Object.assign(new Error("publication lock cleanup denied"), { code: "EACCES" });
     const mock = vi.spyOn(fs, "rmSync").mockImplementation((target, options) => {
@@ -107,25 +104,26 @@ describe("auth publication owner receipts", () => {
     let publications = 0;
     try {
       expect(() =>
-        withAuthProfilePublicationLock(root.env, () => {
+        withAuthProfilePublicationLock(env, () => {
           publications += 1;
         }),
       ).not.toThrow();
       expect(publications).toBe(1);
       expect(() =>
-        withAuthProfilePublicationLock(root.env, () => {
+        withAuthProfilePublicationLock(env, () => {
           publications += 1;
         }),
       ).toThrow(failure);
       expect(publications).toBe(1);
     } finally {
       mock.mockRestore();
-      withAuthProfilePublicationLock(root.env, () => {
+      withAuthProfilePublicationLock(env, () => {
         publications += 1;
       });
     }
     expect(publications).toBe(2);
     expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.readdirSync(stateDir)).toEqual([]);
   });
 
   it.each(["prepare", "activate"] as const)(

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -1167,9 +1167,9 @@ export function restoreAuthProfileStorePersistenceSnapshot(
 
       if (credentialsRestored) {
         if (snapshot.credentialsRaw === null) {
-          deletePersistedAuthProfileStoreRaw(agentDir, database);
+          deletePersistedAuthProfileStoreRaw(agentDir, database, owner);
         } else {
-          writePersistedAuthProfileStoreRaw(snapshot.credentialsRaw, agentDir, database);
+          writePersistedAuthProfileStoreRaw(snapshot.credentialsRaw, agentDir, database, owner);
         }
       }
       if (stateRestored) {
@@ -1994,7 +1994,7 @@ export function createAuthProfileStoreRuntime(
     agentDir: string | undefined,
     options: SaveAuthProfileStoreOptions | undefined,
     database: AuthProfileDatabase,
-    owner: AuthProfileStoreOwner | PreparedAuthProfileStoreOwner,
+    owner: PreparedAuthProfileStoreOwner,
     publishFromSuppliedStore = false,
   ): RuntimeSnapshotPublication {
     // Shared-state rows are global: never scope their persistence or runtime snapshots to an
@@ -2058,7 +2058,7 @@ export function createAuthProfileStoreRuntime(
         )
       : undefined;
     if (credentialsChanged) {
-      writePersistedAuthProfileStoreRaw(payload, persistenceAgentDir, database);
+      writePersistedAuthProfileStoreRaw(payload, persistenceAgentDir, database, owner);
     }
     if (stateChanged) {
       writePersistedAuthProfileStateRaw(statePayload, persistenceAgentDir, database);
@@ -2196,7 +2196,7 @@ export function createAuthProfileStoreRuntime(
     agentDir: string | undefined,
     options: SaveAuthProfileStoreOptions | undefined,
     database: AuthProfileDatabase,
-    owner: AuthProfileStoreOwner | PreparedAuthProfileStoreOwner,
+    owner: PreparedAuthProfileStoreOwner,
   ): void {
     const publish = saveAuthProfileStoreInTransaction(
       store,

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -514,7 +514,10 @@ function createSideQuestionParams(
   overrides: Partial<RunBtwSideQuestionParams> = {},
 ): RunBtwSideQuestionParams {
   return {
-    cfg: { agents: { entries: { main: { default: true } } } } as never,
+    cfg: {
+      agents: { entries: { main: { default: true } } },
+      models: { providers: { anthropic: {} } },
+    } as never,
     agentId: "main",
     agentDir: DEFAULT_AGENT_DIR,
     provider: DEFAULT_PROVIDER,
@@ -897,7 +900,10 @@ describe("runBtwSideQuestion", () => {
     );
 
     const result = await runBtwSideQuestion({
-      cfg: { agents: { entries: { main: { default: true } } } } as never,
+      cfg: {
+        agents: { entries: { main: { default: true } } },
+        models: { providers: { anthropic: {} } },
+      } as never,
       agentId: "main",
       agentDir: DEFAULT_AGENT_DIR,
       provider: DEFAULT_PROVIDER,
@@ -1014,6 +1020,7 @@ describe("runBtwSideQuestion", () => {
         agentId: "work",
         cfg: {
           agents: { ownership: "explicit", entries: { main: {}, work: {} } },
+          models: { providers: { anthropic: {} } },
           session: { scope: "global" },
         },
         sessionKey: "global",
@@ -1163,7 +1170,10 @@ describe("runBtwSideQuestion", () => {
   );
 
   it("keeps model, runtime auth, and stream selection on prepared A after current advances to B", async () => {
-    const cfg = { agents: { entries: { main: { default: true } } } } as never;
+    const cfg = {
+      agents: { entries: { main: { default: true } } },
+      models: { providers: { "local-proxy": {} } },
+    } as never;
     const generationA = createModelGenerationFixture({
       agentDir: state.agentDir(),
       workspaceDir: state.workspaceDir,
@@ -1436,7 +1446,10 @@ describe("runBtwSideQuestion", () => {
       try {
         await expect(
           runSideQuestion({
-            cfg: { diagnostics: { enabled } },
+            cfg: {
+              diagnostics: { enabled },
+              models: { providers: { anthropic: {} } },
+            },
             sessionEntry,
             authorityRunId,
             ...(mode === "direct-block"
@@ -1975,6 +1988,7 @@ describe("runBtwSideQuestion", () => {
 
     const result = await runSideQuestion({
       cfg: {
+        models: { providers: { "github-copilot": {} } },
         agents: {
           defaults: {
             models: {
@@ -2677,6 +2691,7 @@ describe("runBtwSideQuestion", () => {
     mockDoneAnswer("Copilot answer.");
 
     const result = await runSideQuestion({
+      cfg: { models: { providers: { "github-copilot": {} } } },
       provider: "github-copilot",
       model: "gpt-5.4",
     });
@@ -2722,7 +2737,11 @@ describe("runBtwSideQuestion", () => {
       .mockReturnValue(makeAsyncEvents([createDoneEvent("Ollama Cloud answer.")]));
     registerProviderStreamForModelMock.mockReturnValue(providerStreamFn);
 
-    const result = await runSideQuestion({ provider: "ollama", model: "glm-5.1" });
+    const result = await runSideQuestion({
+      cfg: { models: { providers: { ollama: {} } } },
+      provider: "ollama",
+      model: "glm-5.1",
+    });
 
     expect(result).toEqual({ text: "Ollama Cloud answer." });
     const registerParams = expectRecordFields(mockArg(registerProviderStreamForModelMock, 0, 0), {
@@ -2756,6 +2775,7 @@ describe("runBtwSideQuestion", () => {
     });
 
     const result = await runSideQuestion({
+      cfg: { models: { providers: { "minimax-portal": {} } } },
       provider: "minimax-portal",
       model: "MiniMax-M2.7",
     });
@@ -2825,7 +2845,7 @@ describe("runBtwSideQuestion", () => {
     streamSimpleMock.mockReturnValue(makeAsyncEvents([createDoneEvent("Bedrock answer.")]));
 
     const result = await runBtwSideQuestion({
-      cfg: {} as never,
+      cfg: { models: { providers: { "amazon-bedrock": {} } } },
       agentId: "main",
       agentDir: DEFAULT_AGENT_DIR,
       provider: "amazon-bedrock",

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -516,7 +516,7 @@ function createSideQuestionParams(
   return {
     cfg: {
       agents: { entries: { main: { default: true } } },
-      models: { providers: { anthropic: {} } },
+      models: { providers: { anthropic: { baseUrl: "", models: [] } } },
     } as never,
     agentId: "main",
     agentDir: DEFAULT_AGENT_DIR,
@@ -902,7 +902,7 @@ describe("runBtwSideQuestion", () => {
     const result = await runBtwSideQuestion({
       cfg: {
         agents: { entries: { main: { default: true } } },
-        models: { providers: { anthropic: {} } },
+        models: { providers: { anthropic: { baseUrl: "", models: [] } } },
       } as never,
       agentId: "main",
       agentDir: DEFAULT_AGENT_DIR,
@@ -1020,7 +1020,7 @@ describe("runBtwSideQuestion", () => {
         agentId: "work",
         cfg: {
           agents: { ownership: "explicit", entries: { main: {}, work: {} } },
-          models: { providers: { anthropic: {} } },
+          models: { providers: { anthropic: { baseUrl: "", models: [] } } },
           session: { scope: "global" },
         },
         sessionKey: "global",
@@ -1172,7 +1172,7 @@ describe("runBtwSideQuestion", () => {
   it("keeps model, runtime auth, and stream selection on prepared A after current advances to B", async () => {
     const cfg = {
       agents: { entries: { main: { default: true } } },
-      models: { providers: { "local-proxy": {} } },
+      models: { providers: { "local-proxy": { baseUrl: "", models: [] } } },
     } as never;
     const generationA = createModelGenerationFixture({
       agentDir: state.agentDir(),
@@ -1448,7 +1448,7 @@ describe("runBtwSideQuestion", () => {
           runSideQuestion({
             cfg: {
               diagnostics: { enabled },
-              models: { providers: { anthropic: {} } },
+              models: { providers: { anthropic: { baseUrl: "", models: [] } } },
             },
             sessionEntry,
             authorityRunId,
@@ -1988,7 +1988,7 @@ describe("runBtwSideQuestion", () => {
 
     const result = await runSideQuestion({
       cfg: {
-        models: { providers: { "github-copilot": {} } },
+        models: { providers: { "github-copilot": { baseUrl: "", models: [] } } },
         agents: {
           defaults: {
             models: {
@@ -2691,7 +2691,7 @@ describe("runBtwSideQuestion", () => {
     mockDoneAnswer("Copilot answer.");
 
     const result = await runSideQuestion({
-      cfg: { models: { providers: { "github-copilot": {} } } },
+      cfg: { models: { providers: { "github-copilot": { baseUrl: "", models: [] } } } },
       provider: "github-copilot",
       model: "gpt-5.4",
     });
@@ -2738,7 +2738,7 @@ describe("runBtwSideQuestion", () => {
     registerProviderStreamForModelMock.mockReturnValue(providerStreamFn);
 
     const result = await runSideQuestion({
-      cfg: { models: { providers: { ollama: {} } } },
+      cfg: { models: { providers: { ollama: { baseUrl: "", models: [] } } } },
       provider: "ollama",
       model: "glm-5.1",
     });
@@ -2775,7 +2775,7 @@ describe("runBtwSideQuestion", () => {
     });
 
     const result = await runSideQuestion({
-      cfg: { models: { providers: { "minimax-portal": {} } } },
+      cfg: { models: { providers: { "minimax-portal": { baseUrl: "", models: [] } } } },
       provider: "minimax-portal",
       model: "MiniMax-M2.7",
     });
@@ -2845,7 +2845,7 @@ describe("runBtwSideQuestion", () => {
     streamSimpleMock.mockReturnValue(makeAsyncEvents([createDoneEvent("Bedrock answer.")]));
 
     const result = await runBtwSideQuestion({
-      cfg: { models: { providers: { "amazon-bedrock": {} } } },
+      cfg: { models: { providers: { "amazon-bedrock": { baseUrl: "", models: [] } } } },
       agentId: "main",
       agentDir: DEFAULT_AGENT_DIR,
       provider: "amazon-bedrock",

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -851,6 +851,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     const result = await compactEmbeddedAgentSessionDirect({
       ...wrappedCompactionArgs({ provider: "openai", model: "gpt-5.5" }),
       modelFallbacksOverride: ["anthropic/claude-fallback"],
+      config: { models: { providers: { anthropic: {} } } },
       runtimeAuthPlan,
       runtimePlan,
     });
@@ -2556,6 +2557,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       trigger: "overflow" as const,
       modelFallbacksOverride: ["demo/basic"],
       config: {
+        models: { providers: { demo: {} } },
         agents: {
           defaults: {
             compaction: { thinkingLevel: "inherit" as const },
@@ -2912,6 +2914,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
           forwardedAuthProfileId: "openai:test",
         },
         config: {
+          models: { providers: { "github-copilot": {} } },
           agents: {
             defaults:
               targetSource === "override"
@@ -3012,6 +3015,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         details: { ok: true },
       });
     const config = {
+      models: { providers: { anthropic: {} } },
       agents: {
         defaults: {
           model: {
@@ -4367,7 +4371,11 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
 
     const result = await compactEmbeddedAgentSession(
-      wrappedCompactionArgs({ provider: "xai", model: "grok-4.5" }),
+      wrappedCompactionArgs({
+        provider: "xai",
+        model: "grok-4.5",
+        config: { models: { providers: { xai: {} } } },
+      }),
     );
 
     expect(result.compactionKind).toBe("server-endpoint");
@@ -4680,6 +4688,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     await compactEmbeddedAgentSession(
       wrappedCompactionArgs({
         config: {
+          models: { providers: { anthropic: {} } },
           agents: {
             defaults: {
               compaction: {
@@ -4717,6 +4726,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       wrappedCompactionArgs({
         contextTokenBudget: 64_000,
         config: {
+          models: { providers: { anthropic: {} } },
           agents: {
             defaults: {
               compaction: {

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -851,7 +851,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     const result = await compactEmbeddedAgentSessionDirect({
       ...wrappedCompactionArgs({ provider: "openai", model: "gpt-5.5" }),
       modelFallbacksOverride: ["anthropic/claude-fallback"],
-      config: { models: { providers: { anthropic: {} } } },
+      config: { models: { providers: { anthropic: { baseUrl: "", models: [] } } } },
       runtimeAuthPlan,
       runtimePlan,
     });
@@ -2557,7 +2557,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       trigger: "overflow" as const,
       modelFallbacksOverride: ["demo/basic"],
       config: {
-        models: { providers: { demo: {} } },
+        models: { providers: { demo: { baseUrl: "", models: [] } } },
         agents: {
           defaults: {
             compaction: { thinkingLevel: "inherit" as const },
@@ -2914,7 +2914,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
           forwardedAuthProfileId: "openai:test",
         },
         config: {
-          models: { providers: { "github-copilot": {} } },
+          models: { providers: { "github-copilot": { baseUrl: "", models: [] } } },
           agents: {
             defaults:
               targetSource === "override"
@@ -3015,7 +3015,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         details: { ok: true },
       });
     const config = {
-      models: { providers: { anthropic: {} } },
+      models: { providers: { anthropic: { baseUrl: "", models: [] } } },
       agents: {
         defaults: {
           model: {
@@ -4374,7 +4374,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       wrappedCompactionArgs({
         provider: "xai",
         model: "grok-4.5",
-        config: { models: { providers: { xai: {} } } },
+        config: { models: { providers: { xai: { baseUrl: "", models: [] } } } },
       }),
     );
 
@@ -4688,7 +4688,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     await compactEmbeddedAgentSession(
       wrappedCompactionArgs({
         config: {
-          models: { providers: { anthropic: {} } },
+          models: { providers: { anthropic: { baseUrl: "", models: [] } } },
           agents: {
             defaults: {
               compaction: {
@@ -4726,7 +4726,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       wrappedCompactionArgs({
         contextTokenBudget: 64_000,
         config: {
-          models: { providers: { anthropic: {} } },
+          models: { providers: { anthropic: { baseUrl: "", models: [] } } },
           agents: {
             defaults: {
               compaction: {

--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
@@ -105,6 +105,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
     resetSharedRunIntegrationHarnessMocks();
     const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
     state = await createOpenClawTestState({ label: "run.codex-app-server-recovery" });
+    useOpenAIPlatformAuthFixture();
     mockedClassifyFailoverReason.mockReturnValue(null);
   });
 

--- a/src/agents/embedded-agent-runner/run.compaction-loop-guard.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.compaction-loop-guard.test-support.ts
@@ -546,6 +546,7 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
     const result = await runEmbeddedAgent({
       ...session.runParams,
       config: {
+        ...session.runParams.config,
         tools: {
           loopDetection: {
             enabled: false,

--- a/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
@@ -1,6 +1,7 @@
 // Full-entry coverage for current-attempt error context across model fallback.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { createModelFallbackConfig } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
@@ -86,7 +87,7 @@ function makeCrossProviderFallbackConfig() {
 }
 
 function useCrossProviderAuthFixture() {
-  const store = {
+  const store: AuthProfileStore = {
     version: 1 as const,
     profiles: {
       "anthropic:test": {
@@ -107,6 +108,7 @@ function useCrossProviderAuthFixture() {
     const provider = (params as { provider?: string } | undefined)?.provider;
     return provider && `${provider}:test` in store.profiles ? [`${provider}:test`] : [];
   });
+  return store;
 }
 
 function setupCompactionRemovedFallbackAttempt() {
@@ -164,7 +166,10 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
     const { withOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
     await withOpenClawTestState({ label: "cross-provider-warmup" }, async (warmupState) => {
       await warmRunOverflowCompactionHarness(runEmbeddedAgent, warmupState, {
-        config: makeCrossProviderFallbackConfig(),
+        config: {
+          ...makeCrossProviderFallbackConfig(),
+          models: createOverflowRunParams(warmupState, "deepseek").config.models,
+        },
         agentHarnessRuntimeOverride: "openclaw",
         provider: "deepseek",
         model: "deepseek-chat",
@@ -224,6 +229,13 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
   });
 
   it("uses the completed assistant when compaction removes the current attempt slice", async () => {
+    const store = useCrossProviderAuthFixture();
+    store.profiles["anthropic:backup"] = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "backup-fixture",
+    };
+    mockedResolveAuthProfileOrder.mockReturnValue(["anthropic:test", "anthropic:backup"]);
     const getLastFormattedAssistant = captureFormattedAssistant();
     setupCompactionRemovedFallbackAttempt();
     const promise = runCompactionRemovedFallbackAttempt(state);

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test-support.ts
@@ -82,7 +82,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("ollama", "glm-5.1:cloud"));
 
     const result = await runEmbeddedAgent({
-      ...createOverflowRunParams(state),
+      ...createOverflowRunParams(state, "ollama"),
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-empty-error-retry-basic",
@@ -145,7 +145,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
     }
 
     const result = await runEmbeddedAgent({
-      ...createOverflowRunParams(state),
+      ...createOverflowRunParams(state, "ollama"),
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-empty-error-retry-exhausted",

--- a/src/agents/embedded-agent-runner/run.fast-mode-auto.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.fast-mode-auto.test-support.ts
@@ -80,10 +80,11 @@ describe("runEmbeddedAgent fast auto progress", () => {
     });
 
     await runEmbeddedAgent({
-      ...createOverflowRunParams(state),
+      ...createOverflowRunParams(state, "ollama"),
       provider: "ollama",
       model: "glm-5.1:cloud",
       config: {
+        ...createOverflowRunParams(state, "ollama").config,
         agents: {
           defaults: {
             models: {
@@ -134,7 +135,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
     });
 
     const resultPromise = runEmbeddedAgent({
-      ...createOverflowRunParams(state),
+      ...createOverflowRunParams(state, "ollama"),
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-fast-auto-retry",
@@ -241,7 +242,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
     });
 
     const resultPromise = runEmbeddedAgent({
-      ...createOverflowRunParams(state),
+      ...createOverflowRunParams(state, "ollama"),
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-fast-auto-single-off",
@@ -323,7 +324,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
       });
 
       const resultPromise = runEmbeddedAgent({
-        ...createOverflowRunParams(state),
+        ...createOverflowRunParams(state, "ollama"),
         provider: "ollama",
         model: "glm-5.1:cloud",
         runId: `run-fast-auto-off-${failureTarget}`,
@@ -404,7 +405,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
       });
 
       const resultPromise = runEmbeddedAgent({
-        ...createOverflowRunParams(state),
+        ...createOverflowRunParams(state, "ollama"),
         provider: "ollama",
         model: "glm-5.1:cloud",
         runId: `run-fast-auto-reset-${failureTarget}`,

--- a/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
@@ -307,6 +307,7 @@ describe("native harness auth failover", () => {
       await expect(
         runEmbeddedAgent({
           ...createOverflowRunParams(state),
+          config: undefined,
           ...nativePin,
           provider: "openai",
           model: "gpt-5.6-luna",

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -4,6 +4,7 @@
 import { matchesContextOverflowMessage } from "@openclaw/ai/internal/runtime";
 import { type Mock, vi } from "vitest";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine, ContextEngineSessionTarget } from "../../context-engine/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type {
@@ -411,7 +412,7 @@ export const mockedEnsureAuthProfileStoreWithoutExternalProfiles = vi.fn<
 
 export function useOpenAIPlatformAuthFixture(): void {
   const profileId = "openai:test";
-  mockedEnsureAuthProfileStore.mockReturnValue({
+  const store: AuthProfileStore = {
     version: 1,
     profiles: {
       [profileId]: {
@@ -421,7 +422,9 @@ export function useOpenAIPlatformAuthFixture(): void {
       },
     },
     order: { openai: [profileId] },
-  });
+  };
+  mockedEnsureAuthProfileStore.mockReturnValue(store);
+  mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReturnValue(store);
   mockedResolveAuthProfileOrder.mockReturnValue([profileId]);
 }
 export const mockedResolveAuthProfileOrder = vi.fn<(_params?: unknown) => string[]>(
@@ -447,8 +450,15 @@ const mockedShouldPreferExplicitConfigApiKeyAuth = vi.fn(() => false);
 // the mocked codex harness does not claim: such runs select the built-in openclaw
 // host harness and pay its one-time source-compile cost. Suites proving plugin
 // harness behavior must pin provider "openai" (see run.session-permissions.test.ts).
-export function createOverflowRunParams(state: Pick<OpenClawTestState, "workspaceDir">) {
+export function createOverflowRunParams(
+  state: Pick<OpenClawTestState, "workspaceDir">,
+  provider = "anthropic",
+) {
+  const config: OpenClawConfig = {
+    models: { providers: { [provider]: { baseUrl: "", models: [] } } },
+  };
   return {
+    config,
     agentId: "main",
     sessionId: "test-session",
     sessionKey: "agent:main:test-key",

--- a/src/agents/embedded-agent-runner/run.prepared-harness-credentials.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-credentials.test.ts
@@ -105,7 +105,7 @@ describe("prepared plugin harness credentials", () => {
 
   it("does not discover a credential for an implicit harness auth attempt", async () => {
     await runEmbeddedAgent({
-      ...createOverflowRunParams(state),
+      ...createOverflowRunParams(state, "custom-proof"),
       provider: "custom-proof",
       model: "gpt-5.6-luna",
     });

--- a/src/agents/embedded-agent-runner/run.recovery-cancellation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.recovery-cancellation.test-support.ts
@@ -601,6 +601,7 @@ describe("recovery cancellation through the public run owner", () => {
     let manager: ReturnType<typeof PersistentSessionManager.open> | undefined;
     let firstKeptEntryId: string | undefined;
     const runParams = {
+      config: createOverflowRunParams(state).config,
       sessionId: "fresh-plugin-task",
       runId: "fresh-plugin-run",
       workspaceDir: state.workspaceDir,

--- a/src/agents/embedded-agent-runner/run.retry-lifecycle.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.retry-lifecycle.test-support.ts
@@ -6,6 +6,7 @@ import {
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import {
@@ -25,6 +26,7 @@ describe("direct embedded retry lifecycle", () => {
     mockedClassifyAssistantFailoverReason.mockReturnValue(null);
     mockedClassifyFailoverReason.mockReturnValue(null);
     session = await createSharedRunIntegrationSession();
+    session.runParams.config = createOverflowRunParams(session.runParams, "mock").config;
   });
   afterEach(async () => {
     await session?.cleanup();

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -6,6 +6,7 @@ import { formatErrorMessage } from "../../../infra/errors.js";
 import type { Model } from "../../../llm/types.js";
 import type { ProviderModelRouteAuthRequirement } from "../../../plugin-sdk/provider-model-types.js";
 import { prepareProviderRuntimeAuth } from "../../../plugins/provider-runtime.js";
+import { resolveProviderBindingEnvVarCandidates } from "../../../secrets/provider-env-vars.js";
 import { SecretSurfaceUnavailableError } from "../../../secrets/runtime-degraded-state.js";
 import {
   type AuthProfileStore,
@@ -30,6 +31,7 @@ import {
   type ResolvedProviderAuth,
 } from "../../model-auth.js";
 import { buildProviderAuthRecoveryHint } from "../../provider-auth-recovery-hint.js";
+import { resolveProviderUseAdmission } from "../../provider-model-auth-source-plan.js";
 import { providerModelRouteAcceptsAuthMode } from "../../provider-model-route-auth.js";
 import {
   applyPreparedRuntimeAuthToModel,
@@ -150,6 +152,11 @@ export function createEmbeddedRunAuthController(params: {
   log: LogLike;
 }) {
   const { state } = params;
+  const admission = resolveProviderUseAdmission({
+    config: params.config,
+    profiles: params.authStore.profiles,
+    providerEnvVars: resolveProviderBindingEnvVarCandidates(params),
+  });
   // Runtime auth overlays are profile-scoped. Keep the pre-auth model so a
   // later profile cannot inherit an earlier profile's endpoint or headers.
   const baseRuntimeModel = state.models.runtime;
@@ -512,6 +519,7 @@ export function createEmbeddedRunAuthController(params: {
     model = state.models.runtime,
     allowAuthProfileFallback?: boolean,
   ) => {
+    const binding = admission.get(model.provider.trim().toLowerCase());
     return getApiKeyForModelCore({
       model,
       cfg: params.config,
@@ -522,6 +530,7 @@ export function createEmbeddedRunAuthController(params: {
       lockedProfile: candidate != null && candidate === params.lockedProfileId,
       allowAuthProfileFallback,
       secretSentinels: true,
+      boundEnvVar: binding?.kind === "environment" ? binding.envVar : undefined,
     });
   };
 

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -6,7 +6,6 @@ import { formatErrorMessage } from "../../../infra/errors.js";
 import type { Model } from "../../../llm/types.js";
 import type { ProviderModelRouteAuthRequirement } from "../../../plugin-sdk/provider-model-types.js";
 import { prepareProviderRuntimeAuth } from "../../../plugins/provider-runtime.js";
-import { resolveProviderBindingEnvVarCandidates } from "../../../secrets/provider-env-vars.js";
 import { SecretSurfaceUnavailableError } from "../../../secrets/runtime-degraded-state.js";
 import {
   type AuthProfileStore,
@@ -31,7 +30,6 @@ import {
   type ResolvedProviderAuth,
 } from "../../model-auth.js";
 import { buildProviderAuthRecoveryHint } from "../../provider-auth-recovery-hint.js";
-import { resolveProviderUseAdmission } from "../../provider-model-auth-source-plan.js";
 import { providerModelRouteAcceptsAuthMode } from "../../provider-model-route-auth.js";
 import {
   applyPreparedRuntimeAuthToModel,
@@ -147,16 +145,12 @@ export function createEmbeddedRunAuthController(params: {
     runtimeModel: Model;
     authRequirement?: ProviderModelRouteAuthRequirement;
     allowAuthProfileFallback?: boolean;
+    boundEnvVar?: string;
     commit(): void;
   }>;
   log: LogLike;
 }) {
   const { state } = params;
-  const admission = resolveProviderUseAdmission({
-    config: params.config,
-    profiles: params.authStore.profiles,
-    providerEnvVars: resolveProviderBindingEnvVarCandidates(params),
-  });
   // Runtime auth overlays are profile-scoped. Keep the pre-auth model so a
   // later profile cannot inherit an earlier profile's endpoint or headers.
   const baseRuntimeModel = state.models.runtime;
@@ -518,8 +512,8 @@ export function createEmbeddedRunAuthController(params: {
     candidate?: string,
     model = state.models.runtime,
     allowAuthProfileFallback?: boolean,
+    boundEnvVar?: string,
   ) => {
-    const binding = admission.get(model.provider.trim().toLowerCase());
     return getApiKeyForModelCore({
       model,
       cfg: params.config,
@@ -530,7 +524,7 @@ export function createEmbeddedRunAuthController(params: {
       lockedProfile: candidate != null && candidate === params.lockedProfileId,
       allowAuthProfileFallback,
       secretSentinels: true,
-      boundEnvVar: binding?.kind === "environment" ? binding.envVar : undefined,
+      boundEnvVar,
     });
   };
 
@@ -540,6 +534,7 @@ export function createEmbeddedRunAuthController(params: {
       candidate,
       preparedModel?.runtimeModel,
       preparedModel?.allowAuthProfileFallback,
+      preparedModel?.boundEnvVar,
     );
     if (
       preparedModel?.authRequirement &&

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.ts
@@ -314,6 +314,7 @@ export async function prepareEmbeddedRunRuntime(input: {
       runtimeModel: nextRuntimeModel,
       authRequirement: modelDecision.authRequirement,
       allowAuthProfileFallback: attempt.allowAuthProfileFallback,
+      boundEnvVar: attempt.plan.boundEnvVar,
       commit() {
         applyResolvedRuntimeModel(nextRuntimeModel, nextResolvedModel);
         activePreparedAuthPlan = attempt.plan;

--- a/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
+++ b/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
@@ -7,9 +7,13 @@ import { createModelFallbackConfig } from "../test-helpers/model-fallback-config
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedAcquireAgentRunPreparedModelRuntime,
+  mockedEnsureAuthProfileStore,
+  mockedEnsureAuthProfileStoreWithoutExternalProfiles,
+  mockedResolveAuthProfileOrder,
   mockedResolveModelAsync,
   mockedRunEmbeddedAttempt,
   resetSharedRunIntegrationHarnessMocks,
+  useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
@@ -54,6 +58,15 @@ describe("runEmbeddedAgent usage reporting", () => {
     resetSharedRunIntegrationHarnessMocks();
     const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
     state = await createOpenClawTestState({ label: "usage-reporting" });
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "anthropic:usage": { type: "api_key" as const, provider: "anthropic", key: "test-key" },
+      },
+    };
+    mockedEnsureAuthProfileStore.mockReturnValue(store);
+    mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReturnValue(store);
+    mockedResolveAuthProfileOrder.mockReturnValue(["anthropic:usage"]);
   });
 
   afterEach(async () => {
@@ -131,6 +144,7 @@ describe("runEmbeddedAgent usage reporting", () => {
   });
 
   it("preserves an explicitly pinned harness across fallback plugin planning", async () => {
+    useOpenAIPlatformAuthFixture();
     const config = createModelFallbackConfig("codex/test-model", ["openai/gpt-5.5"]);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({ assistantTexts: ["Response 1"] }),
@@ -319,6 +333,15 @@ describe("runEmbeddedAgent usage reporting", () => {
   });
 
   it("reports the resolved model provider when OpenClaw marks the assistant message as the native runtime", async () => {
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openrouter:usage": { type: "api_key" as const, provider: "openrouter", key: "test-key" },
+      },
+    };
+    mockedEnsureAuthProfileStore.mockReturnValue(store);
+    mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReturnValue(store);
+    mockedResolveAuthProfileOrder.mockReturnValue(["openrouter:usage"]);
     mockedResolveModelAsync.mockResolvedValueOnce({
       logicalRef: { provider: "openrouter", model: "openai/gpt-5.4" },
       model: {

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -4111,6 +4111,7 @@ describe("selectAgentHarness", () => {
   });
 
   it("passes runtime model and default credentials to compaction when auth profile id is absent", async () => {
+    const config = { models: { providers: { "local-proxy": {} } } };
     compactAuthMocks.resolveModelAsync.mockResolvedValue({
       model: {
         id: "proxy-model",
@@ -4146,6 +4147,7 @@ describe("selectAgentHarness", () => {
         provider: "local-proxy",
         model: "proxy-model",
         agentHarnessId: "copilot",
+        config,
       }),
     ).resolves.toEqual({ ok: true, compacted: false });
 
@@ -4153,7 +4155,7 @@ describe("selectAgentHarness", () => {
       "local-proxy",
       "proxy-model",
       expect.any(String),
-      undefined,
+      config,
       expect.objectContaining({
         authProfileId: undefined,
         workspaceDir: "/tmp/workspace",

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -4111,7 +4111,7 @@ describe("selectAgentHarness", () => {
   });
 
   it("passes runtime model and default credentials to compaction when auth profile id is absent", async () => {
-    const config = { models: { providers: { "local-proxy": {} } } };
+    const config = { models: { providers: { "local-proxy": { baseUrl: "", models: [] } } } };
     compactAuthMocks.resolveModelAsync.mockResolvedValue({
       model: {
         id: "proxy-model",

--- a/src/agents/model-auth-availability.test.ts
+++ b/src/agents/model-auth-availability.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretRef } from "../config/types.secrets.js";
 import type { ProviderModelRouteCandidate } from "../plugin-sdk/provider-model-types.js";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { createModelAuthAvailabilityResolver } from "./model-auth-availability.js";
 import {
   authStore,
@@ -13,6 +14,13 @@ import {
   subscriptionRoute,
 } from "./model-auth-availability.test-support.js";
 import type { createOpenAIModelRoutesResolver } from "./openai-model-routes.js";
+
+function providerConnectionConfig(
+  provider: string,
+  connection: ModelProviderConfig,
+): OpenClawConfig {
+  return { models: { providers: { [provider]: connection } } };
+}
 
 describe("createModelAuthAvailabilityResolver", () => {
   it.each([
@@ -51,17 +59,11 @@ describe("createModelAuthAvailabilityResolver", () => {
   });
 
   it("canonicalizes prepared runtime auth through provider aliases", () => {
-    const metadataSnapshot = {
-      index: {
-        plugins: [
-          {
-            pluginId: "external-cloud",
-            origin: "global",
-            enabled: true,
-            enabledByDefault: true,
-          },
-        ],
-      },
+    const cfg = providerConnectionConfig("cloud-alias", {
+      baseUrl: "https://cloud.example.test",
+      models: [],
+    });
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
       plugins: [
         {
           id: "external-cloud",
@@ -69,9 +71,9 @@ describe("createModelAuthAvailabilityResolver", () => {
           providerAuthAliases: { "cloud-alias": "external-cloud" },
         },
       ],
-    } as unknown as PluginMetadataSnapshot;
+    });
     const resolver = createModelAuthAvailabilityResolver({
-      cfg: {},
+      cfg,
       authStore: authStore(),
       env: {},
       metadataSnapshot,
@@ -85,7 +87,7 @@ describe("createModelAuthAvailabilityResolver", () => {
       selectedAuthMode: "api_key",
     });
     const syntheticResolver = createModelAuthAvailabilityResolver({
-      cfg: {},
+      cfg,
       authStore: authStore(),
       env: {},
       metadataSnapshot,
@@ -102,8 +104,7 @@ describe("createModelAuthAvailabilityResolver", () => {
   });
 
   it("keeps prepared native-runtime authentication scoped to its exact owner", () => {
-    const metadataSnapshot = {
-      index: { plugins: [] },
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
       plugins: [
         {
           id: "anthropic",
@@ -111,36 +112,30 @@ describe("createModelAuthAvailabilityResolver", () => {
           providerAuthAliases: { "claude-cli": "anthropic" },
         },
       ],
-    } as unknown as PluginMetadataSnapshot;
+    });
     const resolver = createModelAuthAvailabilityResolver({
       cfg: {},
       authStore: authStore(),
       env: {},
       metadataSnapshot,
-      preparedRuntimeAuthModes: { "claude-cli": "api_key" },
+      preparedRuntimeAuthModes: { "claude-cli": { source: "native", mode: "oauth" } },
     });
 
     expect(resolver.evaluateModelAuth("claude-cli")).toMatchObject({
       availability: true,
       evidence: "runtime",
-      selectedAuthMode: "api_key",
+      selectedAuthMode: "oauth",
     });
     expect(resolver.evaluateModelAuth("anthropic").availability).not.toBe(true);
   });
 
   it("keeps configured local providers independent from native-auth probe completion", () => {
     const resolver = createModelAuthAvailabilityResolver({
-      cfg: {
-        models: {
-          providers: {
-            "local-openai": {
-              api: "openai-completions",
-              baseUrl: "http://127.0.0.1:8080/v1",
-              models: [],
-            },
-          },
-        },
-      },
+      cfg: providerConnectionConfig("local-openai", {
+        api: "openai-completions",
+        baseUrl: "http://127.0.0.1:8080/v1",
+        models: [],
+      }),
       authStore: authStore(),
       env: {},
       preparedSyntheticAuthComplete: true,
@@ -156,7 +151,12 @@ describe("createModelAuthAvailabilityResolver", () => {
   ])(
     "uses prepared runtime $mode auth when the profile snapshot is empty",
     ({ mode, selectedRoute }) => {
-      expect(evaluate({ preparedRuntimeAuthModes: { openai: mode } })).toMatchObject({
+      expect(
+        evaluate({
+          cfg: providerConnectionConfig("openai", { baseUrl: platformRoute.baseUrl, models: [] }),
+          preparedRuntimeAuthModes: { openai: mode },
+        }),
+      ).toMatchObject({
         availability: true,
         evidence: "runtime",
         selectedAuthMode: mode,
@@ -209,18 +209,12 @@ describe("createModelAuthAvailabilityResolver", () => {
       ).not.toBe(true);
       expect(
         evaluate({
-          cfg: {
-            models: {
-              providers: {
-                openai: {
-                  auth: "api-key",
-                  apiKey: "configured-platform-key",
-                  baseUrl: "https://api.openai.com/v1",
-                  models: [],
-                },
-              },
-            },
-          },
+          cfg: providerConnectionConfig("openai", {
+            auth: "api-key",
+            apiKey: "configured-platform-key",
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+          }),
           store,
           ref: { modelId },
           preparedRuntimeAuthMaterializations: [materialization],
@@ -978,33 +972,32 @@ describe("createModelAuthAvailabilityResolver", () => {
   it.each([
     {
       label: "explicit",
-      cfg: {
-        models: {
-          providers: {
-            "amazon-bedrock": {
-              api: "bedrock-converse-stream",
-              auth: "aws-sdk",
-              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-              models: [],
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: providerConnectionConfig("amazon-bedrock", {
+        api: "bedrock-converse-stream",
+        auth: "aws-sdk",
+        baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+        models: [],
+      }),
+      expected: {
+        availability: true,
+        evidence: "aws-sdk",
+        routeResolution: null,
+        selectedAuthMode: "aws-sdk",
+      },
     },
-    { label: "implicit", cfg: {} },
-  ])("keeps an $label Bedrock AWS SDK route ready", ({ cfg }) => {
+    {
+      label: "undeclared",
+      cfg: {},
+      expected: { availability: false, unavailableReason: "missing-auth", routeResolution: null },
+    },
+  ])("reports $label Bedrock admission", ({ cfg, expected }) => {
     const result = createModelAuthAvailabilityResolver({
       cfg,
       authStore: authStore(),
       env: {},
     }).evaluateModelAuth("amazon-bedrock", { api: "bedrock-converse-stream" });
 
-    expect(result).toMatchObject({
-      availability: true,
-      evidence: "aws-sdk",
-      routeResolution: null,
-      selectedAuthMode: "aws-sdk",
-    });
+    expect(result).toMatchObject(expected);
   });
 
   it.each<{

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -18,6 +18,7 @@ import type {
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { passesManifestOwnerBasePolicy } from "../plugins/manifest-owner-policy.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import { isValidSecretRef } from "../secrets/ref-contract.js";
 import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes.js";
 import { hasUsableOAuthCredential } from "./auth-profiles/credential-state.js";
@@ -57,10 +58,7 @@ import {
 } from "./cli-backends.js";
 import { resolveBundledCliBackendAuthPolicy } from "./cli-runner/cli-backend-auth-policy.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
-import {
-  listProviderEnvAuthLookupKeys,
-  resolveProviderEnvAuthLookupMaps,
-} from "./model-auth-env-vars.js";
+import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
 import { resolveProviderEnvAuthEvidence } from "./model-auth-env.js";
 import { isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import {
@@ -84,6 +82,7 @@ import {
   buildProviderModelAuthSourcePlan,
   fromProviderModelAuthReadiness,
   toProviderModelAuthReadiness,
+  resolveProviderUseAdmission,
   type ProviderModelAuthEvidence,
   type ProviderModelAuthProfileSource,
   type ProviderModelAuthSourcePlan,
@@ -230,13 +229,14 @@ function evaluateCliRuntimeModelAuthAvailability(
   }
   const runtimeAuthMode =
     params.preparedRuntimeAuthModes?.[normalizeProviderIdForAuth(runtimeProvider)];
+  const mode = typeof runtimeAuthMode === "object" ? runtimeAuthMode.mode : runtimeAuthMode;
   // The prepared native-runtime result is authoritative for this route. Provider
   // credentials cannot prove that the separately authenticated CLI is usable.
-  return typeof runtimeAuthMode === "string"
+  return typeof mode === "string"
     ? {
         availability: true,
         routeResolution: null,
-        selectedAuthMode: runtimeAuthMode,
+        selectedAuthMode: mode,
         evidence: "runtime",
       }
     : params.preparedSyntheticAuthComplete
@@ -410,6 +410,21 @@ export function createModelAuthAvailabilityResolver(
     env,
     metadataSnapshot: params.metadataSnapshot,
   });
+  const admitted = resolveProviderUseAdmission({
+    config: params.cfg,
+    env,
+    profiles: store.profiles,
+    nativeProviders: Object.entries(params.preparedRuntimeAuthModes ?? {}).flatMap(
+      ([provider, mode]) =>
+        typeof mode === "object" && mode.source === "native" ? [provider] : [],
+    ),
+    providerEnvVars: resolveProviderBindingEnvVarCandidates({
+      config: params.cfg,
+      env,
+      workspaceDir: params.workspaceDir,
+      metadataSnapshot: params.metadataSnapshot,
+    }),
+  });
   const synthetic = new Set(
     (params.syntheticAuthProviderRefs ?? []).map(normalizeProviderIdForAuth),
   );
@@ -460,14 +475,19 @@ export function createModelAuthAvailabilityResolver(
       store,
     });
   const envAuth = (provider: string) => {
+    const binding = admitted.get(normalizeProviderId(provider));
+    if (!binding || binding.kind === "profile") {
+      return null;
+    }
     const normalized = normalizeProvider(provider);
     if (!envCache.has(normalized)) {
       envCache.set(
         normalized,
         resolveProviderEnvAuthEvidence(normalized, env, {
-          aliasMap,
-          candidateMap: envCandidateMap,
-          authEvidenceMap,
+          aliasMap: binding.kind === "environment" ? {} : aliasMap,
+          candidateMap:
+            binding.kind === "environment" ? { [normalized]: [binding.envVar] } : envCandidateMap,
+          authEvidenceMap: binding.kind === "environment" ? {} : authEvidenceMap,
           config: params.cfg,
           workspaceDir: params.workspaceDir,
         }),
@@ -481,21 +501,30 @@ export function createModelAuthAvailabilityResolver(
     preferredProfileId?: string,
     pinnedProfileId?: string,
   ) => {
-    const normalized = normalizeProvider(provider);
+    const normalized = normalizeProviderIdForAuth(provider);
     const cacheKey = `${normalized}\u0000${forModel ?? ""}\u0000${preferredProfileId ?? ""}\u0000${pinnedProfileId ?? ""}`;
     const cached = orderCache.get(cacheKey);
     if (cached) {
       return cached;
     }
+    const ordered = resolveAuthProfileOrderWithMetadata({
+      cfg: readOnlyAuthConfig,
+      store: orderStore,
+      provider: normalized,
+      preferredProfile: preferredProfileId,
+      forModel,
+      readinessMode: "read-only",
+    });
     const resolution = prependAuthProfilePin(
-      resolveAuthProfileOrderWithMetadata({
-        cfg: readOnlyAuthConfig,
-        store: orderStore,
-        provider: normalized,
-        preferredProfile: preferredProfileId,
-        forModel,
-        readinessMode: "read-only",
-      }),
+      admitted.get(normalized)?.kind === "profile"
+        ? {
+            ...ordered,
+            profileIds: ordered.profileIds.filter((id) => {
+              const credential = orderStore.profiles[id];
+              return credential && normalizeProviderId(credential.provider) === normalized;
+            }),
+          }
+        : ordered,
       pinnedProfileId,
     );
     orderCache.set(cacheKey, resolution);
@@ -641,6 +670,10 @@ export function createModelAuthAvailabilityResolver(
     });
   };
   const unprofiledEvaluation = (provider: string, target: AuthTarget): AuthSourceEvaluation => {
+    const admissionBinding = admitted.get(normalizeProviderId(provider));
+    if (!admissionBinding || admissionBinding.kind === "profile") {
+      return { availability: false, evidence: "none", unavailableReason: "missing-auth" };
+    }
     const { providerConfig: configured, ref: apiKeyRef } = providerInput(provider);
     const configuredAuth = target.pinnedProfileId ? undefined : configured?.auth;
     if (configuredAuth === "aws-sdk") {
@@ -772,9 +805,11 @@ export function createModelAuthAvailabilityResolver(
         evidence: "aws-sdk",
       };
     }
-    const preparedRuntimeAuthMode =
+    const preparedRuntimeAuth =
       params.preparedRuntimeAuthModes?.[normalizeProviderIdForAuth(provider)] ??
       params.preparedRuntimeAuthModes?.[normalizeProvider(provider)];
+    const preparedRuntimeAuthMode =
+      typeof preparedRuntimeAuth === "object" ? preparedRuntimeAuth.mode : preparedRuntimeAuth;
     if (typeof preparedRuntimeAuthMode === "string") {
       return {
         availability: modeAllowed(provider, target, preparedRuntimeAuthMode),
@@ -1022,6 +1057,9 @@ export function createModelAuthAvailabilityResolver(
     preparedTarget?: AuthTarget,
   ): AuthSourceEvaluation => {
     const provider = normalizeProviderIdForAuth(rawProvider);
+    if (!admitted.has(provider)) {
+      return { availability: false, evidence: "none", unavailableReason: "missing-auth" };
+    }
     const target = preparedTarget ?? prepareAuthTarget(provider, ref);
     const profileLock = ref.requiredProfileId?.trim();
     if (invalidProfilePin(provider, ref)) {
@@ -1421,16 +1459,8 @@ export function createModelAuthAvailabilityResolver(
       providerDiscoveryProviderIds.add(normalized);
     }
   };
-  for (const credential of Object.values(store.profiles)) {
-    addProviderDiscoveryProviderId(credential.provider);
-  }
-  for (const profile of Object.values(params.cfg.auth?.profiles ?? {})) {
-    addProviderDiscoveryProviderId(profile.provider);
-  }
-  for (const provider of listProviderEnvAuthLookupKeys({ envCandidateMap, authEvidenceMap })) {
-    if (envAuth(provider)) {
-      addProviderDiscoveryProviderId(provider);
-    }
+  for (const provider of admitted.keys()) {
+    addProviderDiscoveryProviderId(provider);
   }
   for (const plugin of params.metadataSnapshot?.index?.plugins ?? []) {
     if (

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -138,6 +138,11 @@ export type ModelAuthAvailabilityEvaluation = {
   runtimeAuth?: { id: string; source: "native" };
 };
 export type ModelAuthAvailabilityResolver = {
+  /** Provider auth facts without interpreting a model as a text transport route. */
+  evaluateProviderAuth(
+    provider: string,
+    ref?: ModelAuthAvailabilityRef,
+  ): ModelAuthAvailabilityEvaluation;
   evaluateRuntimeModelAuth(
     this: void,
     provider: string,
@@ -280,6 +285,7 @@ type AuthSourceEvaluation = Pick<
   | "unavailableReason"
   | "unavailableUntil"
   | "environmentVariable"
+  | "runtimeAuth"
 >;
 
 function modeAllowed(provider: string, target: AuthTarget, mode: string | undefined): boolean {
@@ -793,6 +799,7 @@ export function createModelAuthAvailabilityResolver(
             : false,
           selectedAuthMode: configuredBearerMode,
           evidence: "environment",
+          environmentVariable: apiKey.trim(),
         };
       }
       if (!modeAllowed(provider, target, configuredBearerMode)) {
@@ -835,6 +842,7 @@ export function createModelAuthAvailabilityResolver(
         availability: runtimeAvailable ? true : available,
         selectedAuthMode: configuredBearerMode,
         evidence: runtimeAvailable ? "runtime" : "provider-config",
+        ...(apiKeyRef.source === "env" ? { environmentVariable: apiKeyRef.id } : {}),
       };
     }
     if (apiKey !== undefined && !(typeof apiKey === "string" && apiKey.trim() === "")) {
@@ -862,6 +870,9 @@ export function createModelAuthAvailabilityResolver(
         availability: modeAllowed(provider, target, preparedRuntimeAuthMode),
         selectedAuthMode: preparedRuntimeAuthMode,
         evidence: "runtime",
+        ...(typeof preparedRuntimeAuth === "object" && preparedRuntimeAuth.source === "native"
+          ? { runtimeAuth: { id: normalizeProviderIdForAuth(provider), source: "native" as const } }
+          : {}),
       };
     }
     const environment = envAuth(provider);
@@ -1171,18 +1182,22 @@ export function createModelAuthAvailabilityResolver(
   };
   // Provider-only availability is the legacy fallback when no route artifact exists;
   // it never claims a concrete OpenAI endpoint.
+  const evaluateProviderAuth = (
+    provider: string,
+    ref: ModelAuthAvailabilityRef = {},
+  ): ModelAuthAvailabilityEvaluation => ({
+    ...resolveProviderEvaluation(provider, ref),
+    routeResolution: null,
+  });
   const resolveProviderAuthAvailability = (provider: string, ref: ModelAuthAvailabilityRef = {}) =>
-    resolveProviderEvaluation(provider, ref).availability;
+    evaluateProviderAuth(provider, ref).availability;
   const evaluateModelAuth = (
     rawProvider: string,
     ref: ModelAuthAvailabilityRef = {},
   ): ModelAuthAvailabilityEvaluation => {
     const provider = normalizeProviderIdForAuth(rawProvider);
     if (provider !== OPENAI_PROVIDER_ID) {
-      return {
-        ...resolveProviderEvaluation(provider, ref),
-        routeResolution: null,
-      };
+      return evaluateProviderAuth(provider, ref);
     }
     if (invalidProfilePin(provider, ref)) {
       return { availability: false, unavailableReason: "auth-failed", routeResolution: null };
@@ -1540,6 +1555,7 @@ export function createModelAuthAvailabilityResolver(
     providerDiscoveryProviderIds: [...providerDiscoveryProviderIds].toSorted((left, right) =>
       left.localeCompare(right),
     ),
+    evaluateProviderAuth,
     evaluateModelAuth,
     evaluateRuntimeModelAuth: (provider, ref = {}) => {
       const runtimeId =

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -72,11 +72,13 @@ import { resolveManagedSecretRefRuntimeProviderAuth } from "./model-auth-runtime
 import { hasAuthoredProviderRequestParams } from "./model-extra-params.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import { resolveCliRuntimeExecutionProvider } from "./model-runtime-aliases.js";
+import { resolveSelectedModelProviderIds } from "./model-selection-config.js";
 import {
   createOpenAIModelRoutesResolver,
   resolveConfiguredOpenAIAuthMode,
   selectOpenAIModelRouteAuth,
 } from "./openai-model-routes.js";
+import { resolveProviderAuthAliasMap } from "./provider-auth-aliases.js";
 import {
   buildProviderModelAuthDirectSource,
   buildProviderModelAuthSourcePlan,
@@ -414,6 +416,17 @@ export function createModelAuthAvailabilityResolver(
     config: params.cfg,
     env,
     profiles: store.profiles,
+    requestedProviders: resolveSelectedModelProviderIds({
+      cfg: params.cfg,
+      agentId: params.agentId,
+    }),
+    storedCredentialAuthAliases: resolveProviderAuthAliasMap({
+      config: params.cfg,
+      env,
+      workspaceDir: params.workspaceDir,
+      metadataSnapshot: params.metadataSnapshot,
+      storedCredential: true,
+    }),
     nativeProviders: Object.entries(params.preparedRuntimeAuthModes ?? {}).flatMap(
       ([provider, mode]) =>
         typeof mode === "object" && mode.source === "native" ? [provider] : [],
@@ -509,14 +522,22 @@ export function createModelAuthAvailabilityResolver(
     }
     const ordered = resolveAuthProfileOrderWithMetadata({
       cfg: readOnlyAuthConfig,
+      authAliasLookupParams: {
+        config: params.cfg,
+        env,
+        workspaceDir: params.workspaceDir,
+        metadataSnapshot: params.metadataSnapshot,
+      },
       store: orderStore,
       provider: normalized,
       preferredProfile: preferredProfileId,
       forModel,
       readinessMode: "read-only",
     });
+    const binding = admitted.get(normalized);
     const resolution = prependAuthProfilePin(
-      admitted.get(normalized)?.kind === "profile"
+      binding?.kind === "profile" &&
+        normalizeProviderId(orderStore.profiles[binding.profileId]?.provider ?? "") === normalized
         ? {
             ...ordered,
             profileIds: ordered.profileIds.filter((id) => {

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -247,6 +247,7 @@ function evaluateCliRuntimeModelAuthAvailability(
 }
 type CreateModelAuthAvailabilityResolverParams = {
   cfg: OpenClawConfig;
+  requestedProviderIds?: readonly string[];
   agentId?: string;
   authStore: AuthProfileStore;
   agentDir?: string;
@@ -416,10 +417,10 @@ export function createModelAuthAvailabilityResolver(
     config: params.cfg,
     env,
     profiles: store.profiles,
-    requestedProviders: resolveSelectedModelProviderIds({
-      cfg: params.cfg,
-      agentId: params.agentId,
-    }),
+    requestedProviders: [
+      ...resolveSelectedModelProviderIds({ cfg: params.cfg, agentId: params.agentId }),
+      ...(params.requestedProviderIds ?? []),
+    ],
     storedCredentialAuthAliases: resolveProviderAuthAliasMap({
       config: params.cfg,
       env,

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -672,7 +672,10 @@ export function createModelAuthAvailabilityResolver(
   const unprofiledEvaluation = (provider: string, target: AuthTarget): AuthSourceEvaluation => {
     const admissionBinding = admitted.get(normalizeProviderId(provider));
     if (!admissionBinding || admissionBinding.kind === "profile") {
-      return { availability: false, unavailableReason: "missing-auth" };
+      return {
+        availability: false,
+        unavailableReason: admissionBinding ? "auth-failed" : "missing-auth",
+      };
     }
     const { providerConfig: configured, ref: apiKeyRef } = providerInput(provider);
     const configuredAuth = target.pinnedProfileId ? undefined : configured?.auth;

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -672,7 +672,7 @@ export function createModelAuthAvailabilityResolver(
   const unprofiledEvaluation = (provider: string, target: AuthTarget): AuthSourceEvaluation => {
     const admissionBinding = admitted.get(normalizeProviderId(provider));
     if (!admissionBinding || admissionBinding.kind === "profile") {
-      return { availability: false, evidence: "none", unavailableReason: "missing-auth" };
+      return { availability: false, unavailableReason: "missing-auth" };
     }
     const { providerConfig: configured, ref: apiKeyRef } = providerInput(provider);
     const configuredAuth = target.pinnedProfileId ? undefined : configured?.auth;
@@ -1058,7 +1058,7 @@ export function createModelAuthAvailabilityResolver(
   ): AuthSourceEvaluation => {
     const provider = normalizeProviderIdForAuth(rawProvider);
     if (!admitted.has(provider)) {
-      return { availability: false, evidence: "none", unavailableReason: "missing-auth" };
+      return { availability: false, unavailableReason: "missing-auth" };
     }
     const target = preparedTarget ?? prepareAuthTarget(provider, ref);
     const profileLock = ref.requiredProfileId?.trim();

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -41,6 +41,7 @@ import {
 import { getRuntimeExternalCliProfileIds } from "./auth-profiles/runtime-external-profile-references.js";
 import type { RuntimeAuthMaterialization } from "./auth-profiles/runtime-materializations.js";
 import { getRuntimeAuthProfileStoreSnapshotCore } from "./auth-profiles/runtime-snapshots.js";
+import { isSetupCredentialAccessActive } from "./auth-profiles/setup-access.js";
 import type {
   AuthProfileCredential,
   AuthProfileStore,
@@ -84,6 +85,7 @@ import {
   buildProviderModelAuthSourcePlan,
   fromProviderModelAuthReadiness,
   toProviderModelAuthReadiness,
+  resolveProviderEnvironmentAdmission,
   resolveProviderUseAdmission,
   type ProviderModelAuthEvidence,
   type ProviderModelAuthProfileSource,
@@ -132,6 +134,7 @@ export type ModelAuthAvailabilityEvaluation = {
   selectedProfileId?: string;
   selectedAuthMode?: string;
   evidence?: ModelAuthAvailabilityEvidence;
+  environmentVariable?: string;
   runtimeAuth?: { id: string; source: "native" };
 };
 export type ModelAuthAvailabilityResolver = {
@@ -276,6 +279,7 @@ type AuthSourceEvaluation = Pick<
   | "selectedProfileId"
   | "unavailableReason"
   | "unavailableUntil"
+  | "environmentVariable"
 >;
 
 function modeAllowed(provider: string, target: AuthTarget, mode: string | undefined): boolean {
@@ -413,6 +417,16 @@ export function createModelAuthAvailabilityResolver(
     env,
     metadataSnapshot: params.metadataSnapshot,
   });
+  const providerEnvVars = resolveProviderBindingEnvVarCandidates({
+    config: params.cfg,
+    env,
+    workspaceDir: params.workspaceDir,
+    metadataSnapshot: params.metadataSnapshot,
+  });
+  const environmentBindings = resolveProviderEnvironmentAdmission({
+    env,
+    providerEnvVars,
+  }).bindings;
   const admitted = resolveProviderUseAdmission({
     config: params.cfg,
     env,
@@ -432,12 +446,7 @@ export function createModelAuthAvailabilityResolver(
       ([provider, mode]) =>
         typeof mode === "object" && mode.source === "native" ? [provider] : [],
     ),
-    providerEnvVars: resolveProviderBindingEnvVarCandidates({
-      config: params.cfg,
-      env,
-      workspaceDir: params.workspaceDir,
-      metadataSnapshot: params.metadataSnapshot,
-    }),
+    providerEnvVars,
   });
   const synthetic = new Set(
     (params.syntheticAuthProviderRefs ?? []).map(normalizeProviderIdForAuth),
@@ -489,14 +498,22 @@ export function createModelAuthAvailabilityResolver(
       store,
     });
   const envAuth = (provider: string) => {
-    const binding = admitted.get(normalizeProviderId(provider));
-    if (!binding || binding.kind === "profile") {
+    const admittedBinding = admitted.get(normalizeProviderId(provider));
+    if (admittedBinding?.kind === "profile" && isSetupCredentialAccessActive()) {
+      return null;
+    }
+    const binding =
+      admittedBinding?.kind === "profile"
+        ? environmentBindings.get(normalizeProviderId(provider))
+        : admittedBinding;
+    if (!binding) {
       return null;
     }
     const normalized = normalizeProvider(provider);
-    if (!envCache.has(normalized)) {
+    const cacheKey = normalizeProviderId(provider);
+    if (!envCache.has(cacheKey)) {
       envCache.set(
-        normalized,
+        cacheKey,
         resolveProviderEnvAuthEvidence(normalized, env, {
           aliasMap: binding.kind === "environment" ? {} : aliasMap,
           candidateMap:
@@ -507,7 +524,7 @@ export function createModelAuthAvailabilityResolver(
         }),
       );
     }
-    return envCache.get(normalized);
+    return envCache.get(cacheKey);
   };
   const profileOrder = (
     provider: string,
@@ -693,7 +710,12 @@ export function createModelAuthAvailabilityResolver(
   };
   const unprofiledEvaluation = (provider: string, target: AuthTarget): AuthSourceEvaluation => {
     const admissionBinding = admitted.get(normalizeProviderId(provider));
-    if (!admissionBinding || admissionBinding.kind === "profile") {
+    if (
+      !admissionBinding ||
+      (admissionBinding.kind === "profile" &&
+        (isSetupCredentialAccessActive() ||
+          !environmentBindings.has(normalizeProviderId(provider))))
+    ) {
       return {
         availability: false,
         unavailableReason: admissionBinding ? "auth-failed" : "missing-auth",
@@ -987,6 +1009,7 @@ export function createModelAuthAvailabilityResolver(
         ? { unavailableReason: unavailableReason ?? "auth-failed" }
         : {}),
       selectedAuthMode: source.mode,
+      ...(source.boundEnvVar ? { environmentVariable: source.boundEnvVar } : {}),
     };
   };
   const directPolicy = (provider: string, target: AuthTarget) => {
@@ -1020,6 +1043,13 @@ export function createModelAuthAvailabilityResolver(
       // with no authored material is ambient, so browse cannot widen authority.
       authorization:
         evaluation.evidence === "environment" && !hasDirectMaterial ? "ambient" : "declared",
+      boundEnvVar:
+        !pinned &&
+        !hasDirectMaterial &&
+        !isSetupCredentialAccessActive() &&
+        evaluation.evidence === "environment"
+          ? environmentBindings.get(normalizeProviderId(provider))?.envVar
+          : undefined,
     });
     const hasDirectFallback = hasDirectMaterial || (!pinned && direct.evidence !== "none");
     return {

--- a/src/agents/model-auth-model.ts
+++ b/src/agents/model-auth-model.ts
@@ -33,7 +33,7 @@ import {
   resolveScopedAuthProfileStore,
   type ProviderCredentialPrecedence,
 } from "./model-auth-provider.js";
-import type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
+import { ProviderAuthError, type ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 import { prepareSyntheticLocalProviderAuth } from "./model-auth-runtime.js";
 import {
   attachModelProviderRequestTransport,
@@ -252,6 +252,13 @@ export async function getApiKeyForModelCore(params: {
   boundEnvVar?: string;
   secretSentinels?: boolean;
 }): Promise<ResolvedProviderAuth> {
+  if (params.boundEnvVar && !normalizeOptionalSecretInput(process.env[params.boundEnvVar])) {
+    throw new ProviderAuthError(
+      "missing-provider-auth",
+      params.model.provider,
+      `Prepared environment credential "${params.boundEnvVar}" is no longer available for ${params.model.provider}. Restore it or prepare a new request.`,
+    );
+  }
   return resolveApiKeyForProviderCore({
     provider: params.model.provider,
     cfg: params.cfg,

--- a/src/agents/model-auth-model.ts
+++ b/src/agents/model-auth-model.ts
@@ -249,6 +249,7 @@ export async function getApiKeyForModelCore(params: {
   credentialPrecedence?: ProviderCredentialPrecedence;
   allowAuthProfileFallback?: boolean;
   skipSetupProviderFallback?: boolean;
+  boundEnvVar?: string;
   secretSentinels?: boolean;
 }): Promise<ResolvedProviderAuth> {
   return resolveApiKeyForProviderCore({
@@ -263,6 +264,7 @@ export async function getApiKeyForModelCore(params: {
     credentialPrecedence: params.credentialPrecedence,
     allowAuthProfileFallback: params.allowAuthProfileFallback,
     skipSetupProviderFallback: params.skipSetupProviderFallback,
+    boundEnvVar: params.boundEnvVar,
     modelId: params.model.id,
     modelApi: params.model.api,
     modelBaseUrl: params.model.baseUrl,

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -71,10 +71,19 @@ export function resolveConfigAwareEnvApiKey(
   provider: string,
   workspaceDir?: string,
   skipSetupProviderFallback?: boolean,
+  boundEnvVar?: string,
 ): EnvApiKeyResult | null {
   return resolveEnvApiKey(provider, process.env, {
     config: cfg,
     workspaceDir,
+    ...(boundEnvVar
+      ? {
+          aliasMap: {},
+          candidateMap: { [normalizeProviderId(provider)]: [boundEnvVar] },
+          authEvidenceMap: {},
+          skipSetupProviderFallback: true,
+        }
+      : {}),
     ...(skipSetupProviderFallback ? { skipSetupProviderFallback: true } : {}),
   });
 }

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -5,6 +5,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveMergedModelProviderEntry } from "../config/model-provider-config.js";
 import {
   getResolvedConfigEnvSecretRef,
+  resolveConfigProviderUseBindings,
   resolveConfigSecretRef,
 } from "../config/resolution-facts.js";
 import {
@@ -96,13 +97,14 @@ export function resolveProviderConfig(
 }
 
 function resolveProviderSourceConfig(cfg: OpenClawConfig | undefined, provider: string) {
-  return providerConfigMatchesRuntimeSnapshot({
+  const source = providerConfigMatchesRuntimeSnapshot({
     inputConfig: cfg,
     runtimeConfig: getRuntimeConfigSnapshot(),
     provider,
   })
     ? (getRuntimeConfigSourceSnapshot() ?? cfg)
     : cfg;
+  return source ? resolveConfigProviderUseBindings(source) : source;
 }
 
 /** Keeps authored references distinct from opaque bytes in a matching runtime provider. */

--- a/src/agents/model-auth-provider.ts
+++ b/src/agents/model-auth-provider.ts
@@ -182,6 +182,8 @@ export async function resolveApiKeyForProviderCore(input: {
   allowAuthProfileFallback?: boolean;
   /** Skip plugin setup fallback when the prepared route already excludes it. */
   skipSetupProviderFallback?: boolean;
+  /** Exact environment binding selected by the text admission owner. */
+  boundEnvVar?: string;
   modelId?: string;
   modelApi?: string;
   modelBaseUrl?: string;
@@ -340,6 +342,7 @@ export async function resolveApiKeyForProviderCore(input: {
       provider,
       params.workspaceDir,
       params.skipSetupProviderFallback,
+      params.boundEnvVar,
     );
     if (envResolved) {
       const resolvedMode = resolveDirectProviderCredentialMode({
@@ -442,6 +445,7 @@ export async function resolveApiKeyForProviderCore(input: {
     provider,
     params.workspaceDir,
     params.skipSetupProviderFallback,
+    params.boundEnvVar,
   );
   if (localMarkerEnv && isNonSecretApiKeyMarker(localMarkerEnv.apiKey)) {
     return {
@@ -567,6 +571,7 @@ export async function resolveApiKeyForProviderCore(input: {
     provider,
     params.workspaceDir,
     params.skipSetupProviderFallback,
+    params.boundEnvVar,
   );
   if (envResolved) {
     const resolvedMode = resolveDirectProviderCredentialMode({

--- a/src/agents/model-auth.workspace-plugin.test.ts
+++ b/src/agents/model-auth.workspace-plugin.test.ts
@@ -60,6 +60,11 @@ describe("workspace plugin model auth evidence", () => {
     await writeWorkspaceAuthEvidencePlugin(workspaceDir);
 
     const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "workspace-cloud": { baseUrl: "https://workspace-cloud.example.test", models: [] },
+        },
+      },
       plugins: {
         allow: ["workspace-cloud"],
       },

--- a/src/agents/model-catalog-decisions.test.ts
+++ b/src/agents/model-catalog-decisions.test.ts
@@ -75,7 +75,10 @@ describe("captured model decisions", () => {
         },
       });
       const owner = createModelCatalogDecisions({
-        cfg: { plugins: { entries: { copilot: { enabled: true } } } },
+        cfg: {
+          plugins: { entries: { copilot: { enabled: true } } },
+          models: { providers: { "github-copilot": {} } },
+        },
         agentId: "main",
         agentDir: "/tmp/copilot-agent",
         workspaceDir: "/tmp/copilot-workspace",

--- a/src/agents/model-catalog-decisions.test.ts
+++ b/src/agents/model-catalog-decisions.test.ts
@@ -77,7 +77,7 @@ describe("captured model decisions", () => {
       const owner = createModelCatalogDecisions({
         cfg: {
           plugins: { entries: { copilot: { enabled: true } } },
-          models: { providers: { "github-copilot": {} } },
+          models: { providers: { "github-copilot": { baseUrl: "", models: [] } } },
         },
         agentId: "main",
         agentDir: "/tmp/copilot-agent",

--- a/src/agents/model-catalog-decisions.ts
+++ b/src/agents/model-catalog-decisions.ts
@@ -27,6 +27,7 @@ import {
 import { prepareModelCatalogView } from "./model-catalog-view.js";
 import { loadManifestModelCatalog } from "./model-catalog.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
+import type { ModelRef } from "./model-ref-shared.js";
 import { dedupeModelCatalogEntries } from "./model-selection-shared.js";
 import {
   createOpenAIModelRoutesResolver,
@@ -51,6 +52,7 @@ function listEnabledSyntheticAuthProviderRefs(
 
 function createModelsListAuthResolver(params: {
   cfg: OpenClawConfig;
+  selectedModel?: ModelRef;
   agentId: string;
   metadataSnapshot: PluginMetadataSnapshot;
   preparedAuthStore: AuthProfileStore;
@@ -63,6 +65,7 @@ function createModelsListAuthResolver(params: {
   const agentDir = resolveAgentDir(params.cfg, params.agentId);
   return createModelAuthAvailabilityResolver({
     cfg: params.cfg,
+    requestedProviderIds: params.selectedModel ? [params.selectedModel.provider] : undefined,
     agentId: params.agentId,
     authStore: params.preparedAuthStore,
     agentDir,
@@ -165,6 +168,7 @@ function createModelsListEntryEvaluator(params: {
 
 export type ModelCatalogDecisionParams = {
   cfg: OpenClawConfig;
+  selectedModel?: ModelRef;
   agentId: string;
   agentDir?: string;
   workspaceDir?: string;
@@ -223,21 +227,25 @@ export function createModelCatalogDecisions(params: ModelCatalogDecisionParams) 
       }
     }
   }
-  const personalStaticEntries = personalProviders.size
+  const projectedProviders = new Set(personalProviders);
+  if (params.selectedModel) {
+    projectedProviders.add(normalizeProviderId(params.selectedModel.provider));
+  }
+  const projectedStaticEntries = projectedProviders.size
     ? [
         ...(params.snapshot.staticEntries ?? []),
         ...loadManifestModelCatalog({ config: params.cfg, metadataSnapshot }),
-      ].filter((entry) => personalProviders.has(normalizeProviderId(entry.provider)))
+      ].filter((entry) => projectedProviders.has(normalizeProviderId(entry.provider)))
     : [];
-  const snapshot = personalStaticEntries.length
+  const snapshot = projectedStaticEntries.length
     ? {
         ...params.snapshot,
-        entries: dedupeModelCatalogEntries([...params.snapshot.entries, ...personalStaticEntries]),
+        entries: dedupeModelCatalogEntries([...params.snapshot.entries, ...projectedStaticEntries]),
         routeVariants: [
           ...(params.snapshot.routeVariants.length
             ? params.snapshot.routeVariants
             : params.snapshot.entries),
-          ...personalStaticEntries,
+          ...projectedStaticEntries,
         ],
       }
     : params.snapshot;
@@ -277,6 +285,7 @@ export function createModelCatalogDecisions(params: ModelCatalogDecisionParams) 
   );
   const authResolver = createModelsListAuthResolver({
     cfg: params.cfg,
+    selectedModel: params.selectedModel,
     agentId: params.agentId,
     metadataSnapshot,
     preparedAuthStore: authStore,

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -11,7 +11,6 @@ import {
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { createModelVisibilityPolicy } from "./model-visibility-policy.js";
 import { openAIModelCatalogRoutePolicy } from "./openai-model-routes.js";
-import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
 
 describe("resolveLogicalVisibleModelCatalog", () => {
   it.each(["all", "configured", "default"] as const)(
@@ -400,33 +399,4 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       ]);
     },
   );
-});
-
-describe("provider use admission", () => {
-  it.each([
-    {
-      name: "a MiniMax key shared by its declared routes",
-      env: { MINIMAX_API_KEY: "fixture-minimax-key" },
-      expected: ["minimax", "minimax-portal"],
-    },
-    {
-      name: "a generic shared key",
-      env: { MODEL_API_KEY: "fixture-generic-key", GH_TOKEN: "fixture-github-token" },
-      expected: [],
-    },
-  ])("derives discovery scope from $name", ({ env, expected }) => {
-    expect(
-      [
-        ...resolveProviderUseAdmission({
-          env,
-          providerEnvVars: {
-            minimax: ["MINIMAX_API_KEY"],
-            "minimax-portal": ["MINIMAX_API_KEY"],
-            "generic-a": ["MODEL_API_KEY", "GH_TOKEN"],
-            "generic-b": ["MODEL_API_KEY", "GH_TOKEN"],
-          },
-        }).keys(),
-      ].toSorted(),
-    ).toEqual(expected);
-  });
 });

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -11,6 +11,7 @@ import {
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { createModelVisibilityPolicy } from "./model-visibility-policy.js";
 import { openAIModelCatalogRoutePolicy } from "./openai-model-routes.js";
+import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
 
 describe("resolveLogicalVisibleModelCatalog", () => {
   it.each(["all", "configured", "default"] as const)(
@@ -399,4 +400,33 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       ]);
     },
   );
+});
+
+describe("provider use admission", () => {
+  it.each([
+    {
+      name: "a MiniMax key shared by its declared routes",
+      env: { MINIMAX_API_KEY: "fixture-minimax-key" },
+      expected: ["minimax", "minimax-portal"],
+    },
+    {
+      name: "a generic shared key",
+      env: { MODEL_API_KEY: "fixture-generic-key", GH_TOKEN: "fixture-github-token" },
+      expected: [],
+    },
+  ])("derives discovery scope from $name", ({ env, expected }) => {
+    expect(
+      [
+        ...resolveProviderUseAdmission({
+          env,
+          providerEnvVars: {
+            minimax: ["MINIMAX_API_KEY"],
+            "minimax-portal": ["MINIMAX_API_KEY"],
+            "generic-a": ["MODEL_API_KEY", "GH_TOKEN"],
+            "generic-b": ["MODEL_API_KEY", "GH_TOKEN"],
+          },
+        }).keys(),
+      ].toSorted(),
+    ).toEqual(expected);
+  });
 });

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -94,6 +94,60 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       routePolicy: openAIModelCatalogRoutePolicy,
     });
 
+  it("retains a bare fallback under its unique catalog provider", async () => {
+    const catalog = [
+      { provider: "openai", id: "primary", name: "Primary" },
+      { provider: "deepseek", id: "fallback", name: "Fallback" },
+    ];
+    const result = await resolveLogicalVisibleModelCatalog({
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "openai/primary", fallbacks: ["fallback"] },
+            modelPolicy: { allow: ["openai/primary"] },
+          },
+        },
+      },
+      catalog,
+      defaultProvider: "openai",
+      defaultModel: "primary",
+      routePolicy: openAIModelCatalogRoutePolicy,
+      evaluateEntry: evaluateAvailableEntry,
+    });
+    expect(result.map(({ provider, id }) => `${provider}/${id}`)).toEqual([
+      "deepseek/fallback",
+      "openai/primary",
+    ]);
+  });
+
+  it.each(["default", "configured"] as const)(
+    "keeps unverified local models without admitting failed or OpenAI auth in %s browse",
+    async (view) => {
+      const catalog = [
+        { provider: "ollama", id: "local", name: "Local" },
+        { provider: "ollama", id: "offline", name: "Offline" },
+        { provider: "openai", id: "remote", name: "Remote" },
+      ];
+      const result = await resolveLogicalVisibleModelCatalog({
+        cfg: {},
+        catalog,
+        defaultProvider: "example",
+        view,
+        routePolicy: openAIModelCatalogRoutePolicy,
+        evaluateEntry: async (entry) =>
+          resolveLogicalModelCatalogEntryState({
+            evaluation: {
+              availability: entry.id === "offline" ? false : undefined,
+              evidence: "synthetic",
+              routeResolution: null,
+            },
+            routePolicy: openAIModelCatalogRoutePolicy,
+          }),
+      });
+      expect(result).toEqual([catalog[0]]);
+    },
+  );
+
   it.each(["default", "configured"] as const)(
     "hides deprecated and disabled rows from the %s picker view",
     async (view) => {

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -6,10 +6,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { dedupeByKey } from "../shared/dedupe-by-key.js";
-import type {
-  ModelAuthAvailabilityEvaluation,
-  ModelAuthAvailabilityRef,
-} from "./model-auth-availability.js";
+import type { ModelAuthAvailabilityEvaluation } from "./model-auth-availability.js";
 import { compareModelCatalogEntries } from "./model-catalog-order.js";
 import {
   type ModelCatalogRoutePolicy,
@@ -27,10 +24,6 @@ import {
 import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
 
 type ModelCatalogVisibilityView = "default" | "configured" | "all";
-export type ModelCatalogAuthChecker = (
-  provider: string,
-  ref?: ModelAuthAvailabilityRef,
-) => boolean | Promise<boolean>;
 
 type LogicalModelCatalogEntryState = {
   authBacked: boolean;

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -3,6 +3,7 @@
  * combines explicit policy, configured models, defaults, and runtime
  * auth-backed availability.
  */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import type {
@@ -33,6 +34,7 @@ export type ModelCatalogAuthChecker = (
 
 type LogicalModelCatalogEntryState = {
   authBacked: boolean;
+  syntheticAuthUnknown: boolean;
   compatible: boolean;
   routeManaged: boolean;
   routeProjection: ModelCatalogRouteProjection;
@@ -53,6 +55,8 @@ export function resolveLogicalModelCatalogEntryState(params: {
       : { kind: "unresolved", policy: params.routePolicy };
   return {
     authBacked: params.authBacked ?? params.evaluation.availability === true,
+    syntheticAuthUnknown:
+      params.evaluation.availability === undefined && params.evaluation.evidence === "synthetic",
     compatible: params.evaluation.routeResolution?.kind !== "incompatible",
     routeManaged,
     routeProjection,
@@ -177,7 +181,11 @@ export async function prepareLogicalVisibleModelCatalog(
       if (!state) {
         throw new Error("Model catalog publication omitted prepared entry state");
       }
-      return state;
+      return state.syntheticAuthUnknown &&
+        !state.routeManaged &&
+        normalizeProviderId(entry.provider) !== "openai"
+        ? { ...state, authBacked: true }
+        : state;
     };
     const projectEntries = (entries: readonly ModelCatalogEntry[]) => {
       const projected = entries.map((entry) => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -385,6 +385,14 @@ export async function buildPreparedModelCatalogSnapshot(
           ? resolveProviderApiKeyForProvider(providerId)
           : { apiKey: undefined, discoveryApiKey: undefined };
       const supplemental = await augmentModelCatalogWithProviderPlugins({
+        providerIds: [
+          ...new Set(
+            [
+              ...Object.keys(cfg.models?.providers ?? {}),
+              ...Object.keys(params.authCredentials),
+            ].map(normalizeProviderId),
+          ),
+        ],
         config: cfg,
         workspaceDir,
         env,

--- a/src/agents/model-fallback-cooldown.ts
+++ b/src/agents/model-fallback-cooldown.ts
@@ -1,5 +1,7 @@
 /** Decides when cooldowned model candidates may be skipped, probed, or suspended. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { isActiveUnusableWindow } from "./auth-profiles/usage-state.js";
 import { shouldUseTransientCooldownProbeSlot } from "./failover-policy.js";
@@ -13,6 +15,38 @@ const PROBE_MARGIN_MS = 2 * 60 * 1000;
 const PROBE_SCOPE_DELIMITER = "::";
 const PROBE_STATE_TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_PROBE_KEYS = 256;
+const modelAuthAvailabilityLoader = createLazyImportLoader(
+  () => import("./model-auth-availability.js"),
+);
+
+/** A saved-account cooldown cannot block an independently admitted usable env account. */
+export async function hasUsableEnvironmentAuth(
+  scope: {
+    cfg?: OpenClawConfig;
+    agentId?: string;
+    agentDir?: string;
+    userLockedAuthProfileId?: string;
+  },
+  candidate: ModelCandidate,
+  authStore: AuthProfileStore,
+): Promise<boolean> {
+  if (!scope.cfg || normalizeOptionalString(scope.userLockedAuthProfileId)) {
+    return false;
+  }
+  const { createModelAuthAvailabilityResolver } = await modelAuthAvailabilityLoader.load();
+  const availability = createModelAuthAvailabilityResolver({
+    cfg: scope.cfg,
+    authStore,
+    agentId: scope.agentId,
+    agentDir: scope.agentDir,
+  }).evaluateModelAuth(candidate.provider, { modelId: candidate.model });
+  return (
+    availability.availability === true &&
+    (availability.evidence === "environment" ||
+      ((availability.evidence === "provider-config" || availability.evidence === "runtime") &&
+        availability.environmentVariable !== undefined))
+  );
+}
 
 export function resolveProbeThrottleKey(provider: string, agentDir?: string): string {
   const scope = normalizeOptionalString(agentDir) ?? "";

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -62,6 +62,7 @@ import {
 } from "./model-fallback-attempt.js";
 import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
 import {
+  hasUsableEnvironmentAuth,
   markProbeAttempt,
   resolveCooldownDecision,
   resolveProbeThrottleKey,
@@ -386,11 +387,14 @@ async function runWithModelFallbackInternal<T>(
       !candidateHarnessAuth.skipsProviderAuthCooldown
     ) {
       const profileIds = candidateAuthProfileIds;
-      const isAnyProfileAvailable = profileIds.some(
+      let isAnyAuthAvailable = profileIds.some(
         (id) => !authRuntime.isProfileInCooldown(authStore, id, undefined, candidate.model),
       );
+      if (profileIds.length > 0 && !isAnyAuthAvailable) {
+        isAnyAuthAvailable = await hasUsableEnvironmentAuth(params, candidate, authStore);
+      }
 
-      if (profileIds.length > 0 && !isAnyProfileAvailable) {
+      if (profileIds.length > 0 && !isAnyAuthAvailable) {
         // All profiles for this provider are in cooldown.
         const now = Date.now();
         const probeThrottleKey = resolveProbeThrottleKey(candidate.provider, params.agentDir);

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -44,6 +44,7 @@ const modelAuthAvailabilityMocks = vi.hoisted(() => {
   return {
     evaluateModelAuth,
     createModelAuthAvailabilityResolver: vi.fn((_params: unknown) => ({
+      evaluateProviderAuth: evaluateModelAuth,
       evaluateModelAuth,
       evaluateRuntimeModelAuth: evaluateModelAuth,
       resolveProviderAuthAvailability: vi.fn(() => false),

--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -9,7 +9,6 @@ import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
 import {
   createModelPickerVisibleProviderPredicate,
-  isRetiredModelPickerProvider,
   areRuntimeModelRefsEquivalent,
   isCliRuntimeProvider,
   resolveCliRuntimeExecutionProvider as resolveCliRuntimeExecutionProviderBase,
@@ -388,20 +387,9 @@ describe("resolveCliRuntimeExecutionProvider", () => {
     expect(isVisibleProvider("claude-cli")).toBe(false);
     expect(isCliRuntimeProvider("acme-cli")).toBe(false);
     expect(isVisibleProvider("acme-cli")).toBe(true);
-  });
-
-  it("recognizes retired picker providers without loading CLI backend metadata", () => {
-    cliBackendsTesting.setDepsForTest({
-      resolvePluginSetupRegistry: () => {
-        throw new Error("retired provider checks should not load setup metadata");
-      },
-      resolveRuntimeCliBackends: () => {
-        throw new Error("retired provider checks should not load runtime metadata");
-      },
-    });
-
-    expect(isRetiredModelPickerProvider("CODEX-CLI")).toBe(true);
-    expect(isRetiredModelPickerProvider("anthropic")).toBe(false);
+    expect(isVisibleProvider("CODEX")).toBe(false);
+    expect(isVisibleProvider("CODEX-CLI")).toBe(false);
+    expect(isVisibleProvider("anthropic")).toBe(true);
   });
 });
 

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -25,11 +25,6 @@ import {
 
 const RETIRED_MODEL_PICKER_PROVIDERS = new Set(["codex", "codex-cli"]);
 
-/** True for retired provider ids that should stay out of model selection surfaces. */
-export function isRetiredModelPickerProvider(provider: string): boolean {
-  return RETIRED_MODEL_PICKER_PROVIDERS.has(normalizeProviderId(provider));
-}
-
 /** Creates a provider visibility predicate for model picker rendering. */
 export function createModelPickerVisibleProviderPredicate(
   params: { config?: OpenClawConfig; env?: NodeJS.ProcessEnv; includeSetupRegistry?: boolean } = {},
@@ -43,7 +38,7 @@ export function createModelPickerVisibleProviderPredicate(
   );
   return (provider: string): boolean => {
     const normalized = normalizeProviderId(provider);
-    return !isRetiredModelPickerProvider(normalized) && !cliRuntimeProviders.has(normalized);
+    return !RETIRED_MODEL_PICKER_PROVIDERS.has(normalized) && !cliRuntimeProviders.has(normalized);
   };
 }
 

--- a/src/agents/model-selection-config.ts
+++ b/src/agents/model-selection-config.ts
@@ -1,9 +1,53 @@
 /** Pure configured-model selection helpers safe for config validation. */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import type { ModelManifestNormalizationContext, ModelRef } from "./model-ref-shared.js";
-import { normalizeModelSelection, resolveConfiguredModelRef } from "./model-selection-shared.js";
+import { resolveConfiguredModelFallbacks } from "./model-selection-resolve.js";
+import {
+  buildModelAliasIndex,
+  normalizeModelSelection,
+  resolveConfiguredModelRef,
+  resolveModelRefFromString,
+} from "./model-selection-shared.js";
+
+/** Selected primary/fallback identities exclude models listed only for browsing. */
+export function resolveSelectedModelProviderIds(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+}): Set<string> {
+  const selection = {
+    ...params,
+    allowManifestNormalization: false,
+    allowPluginNormalization: false,
+  };
+  const primary = resolveDefaultModelForAgent(selection);
+  const providers = new Set<string>();
+  const rawPrimary = params.agentId
+    ? resolveAgentEffectiveModelPrimary(params.cfg, params.agentId)
+    : resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model);
+  if (rawPrimary) {
+    providers.add(normalizeProviderId(primary.provider));
+  }
+  const aliasIndex = buildModelAliasIndex({ ...selection, defaultProvider: primary.provider });
+  for (const raw of resolveConfiguredModelFallbacks(selection)) {
+    if (typeof raw !== "string") {
+      continue;
+    }
+    const resolved = resolveModelRefFromString({
+      ...selection,
+      raw,
+      defaultProvider: primary.provider,
+      aliasIndex,
+    });
+    if (resolved) {
+      providers.add(normalizeProviderId(resolved.ref.provider));
+    }
+  }
+  return providers;
+}
 
 export function resolveDefaultModelForAgent(
   params: {

--- a/src/agents/model-selection-config.ts
+++ b/src/agents/model-selection-config.ts
@@ -1,11 +1,14 @@
 /** Pure configured-model selection helpers safe for config validation. */
+import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
+import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { resolveSelectedModelFallbacksOverride } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveAgentConfig, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
+import { listAgentEntriesWithSource } from "./agent-scope-config.js";
+import { resolveAgentConfig } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import type { ModelManifestNormalizationContext, ModelRef } from "./model-ref-shared.js";
-import { resolveConfiguredModelFallbacks } from "./model-selection-resolve.js";
 import {
   buildModelAliasIndex,
   normalizeModelSelection,
@@ -13,40 +16,93 @@ import {
   resolveModelRefFromString,
 } from "./model-selection-shared.js";
 
-/** Selected primary/fallback identities exclude models listed only for browsing. */
-export function resolveSelectedModelProviderIds(params: {
+function hasSelectedOverride(entry: unknown, fields: readonly string[]): boolean {
+  let current = entry;
+  for (const field of fields) {
+    if (current === undefined || current === null) {
+      return false;
+    }
+    if (typeof current !== "object" || Array.isArray(current)) {
+      return true;
+    }
+    current = asNullableRecord(current)?.[field];
+  }
+  return current !== undefined;
+}
+
+/** Executable selectors in one agent scope; an omitted agent reads defaults and globals. */
+export function collectSelectedModelProviders(params: {
   cfg: OpenClawConfig;
   agentId?: string;
-}): Set<string> {
+}): { provider: string; path: string; mainModel: boolean }[] {
+  const agentId = params.agentId ? normalizeAgentId(params.agentId) : undefined;
+  const local = agentId
+    ? listAgentEntriesWithSource(params.cfg).find(
+        ({ entry }) => normalizeAgentId(entry.id) === agentId,
+      )
+    : undefined;
+  const localPrefix = agentId
+    ? local?.source.kind === "list"
+      ? `agents.list.${local.source.index}.`
+      : `agents.entries.${local?.source.kind === "entries" ? local.source.key : agentId}.`
+    : undefined;
   const selection = {
     ...params,
+    agentId,
     allowManifestNormalization: false,
     allowPluginNormalization: false,
   };
   const primary = resolveDefaultModelForAgent(selection);
-  const providers = new Set<string>();
-  const rawPrimary = params.agentId
-    ? resolveAgentEffectiveModelPrimary(params.cfg, params.agentId)
-    : resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model);
-  if (rawPrimary) {
-    providers.add(normalizeProviderId(primary.provider));
-  }
+  const providers: { provider: string; path: string; mainModel: boolean }[] = [];
   const aliasIndex = buildModelAliasIndex({ ...selection, defaultProvider: primary.provider });
-  for (const raw of resolveConfiguredModelFallbacks(selection)) {
-    if (typeof raw !== "string") {
+  for (const ref of collectConfiguredModelRefs(params.cfg)) {
+    let suffix: string | undefined;
+    if (ref.path.startsWith("agents.defaults.")) {
+      suffix = ref.path.slice("agents.defaults.".length);
+      const fallbackSelector = suffix.startsWith("model.fallbacks.")
+        ? local?.entry.model
+        : suffix.startsWith("subagents.model.fallbacks.")
+          ? local?.entry.subagents?.model
+          : undefined;
+      if (
+        resolveSelectedModelFallbacksOverride(fallbackSelector) !== undefined ||
+        hasSelectedOverride(local?.entry, suffix.split("."))
+      ) {
+        continue;
+      }
+    } else if (localPrefix && ref.path.startsWith(localPrefix)) {
+      suffix = ref.path.slice(localPrefix.length);
+    } else if (ref.path.startsWith("agents.")) {
+      continue;
+    } else if (hasSelectedOverride(local?.entry, ref.path.split("."))) {
+      continue;
+    }
+    if (suffix?.startsWith("models.")) {
       continue;
     }
     const resolved = resolveModelRefFromString({
       ...selection,
-      raw,
+      raw: ref.value,
       defaultProvider: primary.provider,
       aliasIndex,
     });
     if (resolved) {
-      providers.add(normalizeProviderId(resolved.ref.provider));
+      providers.push({
+        provider: normalizeProviderId(resolved.ref.provider),
+        path: ref.path,
+        mainModel: suffix === "model" || suffix?.startsWith("model.") === true,
+      });
     }
   }
   return providers;
+}
+
+/** Model aliases listed only for browsing do not select a provider. */
+export function resolveSelectedModelProviderIds(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+}): Set<string> {
+  return new Set(collectSelectedModelProviders(params).map(({ provider }) => provider));
 }
 
 export function resolveDefaultModelForAgent(

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -1619,15 +1619,21 @@ export function createModelVisibilityPolicyWithFallbacks(
     raw: string | undefined,
     retained: boolean,
     aliasIndex: ModelAliasIndex,
+    knownProvider?: string,
   ): ModelRef | undefined => {
     if (!raw?.trim() || parseModelPolicyWildcardRef(raw)) {
       return undefined;
     }
+    const defaultProvider =
+      knownProvider ??
+      (!raw.includes("/")
+        ? resolveBareModelDefaultProvider({ ...params, model: raw.trim() })
+        : params.defaultProvider);
     const resolved = resolveModelRefFromString({
       cfg: params.cfg,
       agentId: params.agentId,
       raw,
-      defaultProvider: params.defaultProvider,
+      defaultProvider,
       aliasIndex,
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
@@ -1656,7 +1662,7 @@ export function createModelVisibilityPolicyWithFallbacks(
   for (const raw of params.additionalConfiguredModelRefs ?? []) {
     addConfiguredRef(raw, false, selectionAliasIndex);
   }
-  addConfiguredRef(params.defaultModel, true, selectionAliasIndex);
+  addConfiguredRef(params.defaultModel, true, selectionAliasIndex, params.defaultProvider);
   for (const fallback of params.fallbackModels) {
     // Configured fallbacks remain available for automatic failover and catalog
     // retention, but are not user-selectable overrides unless policy also allows them.

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -48,6 +48,7 @@ export type PreparedModelsConfigContext = Readonly<{
   >;
   preparedStaticProviderCatalog?: PreparedProviderStaticCatalog;
   providerDiscoveryProviderIds?: readonly string[];
+  requestedProviderIds?: readonly string[];
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
   onProviderCatalogOutcome?: (outcome: ProviderCatalogOutcome) => void;
@@ -131,6 +132,7 @@ async function resolveProvidersForModelsJson(params: {
   }
   const implicitProviders = await resolveImplicitProviders({
     agentDir,
+    requestedProviderIds: context.requestedProviderIds,
     ...(params.authStore ? { authStore: params.authStore } : {}),
     config: cfg,
     discoveryAuthConfig: context.discoveryAuthConfig,

--- a/src/agents/models-config.providers.admission.test.ts
+++ b/src/agents/models-config.providers.admission.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildOpenAICompatibleProviderFamilyCatalog } from "../plugin-sdk/provider-catalog-live-runtime.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import type { ProviderPlugin } from "../plugins/types.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { MODELS_CONFIG_IMPLICIT_ENV_VARS } from "./models-config.e2e-harness.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveRuntimePluginDiscoveryProviders: vi.fn(),
+  runProviderCatalog: vi.fn(),
+  runProviderStaticCatalog: vi.fn(),
+}));
+vi.mock("../plugins/provider-discovery.js", () => ({
+  resolveRuntimePluginDiscoveryProviders: mocks.resolveRuntimePluginDiscoveryProviders,
+  runProviderCatalog: mocks.runProviderCatalog,
+  runProviderStaticCatalog: mocks.runProviderStaticCatalog,
+  prepareProviderStaticCatalog: vi.fn(async () => ({ providers: [], entries: [] })),
+  groupPluginDiscoveryProvidersByOrder: (providers: ProviderPlugin[]) => ({
+    simple: providers,
+    profile: [],
+    paired: [],
+    late: [],
+  }),
+  normalizePluginDiscoveryResult: ({
+    result,
+  }: {
+    result?: { providers?: Record<string, unknown> } | null;
+  }) => result?.providers ?? {},
+}));
+import { resolveImplicitProviders } from "./models-config.providers.implicit.js";
+
+function createProvider(id: string): ProviderPlugin {
+  return { id, label: id, auth: [], catalog: { order: "simple", run: async () => null } };
+}
+function createTextModel(id: string, name: string) {
+  return {
+    id,
+    name,
+    reasoning: false,
+    input: ["text" as const],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 8192,
+  };
+}
+describe("catalog destination credential admission", () => {
+  let state: OpenClawTestState;
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.runProviderCatalog.mockReset();
+    state = await createOpenClawTestState({
+      label: "catalog-destination-admission",
+      env: Object.fromEntries(
+        [...MODELS_CONFIG_IMPLICIT_ENV_VARS, "CODEX_API_KEY", "CODEX_HOME", "GOOGLE_CLOUD_API_KEY"]
+          .filter((key) => key !== "VITEST" && key !== "NODE_ENV")
+          .map((key) => [key, undefined]),
+      ),
+    });
+  });
+  afterEach(async () => {
+    await state.cleanup();
+  });
+  it.each([
+    { sibling: "none", configured: true },
+    { sibling: "environment", configured: true },
+    { sibling: "profile", configured: true },
+    { sibling: "environment", configured: false },
+  ])(
+    "keeps SDK donor auth destination-specific (sibling: $sibling, configured: $configured)",
+    async ({ sibling, configured }) => {
+      const family = buildOpenAICompatibleProviderFamilyCatalog({
+        credentialProviderId: "fixture-donor",
+        entries: ["fixture-configured", "fixture-sibling"].map((id) => ({
+          id,
+          label: id,
+          baseUrl: "not-a-url",
+          models: [createTextModel("fixture-live", "Fixture live")],
+          buildProvider: () => ({
+            baseUrl: "not-a-url",
+            api: "openai-completions" as const,
+            models: [createTextModel("fixture-live", "Fixture live")],
+          }),
+        })),
+        staticCatalog: async () => ({ providers: {} }),
+        augmentModelCatalog: vi.fn(),
+      });
+      mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
+        {
+          id: "fixture-configured",
+          aliases: ["fixture-sibling"],
+          pluginId: "fixture-family",
+          label: "Fixture family",
+          auth: [],
+          ...family,
+        },
+      ]);
+      mocks.runProviderCatalog.mockImplementation((params) => family.catalog.run(params));
+      mocks.runProviderStaticCatalog.mockResolvedValue({ providers: {} });
+      const metadata = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "fixture-family",
+            providers: ["fixture-configured", "fixture-sibling"],
+            setup: { providers: [{ id: "fixture-sibling", envVars: ["FIXTURE_SIBLING_KEY"] }] },
+          },
+        ],
+      });
+      const result = await resolveImplicitProviders({
+        agentDir: state.agentDir(),
+        env: {
+          ...state.env,
+          ...(sibling === "environment" ? { FIXTURE_SIBLING_KEY: "sibling-key" } : {}),
+        },
+        authStore: {
+          version: 1,
+          profiles:
+            sibling === "profile"
+              ? {
+                  "fixture-sibling:saved": {
+                    type: "api_key",
+                    provider: "fixture-sibling",
+                    key: "saved-key",
+                  },
+                }
+              : {},
+        },
+        config: {
+          models: {
+            providers: {
+              "fixture-donor": {
+                baseUrl: "https://donor.example",
+                apiKey: "donor-key",
+                models: [],
+              },
+              ...(configured ? { "fixture-configured": { baseUrl: "not-a-url", models: [] } } : {}),
+            },
+          },
+        },
+        pluginMetadataSnapshot: metadata,
+        providerDiscoveryProviderIds: ["fixture-configured", "fixture-sibling"],
+      });
+      expect(result?.["fixture-configured"]?.models?.map((model) => model.id)).toEqual(
+        configured ? ["fixture-live"] : undefined,
+      );
+      expect(result?.["fixture-sibling"]).toBeUndefined();
+    },
+  );
+
+  it.each([true, false])(
+    "admits saved family auth only for the requested session destination: %s",
+    async (requested) => {
+      const config = { agents: { defaults: { model: "test/default" } } };
+      const env = { ...state.env, FAMILY_API_KEY: "fixture-env-account" };
+      const metadata = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "family",
+            providers: ["family", "family-plan", "family-other"],
+            providerAuthAliases: { "family-plan": "family", "family-other": "family" },
+            setup: { providers: [{ id: "family", envVars: ["FAMILY_API_KEY"] }] },
+          },
+        ],
+      });
+      mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
+        {
+          ...createProvider("family"),
+          aliases: ["family-plan", "family-other"],
+        },
+      ]);
+      mocks.runProviderCatalog.mockImplementation((params) => {
+        expect(params.resolveProviderApiKey("family-plan").discoveryApiKey).toBe(
+          "fixture-saved-account",
+        );
+        return {
+          providers: Object.fromEntries(
+            ["family-plan", "family-other"].map((id) => [
+              id,
+              {
+                baseUrl: "https://family.example",
+                api: "openai-completions",
+                models: [createTextModel("account-only", "Account only")],
+              },
+            ]),
+          ),
+        };
+      });
+      const result = await withPluginMetadataSnapshotScope(
+        metadata,
+        () =>
+          resolveImplicitProviders({
+            config,
+            env,
+            agentDir: state.agentDir(),
+            authStore: {
+              version: 1,
+              profiles: {
+                "family:saved": {
+                  type: "api_key",
+                  provider: "family",
+                  key: "fixture-saved-account",
+                },
+              },
+            },
+            pluginMetadataSnapshot: metadata,
+            providerDiscoveryProviderIds: ["family-plan"],
+            requestedProviderIds: requested ? ["family-plan"] : [],
+          }),
+        { config, env },
+      );
+      expect(Object.keys(result ?? {})).toEqual(requested ? ["family-plan"] : []);
+      expect(mocks.runProviderCatalog).toHaveBeenCalledTimes(requested ? 1 : 0);
+    },
+  );
+});

--- a/src/agents/models-config.providers.auth-provenance.test.ts
+++ b/src/agents/models-config.providers.auth-provenance.test.ts
@@ -172,6 +172,16 @@ describe("models-config provider auth provenance", () => {
         [];
       const errors: unknown[] = [];
       const env: NodeJS.ProcessEnv = {};
+      const withHealthyProvider = (config: OpenClawConfig): OpenClawConfig => ({
+        ...config,
+        models: {
+          ...config.models,
+          providers: {
+            healthy: { baseUrl: "https://healthy.example.test", models: [] },
+            ...config.models?.providers,
+          },
+        },
+      });
       let emitProfileOutcome = false;
       discovery.providers = [
         {
@@ -268,19 +278,22 @@ describe("models-config provider auth provenance", () => {
             resolveImplicitProviders({
               agentDir,
               authStore: store,
-              config,
+              config: withHealthyProvider(config),
               env,
               onProviderCatalogOutcome: (outcome) => outcomes.push(outcome),
             }),
           emitOutcome: () => {
             emitProfileOutcome = true;
           },
-          plan: (source = {}, prepared = source) =>
-            planOpenClawModelsJson({
+          plan: (source = {}, prepared = source) => {
+            const configuredSource = withHealthyProvider(source);
+            const configuredPrepared =
+              prepared === source ? configuredSource : withHealthyProvider(prepared);
+            return planOpenClawModelsJson({
               context: {
-                cfg: source,
-                discoveryAuthConfig: prepared,
-                sourceConfigForSecrets: source,
+                cfg: configuredSource,
+                discoveryAuthConfig: configuredPrepared,
+                sourceConfigForSecrets: configuredSource,
                 agentDir,
                 env,
                 envFingerprint: env,
@@ -289,7 +302,8 @@ describe("models-config provider auth provenance", () => {
               authStore: store,
               existingRaw: "",
               existingParsed: null,
-            }),
+            });
+          },
           authorization,
           authResults,
           outcomes,
@@ -521,9 +535,12 @@ describe("models-config provider auth provenance", () => {
         try {
           await fixture.discover();
           await fixture.plan(configWithKey(configRef));
-          const expectedKey =
+          const expectedDeclaredKey =
             callback === "resolveProviderAuth" ? fixture.runtimeKey : "ambient-key";
-          expect(fixture.authorization).toEqual([`Bearer ${expectedKey}`, `Bearer ${expectedKey}`]);
+          expect(fixture.authorization).toEqual([
+            `Bearer ${fixture.runtimeKey}`,
+            `Bearer ${expectedDeclaredKey}`,
+          ]);
           expect(resolveProfile.mock.calls.map(([params]) => params.profileId)).not.toContain(
             "unrelated:oauth",
           );
@@ -544,7 +561,13 @@ describe("models-config provider auth provenance", () => {
         callback,
         async (fixture) => {
           fixture.emitOutcome();
-          await fixture.discover();
+          await fixture.discover({
+            models: {
+              providers: {
+                openai: { baseUrl: "https://catalog.example.test/v1", models: [] },
+              },
+            },
+          });
           expect(fixture.authorization).toEqual([`Bearer ${fixture.runtimeKey}`]);
           expect(fixture.outcomes).toEqual([
             { provider: "openai", profileId: fixture.profileId, status: "ready" },
@@ -812,6 +835,19 @@ describe("models-config provider auth provenance", () => {
     });
   });
 
+  const vllmConfigWithKey = (apiKey: string): OpenClawConfig => ({
+    models: {
+      providers: {
+        vllm: {
+          baseUrl: "http://127.0.0.1:8000/v1",
+          apiKey,
+          api: "openai-completions",
+          models: [],
+        },
+      },
+    },
+  });
+
   it("uses literal configured provider api keys for catalog discovery", () => {
     const auth = createProviderApiKeyResolver(
       {} as NodeJS.ProcessEnv,
@@ -819,18 +855,7 @@ describe("models-config provider auth provenance", () => {
         version: 1,
         profiles: {},
       },
-      {
-        models: {
-          providers: {
-            vllm: {
-              baseUrl: "http://127.0.0.1:8000/v1",
-              apiKey: "proof-key",
-              api: "openai-completions",
-              models: [],
-            },
-          },
-        },
-      },
+      vllmConfigWithKey("proof-key"),
     );
 
     expect(auth("vllm")).toEqual({
@@ -849,18 +874,7 @@ describe("models-config provider auth provenance", () => {
         version: 1,
         profiles: {},
       },
-      {
-        models: {
-          providers: {
-            vllm: {
-              baseUrl: "http://127.0.0.1:8000/v1",
-              apiKey: "${MY_VLLM_KEY}",
-              api: "openai-completions",
-              models: [],
-            },
-          },
-        },
-      },
+      vllmConfigWithKey("${MY_VLLM_KEY}"),
     );
 
     expect(auth("vllm")).toEqual({
@@ -877,18 +891,7 @@ describe("models-config provider auth provenance", () => {
         version: 1,
         profiles: {},
       },
-      {
-        models: {
-          providers: {
-            vllm: {
-              baseUrl: "http://127.0.0.1:8000/v1",
-              apiKey: "${MY_VLLM_KEY}",
-              api: "openai-completions",
-              models: [],
-            },
-          },
-        },
-      },
+      vllmConfigWithKey("${MY_VLLM_KEY}"),
     );
 
     expect(auth("vllm")).toEqual({
@@ -904,18 +907,7 @@ describe("models-config provider auth provenance", () => {
         version: 1,
         profiles: {},
       },
-      {
-        models: {
-          providers: {
-            vllm: {
-              baseUrl: "http://127.0.0.1:8000/v1",
-              apiKey: "VLLM_API_KEY",
-              api: "openai-completions",
-              models: [],
-            },
-          },
-        },
-      },
+      vllmConfigWithKey("VLLM_API_KEY"),
     );
 
     expect(auth("vllm")).toEqual({
@@ -931,18 +923,7 @@ describe("models-config provider auth provenance", () => {
         version: 1,
         profiles: {},
       },
-      {
-        models: {
-          providers: {
-            vllm: {
-              baseUrl: "http://127.0.0.1:8000/v1",
-              apiKey: "ALLCAPS_SAMPLE",
-              api: "openai-completions",
-              models: [],
-            },
-          },
-        },
-      },
+      vllmConfigWithKey("ALLCAPS_SAMPLE"),
     );
 
     expect(auth("vllm")).toEqual({

--- a/src/agents/models-config.providers.catalog-context.ts
+++ b/src/agents/models-config.providers.catalog-context.ts
@@ -19,7 +19,11 @@ import { isTrustedSecretSurfaceUnavailableError } from "../secrets/runtime-degra
 import { resolveRegisteredAgentIdForDir } from "./agent-dir-registry.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveSelectedModelProviderIds } from "./model-selection-config.js";
-import type { ProviderConfig } from "./models-config.providers.secret-helpers.js";
+import type {
+  ProviderApiKeyResolver,
+  ProviderAuthResolver,
+  ProviderConfig,
+} from "./models-config.providers.secret-helpers.js";
 import { resolveProviderAuthAliasMap, resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 import {
   resolveProviderUseAdmission,
@@ -33,7 +37,9 @@ type ProviderCatalogAuthScope = Pick<
 
 /** A destination's donor permission never depends on another destination's admission. */
 export async function runProviderCatalogForAdmittedDestinations(
-  params: ProviderCatalogAuthScope & {
+  params: Omit<ProviderCatalogAuthScope, "resolveProviderApiKey" | "resolveProviderAuth"> & {
+    resolveProviderApiKey: ProviderApiKeyResolver;
+    resolveProviderAuth: ProviderAuthResolver;
     provider: ProviderPlugin;
     providerIds: readonly string[];
     admission: ReadonlyMap<string, ProviderUseBinding>;

--- a/src/agents/models-config.providers.catalog-context.ts
+++ b/src/agents/models-config.providers.catalog-context.ts
@@ -3,6 +3,7 @@ import {
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type {
   ProviderCatalogOutcome,
   ProviderCatalogResult,
@@ -13,10 +14,56 @@ import {
 } from "../plugins/provider-discovery.js";
 import { matchesProviderPluginRef } from "../plugins/provider-registry-shared.js";
 import type { ProviderPlugin } from "../plugins/types.js";
+import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import { isTrustedSecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
+import { resolveRegisteredAgentIdForDir } from "./agent-dir-registry.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { resolveSelectedModelProviderIds } from "./model-selection-config.js";
 import type { ProviderConfig } from "./models-config.providers.secret-helpers.js";
-import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import { resolveProviderAuthAliasMap, resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
+
+/** Translate one catalog generation's source config and metadata into admission facts. */
+export function resolveCatalogProviderUseAdmission(params: {
+  config?: OpenClawConfig;
+  sourceConfigForSecrets?: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  agentDir: string;
+  workspaceDir?: string;
+  profiles?: AuthProfileStore["profiles"];
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry" | "owners">;
+}) {
+  const authAliasLookupParams = {
+    config: params.config,
+    env: params.env,
+    workspaceDir: params.workspaceDir,
+    metadataSnapshot: params.pluginMetadataSnapshot
+      ? {
+          plugins: params.pluginMetadataSnapshot.manifestRegistry.plugins,
+          owners: params.pluginMetadataSnapshot.owners,
+        }
+      : undefined,
+  };
+  return resolveProviderUseAdmission({
+    config: params.sourceConfigForSecrets ?? params.config,
+    env: params.env,
+    profiles: params.profiles,
+    requestedProviders: resolveSelectedModelProviderIds({
+      cfg: params.sourceConfigForSecrets ?? params.config ?? {},
+      agentId: resolveRegisteredAgentIdForDir(params.agentDir, params.env),
+    }),
+    storedCredentialAuthAliases: resolveProviderAuthAliasMap({
+      ...authAliasLookupParams,
+      storedCredential: true,
+    }),
+    providerEnvVars: resolveProviderBindingEnvVarCandidates({
+      config: params.config,
+      env: params.env,
+      workspaceDir: params.workspaceDir,
+      manifestPlugins: params.pluginMetadataSnapshot?.manifestRegistry.plugins,
+    }),
+  });
+}
 
 type CatalogContext = {
   config?: OpenClawConfig;

--- a/src/agents/models-config.providers.catalog-context.ts
+++ b/src/agents/models-config.providers.catalog-context.ts
@@ -21,7 +21,78 @@ import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveSelectedModelProviderIds } from "./model-selection-config.js";
 import type { ProviderConfig } from "./models-config.providers.secret-helpers.js";
 import { resolveProviderAuthAliasMap, resolveProviderIdForAuth } from "./provider-auth-aliases.js";
-import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
+import {
+  resolveProviderUseAdmission,
+  type ProviderUseBinding,
+} from "./provider-model-auth-source-plan.js";
+
+type ProviderCatalogAuthScope = Pick<
+  Parameters<typeof runProviderCatalog>[0],
+  "providerIds" | "resolveProviderApiKey" | "resolveProviderAuth" | "reportCatalogOutcome"
+>;
+
+/** A destination's donor permission never depends on another destination's admission. */
+export async function runProviderCatalogForAdmittedDestinations(
+  params: ProviderCatalogAuthScope & {
+    provider: ProviderPlugin;
+    providerIds: readonly string[];
+    admission: ReadonlyMap<string, ProviderUseBinding>;
+    run: (scope: ProviderCatalogAuthScope) => Promise<ProviderCatalogResult>;
+  },
+): Promise<ProviderCatalogResult> {
+  const configured: string[] = [];
+  const bound: string[] = [];
+  for (const id of new Set(params.providerIds.map(normalizeProviderId))) {
+    (params.admission.get(id)?.kind === "provider-config" ? configured : bound).push(id);
+  }
+  const scopes = [
+    ...(configured.length ? [{ ids: configured, allowDonor: true }] : []),
+    ...bound.map((id) => ({ ids: [id], allowDonor: false })),
+  ];
+  const providers: Record<string, ProviderConfig> = {};
+  const outcomes: ProviderCatalogOutcome[] = [];
+  let hasResult = false;
+  for (const scope of scopes) {
+    const includes = (provider: string) => scope.ids.includes(normalizeProviderId(provider));
+    const canResolve = (provider: string) => scope.allowDonor || includes(provider);
+    const result = await params.run({
+      providerIds: scope.ids,
+      resolveProviderApiKey: (providerId) => {
+        const provider = providerId?.trim() || params.provider.id;
+        return canResolve(provider)
+          ? params.resolveProviderApiKey(provider)
+          : { apiKey: undefined, discoveryApiKey: undefined };
+      },
+      resolveProviderAuth: (providerId, options) => {
+        const provider = providerId?.trim() || params.provider.id;
+        return canResolve(provider)
+          ? params.resolveProviderAuth(provider, options)
+          : { apiKey: undefined, mode: "none", source: "none" };
+      },
+      reportCatalogOutcome: (outcome) => {
+        if (includes(outcome.provider)) {
+          params.reportCatalogOutcome?.(outcome);
+        }
+      },
+    });
+    if (!result) {
+      continue;
+    }
+    hasResult = true;
+    for (const [id, config] of Object.entries(
+      normalizePluginDiscoveryResult({
+        provider: params.provider,
+        result,
+      }),
+    )) {
+      if (includes(id)) {
+        providers[id] = config;
+      }
+    }
+    outcomes.push(...(result.outcomes ?? []).filter((outcome) => includes(outcome.provider)));
+  }
+  return hasResult ? { providers, ...(outcomes.length ? { outcomes } : {}) } : undefined;
+}
 
 /** Translate one catalog generation's source config and metadata into admission facts. */
 export function resolveCatalogProviderUseAdmission(params: {
@@ -31,6 +102,7 @@ export function resolveCatalogProviderUseAdmission(params: {
   agentDir: string;
   workspaceDir?: string;
   profiles?: AuthProfileStore["profiles"];
+  requestedProviderIds?: readonly string[];
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry" | "owners">;
 }) {
   const authAliasLookupParams = {
@@ -48,10 +120,13 @@ export function resolveCatalogProviderUseAdmission(params: {
     config: params.sourceConfigForSecrets ?? params.config,
     env: params.env,
     profiles: params.profiles,
-    requestedProviders: resolveSelectedModelProviderIds({
-      cfg: params.sourceConfigForSecrets ?? params.config ?? {},
-      agentId: resolveRegisteredAgentIdForDir(params.agentDir, params.env),
-    }),
+    requestedProviders: [
+      ...resolveSelectedModelProviderIds({
+        cfg: params.sourceConfigForSecrets ?? params.config ?? {},
+        agentId: resolveRegisteredAgentIdForDir(params.agentDir, params.env),
+      }),
+      ...(params.requestedProviderIds ?? []),
+    ],
     storedCredentialAuthAliases: resolveProviderAuthAliasMap({
       ...authAliasLookupParams,
       storedCredential: true,

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -375,7 +375,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
   it("passes startup provider scopes as plugin owner filters", async () => {
     await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: { models: { providers: { openai: {} } } },
+      config: { models: { providers: { openai: { baseUrl: "", models: [] } } } },
       env: state.env,
       explicitProviders: {},
       pluginMetadataSnapshot: {
@@ -433,7 +433,11 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     const providers = await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: { models: { providers: { alpha: {}, beta: {} } } },
+      config: {
+        models: {
+          providers: { alpha: { baseUrl: "", models: [] }, beta: { baseUrl: "", models: [] } },
+        },
+      },
       env: state.env,
       explicitProviders: {},
       pluginMetadataSnapshot: {
@@ -480,7 +484,14 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     const providers = await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: { models: { providers: { family: {}, "family-plan": {} } } },
+      config: {
+        models: {
+          providers: {
+            family: { baseUrl: "", models: [] },
+            "family-plan": { baseUrl: "", models: [] },
+          },
+        },
+      },
       env: state.env,
       explicitProviders: {},
       pluginMetadataSnapshot: {
@@ -516,7 +527,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     const providers = await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: { models: { providers: { alias: {} } } },
+      config: { models: { providers: { alias: { baseUrl: "", models: [] } } } },
       env: state.env,
       explicitProviders: {},
       pluginMetadataSnapshot: {
@@ -609,7 +620,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: { models: { providers: { openai: {} } } },
+      config: { models: { providers: { openai: { baseUrl: "", models: [] } } } },
       env: state.env,
       explicitProviders: {},
       providerDiscoveryProviderIds: ["openai"],
@@ -657,7 +668,15 @@ describe("resolveImplicitProviders startup discovery scope", () => {
       });
       const providers = await resolveImplicitProviders({
         agentDir: state.agentDir(),
-        config: { models: { providers: { family: {}, "family-plan": {}, healthy: {} } } },
+        config: {
+          models: {
+            providers: {
+              family: { baseUrl: "", models: [] },
+              "family-plan": { baseUrl: "", models: [] },
+              healthy: { baseUrl: "", models: [] },
+            },
+          },
+        },
         env: state.env,
         explicitProviders: {},
         providerDiscoveryProviderIds: ["family", "family-plan", "healthy"],
@@ -697,7 +716,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
     await expect(
       resolveImplicitProviders({
         agentDir: state.agentDir(),
-        config: { models: { providers: { openai: {} } } },
+        config: { models: { providers: { openai: { baseUrl: "", models: [] } } } },
         env: state.env,
         explicitProviders: {},
         providerDiscoveryProviderIds: ["openai"],
@@ -929,7 +948,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     const providers = await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: { models: { providers: { minimax: {} } } },
+      config: { models: { providers: { minimax: { baseUrl: "", models: [] } } } },
       env: state.env,
       explicitProviders: {},
       providerDiscoveryProviderIds: ["minimax"],

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -156,6 +156,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mocks.runProviderCatalog.mockReset();
     state = await createOpenClawTestState({
       label: "provider-discovery-scope",
       env: Object.fromEntries(
@@ -262,6 +263,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
       const config = {
         models: {
           providers: {
+            [provider.id]: { baseUrl: "https://native.example.test", models: [] },
             "custom-native": {
               api,
               baseUrl: "https://native.example.test",
@@ -373,7 +375,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
   it("passes startup provider scopes as plugin owner filters", async () => {
     await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: {},
+      config: { models: { providers: { openai: {} } } },
       env: state.env,
       explicitProviders: {},
       pluginMetadataSnapshot: {
@@ -431,7 +433,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     const providers = await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: {},
+      config: { models: { providers: { alpha: {}, beta: {} } } },
       env: state.env,
       explicitProviders: {},
       pluginMetadataSnapshot: {
@@ -478,7 +480,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     const providers = await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: {},
+      config: { models: { providers: { family: {}, "family-plan": {} } } },
       env: state.env,
       explicitProviders: {},
       pluginMetadataSnapshot: {
@@ -514,7 +516,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     const providers = await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: {},
+      config: { models: { providers: { alias: {} } } },
       env: state.env,
       explicitProviders: {},
       pluginMetadataSnapshot: {
@@ -607,7 +609,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: {},
+      config: { models: { providers: { openai: {} } } },
       env: state.env,
       explicitProviders: {},
       providerDiscoveryProviderIds: ["openai"],
@@ -655,7 +657,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
       });
       const providers = await resolveImplicitProviders({
         agentDir: state.agentDir(),
-        config: {},
+        config: { models: { providers: { family: {}, "family-plan": {}, healthy: {} } } },
         env: state.env,
         explicitProviders: {},
         providerDiscoveryProviderIds: ["family", "family-plan", "healthy"],
@@ -695,7 +697,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
     await expect(
       resolveImplicitProviders({
         agentDir: state.agentDir(),
-        config: {},
+        config: { models: { providers: { openai: {} } } },
         env: state.env,
         explicitProviders: {},
         providerDiscoveryProviderIds: ["openai"],
@@ -927,7 +929,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     const providers = await resolveImplicitProviders({
       agentDir: state.agentDir(),
-      config: {},
+      config: { models: { providers: { minimax: {} } } },
       env: state.env,
       explicitProviders: {},
       providerDiscoveryProviderIds: ["minimax"],

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -25,7 +25,6 @@ import {
 import { matchesProviderPluginRef } from "../plugins/provider-registry-shared.js";
 import { prepareProviderExternalAuthWithPlugin } from "../plugins/provider-runtime.js";
 import { resolveManifestSyntheticAuthProviderRefState } from "../plugins/synthetic-auth.runtime.js";
-import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store-runtime.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import {
@@ -38,6 +37,7 @@ import {
   buildPluginCatalogConfig,
   prepareProviderCatalogRun,
   reportProviderCatalogSecretFailure,
+  resolveCatalogProviderUseAdmission,
 } from "./models-config.providers.catalog-context.js";
 import {
   resolveImplicitProviderDiscoveryScope,
@@ -53,10 +53,7 @@ import {
   createProviderAuthResolver,
   resolveMissingProviderApiKey,
 } from "./models-config.providers.secrets.js";
-import {
-  resolveProviderUseAdmission,
-  type ProviderUseBinding,
-} from "./provider-model-auth-source-plan.js";
+import type { ProviderUseBinding } from "./provider-model-auth-source-plan.js";
 
 const log = createSubsystemLogger("agents/model-providers");
 
@@ -588,16 +585,10 @@ export async function resolveImplicitProviders(
   const sourceConfigForSecrets = params.providerDiscoveryEntriesOnly
     ? undefined
     : (params.sourceConfigForSecrets ?? params.config);
-  const providerAdmission = resolveProviderUseAdmission({
-    config: params.sourceConfigForSecrets ?? params.config,
+  const providerAdmission = resolveCatalogProviderUseAdmission({
+    ...params,
     env,
     profiles: params.providerDiscoveryEntriesOnly ? undefined : getAuthStore().profiles,
-    providerEnvVars: resolveProviderBindingEnvVarCandidates({
-      config: params.config,
-      env,
-      workspaceDir: params.workspaceDir,
-      manifestPlugins: params.pluginMetadataSnapshot?.manifestRegistry.plugins,
-    }),
   });
   const authInputs = [
     env,

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -25,6 +25,7 @@ import {
 import { matchesProviderPluginRef } from "../plugins/provider-registry-shared.js";
 import { prepareProviderExternalAuthWithPlugin } from "../plugins/provider-runtime.js";
 import { resolveManifestSyntheticAuthProviderRefState } from "../plugins/synthetic-auth.runtime.js";
+import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store-runtime.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import {
@@ -52,6 +53,10 @@ import {
   createProviderAuthResolver,
   resolveMissingProviderApiKey,
 } from "./models-config.providers.secrets.js";
+import {
+  resolveProviderUseAdmission,
+  type ProviderUseBinding,
+} from "./provider-model-auth-source-plan.js";
 
 const log = createSubsystemLogger("agents/model-providers");
 
@@ -92,6 +97,7 @@ type ImplicitProviderContext = ImplicitProviderParams & {
   providerDiscoveryScope?: ProviderDiscoveryScope;
   resolveProviderApiKey: ProviderApiKeyResolver;
   resolveProviderAuth: ProviderAuthResolver;
+  providerAdmission: ReadonlyMap<string, ProviderUseBinding>;
 };
 
 function resolveLiveProviderCatalogTimeoutMs(env: NodeJS.ProcessEnv): number | null {
@@ -256,11 +262,26 @@ async function resolvePluginImplicitProviders(
     ) {
       continue;
     }
+    const admittedProviderIds = (providerIds ?? catalogProviderRefs).filter((id) =>
+      ctx.providerAdmission.has(normalizeProviderId(id)),
+    );
+    const canResolveCatalogAuth = (id: string) =>
+      admittedProviderIds.includes(normalizeProviderId(id)) ||
+      admittedProviderIds.every(
+        (target) =>
+          ctx.providerAdmission.get(normalizeProviderId(target))?.kind === "provider-config",
+      );
     const catalogConfig = buildPluginCatalogConfig(ctx, provider);
     const resolveCatalogProviderApiKey = (providerId?: string) => {
       const resolvedProviderId = providerId?.trim() || provider.id;
+      if (!canResolveCatalogAuth(resolvedProviderId)) {
+        return { apiKey: undefined, discoveryApiKey: undefined };
+      }
       const resolved = ctx.resolveProviderApiKey(resolvedProviderId);
-      if (resolved.apiKey) {
+      if (
+        resolved.apiKey ||
+        ctx.providerAdmission.get(normalizeProviderId(resolvedProviderId))?.kind === "profile"
+      ) {
         return resolved;
       }
 
@@ -310,18 +331,20 @@ async function resolvePluginImplicitProviders(
       result = hasPreparedStaticResult
         ? preparedStaticResults.get(provider)
         : await runProviderStaticCatalog({ provider });
-    } else {
+    } else if (admittedProviderIds.length > 0) {
       result = await runProviderCatalogWithTimeout({
         provider,
         authStore: ctx.authStore,
-        ...(providerIds !== undefined ? { providerIds } : {}),
+        providerIds: admittedProviderIds,
         config: catalogConfig,
         agentDir: ctx.agentDir,
         workspaceDir: ctx.workspaceDir,
         env: ctx.env,
         resolveProviderApiKey: resolveCatalogProviderApiKey,
         resolveProviderAuth: (providerId, options) =>
-          ctx.resolveProviderAuth(providerId?.trim() || provider.id, options),
+          canResolveCatalogAuth(providerId?.trim() || provider.id)
+            ? ctx.resolveProviderAuth(providerId?.trim() || provider.id, options)
+            : { apiKey: undefined, mode: "none", source: "none" },
         reportCatalogOutcome: ctx.onProviderCatalogOutcome,
         timeoutMs: ctx.providerDiscoveryTimeoutMs ?? resolveLiveProviderCatalogTimeoutMs(ctx.env),
       });
@@ -565,6 +588,17 @@ export async function resolveImplicitProviders(
   const sourceConfigForSecrets = params.providerDiscoveryEntriesOnly
     ? undefined
     : (params.sourceConfigForSecrets ?? params.config);
+  const providerAdmission = resolveProviderUseAdmission({
+    config: params.sourceConfigForSecrets ?? params.config,
+    env,
+    profiles: params.providerDiscoveryEntriesOnly ? undefined : getAuthStore().profiles,
+    providerEnvVars: resolveProviderBindingEnvVarCandidates({
+      config: params.config,
+      env,
+      workspaceDir: params.workspaceDir,
+      manifestPlugins: params.pluginMetadataSnapshot?.manifestRegistry.plugins,
+    }),
+  });
   const authInputs = [
     env,
     getAuthStore,
@@ -572,6 +606,7 @@ export async function resolveImplicitProviders(
     sourceConfigForSecrets,
     params.workspaceDir,
     discoveryAuthEnv,
+    providerAdmission,
   ] as const;
   const context: ImplicitProviderContext = {
     ...params,
@@ -582,6 +617,7 @@ export async function resolveImplicitProviders(
     ...(discoveryScope ? { providerDiscoveryScope: discoveryScope } : {}),
     resolveProviderApiKey: createProviderApiKeyResolver(...authInputs),
     resolveProviderAuth: createProviderAuthResolver(...authInputs),
+    providerAdmission,
   };
   const preparedStaticEntries = params.preparedStaticProviderCatalog
     ? params.preparedStaticProviderCatalog.entries.filter(

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -38,6 +38,7 @@ import {
   prepareProviderCatalogRun,
   reportProviderCatalogSecretFailure,
   resolveCatalogProviderUseAdmission,
+  runProviderCatalogForAdmittedDestinations,
 } from "./models-config.providers.catalog-context.js";
 import {
   resolveImplicitProviderDiscoveryScope,
@@ -81,6 +82,7 @@ type ImplicitProviderParams = {
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">;
   preparedStaticProviderCatalog?: PreparedProviderStaticCatalog;
   providerDiscoveryProviderIds?: readonly string[];
+  requestedProviderIds?: readonly string[];
   staticCatalogProviderIds?: readonly string[];
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
@@ -262,18 +264,9 @@ async function resolvePluginImplicitProviders(
     const admittedProviderIds = (providerIds ?? catalogProviderRefs).filter((id) =>
       ctx.providerAdmission.has(normalizeProviderId(id)),
     );
-    const canResolveCatalogAuth = (id: string) =>
-      admittedProviderIds.includes(normalizeProviderId(id)) ||
-      admittedProviderIds.every(
-        (target) =>
-          ctx.providerAdmission.get(normalizeProviderId(target))?.kind === "provider-config",
-      );
     const catalogConfig = buildPluginCatalogConfig(ctx, provider);
     const resolveCatalogProviderApiKey = (providerId?: string) => {
       const resolvedProviderId = providerId?.trim() || provider.id;
-      if (!canResolveCatalogAuth(resolvedProviderId)) {
-        return { apiKey: undefined, discoveryApiKey: undefined };
-      }
       const resolved = ctx.resolveProviderApiKey(resolvedProviderId);
       if (
         resolved.apiKey ||
@@ -329,21 +322,25 @@ async function resolvePluginImplicitProviders(
         ? preparedStaticResults.get(provider)
         : await runProviderStaticCatalog({ provider });
     } else if (admittedProviderIds.length > 0) {
-      result = await runProviderCatalogWithTimeout({
+      result = await runProviderCatalogForAdmittedDestinations({
         provider,
-        authStore: ctx.authStore,
         providerIds: admittedProviderIds,
-        config: catalogConfig,
-        agentDir: ctx.agentDir,
-        workspaceDir: ctx.workspaceDir,
-        env: ctx.env,
+        admission: ctx.providerAdmission,
         resolveProviderApiKey: resolveCatalogProviderApiKey,
-        resolveProviderAuth: (providerId, options) =>
-          canResolveCatalogAuth(providerId?.trim() || provider.id)
-            ? ctx.resolveProviderAuth(providerId?.trim() || provider.id, options)
-            : { apiKey: undefined, mode: "none", source: "none" },
+        resolveProviderAuth: ctx.resolveProviderAuth,
         reportCatalogOutcome: ctx.onProviderCatalogOutcome,
-        timeoutMs: ctx.providerDiscoveryTimeoutMs ?? resolveLiveProviderCatalogTimeoutMs(ctx.env),
+        run: (scope) =>
+          runProviderCatalogWithTimeout({
+            provider,
+            authStore: ctx.authStore,
+            config: catalogConfig,
+            agentDir: ctx.agentDir,
+            workspaceDir: ctx.workspaceDir,
+            env: ctx.env,
+            ...scope,
+            timeoutMs:
+              ctx.providerDiscoveryTimeoutMs ?? resolveLiveProviderCatalogTimeoutMs(ctx.env),
+          }),
       });
     }
     if (!result && !useStaticCatalog && provider.staticCatalog) {

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -196,7 +196,8 @@ export function createProviderApiKeyResolver(
 ): ProviderApiKeyResolver {
   const getLookupCaches = createProviderAuthLookupCaches(env, config, admission);
   return (provider: string) => {
-    const profileBound = admission?.get(normalizeProviderId(provider))?.kind === "profile";
+    const binding = admission?.get(normalizeProviderId(provider));
+    const profileBound = binding?.kind === "profile";
     const lookupCaches = getLookupCaches();
     const authProvider = resolveProviderIdForAuthFromCaches(provider, lookupCaches);
     const envVar = profileBound
@@ -246,6 +247,8 @@ export function createProviderApiKeyResolver(
         const credential = authStore.profiles[id];
         return (
           !profileBound ||
+          normalizeProviderId(authStore.profiles[binding.profileId]?.provider ?? "") !==
+            normalizeProviderId(provider) ||
           (credential && normalizeProviderId(credential.provider) === normalizeProviderId(provider))
         );
       }),
@@ -273,7 +276,8 @@ export function createProviderAuthResolver(
 ): ProviderAuthResolver {
   const getLookupCaches = createProviderAuthLookupCaches(env, config, admission);
   return (provider, options) => {
-    const profileBound = admission?.get(normalizeProviderId(provider))?.kind === "profile";
+    const binding = admission?.get(normalizeProviderId(provider));
+    const profileBound = binding?.kind === "profile";
     const lookupCaches = getLookupCaches();
     const authProvider = resolveProviderIdForAuthFromCaches(provider, lookupCaches);
     const authStore = resolveAuthProfileStoreInput(authStoreInput);
@@ -291,6 +295,8 @@ export function createProviderAuthResolver(
       const cred = authStore.profiles[id];
       if (
         profileBound &&
+        normalizeProviderId(authStore.profiles[binding.profileId]?.provider ?? "") ===
+          normalizeProviderId(provider) &&
         (!cred || normalizeProviderId(cred.provider) !== normalizeProviderId(provider))
       ) {
         continue;

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -29,6 +29,7 @@ import {
   type ProviderApiKeyResolver,
   type ProviderAuthResolver,
 } from "./models-config.providers.secret-helpers.js";
+import type { ProviderUseBinding } from "./provider-model-auth-source-plan.js";
 import type { AuthStorageData } from "./sessions/index.js";
 
 export type {
@@ -142,7 +143,13 @@ export function createProviderApiKeyResolverFromPreparedCredentials(
 function createProviderAuthLookupCaches(
   env: NodeJS.ProcessEnv,
   config?: OpenClawConfig,
+  admission?: ReadonlyMap<string, ProviderUseBinding>,
 ): () => ProviderAuthLookupCaches {
+  const boundEnvVars = new Map(
+    [...(admission ?? [])].flatMap(([provider, binding]) =>
+      binding.kind === "environment" ? [[provider, binding.envVar] as const] : [],
+    ),
+  );
   let caches: ProviderAuthLookupCaches | undefined;
   return () => {
     if (!caches) {
@@ -150,8 +157,15 @@ function createProviderAuthLookupCaches(
       // cached normalization pass avoids repeating alias/candidate expansion.
       const lookupMaps = resolveProviderEnvAuthLookupMaps({ config, env });
       caches = {
-        aliasMap: lookupMaps.aliasMap,
-        candidateMap: lookupMaps.envCandidateMap,
+        aliasMap: Object.fromEntries(
+          Object.entries(lookupMaps.aliasMap).filter(([provider]) => !boundEnvVars.has(provider)),
+        ),
+        candidateMap: {
+          ...lookupMaps.envCandidateMap,
+          ...Object.fromEntries(
+            [...boundEnvVars].map(([provider, envVar]) => [provider, [envVar]]),
+          ),
+        },
         authEvidenceMap: lookupMaps.authEvidenceMap,
       };
     }
@@ -178,16 +192,20 @@ export function createProviderApiKeyResolver(
   sourceConfigForSecrets?: OpenClawConfig,
   workspaceDir?: string,
   syntheticAuthEnv = env,
+  admission?: ReadonlyMap<string, ProviderUseBinding>,
 ): ProviderApiKeyResolver {
-  const getLookupCaches = createProviderAuthLookupCaches(env, config);
+  const getLookupCaches = createProviderAuthLookupCaches(env, config, admission);
   return (provider: string) => {
+    const profileBound = admission?.get(normalizeProviderId(provider))?.kind === "profile";
     const lookupCaches = getLookupCaches();
     const authProvider = resolveProviderIdForAuthFromCaches(provider, lookupCaches);
-    const envVar = resolveEnvApiKeyVarName(authProvider, env, {
-      aliasMap: lookupCaches.aliasMap,
-      candidateMap: lookupCaches.candidateMap,
-      authEvidenceMap: lookupCaches.authEvidenceMap,
-    });
+    const envVar = profileBound
+      ? undefined
+      : resolveEnvApiKeyVarName(authProvider, env, {
+          aliasMap: lookupCaches.aliasMap,
+          candidateMap: lookupCaches.candidateMap,
+          authEvidenceMap: lookupCaches.authEvidenceMap,
+        });
     if (envVar) {
       // Public return value carries the env var name, while discovery receives
       // only the redacted/hashable value form.
@@ -197,14 +215,16 @@ export function createProviderApiKeyResolver(
         mode: resolveCatalogDirectAuthMode(config, authProvider),
       };
     }
-    const fromConfig = resolveConfigBackedProviderAuth({
-      provider: authProvider,
-      config,
-      env,
-      sourceConfigForSecrets,
-      workspaceDir,
-      syntheticAuthEnv,
-    });
+    const fromConfig = profileBound
+      ? undefined
+      : resolveConfigBackedProviderAuth({
+          provider: authProvider,
+          config,
+          env,
+          sourceConfigForSecrets,
+          workspaceDir,
+          syntheticAuthEnv,
+        });
     if (fromConfig?.apiKey) {
       return {
         apiKey: fromConfig.apiKey,
@@ -222,6 +242,12 @@ export function createProviderApiKeyResolver(
         env,
         provider,
         store: authStore,
+      }).filter((id) => {
+        const credential = authStore.profiles[id];
+        return (
+          !profileBound ||
+          (credential && normalizeProviderId(credential.provider) === normalizeProviderId(provider))
+        );
       }),
     });
     return fromProfiles?.apiKey
@@ -243,9 +269,11 @@ export function createProviderAuthResolver(
   sourceConfigForSecrets?: OpenClawConfig,
   workspaceDir?: string,
   syntheticAuthEnv = env,
+  admission?: ReadonlyMap<string, ProviderUseBinding>,
 ): ProviderAuthResolver {
-  const getLookupCaches = createProviderAuthLookupCaches(env, config);
+  const getLookupCaches = createProviderAuthLookupCaches(env, config, admission);
   return (provider, options) => {
+    const profileBound = admission?.get(normalizeProviderId(provider))?.kind === "profile";
     const lookupCaches = getLookupCaches();
     const authProvider = resolveProviderIdForAuthFromCaches(provider, lookupCaches);
     const authStore = resolveAuthProfileStoreInput(authStoreInput);
@@ -261,6 +289,12 @@ export function createProviderAuthResolver(
         continue;
       }
       const cred = authStore.profiles[id];
+      if (
+        profileBound &&
+        (!cred || normalizeProviderId(cred.provider) !== normalizeProviderId(provider))
+      ) {
+        continue;
+      }
       if (!cred) {
         continue;
       }
@@ -289,6 +323,9 @@ export function createProviderAuthResolver(
       };
     }
 
+    if (profileBound) {
+      return { apiKey: undefined, mode: "none", source: "none" };
+    }
     const envVar = resolveEnvApiKeyVarName(authProvider, env, {
       aliasMap: lookupCaches.aliasMap,
       candidateMap: lookupCaches.candidateMap,

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -61,6 +61,7 @@ type EnsureOpenClawModelsJsonOptions = {
   preparedStaticProviderCatalog?: PreparedProviderStaticCatalog;
   workspaceDir?: string;
   providerDiscoveryProviderIds?: readonly string[];
+  requestedProviderIds?: readonly string[];
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
   onProviderCatalogOutcome?: (outcome: ProviderCatalogOutcome) => void;
@@ -122,6 +123,7 @@ async function buildModelsJsonFingerprint(context: PreparedModelsConfigContext):
         ? null
         : context.pluginMetadataSnapshot.pluginIds.toSorted(),
     providerDiscoveryProviderIds: context.providerDiscoveryProviderIds,
+    requestedProviderIds: context.requestedProviderIds,
     providerDiscoveryTimeoutMs: context.providerDiscoveryTimeoutMs,
     providerDiscoveryEntriesOnly: context.providerDiscoveryEntriesOnly === true,
   });
@@ -260,6 +262,7 @@ function prepareModelsConfigContext(
     agentDir,
     env,
     envFingerprint: options.env ? hashRuntimeConfigValue(fingerprintEnv) : fingerprintEnv,
+    requestedProviderIds: options.requestedProviderIds,
     ...(workspaceDir ? { workspaceDir } : {}),
     ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
     ...(options.preparedStaticProviderCatalog

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -434,7 +434,9 @@ describe("prepared model catalog worker boundary", () => {
       const syntheticAuthProbePath = path.join(fixture.root, "synthetic-auth-probes.txt");
       const nativeMode = { source: "native", mode: "oauth" };
 
-      expect(fixture.snapshot.authModes[HARNESS_ID]).toEqual(nativeMode);
+      expect(fixture.snapshot.authModes[HARNESS_ID]).toEqual(
+        asyncSyntheticAuth ? undefined : nativeMode,
+      );
       expect(fixture.snapshot.authModes[DISCOVERED_HARNESS_ID]).toBeUndefined();
       expect(fixture.snapshot.authModes[MISSING_AUTH_HARNESS_ID]).toBeUndefined();
       expect(fixture.snapshot.authModes[PROVIDER_ID]).toBeUndefined();

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -64,11 +64,7 @@ const { makeTempDir, retireAfterTest, waitForWorkers, waitForMarker } =
 async function createStaticSnapshot(
   spinMs: number,
   envOverride: NodeJS.ProcessEnv = {},
-  options?: {
-    hydrateExternalCliProviderIds?: readonly string[];
-    codexNativeOwner?: boolean;
-    builtPluginVersion?: string;
-    asyncSyntheticAuth?: boolean;
+  options?: Parameters<typeof createCatalogFixture>[3] & {
     prepareInboundPluginRegistry?: boolean;
     readOnly?: boolean;
     metadataWorkspace?: "gateway" | "none" | "activation";
@@ -184,7 +180,7 @@ describe("prepared model catalog worker boundary", () => {
   });
 
   it("keeps explicit read-only full inventories discoverable without a runtime registry", async () => {
-    const fixture = await createStaticSnapshot(0, {}, { readOnly: true });
+    const fixture = await createStaticSnapshot(0, {}, { readOnly: true, declareProvider: true });
     expect(fixture.snapshot.pluginRegistry).toBeUndefined();
 
     const catalog = await fixture.snapshot.loadFullModelCatalog!();
@@ -436,8 +432,9 @@ describe("prepared model catalog worker boundary", () => {
         },
       );
       const syntheticAuthProbePath = path.join(fixture.root, "synthetic-auth-probes.txt");
+      const nativeMode = { source: "native", mode: "oauth" };
 
-      expect(fixture.snapshot.authModes[HARNESS_ID]).toBe("api_key");
+      expect(fixture.snapshot.authModes[HARNESS_ID]).toEqual(nativeMode);
       expect(fixture.snapshot.authModes[DISCOVERED_HARNESS_ID]).toBeUndefined();
       expect(fixture.snapshot.authModes[MISSING_AUTH_HARNESS_ID]).toBeUndefined();
       expect(fixture.snapshot.authModes[PROVIDER_ID]).toBeUndefined();
@@ -451,6 +448,7 @@ describe("prepared model catalog worker boundary", () => {
       expect(fullAuth?.credentials?.[DISCOVERED_HARNESS_ID]).toEqual({
         type: "api_key",
         key: "discovered-native-login-not-real",
+        nativeAuth: { runtime: DISCOVERED_HARNESS_ID, mode: "oauth" },
       });
       expect(catalog).not.toHaveProperty("credentials");
 
@@ -468,8 +466,8 @@ describe("prepared model catalog worker boundary", () => {
           MISSING_AUTH_HARNESS_ID,
         ]);
       }
-      expect(fullAuth?.authModes[HARNESS_ID]).toBe("api_key");
-      expect(fullAuth?.authModes[DISCOVERED_HARNESS_ID]).toBe("api_key");
+      expect(fullAuth?.authModes[HARNESS_ID]).toEqual(nativeMode);
+      expect(fullAuth?.authModes[DISCOVERED_HARNESS_ID]).toEqual(nativeMode);
       expect(fullAuth?.authModes[MISSING_AUTH_HARNESS_ID]).toBeUndefined();
       expect(fullAuth?.authModes[PROVIDER_ID]).toBe("oauth");
     },
@@ -529,7 +527,7 @@ describe("prepared model catalog worker boundary", () => {
   );
 
   it("refreshes durable auth before provider hooks decide catalog membership", async () => {
-    const fixture = await createStaticSnapshot(0);
+    const fixture = await createStaticSnapshot(0, {}, { declareProvider: true });
     saveAuthProfileStore(
       {
         version: 1,
@@ -1007,7 +1005,7 @@ describe("prepared model catalog worker boundary", () => {
   });
 
   it("preserves ref-only api-key and token profiles through the real worker", async () => {
-    const fixture = await createStaticSnapshot(0);
+    const fixture = await createStaticSnapshot(0, {}, { declareProvider: true });
     const authStore = {
       version: 1,
       profiles: {

--- a/src/agents/prepared-model-catalog-worker.scope.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.scope.integration.test.ts
@@ -41,6 +41,11 @@ describe("prepared model catalog worker plugin scope", () => {
     const pluginFile = writeFixturePlugin({ root, spinMs: 0 });
     const unrelatedPluginFile = writeUnrelatedFixturePlugin(root);
     const config = {
+      models: {
+        providers: {
+          [PROVIDER_ID]: { baseUrl: "https://worker-catalog.invalid/v1", models: [] },
+        },
+      },
       agents: {
         defaults: {
           model: `${PROVIDER_ID}/sqlite-model`,

--- a/src/agents/prepared-model-catalog-worker.secrets.test.ts
+++ b/src/agents/prepared-model-catalog-worker.secrets.test.ts
@@ -5,14 +5,17 @@ import { createConfigIoContext } from "../config/io.context.js";
 import { readConfigFileSnapshotFromContext } from "../config/io.snapshot.js";
 import {
   getAuthoredConfigSecretRef,
+  getConfigProviderUseBindings,
   getConfigResolutionFacts,
   getResolvedConfigEnvSecretRef,
+  serializeConfigResolutionFacts,
 } from "../config/resolution-facts.js";
 import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { prepareSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -33,7 +36,7 @@ vi.mock("node:worker_threads", async (importOriginal) => ({
   parentPort: null,
 }));
 
-const provider = "worker-secret-fixture";
+const defaultProvider = "worker-secret-fixture";
 let state: OpenClawTestState;
 beforeEach(async () => {
   state = await createOpenClawTestState({ label: "catalog-worker-secrets" });
@@ -51,12 +54,14 @@ describe("serialized catalog credential provenance", () => {
     owner: "config" | "profile";
     label: string;
     value: string;
+    migrated?: boolean;
     loader?: { authored: string; env?: NodeJS.ProcessEnv; pending?: boolean; resolved?: boolean };
   }>([
     { owner: "config", label: "literal bytes", value: "synthetic-worker-config-key" },
     { owner: "config", label: "marker bytes", value: NON_ENV_SECRETREF_MARKER },
     { owner: "config", label: "env-template bytes", value: "${OPAQUE_WORKER_KEY}" },
     { owner: "profile", label: "profile-only sibling", value: "synthetic-worker-profile-key" },
+    { owner: "config", label: "migrated binding", value: "synthetic-migrated-key", migrated: true },
     {
       owner: "config",
       label: "loader-substituted literal",
@@ -81,7 +86,8 @@ describe("serialized catalog credential provenance", () => {
     },
   ])(
     "preserves $owner $label through discovery and the writable plan",
-    async ({ owner, value, loader }) => {
+    async ({ owner, value, loader, migrated }) => {
+      const provider = migrated ? "mistral" : defaultProvider;
       const requests: boolean[] = [];
       const server = createServer((request, response) => {
         requests.push(
@@ -124,7 +130,15 @@ module.exports = {
         );
         await state.writeJson("catalog-plugin/openclaw.plugin.json", {
           id: provider,
-          providers: [provider],
+          providers: migrated ? [provider, `${provider}-base`] : [provider],
+          ...(migrated
+            ? {
+                setup: {
+                  providers: [{ id: `${provider}-base`, envVars: ["WORKER_MIGRATION_KEY"] }],
+                },
+                providerAuthAliases: { [provider]: `${provider}-base` },
+              }
+            : {}),
           providerCatalogEntry: "./index.cjs",
           modelCatalog: { discovery: { [provider]: "runtime" } },
           configSchema: { type: "object", additionalProperties: false, properties: {} },
@@ -140,7 +154,10 @@ module.exports = {
           agents: {
             defaults: {
               workspace: state.workspaceDir,
-              model: { primary: "healthy-fixture/model" },
+              model: {
+                primary: "healthy-fixture/model",
+                ...(migrated ? { fallbacks: [`${provider}/discovered-model`] } : {}),
+              },
               modelPolicy: { allow: ["healthy-fixture/model", `${provider}/*`] },
             },
           },
@@ -162,12 +179,16 @@ module.exports = {
                   },
                 ],
               },
-              [provider]: {
-                baseUrl,
-                api: "openai-completions",
-                models: [],
-                ...(owner === "config" ? { apiKey: loader?.authored ?? ref } : {}),
-              },
+              ...(migrated
+                ? {}
+                : {
+                    [provider]: {
+                      baseUrl,
+                      api: "openai-completions",
+                      models: [],
+                      ...(owner === "config" ? { apiKey: loader?.authored ?? ref } : {}),
+                    },
+                  }),
             },
           },
         } satisfies OpenClawConfig;
@@ -187,10 +208,11 @@ module.exports = {
           ...state.env,
           LITERAL_KEY: undefined,
           PENDING_KEY: undefined,
+          WORKER_MIGRATION_KEY: migrated ? value : undefined,
           ...loader?.env,
         };
         let runtimeSource: OpenClawConfig = source;
-        if (loader) {
+        if (loader || migrated) {
           await state.writeConfig(source);
           const snapshot = await readConfigFileSnapshotFromContext(
             createConfigIoContext({
@@ -204,6 +226,22 @@ module.exports = {
           runtime = snapshot.config;
           runtimeSource = snapshot.sourceConfig;
           expect(getConfigResolutionFacts(runtime)).not.toBeNull();
+        }
+        if (migrated) {
+          expect(runtimeSource.models?.providers?.[provider]).toBeUndefined();
+          expect(getConfigProviderUseBindings(runtimeSource)[provider]).toEqual({
+            apiKey: { source: "env", provider: "default", id: "WORKER_MIGRATION_KEY" },
+          });
+          runtime = (
+            await prepareSecretsRuntimeSnapshot({
+              config: runtime,
+              env,
+              agentDirs: [state.agentDir()],
+              includeAuthStoreRefs: false,
+            })
+          ).config;
+          expect(getConfigProviderUseBindings(runtime)[provider]).toBeUndefined();
+          expect(getConfigResolutionFacts(runtime)).toBe(getConfigResolutionFacts(runtimeSource));
         }
         setRuntimeConfigSnapshot(runtime, runtimeSource);
         const prepared = await prepareWorkspaceBuildGroup(
@@ -235,11 +273,12 @@ module.exports = {
         };
         expect(params.agentFacts.providerIds).toContain(provider);
         const expectedAuth = loader?.pending ? undefined : value;
-        const nativeAuth = loader
-          ? resolveUsableCustomProviderApiKey({ cfg: runtime, provider, env })?.apiKey
-          : undefined;
+        const nativeAuth =
+          loader || migrated
+            ? resolveUsableCustomProviderApiKey({ cfg: runtime, provider, env })?.apiKey
+            : undefined;
         let nativeRequests: boolean[] | undefined;
-        if (loader) {
+        if (loader || migrated) {
           await prepareAgentCatalogSource(
             params.agentFacts,
             prepared.pluginGeneration,
@@ -249,11 +288,11 @@ module.exports = {
           );
           nativeRequests = requests.splice(0);
         }
-        const nativeRuntimeFacts = getConfigResolutionFacts(runtime);
-        const nativeSourceFacts = getConfigResolutionFacts(runtimeSource);
+        const nativeRuntimeFacts = serializeConfigResolutionFacts(runtime);
+        const nativeSourceFacts = serializeConfigResolutionFacts(runtimeSource);
         const serialized = structuredClone(createPreparedModelCatalogWorkerInput(params));
         let alternativeFingerprint: string | undefined;
-        if (owner === "config" && !loader?.pending) {
+        if (owner === "config" && !loader?.pending && !migrated) {
           const alternativeSource: OpenClawConfig = {
             ...source,
             models: {
@@ -312,13 +351,12 @@ module.exports = {
           syntheticAuth: [],
         });
         expect(result.status).toBe("ok");
-        const runtimeFacts = getConfigResolutionFacts(serialized.input.config);
-        const sourceFacts = getConfigResolutionFacts(serialized.sourceConfigForSecrets);
-        expect(runtimeFacts === null).toBe(nativeRuntimeFacts === null);
-        expect(sourceFacts === null).toBe(nativeSourceFacts === null);
-        expect(runtimeFacts === sourceFacts).toBe(nativeRuntimeFacts === nativeSourceFacts);
-        if (loader) {
-          const expectedRef = loader.pending
+        expect(serializeConfigResolutionFacts(serialized.input.config)).toEqual(nativeRuntimeFacts);
+        expect(serializeConfigResolutionFacts(serialized.sourceConfigForSecrets)).toEqual(
+          nativeSourceFacts,
+        );
+        if (loader || migrated) {
+          const expectedRef = loader?.pending
             ? { source: "env", provider: "default", id: "PENDING_KEY" }
             : null;
           const workerAuth = resolveUsableCustomProviderApiKey({
@@ -341,15 +379,15 @@ module.exports = {
             ),
           }).toEqual({
             nativeAuthMatches: true,
-            nativeRequests: loader.pending ? [] : [true],
+            nativeRequests: loader?.pending ? [] : [true],
             workerAuthMatches: true,
-            workerRequests: loader.pending ? [] : [true],
+            workerRequests: loader?.pending ? [] : [true],
             authoredRef: expectedRef,
-            resolvedEnvRef: loader.resolved
+            resolvedEnvRef: loader?.resolved
               ? { source: "env", provider: "default", id: "SOURCE_KEY" }
               : null,
           });
-          if (loader.pending) {
+          if (loader?.pending) {
             return;
           }
         }
@@ -366,8 +404,13 @@ module.exports = {
         if (!catalog) {
           throw new Error("Expected the provider-owned writable catalog");
         }
+        const expectedApiKey = migrated
+          ? "WORKER_MIGRATION_KEY"
+          : loader
+            ? value
+            : NON_ENV_SECRETREF_MARKER;
         expect(JSON.parse(catalog.contents)).toMatchObject({
-          providers: { [provider]: { apiKey: loader ? value : NON_ENV_SECRETREF_MARKER } },
+          providers: { [provider]: { apiKey: expectedApiKey } },
         });
         expect(JSON.stringify(plans)).not.toContain("discoveryApiKey");
         if (!loader && value !== NON_ENV_SECRETREF_MARKER) {

--- a/src/agents/prepared-model-catalog-worker.secrets.test.ts
+++ b/src/agents/prepared-model-catalog-worker.secrets.test.ts
@@ -14,7 +14,7 @@ import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "../config/runtime-snapshot.js";
-import type { ModelProviderConfigInput } from "../config/types.models.js";
+import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { prepareSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import {
@@ -145,7 +145,12 @@ module.exports = {
           configSchema: { type: "object", additionalProperties: false, properties: {} },
         });
         const ref = { source: "store", provider: "default", id: "WORKER_CONFIG_KEY" } as const;
-        const providers: Record<string, ModelProviderConfigInput> = {
+        const providerConfig: ModelProviderConfig = {
+          baseUrl,
+          api: "openai-completions",
+          models: [],
+        };
+        const providers: Record<string, ModelProviderConfig> = {
           "healthy-fixture": {
             baseUrl: "https://healthy.example/v1",
             api: "openai-completions",
@@ -166,9 +171,7 @@ module.exports = {
             ? {}
             : {
                 [provider]: {
-                  baseUrl,
-                  api: "openai-completions",
-                  models: [],
+                  ...providerConfig,
                   ...(owner === "config" ? { apiKey: loader?.authored ?? ref } : {}),
                 },
               }),
@@ -198,7 +201,7 @@ module.exports = {
             providers: {
               ...source.models.providers,
               [provider]: {
-                ...source.models.providers[provider],
+                ...providerConfig,
                 ...(owner === "config" ? { apiKey: value } : {}),
               },
             },
@@ -299,7 +302,7 @@ module.exports = {
               providers: {
                 ...source.models.providers,
                 [provider]: {
-                  ...source.models.providers[provider],
+                  ...providerConfig,
                   apiKey: loader ? value : { ...ref, id: "OTHER_WORKER_KEY" },
                 },
               },

--- a/src/agents/prepared-model-catalog-worker.secrets.test.ts
+++ b/src/agents/prepared-model-catalog-worker.secrets.test.ts
@@ -14,6 +14,7 @@ import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "../config/runtime-snapshot.js";
+import type { ModelProviderConfigInput } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { prepareSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import {
@@ -144,6 +145,34 @@ module.exports = {
           configSchema: { type: "object", additionalProperties: false, properties: {} },
         });
         const ref = { source: "store", provider: "default", id: "WORKER_CONFIG_KEY" } as const;
+        const providers: Record<string, ModelProviderConfigInput> = {
+          "healthy-fixture": {
+            baseUrl: "https://healthy.example/v1",
+            api: "openai-completions",
+            apiKey: "synthetic-healthy-key",
+            models: [
+              {
+                id: "model",
+                name: "Model",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 4096,
+                maxTokens: 512,
+              },
+            ],
+          },
+          ...(migrated
+            ? {}
+            : {
+                [provider]: {
+                  baseUrl,
+                  api: "openai-completions",
+                  models: [],
+                  ...(owner === "config" ? { apiKey: loader?.authored ?? ref } : {}),
+                },
+              }),
+        };
         const source = {
           plugins: {
             allow: [provider],
@@ -161,36 +190,7 @@ module.exports = {
               modelPolicy: { allow: ["healthy-fixture/model", `${provider}/*`] },
             },
           },
-          models: {
-            providers: {
-              "healthy-fixture": {
-                baseUrl: "https://healthy.example/v1",
-                api: "openai-completions",
-                apiKey: "synthetic-healthy-key",
-                models: [
-                  {
-                    id: "model",
-                    name: "Model",
-                    reasoning: false,
-                    input: ["text"],
-                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                    contextWindow: 4096,
-                    maxTokens: 512,
-                  },
-                ],
-              },
-              ...(migrated
-                ? {}
-                : {
-                    [provider]: {
-                      baseUrl,
-                      api: "openai-completions",
-                      models: [],
-                      ...(owner === "config" ? { apiKey: loader?.authored ?? ref } : {}),
-                    },
-                  }),
-            },
-          },
+          models: { providers },
         } satisfies OpenClawConfig;
         let runtime: OpenClawConfig = {
           ...source,

--- a/src/agents/prepared-model-catalog-worker.test-support.ts
+++ b/src/agents/prepared-model-catalog-worker.test-support.ts
@@ -333,6 +333,7 @@ export function createCatalogFixture(
     codexNativeOwner?: boolean;
     builtPluginVersion?: string;
     asyncSyntheticAuth?: boolean;
+    declareProvider?: boolean;
   },
 ) {
   const root = makeTempDir("openclaw-model-catalog-worker-");
@@ -356,6 +357,15 @@ export function createCatalogFixture(
     [REF_ONLY_TOKEN_ENV]: "ref-only-token-secret-not-real",
   };
   const config = {
+    ...(options?.declareProvider
+      ? {
+          models: {
+            providers: {
+              [PROVIDER_ID]: { baseUrl: "https://worker-catalog.invalid/v1", models: [] },
+            },
+          },
+        }
+      : {}),
     agents: {
       defaults: {
         model: `${PROVIDER_ID}/sqlite-model`,

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -1,8 +1,5 @@
 /** Runs complete model-catalog discovery outside the Gateway event loop. */
-import {
-  getConfigResolutionFacts,
-  serializeConfigResolutionFacts,
-} from "../config/resolution-facts.js";
+import { serializeConfigResolutionFacts } from "../config/resolution-facts.js";
 import { projectConfigOntoRuntimeSourceSnapshot } from "../config/runtime-source-projection.js";
 import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
@@ -168,10 +165,7 @@ export function createPreparedModelCatalogWorkerInput(params: {
   // Capture the authored pair now; structured cloning cannot carry process-local Ref provenance.
   const sourceConfigForSecrets = projectConfigOntoRuntimeSourceSnapshot(source.config);
   const configResolutionFacts = serializeConfigResolutionFacts(source.config);
-  const sourceConfigResolutionFacts =
-    getConfigResolutionFacts(source.config) === getConfigResolutionFacts(sourceConfigForSecrets)
-      ? configResolutionFacts
-      : serializeConfigResolutionFacts(sourceConfigForSecrets);
+  const sourceConfigResolutionFacts = serializeConfigResolutionFacts(sourceConfigForSecrets);
   const authStore = cloneAuthProfileStore(params.agentFacts.authStore);
   const providerIds = [...params.agentFacts.providerIds];
   const { normalizePluginId: _normalizePluginId, ...pluginMetadataSnapshot } =

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -91,7 +91,7 @@ export type PreparedModelWorkerResult =
 const PREPARED_MODEL_CATALOG_WORKER_TIMEOUT_MS = 180_000;
 const PREPARED_MODEL_CATALOG_WORKER_GENERATION_POLL_MS = 25;
 
-class PreparedModelCatalogGenerationMismatchError extends Error {
+class PreparedModelCatalogGenerationMismatchError extends PreparedModelRuntimePublicationSupersededError {
   constructor(
     readonly agentDir: string,
     readonly generationFingerprint: string,

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -225,9 +225,10 @@ export async function runPreparedModelCatalogWorkerRequest(
       pluginGeneration: prepared.pluginGeneration,
     });
     replaceRuntimeAuthProfileStoreSnapshots([{ agentDir: value.input.agentDir, store: authStore }]);
-    const ambientCredentials = resolveSyntheticCredentials(
-      request.syntheticAuth.map(({ providerRef }) => providerRef),
-    );
+    const ambientCredentials = resolveSyntheticCredentials([
+      ...value.providerIds,
+      ...request.syntheticAuth.map(({ providerRef }) => providerRef),
+    ]);
     const startupProviderIds = new Set(value.providerIds.map(normalizeProviderId));
     const credentials = {
       ...ambientCredentials,

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -17,7 +17,6 @@ import { restorePreparedSyntheticAuthFacts } from "../plugins/provider-synthetic
 import { manifestPluginResolvesRuntimeModelCatalogAugment } from "../plugins/providers.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
-import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import {
   resolveAgentCredentialMapFromStore,
   resolveUsableAgentCredentialModes,
@@ -30,7 +29,6 @@ import { replaceRuntimeAuthProfileStoreSnapshots } from "./auth-profiles/runtime
 import { loadAuthProfileStoreWithoutExternalProfiles } from "./auth-profiles/store-runtime.js";
 import { preserveResolvedSecretBackedCredentials } from "./auth-profiles/store.js";
 import { prepareModelCatalogAuthLabels } from "./model-catalog-auth-labels.js";
-import { resolveSelectedModelProviderIds } from "./model-selection-config.js";
 import { resolveImplicitProviderDiscoveryScope } from "./models-config.providers.discovery-scope.js";
 import {
   fingerprintPreparedModelCatalogGeneration,
@@ -41,8 +39,6 @@ import {
 } from "./prepared-model-catalog-worker.js";
 import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import { scopeSyntheticAuthProviderRefs } from "./prepared-model-runtime.synthetic-auth.js";
-import { resolveProviderAuthAliasMap } from "./provider-auth-aliases.js";
-import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
 import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
 
@@ -222,6 +218,8 @@ export async function runPreparedModelCatalogWorkerRequest(
     const { prepareAgentCatalogSource } =
       await import("./prepared-model-runtime.scoped-catalog.js");
     const { prepareFullCatalogFacts } = await import("./prepared-model-runtime.full-catalog.js");
+    const { resolvePreparedModelRuntimeProviderIds } =
+      await import("./prepared-model-runtime.facts.js");
     // Full discovery is one point-in-time operation: refresh first, then let every provider hook
     // and the returned availability projection consume the same exact store.
     const authStore = refreshAuthStore({
@@ -234,41 +232,25 @@ export async function runPreparedModelCatalogWorkerRequest(
       pluginGeneration: prepared.pluginGeneration,
     });
     replaceRuntimeAuthProfileStoreSnapshots([{ agentDir: value.input.agentDir, store: authStore }]);
-    const ambientCredentials = resolveSyntheticCredentials(value.providerIds);
+    const ambientCredentials = resolveSyntheticCredentials(
+      request.syntheticAuth.map(({ providerRef }) => providerRef),
+    );
     const startupProviderIds = new Set(value.providerIds.map(normalizeProviderId));
     const credentials = {
       ...ambientCredentials,
       ...resolveAgentCredentialMapFromStore(authStore, { config: value.input.config }),
     };
-    const admitted = resolveProviderUseAdmission({
-      config: value.input.config,
-      env: value.input.env,
-      profiles: authStore.profiles,
-      requestedProviders: resolveSelectedModelProviderIds({
-        cfg: value.input.config,
-        agentId: value.input.agentId,
-      }),
-      storedCredentialAuthAliases: resolveProviderAuthAliasMap({
-        ...value.input,
-        metadataSnapshot: prepared.pluginGeneration.pluginMetadataSnapshot,
-        storedCredential: true,
-      }),
-      nativeProviders: Object.entries(credentials).flatMap(([provider, credential]) =>
-        credential.type === "api_key" && credential.nativeAuth ? [provider] : [],
-      ),
-      providerEnvVars: resolveProviderBindingEnvVarCandidates({
-        ...value.input,
-        metadataSnapshot: prepared.pluginGeneration.pluginMetadataSnapshot,
-      }),
-    });
     const exactAgentFacts = {
       ...prepared.agentFacts,
       authStore,
       templateAuthStorage: AuthStorage.inMemory(credentials),
       credentials,
-      providerIds: [...new Set([...value.providerIds, ...admitted.keys()])].toSorted(
-        (left, right) => left.localeCompare(right),
-      ),
+      providerIds: resolvePreparedModelRuntimeProviderIds({
+        input: value.input,
+        authStore,
+        credentials,
+        pluginMetadataSnapshot: prepared.pluginGeneration.pluginMetadataSnapshot,
+      }),
     };
     const { pluginMetadataSnapshot, pluginRegistry } = prepared.pluginGeneration;
     const discoveryScope = resolveImplicitProviderDiscoveryScope({

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -30,6 +30,7 @@ import { replaceRuntimeAuthProfileStoreSnapshots } from "./auth-profiles/runtime
 import { loadAuthProfileStoreWithoutExternalProfiles } from "./auth-profiles/store-runtime.js";
 import { preserveResolvedSecretBackedCredentials } from "./auth-profiles/store.js";
 import { prepareModelCatalogAuthLabels } from "./model-catalog-auth-labels.js";
+import { resolveSelectedModelProviderIds } from "./model-selection-config.js";
 import { resolveImplicitProviderDiscoveryScope } from "./models-config.providers.discovery-scope.js";
 import {
   fingerprintPreparedModelCatalogGeneration,
@@ -40,6 +41,7 @@ import {
 } from "./prepared-model-catalog-worker.js";
 import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import { scopeSyntheticAuthProviderRefs } from "./prepared-model-runtime.synthetic-auth.js";
+import { resolveProviderAuthAliasMap } from "./provider-auth-aliases.js";
 import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
 import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
@@ -242,6 +244,15 @@ export async function runPreparedModelCatalogWorkerRequest(
       config: value.input.config,
       env: value.input.env,
       profiles: authStore.profiles,
+      requestedProviders: resolveSelectedModelProviderIds({
+        cfg: value.input.config,
+        agentId: value.input.agentId,
+      }),
+      storedCredentialAuthAliases: resolveProviderAuthAliasMap({
+        ...value.input,
+        metadataSnapshot: prepared.pluginGeneration.pluginMetadataSnapshot,
+        storedCredential: true,
+      }),
       nativeProviders: Object.entries(credentials).flatMap(([provider, credential]) =>
         credential.type === "api_key" && credential.nativeAuth ? [provider] : [],
       ),

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -17,6 +17,7 @@ import { restorePreparedSyntheticAuthFacts } from "../plugins/provider-synthetic
 import { manifestPluginResolvesRuntimeModelCatalogAugment } from "../plugins/providers.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
+import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import {
   resolveAgentCredentialMapFromStore,
   resolveUsableAgentCredentialModes,
@@ -39,6 +40,7 @@ import {
 } from "./prepared-model-catalog-worker.js";
 import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import { scopeSyntheticAuthProviderRefs } from "./prepared-model-runtime.synthetic-auth.js";
+import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
 import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
 
@@ -236,12 +238,24 @@ export async function runPreparedModelCatalogWorkerRequest(
       ...ambientCredentials,
       ...resolveAgentCredentialMapFromStore(authStore, { config: value.input.config }),
     };
+    const admitted = resolveProviderUseAdmission({
+      config: value.input.config,
+      env: value.input.env,
+      profiles: authStore.profiles,
+      nativeProviders: Object.entries(credentials).flatMap(([provider, credential]) =>
+        credential.type === "api_key" && credential.nativeAuth ? [provider] : [],
+      ),
+      providerEnvVars: resolveProviderBindingEnvVarCandidates({
+        ...value.input,
+        metadataSnapshot: prepared.pluginGeneration.pluginMetadataSnapshot,
+      }),
+    });
     const exactAgentFacts = {
       ...prepared.agentFacts,
       authStore,
       templateAuthStorage: AuthStorage.inMemory(credentials),
       credentials,
-      providerIds: [...new Set([...value.providerIds, ...Object.keys(credentials)])].toSorted(
+      providerIds: [...new Set([...value.providerIds, ...admitted.keys()])].toSorted(
         (left, right) => left.localeCompare(right),
       ),
     };

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -2,10 +2,7 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import {
-  copyConfigResolutionFacts,
-  restoreConfigResolutionFacts,
-} from "../config/resolution-facts.js";
+import { restoreConfigResolutionFacts } from "../config/resolution-facts.js";
 import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import { serveWorkerTasks } from "../infra/worker-task-pool.js";
 import { listRuntimePluginIdsFromRegistry } from "../plugins/active-runtime-registry.js";
@@ -93,14 +90,10 @@ function refreshAuthStore(params: {
 }
 
 async function prepareWorkerGeneration(value: PreparedModelCatalogWorkerInput) {
-  // Restore the captured pair before discovery, including known-empty facts and shared identity.
+  // Restore each captured config's complete provenance before discovery, including known-empty facts.
   // Without loader facts, decoded literal strings can be reparsed as references.
   restoreConfigResolutionFacts(value.input.config, value.configResolutionFacts);
-  if (value.sourceConfigResolutionFacts === value.configResolutionFacts) {
-    copyConfigResolutionFacts(value.input.config, value.sourceConfigForSecrets);
-  } else {
-    restoreConfigResolutionFacts(value.sourceConfigForSecrets, value.sourceConfigResolutionFacts);
-  }
+  restoreConfigResolutionFacts(value.sourceConfigForSecrets, value.sourceConfigResolutionFacts);
   setRuntimeConfigSnapshot(value.input.config, value.sourceConfigForSecrets);
   const { prepareWorkspaceBuildGroup } = await import("./prepared-model-runtime.facts.js");
   // Rediscovery under agent workspaces or runtime activation overlays loses the owner's

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -24,7 +24,6 @@ type PreparedModelRuntimeAuthTransaction = {
   adoptedBy?: PreparedModelRuntimeReplacementGateId;
   ownerGates: Map<PreparedModelRuntimeOwner, Deferred<PreparedModelRuntimeSnapshot>>;
   publicationQueued: boolean;
-  profileSetChanged: boolean;
 };
 
 function partitionAuthMutationOwners(
@@ -57,7 +56,6 @@ export class PreparedModelRuntimeAuthPublicationOwner {
 
   enqueue(
     invalidatedOwners: readonly PreparedModelRuntimeOwner[],
-    profileSetChanged = false,
   ): PreparedModelRuntimeAuthTransaction {
     this.#events.push([...invalidatedOwners]);
     const transaction =
@@ -65,9 +63,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
       (this.#transaction = {
         ownerGates: new Map(),
         publicationQueued: false,
-        profileSetChanged: false,
       });
-    transaction.profileSetChanged ||= profileSetChanged;
     for (const owner of invalidatedOwners) {
       let gate = transaction.ownerGates.get(owner);
       if (!gate) {
@@ -224,7 +220,6 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         owner: PreparedModelRuntimeOwner;
         input: PreparedModelRuntimeOwner["input"];
       }>,
-      includeCredentialProviders: boolean,
     ) => Promise<void>;
     publishOwners: (owners: readonly PreparedModelRuntimeOwner[]) => void;
     commit?: () => void;
@@ -238,7 +233,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         );
         try {
           if (entries.length > 0) {
-            await params.publish(entries, this.#transaction?.profileSetChanged === true);
+            await params.publish(entries);
           }
           const transaction = this.#transaction;
           if (transaction) {

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -381,7 +381,6 @@ async function buildSnapshotBatch(
   agentBuildCompletions: Map<string, Promise<void>>,
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
-  includeCredentialProviders = catalogMode === "live",
   onStage?: (stage: string) => void,
   registryResources?: PreparedModelRuntimeBuildResources,
 ): Promise<PreparedModelRuntimeBuildResult[]> {
@@ -452,7 +451,6 @@ async function buildSnapshotBatch(
       catalogMode,
       {
         preferBuiltPluginArtifacts,
-        includeCredentialProviders,
         getConfiguredHarnessRuntimes,
         onStage,
         ...(groupCandidates.some((candidate) => candidate.ownsRegistryResources)
@@ -634,7 +632,6 @@ export function startSerializedSnapshotBuildBatch(
   catalogMode: PreparedModelRuntimeCatalogMode = "live",
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
-  includeCredentialProviders = catalogMode === "live",
 ): {
   pending: Promise<PreparedModelRuntimeBuildResult[]>;
   completion: Promise<void>;
@@ -661,7 +658,6 @@ export function startSerializedSnapshotBuildBatch(
         agentBuildCompletions,
         pluginMetadataSnapshot,
         onBuildStats,
-        includeCredentialProviders,
         (nextStage) => {
           stage = nextStage;
         },

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -27,7 +27,6 @@ import {
 import type { StaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
 import { resolveConfiguredModelHarnessRuntime } from "./harness-runtimes.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
-import type { AuthStorageData } from "./sessions/auth-storage.js";
 import { resolveEffectiveAgentRuntime } from "./thinking-runtime.js";
 
 export type PreparedConfiguredRuntimeModel = Readonly<{
@@ -63,7 +62,7 @@ export function collectPreparedModelRuntimeConfiguredRefs(
 
 export function collectPreparedModelRuntimeProviderIds(
   config: OpenClawConfig,
-  credentials: Readonly<AuthStorageData>,
+  admittedProviderIds: Iterable<string>,
   includeCredentialProviders: boolean,
   configuredModelRefs: readonly ConfiguredModelRef[] = collectConfiguredModelRefs(config),
   agentId?: string,
@@ -76,7 +75,7 @@ export function collectPreparedModelRuntimeProviderIds(
     }
   };
   if (includeCredentialProviders) {
-    for (const providerId of Object.keys(credentials)) {
+    for (const providerId of admittedProviderIds) {
       addProviderId(providerId);
     }
   }

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -62,8 +62,7 @@ export function collectPreparedModelRuntimeConfiguredRefs(
 
 export function collectPreparedModelRuntimeProviderIds(
   config: OpenClawConfig,
-  admittedProviderIds: Iterable<string>,
-  includeCredentialProviders: boolean,
+  admittedProviders: Iterable<string>,
   configuredModelRefs: readonly ConfiguredModelRef[] = collectConfiguredModelRefs(config),
   agentId?: string,
 ): string[] {
@@ -74,10 +73,8 @@ export function collectPreparedModelRuntimeProviderIds(
       providerIds.add(providerId);
     }
   };
-  if (includeCredentialProviders) {
-    for (const providerId of admittedProviderIds) {
-      addProviderId(providerId);
-    }
+  for (const providerId of admittedProviders) {
+    addProviderId(providerId);
   }
   for (const ref of configuredModelRefs) {
     const separator = ref.value.indexOf("/");

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -35,6 +35,7 @@ import {
 } from "./embedded-agent-runner/model.static-catalog.js";
 import { createStaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
 import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
+import { resolveSelectedModelProviderIds } from "./model-selection-config.js";
 import {
   buildConfiguredModelCatalog,
   parseConfiguredModelVisibilityEntries,
@@ -78,6 +79,7 @@ import type {
   PreparedModelRuntimeInput,
   PreparedModelRuntimePluginGeneration,
 } from "./prepared-model-runtime.types.js";
+import { resolveProviderAuthAliasMap } from "./provider-auth-aliases.js";
 import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
 
@@ -110,11 +112,20 @@ function prepareAgentFacts(
     ...(input.env ? { env } : {}),
   });
   const credentials = authFacts.credentials;
+  const requestedProviders = resolveSelectedModelProviderIds({
+    cfg: input.config,
+    agentId: input.agentId,
+  });
   const admitted = includeCredentialProviders
     ? resolveProviderUseAdmission({
         config: input.config,
         env,
         profiles: authFacts.store.profiles,
+        requestedProviders,
+        storedCredentialAuthAliases: resolveProviderAuthAliasMap({
+          ...input,
+          storedCredential: true,
+        }),
         nativeProviders: Object.entries(credentials).flatMap(([provider, credential]) =>
           credential.type === "api_key" && credential.nativeAuth ? [provider] : [],
         ),
@@ -142,6 +153,7 @@ function prepareAgentFacts(
     // stored credential must not pull that provider's complete catalog into the admission path.
     providerIds: [
       ...new Set([
+        ...requestedProviders,
         ...collectPreparedModelRuntimeProviderIds(
           input.config,
           admitted,

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -82,6 +82,7 @@ import type {
 } from "./prepared-model-runtime.types.js";
 import { resolveProviderAuthAliasMap } from "./provider-auth-aliases.js";
 import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
+import { getAuthStorageOAuthProviderRegistry } from "./sessions/auth-storage-oauth-registry.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
 
 type PreparedConfiguredRegistryGroup = {
@@ -382,9 +383,13 @@ export async function prepareWorkspaceBuildGroup(
       const credentials = facts.input.skipCredentials
         ? {}
         : { ...ambientCredentials, ...facts.credentials };
+      const templateAuthStorage = AuthStorage.inMemory(credentials);
+      for (const provider of facts.templateAuthStorage.getOAuthProviders()) {
+        getAuthStorageOAuthProviderRegistry(templateAuthStorage).register(provider);
+      }
       Object.assign(facts, {
         credentials,
-        templateAuthStorage: AuthStorage.inMemory(credentials),
+        templateAuthStorage,
         providerIds: options.providerDiscoveryProviderIds
           ? [...options.providerDiscoveryProviderIds]
           : resolvePreparedModelRuntimeProviderIds({

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -20,7 +20,10 @@ import { capturePluginLifecycleAuthority } from "../plugins/registry-lifecycle.j
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
 import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
-import { prepareAmbientAgentCredentialsForDiscovery } from "./agent-auth-discovery.js";
+import {
+  prepareAmbientAgentCredentialsForDiscovery,
+  resolveAmbientAgentCredentialsForDiscovery,
+} from "./agent-auth-discovery.js";
 import {
   discoverAuthStorageFacts,
   discoverModelsFromCapturedSources,
@@ -69,7 +72,6 @@ import { createPreparedPluginGeneration } from "./prepared-model-runtime.plugin-
 import type { PreparedModelRuntimeBuildResources } from "./prepared-model-runtime.resources.js";
 import {
   listPreparedSyntheticAuthProviderRefs,
-  prepareSyntheticAuth,
   scopeSyntheticAuthProviderRefs,
 } from "./prepared-model-runtime.synthetic-auth.js";
 import type {
@@ -142,6 +144,7 @@ function prepareAgentFacts(
     config: input.config,
     // External CLI hydration belongs to startup/control-plane producers, never auth-store reads.
     readOnly: true,
+    skipExternalAuthProfiles: true,
     ambientCredentials: {},
     ...(preparedStore ? { preparedStore } : {}),
     ...(input.skipCredentials ? { skipCredentials: true } : {}),
@@ -292,14 +295,12 @@ export async function prepareWorkspaceBuildGroup(
     const authStoreMs = performance.now() - authStoreStartedAt;
     const configuredProviderIds =
       options.providerDiscoveryProviderIds ??
-      [
-        ...new Set([
-          ...agentBaseFacts.flatMap((facts) => facts.providerIds),
-          ...pluginMetadataSnapshot.owners.cliBackends.keys(),
-        ]),
-      ].toSorted((left, right) => left.localeCompare(right));
+      [...new Set(agentBaseFacts.flatMap((facts) => facts.providerIds))].toSorted((left, right) =>
+        left.localeCompare(right),
+      );
     const staticCatalogProviderIds = [
       ...new Set([
+        ...configuredProviderIds,
         ...collectConfiguredProviderIdsNeedingStaticCatalog({
           config: input.config,
           matchesStaticModelId,
@@ -351,7 +352,11 @@ export async function prepareWorkspaceBuildGroup(
     // Static Gateway publication consumes discovery entrypoints; the run owns activation.
     const ambientCredentialsStartedAt = performance.now();
     reportStage("ambient credentials");
-    const ambientCredentials = await prepareAmbientAgentCredentialsForDiscovery({
+    const resolveAmbientCredentials =
+      catalogMode === "static"
+        ? resolveAmbientAgentCredentialsForDiscovery
+        : prepareAmbientAgentCredentialsForDiscovery;
+    const ambientCredentials = await resolveAmbientCredentials({
       config: input.config,
       env,
       authoritativeSyntheticAuthProviderRefs: pluginMetadataSnapshot.owners.cliBackends.keys(),
@@ -368,18 +373,6 @@ export async function prepareWorkspaceBuildGroup(
               }),
               configuredProviderIds,
             ),
-      ...(catalogMode === "static"
-        ? {
-            resolveSyntheticAuth: (provider: string) =>
-              prepareSyntheticAuth({
-                config: input.config,
-                env,
-                workspaceDir: input.workspaceDir,
-                provider,
-                providers: preparedSyntheticAuthProviders,
-              }),
-          }
-        : {}),
       ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     });
     const ambientCredentialsMs = performance.now() - ambientCredentialsStartedAt;
@@ -411,6 +404,7 @@ export async function prepareWorkspaceBuildGroup(
         : await loadBundledProviderStaticCatalogContextModels({
             cfg: input.config,
             env,
+            providerIds: [...new Set(agentBaseFacts.flatMap(({ providerIds }) => providerIds))],
             metadataSnapshot: pluginMetadataSnapshot,
             registeredProviders: runtimePluginRegistry?.providers,
             ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
@@ -622,6 +616,7 @@ function groupConfiguredRegistrySources(
       config: facts.input.config,
       sourceModels: projectConfigOntoRuntimeSourceSnapshot(facts.input.config).models,
       credentials: facts.credentials,
+      providerIds: [...new Set(facts.providerIds.map(normalizeProviderId))].toSorted(),
       modelsJsonContents,
       pluginCatalogs,
     });
@@ -661,6 +656,7 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
     if (!representative) {
       continue;
     }
+    const admittedProviders = new Set(representative.providerIds.map(normalizeProviderId));
     // Parse identical catalog/auth sources once, then fork request auth.
     const templateModelRegistry = discoverModelsFromCapturedSources(
       representative.templateAuthStorage,
@@ -669,7 +665,11 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
         includePluginCatalogs: true,
         modelsJsonContents: group.modelsJsonContents,
         pluginCatalogs: group.pluginCatalogs,
-        staticProviderConfigs,
+        staticProviderConfigs: Object.fromEntries(
+          Object.entries(staticProviderConfigs).filter(([provider]) =>
+            admittedProviders.has(normalizeProviderId(provider)),
+          ),
+        ),
         pluginMetadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
         ...(representative.input.workspaceDir
           ? { workspaceDir: representative.input.workspaceDir }

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -20,7 +20,6 @@ import { capturePluginLifecycleAuthority } from "../plugins/registry-lifecycle.j
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
 import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
-import type { AgentCredentialMap } from "./agent-auth-credentials.js";
 import { prepareAmbientAgentCredentialsForDiscovery } from "./agent-auth-discovery.js";
 import {
   discoverAuthStorageFacts,
@@ -90,84 +89,85 @@ type PreparedConfiguredRegistryGroup = {
   pluginCatalogs: readonly PersistedPluginModelCatalog[];
 };
 
+export function resolvePreparedModelRuntimeProviderIds(
+  params: Pick<PreparedModelRuntimeAgentBaseFacts, "input" | "authStore" | "credentials"> & {
+    pluginMetadataSnapshot: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"];
+  },
+): string[] {
+  const { input, authStore, credentials, pluginMetadataSnapshot } = params;
+  const requestedProviders = resolveSelectedModelProviderIds({
+    cfg: input.config,
+    agentId: input.agentId,
+  });
+  const admitted = resolveProviderUseAdmission({
+    config: input.config,
+    env: input.env,
+    profiles: authStore.profiles,
+    requestedProviders,
+    storedCredentialAuthAliases: resolveProviderAuthAliasMap({
+      ...input,
+      metadataSnapshot: pluginMetadataSnapshot,
+      storedCredential: true,
+    }),
+    nativeProviders: Object.entries(credentials).flatMap(([provider, credential]) =>
+      credential.type === "api_key" && credential.nativeAuth ? [provider] : [],
+    ),
+    providerEnvVars: resolveProviderBindingEnvVarCandidates({
+      ...input,
+      metadataSnapshot: pluginMetadataSnapshot,
+    }),
+  });
+  return [
+    ...new Set([
+      ...requestedProviders,
+      ...collectPreparedModelRuntimeProviderIds(
+        input.config,
+        admitted.keys(),
+        collectPreparedModelRuntimeConfiguredRefs(input.config, input.agentId),
+        input.agentId,
+      ),
+      ...parseConfiguredModelVisibilityEntries({ cfg: input.config, agentId: input.agentId })
+        .providerWildcards,
+    ]),
+  ].toSorted((left, right) => left.localeCompare(right));
+}
+
 function prepareAgentFacts(
   input: PreparedModelRuntimeInput,
-  catalogMode: PreparedModelRuntimeCatalogMode,
-  ambientCredentials: Readonly<AgentCredentialMap>,
-  additionalProviderIds: readonly string[] = [],
-  includeCredentialProviders = catalogMode === "live",
+  pluginMetadataSnapshot: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
 ): PreparedModelRuntimeAgentBaseFacts {
   const env = input.env ?? process.env;
   const preparedStore = loadPreparedModelRuntimeAuthStore(input);
   const authFacts = discoverAuthStorageFacts(input.agentDir, {
     config: input.config,
-    // Prepared owners consume only the already-published runtime auth generation. External CLI
-    // hydration belongs to startup/control-plane and turn-time producers, never rebuilds.
+    // External CLI hydration belongs to startup/control-plane producers, never auth-store reads.
     readOnly: true,
-    ambientCredentials,
+    ambientCredentials: {},
     ...(preparedStore ? { preparedStore } : {}),
     ...(input.skipCredentials ? { skipCredentials: true } : {}),
     ...(input.inheritedAuthDir ? { inheritedAuthDir: input.inheritedAuthDir } : {}),
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     ...(input.env ? { env } : {}),
   });
-  const credentials = authFacts.credentials;
-  const requestedProviders = resolveSelectedModelProviderIds({
-    cfg: input.config,
-    agentId: input.agentId,
-  });
-  const admitted = includeCredentialProviders
-    ? resolveProviderUseAdmission({
-        config: input.config,
-        env,
-        profiles: authFacts.store.profiles,
-        requestedProviders,
-        storedCredentialAuthAliases: resolveProviderAuthAliasMap({
-          ...input,
-          storedCredential: true,
-        }),
-        nativeProviders: Object.entries(credentials).flatMap(([provider, credential]) =>
-          credential.type === "api_key" && credential.nativeAuth ? [provider] : [],
-        ),
-        providerEnvVars: resolveProviderBindingEnvVarCandidates({ ...input, env }),
-      }).keys()
-    : [];
-  const templateAuthStorage = authFacts.authStorage;
-  const rawConfiguredModelRefs = collectPreparedModelRuntimeConfiguredRefs(
-    input.config,
-    input.agentId,
-  );
   return {
     input,
     env,
     authStore: authFacts.store,
-    templateAuthStorage,
-    credentials,
-    // Keep order and case-distinct refs: registry lookup remains exact-case even
-    // where static/dynamic completion deduplicates case-insensitive merge keys.
-    configuredModelRefs: rawConfiguredModelRefs.flatMap(({ value }) => {
+    templateAuthStorage: authFacts.authStorage,
+    credentials: authFacts.credentials,
+    configuredModelRefs: collectPreparedModelRuntimeConfiguredRefs(
+      input.config,
+      input.agentId,
+    ).flatMap(({ value }) => {
       const ref = parseModelCatalogRef(value);
       return ref ? [ref] : [];
     }),
-    // Gateway startup prepares only providers named by config/model selection. An unrelated
-    // stored credential must not pull that provider's complete catalog into the admission path.
-    providerIds: [
-      ...new Set([
-        ...requestedProviders,
-        ...collectPreparedModelRuntimeProviderIds(
-          input.config,
-          admitted,
-          includeCredentialProviders,
-          rawConfiguredModelRefs,
-          input.agentId,
-        ),
-        ...parseConfiguredModelVisibilityEntries({
-          cfg: input.config,
-          agentId: input.agentId,
-        }).providerWildcards,
-        ...additionalProviderIds.map(normalizeProviderId).filter(Boolean),
-      ]),
-    ].toSorted((left, right) => left.localeCompare(right)),
+    providerIds: resolvePreparedModelRuntimeProviderIds({
+      input,
+      authStore: authFacts.store,
+      credentials: authFacts.credentials,
+      pluginMetadataSnapshot,
+    }),
   };
 }
 
@@ -177,7 +177,6 @@ export async function prepareWorkspaceBuildGroup(
   options: {
     providerDiscoveryProviderIds?: readonly string[];
     preferBuiltPluginArtifacts?: boolean;
-    includeCredentialProviders?: boolean;
     getConfiguredHarnessRuntimes?: () => readonly string[];
     basePluginIds?: readonly string[];
     onStage?: (stage: string) => void;
@@ -284,23 +283,21 @@ export async function prepareWorkspaceBuildGroup(
       configuredManifestModels.set(key, model);
       return model;
     };
-    const configuredProviderIds = [
-      ...new Set([
-        ...inputs.flatMap(({ config, agentId }) =>
-          withAgentRosterFactsBatch(config, () => [
-            ...collectPreparedModelRuntimeProviderIds(
-              config,
-              [],
-              false,
-              collectPreparedModelRuntimeConfiguredRefs(config, agentId),
-              agentId,
-            ),
-            ...parseConfiguredModelVisibilityEntries({ cfg: config, agentId }).providerWildcards,
-          ]),
-        ),
-        ...(options.providerDiscoveryProviderIds ?? []).map(normalizeProviderId).filter(Boolean),
-      ]),
-    ].toSorted((left, right) => left.localeCompare(right));
+    const authStoreStartedAt = performance.now();
+    const agentBaseFacts = inputs.map((candidate) =>
+      withAgentRosterFactsBatch(candidate.config, () =>
+        prepareAgentFacts(candidate, pluginMetadataSnapshot),
+      ),
+    );
+    const authStoreMs = performance.now() - authStoreStartedAt;
+    const configuredProviderIds =
+      options.providerDiscoveryProviderIds ??
+      [
+        ...new Set([
+          ...agentBaseFacts.flatMap((facts) => facts.providerIds),
+          ...pluginMetadataSnapshot.owners.cliBackends.keys(),
+        ]),
+      ].toSorted((left, right) => left.localeCompare(right));
     const staticCatalogProviderIds = [
       ...new Set([
         ...collectConfiguredProviderIdsNeedingStaticCatalog({
@@ -388,18 +385,23 @@ export async function prepareWorkspaceBuildGroup(
     const ambientCredentialsMs = performance.now() - ambientCredentialsStartedAt;
     const agentFactsStartedAt = performance.now();
     reportStage("agent facts");
-    const agentBaseFacts = inputs.map((candidate) =>
-      withAgentRosterFactsBatch(candidate.config, () =>
-        prepareAgentFacts(
-          candidate,
-          catalogMode,
-          ambientCredentials,
-          options.providerDiscoveryProviderIds,
-          options.includeCredentialProviders,
-        ),
-      ),
-    );
-    const agentFactsMs = performance.now() - agentFactsStartedAt;
+    for (const facts of agentBaseFacts) {
+      const credentials = facts.input.skipCredentials
+        ? {}
+        : { ...ambientCredentials, ...facts.credentials };
+      Object.assign(facts, {
+        credentials,
+        templateAuthStorage: AuthStorage.inMemory(credentials),
+        providerIds: options.providerDiscoveryProviderIds
+          ? [...options.providerDiscoveryProviderIds]
+          : resolvePreparedModelRuntimeProviderIds({
+              ...facts,
+              credentials,
+              pluginMetadataSnapshot,
+            }),
+      });
+    }
+    const agentFactsMs = authStoreMs + performance.now() - agentFactsStartedAt;
     const configuredProjectionStartedAt = performance.now();
     reportStage("configured model projection");
     const providerStaticModels =

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -19,6 +19,7 @@ import { getPluginRegistryInspectionResources } from "../plugins/registry-inspec
 import { capturePluginLifecycleAuthority } from "../plugins/registry-lifecycle.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
+import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import type { AgentCredentialMap } from "./agent-auth-credentials.js";
 import { prepareAmbientAgentCredentialsForDiscovery } from "./agent-auth-discovery.js";
 import {
@@ -77,6 +78,7 @@ import type {
   PreparedModelRuntimeInput,
   PreparedModelRuntimePluginGeneration,
 } from "./prepared-model-runtime.types.js";
+import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
 
 type PreparedConfiguredRegistryGroup = {
@@ -108,6 +110,17 @@ function prepareAgentFacts(
     ...(input.env ? { env } : {}),
   });
   const credentials = authFacts.credentials;
+  const admitted = includeCredentialProviders
+    ? resolveProviderUseAdmission({
+        config: input.config,
+        env,
+        profiles: authFacts.store.profiles,
+        nativeProviders: Object.entries(credentials).flatMap(([provider, credential]) =>
+          credential.type === "api_key" && credential.nativeAuth ? [provider] : [],
+        ),
+        providerEnvVars: resolveProviderBindingEnvVarCandidates({ ...input, env }),
+      }).keys()
+    : [];
   const templateAuthStorage = authFacts.authStorage;
   const rawConfiguredModelRefs = collectPreparedModelRuntimeConfiguredRefs(
     input.config,
@@ -131,7 +144,7 @@ function prepareAgentFacts(
       ...new Set([
         ...collectPreparedModelRuntimeProviderIds(
           input.config,
-          credentials,
+          admitted,
           includeCredentialProviders,
           rawConfiguredModelRefs,
           input.agentId,
@@ -265,7 +278,7 @@ export async function prepareWorkspaceBuildGroup(
           withAgentRosterFactsBatch(config, () => [
             ...collectPreparedModelRuntimeProviderIds(
               config,
-              {},
+              [],
               false,
               collectPreparedModelRuntimeConfiguredRefs(config, agentId),
               agentId,

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -87,6 +87,7 @@ export async function prepareFullCatalogFacts(
         (await loadBundledProviderStaticCatalogContextModels({
           cfg: input.config,
           env,
+          providerIds: agentFacts.providerIds,
           metadataSnapshot: pluginMetadataSnapshot,
           registeredProviders: pluginGeneration.pluginRegistry?.providers,
           ...(preparedStaticProviderCatalog ? { preparedStaticProviderCatalog } : {}),

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -141,7 +141,10 @@ describe("prepared reply dispatch runtime", () => {
       getOAuthProviders: () => [],
     }));
     mocks.configuredAgentIds = ["default"];
-    const config = { agents: { defaults: { model: "initial/model" } } };
+    const config = {
+      agents: { defaults: { model: "initial/model" } },
+      models: { providers: { selected: {} } },
+    };
     const selectedRegistry = createEmptyPluginRegistry();
     selectedRegistry.providers.push({
       pluginId: "selected-provider",

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -143,7 +143,7 @@ describe("prepared reply dispatch runtime", () => {
     mocks.configuredAgentIds = ["default"];
     const config = {
       agents: { defaults: { model: "initial/model" } },
-      models: { providers: { selected: {} } },
+      models: { providers: { selected: { baseUrl: "", models: [] } } },
     };
     const selectedRegistry = createEmptyPluginRegistry();
     selectedRegistry.providers.push({

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -452,7 +452,6 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
   owners: Map<string, PreparedModelRuntimeOwner>;
   agentBuildCompletions: Map<string, Promise<void>>;
   buildTimeoutMs: number;
-  includeCredentialProviders?: boolean;
   isPublicationCurrent?: () => boolean;
   isBuildCurrent?: () => boolean;
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void;
@@ -543,7 +542,6 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
               catalogMode,
               params.onBuildStats,
               params.pluginMetadataSnapshot,
-              params.includeCredentialProviders,
             );
             for (const candidate of currentGroup) {
               if (params.registerEntriesAfterBuildStart === true) {

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -379,17 +379,20 @@ describe("prepared model runtime reload auth adoption", () => {
     });
     mocks.runPreparedModelCatalogWorker.mockClear();
     mocks.createPreparedModelCatalogWorker.mockClear();
+    mocks.authStorage.getAll.mockReturnValue({
+      custom: { type: "api_key", key: "rotated-key" },
+    });
     mocks.mutationListener?.({
       agentDir: input.agentDir,
       affectsInheritedStores: false,
       profileSetChanged: false,
     });
 
-    await prepareModelRuntimeSnapshot(input);
+    const rotated = await prepareModelRuntimeSnapshot(input);
     expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
-    expect(
-      mocks.createPreparedModelCatalogWorker.mock.calls.at(-1)?.[0].agentFacts.providerIds,
-    ).toEqual([]);
+    expect(rotated.createStores().authStorage.getAll()).toMatchObject({
+      custom: { type: "api_key", key: "rotated-key" },
+    });
   });
 
   it("shares one live rebuild across concurrent stale catalog reads", async () => {

--- a/src/agents/prepared-model-runtime.scoped-catalog.ts
+++ b/src/agents/prepared-model-runtime.scoped-catalog.ts
@@ -1,3 +1,4 @@
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
@@ -26,16 +27,26 @@ import type {
 
 const MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
 
+type ScopedCatalogSelection = {
+  requestedProviderIds?: readonly string[];
+  metadataSnapshot?: PluginMetadataSnapshot;
+  authStore?: AuthProfileStore;
+};
+
 async function prepareScopedReadOnlyModelCatalogWithMode(
   input: PreparedModelRuntimeInput,
   providerDiscoveryProviderIds: readonly string[],
   catalogMode: PreparedModelRuntimeCatalogMode,
+  selection?: ScopedCatalogSelection,
 ): Promise<ModelCatalogSnapshot> {
   const scopedInput = input.readOnly ? input : { ...input, readOnly: true };
   const { agentFacts, pluginGeneration } = await prepareWorkspaceBuildGroup(
     [scopedInput],
     catalogMode,
     { providerDiscoveryProviderIds },
+    undefined,
+    undefined,
+    selection?.metadataSnapshot,
   );
   const agentFactsForInput = agentFacts[0];
   if (!agentFactsForInput) {
@@ -46,7 +57,7 @@ async function prepareScopedReadOnlyModelCatalogWithMode(
     pluginGeneration,
     catalogMode,
     false,
-    catalogMode === "live" ? { providerDiscoveryProviderIds } : {},
+    catalogMode === "live" ? { providerDiscoveryProviderIds, ...selection } : {},
   );
   const { modelCatalog, configuredRuntimeModels } = await prepareFullCatalogFacts(
     agentFactsForInput,
@@ -75,8 +86,14 @@ export function prepareScopedReadOnlyModelCatalog(
 export function prepareScopedReadOnlyLiveModelCatalog(
   input: PreparedModelRuntimeInput,
   providerDiscoveryProviderIds: readonly string[],
+  selection?: ScopedCatalogSelection,
 ): Promise<ModelCatalogSnapshot> {
-  return prepareScopedReadOnlyModelCatalogWithMode(input, providerDiscoveryProviderIds, "live");
+  return prepareScopedReadOnlyModelCatalogWithMode(
+    input,
+    providerDiscoveryProviderIds,
+    "live",
+    selection,
+  );
 }
 
 export async function prepareAgentCatalogSource(
@@ -87,6 +104,7 @@ export async function prepareAgentCatalogSource(
   sourceOptions: {
     authStore?: AuthProfileStore;
     providerDiscoveryProviderIds?: readonly string[];
+    requestedProviderIds?: readonly string[];
   } = {},
 ): Promise<PreparedModelRuntimeCatalogSource> {
   const { env, input, providerIds } = agentFacts;
@@ -111,6 +129,7 @@ export async function prepareAgentCatalogSource(
   const options = {
     pluginMetadataSnapshot: pluginGeneration.pluginMetadataSnapshot,
     providerDiscoveryProviderIds: sourceOptions.providerDiscoveryProviderIds ?? providerIds,
+    requestedProviderIds: sourceOptions.requestedProviderIds,
     ...(pluginGeneration.preparedStaticProviderCatalog
       ? { preparedStaticProviderCatalog: pluginGeneration.preparedStaticProviderCatalog }
       : {}),

--- a/src/agents/prepared-model-runtime.sources.test.ts
+++ b/src/agents/prepared-model-runtime.sources.test.ts
@@ -252,6 +252,57 @@ describe("prepared catalog source composition", () => {
     ).toBeUndefined();
   });
 
+  it("isolates admitted static scopes while sharing equal scopes and retaining authored rows", () => {
+    const { facts, generation, staticConfig, modelsJsonContents } = fixture();
+    generation.preparedStaticProviderCatalog = {
+      entries: [
+        ...generation.preparedStaticProviderCatalog.entries,
+        {
+          provider: { id: "sibling-static", label: "Sibling static", auth: [] },
+          result: { provider: { ...staticConfig, models: [model("sibling-only")] } },
+        },
+      ],
+    };
+    const sibling = (agentId: string, providerIds: string[]): PreparedModelRuntimeAgentFacts => {
+      const agentDir = tempDirs.make("openclaw-prepared-scope-");
+      fs.writeFileSync(path.join(agentDir, "models.json"), modelsJsonContents);
+      return { ...facts, input: { ...facts.input, agentId, agentDir }, providerIds };
+    };
+    const wider = sibling("wider", [providerId, "sibling-static"]);
+    const equal = sibling("equal", [providerId]);
+    const result = prepareConfiguredRuntimeFactsBatch({
+      agentFacts: [facts, wider, equal],
+      pluginGeneration: generation,
+    });
+    const narrowCatalog = result.catalogs.get(facts.input)!;
+    const widerCatalog = result.catalogs.get(wider.input)!;
+    const equalCatalog = result.catalogs.get(equal.input)!;
+    const authoredAndStatic = ["authored-only", "configured-only", "curated-only", "shared"];
+    expect(narrowCatalog.modelCatalog.entries.map((row) => row.id).toSorted()).toEqual(
+      authoredAndStatic,
+    );
+    expect(
+      narrowCatalog.templateModelRegistry
+        .getAll()
+        .map((row) => row.id)
+        .toSorted(),
+    ).toEqual(authoredAndStatic);
+    expect(widerCatalog.modelCatalog.entries.map((row) => row.id).toSorted()).toEqual([
+      "authored-only",
+      "configured-only",
+      "curated-only",
+      "shared",
+      "sibling-only",
+    ]);
+    expect(widerCatalog.templateModelRegistry.find("sibling-static", "sibling-only")).toBeDefined();
+    expect(equalCatalog.modelCatalog.entries.map((row) => row.id).toSorted()).toEqual(
+      authoredAndStatic,
+    );
+    expect(equalCatalog.templateModelRegistry).toBe(narrowCatalog.templateModelRegistry);
+    expect(widerCatalog.templateModelRegistry).not.toBe(narrowCatalog.templateModelRegistry);
+    expect(result.registryCount).toBe(2);
+  });
+
   it("keeps an authored route when the prepared static catalog is empty", () => {
     const { facts, generation, configured } = fixture();
     const authoredEndpoint = "https://authored.example.invalid/v1";

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -52,6 +52,7 @@ const mocks = vi.hoisted(() => {
     metadataSnapshot,
     resolvePluginMetadataSnapshot: vi.fn(() => metadataSnapshot),
     resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
+    prepareAmbientCredentials: vi.fn(async (..._args: unknown[]) => ({})),
     discoverAuthStorage: vi.fn((_agentDir?: string, _options?: unknown) => authStorage),
     discoverModels: vi.fn((_authStorage: AuthStorage, _options?: unknown) => modelRegistry),
     ensureOpenClawModelsJson: vi.fn(
@@ -126,7 +127,8 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
 }));
 
 vi.mock("./agent-auth-discovery.js", () => ({
-  prepareAmbientAgentCredentialsForDiscovery: mocks.resolveAmbientCredentials,
+  resolveAmbientAgentCredentialsForDiscovery: mocks.resolveAmbientCredentials,
+  prepareAmbientAgentCredentialsForDiscovery: mocks.prepareAmbientCredentials,
 }));
 
 vi.mock("../plugins/provider-public-artifacts.js", () => ({
@@ -637,20 +639,10 @@ describe("prepared model runtime Gateway catalog mode", () => {
     expect(mocks.resolveAmbientCredentials).toHaveBeenCalledWith(
       expect.objectContaining({
         syntheticAuthProviderRefs: ["openai"],
-        resolveSyntheticAuth: expect.any(Function),
       }),
     );
-    const ambientOptions = mocks.resolveAmbientCredentials.mock.calls[0]?.[0] as
-      | { resolveSyntheticAuth?: (provider: string) => Promise<{ apiKey?: string } | undefined> }
-      | undefined;
-    expect(await ambientOptions?.resolveSyntheticAuth?.("openai")).toMatchObject({
-      apiKey: "synthetic-openai-key",
-    });
-    expect(mocks.resolveSyntheticAuth).toHaveBeenCalledWith({
-      config,
-      provider: "openai",
-      providerConfig: undefined,
-    });
+    expect(mocks.prepareAmbientCredentials).not.toHaveBeenCalled();
+    expect(mocks.resolveSyntheticAuth).not.toHaveBeenCalled();
     const catalogAuthStorage = mocks.discoverModels.mock.lastCall?.[0];
     expect(catalogAuthStorage?.getAll()).toEqual({
       openai: { type: "api_key", key: "test-openai-key" },
@@ -872,7 +864,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledWith(
       expect.objectContaining({
         providerDiscoveryProviderIds: [provider, "openai", "provider-only", "registry-only"],
-        staticCatalogProviderIds: [provider, "openai", "registry-only"],
+        staticCatalogProviderIds: [provider, "openai", "provider-only", "registry-only"],
       }),
     );
     expect(mocks.discoverModels).toHaveBeenCalledOnce();
@@ -882,7 +874,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
   });
 
-  it("does not request a static provider hook when manifest facts resolve the configured model", async () => {
+  it("prepares admitted static rows when manifest facts already resolve the selected model", async () => {
     mocks.resolveStaticCatalogModel.mockReturnValue({
       id: "gpt-5.5",
       name: "GPT-5.5",
@@ -911,7 +903,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledWith(
       expect.objectContaining({
         providerDiscoveryProviderIds: ["openai"],
-        staticCatalogProviderIds: [],
+        staticCatalogProviderIds: ["openai"],
       }),
     );
     const snapshot = getPreparedModelRuntimeSnapshot({

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -3,6 +3,7 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { setPreparedModelFullCatalogAuth } from "./prepared-model-runtime-auth.js";
+import type { AuthStorage } from "./sessions/auth-storage.js";
 import type { ModelRegistry } from "./sessions/model-registry.js";
 
 type CreateStaticCatalogResolver =
@@ -52,7 +53,7 @@ const mocks = vi.hoisted(() => {
     resolvePluginMetadataSnapshot: vi.fn(() => metadataSnapshot),
     resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
     discoverAuthStorage: vi.fn((_agentDir?: string, _options?: unknown) => authStorage),
-    discoverModels: vi.fn(() => modelRegistry),
+    discoverModels: vi.fn((_authStorage: AuthStorage, _options?: unknown) => modelRegistry),
     ensureOpenClawModelsJson: vi.fn(
       async (_config: unknown, _agentDir: unknown, _options?: unknown) => ({
         agentDir: "/tmp/agent",
@@ -462,7 +463,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     },
   );
 
-  it("imports and materializes only configured and auth-candidate providers", async () => {
+  it("keeps explicit provider discovery scoped while preparing configured static rows", async () => {
     const config = {
       models: {
         providers: {
@@ -497,7 +498,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
 
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledWith(
       expect.objectContaining({
-        providerDiscoveryProviderIds: ["anthropic", "local-runtime", "openai", "vllm"],
+        providerDiscoveryProviderIds: ["anthropic", "local-runtime"],
         staticCatalogProviderIds: ["anthropic", "local-runtime", "openai"],
       }),
     );
@@ -506,7 +507,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
       "/tmp/prepared-static-agent",
       expect.objectContaining({
         providerDiscoveryEntriesOnly: true,
-        providerDiscoveryProviderIds: ["anthropic", "local-runtime", "openai", "vllm"],
+        providerDiscoveryProviderIds: ["anthropic", "local-runtime"],
       }),
     );
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
@@ -650,8 +651,12 @@ describe("prepared model runtime Gateway catalog mode", () => {
       provider: "openai",
       providerConfig: undefined,
     });
+    const catalogAuthStorage = mocks.discoverModels.mock.lastCall?.[0];
+    expect(catalogAuthStorage?.getAll()).toEqual({
+      openai: { type: "api_key", key: "test-openai-key" },
+    });
     expect(mocks.discoverModels).toHaveBeenLastCalledWith(
-      mocks.authStorage,
+      catalogAuthStorage,
       expect.objectContaining({
         config,
         includePluginCatalogs: true,

--- a/src/agents/prepared-model-runtime.synthetic-auth.ts
+++ b/src/agents/prepared-model-runtime.synthetic-auth.ts
@@ -1,8 +1,5 @@
 /** Synthetic-auth provider ref selection and prepared-catalog resolution for model-runtime builds. */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { ProviderSyntheticAuthResult } from "../plugins/provider-external-auth.types.js";
-import { prepareSyntheticAuthWithProvider } from "../plugins/provider-synthetic-auth.js";
 import type { ProviderPlugin } from "../plugins/types.js";
 
 // Provider-scoped live builds must not fan ambient synthetic-auth discovery out to every
@@ -34,30 +31,4 @@ export function listPreparedSyntheticAuthProviderRefs(
       ),
     ),
   ].toSorted((left, right) => left.localeCompare(right));
-}
-
-export async function prepareSyntheticAuth(params: {
-  config: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-  signal?: AbortSignal;
-  workspaceDir?: string;
-  provider: string;
-  providers: readonly ProviderPlugin[];
-}): Promise<ProviderSyntheticAuthResult | undefined> {
-  const normalizedProvider = normalizeProviderId(params.provider);
-  const providerPlugin = params.providers.find((candidate) =>
-    [candidate.id, ...(candidate.aliases ?? []), ...(candidate.hookAliases ?? [])].some(
-      (ref) => normalizeProviderId(ref) === normalizedProvider,
-    ),
-  );
-  const context = {
-    config: params.config,
-    provider: params.provider,
-    providerConfig: Object.entries(params.config.models?.providers ?? {}).find(
-      ([providerId]) => normalizeProviderId(providerId) === normalizedProvider,
-    )?.[1],
-  };
-  return providerPlugin
-    ? await prepareSyntheticAuthWithProvider(providerPlugin, context, params)
-    : undefined;
 }

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -154,6 +154,8 @@ vi.mock("./model-catalog.js", async () => ({
 }));
 
 vi.mock("./agent-auth-discovery.js", () => ({
+  resolveAmbientAgentCredentialsForDiscovery: (...args: unknown[]) =>
+    preparedModelRuntimeMocks.resolveAmbientCredentials(...args),
   prepareAmbientAgentCredentialsForDiscovery: async (...args: unknown[]) =>
     preparedModelRuntimeMocks.resolveAmbientCredentials(...args),
 }));

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -338,7 +338,7 @@ describe("prepared model runtime snapshots", () => {
     ]);
   });
 
-  it("limits live discovery to the selected agent's models and authenticated providers", async () => {
+  it("limits live discovery to the selected agent's models and admitted providers", async () => {
     const config = {
       agents: {
         defaults: { model: { primary: "openai/gpt-5.6" } },
@@ -378,7 +378,14 @@ describe("prepared model runtime snapshots", () => {
       config,
       state.agentDir("selected-provider-scope"),
       expect.objectContaining({
-        providerDiscoveryProviderIds: ["anthropic", "custom", "openai", "selected-runtime", "vllm"],
+        providerDiscoveryProviderIds: [
+          "anthropic",
+          "custom",
+          "openai",
+          "selected-runtime",
+          "unrelated",
+          "vllm",
+        ],
       }),
     );
     expect(mocks.resolveAmbientCredentials).toHaveBeenCalledWith(

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -658,13 +658,12 @@ function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Prom
 async function drainPendingAuthMutations(commit?: () => void): Promise<void> {
   await authPublication.drain({
     owners,
-    publish: async (entries, includeCredentialProviders) =>
+    publish: async (entries) =>
       await publishPreparedModelRuntimeOwnerBatch({
         entries,
         owners,
         agentBuildCompletions,
         buildTimeoutMs: modelRuntimeBuildTimeoutMs,
-        ...(includeCredentialProviders ? { includeCredentialProviders: true } : {}),
         reusePluginGenerations: true,
       }),
     publishOwners: (publishedOwners) => replyDispatchPublication.replace(publishedOwners),
@@ -690,7 +689,7 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
     return;
   }
   replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
-  const transaction = authPublication.enqueue(invalidatedOwners, normalizedEvent.profileSetChanged);
+  const transaction = authPublication.enqueue(invalidatedOwners);
   if (pendingModelRuntimeReplacement) {
     // The active config transaction drains this event before its atomic dispatch commit. Retire
     // the superseded build gate; queuing another task would make this commit depend on future work.

--- a/src/agents/provider-auth-recovery-hint.ts
+++ b/src/agents/provider-auth-recovery-hint.ts
@@ -6,8 +6,13 @@
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveManifestProviderAuthChoices } from "../plugins/provider-auth-choices.js";
+import {
+  resolveProviderAuthEnvVarCandidates,
+  resolveProviderBindingEnvVarCandidates,
+} from "../secrets/provider-env-vars.js";
 import { normalizeProviderId } from "./model-selection.js";
 import { resolveProviderAuthAliasMap } from "./provider-auth-aliases.js";
+import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
 
 // Builds short auth recovery hints for provider errors. Manifest auth choices
 // can supply a provider-specific login command before generic configure/env help.
@@ -57,6 +62,26 @@ export function buildProviderAuthRecoveryHint(params: {
   includeConfigure?: boolean;
   includeEnvVar?: boolean;
 }): string {
+  const env = params.env ?? process.env;
+  const provider = normalizeProviderId(params.provider);
+  const aliases = resolveProviderAuthAliasMap(params);
+  const candidates = resolveProviderAuthEnvVarCandidates(params);
+  const presentVariables = (
+    candidates[provider] ??
+    candidates[aliases[provider] ?? provider] ??
+    []
+  ).filter((name) => env[name]?.trim());
+  if (
+    params.includeEnvVar !== false &&
+    presentVariables.length > 0 &&
+    !resolveProviderUseAdmission({
+      config: params.config,
+      env,
+      providerEnvVars: resolveProviderBindingEnvVarCandidates(params),
+    }).has(provider)
+  ) {
+    return `${presentVariables.join(", ")} is set, but it is not bound to provider "${provider}". Run \`${formatCliCommand("openclaw doctor --fix")}\` to check an existing selection, or add an environment reference at \`models.providers.${provider}.apiKey\`.`;
+  }
   const loginCommand = resolveProviderAuthLoginCommand(params);
   const parts: string[] = [];
   if (loginCommand) {
@@ -65,7 +90,7 @@ export function buildProviderAuthRecoveryHint(params: {
   if (params.includeConfigure !== false) {
     parts.push(`\`${formatCliCommand("openclaw configure")}\``);
   }
-  if (params.includeEnvVar) {
+  if (params.includeEnvVar && presentVariables.length === 0) {
     parts.push("set an API key env var");
   }
   if (parts.length === 0) {

--- a/src/agents/provider-model-auth-source-plan.ts
+++ b/src/agents/provider-model-auth-source-plan.ts
@@ -1,5 +1,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isSetupCredentialAccessible } from "./auth-profiles/setup-access.js";
+import type { AuthProfileCredential } from "./auth-profiles/types.js";
 
 export type ProviderUseBinding =
   | { kind: "provider-config" }
@@ -23,7 +25,7 @@ export function resolveProviderUseAdmission(params: {
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   providerEnvVars?: Readonly<Record<string, readonly string[]>>;
-  profiles?: Readonly<Record<string, { provider: string }>>;
+  profiles?: Readonly<Record<string, Pick<AuthProfileCredential, "provider" | "setup">>>;
   nativeProviders?: Iterable<string>;
 }): ReadonlyMap<string, ProviderUseBinding> {
   const admitted = new Map<string, ProviderUseBinding>();
@@ -37,6 +39,9 @@ export function resolveProviderUseAdmission(params: {
     add(provider, { kind: "provider-config" });
   }
   for (const [profileId, profile] of Object.entries(params.profiles ?? {})) {
+    if (!isSetupCredentialAccessible({ profileId, credential: profile })) {
+      continue;
+    }
     add(profile.provider, { kind: "profile", profileId });
   }
   for (const provider of params.nativeProviders ?? []) {

--- a/src/agents/provider-model-auth-source-plan.ts
+++ b/src/agents/provider-model-auth-source-plan.ts
@@ -20,6 +20,10 @@ const GENERIC_CREDENTIAL_ENV_VARS = new Set([
   "GOOGLE_APPLICATION_CREDENTIALS",
 ]);
 
+export function isGenericProviderCredentialEnvVar(name: string): boolean {
+  return GENERIC_CREDENTIAL_ENV_VARS.has(name);
+}
+
 /** Provider intent is independent of credential readiness and catalog visibility. */
 export function resolveProviderUseAdmission(params: {
   config?: OpenClawConfig;
@@ -27,6 +31,9 @@ export function resolveProviderUseAdmission(params: {
   providerEnvVars?: Readonly<Record<string, readonly string[]>>;
   profiles?: Readonly<Record<string, Pick<AuthProfileCredential, "provider" | "setup">>>;
   nativeProviders?: Iterable<string>;
+  /** Selected routes may retain accounts through unconditional credential-family aliases. */
+  requestedProviders?: Iterable<string>;
+  storedCredentialAuthAliases?: Readonly<Record<string, string>>;
 }): ReadonlyMap<string, ProviderUseBinding> {
   const admitted = new Map<string, ProviderUseBinding>();
   const add = (provider: string, binding: ProviderUseBinding) => {
@@ -44,6 +51,23 @@ export function resolveProviderUseAdmission(params: {
     }
     add(profile.provider, { kind: "profile", profileId });
   }
+  for (const provider of params.requestedProviders ?? []) {
+    if (admitted.has(normalizeProviderId(provider))) {
+      continue;
+    }
+    const normalized = normalizeProviderId(provider);
+    const credentialProvider = params.storedCredentialAuthAliases?.[normalized] ?? normalized;
+    for (const [profileId, profile] of Object.entries(params.profiles ?? {})) {
+      if (
+        isSetupCredentialAccessible({ profileId, credential: profile }) &&
+        (params.storedCredentialAuthAliases?.[normalizeProviderId(profile.provider)] ??
+          normalizeProviderId(profile.provider)) === credentialProvider
+      ) {
+        add(provider, { kind: "profile", profileId });
+        break;
+      }
+    }
+  }
   for (const provider of params.nativeProviders ?? []) {
     add(provider, { kind: "native-account" });
   }
@@ -57,7 +81,7 @@ export function resolveProviderUseAdmission(params: {
   }
   const env = params.env ?? process.env;
   for (const [envVar, owners] of envOwners) {
-    if (owners.size !== 1 || GENERIC_CREDENTIAL_ENV_VARS.has(envVar) || !env[envVar]?.trim()) {
+    if (owners.size !== 1 || isGenericProviderCredentialEnvVar(envVar) || !env[envVar]?.trim()) {
       continue;
     }
     for (const provider of owners) {

--- a/src/agents/provider-model-auth-source-plan.ts
+++ b/src/agents/provider-model-auth-source-plan.ts
@@ -1,5 +1,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { resolveConfigProviderUseBindings } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import { isSetupCredentialAccessible } from "./auth-profiles/setup-access.js";
 import type { AuthProfileCredential } from "./auth-profiles/types.js";
 
@@ -24,17 +26,79 @@ export function isGenericProviderCredentialEnvVar(name: string): boolean {
   return GENERIC_CREDENTIAL_ENV_VARS.has(name);
 }
 
+/** One declaring chat plugin may bind its own family, but never a competing plugin. */
+export function resolveProviderEnvironmentAdmission(params: {
+  env?: NodeJS.ProcessEnv;
+  providerEnvVars?: ProviderBindingEnvVarCandidates;
+}): {
+  bindings: ReadonlyMap<string, { kind: "environment"; envVar: string }>;
+  conflicts: readonly {
+    envVar: string;
+    pluginIds: readonly string[];
+    providers: readonly string[];
+  }[];
+} {
+  const env = params.env ?? process.env;
+  const owners = new Map<string, Map<string, Set<string>>>();
+  for (const [provider, declarations] of Object.entries(params.providerEnvVars ?? {})) {
+    for (const declaration of declarations) {
+      for (const envVar of declaration.envVars) {
+        if (isGenericProviderCredentialEnvVar(envVar) || !env[envVar]?.trim()) {
+          continue;
+        }
+        const plugins = owners.get(envVar) ?? new Map<string, Set<string>>();
+        const pluginId = declaration.pluginId.trim().toLowerCase();
+        const providers = plugins.get(pluginId) ?? new Set<string>();
+        providers.add(normalizeProviderId(provider));
+        plugins.set(pluginId, providers);
+        owners.set(envVar, plugins);
+      }
+    }
+  }
+  const bindings = new Map<string, { kind: "environment"; envVar: string }>();
+  const conflicts: Array<{ envVar: string; pluginIds: string[]; providers: string[] }> = [];
+  for (const [envVar, plugins] of owners) {
+    const providerIds = new Set<string>();
+    for (const ids of plugins.values()) {
+      for (const id of ids) {
+        providerIds.add(id);
+      }
+    }
+    if (plugins.size !== 1) {
+      conflicts.push({ envVar, pluginIds: [...plugins.keys()], providers: [...providerIds] });
+    }
+  }
+  // Each provider's manifest order chooses its credential, not a sibling's declaration order.
+  for (const [provider, declarations] of Object.entries(params.providerEnvVars ?? {})) {
+    const id = normalizeProviderId(provider);
+    for (const declaration of declarations) {
+      for (const envVar of declaration.envVars) {
+        if (owners.get(envVar)?.size === 1 && !bindings.has(id)) {
+          bindings.set(id, { kind: "environment", envVar });
+        }
+      }
+    }
+  }
+  return { bindings, conflicts };
+}
+
 /** Provider intent is independent of credential readiness and catalog visibility. */
 export function resolveProviderUseAdmission(params: {
   config?: OpenClawConfig;
+  /** Persistence planning must distinguish runtime upgrade facts from authored entries. */
+  includeRuntimeBindings?: boolean;
   env?: NodeJS.ProcessEnv;
-  providerEnvVars?: Readonly<Record<string, readonly string[]>>;
+  providerEnvVars?: ProviderBindingEnvVarCandidates;
   profiles?: Readonly<Record<string, Pick<AuthProfileCredential, "provider" | "setup">>>;
   nativeProviders?: Iterable<string>;
   /** Selected routes may retain accounts through unconditional credential-family aliases. */
   requestedProviders?: Iterable<string>;
   storedCredentialAuthAliases?: Readonly<Record<string, string>>;
 }): ReadonlyMap<string, ProviderUseBinding> {
+  const config =
+    params.config && params.includeRuntimeBindings !== false
+      ? resolveConfigProviderUseBindings(params.config)
+      : params.config;
   const admitted = new Map<string, ProviderUseBinding>();
   const add = (provider: string, binding: ProviderUseBinding) => {
     const id = normalizeProviderId(provider);
@@ -42,7 +106,7 @@ export function resolveProviderUseAdmission(params: {
       admitted.set(id, binding);
     }
   };
-  for (const provider of Object.keys(params.config?.models?.providers ?? {})) {
+  for (const provider of Object.keys(config?.models?.providers ?? {})) {
     add(provider, { kind: "provider-config" });
   }
   for (const [profileId, profile] of Object.entries(params.profiles ?? {})) {
@@ -71,22 +135,8 @@ export function resolveProviderUseAdmission(params: {
   for (const provider of params.nativeProviders ?? []) {
     add(provider, { kind: "native-account" });
   }
-  const envOwners = new Map<string, Set<string>>();
-  for (const [provider, envVars] of Object.entries(params.providerEnvVars ?? {})) {
-    for (const envVar of envVars) {
-      const owners = envOwners.get(envVar) ?? new Set<string>();
-      owners.add(normalizeProviderId(provider));
-      envOwners.set(envVar, owners);
-    }
-  }
-  const env = params.env ?? process.env;
-  for (const [envVar, owners] of envOwners) {
-    if (owners.size !== 1 || isGenericProviderCredentialEnvVar(envVar) || !env[envVar]?.trim()) {
-      continue;
-    }
-    for (const provider of owners) {
-      add(provider, { kind: "environment", envVar });
-    }
+  for (const [provider, binding] of resolveProviderEnvironmentAdmission(params).bindings) {
+    add(provider, binding);
   }
   return admitted;
 }
@@ -129,6 +179,8 @@ export type ProviderModelAuthDirectSource = {
   readiness: ProviderModelAuthReadiness;
   evidence: ProviderModelAuthEvidence;
   authorization: ProviderModelAuthAuthorization;
+  /** Independently admitted environment source; does not inherit a profile's authority. */
+  boundEnvVar?: string;
 };
 
 export type ProviderModelAuthSource =
@@ -222,6 +274,7 @@ export function buildProviderModelAuthDirectSource(params: {
    * escapes the ambient-credential rule. Make each caller state it.
    */
   authorization: ProviderModelAuthAuthorization;
+  boundEnvVar?: string;
 }): ProviderModelAuthDirectSource {
   return {
     kind: "direct",
@@ -229,6 +282,7 @@ export function buildProviderModelAuthDirectSource(params: {
     readiness: toProviderModelAuthReadiness(params.availability),
     evidence: params.evidence,
     authorization: params.authorization,
+    ...(params.boundEnvVar ? { boundEnvVar: params.boundEnvVar } : {}),
   };
 }
 

--- a/src/agents/provider-model-auth-source-plan.ts
+++ b/src/agents/provider-model-auth-source-plan.ts
@@ -1,3 +1,67 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+export type ProviderUseBinding =
+  | { kind: "provider-config" }
+  | { kind: "profile"; profileId: string }
+  | { kind: "native-account" }
+  | { kind: "environment"; envVar: string };
+
+const GENERIC_CREDENTIAL_ENV_VARS = new Set([
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "MODEL_API_KEY",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_PROFILE",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+]);
+
+/** Provider intent is independent of credential readiness and catalog visibility. */
+export function resolveProviderUseAdmission(params: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  providerEnvVars?: Readonly<Record<string, readonly string[]>>;
+  profiles?: Readonly<Record<string, { provider: string }>>;
+  nativeProviders?: Iterable<string>;
+}): ReadonlyMap<string, ProviderUseBinding> {
+  const admitted = new Map<string, ProviderUseBinding>();
+  const add = (provider: string, binding: ProviderUseBinding) => {
+    const id = normalizeProviderId(provider);
+    if (id && !admitted.has(id)) {
+      admitted.set(id, binding);
+    }
+  };
+  for (const provider of Object.keys(params.config?.models?.providers ?? {})) {
+    add(provider, { kind: "provider-config" });
+  }
+  for (const [profileId, profile] of Object.entries(params.profiles ?? {})) {
+    add(profile.provider, { kind: "profile", profileId });
+  }
+  for (const provider of params.nativeProviders ?? []) {
+    add(provider, { kind: "native-account" });
+  }
+  const envOwners = new Map<string, Set<string>>();
+  for (const [provider, envVars] of Object.entries(params.providerEnvVars ?? {})) {
+    for (const envVar of envVars) {
+      const owners = envOwners.get(envVar) ?? new Set<string>();
+      owners.add(normalizeProviderId(provider));
+      envOwners.set(envVar, owners);
+    }
+  }
+  const env = params.env ?? process.env;
+  for (const [envVar, owners] of envOwners) {
+    if (owners.size !== 1 || GENERIC_CREDENTIAL_ENV_VARS.has(envVar) || !env[envVar]?.trim()) {
+      continue;
+    }
+    for (const provider of owners) {
+      add(provider, { kind: "environment", envVar });
+    }
+  }
+  return admitted;
+}
+
 type ProviderModelAuthReadiness = "ready" | "unknown" | "unavailable";
 
 export type ProviderModelAuthEvidence =

--- a/src/agents/provider-model-route-auth.ts
+++ b/src/agents/provider-model-route-auth.ts
@@ -160,6 +160,13 @@ export function selectProviderModelAuthSources(params: {
 
   const { fallback, profiles } = params.plan;
   if (profiles.kind === "all-cooldown") {
+    if (fallback?.boundEnvVar && fallback.readiness === "ready" && !profiles.explicitOrder) {
+      return {
+        kind: "selected",
+        selection: { kind: "selected", source: fallback },
+        attempts: [directAttempt(fallback)],
+      };
+    }
     return {
       kind: "rejected",
       reason: "all-cooldown",
@@ -178,11 +185,11 @@ export function selectProviderModelAuthSources(params: {
       ...(profiles.kind === "all-unavailable" ? { source: profiles.first } : {}),
     };
   }
-  // An ambient credential — one config names nowhere — may serve a provider the
+  // An unbound ambient credential may serve a provider the
   // operator left entirely unconfigured (the documented zero-config
   // `PROVIDER_API_KEY` path), but it must never *succeed* a credential the
   // operator did declare. Those can bill different accounts, so that transition
-  // needs a declaration, not a discovery. `auth.order` filtering already refuses
+  // needs an independent provider binding. `auth.order` filtering already refuses
   // to silently try a declared profile the operator omitted from an explicit
   // order (docs/auth-credential-semantics.md, "Explicit auth order filtering");
   // an undeclared credential cannot rank above that.
@@ -191,7 +198,9 @@ export function selectProviderModelAuthSources(params: {
   // this plan from a narrowed profile list, so an operator who declared only
   // route-incompatible profiles must not be treated as zero-config.
   const authorizedFallback =
-    fallback?.authorization === "ambient" && params.plan.declaredProfileCount > 0
+    fallback?.authorization === "ambient" &&
+    params.plan.declaredProfileCount > 0 &&
+    (!fallback.boundEnvVar || profiles.explicitOrder)
       ? undefined
       : fallback;
   if (profiles.kind === "usable") {

--- a/src/agents/provider-use-admission.test.ts
+++ b/src/agents/provider-use-admission.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { createModelAuthAvailabilityResolver } from "./model-auth-availability.js";
+import {
+  createProviderApiKeyResolver,
+  createProviderAuthResolver,
+} from "./models-config.providers.secrets.js";
+import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
+
+const sharedProviderEnvVars = {
+  opencode: ["OPENCODE_API_KEY"],
+  "opencode-go": ["OPENCODE_API_KEY"],
+};
+
+describe("resolveProviderUseAdmission", () => {
+  it("does not replace an expired bound profile with shared environment auth", () => {
+    const env = { OPENCODE_API_KEY: "unbound-key" };
+    const store = {
+      version: 1,
+      profiles: {
+        "opencode:expired": {
+          provider: "opencode",
+          type: "token" as const,
+          token: "expired",
+          expires: 1,
+        },
+        "opencode-go:other": {
+          provider: "opencode-go",
+          type: "api_key" as const,
+          key: "other-key",
+        },
+      },
+    };
+    const admission = resolveProviderUseAdmission({ env, profiles: store.profiles });
+    const apiKey = createProviderApiKeyResolver(
+      env,
+      store,
+      {},
+      undefined,
+      undefined,
+      env,
+      admission,
+    );
+    const auth = createProviderAuthResolver(env, store, {}, undefined, undefined, env, admission);
+    expect(apiKey("opencode").apiKey).toBeUndefined();
+    expect(auth("opencode").mode).toBe("none");
+    expect(apiKey("opencode-go").discoveryApiKey).toBe("other-key");
+    const availability = createModelAuthAvailabilityResolver({ cfg: {}, env, authStore: store });
+    expect(availability.resolveProviderAuthAvailability("opencode")).toBe(false);
+    expect(availability.resolveProviderAuthAvailability("opencode-go")).toBe(true);
+  });
+  it("uses the admitted environment binding during catalog credential lookup", () => {
+    const env = { OPENAI_API_KEY: "bound-key", CODEX_API_KEY: "unbound-key" };
+    const resolve = createProviderApiKeyResolver(
+      env,
+      { version: 1, profiles: {} },
+      {},
+      undefined,
+      undefined,
+      env,
+      new Map([["openai", { kind: "environment", envVar: "OPENAI_API_KEY" }]]),
+    );
+    expect(resolve("openai")).toMatchObject({
+      apiKey: "OPENAI_API_KEY",
+      discoveryApiKey: "bound-key",
+    });
+  });
+  it("does not expose an auth-alias sibling through a stored family profile", () => {
+    const resolver = createModelAuthAvailabilityResolver({
+      cfg: {},
+      env: {},
+      authStore: {
+        version: 1,
+        profiles: {
+          "family:account": { type: "api_key", provider: "family", key: "synthetic-key" },
+        },
+      },
+      metadataSnapshot: createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "family",
+            providers: ["family", "family-plan"],
+            providerAuthAliases: { "family-plan": "family" },
+          },
+        ],
+      }),
+    });
+    expect(resolver.resolveProviderAuthAvailability("family")).toBe(true);
+    expect(resolver.resolveProviderAuthAvailability("family-plan")).toBe(false);
+  });
+  it("admits only the normalized direct owner and records no credential value", () => {
+    const admission = resolveProviderUseAdmission({
+      env: { OWNER_API_KEY: "synthetic-secret", EMPTY_API_KEY: "  " },
+      providerEnvVars: {
+        " Owner ": ["OWNER_API_KEY"],
+        owner: ["OWNER_API_KEY"],
+        borrower: [],
+        empty: ["EMPTY_API_KEY"],
+      },
+    });
+
+    expect(admission).toEqual(
+      new Map([["owner", { kind: "environment", envVar: "OWNER_API_KEY" }]]),
+    );
+  });
+
+  it("does not choose either provider from a shared environment key", () => {
+    expect(
+      resolveProviderUseAdmission({
+        env: { OPENCODE_API_KEY: "synthetic-shared-secret" },
+        providerEnvVars: sharedProviderEnvVars,
+      }),
+    ).toEqual(new Map());
+  });
+
+  it.each([
+    {
+      kind: "provider-config",
+      binding: {
+        config: {
+          models: {
+            providers: { " OPENCODE ": { baseUrl: "https://models.example", models: [] } },
+          },
+        } satisfies OpenClawConfig,
+      },
+      source: { kind: "provider-config" },
+    },
+    {
+      kind: "profile",
+      binding: { profiles: { "saved-account": { provider: " OPENCODE " } } },
+      source: { kind: "profile", profileId: "saved-account" },
+    },
+    {
+      kind: "native-account",
+      binding: { nativeProviders: new Set([" OPENCODE "]) },
+      source: { kind: "native-account" },
+    },
+  ])("keeps shared credentials bound to the $kind provider", ({ binding, source }) => {
+    const admission = resolveProviderUseAdmission({
+      ...binding,
+      env: { OPENCODE_API_KEY: "synthetic-shared-secret" },
+      providerEnvVars: sharedProviderEnvVars,
+    });
+
+    expect(admission).toEqual(new Map([["opencode", source]]));
+  });
+
+  it.each([
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "MODEL_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_PROFILE",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+  ])("does not admit a provider from generic credential %s", (envVar) => {
+    expect(
+      resolveProviderUseAdmission({
+        env: { [envVar]: "synthetic-value" },
+        providerEnvVars: { cloud: [envVar] },
+      }),
+    ).toEqual(new Map());
+  });
+
+  it.each([undefined, "api-key", "aws-sdk"] as const)(
+    "accepts an explicit %s provider without inline credentials",
+    (auth) => {
+      const admission = resolveProviderUseAdmission({
+        config: {
+          models: {
+            providers: {
+              cloud: { baseUrl: "https://models.example", auth, models: [] },
+            },
+          },
+        },
+        env: {},
+        providerEnvVars: {},
+      });
+
+      expect(admission).toEqual(new Map([["cloud", { kind: "provider-config" }]]));
+    },
+  );
+});

--- a/src/agents/runtime-plan/auth.ts
+++ b/src/agents/runtime-plan/auth.ts
@@ -40,6 +40,7 @@ export function buildAgentRuntimeAuthPlan(params: {
   modelRoute?: AgentRuntimeAuthPlan["modelRoute"];
   deferredRouteSupport?: AgentRuntimeAuthPlan["deferredRouteSupport"];
   credentialSource?: AgentRuntimeAuthPlan["credentialSource"];
+  boundEnvVar?: string;
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
@@ -105,5 +106,6 @@ export function buildAgentRuntimeAuthPlan(params: {
     ...(params.modelRoute ? { modelRoute: params.modelRoute } : {}),
     ...(params.deferredRouteSupport ? { deferredRouteSupport: params.deferredRouteSupport } : {}),
     ...(params.credentialSource ? { credentialSource: params.credentialSource } : {}),
+    ...(params.boundEnvVar ? { boundEnvVar: params.boundEnvVar } : {}),
   } satisfies AgentRuntimeAuthPlan;
 }

--- a/src/agents/runtime-plan/catalog-provider-admission.test.ts
+++ b/src/agents/runtime-plan/catalog-provider-admission.test.ts
@@ -1,20 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildOpenAICompatibleProviderFamilyCatalog } from "../plugin-sdk/provider-catalog-live-runtime.js";
-import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
-import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
-import type { ProviderPlugin } from "../plugins/types.js";
+import { buildOpenAICompatibleProviderFamilyCatalog } from "../../plugin-sdk/provider-catalog-live-runtime.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import type { ProviderPlugin } from "../../plugins/types.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
-} from "../test-utils/openclaw-test-state.js";
-import { MODELS_CONFIG_IMPLICIT_ENV_VARS } from "./models-config.e2e-harness.js";
+} from "../../test-utils/openclaw-test-state.js";
+import { MODELS_CONFIG_IMPLICIT_ENV_VARS } from "../models-config.e2e-harness.js";
 
 const mocks = vi.hoisted(() => ({
   resolveRuntimePluginDiscoveryProviders: vi.fn(),
   runProviderCatalog: vi.fn(),
   runProviderStaticCatalog: vi.fn(),
 }));
-vi.mock("../plugins/provider-discovery.js", () => ({
+vi.mock("../../plugins/provider-discovery.js", () => ({
   resolveRuntimePluginDiscoveryProviders: mocks.resolveRuntimePluginDiscoveryProviders,
   runProviderCatalog: mocks.runProviderCatalog,
   runProviderStaticCatalog: mocks.runProviderStaticCatalog,
@@ -31,7 +31,7 @@ vi.mock("../plugins/provider-discovery.js", () => ({
     result?: { providers?: Record<string, unknown> } | null;
   }) => result?.providers ?? {},
 }));
-import { resolveImplicitProviders } from "./models-config.providers.implicit.js";
+import { resolveImplicitProviders } from "../models-config.providers.implicit.js";
 
 function createProvider(id: string): ProviderPlugin {
   return { id, label: id, auth: [], catalog: { order: "simple", run: async () => null } };

--- a/src/agents/runtime-plan/model-fallback.own-env.test.ts
+++ b/src/agents/runtime-plan/model-fallback.own-env.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { Model } from "../../llm/types.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { ensureAuthProfileStore } from "../auth-profiles/store-runtime.js";
+import { runWithModelFallback } from "../model-fallback-runner.js";
+import { prepareAgentRuntimeAuth } from "./prepare-auth.js";
+import { resolvePreparedRuntimeModelAuth } from "./resolve-auth.js";
+
+const metadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "fixture-plugin",
+      providers: ["fixture-api", "fixture-plan"],
+      providerAuthAliases: { "fixture-plan": "fixture-api" },
+      setup: { providers: [{ id: "fixture-api", envVars: ["FIXTURE_API_KEY"] }] },
+    },
+  ],
+});
+const profileId = "fixture-api:revoked";
+afterEach(clearRuntimeConfigSnapshot);
+
+it.each([
+  "own-env",
+  "configured-env",
+  "prepared-env",
+  "unbound-env",
+  "missing-env",
+  "pin",
+  "config-order",
+  "store-order",
+  "shared-alias",
+] as const)(
+  "keeps model fallback aligned with usable account selection for %s",
+  async (selection) => {
+    await withOpenClawTestState(
+      {
+        layout: "home",
+        prefix: "fallback-own-env-",
+        env: {
+          FIXTURE_API_KEY: [
+            "missing-env",
+            "configured-env",
+            "prepared-env",
+            "unbound-env",
+          ].includes(selection)
+            ? undefined
+            : "environment-account",
+          EXPLICIT_AUTH_KEY: "configured-environment-account",
+        },
+      },
+      async (state) => {
+        const provider = selection === "shared-alias" ? "fixture-plan" : "fixture-api";
+        const cfg: OpenClawConfig = {
+          agents: { defaults: { model: `${provider}/test-model` }, entries: { main: {} } },
+          ...(selection === "config-order"
+            ? { auth: { order: { "fixture-api": [profileId] } } }
+            : {}),
+        };
+        if (selection === "configured-env" || selection === "prepared-env") {
+          cfg.models = {
+            providers: {
+              "fixture-api": {
+                baseUrl: "https://fixture.invalid/v1",
+                models: [],
+                apiKey: { source: "env", provider: "default", id: "EXPLICIT_AUTH_KEY" },
+              },
+            },
+          };
+        }
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: {
+            [profileId]: { type: "api_key", provider: "fixture-api", key: "revoked-account" },
+          },
+          usageStats: {
+            [profileId]: { disabledUntil: Date.now() + 600_000, disabledReason: "auth_permanent" },
+          },
+          ...(selection === "store-order" ? { order: { "fixture-api": [profileId] } } : {}),
+        });
+        await withPluginMetadataSnapshotScope(
+          metadataSnapshot,
+          async () => {
+            if (selection === "prepared-env") {
+              setRuntimeConfigSnapshot(
+                {
+                  ...cfg,
+                  models: {
+                    providers: {
+                      "fixture-api": {
+                        baseUrl: "https://fixture.invalid/v1",
+                        models: [],
+                        apiKey: "configured-environment-account",
+                      },
+                    },
+                  },
+                },
+                cfg,
+              );
+            }
+            const model: Model = {
+              provider,
+              id: "test-model",
+              name: "Fixture",
+              api: "openai-completions",
+              baseUrl: "https://fixture.invalid/v1",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 8192,
+              maxTokens: 1024,
+            };
+            const run = vi.fn(async () => {
+              const store = ensureAuthProfileStore(state.agentDir());
+              const prepared = prepareAgentRuntimeAuth({
+                provider,
+                modelId: model.id,
+                modelApi: model.api,
+                modelBaseUrl: model.baseUrl,
+                config: cfg,
+                env: process.env,
+                authProfileStore: store,
+                metadataSnapshot,
+              });
+              const resolved = await resolvePreparedRuntimeModelAuth({
+                plan: prepared.plan,
+                model,
+                cfg,
+                store,
+              });
+              return resolved.auth.apiKey;
+            });
+            const result = runWithModelFallback({
+              cfg,
+              provider,
+              model: model.id,
+              agentId: "main",
+              agentDir: state.agentDir(),
+              fallbacksOverride: [],
+              manifestPlugins: metadataSnapshot.manifestRegistry.plugins,
+              ...(selection === "pin" ? { userLockedAuthProfileId: profileId } : {}),
+              run,
+            });
+            if (
+              selection === "own-env" ||
+              selection === "configured-env" ||
+              selection === "prepared-env"
+            ) {
+              await expect(result).resolves.toMatchObject({
+                outcome: "completed",
+                result:
+                  selection !== "own-env"
+                    ? "configured-environment-account"
+                    : "environment-account",
+              });
+              expect(run).toHaveBeenCalledOnce();
+            } else {
+              await expect(result).rejects.toThrow("All models failed");
+              expect(run).not.toHaveBeenCalled();
+            }
+          },
+          { config: cfg, trustConfigIdentity: true },
+        );
+      },
+    );
+  },
+);

--- a/src/agents/runtime-plan/model-selection-admission.test.ts
+++ b/src/agents/runtime-plan/model-selection-admission.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { AgentModelConfig } from "../../config/types.agents-shared.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { registerResolvedAgentDir, unregisterResolvedAgentDir } from "../agent-dir-registry.js";
+import type { AuthProfileStore } from "../auth-profiles/types.js";
+import { createModelAuthAvailabilityResolver } from "../model-auth-availability.js";
+import { resolveCatalogProviderUseAdmission } from "../models-config.providers.catalog-context.js";
+import { createProviderApiKeyResolver } from "../models-config.providers.secrets.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const registered: { agentId: string; agentDir: string }[] = [];
+afterEach(() => {
+  for (const registration of registered.splice(0)) {
+    unregisterResolvedAgentDir(registration);
+  }
+});
+
+const metadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "byteplus",
+      providers: ["byteplus", "byteplus-plan"],
+      setup: { providers: [{ id: "byteplus", envVars: ["BYTEPLUS_API_KEY"] }] },
+      providerAuthAliases: { "byteplus-plan": "byteplus" },
+    },
+  ],
+});
+const authStore: AuthProfileStore = {
+  version: 1,
+  profiles: {
+    "byteplus:saved": { type: "api_key", provider: "byteplus", key: "saved-account" },
+  },
+};
+
+it.each(["utility", "child"] as const)(
+  "uses the saved family account in availability and catalog for a %s-only selection",
+  (selector) => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: "openai/primary",
+          ...(selector === "utility" ? { utilityModel: "plan" } : { subagents: { model: "plan" } }),
+          models: { "byteplus-plan/plan-model": { alias: "plan" } },
+        },
+        entries: {
+          inherited: {},
+          overridden:
+            selector === "utility"
+              ? { utilityModel: "openai/utility" }
+              : { subagents: { model: "openai/child" } },
+        },
+      },
+    };
+    for (const agentId of [undefined, "inherited", "overridden"]) {
+      const selected = agentId !== "overridden";
+      expect(
+        createModelAuthAvailabilityResolver({
+          cfg,
+          agentId,
+          authStore,
+          env: {},
+          metadataSnapshot,
+        }).resolveProviderAuthAvailability("byteplus-plan"),
+      ).toBe(selected);
+      const agentDir = tempDirs.make("selected-provider-catalog-");
+      if (agentId) {
+        const registration = { agentId, agentDir };
+        registerResolvedAgentDir(registration);
+        registered.push(registration);
+      }
+      const admission = resolveCatalogProviderUseAdmission({
+        config: cfg,
+        env: {},
+        agentDir,
+        profiles: authStore.profiles,
+        pluginMetadataSnapshot: metadataSnapshot,
+      });
+      expect(admission.get("byteplus-plan")).toEqual(
+        selected ? { kind: "profile", profileId: "byteplus:saved" } : undefined,
+      );
+      if (selected) {
+        expect(
+          createProviderApiKeyResolver(
+            {},
+            authStore,
+            cfg,
+            undefined,
+            undefined,
+            {},
+            admission,
+          )("byteplus-plan").discoveryApiKey,
+        ).toBe("saved-account");
+      }
+    }
+  },
+);
+
+it("does not select an unused alias or another agent's utility provider", () => {
+  const cfg: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: "openai/primary",
+        models: { "byteplus-plan/plan-model": { alias: "plan" } },
+      },
+      entries: { alpha: {}, beta: { utilityModel: "plan" } },
+    },
+  };
+  for (const agentId of [undefined, "alpha", "beta"]) {
+    expect(
+      createModelAuthAvailabilityResolver({
+        cfg,
+        agentId,
+        authStore,
+        env: {},
+        metadataSnapshot,
+      }).resolveProviderAuthAvailability("byteplus-plan"),
+    ).toBe(agentId === "beta");
+  }
+});
+
+it.each(["main", "child"] as const)(
+  "does not admit displaced global %s fallbacks after an agent selects its own primary",
+  (selector) => {
+    const defaults = { primary: "openai/default", fallbacks: ["byteplus-plan/plan-model"] };
+    const localModels: Record<string, AgentModelConfig | undefined> = {
+      string: "openai/local",
+      object: { primary: "openai/local" },
+      empty: { fallbacks: [] },
+      inherited: undefined,
+    };
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: selector === "main" ? { model: defaults } : { subagents: { model: defaults } },
+        entries: Object.fromEntries(
+          Object.entries(localModels).map(([id, model]) => [
+            id,
+            selector === "main" ? { model } : { subagents: { model } },
+          ]),
+        ),
+      },
+    };
+    for (const agentId of [undefined, "string", " STRING ", "object", "empty", "inherited"]) {
+      expect(
+        createModelAuthAvailabilityResolver({
+          cfg,
+          agentId,
+          authStore,
+          env: {},
+          metadataSnapshot,
+        }).resolveProviderAuthAvailability("byteplus-plan"),
+      ).toBe(agentId === undefined || agentId === "inherited");
+    }
+  },
+);
+
+it("uses an agent's summary model instead of the global summary provider", () => {
+  const cfg: OpenClawConfig = {
+    tts: { summaryModel: "byteplus-plan/plan-model" },
+    agents: {
+      entries: { inherited: {}, overridden: { tts: { summaryModel: "openai/local-summary" } } },
+    },
+  };
+  for (const agentId of [undefined, "inherited", "overridden"]) {
+    expect(
+      createModelAuthAvailabilityResolver({
+        cfg,
+        agentId,
+        authStore,
+        env: {},
+        metadataSnapshot,
+      }).resolveProviderAuthAvailability("byteplus-plan"),
+    ).toBe(agentId !== "overridden");
+  }
+});

--- a/src/agents/runtime-plan/prepare-auth.environment-source.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.environment-source.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { Model } from "../../llm/types.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import type { AuthProfileStore } from "../auth-profiles/types.js";
+import { prepareAgentRuntimeAuth } from "./prepare-auth.js";
+import {
+  resolvePreparedRuntimeAuthAttempts,
+  resolvePreparedRuntimeModelAuth,
+} from "./resolve-auth.js";
+
+const model: Model = {
+  id: "gpt-5.4",
+  name: "Platform model",
+  provider: "openai",
+  api: "openai-responses",
+  baseUrl: "https://api.openai.com/v1",
+  input: ["text"],
+  reasoning: true,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 8_000,
+};
+
+const metadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "openai",
+      providers: ["openai"],
+      setup: {
+        requiresRuntime: false,
+        providers: [{ id: "openai", envVars: ["OPENAI_API_KEY"] }],
+      },
+    },
+  ],
+});
+
+describe("prepared environment credential identity", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each(["unchanged", "withdrawn", "rotated"] as const)(
+    "keeps resolution on the admitted variable when it is %s during model materialization",
+    async (change) => {
+      vi.stubEnv("OPENAI_API_KEY", "admitted-account-key");
+      vi.stubEnv("CODEX_API_KEY", "other-account-key");
+      const config: OpenClawConfig = {};
+      const store: AuthProfileStore = { version: 1, profiles: {} };
+
+      await withPluginMetadataSnapshotScope(
+        metadataSnapshot,
+        async () => {
+          const prepared = prepareAgentRuntimeAuth({
+            provider: model.provider,
+            modelId: model.id,
+            modelApi: model.api,
+            modelBaseUrl: model.baseUrl,
+            config,
+            env: process.env,
+            authProfileStore: store,
+            metadataSnapshot,
+            harnessId: "openclaw",
+          });
+          const resolution = resolvePreparedRuntimeAuthAttempts({
+            attempts: prepared.attempts,
+            store,
+            modelId: model.id,
+            model,
+            materializeModel: async ({ model: preparedModel }) => {
+              if (change !== "unchanged") {
+                vi.stubEnv(
+                  "OPENAI_API_KEY",
+                  change === "withdrawn" ? undefined : "rotated-admitted-key",
+                );
+              }
+              return preparedModel;
+            },
+            resolveAuth: ({ attempt, model: preparedModel }) =>
+              resolvePreparedRuntimeModelAuth({
+                plan: attempt.plan,
+                model: preparedModel,
+                cfg: config,
+                store,
+              }),
+            errorMessage: "Prepared environment credential could not be resolved.",
+          });
+
+          if (change === "withdrawn") {
+            await expect(resolution).rejects.toMatchObject({
+              code: "missing-provider-auth",
+              provider: "openai",
+            });
+          } else {
+            await expect(resolution).resolves.toMatchObject({
+              auth: {
+                apiKey: change === "rotated" ? "rotated-admitted-key" : "admitted-account-key",
+                source: "env: OPENAI_API_KEY",
+              },
+            });
+          }
+        },
+        { config, trustConfigIdentity: true },
+      );
+    },
+  );
+});

--- a/src/agents/runtime-plan/prepare-auth.environment-source.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.environment-source.test.ts
@@ -4,6 +4,10 @@ import type { Model } from "../../llm/types.js";
 import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
+import {
+  createEmbeddedRunAuthController,
+  type EmbeddedRunAuthState,
+} from "../embedded-agent-runner/run/auth-controller.js";
 import { prepareAgentRuntimeAuth } from "./prepare-auth.js";
 import {
   resolvePreparedRuntimeAuthAttempts,
@@ -39,9 +43,13 @@ const metadataSnapshot = createPluginMetadataSnapshotFixture({
 describe("prepared environment credential identity", () => {
   afterEach(() => vi.unstubAllEnvs());
 
-  it.each(["unchanged", "withdrawn", "rotated"] as const)(
-    "keeps resolution on the admitted variable when it is %s during model materialization",
-    async (change) => {
+  it.each(
+    (["prepared-resolver", "ordinary-controller"] as const).flatMap((consumer) =>
+      (["unchanged", "withdrawn", "rotated"] as const).map((change) => ({ consumer, change })),
+    ),
+  )(
+    "$consumer keeps the admitted variable when it is $change during model materialization",
+    async ({ consumer, change }) => {
       vi.stubEnv("OPENAI_API_KEY", "admitted-account-key");
       vi.stubEnv("CODEX_API_KEY", "other-account-key");
       const config: OpenClawConfig = {};
@@ -61,29 +69,69 @@ describe("prepared environment credential identity", () => {
             metadataSnapshot,
             harnessId: "openclaw",
           });
-          const resolution = resolvePreparedRuntimeAuthAttempts({
-            attempts: prepared.attempts,
-            store,
-            modelId: model.id,
-            model,
-            materializeModel: async ({ model: preparedModel }) => {
-              if (change !== "unchanged") {
-                vi.stubEnv(
-                  "OPENAI_API_KEY",
-                  change === "withdrawn" ? undefined : "rotated-admitted-key",
-                );
-              }
-              return preparedModel;
-            },
-            resolveAuth: ({ attempt, model: preparedModel }) =>
-              resolvePreparedRuntimeModelAuth({
-                plan: attempt.plan,
-                model: preparedModel,
-                cfg: config,
-                store,
+          const materializeModel = async () => {
+            if (change !== "unchanged") {
+              vi.stubEnv(
+                "OPENAI_API_KEY",
+                change === "withdrawn" ? undefined : "rotated-admitted-key",
+              );
+            }
+            return model;
+          };
+          const resolveOrdinaryController = async () => {
+            const runtimeModel = await materializeModel();
+            const state: EmbeddedRunAuthState = {
+              models: { runtime: runtimeModel, effective: runtimeModel },
+              apiKeyInfo: null,
+              lastProfileId: undefined,
+              runtimeAuthState: null,
+              runtimeAuthRefreshCancelled: false,
+              profileIndex: 0,
+              thinkLevel: "off",
+            };
+            const controller = createEmbeddedRunAuthController({
+              config,
+              agentDir: "/unused/agent",
+              workspaceDir: "/unused/workspace",
+              authStore: store,
+              authStorage: { setRuntimeApiKey: vi.fn() },
+              profileCandidates: [undefined],
+              initialThinkLevel: "off",
+              attemptedThinking: new Set(),
+              fallbackConfigured: false,
+              allowTransientCooldownProbe: false,
+              provider: model.provider,
+              modelId: model.id,
+              state,
+              prepareModelForAuthProfile: async () => ({
+                runtimeModel,
+                boundEnvVar: prepared.plan.boundEnvVar,
+                allowAuthProfileFallback: false,
+                commit() {},
               }),
-            errorMessage: "Prepared environment credential could not be resolved.",
-          });
+              log: { debug() {}, info() {}, warn() {} },
+            });
+            await controller.initializeAuthProfile();
+            return { auth: state.apiKeyInfo };
+          };
+          const resolution =
+            consumer === "ordinary-controller"
+              ? resolveOrdinaryController()
+              : resolvePreparedRuntimeAuthAttempts({
+                  attempts: prepared.attempts,
+                  store,
+                  modelId: model.id,
+                  model,
+                  materializeModel,
+                  resolveAuth: ({ attempt, model: preparedModel }) =>
+                    resolvePreparedRuntimeModelAuth({
+                      plan: attempt.plan,
+                      model: preparedModel,
+                      cfg: config,
+                      store,
+                    }),
+                  errorMessage: "Prepared environment credential could not be resolved.",
+                });
 
           if (change === "withdrawn") {
             await expect(resolution).rejects.toMatchObject({

--- a/src/agents/runtime-plan/prepare-auth.metadata.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.metadata.test.ts
@@ -25,7 +25,7 @@ describe("prepared auth metadata ownership", () => {
           },
         ],
       });
-    const config = {};
+    const config = { models: { providers: { "fixture-provider": { baseUrl: "", models: [] } } } };
     const prepared = withPluginMetadataSnapshotScope(
       snapshot("AMBIENT_PROVIDER_KEY"),
       () =>
@@ -64,7 +64,7 @@ describe("prepared auth metadata ownership", () => {
                 },
               },
             }
-          : {};
+          : { models: { providers: { "fixture-alias": { baseUrl: "", models: [] } } } };
       const prepare = () =>
         prepareAgentRuntimeAuth({
           provider: "fixture-alias",

--- a/src/agents/runtime-plan/prepare-auth.own-env-fallback.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.own-env-fallback.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { Model } from "../../llm/types.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { withSetupCredentialAccess } from "../auth-profiles/setup-access.js";
+import type { AuthProfileStore } from "../auth-profiles/types.js";
+import { createModelAuthAvailabilityResolver } from "../model-auth-availability.js";
+import { prepareAgentRuntimeAuth } from "./prepare-auth.js";
+import {
+  resolvePreparedRuntimeAuthAttempts,
+  resolvePreparedRuntimeModelAuth,
+} from "./resolve-auth.js";
+
+const metadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "fixture-plugin",
+      providers: ["fixture-api", "fixture-plan"],
+      providerAuthAliases: { "fixture-plan": "fixture-api" },
+      setup: {
+        requiresRuntime: false,
+        providers: [{ id: "fixture-api", envVars: ["FIXTURE_API_KEY"] }],
+      },
+    },
+  ],
+});
+const model: Model = {
+  provider: "fixture-api",
+  id: "chat",
+  name: "Chat",
+  api: "openai-completions",
+  baseUrl: "https://fixture.invalid/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 8192,
+  maxTokens: 1024,
+};
+const profileId = "fixture-api:saved";
+
+function account(state: "healthy" | "expired" | "revoked"): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      [profileId]: {
+        type: "token",
+        provider: model.provider,
+        token: "saved-account",
+        expires: state === "expired" ? 1 : Date.now() + 60_000,
+      },
+    },
+    ...(state === "revoked"
+      ? {
+          usageStats: {
+            [profileId]: {
+              disabledUntil: Date.now() + 60_000,
+              disabledReason: "auth_permanent" as const,
+            },
+          },
+        }
+      : {}),
+  };
+}
+
+describe("independently admitted provider environment fallback", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each(["healthy", "expired", "revoked"] as const)(
+    "resolves the usable source and reports readiness for a %s saved account",
+    async (state) => {
+      vi.stubEnv("FIXTURE_API_KEY", "environment-account");
+      const config: OpenClawConfig = {};
+      const store = account(state);
+      await withPluginMetadataSnapshotScope(
+        metadataSnapshot,
+        async () => {
+          const prepared = prepareAgentRuntimeAuth({
+            provider: model.provider,
+            modelId: model.id,
+            modelApi: model.api,
+            modelBaseUrl: model.baseUrl,
+            config,
+            env: process.env,
+            authProfileStore: store,
+            metadataSnapshot,
+            harnessId: "openclaw",
+          });
+          const resolved = await resolvePreparedRuntimeAuthAttempts({
+            attempts: prepared.attempts,
+            store,
+            modelId: model.id,
+            model,
+            materializeModel: async ({ model: selected }) => selected,
+            resolveAuth: ({ attempt, model: selected }) =>
+              resolvePreparedRuntimeModelAuth({
+                plan: attempt.plan,
+                model: selected,
+                cfg: config,
+                store,
+              }),
+            errorMessage: "No usable account",
+          });
+          expect(resolved.auth.apiKey).toBe(
+            state === "healthy" ? "saved-account" : "environment-account",
+          );
+          const readiness = createModelAuthAvailabilityResolver({
+            cfg: config,
+            authStore: store,
+            metadataSnapshot,
+            env: process.env,
+          }).evaluateModelAuth(model.provider, { modelId: model.id });
+          expect(readiness).toMatchObject({
+            availability: true,
+            evidence: state === "healthy" ? "profile" : "environment",
+          });
+          if (state !== "healthy") {
+            expect(readiness.environmentVariable).toBe("FIXTURE_API_KEY");
+          }
+        },
+        { config, trustConfigIdentity: true },
+      );
+    },
+  );
+
+  it("does not verify an unavailable setup replacement through the current environment account", async () => {
+    const config: OpenClawConfig = {};
+    const env = { FIXTURE_API_KEY: "environment-account" };
+    const store = account("expired");
+    store.profiles[profileId].setup = {
+      replacement: true,
+      modelRef: `${model.provider}/${model.id}`,
+      configJson: "{}",
+    };
+    const prepare = () =>
+      prepareAgentRuntimeAuth({
+        provider: model.provider,
+        modelId: model.id,
+        config,
+        env,
+        authProfileStore: store,
+        metadataSnapshot,
+      });
+    const available = () =>
+      createModelAuthAvailabilityResolver({
+        cfg: config,
+        env,
+        authStore: store,
+        metadataSnapshot,
+      }).resolveProviderAuthAvailability(model.provider);
+
+    expect(prepare().attempts).toMatchObject([{ kind: "direct" }]);
+    expect(available()).toBe(true);
+    await withSetupCredentialAccess({ profileId }, async () => {
+      expect(prepare).toThrow("No usable bound auth profile");
+      expect(available()).toBe(false);
+    });
+    expect(prepare().attempts).toMatchObject([{ kind: "direct" }]);
+    expect(available()).toBe(true);
+  });
+
+  it.each(["user", "user-link"] as const)(
+    "keeps a healthy %s pin on saved accounts when an own environment key exists",
+    async (sessionAuthProfileSource) => {
+      vi.stubEnv("FIXTURE_API_KEY", "environment-account");
+      const config: OpenClawConfig = {};
+      const store = account("healthy");
+      const backupProfileId = "fixture-api:backup";
+      store.profiles[backupProfileId] = {
+        type: "token",
+        provider: model.provider,
+        token: "backup-account",
+        expires: Date.now() + 60_000,
+      };
+      await withPluginMetadataSnapshotScope(
+        metadataSnapshot,
+        async () => {
+          const prepared = prepareAgentRuntimeAuth({
+            provider: model.provider,
+            modelId: model.id,
+            modelApi: model.api,
+            modelBaseUrl: model.baseUrl,
+            config,
+            env: process.env,
+            authProfileStore: store,
+            metadataSnapshot,
+            sessionAuthProfileId: profileId,
+            sessionAuthProfileSource,
+          });
+          expect(prepared.attempts).toHaveLength(2);
+          expect(prepared.attempts).toMatchObject([
+            { kind: "profile", profileId },
+            { kind: "profile", profileId: backupProfileId },
+          ]);
+          vi.stubEnv("FIXTURE_API_KEY", undefined);
+          for (const [index, attempt] of prepared.attempts.entries()) {
+            expect(attempt.plan.boundEnvVar).toBeUndefined();
+            const resolved = await resolvePreparedRuntimeModelAuth({
+              plan: attempt.plan,
+              model,
+              cfg: config,
+              store,
+            });
+            expect(resolved.auth.apiKey).toBe(index === 0 ? "saved-account" : "backup-account");
+          }
+        },
+        { config, trustConfigIdentity: true },
+      );
+    },
+  );
+
+  it.each(["pin", "order", "shared-alias"] as const)(
+    "does not use the environment key to bypass %s selection",
+    (selection) => {
+      vi.stubEnv("FIXTURE_API_KEY", "environment-account");
+      const config: OpenClawConfig =
+        selection === "order" ? { auth: { order: { "fixture-api": [profileId] } } } : {};
+      const provider = selection === "shared-alias" ? "fixture-plan" : model.provider;
+      expect(() =>
+        prepareAgentRuntimeAuth({
+          provider,
+          modelId: model.id,
+          config,
+          env: process.env,
+          authProfileStore: account("expired"),
+          metadataSnapshot,
+          ...(selection === "pin"
+            ? { sessionAuthProfileId: profileId, sessionAuthProfileSource: "user" }
+            : {}),
+        }),
+      ).toThrow();
+      expect(
+        createModelAuthAvailabilityResolver({
+          cfg: config,
+          authStore: account("expired"),
+          metadataSnapshot,
+          env: process.env,
+          requestedProviderIds: [provider],
+        }).resolveProviderAuthAvailability(
+          provider,
+          selection === "pin" ? { pinnedProfileId: profileId } : {},
+        ),
+      ).toBe(false);
+    },
+  );
+});

--- a/src/agents/runtime-plan/prepare-auth.setup-provider.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.setup-provider.test.ts
@@ -39,6 +39,7 @@ describe("prepared setup-provider auth fallback", () => {
     const profileId = "anthropic-vertex:missing";
     const config = {
       auth: { order: { "anthropic-vertex": [profileId] } },
+      models: { providers: { "anthropic-vertex": {} } },
     } as OpenClawConfig;
     const store = {
       version: 1,

--- a/src/agents/runtime-plan/prepare-auth.setup-provider.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.setup-provider.test.ts
@@ -39,7 +39,7 @@ describe("prepared setup-provider auth fallback", () => {
     const profileId = "anthropic-vertex:missing";
     const config = {
       auth: { order: { "anthropic-vertex": [profileId] } },
-      models: { providers: { "anthropic-vertex": {} } },
+      models: { providers: { "anthropic-vertex": { baseUrl: "", models: [] } } },
     } as OpenClawConfig;
     const store = {
       version: 1,

--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -1479,12 +1479,15 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         plugins: [
           {
             id: "fixture",
+            providers: ["openai"],
             setup: {
-              providers: [
-                { id: "openai", envVars: ["SHARED_OAUTH_TOKEN", "OPENAI_API_KEY"] },
-                { id: "other", envVars: ["SHARED_OAUTH_TOKEN"] },
-              ],
+              providers: [{ id: "openai", envVars: ["SHARED_OAUTH_TOKEN", "OPENAI_API_KEY"] }],
             },
+          },
+          {
+            id: "other-plugin",
+            providers: ["other"],
+            setup: { providers: [{ id: "other", envVars: ["SHARED_OAUTH_TOKEN"] }] },
           },
         ],
       }),

--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -169,6 +169,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
     const plan = prepareAgentRuntimeAuthPlan({
       provider: "legacy-provider",
       modelId: "model",
+      config: providerConfig("legacy-provider", {}),
       env: {},
       authProfileStore: authStore({}),
       metadataSnapshot: createPluginMetadataSnapshotFixture({
@@ -190,6 +191,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       provider: "openai",
       modelId: "gpt-5.4-nano",
       env: {},
+      harnessAuthBootstrap: "harness",
       harnessId: "codex",
       harnessRuntime: "codex",
       authProfileStore: authStore({}),
@@ -1468,25 +1470,68 @@ describe("prepareAgentRuntimeAuthPlan", () => {
     ).toBe(true);
   });
 
-  // Zero-config still works: when a provider has no usable auth profile at all,
-  // a bare `PROVIDER_API_KEY` remains the credential for the route. Refusing an
-  // undeclared credential is about not letting it silently *succeed a declared
-  // profile*, not about banning the documented zero-config path.
-  it("still uses an undeclared env key when the provider has no usable profile", () => {
+  it("uses the uniquely bound env key before shared credential candidates", () => {
     const prepared = prepareAgentRuntimeAuth({
       provider: "openai",
       modelId: "gpt-5.5",
-      env: { OPENAI_API_KEY: "ambient-platform-key" },
+      env: { OPENAI_API_KEY: "ambient-platform-key", SHARED_OAUTH_TOKEN: "shared-token" },
+      metadataSnapshot: createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "fixture",
+            setup: {
+              providers: [
+                { id: "openai", envVars: ["SHARED_OAUTH_TOKEN", "OPENAI_API_KEY"] },
+                { id: "other", envVars: ["SHARED_OAUTH_TOKEN"] },
+              ],
+            },
+          },
+        ],
+      }),
       authProfileStore: authStore({}),
     });
 
     expect(prepared.attempts).toMatchObject([{ kind: "direct" }]);
+    expect(prepared.plan.selectedAuthMode).toBe("api-key");
     expect(prepared.attempts.some((attempt) => attempt.kind === "profile")).toBe(false);
     expect(prepared.plan.credentialSource).toEqual({
       kind: "direct",
       evidence: "environment",
       authorization: "ambient",
     });
+  });
+
+  it.each([
+    ["github-copilot", "GH_TOKEN", []],
+    ["meta", "MODEL_API_KEY", []],
+    ["google-vertex", "GOOGLE_APPLICATION_CREDENTIALS", []],
+    ["opencode-go", "OPENCODE_API_KEY", ["OPENCODE_API_KEY"]],
+  ] as const)("rejects unconfigured %s despite %s", (provider, envVar, sharedEnvVars) => {
+    expect(() =>
+      prepareAgentRuntimeAuth({
+        provider,
+        modelId: "fixture-model",
+        modelBaseUrl: "https://models.example/v1",
+        env: { [envVar]: "synthetic-key" },
+        authProfileStore: authStore({ "other:account": apiKeyProfile("other", "stored-key") }),
+        metadataSnapshot: createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: "fixture",
+              providerAuthAliases: {
+                [provider]: { provider: "other", baseUrls: ["https://models.example/v1"] },
+              },
+              setup: {
+                providers: [
+                  { id: provider, envVars: [envVar] },
+                  { id: "other", envVars: [...sharedEnvVars] },
+                ],
+              },
+            },
+          ],
+        }),
+      }),
+    ).toThrow(/not configured for model use/u);
   });
 
   // Declared apiKey material keeps normal direct-source standing, so the
@@ -2075,6 +2120,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
     const plan = prepareAgentRuntimeAuthPlan({
       provider: "anthropic",
       modelId: "claude-sonnet-4-6",
+      config: providerConfig("anthropic", {}),
       env: {},
       authProfileStore: authStore({}),
     });

--- a/src/agents/runtime-plan/prepare-auth.ts
+++ b/src/agents/runtime-plan/prepare-auth.ts
@@ -1,12 +1,14 @@
 /**
- * Prepares route-aware auth forwarding for auxiliary agent-runtime calls.
+ * Prepares route-aware auth forwarding for agent-runtime calls.
  * Callers supply an already loaded credential snapshot; this module never
  * resolves secrets or loads a provider runtime.
  */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveMergedModelProviderConfig } from "../../config/model-provider-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRouteOverridePresence } from "../../plugin-sdk/provider-model-types.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { resolveProviderBindingEnvVarCandidates } from "../../secrets/provider-env-vars.js";
 import { isPendingOAuthRefreshFence } from "../auth-profiles/oauth-refresh-marker.js";
 import {
   prependAuthProfilePin,
@@ -20,6 +22,7 @@ import { isProfileInCooldown } from "../auth-profiles/usage-state.js";
 import { resolveProviderDirectAuthPlanningEvidence } from "../model-auth-env.js";
 import { resolveProviderConfigSecretInput } from "../model-auth-provider-config.js";
 import { resolveModelProviderAuthConfig } from "../model-auth-provider-route.js";
+import { ProviderAuthError } from "../model-auth-runtime-shared.js";
 import {
   hasUsableCustomProviderApiKey,
   resolveProviderEntryApiKeyProfileReference,
@@ -30,6 +33,7 @@ import {
   buildProviderModelAuthDirectSource,
   buildProviderModelAuthSourcePlan,
   classifyProviderModelAuthSource,
+  resolveProviderUseAdmission,
   type ProviderModelAuthDirectSource,
   type ProviderModelAuthProfileSource,
 } from "../provider-model-auth-source-plan.js";
@@ -214,6 +218,13 @@ function resolvePreparedProviderEntryApiKeyProfileReference(
 export function prepareAgentRuntimeAuth(
   input: PrepareAgentRuntimeAuthPlanParams,
 ): PreparedAgentRuntimeAuth {
+  // Route projection may add a provider entry; only authored config grants use.
+  const providerUseAdmission = resolveProviderUseAdmission({
+    config: input.config,
+    env: input.env,
+    providerEnvVars: resolveProviderBindingEnvVarCandidates(input),
+    profiles: input.authProfileStore?.profiles,
+  });
   const params = { ...input, config: resolveModelProviderAuthConfig(input) };
   const requestedProfileId = params.sessionAuthProfileId?.trim() || undefined;
   const userPinnedProfileId =
@@ -236,6 +247,9 @@ export function prepareAgentRuntimeAuth(
   }
   const store = params.authProfileStore;
   const authProfileSelectionProvider = harnessOwnsOpenAIAuth ? "openai" : params.provider;
+  const providerUseBinding =
+    providerUseAdmission.get(normalizeProviderId(input.provider)) ??
+    (harnessOwnsOpenAIAuth ? providerUseAdmission.get("openai") : undefined);
   if (userPinnedProfileId) {
     const eligibility = store
       ? resolveAuthProfileEligibility({
@@ -262,6 +276,14 @@ export function prepareAgentRuntimeAuth(
         `Auth profile "${userPinnedProfileId}" is not configured for ${authProfileSelectionProvider}.`,
       );
     }
+  }
+
+  if (!providerUseBinding && !runtimeAuthOwner) {
+    throw new ProviderAuthError(
+      "missing-provider-auth",
+      params.provider,
+      `Provider "${params.provider}" is not configured for model use. Add a provider entry or authenticate this provider.`,
+    );
   }
 
   const configuredProvider = resolveMergedModelProviderConfig(params.config, params.provider);
@@ -329,7 +351,16 @@ export function prepareAgentRuntimeAuth(
           includePendingOAuthRefresh: true,
         });
   const automaticOrderResolution = prependAuthProfilePin(
-    resolvedAutomaticOrder,
+    providerUseBinding?.kind === "profile"
+      ? {
+          ...resolvedAutomaticOrder,
+          profileIds: resolvedAutomaticOrder.profileIds.filter(
+            (id) =>
+              normalizeProviderId(store?.profiles[id]?.provider ?? "") ===
+              normalizeProviderId(authProfileSelectionProvider),
+          ),
+        }
+      : resolvedAutomaticOrder,
     userPinnedProfileId,
   );
   const providerPreferredProfileId =
@@ -372,17 +403,32 @@ export function prepareAgentRuntimeAuth(
     availability?: boolean,
     authorization: ProviderModelAuthDirectSource["authorization"] = "declared",
   ) => buildProviderModelAuthDirectSource({ mode, evidence, availability, authorization });
-  const directPlanningCandidate = harnessAllowsAuthProfileForwarding
-    ? resolveProviderDirectAuthPlanningEvidence(
-        authProfileSelectionProvider,
-        params.env ?? process.env,
-        {
-          config: params.config,
-          workspaceDir: params.workspaceDir,
-          metadataSnapshot: params.metadataSnapshot,
-        },
-      )
-    : null;
+  const directPlanningCandidate =
+    harnessAllowsAuthProfileForwarding &&
+    providerUseBinding &&
+    providerUseBinding.kind !== "profile"
+      ? resolveProviderDirectAuthPlanningEvidence(
+          authProfileSelectionProvider,
+          params.env ?? process.env,
+          {
+            config: params.config,
+            workspaceDir: params.workspaceDir,
+            metadataSnapshot: params.metadataSnapshot,
+            ...(providerUseBinding.kind === "environment"
+              ? {
+                  aliasMap: {},
+                  candidateMap: {
+                    [normalizeProviderId(authProfileSelectionProvider)]: [
+                      providerUseBinding.envVar,
+                    ],
+                  },
+                  authEvidenceMap: {},
+                  setupProviderFallbackRefs: [],
+                }
+              : {}),
+          },
+        )
+      : null;
   // OpenAI native account discovery is harness-owned synthetic auth, not a
   // bearer credential for an OpenClaw request route.
   const directPlanningEvidence =
@@ -443,6 +489,18 @@ export function prepareAgentRuntimeAuth(
     ...(fallbackDirectSource ? { fallback: fallbackDirectSource } : {}),
     allowCooldown: params.allowTransientCooldownProbe,
   });
+  if (
+    providerUseBinding?.kind === "profile" &&
+    sourcePlan.kind === "automatic" &&
+    !sourcePlan.profiles.explicitOrder &&
+    (sourcePlan.profiles.kind === "empty" || sourcePlan.profiles.kind === "all-unavailable")
+  ) {
+    throw new ProviderAuthError(
+      "missing-provider-auth",
+      params.provider,
+      `No usable bound auth profile for ${params.provider}. Authenticate this provider again.`,
+    );
+  }
   const resolution = resolveOpenAIModelRoutes({
     provider: params.provider,
     modelId: params.modelId,

--- a/src/agents/runtime-plan/prepare-auth.ts
+++ b/src/agents/runtime-plan/prepare-auth.ts
@@ -253,6 +253,8 @@ export function prepareAgentRuntimeAuth(
   const providerUseBinding =
     providerUseAdmission.get(normalizeProviderId(input.provider)) ??
     (harnessOwnsOpenAIAuth ? providerUseAdmission.get("openai") : undefined);
+  const boundEnvVar =
+    providerUseBinding?.kind === "environment" ? providerUseBinding.envVar : undefined;
   if (userPinnedProfileId) {
     const eligibility = store
       ? resolveAuthProfileEligibility({
@@ -539,6 +541,7 @@ export function prepareAgentRuntimeAuth(
       return buildAgentRuntimeAuthPlan({
         provider: params.provider,
         modelId: params.modelId,
+        boundEnvVar,
         authProfileProvider: profile?.provider,
         authProfileMode:
           profile?.mode ??
@@ -617,6 +620,7 @@ export function prepareAgentRuntimeAuth(
     const plan = buildAgentRuntimeAuthPlan({
       provider: params.provider,
       modelId: params.modelId,
+      boundEnvVar,
       config: params.config,
       env: params.env,
       workspaceDir: params.workspaceDir,
@@ -646,6 +650,7 @@ export function prepareAgentRuntimeAuth(
     return buildAgentRuntimeAuthPlan({
       provider: params.provider,
       modelId: params.modelId,
+      boundEnvVar,
       authProfileProvider: profile?.provider,
       authProfileMode:
         profile?.mode ??

--- a/src/agents/runtime-plan/prepare-auth.ts
+++ b/src/agents/runtime-plan/prepare-auth.ts
@@ -17,6 +17,7 @@ import {
 } from "../auth-profiles/order.js";
 import { resolveStoredCredentialReadOnlyAvailability } from "../auth-profiles/read-only-availability.js";
 import { createSelectedAuthProfileUnavailableError } from "../auth-profiles/selection-error.js";
+import { isSetupCredentialAccessActive } from "../auth-profiles/setup-access.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { isProfileInCooldown } from "../auth-profiles/usage-state.js";
 import { resolveProviderDirectAuthPlanningEvidence } from "../model-auth-env.js";
@@ -34,6 +35,7 @@ import {
   buildProviderModelAuthDirectSource,
   buildProviderModelAuthSourcePlan,
   classifyProviderModelAuthSource,
+  resolveProviderEnvironmentAdmission,
   resolveProviderUseAdmission,
   type ProviderModelAuthDirectSource,
   type ProviderModelAuthProfileSource,
@@ -220,11 +222,12 @@ export function prepareAgentRuntimeAuth(
   input: PrepareAgentRuntimeAuthPlanParams,
 ): PreparedAgentRuntimeAuth {
   const params = { ...input, config: resolveModelProviderAuthConfig(input) };
+  const providerEnvVars = resolveProviderBindingEnvVarCandidates(input);
   // Route projection may add a provider entry; only authored config grants use.
   const providerUseAdmission = resolveProviderUseAdmission({
     config: input.config,
     env: input.env,
-    providerEnvVars: resolveProviderBindingEnvVarCandidates(input),
+    providerEnvVars,
     profiles: input.authProfileStore?.profiles,
     requestedProviders: [input.provider],
     storedCredentialAuthAliases: resolveProviderAuthAliasMap({ ...params, storedCredential: true }),
@@ -253,8 +256,12 @@ export function prepareAgentRuntimeAuth(
   const providerUseBinding =
     providerUseAdmission.get(normalizeProviderId(input.provider)) ??
     (harnessOwnsOpenAIAuth ? providerUseAdmission.get("openai") : undefined);
-  const boundEnvVar =
-    providerUseBinding?.kind === "environment" ? providerUseBinding.envVar : undefined;
+  const environmentBinding = resolveProviderEnvironmentAdmission({
+    env: input.env,
+    providerEnvVars,
+  }).bindings.get(normalizeProviderId(authProfileSelectionProvider));
+  const directUseBinding =
+    providerUseBinding?.kind === "profile" ? environmentBinding : providerUseBinding;
   if (userPinnedProfileId) {
     const eligibility = store
       ? resolveAuthProfileEligibility({
@@ -409,11 +416,17 @@ export function prepareAgentRuntimeAuth(
         : "provider-config",
     availability?: boolean,
     authorization: ProviderModelAuthDirectSource["authorization"] = "declared",
-  ) => buildProviderModelAuthDirectSource({ mode, evidence, availability, authorization });
+    boundEnvVar?: string,
+  ) =>
+    buildProviderModelAuthDirectSource({
+      mode,
+      evidence,
+      availability,
+      authorization,
+      boundEnvVar,
+    });
   const directPlanningCandidate =
-    harnessAllowsAuthProfileForwarding &&
-    providerUseBinding &&
-    providerUseBinding.kind !== "profile"
+    harnessAllowsAuthProfileForwarding && directUseBinding
       ? resolveProviderDirectAuthPlanningEvidence(
           authProfileSelectionProvider,
           params.env ?? process.env,
@@ -421,13 +434,11 @@ export function prepareAgentRuntimeAuth(
             config: params.config,
             workspaceDir: params.workspaceDir,
             metadataSnapshot: params.metadataSnapshot,
-            ...(providerUseBinding.kind === "environment"
+            ...(directUseBinding.kind === "environment"
               ? {
                   aliasMap: {},
                   candidateMap: {
-                    [normalizeProviderId(authProfileSelectionProvider)]: [
-                      providerUseBinding.envVar,
-                    ],
+                    [normalizeProviderId(authProfileSelectionProvider)]: [directUseBinding.envVar],
                   },
                   authEvidenceMap: {},
                   setupProviderFallbackRefs: [],
@@ -459,6 +470,9 @@ export function prepareAgentRuntimeAuth(
         directPlanningEvidence?.kind === "environment" ? "environment" : "runtime",
         directPlanningEvidence?.kind === "environment" ? true : undefined,
         fallbackIsAmbientCredential ? "ambient" : "declared",
+        fallbackIsAmbientCredential && !userPinnedProfileId && !isSetupCredentialAccessActive()
+          ? environmentBinding?.envVar
+          : undefined,
       )
     : providerBindingNeedsNonProfileFallback
       ? directSource(selectedConfiguredAuthMode)
@@ -500,6 +514,7 @@ export function prepareAgentRuntimeAuth(
     providerUseBinding?.kind === "profile" &&
     sourcePlan.kind === "automatic" &&
     !sourcePlan.profiles.explicitOrder &&
+    !sourcePlan.fallback?.boundEnvVar &&
     (sourcePlan.profiles.kind === "empty" || sourcePlan.profiles.kind === "all-unavailable")
   ) {
     throw new ProviderAuthError(
@@ -541,7 +556,7 @@ export function prepareAgentRuntimeAuth(
       return buildAgentRuntimeAuthPlan({
         provider: params.provider,
         modelId: params.modelId,
-        boundEnvVar,
+        boundEnvVar: attempt?.kind === "direct" ? attempt.source.boundEnvVar : undefined,
         authProfileProvider: profile?.provider,
         authProfileMode:
           profile?.mode ??
@@ -620,7 +635,8 @@ export function prepareAgentRuntimeAuth(
     const plan = buildAgentRuntimeAuthPlan({
       provider: params.provider,
       modelId: params.modelId,
-      boundEnvVar,
+      boundEnvVar:
+        providerUseBinding?.kind === "environment" ? providerUseBinding.envVar : undefined,
       config: params.config,
       env: params.env,
       workspaceDir: params.workspaceDir,
@@ -650,7 +666,7 @@ export function prepareAgentRuntimeAuth(
     return buildAgentRuntimeAuthPlan({
       provider: params.provider,
       modelId: params.modelId,
-      boundEnvVar,
+      boundEnvVar: attempt?.kind === "direct" ? attempt.source.boundEnvVar : undefined,
       authProfileProvider: profile?.provider,
       authProfileMode:
         profile?.mode ??

--- a/src/agents/runtime-plan/prepare-auth.ts
+++ b/src/agents/runtime-plan/prepare-auth.ts
@@ -29,6 +29,7 @@ import {
   shouldPreferExplicitConfigApiKeyAuth,
 } from "../model-auth.js";
 import { resolveOpenAIModelRoutes, selectOpenAIModelRouteAuth } from "../openai-model-routes.js";
+import { resolveProviderAuthAliasMap } from "../provider-auth-aliases.js";
 import {
   buildProviderModelAuthDirectSource,
   buildProviderModelAuthSourcePlan,
@@ -218,14 +219,16 @@ function resolvePreparedProviderEntryApiKeyProfileReference(
 export function prepareAgentRuntimeAuth(
   input: PrepareAgentRuntimeAuthPlanParams,
 ): PreparedAgentRuntimeAuth {
+  const params = { ...input, config: resolveModelProviderAuthConfig(input) };
   // Route projection may add a provider entry; only authored config grants use.
   const providerUseAdmission = resolveProviderUseAdmission({
     config: input.config,
     env: input.env,
     providerEnvVars: resolveProviderBindingEnvVarCandidates(input),
     profiles: input.authProfileStore?.profiles,
+    requestedProviders: [input.provider],
+    storedCredentialAuthAliases: resolveProviderAuthAliasMap({ ...params, storedCredential: true }),
   });
-  const params = { ...input, config: resolveModelProviderAuthConfig(input) };
   const requestedProfileId = params.sessionAuthProfileId?.trim() || undefined;
   const userPinnedProfileId =
     params.sessionAuthProfileSource === "user" || params.sessionAuthProfileSource === "user-link"
@@ -351,7 +354,9 @@ export function prepareAgentRuntimeAuth(
           includePendingOAuthRefresh: true,
         });
   const automaticOrderResolution = prependAuthProfilePin(
-    providerUseBinding?.kind === "profile"
+    providerUseBinding?.kind === "profile" &&
+      normalizeProviderId(store?.profiles[providerUseBinding.profileId]?.provider ?? "") ===
+        normalizeProviderId(authProfileSelectionProvider)
       ? {
           ...resolvedAutomaticOrder,
           profileIds: resolvedAutomaticOrder.profileIds.filter(

--- a/src/agents/runtime-plan/provider-auth-recovery-hint.test.ts
+++ b/src/agents/runtime-plan/provider-auth-recovery-hint.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { buildProviderAuthRecoveryHint } from "../provider-auth-recovery-hint.js";
+
+afterEach(() => vi.unstubAllEnvs());
+
+it("explains an existing unbound variable without asking the user to set it again", () => {
+  vi.stubEnv("FIXTURE_API_KEY", "private-fixture-value");
+  const config = {};
+  const metadata = createPluginMetadataSnapshotFixture({
+    plugins: ["fixture-api", "other-api"].map((id) => ({
+      id,
+      providers: [id],
+      setup: { providers: [{ id, envVars: ["FIXTURE_API_KEY"] }] },
+    })),
+  });
+  const hint = withPluginMetadataSnapshotScope(
+    metadata,
+    () =>
+      buildProviderAuthRecoveryHint({
+        provider: "fixture-api",
+        config,
+        env: process.env,
+        includeEnvVar: true,
+      }),
+    { config, trustConfigIdentity: true },
+  );
+  expect(hint).toContain('FIXTURE_API_KEY is set, but it is not bound to provider "fixture-api"');
+  expect(hint).toContain("openclaw doctor --fix");
+  expect(hint).toContain("models.providers.fixture-api.apiKey");
+  expect(hint).not.toContain("set an API key env var");
+  expect(hint).not.toContain("private-fixture-value");
+});
+
+it("does not recommend setting an already admitted variable", () => {
+  vi.stubEnv("FIXTURE_API_KEY", "private-fixture-value");
+  const config = {};
+  const metadata = createPluginMetadataSnapshotFixture({
+    plugins: [
+      {
+        id: "fixture-api",
+        providers: ["fixture-api"],
+        setup: { providers: [{ id: "fixture-api", envVars: ["FIXTURE_API_KEY"] }] },
+      },
+    ],
+  });
+  const hint = withPluginMetadataSnapshotScope(
+    metadata,
+    () =>
+      buildProviderAuthRecoveryHint({
+        provider: "fixture-api",
+        config,
+        env: process.env,
+        includeEnvVar: true,
+      }),
+    { config, trustConfigIdentity: true },
+  );
+  expect(hint).not.toContain("set an API key env var");
+  expect(hint).not.toContain("not bound");
+});

--- a/src/agents/runtime-plan/provider-use-admission.test.ts
+++ b/src/agents/runtime-plan/provider-use-admission.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
-import { createModelAuthAvailabilityResolver } from "./model-auth-availability.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { createModelAuthAvailabilityResolver } from "../model-auth-availability.js";
 import {
   createProviderApiKeyResolver,
   createProviderAuthResolver,
-} from "./models-config.providers.secrets.js";
-import { resolveProviderUseAdmission } from "./provider-model-auth-source-plan.js";
+} from "../models-config.providers.secrets.js";
+import { resolveProviderUseAdmission } from "../provider-model-auth-source-plan.js";
 
 const sharedProviderEnvVars = {
   opencode: ["OPENCODE_API_KEY"],

--- a/src/agents/runtime-plan/provider-use-admission.test.ts
+++ b/src/agents/runtime-plan/provider-use-admission.test.ts
@@ -15,8 +15,188 @@ const sharedProviderEnvVars = {
   opencode: ["OPENCODE_API_KEY"],
   "opencode-go": ["OPENCODE_API_KEY"],
 };
+const byteplusMetadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "byteplus",
+      providers: ["byteplus", "byteplus-plan"],
+      setup: { providers: [{ id: "byteplus", envVars: ["BYTEPLUS_API_KEY"] }] },
+      providerAuthAliases: { "byteplus-plan": "byteplus" },
+    },
+  ],
+});
 
 describe("resolveProviderUseAdmission", () => {
+  it("binds only a requested sibling to its saved credential realm", () => {
+    expect(
+      resolveProviderUseAdmission({
+        env: { BYTEPLUS_API_KEY: "environment-account" },
+        providerEnvVars: { byteplus: ["BYTEPLUS_API_KEY"] },
+        profiles: { "byteplus:saved": { provider: "byteplus" } },
+        requestedProviders: ["byteplus-plan"],
+        storedCredentialAuthAliases: { "byteplus-plan": "byteplus", "byteplus-other": "byteplus" },
+      }),
+    ).toEqual(
+      new Map([
+        ["byteplus", { kind: "profile", profileId: "byteplus:saved" }],
+        ["byteplus-plan", { kind: "profile", profileId: "byteplus:saved" }],
+      ]),
+    );
+  });
+
+  it.each(["primary", "fallback", "alias"])(
+    "preserves the saved account for a %s-selected Plan instead of its environment key",
+    (selection) => {
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model:
+              selection === "fallback"
+                ? { primary: "byteplus/base-model", fallbacks: ["byteplus-plan/plan-model"] }
+                : { primary: selection === "alias" ? "plan" : "byteplus-plan/plan-model" },
+            models: { "byteplus-plan/plan-model": { alias: "plan" } },
+          },
+        },
+      };
+      const env = { BYTEPLUS_API_KEY: "environment-account" };
+      const authProfileStore: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          "byteplus:saved": { type: "api_key", provider: "byteplus", key: "saved-account" },
+        },
+      };
+      const metadataSnapshot = byteplusMetadataSnapshot;
+      expect(
+        prepareAgentRuntimeAuth({
+          provider: "byteplus-plan",
+          modelId: "plan-model",
+          config,
+          env,
+          authProfileStore,
+          metadataSnapshot,
+        }).attempts,
+      ).toMatchObject([{ kind: "profile", profileId: "byteplus:saved" }]);
+      expect(
+        createModelAuthAvailabilityResolver({
+          cfg: config,
+          env,
+          authStore: authProfileStore,
+          metadataSnapshot,
+        }).resolveProviderAuthAvailability("byteplus-plan"),
+      ).toBe(true);
+      const admission = resolveProviderUseAdmission({
+        config,
+        env,
+        profiles: authProfileStore.profiles,
+        requestedProviders: ["byteplus-plan"],
+        storedCredentialAuthAliases: { "byteplus-plan": "byteplus" },
+      });
+      expect(
+        createProviderApiKeyResolver(
+          env,
+          authProfileStore,
+          config,
+          undefined,
+          undefined,
+          env,
+          admission,
+        )("byteplus-plan").discoveryApiKey,
+      ).toBe("saved-account");
+      expect(
+        createProviderAuthResolver(
+          env,
+          authProfileStore,
+          config,
+          undefined,
+          undefined,
+          env,
+          admission,
+        )("byteplus-plan"),
+      ).toMatchObject({ profileId: "byteplus:saved", source: "profile" });
+    },
+  );
+
+  it.each(["absent", "inactive", "expired"])(
+    "does not replace an %s family account with an environment key for a selected Plan",
+    (state) => {
+      const authProfileStore: AuthProfileStore = {
+        version: 1,
+        profiles:
+          state === "absent"
+            ? {}
+            : {
+                "byteplus:saved":
+                  state === "expired"
+                    ? { type: "token", provider: "byteplus", token: "expired-account", expires: 1 }
+                    : {
+                        type: "api_key",
+                        provider: "byteplus",
+                        key: "inactive-account",
+                        setup: {
+                          replacement: true,
+                          modelRef: "byteplus-plan/plan-model",
+                          configJson: "{}",
+                        },
+                      },
+              },
+      };
+      expect(() =>
+        prepareAgentRuntimeAuth({
+          provider: "byteplus-plan",
+          modelId: "plan-model",
+          config: {},
+          env: { BYTEPLUS_API_KEY: "environment-account" },
+          authProfileStore,
+          metadataSnapshot: byteplusMetadataSnapshot,
+        }),
+      ).toThrow(
+        state === "expired" ? "No usable bound auth profile" : "not configured for model use",
+      );
+    },
+  );
+
+  it("keeps exact-provider saved accounts ahead of family accounts", () => {
+    const authProfileStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "byteplus:family": { type: "api_key", provider: "byteplus", key: "family-account" },
+        "byteplus-plan:saved": { type: "api_key", provider: "byteplus-plan", key: "plan-account" },
+      },
+    };
+    const prepared = prepareAgentRuntimeAuth({
+      provider: "byteplus-plan",
+      modelId: "plan-model",
+      config: {},
+      env: { BYTEPLUS_API_KEY: "environment-account" },
+      authProfileStore,
+      metadataSnapshot: byteplusMetadataSnapshot,
+    });
+    expect(prepared.attempts.map((attempt) => attempt.profileId)).toEqual(["byteplus-plan:saved"]);
+  });
+
+  it("retains saved family account order and fallback without adding an environment attempt", () => {
+    const authProfileStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "byteplus:first": { type: "api_key", provider: "byteplus", key: "first-account" },
+        "byteplus:second": { type: "api_key", provider: "byteplus", key: "second-account" },
+      },
+      order: { byteplus: ["byteplus:second", "byteplus:first"] },
+    };
+    const prepared = prepareAgentRuntimeAuth({
+      provider: "byteplus-plan",
+      modelId: "plan-model",
+      config: {},
+      env: { BYTEPLUS_API_KEY: "environment-account" },
+      authProfileStore,
+      metadataSnapshot: byteplusMetadataSnapshot,
+    });
+    expect(prepared.attempts.map((attempt) => attempt.profileId)).toEqual([
+      "byteplus:second",
+      "byteplus:first",
+    ]);
+  });
+
   it("keeps the environment account until a saved replacement is activated", async () => {
     const profileId = "anthropic:replacement";
     const env = { ANTHROPIC_API_KEY: "current-environment-key" };

--- a/src/agents/runtime-plan/provider-use-admission.test.ts
+++ b/src/agents/runtime-plan/provider-use-admission.test.ts
@@ -12,8 +12,8 @@ import { resolveProviderUseAdmission } from "../provider-model-auth-source-plan.
 import { prepareAgentRuntimeAuth } from "./prepare-auth.js";
 
 const sharedProviderEnvVars = {
-  opencode: ["OPENCODE_API_KEY"],
-  "opencode-go": ["OPENCODE_API_KEY"],
+  opencode: [{ pluginId: "opencode", envVars: ["OPENCODE_API_KEY"] }],
+  "opencode-go": [{ pluginId: "opencode-go", envVars: ["OPENCODE_API_KEY"] }],
 };
 const byteplusMetadataSnapshot = createPluginMetadataSnapshotFixture({
   plugins: [
@@ -31,7 +31,7 @@ describe("resolveProviderUseAdmission", () => {
     expect(
       resolveProviderUseAdmission({
         env: { BYTEPLUS_API_KEY: "environment-account" },
-        providerEnvVars: { byteplus: ["BYTEPLUS_API_KEY"] },
+        providerEnvVars: { byteplus: [{ pluginId: "byteplus", envVars: ["BYTEPLUS_API_KEY"] }] },
         profiles: { "byteplus:saved": { provider: "byteplus" } },
         requestedProviders: ["byteplus-plan"],
         storedCredentialAuthAliases: { "byteplus-plan": "byteplus", "byteplus-other": "byteplus" },
@@ -328,10 +328,10 @@ describe("resolveProviderUseAdmission", () => {
     const admission = resolveProviderUseAdmission({
       env: { OWNER_API_KEY: "synthetic-secret", EMPTY_API_KEY: "  " },
       providerEnvVars: {
-        " Owner ": ["OWNER_API_KEY"],
-        owner: ["OWNER_API_KEY"],
+        " Owner ": [{ pluginId: "owner", envVars: ["OWNER_API_KEY"] }],
+        owner: [{ pluginId: "owner", envVars: ["OWNER_API_KEY"] }],
         borrower: [],
-        empty: ["EMPTY_API_KEY"],
+        empty: [{ pluginId: "empty", envVars: ["EMPTY_API_KEY"] }],
       },
     });
 
@@ -393,7 +393,7 @@ describe("resolveProviderUseAdmission", () => {
     expect(
       resolveProviderUseAdmission({
         env: { [envVar]: "synthetic-value" },
-        providerEnvVars: { cloud: [envVar] },
+        providerEnvVars: { cloud: [{ pluginId: "cloud", envVars: [envVar] }] },
       }),
     ).toEqual(new Map());
   });

--- a/src/agents/runtime-plan/provider-use-admission.test.ts
+++ b/src/agents/runtime-plan/provider-use-admission.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { withSetupCredentialAccess } from "../auth-profiles/setup-access.js";
+import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { createModelAuthAvailabilityResolver } from "../model-auth-availability.js";
 import {
   createProviderApiKeyResolver,
   createProviderAuthResolver,
 } from "../models-config.providers.secrets.js";
 import { resolveProviderUseAdmission } from "../provider-model-auth-source-plan.js";
+import { prepareAgentRuntimeAuth } from "./prepare-auth.js";
 
 const sharedProviderEnvVars = {
   opencode: ["OPENCODE_API_KEY"],
@@ -14,6 +17,58 @@ const sharedProviderEnvVars = {
 };
 
 describe("resolveProviderUseAdmission", () => {
+  it("keeps the environment account until a saved replacement is activated", async () => {
+    const profileId = "anthropic:replacement";
+    const env = { ANTHROPIC_API_KEY: "current-environment-key" };
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider: "anthropic",
+          key: "replacement-key",
+          setup: {
+            replacement: true,
+            modelRef: "anthropic/claude-sonnet-4-6",
+            configJson: "{}",
+          },
+        },
+      },
+    };
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "anthropic",
+          providers: ["anthropic"],
+          setup: { providers: [{ id: "anthropic", envVars: ["ANTHROPIC_API_KEY"] }] },
+        },
+      ],
+    });
+    const prepare = () =>
+      prepareAgentRuntimeAuth({
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+        config: {},
+        env,
+        authProfileStore: store,
+        metadataSnapshot,
+      });
+
+    expect(prepare().attempts).toMatchObject([{ kind: "direct" }]);
+    const availability = createModelAuthAvailabilityResolver({
+      cfg: {},
+      env,
+      authStore: store,
+      metadataSnapshot,
+    });
+    expect(availability.resolveProviderAuthAvailability("anthropic")).toBe(true);
+
+    await withSetupCredentialAccess({ profileId }, async () => {
+      expect(prepare().attempts).toMatchObject([{ kind: "profile", profileId }]);
+    });
+    expect(prepare().attempts).toMatchObject([{ kind: "direct" }]);
+  });
+
   it("does not replace an expired bound profile with shared environment auth", () => {
     const env = { OPENCODE_API_KEY: "unbound-key" };
     const store = {

--- a/src/agents/runtime-plan/resolve-auth.ts
+++ b/src/agents/runtime-plan/resolve-auth.ts
@@ -1,11 +1,9 @@
 /** Resolves credentials for an immutable prepared runtime route. */
 import { toErrorObject } from "../../infra/errors.js";
 import { SecretSurfaceUnavailableError } from "../../secrets/runtime-degraded-state.js";
-import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input.js";
 import { OAuthRefreshFailureError } from "../auth-profiles/oauth-refresh-failure.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { isProfileInCooldown } from "../auth-profiles/usage-state.js";
-import { ProviderAuthError } from "../model-auth-runtime-shared.js";
 import { getApiKeyForModelCore } from "../model-auth.js";
 import { providerModelRouteAcceptsAuthMode } from "../provider-model-route-auth.js";
 import { shouldForceDirectAuthFallbackModelResolve } from "./credential-scoped-model.js";
@@ -275,13 +273,6 @@ export async function resolvePreparedRuntimeModelAuth(
     return Boolean(profileId?.trim()) && values.indexOf(profileId) === index;
   });
   if (candidates.length === 0) {
-    if (plan.boundEnvVar && !normalizeOptionalSecretInput(process.env[plan.boundEnvVar])) {
-      throw new ProviderAuthError(
-        "missing-provider-auth",
-        params.model.provider,
-        `Prepared environment credential "${plan.boundEnvVar}" is no longer available for ${params.model.provider}. Restore it or prepare a new request.`,
-      );
-    }
     // The planner selected direct auth. Resolve only env/config material so an
     // unrelated full store cannot replace or pre-reject that immutable source.
     const auth = await getApiKeyForModelCore({

--- a/src/agents/runtime-plan/resolve-auth.ts
+++ b/src/agents/runtime-plan/resolve-auth.ts
@@ -1,12 +1,12 @@
 /** Resolves credentials for an immutable prepared runtime route. */
 import { toErrorObject } from "../../infra/errors.js";
-import { resolveProviderBindingEnvVarCandidates } from "../../secrets/provider-env-vars.js";
 import { SecretSurfaceUnavailableError } from "../../secrets/runtime-degraded-state.js";
+import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input.js";
 import { OAuthRefreshFailureError } from "../auth-profiles/oauth-refresh-failure.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { isProfileInCooldown } from "../auth-profiles/usage-state.js";
+import { ProviderAuthError } from "../model-auth-runtime-shared.js";
 import { getApiKeyForModelCore } from "../model-auth.js";
-import { resolveProviderUseAdmission } from "../provider-model-auth-source-plan.js";
 import { providerModelRouteAcceptsAuthMode } from "../provider-model-route-auth.js";
 import { shouldForceDirectAuthFallbackModelResolve } from "./credential-scoped-model.js";
 import { sameAgentRuntimeAuthModelRoute } from "./model-route.js";
@@ -275,13 +275,13 @@ export async function resolvePreparedRuntimeModelAuth(
     return Boolean(profileId?.trim()) && values.indexOf(profileId) === index;
   });
   if (candidates.length === 0) {
-    const binding = resolveProviderUseAdmission({
-      config: params.cfg,
-      providerEnvVars: resolveProviderBindingEnvVarCandidates({
-        config: params.cfg,
-        workspaceDir: params.workspaceDir,
-      }),
-    }).get(params.model.provider.trim().toLowerCase());
+    if (plan.boundEnvVar && !normalizeOptionalSecretInput(process.env[plan.boundEnvVar])) {
+      throw new ProviderAuthError(
+        "missing-provider-auth",
+        params.model.provider,
+        `Prepared environment credential "${plan.boundEnvVar}" is no longer available for ${params.model.provider}. Restore it or prepare a new request.`,
+      );
+    }
     // The planner selected direct auth. Resolve only env/config material so an
     // unrelated full store cannot replace or pre-reject that immutable source.
     const auth = await getApiKeyForModelCore({
@@ -290,7 +290,7 @@ export async function resolvePreparedRuntimeModelAuth(
       lockedProfile: false,
       allowAuthProfileFallback: false,
       skipSetupProviderFallback: plan.modelRoute?.provider === "openai",
-      boundEnvVar: binding?.kind === "environment" ? binding.envVar : undefined,
+      boundEnvVar: plan.boundEnvVar,
     });
     assertResolvedAuthMatchesPreparedRoute({ plan, auth });
     return { auth, plan: applyResolvedAuthToPlan({ plan, auth, candidates }) };

--- a/src/agents/runtime-plan/resolve-auth.ts
+++ b/src/agents/runtime-plan/resolve-auth.ts
@@ -1,10 +1,12 @@
 /** Resolves credentials for an immutable prepared runtime route. */
 import { toErrorObject } from "../../infra/errors.js";
+import { resolveProviderBindingEnvVarCandidates } from "../../secrets/provider-env-vars.js";
 import { SecretSurfaceUnavailableError } from "../../secrets/runtime-degraded-state.js";
 import { OAuthRefreshFailureError } from "../auth-profiles/oauth-refresh-failure.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { isProfileInCooldown } from "../auth-profiles/usage-state.js";
 import { getApiKeyForModelCore } from "../model-auth.js";
+import { resolveProviderUseAdmission } from "../provider-model-auth-source-plan.js";
 import { providerModelRouteAcceptsAuthMode } from "../provider-model-route-auth.js";
 import { shouldForceDirectAuthFallbackModelResolve } from "./credential-scoped-model.js";
 import { sameAgentRuntimeAuthModelRoute } from "./model-route.js";
@@ -273,6 +275,13 @@ export async function resolvePreparedRuntimeModelAuth(
     return Boolean(profileId?.trim()) && values.indexOf(profileId) === index;
   });
   if (candidates.length === 0) {
+    const binding = resolveProviderUseAdmission({
+      config: params.cfg,
+      providerEnvVars: resolveProviderBindingEnvVarCandidates({
+        config: params.cfg,
+        workspaceDir: params.workspaceDir,
+      }),
+    }).get(params.model.provider.trim().toLowerCase());
     // The planner selected direct auth. Resolve only env/config material so an
     // unrelated full store cannot replace or pre-reject that immutable source.
     const auth = await getApiKeyForModelCore({
@@ -281,6 +290,7 @@ export async function resolvePreparedRuntimeModelAuth(
       lockedProfile: false,
       allowAuthProfileFallback: false,
       skipSetupProviderFallback: plan.modelRoute?.provider === "openai",
+      boundEnvVar: binding?.kind === "environment" ? binding.envVar : undefined,
     });
     assertResolvedAuthMatchesPreparedRoute({ plan, auth });
     return { auth, plan: applyResolvedAuthToPlan({ plan, auth, candidates }) };

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -196,6 +196,8 @@ export type AgentRuntimeAuthPlan = {
   forwardedAuthProfileCandidateIds?: string[];
   /** Exact selected credential/config mode; secret-free route materialization input. */
   selectedAuthMode?: string;
+  /** Environment source admitted for this request; resolution cannot choose another variable. */
+  boundEnvVar?: string;
   /** Concrete provider-owned route selected before runtime dispatch. */
   modelRoute?: AgentRuntimeAuthModelRoute;
   /** Secret-free support shared by every route deferred to harness-owned auth. */

--- a/src/agents/tools/media-generate-tool.donor-resources.test.ts
+++ b/src/agents/tools/media-generate-tool.donor-resources.test.ts
@@ -190,7 +190,7 @@ module.exports = { id: '${id}', register(api) {
               },
             ],
             "static",
-            { includeCredentialProviders: false, registryResources: construction },
+            { registryResources: construction },
           );
           if (mode === "rollback") {
             const source = getPluginRegistryInspectionResources(

--- a/src/agents/tools/media-generate-tool.resources.test.ts
+++ b/src/agents/tools/media-generate-tool.resources.test.ts
@@ -252,7 +252,7 @@ async function prepareSnapshot(
       },
     ],
     "static",
-    { includeCredentialProviders: false },
+    {},
     () => registry,
   );
   const facts = prepared.agentFacts[0]!;

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -163,6 +163,7 @@ describe("/models browse catalog recovery", () => {
       });
       catalogMocks.authModes = nativeAuth ? { "claude-cli": "api_key" } : {};
       const cfg: OpenClawConfig = {
+        models: { providers: { anthropic: {} } },
         agents: {
           defaults: {
             model: { primary: "anthropic/claude-opus-4-5" },

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -163,7 +163,7 @@ describe("/models browse catalog recovery", () => {
       });
       catalogMocks.authModes = nativeAuth ? { "claude-cli": "api_key" } : {};
       const cfg: OpenClawConfig = {
-        models: { providers: { anthropic: {} } },
+        models: { providers: { anthropic: { baseUrl: "", models: [] } } },
         agents: {
           defaults: {
             model: { primary: "anthropic/claude-opus-4-5" },

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -2,6 +2,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import * as preparedCatalog from "../../agents/prepared-model-catalog.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -283,6 +284,26 @@ describe("handleModelsCommand", () => {
     expect(params).not.toHaveProperty("metadataSnapshot");
   });
 
+  it.each([false, true])(
+    "retains an unauthenticated default only when configured=%s",
+    async (configured) => {
+      modelProviderAuthMocks.authenticatedProviders.clear();
+      modelCatalogMocks.loadModelCatalog.mockReturnValue([
+        { provider: DEFAULT_PROVIDER, id: DEFAULT_MODEL, name: "Default model" },
+      ]);
+      const data = await buildPreparedModelsProviderData(
+        configured
+          ? {
+              agents: { defaults: { model: `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}` } },
+            }
+          : {},
+      );
+      expect([...(data.byProvider.get(DEFAULT_PROVIDER) ?? [])]).toEqual(
+        configured ? [DEFAULT_MODEL] : [],
+      );
+    },
+  );
+
   it("loads the selected agent lifecycle catalog", async () => {
     const cfg = {
       agents: {
@@ -434,7 +455,7 @@ describe("handleModelsCommand", () => {
     expect(pluginMetadataMocks.getCurrent).toHaveBeenCalledTimes(1);
   });
 
-  it("does not re-add the default provider when provider visibility is restricted", async () => {
+  it("retains the published default alongside allowed provider models", async () => {
     modelCatalogMocks.loadModelCatalog.mockReturnValue([
       { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
       { provider: "openai", id: "gpt-5.4-codex", name: "GPT-5.4 Codex" },
@@ -464,7 +485,7 @@ describe("handleModelsCommand", () => {
     );
     expect(result?.reply?.text).toContain("- openai (2)");
     expect(result?.reply?.text).toContain("- vllm (2)");
-    expect(result?.reply?.text).not.toContain("- anthropic");
+    expect(result?.reply?.text).toContain("- anthropic (1)");
   });
 
   it("hides bare backwards-compat aliases but surfaces supported CLI runtime providers in /models lists", async () => {
@@ -500,7 +521,7 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).not.toMatch(/^- codex-cli \(/m);
   });
 
-  it("sources CLI runtime provider model lists from the catalog", async () => {
+  it("applies the same configured model restriction to CLI runtime providers", async () => {
     modelCatalogMocks.loadModelCatalog.mockReturnValue([
       { provider: "claude-cli", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
       { provider: "claude-cli", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
@@ -515,8 +536,6 @@ describe("handleModelsCommand", () => {
       agents: {
         defaults: {
           model: { primary: "anthropic/claude-opus-4-7" },
-          // User only declared 2 of claude-cli's 6 supported models.
-          // For claude-cli this narrowing must be ignored.
           models: {
             "claude-cli/claude-opus-4-6": {},
             "claude-cli/claude-sonnet-4-6": {},
@@ -526,11 +545,7 @@ describe("handleModelsCommand", () => {
     } as OpenClawConfig);
 
     expect([...(data.byProvider.get("claude-cli") ?? [])].toSorted()).toEqual([
-      "claude-haiku-4-5",
-      "claude-opus-4-5",
       "claude-opus-4-6",
-      "claude-opus-4-7",
-      "claude-sonnet-4-5",
       "claude-sonnet-4-6",
     ]);
   });
@@ -563,16 +578,16 @@ describe("handleModelsCommand", () => {
       expected: ["claude-opus-4-6"],
     },
     {
-      name: "an excluded CLI primary",
+      name: "configured CLI primary retention under provider wildcards",
       allow: ["anthropic/*"],
       primary: "claude-cli/claude-sonnet-4-6",
-      expected: [],
+      expected: ["claude-sonnet-4-6"],
     },
     {
-      name: "an excluded CLI fallback under provider wildcards",
+      name: "configured CLI fallback retention under provider wildcards",
       allow: ["anthropic/*"],
       fallbacks: ["claude-cli/claude-sonnet-4-6"],
-      expected: [],
+      expected: ["claude-sonnet-4-6"],
     },
     {
       name: "configured CLI fallback retention under exact refs",
@@ -585,17 +600,17 @@ describe("handleModelsCommand", () => {
       name: "an unrestricted agent override",
       allow: ["anthropic/*"],
       agentAllow: [],
-      expected: ["claude-opus-4-6", "claude-sonnet-4-6"],
+      expected: ["claude-sonnet-4-6"],
     },
     {
       name: "an empty explicit allowlist",
       allow: [],
-      expected: ["claude-opus-4-6", "claude-sonnet-4-6"],
+      expected: ["claude-sonnet-4-6"],
     },
     {
       name: "legacy provider wildcards",
       legacyAllow: ["anthropic/*"],
-      expected: ["claude-opus-4-6", "claude-sonnet-4-6"],
+      expected: [],
     },
     {
       name: "explicit all browse",

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -21,6 +21,7 @@ import {
   resolveLogicalVisibleModelCatalog,
 } from "../../agents/model-catalog-visibility.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import { modelKey } from "../../agents/model-ref-shared.js";
 import { dedupeModelCatalogEntries } from "../../agents/model-selection-shared.js";
 import { normalizeProviderId, resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
@@ -36,6 +37,7 @@ import {
   PreparedModelRuntimePublicationSupersededError,
 } from "../../agents/prepared-model-runtime.errors.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.types.js";
+import { resolveSessionModelRef } from "../../agents/session-model-ref.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -57,6 +59,10 @@ type ModelsCommandSessionEntry = Partial<
     | "authProfileOverrideSource"
     | "modelProvider"
     | "providerOverride"
+    | "modelOverride"
+    | "modelOverrideRouteResolution"
+    | "modelOverrideFallbackOriginProvider"
+    | "modelOverrideFallbackOriginModel"
     | "model"
     | "modelSelectionLocked"
     | "agentRuntimeOverride"
@@ -195,18 +201,15 @@ async function projectPreparedModelsProviderData(
   const cliRuntimeProviders = new Set(
     listCliRuntimeModelBackendBindings().map((binding) => normalizeProviderId(binding.runtime)),
   );
-  const snapshot = owner.modelCatalog;
   const authStore = getPreparedModelRuntimeAuthStore(owner);
-  const catalog = snapshot.entries;
-  const defaultModel = resolveAgentEffectiveModelPrimary(cfg, selectedAgentId);
-  const visibilityPolicy = createModelVisibilityPolicy({
-    cfg,
-    catalog,
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel,
-    agentId: selectedAgentId,
-    ...runtimeNormalization,
-  });
+  const selectedModel = options.sessionEntry?.modelOverride
+    ? resolveSessionModelRef(cfg, options.sessionEntry, selectedAgentId, {
+        allowPluginNormalization: false,
+      })
+    : undefined;
+  const defaultModel = selectedModel
+    ? modelKey(selectedModel.provider, selectedModel.model)
+    : resolveAgentEffectiveModelPrimary(cfg, selectedAgentId);
   if (!authStore) {
     throw new Error("Model catalog owner omitted its auth store");
   }
@@ -215,7 +218,8 @@ async function projectPreparedModelsProviderData(
     agentId: selectedAgentId,
     agentDir: owner.agentDir,
     workspaceDir,
-    snapshot,
+    selectedModel,
+    snapshot: owner.modelCatalog,
     metadataSnapshot: owner.metadataSnapshot,
     preparedAuthStore: authStore,
     preparedRuntimeAuthModes: owner.authModes,
@@ -229,6 +233,16 @@ async function projectPreparedModelsProviderData(
         : undefined,
     profileProvider: options.sessionEntry?.providerOverride ?? options.sessionEntry?.modelProvider,
     runtimeOverride: options.sessionEntry?.agentRuntimeOverride,
+  });
+  const snapshot = decisions.snapshot;
+  const catalog = snapshot.entries;
+  const visibilityPolicy = createModelVisibilityPolicy({
+    cfg,
+    catalog,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel,
+    agentId: selectedAgentId,
+    ...runtimeNormalization,
   });
   const visibleCatalog = await resolveLogicalVisibleModelCatalog({
     cfg,

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -709,4 +709,3 @@ export const handleModelsCommand: CommandHandler = async (params, allowTextComma
   }
   return { reply, shouldContinue: false };
 };
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -6,31 +6,23 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import {
   resolveAgentDir,
+  resolveAgentEffectiveModelPrimary,
   resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
 import { listCliRuntimeModelBackendBindings } from "../../agents/cli-backends.js";
+import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import { createModelCatalogDecisions } from "../../agents/model-catalog-decisions.js";
 import {
   resolveLogicalModelCatalogEntryState,
   resolveLogicalVisibleModelCatalog,
-  type ModelCatalogAuthChecker,
 } from "../../agents/model-catalog-visibility.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
-import { isRetiredModelPickerProvider } from "../../agents/model-runtime-aliases.js";
-import {
-  dedupeModelCatalogEntries,
-  LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH,
-} from "../../agents/model-selection-shared.js";
-import {
-  buildModelAliasIndex,
-  normalizeProviderId,
-  resolveBareModelDefaultProvider,
-  resolveDefaultModelForAgent,
-  resolveModelRefFromString,
-} from "../../agents/model-selection.js";
+import { dedupeModelCatalogEntries } from "../../agents/model-selection-shared.js";
+import { normalizeProviderId, resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
 import {
   openAIModelCatalogRoutePolicy,
@@ -44,7 +36,6 @@ import {
   PreparedModelRuntimePublicationSupersededError,
 } from "../../agents/prepared-model-runtime.errors.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.types.js";
-import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -112,10 +103,6 @@ type ParsedModelsCommand =
       provider?: string;
       modelId?: string;
     };
-
-function isModelsBrowseVisibleProvider(provider: string): boolean {
-  return !isRetiredModelPickerProvider(provider);
-}
 
 function normalizeRuntimeChoiceId(runtime: string | undefined): string {
   const normalized = normalizeLowercaseStringOrEmpty(runtime);
@@ -196,28 +183,28 @@ async function projectPreparedModelsProviderData(
   options: ModelsBrowseOptions,
   owner: PreparedModelRuntimeSnapshot,
 ): Promise<PreparedModelsProviderData> {
+  const selectedAgentId = owner.agentId ?? agentId ?? resolveDefaultAgentId(cfg);
   const runtimeNormalization = resolveRuntimeNormalization(cfg);
   const resolvedDefault = resolveDefaultModelForAgent({
     cfg,
-    agentId,
+    agentId: selectedAgentId,
     ...runtimeNormalization,
   });
   const workspaceDir =
-    options.workspaceDir ??
-    (agentId ? resolveAgentWorkspaceDir(cfg, agentId) : undefined) ??
-    resolveDefaultAgentWorkspaceDir();
+    options.workspaceDir ?? owner.workspaceDir ?? resolveAgentWorkspaceDir(cfg, selectedAgentId);
   const cliRuntimeProviders = new Set(
     listCliRuntimeModelBackendBindings().map((binding) => normalizeProviderId(binding.runtime)),
   );
   const snapshot = owner.modelCatalog;
   const authStore = getPreparedModelRuntimeAuthStore(owner);
   const catalog = snapshot.entries;
+  const defaultModel = resolveAgentEffectiveModelPrimary(cfg, selectedAgentId);
   const visibilityPolicy = createModelVisibilityPolicy({
     cfg,
     catalog,
-    defaultProvider: resolvedDefault.provider,
-    defaultModel: resolvedDefault.model,
-    agentId,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel,
+    agentId: selectedAgentId,
     ...runtimeNormalization,
   });
   if (!authStore) {
@@ -225,7 +212,7 @@ async function projectPreparedModelsProviderData(
   }
   const decisions = createModelCatalogDecisions({
     cfg,
-    agentId: owner.agentId ?? agentId ?? "main",
+    agentId: selectedAgentId,
     agentDir: owner.agentDir,
     workspaceDir,
     snapshot,
@@ -243,28 +230,12 @@ async function projectPreparedModelsProviderData(
     profileProvider: options.sessionEntry?.providerOverride ?? options.sessionEntry?.modelProvider,
     runtimeOverride: options.sessionEntry?.agentRuntimeOverride,
   });
-  // Configured/default rows may remain visible without auth, but must not
-  // reintroduce a model that its provider route contract rejected.
-  const incompatibleModelKeys = new Set<string>();
-  const hasAuth: ModelCatalogAuthChecker =
-    options.view === "all"
-      ? async () => true
-      : async (provider, ref) => {
-          const entry = catalog.find((row) => row.provider === provider && row.id === ref?.modelId);
-          if (!entry) {
-            return false;
-          }
-          return (
-            decisions.evaluateNative(entry, await decisions.evaluateEntry(entry)).availability ===
-            true
-          );
-        };
   const visibleCatalog = await resolveLogicalVisibleModelCatalog({
     cfg,
     catalog,
-    defaultProvider: resolvedDefault.provider,
-    defaultModel: resolvedDefault.model,
-    agentId,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel,
+    agentId: selectedAgentId,
     workspaceDir,
     view: options.view,
     policy: visibilityPolicy,
@@ -275,9 +246,6 @@ async function projectPreparedModelsProviderData(
         entry,
         await decisions.evaluateEntry(entry, routeVariants),
       );
-      if (evaluation.routeResolution?.kind === "incompatible") {
-        incompatibleModelKeys.add(resolveModelCatalogIdentityKey(entry));
-      }
       return resolveLogicalModelCatalogEntryState({
         evaluation,
         authBacked: options.view === "all" || evaluation.availability === true,
@@ -286,132 +254,13 @@ async function projectPreparedModelsProviderData(
     },
   });
 
-  const aliasIndex = buildModelAliasIndex({
-    cfg,
-    defaultProvider: resolvedDefault.provider,
-    agentId,
-    ...runtimeNormalization,
-  });
-  const restrictToProviderWildcards =
-    options.view !== "all" && visibilityPolicy.hasProviderWildcards;
-  // Preserve legacy/unrestricted CLI browsing without widening an explicit policy.
-  const useUnfilteredCliCatalog =
-    options.view === "all" ||
-    visibilityPolicy.allowAny ||
-    visibilityPolicy.allowConfigPath === LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH;
-
   const byProvider = new Map<string, Set<string>>();
-  const add = (p: string, m: string) => {
-    const key = normalizeProviderId(p);
-    if (!isModelsBrowseVisibleProvider(key)) {
-      return;
-    }
-    if (
-      restrictToProviderWildcards &&
-      !(useUnfilteredCliCatalog && cliRuntimeProviders.has(key)) &&
-      !visibilityPolicy.allows({ provider: key, model: m })
-    ) {
-      return;
-    }
-    const set = byProvider.get(key) ?? new Set<string>();
-    set.add(m);
-    byProvider.set(key, set);
-  };
-
-  const addRawModelRef = (raw?: string) => {
-    const trimmed = normalizeOptionalString(raw);
-    if (!trimmed) {
-      return;
-    }
-    const defaultProvider = !trimmed.includes("/")
-      ? resolveBareModelDefaultProvider({
-          cfg,
-          catalog,
-          model: trimmed,
-          defaultProvider: resolvedDefault.provider,
-          agentId,
-          manifestPlugins: runtimeNormalization.manifestPlugins,
-        })
-      : resolvedDefault.provider;
-    const resolved = resolveModelRefFromString({
-      cfg,
-      agentId,
-      raw: trimmed,
-      defaultProvider,
-      aliasIndex,
-      ...runtimeNormalization,
-    });
-    if (!resolved) {
-      return;
-    }
-    if (
-      incompatibleModelKeys.has(
-        resolveModelCatalogIdentityKey({ provider: resolved.ref.provider, id: resolved.ref.model }),
-      )
-    ) {
-      return;
-    }
-    add(resolved.ref.provider, resolved.ref.model);
-  };
-
-  const addModelConfigEntries = () => {
-    const modelConfig = cfg.agents?.defaults?.model;
-    if (typeof modelConfig === "string") {
-      addRawModelRef(modelConfig);
-    } else if (modelConfig && typeof modelConfig === "object") {
-      addRawModelRef(modelConfig.primary);
-      for (const fallback of modelConfig.fallbacks ?? []) {
-        addRawModelRef(fallback);
-      }
-    }
-
-    const imageConfig = cfg.agents?.defaults?.imageModel;
-    if (typeof imageConfig === "string") {
-      addRawModelRef(imageConfig);
-    } else if (imageConfig && typeof imageConfig === "object") {
-      addRawModelRef(imageConfig.primary);
-      for (const fallback of imageConfig.fallbacks ?? []) {
-        addRawModelRef(fallback);
-      }
-    }
-  };
-
   for (const entry of visibleCatalog) {
-    if (incompatibleModelKeys.has(resolveModelCatalogIdentityKey(entry))) {
-      continue;
-    }
-    add(entry.provider, entry.id);
+    const provider = normalizeProviderId(entry.provider);
+    const models = byProvider.get(provider) ?? new Set<string>();
+    models.add(entry.id);
+    byProvider.set(provider, models);
   }
-
-  for (const entry of catalog) {
-    if (
-      useUnfilteredCliCatalog &&
-      cliRuntimeProviders.has(normalizeProviderId(entry.provider)) &&
-      (await hasAuth(entry.provider, {
-        modelId: entry.id,
-        api: entry.api,
-        baseUrl: entry.baseUrl,
-      }))
-    ) {
-      add(entry.provider, entry.id);
-    }
-  }
-
-  for (const raw of visibilityPolicy.exactModelRefs) {
-    addRawModelRef(raw);
-  }
-
-  if (
-    !incompatibleModelKeys.has(
-      resolveModelCatalogIdentityKey({
-        provider: resolvedDefault.provider,
-        id: resolvedDefault.model,
-      }),
-    )
-  ) {
-    add(resolvedDefault.provider, resolvedDefault.model);
-  }
-  addModelConfigEntries();
 
   const providers = [...byProvider.keys()].toSorted();
 

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1112,6 +1112,7 @@ describe("/model chat UX", () => {
           workspaceDir,
           cfg: {
             ...baseConfig(),
+            models: { providers: { anthropic: {} } },
             plugins: { allow: ["workspace-model-list"] },
           } as unknown as OpenClawConfig,
         });

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1112,7 +1112,7 @@ describe("/model chat UX", () => {
           workspaceDir,
           cfg: {
             ...baseConfig(),
-            models: { providers: { anthropic: {} } },
+            models: { providers: { anthropic: { baseUrl: "", models: [] } } },
             plugins: { allow: ["workspace-model-list"] },
           } as unknown as OpenClawConfig,
         });

--- a/src/commands/doctor-config-analysis.test.ts
+++ b/src/commands/doctor-config-analysis.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveConfiguredModelFallbacks } from "../agents/model-selection-resolve.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { validateConfigObjectRaw } from "../config/validation-core.js";
 import { OpenClawSchema } from "../config/zod-schema.js";
 import {
   formatConfigKeyPath,
@@ -30,18 +31,22 @@ describe("doctor config analysis helpers", () => {
     "keeps an auth-only %s binding out of catalog cleanup advice",
     (provider) => {
       noteMock.mockClear();
-      noteOpencodeProviderOverrides(
-        {
-          models: {
-            providers: {
-              [provider]: {
-                apiKey: { source: "env", provider: "default", id: "OPENCODE_API_KEY" },
-              },
+      const validated = validateConfigObjectRaw({
+        models: {
+          providers: {
+            [provider]: {
+              apiKey: { source: "env", provider: "default", id: "OPENCODE_API_KEY" },
             },
           },
         },
-        { opencodePluginActive: true, opencodeGoPluginActive: true },
-      );
+      });
+      if (!validated.ok) {
+        throw new Error("Expected a valid auth-only provider overlay");
+      }
+      noteOpencodeProviderOverrides(validated.config, {
+        opencodePluginActive: true,
+        opencodeGoPluginActive: true,
+      });
       expect(noteMock).not.toHaveBeenCalled();
     },
   );

--- a/src/commands/doctor-config-analysis.test.ts
+++ b/src/commands/doctor-config-analysis.test.ts
@@ -26,6 +26,26 @@ function collectImplicitFallbackClobberWarnings(cfg: OpenClawConfig): string[] {
 }
 
 describe("doctor config analysis helpers", () => {
+  it.each(["opencode", "opencode-go"])(
+    "keeps an auth-only %s binding out of catalog cleanup advice",
+    (provider) => {
+      noteMock.mockClear();
+      noteOpencodeProviderOverrides(
+        {
+          models: {
+            providers: {
+              [provider]: {
+                apiKey: { source: "env", provider: "default", id: "OPENCODE_API_KEY" },
+              },
+            },
+          },
+        },
+        { opencodePluginActive: true, opencodeGoPluginActive: true },
+      );
+      expect(noteMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("describes OpenCode overrides against the plugin-provided catalog", () => {
     noteMock.mockClear();
 
@@ -49,6 +69,9 @@ describe("doctor config analysis helpers", () => {
       "OpenCode",
     );
     expect(noteMock.mock.calls.at(-1)?.[0]).not.toContain("built-in");
+    expect(noteMock.mock.calls.at(-1)?.[0]).toContain(
+      "Keep each provider entry and its apiKey binding",
+    );
   });
 
   it("classifies external OpenCode overrides only while their plugins are active", () => {

--- a/src/commands/doctor-config-analysis.ts
+++ b/src/commands/doctor-config-analysis.ts
@@ -4,12 +4,14 @@ import { resolvePrimaryStringValue } from "@openclaw/normalization-core/string-c
 import type { ZodIssue } from "zod";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
+import { resolveProviderEnvironmentAdmission } from "../agents/provider-model-auth-source-plan.js";
 import { CONFIG_PATH } from "../config/config.js";
 import { INCLUDE_KEY } from "../config/includes.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { OpenClawSchema } from "../config/zod-schema.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { resolveProviderBindingEnvVarCandidates } from "../secrets/provider-env-vars.js";
 import { isRecord } from "../utils.js";
 
 type UnrecognizedKeysIssue = ZodIssue & {
@@ -152,7 +154,26 @@ export function stripUnknownConfigKeys(config: OpenClawConfig): {
   return { config: next, removed };
 }
 
-/** Warns when legacy OpenCode overrides shadow an active plugin-provided catalog. */
+/** Explains why present credentials do not select a model provider. */
+export function noteProviderEnvOwnershipConflicts(cfg: OpenClawConfig): void {
+  const { conflicts } = resolveProviderEnvironmentAdmission({
+    providerEnvVars: resolveProviderBindingEnvVarCandidates({ config: cfg }),
+  });
+  if (conflicts.length === 0) {
+    return;
+  }
+  note(
+    conflicts
+      .map(
+        ({ envVar, pluginIds, providers }) =>
+          `${envVar} is set, but model plugins ${pluginIds.join(", ")} share its declaration. Keep explicit provider bindings for the identities you use (${providers.map((provider) => `models.providers.${provider}`).join(", ")}); the variable alone cannot choose between them.`,
+      )
+      .join("\n"),
+    "Provider credentials",
+  );
+}
+
+/** Warns when catalog fields shadow an active plugin-provided catalog. */
 export function noteOpencodeProviderOverrides(
   cfg: OpenClawConfig,
   options: { opencodePluginActive?: boolean; opencodeGoPluginActive?: boolean } = {},
@@ -163,13 +184,15 @@ export function noteOpencodeProviderOverrides(
   }
 
   const overrides: string[] = [];
-  if (options.opencodePluginActive === true && providers.opencode) {
+  const hasOverride = (id: string) =>
+    Object.keys(providers[id] ?? {}).some((key) => key !== "apiKey");
+  if (options.opencodePluginActive === true && hasOverride("opencode")) {
     overrides.push("opencode");
   }
-  if (options.opencodePluginActive === true && providers["opencode-zen"]) {
+  if (options.opencodePluginActive === true && hasOverride("opencode-zen")) {
     overrides.push("opencode-zen");
   }
-  if (options.opencodeGoPluginActive === true && providers["opencode-go"]) {
+  if (options.opencodeGoPluginActive === true && hasOverride("opencode-go")) {
     overrides.push("opencode-go");
   }
   if (overrides.length === 0) {
@@ -190,7 +213,7 @@ export function noteOpencodeProviderOverrides(
   });
 
   lines.push(
-    "- Remove these entries to restore per-model API routing + costs (then re-run setup if needed).",
+    "- Remove catalog and transport overrides to restore per-model API routing + costs. Keep each provider entry and its apiKey binding.",
   );
   note(lines.join("\n"), "OpenCode");
 }

--- a/src/commands/doctor-config-analysis.ts
+++ b/src/commands/doctor-config-analysis.ts
@@ -9,12 +9,34 @@ import { INCLUDE_KEY } from "../config/includes.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { OpenClawSchema } from "../config/zod-schema.js";
+import { isPathInside } from "../infra/path-guards.js";
 import { isRecord } from "../utils.js";
 
 type UnrecognizedKeysIssue = ZodIssue & {
   code: "unrecognized_keys";
   keys: PropertyKey[];
 };
+
+export function collectInvalidHookTransformsDirWarnings(
+  cfg: OpenClawConfig,
+  configPath: string,
+): string[] {
+  const transformsDir = cfg.hooks?.transformsDir?.trim();
+  if (!transformsDir) {
+    return [];
+  }
+  const configDir = path.dirname(configPath);
+  const transformsRoot = path.join(configDir, "hooks", "transforms");
+  const resolved = path.isAbsolute(transformsDir)
+    ? path.resolve(transformsDir)
+    : path.resolve(transformsRoot, transformsDir);
+  if (isPathInside(transformsRoot, resolved)) {
+    return [];
+  }
+  return [
+    `- hooks.transformsDir: ${transformsDir} is outside ${transformsRoot}. Hook transform modules must live under ${transformsRoot}; move custom transforms there or remove hooks.transformsDir.`,
+  ];
+}
 
 function normalizeIssuePath(pathValue: PropertyKey[]): Array<string | number> {
   return pathValue.filter((part): part is string | number => typeof part !== "symbol");

--- a/src/commands/doctor-config-analysis.ts
+++ b/src/commands/doctor-config-analysis.ts
@@ -185,7 +185,15 @@ export function noteOpencodeProviderOverrides(
 
   const overrides: string[] = [];
   const hasOverride = (id: string) =>
-    Object.keys(providers[id] ?? {}).some((key) => key !== "apiKey");
+    Object.entries(providers[id] ?? {}).some(([key, value]) =>
+      key === "apiKey"
+        ? false
+        : key === "baseUrl"
+          ? Boolean(value)
+          : key === "models"
+            ? Array.isArray(value) && value.length > 0
+            : true,
+    );
   if (options.opencodePluginActive === true && hasOverride("opencode")) {
     overrides.push("opencode");
   }

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1381,7 +1381,10 @@ vi.mock("./doctor-config-preflight.js", async () => {
   };
 });
 
-vi.mock("./doctor-config-analysis.js", () => {
+vi.mock("./doctor-config-analysis.js", async () => {
+  const { collectInvalidHookTransformsDirWarnings } = await vi.importActual<
+    typeof import("./doctor-config-analysis.js")
+  >("./doctor-config-analysis.js");
   function formatConfigKeyPath(parts: Array<string | number>): string {
     if (parts.length === 0) {
       return "<root>";
@@ -1417,6 +1420,7 @@ vi.mock("./doctor-config-analysis.js", () => {
 
   return {
     collectImplicitFallbackClobberWarnings: collectImplicitFallbackClobberWarningsMock,
+    collectInvalidHookTransformsDirWarnings,
     formatConfigKeyPath,
     noteImplicitFallbackClobberWarnings: noteImplicitFallbackClobberWarningsMock,
     noteIncludeConfinementWarning: vi.fn(),

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -699,6 +699,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       shouldWriteConfig,
       shouldRepair,
       blocksWrite: legacyStep.blocksWrite,
+      explicitSetPaths,
     }),
     ...(pluginInstallConfigImport ? { pluginInstallConfigImport } : {}),
     path: snapshot.path ?? CONFIG_PATH,
@@ -707,7 +708,6 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     sourceConfigValid: snapshot.valid,
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),
     ...(legacyStep.partiallyValid === true ? { skipPluginValidationOnWrite: true } : {}),
-    ...(shouldWriteConfig && explicitSetPaths.length > 0 ? { explicitSetPaths } : {}),
     ...(shouldWriteConfig && persistCanonicalAgentRoster
       ? { persistCanonicalAgentRoster: true }
       : {}),

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -722,6 +722,9 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),
     ...(legacyStep.partiallyValid === true ? { skipPluginValidationOnWrite: true } : {}),
     ...(shouldWriteConfig && explicitSetPaths.length > 0 ? { explicitSetPaths } : {}),
+    ...(shouldWriteConfig && providerUseBindingMigration.unsetPaths
+      ? { unsetPaths: providerUseBindingMigration.unsetPaths }
+      : {}),
     ...(shouldWriteConfig && persistCanonicalAgentRoster
       ? { persistCanonicalAgentRoster: true }
       : {}),

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -35,7 +35,11 @@ import {
 import type { DoctorOptions, DoctorPrompter } from "./doctor-prompter.js";
 import { createWorkspaceAliasMigrationRepair } from "./doctor-workspace-alias.js";
 import { cronCodexRuntimePolicyTargetKey } from "./doctor/cron/store-migration.js";
-import { emitDoctorNotes, sanitizeDoctorNote } from "./doctor/emit-notes.js";
+import {
+  createDoctorChangesPanelSink,
+  emitDoctorNotes,
+  sanitizeDoctorNote,
+} from "./doctor/emit-notes.js";
 import { finalizeDoctorConfigFlow } from "./doctor/finalize-config-flow.js";
 import {
   applyLegacyCompatibilityStep,
@@ -74,34 +78,6 @@ function collectUnsupportedInternalHookEntryWarnings(cfg: OpenClawConfig): strin
     ({ hookKey, unsupportedKeys }) =>
       `- hooks.internal.entries.${hookKey}: unsupported loader key${unsupportedKeys.length === 1 ? "" : "s"} ${unsupportedKeys.join(", ")} will not load hook modules. Use bootstrap-extra-files for session bootstrap content, or create a managed/workspace hook directory with HOOK.md + handler.js. Doctor cannot rewrite this automatically because per-hook entry keys are open-ended hook configuration.`,
   );
-}
-
-// Repair-mode "Doctor changes" panels queue until the final candidate passes the
-// same validation the atomic writer enforces: printing "Doctor changes" and then
-// refusing the write would report repairs that never reached disk. Preview
-// panels print immediately — they promise nothing.
-type DoctorChangesPanelSink = {
-  emit: (changeLines: ReadonlyArray<string>, options?: { sanitize?: boolean }) => void;
-  drain: () => string[];
-};
-
-function createDoctorChangesPanelSink(shouldRepair: boolean): DoctorChangesPanelSink {
-  const pending: string[] = [];
-  return {
-    emit: (changeLines, options = {}) => {
-      if (changeLines.length === 0) {
-        return;
-      }
-      const body = changeLines.join("\n");
-      const message = options.sanitize ? sanitizeDoctorNote(body) : body;
-      if (shouldRepair) {
-        pending.push(message);
-        return;
-      }
-      note(message, "Doctor changes preview");
-    },
-    drain: () => pending.splice(0),
-  };
 }
 
 async function refreshGatewayAuthStateAfterAuthProfileRepair(): Promise<void> {
@@ -221,12 +197,19 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   let openAICodexAuthProfileIdMap: ReadonlyMap<string, string> | undefined;
   let retiredModelRefConfig: Pick<OpenClawConfig, "agents" | "models"> | undefined;
   const doctorFixCommand = formatCliCommand("openclaw doctor --fix");
-  const changesPanelSink = createDoctorChangesPanelSink(shouldRepair);
+  const changesPanelSink = createDoctorChangesPanelSink(shouldRepair, note);
   const applyConfigMutation = (
     mutation: DoctorConfigMutationResult & { warnings?: string[] },
-    options: { fixHint: string; sanitize?: boolean; emitWarnings?: boolean },
+    options: {
+      fixHint: string;
+      sanitize?: boolean;
+      emitWarnings?: boolean;
+      recheckBeforeWrite?: boolean;
+    },
   ): void => {
-    changesPanelSink.emit(mutation.changes, options.sanitize ? { sanitize: true } : {});
+    if (!shouldRepair || !options.recheckBeforeWrite) {
+      changesPanelSink.emit(mutation.changes, options.sanitize ? { sanitize: true } : {});
+    }
     if (options.emitWarnings && mutation.warnings?.length) {
       emitDoctorNotes({ note, warningNotes: mutation.warnings });
     }
@@ -414,7 +397,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     emitWarnings: true,
   });
 
-  const { prepareProviderUseBindingMigration } =
+  const { prepareProviderUseBindingMigration, resolveProviderUseBindingWriteMetadata } =
     await import("./doctor/shared/provider-use-binding-migration.js");
   const providerUseBindingMigration = await runWithCurrentPluginMetadata(state.candidate, () =>
     prepareProviderUseBindingMigration({
@@ -426,6 +409,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   applyConfigMutation(providerUseBindingMigration, {
     fixHint: `Run "${doctorFixCommand}" to preserve selected shared-key providers.`,
     emitWarnings: true,
+    recheckBeforeWrite: true,
   });
 
   const { repairUnownedChannelAccountBindings } =
@@ -709,11 +693,11 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
 
   return {
     cfg,
-    ...(providerUseBindingMigration.pending &&
-    legacyStep.blocksWrite !== true &&
-    (shouldWriteConfig || (shouldRepair && providerUseBindingMigration.changes.length === 0))
-      ? { providerUseBindingMigrationPending: true }
-      : {}),
+    ...resolveProviderUseBindingWriteMetadata(providerUseBindingMigration, {
+      shouldWriteConfig,
+      shouldRepair,
+      blocksWrite: legacyStep.blocksWrite,
+    }),
     ...(pluginInstallConfigImport ? { pluginInstallConfigImport } : {}),
     path: snapshot.path ?? CONFIG_PATH,
     shouldWriteConfig,
@@ -722,9 +706,6 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),
     ...(legacyStep.partiallyValid === true ? { skipPluginValidationOnWrite: true } : {}),
     ...(shouldWriteConfig && explicitSetPaths.length > 0 ? { explicitSetPaths } : {}),
-    ...(shouldWriteConfig && providerUseBindingMigration.unsetPaths
-      ? { unsetPaths: providerUseBindingMigration.unsetPaths }
-      : {}),
     ...(shouldWriteConfig && persistCanonicalAgentRoster
       ? { persistCanonicalAgentRoster: true }
       : {}),

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,6 +1,5 @@
 import { homedir } from "node:os";
 /** Main doctor config flow: preflight, migrations, previews, repairs, and final write decision. */
-import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
 import {
   listAgentEntries,
@@ -19,11 +18,11 @@ import { CONFIG_PATH } from "../config/paths.js";
 import { inspectShippedPluginInstallConfigRecords } from "../config/plugin-install-config-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
-import { isPathInside } from "../infra/path-guards.js";
 import { withoutPluginInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createPluginCapabilityConsentPrompter } from "../wizard/plugin-capability-consent.js";
 import {
+  collectInvalidHookTransformsDirWarnings,
   noteImplicitFallbackClobberWarnings,
   noteMcpOriginWarning,
   noteOpencodeProviderOverrides,
@@ -51,27 +50,6 @@ import { listDoctorConfiguredChannelIds } from "./doctor/shared/configured-chann
 import { containsAuthoredInclude } from "./doctor/shared/include-migration-ownership.js";
 import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
 import type { DoctorPluginMetadataSnapshotState } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
-
-function collectInvalidHookTransformsDirWarnings(
-  cfg: OpenClawConfig,
-  configPath: string,
-): string[] {
-  const transformsDir = cfg.hooks?.transformsDir?.trim();
-  if (!transformsDir) {
-    return [];
-  }
-  const configDir = path.dirname(configPath);
-  const transformsRoot = path.join(configDir, "hooks", "transforms");
-  const resolved = path.isAbsolute(transformsDir)
-    ? path.resolve(transformsDir)
-    : path.resolve(transformsRoot, transformsDir);
-  if (isPathInside(transformsRoot, resolved)) {
-    return [];
-  }
-  return [
-    `- hooks.transformsDir: ${transformsDir} is outside ${transformsRoot}. Hook transform modules must live under ${transformsRoot}; move custom transforms there or remove hooks.transformsDir.`,
-  ];
-}
 
 function collectUnsupportedInternalHookEntryWarnings(cfg: OpenClawConfig): string[] {
   const entries = cfg.hooks?.internal?.entries;
@@ -436,6 +414,20 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     emitWarnings: true,
   });
 
+  const { prepareProviderUseBindingMigration } =
+    await import("./doctor/shared/provider-use-binding-migration.js");
+  const providerUseBindingMigration = await runWithCurrentPluginMetadata(state.candidate, () =>
+    prepareProviderUseBindingMigration({
+      config: state.candidate,
+      configPath: snapshot.path,
+      env: process.env,
+    }),
+  );
+  applyConfigMutation(providerUseBindingMigration, {
+    fixHint: `Run "${doctorFixCommand}" to preserve selected shared-key providers.`,
+    emitWarnings: true,
+  });
+
   const { repairUnownedChannelAccountBindings } =
     await import("./doctor/shared/legacy-config-binding-repair.js");
   applyConfigMutation(
@@ -717,6 +709,11 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
 
   return {
     cfg,
+    ...(providerUseBindingMigration.pending &&
+    legacyStep.blocksWrite !== true &&
+    (shouldWriteConfig || (shouldRepair && providerUseBindingMigration.changes.length === 0))
+      ? { providerUseBindingMigrationPending: true }
+      : {}),
     ...(pluginInstallConfigImport ? { pluginInstallConfigImport } : {}),
     path: snapshot.path ?? CONFIG_PATH,
     shouldWriteConfig,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -26,6 +26,7 @@ import {
   noteImplicitFallbackClobberWarnings,
   noteMcpOriginWarning,
   noteOpencodeProviderOverrides,
+  noteProviderEnvOwnershipConflicts,
   noteSandboxOriginProxyWarning,
 } from "./doctor-config-analysis.js";
 import {
@@ -675,6 +676,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       }),
     );
   }
+  runWithCurrentPluginMetadata(cfg, () => noteProviderEnvOwnershipConflicts(cfg));
   noteOpencodeProviderOverrides(cfg, {
     opencodePluginActive: activeOpencodePluginIds.includes("opencode"),
     opencodeGoPluginActive: activeOpencodePluginIds.includes("opencode-go"),

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -399,7 +399,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
 
   const { prepareProviderUseBindingMigration, resolveProviderUseBindingWriteMetadata } =
     await import("./doctor/shared/provider-use-binding-migration.js");
-  const providerUseBindingMigration = await runWithCurrentPluginMetadata(state.candidate, () =>
+  const providerUseBindingMigration = runWithCurrentPluginMetadata(state.candidate, () =>
     prepareProviderUseBindingMigration({
       config: state.candidate,
       configPath: snapshot.path,

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -106,7 +106,7 @@ export async function commitStartupConfigRepairs(params: {
       completeProviderUseBindingMigration,
     } = await import("./doctor/shared/provider-use-binding-migration.js");
     const config = snapshot.sourceConfig ?? snapshot.config ?? {};
-    let bindingMigration = await params.runWithPluginMetadataSnapshot({ config }, () =>
+    let bindingMigration = params.runWithPluginMetadataSnapshot({ config }, () =>
       prepareProviderUseBindingMigration({ config, configPath: snapshot.path, env: params.env }),
     );
     params.report({ changes: [], warnings: bindingMigration.warnings ?? [] });

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -53,14 +53,11 @@ export async function commitStartupConfigRepairs(params: {
   automaticConfigRepair: ReturnType<typeof planAutomaticConfigRepair>;
   activeConfigRepair: boolean;
   gatewayStartupCheckpointRequired: boolean;
-  migrateProviderBindings: boolean;
-  env: NodeJS.ProcessEnv;
   lease: StartupMigrationLease | undefined;
   measure?: ConfigSnapshotReadMeasure;
   beforeStateMigrations?: () => Promise<boolean>;
   readSnapshot: () => Promise<DoctorConfigPreflightPluginSnapshotRead>;
   runWithPluginMetadataSnapshot: PluginMetadataSnapshotScopeRunner;
-  report: (result: MigrationMessages) => void;
 }): Promise<DoctorConfigPreflightPluginSnapshotRead> {
   let snapshotRead = params.snapshotRead;
   let snapshot = snapshotRead.snapshot;
@@ -98,53 +95,6 @@ export async function commitStartupConfigRepairs(params: {
     );
     snapshotRead = await params.readSnapshot();
     snapshot = snapshotRead.snapshot;
-  }
-  if (params.migrateProviderBindings && snapshot.valid && snapshot.exists) {
-    const {
-      prepareProviderUseBindingMigration,
-      writeProviderUseBindingMigration,
-      completeProviderUseBindingMigration,
-    } = await import("./doctor/shared/provider-use-binding-migration.js");
-    const config = snapshot.sourceConfig ?? snapshot.config ?? {};
-    let bindingMigration = params.runWithPluginMetadataSnapshot({ config }, () =>
-      prepareProviderUseBindingMigration({ config, configPath: snapshot.path, env: params.env }),
-    );
-    params.report({ changes: [], warnings: bindingMigration.warnings ?? [] });
-    if (bindingMigration.changes.length > 0 || bindingMigration.pending) {
-      await guardWrite();
-      if (bindingMigration.bindings) {
-        const checked = await writeProviderUseBindingMigration(
-          {
-            config: bindingMigration.config,
-            sourceConfig: snapshot.sourceConfig,
-            configPath: snapshot.path,
-            env: params.env,
-            bindings: bindingMigration.bindings,
-          },
-          async (current, withCommit) => {
-            if (current.changes.length > 0) {
-              await commitAutomaticConfigRepair(
-                current,
-                snapshot,
-                bindingMigration.unsetPaths,
-                withCommit,
-              );
-            }
-          },
-        );
-        bindingMigration = { ...bindingMigration, ...checked };
-        params.report({ changes: checked.changes, warnings: checked.warnings });
-        snapshotRead = await params.readSnapshot();
-        snapshot = snapshotRead.snapshot;
-      }
-      params.lease?.heartbeat();
-      if (bindingMigration.pending) {
-        params.report({
-          changes: [],
-          warnings: completeProviderUseBindingMigration(snapshot.path, params.env),
-        });
-      }
-    }
   }
   return snapshotRead;
 }

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -20,6 +20,7 @@ import type {
   LegacyStateMigrationStepReceipt,
   MigrationMessages,
 } from "../infra/state-migrations.types.js";
+import type { PluginMetadataSnapshotScopeRunner } from "../plugins/current-plugin-metadata-snapshot.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
 import { ExitError } from "../runtime.js";
 import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
@@ -41,9 +42,104 @@ import {
   throwStartupMigrationRefusal,
 } from "./doctor-startup-migration-refusal.js";
 import {
+  commitAutomaticConfigRepair,
   type planAutomaticConfigRepair,
   resolveStartupConfigSnapshot,
 } from "./doctor/shared/automatic-startup-config-repair.js";
+
+/** Persist approved config repairs after state migrations consume their legacy locators. */
+export async function commitStartupConfigRepairs(params: {
+  snapshotRead: DoctorConfigPreflightPluginSnapshotRead;
+  automaticConfigRepair: ReturnType<typeof planAutomaticConfigRepair>;
+  activeConfigRepair: boolean;
+  gatewayStartupCheckpointRequired: boolean;
+  migrateProviderBindings: boolean;
+  env: NodeJS.ProcessEnv;
+  lease: StartupMigrationLease | undefined;
+  measure?: ConfigSnapshotReadMeasure;
+  beforeStateMigrations?: () => Promise<boolean>;
+  readSnapshot: () => Promise<DoctorConfigPreflightPluginSnapshotRead>;
+  runWithPluginMetadataSnapshot: PluginMetadataSnapshotScopeRunner;
+  report: (result: MigrationMessages) => void;
+}): Promise<DoctorConfigPreflightPluginSnapshotRead> {
+  let snapshotRead = params.snapshotRead;
+  let snapshot = snapshotRead.snapshot;
+  const guardWrite = async () => {
+    if (params.gatewayStartupCheckpointRequired && !params.lease) {
+      throw new Error("Automatic startup config repair requires the startup migration lease.");
+    }
+    // Re-read disk at the write edge; an external edit cannot reuse the admitted plan.
+    if (
+      params.beforeStateMigrations &&
+      !(await measureDoctorConfigPreflightStep(
+        "startup-config-repair-guard",
+        params.beforeStateMigrations,
+        params.measure,
+      ))
+    ) {
+      throwStartupMigrationGuardRejected();
+    }
+    params.lease?.heartbeat();
+  };
+  const automaticConfigRepair = params.automaticConfigRepair;
+  if (automaticConfigRepair) {
+    await guardWrite();
+    await measureDoctorConfigPreflightStep(
+      "automatic-config-repair",
+      () =>
+        params.runWithPluginMetadataSnapshot({ config: automaticConfigRepair.config }, () =>
+          commitAutomaticConfigRepair(automaticConfigRepair, snapshot),
+        ),
+      params.measure,
+    );
+    note(
+      `Migrated legacy config keys${params.activeConfigRepair ? " in the active openclaw.json" : " at startup"}:\n${automaticConfigRepair.changes.map((entry) => `- ${entry}`).join("\n")}`,
+      "Doctor changes",
+    );
+    snapshotRead = await params.readSnapshot();
+    snapshot = snapshotRead.snapshot;
+  }
+  if (params.migrateProviderBindings && snapshot.valid && snapshot.exists) {
+    const {
+      prepareProviderUseBindingMigration,
+      revalidateProviderUseBindingMigration,
+      completeProviderUseBindingMigration,
+    } = await import("./doctor/shared/provider-use-binding-migration.js");
+    const config = snapshot.sourceConfig ?? snapshot.config ?? {};
+    let bindingMigration = await params.runWithPluginMetadataSnapshot({ config }, () =>
+      prepareProviderUseBindingMigration({ config, configPath: snapshot.path, env: params.env }),
+    );
+    params.report({ changes: [], warnings: bindingMigration.warnings ?? [] });
+    if (bindingMigration.changes.length > 0 || bindingMigration.pending) {
+      await guardWrite();
+      if (bindingMigration.bindings) {
+        const checked = await revalidateProviderUseBindingMigration({
+          config: bindingMigration.config,
+          sourceConfig: snapshot.sourceConfig,
+          configPath: snapshot.path,
+          env: params.env,
+          bindings: bindingMigration.bindings,
+        });
+        bindingMigration = { ...bindingMigration, ...checked };
+        params.report({ changes: [], warnings: checked.warnings });
+      }
+      if (bindingMigration.changes.length > 0) {
+        await commitAutomaticConfigRepair(bindingMigration, snapshot, bindingMigration.unsetPaths);
+        params.report({ changes: bindingMigration.changes, warnings: [] });
+        snapshotRead = await params.readSnapshot();
+        snapshot = snapshotRead.snapshot;
+      }
+      params.lease?.heartbeat();
+      if (bindingMigration.pending) {
+        params.report({
+          changes: [],
+          warnings: completeProviderUseBindingMigration(snapshot.path, params.env),
+        });
+      }
+    }
+  }
+  return snapshotRead;
+}
 
 /** Admit the same config and state before the lease and again before migration writes. */
 export async function readStartupMigrationSnapshot(params: {

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -102,7 +102,7 @@ export async function commitStartupConfigRepairs(params: {
   if (params.migrateProviderBindings && snapshot.valid && snapshot.exists) {
     const {
       prepareProviderUseBindingMigration,
-      revalidateProviderUseBindingMigration,
+      writeProviderUseBindingMigration,
       completeProviderUseBindingMigration,
     } = await import("./doctor/shared/provider-use-binding-migration.js");
     const config = snapshot.sourceConfig ?? snapshot.config ?? {};
@@ -113,19 +113,27 @@ export async function commitStartupConfigRepairs(params: {
     if (bindingMigration.changes.length > 0 || bindingMigration.pending) {
       await guardWrite();
       if (bindingMigration.bindings) {
-        const checked = await revalidateProviderUseBindingMigration({
-          config: bindingMigration.config,
-          sourceConfig: snapshot.sourceConfig,
-          configPath: snapshot.path,
-          env: params.env,
-          bindings: bindingMigration.bindings,
-        });
+        const checked = await writeProviderUseBindingMigration(
+          {
+            config: bindingMigration.config,
+            sourceConfig: snapshot.sourceConfig,
+            configPath: snapshot.path,
+            env: params.env,
+            bindings: bindingMigration.bindings,
+          },
+          async (current, withCommit) => {
+            if (current.changes.length > 0) {
+              await commitAutomaticConfigRepair(
+                current,
+                snapshot,
+                bindingMigration.unsetPaths,
+                withCommit,
+              );
+            }
+          },
+        );
         bindingMigration = { ...bindingMigration, ...checked };
-        params.report({ changes: [], warnings: checked.warnings });
-      }
-      if (bindingMigration.changes.length > 0) {
-        await commitAutomaticConfigRepair(bindingMigration, snapshot, bindingMigration.unsetPaths);
-        params.report({ changes: bindingMigration.changes, warnings: [] });
+        params.report({ changes: checked.changes, warnings: checked.warnings });
         snapshotRead = await params.readSnapshot();
         snapshot = snapshotRead.snapshot;
       }

--- a/src/commands/doctor-config-preflight.state-migration.test-helpers.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test-helpers.ts
@@ -1,4 +1,17 @@
 import { expect, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+
+export function mockCompletedProviderUseBindingMigration() {
+  vi.doMock("./doctor/shared/provider-use-binding-migration.js", () => ({
+    prepareProviderUseBindingMigration: vi.fn(async ({ config }: { config: OpenClawConfig }) => ({
+      config,
+      changes: [],
+      pending: false,
+    })),
+    revalidateProviderUseBindingMigration: vi.fn(),
+    completeProviderUseBindingMigration: vi.fn(() => []),
+  }));
+}
 
 export function makePreflightConfigSnapshot(config: Record<string, unknown>) {
   return {

--- a/src/commands/doctor-config-preflight.state-migration.test-helpers.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test-helpers.ts
@@ -3,12 +3,12 @@ import type { OpenClawConfig } from "../config/types.js";
 
 export function mockCompletedProviderUseBindingMigration() {
   vi.doMock("./doctor/shared/provider-use-binding-migration.js", () => ({
-    prepareProviderUseBindingMigration: vi.fn(async ({ config }: { config: OpenClawConfig }) => ({
+    prepareProviderUseBindingMigration: vi.fn(({ config }: { config: OpenClawConfig }) => ({
       config,
       changes: [],
       pending: false,
     })),
-    revalidateProviderUseBindingMigration: vi.fn(),
+    writeProviderUseBindingMigration: vi.fn(),
     completeProviderUseBindingMigration: vi.fn(() => []),
   }));
 }

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -17,6 +17,7 @@ import {
   makePreflightConfigSnapshot,
   makeStartupConvergenceResult,
   makeStateMigrationResult,
+  mockCompletedProviderUseBindingMigration,
   queueConfigSnapshot,
   stateCheckpointOptions,
   startupCheckpointOptions,
@@ -26,6 +27,7 @@ import {
 } from "./doctor-config-preflight.state-migration.test-helpers.js";
 
 const maybeRepairPluginOpenClawHostLinks = getMaybeRepairPluginOpenClawHostLinksMock();
+mockCompletedProviderUseBindingMigration();
 
 const autoMigrateLegacyStateDir = vi.hoisted(() =>
   vi.fn(async (): Promise<StateMigrationResult> => makeStateMigrationResult([], false)),

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -1,6 +1,7 @@
 // Doctor config preflight tests cover last-known-good snapshots and config snapshot promotion.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyCliProfileEnv } from "../cli/profile.js";
 import { promoteConfigSnapshotToLastKnownGood, readConfigFileSnapshot } from "../config/config.js";
@@ -11,6 +12,7 @@ import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/k
 import {
   hasActiveStartupMigrationLease,
   readMigrationCheckpointStatus,
+  recordSuccessfulStartupMigrations,
 } from "../infra/startup-migration-checkpoint.js";
 import {
   createUpdateRun,
@@ -29,6 +31,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { resolveMigrationCheckpointIdentity } from "./doctor-config-preflight-checkpoint.js";
+import { readDoctorConfigPreflightSnapshot } from "./doctor-config-preflight-plugin-index.js";
 import {
   runDoctorConfigPreflight,
   shouldSkipPluginValidationForDoctorConfigPreflight,
@@ -237,6 +240,67 @@ describe("runDoctorConfigPreflight", () => {
       expect(JSON.parse(await fs.readFile(`${configPath}.bak`, "utf-8"))).toHaveProperty(
         "cron.store",
         storePath,
+      );
+    });
+  });
+
+  it("binds an env-only selected Plan during startup before Doctor and keeps the write sparse", async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync(
+        {
+          BYTEPLUS_API_KEY: "fixture-byteplus-env-key",
+          OPENCLAW_BUNDLED_PLUGINS_DIR: fileURLToPath(
+            new URL("../../extensions/", import.meta.url),
+          ),
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "0",
+        },
+        async () => {
+          const configPath = await writeOpenClawConfig(home, {
+            gateway: { mode: "local" },
+            agents: {
+              defaults: { model: "byteplus-plan/ark-code-latest" },
+              entries: { main: {} },
+            },
+            plugins: { allow: ["byteplus"], entries: { byteplus: { enabled: true } } },
+          });
+          const previous = await readDoctorConfigPreflightSnapshot({
+            allowCurrentPluginMetadata: false,
+            includePluginMetadata: true,
+            preparePluginMetadataSnapshot: false,
+            skipPluginValidation: false,
+          });
+          const previousCheckpoint = {
+            buildIdentity: "previous-build-same-package-version",
+            identity: resolveMigrationCheckpointIdentity({
+              snapshot: previous.snapshot,
+              baseConfig: previous.snapshot.sourceConfig,
+              pluginMigrationFingerprint: previous.pluginMigrationFingerprint,
+            }),
+          };
+          recordSuccessfulStartupMigrations(previousCheckpoint);
+          expect(readMigrationCheckpointStatus(previousCheckpoint)).toBe("startup-current");
+
+          const preflight = await runDoctorConfigPreflight(startupCheckpointOptions);
+
+          const expected = {
+            apiKey: { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" },
+          };
+          expect(preflight.snapshot.valid).toBe(true);
+          expect(preflight.baseConfig.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(
+            expected.apiKey,
+          );
+          const written = await fs.readFile(configPath, "utf8");
+          expect(JSON.parse(written).models.providers).toEqual({ "byteplus-plan": expected });
+          expect(written).not.toContain("fixture-byteplus-env-key");
+          expect(noteMock).toHaveBeenCalledWith(
+            expect.stringContaining("Bound selected provider byteplus-plan to BYTEPLUS_API_KEY"),
+            "Doctor changes",
+          );
+
+          await runDoctorConfigPreflight(startupCheckpointOptions);
+
+          expect(await fs.readFile(configPath, "utf8")).toBe(written);
+        },
       );
     });
   });

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -244,7 +244,7 @@ describe("runDoctorConfigPreflight", () => {
     });
   });
 
-  it("binds an env-only selected Plan during startup before Doctor and keeps the write sparse", async () => {
+  it("serves a selected Plan with an in-memory binding while startup leaves the source untouched", async () => {
     await withDoctorConfigPreflightHome(async (home) => {
       await withEnvAsync(
         {
@@ -269,6 +269,7 @@ describe("runDoctorConfigPreflight", () => {
             preparePluginMetadataSnapshot: false,
             skipPluginValidation: false,
           });
+          const original = await fs.readFile(configPath, "utf8");
           const previousCheckpoint = {
             buildIdentity: "previous-build-same-package-version",
             identity: resolveMigrationCheckpointIdentity({
@@ -286,16 +287,20 @@ describe("runDoctorConfigPreflight", () => {
             apiKey: { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" },
           };
           expect(preflight.snapshot.valid).toBe(true);
-          expect(preflight.baseConfig.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(
-            expected.apiKey,
-          );
+          expect(
+            preflight.snapshot.runtimeConfig.models?.providers?.["byteplus-plan"]?.apiKey,
+          ).toEqual(expected.apiKey);
           const written = await fs.readFile(configPath, "utf8");
-          expect(JSON.parse(written).models.providers).toEqual({ "byteplus-plan": expected });
+          expect(written).toBe(original);
+          expect(
+            preflight.snapshot.sourceConfig.models?.providers?.["byteplus-plan"],
+          ).toBeUndefined();
           expect(written).not.toContain("fixture-byteplus-env-key");
-          expect(noteMock).toHaveBeenCalledWith(
-            expect.stringContaining("Bound selected provider byteplus-plan to BYTEPLUS_API_KEY"),
-            "Doctor changes",
-          );
+          expect(
+            preflight.snapshot.warnings.some((warning) =>
+              warning.message.includes("in memory only"),
+            ),
+          ).toBe(true);
 
           await runDoctorConfigPreflight(startupCheckpointOptions);
 

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -46,6 +46,7 @@ import {
   assertDoctorPreflightMigrationsComplete,
   readStartupMigrationSnapshot,
   completeStartupMigrationPreflight,
+  commitStartupConfigRepairs,
   noteStateMigrationResult,
   prepareStartupMigrationPlugins,
 } from "./doctor-config-preflight-startup.js";
@@ -54,10 +55,7 @@ import { maybeRepairPluginOpenClawHostLinks } from "./doctor-plugin-host-links.j
 import { throwStartupMigrationGuardRejected } from "./doctor-startup-migration-refusal.js";
 import { noteStaleUpdateRuns } from "./doctor-update-run.js";
 import type { CronCodexRuntimePolicyTarget } from "./doctor/cron/store-migration.js";
-import {
-  commitAutomaticConfigRepair,
-  planAutomaticConfigRepair,
-} from "./doctor/shared/automatic-startup-config-repair.js";
+import { planAutomaticConfigRepair } from "./doctor/shared/automatic-startup-config-repair.js";
 import { resolveStateMigrationConfigInput } from "./doctor/shared/legacy-config-state-migration-input.js";
 import { createDoctorPluginMetadataSnapshotScope } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
 
@@ -641,37 +639,31 @@ export async function runDoctorConfigPreflight(
         ),
       );
     }
-    // State migrations must consume retired locators before the config write removes them.
-    // Unsafe migration failures throw; advisory findings must not strand repairable config.
-    if (automaticConfigRepair && stateMigrationsAllowed && freshConfigGuardAllowed) {
-      if (gatewayStartupCheckpointRequired && !startupMigrationLease) {
-        throw new Error("Automatic startup config repair requires the startup migration lease.");
-      }
-      // No snapshot argument: the guard re-reads the config from disk, so an external
-      // edit made while state migrations ran refuses the stale planned write here.
-      const configRepairAllowed =
-        options.beforeStateMigrations === undefined ||
-        (await measurePreflightStep("startup-config-repair-guard", () =>
-          options.beforeStateMigrations?.(),
-        ));
-      if (!configRepairAllowed) {
-        throwStartupMigrationGuardRejected();
-      }
-      startupMigrationLease?.heartbeat();
-      await measurePreflightStep("automatic-config-repair", () =>
-        runWithPluginMetadataSnapshot({ config: automaticConfigRepair.config }, () =>
-          commitAutomaticConfigRepair(automaticConfigRepair, snapshot),
-        ),
-      );
-      note(
-        `Migrated legacy config keys${activeConfigRepair ? " in the active openclaw.json" : " at startup"}:\n${automaticConfigRepair.changes.map((entry) => `- ${entry}`).join("\n")}`,
-        "Doctor changes",
-      );
-      configSnapshotRead = await readConfigSnapshotForPreflight(false);
-      snapshot = configSnapshotRead.snapshot;
-      baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
-      if (migrationCheckpoint) {
-        refreshMigrationCheckpoint(migrationCheckpoint, configSnapshotRead);
+    if (stateMigrationsAllowed && freshConfigGuardAllowed) {
+      const repaired = await commitStartupConfigRepairs({
+        snapshotRead: configSnapshotRead,
+        automaticConfigRepair,
+        activeConfigRepair: Boolean(activeConfigRepair),
+        gatewayStartupCheckpointRequired,
+        migrateProviderBindings:
+          gatewayStartupCheckpointRequired &&
+          shouldRecordStartupCheckpoint &&
+          !shouldSkipPluginValidationForDoctorConfigPreflight(),
+        env: startupMigrationEnv,
+        lease: startupMigrationLease,
+        measure: options.measure,
+        beforeStateMigrations: options.beforeStateMigrations,
+        readSnapshot: () => readConfigSnapshotForPreflight(false),
+        runWithPluginMetadataSnapshot,
+        report: noteStartupStateMigrationResult,
+      });
+      if (repaired !== configSnapshotRead) {
+        configSnapshotRead = repaired;
+        snapshot = repaired.snapshot;
+        baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
+        if (migrationCheckpoint) {
+          refreshMigrationCheckpoint(migrationCheckpoint, configSnapshotRead);
+        }
       }
     }
     if (

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -645,17 +645,11 @@ export async function runDoctorConfigPreflight(
         automaticConfigRepair,
         activeConfigRepair: Boolean(activeConfigRepair),
         gatewayStartupCheckpointRequired,
-        migrateProviderBindings:
-          gatewayStartupCheckpointRequired &&
-          shouldRecordStartupCheckpoint &&
-          !shouldSkipPluginValidationForDoctorConfigPreflight(),
-        env: startupMigrationEnv,
         lease: startupMigrationLease,
         measure: options.measure,
         beforeStateMigrations: options.beforeStateMigrations,
         readSnapshot: () => readConfigSnapshotForPreflight(false),
         runWithPluginMetadataSnapshot,
-        report: noteStartupStateMigrationResult,
       });
       if (repaired !== configSnapshotRead) {
         configSnapshotRead = repaired;

--- a/src/commands/doctor-session-canonical-candidates.ts
+++ b/src/commands/doctor-session-canonical-candidates.ts
@@ -18,7 +18,7 @@ import {
   projectExistingAgentDatabaseTargets,
   resolveTargetSqlitePath,
   type ExistingAgentDatabaseTarget,
-} from "./doctor-session-sqlite-readers.js";
+} from "./doctor-session-sqlite-targets.js";
 
 export type CanonicalSessionCandidate = {
   agentId: string;

--- a/src/commands/doctor-session-delivery-state.ts
+++ b/src/commands/doctor-session-delivery-state.ts
@@ -11,7 +11,7 @@ import {
   isOpenClawAgentDatabaseOpen,
 } from "../state/openclaw-agent-db.js";
 import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
-import { listExistingAgentDatabaseTargets } from "./doctor-session-sqlite-readers.js";
+import { listExistingAgentDatabaseTargets } from "./doctor-session-sqlite-targets.js";
 
 export type SessionDeliveryStateRepairReport = {
   found: number;

--- a/src/commands/doctor-session-incognito-key-repair.ts
+++ b/src/commands/doctor-session-incognito-key-repair.ts
@@ -36,7 +36,7 @@ import {
 import {
   listExistingAgentDatabaseTargets,
   resolveTargetSqliteOptions,
-} from "./doctor-session-sqlite-readers.js";
+} from "./doctor-session-sqlite-targets.js";
 
 export type ReservedIncognitoKeyRepairReport = {
   found: number;

--- a/src/commands/doctor-session-sqlite-compact.ts
+++ b/src/commands/doctor-session-sqlite-compact.ts
@@ -10,7 +10,7 @@ import {
   resolveOpenClawAgentSqlitePath,
   withAgentDatabaseMaintenanceLease,
 } from "../state/openclaw-agent-db.js";
-import { resolveTargetSqliteOptions } from "./doctor-session-sqlite-readers.js";
+import { resolveTargetSqliteOptions } from "./doctor-session-sqlite-targets.js";
 import type { DoctorSessionSqliteCompactReport } from "./doctor-session-sqlite-types.js";
 import { compactDoctorSqliteFile } from "./doctor-sqlite-compact.js";
 

--- a/src/commands/doctor-session-sqlite-readers.ts
+++ b/src/commands/doctor-session-sqlite-readers.ts
@@ -15,20 +15,12 @@ import type { FileEntry } from "../agents/sessions/session-manager-types.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { resolveSessionFilePathCore } from "../config/sessions/paths.js";
 import type { TranscriptEvent } from "../config/sessions/session-accessor.js";
-import {
-  resolveSqliteReadScope,
-  toDatabaseOptions,
-} from "../config/sessions/session-accessor.sqlite-scope.js";
 import type { SessionStoreTarget as ResolvedSessionStoreTarget } from "../config/sessions/targets.js";
-import { resolveAllAgentSessionStoreCandidateTargetsSync } from "../config/sessions/targets.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
 import { tableExists, tableHasColumn } from "../state/openclaw-state-db-schema-helpers.js";
+import { resolveTargetSqlitePath } from "./doctor-session-sqlite-targets.js";
 
 type SessionStoreTarget = ResolvedSessionStoreTarget & { sqlitePath?: string };
-
-export type ExistingAgentDatabaseTarget = SessionStoreTarget & { sqlitePath: string };
 
 export type ReadOnlySqliteValidationSnapshot = {
   sessionIdsBySessionKey: ReadonlyMap<string, string>;
@@ -497,53 +489,6 @@ export function readOnlySqliteDbStats(target: SessionStoreTarget): ReadOnlySqlit
   } finally {
     database?.close();
   }
-}
-
-export function resolveTargetSqliteOptions(target: SessionStoreTarget, env?: NodeJS.ProcessEnv) {
-  return toDatabaseOptions(
-    resolveSqliteReadScope({
-      agentId: target.agentId,
-      env,
-      storePath: target.sqlitePath ?? target.storePath,
-    }),
-  );
-}
-
-export function resolveTargetSqlitePath(
-  target: SessionStoreTarget,
-  env?: NodeJS.ProcessEnv,
-): string {
-  return resolveOpenClawAgentSqlitePath(resolveTargetSqliteOptions(target, env));
-}
-
-/**
- * Projects each caller's ordered targets onto existing physical databases.
- * Keep target selection with the caller: canonical repair selects owners,
- * while ordinary row repairs enumerate candidates. First physical path wins.
- */
-export function projectExistingAgentDatabaseTargets(
-  targets: readonly SessionStoreTarget[],
-  env: NodeJS.ProcessEnv,
-): ExistingAgentDatabaseTarget[] {
-  const seenPaths = new Set<string>();
-  return targets.flatMap((target) => {
-    const sqlitePath = resolveTargetSqlitePath(target, env);
-    if (seenPaths.has(sqlitePath) || !fs.existsSync(sqlitePath)) {
-      return [];
-    }
-    seenPaths.add(sqlitePath);
-    return [{ agentId: target.agentId, sqlitePath, storePath: target.storePath }];
-  });
-}
-
-export function listExistingAgentDatabaseTargets(
-  cfg: OpenClawConfig,
-  env: NodeJS.ProcessEnv,
-): ExistingAgentDatabaseTarget[] {
-  return projectExistingAgentDatabaseTargets(
-    resolveAllAgentSessionStoreCandidateTargetsSync(cfg, { env }),
-    env,
-  );
 }
 
 function* iterateJsonlLinesSync(filePath: string): Generator<string> {

--- a/src/commands/doctor-session-sqlite-recover-report.ts
+++ b/src/commands/doctor-session-sqlite-recover-report.ts
@@ -30,11 +30,11 @@ import {
   resolveSessionSqliteMigrationRunsDir,
   type SessionSqliteMigrationTargetInput,
 } from "./doctor-session-sqlite-migration-run.js";
+import { restoreSessionSqliteMigrationRun } from "./doctor-session-sqlite-restore.js";
 import {
   resolveTargetSqliteOptions,
   resolveTargetSqlitePath,
-} from "./doctor-session-sqlite-readers.js";
-import { restoreSessionSqliteMigrationRun } from "./doctor-session-sqlite-restore.js";
+} from "./doctor-session-sqlite-targets.js";
 import {
   createDoctorSessionSqliteTotals,
   createDoctorSessionSqliteTargetReport,

--- a/src/commands/doctor-session-sqlite-restore-report.ts
+++ b/src/commands/doctor-session-sqlite-restore-report.ts
@@ -1,8 +1,9 @@
 /** Builds doctor reports for session SQLite migration restore mode. */
 import type { SessionStoreTarget } from "../config/sessions/targets.js";
 import { resolveSessionSqliteMigrationRunsDir } from "./doctor-session-sqlite-migration-run.js";
-import { readSqliteEntryCount, resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
+import { readSqliteEntryCount } from "./doctor-session-sqlite-readers.js";
 import { restoreSessionSqliteMigrationRuns } from "./doctor-session-sqlite-restore.js";
+import { resolveTargetSqlitePath } from "./doctor-session-sqlite-targets.js";
 import {
   createDoctorSessionSqliteTargetReport,
   createDoctorSessionSqliteTotals,

--- a/src/commands/doctor-session-sqlite-targets.ts
+++ b/src/commands/doctor-session-sqlite-targets.ts
@@ -1,0 +1,58 @@
+/** Read-only target layout shared by startup migration and Doctor session repairs. */
+import fs from "node:fs";
+import {
+  resolveSqliteReadScope,
+  toDatabaseOptions,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
+import {
+  resolveAllAgentSessionStoreCandidateTargetsSync,
+  type SessionStoreTarget as ResolvedSessionStoreTarget,
+} from "../config/sessions/targets.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
+
+type SessionStoreTarget = ResolvedSessionStoreTarget & { sqlitePath?: string };
+export type ExistingAgentDatabaseTarget = SessionStoreTarget & { sqlitePath: string };
+
+export function resolveTargetSqliteOptions(target: SessionStoreTarget, env?: NodeJS.ProcessEnv) {
+  return toDatabaseOptions(
+    resolveSqliteReadScope({
+      agentId: target.agentId,
+      env,
+      storePath: target.sqlitePath ?? target.storePath,
+    }),
+  );
+}
+
+export function resolveTargetSqlitePath(
+  target: SessionStoreTarget,
+  env?: NodeJS.ProcessEnv,
+): string {
+  return resolveOpenClawAgentSqlitePath(resolveTargetSqliteOptions(target, env));
+}
+
+/** First physical path wins; callers retain ownership of target selection. */
+export function projectExistingAgentDatabaseTargets(
+  targets: readonly SessionStoreTarget[],
+  env: NodeJS.ProcessEnv,
+): ExistingAgentDatabaseTarget[] {
+  const seenPaths = new Set<string>();
+  return targets.flatMap((target) => {
+    const sqlitePath = resolveTargetSqlitePath(target, env);
+    if (seenPaths.has(sqlitePath) || !fs.existsSync(sqlitePath)) {
+      return [];
+    }
+    seenPaths.add(sqlitePath);
+    return [{ agentId: target.agentId, sqlitePath, storePath: target.storePath }];
+  });
+}
+
+export function listExistingAgentDatabaseTargets(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): ExistingAgentDatabaseTarget[] {
+  return projectExistingAgentDatabaseTargets(
+    resolveAllAgentSessionStoreCandidateTargetsSync(cfg, { env }),
+    env,
+  );
+}

--- a/src/commands/doctor-session-sqlite.memory.test-support.ts
+++ b/src/commands/doctor-session-sqlite.memory.test-support.ts
@@ -7,7 +7,7 @@ import { withSuppressedNotes } from "../../packages/terminal-core/src/note.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
+import { resolveTargetSqlitePath } from "./doctor-session-sqlite-targets.js";
 import { runDoctorSessionSqlite } from "./doctor-session-sqlite.js";
 import { noteSessionTranscriptHealth } from "./doctor-session-transcripts.js";
 

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -72,12 +72,12 @@ import * as sqliteReaders from "./doctor-session-sqlite-readers.js";
 import {
   createTranscriptEventReader,
   readOnlySqliteValidationSnapshot,
-  resolveTargetSqlitePath,
 } from "./doctor-session-sqlite-readers.js";
 import { recoverDoctorSessionSqliteTargets } from "./doctor-session-sqlite-recover-report.js";
 import { inspectSessionSqliteRecovery } from "./doctor-session-sqlite-recovery-inventory.js";
 import { restoreSessionSqliteMigrationRun } from "./doctor-session-sqlite-restore.js";
 import { retireSessionSqliteRecovery } from "./doctor-session-sqlite-retirement.js";
+import { resolveTargetSqlitePath } from "./doctor-session-sqlite-targets.js";
 import { createDoctorSessionSqliteTargetReport } from "./doctor-session-sqlite-types.js";
 import { runDoctorSessionSqlite, type DoctorSessionSqliteReport } from "./doctor-session-sqlite.js";
 import { withDoctorSqliteMaintenanceLock } from "./doctor-sqlite-maintenance-lock.js";

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -61,13 +61,13 @@ import {
   readTranscriptFingerprint,
   readSqliteEntryCount,
   resolveLegacyTranscriptPaths,
-  resolveTargetSqlitePath,
   scanReadOnlySqliteActiveTranscriptFiles,
   type ReadOnlySqliteValidationSnapshot,
 } from "./doctor-session-sqlite-readers.js";
 import { recoverDoctorSessionSqliteTargets } from "./doctor-session-sqlite-recover-report.js";
 import { restoreDoctorSessionSqliteTargets } from "./doctor-session-sqlite-restore-report.js";
 import { reconcileSessionSqliteMigrationPublications } from "./doctor-session-sqlite-restore.js";
+import { resolveTargetSqlitePath } from "./doctor-session-sqlite-targets.js";
 import {
   createDoctorSessionSqliteTotals,
   createDoctorSessionSqliteTargetReport,

--- a/src/commands/doctor-session-transcript-headers.ts
+++ b/src/commands/doctor-session-transcript-headers.ts
@@ -27,7 +27,7 @@ import {
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
-import { resolveTargetSqliteOptions } from "./doctor-session-sqlite-readers.js";
+import { resolveTargetSqliteOptions } from "./doctor-session-sqlite-targets.js";
 import { ReadOnlySqliteTranscriptReader } from "./doctor-session-sqlite-transcript-readers.js";
 
 const NOTE_TITLE = "Session transcript headers";

--- a/src/commands/doctor-session-transcript-labels.ts
+++ b/src/commands/doctor-session-transcript-labels.ts
@@ -16,7 +16,7 @@ import {
   resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
-import { resolveTargetSqliteOptions } from "./doctor-session-sqlite-readers.js";
+import { resolveTargetSqliteOptions } from "./doctor-session-sqlite-targets.js";
 import { ReadOnlySqliteTranscriptReader } from "./doctor-session-sqlite-transcript-readers.js";
 
 const NOTE_TITLE = "Session transcript labels";

--- a/src/commands/doctor/emit-notes.ts
+++ b/src/commands/doctor/emit-notes.ts
@@ -26,3 +26,34 @@ export function emitDoctorNotes(params: {
     params.note(sanitizeDoctorNote(warning), "Doctor warnings");
   }
 }
+
+// Repair-mode "Doctor changes" panels queue until the final candidate passes the
+// same validation the atomic writer enforces: printing "Doctor changes" and then
+// refusing the write would report repairs that never reached disk. Preview
+// panels print immediately — they promise nothing.
+type DoctorChangesPanelSink = {
+  emit: (changeLines: ReadonlyArray<string>, options?: { sanitize?: boolean }) => void;
+  drain: () => string[];
+};
+
+export function createDoctorChangesPanelSink(
+  shouldRepair: boolean,
+  note: (message: string, title?: string) => void,
+): DoctorChangesPanelSink {
+  const pending: string[] = [];
+  return {
+    emit: (changeLines, options = {}) => {
+      if (changeLines.length === 0) {
+        return;
+      }
+      const body = changeLines.join("\n");
+      const message = options.sanitize ? sanitizeDoctorNote(body) : body;
+      if (shouldRepair) {
+        pending.push(message);
+        return;
+      }
+      note(message, "Doctor changes preview");
+    },
+    drain: () => pending.splice(0),
+  };
+}

--- a/src/commands/doctor/shared/automatic-startup-config-repair.ts
+++ b/src/commands/doctor/shared/automatic-startup-config-repair.ts
@@ -131,6 +131,7 @@ export async function commitAutomaticConfigRepair(
   plan: Pick<AutomaticConfigRepairPlan, "config">,
   snapshot: ConfigFileSnapshot,
   unsetPaths?: string[][],
+  withCommit?: import("../../../config/io.types.js").ConfigWriteOptions["withCommit"],
 ): Promise<void> {
   await transformConfigFile({
     baseHash: resolveConfigSnapshotHash(snapshot) ?? undefined,
@@ -141,6 +142,7 @@ export async function commitAutomaticConfigRepair(
     }),
     afterWrite: { mode: "none", reason: "automatic migration" },
     writeOptions: {
+      withCommit,
       expectedConfigPath: snapshot.path,
       auditOrigin: "doctor",
       skipOutputLogs: true,

--- a/src/commands/doctor/shared/automatic-startup-config-repair.ts
+++ b/src/commands/doctor/shared/automatic-startup-config-repair.ts
@@ -128,8 +128,9 @@ export function isStartupConfigRepairResult(
 
 /** Commits a planned repair against the exact snapshot admitted by its caller. */
 export async function commitAutomaticConfigRepair(
-  plan: AutomaticConfigRepairPlan,
+  plan: Pick<AutomaticConfigRepairPlan, "config">,
   snapshot: ConfigFileSnapshot,
+  unsetPaths?: string[][],
 ): Promise<void> {
   await transformConfigFile({
     baseHash: resolveConfigSnapshotHash(snapshot) ?? undefined,
@@ -144,6 +145,7 @@ export async function commitAutomaticConfigRepair(
       auditOrigin: "doctor",
       skipOutputLogs: true,
       skipRuntimeSnapshotRefresh: true,
+      ...(unsetPaths ? { unsetPaths } : {}),
       // The reader retired legacy markers; persist their canonical owners in this write.
       // Startup verification above uses the same writer topology preparation.
       persistCanonicalAgentRoster: true,

--- a/src/commands/doctor/shared/configured-provider-selection-ids.test.ts
+++ b/src/commands/doctor/shared/configured-provider-selection-ids.test.ts
@@ -1,0 +1,128 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { assert, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { resolveCronJobsStorePathFromConfig, saveCronJobsStore } from "../../../cron/store.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import { collectConfiguredProviderUseSelections } from "./configured-provider-selection-ids.js";
+
+it.each([
+  "agents.defaults.subagents.model",
+  "agents.entries.alpha.subagents.model",
+  "agents.defaults.utilityModel",
+  "agents.defaults.imageModel",
+  "agents.defaults.pdfModel",
+  "agents.defaults.voiceModel",
+  "agents.defaults.mediaModels.image",
+  "agents.defaults.mediaModels.video",
+  "agents.defaults.mediaModels.music",
+  "agents.defaults.heartbeat.model",
+  "agents.defaults.compaction.model",
+  "agents.defaults.compaction.memoryFlush.model",
+  "tools.exec.reviewer.model",
+  "agents.entries.alpha.tools.exec.reviewer.model",
+  "channels.modelByChannel.discord.channel",
+])("collects the executable selection at %s", async (selector) => {
+  await withOpenClawTestState({ label: "provider-selection" }, async (state) => {
+    const config: OpenClawConfig = {
+      agents: { defaults: { model: "openai/unrelated" }, entries: { alpha: {} } },
+    };
+    let target: unknown = config;
+    const fields = selector.split(".");
+    for (const field of fields.slice(0, -1)) {
+      assert(isRecord(target));
+      target[field] ??= {};
+      target = target[field];
+    }
+    assert(isRecord(target));
+    target[fields.at(-1)!] = "byteplus-plan/ark-code-latest";
+    expect(collectConfiguredProviderUseSelections({ config, env: state.env })).toContainEqual({
+      agentId: "alpha",
+      provider: "byteplus-plan",
+      previouslyCovered: false,
+    });
+  });
+});
+
+it("resolves selected aliases per agent without enrolling catalog-only siblings", async () => {
+  await withOpenClawTestState({ label: "provider-selection-alias" }, async (state) => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/unrelated", fallbacks: ["anthropic/fallback"] },
+          subagents: { model: "plan" },
+          models: {
+            "byteplus-plan/ark-code-latest": { alias: "plan" },
+            "volcengine-plan/ark-code-latest": {},
+          },
+        },
+        entries: {
+          alpha: { model: "openai/alpha" },
+          beta: { subagents: { model: "openai/beta-child" } },
+        },
+      },
+    };
+    const selected = collectConfiguredProviderUseSelections({ config, env: state.env });
+    expect(selected).toContainEqual({
+      agentId: "alpha",
+      provider: "byteplus-plan",
+      previouslyCovered: false,
+    });
+    expect(selected).not.toContainEqual({
+      agentId: "alpha",
+      provider: "anthropic",
+      previouslyCovered: true,
+    });
+    expect(selected).toContainEqual({
+      agentId: "beta",
+      provider: "anthropic",
+      previouslyCovered: true,
+    });
+    expect(
+      selected.some(
+        (selection) => selection.agentId === "beta" && selection.provider === "byteplus-plan",
+      ),
+    ).toBe(false);
+    expect(selected.some((selection) => selection.provider === "volcengine-plan")).toBe(false);
+  });
+});
+
+it("reads a persisted cron model and fallbacks in the job's agent scope", async () => {
+  await withOpenClawTestState({ label: "provider-selection-cron" }, async (state) => {
+    const config: OpenClawConfig = { agents: { entries: { alpha: {}, beta: {} } } };
+    await saveCronJobsStore(resolveCronJobsStorePathFromConfig(config, state.env), {
+      version: 1,
+      jobs: [
+        {
+          id: "selected-job",
+          name: "Selected job",
+          enabled: true,
+          agentId: "beta",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: {
+            kind: "agentTurn",
+            message: "fixture",
+            model: "byteplus-plan/ark-code-latest",
+            fallbacks: ["volcengine-plan/ark-code-latest"],
+          },
+          state: {},
+        },
+      ],
+    });
+    const selected = collectConfiguredProviderUseSelections({ config, env: state.env });
+    expect(selected).toContainEqual({
+      agentId: "beta",
+      provider: "byteplus-plan",
+      previouslyCovered: false,
+    });
+    expect(selected).toContainEqual({
+      agentId: "beta",
+      provider: "volcengine-plan",
+      previouslyCovered: false,
+    });
+    expect(selected.some((selection) => selection.agentId === "alpha")).toBe(false);
+  });
+});

--- a/src/commands/doctor/shared/configured-provider-selection-ids.ts
+++ b/src/commands/doctor/shared/configured-provider-selection-ids.ts
@@ -1,8 +1,27 @@
 // Reads provider ids selected by auth, model, channel, and media configuration.
-import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
+import {
+  collectConfiguredModelRefs,
+  listModelRefsFromConfigValue,
+} from "@openclaw/model-catalog-core/configured-model-refs";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeNullableString as normalizeId } from "@openclaw/normalization-core/string-coerce";
+import { listAgentIds, tryResolveAmbientOwnerAgentId } from "../../../agents/agent-scope-config.js";
+import {
+  collectSelectedModelProviders,
+  resolveDefaultModelForAgent,
+} from "../../../agents/model-selection-config.js";
+import {
+  buildModelAliasIndex,
+  resolveModelRefFromString,
+} from "../../../agents/model-selection-shared.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { resolveCronJobsStorePathFromConfig } from "../../../cron/store.js";
+import { cronStoreKey } from "../../../cron/store/key.js";
+import { loadedCronStoreFromRows, loadCronRows } from "../../../cron/store/row-codec.js";
+import { parseAgentSessionKey } from "../../../routing/session-key.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../../../state/openclaw-state-db-readonly.js";
+import { tableExists } from "../../../state/openclaw-state-db-schema-helpers.js";
 
 function collectConfiguredProviderIds(cfg: OpenClawConfig): Set<string> {
   const ids = new Set<string>();
@@ -19,8 +38,7 @@ function collectConfiguredProviderIds(cfg: OpenClawConfig): Set<string> {
     add(providerId);
   }
   const modelByChannel = asNullableRecord(cfg.channels?.modelByChannel);
-  for (const [providerId, channelMap] of Object.entries(modelByChannel ?? {})) {
-    add(providerId);
+  for (const channelMap of Object.values(modelByChannel ?? {})) {
     for (const modelRef of Object.values(asNullableRecord(channelMap) ?? {})) {
       if (typeof modelRef !== "string") {
         continue;
@@ -40,6 +58,97 @@ function collectConfiguredProviderIds(cfg: OpenClawConfig): Set<string> {
     }
   }
   return ids;
+}
+
+export type ConfiguredProviderUseSelection = {
+  agentId: string;
+  provider: string;
+  /** Version one already covered primary/fallback selections. */
+  previouslyCovered: boolean;
+};
+
+/** Resolve every executable selector in its agent scope; catalog aliases alone are not use. */
+export function collectConfiguredProviderUseSelections(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  agentIds?: Iterable<string>;
+}): ConfiguredProviderUseSelection[] {
+  const { config, env } = params;
+  const selections: ConfiguredProviderUseSelection[] = [
+    ...(params.agentIds ?? listAgentIds(config)),
+  ].flatMap((agentId) =>
+    collectSelectedModelProviders({ cfg: config, agentId }).map(({ provider, mainModel }) => ({
+      agentId,
+      provider,
+      previouslyCovered: mainModel,
+    })),
+  );
+  const contexts = new Map<
+    string,
+    {
+      defaultProvider: string;
+      aliasIndex: ReturnType<typeof buildModelAliasIndex>;
+    }
+  >();
+  const add = (agentId: string, raw: string, previouslyCovered: boolean) => {
+    let context = contexts.get(agentId);
+    const selection = {
+      cfg: config,
+      agentId,
+      allowManifestNormalization: false,
+      allowPluginNormalization: false,
+    };
+    if (!context) {
+      const defaultProvider = resolveDefaultModelForAgent(selection).provider;
+      context = {
+        defaultProvider,
+        aliasIndex: buildModelAliasIndex({ ...selection, defaultProvider }),
+      };
+      contexts.set(agentId, context);
+    }
+    const resolved = resolveModelRefFromString({ ...selection, ...context, raw });
+    if (resolved) {
+      selections.push({
+        agentId,
+        provider: normalizeProviderId(resolved.ref.provider),
+        previouslyCovered,
+      });
+    }
+  };
+  const storePath = resolveCronJobsStorePathFromConfig(config, env);
+  const cron = withExistingOpenClawStateDatabaseReadOnly(
+    ({ db }) =>
+      tableExists(db, "cron_jobs")
+        ? loadedCronStoreFromRows(loadCronRows(db, cronStoreKey(storePath)))
+        : undefined,
+    { env },
+  );
+  if (cron?.invalidConfigRows.length) {
+    throw new Error("Cannot complete provider migration with unreadable cron selections.");
+  }
+  for (const job of [...(cron?.store.jobs ?? []), ...(cron?.configJobs ?? [])]) {
+    const record = asNullableRecord(job);
+    const payload = asNullableRecord(record?.payload);
+    const values = listModelRefsFromConfigValue({
+      primary: payload?.model,
+      fallbacks: payload?.fallbacks,
+    });
+    if (values.length === 0) {
+      continue;
+    }
+    const agentId =
+      normalizeId(record?.agentId) ??
+      normalizeId(asNullableRecord(record?.owner)?.agentId) ??
+      parseAgentSessionKey(normalizeId(record?.sessionKey) ?? "")?.agentId ??
+      tryResolveAmbientOwnerAgentId(config);
+    if (!agentId) {
+      throw new Error("Cannot complete provider migration without the selected cron agent owner.");
+    }
+    for (const value of values) {
+      add(agentId, value, false);
+    }
+  }
+  return selections;
 }
 
 function collectConfiguredMediaProviderIds(cfg: OpenClawConfig): Set<string> {

--- a/src/commands/doctor/shared/configured-provider-selection-ids.ts
+++ b/src/commands/doctor/shared/configured-provider-selection-ids.ts
@@ -38,7 +38,8 @@ function collectConfiguredProviderIds(cfg: OpenClawConfig): Set<string> {
     add(providerId);
   }
   const modelByChannel = asNullableRecord(cfg.channels?.modelByChannel);
-  for (const channelMap of Object.values(modelByChannel ?? {})) {
+  for (const [providerId, channelMap] of Object.entries(modelByChannel ?? {})) {
+    add(providerId);
     for (const modelRef of Object.values(asNullableRecord(channelMap) ?? {})) {
       if (typeof modelRef !== "string") {
         continue;

--- a/src/commands/doctor/shared/provider-use-binding-migration.test.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.test.ts
@@ -13,6 +13,7 @@ import {
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { SecretRef } from "../../../config/types.secrets.js";
+import { acquireFileLockSyncWithRetry } from "../../../infra/file-lock-sync.js";
 import { resolveProviderBindingEnvVarCandidates } from "../../../secrets/provider-env-vars.js";
 import { runOpenClawAgentWriteTransaction } from "../../../state/openclaw-agent-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
@@ -24,6 +25,7 @@ import {
   completeProviderUseBindingMigration,
   prepareProviderUseBindingMigration,
   revalidateProviderUseBindingMigration,
+  writeProviderUseBindingMigration,
 } from "./provider-use-binding-migration.js";
 
 vi.mock("./active-tool-schema-warnings.js", () => ({
@@ -79,6 +81,40 @@ function prepare(config: OpenClawConfig) {
     env: state.env,
   });
 }
+
+it("defers shared-key bindings without failing when account publication is busy", async () => {
+  const migration = prepare(selectedPlan);
+  assert(migration.bindings);
+  const locks = path.join(state.stateDir, "locks");
+  await fs.mkdir(locks, { recursive: true });
+  const release = acquireFileLockSyncWithRetry(path.join(locks, "auth-profile-publication"));
+  const publish = vi.fn();
+  try {
+    const result = await writeProviderUseBindingMigration(
+      {
+        config: { ...migration.config, browser: { enabled: false } },
+        sourceConfig: selectedPlan,
+        configPath: state.configPath,
+        env: state.env,
+        bindings: migration.bindings,
+      },
+      async (checked, withCommit) => {
+        if (withCommit) {
+          withCommit(publish);
+        } else {
+          expect(checked.config.models?.providers?.["byteplus-plan"]).toBeUndefined();
+          expect(checked.config.browser?.enabled).toBe(false);
+        }
+      },
+    );
+    expect(publish).not.toHaveBeenCalled();
+    expect(result.pending).toBe(false);
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("bindings were deferred");
+  } finally {
+    release();
+  }
+});
 
 function admitted(config: OpenClawConfig) {
   return resolveProviderUseAdmission({

--- a/src/commands/doctor/shared/provider-use-binding-migration.test.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.test.ts
@@ -1,0 +1,449 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveProviderUseAdmission } from "../../../agents/provider-model-auth-source-plan.js";
+import {
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "../../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { resolveProviderBindingEnvVarCandidates } from "../../../secrets/provider-env-vars.js";
+import { runOpenClawAgentWriteTransaction } from "../../../state/openclaw-agent-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../../test-utils/openclaw-test-state.js";
+import {
+  completeProviderUseBindingMigration,
+  prepareProviderUseBindingMigration,
+} from "./provider-use-binding-migration.js";
+
+vi.mock("./active-tool-schema-warnings.js", () => ({
+  collectActiveToolSchemaProjectionWarnings: async () => [],
+}));
+
+const bundledPlugins = fileURLToPath(new URL("../../../../extensions/", import.meta.url));
+const selectedPlan: OpenClawConfig = {
+  agents: {
+    defaults: { model: "byteplus-plan/ark-code-latest" },
+    entries: { main: {} },
+  },
+};
+const byteplusRef = { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" };
+let state: OpenClawTestState;
+
+beforeEach(async () => {
+  state = await createOpenClawTestState({
+    label: "provider-binding-migration",
+    env: {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPlugins,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "0",
+      BYTEPLUS_API_KEY: "fixture-byteplus-key",
+      VOLCANO_ENGINE_API_KEY: "fixture-volcengine-key",
+      MINIMAX_API_KEY: "fixture-minimax-shared-key",
+      MINIMAX_CODE_PLAN_KEY: undefined,
+      MINIMAX_CODING_API_KEY: undefined,
+      MINIMAX_OAUTH_TOKEN: undefined,
+      GITHUB_TOKEN: undefined,
+      GH_TOKEN: undefined,
+      MODEL_API_KEY: undefined,
+      AWS_ACCESS_KEY_ID: undefined,
+      AWS_SECRET_ACCESS_KEY: undefined,
+      AWS_PROFILE: undefined,
+      GOOGLE_APPLICATION_CREDENTIALS: undefined,
+      OPENCLAW_UPDATE_IN_PROGRESS: undefined,
+    },
+  });
+});
+
+afterEach(async () => {
+  await state.cleanup();
+});
+
+function prepare(config: OpenClawConfig) {
+  return prepareProviderUseBindingMigration({
+    config,
+    configPath: state.configPath,
+    env: state.env,
+  });
+}
+
+function admitted(config: OpenClawConfig) {
+  return resolveProviderUseAdmission({
+    config,
+    env: state.env,
+    providerEnvVars: resolveProviderBindingEnvVarCandidates({ config, env: state.env }),
+  });
+}
+
+describe("selected shared-provider upgrade", () => {
+  it.each(["entries", "list"] as const)(
+    "preserves default, fallback and per-agent selections from the %s roster",
+    async (roster) => {
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "byteplus-plan/ark-code-latest",
+              fallbacks: ["volcengine-plan/ark-code-latest"],
+            },
+          },
+          ...(roster === "entries"
+            ? { entries: { main: {}, worker: { model: "minimax/MiniMax-M2.7" } } }
+            : { list: [{ id: "main" }, { id: "worker", model: "minimax/MiniMax-M2.7" }] }),
+        },
+      };
+      const original = structuredClone(config);
+
+      const result = await prepare(config);
+
+      expect(result.pending).toBe(true);
+      expect(result.config.models?.providers).toEqual({
+        "byteplus-plan": { apiKey: byteplusRef, baseUrl: "", models: [] },
+        "volcengine-plan": {
+          apiKey: { source: "env", provider: "default", id: "VOLCANO_ENGINE_API_KEY" },
+          baseUrl: "",
+          models: [],
+        },
+        minimax: {
+          apiKey: { source: "env", provider: "default", id: "MINIMAX_API_KEY" },
+          baseUrl: "",
+          models: [],
+        },
+      });
+      expect(config).toEqual(original);
+      expect(admitted(result.config).has("byteplus-plan")).toBe(true);
+      expect(admitted(result.config).has("volcengine-plan")).toBe(true);
+      expect(admitted(result.config).has("minimax-portal")).toBe(false);
+      const second = await prepare(result.config);
+      expect(second.config).toBe(result.config);
+      expect(second.changes).toEqual([]);
+    },
+  );
+
+  it("preserves persisted user and legacy pins without promoting automatic fallbacks", async () => {
+    const config: OpenClawConfig = { agents: { entries: { main: {}, worker: {} } } };
+    const pins: Array<{ agentId: string; name: string; entry: SessionEntry }> = [
+      {
+        agentId: "main",
+        name: "user",
+        entry: {
+          sessionId: "pin-user",
+          updatedAt: 1,
+          providerOverride: "byteplus-plan",
+          modelOverride: "ark-code-latest",
+          modelOverrideSource: "user",
+        },
+      },
+      {
+        agentId: "worker",
+        name: "legacy",
+        entry: {
+          sessionId: "pin-legacy",
+          updatedAt: 2,
+          providerOverride: "volcengine-plan",
+          modelOverride: "volcengine-plan/ark-code-latest",
+        },
+      },
+      {
+        agentId: "main",
+        name: "automatic",
+        entry: {
+          sessionId: "pin-auto",
+          updatedAt: 3,
+          providerOverride: "minimax",
+          modelOverride: "MiniMax-M2.7",
+          modelOverrideSource: "auto",
+        },
+      },
+      {
+        agentId: "worker",
+        name: "default",
+        entry: {
+          sessionId: "pin-default",
+          updatedAt: 4,
+          providerOverride: "minimax-portal",
+          modelOverride: "MiniMax-M2.7",
+          modelOverrideSource: "default",
+        },
+      },
+      {
+        agentId: "worker",
+        name: "legacy-automatic",
+        entry: {
+          sessionId: "pin-legacy-auto",
+          updatedAt: 5,
+          providerOverride: "minimax-portal",
+          modelOverride: "MiniMax-M2.7",
+          modelOverrideFallbackOriginProvider: "openai",
+          modelOverrideFallbackOriginModel: "fixture-model",
+        },
+      },
+    ];
+    const scopes = pins.map(({ agentId, name }) => ({
+      agentId,
+      storePath: path.join(state.sessionsDir(agentId), "sessions.json"),
+      sessionKey: `agent:${agentId}:${name}`,
+      env: state.env,
+    }));
+    for (let index = 0; index < pins.length; index += 1) {
+      await replaceSessionEntry(scopes[index]!, pins[index]!.entry);
+    }
+    const before = scopes.map((scope) => loadSessionEntry(scope));
+
+    const result = await prepare(config);
+
+    expect(Object.keys(result.config.models?.providers ?? {}).toSorted()).toEqual([
+      "byteplus-plan",
+      "volcengine-plan",
+    ]);
+    expect(result.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+    expect(scopes.map((scope) => loadSessionEntry(scope))).toEqual(before);
+    expect(admitted(result.config).has("minimax")).toBe(false);
+    expect(admitted(result.config).has("minimax-portal")).toBe(false);
+  });
+
+  it("does not bind unselected siblings or selected generic credential providers", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "github-copilot/gpt-4o",
+            fallbacks: ["amazon-bedrock/fixture", "google-vertex/fixture"],
+          },
+        },
+      },
+    };
+    const env = {
+      ...state.env,
+      GITHUB_TOKEN: "fixture-github-token",
+      GH_TOKEN: "fixture-gh-token",
+      MODEL_API_KEY: "fixture-generic-key",
+      AWS_PROFILE: "default",
+      AWS_ACCESS_KEY_ID: "fixture-access",
+      AWS_SECRET_ACCESS_KEY: "fixture-secret",
+      GOOGLE_APPLICATION_CREDENTIALS: state.path("fixture-adc.json"),
+    };
+    await fs.writeFile(
+      env.GOOGLE_APPLICATION_CREDENTIALS,
+      JSON.stringify({ type: "authorized_user" }),
+    );
+
+    const result = await prepareProviderUseBindingMigration({
+      config,
+      configPath: state.configPath,
+      env,
+    });
+
+    expect(result.config).toBe(config);
+    expect(result.changes).toEqual([]);
+    expect(result.pending).toBe(true);
+    expect(result.config.models?.providers).toBeUndefined();
+  });
+
+  it("preserves an existing selected account instead of replacing it with a shared env key", async () => {
+    await state.writeAuthProfiles({
+      version: 1,
+      profiles: {
+        "byteplus-plan:work": {
+          type: "api_key",
+          provider: "byteplus-plan",
+          key: "fixture-account-key",
+        },
+      },
+    });
+
+    const result = await prepare(selectedPlan);
+
+    expect(result.config).toBe(selectedPlan);
+    expect(result.changes).toEqual([]);
+    expect(result.config.models?.providers?.["byteplus-plan"]).toBeUndefined();
+  });
+
+  it.each([
+    '{"models":null}',
+    '{"models":{"providers":[]}}',
+    '{"agents":{"defaults":{"model":{"primary":9,"fallbacks":[null,3,{}]}},"entries":{"broken":null}}}',
+  ])("leaves malformed operator shapes intact: %s", async (serialized) => {
+    const config: OpenClawConfig = JSON.parse(serialized);
+    const result = await prepare(config);
+    expect(result.config).toEqual(config);
+    expect(result.changes).toEqual([]);
+  });
+
+  it("does not reopen a completed upgrade after binding removal or a later selection", async () => {
+    const migrated = await prepare(selectedPlan);
+    expect(migrated.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+    expect(completeProviderUseBindingMigration(state.configPath, state.env)).toEqual([]);
+
+    for (const model of ["byteplus-plan/ark-code-latest", "volcengine-plan/ark-code-latest"]) {
+      const config: OpenClawConfig = { agents: { defaults: { model } } };
+      const result = await prepare(config);
+      expect(result).toEqual({ config, changes: [], pending: false });
+      expect(admitted(result.config).has(model.split("/")[0]!)).toBe(false);
+    }
+  });
+
+  it("closes an empty successful upgrade before a new shared-key selection appears", async () => {
+    const empty = await prepare({ agents: { entries: { main: {} } } });
+    expect(empty.changes).toEqual([]);
+    expect(empty.pending).toBe(true);
+    expect(completeProviderUseBindingMigration(state.configPath, state.env)).toEqual([]);
+
+    const result = await prepare(selectedPlan);
+    expect(result).toEqual({ config: selectedPlan, changes: [], pending: false });
+    expect(admitted(result.config).has("byteplus-plan")).toBe(false);
+  });
+
+  it("defers an incomplete recovered session inventory without binding or completing", async () => {
+    const scope = {
+      agentId: "main",
+      storePath: path.join(state.sessionsDir(), "sessions.json"),
+      sessionKey: "agent:main:damaged",
+      env: state.env,
+    };
+    await replaceSessionEntry(scope, {
+      sessionId: "damaged",
+      updatedAt: 1,
+      providerOverride: "byteplus-plan",
+      modelOverride: "ark-code-latest",
+      modelOverrideSource: "user",
+    });
+    // Deliberate corruption bypasses the normal writer so Doctor sees a recoverable row.
+    runOpenClawAgentWriteTransaction(
+      ({ db }) => {
+        db.prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?").run(
+          "{",
+          scope.sessionKey,
+        );
+      },
+      { agentId: "main", env: state.env },
+    );
+
+    const result = await prepare(selectedPlan);
+
+    expect(result).toMatchObject({ config: selectedPlan, changes: [], pending: false });
+    expect(result.warnings).toEqual([expect.stringContaining("Rerun")]);
+  });
+
+  it("defers unreadable receipt state without creating a provider binding", async () => {
+    const databasePath = resolveOpenClawStateSqlitePath(state.env);
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    await fs.writeFile(databasePath, "not a SQLite database");
+
+    const result = await prepare(selectedPlan);
+
+    expect(result).toMatchObject({ config: selectedPlan, changes: [], pending: false });
+    expect(result.warnings).toEqual([expect.stringContaining("Rerun")]);
+  });
+});
+
+describe("Doctor provider-binding write composition", () => {
+  it("persists a primary Plan env SecretRef and closes the upgrade after the actual write", async () => {
+    const { prepareDoctorContext } = await import("../../doctor-config-flow.test-support.js");
+    const { runWriteConfigHealth } =
+      await import("../../../flows/doctor-health-contribution-runners.config.js");
+    await state.writeConfig({
+      ...selectedPlan,
+      gateway: { mode: "local", auth: { mode: "token", token: "fixture-gateway-token" } },
+      env: { vars: { BYTEPLUS_API_KEY: "fixture-byteplus-key" } },
+    });
+
+    const context = await prepareDoctorContext(state.configPath);
+    expect(context.configResult.shouldWriteConfig).toBe(true);
+    await runWriteConfigHealth(context, { runPostWriteRepairs: false });
+
+    const persisted: OpenClawConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+    expect(persisted.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+    expect(context.configWriteRefusal).toBeUndefined();
+    expect(await prepare(selectedPlan)).toEqual({
+      config: selectedPlan,
+      changes: [],
+      pending: false,
+    });
+  });
+
+  it("does not complete the upgrade when ambiguous include ownership blocks the config write", async () => {
+    const { prepareDoctorContext } = await import("../../doctor-config-flow.test-support.js");
+    const { runWriteConfigHealth } =
+      await import("../../../flows/doctor-health-contribution-runners.config.js");
+    const configDir = path.dirname(state.configPath);
+    await fs.writeFile(
+      path.join(configDir, "telemetry-a.json"),
+      JSON.stringify({ otel: { protocol: "grpc" } }),
+    );
+    await fs.writeFile(
+      path.join(configDir, "telemetry-b.json"),
+      JSON.stringify({ otel: { enabled: true } }),
+    );
+    await state.writeConfig({
+      ...selectedPlan,
+      diagnostics: { $include: ["./telemetry-a.json", "./telemetry-b.json"] },
+    });
+    const original = await fs.readFile(state.configPath, "utf8");
+
+    const context = await prepareDoctorContext(state.configPath);
+    expect(context.configResult.shouldWriteConfig).toBe(false);
+    await runWriteConfigHealth(context, { runPostWriteRepairs: false });
+
+    expect(await fs.readFile(state.configPath, "utf8")).toBe(original);
+    const retry = await prepare(selectedPlan);
+    expect(retry.pending).toBe(true);
+    expect(retry.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+  });
+
+  it("records completion when the operator accepts a preview without repair flags", async () => {
+    const { loadAndMaybeMigrateDoctorConfig } = await import("../../doctor-config-flow.js");
+    const { createDoctorPrompter } = await import("../../doctor-prompter.js");
+    const { runWriteConfigHealth } =
+      await import("../../../flows/doctor-health-contribution-runners.config.js");
+    await state.writeConfig(selectedPlan);
+    const options = { json: true };
+    const messages: string[] = [];
+    const runtime = {
+      log: () => {},
+      error: () => {},
+      exit: (code: number) => {
+        throw new Error(`Unexpected Doctor exit ${code}`);
+      },
+    };
+    const prompter = createDoctorPrompter({ runtime, options });
+    const configResult = await loadAndMaybeMigrateDoctorConfig({
+      options,
+      runtime,
+      prompter,
+      confirm: async ({ message }) => {
+        messages.push(message);
+        return true;
+      },
+    });
+    expect(messages).toContain("Apply recommended config repairs now?");
+    expect(configResult.shouldWriteConfig).toBe(true);
+    const context = {
+      runtime,
+      options,
+      prompter,
+      configResult,
+      cfg: configResult.cfg,
+      cfgForPersistence: structuredClone(configResult.cfg),
+      sourceConfigValid: configResult.sourceConfigValid,
+      configPath: state.configPath,
+      env: state.env,
+      runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot,
+      invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot,
+    };
+
+    await runWriteConfigHealth(context, { runPostWriteRepairs: false });
+
+    const persisted: OpenClawConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+    expect(persisted.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+    expect(await prepare(selectedPlan)).toEqual({
+      config: selectedPlan,
+      changes: [],
+      pending: false,
+    });
+  });
+});

--- a/src/commands/doctor/shared/provider-use-binding-migration.test.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadAuthProfileStoreForRuntime } from "../../../agents/auth-profiles.js";
+import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
 import { resolveProviderUseAdmission } from "../../../agents/provider-model-auth-source-plan.js";
 import {
   loadSessionEntry,
@@ -9,6 +11,7 @@ import {
 } from "../../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { SecretRef } from "../../../config/types.secrets.js";
 import { resolveProviderBindingEnvVarCandidates } from "../../../secrets/provider-env-vars.js";
 import { runOpenClawAgentWriteTransaction } from "../../../state/openclaw-agent-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
@@ -32,7 +35,11 @@ const selectedPlan: OpenClawConfig = {
     entries: { main: {} },
   },
 };
-const byteplusRef = { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" };
+const byteplusRef = {
+  source: "env",
+  provider: "default",
+  id: "BYTEPLUS_API_KEY",
+} satisfies SecretRef;
 let state: OpenClawTestState;
 
 beforeEach(async () => {
@@ -80,6 +87,177 @@ function admitted(config: OpenClawConfig) {
 }
 
 describe("selected shared-provider upgrade", () => {
+  it.each([true, false])(
+    "defers a conflicting local account without losing safe bindings (owner selects it: %s)",
+    async (ownerSelectsProvider) => {
+      const config: OpenClawConfig = {
+        agents: {
+          entries: {
+            alpha: {
+              model: ownerSelectsProvider ? "byteplus-plan/ark-code-latest" : "openai/fixture",
+            },
+            beta: {
+              model: {
+                primary: "byteplus-plan/ark-code-latest",
+                fallbacks: ["volcengine-plan/ark-code-latest"],
+              },
+            },
+          },
+        },
+      };
+      const alphaAccount: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          "byteplus-plan:alpha": {
+            type: "api_key",
+            provider: "byteplus-plan",
+            key: "private-alpha-key",
+          },
+        },
+      };
+      await state.writeAuthProfiles(alphaAccount, "alpha");
+      const readProfiles = (agentId: string) =>
+        loadAuthProfileStoreForRuntime(
+          state.agentDir(agentId),
+          { config, readOnly: true, allowKeychainPrompt: false },
+          state.env,
+        ).profiles;
+      expect(readProfiles("alpha")).toEqual(alphaAccount.profiles);
+      expect(readProfiles("beta")).toEqual({});
+      const before = structuredClone(config);
+
+      const result = await prepare(config);
+
+      expect(result.pending).toBe(false);
+      expect(result.config.models?.providers?.["byteplus-plan"]).toBeUndefined();
+      expect(result.config.models?.providers?.["volcengine-plan"]?.apiKey).toEqual({
+        source: "env",
+        provider: "default",
+        id: "VOLCANO_ENGINE_API_KEY",
+      });
+      expect(result.changes).toHaveLength(1);
+      expect(result.warnings).toEqual([
+        expect.stringContaining("Provider byteplus-plan was not migrated for agents beta"),
+      ]);
+      expect(result.warnings?.[0]).toContain("existing account for agents alpha");
+      expect(result.warnings?.join("\n")).not.toContain("private-alpha-key");
+      expect(config).toEqual(before);
+      expect(readProfiles("alpha")).toEqual(alphaAccount.profiles);
+      expect(readProfiles("beta")).toEqual({});
+      const repeated = await prepare(result.config);
+      expect(repeated.pending).toBe(false);
+      expect(repeated.changes).toEqual([]);
+
+      // The operator repairs only beta through the existing account owner.
+      await state.writeAuthProfiles(
+        {
+          version: 1,
+          profiles: {
+            "byteplus-plan:beta": {
+              type: "api_key",
+              provider: "byteplus-plan",
+              keyRef: byteplusRef,
+            },
+          },
+        },
+        "beta",
+      );
+      const repaired = await prepare(result.config);
+      expect(repaired.pending).toBe(true);
+      expect(repaired.changes).toEqual([]);
+      expect(repaired.warnings).toBeUndefined();
+      expect(readProfiles("alpha")).toEqual(alphaAccount.profiles);
+      expect(completeProviderUseBindingMigration(state.configPath, state.env)).toEqual([]);
+      expect((await prepare(result.config)).pending).toBe(false);
+    },
+  );
+
+  it("keeps the agent owner of a persisted pin when deciding migration conflicts", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        entries: { alpha: { model: "openai/fixture" }, beta: { model: "openai/fixture" } },
+      },
+    };
+    await state.writeAuthProfiles(
+      {
+        version: 1,
+        profiles: {
+          "byteplus-plan:alpha": {
+            type: "api_key",
+            provider: "byteplus-plan",
+            key: "private-alpha-key",
+          },
+        },
+      },
+      "alpha",
+    );
+    const scope = {
+      agentId: "beta",
+      env: state.env,
+      storePath: path.join(state.sessionsDir("beta"), "sessions.json"),
+      sessionKey: "agent:beta:pinned",
+    };
+    await replaceSessionEntry(scope, {
+      sessionId: "beta-pin",
+      updatedAt: 1,
+      providerOverride: "byteplus-plan",
+      modelOverride: "ark-code-latest",
+      modelOverrideSource: "user",
+    });
+    const before = loadSessionEntry(scope);
+
+    const result = await prepare(config);
+
+    expect(result.config).toBe(config);
+    expect(result.changes).toEqual([]);
+    expect(result.pending).toBe(false);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("Provider byteplus-plan was not migrated for agents beta"),
+    ]);
+    expect(result.warnings?.[0]).toContain("existing account for agents alpha");
+    expect(loadSessionEntry(scope)).toEqual(before);
+  });
+
+  it("does not treat another agent's inactive setup replacement as an account conflict", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        entries: {
+          alpha: { model: "openai/fixture" },
+          beta: { model: "byteplus-plan/ark-code-latest" },
+        },
+      },
+    };
+    const inactive: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "byteplus-plan:replacement": {
+          type: "api_key",
+          provider: "byteplus-plan",
+          key: "inactive-alpha-key",
+          setup: { replacement: true, modelRef: "byteplus-plan/ark-code-latest", configJson: "{}" },
+        },
+      },
+    };
+    await state.writeAuthProfiles(inactive, "alpha");
+
+    const result = await prepare(config);
+
+    expect(result.pending).toBe(true);
+    expect(result.warnings).toBeUndefined();
+    expect(result.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+    expect(
+      loadAuthProfileStoreForRuntime(
+        state.agentDir("alpha"),
+        {
+          config,
+          readOnly: true,
+          allowKeychainPrompt: false,
+        },
+        state.env,
+      ).profiles,
+    ).toEqual(inactive.profiles);
+  });
+
   it.each(["entries", "list"] as const)(
     "preserves default, fallback and per-agent selections from the %s roster",
     async (roster) => {

--- a/src/commands/doctor/shared/provider-use-binding-migration.test.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveProviderUseAdmission } from "../../../agents/provider-model-auth-source-plan.js";
 import {
   loadSessionEntry,
@@ -121,6 +121,86 @@ describe("selected shared-provider upgrade", () => {
       const second = await prepare(result.config);
       expect(second.config).toBe(result.config);
       expect(second.changes).toEqual([]);
+    },
+  );
+
+  it.each(["primary", "fallback"] as const)(
+    "preserves a selected %s alias without enrolling unselected siblings",
+    async (position) => {
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model:
+              position === "primary"
+                ? { primary: "plan" }
+                : { primary: "openai/gpt-5.4", fallbacks: ["plan"] },
+            models: {
+              "byteplus-plan/ark-code-latest": { alias: "plan" },
+              "minimax-portal/MiniMax-M2.7": { alias: "unused" },
+            },
+          },
+          entries: { main: {} },
+        },
+      };
+      const original = structuredClone(config);
+
+      const result = await prepare(config);
+
+      expect(Object.keys(result.config.models?.providers ?? {})).toEqual(["byteplus-plan"]);
+      expect(result.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+      expect(config).toEqual(original);
+    },
+  );
+
+  it.each(["entries", "list"] as const)(
+    "resolves selected aliases in each agent's scope from the %s roster",
+    async (roster) => {
+      const worker = {
+        model: "plan",
+        models: { "volcengine-plan/ark-code-latest": { alias: "plan" } },
+      };
+      const inherited = { models: { "minimax/MiniMax-M2.7": { alias: "plan" } } };
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: "plan",
+            models: {
+              "byteplus-plan/ark-code-latest": { alias: "plan" },
+              "minimax-portal/MiniMax-M2.7": { alias: "unused" },
+            },
+          },
+          ...(roster === "entries"
+            ? { entries: { main: {}, worker, inherited } }
+            : {
+                list: [
+                  { id: "main" },
+                  { id: "worker", ...worker },
+                  { id: "inherited", ...inherited },
+                ],
+              }),
+        },
+      };
+      const original = structuredClone(config);
+
+      const result = await prepare(config);
+
+      expect(Object.keys(result.config.models?.providers ?? {}).toSorted()).toEqual([
+        "byteplus-plan",
+        "minimax",
+        "volcengine-plan",
+      ]);
+      expect(result.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+      expect(result.config.models?.providers?.["volcengine-plan"]?.apiKey).toEqual({
+        source: "env",
+        provider: "default",
+        id: "VOLCANO_ENGINE_API_KEY",
+      });
+      expect(result.config.models?.providers?.minimax?.apiKey).toEqual({
+        source: "env",
+        provider: "default",
+        id: "MINIMAX_API_KEY",
+      });
+      expect(config).toEqual(original);
     },
   );
 
@@ -349,29 +429,49 @@ describe("selected shared-provider upgrade", () => {
 });
 
 describe("Doctor provider-binding write composition", () => {
-  it("persists a primary Plan env SecretRef and closes the upgrade after the actual write", async () => {
-    const { prepareDoctorContext } = await import("../../doctor-config-flow.test-support.js");
-    const { runWriteConfigHealth } =
-      await import("../../../flows/doctor-health-contribution-runners.config.js");
-    await state.writeConfig({
-      ...selectedPlan,
-      gateway: { mode: "local", auth: { mode: "token", token: "fixture-gateway-token" } },
-      env: { vars: { BYTEPLUS_API_KEY: "fixture-byteplus-key" } },
-    });
+  it.each([false, true])(
+    "persists a primary Plan binding and later repair fields: %s",
+    async (laterRepair) => {
+      const { prepareDoctorContext } = await import("../../doctor-config-flow.test-support.js");
+      const { runWriteConfigHealth } =
+        await import("../../../flows/doctor-health-contribution-runners.config.js");
+      await state.writeConfig({
+        ...selectedPlan,
+        gateway: { mode: "local", auth: { mode: "token", token: "fixture-gateway-token" } },
+        env: { vars: { BYTEPLUS_API_KEY: "fixture-byteplus-key" } },
+      });
 
-    const context = await prepareDoctorContext(state.configPath);
-    expect(context.configResult.shouldWriteConfig).toBe(true);
-    await runWriteConfigHealth(context, { runPostWriteRepairs: false });
+      const context = await prepareDoctorContext(state.configPath);
+      expect(context.configResult.shouldWriteConfig).toBe(true);
+      const provider = context.cfg.models?.providers?.["byteplus-plan"];
+      assert(provider);
+      if (laterRepair) {
+        provider.baseUrl = "https://provider.example/v1";
+        provider.models = [
+          {
+            id: "fixture",
+            name: "Fixture",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 8192,
+            maxTokens: 1024,
+          },
+        ];
+      }
+      const expected = laterRepair ? structuredClone(provider) : { apiKey: byteplusRef };
+      await runWriteConfigHealth(context, { runPostWriteRepairs: false });
 
-    const persisted: OpenClawConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
-    expect(persisted.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
-    expect(context.configWriteRefusal).toBeUndefined();
-    expect(await prepare(selectedPlan)).toEqual({
-      config: selectedPlan,
-      changes: [],
-      pending: false,
-    });
-  });
+      const persisted: OpenClawConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+      expect(persisted.models?.providers?.["byteplus-plan"]).toEqual(expected);
+      expect(context.configWriteRefusal).toBeUndefined();
+      expect(await prepare(selectedPlan)).toEqual({
+        config: selectedPlan,
+        changes: [],
+        pending: false,
+      });
+    },
+  );
 
   it("does not complete the upgrade when ambiguous include ownership blocks the config write", async () => {
     const { prepareDoctorContext } = await import("../../doctor-config-flow.test-support.js");
@@ -446,7 +546,7 @@ describe("Doctor provider-binding write composition", () => {
     await runWriteConfigHealth(context, { runPostWriteRepairs: false });
 
     const persisted: OpenClawConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
-    expect(persisted.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+    expect(persisted.models?.providers?.["byteplus-plan"]).toEqual({ apiKey: byteplusRef });
     expect(await prepare(selectedPlan)).toEqual({
       config: selectedPlan,
       changes: [],

--- a/src/commands/doctor/shared/provider-use-binding-migration.test.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadAuthProfileStoreForRuntime } from "../../../agents/auth-profiles.js";
 import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
+import { persistAuthProfileBatch } from "../../../agents/auth-profiles/upsert-with-lock.js";
 import { resolveProviderUseAdmission } from "../../../agents/provider-model-auth-source-plan.js";
 import {
   loadSessionEntry,
@@ -22,6 +23,7 @@ import {
 import {
   completeProviderUseBindingMigration,
   prepareProviderUseBindingMigration,
+  revalidateProviderUseBindingMigration,
 } from "./provider-use-binding-migration.js";
 
 vi.mock("./active-tool-schema-warnings.js", () => ({
@@ -87,6 +89,92 @@ function admitted(config: OpenClawConfig) {
 }
 
 describe("selected shared-provider upgrade", () => {
+  it("keeps a newly selected shared-key fallback pending at the write recheck", async () => {
+    const prepared = await prepare(selectedPlan);
+    assert(prepared.bindings);
+    const config = structuredClone(prepared.config);
+    config.agents = {
+      ...config.agents,
+      defaults: {
+        model: {
+          primary: "byteplus-plan/ark-code-latest",
+          fallbacks: ["volcengine-plan/ark-code-latest"],
+        },
+      },
+    };
+    const checked = await revalidateProviderUseBindingMigration({
+      config,
+      configPath: state.configPath,
+      env: state.env,
+      bindings: prepared.bindings,
+    });
+    expect(checked.pending).toBe(false);
+    expect(checked.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+    expect(checked.config.models?.providers?.["volcengine-plan"]).toBeUndefined();
+    expect(checked.warnings.join("\n")).toContain("volcengine-plan");
+  });
+
+  it("leaves completion open when one selected service key is missing despite another repair", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "byteplus-plan/ark-code-latest",
+            fallbacks: ["volcengine-plan/ark-code-latest"],
+          },
+        },
+        entries: { main: {} },
+      },
+    };
+    const result = await prepareProviderUseBindingMigration({
+      config,
+      configPath: state.configPath,
+      env: { ...state.env, BYTEPLUS_API_KEY: undefined },
+    });
+    expect(result.pending).toBe(false);
+    expect(result.config.models?.providers?.["byteplus-plan"]).toBeUndefined();
+    expect(result.config.models?.providers?.["volcengine-plan"]?.apiKey).toEqual({
+      source: "env",
+      provider: "default",
+      id: "VOLCANO_ENGINE_API_KEY",
+    });
+    expect(result.warnings?.join("\n")).toContain("BYTEPLUS_API_KEY");
+  });
+
+  it.each(["main", "other", "shared"])(
+    "does not replace a saved family account in the %s scope with an env binding",
+    async (scope) => {
+      const profileId = "byteplus:saved-account";
+      await persistAuthProfileBatch({
+        stateDir: state.stateDir,
+        ...(scope === "shared" ? {} : { agentDir: state.agentDir(scope) }),
+        profiles: [
+          {
+            profileId,
+            credential: { type: "api_key", provider: "byteplus", key: "saved-account-key" },
+          },
+        ],
+      });
+
+      const result = await prepare(selectedPlan);
+
+      expect(result.config).toBe(selectedPlan);
+      expect(result.changes).toEqual([]);
+      expect(result.pending).toBe(false);
+      expect(result.warnings?.join("\n")).toContain("byteplus-plan");
+      expect(result.warnings?.join("\n")).toContain(profileId);
+      expect(result.warnings?.join("\n")).not.toContain("saved-account-key");
+      expect((await prepare(selectedPlan)).changes).toEqual([]);
+      const withoutEnv = await prepareProviderUseBindingMigration({
+        config: selectedPlan,
+        configPath: state.configPath,
+        env: { ...state.env, BYTEPLUS_API_KEY: undefined },
+      });
+      expect(withoutEnv.config).toBe(selectedPlan);
+      expect(withoutEnv.warnings?.join("\n")).toContain(profileId);
+    },
+  );
+
   it.each([true, false])(
     "defers a conflicting local account without losing safe bindings (owner selects it: %s)",
     async (ownerSelectsProvider) => {
@@ -218,7 +306,7 @@ describe("selected shared-provider upgrade", () => {
     expect(loadSessionEntry(scope)).toEqual(before);
   });
 
-  it("does not treat another agent's inactive setup replacement as an account conflict", async () => {
+  it("preserves another agent's inactive saved account before materializing an env binding", async () => {
     const config: OpenClawConfig = {
       agents: {
         entries: {
@@ -242,9 +330,10 @@ describe("selected shared-provider upgrade", () => {
 
     const result = await prepare(config);
 
-    expect(result.pending).toBe(true);
-    expect(result.warnings).toBeUndefined();
-    expect(result.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+    expect(result.pending).toBe(false);
+    expect(result.warnings?.join("\n")).toContain("byteplus-plan:replacement");
+    expect(result.config).toBe(config);
+    expect(result.changes).toEqual([]);
     expect(
       loadAuthProfileStoreForRuntime(
         state.agentDir("alpha"),
@@ -607,6 +696,41 @@ describe("selected shared-provider upgrade", () => {
 });
 
 describe("Doctor provider-binding write composition", () => {
+  it("keeps an unevaluated service-environment selection open until its key is visible", async () => {
+    const { prepareDoctorContext } = await import("../../doctor-config-flow.test-support.js");
+    const { runWriteConfigHealth } =
+      await import("../../../flows/doctor-health-contribution-runners.config.js");
+    await state.writeConfig(selectedPlan);
+    vi.stubEnv("BYTEPLUS_API_KEY", undefined);
+    const absent = await prepareProviderUseBindingMigration({
+      config: selectedPlan,
+      configPath: state.configPath,
+      env: { ...state.env, BYTEPLUS_API_KEY: undefined },
+    });
+    const shellDoctor = await prepareDoctorContext(state.configPath);
+    await runWriteConfigHealth(shellDoctor, { runPostWriteRepairs: false });
+
+    vi.stubEnv("BYTEPLUS_API_KEY", state.env.BYTEPLUS_API_KEY);
+    const retry = await prepare(selectedPlan);
+    expect(retry.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
+    expect(absent.pending).toBe(false);
+    expect(absent.warnings?.join("\n")).toContain("BYTEPLUS_API_KEY");
+    expect(absent.warnings?.join("\n")).toContain("service environment");
+    const serviceDoctor = await prepareDoctorContext(state.configPath);
+    await runWriteConfigHealth(serviceDoctor, { runPostWriteRepairs: false });
+    const written = await fs.readFile(state.configPath, "utf8");
+    expect(JSON.parse(written).models.providers["byteplus-plan"]).toEqual({ apiKey: byteplusRef });
+
+    const third = await prepareDoctorContext(state.configPath);
+    await runWriteConfigHealth(third, { runPostWriteRepairs: false });
+    expect(await fs.readFile(state.configPath, "utf8")).toBe(written);
+    expect(await prepare(selectedPlan)).toEqual({
+      config: selectedPlan,
+      changes: [],
+      pending: false,
+    });
+  });
+
   it.each([false, true])(
     "persists a primary Plan binding and later repair fields: %s",
     async (laterRepair) => {

--- a/src/commands/doctor/shared/provider-use-binding-migration.test.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.test.ts
@@ -464,6 +464,13 @@ describe("Doctor provider-binding write composition", () => {
 
       const persisted: OpenClawConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
       expect(persisted.models?.providers?.["byteplus-plan"]).toEqual(expected);
+      context.cfg.gateway = { ...context.cfg.gateway, port: 19491 };
+      await runWriteConfigHealth(context, { runPostWriteRepairs: false });
+      const afterHealthRepair: OpenClawConfig = JSON.parse(
+        await fs.readFile(state.configPath, "utf8"),
+      );
+      expect(afterHealthRepair.models?.providers?.["byteplus-plan"]).toEqual(expected);
+      expect(afterHealthRepair.gateway?.port).toBe(19491);
       expect(context.configWriteRefusal).toBeUndefined();
       expect(await prepare(selectedPlan)).toEqual({
         config: selectedPlan,

--- a/src/commands/doctor/shared/provider-use-binding-migration.test.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.test.ts
@@ -6,6 +6,8 @@ import { loadAuthProfileStoreForRuntime } from "../../../agents/auth-profiles.js
 import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
 import { persistAuthProfileBatch } from "../../../agents/auth-profiles/upsert-with-lock.js";
 import { resolveProviderUseAdmission } from "../../../agents/provider-model-auth-source-plan.js";
+import { readConfigFileSnapshot } from "../../../config/io.js";
+import { getConfigProviderUseBindings } from "../../../config/resolution-facts.js";
 import {
   loadSessionEntry,
   replaceSessionEntry,
@@ -14,8 +16,14 @@ import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { SecretRef } from "../../../config/types.secrets.js";
 import { acquireFileLockSyncWithRetry } from "../../../infra/file-lock-sync.js";
+import {
+  readLegacyMigrationReceiptFromDatabase,
+  recordLegacyMigrationReceipt,
+  resolveLegacyMigrationSourceKey,
+} from "../../../infra/state-migrations.receipts.js";
 import { resolveProviderBindingEnvVarCandidates } from "../../../secrets/provider-env-vars.js";
 import { runOpenClawAgentWriteTransaction } from "../../../state/openclaw-agent-db.js";
+import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import {
   createOpenClawTestState,
@@ -58,6 +66,8 @@ beforeEach(async () => {
       MINIMAX_CODE_PLAN_KEY: undefined,
       MINIMAX_CODING_API_KEY: undefined,
       MINIMAX_OAUTH_TOKEN: undefined,
+      OPENCODE_API_KEY: "fixture-opencode-shared-key",
+      OPENCODE_ZEN_API_KEY: undefined,
       GITHUB_TOKEN: undefined,
       GH_TOKEN: undefined,
       MODEL_API_KEY: undefined,
@@ -85,9 +95,9 @@ function prepare(config: OpenClawConfig) {
 it("defers shared-key bindings without failing when account publication is busy", async () => {
   const migration = prepare(selectedPlan);
   assert(migration.bindings);
-  const locks = path.join(state.stateDir, "locks");
-  await fs.mkdir(locks, { recursive: true });
-  const release = acquireFileLockSyncWithRetry(path.join(locks, "auth-profile-publication"));
+  const release = acquireFileLockSyncWithRetry(
+    path.join(state.stateDir, "auth-profile-publication"),
+  );
   const publish = vi.fn();
   try {
     const result = await writeProviderUseBindingMigration(
@@ -125,6 +135,29 @@ function admitted(config: OpenClawConfig) {
 }
 
 describe("selected shared-provider upgrade", () => {
+  it("persists a selected binding even when validation already supplied its runtime-only facts", async () => {
+    const { prepareDoctorContext } = await import("../../doctor-config-flow.test-support.js");
+    const { runWriteConfigHealth } =
+      await import("../../../flows/doctor-health-contribution-runners.config.js");
+    await state.writeConfig(selectedPlan);
+    const snapshot = await readConfigFileSnapshot({ observe: false });
+    expect(snapshot.sourceConfig.models?.providers?.["byteplus-plan"]).toBeUndefined();
+    expect(getConfigProviderUseBindings(snapshot.sourceConfig)["byteplus-plan"]).toEqual({
+      apiKey: byteplusRef,
+    });
+    expect(prepare(snapshot.sourceConfig).bindings?.["byteplus-plan"]).toEqual({
+      apiKey: byteplusRef,
+    });
+
+    const context = await prepareDoctorContext(state.configPath);
+    await runWriteConfigHealth(context, { runPostWriteRepairs: false });
+
+    expect(
+      JSON.parse(await fs.readFile(state.configPath, "utf8")).models.providers["byteplus-plan"],
+    ).toEqual({ apiKey: byteplusRef });
+    expect(prepare(selectedPlan).pending).toBe(false);
+  });
+
   it("keeps a newly selected shared-key fallback pending at the write recheck", async () => {
     const prepared = prepare(selectedPlan);
     assert(prepared.bindings);
@@ -395,8 +428,8 @@ describe("selected shared-provider upgrade", () => {
             },
           },
           ...(roster === "entries"
-            ? { entries: { main: {}, worker: { model: "minimax/MiniMax-M2.7" } } }
-            : { list: [{ id: "main" }, { id: "worker", model: "minimax/MiniMax-M2.7" }] }),
+            ? { entries: { main: {}, worker: { model: "opencode/fixture-model" } } }
+            : { list: [{ id: "main" }, { id: "worker", model: "opencode/fixture-model" }] }),
         },
       };
       const original = structuredClone(config);
@@ -411,8 +444,8 @@ describe("selected shared-provider upgrade", () => {
           baseUrl: "",
           models: [],
         },
-        minimax: {
-          apiKey: { source: "env", provider: "default", id: "MINIMAX_API_KEY" },
+        opencode: {
+          apiKey: { source: "env", provider: "default", id: "OPENCODE_API_KEY" },
           baseUrl: "",
           models: [],
         },
@@ -420,7 +453,15 @@ describe("selected shared-provider upgrade", () => {
       expect(config).toEqual(original);
       expect(admitted(result.config).has("byteplus-plan")).toBe(true);
       expect(admitted(result.config).has("volcengine-plan")).toBe(true);
-      expect(admitted(result.config).has("minimax-portal")).toBe(false);
+      expect(admitted(result.config).has("opencode")).toBe(true);
+      expect(admitted(result.config).has("opencode-go")).toBe(false);
+      for (const provider of ["minimax", "minimax-portal"]) {
+        expect(result.config.models?.providers?.[provider]).toBeUndefined();
+        expect(admitted(result.config).get(provider)).toEqual({
+          kind: "environment",
+          envVar: "MINIMAX_API_KEY",
+        });
+      }
       const second = prepare(result.config);
       expect(second.config).toBe(result.config);
       expect(second.changes).toEqual([]);
@@ -462,14 +503,14 @@ describe("selected shared-provider upgrade", () => {
         model: "plan",
         models: { "volcengine-plan/ark-code-latest": { alias: "plan" } },
       };
-      const inherited = { models: { "minimax/MiniMax-M2.7": { alias: "plan" } } };
+      const inherited = { models: { "opencode/fixture-model": { alias: "plan" } } };
       const config: OpenClawConfig = {
         agents: {
           defaults: {
             model: "plan",
             models: {
               "byteplus-plan/ark-code-latest": { alias: "plan" },
-              "minimax-portal/MiniMax-M2.7": { alias: "unused" },
+              "opencode-go/fixture-model": { alias: "unused" },
             },
           },
           ...(roster === "entries"
@@ -489,7 +530,7 @@ describe("selected shared-provider upgrade", () => {
 
       expect(Object.keys(result.config.models?.providers ?? {}).toSorted()).toEqual([
         "byteplus-plan",
-        "minimax",
+        "opencode",
         "volcengine-plan",
       ]);
       expect(result.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
@@ -498,11 +539,12 @@ describe("selected shared-provider upgrade", () => {
         provider: "default",
         id: "VOLCANO_ENGINE_API_KEY",
       });
-      expect(result.config.models?.providers?.minimax?.apiKey).toEqual({
+      expect(result.config.models?.providers?.opencode?.apiKey).toEqual({
         source: "env",
         provider: "default",
-        id: "MINIMAX_API_KEY",
+        id: "OPENCODE_API_KEY",
       });
+      expect(admitted(result.config).has("opencode-go")).toBe(false);
       expect(config).toEqual(original);
     },
   );
@@ -537,8 +579,8 @@ describe("selected shared-provider upgrade", () => {
         entry: {
           sessionId: "pin-auto",
           updatedAt: 3,
-          providerOverride: "minimax",
-          modelOverride: "MiniMax-M2.7",
+          providerOverride: "opencode",
+          modelOverride: "fixture-model",
           modelOverrideSource: "auto",
         },
       },
@@ -548,8 +590,8 @@ describe("selected shared-provider upgrade", () => {
         entry: {
           sessionId: "pin-default",
           updatedAt: 4,
-          providerOverride: "minimax-portal",
-          modelOverride: "MiniMax-M2.7",
+          providerOverride: "opencode-go",
+          modelOverride: "fixture-model",
           modelOverrideSource: "default",
         },
       },
@@ -559,8 +601,8 @@ describe("selected shared-provider upgrade", () => {
         entry: {
           sessionId: "pin-legacy-auto",
           updatedAt: 5,
-          providerOverride: "minimax-portal",
-          modelOverride: "MiniMax-M2.7",
+          providerOverride: "opencode-go",
+          modelOverride: "fixture-model",
           modelOverrideFallbackOriginProvider: "openai",
           modelOverrideFallbackOriginModel: "fixture-model",
         },
@@ -585,11 +627,11 @@ describe("selected shared-provider upgrade", () => {
     ]);
     expect(result.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
     expect(scopes.map((scope) => loadSessionEntry(scope))).toEqual(before);
-    expect(admitted(result.config).has("minimax")).toBe(false);
-    expect(admitted(result.config).has("minimax-portal")).toBe(false);
+    expect(admitted(result.config).has("opencode")).toBe(false);
+    expect(admitted(result.config).has("opencode-go")).toBe(false);
   });
 
-  it("does not bind unselected siblings or selected generic credential providers", async () => {
+  it("declares selected chain providers without activating generic credentials or unselected siblings", async () => {
     const config: OpenClawConfig = {
       agents: {
         defaults: {
@@ -621,11 +663,141 @@ describe("selected shared-provider upgrade", () => {
       env,
     });
 
-    expect(result.config).toBe(config);
-    expect(result.changes).toEqual([]);
+    expect(result.bindings).toEqual({ "amazon-bedrock": {}, "google-vertex": {} });
+    expect(Object.keys(result.config.models?.providers ?? {})).toEqual([
+      "amazon-bedrock",
+      "google-vertex",
+    ]);
     expect(result.pending).toBe(true);
-    expect(result.config.models?.providers).toBeUndefined();
+    const unselected = prepareProviderUseBindingMigration({
+      config: {},
+      configPath: state.configPath,
+      env,
+    });
+    expect(unselected.config.models?.providers).toBeUndefined();
   });
+
+  it.each(["amazon-bedrock", "amazon-bedrock-mantle", "google-vertex"])(
+    "preserves a stored account instead of materializing a chain declaration for %s",
+    async (provider) => {
+      await state.writeAuthProfiles(
+        {
+          version: 1,
+          profiles: {
+            [`${provider}:saved`]: { type: "api_key", provider, key: "fixture-saved-account" },
+          },
+        },
+        "other",
+      );
+      const config: OpenClawConfig = {
+        agents: { defaults: { model: `${provider}/fixture` }, entries: { main: {} } },
+      };
+      const result = prepare(config);
+      expect(result.config).toBe(config);
+      expect(result.pending).toBe(false);
+      expect(result.warnings?.join("\n")).toContain(`${provider}:saved`);
+    },
+  );
+
+  it("repairs a narrow receipt for new selectors while respecting an old primary binding removal", () => {
+    const sourceKey = resolveLegacyMigrationSourceKey(
+      "selected-shared-provider-bindings:v1",
+      state.configPath,
+    );
+    runOpenClawStateWriteTransaction(
+      ({ db }) =>
+        recordLegacyMigrationReceipt(db, {
+          sourceKey,
+          migrationKind: "selected-shared-provider-bindings:v1",
+          sourcePath: state.configPath,
+          targetTable: "migration_sources",
+          sourceSha256: null,
+          sourceSizeBytes: null,
+          sourceRecordCount: null,
+          runId: sourceKey,
+          now: 1,
+          reportJson: JSON.stringify({ completed: true, target: "models.providers" }),
+        }),
+      { env: state.env },
+    );
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: "byteplus-plan/ark-code-latest",
+          subagents: { model: "volcengine-plan/ark-code-latest" },
+          utilityModel: "google-vertex/fixture",
+        },
+        entries: { main: {} },
+      },
+    };
+
+    const result = prepare(config);
+
+    expect(result.config.models?.providers?.["byteplus-plan"]).toBeUndefined();
+    expect(result.bindings).toEqual({
+      "volcengine-plan": {
+        apiKey: { source: "env", provider: "default", id: "VOLCANO_ENGINE_API_KEY" },
+      },
+      "google-vertex": {},
+    });
+    expect(completeProviderUseBindingMigration(state.configPath, state.env)).toEqual([]);
+    const receipt = runOpenClawStateWriteTransaction(
+      ({ db }) => readLegacyMigrationReceiptFromDatabase(db, sourceKey),
+      { env: state.env },
+    );
+    expect(JSON.parse(receipt?.reportJson ?? "null")).toMatchObject({ selectionVersion: 2 });
+    expect(prepare(config)).toEqual({ config, changes: [], pending: false });
+  });
+
+  it.each(["provider-config", "profile"] as const)(
+    "does not require a shared env variable when %s already binds the selected provider",
+    async (source) => {
+      const config: OpenClawConfig = {
+        ...selectedPlan,
+        ...(source === "provider-config"
+          ? {
+              models: {
+                providers: {
+                  "byteplus-plan": { apiKey: "fixture-explicit-account", baseUrl: "", models: [] },
+                },
+              },
+            }
+          : {}),
+      };
+      if (source === "profile") {
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: {
+            "byteplus-plan:saved": {
+              type: "api_key",
+              provider: "byteplus-plan",
+              key: "fixture-saved-account",
+            },
+          },
+        });
+      }
+      const env = { ...state.env, BYTEPLUS_API_KEY: undefined };
+
+      const result = prepareProviderUseBindingMigration({
+        config,
+        configPath: state.configPath,
+        env,
+      });
+
+      expect(result.config).toBe(config);
+      expect(result.changes).toEqual([]);
+      expect(result.warnings).toBeUndefined();
+      expect(result.pending).toBe(true);
+      expect(completeProviderUseBindingMigration(state.configPath, env)).toEqual([]);
+      expect(
+        prepareProviderUseBindingMigration({ config, configPath: state.configPath, env }),
+      ).toEqual({
+        config,
+        changes: [],
+        pending: false,
+      });
+    },
+  );
 
   it("preserves an existing selected account instead of replacing it with a shared env key", async () => {
     await state.writeAuthProfiles({

--- a/src/commands/doctor/shared/provider-use-binding-migration.test.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.test.ts
@@ -126,7 +126,7 @@ function admitted(config: OpenClawConfig) {
 
 describe("selected shared-provider upgrade", () => {
   it("keeps a newly selected shared-key fallback pending at the write recheck", async () => {
-    const prepared = await prepare(selectedPlan);
+    const prepared = prepare(selectedPlan);
     assert(prepared.bindings);
     const config = structuredClone(prepared.config);
     config.agents = {
@@ -138,7 +138,7 @@ describe("selected shared-provider upgrade", () => {
         },
       },
     };
-    const checked = await revalidateProviderUseBindingMigration({
+    const checked = revalidateProviderUseBindingMigration({
       config,
       configPath: state.configPath,
       env: state.env,
@@ -162,7 +162,7 @@ describe("selected shared-provider upgrade", () => {
         entries: { main: {} },
       },
     };
-    const result = await prepareProviderUseBindingMigration({
+    const result = prepareProviderUseBindingMigration({
       config,
       configPath: state.configPath,
       env: { ...state.env, BYTEPLUS_API_KEY: undefined },
@@ -192,7 +192,7 @@ describe("selected shared-provider upgrade", () => {
         ],
       });
 
-      const result = await prepare(selectedPlan);
+      const result = prepare(selectedPlan);
 
       expect(result.config).toBe(selectedPlan);
       expect(result.changes).toEqual([]);
@@ -200,8 +200,8 @@ describe("selected shared-provider upgrade", () => {
       expect(result.warnings?.join("\n")).toContain("byteplus-plan");
       expect(result.warnings?.join("\n")).toContain(profileId);
       expect(result.warnings?.join("\n")).not.toContain("saved-account-key");
-      expect((await prepare(selectedPlan)).changes).toEqual([]);
-      const withoutEnv = await prepareProviderUseBindingMigration({
+      expect(prepare(selectedPlan).changes).toEqual([]);
+      const withoutEnv = prepareProviderUseBindingMigration({
         config: selectedPlan,
         configPath: state.configPath,
         env: { ...state.env, BYTEPLUS_API_KEY: undefined },
@@ -250,7 +250,7 @@ describe("selected shared-provider upgrade", () => {
       expect(readProfiles("beta")).toEqual({});
       const before = structuredClone(config);
 
-      const result = await prepare(config);
+      const result = prepare(config);
 
       expect(result.pending).toBe(false);
       expect(result.config.models?.providers?.["byteplus-plan"]).toBeUndefined();
@@ -268,7 +268,7 @@ describe("selected shared-provider upgrade", () => {
       expect(config).toEqual(before);
       expect(readProfiles("alpha")).toEqual(alphaAccount.profiles);
       expect(readProfiles("beta")).toEqual({});
-      const repeated = await prepare(result.config);
+      const repeated = prepare(result.config);
       expect(repeated.pending).toBe(false);
       expect(repeated.changes).toEqual([]);
 
@@ -286,13 +286,13 @@ describe("selected shared-provider upgrade", () => {
         },
         "beta",
       );
-      const repaired = await prepare(result.config);
+      const repaired = prepare(result.config);
       expect(repaired.pending).toBe(true);
       expect(repaired.changes).toEqual([]);
       expect(repaired.warnings).toBeUndefined();
       expect(readProfiles("alpha")).toEqual(alphaAccount.profiles);
       expect(completeProviderUseBindingMigration(state.configPath, state.env)).toEqual([]);
-      expect((await prepare(result.config)).pending).toBe(false);
+      expect(prepare(result.config).pending).toBe(false);
     },
   );
 
@@ -330,7 +330,7 @@ describe("selected shared-provider upgrade", () => {
     });
     const before = loadSessionEntry(scope);
 
-    const result = await prepare(config);
+    const result = prepare(config);
 
     expect(result.config).toBe(config);
     expect(result.changes).toEqual([]);
@@ -364,7 +364,7 @@ describe("selected shared-provider upgrade", () => {
     };
     await state.writeAuthProfiles(inactive, "alpha");
 
-    const result = await prepare(config);
+    const result = prepare(config);
 
     expect(result.pending).toBe(false);
     expect(result.warnings?.join("\n")).toContain("byteplus-plan:replacement");
@@ -401,7 +401,7 @@ describe("selected shared-provider upgrade", () => {
       };
       const original = structuredClone(config);
 
-      const result = await prepare(config);
+      const result = prepare(config);
 
       expect(result.pending).toBe(true);
       expect(result.config.models?.providers).toEqual({
@@ -421,7 +421,7 @@ describe("selected shared-provider upgrade", () => {
       expect(admitted(result.config).has("byteplus-plan")).toBe(true);
       expect(admitted(result.config).has("volcengine-plan")).toBe(true);
       expect(admitted(result.config).has("minimax-portal")).toBe(false);
-      const second = await prepare(result.config);
+      const second = prepare(result.config);
       expect(second.config).toBe(result.config);
       expect(second.changes).toEqual([]);
     },
@@ -447,7 +447,7 @@ describe("selected shared-provider upgrade", () => {
       };
       const original = structuredClone(config);
 
-      const result = await prepare(config);
+      const result = prepare(config);
 
       expect(Object.keys(result.config.models?.providers ?? {})).toEqual(["byteplus-plan"]);
       expect(result.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
@@ -485,7 +485,7 @@ describe("selected shared-provider upgrade", () => {
       };
       const original = structuredClone(config);
 
-      const result = await prepare(config);
+      const result = prepare(config);
 
       expect(Object.keys(result.config.models?.providers ?? {}).toSorted()).toEqual([
         "byteplus-plan",
@@ -577,7 +577,7 @@ describe("selected shared-provider upgrade", () => {
     }
     const before = scopes.map((scope) => loadSessionEntry(scope));
 
-    const result = await prepare(config);
+    const result = prepare(config);
 
     expect(Object.keys(result.config.models?.providers ?? {}).toSorted()).toEqual([
       "byteplus-plan",
@@ -615,7 +615,7 @@ describe("selected shared-provider upgrade", () => {
       JSON.stringify({ type: "authorized_user" }),
     );
 
-    const result = await prepareProviderUseBindingMigration({
+    const result = prepareProviderUseBindingMigration({
       config,
       configPath: state.configPath,
       env,
@@ -639,7 +639,7 @@ describe("selected shared-provider upgrade", () => {
       },
     });
 
-    const result = await prepare(selectedPlan);
+    const result = prepare(selectedPlan);
 
     expect(result.config).toBe(selectedPlan);
     expect(result.changes).toEqual([]);
@@ -652,19 +652,19 @@ describe("selected shared-provider upgrade", () => {
     '{"agents":{"defaults":{"model":{"primary":9,"fallbacks":[null,3,{}]}},"entries":{"broken":null}}}',
   ])("leaves malformed operator shapes intact: %s", async (serialized) => {
     const config: OpenClawConfig = JSON.parse(serialized);
-    const result = await prepare(config);
+    const result = prepare(config);
     expect(result.config).toEqual(config);
     expect(result.changes).toEqual([]);
   });
 
   it("does not reopen a completed upgrade after binding removal or a later selection", async () => {
-    const migrated = await prepare(selectedPlan);
+    const migrated = prepare(selectedPlan);
     expect(migrated.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
     expect(completeProviderUseBindingMigration(state.configPath, state.env)).toEqual([]);
 
     for (const model of ["byteplus-plan/ark-code-latest", "volcengine-plan/ark-code-latest"]) {
       const config: OpenClawConfig = { agents: { defaults: { model } } };
-      const result = await prepare(config);
+      const result = prepare(config);
       expect(result).toEqual({ config, changes: [], pending: false });
       expect(admitted(result.config).has(model.split("/")[0]!)).toBe(false);
     }
@@ -674,16 +674,16 @@ describe("selected shared-provider upgrade", () => {
     const config: OpenClawConfig = JSON.parse(
       `{"agents":{"defaults":{"model":"byteplus-plan/ark-code-latest"}},"secrets":{"defaults":{"env":${alias}}}}`,
     );
-    expect(await prepare(config)).toEqual({ config, changes: [], pending: false });
+    expect(prepare(config)).toEqual({ config, changes: [], pending: false });
   });
 
   it("closes an empty successful upgrade before a new shared-key selection appears", async () => {
-    const empty = await prepare({ agents: { entries: { main: {} } } });
+    const empty = prepare({ agents: { entries: { main: {} } } });
     expect(empty.changes).toEqual([]);
     expect(empty.pending).toBe(true);
     expect(completeProviderUseBindingMigration(state.configPath, state.env)).toEqual([]);
 
-    const result = await prepare(selectedPlan);
+    const result = prepare(selectedPlan);
     expect(result).toEqual({ config: selectedPlan, changes: [], pending: false });
     expect(admitted(result.config).has("byteplus-plan")).toBe(false);
   });
@@ -713,7 +713,7 @@ describe("selected shared-provider upgrade", () => {
       { agentId: "main", env: state.env },
     );
 
-    const result = await prepare(selectedPlan);
+    const result = prepare(selectedPlan);
 
     expect(result).toMatchObject({ config: selectedPlan, changes: [], pending: false });
     expect(result.warnings).toEqual([expect.stringContaining("Rerun")]);
@@ -724,7 +724,7 @@ describe("selected shared-provider upgrade", () => {
     await fs.mkdir(path.dirname(databasePath), { recursive: true });
     await fs.writeFile(databasePath, "not a SQLite database");
 
-    const result = await prepare(selectedPlan);
+    const result = prepare(selectedPlan);
 
     expect(result).toMatchObject({ config: selectedPlan, changes: [], pending: false });
     expect(result.warnings).toEqual([expect.stringContaining("Rerun")]);
@@ -738,7 +738,7 @@ describe("Doctor provider-binding write composition", () => {
       await import("../../../flows/doctor-health-contribution-runners.config.js");
     await state.writeConfig(selectedPlan);
     vi.stubEnv("BYTEPLUS_API_KEY", undefined);
-    const absent = await prepareProviderUseBindingMigration({
+    const absent = prepareProviderUseBindingMigration({
       config: selectedPlan,
       configPath: state.configPath,
       env: { ...state.env, BYTEPLUS_API_KEY: undefined },
@@ -747,7 +747,7 @@ describe("Doctor provider-binding write composition", () => {
     await runWriteConfigHealth(shellDoctor, { runPostWriteRepairs: false });
 
     vi.stubEnv("BYTEPLUS_API_KEY", state.env.BYTEPLUS_API_KEY);
-    const retry = await prepare(selectedPlan);
+    const retry = prepare(selectedPlan);
     expect(retry.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
     expect(absent.pending).toBe(false);
     expect(absent.warnings?.join("\n")).toContain("BYTEPLUS_API_KEY");
@@ -760,7 +760,7 @@ describe("Doctor provider-binding write composition", () => {
     const third = await prepareDoctorContext(state.configPath);
     await runWriteConfigHealth(third, { runPostWriteRepairs: false });
     expect(await fs.readFile(state.configPath, "utf8")).toBe(written);
-    expect(await prepare(selectedPlan)).toEqual({
+    expect(prepare(selectedPlan)).toEqual({
       config: selectedPlan,
       changes: [],
       pending: false,
@@ -810,7 +810,7 @@ describe("Doctor provider-binding write composition", () => {
       expect(afterHealthRepair.models?.providers?.["byteplus-plan"]).toEqual(expected);
       expect(afterHealthRepair.gateway?.port).toBe(19491);
       expect(context.configWriteRefusal).toBeUndefined();
-      expect(await prepare(selectedPlan)).toEqual({
+      expect(prepare(selectedPlan)).toEqual({
         config: selectedPlan,
         changes: [],
         pending: false,
@@ -842,7 +842,7 @@ describe("Doctor provider-binding write composition", () => {
     await runWriteConfigHealth(context, { runPostWriteRepairs: false });
 
     expect(await fs.readFile(state.configPath, "utf8")).toBe(original);
-    const retry = await prepare(selectedPlan);
+    const retry = prepare(selectedPlan);
     expect(retry.pending).toBe(true);
     expect(retry.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(byteplusRef);
   });
@@ -892,7 +892,7 @@ describe("Doctor provider-binding write composition", () => {
 
     const persisted: OpenClawConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
     expect(persisted.models?.providers?.["byteplus-plan"]).toEqual({ apiKey: byteplusRef });
-    expect(await prepare(selectedPlan)).toEqual({
+    expect(prepare(selectedPlan)).toEqual({
       config: selectedPlan,
       changes: [],
       pending: false,

--- a/src/commands/doctor/shared/provider-use-binding-migration.test.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.test.ts
@@ -287,6 +287,13 @@ describe("selected shared-provider upgrade", () => {
     }
   });
 
+  it.each(["17", "null", "{}"])("defers an invalid env SecretRef alias %s", async (alias) => {
+    const config: OpenClawConfig = JSON.parse(
+      `{"agents":{"defaults":{"model":"byteplus-plan/ark-code-latest"}},"secrets":{"defaults":{"env":${alias}}}}`,
+    );
+    expect(await prepare(config)).toEqual({ config, changes: [], pending: false });
+  });
+
   it("closes an empty successful upgrade before a new shared-key selection appears", async () => {
     const empty = await prepare({ agents: { entries: { main: {} } } });
     expect(empty.changes).toEqual([]);

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -42,7 +42,7 @@ import {
 import { withExistingOpenClawStateDatabaseReadOnly } from "../../../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
-import { listExistingAgentDatabaseTargets } from "../../doctor-session-sqlite-readers.js";
+import { listExistingAgentDatabaseTargets } from "../../doctor-session-sqlite-targets.js";
 import {
   collectConfiguredProviderUseSelections,
   type ConfiguredProviderUseSelection,
@@ -260,10 +260,11 @@ export function prepareProviderUseBindingMigration(params: {
   const bindings: ProviderUseBindingMigrationBindings = {};
   const changes: string[] = [];
   const warnings: string[] = [];
-  for (const [identity, candidates] of Object.entries({
+  const providerCandidates: Readonly<Record<string, readonly string[]>> = {
     ...Object.fromEntries([...CHAIN_PROVIDERS].map((provider) => [provider, []])),
     ...envCandidateMap,
-  })) {
+  };
+  for (const [identity, candidates] of Object.entries(providerCandidates)) {
     const provider = normalizeProviderId(identity);
     const chain = CHAIN_PROVIDERS.has(provider);
     const selectedAgents = [...selectedProviders]
@@ -385,9 +386,21 @@ export function prepareProviderUseBindingMigration(params: {
 /** Carry only approved migration work into Doctor's delayed config writer. */
 export function resolveProviderUseBindingWriteMetadata(
   migration: Awaited<ReturnType<typeof prepareProviderUseBindingMigration>>,
-  options: { shouldWriteConfig: boolean; shouldRepair: boolean; blocksWrite?: boolean },
+  options: {
+    shouldWriteConfig: boolean;
+    shouldRepair: boolean;
+    blocksWrite?: boolean;
+    explicitSetPaths?: readonly (readonly string[])[];
+  },
 ) {
+  // Startup may already project these values. Doctor must persist the selected entries
+  // even when they are identical to the runtime snapshot, including an empty declaration.
+  const explicitSetPaths = [
+    ...(options.explicitSetPaths ?? []),
+    ...Object.keys(migration.bindings ?? {}).map((provider) => ["models", "providers", provider]),
+  ];
   return {
+    ...(options.shouldWriteConfig && explicitSetPaths.length > 0 ? { explicitSetPaths } : {}),
     ...(options.shouldWriteConfig && migration.bindings
       ? { providerUseBindings: migration.bindings }
       : {}),

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -1,13 +1,14 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { listAgentIds } from "../../../agents/agent-scope-config.js";
-import { resolveAgentEffectiveModelPrimary } from "../../../agents/agent-scope.js";
-import { ensureAuthProfileStore } from "../../../agents/auth-profiles.js";
+import { resolveAgentDir, resolveAgentEffectiveModelPrimary } from "../../../agents/agent-scope.js";
+import { loadAuthProfileStoreForRuntime } from "../../../agents/auth-profiles.js";
 import {
   listCandidateAuthProfileStores,
   loadCandidateAuthProfileStore,
+  type CandidateAuthProfileStore,
 } from "../../../agents/auth-profiles/candidate-stores.js";
-import { loadPersistedSharedAuthProfileStore } from "../../../agents/auth-profiles/persisted.js";
+import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
 import { resolveDefaultModelForAgent } from "../../../agents/model-selection-config.js";
 import { resolveConfiguredModelFallbacks } from "../../../agents/model-selection-resolve.js";
 import {
@@ -15,7 +16,6 @@ import {
   resolveModelRefFromString,
 } from "../../../agents/model-selection-shared.js";
 import { resolveProviderUseAdmission } from "../../../agents/provider-model-auth-source-plan.js";
-import { resolveAgentModelPrimaryValue } from "../../../config/model-input.js";
 import { resolveResetPreservedSelection } from "../../../config/sessions/reset-preserved-selection.js";
 import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.js";
 import type { ModelProviderConfigInput } from "../../../config/types.models.js";
@@ -60,11 +60,12 @@ export async function prepareProviderUseBindingMigration(params: {
     return unchanged;
   }
   const sourceKey = resolveLegacyMigrationSourceKey(MIGRATION, configPath);
-  const sessionSelections: unknown[] = [];
+  const sessionSelections: Array<{ agentId: string; model: string }> = [];
   let direct: Record<string, readonly string[]>;
   let envCandidateMap: Readonly<Record<string, readonly string[]>>;
   let aliasMap: Readonly<Record<string, string>>;
-  const profiles: Record<string, { provider: string }> = {};
+  const authScopes = new Map<string, { agentDir: string; store: AuthProfileStore }>();
+  const localAccounts: Array<CandidateAuthProfileStore & { store: AuthProfileStore }> = [];
   // Receipts and session pins are external state. A failed read must not turn an
   // incomplete selection snapshot into a completed upgrade or prevent startup.
   try {
@@ -75,20 +76,10 @@ export async function prepareProviderUseBindingMigration(params: {
     if (completed) {
       return unchanged;
     }
-    const stores = [
-      loadPersistedSharedAuthProfileStore(env),
-      ensureAuthProfileStore(undefined, {
-        config,
-        readOnly: true,
-        allowKeychainPrompt: false,
-      }),
-    ];
     for (const candidate of await listCandidateAuthProfileStores({ cfg: config, env })) {
-      stores.push(loadCandidateAuthProfileStore(candidate));
-    }
-    for (const store of stores) {
-      for (const profile of Object.values(store?.profiles ?? {})) {
-        profiles[profile.provider] = { provider: profile.provider };
+      const store = loadCandidateAuthProfileStore(candidate);
+      if (store) {
+        localAccounts.push({ ...candidate, store });
       }
     }
     let incompletePins = false;
@@ -102,17 +93,37 @@ export async function prepareProviderUseBindingMigration(params: {
           }
           const pin = resolveResetPreservedSelection({ entry });
           if (typeof pin.modelOverride === "string") {
-            sessionSelections.push(
-              pin.providerOverride && !pin.modelOverride.startsWith(`${pin.providerOverride}/`)
-                ? `${pin.providerOverride}/${pin.modelOverride}`
-                : pin.modelOverride,
-            );
+            sessionSelections.push({
+              agentId: target.agentId,
+              model:
+                pin.providerOverride && !pin.modelOverride.startsWith(`${pin.providerOverride}/`)
+                  ? `${pin.providerOverride}/${pin.modelOverride}`
+                  : pin.modelOverride,
+            });
           }
         },
       );
     }
     if (incompletePins) {
       return { ...unchanged, warnings: [DEFERRED] };
+    }
+    for (const agentId of new Set([
+      ...listAgentIds(config),
+      ...sessionSelections.map((selection) => selection.agentId),
+    ])) {
+      const agentDir = resolveAgentDir(config, agentId, env);
+      authScopes.set(agentId, {
+        agentDir,
+        store: loadAuthProfileStoreForRuntime(
+          agentDir,
+          {
+            config,
+            readOnly: true,
+            allowKeychainPrompt: false,
+          },
+          env,
+        ),
+      });
     }
     direct = resolveProviderBindingEnvVarCandidates({ config, env });
     ({ envCandidateMap, aliasMap } = resolveProviderAuthLookupMaps({
@@ -129,8 +140,10 @@ export async function prepareProviderUseBindingMigration(params: {
   if (config.models?.providers !== undefined && !isRecord(config.models.providers)) {
     return unchanged;
   }
-  const selectedProviders = new Set<string>();
-  for (const agentId of [undefined, ...listAgentIds(config)]) {
+  const selectedProviders = new Map<string, Set<string>>();
+  for (const agentId of authScopes.keys()) {
+    const selected = new Set<string>();
+    selectedProviders.set(agentId, selected);
     const selection = {
       cfg: config,
       agentId,
@@ -138,11 +151,9 @@ export async function prepareProviderUseBindingMigration(params: {
       allowPluginNormalization: false,
     };
     const primary = resolveDefaultModelForAgent(selection);
-    const rawPrimary = agentId
-      ? resolveAgentEffectiveModelPrimary(config, agentId)
-      : resolveAgentModelPrimaryValue(config.agents?.defaults?.model);
+    const rawPrimary = resolveAgentEffectiveModelPrimary(config, agentId);
     if (rawPrimary) {
-      selectedProviders.add(normalizeProviderId(primary.provider));
+      selected.add(normalizeProviderId(primary.provider));
     }
     const aliasIndex = buildModelAliasIndex({
       ...selection,
@@ -159,23 +170,46 @@ export async function prepareProviderUseBindingMigration(params: {
         aliasIndex,
       });
       if (resolved) {
-        selectedProviders.add(normalizeProviderId(resolved.ref.provider));
+        selected.add(normalizeProviderId(resolved.ref.provider));
       }
     }
   }
   const manifestVariables = new Set(Object.values(direct).flat());
-  const admitted = resolveProviderUseAdmission({ config, env, providerEnvVars: direct, profiles });
+  const admissions = new Map(
+    [...authScopes].map(([agentId, { store }]) => [
+      agentId,
+      resolveProviderUseAdmission({
+        config,
+        env,
+        providerEnvVars: direct,
+        profiles: store.profiles,
+      }),
+    ]),
+  );
+  const accountBindings = localAccounts.map((scope) => ({
+    agentId: scope.agentId,
+    admitted: resolveProviderUseAdmission({ profiles: scope.store.profiles }),
+  }));
   const providers: Record<string, ModelProviderConfigInput> = {};
   const changes: string[] = [];
+  const warnings: string[] = [];
   for (const [identity, candidates] of Object.entries(envCandidateMap)) {
     const provider = normalizeProviderId(identity);
+    const missingAgents = [...selectedProviders]
+      .filter(
+        ([agentId, selected]) =>
+          !admissions.get(agentId)?.has(provider) &&
+          (selected.has(provider) ||
+            sessionSelections.some(
+              (selection) =>
+                selection.agentId === agentId &&
+                selectedCanonicalModelRefsForRuntimePolicy(selection.model, provider).length > 0,
+            )),
+      )
+      .map(([agentId]) => agentId);
     if (
       (!Object.hasOwn(direct, identity) && !Object.hasOwn(aliasMap, identity)) ||
-      admitted.has(provider) ||
-      (!selectedProviders.has(provider) &&
-        !sessionSelections.some(
-          (model) => selectedCanonicalModelRefsForRuntimePolicy(model, provider).length > 0,
-        ))
+      missingAgents.length === 0
     ) {
       continue;
     }
@@ -194,11 +228,28 @@ export async function prepareProviderUseBindingMigration(params: {
     if (!apiKey) {
       continue;
     }
+    const accountOwners = [
+      ...new Set(
+        accountBindings
+          .filter((scope) => scope.admitted.has(provider))
+          .map((scope) => scope.agentId),
+      ),
+    ];
+    if (accountOwners.length > 0) {
+      warnings.push(
+        `Provider ${provider} was not migrated for agents ${missingAgents.join(", ")}: a global env binding would replace an existing account for agents ${accountOwners.join(", ")}. Configure the missing agents explicitly, then rerun "openclaw doctor --fix".`,
+      );
+      continue;
+    }
     providers[provider] = { apiKey };
     changes.push(`Bound selected provider ${provider} to ${variable} with an env SecretRef.`);
   }
   if (changes.length === 0) {
-    return { ...unchanged, pending: true };
+    return {
+      ...unchanged,
+      pending: warnings.length === 0,
+      ...(warnings.length ? { warnings } : {}),
+    };
   }
   const validated = validateConfigObjectRaw({ models: { providers } }, { env });
   if (!validated.ok) {
@@ -216,7 +267,8 @@ export async function prepareProviderUseBindingMigration(params: {
       },
     },
     changes,
-    pending: true,
+    pending: warnings.length === 0,
+    ...(warnings.length ? { warnings } : {}),
     // Doctor consumes materialized config; its writer preserves the sparse source overlay.
     unsetPaths: Object.keys(providers).flatMap((provider) =>
       ["baseUrl", "models"].map((field) => ["models", "providers", provider, field]),

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -1,26 +1,25 @@
+import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { listAgentIds } from "../../../agents/agent-scope-config.js";
-import { resolveAgentDir, resolveAgentEffectiveModelPrimary } from "../../../agents/agent-scope.js";
+import { resolveAgentDir } from "../../../agents/agent-scope.js";
 import { loadAuthProfileStoreForRuntime } from "../../../agents/auth-profiles.js";
 import {
   listCandidateAuthProfileStores,
   loadCandidateAuthProfileStore,
-  type CandidateAuthProfileStore,
 } from "../../../agents/auth-profiles/candidate-stores.js";
+import { loadPersistedAuthProfileStoreAtDatabasePath } from "../../../agents/auth-profiles/persisted.js";
 import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
-import { resolveDefaultModelForAgent } from "../../../agents/model-selection-config.js";
-import { resolveConfiguredModelFallbacks } from "../../../agents/model-selection-resolve.js";
+import { resolveSelectedModelProviderIds } from "../../../agents/model-selection-config.js";
 import {
-  buildModelAliasIndex,
-  resolveModelRefFromString,
-} from "../../../agents/model-selection-shared.js";
-import { resolveProviderUseAdmission } from "../../../agents/provider-model-auth-source-plan.js";
+  isGenericProviderCredentialEnvVar,
+  resolveProviderUseAdmission,
+} from "../../../agents/provider-model-auth-source-plan.js";
 import { resolveResetPreservedSelection } from "../../../config/sessions/reset-preserved-selection.js";
 import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.js";
 import type { ModelProviderConfigInput } from "../../../config/types.models.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { parseEnvTemplateSecretRef } from "../../../config/types.secrets.js";
+import { parseEnvTemplateSecretRef, type SecretRef } from "../../../config/types.secrets.js";
 import { validateConfigObjectRaw } from "../../../config/validation-core.js";
 import {
   readLegacyMigrationReceiptFromDatabase,
@@ -33,6 +32,7 @@ import {
 } from "../../../secrets/provider-env-vars.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../../../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { listExistingAgentDatabaseTargets } from "../../doctor-session-sqlite-readers.js";
 import { selectedCanonicalModelRefsForRuntimePolicy } from "./legacy-runtime-model-policy.js";
 
@@ -51,6 +51,7 @@ export async function prepareProviderUseBindingMigration(params: {
   pending: boolean;
   warnings?: string[];
   unsetPaths?: string[][];
+  bindings?: Record<string, SecretRef>;
 }> {
   const { config, configPath, env } = params;
   const unchanged = { config, changes: [], pending: false };
@@ -65,7 +66,7 @@ export async function prepareProviderUseBindingMigration(params: {
   let envCandidateMap: Readonly<Record<string, readonly string[]>>;
   let aliasMap: Readonly<Record<string, string>>;
   const authScopes = new Map<string, { agentDir: string; store: AuthProfileStore }>();
-  const localAccounts: Array<CandidateAuthProfileStore & { store: AuthProfileStore }> = [];
+  const accountScopes: Array<{ owner: string; store: AuthProfileStore }> = [];
   // Receipts and session pins are external state. A failed read must not turn an
   // incomplete selection snapshot into a completed upgrade or prevent startup.
   try {
@@ -76,10 +77,18 @@ export async function prepareProviderUseBindingMigration(params: {
     if (completed) {
       return unchanged;
     }
-    for (const candidate of await listCandidateAuthProfileStores({ cfg: config, env })) {
+    const candidates = await listCandidateAuthProfileStores({ cfg: config, env });
+    const sharedStore = loadPersistedAuthProfileStoreAtDatabasePath(
+      resolveOpenClawStateSqlitePath(env),
+      "shared-state",
+    );
+    if (sharedStore) {
+      accountScopes.push({ owner: "shared", store: sharedStore });
+    }
+    for (const candidate of candidates) {
       const store = loadCandidateAuthProfileStore(candidate);
       if (store) {
-        localAccounts.push({ ...candidate, store });
+        accountScopes.push({ owner: candidate.agentId, store });
       }
     }
     let incompletePins = false;
@@ -142,37 +151,7 @@ export async function prepareProviderUseBindingMigration(params: {
   }
   const selectedProviders = new Map<string, Set<string>>();
   for (const agentId of authScopes.keys()) {
-    const selected = new Set<string>();
-    selectedProviders.set(agentId, selected);
-    const selection = {
-      cfg: config,
-      agentId,
-      allowManifestNormalization: false,
-      allowPluginNormalization: false,
-    };
-    const primary = resolveDefaultModelForAgent(selection);
-    const rawPrimary = resolveAgentEffectiveModelPrimary(config, agentId);
-    if (rawPrimary) {
-      selected.add(normalizeProviderId(primary.provider));
-    }
-    const aliasIndex = buildModelAliasIndex({
-      ...selection,
-      defaultProvider: primary.provider,
-    });
-    for (const raw of resolveConfiguredModelFallbacks(selection)) {
-      if (typeof raw !== "string") {
-        continue;
-      }
-      const resolved = resolveModelRefFromString({
-        ...selection,
-        raw,
-        defaultProvider: primary.provider,
-        aliasIndex,
-      });
-      if (resolved) {
-        selected.add(normalizeProviderId(resolved.ref.provider));
-      }
-    }
+    selectedProviders.set(agentId, resolveSelectedModelProviderIds({ cfg: config, agentId }));
   }
   const manifestVariables = new Set(Object.values(direct).flat());
   const admissions = new Map(
@@ -186,62 +165,82 @@ export async function prepareProviderUseBindingMigration(params: {
       }),
     ]),
   );
-  const accountBindings = localAccounts.map((scope) => ({
-    agentId: scope.agentId,
-    admitted: resolveProviderUseAdmission({ profiles: scope.store.profiles }),
-  }));
   const providers: Record<string, ModelProviderConfigInput> = {};
+  const bindings: Record<string, SecretRef> = {};
   const changes: string[] = [];
   const warnings: string[] = [];
   for (const [identity, candidates] of Object.entries(envCandidateMap)) {
     const provider = normalizeProviderId(identity);
-    const missingAgents = [...selectedProviders]
+    const selectedAgents = [...selectedProviders]
       .filter(
         ([agentId, selected]) =>
-          !admissions.get(agentId)?.has(provider) &&
-          (selected.has(provider) ||
-            sessionSelections.some(
-              (selection) =>
-                selection.agentId === agentId &&
-                selectedCanonicalModelRefsForRuntimePolicy(selection.model, provider).length > 0,
-            )),
+          selected.has(provider) ||
+          sessionSelections.some(
+            (selection) =>
+              selection.agentId === agentId &&
+              selectedCanonicalModelRefsForRuntimePolicy(selection.model, provider).length > 0,
+          ),
       )
       .map(([agentId]) => agentId);
     if (
       (!Object.hasOwn(direct, identity) && !Object.hasOwn(aliasMap, identity)) ||
-      missingAgents.length === 0
+      selectedAgents.length === 0
     ) {
       continue;
     }
-    const variable = candidates.find(
+    const sharedVariables = candidates.filter(
       (name) =>
         manifestVariables.has(name) &&
-        // The admission owner excludes generic credentials even if a manifest names one.
-        resolveProviderUseAdmission({ env, providerEnvVars: { [provider]: [name] } }).has(
-          provider,
-        ) &&
+        !isGenericProviderCredentialEnvVar(name) &&
         Object.entries(envCandidateMap).some(
           ([sibling, names]) => normalizeProviderId(sibling) !== provider && names.includes(name),
         ),
     );
+    if (sharedVariables.length === 0) {
+      continue;
+    }
+    const variable = sharedVariables.find((name) => env[name]?.trim());
+    if (!variable) {
+      warnings.push(
+        `Could not evaluate the shared-key upgrade for provider ${provider}: ${sharedVariables.join(", ")} is not set. Rerun "openclaw doctor --fix" from the service environment or with a candidate variable set.`,
+      );
+    }
+    const missingAgents = selectedAgents.filter(
+      (agentId) => !admissions.get(agentId)?.has(provider),
+    );
+    if (missingAgents.length === 0) {
+      continue;
+    }
+    const credentialProvider = aliasMap[provider] ?? provider;
+    const accountOwners = new Set<string>();
+    const conflictingProfiles = new Set<string>();
+    for (const { owner, store } of accountScopes) {
+      for (const [profileId, profile] of Object.entries(store.profiles)) {
+        const storedProvider = normalizeProviderId(profile.provider);
+        if (
+          storedProvider === provider ||
+          (aliasMap[storedProvider] ?? storedProvider) === credentialProvider ||
+          (envCandidateMap[storedProvider] ?? []).some(
+            (name) => manifestVariables.has(name) && candidates.includes(name),
+          )
+        ) {
+          accountOwners.add(owner);
+          conflictingProfiles.add(profileId);
+        }
+      }
+    }
+    if (conflictingProfiles.size > 0) {
+      warnings.push(
+        `Provider ${provider} was not migrated for agents ${missingAgents.join(", ")}: a global env binding could replace an existing account for agents ${[...accountOwners].join(", ")} (profiles ${[...conflictingProfiles].join(", ")}). Bind the provider explicitly to the saved account, then rerun "openclaw doctor --fix".`,
+      );
+      continue;
+    }
     const apiKey = variable ? parseEnvTemplateSecretRef(`\${${variable}}`, envProvider) : null;
     if (!apiKey) {
       continue;
     }
-    const accountOwners = [
-      ...new Set(
-        accountBindings
-          .filter((scope) => scope.admitted.has(provider))
-          .map((scope) => scope.agentId),
-      ),
-    ];
-    if (accountOwners.length > 0) {
-      warnings.push(
-        `Provider ${provider} was not migrated for agents ${missingAgents.join(", ")}: a global env binding would replace an existing account for agents ${accountOwners.join(", ")}. Configure the missing agents explicitly, then rerun "openclaw doctor --fix".`,
-      );
-      continue;
-    }
     providers[provider] = { apiKey };
+    bindings[provider] = apiKey;
     changes.push(`Bound selected provider ${provider} to ${variable} with an env SecretRef.`);
   }
   if (changes.length === 0) {
@@ -267,11 +266,109 @@ export async function prepareProviderUseBindingMigration(params: {
       },
     },
     changes,
+    bindings,
     pending: warnings.length === 0,
     ...(warnings.length ? { warnings } : {}),
     // Doctor consumes materialized config; its writer preserves the sparse source overlay.
     unsetPaths: Object.keys(providers).flatMap((provider) =>
       ["baseUrl", "models"].map((field) => ["models", "providers", provider, field]),
+    ),
+  };
+}
+
+/** Carry only approved migration work into Doctor's delayed config writer. */
+export function resolveProviderUseBindingWriteMetadata(
+  migration: Awaited<ReturnType<typeof prepareProviderUseBindingMigration>>,
+  options: { shouldWriteConfig: boolean; shouldRepair: boolean; blocksWrite?: boolean },
+) {
+  return {
+    ...(options.shouldWriteConfig && migration.bindings
+      ? { providerUseBindings: migration.bindings }
+      : {}),
+    ...(options.shouldWriteConfig && migration.unsetPaths
+      ? { unsetPaths: migration.unsetPaths }
+      : {}),
+    ...(migration.pending &&
+    options.blocksWrite !== true &&
+    (options.shouldWriteConfig || (options.shouldRepair && migration.changes.length === 0))
+      ? { providerUseBindingMigrationPending: true }
+      : {}),
+  };
+}
+
+/** Recheck proposed bindings after interactive or asynchronous repairs, before persistence. */
+export async function revalidateProviderUseBindingMigration(params: {
+  config: OpenClawConfig;
+  sourceConfig?: OpenClawConfig;
+  configPath: string;
+  env: NodeJS.ProcessEnv;
+  bindings: Readonly<Record<string, SecretRef>>;
+}) {
+  const config = structuredClone(params.config);
+  for (const [provider, apiKey] of Object.entries(params.bindings)) {
+    const persisted = params.sourceConfig?.models?.providers?.[provider];
+    if (
+      persisted &&
+      config.models?.providers &&
+      isDeepStrictEqual(config.models.providers[provider]?.apiKey, apiKey)
+    ) {
+      config.models.providers[provider] = structuredClone(persisted);
+    }
+  }
+  const analysis = structuredClone(config);
+  const proposed = Object.entries(params.bindings).filter(
+    ([provider, apiKey]) =>
+      !params.sourceConfig?.models?.providers?.[provider] &&
+      isDeepStrictEqual(config.models?.providers?.[provider]?.apiKey, apiKey),
+  );
+  for (const [provider] of proposed) {
+    delete analysis.models?.providers?.[provider];
+  }
+  const checked = await prepareProviderUseBindingMigration({ ...params, config: analysis });
+  const bindings: Record<string, SecretRef> = {};
+  for (const [provider, apiKey] of proposed) {
+    if (isDeepStrictEqual(checked.bindings?.[provider], apiKey)) {
+      bindings[provider] = apiKey;
+      continue;
+    }
+    const entry = config.models?.providers?.[provider];
+    if (entry) {
+      delete entry.apiKey;
+      const authoredFields = Object.entries(entry).filter(
+        ([key, value]) =>
+          !(key === "baseUrl" && value === "") &&
+          !(key === "models" && Array.isArray(value) && value.length === 0),
+      );
+      if (authoredFields.length === 0) {
+        delete config.models?.providers?.[provider];
+      }
+    }
+  }
+  if (config.models?.providers && Object.keys(config.models.providers).length === 0) {
+    delete config.models.providers;
+    if (Object.keys(config.models).length === 0) {
+      delete config.models;
+    }
+  }
+  const deferred = Object.keys(checked.bindings ?? {}).filter(
+    (provider) => !Object.hasOwn(bindings, provider),
+  );
+  return {
+    config,
+    bindings,
+    pending:
+      checked.pending && Object.keys(bindings).length === proposed.length && deferred.length === 0,
+    warnings: [
+      ...(checked.warnings ?? []),
+      ...(deferred.length
+        ? [
+            `Selected providers ${deferred.join(", ")} still need binding; rerun "openclaw doctor --fix".`,
+          ]
+        : []),
+    ],
+    changes: Object.entries(bindings).map(
+      ([provider, apiKey]) =>
+        `Bound selected provider ${provider} to ${apiKey.id} with an env SecretRef.`,
     ),
   };
 }

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -24,7 +24,7 @@ import {
   setConfigProviderUseBindings,
 } from "../../../config/resolution-facts.js";
 import { resolveResetPreservedSelection } from "../../../config/sessions/reset-preserved-selection.js";
-import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.js";
+import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.sqlite-canonical-inventory.js";
 import type { ModelProviderConfigInput } from "../../../config/types.models.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { parseEnvTemplateSecretRef, type SecretRef } from "../../../config/types.secrets.js";

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -8,13 +8,17 @@ import {
   listCandidateAuthProfileStores,
   loadCandidateAuthProfileStore,
 } from "../../../agents/auth-profiles/candidate-stores.js";
+import { captureAuthProfileOwnerScope } from "../../../agents/auth-profiles/path-resolve.js";
 import { loadPersistedAuthProfileStoreAtDatabasePath } from "../../../agents/auth-profiles/persisted.js";
+import { withAuthProfilePublicationLock } from "../../../agents/auth-profiles/publication.js";
 import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
 import { resolveSelectedModelProviderIds } from "../../../agents/model-selection-config.js";
 import {
   isGenericProviderCredentialEnvVar,
   resolveProviderUseAdmission,
 } from "../../../agents/provider-model-auth-source-plan.js";
+import { GuardedConfigIncludeWriteError } from "../../../config/mutation-conflict.js";
+import type { ConfigWriteOptions } from "../../../config/io.types.js";
 import { resolveResetPreservedSelection } from "../../../config/sessions/reset-preserved-selection.js";
 import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.js";
 import type { ModelProviderConfigInput } from "../../../config/types.models.js";
@@ -41,18 +45,18 @@ const DEFERRED =
   'Could not read provider upgrade state; shared-key bindings were left unchanged. Rerun "openclaw doctor --fix".';
 
 /** Preserve selected shared-key routes once; ordinary runtime selection never creates bindings. */
-export async function prepareProviderUseBindingMigration(params: {
+export function prepareProviderUseBindingMigration(params: {
   config: OpenClawConfig;
   configPath: string;
   env: NodeJS.ProcessEnv;
-}): Promise<{
+}): {
   config: OpenClawConfig;
   changes: string[];
   pending: boolean;
   warnings?: string[];
   unsetPaths?: string[][];
   bindings?: Record<string, SecretRef>;
-}> {
+} {
   const { config, configPath, env } = params;
   const unchanged = { config, changes: [], pending: false };
   // Doctor retains invalid source values until its config validation step.
@@ -77,7 +81,7 @@ export async function prepareProviderUseBindingMigration(params: {
     if (completed) {
       return unchanged;
     }
-    const candidates = await listCandidateAuthProfileStores({ cfg: config, env });
+    const candidates = listCandidateAuthProfileStores({ cfg: config, env });
     const sharedStore = loadPersistedAuthProfileStoreAtDatabasePath(
       resolveOpenClawStateSqlitePath(env),
       "shared-state",
@@ -297,7 +301,7 @@ export function resolveProviderUseBindingWriteMetadata(
 }
 
 /** Recheck proposed bindings after interactive or asynchronous repairs, before persistence. */
-export async function revalidateProviderUseBindingMigration(params: {
+export function revalidateProviderUseBindingMigration(params: {
   config: OpenClawConfig;
   sourceConfig?: OpenClawConfig;
   configPath: string;
@@ -324,31 +328,14 @@ export async function revalidateProviderUseBindingMigration(params: {
   for (const [provider] of proposed) {
     delete analysis.models?.providers?.[provider];
   }
-  const checked = await prepareProviderUseBindingMigration({ ...params, config: analysis });
+  const checked = prepareProviderUseBindingMigration({ ...params, config: analysis });
   const bindings: Record<string, SecretRef> = {};
   for (const [provider, apiKey] of proposed) {
     if (isDeepStrictEqual(checked.bindings?.[provider], apiKey)) {
       bindings[provider] = apiKey;
       continue;
     }
-    const entry = config.models?.providers?.[provider];
-    if (entry) {
-      delete entry.apiKey;
-      const authoredFields = Object.entries(entry).filter(
-        ([key, value]) =>
-          !(key === "baseUrl" && value === "") &&
-          !(key === "models" && Array.isArray(value) && value.length === 0),
-      );
-      if (authoredFields.length === 0) {
-        delete config.models?.providers?.[provider];
-      }
-    }
-  }
-  if (config.models?.providers && Object.keys(config.models.providers).length === 0) {
-    delete config.models.providers;
-    if (Object.keys(config.models).length === 0) {
-      delete config.models;
-    }
+    removeGeneratedProviderCredential(config, provider);
   }
   const deferred = Object.keys(checked.bindings ?? {}).filter(
     (provider) => !Object.hasOwn(bindings, provider),
@@ -371,6 +358,104 @@ export async function revalidateProviderUseBindingMigration(params: {
         `Bound selected provider ${provider} to ${apiKey.id} with an env SecretRef.`,
     ),
   };
+}
+
+function removeGeneratedProviderCredential(config: OpenClawConfig, provider: string): void {
+  const entry = config.models?.providers?.[provider];
+  if (entry) {
+    delete entry.apiKey;
+    const authoredFields = Object.entries(entry).filter(
+      ([key, value]) =>
+        !(key === "baseUrl" && value === "") &&
+        !(key === "models" && Array.isArray(value) && value.length === 0),
+    );
+    if (authoredFields.length === 0) {
+      delete config.models?.providers?.[provider];
+    }
+  }
+  if (config.models?.providers && Object.keys(config.models.providers).length === 0) {
+    delete config.models.providers;
+    if (Object.keys(config.models).length === 0) {
+      delete config.models;
+    }
+  }
+}
+
+type CheckedProviderBindings = ReturnType<typeof revalidateProviderUseBindingMigration>;
+class ProviderUseBindingPublicationChanged extends Error {
+  constructor(readonly checked: CheckedProviderBindings) {
+    super("Provider credentials changed before binding publication.");
+  }
+}
+
+/** Account writes and the config rename share one synchronous publication fence. */
+export async function writeProviderUseBindingMigration(
+  params: Parameters<typeof revalidateProviderUseBindingMigration>[0],
+  write: (
+    checked: CheckedProviderBindings,
+    withCommit?: ConfigWriteOptions["withCommit"],
+  ) => Promise<void>,
+): Promise<CheckedProviderBindings> {
+  const owner = captureAuthProfileOwnerScope(params.env);
+  const scopedParams = () => ({
+    ...params,
+    env: {
+      ...params.env,
+      OPENCLAW_STATE_DIR: owner.stateDir,
+      OPENCLAW_AGENT_DIR: owner.sharedMainDir,
+    },
+  });
+  let checked = revalidateProviderUseBindingMigration(scopedParams());
+  try {
+    await write(checked, Object.keys(checked.bindings).length === 0 ? undefined : (publish) => {
+      let entered = false;
+      try {
+        const currentParams = scopedParams();
+        withAuthProfilePublicationLock(currentParams.env, () => {
+          entered = true;
+          const current = revalidateProviderUseBindingMigration({
+            ...currentParams,
+            config: checked.config,
+            bindings: checked.bindings,
+          });
+          if (
+            !isDeepStrictEqual(current.config, checked.config) ||
+            !isDeepStrictEqual(current.bindings, checked.bindings) ||
+            (checked.pending && !current.pending)
+          ) {
+            throw new ProviderUseBindingPublicationChanged(current);
+          }
+          publish();
+        });
+      } catch (error) {
+        if (entered) {
+          throw error;
+        }
+        // An unavailable external lock cannot certify a migration or prevent startup.
+        throw new ProviderUseBindingPublicationChanged(checked);
+      }
+    });
+  } catch (error) {
+    if (error instanceof ProviderUseBindingPublicationChanged) {
+      checked = error.checked;
+    } else if (error instanceof GuardedConfigIncludeWriteError) {
+      checked.warnings.push("Provider bindings in included config require an explicit edit to the included file.");
+    } else {
+      throw error;
+    }
+    // Publish independent repairs, but do not retry newly stale credential authority.
+    for (const provider of Object.keys(checked.bindings)) {
+      removeGeneratedProviderCredential(checked.config, provider);
+    }
+    checked.bindings = {};
+    checked.pending = false;
+    checked.changes = [];
+    checked.warnings.push(
+      'Could not verify stored accounts before saving provider bindings; shared-key bindings were deferred. Rerun "openclaw doctor --fix".',
+    );
+    await write(checked);
+  }
+  return checked;
 }
 
 /** A successful Doctor write closes the upgrade window, including an empty selection. */

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -3,7 +3,6 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { listAgentIds } from "../../../agents/agent-scope-config.js";
 import { resolveAgentDir } from "../../../agents/agent-scope.js";
-import { loadAuthProfileStoreForRuntime } from "../../../agents/auth-profiles.js";
 import {
   listCandidateAuthProfileStores,
   loadCandidateAuthProfileStore,
@@ -12,7 +11,7 @@ import { captureAuthProfileOwnerScope } from "../../../agents/auth-profiles/path
 import { loadPersistedAuthProfileStoreAtDatabasePath } from "../../../agents/auth-profiles/persisted.js";
 import { withAuthProfilePublicationLock } from "../../../agents/auth-profiles/publication.js";
 import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
-import { resolveSelectedModelProviderIds } from "../../../agents/model-selection-config.js";
+import { resolveProviderAuthAliasMap } from "../../../agents/provider-auth-aliases.js";
 import {
   isGenericProviderCredentialEnvVar,
   resolveProviderUseAdmission,
@@ -20,6 +19,10 @@ import {
 import type { ConfigWriteOptions } from "../../../config/io.types.js";
 import { isConfigIncludeOwnershipError } from "../../../config/io.write-errors.js";
 import { GuardedConfigIncludeWriteError } from "../../../config/mutation-conflict.js";
+import {
+  resolveConfigProviderUseBindings,
+  setConfigProviderUseBindings,
+} from "../../../config/resolution-facts.js";
 import { resolveResetPreservedSelection } from "../../../config/sessions/reset-preserved-selection.js";
 import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.js";
 import type { ModelProviderConfigInput } from "../../../config/types.models.js";
@@ -31,32 +34,63 @@ import {
   recordLegacyMigrationReceipt,
   resolveLegacyMigrationSourceKey,
 } from "../../../infra/state-migrations.receipts.js";
+import type { PluginManifestRegistry } from "../../../plugins/manifest-registry.js";
 import {
-  resolveProviderAuthLookupMaps,
   resolveProviderBindingEnvVarCandidates,
+  type ProviderBindingEnvVarCandidates,
 } from "../../../secrets/provider-env-vars.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../../../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { listExistingAgentDatabaseTargets } from "../../doctor-session-sqlite-readers.js";
+import {
+  collectConfiguredProviderUseSelections,
+  type ConfiguredProviderUseSelection,
+} from "./configured-provider-selection-ids.js";
 import { selectedCanonicalModelRefsForRuntimePolicy } from "./legacy-runtime-model-policy.js";
 
 const MIGRATION = "selected-shared-provider-bindings:v1";
+const SELECTION_VERSION = 2;
+const CHAIN_PROVIDERS = new Set(["amazon-bedrock", "amazon-bedrock-mantle", "google-vertex"]);
+export type ProviderUseBindingMigrationBindings = Record<string, { apiKey?: SecretRef }>;
 const DEFERRED =
   'Could not read provider upgrade state; shared-key bindings were left unchanged. Rerun "openclaw doctor --fix".';
+
+/** Runtime projection shares Doctor's transform but neither writes config nor completes receipts. */
+export function applyProviderUseBindingsToRuntime(
+  params: Parameters<typeof prepareProviderUseBindingMigration>[0] & {
+    runtimeConfig: OpenClawConfig;
+  },
+): { config: OpenClawConfig; warnings: string[] } {
+  const migration = prepareProviderUseBindingMigration(params);
+  setConfigProviderUseBindings(params.runtimeConfig, migration.bindings ?? {});
+  const warnings = [...(migration.warnings ?? [])];
+  const entries = Object.entries(migration.bindings ?? {}).map(([id, binding]) =>
+    binding.apiKey
+      ? `models.providers.${id}.apiKey = ${JSON.stringify(binding.apiKey)}`
+      : `models.providers.${id} = {}`,
+  );
+  if (entries.length > 0) {
+    warnings.push(
+      `Selected provider bindings are active in memory only. Run "openclaw doctor --fix" or update the managed config ${params.configPath}: ${entries.join("; ")}.`,
+    );
+  }
+  return { config: resolveConfigProviderUseBindings(params.runtimeConfig), warnings };
+}
 
 /** Preserve selected shared-key routes once; ordinary runtime selection never creates bindings. */
 export function prepareProviderUseBindingMigration(params: {
   config: OpenClawConfig;
   configPath: string;
   env: NodeJS.ProcessEnv;
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): {
   config: OpenClawConfig;
   changes: string[];
   pending: boolean;
   warnings?: string[];
   unsetPaths?: string[][];
-  bindings?: Record<string, SecretRef>;
+  bindings?: ProviderUseBindingMigrationBindings;
 } {
   const { config, configPath, env } = params;
   const unchanged = { config, changes: [], pending: false };
@@ -67,7 +101,9 @@ export function prepareProviderUseBindingMigration(params: {
   }
   const sourceKey = resolveLegacyMigrationSourceKey(MIGRATION, configPath);
   const sessionSelections: Array<{ agentId: string; model: string }> = [];
-  let direct: Record<string, readonly string[]>;
+  let configuredSelections: ConfiguredProviderUseSelection[];
+  let narrowReceipt = false;
+  let direct: ProviderBindingEnvVarCandidates;
   let envCandidateMap: Readonly<Record<string, readonly string[]>>;
   let aliasMap: Readonly<Record<string, string>>;
   const authScopes = new Map<string, { agentDir: string; store: AuthProfileStore }>();
@@ -80,8 +116,22 @@ export function prepareProviderUseBindingMigration(params: {
       { env },
     );
     if (completed) {
-      return unchanged;
+      let report: unknown;
+      try {
+        report = JSON.parse(completed.reportJson);
+      } catch {
+        report = undefined;
+      }
+      if (
+        isRecord(report) &&
+        typeof report.selectionVersion === "number" &&
+        report.selectionVersion >= SELECTION_VERSION
+      ) {
+        return unchanged;
+      }
+      narrowReceipt = true;
     }
+    configuredSelections = collectConfiguredProviderUseSelections({ config, env });
     const candidates = listCandidateAuthProfileStores({ cfg: config, env });
     const sharedStore = loadPersistedAuthProfileStoreAtDatabasePath(
       resolveOpenClawStateSqlitePath(env),
@@ -123,28 +173,46 @@ export function prepareProviderUseBindingMigration(params: {
     }
     for (const agentId of new Set([
       ...listAgentIds(config),
+      ...configuredSelections.map((selection) => selection.agentId),
       ...sessionSelections.map((selection) => selection.agentId),
     ])) {
       const agentDir = resolveAgentDir(config, agentId, env);
       authScopes.set(agentId, {
         agentDir,
-        store: loadAuthProfileStoreForRuntime(
-          agentDir,
-          {
-            config,
-            readOnly: true,
-            allowKeychainPrompt: false,
-          },
-          env,
-        ),
+        store: {
+          version: 1,
+          profiles: Object.assign(
+            {},
+            ...accountScopes
+              .filter((scope) => scope.owner === "shared" || scope.owner === agentId)
+              .map((scope) => scope.store.profiles),
+          ),
+        },
       });
     }
-    direct = resolveProviderBindingEnvVarCandidates({ config, env });
-    ({ envCandidateMap, aliasMap } = resolveProviderAuthLookupMaps({
+    direct = resolveProviderBindingEnvVarCandidates({
+      config,
+      env,
+      manifestPlugins: params.manifestRegistry?.plugins,
+    });
+    aliasMap = resolveProviderAuthAliasMap({
       config,
       env,
       includeUntrustedWorkspacePlugins: false,
-    }));
+      ...(params.manifestRegistry
+        ? { metadataSnapshot: { plugins: params.manifestRegistry.plugins } }
+        : {}),
+    });
+    const envCandidates: Record<string, readonly string[]> = Object.fromEntries(
+      Object.entries(direct).map(([provider, declarations]) => [
+        provider,
+        declarations.flatMap((declaration) => declaration.envVars),
+      ]),
+    );
+    for (const [alias, provider] of Object.entries(aliasMap)) {
+      envCandidates[alias] ??= envCandidates[provider] ?? [];
+    }
+    envCandidateMap = envCandidates;
   } catch {
     return { ...unchanged, warnings: [DEFERRED] };
   }
@@ -156,14 +224,32 @@ export function prepareProviderUseBindingMigration(params: {
   }
   const selectedProviders = new Map<string, Set<string>>();
   for (const agentId of authScopes.keys()) {
-    selectedProviders.set(agentId, resolveSelectedModelProviderIds({ cfg: config, agentId }));
+    selectedProviders.set(
+      agentId,
+      new Set(
+        configuredSelections
+          .filter(
+            (selection) =>
+              selection.agentId === agentId &&
+              (!narrowReceipt ||
+                !selection.previouslyCovered ||
+                CHAIN_PROVIDERS.has(selection.provider)),
+          )
+          .map((selection) => selection.provider),
+      ),
+    );
   }
-  const manifestVariables = new Set(Object.values(direct).flat());
+  const manifestVariables = new Set(
+    Object.values(direct).flatMap((declarations) =>
+      declarations.flatMap((declaration) => declaration.envVars),
+    ),
+  );
   const admissions = new Map(
     [...authScopes].map(([agentId, { store }]) => [
       agentId,
       resolveProviderUseAdmission({
         config,
+        includeRuntimeBindings: false,
         env,
         providerEnvVars: direct,
         profiles: store.profiles,
@@ -171,24 +257,29 @@ export function prepareProviderUseBindingMigration(params: {
     ]),
   );
   const providers: Record<string, ModelProviderConfigInput> = {};
-  const bindings: Record<string, SecretRef> = {};
+  const bindings: ProviderUseBindingMigrationBindings = {};
   const changes: string[] = [];
   const warnings: string[] = [];
-  for (const [identity, candidates] of Object.entries(envCandidateMap)) {
+  for (const [identity, candidates] of Object.entries({
+    ...Object.fromEntries([...CHAIN_PROVIDERS].map((provider) => [provider, []])),
+    ...envCandidateMap,
+  })) {
     const provider = normalizeProviderId(identity);
+    const chain = CHAIN_PROVIDERS.has(provider);
     const selectedAgents = [...selectedProviders]
       .filter(
         ([agentId, selected]) =>
           selected.has(provider) ||
-          sessionSelections.some(
-            (selection) =>
-              selection.agentId === agentId &&
-              selectedCanonicalModelRefsForRuntimePolicy(selection.model, provider).length > 0,
-          ),
+          ((!narrowReceipt || chain) &&
+            sessionSelections.some(
+              (selection) =>
+                selection.agentId === agentId &&
+                selectedCanonicalModelRefsForRuntimePolicy(selection.model, provider).length > 0,
+            )),
       )
       .map(([agentId]) => agentId);
     if (
-      (!Object.hasOwn(direct, identity) && !Object.hasOwn(aliasMap, identity)) ||
+      (!chain && !Object.hasOwn(direct, identity) && !Object.hasOwn(aliasMap, identity)) ||
       selectedAgents.length === 0
     ) {
       continue;
@@ -201,14 +292,8 @@ export function prepareProviderUseBindingMigration(params: {
           ([sibling, names]) => normalizeProviderId(sibling) !== provider && names.includes(name),
         ),
     );
-    if (sharedVariables.length === 0) {
+    if (!chain && sharedVariables.length === 0) {
       continue;
-    }
-    const variable = sharedVariables.find((name) => env[name]?.trim());
-    if (!variable) {
-      warnings.push(
-        `Could not evaluate the shared-key upgrade for provider ${provider}: ${sharedVariables.join(", ")} is not set. Rerun "openclaw doctor --fix" from the service environment or with a candidate variable set.`,
-      );
     }
     const missingAgents = selectedAgents.filter(
       (agentId) => !admissions.get(agentId)?.has(provider),
@@ -224,6 +309,9 @@ export function prepareProviderUseBindingMigration(params: {
         const storedProvider = normalizeProviderId(profile.provider);
         if (
           storedProvider === provider ||
+          [provider, storedProvider].every(
+            (id) => id === "amazon-bedrock" || id === "amazon-bedrock-mantle",
+          ) ||
           (aliasMap[storedProvider] ?? storedProvider) === credentialProvider ||
           (envCandidateMap[storedProvider] ?? []).some(
             (name) => manifestVariables.has(name) && candidates.includes(name),
@@ -236,17 +324,30 @@ export function prepareProviderUseBindingMigration(params: {
     }
     if (conflictingProfiles.size > 0) {
       warnings.push(
-        `Provider ${provider} was not migrated for agents ${missingAgents.join(", ")}: a global env binding could replace an existing account for agents ${[...accountOwners].join(", ")} (profiles ${[...conflictingProfiles].join(", ")}). Bind the provider explicitly to the saved account, then rerun "openclaw doctor --fix".`,
+        `Provider ${provider} was not migrated for agents ${missingAgents.join(", ")}: a global binding could replace an existing account for agents ${[...accountOwners].join(", ")} (profiles ${[...conflictingProfiles].join(", ")}). Bind the provider explicitly to the saved account, then rerun "openclaw doctor --fix".`,
       );
       continue;
     }
-    const apiKey = variable ? parseEnvTemplateSecretRef(`\${${variable}}`, envProvider) : null;
-    if (!apiKey) {
+    const variable = sharedVariables.find((name) => env[name]?.trim());
+    if (!chain && !variable) {
+      warnings.push(
+        `Could not evaluate the shared-key upgrade for provider ${provider}: ${sharedVariables.join(", ")} is not set. Rerun "openclaw doctor --fix" from the service environment or with a candidate variable set.`,
+      );
       continue;
     }
-    providers[provider] = { apiKey };
-    bindings[provider] = apiKey;
-    changes.push(`Bound selected provider ${provider} to ${variable} with an env SecretRef.`);
+    const apiKey =
+      !chain && variable ? parseEnvTemplateSecretRef(`\${${variable}}`, envProvider) : null;
+    if (!chain && !apiKey) {
+      continue;
+    }
+    const binding = apiKey ? { apiKey } : {};
+    providers[provider] = binding;
+    bindings[provider] = binding;
+    changes.push(
+      chain
+        ? `Declared selected provider ${provider} for its configured credential chain.`
+        : `Bound selected provider ${provider} to ${variable} with an env SecretRef.`,
+    );
   }
   if (changes.length === 0) {
     return {
@@ -307,33 +408,34 @@ export function revalidateProviderUseBindingMigration(params: {
   sourceConfig?: OpenClawConfig;
   configPath: string;
   env: NodeJS.ProcessEnv;
-  bindings: Readonly<Record<string, SecretRef>>;
+  bindings: Readonly<ProviderUseBindingMigrationBindings>;
 }) {
   const config = structuredClone(params.config);
-  for (const [provider, apiKey] of Object.entries(params.bindings)) {
+  for (const [provider, binding] of Object.entries(params.bindings)) {
     const persisted = params.sourceConfig?.models?.providers?.[provider];
     if (
       persisted &&
       config.models?.providers &&
-      isDeepStrictEqual(config.models.providers[provider]?.apiKey, apiKey)
+      isDeepStrictEqual(config.models.providers[provider]?.apiKey, binding.apiKey)
     ) {
       config.models.providers[provider] = structuredClone(persisted);
     }
   }
   const analysis = structuredClone(config);
   const proposed = Object.entries(params.bindings).filter(
-    ([provider, apiKey]) =>
+    ([provider, binding]) =>
       !params.sourceConfig?.models?.providers?.[provider] &&
-      isDeepStrictEqual(config.models?.providers?.[provider]?.apiKey, apiKey),
+      Object.hasOwn(config.models?.providers ?? {}, provider) &&
+      isDeepStrictEqual(config.models?.providers?.[provider]?.apiKey, binding.apiKey),
   );
   for (const [provider] of proposed) {
     delete analysis.models?.providers?.[provider];
   }
   const checked = prepareProviderUseBindingMigration({ ...params, config: analysis });
-  const bindings: Record<string, SecretRef> = {};
-  for (const [provider, apiKey] of proposed) {
-    if (isDeepStrictEqual(checked.bindings?.[provider], apiKey)) {
-      bindings[provider] = apiKey;
+  const bindings: ProviderUseBindingMigrationBindings = {};
+  for (const [provider, binding] of proposed) {
+    if (isDeepStrictEqual(checked.bindings?.[provider], binding)) {
+      bindings[provider] = binding;
       continue;
     }
     removeGeneratedProviderCredential(config, provider, params.sourceConfig);
@@ -354,9 +456,10 @@ export function revalidateProviderUseBindingMigration(params: {
           ]
         : []),
     ],
-    changes: Object.entries(bindings).map(
-      ([provider, apiKey]) =>
-        `Bound selected provider ${provider} to ${apiKey.id} with an env SecretRef.`,
+    changes: Object.entries(bindings).map(([provider, binding]) =>
+      binding.apiKey
+        ? `Bound selected provider ${provider} to ${binding.apiKey.id} with an env SecretRef.`
+        : `Declared selected provider ${provider} for its configured credential chain.`,
     ),
   };
 }
@@ -457,7 +560,7 @@ export async function writeProviderUseBindingMigration(
       isConfigIncludeOwnershipError(error)
     ) {
       const selections = Object.entries(checked.bindings)
-        .map(([provider, ref]) => `${provider} (${ref.id})`)
+        .map(([provider, binding]) => `${provider} (${binding.apiKey?.id ?? "credential chain"})`)
         .join(", ");
       const includePaths =
         error instanceof GuardedConfigIncludeWriteError
@@ -493,8 +596,21 @@ export function completeProviderUseBindingMigration(
   try {
     runOpenClawStateWriteTransaction(
       ({ db }) => {
-        if (readLegacyMigrationReceiptFromDatabase(db, sourceKey)) {
-          return;
+        const completed = readLegacyMigrationReceiptFromDatabase(db, sourceKey);
+        if (completed) {
+          let report: unknown;
+          try {
+            report = JSON.parse(completed.reportJson);
+          } catch {
+            report = undefined;
+          }
+          if (
+            isRecord(report) &&
+            typeof report.selectionVersion === "number" &&
+            report.selectionVersion >= SELECTION_VERSION
+          ) {
+            return;
+          }
         }
         recordLegacyMigrationReceipt(db, {
           sourceKey,
@@ -506,7 +622,12 @@ export function completeProviderUseBindingMigration(
           sourceRecordCount: null,
           runId: sourceKey,
           now: Date.now(),
-          reportJson: JSON.stringify({ completed: true, target: "models.providers" }),
+          reportJson: JSON.stringify({
+            completed: true,
+            target: "models.providers",
+            selectionVersion: SELECTION_VERSION,
+          }),
+          upsert: completed !== null,
         });
       },
       { env },

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -37,6 +37,11 @@ export async function prepareProviderUseBindingMigration(params: {
 }): Promise<{ config: OpenClawConfig; changes: string[]; pending: boolean; warnings?: string[] }> {
   const { config, configPath, env } = params;
   const unchanged = { config, changes: [], pending: false };
+  // Doctor retains invalid source values until its config validation step.
+  const envProvider: unknown = config.secrets?.defaults?.env;
+  if (envProvider !== undefined && typeof envProvider !== "string") {
+    return unchanged;
+  }
   const sourceKey = resolveLegacyMigrationSourceKey(MIGRATION, configPath);
   const selections: unknown[] = [config.agents?.defaults?.model];
   let direct: Record<string, readonly string[]>;
@@ -144,9 +149,7 @@ export async function prepareProviderUseBindingMigration(params: {
           ([sibling, names]) => normalizeProviderId(sibling) !== provider && names.includes(name),
         ),
     );
-    const apiKey = variable
-      ? parseEnvTemplateSecretRef(`\${${variable}}`, config.secrets?.defaults?.env)
-      : null;
+    const apiKey = variable ? parseEnvTemplateSecretRef(`\${${variable}}`, envProvider) : null;
     if (!apiKey) {
       continue;
     }

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -18,6 +18,7 @@ import {
   resolveProviderUseAdmission,
 } from "../../../agents/provider-model-auth-source-plan.js";
 import type { ConfigWriteOptions } from "../../../config/io.types.js";
+import { isConfigIncludeOwnershipError } from "../../../config/io.write-errors.js";
 import { GuardedConfigIncludeWriteError } from "../../../config/mutation-conflict.js";
 import { resolveResetPreservedSelection } from "../../../config/sessions/reset-preserved-selection.js";
 import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.js";
@@ -451,12 +452,19 @@ export async function writeProviderUseBindingMigration(
   } catch (error) {
     if (error instanceof ProviderUseBindingPublicationChanged) {
       checked = error.checked;
-    } else if (error instanceof GuardedConfigIncludeWriteError) {
+    } else if (
+      error instanceof GuardedConfigIncludeWriteError ||
+      isConfigIncludeOwnershipError(error)
+    ) {
       const selections = Object.entries(checked.bindings)
         .map(([provider, ref]) => `${provider} (${ref.id})`)
         .join(", ");
+      const includePaths =
+        error instanceof GuardedConfigIncludeWriteError
+          ? error.includePath
+          : (error.includeTargets?.join(", ") ?? error.ownedConfigPath);
       checked.warnings.push(
-        `Provider bindings ${selections} were not written to included config ${error.includePath}. Bind them explicitly in that file.`,
+        `Provider bindings ${selections} were not written to included config ${includePaths}. Bind them explicitly in that file.`,
       );
     } else {
       throw error;

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -1,0 +1,194 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { ensureAuthProfileStore } from "../../../agents/auth-profiles.js";
+import {
+  listCandidateAuthProfileStores,
+  loadCandidateAuthProfileStore,
+} from "../../../agents/auth-profiles/candidate-stores.js";
+import { loadPersistedSharedAuthProfileStore } from "../../../agents/auth-profiles/persisted.js";
+import { resolveProviderUseAdmission } from "../../../agents/provider-model-auth-source-plan.js";
+import { resolveResetPreservedSelection } from "../../../config/sessions/reset-preserved-selection.js";
+import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { parseEnvTemplateSecretRef } from "../../../config/types.secrets.js";
+import {
+  readLegacyMigrationReceiptFromDatabase,
+  recordLegacyMigrationReceipt,
+  resolveLegacyMigrationSourceKey,
+} from "../../../infra/state-migrations.receipts.js";
+import {
+  resolveProviderAuthLookupMaps,
+  resolveProviderBindingEnvVarCandidates,
+} from "../../../secrets/provider-env-vars.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../../../state/openclaw-state-db-readonly.js";
+import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
+import { listExistingAgentDatabaseTargets } from "../../doctor-session-sqlite-readers.js";
+import { selectedCanonicalModelRefsForRuntimePolicy } from "./legacy-runtime-model-policy.js";
+
+const MIGRATION = "selected-shared-provider-bindings:v1";
+const DEFERRED =
+  'Could not read provider upgrade state; shared-key bindings were left unchanged. Rerun "openclaw doctor --fix".';
+
+/** Preserve selected shared-key routes once; ordinary runtime selection never creates bindings. */
+export async function prepareProviderUseBindingMigration(params: {
+  config: OpenClawConfig;
+  configPath: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<{ config: OpenClawConfig; changes: string[]; pending: boolean; warnings?: string[] }> {
+  const { config, configPath, env } = params;
+  const unchanged = { config, changes: [], pending: false };
+  const sourceKey = resolveLegacyMigrationSourceKey(MIGRATION, configPath);
+  const selections: unknown[] = [config.agents?.defaults?.model];
+  let direct: Record<string, readonly string[]>;
+  let envCandidateMap: Readonly<Record<string, readonly string[]>>;
+  let aliasMap: Readonly<Record<string, string>>;
+  const profiles: Record<string, { provider: string }> = {};
+  // Receipts and session pins are external state. A failed read must not turn an
+  // incomplete selection snapshot into a completed upgrade or prevent startup.
+  try {
+    const completed = withExistingOpenClawStateDatabaseReadOnly(
+      ({ db }) => readLegacyMigrationReceiptFromDatabase(db, sourceKey),
+      { env },
+    );
+    if (completed) {
+      return unchanged;
+    }
+    const stores = [
+      loadPersistedSharedAuthProfileStore(env),
+      ensureAuthProfileStore(undefined, {
+        config,
+        readOnly: true,
+        allowKeychainPrompt: false,
+      }),
+    ];
+    for (const candidate of await listCandidateAuthProfileStores({ cfg: config, env })) {
+      stores.push(loadCandidateAuthProfileStore(candidate));
+    }
+    for (const store of stores) {
+      for (const profile of Object.values(store?.profiles ?? {})) {
+        profiles[profile.provider] = { provider: profile.provider };
+      }
+    }
+    let incompletePins = false;
+    for (const target of listExistingAgentDatabaseTargets(config, env)) {
+      scanDoctorSessionEntriesTolerant(
+        { agentId: target.agentId, storePath: target.storePath, env },
+        ({ entry, recoveredFromProjections }) => {
+          if (recoveredFromProjections) {
+            incompletePins = true;
+            return;
+          }
+          const pin = resolveResetPreservedSelection({ entry });
+          if (typeof pin.modelOverride === "string") {
+            selections.push(
+              pin.providerOverride && !pin.modelOverride.startsWith(`${pin.providerOverride}/`)
+                ? `${pin.providerOverride}/${pin.modelOverride}`
+                : pin.modelOverride,
+            );
+          }
+        },
+      );
+    }
+    if (incompletePins) {
+      return { ...unchanged, warnings: [DEFERRED] };
+    }
+    direct = resolveProviderBindingEnvVarCandidates({ config, env });
+    ({ envCandidateMap, aliasMap } = resolveProviderAuthLookupMaps({
+      config,
+      env,
+      includeUntrustedWorkspacePlugins: false,
+    }));
+  } catch {
+    return { ...unchanged, warnings: [DEFERRED] };
+  }
+  const agents = config.agents;
+  const roster = isRecord(agents?.entries)
+    ? Object.values(agents.entries)
+    : Array.isArray(agents?.list)
+      ? agents.list
+      : [];
+  for (const agent of roster) {
+    if (isRecord(agent)) {
+      selections.push(agent.model);
+    }
+  }
+  if (config.models !== undefined && !isRecord(config.models)) {
+    return unchanged;
+  }
+  if (config.models?.providers !== undefined && !isRecord(config.models.providers)) {
+    return unchanged;
+  }
+  const manifestVariables = new Set(Object.values(direct).flat());
+  const admitted = resolveProviderUseAdmission({ config, env, providerEnvVars: direct, profiles });
+  const providers = { ...config.models?.providers };
+  const changes: string[] = [];
+  for (const [identity, candidates] of Object.entries(envCandidateMap)) {
+    const provider = normalizeProviderId(identity);
+    if (
+      (!Object.hasOwn(direct, identity) && !Object.hasOwn(aliasMap, identity)) ||
+      admitted.has(provider) ||
+      !selections.some(
+        (model) => selectedCanonicalModelRefsForRuntimePolicy(model, provider).length > 0,
+      )
+    ) {
+      continue;
+    }
+    const variable = candidates.find(
+      (name) =>
+        manifestVariables.has(name) &&
+        // The admission owner excludes generic credentials even if a manifest names one.
+        resolveProviderUseAdmission({ env, providerEnvVars: { [provider]: [name] } }).has(
+          provider,
+        ) &&
+        Object.entries(envCandidateMap).some(
+          ([sibling, names]) => normalizeProviderId(sibling) !== provider && names.includes(name),
+        ),
+    );
+    const apiKey = variable
+      ? parseEnvTemplateSecretRef(`\${${variable}}`, config.secrets?.defaults?.env)
+      : null;
+    if (!apiKey) {
+      continue;
+    }
+    providers[provider] = { apiKey, baseUrl: "", models: [] };
+    changes.push(`Bound selected provider ${provider} to ${variable} with an env SecretRef.`);
+  }
+  return {
+    config: changes.length ? { ...config, models: { ...config.models, providers } } : config,
+    changes,
+    pending: true,
+  };
+}
+
+/** A successful Doctor write closes the upgrade window, including an empty selection. */
+export function completeProviderUseBindingMigration(
+  configPath: string,
+  env: NodeJS.ProcessEnv,
+): string[] {
+  const sourceKey = resolveLegacyMigrationSourceKey(MIGRATION, configPath);
+  try {
+    runOpenClawStateWriteTransaction(
+      ({ db }) => {
+        if (readLegacyMigrationReceiptFromDatabase(db, sourceKey)) {
+          return;
+        }
+        recordLegacyMigrationReceipt(db, {
+          sourceKey,
+          migrationKind: MIGRATION,
+          sourcePath: configPath,
+          targetTable: "migration_sources",
+          sourceSha256: null,
+          sourceSizeBytes: null,
+          sourceRecordCount: null,
+          runId: sourceKey,
+          now: Date.now(),
+          reportJson: JSON.stringify({ completed: true, target: "models.providers" }),
+        });
+      },
+      { env },
+    );
+    return [];
+  } catch {
+    return ['Could not record the shared-key provider upgrade; rerun "openclaw doctor --fix".'];
+  }
+}

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -1,16 +1,27 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { listAgentIds } from "../../../agents/agent-scope-config.js";
+import { resolveAgentEffectiveModelPrimary } from "../../../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../../../agents/auth-profiles.js";
 import {
   listCandidateAuthProfileStores,
   loadCandidateAuthProfileStore,
 } from "../../../agents/auth-profiles/candidate-stores.js";
 import { loadPersistedSharedAuthProfileStore } from "../../../agents/auth-profiles/persisted.js";
+import { resolveDefaultModelForAgent } from "../../../agents/model-selection-config.js";
+import { resolveConfiguredModelFallbacks } from "../../../agents/model-selection-resolve.js";
+import {
+  buildModelAliasIndex,
+  resolveModelRefFromString,
+} from "../../../agents/model-selection-shared.js";
 import { resolveProviderUseAdmission } from "../../../agents/provider-model-auth-source-plan.js";
+import { resolveAgentModelPrimaryValue } from "../../../config/model-input.js";
 import { resolveResetPreservedSelection } from "../../../config/sessions/reset-preserved-selection.js";
 import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.js";
+import type { ModelProviderConfigInput } from "../../../config/types.models.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { parseEnvTemplateSecretRef } from "../../../config/types.secrets.js";
+import { validateConfigObjectRaw } from "../../../config/validation-core.js";
 import {
   readLegacyMigrationReceiptFromDatabase,
   recordLegacyMigrationReceipt,
@@ -34,7 +45,13 @@ export async function prepareProviderUseBindingMigration(params: {
   config: OpenClawConfig;
   configPath: string;
   env: NodeJS.ProcessEnv;
-}): Promise<{ config: OpenClawConfig; changes: string[]; pending: boolean; warnings?: string[] }> {
+}): Promise<{
+  config: OpenClawConfig;
+  changes: string[];
+  pending: boolean;
+  warnings?: string[];
+  unsetPaths?: string[][];
+}> {
   const { config, configPath, env } = params;
   const unchanged = { config, changes: [], pending: false };
   // Doctor retains invalid source values until its config validation step.
@@ -43,7 +60,7 @@ export async function prepareProviderUseBindingMigration(params: {
     return unchanged;
   }
   const sourceKey = resolveLegacyMigrationSourceKey(MIGRATION, configPath);
-  const selections: unknown[] = [config.agents?.defaults?.model];
+  const sessionSelections: unknown[] = [];
   let direct: Record<string, readonly string[]>;
   let envCandidateMap: Readonly<Record<string, readonly string[]>>;
   let aliasMap: Readonly<Record<string, string>>;
@@ -85,7 +102,7 @@ export async function prepareProviderUseBindingMigration(params: {
           }
           const pin = resolveResetPreservedSelection({ entry });
           if (typeof pin.modelOverride === "string") {
-            selections.push(
+            sessionSelections.push(
               pin.providerOverride && !pin.modelOverride.startsWith(`${pin.providerOverride}/`)
                 ? `${pin.providerOverride}/${pin.modelOverride}`
                 : pin.modelOverride,
@@ -106,35 +123,59 @@ export async function prepareProviderUseBindingMigration(params: {
   } catch {
     return { ...unchanged, warnings: [DEFERRED] };
   }
-  const agents = config.agents;
-  const roster = isRecord(agents?.entries)
-    ? Object.values(agents.entries)
-    : Array.isArray(agents?.list)
-      ? agents.list
-      : [];
-  for (const agent of roster) {
-    if (isRecord(agent)) {
-      selections.push(agent.model);
-    }
-  }
   if (config.models !== undefined && !isRecord(config.models)) {
     return unchanged;
   }
   if (config.models?.providers !== undefined && !isRecord(config.models.providers)) {
     return unchanged;
   }
+  const selectedProviders = new Set<string>();
+  for (const agentId of [undefined, ...listAgentIds(config)]) {
+    const selection = {
+      cfg: config,
+      agentId,
+      allowManifestNormalization: false,
+      allowPluginNormalization: false,
+    };
+    const primary = resolveDefaultModelForAgent(selection);
+    const rawPrimary = agentId
+      ? resolveAgentEffectiveModelPrimary(config, agentId)
+      : resolveAgentModelPrimaryValue(config.agents?.defaults?.model);
+    if (rawPrimary) {
+      selectedProviders.add(normalizeProviderId(primary.provider));
+    }
+    const aliasIndex = buildModelAliasIndex({
+      ...selection,
+      defaultProvider: primary.provider,
+    });
+    for (const raw of resolveConfiguredModelFallbacks(selection)) {
+      if (typeof raw !== "string") {
+        continue;
+      }
+      const resolved = resolveModelRefFromString({
+        ...selection,
+        raw,
+        defaultProvider: primary.provider,
+        aliasIndex,
+      });
+      if (resolved) {
+        selectedProviders.add(normalizeProviderId(resolved.ref.provider));
+      }
+    }
+  }
   const manifestVariables = new Set(Object.values(direct).flat());
   const admitted = resolveProviderUseAdmission({ config, env, providerEnvVars: direct, profiles });
-  const providers = { ...config.models?.providers };
+  const providers: Record<string, ModelProviderConfigInput> = {};
   const changes: string[] = [];
   for (const [identity, candidates] of Object.entries(envCandidateMap)) {
     const provider = normalizeProviderId(identity);
     if (
       (!Object.hasOwn(direct, identity) && !Object.hasOwn(aliasMap, identity)) ||
       admitted.has(provider) ||
-      !selections.some(
-        (model) => selectedCanonicalModelRefsForRuntimePolicy(model, provider).length > 0,
-      )
+      (!selectedProviders.has(provider) &&
+        !sessionSelections.some(
+          (model) => selectedCanonicalModelRefsForRuntimePolicy(model, provider).length > 0,
+        ))
     ) {
       continue;
     }
@@ -153,13 +194,33 @@ export async function prepareProviderUseBindingMigration(params: {
     if (!apiKey) {
       continue;
     }
-    providers[provider] = { apiKey, baseUrl: "", models: [] };
+    providers[provider] = { apiKey };
     changes.push(`Bound selected provider ${provider} to ${variable} with an env SecretRef.`);
   }
+  if (changes.length === 0) {
+    return { ...unchanged, pending: true };
+  }
+  const validated = validateConfigObjectRaw({ models: { providers } }, { env });
+  if (!validated.ok) {
+    return {
+      ...unchanged,
+      warnings: ["Could not validate shared-key provider bindings; config was left unchanged."],
+    };
+  }
   return {
-    config: changes.length ? { ...config, models: { ...config.models, providers } } : config,
+    config: {
+      ...config,
+      models: {
+        ...config.models,
+        providers: { ...config.models?.providers, ...validated.config.models?.providers },
+      },
+    },
     changes,
     pending: true,
+    // Doctor consumes materialized config; its writer preserves the sparse source overlay.
+    unsetPaths: Object.keys(providers).flatMap((provider) =>
+      ["baseUrl", "models"].map((field) => ["models", "providers", provider, field]),
+    ),
   };
 }
 

--- a/src/commands/doctor/shared/provider-use-binding-migration.ts
+++ b/src/commands/doctor/shared/provider-use-binding-migration.ts
@@ -17,8 +17,8 @@ import {
   isGenericProviderCredentialEnvVar,
   resolveProviderUseAdmission,
 } from "../../../agents/provider-model-auth-source-plan.js";
-import { GuardedConfigIncludeWriteError } from "../../../config/mutation-conflict.js";
 import type { ConfigWriteOptions } from "../../../config/io.types.js";
+import { GuardedConfigIncludeWriteError } from "../../../config/mutation-conflict.js";
 import { resolveResetPreservedSelection } from "../../../config/sessions/reset-preserved-selection.js";
 import { scanDoctorSessionEntriesTolerant } from "../../../config/sessions/session-accessor.js";
 import type { ModelProviderConfigInput } from "../../../config/types.models.js";
@@ -335,7 +335,7 @@ export function revalidateProviderUseBindingMigration(params: {
       bindings[provider] = apiKey;
       continue;
     }
-    removeGeneratedProviderCredential(config, provider);
+    removeGeneratedProviderCredential(config, provider, params.sourceConfig);
   }
   const deferred = Object.keys(checked.bindings ?? {}).filter(
     (provider) => !Object.hasOwn(bindings, provider),
@@ -360,7 +360,11 @@ export function revalidateProviderUseBindingMigration(params: {
   };
 }
 
-function removeGeneratedProviderCredential(config: OpenClawConfig, provider: string): void {
+function removeGeneratedProviderCredential(
+  config: OpenClawConfig,
+  provider: string,
+  sourceConfig?: OpenClawConfig,
+): void {
   const entry = config.models?.providers?.[provider];
   if (entry) {
     delete entry.apiKey;
@@ -373,9 +377,13 @@ function removeGeneratedProviderCredential(config: OpenClawConfig, provider: str
       delete config.models?.providers?.[provider];
     }
   }
-  if (config.models?.providers && Object.keys(config.models.providers).length === 0) {
+  if (
+    config.models?.providers &&
+    Object.keys(config.models.providers).length === 0 &&
+    !sourceConfig?.models?.providers
+  ) {
     delete config.models.providers;
-    if (Object.keys(config.models).length === 0) {
+    if (Object.keys(config.models).length === 0 && !sourceConfig?.models) {
       delete config.models;
     }
   }
@@ -407,45 +415,55 @@ export async function writeProviderUseBindingMigration(
   });
   let checked = revalidateProviderUseBindingMigration(scopedParams());
   try {
-    await write(checked, Object.keys(checked.bindings).length === 0 ? undefined : (publish) => {
-      let entered = false;
-      try {
-        const currentParams = scopedParams();
-        withAuthProfilePublicationLock(currentParams.env, () => {
-          entered = true;
-          const current = revalidateProviderUseBindingMigration({
-            ...currentParams,
-            config: checked.config,
-            bindings: checked.bindings,
-          });
-          if (
-            !isDeepStrictEqual(current.config, checked.config) ||
-            !isDeepStrictEqual(current.bindings, checked.bindings) ||
-            (checked.pending && !current.pending)
-          ) {
-            throw new ProviderUseBindingPublicationChanged(current);
-          }
-          publish();
-        });
-      } catch (error) {
-        if (entered) {
-          throw error;
-        }
-        // An unavailable external lock cannot certify a migration or prevent startup.
-        throw new ProviderUseBindingPublicationChanged(checked);
-      }
-    });
+    await write(
+      checked,
+      Object.keys(checked.bindings).length === 0
+        ? undefined
+        : (publish) => {
+            let entered = false;
+            try {
+              const currentParams = scopedParams();
+              withAuthProfilePublicationLock(currentParams.env, () => {
+                entered = true;
+                const current = revalidateProviderUseBindingMigration({
+                  ...currentParams,
+                  config: checked.config,
+                  bindings: checked.bindings,
+                });
+                if (
+                  !isDeepStrictEqual(current.config, checked.config) ||
+                  !isDeepStrictEqual(current.bindings, checked.bindings) ||
+                  (checked.pending && !current.pending)
+                ) {
+                  throw new ProviderUseBindingPublicationChanged(current);
+                }
+                publish();
+              });
+            } catch (error) {
+              if (entered) {
+                throw error;
+              }
+              // An unavailable external lock cannot certify a migration or prevent startup.
+              throw new ProviderUseBindingPublicationChanged(checked);
+            }
+          },
+    );
   } catch (error) {
     if (error instanceof ProviderUseBindingPublicationChanged) {
       checked = error.checked;
     } else if (error instanceof GuardedConfigIncludeWriteError) {
-      checked.warnings.push("Provider bindings in included config require an explicit edit to the included file.");
+      const selections = Object.entries(checked.bindings)
+        .map(([provider, ref]) => `${provider} (${ref.id})`)
+        .join(", ");
+      checked.warnings.push(
+        `Provider bindings ${selections} were not written to included config ${error.includePath}. Bind them explicitly in that file.`,
+      );
     } else {
       throw error;
     }
     // Publish independent repairs, but do not retry newly stale credential authority.
     for (const provider of Object.keys(checked.bindings)) {
-      removeGeneratedProviderCredential(checked.config, provider);
+      removeGeneratedProviderCredential(checked.config, provider, params.sourceConfig);
     }
     checked.bindings = {};
     checked.pending = false;

--- a/src/commands/models/auth-api-key.ts
+++ b/src/commands/models/auth-api-key.ts
@@ -114,7 +114,7 @@ export async function saveModelProviderApiKey(params: {
       ? resolvePersistedAuthProfileOwnerAgentDir({ agentDir: params.agentDir, profileId })
       : params.agentDir;
   const localCandidates = connectionId
-    ? (await listCandidateAuthProfileStores({ cfg: config })).filter(
+    ? listCandidateAuthProfileStores({ cfg: config }).filter(
         (candidate) =>
           candidate.databasePath !==
           resolvePathViaExistingAncestorSync(resolveSharedAuthStorePath()),

--- a/src/commands/models/list.auth-overview.environment.test.ts
+++ b/src/commands/models/list.auth-overview.environment.test.ts
@@ -1,0 +1,35 @@
+import { expect, it } from "vitest";
+import { withEnv } from "../../test-utils/env.js";
+import { resolveProviderAuthOverview } from "./list.auth-overview.js";
+
+it("reports the working admitted environment source while retaining the unusable saved account", () => {
+  withEnv(
+    { FIXTURE_API_KEY: "working-environment-key", OTHER_API_KEY: "unselected-environment-key" },
+    () => {
+      const overview = resolveProviderAuthOverview({
+        provider: "fixture-api",
+        cfg: {},
+        store: {
+          version: 1,
+          profiles: {
+            "fixture-api:expired": {
+              type: "token",
+              provider: "fixture-api",
+              token: "expired-account",
+              expires: 1,
+            },
+          },
+        },
+        modelsPath: "/unused/models.json",
+        aliasMap: {},
+        envCandidateMap: { "fixture-api": ["OTHER_API_KEY", "FIXTURE_API_KEY"] },
+        authEvidenceMap: {},
+        selectedEnvironmentVariable: "FIXTURE_API_KEY",
+      });
+      expect(overview.effective.kind).toBe("env");
+      expect(overview.env?.source).toBe("env: FIXTURE_API_KEY");
+      expect(overview.profiles.count).toBe(1);
+      expect(overview.profiles.labels[0]).toContain("fixture-api:expired");
+    },
+  );
+});

--- a/src/commands/models/list.auth-overview.environment.test.ts
+++ b/src/commands/models/list.auth-overview.environment.test.ts
@@ -1,4 +1,9 @@
 import { expect, it } from "vitest";
+import {
+  createModelAuthAvailabilityResolver,
+  type ModelAuthAvailabilityEvaluation,
+} from "../../agents/model-auth-availability.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withEnv } from "../../test-utils/env.js";
 import { resolveProviderAuthOverview } from "./list.auth-overview.js";
 
@@ -24,7 +29,12 @@ it("reports the working admitted environment source while retaining the unusable
         aliasMap: {},
         envCandidateMap: { "fixture-api": ["OTHER_API_KEY", "FIXTURE_API_KEY"] },
         authEvidenceMap: {},
-        selectedEnvironmentVariable: "FIXTURE_API_KEY",
+        evaluation: {
+          availability: true,
+          evidence: "environment",
+          environmentVariable: "FIXTURE_API_KEY",
+          routeResolution: null,
+        },
       });
       expect(overview.effective.kind).toBe("env");
       expect(overview.env?.source).toBe("env: FIXTURE_API_KEY");
@@ -32,4 +42,145 @@ it("reports the working admitted environment source while retaining the unusable
       expect(overview.profiles.labels[0]).toContain("fixture-api:expired");
     },
   );
+});
+
+it.each([
+  {
+    name: "saved profile",
+    evaluation: {
+      availability: true,
+      evidence: "profile",
+      selectedProfileId: "fixture-api:saved",
+      routeResolution: null,
+    },
+    expected: "profiles",
+  },
+  {
+    name: "unavailable route",
+    evaluation: { availability: false, routeResolution: null },
+    expected: "missing",
+  },
+] satisfies Array<{ name: string; evaluation: ModelAuthAvailabilityEvaluation; expected: string }>)(
+  "keeps the routing owner's $name decision when environment credentials are also present",
+  ({ evaluation, expected }) => {
+    withEnv({ FIXTURE_API_KEY: "working-environment-key" }, () => {
+      const overview = resolveProviderAuthOverview({
+        provider: "fixture-api",
+        cfg: {},
+        store: {
+          version: 1,
+          profiles: {
+            "fixture-api:saved": { type: "token", provider: "fixture-api", token: "saved-account" },
+          },
+        },
+        modelsPath: "/unused/models.json",
+        aliasMap: {},
+        envCandidateMap: { "fixture-api": ["FIXTURE_API_KEY"] },
+        authEvidenceMap: {},
+        evaluation,
+      });
+      expect(overview.effective.kind).toBe(expected);
+      expect(overview.env?.source).toBe("env: FIXTURE_API_KEY");
+      expect(overview.profiles.count).toBe(1);
+    });
+  },
+);
+
+it.each([
+  "OPENAI_API_KEY",
+  "${OPENAI_API_KEY}",
+  { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+] as const)(
+  "reports the exact authored env source for %j without borrowing a candidate key",
+  (apiKey) => {
+    withEnv(
+      { OPENAI_API_KEY: "chosen-config-account", OTHER_API_KEY: "unselected-candidate-account" },
+      () => {
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              "fixture-api": {
+                apiKey,
+                api: "openai-completions",
+                baseUrl: "https://fixture.invalid/v1",
+                models: [],
+              },
+            },
+          },
+        };
+        const store = { version: 1, profiles: {} };
+        const evaluation = createModelAuthAvailabilityResolver({
+          cfg,
+          authStore: store,
+          env: process.env,
+        }).evaluateProviderAuth("fixture-api");
+        expect(evaluation).toMatchObject({
+          availability: true,
+          environmentVariable: "OPENAI_API_KEY",
+          routeResolution: null,
+        });
+        const overview = resolveProviderAuthOverview({
+          provider: "fixture-api",
+          cfg,
+          store,
+          modelsPath: "/unused/models.json",
+          aliasMap: {},
+          envCandidateMap: { "fixture-api": ["OTHER_API_KEY"] },
+          authEvidenceMap: {},
+          evaluation,
+        });
+        expect(overview.effective.kind).toBe("env");
+        expect(overview.env?.source).toBe("env: OPENAI_API_KEY");
+        expect(JSON.stringify(overview)).not.toContain("chosen-config-account");
+        expect(JSON.stringify(overview)).not.toContain("unselected-candidate-account");
+      },
+    );
+  },
+);
+
+it("shows a ready local provider without requiring a plugin credential record", () => {
+  const cfg: OpenClawConfig = {
+    models: {
+      providers: {
+        "fixture-local": {
+          api: "openai-completions",
+          baseUrl: "http://127.0.0.1:8080/v1",
+          models: [
+            {
+              id: "fixture",
+              name: "Fixture",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 4096,
+              maxTokens: 1024,
+            },
+          ],
+        },
+      },
+    },
+  };
+  const store = { version: 1, profiles: {} };
+  const evaluation = createModelAuthAvailabilityResolver({
+    cfg,
+    authStore: store,
+    env: {},
+  }).evaluateProviderAuth("fixture-local");
+  expect(evaluation).toMatchObject({
+    availability: true,
+    evidence: "synthetic",
+    routeResolution: null,
+  });
+  const overview = resolveProviderAuthOverview({
+    provider: "fixture-local",
+    cfg,
+    store,
+    modelsPath: "/unused/models.json",
+    aliasMap: {},
+    envCandidateMap: {},
+    authEvidenceMap: {},
+    evaluation,
+  });
+  expect(overview.effective).toEqual({ kind: "synthetic", detail: "provider-managed" });
+  expect(overview.syntheticAuth).toBeUndefined();
 });

--- a/src/commands/models/list.auth-overview.secret-ref.test.ts
+++ b/src/commands/models/list.auth-overview.secret-ref.test.ts
@@ -42,9 +42,10 @@ function publishResolvedConfig(source: ReturnType<typeof sourceConfig>) {
   return resolved;
 }
 
-function overview(cfg: OpenClawConfig) {
+function overview(cfg: OpenClawConfig, availability: boolean) {
   return resolveProviderAuthOverview({
     provider: "diagnostic",
+    evaluation: { availability, evidence: "provider-config", routeResolution: null },
     cfg,
     store: { version: 1, profiles: {} },
     modelsPath: "/synthetic/models.json",
@@ -60,7 +61,7 @@ describe("resolved non-env config credentials in the auth overview", () => {
   it("shows the resolved config source without exposing its credential", () => {
     const cfg = publishResolvedConfig(sourceConfig());
 
-    const result = overview(cfg);
+    const result = overview(cfg, true);
 
     expect(result.effective).toEqual({
       kind: "models.json",
@@ -71,7 +72,7 @@ describe("resolved non-env config credentials in the auth overview", () => {
   });
 
   it("keeps a cold configured reference missing without resolved material", () => {
-    const result = overview(sourceConfig());
+    const result = overview(sourceConfig(), false);
 
     expect(result.effective).toEqual({ kind: "missing", detail: "missing" });
     expect(result.modelsJson?.value).toBe(`marker(${NON_ENV_SECRETREF_MARKER})`);
@@ -80,7 +81,7 @@ describe("resolved non-env config credentials in the auth overview", () => {
   it("does not borrow resolved material after the configured reference changes", () => {
     publishResolvedConfig(sourceConfig("old-reference"));
 
-    const result = overview(sourceConfig("new-reference"));
+    const result = overview(sourceConfig("new-reference"), false);
 
     expect(result.effective).toEqual({ kind: "missing", detail: "missing" });
     expect(JSON.stringify(result)).not.toContain(credential);

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -1,5 +1,6 @@
 // Model auth overview tests cover provider auth overview rows for model listings.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelAuthAvailabilityEvaluation } from "../../agents/model-auth-availability.js";
 import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import { resolveEnvApiKey } from "../../agents/model-auth.js";
 import {
@@ -103,9 +104,10 @@ vi.mock("../../agents/model-auth.js", () => {
   };
 });
 
-function resolveOpenAiOverview(apiKey: string) {
+function resolveOpenAiOverview(apiKey: string, evaluation: ModelAuthAvailabilityEvaluation) {
   return resolveProviderAuthOverview({
     provider: "openai",
+    evaluation,
     cfg: {
       models: {
         providers: {
@@ -141,6 +143,7 @@ describe("resolveProviderAuthOverview", () => {
     };
     const overview = resolveProviderAuthOverview({
       provider: "xai",
+      evaluation: { availability: true, evidence: "synthetic", routeResolution: null },
       cfg: {},
       store: { version: 1, profiles: {} } as never,
       modelsPath: "/tmp/models.json",
@@ -157,6 +160,7 @@ describe("resolveProviderAuthOverview", () => {
   it("labels token profiles that only have tokenRef", () => {
     const overview = resolveProviderAuthOverview({
       provider: "github-copilot",
+      evaluation: { availability: undefined, routeResolution: null },
       cfg: {},
       store: {
         version: 1,
@@ -182,6 +186,12 @@ describe("resolveProviderAuthOverview", () => {
     });
     const overview = resolveProviderAuthOverview({
       provider: "openai",
+      evaluation: {
+        availability: true,
+        evidence: "profile",
+        selectedProfileId: "openai:peter@example.test",
+        routeResolution: null,
+      },
       cfg: {},
       store: {
         version: 1,
@@ -229,6 +239,7 @@ describe("resolveProviderAuthOverview", () => {
     const overview = withEnv({ CUSTOM_PROVIDER_KEY: "current-provider-key" }, () =>
       resolveProviderAuthOverview({
         provider: "custom",
+        evaluation: { availability: true, evidence: "provider-config", routeResolution: null },
         cfg: cfg as never,
         store: {
           version: 1,
@@ -259,6 +270,12 @@ describe("resolveProviderAuthOverview", () => {
     });
     const overview = resolveProviderAuthOverview({
       provider: "openai",
+      evaluation: {
+        availability: true,
+        evidence: "profile",
+        selectedProfileId: "openai:peter@example.test",
+        routeResolution: null,
+      },
       cfg: {},
       store: {
         version: 1,
@@ -284,7 +301,10 @@ describe("resolveProviderAuthOverview", () => {
 
   it("renders marker-backed models.json auth as marker detail", () => {
     const overview = withEnv({ OPENAI_API_KEY: undefined }, () =>
-      resolveOpenAiOverview(NON_ENV_SECRETREF_MARKER),
+      resolveOpenAiOverview(NON_ENV_SECRETREF_MARKER, {
+        availability: false,
+        routeResolution: null,
+      }),
     );
 
     expect(overview.effective.kind).toBe("missing");
@@ -294,7 +314,11 @@ describe("resolveProviderAuthOverview", () => {
 
   it("treats OAuth delegation markers as effective models.json auth", () => {
     const overview = withEnv({ OPENAI_API_KEY: undefined }, () =>
-      resolveOpenAiOverview("oauth:openai"),
+      resolveOpenAiOverview("oauth:openai", {
+        availability: true,
+        evidence: "provider-config",
+        routeResolution: null,
+      }),
     );
 
     expect(overview.effective).toEqual({
@@ -306,7 +330,7 @@ describe("resolveProviderAuthOverview", () => {
 
   it("keeps env-var-shaped models.json values masked to avoid accidental plaintext exposure", () => {
     const overview = withEnv({ OPENAI_API_KEY: undefined }, () =>
-      resolveOpenAiOverview("OPENAI_API_KEY"),
+      resolveOpenAiOverview("OPENAI_API_KEY", { availability: false, routeResolution: null }),
     );
 
     expect(overview.effective.kind).toBe("missing");
@@ -319,7 +343,12 @@ describe("resolveProviderAuthOverview", () => {
     const prior = process.env.OPENAI_API_KEY;
     process.env.OPENAI_API_KEY = "sk-openai-from-env"; // pragma: allowlist secret
     try {
-      const overview = resolveOpenAiOverview("OPENAI_API_KEY");
+      const overview = resolveOpenAiOverview("OPENAI_API_KEY", {
+        availability: true,
+        evidence: "environment",
+        environmentVariable: "OPENAI_API_KEY",
+        routeResolution: null,
+      });
       expect(overview.effective.kind).toBe("env");
       expect(overview.effective.detail).not.toContain("OPENAI_API_KEY");
     } finally {
@@ -334,6 +363,7 @@ describe("resolveProviderAuthOverview", () => {
   it("keeps setup fallback when precomputed auth maps do not cover the provider", () => {
     resolveProviderAuthOverview({
       provider: "amazon-bedrock",
+      evaluation: { availability: undefined, routeResolution: null },
       cfg: {},
       store: { version: 1, profiles: {} } as never,
       modelsPath: "/tmp/models.json",
@@ -354,6 +384,7 @@ describe("resolveProviderAuthOverview", () => {
   it("skips setup fallback when precomputed auth maps cover the provider", () => {
     resolveProviderAuthOverview({
       provider: "openai",
+      evaluation: { availability: undefined, routeResolution: null },
       cfg: {},
       store: { version: 1, profiles: {} } as never,
       modelsPath: "/tmp/models.json",

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -11,6 +11,7 @@ import { loadPersistedAuthProfileStore } from "../../agents/auth-profiles/persis
 import { listProfilesForProvider } from "../../agents/auth-profiles/profiles.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
+import type { ModelAuthAvailabilityEvaluation } from "../../agents/model-auth-availability.js";
 import {
   isNonSecretApiKeyMarker,
   isOAuthApiKeyMarker,
@@ -87,12 +88,12 @@ export function resolveProviderAuthOverview(params: {
   modelsPath: string;
   agentDir?: string;
   workspaceDir?: string;
-  syntheticAuth?: { value: string; source: string };
+  syntheticAuth?: { value: string; source: string; profileId?: string };
   aliasMap?: Readonly<Record<string, string>>;
   envCandidateMap?: Readonly<Record<string, readonly string[]>>;
   authEvidenceMap?: Readonly<Record<string, readonly ProviderAuthEvidence[]>>;
-  /** The readiness owner selected this admitted environment variable for a working route. */
-  selectedEnvironmentVariable?: string;
+  /** The routing owner's selected credential; inventory presence cannot override this result. */
+  evaluation: ModelAuthAvailabilityEvaluation;
 }): ProviderAuthOverview {
   const { provider, cfg, store } = params;
   const now = Date.now();
@@ -164,10 +165,10 @@ export function resolveProviderAuthOverview(params: {
     candidateMap: params.envCandidateMap,
     authEvidenceMap: params.authEvidenceMap,
     skipSetupProviderFallback: hasPrecomputedCandidates || hasPrecomputedEvidence,
-    ...(params.selectedEnvironmentVariable
+    ...(params.evaluation.environmentVariable
       ? {
           aliasMap: {},
-          candidateMap: { [normalizedProvider]: [params.selectedEnvironmentVariable] },
+          candidateMap: { [normalizedProvider]: [params.evaluation.environmentVariable] },
           authEvidenceMap: {},
           skipSetupProviderFallback: true,
         }
@@ -176,55 +177,70 @@ export function resolveProviderAuthOverview(params: {
   const customKey = getCustomProviderApiKey(cfg, provider);
   const usableCustomKey = resolveUsableCustomProviderApiKey({ cfg, provider });
   const providerApiKeyRef = resolveProviderConfigSecretInput(cfg, provider).ref;
+  const envValue = envKey
+    ? envKey.source.includes("OAUTH_TOKEN") ||
+      normalizeLowercaseStringOrEmpty(envKey.source).includes("oauth")
+      ? "OAuth (env)"
+      : maskApiKey(envKey.apiKey)
+    : undefined;
+  const profileSource = (profileIds: string[]): ProviderAuthOverview["effective"] => ({
+    kind: "profiles",
+    detail: shortenHomePath(
+      resolveAuthStorePathForDisplay(
+        resolveProfileSourceAgentDir({ agentDir: params.agentDir, profileIds }),
+      ),
+    ),
+  });
+  const configuredSource = (): ProviderAuthOverview["effective"] => {
+    if (
+      providerApiKeyRef &&
+      providerApiKeyRef.source !== "env" &&
+      resolveManagedSecretRefRuntimeProviderAuth({ cfg, provider })
+    ) {
+      return { kind: "models.json", detail: formatMarkerOrSecret(NON_ENV_SECRETREF_MARKER) };
+    }
+    if (!usableCustomKey) {
+      if (customKey && isOAuthApiKeyMarker(customKey)) {
+        return { kind: "models.json", detail: formatMarkerOrSecret(customKey) };
+      }
+      return { kind: "missing", detail: "missing" };
+    }
+    return providerApiKeyRef?.source === "env"
+      ? { kind: "env", detail: maskApiKey(usableCustomKey.apiKey) }
+      : { kind: "models.json", detail: formatMarkerOrSecret(usableCustomKey.apiKey) };
+  };
 
   const effective: ProviderAuthOverview["effective"] = (() => {
-    if (params.selectedEnvironmentVariable && envKey) {
-      return { kind: "env", detail: maskApiKey(envKey.apiKey) };
+    const evaluation = params.evaluation;
+    if (evaluation.availability === false) {
+      return { kind: "missing", detail: "missing" };
     }
-    if (providerApiKeyRef) {
-      if (
-        providerApiKeyRef.source !== "env" &&
-        resolveManagedSecretRefRuntimeProviderAuth({ cfg, provider })
-      ) {
-        return { kind: "models.json", detail: formatMarkerOrSecret(NON_ENV_SECRETREF_MARKER) };
-      }
-      if (!usableCustomKey) {
-        return { kind: "missing", detail: "missing" };
-      }
-      return providerApiKeyRef.source === "env"
-        ? { kind: "env", detail: maskApiKey(usableCustomKey.apiKey) }
-        : { kind: "models.json", detail: formatMarkerOrSecret(usableCustomKey.apiKey) };
+    if (evaluation.runtimeAuth?.source === "native") {
+      return { kind: "synthetic", detail: params.syntheticAuth?.source ?? "native login" };
     }
-    if (profiles.length > 0) {
-      return {
-        kind: "profiles",
-        detail: shortenHomePath(
-          resolveAuthStorePathForDisplay(
-            resolveProfileSourceAgentDir({
-              agentDir: params.agentDir,
-              profileIds: profiles,
-            }),
-          ),
-        ),
-      };
+    if (evaluation.selectedProfileId) {
+      return store.profiles[evaluation.selectedProfileId]
+        ? profileSource([evaluation.selectedProfileId])
+        : params.syntheticAuth?.profileId === evaluation.selectedProfileId
+          ? { kind: "synthetic", detail: params.syntheticAuth.source }
+          : { kind: "profiles", detail: evaluation.selectedProfileId };
     }
-    if (envKey) {
-      const normalizedSource = normalizeLowercaseStringOrEmpty(envKey.source);
-      const isOAuthEnv =
-        envKey.source.includes("OAUTH_TOKEN") || normalizedSource.includes("oauth");
-      return {
-        kind: "env",
-        detail: isOAuthEnv ? "OAuth (env)" : maskApiKey(envKey.apiKey),
-      };
+    if (evaluation.evidence === "environment" && envValue) {
+      return { kind: "env", detail: envValue };
     }
-    if (usableCustomKey) {
-      return { kind: "models.json", detail: formatMarkerOrSecret(usableCustomKey.apiKey) };
+    if (evaluation.evidence === "provider-config") {
+      return configuredSource();
     }
-    if (params.syntheticAuth) {
-      return { kind: "synthetic", detail: params.syntheticAuth.source };
+    if (evaluation.evidence === "synthetic") {
+      return { kind: "synthetic", detail: params.syntheticAuth?.source ?? "provider-managed" };
     }
-    if (customKey && isOAuthApiKeyMarker(customKey)) {
-      return { kind: "models.json", detail: formatMarkerOrSecret(customKey) };
+    if (evaluation.evidence === "runtime") {
+      return usableCustomKey
+        ? configuredSource()
+        : { kind: "runtime", detail: evaluation.selectedAuthMode ?? "runtime auth" };
+    }
+    if (evaluation.evidence === "aws-sdk") {
+      return { kind: "runtime", detail: "aws-sdk" };
     }
     return { kind: "missing", detail: "missing" };
   })();
@@ -239,15 +255,10 @@ export function resolveProviderAuthOverview(params: {
       apiKey: apiKeyCount,
       labels,
     },
-    ...(envKey
+    ...(envKey && envValue
       ? {
           env: {
-            value: (() => {
-              const normalizedSource = normalizeLowercaseStringOrEmpty(envKey.source);
-              return envKey.source.includes("OAUTH_TOKEN") || normalizedSource.includes("oauth")
-                ? "OAuth (env)"
-                : maskApiKey(envKey.apiKey);
-            })(),
+            value: envValue,
             source: envKey.source,
           },
         }

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -91,6 +91,8 @@ export function resolveProviderAuthOverview(params: {
   aliasMap?: Readonly<Record<string, string>>;
   envCandidateMap?: Readonly<Record<string, readonly string[]>>;
   authEvidenceMap?: Readonly<Record<string, readonly ProviderAuthEvidence[]>>;
+  /** The readiness owner selected this admitted environment variable for a working route. */
+  selectedEnvironmentVariable?: string;
 }): ProviderAuthOverview {
   const { provider, cfg, store } = params;
   const now = Date.now();
@@ -162,12 +164,23 @@ export function resolveProviderAuthOverview(params: {
     candidateMap: params.envCandidateMap,
     authEvidenceMap: params.authEvidenceMap,
     skipSetupProviderFallback: hasPrecomputedCandidates || hasPrecomputedEvidence,
+    ...(params.selectedEnvironmentVariable
+      ? {
+          aliasMap: {},
+          candidateMap: { [normalizedProvider]: [params.selectedEnvironmentVariable] },
+          authEvidenceMap: {},
+          skipSetupProviderFallback: true,
+        }
+      : {}),
   });
   const customKey = getCustomProviderApiKey(cfg, provider);
   const usableCustomKey = resolveUsableCustomProviderApiKey({ cfg, provider });
   const providerApiKeyRef = resolveProviderConfigSecretInput(cfg, provider).ref;
 
   const effective: ProviderAuthOverview["effective"] = (() => {
+    if (params.selectedEnvironmentVariable && envKey) {
+      return { kind: "env", detail: maskApiKey(envKey.apiKey) };
+    }
     if (providerApiKeyRef) {
       if (
         providerApiKeyRef.source !== "env" &&

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -56,7 +56,6 @@ import { createModelVisibilityPolicy } from "../../agents/model-visibility-polic
 import { resolveModelCatalogIdentityKey } from "../../agents/openai-model-routes.js";
 import { OPENAI_PROVIDER_ID } from "../../agents/openai-routing.js";
 import { loadPreparedModelCatalogSnapshot } from "../../agents/prepared-model-catalog.js";
-import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import {
   readUtilityModelSetting,
   resolveUtilityModelRefForAgent,
@@ -508,6 +507,11 @@ export async function modelsStatusCommand(
       };
       const { aliasMap, envCandidateMap, authEvidenceMap } =
         resolveProviderEnvAuthLookupMaps(envLookupParams);
+      const modelProviderIds = new Set(
+        metadataSnapshot.plugins
+          .flatMap((plugin) => plugin.providers ?? [])
+          .map(normalizeProviderId),
+      );
       for (const provider of listProviderEnvAuthLookupKeys({ envCandidateMap, authEvidenceMap })) {
         if (
           resolveEnvApiKey(provider, process.env, {
@@ -519,7 +523,11 @@ export async function modelsStatusCommand(
             skipSetupProviderFallback: true,
           })
         ) {
-          providersFromEnv.add(provider);
+          const normalized = normalizeProviderId(provider);
+          // Auth-only aliases are lookup spellings; declared providers keep distinct status rows.
+          providersFromEnv.add(
+            modelProviderIds.has(normalized) ? normalized : (aliasMap[normalized] ?? normalized),
+          );
         }
       }
       const syntheticAuthProviderRefs = new Set(
@@ -631,10 +639,7 @@ export async function modelsStatusCommand(
                 ? usage.allowCodexRuntimeFallback
                   ? resolver.evaluateRuntimeModelAuth(usage.provider, ref)
                   : resolver.evaluateModelAuth(usage.provider, ref)
-                : {
-                    availability: resolver.resolveProviderAuthAvailability(usage.provider, ref),
-                    routeResolution: null,
-                  };
+                : resolver.evaluateProviderAuth(usage.provider, ref);
             const providerRouteIncompatible =
               rawEvaluation.routeResolution?.kind === "incompatible";
             const requestedCodexRuntimeAuth =
@@ -791,6 +796,33 @@ export async function modelsStatusCommand(
       const applied = getShellEnvAppliedKeys();
       const shellFallbackEnabled =
         shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true;
+      const resolveAuthOverview = (
+        provider: string,
+        evaluation: ModelAuthAvailabilityEvaluation,
+      ) => {
+        const syntheticProvider = evaluation.runtimeAuth?.id ?? provider;
+        const syntheticAuth = syntheticAuthByProvider.get(syntheticProvider);
+        return resolveProviderAuthOverview({
+          provider,
+          cfg,
+          store,
+          modelsPath,
+          agentDir,
+          workspaceDir,
+          syntheticAuth: syntheticAuth
+            ? {
+                ...syntheticAuth,
+                ...(runtimeCredentialsByProvider.has(syntheticProvider)
+                  ? { profileId: `${syntheticProvider}:runtime-synthetic` }
+                  : {}),
+              }
+            : undefined,
+          aliasMap,
+          envCandidateMap,
+          authEvidenceMap,
+          evaluation,
+        });
+      };
       const providerAuth = Array.from(
         new Set([
           ...providers,
@@ -800,26 +832,16 @@ export async function modelsStatusCommand(
         ]),
       )
         .toSorted((a, b) => a.localeCompare(b))
-        .map((provider) =>
-          resolveProviderAuthOverview({
-            provider,
-            cfg,
-            store,
-            modelsPath,
-            agentDir,
-            workspaceDir,
-            syntheticAuth: syntheticAuthByProvider.get(provider),
-            aliasMap,
-            envCandidateMap,
-            authEvidenceMap,
-            selectedEnvironmentVariable: providerUses.find(
-              (usage) =>
-                normalizeProviderId(usage.provider) === normalizeProviderId(provider) &&
-                usage.evaluation.availability === true &&
-                usage.evaluation.environmentVariable !== undefined,
-            )?.evaluation.environmentVariable,
-          }),
-        )
+        .map((provider) => {
+          const uses = providerUses.filter(
+            (usage) => normalizeProviderId(usage.provider) === normalizeProviderId(provider),
+          );
+          const evaluation =
+            uses.find((usage) => usage.evaluation.availability === true)?.evaluation ??
+            uses[0]?.evaluation ??
+            authResolver.evaluateModelAuth(provider);
+          return resolveAuthOverview(provider, evaluation);
+        })
         .filter((entry) => {
           const hasAny =
             entry.profiles.count > 0 ||
@@ -828,11 +850,6 @@ export async function modelsStatusCommand(
             Boolean(entry.syntheticAuth);
           return hasAny;
         });
-      const providerAuthMap = new Map(providerAuth.map((entry) => [entry.provider, entry]));
-      const missingProviderAuthEffective: ProviderAuthOverview["effective"] = {
-        kind: "missing",
-        detail: "missing",
-      };
       const runtimeAuthStore = getRuntimeAuthProfileStoreSnapshot(agentDir);
       const healthStore = runtimeAuthStore
         ? {
@@ -844,65 +861,11 @@ export async function modelsStatusCommand(
         store: healthStore,
         cfg,
         warnAfterMs: DEFAULT_OAUTH_WARN_MS,
-        runtimeCredentialsByProvider,
         allowKeychainPrompt: false,
       });
       const authProfileHealthById = new Map(
         authHealth.profiles.map((profile) => [profile.profileId, profile]),
       );
-      const resolveProviderAuthHealthId = (provider: string): string =>
-        resolveProviderIdForAuth(provider, envLookupParams);
-      const resolveRuntimeAuthRouteEffective = (
-        provider: string,
-        evaluation?: ModelAuthAvailabilityEvaluation,
-      ): ProviderAuthOverview["effective"] => {
-        if (!evaluation) {
-          return providerAuthMap.get(provider)?.effective ?? missingProviderAuthEffective;
-        }
-        if (evaluation?.availability === false) {
-          return missingProviderAuthEffective;
-        }
-        if (evaluation.runtimeAuth?.source === "native") {
-          return {
-            kind: "synthetic",
-            detail:
-              syntheticAuthByProvider.get(evaluation.runtimeAuth.id)?.source ?? "native login",
-          };
-        }
-        const candidates = Array.from(
-          new Set([normalizeProviderId(provider), resolveProviderAuthHealthId(provider)]),
-        );
-        const profileId = evaluation.selectedProfileId;
-        if (profileId) {
-          const credentialProvider = store.profiles[profileId]?.provider ?? provider;
-          const source = providerAuthMap.get(
-            resolveProviderAuthHealthId(credentialProvider),
-          )?.effective;
-          return source && source.kind !== "missing"
-            ? source
-            : { kind: "profiles", detail: profileId };
-        }
-        for (const candidate of candidates) {
-          const auth = providerAuthMap.get(candidate);
-          if (evaluation.evidence === "environment" && auth?.env) {
-            return { kind: "env", detail: auth.env.value };
-          }
-          if (
-            (evaluation.evidence === "provider-config" || evaluation.evidence === "runtime") &&
-            auth?.modelsJson
-          ) {
-            return { kind: "models.json", detail: auth.modelsJson.value };
-          }
-          if (evaluation.evidence === "synthetic" && syntheticAuthByProvider.has(candidate)) {
-            return {
-              kind: "synthetic",
-              detail: syntheticAuthByProvider.get(candidate)?.source ?? "plugin-owned",
-            };
-          }
-        }
-        const direct = providerAuthMap.get(provider)?.effective;
-        return direct ?? missingProviderAuthEffective;
-      };
       const resolveCliRuntimeAuthProvider = (usage: (typeof providerUses)[number]) =>
         cliRuntimeAuthUsages.find(
           (candidate) =>
@@ -932,10 +895,10 @@ export async function modelsStatusCommand(
         ...Array.from(codexRuntimeUsagesByProvider.entries()).map(([provider, usages]) => {
           const representative =
             usages.find((usage) => usage.evaluation.availability === true) ?? usages[0];
-          const effective = resolveRuntimeAuthRouteEffective(
+          const effective = resolveAuthOverview(
             codexProvider,
-            representative?.evaluation,
-          );
+            representative?.evaluation ?? authResolver.evaluateModelAuth(codexProvider),
+          ).effective;
           const availabilities = usages.map((usage) => usage.evaluation.availability);
           const authStatus = availabilities.every((availability) => availability === true)
             ? "usable"
@@ -968,7 +931,7 @@ export async function modelsStatusCommand(
         }),
         ...cliRuntimeAuthUsages.map((usage) => {
           const evaluation = authResolver.evaluateModelAuth(usage.runtime);
-          const effective = resolveRuntimeAuthRouteEffective(usage.runtime, evaluation);
+          const effective = resolveAuthOverview(usage.runtime, evaluation).effective;
           return [
             `${usage.provider}:${usage.runtime}:${usage.runtime}`,
             {

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -812,6 +812,12 @@ export async function modelsStatusCommand(
             aliasMap,
             envCandidateMap,
             authEvidenceMap,
+            selectedEnvironmentVariable: providerUses.find(
+              (usage) =>
+                normalizeProviderId(usage.provider) === normalizeProviderId(provider) &&
+                usage.evaluation.availability === true &&
+                usage.evaluation.environmentVariable !== undefined,
+            )?.evaluation.environmentVariable,
           }),
         )
         .filter((entry) => {
@@ -1529,6 +1535,8 @@ export async function modelsStatusCommand(
           const hint = buildProviderAuthRecoveryHint({
             provider,
             config: cfg,
+            workspaceDir,
+            env: process.env,
             includeEnvVar: !requiresSubscription,
           });
           runtime.log(`- ${theme.heading(provider)} ${hint}`);

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -908,7 +908,7 @@ describe("modelsStatusCommand auth overview", () => {
       // staying invisible to `models status`.
       mocks.loadConfig.mockReturnValue({
         ...baseConfig,
-        models: { providers: { mistral: {} } },
+        models: { providers: { mistral: { baseUrl: "", models: [] } } },
         agents: {
           defaults: { ...baseConfig.agents.defaults, utilityModel: "mistral/mistral-small" },
         },
@@ -1900,7 +1900,7 @@ describe("modelsStatusCommand auth overview", () => {
           models: { "codex/gpt-5.5": {} },
         },
       },
-      models: { providers: { codex: {} } },
+      models: { providers: { codex: { baseUrl: "", models: [] } } },
       env: { shellEnv: { enabled: false } },
     });
     mocks.store.profiles = {};

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -1,4 +1,5 @@
 // Model list status tests cover status column construction and auth/probe summaries.
+import { fileURLToPath } from "node:url";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, type Mock, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -760,7 +761,12 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("includes masked auth sources in JSON output", async () => {
-    await modelsStatusCommand({ json: true }, runtime);
+    const cfg = mocks.loadConfig();
+    await withConfig({ ...cfg, models: { providers: { minimax: {}, fal: {} } } }, () =>
+      withEnvAsync({ MINIMAX_API_KEY: "fixture-minimax-key", FAL_KEY: "fixture-fal-key" }, () =>
+        modelsStatusCommand({ json: true }, runtime),
+      ),
+    );
     const payload = parseFirstJsonLog(runtime);
 
     expect(mocks.loadModelsConfigArgs.mock.calls.at(-1)?.[0]).toMatchObject({
@@ -863,6 +869,35 @@ describe("modelsStatusCommand auth overview", () => {
         expect(parseFirstJsonLog(localRuntime).allowed).toEqual(["clawrouter/anthropic/*"]);
       },
     );
+  });
+
+  it("retains provider credential facts for an image-only model without text route interpretation", async () => {
+    const localRuntime = createTestRuntime();
+    const cfg = mocks.loadConfig();
+    await withConfig(
+      {
+        ...cfg,
+        agents: {
+          defaults: {
+            ...cfg.agents.defaults,
+            utilityModel: "",
+            imageModel: "openai/image-only-fixture",
+          },
+        },
+        auth: { profiles: { "openai:api-key": { provider: "openai", mode: "api_key" } } },
+      },
+      () => modelsStatusCommand({ json: true }, localRuntime),
+    );
+    const payload = parseFirstJsonLog(localRuntime);
+    expect(requireProvider(payload.auth.providers, "openai").effective).toMatchObject({
+      kind: "profiles",
+    });
+    expect(payload.auth.missingProvidersInUse).not.toContain("openai");
+    expect(
+      payload.auth.modelRouteIssues.filter(
+        (issue: { provider: string }) => issue.provider === "openai",
+      ),
+    ).toEqual([]);
   });
 
   it("reports the resolved utility model in JSON output", async () => {
@@ -987,18 +1022,33 @@ describe("modelsStatusCommand auth overview", () => {
     const localRuntime = createTestRuntime();
     await withAgentScopeOverrides(
       {
-        primary: "openai/gpt-4",
-        fallbacks: ["openai/gpt-3.5"],
+        primary: "openai/gpt-5.6",
+        fallbacks: ["openai/gpt-5.5"],
         agentDir: "/tmp/openclaw-agent-custom",
       },
       async () => {
-        await modelsStatusCommand({ json: true, agent: "Jeremiah" }, localRuntime);
+        await withOpenAIStatusFixture(
+          {
+            primary: "openai/gpt-5.6",
+            fallbacks: ["openai/gpt-5.5"],
+            profiles: {
+              "openai:api-key": {
+                type: "api_key",
+                provider: "openai",
+                key: "sk-openai-platform-fixture",
+              },
+            },
+            providerAuth: "api-key",
+            agentRuntime: "openclaw",
+          },
+          () => modelsStatusCommand({ json: true, agent: "Jeremiah" }, localRuntime),
+        );
         expectResolveAgentDirCalledFor("jeremiah");
         const payload = parseFirstJsonLog(localRuntime);
         expect(payload.agentId).toBe("jeremiah");
         expect(payload.agentDir).toBe("/tmp/openclaw-agent-custom");
-        expect(payload.defaultModel).toBe("openai/gpt-4");
-        expect(payload.fallbacks).toEqual(["openai/gpt-3.5"]);
+        expect(payload.defaultModel).toBe("openai/gpt-5.6");
+        expect(payload.fallbacks).toEqual(["openai/gpt-5.5"]);
         expect(payload.modelConfig).toEqual({
           defaultSource: "agent",
           fallbacksSource: "agent",
@@ -1819,6 +1869,87 @@ describe("modelsStatusCommand auth overview", () => {
     }
   });
 
+  it("keeps saved token expiry visible when an independent runtime credential serves the provider", async () => {
+    const { buildAuthHealthSummary } = await import("../../agents/auth-health.js");
+    const actualAuthHealth = await vi.importActual<typeof import("../../agents/auth-health.js")>(
+      "../../agents/auth-health.js",
+    );
+    const originalHealth = vi.mocked(buildAuthHealthSummary).getMockImplementation();
+    const now = Date.now();
+    const localRuntime = createTestRuntime();
+    const originalConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = mocks.store.profiles;
+    const originalEnv = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalRefs = mocks.resolveRuntimeSyntheticAuthProviderRefs.getMockImplementation();
+    const originalSynthetic = mocks.resolveProviderSyntheticAuthWithPlugin.getMockImplementation();
+    const originalLookupMaps = mocks.resolveProviderEnvAuthLookupMaps();
+    const originalLookupKeys = mocks.listProviderEnvAuthLookupKeys.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: { defaults: { model: "xai/grok-fixture" } },
+      auth: { profiles: { "xai:saved": { provider: "xai", mode: "token" } } },
+    });
+    mocks.store.profiles = {
+      "xai:saved": {
+        type: "token",
+        provider: "xai",
+        token: "saved-account",
+        expires: now - 10_000,
+      },
+    };
+    mocks.resolveEnvApiKey.mockReturnValue({
+      apiKey: "independent-runtime-account",
+      source: "env: XAI_API_KEY",
+    });
+    mocks.resolveProviderEnvAuthLookupMaps.mockReturnValue({
+      ...originalLookupMaps,
+      aliasMap: { ...originalLookupMaps.aliasMap, "x-ai": "xai", "byteplus-plan": "byteplus" },
+      envCandidateMap: { ...originalLookupMaps.envCandidateMap, xai: ["XAI_API_KEY"] },
+    });
+    mocks.listProviderEnvAuthLookupKeys.mockReturnValue(["x-ai", "xai", "byteplus-plan"]);
+    mocks.resolveRuntimeSyntheticAuthProviderRefs.mockReturnValue(["xai"]);
+    mocks.resolveProviderSyntheticAuthWithPlugin.mockReturnValue({
+      apiKey: "independent-runtime-account",
+      source: "env:XAI_API_KEY",
+      mode: "api-key",
+    });
+
+    try {
+      vi.mocked(buildAuthHealthSummary).mockImplementation(actualAuthHealth.buildAuthHealthSummary);
+      await withEnvAsync({ XAI_API_KEY: "independent-runtime-account" }, () =>
+        modelsStatusCommand({ json: true }, localRuntime),
+      );
+      const payload = parseFirstJsonLog(localRuntime);
+      expect(payload.auth.oauth.profiles).toEqual([
+        expect.objectContaining({
+          profileId: "xai:saved",
+          type: "token",
+          status: "expired",
+          reasonCode: "expired",
+        }),
+      ]);
+      const provider = requireProvider(payload.auth.providers, "xai");
+      expect(provider.syntheticAuth).toEqual({ value: "plugin-owned", source: "env:XAI_API_KEY" });
+      expect(provider.effective).toMatchObject({ kind: "env" });
+      expect(
+        payload.auth.providers.map((entry: { provider: string }) => entry.provider),
+      ).not.toContain("x-ai");
+      expect(requireProvider(payload.auth.providers, "byteplus-plan").provider).toBe(
+        "byteplus-plan",
+      );
+      expect(payload.auth.missingProvidersInUse).toEqual([]);
+      expect(JSON.stringify(payload)).not.toContain("independent-runtime-account");
+    } finally {
+      vi.mocked(buildAuthHealthSummary).mockImplementation(originalHealth!);
+      mocks.store.profiles = originalProfiles;
+      mocks.loadConfig.mockImplementation(originalConfig!);
+      mocks.resolveEnvApiKey.mockImplementation(originalEnv!);
+      mocks.resolveRuntimeSyntheticAuthProviderRefs.mockImplementation(originalRefs!);
+      mocks.resolveProviderSyntheticAuthWithPlugin.mockImplementation(originalSynthetic!);
+      mocks.resolveProviderEnvAuthLookupMaps.mockReturnValue(originalLookupMaps);
+      mocks.listProviderEnvAuthLookupKeys.mockImplementation(originalLookupKeys!);
+    }
+  });
+
   it("passes the canonical merged provider config to synthetic auth plugins", async () => {
     const localRuntime = createTestRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();
@@ -1957,6 +2088,7 @@ describe("modelsStatusCommand auth overview", () => {
         "workspace-cloud": [
           {
             type: "local-file-with-env",
+            fallbackPaths: [fileURLToPath(import.meta.url)],
             credentialMarker: "workspace-cloud-local-credentials",
             source: "workspace cloud credentials",
           },
@@ -1974,7 +2106,10 @@ describe("modelsStatusCommand auth overview", () => {
     );
 
     try {
-      await modelsStatusCommand({ json: true }, localRuntime);
+      await withConfig(
+        { ...mocks.loadConfig(), models: { providers: { "workspace-cloud": {} } } },
+        () => modelsStatusCommand({ json: true }, localRuntime),
+      );
       const payload = parseFirstJsonLog(localRuntime);
       const workspaceProvider = requireProvider(payload.auth.providers, "workspace-cloud");
       expect(requireRecord(workspaceProvider.effective, "workspace effective auth").kind).toBe(

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -908,6 +908,7 @@ describe("modelsStatusCommand auth overview", () => {
       // staying invisible to `models status`.
       mocks.loadConfig.mockReturnValue({
         ...baseConfig,
+        models: { providers: { mistral: {} } },
         agents: {
           defaults: { ...baseConfig.agents.defaults, utilityModel: "mistral/mistral-small" },
         },
@@ -1899,7 +1900,7 @@ describe("modelsStatusCommand auth overview", () => {
           models: { "codex/gpt-5.5": {} },
         },
       },
-      models: { providers: {} },
+      models: { providers: { codex: {} } },
       env: { shellEnv: { enabled: false } },
     });
     mocks.store.profiles = {};

--- a/src/config/config-path-mutation.ts
+++ b/src/config/config-path-mutation.ts
@@ -19,6 +19,9 @@ function unsetPathForWriteAt(
   }
   const segment = expectDefined(pathSegments[depth], "path segments entry at depth");
   const isLeaf = depth === pathSegments.length - 1;
+  // A provider object is an explicit declaration even after its last field is removed.
+  const preserveEmptyDeclaration =
+    depth === 3 && pathSegments[0] === "models" && pathSegments[1] === "providers";
 
   if (Array.isArray(value)) {
     const index = parseConfigPathArrayIndex(segment);
@@ -51,7 +54,8 @@ function unsetPathForWriteAt(
     delete next[segment];
     return {
       changed: true,
-      value: Object.keys(next).length === 0 ? WRITE_PRUNED_OBJECT : next,
+      value:
+        Object.keys(next).length === 0 && !preserveEmptyDeclaration ? WRITE_PRUNED_OBJECT : next,
     };
   }
 
@@ -67,7 +71,7 @@ function unsetPathForWriteAt(
   }
   return {
     changed: true,
-    value: Object.keys(next).length === 0 ? WRITE_PRUNED_OBJECT : next,
+    value: Object.keys(next).length === 0 && !preserveEmptyDeclaration ? WRITE_PRUNED_OBJECT : next,
   };
 }
 

--- a/src/config/config-startup-corpus.test.ts
+++ b/src/config/config-startup-corpus.test.ts
@@ -21,6 +21,10 @@ const expectations: Record<
   string,
   { providers: string[]; model?: string; sourceConfig?: OpenClawConfig }
 > = {
+  "provider-admission-generic.json": { providers: [] },
+  "provider-admission-openai.json": { providers: [] },
+  "provider-admission-family.json": { providers: [] },
+  "provider-admission-bedrock.json": { providers: [] },
   "agent-override.json": { providers: ["openai", "fixture-provider"] },
   "api-key-no-models.json": { providers: ["openai"] },
   "coach-lassi.json": {

--- a/src/config/config-startup-corpus.test.ts
+++ b/src/config/config-startup-corpus.test.ts
@@ -24,6 +24,7 @@ const expectations: Record<
   "provider-admission-generic.json": { providers: [] },
   "provider-admission-openai.json": { providers: [] },
   "provider-admission-family.json": { providers: [] },
+  "provider-admission-selected-plan.json": { providers: [] },
   "provider-admission-bedrock.json": { providers: [] },
   "agent-override.json": { providers: ["openai", "fixture-provider"] },
   "api-key-no-models.json": { providers: ["openai"] },

--- a/src/config/io.snapshot-shared.ts
+++ b/src/config/io.snapshot-shared.ts
@@ -1,7 +1,12 @@
 import { observeConfigSnapshot } from "./io.observe.js";
 import type { NormalizedConfigIoDeps, ReadConfigFileSnapshotInternalResult } from "./io.types.js";
 import { asResolvedSourceConfig, asRuntimeConfig } from "./materialize.js";
-import { setConfigResolutionFacts, type ConfigResolutionFacts } from "./resolution-facts.js";
+import {
+  getConfigProviderUseBindings,
+  setConfigProviderUseBindings,
+  setConfigResolutionFacts,
+  type ConfigResolutionFacts,
+} from "./resolution-facts.js";
 import type { ConfigFileSnapshot, LegacyConfigIssue, OpenClawConfig } from "./types.js";
 
 export function createConfigFileSnapshot(params: {
@@ -29,11 +34,14 @@ export function createConfigFileSnapshot(params: {
     : undefined;
   const sourceConfig = asResolvedSourceConfig(params.sourceConfig);
   const runtimeConfig = asRuntimeConfig(params.runtimeConfig);
+  const providerUseBindings = getConfigProviderUseBindings(runtimeConfig);
   if (params.resolutionFacts !== undefined) {
     setConfigResolutionFacts(sourceConfigBeforeMigrations, params.resolutionFacts);
     setConfigResolutionFacts(sourceConfig, params.resolutionFacts);
     setConfigResolutionFacts(runtimeConfig, params.resolutionFacts);
   }
+  setConfigProviderUseBindings(sourceConfig, providerUseBindings);
+  setConfigProviderUseBindings(runtimeConfig, providerUseBindings);
   return {
     path: params.path,
     includedPaths: [...(params.includedPaths ?? [])],

--- a/src/config/io.types.ts
+++ b/src/config/io.types.ts
@@ -86,6 +86,8 @@ export type ConfigWriteOptions = {
   preCommitRuntimePreflight?: (sourceConfig: OpenClawConfig) => Promise<unknown>;
   /** Revalidate authority at the final root-file publication; requires atomic rename. */
   beforeCommit?: () => void | Promise<void>;
+  /** Hold synchronous owner authority through the atomic root-file rename. */
+  withCommit?: (publish: () => void) => void;
   /** Snapshot-time hashes for include files that mutation writers may update. */
   includeFileHashesForWrite?: Record<string, string>;
   /** Snapshot-time canonical include targets that writers may update. */

--- a/src/config/io.write-lock.test.ts
+++ b/src/config/io.write-lock.test.ts
@@ -396,7 +396,6 @@ describe("included config writer exclusion", () => {
     },
   );
 
-
   it.each([false, true])(
     "refuses inherited include authority before preparation (revoke=%s)",
     async (revoke) => {

--- a/src/config/io.write-lock.test.ts
+++ b/src/config/io.write-lock.test.ts
@@ -1,4 +1,5 @@
 import { AsyncResource } from "node:async_hooks";
+import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -341,6 +342,61 @@ describe("direct config writer exclusion", () => {
 });
 
 describe("included config writer exclusion", () => {
+  it.each([false, true])(
+    "preserves publication authority and include refusal (include: %s)",
+    async (include) => {
+      const stateDir = tempDirs.make("openclaw-config-publication-");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const target = include ? path.join(stateDir, "gateway.json5") : configPath;
+      const original = include
+        ? '{"mode":"local","port":18789}\n'
+        : '{"gateway":{"mode":"local","port":18789}}\n';
+      if (include) {
+        await fs.writeFile(configPath, '{"gateway":{"$include":"./gateway.json5"}}\n');
+      }
+      await fs.writeFile(target, original);
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_CONFIG_PATH: configPath },
+        async () => {
+          let allowed = false;
+          let committedUnderAuthority = false;
+          const write = () =>
+            mutateConfigFile({
+              mutate: (draft) => {
+                draft.gateway = { ...draft.gateway, port: 19876 };
+              },
+              writeOptions: {
+                skipPluginValidation: true,
+                skipRuntimeSnapshotRefresh: true,
+                withCommit: (publish) => {
+                  expect(readFileSync(target, "utf8")).toBe(original);
+                  if (!allowed) {
+                    throw new Error("Publication authority changed");
+                  }
+                  publish();
+                  const published = JSON.parse(readFileSync(target, "utf8"));
+                  expect(include ? published.port : published.gateway.port).toBe(19876);
+                  committedUnderAuthority = true;
+                },
+              },
+            });
+          if (include) {
+            await expect(write()).rejects.toThrow("cannot update include-owned configuration");
+            expect(await fs.readFile(target, "utf8")).toBe(original);
+            expect(committedUnderAuthority).toBe(false);
+            return;
+          }
+          await expect(write()).rejects.toThrow("Publication authority changed");
+          expect(await fs.readFile(target, "utf8")).toBe(original);
+          allowed = true;
+          await write();
+          expect(committedUnderAuthority).toBe(true);
+        },
+      );
+    },
+  );
+
+
   it.each([false, true])(
     "refuses inherited include authority before preparation (revoke=%s)",
     async (revoke) => {

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -1597,6 +1597,32 @@ describe("config io write prepare", () => {
     expect(input).toEqual(before);
   });
 
+  it.each(["amazon-bedrock", "amazon-bedrock-mantle", "google-vertex", "openai", "custom"])(
+    "retains the %s declaration when fields are unset, until the declaration itself is unset",
+    (provider) => {
+      const input: OpenClawConfig = {
+        models: {
+          providers: {
+            [provider]: {
+              baseUrl: "https://fixture.invalid/v1",
+              models: [],
+              headers: { Authorization: "fixture" },
+            },
+          },
+        },
+      };
+      const before = structuredClone(input);
+      const stripped = applyUnsetPathsForWrite(input, [
+        ["models", "providers", provider, "baseUrl"],
+        ["models", "providers", provider, "models"],
+        ["models", "providers", provider, "headers", "Authorization"],
+      ]);
+      expect(stripped).toEqual({ models: { providers: { [provider]: {} } } });
+      expect(input).toEqual(before);
+      expect(applyUnsetPathsForWrite(stripped, [["models", "providers", provider]])).toEqual({});
+    },
+  );
+
   it.each([
     ["invalid array suffix", ["tools", "alsoAllow", "1abc"]],
     ["signed array index", ["tools", "alsoAllow", "+0"]],

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -456,6 +456,7 @@ export async function writeConfigFileFromContext(
 
   try {
     const beforeCommit = options.beforeCommit;
+    const withCommit = options.withCommit;
     const guardedFs = createGuardedConfigFileSystem(
       configPath,
       deps.fs,
@@ -469,16 +470,25 @@ export async function writeConfigFileFromContext(
       tempPrefix: path.basename(configPath),
       // fs-safe's copy fallback has no final authority hook. Guarded operations
       // must publish by rename so a failed attempt cannot continue under stale authority.
-      copyFallbackOnPermissionError: !beforeCommit,
-      fileSystem: beforeCommit
+      copyFallbackOnPermissionError: !beforeCommit && !withCommit,
+      fileSystem: beforeCommit || withCommit
         ? {
             promises: {
               ...guardedFs.promises,
               rename: async (source, destination) => {
-                await beforeCommit();
+                await beforeCommit?.();
                 options.assertConfigPathForWrite?.();
                 if (options.baseSnapshot) {
                   assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
+                }
+                if (withCommit) {
+                  return withCommit(() => {
+                    options.assertConfigPathForWrite?.();
+                    if (options.baseSnapshot) {
+                      assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
+                    }
+                    guardedFs.renameSync(source, destination);
+                  });
                 }
                 return guardedFs.promises.rename(source, destination);
               },

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -471,30 +471,31 @@ export async function writeConfigFileFromContext(
       // fs-safe's copy fallback has no final authority hook. Guarded operations
       // must publish by rename so a failed attempt cannot continue under stale authority.
       copyFallbackOnPermissionError: !beforeCommit && !withCommit,
-      fileSystem: beforeCommit || withCommit
-        ? {
-            promises: {
-              ...guardedFs.promises,
-              rename: async (source, destination) => {
-                await beforeCommit?.();
-                options.assertConfigPathForWrite?.();
-                if (options.baseSnapshot) {
-                  assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
-                }
-                if (withCommit) {
-                  return withCommit(() => {
-                    options.assertConfigPathForWrite?.();
-                    if (options.baseSnapshot) {
-                      assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
-                    }
-                    guardedFs.renameSync(source, destination);
-                  });
-                }
-                return guardedFs.promises.rename(source, destination);
+      fileSystem:
+        beforeCommit || withCommit
+          ? {
+              promises: {
+                ...guardedFs.promises,
+                rename: async (source, destination) => {
+                  await beforeCommit?.();
+                  options.assertConfigPathForWrite?.();
+                  if (options.baseSnapshot) {
+                    assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
+                  }
+                  if (withCommit) {
+                    return withCommit(() => {
+                      options.assertConfigPathForWrite?.();
+                      if (options.baseSnapshot) {
+                        assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
+                      }
+                      guardedFs.renameSync(source, destination);
+                    });
+                  }
+                  return guardedFs.promises.rename(source, destination);
+                },
               },
-            },
-          }
-        : guardedFs,
+            }
+          : guardedFs,
       beforeRename: async () => {
         options.assertConfigPathForWrite?.();
         if (options.baseSnapshot) {

--- a/src/config/materialize.ts
+++ b/src/config/materialize.ts
@@ -11,6 +11,7 @@ import {
 import { inheritLegacyDefaultAgentId } from "./legacy.default-agent-owner.js";
 import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
+import { copyConfigResolutionFacts } from "./resolution-facts.js";
 import { normalizeTalkConfig } from "./talk.js";
 import type { OpenClawConfig, ResolvedSourceConfig, RuntimeConfig } from "./types.js";
 
@@ -47,5 +48,6 @@ export function materializeRuntimeConfig(
   next = normalizeTalkConfig(next);
   normalizeConfigPaths(next, options);
   normalizeExecSafeBinProfilesInConfig(next);
+  copyConfigResolutionFacts(config, next);
   return asRuntimeConfig(inheritLegacyDefaultAgentId(config, next));
 }

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -32,6 +32,23 @@ export function resolveAgentModelFallbackValues(model?: AgentModelInput): string
   return Array.isArray(model.fallbacks) ? model.fallbacks : [];
 }
 
+/** Distinguishes inherited fallbacks from an explicit local primary or fallback list. */
+export function resolveSelectedModelFallbacksOverride(
+  raw: AgentModelConfig | undefined,
+): string[] | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  if (typeof raw === "string") {
+    return resolvePrimaryStringValue(raw) ? [] : undefined;
+  }
+  // An explicit empty list disables inherited fallbacks.
+  if (!Object.hasOwn(raw, "fallbacks")) {
+    return Object.hasOwn(raw, "primary") && resolvePrimaryStringValue(raw) ? [] : undefined;
+  }
+  return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
+}
+
 /** Returns a positive finite tool timeout rounded down to whole milliseconds. */
 export function resolveAgentModelTimeoutMsValue(model?: AgentToolModelConfig): number | undefined {
   if (!model || typeof model !== "object") {

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -56,7 +56,7 @@ import { injectExplicitlySetPaths, projectConfigWriteSource } from "./io.write-p
 import { warnIfJSON5CommentsWillBeStripped } from "./json5-comments.js";
 import {
   ConfigMutationConflictError,
-  GUARDED_CONFIG_INCLUDE_WRITE_ERROR,
+  GuardedConfigIncludeWriteError,
 } from "./mutation-conflict.js";
 import type { ConfigMutationBase } from "./mutation-types.js";
 import { resolveConfigPath } from "./paths.js";
@@ -756,11 +756,12 @@ async function tryWriteIncludeOwnedConfigMutation(params: {
   if (
     captureConfigWriteLockGuard(params.snapshot.path) ||
     params.writeOptions?.assertCurrent ||
-    params.writeOptions?.beforeCommit
+    params.writeOptions?.beforeCommit ||
+    params.writeOptions?.withCommit
   ) {
     // Root-backed include backups/publication cannot recheck caller authority
     // at their final effects. Refuse before preparing any include mutation.
-    throw new Error(GUARDED_CONFIG_INCLUDE_WRITE_ERROR);
+    throw new GuardedConfigIncludeWriteError();
   }
 
   const writeEnv = params.io?.env ?? process.env;

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -761,7 +761,7 @@ async function tryWriteIncludeOwnedConfigMutation(params: {
   ) {
     // Root-backed include backups/publication cannot recheck caller authority
     // at their final effects. Refuse before preparing any include mutation.
-    throw new GuardedConfigIncludeWriteError();
+    throw new GuardedConfigIncludeWriteError(includePath);
   }
 
   const writeEnv = params.io?.env ?? process.env;

--- a/src/config/mutation-conflict.ts
+++ b/src/config/mutation-conflict.ts
@@ -13,7 +13,7 @@ export const GUARDED_CONFIG_INCLUDE_WRITE_ERROR =
 
 /** The include owner cannot retain caller authority through its final effects. */
 export class GuardedConfigIncludeWriteError extends Error {
-  constructor() {
+  constructor(readonly includePath: string) {
     super(GUARDED_CONFIG_INCLUDE_WRITE_ERROR);
     this.name = "GuardedConfigIncludeWriteError";
   }

--- a/src/config/mutation-conflict.ts
+++ b/src/config/mutation-conflict.ts
@@ -10,3 +10,11 @@ export class ConfigMutationConflictError extends Error {
 }
 export const GUARDED_CONFIG_INCLUDE_WRITE_ERROR =
   "This approved operation cannot update include-owned configuration. Use a trusted shell for this change.";
+
+/** The include owner cannot retain caller authority through its final effects. */
+export class GuardedConfigIncludeWriteError extends Error {
+  constructor() {
+    super(GUARDED_CONFIG_INCLUDE_WRITE_ERROR);
+    this.name = "GuardedConfigIncludeWriteError";
+  }
+}

--- a/src/config/resolution-facts.ts
+++ b/src/config/resolution-facts.ts
@@ -1,10 +1,13 @@
 import type { EnvSubstitutionWarning } from "./env-substitution.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
 import { coerceSecretRef, DEFAULT_SECRET_PROVIDER_ALIAS, type SecretRef } from "./types.secrets.js";
 
 /** `null` means this value has not passed through authoritative config env substitution. */
 export type ConfigResolutionFacts = ReadonlySet<string> | null;
 
 const configResolutionFacts = new WeakMap<object, ReadonlySet<string>>();
+export type ConfigProviderUseBindings = Readonly<Record<string, { apiKey?: SecretRef }>>;
+const providerUseBindingsByConfig = new WeakMap<object, ConfigProviderUseBindings>();
 type ConfigEnvSecretRefFact = Readonly<{
   ref: SecretRef;
   state: "pending" | "resolved";
@@ -59,6 +62,42 @@ export function getConfigResolutionFacts(target: unknown): ConfigResolutionFacts
 
 export function copyConfigResolutionFacts(source: unknown, target: unknown): void {
   setConfigResolutionFacts(target, getConfigResolutionFacts(source));
+  setConfigProviderUseBindings(target, getConfigProviderUseBindings(source));
+}
+
+/** Approved startup bindings are runtime facts, never authored fields for config writers. */
+export function setConfigProviderUseBindings(
+  target: unknown,
+  bindings: ConfigProviderUseBindings,
+): void {
+  if (!target || typeof target !== "object") {
+    return;
+  }
+  if (Object.keys(bindings).length > 0) {
+    providerUseBindingsByConfig.set(target, bindings);
+  } else {
+    providerUseBindingsByConfig.delete(target);
+  }
+}
+
+export function getConfigProviderUseBindings(target: unknown): ConfigProviderUseBindings {
+  return target && typeof target === "object"
+    ? (providerUseBindingsByConfig.get(target) ?? {})
+    : {};
+}
+
+/** Only the shared migration can add runtime declarations to an authored auth view. */
+export function resolveConfigProviderUseBindings(config: OpenClawConfig): OpenClawConfig {
+  const bindings = getConfigProviderUseBindings(config);
+  if (Object.keys(bindings).length === 0) {
+    return config;
+  }
+  const resolved = {
+    ...config,
+    models: { ...config.models, providers: { ...bindings, ...config.models?.providers } },
+  };
+  copyConfigResolutionFacts(config, resolved);
+  return resolved;
 }
 
 export function cloneConfigWithResolutionFacts<T>(value: T): T {
@@ -72,6 +111,19 @@ export function copyConfigResolutionFactsExcept(
   target: unknown,
   paths: readonly string[],
 ): void {
+  const bindings = getConfigProviderUseBindings(source);
+  const removesBinding = (provider: string) =>
+    paths.some(
+      (path) =>
+        path === "models" ||
+        path === "models.providers" ||
+        path === `models.providers.${provider}` ||
+        path.startsWith(`models.providers.${provider}.`),
+    );
+  setConfigProviderUseBindings(
+    target,
+    Object.fromEntries(Object.entries(bindings).filter(([provider]) => !removesBinding(provider))),
+  );
   const facts = getConfigResolutionFacts(source);
   if (facts === null) {
     setConfigResolutionFacts(target, null);
@@ -100,18 +152,23 @@ export function copyConfigResolutionFactsExcept(
 type SerializedConfigResolutionFacts = Readonly<{
   unresolvedPaths: readonly string[];
   envSecretRefs: readonly (readonly [string, ConfigEnvSecretRefFact])[];
+  providerUseBindings?: ConfigProviderUseBindings;
+  envSubstitutionKnown?: boolean;
 }> | null;
 
 /** Captures loader provenance as deterministic data for a prepared worker generation. */
 export function serializeConfigResolutionFacts(target: unknown): SerializedConfigResolutionFacts {
   const facts = getConfigResolutionFacts(target);
-  return facts === null
+  const bindings = getConfigProviderUseBindings(target);
+  return facts === null && Object.keys(bindings).length === 0
     ? null
     : {
-        unresolvedPaths: [...facts].toSorted(),
-        envSecretRefs: [...(envSecretRefsByFacts.get(facts) ?? [])].toSorted(([left], [right]) =>
-          left.localeCompare(right),
+        unresolvedPaths: [...(facts ?? [])].toSorted(),
+        envSecretRefs: [...(facts ? (envSecretRefsByFacts.get(facts) ?? []) : [])].toSorted(
+          ([left], [right]) => left.localeCompare(right),
         ),
+        ...(Object.keys(bindings).length > 0 ? { providerUseBindings: bindings } : {}),
+        ...(facts === null ? { envSubstitutionKnown: false } : {}),
       };
 }
 
@@ -122,13 +179,15 @@ export function restoreConfigResolutionFacts(
 ): void {
   if (data === null) {
     setConfigResolutionFacts(target, null);
+    setConfigProviderUseBindings(target, {});
     return;
   }
   const facts = new Set(data.unresolvedPaths);
   if (data.envSecretRefs.length > 0) {
     envSecretRefsByFacts.set(facts, new Map(data.envSecretRefs));
   }
-  setConfigResolutionFacts(target, facts);
+  setConfigProviderUseBindings(target, data.providerUseBindings ?? {});
+  setConfigResolutionFacts(target, data.envSubstitutionKnown === false ? null : facts);
 }
 
 export function hasUnresolvedConfigPath(target: unknown, path: string): boolean {

--- a/src/config/resolution-facts.ts
+++ b/src/config/resolution-facts.ts
@@ -94,7 +94,19 @@ export function resolveConfigProviderUseBindings(config: OpenClawConfig): OpenCl
   }
   const resolved = {
     ...config,
-    models: { ...config.models, providers: { ...bindings, ...config.models?.providers } },
+    models: {
+      ...config.models,
+      providers: {
+        // Runtime provider overlays use sentinels; the recorded source bindings stay sparse.
+        ...Object.fromEntries(
+          Object.entries(bindings).map(([provider, binding]) => [
+            provider,
+            { baseUrl: "", models: [], ...binding },
+          ]),
+        ),
+        ...config.models?.providers,
+      },
+    },
   };
   copyConfigResolutionFacts(config, resolved);
   return resolved;

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -1,11 +1,19 @@
 // Verifies runtime config snapshots preserve normalized public settings.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveUsableCustomProviderApiKey } from "../agents/model-auth-provider-config.js";
+import { resolveProviderUseAdmission } from "../agents/provider-model-auth-source-plan.js";
+import { createConfigFileSnapshot } from "./io.snapshot-shared.js";
 import {
   cloneConfigWithResolutionFacts,
+  copyConfigResolutionFactsExcept,
   createConfigResolutionFacts,
   getAuthoredConfigSecretRef,
   getConfigResolutionFacts,
+  resolveConfigSecretRef,
   setConfigResolutionFacts,
+  setConfigProviderUseBindings,
+  serializeConfigResolutionFacts,
+  restoreConfigResolutionFacts,
 } from "./resolution-facts.js";
 import {
   createRuntimeConfigReader,
@@ -40,6 +48,101 @@ function resetRuntimeConfigState(): void {
 describe("runtime snapshot state", () => {
   afterEach(() => {
     resetRuntimeConfigState();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([false, true])(
+    "keeps raw env templates unprocessed while carrying runtime bindings: %s",
+    (withBinding) => {
+      const source: OpenClawConfig = {
+        models: {
+          providers: {
+            openai: {
+              apiKey: "${OPENAI_API_KEY}",
+              baseUrl: "https://api.openai.com/v1",
+              models: [],
+            },
+          },
+        },
+      };
+      setConfigProviderUseBindings(
+        source,
+        withBinding
+          ? {
+              "byteplus-plan": {
+                apiKey: { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" },
+              },
+            }
+          : {},
+      );
+      expect(getConfigResolutionFacts(source)).toBeNull();
+      const transferred = structuredClone(source);
+      restoreConfigResolutionFacts(transferred, serializeConfigResolutionFacts(source));
+      expect(getConfigResolutionFacts(transferred)).toBeNull();
+      expect(
+        resolveConfigSecretRef({
+          config: transferred,
+          path: "models.providers.openai.apiKey",
+          value: transferred.models?.providers?.openai?.apiKey,
+        }),
+      ).toEqual({ source: "env", provider: "default", id: "OPENAI_API_KEY" });
+      expect(
+        resolveProviderUseAdmission({ config: transferred, providerEnvVars: {}, env: {} }).has(
+          "byteplus-plan",
+        ),
+      ).toBe(withBinding);
+      expect(transferred.models?.providers?.["byteplus-plan"]).toBeUndefined();
+    },
+  );
+
+  it("carries approved runtime auth through a worker snapshot without authoring the source", () => {
+    vi.stubEnv("BYTEPLUS_API_KEY", "fixture-runtime-key");
+    const source: OpenClawConfig = {
+      agents: { defaults: { model: "byteplus-plan/ark-code-latest" } },
+    };
+    const bindings = {
+      "byteplus-plan": {
+        apiKey: { source: "env" as const, provider: "default", id: "BYTEPLUS_API_KEY" },
+      },
+    };
+    const runtime: OpenClawConfig = { ...source, models: { providers: bindings } };
+    setConfigProviderUseBindings(runtime, bindings);
+    const snapshot = createConfigFileSnapshot({
+      path: "/fixture/openclaw.json",
+      exists: true,
+      raw: JSON.stringify(source),
+      parsed: source,
+      sourceConfig: source,
+      runtimeConfig: runtime,
+      valid: true,
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+      resolutionFacts: createConfigResolutionFacts([]),
+    });
+    const transferred = structuredClone(snapshot.sourceConfig);
+    restoreConfigResolutionFacts(
+      transferred,
+      serializeConfigResolutionFacts(snapshot.sourceConfig),
+    );
+    expect(transferred.models).toBeUndefined();
+    expect(JSON.stringify(transferred)).toBe(snapshot.raw);
+    expect(
+      resolveProviderUseAdmission({ config: transferred, providerEnvVars: {}, env: {} }).has(
+        "byteplus-plan",
+      ),
+    ).toBe(true);
+    setRuntimeConfigSnapshot(runtime, transferred);
+    expect(
+      resolveUsableCustomProviderApiKey({ cfg: runtime, provider: "byteplus-plan" })?.apiKey,
+    ).toBe("fixture-runtime-key");
+    const changedSource = structuredClone(transferred);
+    copyConfigResolutionFactsExcept(transferred, changedSource, ["models.providers.byteplus-plan"]);
+    expect(
+      resolveProviderUseAdmission({ config: changedSource, providerEnvVars: {}, env: {} }).has(
+        "byteplus-plan",
+      ),
+    ).toBe(false);
   });
 
   it("pins the first successful load in memory until the snapshot is cleared", () => {

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -10,6 +10,7 @@ import {
   getAuthoredConfigSecretRef,
   getConfigResolutionFacts,
   resolveConfigSecretRef,
+  resolveConfigProviderUseBindings,
   setConfigResolutionFacts,
   setConfigProviderUseBindings,
   serializeConfigResolutionFacts,
@@ -105,8 +106,9 @@ describe("runtime snapshot state", () => {
         apiKey: { source: "env" as const, provider: "default", id: "BYTEPLUS_API_KEY" },
       },
     };
-    const runtime: OpenClawConfig = { ...source, models: { providers: bindings } };
-    setConfigProviderUseBindings(runtime, bindings);
+    const runtimeInput: OpenClawConfig = { ...source };
+    setConfigProviderUseBindings(runtimeInput, bindings);
+    const runtime = resolveConfigProviderUseBindings(runtimeInput);
     const snapshot = createConfigFileSnapshot({
       path: "/fixture/openclaw.json",
       exists: true,

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -17,7 +17,7 @@ import {
 import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveAgentsDirFromSessionStorePath, resolveSessionStorePathCore } from "./paths.js";
-import { iterateSessionEntryKeys } from "./session-accessor.sqlite-entry-store.js";
+import { iterateSessionEntryKeys } from "./session-accessor.sqlite-entry-inventory.js";
 import {
   listDurableSqliteTargetOwnersForSessionStorePath,
   listSqliteTargetCandidatePathsForSessionStorePath,

--- a/src/config/state-startup-corpus.test.ts
+++ b/src/config/state-startup-corpus.test.ts
@@ -236,7 +236,15 @@ describe("prior-release state startup corpus", () => {
               { catalogMode: "static" },
             );
             try {
-              if (configName === "generic-github-token.json") {
+              if (
+                [
+                  "generic-github-token.json",
+                  "provider-admission-bedrock.json",
+                  "provider-admission-family.json",
+                  "provider-admission-generic.json",
+                  "provider-admission-openai.json",
+                ].includes(configName)
+              ) {
                 expect(lease.snapshot.modelCatalog.entries).toEqual([]);
               } else {
                 expect(lease.snapshot.modelCatalog.entries.length).toBeGreaterThan(0);

--- a/src/config/state-startup-corpus.test.ts
+++ b/src/config/state-startup-corpus.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { listAgentIds } from "../agents/agent-scope-config.js";
 import { loadAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-profiles.js";
@@ -22,6 +22,7 @@ import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contra
 import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { getUserPreferences } from "../state/user-preferences.js";
+import { captureFullEnv } from "../test-utils/env.js";
 import { createConfigIO } from "./io.js";
 import {
   readRecentUserAssistantTextForSession,
@@ -67,7 +68,14 @@ const cases = releases.flatMap((release) =>
   configNames.map((configName) => [release, configName] as const),
 );
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-afterEach(() => vi.unstubAllEnvs());
+let environment: ReturnType<typeof captureFullEnv>;
+beforeEach(() => {
+  environment = captureFullEnv();
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  environment.restore();
+});
 
 function prepareState(release: string, configName: string) {
   const home = tempDirs.make("openclaw-state-corpus-");
@@ -236,22 +244,29 @@ describe("prior-release state startup corpus", () => {
               { catalogMode: "static" },
             );
             try {
+              const entries = lease.snapshot.modelCatalog.entries;
               if (configName === "provider-admission-selected-plan.json") {
-                expect(lease.snapshot.modelCatalog.entries).toEqual([
+                expect(entries).toContainEqual(
                   expect.objectContaining({ provider: "byteplus-plan", id: "ark-code-latest" }),
+                );
+                expect([...new Set(entries.map(({ provider }) => provider))].toSorted()).toEqual([
+                  "byteplus",
+                  "byteplus-plan",
                 ]);
+              } else if (configName === "provider-admission-family.json") {
+                expect(entries.length).toBeGreaterThan(0);
+                expect([...new Set(entries.map(({ provider }) => provider))]).toEqual(["byteplus"]);
               } else if (
                 [
                   "generic-github-token.json",
                   "provider-admission-bedrock.json",
-                  "provider-admission-family.json",
                   "provider-admission-generic.json",
                   "provider-admission-openai.json",
                 ].includes(configName)
               ) {
-                expect(lease.snapshot.modelCatalog.entries).toEqual([]);
+                expect(entries).toEqual([]);
               } else {
-                expect(lease.snapshot.modelCatalog.entries.length).toBeGreaterThan(0);
+                expect(entries.length).toBeGreaterThan(0);
               }
             } finally {
               lease.release();

--- a/src/config/state-startup-corpus.test.ts
+++ b/src/config/state-startup-corpus.test.ts
@@ -236,7 +236,11 @@ describe("prior-release state startup corpus", () => {
               { catalogMode: "static" },
             );
             try {
-              if (
+              if (configName === "provider-admission-selected-plan.json") {
+                expect(lease.snapshot.modelCatalog.entries).toEqual([
+                  expect.objectContaining({ provider: "byteplus-plan", id: "ark-code-latest" }),
+                ]);
+              } else if (
                 [
                   "generic-github-token.json",
                   "provider-admission-bedrock.json",

--- a/src/config/validation-secretrefs.ts
+++ b/src/config/validation-secretrefs.ts
@@ -1,0 +1,43 @@
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { resolveSecretRefProviderSourceMismatch } from "../secrets/ref-contract.js";
+import { discoverConfigSecretTargets } from "../secrets/target-registry.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
+import { resolveSecretInputRef } from "./types.secrets.js";
+import { withConfigIssuePath } from "./validation-issues.js";
+
+export function collectSecretRefProviderSourceIssues(params: {
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  manifestRegistry: PluginManifestRegistry;
+}): ConfigValidationIssue[] {
+  const issues: ConfigValidationIssue[] = [];
+  for (const target of discoverConfigSecretTargets(params.config, {
+    env: params.env,
+    manifestRegistry: params.manifestRegistry,
+  })) {
+    const { ref } = resolveSecretInputRef({
+      value: target.value,
+      refValue: target.refValue,
+      defaults: params.config.secrets?.defaults,
+    });
+    if (!ref) {
+      continue;
+    }
+    const configuredSource = resolveSecretRefProviderSourceMismatch(params.config, ref);
+    if (!configuredSource) {
+      continue;
+    }
+    const path = target.refPath ?? target.path;
+    const pathSegments = target.refPathSegments ?? target.pathSegments;
+    issues.push(
+      withConfigIssuePath(
+        {
+          path,
+          message: `Secret provider "${ref.provider}" has source "${configuredSource}" but ref requests "${ref.source}".`,
+        },
+        pathSegments,
+      ),
+    );
+  }
+  return issues;
+}

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -3,6 +3,7 @@ import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configu
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { listAgentEntriesWithSource } from "../agents/agent-scope.js";
+import { applyProviderUseBindingsToRuntime } from "../commands/doctor/shared/provider-use-binding-migration.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
 import { listChannelIdsForOwnershipMigration } from "../plugins/channel-presence-policy.js";
 import { normalizePluginsConfig, normalizePluginId } from "../plugins/config-state.js";
@@ -12,8 +13,6 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
 import { validatePluginSchemaValue } from "../plugins/schema-validator.js";
 import { resolveWebSearchInstallCatalogEntries } from "../plugins/web-search-install-catalog.js";
-import { resolveSecretRefProviderSourceMismatch } from "../secrets/ref-contract.js";
-import { discoverConfigSecretTargets } from "../secrets/target-registry.js";
 import { isRecord } from "../utils.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
 import {
@@ -31,8 +30,9 @@ import { materializeLegacyDefaultAgentRoles } from "./legacy.default-agent-roles
 import { removeLegacyCopilotDiscovery } from "./legacy.github-copilot.js";
 import { migratePersistedImplicitMainRoster } from "./legacy.roster.js";
 import { materializeRuntimeConfig } from "./materialize.js";
+import { resolveConfigPath } from "./paths.js";
+import { copyConfigResolutionFacts } from "./resolution-facts.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
-import { resolveSecretInputRef } from "./types.secrets.js";
 import {
   bundledChannelIds,
   collectChannelDmPolicyDependencyWarnings,
@@ -41,12 +41,12 @@ import {
   normalizeBundledChannelId,
 } from "./validation-channel-rules.js";
 import { collectHeartbeatOwnerWarnings, validateConfigObjectRaw } from "./validation-core.js";
-import { withConfigIssuePath } from "./validation-issues.js";
 import {
   collectExplicitPluginReferences,
   resolveExplicitPluginReferencePath,
   validateExplicitPluginConfig,
 } from "./validation-plugin-config.js";
+import { collectSecretRefProviderSourceIssues } from "./validation-secretrefs.js";
 
 export { validateConfigObject, validateConfigObjectRaw } from "./validation-core.js";
 export { collectUnsupportedSecretRefPolicyIssues } from "./validation-issues.js";
@@ -81,43 +81,6 @@ type RegistryInfo = {
   >;
 };
 
-function collectSecretRefProviderSourceIssues(params: {
-  config: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-  manifestRegistry: PluginManifestRegistry;
-}): ConfigValidationIssue[] {
-  const issues: ConfigValidationIssue[] = [];
-  for (const target of discoverConfigSecretTargets(params.config, {
-    env: params.env,
-    manifestRegistry: params.manifestRegistry,
-  })) {
-    const { ref } = resolveSecretInputRef({
-      value: target.value,
-      refValue: target.refValue,
-      defaults: params.config.secrets?.defaults,
-    });
-    if (!ref) {
-      continue;
-    }
-    const configuredSource = resolveSecretRefProviderSourceMismatch(params.config, ref);
-    if (!configuredSource) {
-      continue;
-    }
-    const path = target.refPath ?? target.path;
-    const pathSegments = target.refPathSegments ?? target.pathSegments;
-    issues.push(
-      withConfigIssuePath(
-        {
-          path,
-          message: `Secret provider "${ref.provider}" has source "${configuredSource}" but ref requests "${ref.source}".`,
-        },
-        pathSegments,
-      ),
-    );
-  }
-  return issues;
-}
-
 export function validateConfigObjectWithPlugins(
   raw: unknown,
   params?: ValidateConfigWithPluginsParams,
@@ -144,7 +107,7 @@ function validateConfigObjectWithPluginMode(
     homedir: params?.homedir,
   }).config as OpenClawConfig;
   let manifestRegistry = params?.pluginMetadataSnapshot?.manifestRegistry;
-  const result = validateConfigObjectWithPluginsBase(migrated, {
+  let result = validateConfigObjectWithPluginsBase(migrated, {
     ...params,
     applyDefaults,
     pluginValidation: params?.pluginValidation ?? "full",
@@ -153,6 +116,30 @@ function validateConfigObjectWithPluginMode(
       manifestRegistry = registry;
     },
   });
+  if (
+    result.ok &&
+    applyDefaults &&
+    params?.pluginValidation !== "core-only" &&
+    params?.semanticValidation !== "strict"
+  ) {
+    const env = params?.env ?? process.env;
+    const migration = applyProviderUseBindingsToRuntime({
+      config: migrated,
+      runtimeConfig: result.config,
+      configPath: resolveConfigPath(env, undefined, params?.homedir),
+      env,
+      manifestRegistry:
+        manifestRegistry ?? resolveConfigWidePluginManifestRegistry({ config: migrated, env }),
+    });
+    result = {
+      ...result,
+      config: migration.config,
+      warnings: [
+        ...result.warnings,
+        ...migration.warnings.map((message) => ({ path: "models.providers", message })),
+      ],
+    };
+  }
   const legacyDefaultAgentId = tryGetLegacyDefaultAgentId(migrated);
   // Core roster normalization already ran; ambient channel ownership belongs to Gateway discovery.
   if (!result.ok || !legacyDefaultAgentId || params?.pluginValidation === "core-only") {
@@ -166,6 +153,7 @@ function validateConfigObjectWithPluginMode(
     params?.env,
     manifestRegistry?.plugins,
   );
+  copyConfigResolutionFacts(result.config, materialized.config);
   return { ...result, config: materialized.config };
 }
 

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -4,6 +4,8 @@ import { isDeepStrictEqual } from "node:util";
 import { UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV } from "../commands/doctor/shared/update-phase.js";
 import { getConfigValueAtPath } from "../config/config-paths.js";
 import { resolveIsConfigReadOnly, resolveIsNixMode } from "../config/paths.js";
+import { collectNestedErrorCandidates } from "../infra/error-graph-internal.js";
+import { extractErrorCode } from "../infra/errors.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
 import {
   isUpdateDoctorRun,
@@ -58,7 +60,9 @@ export async function runWriteConfigHealth(
       import("../commands/doctor/shared/provider-use-binding-migration.js"),
       import("../../packages/terminal-core/src/note.js"),
     ]);
+  let entered = false;
   await withConfigMutationExclusive(async (sourceConfig) => {
+    entered = true;
     const panels = ctx.configResult.pendingChangePanels ?? [];
     const checked = await writeProviderUseBindingMigration(
       {
@@ -88,7 +92,50 @@ export async function runWriteConfigHealth(
     if (!ctx.configWriteRefusal) {
       delete ctx.configResult.providerUseBindings;
     }
+  }).catch(async (error: unknown) => {
+    if (entered || !(await noteReadOnlyConfigWrite(ctx, error))) {
+      throw error;
+    }
   });
+}
+
+async function noteReadOnlyConfigWrite(
+  ctx: DoctorHealthFlowContext,
+  error: unknown,
+): Promise<boolean> {
+  const codes = new Set([
+    "EROFS",
+    "EACCES",
+    "EPERM",
+    "OPENCLAW_CONFIG_READONLY",
+    "OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE",
+  ]);
+  if (
+    !collectNestedErrorCandidates(error).some((candidate) =>
+      codes.has(extractErrorCode(candidate) ?? ""),
+    )
+  ) {
+    return false;
+  }
+  const { note } = await import("../../packages/terminal-core/src/note.js");
+  const entries = Object.entries(ctx.configResult.providerUseBindings ?? {}).map(
+    ([provider, binding]) =>
+      binding.apiKey
+        ? `models.providers.${provider}.apiKey = ${JSON.stringify(binding.apiKey)}`
+        : `models.providers.${provider} = {}`,
+  );
+  note(
+    [
+      `Doctor cannot write the read-only config ${ctx.configPath}. Edit its managed source instead.`,
+      ...entries,
+      "Provider binding completion remains pending; no receipt was written.",
+    ].join("\n"),
+    "Doctor warnings",
+  );
+  ctx.configWriteRefusal = "read-only";
+  ctx.configResult.providerUseBindingMigrationPending = false;
+  ctx.configResult.pendingChangePanels = [];
+  return true;
 }
 
 async function writeConfigHealth(
@@ -164,6 +211,9 @@ async function writeConfigHealth(
         },
       });
     } catch (error) {
+      if (await noteReadOnlyConfigWrite(ctx, error)) {
+        return;
+      }
       const { isConfigIncludeOwnershipError, isConfigValidationFailedError } =
         await import("../config/io.write-errors.js");
       // A refused write persisted nothing. Queued "Doctor changes" panels stay

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -195,6 +195,17 @@ export async function runWriteConfigHealth(
       );
     }
   }
+  if (ctx.configResult.providerUseBindingMigrationPending === true) {
+    const { completeProviderUseBindingMigration } =
+      await import("../commands/doctor/shared/provider-use-binding-migration.js");
+    const warnings = completeProviderUseBindingMigration(ctx.configPath, ctx.env ?? process.env);
+    if (warnings.length > 0) {
+      const { note } = await import("../../packages/terminal-core/src/note.js");
+      note(warnings.join("\n"), "Doctor warnings");
+    } else {
+      delete ctx.configResult.providerUseBindingMigrationPending;
+    }
+  }
   if (options.runPostWriteRepairs === false) {
     return;
   }

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -190,7 +190,6 @@ export async function runWriteConfigHealth(
     // The final writer runs again after health repairs. Advance its baseline only
     // after the atomic write succeeds so later failures cannot mark volatile state durable.
     ctx.cfgForPersistence = structuredClone(ctx.cfg);
-    delete ctx.configResult.unsetPaths;
     if (ctx.configResult.shouldWriteConfig === true) {
       ctx.configResultWriteCommitted = true;
     }

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -5,7 +5,7 @@ import { UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV } from "../commands/doct
 import { getConfigValueAtPath } from "../config/config-paths.js";
 import { resolveIsConfigReadOnly, resolveIsNixMode } from "../config/paths.js";
 import { collectNestedErrorCandidates } from "../infra/error-graph-internal.js";
-import { extractErrorCode } from "../infra/errors.js";
+import { extractErrorCode, isErrno } from "../infra/errors.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
 import {
   isUpdateDoctorRun,
@@ -103,17 +103,49 @@ async function noteReadOnlyConfigWrite(
   ctx: DoctorHealthFlowContext,
   error: unknown,
 ): Promise<boolean> {
-  const codes = new Set([
-    "EROFS",
-    "EACCES",
-    "EPERM",
-    "OPENCLAW_CONFIG_READONLY",
-    "OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE",
+  const [
+    { isCronOwnerWriteRefusalError },
+    { isConfigIncludeOwnershipError, isConfigValidationFailedError },
+    { ConfigRuntimeRefreshError },
+  ] = await Promise.all([
+    import("../config/io.cron-owner-refusal.js"),
+    import("../config/io.write-errors.js"),
+    import("../config/io.types.js"),
   ]);
+  const causes = collectNestedErrorCandidates(error);
   if (
-    !collectNestedErrorCandidates(error).some((candidate) =>
-      codes.has(extractErrorCode(candidate) ?? ""),
+    causes.some(
+      (cause) =>
+        isCronOwnerWriteRefusalError(cause) ||
+        isConfigIncludeOwnershipError(cause) ||
+        isConfigValidationFailedError(cause) ||
+        cause instanceof ConfigRuntimeRefreshError,
     )
+  ) {
+    return false;
+  }
+  const configPath = nodePath.resolve(ctx.configPath);
+  if (
+    !causes.some((candidate) => {
+      const code = extractErrorCode(candidate);
+      if (code === "OPENCLAW_CONFIG_READONLY" || code === "OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE") {
+        return true;
+      }
+      if (
+        !isErrno(candidate) ||
+        !["EROFS", "EACCES", "EPERM"].includes(code ?? "") ||
+        typeof candidate.path !== "string"
+      ) {
+        return false;
+      }
+      const failedPath = nodePath.resolve(candidate.path);
+      return (
+        failedPath === nodePath.dirname(configPath) ||
+        failedPath === configPath ||
+        (nodePath.dirname(failedPath) === nodePath.dirname(configPath) &&
+          nodePath.basename(failedPath).startsWith(`${nodePath.basename(configPath)}.`))
+      );
+    })
   ) {
     return false;
   }
@@ -128,7 +160,9 @@ async function noteReadOnlyConfigWrite(
     [
       `Doctor cannot write the read-only config ${ctx.configPath}. Edit its managed source instead.`,
       ...entries,
-      "Provider binding completion remains pending; no receipt was written.",
+      ...(ctx.configResult.providerUseBindingMigrationPending || entries.length > 0
+        ? ["Provider binding completion remains pending; no receipt was written."]
+        : []),
     ].join("\n"),
     "Doctor warnings",
   );

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import nodePath from "node:path";
 import { UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV } from "../commands/doctor/shared/update-phase.js";
+import { getConfigValueAtPath } from "../config/config-paths.js";
 import { resolveIsConfigReadOnly, resolveIsNixMode } from "../config/paths.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
 import {
@@ -97,6 +98,12 @@ export async function runWriteConfigHealth(
           ...(ctx.configResult.explicitSetPaths
             ? { explicitSetPaths: ctx.configResult.explicitSetPaths }
             : {}),
+          unsetPaths: ctx.configResult.unsetPaths?.filter((path) => {
+            const value = getConfigValueAtPath(ctx.cfg, path);
+            return path.at(-1) === "baseUrl"
+              ? value === ""
+              : Array.isArray(value) && value.length === 0;
+          }),
           persistCanonicalAgentRoster: configResultWritePending
             ? ctx.configResult.persistCanonicalAgentRoster
             : undefined,
@@ -183,6 +190,7 @@ export async function runWriteConfigHealth(
     // The final writer runs again after health repairs. Advance its baseline only
     // after the atomic write succeeds so later failures cannot mark volatile state durable.
     ctx.cfgForPersistence = structuredClone(ctx.cfg);
+    delete ctx.configResult.unsetPaths;
     if (ctx.configResult.shouldWriteConfig === true) {
       ctx.configResultWriteCommitted = true;
     }

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import nodePath from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV } from "../commands/doctor/shared/update-phase.js";
 import { getConfigValueAtPath } from "../config/config-paths.js";
 import { resolveIsConfigReadOnly, resolveIsNixMode } from "../config/paths.js";
@@ -47,6 +48,52 @@ export async function runWriteConfigHealth(
   ctx: DoctorHealthFlowContext,
   options: { runPostWriteRepairs?: boolean } = {},
 ): Promise<void> {
+  const bindings = ctx.configResult.providerUseBindings;
+  if (!bindings || ctx.configWriteRefusal) {
+    return writeConfigHealth(ctx, options);
+  }
+  const [{ withConfigMutationExclusive }, { revalidateProviderUseBindingMigration }, { note }] =
+    await Promise.all([
+      import("../config/config.js"),
+      import("../commands/doctor/shared/provider-use-binding-migration.js"),
+      import("../../packages/terminal-core/src/note.js"),
+    ]);
+  // The canonical config lock is reentrant; the existing writer retains its own checks.
+  await withConfigMutationExclusive(async (sourceConfig) => {
+    await writeConfigHealth(ctx, options, async () => {
+      const checked = await revalidateProviderUseBindingMigration({
+        config: ctx.cfg,
+        sourceConfig,
+        configPath: ctx.configPath,
+        env: ctx.env ?? process.env,
+        bindings,
+      });
+      ctx.cfg = checked.config;
+      ctx.configResult.providerUseBindingMigrationPending &&= checked.pending;
+      if (checked.warnings.length > 0) {
+        note(checked.warnings.join("\n"), "Doctor warnings");
+      }
+      if (checked.changes.length > 0) {
+        ctx.configResult.pendingChangePanels = [
+          ...(ctx.configResult.pendingChangePanels ?? []),
+          checked.changes.join("\n"),
+        ];
+      } else if (isDeepStrictEqual(ctx.cfg, sourceConfig)) {
+        ctx.configResult.shouldWriteConfig = false;
+        ctx.cfgForPersistence = structuredClone(ctx.cfg);
+      }
+    });
+    if (!ctx.configWriteRefusal) {
+      delete ctx.configResult.providerUseBindings;
+    }
+  });
+}
+
+async function writeConfigHealth(
+  ctx: DoctorHealthFlowContext,
+  options: { runPostWriteRepairs?: boolean } = {},
+  revalidateBindings?: () => Promise<void>,
+): Promise<void> {
   if (ctx.configWriteRefusal) {
     // The initial write already reported the refusal; retrying the
     // same candidate would fail identically and duplicate the warning.
@@ -56,6 +103,11 @@ export async function runWriteConfigHealth(
   const { transformConfigFile } = await import("../config/config.js");
   const { logConfigUpdated } = await import("../config/logging.js");
   const { shortenHomePath } = await import("../utils.js");
+  const { restoreDoctorConfigEnvRefs } =
+    await import("../commands/doctor/shared/config-flow-steps.js");
+  const { assertShippedPluginInstallConfigImportCurrent } =
+    await import("../commands/doctor/shared/plugin-registry-migration.js");
+  await revalidateBindings?.();
   const configResultWritePending =
     ctx.configResult.shouldWriteConfig === true && ctx.configResultWriteCommitted !== true;
   const shouldWriteConfig =
@@ -74,10 +126,6 @@ export async function runWriteConfigHealth(
     }
     const legacyParentVersionOverride =
       resolveLegacyParentVersionOverride(ctx).lastTouchedVersionOverride;
-    const { restoreDoctorConfigEnvRefs } =
-      await import("../commands/doctor/shared/config-flow-steps.js");
-    const { assertShippedPluginInstallConfigImportCurrent } =
-      await import("../commands/doctor/shared/plugin-registry-migration.js");
     try {
       await transformConfigFile({
         transform: (_current, { snapshot }, { envSnapshotForRestore }) => {

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -175,6 +175,9 @@ async function writeConfigHealth(
           ? "Earlier config fixes were already saved; the remaining changes were not written."
           : "No config changes were written.";
       if (isConfigIncludeOwnershipError(error)) {
+        if (withCommit) {
+          throw error;
+        }
         // The candidate mixed an include-owned repair with root-owned changes; the
         // writer keeps every file intact and names the include boundary, plus its
         // file when the root file authors the directive, to repair first.

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -52,37 +52,39 @@ export async function runWriteConfigHealth(
   if (!bindings || ctx.configWriteRefusal) {
     return writeConfigHealth(ctx, options);
   }
-  const [{ withConfigMutationExclusive }, { revalidateProviderUseBindingMigration }, { note }] =
+  const [{ withConfigMutationExclusive }, { writeProviderUseBindingMigration }, { note }] =
     await Promise.all([
       import("../config/config.js"),
       import("../commands/doctor/shared/provider-use-binding-migration.js"),
       import("../../packages/terminal-core/src/note.js"),
     ]);
-  // The canonical config lock is reentrant; the existing writer retains its own checks.
   await withConfigMutationExclusive(async (sourceConfig) => {
-    await writeConfigHealth(ctx, options, async () => {
-      const checked = await revalidateProviderUseBindingMigration({
+    const panels = ctx.configResult.pendingChangePanels ?? [];
+    const checked = await writeProviderUseBindingMigration(
+      {
         config: ctx.cfg,
         sourceConfig,
         configPath: ctx.configPath,
         env: ctx.env ?? process.env,
         bindings,
-      });
-      ctx.cfg = checked.config;
-      ctx.configResult.providerUseBindingMigrationPending &&= checked.pending;
-      if (checked.warnings.length > 0) {
-        note(checked.warnings.join("\n"), "Doctor warnings");
-      }
-      if (checked.changes.length > 0) {
+      },
+      async (current, withCommit) => {
+        ctx.cfg = current.config;
+        ctx.configResult.providerUseBindingMigrationPending &&= current.pending;
         ctx.configResult.pendingChangePanels = [
-          ...(ctx.configResult.pendingChangePanels ?? []),
-          checked.changes.join("\n"),
+          ...panels,
+          ...(current.changes.length ? [current.changes.join("\n")] : []),
         ];
-      } else if (isDeepStrictEqual(ctx.cfg, sourceConfig)) {
-        ctx.configResult.shouldWriteConfig = false;
-        ctx.cfgForPersistence = structuredClone(ctx.cfg);
-      }
-    });
+        if (isDeepStrictEqual(ctx.cfg, sourceConfig)) {
+          ctx.configResult.shouldWriteConfig = false;
+          ctx.cfgForPersistence = structuredClone(ctx.cfg);
+        }
+        await writeConfigHealth(ctx, options, withCommit);
+      },
+    );
+    if (checked.warnings.length > 0) {
+      note(checked.warnings.join("\n"), "Doctor warnings");
+    }
     if (!ctx.configWriteRefusal) {
       delete ctx.configResult.providerUseBindings;
     }
@@ -92,7 +94,7 @@ export async function runWriteConfigHealth(
 async function writeConfigHealth(
   ctx: DoctorHealthFlowContext,
   options: { runPostWriteRepairs?: boolean } = {},
-  revalidateBindings?: () => Promise<void>,
+  withCommit?: import("../config/io.types.js").ConfigWriteOptions["withCommit"],
 ): Promise<void> {
   if (ctx.configWriteRefusal) {
     // The initial write already reported the refusal; retrying the
@@ -107,7 +109,6 @@ async function writeConfigHealth(
     await import("../commands/doctor/shared/config-flow-steps.js");
   const { assertShippedPluginInstallConfigImportCurrent } =
     await import("../commands/doctor/shared/plugin-registry-migration.js");
-  await revalidateBindings?.();
   const configResultWritePending =
     ctx.configResult.shouldWriteConfig === true && ctx.configResultWriteCommitted !== true;
   const shouldWriteConfig =
@@ -139,6 +140,7 @@ async function writeConfigHealth(
         },
         afterWrite: { mode: "auto" },
         writeOptions: {
+          withCommit,
           auditOrigin: "doctor",
           allowConfigSizeDrop: ctx.configResult.shouldWriteConfig === true || updateDoctorRun,
           skipPluginValidation:

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -2,8 +2,8 @@ import type { RetiredAuthProfileCleanupPlan } from "../commands/doctor-auth-lega
 import type { probeGatewayMemoryStatus } from "../commands/doctor-gateway-health.js";
 import type { DoctorOptions, DoctorPrompter } from "../commands/doctor-prompter.js";
 import type { ShippedPluginInstallConfigImport } from "../commands/doctor/shared/plugin-registry-migration.js";
+import type { ProviderUseBindingMigrationBindings } from "../commands/doctor/shared/provider-use-binding-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { SecretRef } from "../config/types.secrets.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import type {
   LegacyStateMigrationStepReceipt,
@@ -34,7 +34,7 @@ type DoctorConfigResult = {
   shouldRepairCronCodexModelRefsAfterConfigWrite?: boolean;
   retiredPhoneControlStateCleanupPending?: boolean;
   providerUseBindingMigrationPending?: boolean;
-  providerUseBindings?: Record<string, SecretRef>;
+  providerUseBindings?: ProviderUseBindingMigrationBindings;
   /** Store cleanup deferred until the repaired config reaches disk. */
   retiredAuthProfileCleanupPlans?: readonly RetiredAuthProfileCleanupPlan[];
   blockedCodexModelIdentities?: readonly string[];
@@ -59,7 +59,7 @@ export type DoctorHealthFlowContext = {
   /** The finalized config-flow candidate crossed the atomic writer boundary. */
   configResultWriteCommitted?: boolean;
   /** The requested config write was refused; later repairs must not consume its candidate. */
-  configWriteRefusal?: "validation" | "cron-owner-safety" | "include-ownership";
+  configWriteRefusal?: "validation" | "cron-owner-safety" | "include-ownership" | "read-only";
   /** One-shot repairs that require a durable config write have completed. */
   postConfigWriteRepairsCommitted?: boolean;
   sourceConfigValid: boolean;

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -3,6 +3,7 @@ import type { probeGatewayMemoryStatus } from "../commands/doctor-gateway-health
 import type { DoctorOptions, DoctorPrompter } from "../commands/doctor-prompter.js";
 import type { ShippedPluginInstallConfigImport } from "../commands/doctor/shared/plugin-registry-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretRef } from "../config/types.secrets.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import type {
   LegacyStateMigrationStepReceipt,
@@ -33,6 +34,7 @@ type DoctorConfigResult = {
   shouldRepairCronCodexModelRefsAfterConfigWrite?: boolean;
   retiredPhoneControlStateCleanupPending?: boolean;
   providerUseBindingMigrationPending?: boolean;
+  providerUseBindings?: Record<string, SecretRef>;
   /** Store cleanup deferred until the repaired config reaches disk. */
   retiredAuthProfileCleanupPlans?: readonly RetiredAuthProfileCleanupPlan[];
   blockedCodexModelIdentities?: readonly string[];

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -31,6 +31,7 @@ type DoctorConfigResult = {
   preservedLegacyRootKeys?: readonly string[];
   shouldRepairCronCodexModelRefsAfterConfigWrite?: boolean;
   retiredPhoneControlStateCleanupPending?: boolean;
+  providerUseBindingMigrationPending?: boolean;
   /** Store cleanup deferred until the repaired config reaches disk. */
   retiredAuthProfileCleanupPlans?: readonly RetiredAuthProfileCleanupPlan[];
   blockedCodexModelIdentities?: readonly string[];

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -26,6 +26,7 @@ type DoctorConfigResult = {
   sourceLastTouchedVersion?: string;
   skipPluginValidationOnWrite?: boolean;
   explicitSetPaths?: readonly (readonly string[])[];
+  unsetPaths?: string[][];
   persistCanonicalAgentRoster?: boolean;
   skipWizardMetadataForIncludeWrite?: boolean;
   preservedLegacyRootKeys?: readonly string[];

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -4,6 +4,7 @@ import nodePath from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDoctorConfigSnapshot } from "../commands/doctor-config-snapshot.test-helpers.js";
 import type { DoctorPrompter } from "../commands/doctor-prompter.js";
+import { ConfigRuntimeRefreshError } from "../config/io.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { LEGACY_SECRETREF_ENV_MARKER_PREFIX } from "../config/types.secrets.js";
 import { fetchNpmPackageTargetStatus } from "../infra/update-check-package-target.js";
@@ -1334,6 +1335,32 @@ describe("doctor health contributions", () => {
     expect(mocks.note).not.toHaveBeenCalledWith(expect.anything(), "Doctor changes");
   });
 
+  it.each(["EACCES", "EROFS"])(
+    "does not soften a SecretRef %s failure into a read-only config warning",
+    async (code) => {
+      const cfg: OpenClawConfig = {};
+      const ctx = createDoctorContext({
+        cfg,
+        configResult: { cfg, shouldWriteConfig: true },
+        shouldRepair: true,
+        env: {},
+      });
+      const error = new ConfigRuntimeRefreshError("active SecretRef resolution failed", {
+        cause: Object.assign(new Error("cannot read credential file"), {
+          code,
+          path: "/managed/secrets/account",
+        }),
+      });
+      mocks.replaceConfigFile.mockRejectedValueOnce(error);
+
+      await expect(
+        requireDoctorContribution("doctor:write-config-migrations").run(ctx),
+      ).rejects.toBe(error);
+      expect(ctx.configWriteRefusal).toBeUndefined();
+      expect(ctx.configResultWriteCommitted).not.toBe(true);
+    },
+  );
+
   it("defers every config write after a cron ownership handoff refusal", async () => {
     const laterRun = vi.fn(async () => undefined);
     const cfg = {
@@ -1356,6 +1383,7 @@ describe("doctor health contributions", () => {
       Object.assign(
         new Error(
           'Config write refused: cannot inspect cron ownership. Run "openclaw doctor --fix", then retry.',
+          { cause: Object.assign(new Error("cannot read cron store"), { code: "EACCES" }) },
         ),
         { code: "CONFIG_WRITE_REJECTED", refusal: "cron-owner-safety" },
       ),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -68,7 +68,9 @@ async function reportDeferredLegacyState(ctx: DoctorHealthFlowContext): Promise<
       ? "Fix the config errors above."
       : ctx.configWriteRefusal === "include-ownership"
         ? "Repair the include boundary named above by hand."
-        : "Resolve the Gateway or cron-store condition above.";
+        : ctx.configWriteRefusal === "read-only"
+          ? `Update the managed source of ${ctx.configPath}.`
+          : "Resolve the Gateway or cron-store condition above.";
   note(
     [
       "Pending owners and blockers:",

--- a/src/flows/doctor-health.test-support.ts
+++ b/src/flows/doctor-health.test-support.ts
@@ -174,6 +174,24 @@ export function registerDoctorConfigReceiptTests(
   runDoctorHealthFlow: typeof import("./doctor-health.js").runDoctorHealthFlow,
   postInstallAdvisory: NonNullable<DoctorHealthFlowContext["postInstallDoctorResult"]>,
 ) {
+  it("finishes with a warning when a valid managed config is read-only", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      await state.writeConfig({});
+      mocks.runContributions.mockImplementation(async (ctx) => {
+        ctx.configPath = state.configPath;
+        ctx.configWriteRefusal = "read-only";
+      });
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+      await runDoctorHealthFlow(runtime, {});
+
+      expect(runtime.exit).not.toHaveBeenCalledWith(1);
+      expect(mocks.outro).toHaveBeenCalledWith(
+        "Doctor complete. The config is read-only; pending config fixes were left unchanged.",
+      );
+    });
+  });
+
   it.each(["unchanged", "ok", "error", "advisory", "interleaved"] as const)(
     "reports the consumed input and last committed Doctor config hash before exiting (%s)",
     async (outcome) => {

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -197,7 +197,15 @@ async function runDoctorHealthFlowWithResult(
     }
     if (readOnlyConfig) {
       const { createConfigIO } = await import("../config/io.js");
-      ctx.cfg = createConfigIO({ configPath: ctx.configPath, observe: false }).loadConfig();
+      const snapshot = await createConfigIO({
+        configPath: ctx.configPath,
+        observe: false,
+      }).readConfigFileSnapshot();
+      if (!snapshot.valid) {
+        const { createConfigValidationFailedError } = await import("../config/io.write-errors.js");
+        throw createConfigValidationFailedError(snapshot.issues);
+      }
+      ctx.cfg = snapshot.config;
     }
     if (options.repair === true || options.yes === true) {
       // Contributions can report optional migration warnings, but repair must not

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -115,6 +115,7 @@ async function runDoctorHealthFlowWithResult(
     ReturnType<typeof import("../commands/doctor-maintenance.js").beginDoctorMaintenance>
   >;
   let exitCode: number | undefined;
+  let readOnlyConfig = false;
   let doctorResult: UpdatePostInstallDoctorResult = { status: "error" };
   try {
     const { beginDoctorMaintenance } = await import("../commands/doctor-maintenance.js");
@@ -181,7 +182,8 @@ async function runDoctorHealthFlowWithResult(
     };
     const { runDoctorHealthContributions } = await import("./doctor-health-contributions.js");
     await runDoctorHealthContributions(ctx);
-    if (ctx.configWriteRefusal) {
+    readOnlyConfig = ctx.configWriteRefusal === "read-only" && ctx.sourceConfigValid;
+    if (ctx.configWriteRefusal && !readOnlyConfig) {
       // Config fixes were computed but refused by the writer; the warning above
       // already lists the manual work. This failure outranks a recoverable
       // post-install advisory because the run did not converge.
@@ -192,6 +194,10 @@ async function runDoctorHealthFlowWithResult(
       );
       exitCode = 1;
       return;
+    }
+    if (readOnlyConfig) {
+      const { createConfigIO } = await import("../config/io.js");
+      ctx.cfg = createConfigIO({ configPath: ctx.configPath, observe: false }).loadConfig();
     }
     if (options.repair === true || options.yes === true) {
       // Contributions can report optional migration warnings, but repair must not
@@ -228,6 +234,9 @@ async function runDoctorHealthFlowWithResult(
       ),
       ...(ctx.postInstallDoctorResult?.warnings ?? []),
       ...(ctx.updateWarnings ?? []),
+      ...(readOnlyConfig
+        ? [`Config ${ctx.configPath} is read-only; pending config fixes were left unchanged.`]
+        : []),
     ]);
     doctorResult = {
       ...(ctx.postInstallDoctorResult ?? { status: "ok" }),
@@ -272,5 +281,9 @@ async function runDoctorHealthFlowWithResult(
     }
   }
 
-  outro("Doctor complete.");
+  outro(
+    readOnlyConfig
+      ? "Doctor complete. The config is read-only; pending config fixes were left unchanged."
+      : "Doctor complete.",
+  );
 }

--- a/src/flows/doctor-provider-use-binding-write.test.ts
+++ b/src/flows/doctor-provider-use-binding-write.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, expect, it, vi } from "vitest";
 import { createDoctorPrompter } from "../commands/doctor-prompter.js";
 import { prepareProviderUseBindingMigration } from "../commands/doctor/shared/provider-use-binding-migration.js";
+import { readConfigFileSnapshot } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretRef } from "../config/types.secrets.js";
 import {
@@ -135,5 +136,81 @@ it.each(
       env: state.env,
     });
     expect(repeated.warnings?.join("\n")).toContain("byteplus:saved");
+  },
+);
+
+it.each(["models", "providers"] as const)(
+  "defers a selected provider binding owned by a %s include without changing either file",
+  async (includeOwner) => {
+    state = await createOpenClawTestState({
+      label: "doctor-provider-binding-include",
+      env: {
+        BYTEPLUS_API_KEY: "fixture-env-account",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: fileURLToPath(new URL("../../extensions/", import.meta.url)),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "0",
+        OPENCLAW_UPDATE_IN_PROGRESS: undefined,
+      },
+    });
+    const includeName = `${includeOwner}-owned.json`;
+    const includePath = path.join(path.dirname(state.configPath), includeName);
+    const includeContents = `${JSON.stringify(includeOwner === "models" ? { providers: {} } : {}, null, 2)}\n`;
+    await fs.mkdir(path.dirname(includePath), { recursive: true });
+    await fs.writeFile(includePath, includeContents);
+    await state.writeConfig({
+      agents: { defaults: { model: "byteplus-plan/ark-code-latest" }, entries: { main: {} } },
+      models:
+        includeOwner === "models"
+          ? { $include: `./${includeName}` }
+          : { providers: { $include: `./${includeName}` } },
+    });
+    const rootContents = await fs.readFile(state.configPath, "utf8");
+    const snapshot = await readConfigFileSnapshot({ observe: false });
+    expect(snapshot.valid).toBe(true);
+    const prepared = prepareProviderUseBindingMigration({
+      config: snapshot.sourceConfig,
+      configPath: state.configPath,
+      env: state.env,
+    });
+    expect(prepared.bindings).toEqual({
+      "byteplus-plan": { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" },
+    });
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const options = { repair: true, nonInteractive: true };
+    const ctx: DoctorHealthFlowContext = {
+      runtime,
+      options,
+      prompter: createDoctorPrompter({ runtime, options }),
+      cfg: prepared.config,
+      cfgForPersistence: structuredClone(prepared.config),
+      configPath: state.configPath,
+      sourceConfigValid: true,
+      env: state.env,
+      configResult: {
+        cfg: prepared.config,
+        shouldWriteConfig: true,
+        providerUseBindings: prepared.bindings,
+        providerUseBindingMigrationPending: prepared.pending,
+        unsetPaths: prepared.unsetPaths,
+      },
+    };
+
+    await runWriteConfigHealth(ctx, { runPostWriteRepairs: false });
+
+    expect(await fs.readFile(state.configPath, "utf8")).toBe(rootContents);
+    expect(await fs.readFile(includePath, "utf8")).toBe(includeContents);
+    expect(ctx.cfg.models?.providers?.["byteplus-plan"]).toBeUndefined();
+    expect(ctx.configResult.providerUseBindingMigrationPending).toBe(false);
+    const output = note.mock.calls.flat().join("\n");
+    expect(output).toContain("byteplus-plan");
+    expect(output).toContain("BYTEPLUS_API_KEY");
+    expect(output).toContain(includeName);
+    expect(output).not.toContain("Bound selected provider");
+    expect(output).not.toContain("fixture-env-account");
+    const repeated = prepareProviderUseBindingMigration({
+      config: snapshot.sourceConfig,
+      configPath: state.configPath,
+      env: state.env,
+    });
+    expect(repeated.bindings).toEqual(prepared.bindings);
   },
 );

--- a/src/flows/doctor-provider-use-binding-write.test.ts
+++ b/src/flows/doctor-provider-use-binding-write.test.ts
@@ -50,7 +50,7 @@ it.each(
     };
     await state.writeConfig(config);
     const original = await fs.readFile(state.configPath, "utf8");
-    const prepared = await prepareProviderUseBindingMigration({
+    const prepared = prepareProviderUseBindingMigration({
       config,
       configPath: state.configPath,
       env: state.env,
@@ -130,7 +130,7 @@ it.each(
     ]);
     expect(note.mock.calls.flat().join("\n")).not.toContain("Bound selected provider");
     expect(note.mock.calls.flat().join("\n")).not.toContain("fixture-saved-account");
-    const repeated = await prepareProviderUseBindingMigration({
+    const repeated = prepareProviderUseBindingMigration({
       config,
       configPath: state.configPath,
       env: state.env,
@@ -139,9 +139,13 @@ it.each(
   },
 );
 
-it.each(["models", "providers"] as const)(
-  "defers a selected provider binding owned by a %s include without changing either file",
-  async (includeOwner) => {
+it.each(
+  (["models", "providers"] as const).flatMap((includeOwner) =>
+    [false, true].map((repairRoot) => ({ includeOwner, repairRoot })),
+  ),
+)(
+  "defers a selected provider binding owned by a $includeOwner include (root repair: $repairRoot)",
+  async ({ includeOwner, repairRoot }) => {
     state = await createOpenClawTestState({
       label: "doctor-provider-binding-include",
       env: {
@@ -174,19 +178,23 @@ it.each(["models", "providers"] as const)(
     expect(prepared.bindings).toEqual({
       "byteplus-plan": { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" },
     });
+    const cfg = structuredClone(prepared.config);
+    if (repairRoot) {
+      cfg.browser = { enabled: false };
+    }
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
     const options = { repair: true, nonInteractive: true };
     const ctx: DoctorHealthFlowContext = {
       runtime,
       options,
       prompter: createDoctorPrompter({ runtime, options }),
-      cfg: prepared.config,
+      cfg,
       cfgForPersistence: structuredClone(prepared.config),
       configPath: state.configPath,
       sourceConfigValid: true,
       env: state.env,
       configResult: {
-        cfg: prepared.config,
+        cfg,
         shouldWriteConfig: true,
         providerUseBindings: prepared.bindings,
         providerUseBindingMigrationPending: prepared.pending,
@@ -196,8 +204,17 @@ it.each(["models", "providers"] as const)(
 
     await runWriteConfigHealth(ctx, { runPostWriteRepairs: false });
 
-    expect(await fs.readFile(state.configPath, "utf8")).toBe(rootContents);
+    const writtenRoot = await fs.readFile(state.configPath, "utf8");
+    if (repairRoot) {
+      expect(JSON.parse(writtenRoot)).toMatchObject({
+        browser: { enabled: false },
+        models: JSON.parse(rootContents).models,
+      });
+    } else {
+      expect(writtenRoot).toBe(rootContents);
+    }
     expect(await fs.readFile(includePath, "utf8")).toBe(includeContents);
+    expect(ctx.configWriteRefusal).toBeUndefined();
     expect(ctx.cfg.models?.providers?.["byteplus-plan"]).toBeUndefined();
     expect(ctx.configResult.providerUseBindingMigrationPending).toBe(false);
     const output = note.mock.calls.flat().join("\n");

--- a/src/flows/doctor-provider-use-binding-write.test.ts
+++ b/src/flows/doctor-provider-use-binding-write.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, expect, it, vi } from "vitest";
 import { createDoctorPrompter } from "../commands/doctor-prompter.js";
@@ -20,12 +21,20 @@ vi.mock("../commands/onboard-helpers.js", () => ({
 let state: OpenClawTestState;
 afterEach(async () => {
   await state?.cleanup();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
-it.each([false, true])(
-  "retracts an env binding when a saved family account appears before the write (endpoint repair: %s)",
-  async (repairEndpoint) => {
+it.each(
+  [false, true].flatMap((repairEndpoint) =>
+    ["before-write", "temporary-file", "temporary-file-other-root"].map((timing) => ({
+      repairEndpoint,
+      timing,
+    })),
+  ),
+)(
+  "retracts an env binding when an account appears at $timing (endpoint repair: $repairEndpoint)",
+  async ({ repairEndpoint, timing }) => {
     state = await createOpenClawTestState({
       label: "doctor-provider-binding-write",
       env: {
@@ -66,7 +75,7 @@ it.each([false, true])(
       cfgForPersistence: structuredClone(prepared.config),
       configPath: state.configPath,
       sourceConfigValid: true,
-      env: state.env,
+      env: timing === "temporary-file-other-root" ? undefined : state.env,
       configResult: {
         cfg,
         shouldWriteConfig: true,
@@ -75,12 +84,34 @@ it.each([false, true])(
         unsetPaths: prepared.unsetPaths,
       },
     };
-    await state.writeAuthProfiles({
-      version: 1,
-      profiles: {
-        "byteplus:saved": { type: "api_key", provider: "byteplus", key: "fixture-saved-account" },
-      },
-    });
+    const saveAccount = () =>
+      state.writeAuthProfiles({
+        version: 1,
+        profiles: {
+          "byteplus:saved": { type: "api_key", provider: "byteplus", key: "fixture-saved-account" },
+        },
+      });
+    if (timing === "before-write") {
+      await saveAccount();
+    } else {
+      const writeFile = fs.writeFile;
+      let saved = false;
+      vi.spyOn(fs, "writeFile").mockImplementation(async (file, data, fileOptions) => {
+        await writeFile(file, data, fileOptions);
+        if (
+          !saved &&
+          typeof data === "string" &&
+          data.includes('"byteplus-plan"') &&
+          data.includes('"BYTEPLUS_API_KEY"')
+        ) {
+          saved = true;
+          await saveAccount();
+          if (timing === "temporary-file-other-root") {
+            process.env.OPENCLAW_STATE_DIR = path.join(state.stateDir, "other-root");
+          }
+        }
+      });
+    }
 
     await runWriteConfigHealth(ctx, { runPostWriteRepairs: false });
 

--- a/src/flows/doctor-provider-use-binding-write.test.ts
+++ b/src/flows/doctor-provider-use-binding-write.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, expect, it, vi } from "vitest";
+import { resolveProviderUseAdmission } from "../agents/provider-model-auth-source-plan.js";
 import { createDoctorPrompter } from "../commands/doctor-prompter.js";
 import {
   prepareProviderUseBindingMigration,
@@ -27,6 +28,53 @@ afterEach(async () => {
   vi.restoreAllMocks();
   vi.clearAllMocks();
 });
+
+it.each(["amazon-bedrock", "amazon-bedrock-mantle", "google-vertex"])(
+  "persists the empty %s declaration before completion and preserves it through later repairs",
+  async (provider) => {
+    state = await createOpenClawTestState({
+      label: "doctor-chain-binding-write",
+      env: {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: fileURLToPath(new URL("../../extensions/", import.meta.url)),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "0",
+        OPENCLAW_UPDATE_IN_PROGRESS: undefined,
+      },
+    });
+    const { prepareDoctorContext } = await import("../commands/doctor-config-flow.test-support.js");
+    await state.writeConfig({
+      agents: { defaults: { model: `${provider}/fixture` }, entries: { main: {} } },
+      gateway: { mode: "local" },
+    });
+    const context = await prepareDoctorContext(state.configPath);
+    expect(context.cfg.models?.providers?.[provider]).toEqual({ baseUrl: "", models: [] });
+
+    await runWriteConfigHealth(context, { runPostWriteRepairs: false });
+
+    const persisted: OpenClawConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+    expect(persisted.models?.providers).toEqual({ [provider]: {} });
+    expect(resolveProviderUseAdmission({ config: persisted, env: {} }).get(provider)).toEqual({
+      kind: "provider-config",
+    });
+    expect(
+      prepareProviderUseBindingMigration({
+        config: persisted,
+        configPath: state.configPath,
+        env: state.env,
+      }).pending,
+    ).toBe(false);
+
+    context.cfg.gateway = { ...context.cfg.gateway, port: 19491 };
+    await runWriteConfigHealth(context, { runPostWriteRepairs: false });
+    const afterRepair: OpenClawConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+    expect(afterRepair.models?.providers).toEqual({ [provider]: {} });
+    expect(afterRepair.gateway?.port).toBe(19491);
+
+    const written = await fs.readFile(state.configPath, "utf8");
+    const repeat = await prepareDoctorContext(state.configPath);
+    await runWriteConfigHealth(repeat, { runPostWriteRepairs: false });
+    expect(await fs.readFile(state.configPath, "utf8")).toBe(written);
+  },
+);
 
 it("warns on a read-only config lock without writing a binding or completion receipt", async () => {
   state = await createOpenClawTestState({

--- a/src/flows/doctor-provider-use-binding-write.test.ts
+++ b/src/flows/doctor-provider-use-binding-write.test.ts
@@ -3,10 +3,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, expect, it, vi } from "vitest";
 import { createDoctorPrompter } from "../commands/doctor-prompter.js";
-import { prepareProviderUseBindingMigration } from "../commands/doctor/shared/provider-use-binding-migration.js";
+import {
+  prepareProviderUseBindingMigration,
+  type ProviderUseBindingMigrationBindings,
+} from "../commands/doctor/shared/provider-use-binding-migration.js";
 import { readConfigFileSnapshot } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { SecretRef } from "../config/types.secrets.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -24,6 +26,65 @@ afterEach(async () => {
   await state?.cleanup();
   vi.restoreAllMocks();
   vi.clearAllMocks();
+});
+
+it("warns on a read-only config lock without writing a binding or completion receipt", async () => {
+  state = await createOpenClawTestState({
+    label: "readonly-provider-binding",
+    env: {
+      BYTEPLUS_API_KEY: "fixture-env-account",
+      OPENCLAW_BUNDLED_PLUGINS_DIR: fileURLToPath(new URL("../../extensions/", import.meta.url)),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "0",
+    },
+  });
+  const config: OpenClawConfig = {
+    agents: { defaults: { model: "byteplus-plan/ark-code-latest" }, entries: { main: {} } },
+  };
+  await state.writeConfig(config);
+  const original = await fs.readFile(state.configPath, "utf8");
+  const prepared = prepareProviderUseBindingMigration({
+    config,
+    configPath: state.configPath,
+    env: state.env,
+  });
+  expect(prepared.bindings).toHaveProperty("byteplus-plan");
+  const open = fs.open;
+  vi.spyOn(fs, "open").mockImplementation((file, ...args) => {
+    if (String(file) === `${state.configPath}.lock`) {
+      return Promise.reject(
+        Object.assign(new Error("read-only filesystem"), { code: "EROFS", path: String(file) }),
+      );
+    }
+    return open(file, ...args);
+  });
+  const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+  const options = { repair: true, nonInteractive: true };
+  const ctx: DoctorHealthFlowContext = {
+    runtime,
+    options,
+    prompter: createDoctorPrompter({ runtime, options }),
+    cfg: prepared.config,
+    cfgForPersistence: config,
+    configPath: state.configPath,
+    sourceConfigValid: true,
+    env: state.env,
+    configResult: {
+      cfg: prepared.config,
+      shouldWriteConfig: true,
+      providerUseBindings: prepared.bindings,
+      providerUseBindingMigrationPending: prepared.pending,
+    },
+  };
+  await expect(runWriteConfigHealth(ctx, { runPostWriteRepairs: false })).resolves.toBeUndefined();
+  expect(await fs.readFile(state.configPath, "utf8")).toBe(original);
+  expect(note).toHaveBeenCalledWith(
+    expect.stringContaining(`read-only config ${state.configPath}`),
+    "Doctor warnings",
+  );
+  expect(
+    prepareProviderUseBindingMigration({ config, configPath: state.configPath, env: state.env })
+      .pending,
+  ).toBe(true);
 });
 
 it.each(
@@ -55,11 +116,11 @@ it.each(
       configPath: state.configPath,
       env: state.env,
     });
-    const bindings: Record<string, SecretRef> = {
-      "byteplus-plan": { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" },
+    const bindings: ProviderUseBindingMigrationBindings = {
+      "byteplus-plan": { apiKey: { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" } },
     };
     expect(prepared.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(
-      bindings["byteplus-plan"],
+      bindings["byteplus-plan"]?.apiKey,
     );
     const endpoint = "https://example.com/repaired-provider";
     const cfg = structuredClone(prepared.config);
@@ -176,7 +237,7 @@ it.each(
       env: state.env,
     });
     expect(prepared.bindings).toEqual({
-      "byteplus-plan": { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" },
+      "byteplus-plan": { apiKey: { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" } },
     });
     const cfg = structuredClone(prepared.config);
     if (repairRoot) {

--- a/src/flows/doctor-provider-use-binding-write.test.ts
+++ b/src/flows/doctor-provider-use-binding-write.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { afterEach, expect, it, vi } from "vitest";
+import { createDoctorPrompter } from "../commands/doctor-prompter.js";
+import { prepareProviderUseBindingMigration } from "../commands/doctor/shared/provider-use-binding-migration.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretRef } from "../config/types.secrets.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { runWriteConfigHealth } from "./doctor-health-contribution-runners.config.js";
+import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
+
+const note = vi.hoisted(() => vi.fn());
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
+vi.mock("../commands/onboard-helpers.js", () => ({
+  applyWizardMetadata: (config: OpenClawConfig) => config,
+}));
+let state: OpenClawTestState;
+afterEach(async () => {
+  await state?.cleanup();
+  vi.clearAllMocks();
+});
+
+it.each([false, true])(
+  "retracts an env binding when a saved family account appears before the write (endpoint repair: %s)",
+  async (repairEndpoint) => {
+    state = await createOpenClawTestState({
+      label: "doctor-provider-binding-write",
+      env: {
+        BYTEPLUS_API_KEY: "fixture-env-account",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: fileURLToPath(new URL("../../extensions/", import.meta.url)),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "0",
+        OPENCLAW_UPDATE_IN_PROGRESS: undefined,
+      },
+    });
+    const config: OpenClawConfig = {
+      agents: { defaults: { model: "byteplus-plan/ark-code-latest" }, entries: { main: {} } },
+    };
+    await state.writeConfig(config);
+    const original = await fs.readFile(state.configPath, "utf8");
+    const prepared = await prepareProviderUseBindingMigration({
+      config,
+      configPath: state.configPath,
+      env: state.env,
+    });
+    const bindings: Record<string, SecretRef> = {
+      "byteplus-plan": { source: "env", provider: "default", id: "BYTEPLUS_API_KEY" },
+    };
+    expect(prepared.config.models?.providers?.["byteplus-plan"]?.apiKey).toEqual(
+      bindings["byteplus-plan"],
+    );
+    const endpoint = "https://example.com/repaired-provider";
+    const cfg = structuredClone(prepared.config);
+    if (repairEndpoint && cfg.models?.providers?.["byteplus-plan"]) {
+      cfg.models.providers["byteplus-plan"].baseUrl = endpoint;
+    }
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const options = { repair: true, nonInteractive: true };
+    const ctx: DoctorHealthFlowContext = {
+      runtime,
+      options,
+      prompter: createDoctorPrompter({ runtime, options }),
+      cfg,
+      cfgForPersistence: structuredClone(prepared.config),
+      configPath: state.configPath,
+      sourceConfigValid: true,
+      env: state.env,
+      configResult: {
+        cfg,
+        shouldWriteConfig: true,
+        providerUseBindings: bindings,
+        providerUseBindingMigrationPending: prepared.pending,
+        unsetPaths: prepared.unsetPaths,
+      },
+    };
+    await state.writeAuthProfiles({
+      version: 1,
+      profiles: {
+        "byteplus:saved": { type: "api_key", provider: "byteplus", key: "fixture-saved-account" },
+      },
+    });
+
+    await runWriteConfigHealth(ctx, { runPostWriteRepairs: false });
+
+    expect(ctx.cfg.models?.providers?.["byteplus-plan"]?.apiKey).toBeUndefined();
+    expect(ctx.configResult.providerUseBindingMigrationPending).toBe(false);
+    const written = await fs.readFile(state.configPath, "utf8");
+    if (repairEndpoint) {
+      expect(JSON.parse(written).models.providers["byteplus-plan"]).toEqual({ baseUrl: endpoint });
+    } else {
+      expect(written).toBe(original);
+    }
+    expect(note.mock.calls).toContainEqual([
+      expect.stringContaining("byteplus:saved"),
+      "Doctor warnings",
+    ]);
+    expect(note.mock.calls.flat().join("\n")).not.toContain("Bound selected provider");
+    expect(note.mock.calls.flat().join("\n")).not.toContain("fixture-saved-account");
+    const repeated = await prepareProviderUseBindingMigration({
+      config,
+      configPath: state.configPath,
+      env: state.env,
+    });
+    expect(repeated.warnings?.join("\n")).toContain("byteplus:saved");
+  },
+);

--- a/src/gateway/gateway-auth-recovery.test.ts
+++ b/src/gateway/gateway-auth-recovery.test.ts
@@ -383,6 +383,7 @@ describe("Gateway configured catalog authentication", () => {
               OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
               OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
               OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+              OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
             },
           });
           const gateway = instance;
@@ -428,6 +429,8 @@ describe("Gateway configured catalog authentication", () => {
           const startupStarted = performance.now();
           await gateway.startGateway();
           const startupMs = performance.now() - startupStarted;
+          const startupRssMb = readProcessRssMb(gateway.child?.pid);
+          expect(startupRssMb).toBeGreaterThan(0);
           client = await acquireGatewayTestClient(
             {
               url: gateway.url,
@@ -444,24 +447,40 @@ describe("Gateway configured catalog authentication", () => {
             },
           );
           const expectedIds = new Set(models.map((model) => model.id));
+          const postReadyModels = new Map<string, ModelChoice[]>();
           let returnedRows = 0;
           const rpcStarted = performance.now();
-          for (const agentId of agentIds) {
-            const result = await client.request<{ models: ModelChoice[] }>(
-              "models.list",
-              { agentId, view: "configured" },
-              { timeoutMs: 30_000 },
-            );
-            const configured = result.models.filter(
-              (model) => model.provider === provider.providerId,
-            );
-            expect(configured, agentId).toHaveLength(models.length);
-            expect(new Set(configured.map((model) => model.id)), agentId).toEqual(expectedIds);
-            expect(
-              configured.every((model) => model.available === true),
-              agentId,
-            ).toBe(true);
-            returnedRows += configured.length;
+          for (const phase of ["startup", "background", "refresh"] as const) {
+            if (phase === "background") {
+              await expect
+                .poll(() => gateway.logs(), { timeout: 60_000 })
+                .toContain("startup trace: sidecars.model-catalog ");
+            }
+            returnedRows = 0;
+            for (const agentId of agentIds) {
+              const result = await client.request<{ models: ModelChoice[] }>(
+                "models.list",
+                { agentId, view: "configured", ...(phase === "refresh" ? { refresh: true } : {}) },
+                { timeoutMs: 30_000 },
+              );
+              expect(result).not.toHaveProperty("refreshFailed", true);
+              if (phase === "background") {
+                postReadyModels.set(agentId, result.models);
+              } else if (phase === "refresh") {
+                expect(result.models, agentId).toEqual(postReadyModels.get(agentId));
+              }
+              const configured = result.models.filter(
+                (model) => model.provider === provider.providerId,
+              );
+              expect(configured, agentId).toHaveLength(models.length);
+              expect(new Set(configured.map((model) => model.id)), agentId).toEqual(expectedIds);
+              expect(
+                configured.every((model) => model.available === true),
+                agentId,
+              ).toBe(true);
+              returnedRows += configured.length;
+            }
+            expect(returnedRows, phase).toBe(4_400);
           }
           const rpcElapsedMs = performance.now() - rpcStarted;
           const gatewayRssMb = readProcessRssMb(gateway.child?.pid);
@@ -473,10 +492,12 @@ describe("Gateway configured catalog authentication", () => {
               head,
               configuredModels: models.length,
               agents: agentIds.length,
-              rpcRequests: agentIds.length,
+              rpcRequests: agentIds.length * 3,
+              verifiedPhases: ["startup", "background", "refresh"],
               returnedRows,
               allAvailable: true,
               startupMs,
+              startupRssMb,
               rpcElapsedMs,
               gatewayRssMb,
               upstreamRequests,

--- a/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
@@ -75,14 +75,21 @@ beforeEach(async () => {
   state = await createOpenClawTestState({ label: "prepared-model-runtime" });
   await resetPreparedModelRuntimeHarness(state);
   mocks.configuredAgentIds = ["main"];
+  const preparedOAuth = {
+    type: "oauth" as const,
+    access: "prepared-access",
+    refresh: "prepared-refresh",
+    expires: Date.now() + 30 * 60_000,
+  };
   mocks.authStorage.getAll.mockReturnValue({
-    openai: {
-      type: "oauth",
-      access: "prepared-access",
-      refresh: "prepared-refresh",
-      expires: Date.now() + 30 * 60_000,
-    },
+    openai: preparedOAuth,
   });
+  mocks.preparedAuthStore = {
+    version: 1,
+    profiles: {
+      "openai:default": { ...preparedOAuth, provider: "openai" },
+    },
+  };
   mocks.buildPreparedModelCatalogSnapshot.mockResolvedValue({
     entries: [model],
     routeVariants: [model],

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -546,7 +546,21 @@ describe("gateway chat metadata runtime", () => {
   test.each(["before", "after"] as const)(
     "converges to models.list availability when owner auth publishes %s attachment",
     async (publicationOrder) => {
-      const harness = createChatMetadataHarness(undefined, { useDefaultProjection: true });
+      const harness = createChatMetadataHarness(
+        {
+          agents: { list: [{ id: "main", default: true }] },
+          models: {
+            providers: {
+              openai: {
+                api: "openai-chatgpt-responses",
+                baseUrl: "https://chatgpt.com/backend-api/codex",
+                models: [],
+              },
+            },
+          },
+        },
+        { useDefaultProjection: true },
+      );
       harness.setAuthStore({ version: 1, profiles: {} });
       const preparedOwner = createChatMetadataOwner(
         harness.getPreparedOwner()!.config,
@@ -663,7 +677,19 @@ describe("gateway chat metadata runtime", () => {
   });
 
   test("keeps a locked session unavailable while the neutral prepared route is usable", async () => {
-    const harness = createChatMetadataHarness(createOpenAIChatMetadataConfig(), {
+    const config: OpenClawConfig = {
+      ...createOpenAIChatMetadataConfig(),
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://chatgpt.com/backend-api/codex",
+            models: [],
+          },
+        },
+      },
+    };
+    const harness = createChatMetadataHarness(config, {
       useDefaultProjection: true,
     });
     harness.setOwner(

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -188,6 +188,8 @@ function sessionProjectionKey(
     profiles.pinnedProfileId ?? "",
     profiles.profileProvider ?? "",
     profiles.runtimeOverride ?? "",
+    profiles.selectedModel?.provider ?? "",
+    profiles.selectedModel?.model ?? "",
   ].join("\0");
 }
 
@@ -196,7 +198,8 @@ function hasSessionCatalogContext(profiles: ReturnType<typeof resolveSessionCata
     profiles.preferredProfileId !== undefined ||
     profiles.pinnedProfileId !== undefined ||
     profiles.profileProvider !== undefined ||
-    profiles.runtimeOverride !== undefined
+    profiles.runtimeOverride !== undefined ||
+    profiles.selectedModel !== undefined
   );
 }
 

--- a/src/gateway/server-methods/chat-metadata-session-projection.ts
+++ b/src/gateway/server-methods/chat-metadata-session-projection.ts
@@ -3,6 +3,7 @@ import type { PreparedAgentCredentialModes } from "../../agents/agent-auth-crede
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { readSessionRuntimeOwnership } from "../../agents/harness/session-runtime-ownership.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import type { ModelRef } from "../../agents/model-ref-shared.js";
 import { getPreparedModelRuntimeAuthMaterializations } from "../../agents/prepared-model-runtime-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
 import { resolveSessionModelRef } from "../../agents/session-model-ref.js";
@@ -36,6 +37,7 @@ export async function prepareChatMetadataModelProjection(params: {
   preferredProfileId?: string;
   pinnedProfileId?: string;
   profileProvider?: string;
+  selectedModel?: ModelRef;
   runtimeOverride?: string;
   assertCurrent?: () => void;
 }): Promise<PreparedAgentProjection<{ models?: ModelChoice[] }>> {
@@ -48,6 +50,7 @@ export async function prepareChatMetadataModelProjection(params: {
   const snapshot = params.facts.modelCatalog;
   const projector = createGatewayAgentModelCatalogProjector({
     cfg: params.facts.owner.config,
+    selectedModel: params.selectedModel,
     agentId: params.facts.agentId,
     snapshot,
     metadataSnapshot: params.facts.owner.metadataSnapshot,
@@ -97,6 +100,7 @@ export function resolveSessionCatalogProfiles(
   pinnedProfileId?: string;
   profileProvider?: string;
   runtimeOverride?: string;
+  selectedModel?: ModelRef;
 } {
   const profileId = sessionEntry?.authProfileOverride?.trim();
   const runtime = sessionEntry?.agentRuntimeOverride?.trim();
@@ -108,6 +112,13 @@ export function resolveSessionCatalogProfiles(
         }).provider
       : undefined);
   const context = {
+    ...(sessionEntry?.modelOverride
+      ? {
+          selectedModel: resolveSessionModelRef(config, sessionEntry, agentId, {
+            allowPluginNormalization: false,
+          }),
+        }
+      : {}),
     ...(provider ? { profileProvider: provider } : {}),
     ...(runtime ? { runtimeOverride: runtime } : {}),
   };

--- a/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
+++ b/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
@@ -49,7 +49,9 @@ async function listClaudeCliModel(
       (params.pluginDisabled
         ? { ...config, plugins: { entries: { anthropic: { enabled: false } } } }
         : config),
-    preparedAuthModes: params.authenticated ? { "claude-cli": "api_key" } : {},
+    preparedAuthModes: params.authenticated
+      ? { "claude-cli": { source: "native", mode: "oauth" } }
+      : {},
     catalogComplete: true,
     view: "configured",
   });
@@ -66,7 +68,9 @@ async function listDirectClaudeCliModel(params: {
     catalog: [providerCatalogEntry("claude-cli", "claude-opus-5")],
     cfg,
     preparedAuthModes:
-      params.authenticated && !params.pluginDisabled ? { "claude-cli": "oauth" } : {},
+      params.authenticated && !params.pluginDisabled
+        ? { "claude-cli": { source: "native", mode: "oauth" } }
+        : {},
     catalogComplete: true,
     view: "all",
   });
@@ -241,7 +245,7 @@ describe("models.list CLI runtime availability", () => {
             workspaceDir: state.workspaceDir,
             catalog: [providerCatalogEntry("anthropic", "claude-opus-5")],
             catalogComplete: true,
-            preparedAuthModes: expired ? { "claude-cli": "oauth" } : {},
+            preparedAuthModes: expired ? { "claude-cli": { source: "native", mode: "oauth" } } : {},
           });
           const snapshot = await loadDeferredCatalog(context, "main", { readOnly: true });
           const result = await buildModelsListResult({
@@ -297,8 +301,14 @@ describe("models.list CLI runtime availability", () => {
       scenario: "canonical pin",
       provider: "anthropic",
       pinProvider: "anthropic",
-      expired: true,
       available: true,
+    },
+    {
+      scenario: "canonical pin awaiting refresh",
+      provider: "anthropic",
+      pinProvider: "anthropic",
+      expired: true,
+      available: false,
     },
     {
       scenario: "CLI pin",
@@ -353,7 +363,7 @@ describe("models.list CLI runtime availability", () => {
           workspaceDir: state.workspaceDir,
           catalog: [providerCatalogEntry(provider, modelId)],
           catalogComplete: true,
-          preparedAuthModes: { "claude-cli": "oauth" },
+          preparedAuthModes: { "claude-cli": { source: "native", mode: "oauth" } },
         });
         const snapshot = await loadDeferredCatalog(context, "main", { readOnly: true });
         const result = await buildModelsListResult({

--- a/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
+++ b/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
@@ -19,32 +19,36 @@ const emptyAuthStore = { version: 1, profiles: {} } as const;
 describe("models.list provider catalog outcomes", () => {
   it.each([
     {
-      name: "implicit provider",
-      providers: undefined,
+      name: "declared local connection",
+      providers: { ollama: { baseUrl: "http://127.0.0.1:11434", models: [] } },
       baseUrl: "http://127.0.0.1:11434",
       available: true,
+      authStore: emptyAuthStore,
     },
     {
       name: "empty provider config",
       providers: { ollama: {} },
       baseUrl: "http://127.0.0.1:11434",
       available: true,
+      authStore: emptyAuthStore,
     },
     {
       name: "remote route without credentials",
       providers: undefined,
       baseUrl: "https://ollama.example.com",
       available: false,
+      authStore: emptyAuthStore,
     },
     {
       name: "explicit auth ownership without credentials",
       providers: { ollama: { auth: "token" as const } },
       baseUrl: "http://127.0.0.1:11434",
       available: false,
+      authStore: emptyAuthStore,
     },
   ])(
     "projects a discovered Ollama model with $name as available=$available",
-    async ({ providers, baseUrl, available }) => {
+    async ({ providers, baseUrl, available, authStore }) => {
       const config = {
         ...(providers ? { models: { providers } } : {}),
         agents: { defaults: { models: { "ollama/qwen3.5": {} } } },
@@ -64,7 +68,7 @@ describe("models.list provider catalog outcomes", () => {
         metadataSnapshot: createPluginMetadataSnapshotFixture({
           plugins: [{ id: "ollama", providers: ["ollama"], syntheticAuthRefs: ["ollama"] }],
         }),
-        preparedAuthStore: emptyAuthStore,
+        preparedAuthStore: authStore,
       });
       const context = {
         getRuntimeConfig: () => config,

--- a/src/gateway/server-methods/models-list-result.session-binding.test.ts
+++ b/src/gateway/server-methods/models-list-result.session-binding.test.ts
@@ -1,0 +1,165 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, expect, it, vi } from "vitest";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import {
+  createModelsListTestContext,
+  providerCatalogEntry,
+  WITHOUT_OPENAI_ENV_AUTH,
+} from "./models-list-result.openai-routes.test-support.js";
+import { modelsHandlers } from "./models.js";
+import type { RespondFn } from "./types.js";
+
+const liveCatalog = vi.hoisted(() => vi.fn());
+vi.mock("../../agents/prepared-model-runtime.scoped-catalog.js", () => ({
+  prepareScopedReadOnlyLiveModelCatalog: liveCatalog,
+  prepareScopedReadOnlyModelCatalog: () => {
+    throw new Error("Unexpected static acquisition");
+  },
+}));
+afterEach(() => vi.clearAllMocks());
+
+it.each(["default", "all", "refresh"] as const)(
+  "admits a saved family account only for the session-selected provider in %s listings",
+  async (view) => {
+    await withOpenClawTestState(
+      {
+        label: "session-provider-catalog",
+        env: { ...WITHOUT_OPENAI_ENV_AUTH, BYTEPLUS_API_KEY: undefined },
+      },
+      async (state) => {
+        const cfg: OpenClawConfig = {
+          agents: { defaults: { model: "test/unrelated" }, entries: { main: {} } },
+        };
+        await state.writeConfig(cfg);
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: {
+            "byteplus:saved": {
+              type: "api_key",
+              provider: "byteplus",
+              key: "fixture-saved-account",
+            },
+          },
+        });
+        const sessionKey = "agent:main:family-pin";
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          {
+            sessionId: "family-pin",
+            updatedAt: 1,
+            providerOverride: "byteplus-plan",
+            modelOverride: "ark-code-latest",
+            modelOverrideSource: "user",
+          },
+        );
+        const selected = providerCatalogEntry("byteplus-plan", "ark-code-latest");
+        const sibling = providerCatalogEntry("byteplus-other", "unselected-model");
+        const dynamic = providerCatalogEntry("byteplus-plan", "account-only-model");
+        const metadataSnapshot = createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: "byteplus",
+              providers: ["byteplus", "byteplus-plan", "byteplus-other"],
+              providerAuthAliases: { "byteplus-plan": "byteplus", "byteplus-other": "byteplus" },
+              setup: { providers: [{ id: "byteplus", envVars: ["BYTEPLUS_API_KEY"] }] },
+            },
+          ],
+        });
+        const context = createModelsListTestContext({
+          cfg,
+          agentDir: state.agentDir(),
+          workspaceDir: state.workspaceDir,
+          metadataSnapshot,
+          catalog: [],
+          staticEntries: [selected, sibling],
+        });
+        liveCatalog.mockResolvedValue({
+          entries: [dynamic, sibling],
+          routeVariants: [dynamic, sibling],
+        });
+        const request = async (params: Record<string, unknown>) => {
+          const respond = vi.fn<RespondFn>();
+          await expectDefined(
+            modelsHandlers["models.list"],
+            "models.list handler",
+          )({
+            req: { type: "req", id: "session-provider-catalog", method: "models.list", params },
+            params,
+            context,
+            client: null,
+            respond,
+            isWebchatConnect: () => false,
+          });
+          return respond;
+        };
+
+        const pinned = await request({
+          sessionKey,
+          view: view === "refresh" ? "all" : view,
+          includeDetails: true,
+          ...(view === "refresh" ? { refresh: true } : {}),
+        });
+
+        expect(pinned).toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({
+            models: expect.arrayContaining([
+              expect.objectContaining({
+                provider: "byteplus-plan",
+                id: selected.id,
+                available: true,
+              }),
+            ]),
+          }),
+          undefined,
+        );
+        expect(pinned).not.toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({
+            models: expect.arrayContaining([
+              expect.objectContaining({ provider: "byteplus-other", available: true }),
+            ]),
+          }),
+          undefined,
+        );
+        if (view === "refresh") {
+          expect(liveCatalog).toHaveBeenCalledWith(
+            expect.objectContaining({ config: cfg, readOnly: true }),
+            ["byteplus-plan"],
+            expect.objectContaining({
+              requestedProviderIds: ["byteplus-plan"],
+              authStore: expect.objectContaining({
+                profiles: expect.objectContaining({ "byteplus:saved": expect.anything() }),
+              }),
+            }),
+          );
+          expect(pinned).toHaveBeenCalledWith(
+            true,
+            expect.objectContaining({
+              models: expect.arrayContaining([
+                expect.objectContaining({ id: dynamic.id, available: true }),
+              ]),
+            }),
+            undefined,
+          );
+        } else {
+          expect(liveCatalog).not.toHaveBeenCalled();
+        }
+        const unscoped = await request({ agentId: "main", view: "all", includeDetails: true });
+        expect(unscoped).not.toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({
+            models: expect.arrayContaining([
+              expect.objectContaining({ provider: "byteplus-plan", available: true }),
+            ]),
+          }),
+          undefined,
+        );
+        expect(cfg.models?.providers).toBeUndefined();
+      },
+    );
+  },
+);

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -1,4 +1,5 @@
 // Resolves public model catalogs without exposing runtime-only provider params.
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type {
   ModelChoice,
   ModelsListParams,

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -1,5 +1,4 @@
 // Resolves public model catalogs without exposing runtime-only provider params.
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type {
   ModelChoice,
   ModelsListParams,
@@ -583,15 +582,8 @@ export async function prepareModelsListResult(
       return () => {
         const evaluation = evaluateNative(entry, host);
         evaluations.set(resolveModelCatalogIdentityKey(entry), evaluation);
-        const routeManaged = evaluation.routeResolution !== null;
-        const syntheticLocal =
-          !routeManaged &&
-          normalizeProviderId(entry.provider) !== "openai" &&
-          evaluation.availability === undefined &&
-          evaluation.evidence === "synthetic";
         return resolveLogicalModelCatalogEntryState({
           evaluation,
-          authBacked: evaluation.availability === true || syntheticLocal,
           routePolicy: openAIModelCatalogRoutePolicy,
         });
       };

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -5,7 +5,11 @@ import type {
   ModelsListParams,
   ModelsListResult,
 } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../../agents/agent-scope.js";
 import type { RuntimeAuthMaterialization } from "../../agents/auth-profiles/runtime-materializations.js";
 import { resolveConfiguredModelEntries } from "../../agents/configured-model-entries.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
@@ -364,38 +368,75 @@ export async function prepareModelsListResult(
       : {}),
   });
   snapshot = preparedCatalog.snapshot;
-  const { defaultModel } = preparedCatalog;
+  const defaultModel = profiles.selectedModel
+    ? modelKey(profiles.selectedModel.provider, profiles.selectedModel.model)
+    : preparedCatalog.defaultModel;
   const preparedRuntimeAuthModes = preparedProjectionOwner?.authModes;
   const preparedRuntimeAuthMaterializations = preparedProjectionOwner?.authMaterializations;
   // Capture authority again after acquisition and before hydrating a personal projection.
   draft?.assertCurrent();
-  const projector =
+  const projectionParams: ModelCatalogDecisionParams = {
+    cfg,
+    agentId,
+    agentDir: sourceOwner?.agentDir,
+    workspaceDir,
+    snapshot: { ...snapshot, entries: preparedCatalog.catalog },
+    metadataSnapshot,
+    preparedAuthStore,
+    preparedRuntimeAuthModes,
+    preparedRuntimeAuthMaterializations,
+    // A complete catalog and its synthetic-auth probes cross the worker boundary together.
+    preparedSyntheticAuthComplete: publishedOwner
+      ? isPreparedModelCatalogFull(publishedOwner.modelCatalog)
+      : ownerSnapshot?.catalogComplete === true,
+    // Provider-config inventory describes shared authored configuration, not personal accounts.
+    requesterProfileId:
+      view === "provider-config" || !useRequesterDefaults
+        ? undefined
+        : (draft?.owner ?? params.requesterProfileId),
+    ...(view === "provider-config" ? {} : profiles),
+    routeResolverFactory: params.routeResolverFactory,
+    pluginRegistry: preparedPluginRegistry,
+    isCurrent,
+    observationConfig: preparedProjectionOwner?.observationConfig,
+  };
+  let projector =
     (usedPreloadedCatalog ? params.catalogProjector : undefined) ??
-    createGatewayAgentModelCatalogProjector({
-      cfg,
-      agentId,
-      agentDir: sourceOwner?.agentDir,
-      workspaceDir,
-      snapshot: { ...snapshot, entries: preparedCatalog.catalog },
-      metadataSnapshot,
-      preparedAuthStore,
-      preparedRuntimeAuthModes,
-      preparedRuntimeAuthMaterializations,
-      // A complete catalog and its synthetic-auth probes cross the worker boundary together.
-      preparedSyntheticAuthComplete: publishedOwner
-        ? isPreparedModelCatalogFull(publishedOwner.modelCatalog)
-        : ownerSnapshot?.catalogComplete === true,
-      // Provider-config inventory describes shared authored configuration, not personal accounts.
-      requesterProfileId:
-        view === "provider-config" || !useRequesterDefaults
-          ? undefined
-          : (draft?.owner ?? params.requesterProfileId),
-      ...(view === "provider-config" ? {} : profiles),
-      routeResolverFactory: params.routeResolverFactory,
-      pluginRegistry: preparedPluginRegistry,
-      isCurrent,
-      observationConfig: preparedProjectionOwner?.observationConfig,
-    });
+    createGatewayAgentModelCatalogProjector(projectionParams);
+  if (refresh && !params.preloadedOnly && view !== "provider-config" && profiles.selectedModel) {
+    const { prepareScopedReadOnlyLiveModelCatalog } =
+      await import("../../agents/prepared-model-runtime.scoped-catalog.js");
+    const provider = normalizeProviderId(profiles.selectedModel.provider);
+    const selected = await prepareScopedReadOnlyLiveModelCatalog(
+      {
+        config: cfg,
+        agentId,
+        agentDir: sourceOwner?.agentDir ?? resolveAgentDir(cfg, agentId),
+        workspaceDir,
+        readOnly: true,
+      },
+      [provider],
+      { requestedProviderIds: [provider], metadataSnapshot, authStore: projector.authStore },
+    );
+    const belongsToSelection = (entry: { provider: string }) =>
+      normalizeProviderId(entry.provider) === provider;
+    snapshot = {
+      ...snapshot,
+      entries: dedupeModelCatalogEntries([
+        ...projectionParams.snapshot.entries,
+        ...selected.entries.filter(belongsToSelection),
+      ]),
+      routeVariants: [
+        ...snapshot.routeVariants.filter((entry) => !belongsToSelection(entry)),
+        ...selected.routeVariants.filter(belongsToSelection),
+      ],
+      providerOutcomes: [
+        ...(snapshot.providerOutcomes ?? []).filter((entry) => !belongsToSelection(entry)),
+        ...(selected.providerOutcomes ?? []).filter(belongsToSelection),
+      ],
+    };
+    projector = createGatewayAgentModelCatalogProjector({ ...projectionParams, snapshot });
+  }
   const catalog = dedupeModelCatalogEntries([
     ...preparedCatalog.catalog,
     ...projector.snapshot.entries,

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1869,7 +1869,7 @@ describe("startGatewayPostAttachRuntime", () => {
   it.each(["complete", "before readiness", "between agents"] as const)(
     "keeps catalog acquisition after readiness and stops at %s",
     async (stopAt) => {
-      const ready = createDeferred<void>();
+      const ready = createDeferred();
       const firstCatalog = createDeferred<{ entries: []; routeVariants: [] }>();
       const cfg: OpenClawConfig = { agents: { entries: { main: {}, second: {} } } };
       hoisted.acquireModelCatalog.mockImplementationOnce(() => firstCatalog.promise);
@@ -1919,7 +1919,7 @@ describe("startGatewayPostAttachRuntime", () => {
     ["config replaced", new PreparedModelCatalogConfigReplacedError("/tmp/agent"), 1],
     ["retired owner", new Error("lifetime closed"), 1],
   ] as const)("contains %s catalog failure after readiness", async (kind, error, calls) => {
-    const ready = createDeferred<void>();
+    const ready = createDeferred();
     const cfg: OpenClawConfig = { agents: { entries: { main: {}, second: {} } } };
     hoisted.catalogOwnerIsCurrent.mockReturnValue(kind !== "retired owner");
     hoisted.acquireModelCatalog.mockRejectedValueOnce(error);

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -10,8 +10,11 @@ import {
   createInfoWarnErrorLogger,
 } from "../../test/helpers/mock-logger.js";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { PreparedModelCatalogConfigReplacedError } from "../agents/prepared-model-catalog.errors.js";
+import { PreparedModelRuntimePublicationSupersededError } from "../agents/prepared-model-runtime.errors.js";
 import * as configPaths from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createAbortError } from "../infra/abort-signal.js";
 import { writeRestartSentinel } from "../infra/restart-sentinel.js";
 import type { PluginHookGatewayContext, PluginHookHandlerMap } from "../plugins/hook-types.js";
 import { registerPluginHttpRoute } from "../plugins/http-registry.js";
@@ -91,6 +94,11 @@ const hoisted = vi.hoisted(() => {
     throw new Error("full model catalog should not materialize");
   });
   const loadModelCatalog = vi.fn(async (_options?: unknown): Promise<unknown> => ({}));
+  const catalogOwnerIsCurrent = vi.fn(() => true);
+  const acquireModelCatalog = vi.fn(async (_options: { agentId?: string }) => ({
+    entries: [],
+    routeVariants: [],
+  }));
   const getModelRefStatus = vi.fn(() => ({
     key: "openai/gpt-5.4",
     allowed: true,
@@ -132,6 +140,8 @@ const hoisted = vi.hoisted(() => {
     resolveHooksGmailModel,
     loadFullModelCatalog,
     loadModelCatalog,
+    catalogOwnerIsCurrent,
+    acquireModelCatalog,
     getModelRefStatus,
     prepareModelRuntimeSnapshot,
     refreshPreparedModelRuntimeSnapshots,
@@ -223,6 +233,10 @@ vi.mock("../infra/update-startup.js", () => ({
 }));
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
+  getPublishedPreparedModelCatalogOwnerSnapshot: () => ({
+    isCurrent: hoisted.catalogOwnerIsCurrent,
+  }),
+  loadPreparedModelCatalogSnapshot: hoisted.acquireModelCatalog,
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
   readPreparedModelCatalog: hoisted.loadModelCatalog,
 }));
@@ -497,6 +511,8 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.loadFullModelCatalog.mockClear();
     hoisted.loadModelCatalog.mockReset();
     hoisted.loadModelCatalog.mockResolvedValue({});
+    hoisted.catalogOwnerIsCurrent.mockReturnValue(true);
+    hoisted.acquireModelCatalog.mockReset().mockResolvedValue({ entries: [], routeVariants: [] });
     hoisted.getModelRefStatus.mockReset();
     hoisted.getModelRefStatus.mockReturnValue({
       key: "openai/gpt-5.4",
@@ -1850,6 +1866,80 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(returned).toBe(true);
   });
 
+  it.each(["complete", "before readiness", "between agents"] as const)(
+    "keeps catalog acquisition after readiness and stops at %s",
+    async (stopAt) => {
+      const ready = createDeferred<void>();
+      const firstCatalog = createDeferred<{ entries: []; routeVariants: [] }>();
+      const cfg: OpenClawConfig = { agents: { entries: { main: {}, second: {} } } };
+      hoisted.acquireModelCatalog.mockImplementationOnce(() => firstCatalog.promise);
+      const params = createPostAttachParams({
+        getConfig: () => cfg,
+        waitForPostReadyWork: () => ready.promise,
+      });
+      const runtime = await startGatewayPostAttachRuntime(params, createPostAttachRuntimeDeps());
+      try {
+        await runtime.startupSettled;
+        expect(params.unlockStartupMethods).toHaveBeenCalledOnce();
+        expect(hoisted.acquireModelCatalog).not.toHaveBeenCalled();
+        if (stopAt === "before readiness") {
+          await stopTrackedSidecars(publishedGatewayLifetimeSidecars);
+        }
+        ready.resolve();
+        if (stopAt !== "before readiness") {
+          await waitForGatewayTestState(() =>
+            expect(hoisted.acquireModelCatalog).toHaveBeenCalledTimes(1),
+          );
+          if (stopAt === "between agents") {
+            await stopTrackedSidecars(publishedGatewayLifetimeSidecars);
+          }
+        }
+        firstCatalog.resolve({ entries: [], routeVariants: [] });
+        await vi.dynamicImportSettled();
+        await waitForGatewayTestState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+        expect(hoisted.acquireModelCatalog.mock.calls.map(([input]) => input.agentId)).toEqual(
+          stopAt === "before readiness"
+            ? []
+            : stopAt === "between agents"
+              ? ["main"]
+              : ["main", "second"],
+        );
+      } finally {
+        ready.resolve();
+        firstCatalog.resolve({ entries: [], routeVariants: [] });
+        await stopTrackedSidecars(publishedGatewayLifetimeSidecars);
+      }
+    },
+  );
+
+  it.each([
+    ["ordinary", new Error("catalog unavailable"), 2],
+    ["abort", createAbortError("cancelled"), 1],
+    ["superseded", new PreparedModelRuntimePublicationSupersededError("superseded"), 1],
+    ["config replaced", new PreparedModelCatalogConfigReplacedError("/tmp/agent"), 1],
+    ["retired owner", new Error("lifetime closed"), 1],
+  ] as const)("contains %s catalog failure after readiness", async (kind, error, calls) => {
+    const ready = createDeferred<void>();
+    const cfg: OpenClawConfig = { agents: { entries: { main: {}, second: {} } } };
+    hoisted.catalogOwnerIsCurrent.mockReturnValue(kind !== "retired owner");
+    hoisted.acquireModelCatalog.mockRejectedValueOnce(error);
+    const params = createPostAttachParams({
+      getConfig: () => cfg,
+      waitForPostReadyWork: () => ready.promise,
+    });
+    await startGatewayPostAttachRuntime(params, createPostAttachRuntimeDeps());
+    ready.resolve();
+    await waitForGatewayTestState(() =>
+      expect(hoisted.acquireModelCatalog).toHaveBeenCalledTimes(calls),
+    );
+    await waitForGatewayTestState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    expect(params.log.warn).toHaveBeenCalledWith(
+      kind === "ordinary"
+        ? `Model catalog acquisition failed for main: ${String(error)}`
+        : `sidecars.model-catalog failed after gateway ready: ${String(error)}`,
+    );
+  });
+
   it("defers context-window cache prewarm to a post-ready sidecar", async () => {
     vi.useFakeTimers();
     const startupConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
@@ -1927,7 +2017,7 @@ describe("startGatewayPostAttachRuntime", () => {
       | undefined;
     const lifetimeSidecars = [...publishedGatewayLifetimeSidecars];
     expect(gmailSidecars).toHaveLength(2);
-    expect(lifetimeSidecars).toHaveLength(4);
+    expect(lifetimeSidecars).toHaveLength(5);
 
     await waitForGatewayTestState(() => {
       expect(hoisted.transcriptsAutoStartService.start).toHaveBeenCalledTimes(1);
@@ -3154,7 +3244,7 @@ describe("startGatewayPostAttachRuntime", () => {
       name: "sidecars.ready",
       metrics: [
         ["loadedPluginCount", 2],
-        ["postReadySidecarCount", 3],
+        ["postReadySidecarCount", 4],
       ],
     });
   });

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -404,20 +404,43 @@ async function publishConfiguredModelRuntimeSnapshots(params: {
         : {}),
     },
   );
-  const [{ listAgentIds }, { loadPreparedModelCatalogSnapshot }] = await Promise.all([
+  const [
+    { listAgentIds },
+    { loadPreparedModelCatalogSnapshot, getPublishedPreparedModelCatalogOwnerSnapshot },
+    { PreparedModelRuntimeOwnerNotPublishedError },
+    { PreparedModelCatalogConfigReplacedError },
+    { isAbortError },
+  ] = await Promise.all([
     import("../agents/agent-scope.js"),
     import("../agents/prepared-model-catalog.js"),
+    import("../agents/prepared-model-runtime.errors.js"),
+    import("../agents/prepared-model-catalog.errors.js"),
+    import("../infra/abort-signal.js"),
   ]);
   for (const agentId of listAgentIds(config)) {
     if (params.isCurrent?.() === false) {
       return;
     }
-    await loadPreparedModelCatalogSnapshot({
-      config,
-      agentId,
-      readOnly: false,
-      refreshFullCatalog: true,
-    });
+    const owner = getPublishedPreparedModelCatalogOwnerSnapshot({ config, agentId });
+    try {
+      await loadPreparedModelCatalogSnapshot({
+        config,
+        agentId,
+        readOnly: false,
+        refreshFullCatalog: true,
+      });
+    } catch (error) {
+      if (
+        params.isCurrent?.() === false ||
+        !owner?.isCurrent() ||
+        error instanceof PreparedModelRuntimeOwnerNotPublishedError ||
+        error instanceof PreparedModelCatalogConfigReplacedError ||
+        isAbortError(error)
+      ) {
+        throw error;
+      }
+      params.log.warn(`Model catalog acquisition failed for ${agentId}: ${String(error)}`);
+    }
   }
 }
 

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -296,6 +296,7 @@ type StartupExternalAuthHydrationDeps = {
 
 async function hydrateConfiguredExternalCliAuth(params: {
   getConfig: () => OpenClawConfig;
+  isCurrent?: () => boolean;
   log: { warn: (msg: string) => void };
   deps?: StartupExternalAuthHydrationDeps | Promise<StartupExternalAuthHydrationDeps>;
 }): Promise<OpenClawConfig> {
@@ -327,6 +328,9 @@ async function hydrateConfiguredExternalCliAuth(params: {
   const cfg = params.getConfig();
   const hydratedDirs = new Set<string>();
   for (const agentId of deps.listAgentIds(cfg)) {
+    if (params.isCurrent?.() === false) {
+      break;
+    }
     const providers = deps.collectConfiguredRefs(cfg, agentId).flatMap(({ value }) => {
       const separator = value.indexOf("/");
       return separator > 0 ? [value.slice(0, separator)] : [];
@@ -361,87 +365,103 @@ async function publishConfiguredModelRuntimeSnapshots(params: {
   if (params.isCurrent?.() === false) {
     return;
   }
-  let config = params.cfg;
-  const getConfig = params.getConfig;
-  await refreshPreparedModelRuntimeSnapshots(
-    getConfig ? async () => (config = await getConfig()) : config,
-    {
-      gatewayLifecycle: true,
-      catalogMode: "static",
-      allowGatewaySubagentBinding: true,
-      ...(params.isCurrent ? { isPublicationCurrent: params.isCurrent } : {}),
-      ...(params.pluginMetadataSnapshot
-        ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
-        : {}),
-      ...(params.workspaceDir ? { defaultWorkspaceDir: params.workspaceDir } : {}),
-      ...(params.startupTrace
-        ? {
-            onBuildStats: (stats) =>
-              params.startupTrace?.detail("sidecars.model-runtime-build", [
-                ["agentCount", stats.agentCount],
-                ["workspaceGroupCount", stats.workspaceGroupCount],
-                ["configuredFactsGroupCount", stats.configuredFactsGroupCount],
-                ["catalogSourceCount", stats.catalogSourceCount],
-                ["credentialGroupCount", stats.credentialGroupCount],
-                ["catalogGroupCount", stats.catalogGroupCount],
-                ["runtimeRegistryCount", stats.runtimeRegistryCount],
-                ["configuredRuntimeModelCount", stats.configuredRuntimeModelCount],
-                ["generatedCatalogPluginCount", stats.generatedCatalogPluginCount],
-                ["generatedCatalogReadCount", stats.generatedCatalogReadCount],
-                ["workspaceFactsMs", stats.workspaceFactsMs],
-                ["runtimePluginMs", stats.runtimePluginMs],
-                ["pluginMetadataMs", stats.pluginMetadataMs],
-                ["staticProviderCatalogMs", stats.staticProviderCatalogMs],
-                ["ambientCredentialsMs", stats.ambientCredentialsMs],
-                ["agentFactsMs", stats.agentFactsMs],
-                ["configuredProjectionMs", stats.configuredProjectionMs],
-                ["catalogSourceMs", stats.catalogSourceMs],
-                ["registryMs", stats.registryMs],
-                ["sourceConcurrencyLimitCount", stats.sourceConcurrencyLimit],
-                ["fullCatalogConcurrencyLimitCount", stats.fullCatalogConcurrencyLimit],
-              ]),
-          }
-        : {}),
-    },
-  );
-  const [
-    { listAgentIds },
-    { loadPreparedModelCatalogSnapshot, getPublishedPreparedModelCatalogOwnerSnapshot },
-    { PreparedModelRuntimeOwnerNotPublishedError },
-    { PreparedModelCatalogConfigReplacedError },
-    { isAbortError },
-  ] = await Promise.all([
-    import("../agents/agent-scope.js"),
-    import("../agents/prepared-model-catalog.js"),
-    import("../agents/prepared-model-runtime.errors.js"),
-    import("../agents/prepared-model-catalog.errors.js"),
-    import("../infra/abort-signal.js"),
-  ]);
-  for (const agentId of listAgentIds(config)) {
-    if (params.isCurrent?.() === false) {
-      return;
-    }
-    const owner = getPublishedPreparedModelCatalogOwnerSnapshot({ config, agentId });
-    try {
-      await loadPreparedModelCatalogSnapshot({
-        config,
-        agentId,
-        readOnly: false,
-        refreshFullCatalog: true,
+  await refreshPreparedModelRuntimeSnapshots(params.getConfig ?? params.cfg, {
+    gatewayLifecycle: true,
+    catalogMode: "static",
+    allowGatewaySubagentBinding: true,
+    ...(params.isCurrent ? { isPublicationCurrent: params.isCurrent } : {}),
+    ...(params.pluginMetadataSnapshot
+      ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
+      : {}),
+    ...(params.workspaceDir ? { defaultWorkspaceDir: params.workspaceDir } : {}),
+    ...(params.startupTrace
+      ? {
+          onBuildStats: (stats) =>
+            params.startupTrace?.detail("sidecars.model-runtime-build", [
+              ["agentCount", stats.agentCount],
+              ["workspaceGroupCount", stats.workspaceGroupCount],
+              ["configuredFactsGroupCount", stats.configuredFactsGroupCount],
+              ["catalogSourceCount", stats.catalogSourceCount],
+              ["credentialGroupCount", stats.credentialGroupCount],
+              ["catalogGroupCount", stats.catalogGroupCount],
+              ["runtimeRegistryCount", stats.runtimeRegistryCount],
+              ["configuredRuntimeModelCount", stats.configuredRuntimeModelCount],
+              ["generatedCatalogPluginCount", stats.generatedCatalogPluginCount],
+              ["generatedCatalogReadCount", stats.generatedCatalogReadCount],
+              ["workspaceFactsMs", stats.workspaceFactsMs],
+              ["runtimePluginMs", stats.runtimePluginMs],
+              ["pluginMetadataMs", stats.pluginMetadataMs],
+              ["staticProviderCatalogMs", stats.staticProviderCatalogMs],
+              ["ambientCredentialsMs", stats.ambientCredentialsMs],
+              ["agentFactsMs", stats.agentFactsMs],
+              ["configuredProjectionMs", stats.configuredProjectionMs],
+              ["catalogSourceMs", stats.catalogSourceMs],
+              ["registryMs", stats.registryMs],
+              ["sourceConcurrencyLimitCount", stats.sourceConcurrencyLimit],
+              ["fullCatalogConcurrencyLimitCount", stats.fullCatalogConcurrencyLimit],
+            ]),
+        }
+      : {}),
+  });
+}
+
+function scheduleStartupModelCatalogs(params: {
+  getConfig: () => OpenClawConfig;
+  isCurrent: () => boolean;
+  waitForPostReadyWork?: () => Promise<void>;
+  startupTrace?: GatewayStartupTrace;
+  log: { warn: (msg: string) => void };
+}): GatewayPostReadySidecarHandle {
+  return schedulePostReadySidecarTask({
+    ...params,
+    name: "sidecars.model-catalog",
+    shouldRun: params.isCurrent,
+    run: async (isStopped) => {
+      const config = await hydrateConfiguredExternalCliAuth({
+        getConfig: params.getConfig,
+        isCurrent: () => !isStopped(),
+        log: params.log,
       });
-    } catch (error) {
-      if (
-        params.isCurrent?.() === false ||
-        !owner?.isCurrent() ||
-        error instanceof PreparedModelRuntimeOwnerNotPublishedError ||
-        error instanceof PreparedModelCatalogConfigReplacedError ||
-        isAbortError(error)
-      ) {
-        throw error;
+      const [
+        { listAgentIds },
+        { loadPreparedModelCatalogSnapshot, getPublishedPreparedModelCatalogOwnerSnapshot },
+        { PreparedModelRuntimeOwnerNotPublishedError },
+        { PreparedModelCatalogConfigReplacedError },
+        { isAbortError },
+      ] = await Promise.all([
+        import("../agents/agent-scope.js"),
+        import("../agents/prepared-model-catalog.js"),
+        import("../agents/prepared-model-runtime.errors.js"),
+        import("../agents/prepared-model-catalog.errors.js"),
+        import("../infra/abort-signal.js"),
+      ]);
+      for (const agentId of listAgentIds(config)) {
+        if (isStopped()) {
+          return;
+        }
+        const owner = getPublishedPreparedModelCatalogOwnerSnapshot({ config, agentId });
+        try {
+          await loadPreparedModelCatalogSnapshot({
+            config,
+            agentId,
+            readOnly: false,
+            refreshFullCatalog: true,
+          });
+        } catch (error) {
+          if (
+            isStopped() ||
+            !owner?.isCurrent() ||
+            error instanceof PreparedModelRuntimeOwnerNotPublishedError ||
+            error instanceof PreparedModelCatalogConfigReplacedError ||
+            isAbortError(error)
+          ) {
+            throw error;
+          }
+          params.log.warn(`Model catalog acquisition failed for ${agentId}: ${String(error)}`);
+        }
       }
-      params.log.warn(`Model catalog acquisition failed for ${agentId}: ${String(error)}`);
-    }
-  }
+    },
+  });
 }
 
 async function publishStartupModelRuntime(
@@ -567,20 +587,14 @@ export async function startGatewaySidecars(params: {
     }
   });
   const getModelRuntimeConfig = params.getModelRuntimeConfig ?? (() => params.cfg);
-  // Initialize the same complete catalog used by explicit refresh before accepting agent work.
+  // Readiness publishes captured static facts; catalog acquisition runs after the ready barrier.
   if ((await params.pluginRuntimeClaim?.waitForUnblocked()) !== false) {
     await measureStartup(params.startupTrace, "sidecars.model-runtime", () =>
       withPluginRuntimeRegistryScope(params.pluginRegistry, () =>
         publishStartupModelRuntime(
           {
             cfg: params.cfg,
-            getConfig: async () =>
-              await measureStartup(params.startupTrace, "sidecars.model-auth", () =>
-                hydrateConfiguredExternalCliAuth({
-                  getConfig: getModelRuntimeConfig,
-                  log: params.log,
-                }),
-              ),
+            getConfig: getModelRuntimeConfig,
             isCurrent: params.pluginRuntimeClaim?.isCurrent,
             ...(params.pluginMetadataSnapshot
               ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
@@ -1458,6 +1472,14 @@ export async function startGatewayPostAttachRuntime(
           }
           const postReadySidecars = [...result.postReadySidecars];
           const newGatewayLifetimeSidecars = [
+            scheduleStartupModelCatalogs({
+              getConfig: params.getConfig,
+              isCurrent: () =>
+                params.isClosing?.() !== true && params.pluginRuntimeClaim?.isCurrent() !== false,
+              waitForPostReadyWork: params.waitForPostReadyWork,
+              startupTrace: params.startupTrace,
+              log: params.log,
+            }),
             scheduleContextCachePrewarm(params),
             scheduleGatewayHandlerPrewarm(params),
             ...(mainSessionRecoverySidecar ? [mainSessionRecoverySidecar] : []),

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -361,44 +361,64 @@ async function publishConfiguredModelRuntimeSnapshots(params: {
   if (params.isCurrent?.() === false) {
     return;
   }
-  await refreshPreparedModelRuntimeSnapshots(params.getConfig ?? params.cfg, {
-    gatewayLifecycle: true,
-    catalogMode: "static",
-    allowGatewaySubagentBinding: true,
-    ...(params.isCurrent ? { isPublicationCurrent: params.isCurrent } : {}),
-    ...(params.pluginMetadataSnapshot
-      ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
-      : {}),
-    ...(params.workspaceDir ? { defaultWorkspaceDir: params.workspaceDir } : {}),
-    ...(params.startupTrace
-      ? {
-          onBuildStats: (stats) =>
-            params.startupTrace?.detail("sidecars.model-runtime-build", [
-              ["agentCount", stats.agentCount],
-              ["workspaceGroupCount", stats.workspaceGroupCount],
-              ["configuredFactsGroupCount", stats.configuredFactsGroupCount],
-              ["catalogSourceCount", stats.catalogSourceCount],
-              ["credentialGroupCount", stats.credentialGroupCount],
-              ["catalogGroupCount", stats.catalogGroupCount],
-              ["runtimeRegistryCount", stats.runtimeRegistryCount],
-              ["configuredRuntimeModelCount", stats.configuredRuntimeModelCount],
-              ["generatedCatalogPluginCount", stats.generatedCatalogPluginCount],
-              ["generatedCatalogReadCount", stats.generatedCatalogReadCount],
-              ["workspaceFactsMs", stats.workspaceFactsMs],
-              ["runtimePluginMs", stats.runtimePluginMs],
-              ["pluginMetadataMs", stats.pluginMetadataMs],
-              ["staticProviderCatalogMs", stats.staticProviderCatalogMs],
-              ["ambientCredentialsMs", stats.ambientCredentialsMs],
-              ["agentFactsMs", stats.agentFactsMs],
-              ["configuredProjectionMs", stats.configuredProjectionMs],
-              ["catalogSourceMs", stats.catalogSourceMs],
-              ["registryMs", stats.registryMs],
-              ["sourceConcurrencyLimitCount", stats.sourceConcurrencyLimit],
-              ["fullCatalogConcurrencyLimitCount", stats.fullCatalogConcurrencyLimit],
-            ]),
-        }
-      : {}),
-  });
+  let config = params.cfg;
+  const getConfig = params.getConfig;
+  await refreshPreparedModelRuntimeSnapshots(
+    getConfig ? async () => (config = await getConfig()) : config,
+    {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+      allowGatewaySubagentBinding: true,
+      ...(params.isCurrent ? { isPublicationCurrent: params.isCurrent } : {}),
+      ...(params.pluginMetadataSnapshot
+        ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
+        : {}),
+      ...(params.workspaceDir ? { defaultWorkspaceDir: params.workspaceDir } : {}),
+      ...(params.startupTrace
+        ? {
+            onBuildStats: (stats) =>
+              params.startupTrace?.detail("sidecars.model-runtime-build", [
+                ["agentCount", stats.agentCount],
+                ["workspaceGroupCount", stats.workspaceGroupCount],
+                ["configuredFactsGroupCount", stats.configuredFactsGroupCount],
+                ["catalogSourceCount", stats.catalogSourceCount],
+                ["credentialGroupCount", stats.credentialGroupCount],
+                ["catalogGroupCount", stats.catalogGroupCount],
+                ["runtimeRegistryCount", stats.runtimeRegistryCount],
+                ["configuredRuntimeModelCount", stats.configuredRuntimeModelCount],
+                ["generatedCatalogPluginCount", stats.generatedCatalogPluginCount],
+                ["generatedCatalogReadCount", stats.generatedCatalogReadCount],
+                ["workspaceFactsMs", stats.workspaceFactsMs],
+                ["runtimePluginMs", stats.runtimePluginMs],
+                ["pluginMetadataMs", stats.pluginMetadataMs],
+                ["staticProviderCatalogMs", stats.staticProviderCatalogMs],
+                ["ambientCredentialsMs", stats.ambientCredentialsMs],
+                ["agentFactsMs", stats.agentFactsMs],
+                ["configuredProjectionMs", stats.configuredProjectionMs],
+                ["catalogSourceMs", stats.catalogSourceMs],
+                ["registryMs", stats.registryMs],
+                ["sourceConcurrencyLimitCount", stats.sourceConcurrencyLimit],
+                ["fullCatalogConcurrencyLimitCount", stats.fullCatalogConcurrencyLimit],
+              ]),
+          }
+        : {}),
+    },
+  );
+  const [{ listAgentIds }, { loadPreparedModelCatalogSnapshot }] = await Promise.all([
+    import("../agents/agent-scope.js"),
+    import("../agents/prepared-model-catalog.js"),
+  ]);
+  for (const agentId of listAgentIds(config)) {
+    if (params.isCurrent?.() === false) {
+      return;
+    }
+    await loadPreparedModelCatalogSnapshot({
+      config,
+      agentId,
+      readOnly: false,
+      refreshFullCatalog: true,
+    });
+  }
 }
 
 async function publishStartupModelRuntime(
@@ -524,8 +544,7 @@ export async function startGatewaySidecars(params: {
     }
   });
   const getModelRuntimeConfig = params.getModelRuntimeConfig ?? (() => params.cfg);
-  // Agent RPC remains available when transports are disabled. Publish configured/static facts before
-  // accepting work; live provider catalogs stay advisory and never enter the Gateway lifecycle.
+  // Initialize the same complete catalog used by explicit refresh before accepting agent work.
   if ((await params.pluginRuntimeClaim?.waitForUnblocked()) !== false) {
     await measureStartup(params.startupTrace, "sidecars.model-runtime", () =>
       withPluginRuntimeRegistryScope(params.pluginRegistry, () =>

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -4,6 +4,15 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
+const loadPreparedModelCatalogSnapshotMock = vi.fn(async (_params: unknown) => ({
+  entries: [],
+  routeVariants: [],
+}));
+vi.mock("../agents/prepared-model-catalog.js", () => ({
+  loadPreparedModelCatalogSnapshot: (params: unknown) =>
+    loadPreparedModelCatalogSnapshotMock(params),
+}));
+
 const prepareModelRuntimeSnapshotMock = vi.fn(async (_params: unknown) => ({}));
 const refreshPreparedModelRuntimeSnapshotsMock = vi.fn(
   async (
@@ -22,6 +31,7 @@ vi.mock("../agents/agent-scope.js", () => ({
   resolveDefaultAgentDir: () => "/tmp/agent",
   resolveAgentWorkspaceDir: () => "/tmp/workspace",
   resolveDefaultAgentId: () => "default",
+  listAgentIds: () => ["default"],
 }));
 
 vi.mock("../agents/prepared-model-runtime.js", () => ({
@@ -56,6 +66,7 @@ describe("gateway startup primary model warmup", () => {
   });
 
   beforeEach(() => {
+    loadPreparedModelCatalogSnapshotMock.mockClear();
     prepareModelRuntimeSnapshotMock.mockClear();
     refreshPreparedModelRuntimeSnapshotsMock.mockClear();
   });
@@ -80,6 +91,17 @@ describe("gateway startup primary model warmup", () => {
       allowGatewaySubagentBinding: true,
       gatewayLifecycle: true,
       catalogMode: "static",
+    });
+  });
+
+  it("publishes the full startup catalog through the refresh owner", async () => {
+    const cfg = {};
+    await prewarmConfiguredPrimaryModel({ cfg, log: { warn: vi.fn() } });
+    expect(loadPreparedModelCatalogSnapshotMock).toHaveBeenCalledWith({
+      config: cfg,
+      agentId: "default",
+      readOnly: false,
+      refreshFullCatalog: true,
     });
   });
 

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -2,13 +2,18 @@
  * Gateway startup orchestration tests.
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { PreparedModelCatalogConfigReplacedError } from "../agents/prepared-model-catalog.errors.js";
+import { PreparedModelRuntimePublicationSupersededError } from "../agents/prepared-model-runtime.errors.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { createAbortError } from "../infra/abort-signal.js";
 
+const catalogOwnerIsCurrent = vi.fn(() => true);
 const loadPreparedModelCatalogSnapshotMock = vi.fn(async (_params: unknown) => ({
   entries: [],
   routeVariants: [],
 }));
 vi.mock("../agents/prepared-model-catalog.js", () => ({
+  getPublishedPreparedModelCatalogOwnerSnapshot: () => ({ isCurrent: catalogOwnerIsCurrent }),
   loadPreparedModelCatalogSnapshot: (params: unknown) =>
     loadPreparedModelCatalogSnapshotMock(params),
 }));
@@ -66,6 +71,7 @@ describe("gateway startup primary model warmup", () => {
   });
 
   beforeEach(() => {
+    catalogOwnerIsCurrent.mockReturnValue(true);
     loadPreparedModelCatalogSnapshotMock.mockClear();
     prepareModelRuntimeSnapshotMock.mockClear();
     refreshPreparedModelRuntimeSnapshotsMock.mockClear();
@@ -103,6 +109,21 @@ describe("gateway startup primary model warmup", () => {
       readOnly: false,
       refreshFullCatalog: true,
     });
+  });
+
+  it.each([
+    ["abort", createAbortError("cancelled")],
+    ["superseded", new PreparedModelRuntimePublicationSupersededError("superseded")],
+    ["config replaced", new PreparedModelCatalogConfigReplacedError("/tmp/agent")],
+    ["retired owner", new Error("lifetime closed")],
+  ])("propagates catalog lifecycle failure: %s", async (kind, error) => {
+    if (kind === "retired owner") {
+      catalogOwnerIsCurrent.mockReturnValue(false);
+    }
+    loadPreparedModelCatalogSnapshotMock.mockRejectedValueOnce(error);
+    const warn = vi.fn();
+    await expect(prewarmConfiguredPrimaryModel({ cfg: {}, log: { warn } })).rejects.toBe(error);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("hydrates configured external CLI auth before prepared owner publication", async () => {

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -2,18 +2,13 @@
  * Gateway startup orchestration tests.
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { PreparedModelCatalogConfigReplacedError } from "../agents/prepared-model-catalog.errors.js";
-import { PreparedModelRuntimePublicationSupersededError } from "../agents/prepared-model-runtime.errors.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { createAbortError } from "../infra/abort-signal.js";
 
-const catalogOwnerIsCurrent = vi.fn(() => true);
 const loadPreparedModelCatalogSnapshotMock = vi.fn(async (_params: unknown) => ({
   entries: [],
   routeVariants: [],
 }));
 vi.mock("../agents/prepared-model-catalog.js", () => ({
-  getPublishedPreparedModelCatalogOwnerSnapshot: () => ({ isCurrent: catalogOwnerIsCurrent }),
   loadPreparedModelCatalogSnapshot: (params: unknown) =>
     loadPreparedModelCatalogSnapshotMock(params),
 }));
@@ -71,7 +66,6 @@ describe("gateway startup primary model warmup", () => {
   });
 
   beforeEach(() => {
-    catalogOwnerIsCurrent.mockReturnValue(true);
     loadPreparedModelCatalogSnapshotMock.mockClear();
     prepareModelRuntimeSnapshotMock.mockClear();
     refreshPreparedModelRuntimeSnapshotsMock.mockClear();
@@ -100,33 +94,13 @@ describe("gateway startup primary model warmup", () => {
     });
   });
 
-  it("publishes the full startup catalog through the refresh owner", async () => {
+  it("publishes readiness without acquiring the full catalog", async () => {
     const cfg = {};
     await prewarmConfiguredPrimaryModel({ cfg, log: { warn: vi.fn() } });
-    expect(loadPreparedModelCatalogSnapshotMock).toHaveBeenCalledWith({
-      config: cfg,
-      agentId: "default",
-      readOnly: false,
-      refreshFullCatalog: true,
-    });
+    expect(loadPreparedModelCatalogSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ["abort", createAbortError("cancelled")],
-    ["superseded", new PreparedModelRuntimePublicationSupersededError("superseded")],
-    ["config replaced", new PreparedModelCatalogConfigReplacedError("/tmp/agent")],
-    ["retired owner", new Error("lifetime closed")],
-  ])("propagates catalog lifecycle failure: %s", async (kind, error) => {
-    if (kind === "retired owner") {
-      catalogOwnerIsCurrent.mockReturnValue(false);
-    }
-    loadPreparedModelCatalogSnapshotMock.mockRejectedValueOnce(error);
-    const warn = vi.fn();
-    await expect(prewarmConfiguredPrimaryModel({ cfg: {}, log: { warn } })).rejects.toBe(error);
-    expect(warn).not.toHaveBeenCalled();
-  });
-
-  it("hydrates configured external CLI auth before prepared owner publication", async () => {
+  it("hydrates configured external CLI auth without republishing prepared owners", async () => {
     const cfg = {} as OpenClawConfig;
     const hydrate = vi.fn();
 

--- a/src/infra/file-lock-sync.ts
+++ b/src/infra/file-lock-sync.ts
@@ -5,7 +5,7 @@ import { acquireFileLockSync } from "./file-lock-manager.js";
 import { isLockOwnerDefinitelyStale } from "./stale-lock-file.js";
 
 /** Synchronous lock for legacy stores that cannot transact in SQLite yet. */
-export function acquireFileLockSyncWithRetry(path: string): () => void {
+export function acquireFileLockSyncWithRetry(path: string, reentrantOwner?: string): () => void {
   rejectUnsupportedLockPath(`${path}.lock`);
   const processStartTime = getFileLockProcessStartTime(process.pid);
   const createPayload = () => ({
@@ -18,6 +18,7 @@ export function acquireFileLockSyncWithRetry(path: string): () => void {
       payload: isRecord(payload) ? payload : null,
     });
   const lock = acquireFileLockSync(path, {
+    reentrantOwner,
     staleMs: 30_000,
     retry: { retries: 9, factor: 1, minTimeout: 20, maxTimeout: 20, randomize: false },
     staleRecovery: "remove-if-unchanged",

--- a/src/plugin-sdk/provider-catalog-live-runtime.scope.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.scope.test.ts
@@ -15,7 +15,6 @@ describe("provider catalog live-runtime scope", () => {
       models: [],
     }));
     const family = buildOpenAICompatibleProviderFamilyCatalog({
-      credentialProviderId: "family",
       entries: [
         {
           id: "family",
@@ -36,7 +35,9 @@ describe("provider catalog live-runtime scope", () => {
       augmentModelCatalog: vi.fn(),
     });
 
-    const resolveProviderApiKey = vi.fn(() => ({ apiKey: "family-key" }));
+    const resolveProviderApiKey = vi.fn((provider: string) => ({
+      apiKey: provider === "family-plan" ? "plan-key" : undefined,
+    }));
     const context: ProviderCatalogContext = {
       providerIds: ["family-plan"],
       config: {},
@@ -51,6 +52,11 @@ describe("provider catalog live-runtime scope", () => {
     ]);
     expect(buildPrimary).not.toHaveBeenCalled();
     expect(buildPlan).toHaveBeenCalledOnce();
+    expect(result && "providers" in result && result.providers["family-plan"].apiKey).toBe(
+      "plan-key",
+    );
+    resolveProviderApiKey.mockReturnValueOnce({ apiKey: undefined });
+    await expect(family.catalog.run(context)).resolves.toBeNull();
 
     resolveProviderApiKey.mockClear();
     await expect(family.catalog.run({ ...context, providerIds: ["other"] })).resolves.toBeNull();

--- a/src/plugin-sdk/provider-catalog-live-runtime.scope.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.scope.test.ts
@@ -41,9 +41,11 @@ describe("provider catalog live-runtime scope", () => {
         augmentModelCatalog: vi.fn(),
       });
 
-      const resolveProviderApiKey = vi.fn((provider: string) => ({
-        apiKey: provider === source ? "plan-key" : undefined,
-      }));
+      const resolveProviderApiKey = vi.fn<ProviderCatalogContext["resolveProviderApiKey"]>(
+        (provider) => ({
+          apiKey: provider === source ? "plan-key" : undefined,
+        }),
+      );
       const context: ProviderCatalogContext = {
         providerIds: ["family-plan"],
         config: {},
@@ -58,7 +60,7 @@ describe("provider catalog live-runtime scope", () => {
       ]);
       expect(buildPrimary).not.toHaveBeenCalled();
       expect(buildPlan).toHaveBeenCalledOnce();
-      expect(result && "providers" in result && result.providers["family-plan"].apiKey).toBe(
+      expect(result && "providers" in result && result.providers["family-plan"]?.apiKey).toBe(
         "plan-key",
       );
       resolveProviderApiKey.mockReturnValueOnce({ apiKey: undefined });

--- a/src/plugin-sdk/provider-catalog-live-runtime.scope.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.scope.test.ts
@@ -3,63 +3,70 @@ import { buildOpenAICompatibleProviderFamilyCatalog } from "./provider-catalog-l
 import type { ProviderCatalogContext } from "./provider-catalog-shared.js";
 
 describe("provider catalog live-runtime scope", () => {
-  it("scopes shared family credentials and construction to selected entries", async () => {
-    const buildPrimary = vi.fn(() => ({
-      baseUrl: "not-a-url",
-      api: "openai-completions" as const,
-      models: [],
-    }));
-    const buildPlan = vi.fn(() => ({
-      baseUrl: "not-a-url",
-      api: "openai-completions" as const,
-      models: [],
-    }));
-    const family = buildOpenAICompatibleProviderFamilyCatalog({
-      entries: [
-        {
-          id: "family",
-          label: "Family",
-          baseUrl: "not-a-url",
-          models: [],
-          buildProvider: buildPrimary,
-        },
-        {
-          id: "family-plan",
-          label: "Family Plan",
-          baseUrl: "not-a-url",
-          models: [],
-          buildProvider: buildPlan,
-        },
-      ],
-      staticCatalog: async () => ({ providers: {} }),
-      augmentModelCatalog: vi.fn(),
-    });
+  it.each([
+    { credentialProviderId: undefined, source: "family-plan" },
+    { credentialProviderId: "shared-source", source: "shared-source" },
+  ])(
+    "scopes family entries with credential source $source",
+    async ({ credentialProviderId, source }) => {
+      const buildPrimary = vi.fn(() => ({
+        baseUrl: "not-a-url",
+        api: "openai-completions" as const,
+        models: [],
+      }));
+      const buildPlan = vi.fn(() => ({
+        baseUrl: "not-a-url",
+        api: "openai-completions" as const,
+        models: [],
+      }));
+      const family = buildOpenAICompatibleProviderFamilyCatalog({
+        credentialProviderId,
+        entries: [
+          {
+            id: "family",
+            label: "Family",
+            baseUrl: "not-a-url",
+            models: [],
+            buildProvider: buildPrimary,
+          },
+          {
+            id: "family-plan",
+            label: "Family Plan",
+            baseUrl: "not-a-url",
+            models: [],
+            buildProvider: buildPlan,
+          },
+        ],
+        staticCatalog: async () => ({ providers: {} }),
+        augmentModelCatalog: vi.fn(),
+      });
 
-    const resolveProviderApiKey = vi.fn((provider: string) => ({
-      apiKey: provider === "family-plan" ? "plan-key" : undefined,
-    }));
-    const context: ProviderCatalogContext = {
-      providerIds: ["family-plan"],
-      config: {},
-      env: {},
-      resolveProviderApiKey,
-      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
-    };
-    const result = await family.catalog.run(context);
+      const resolveProviderApiKey = vi.fn((provider: string) => ({
+        apiKey: provider === source ? "plan-key" : undefined,
+      }));
+      const context: ProviderCatalogContext = {
+        providerIds: ["family-plan"],
+        config: {},
+        env: {},
+        resolveProviderApiKey,
+        resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+      };
+      const result = await family.catalog.run(context);
 
-    expect(result && "providers" in result ? Object.keys(result.providers) : []).toEqual([
-      "family-plan",
-    ]);
-    expect(buildPrimary).not.toHaveBeenCalled();
-    expect(buildPlan).toHaveBeenCalledOnce();
-    expect(result && "providers" in result && result.providers["family-plan"].apiKey).toBe(
-      "plan-key",
-    );
-    resolveProviderApiKey.mockReturnValueOnce({ apiKey: undefined });
-    await expect(family.catalog.run(context)).resolves.toBeNull();
+      expect(result && "providers" in result ? Object.keys(result.providers) : []).toEqual([
+        "family-plan",
+      ]);
+      expect(buildPrimary).not.toHaveBeenCalled();
+      expect(buildPlan).toHaveBeenCalledOnce();
+      expect(result && "providers" in result && result.providers["family-plan"].apiKey).toBe(
+        "plan-key",
+      );
+      resolveProviderApiKey.mockReturnValueOnce({ apiKey: undefined });
+      await expect(family.catalog.run(context)).resolves.toBeNull();
 
-    resolveProviderApiKey.mockClear();
-    await expect(family.catalog.run({ ...context, providerIds: ["other"] })).resolves.toBeNull();
-    expect(resolveProviderApiKey).not.toHaveBeenCalled();
-  });
+      resolveProviderApiKey.mockClear();
+      await expect(family.catalog.run({ ...context, providerIds: ["other"] })).resolves.toBeNull();
+      expect(resolveProviderApiKey).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/plugin-sdk/provider-catalog-live-runtime.strict.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.strict.test.ts
@@ -94,7 +94,6 @@ describe("strict catalog acquisition", () => {
       });
       const family = buildOpenAICompatibleProviderFamilyCatalog({
         discoveryMode: "strict",
-        credentialProviderId: "family",
         entries: ["unavailable", "healthy"].map((id) => ({
           id,
           label: id,
@@ -127,7 +126,7 @@ describe("strict catalog acquisition", () => {
           { provider: "healthy", profileId: "family:profile", status: "ready" },
         ],
       });
-      expect(resolveProviderApiKey).toHaveBeenCalledOnce();
+      expect(resolveProviderApiKey).toHaveBeenCalledTimes(2);
       expect(resolveProviderAuth).not.toHaveBeenCalled();
       expect(release).toHaveBeenCalledTimes(2);
     },

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -318,7 +318,8 @@ export async function buildOpenAICompatibleLiveProviderCatalog(
 
 /** Builds the shared authenticated live/static hooks for an ordered provider family. */
 export function buildOpenAICompatibleProviderFamilyCatalog(params: {
-  credentialProviderId: string;
+  /** @deprecated Since v2026.9.4 callers may pass this field; credentials now resolve per entry. */
+  credentialProviderId?: string;
   entries: readonly ManifestProviderCatalogEntry[];
   staticCatalog: () => Promise<{ providers: Record<string, ModelProviderConfig> }>;
   augmentModelCatalog: NonNullable<ProviderPlugin["augmentModelCatalog"]>;
@@ -332,23 +333,27 @@ export function buildOpenAICompatibleProviderFamilyCatalog(params: {
         if (entries.length === 0) {
           return null;
         }
-        const auth = ctx.resolveProviderApiKey(params.credentialProviderId);
-        if (!auth.apiKey) {
+        const results = await Promise.all(
+          entries.map(async ({ id, buildProvider }) => {
+            const auth = ctx.resolveProviderApiKey(id);
+            return {
+              id,
+              result: auth.apiKey
+                ? await buildOpenAICompatibleLiveProviderCatalog({
+                    providerId: id,
+                    providerConfig: buildProvider(),
+                    apiKey: auth.apiKey,
+                    discoveryApiKey: auth.discoveryApiKey,
+                    profileId: auth.profileId,
+                    discoveryMode: params.discoveryMode,
+                  })
+                : null,
+            };
+          }),
+        );
+        if (results.every(({ result }) => !result)) {
           return null;
         }
-        const results = await Promise.all(
-          entries.map(async ({ id, buildProvider }) => ({
-            id,
-            result: await buildOpenAICompatibleLiveProviderCatalog({
-              providerId: id,
-              providerConfig: buildProvider(),
-              apiKey: auth.apiKey,
-              discoveryApiKey: auth.discoveryApiKey,
-              profileId: auth.profileId,
-              discoveryMode: params.discoveryMode,
-            }),
-          })),
-        );
         return {
           providers: Object.fromEntries(
             results.flatMap(({ id, result }) =>

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -318,7 +318,7 @@ export async function buildOpenAICompatibleLiveProviderCatalog(
 
 /** Builds the shared authenticated live/static hooks for an ordered provider family. */
 export function buildOpenAICompatibleProviderFamilyCatalog(params: {
-  /** @deprecated Since v2026.9.4 callers may pass this field; credentials now resolve per entry. */
+  /** Shipped shared-source contract; the host separately enforces target admission. */
   credentialProviderId?: string;
   entries: readonly ManifestProviderCatalogEntry[];
   staticCatalog: () => Promise<{ providers: Record<string, ModelProviderConfig> }>;
@@ -335,7 +335,7 @@ export function buildOpenAICompatibleProviderFamilyCatalog(params: {
         }
         const results = await Promise.all(
           entries.map(async ({ id, buildProvider }) => {
-            const auth = ctx.resolveProviderApiKey(id);
+            const auth = ctx.resolveProviderApiKey(params.credentialProviderId ?? id);
             return {
               id,
               result: auth.apiKey

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -1106,10 +1106,17 @@ export async function augmentModelCatalogWithProviderPlugins(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   metadataSnapshot?: PluginMetadataSnapshot;
+  providerIds?: readonly string[];
   context: ProviderAugmentModelCatalogContext;
 }) {
   const supplemental = [] as ProviderAugmentModelCatalogContext["entries"];
   for (const plugin of resolveProviderPluginsForCatalogHooks(params)) {
+    if (
+      params.providerIds &&
+      !params.providerIds.some((id) => matchesProviderPluginRef(plugin, id))
+    ) {
+      continue;
+    }
     const next = await plugin.augmentModelCatalog?.(params.context);
     if (!next || next.length === 0) {
       continue;

--- a/src/secrets/provider-env-vars.test.ts
+++ b/src/secrets/provider-env-vars.test.ts
@@ -1,13 +1,221 @@
 /** Tests provider env-var candidate and auth evidence lookup. */
 import { describe, expect, it } from "vitest";
 import {
+  resolveProviderEnvironmentAdmission,
+  resolveProviderUseAdmission,
+} from "../agents/provider-model-auth-source-plan.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import {
   getProviderEnvVars,
   listKnownProviderAuthEnvVarNames,
   listKnownSecretEnvVarNames,
   omitEnvKeysCaseInsensitive,
+  resolveProviderAuthEnvVarCandidates,
+  resolveProviderBindingEnvVarCandidates,
 } from "./provider-env-vars.js";
 
 describe("provider env vars", () => {
+  it("excludes non-model setup claims while retaining their authentication variables", () => {
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "openrouter",
+          providers: ["openrouter"],
+          setup: { providers: [{ id: "openrouter", envVars: ["OPENROUTER_API_KEY"] }] },
+        },
+        {
+          id: "perplexity",
+          setup: { providers: [{ id: "perplexity", envVars: ["OPENROUTER_API_KEY"] }] },
+        },
+        { id: "media", setup: { providers: [{ id: "media", envVars: ["MEDIA_API_KEY"] }] } },
+      ],
+    });
+    const params = { metadataSnapshot, config: {} };
+    const providerEnvVars = resolveProviderBindingEnvVarCandidates(params);
+    expect(providerEnvVars).toEqual({
+      openrouter: [{ pluginId: "openrouter", envVars: ["OPENROUTER_API_KEY"] }],
+    });
+    expect(resolveProviderAuthEnvVarCandidates(params)).toMatchObject({
+      perplexity: ["OPENROUTER_API_KEY"],
+      media: ["MEDIA_API_KEY"],
+    });
+    expect([
+      ...resolveProviderUseAdmission({
+        providerEnvVars,
+        env: { OPENROUTER_API_KEY: "fake-router-key", MEDIA_API_KEY: "fake-media-key" },
+      }).keys(),
+    ]).toEqual(["openrouter"]);
+  });
+
+  it("admits only directly declared model identities in one plugin's credential family", () => {
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "family",
+          origin: "bundled",
+          providers: ["family", "family-plan", "family-unselected"],
+          providerAuthAliases: { "family-alias": "family" },
+          setup: {
+            providers: [
+              { id: "family", envVars: ["FAMILY_API_KEY"] },
+              { id: "family-plan", envVars: ["FAMILY_API_KEY"] },
+              { id: "family-media", envVars: ["FAMILY_API_KEY"] },
+            ],
+          },
+        },
+      ],
+    });
+    const providerEnvVars = resolveProviderBindingEnvVarCandidates({
+      metadataSnapshot,
+      config: {},
+    });
+    const result = resolveProviderEnvironmentAdmission({
+      providerEnvVars,
+      env: { FAMILY_API_KEY: "fake-key" },
+    });
+    expect([...result.bindings.keys()]).toEqual(["family", "family-plan"]);
+    expect(result.conflicts).toEqual([]);
+    expect(providerEnvVars["family-media"]).toBeUndefined();
+    expect(providerEnvVars["family-alias"]).toBeUndefined();
+  });
+
+  it("reports rival plugin claims without letting one key bind either plugin", () => {
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "first-plugin",
+          providers: ["first"],
+          setup: { providers: [{ id: "first", envVars: ["SHARED_API_KEY"] }] },
+        },
+        {
+          id: "second-plugin",
+          providers: ["second"],
+          setup: { providers: [{ id: "second", envVars: ["SHARED_API_KEY"] }] },
+        },
+      ],
+    });
+    const providerEnvVars = resolveProviderBindingEnvVarCandidates({ metadataSnapshot });
+    const result = resolveProviderEnvironmentAdmission({
+      providerEnvVars,
+      env: { SHARED_API_KEY: "fake-private-value" },
+    });
+    expect(result.bindings.size).toBe(0);
+    expect(result.conflicts).toEqual([
+      {
+        envVar: "SHARED_API_KEY",
+        pluginIds: ["first-plugin", "second-plugin"],
+        providers: ["first", "second"],
+      },
+    ]);
+    expect(
+      resolveProviderUseAdmission({
+        config: {
+          models: { providers: { first: { baseUrl: "https://first.example", models: [] } } },
+        },
+        providerEnvVars,
+        env: { SHARED_API_KEY: "fake-private-value" },
+      }),
+    ).toEqual(new Map([["first", { kind: "provider-config" }]]));
+  });
+
+  it("keeps each family provider's declared variable precedence", () => {
+    const result = resolveProviderEnvironmentAdmission({
+      env: { PARENT_KEY: "parent-account", PLAN_KEY: "plan-account" },
+      providerEnvVars: {
+        family: [{ pluginId: "family", envVars: ["PARENT_KEY", "PLAN_KEY"] }],
+        "family-plan": [{ pluginId: "family", envVars: ["PLAN_KEY", "PARENT_KEY"] }],
+      },
+    });
+    expect(result.bindings).toEqual(
+      new Map([
+        ["family", { kind: "environment", envVar: "PARENT_KEY" }],
+        ["family-plan", { kind: "environment", envVar: "PLAN_KEY" }],
+      ]),
+    );
+  });
+
+  it.each(["disabled", "denied"])(
+    "ignores an explicitly %s model plugin's ownership claim",
+    (policy) => {
+      const metadataSnapshot = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "active",
+            origin: "bundled",
+            providers: ["active"],
+            setup: { providers: [{ id: "active", envVars: ["OWNER_API_KEY"] }] },
+          },
+          {
+            id: "inactive",
+            origin: "bundled",
+            providers: ["inactive"],
+            setup: { providers: [{ id: "inactive", envVars: ["OWNER_API_KEY"] }] },
+          },
+        ],
+      });
+      const providerEnvVars = resolveProviderBindingEnvVarCandidates({
+        metadataSnapshot,
+        config: {
+          plugins:
+            policy === "disabled"
+              ? { entries: { inactive: { enabled: false } } }
+              : { deny: ["inactive"] },
+        },
+      });
+      expect([
+        ...resolveProviderEnvironmentAdmission({
+          providerEnvVars,
+          env: { OWNER_API_KEY: "fake-key" },
+        }).bindings.keys(),
+      ]).toEqual(["active"]);
+    },
+  );
+
+  it("keeps workspace ownership claims behind the existing trust policy", () => {
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "official",
+          origin: "bundled",
+          providers: ["official"],
+          setup: { providers: [{ id: "official", envVars: ["OWNER_API_KEY"] }] },
+        },
+        {
+          id: "workspace",
+          origin: "workspace",
+          providers: ["workspace"],
+          setup: { providers: [{ id: "workspace", envVars: ["OWNER_API_KEY"] }] },
+        },
+      ],
+    });
+    const env = { OWNER_API_KEY: "fake-key" };
+    expect([
+      ...resolveProviderEnvironmentAdmission({
+        env,
+        providerEnvVars: resolveProviderBindingEnvVarCandidates({ metadataSnapshot }),
+      }).bindings.keys(),
+    ]).toEqual(["official"]);
+    expect(
+      resolveProviderEnvironmentAdmission({
+        env,
+        providerEnvVars: resolveProviderBindingEnvVarCandidates({
+          metadataSnapshot,
+          config: { plugins: { allow: ["workspace"] } },
+        }),
+      }).conflicts,
+    ).toEqual([
+      {
+        envVar: "OWNER_API_KEY",
+        pluginIds: ["official", "workspace"],
+        providers: ["official", "workspace"],
+      },
+    ]);
+  });
+
+  it("does not use a Kimi subscription key as a Moonshot model credential", () => {
+    expect(getProviderEnvVars("moonshot")).toEqual(["MOONSHOT_API_KEY"]);
+  });
+
   it("keeps provider credentials in auth and secret inventories", () => {
     const sharedSecretNames = [
       "ANTHROPIC_OAUTH_TOKEN",

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { createInstalledPluginEnabledPredicate } from "../plugins/installed-plugin-index.js";
+import { passesManifestOwnerBasePolicy } from "../plugins/manifest-owner-policy.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import {
   isWorkspacePluginAllowedByConfig,
@@ -40,6 +41,11 @@ export type ProviderEnvVarLookupParams = {
   includeUntrustedWorkspacePlugins?: boolean;
   metadataSnapshot?: PluginMetadataSnapshot;
 };
+
+/** Direct chat-provider credential declarations retain the plugin that owns each variable. */
+export type ProviderBindingEnvVarCandidates = Readonly<
+  Record<string, readonly { pluginId: string; envVars: readonly string[] }[]>
+>;
 
 /** Manifest-provided evidence that a provider auth credential exists outside config. */
 export type ProviderAuthEvidence = {
@@ -210,14 +216,34 @@ function resolveManifestProviderAuthEnvVarCandidates(
 /** Direct manifest bindings exclude auth aliases and legacy lookup fallbacks. */
 export function resolveProviderBindingEnvVarCandidates(
   params: ProviderEnvVarLookupParams & { manifestPlugins?: readonly PluginManifestRecord[] } = {},
-): Record<string, readonly string[]> {
-  return resolveManifestProviderAuthEnvVarCandidates(
-    { ...params, includeUntrustedWorkspacePlugins: false },
-    params.manifestPlugins
-      ? { plugins: params.manifestPlugins }
-      : resolveProviderMetadataSnapshot(params),
-    [],
-  );
+): ProviderBindingEnvVarCandidates {
+  const plugins = params.manifestPlugins ?? resolveProviderMetadataSnapshot(params).plugins;
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
+  const candidates: Record<string, Array<{ pluginId: string; envVars: readonly string[] }>> = {};
+  for (const plugin of plugins) {
+    if (
+      !shouldUsePluginProviderEnvVars(plugin, {
+        ...params,
+        includeUntrustedWorkspacePlugins: false,
+      }) ||
+      !passesManifestOwnerBasePolicy({
+        plugin,
+        normalizedConfig,
+        allowRestrictiveAllowlistBypass: plugin.origin === "bundled",
+      })
+    ) {
+      continue;
+    }
+    const modelProviders = new Set((plugin.providers ?? []).map(normalizeProviderId));
+    for (const provider of plugin.setup?.providers ?? []) {
+      const providerId = normalizeProviderId(provider.id);
+      if (!modelProviders.has(providerId) || !provider.envVars?.length) {
+        continue;
+      }
+      (candidates[providerId] ??= []).push({ pluginId: plugin.id, envVars: provider.envVars });
+    }
+  }
+  return candidates;
 }
 
 function resolveManifestRuntimeAuthFacts(

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -186,7 +186,7 @@ function resolveManifestProviderUsageAuthEnvVarNames(
 
 function resolveManifestProviderAuthEnvVarCandidates(
   params: ProviderEnvVarLookupParams | undefined,
-  snapshot: PluginMetadataSnapshot,
+  snapshot: Pick<PluginMetadataSnapshot, "plugins">,
   sortedAliases: readonly (readonly [string, string])[],
 ): Record<string, string[]> {
   const candidates: Record<string, string[]> = {};
@@ -205,6 +205,19 @@ function resolveManifestProviderAuthEnvVarCandidates(
     }
   }
   return candidates;
+}
+
+/** Direct manifest bindings exclude auth aliases and legacy lookup fallbacks. */
+export function resolveProviderBindingEnvVarCandidates(
+  params: ProviderEnvVarLookupParams & { manifestPlugins?: readonly PluginManifestRecord[] } = {},
+): Record<string, readonly string[]> {
+  return resolveManifestProviderAuthEnvVarCandidates(
+    { ...params, includeUntrustedWorkspacePlugins: false },
+    params.manifestPlugins
+      ? { plugins: params.manifestPlugins }
+      : resolveProviderMetadataSnapshot(params),
+    [],
+  );
 }
 
 function resolveManifestRuntimeAuthFacts(

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
@@ -17,7 +17,7 @@ import type { ModelDefinitionConfig } from "../../../../src/config/types.models.
 import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
 import { executeSqliteQuerySync } from "../../../../src/infra/kysely-sync.js";
 import { openExistingOpenClawStateDatabaseReadOnly } from "../../../../src/state/openclaw-state-db.js";
-import { withTestTimeout } from "../../../helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../../../helpers/promise.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 
 type JsonObject = Record<string, unknown>;
@@ -728,6 +728,7 @@ test("keeps native model choices through Telegram browsing, refresh, and restart
   const boundRef = "anthropic/claude-sonnet-4-6";
   const accountProvider = "catalog-account-fixture";
   const faultProvider = "catalog-fault-fixture";
+  const faultCatalogResponse = createDeferred<void>();
   let rejectCatalog = true;
   let rejectedCatalogRequests = 0;
   let catalogRequests = 0;
@@ -737,6 +738,7 @@ test("keeps native model choices through Telegram browsing, refresh, and restart
     const pathname = url.pathname;
     if (pathname === "/fault-models") {
       if (rejectCatalog && url.searchParams.get("agent") === "broken") {
+        await faultCatalogResponse.promise;
         rejectedCatalogRequests += 1;
         res.writeHead(200, { "content-type": "application/json" });
         res.end("{");
@@ -882,6 +884,7 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
               TELEGRAM_BOT_TOKEN: undefined,
               OPENCLAW_SKIP_STARTUP_MODEL_PREWARM: undefined,
               OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+              OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
             },
             mutateConfig: (cfg) => ({
               ...cfg,
@@ -924,6 +927,15 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
             }),
           });
 
+          const waitForCatalogPass = async (mark: ReturnType<typeof gateway.markLogs>) => {
+            await expect
+              .poll(() => gateway.readLogsSince(mark), { timeout: 30_000 })
+              .toContain("startup trace: sidecars.model-catalog ");
+          };
+          const startupLogMark = gateway.markLogs();
+          expect(rejectedCatalogRequests).toBe(0);
+          faultCatalogResponse.resolve();
+          await waitForCatalogPass(startupLogMark);
           expect(rejectedCatalogRequests).toBeGreaterThan(0);
           const degraded = await gateway.call("models.list", {
             agentId: "broken",
@@ -935,14 +947,29 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
               expect.objectContaining({
                 provider: "anthropic",
                 id: "claude-haiku-4-5",
+                agentRuntime: expect.objectContaining({ id: "claude-cli" }),
+              }),
+              expect.objectContaining({
+                provider: faultProvider,
+                id: "fault-model",
                 available: true,
               }),
             ]),
           });
+          const healthy = await gateway.call("models.list", { agentId: "qa", preparedOnly: true });
+          const nativeAvailable = expect.objectContaining({
+            provider: "anthropic",
+            id: "claude-haiku-4-5",
+            available: true,
+            agentRuntime: expect.objectContaining({ id: "claude-cli" }),
+          });
+          expect(healthy).toMatchObject({ models: expect.arrayContaining([nativeAvailable]) });
+          expect(healthy).not.toHaveProperty("refreshFailed", true);
           rejectCatalog = false;
           const recovered = await gateway.call("models.list", { agentId: "broken", refresh: true });
           expect(recovered).toMatchObject({
             models: expect.arrayContaining([
+              nativeAvailable,
               expect.objectContaining({
                 provider: faultProvider,
                 id: "fault-model",
@@ -951,12 +978,49 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
             ]),
           });
           expect(recovered).not.toHaveProperty("refreshFailed", true);
+          const firstFailureRequests = rejectedCatalogRequests;
+          rejectCatalog = true;
+          let retainedRefreshError: unknown;
+          await expect(
+            gateway
+              .call("models.list", { agentId: "broken", refresh: true })
+              .catch((error: unknown) => {
+                retainedRefreshError = error;
+                throw error;
+              }),
+          ).rejects.toThrow();
+          expect(rejectedCatalogRequests).toBe(firstFailureRequests + 1);
+          const retained = await gateway.call("models.list", {
+            agentId: "broken",
+            preparedOnly: true,
+          });
+          expect(retained).toMatchObject({
+            refreshFailed: true,
+            models: expect.arrayContaining([nativeAvailable]),
+          });
+          rejectCatalog = false;
+          const recoveredAgain = await gateway.call("models.list", {
+            agentId: "broken",
+            refresh: true,
+          });
+          expect(recoveredAgain).toMatchObject({
+            models: expect.arrayContaining([nativeAvailable]),
+          });
+          expect(recoveredAgain).not.toHaveProperty("refreshFailed", true);
           console.info(
             "STARTUP_CATALOG_FAILURE_PROOF",
             JSON.stringify({
               rejectedCatalogRequests,
+              firstFailureRequests,
               degraded,
+              healthy,
               recovered,
+              retainedRefreshError:
+                retainedRefreshError instanceof Error
+                  ? { name: retainedRefreshError.name, message: retainedRefreshError.message }
+                  : retainedRefreshError,
+              retained,
+              recoveredAgain,
             }),
           );
 
@@ -1044,7 +1108,9 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
             refresh: true,
           })) as ModelsListResult;
           expect(catalogChoices(refreshedModels)).toEqual(startupChoices);
+          const restartLogMark = gateway.markLogs();
           await gateway.restartAfterStateMutation(async () => {});
+          await waitForCatalogPass(restartLogMark);
           const restartedModels = (await gateway.call("models.list", {
             view: "default",
             preparedOnly: true,
@@ -1103,7 +1169,9 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
             startupChoices,
           );
           expect(catalogRequests).toBeGreaterThan(0);
+          const accountRestartLogMark = gateway.markLogs();
           await gateway.restartAfterStateMutation(async () => {});
+          await waitForCatalogPass(accountRestartLogMark);
           for (const view of ["default", "configured"] as const) {
             const result = await gateway.call("models.list", { view, preparedOnly: true });
             // SAFETY: the real Gateway validates models.list replies against ModelsListResult.
@@ -1120,6 +1188,7 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
           ).toBe(true);
           expect(providerRequests).toBe(0);
         } finally {
+          faultCatalogResponse.resolve();
           await stopQaGatewayFixture(gatewayOwner);
         }
       },

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
@@ -727,10 +727,24 @@ test("keeps native model choices through Telegram browsing, refresh, and restart
   const primaryRef = "anthropic/claude-haiku-4-5";
   const boundRef = "anthropic/claude-sonnet-4-6";
   const accountProvider = "catalog-account-fixture";
+  const faultProvider = "catalog-fault-fixture";
+  let rejectCatalog = true;
+  let rejectedCatalogRequests = 0;
   let catalogRequests = 0;
   let providerRequests = 0;
   const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
-    const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const pathname = url.pathname;
+    if (pathname === "/fault-models") {
+      if (rejectCatalog && url.searchParams.get("agent") === "broken") {
+        rejectedCatalogRequests += 1;
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end("{");
+      } else {
+        writeJson(res, 200, [configuredModel("fault-model")]);
+      }
+      return;
+    }
     if (pathname === "/account-models") {
       expect(req.headers.authorization).toBe("Bearer fixture-account-token");
       catalogRequests += 1;
@@ -802,7 +816,7 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
           path.join(accountPlugin, "openclaw.plugin.json"),
           JSON.stringify({
             id: accountProvider,
-            providers: [accountProvider],
+            providers: [accountProvider, faultProvider],
             configSchema: { type: "object", properties: {}, additionalProperties: false },
           }),
         );
@@ -810,6 +824,14 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
           path.join(accountPlugin, "index.js"),
           `module.exports = {
           id: ${JSON.stringify(accountProvider)}, register(api) {
+            api.registerProvider({ id: ${JSON.stringify(faultProvider)}, label: "Fault fixture", auth: [],
+              catalog: { async run(ctx) {
+                const agent = require("node:path").basename(require("node:path").dirname(ctx.agentDir));
+                const response = await fetch(${JSON.stringify(`${apiRoot}/fault-models?agent=`)} + agent);
+                return { provider: { baseUrl: ${JSON.stringify(apiRoot)}, api: "openai-responses",
+                  apiKey: "fixture-fault", models: await response.json() } };
+              } },
+            });
             api.registerProvider({ id: ${JSON.stringify(accountProvider)}, label: "Account fixture", auth: [],
               catalog: { async run(ctx) {
                 const auth = ctx.resolveProviderApiKey(${JSON.stringify(accountProvider)});
@@ -870,10 +892,12 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
                 entries: { ...cfg.plugins?.entries, [accountProvider]: { enabled: true } },
               },
               auth: { profiles: {} },
+              bindings: [{ agentId: "qa", match: { channel: "telegram" } }],
               agents: {
                 ...cfg.agents,
                 defaults: {
                   ...cfg.agents?.defaults,
+                  systemAgent: { agentId: "qa" },
                   model: primaryRef,
                   modelPolicy: { allow: [] },
                   models: {
@@ -884,11 +908,57 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
                 entries: {
                   ...cfg.agents?.entries,
                   qa: { ...cfg.agents?.entries?.qa, model: primaryRef },
+                  broken: { model: primaryRef },
                 },
               },
-              models: { providers: {} },
+              models: {
+                providers: {
+                  [faultProvider]: {
+                    baseUrl: apiRoot,
+                    api: "openai-responses",
+                    apiKey: "fixture-fault",
+                    models: [configuredModel("fault-model")],
+                  },
+                },
+              },
             }),
           });
+
+          expect(rejectedCatalogRequests).toBeGreaterThan(0);
+          const degraded = await gateway.call("models.list", {
+            agentId: "broken",
+            preparedOnly: true,
+          });
+          expect(degraded).toMatchObject({
+            refreshFailed: true,
+            models: expect.arrayContaining([
+              expect.objectContaining({
+                provider: "anthropic",
+                id: "claude-haiku-4-5",
+                available: true,
+              }),
+            ]),
+          });
+          rejectCatalog = false;
+          const recovered = await gateway.call("models.list", { agentId: "broken", refresh: true });
+          expect(recovered).toMatchObject({
+            models: expect.arrayContaining([
+              expect.objectContaining({
+                provider: faultProvider,
+                id: "fault-model",
+                available: true,
+              }),
+            ]),
+          });
+          expect(recovered).not.toHaveProperty("refreshFailed", true);
+          console.info(
+            "STARTUP_CATALOG_FAILURE_PROOF",
+            JSON.stringify({
+              rejectedCatalogRequests,
+              degraded,
+              recovered,
+            }),
+          );
 
           await expect
             .poll(() => gateway.call("models.list", { preparedOnly: true }), {

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
@@ -8,6 +8,7 @@ import { pathToFileURL } from "node:url";
 import { createWindowsCmdShimFixture, withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { expect, test } from "vitest";
 import { createQaGatewayChild, writeJson } from "../../../../extensions/qa-lab/api.js";
+import type { ModelsListResult } from "../../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import {
   createChannelIngressQueue,
   getChannelIngressKysely,
@@ -720,14 +721,22 @@ test("initializes unrestricted Telegram model browsing and reuses its prepared c
   );
 }, 120_000);
 
-test("lists native CLI-bound models through Telegram polling and provider callbacks", async () => {
+test("keeps native model choices through Telegram browsing, refresh, and restart", async () => {
   const telegramCalls: TelegramCall[] = [];
   const pendingUpdates: unknown[] = [];
   const primaryRef = "anthropic/claude-haiku-4-5";
   const boundRef = "anthropic/claude-sonnet-4-6";
+  const accountProvider = "catalog-account-fixture";
+  let catalogRequests = 0;
   let providerRequests = 0;
   const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
     const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    if (pathname === "/account-models") {
+      expect(req.headers.authorization).toBe("Bearer fixture-account-token");
+      catalogRequests += 1;
+      writeJson(res, 200, [configuredModel("account-model")]);
+      return;
+    }
     const telegramMatch = pathname.match(/^\/bot([^/]+)\/([^/]+)$/);
     if (!telegramMatch) {
       providerRequests += 1;
@@ -787,6 +796,35 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
         void handleRequest(req, res);
       },
       async (apiRoot) => {
+        const accountPlugin = path.join(fixtureRoot, accountProvider);
+        await fs.mkdir(accountPlugin);
+        await fs.writeFile(
+          path.join(accountPlugin, "openclaw.plugin.json"),
+          JSON.stringify({
+            id: accountProvider,
+            providers: [accountProvider],
+            configSchema: { type: "object", properties: {}, additionalProperties: false },
+          }),
+        );
+        await fs.writeFile(
+          path.join(accountPlugin, "index.js"),
+          `module.exports = {
+          id: ${JSON.stringify(accountProvider)}, register(api) {
+            api.registerProvider({ id: ${JSON.stringify(accountProvider)}, label: "Account fixture", auth: [],
+              catalog: { async run(ctx) {
+                const auth = ctx.resolveProviderApiKey(${JSON.stringify(accountProvider)});
+                if (!auth.apiKey) return null;
+                const response = await fetch(${JSON.stringify(`${apiRoot}/account-models`)}, {
+                  headers: { authorization: "Bearer " + auth.apiKey },
+                });
+                if (!response.ok) throw Error("Fixture catalog credential rejected");
+                return { provider: { baseUrl: ${JSON.stringify(apiRoot)}, api: "openai-responses",
+                  apiKey: auth.apiKey, models: await response.json() } };
+              } },
+            });
+          },
+        };`,
+        );
         const gatewayOwner = createQaGatewayChild();
         try {
           const gateway = await gatewayOwner.start({
@@ -816,6 +854,7 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
               PATH: `${fixtureRoot}${path.delimiter}${process.env.PATH ?? ""}`,
               ANTHROPIC_API_KEY: undefined,
               ANTHROPIC_AUTH_TOKEN: undefined,
+              ANTHROPIC_OAUTH_TOKEN: undefined,
               CLAUDE_CODE_OAUTH_TOKEN: undefined,
               CLAUDE_CONFIG_DIR: path.join(fixtureRoot, "claude-state"),
               TELEGRAM_BOT_TOKEN: undefined,
@@ -824,6 +863,12 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
             },
             mutateConfig: (cfg) => ({
               ...cfg,
+              plugins: {
+                ...cfg.plugins,
+                allow: [...(cfg.plugins?.allow ?? []), accountProvider],
+                load: { paths: [accountPlugin] },
+                entries: { ...cfg.plugins?.entries, [accountProvider]: { enabled: true } },
+              },
               auth: { profiles: {} },
               agents: {
                 ...cfg.agents,
@@ -845,7 +890,6 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
             }),
           });
 
-          // Observe startup auth without warming provider discovery before the channel command.
           await expect
             .poll(() => gateway.call("models.list", { preparedOnly: true }), {
               interval: 50,
@@ -860,6 +904,23 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
                 }),
               ]),
             });
+          const catalogChoices = (result: ModelsListResult) =>
+            result.models
+              .map(({ provider, id, available }) => ({ provider, id, available }))
+              .toSorted((left, right) =>
+                `${left.provider}/${left.id}`.localeCompare(`${right.provider}/${right.id}`),
+              );
+          const startupChoices = catalogChoices(
+            (await gateway.call("models.list", {
+              view: "default",
+              preparedOnly: true,
+            })) as ModelsListResult,
+          );
+          expect(startupChoices).toContainEqual({
+            provider: "claude-cli",
+            id: "claude-opus-5",
+            available: true,
+          });
           pendingUpdates.push(initialModelsUpdate());
           await expect
             .poll(() => telegramCalls.find((call) => call.method === "editMessageText"), {
@@ -895,12 +956,6 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
               fixtureProviderRequests: providerRequests,
             }),
           );
-          const cliCalls = (await fs.readFile(authCallsPath, "utf8"))
-            .trim()
-            .split("\n")
-            .map((line) => JSON.parse(line));
-          console.info("MODEL_INVENTORY_AUTH_PROOF", JSON.stringify(cliCalls));
-          expect(cliCalls.length).toBeGreaterThan(0);
           expect(providerButton?.text).toBe("anthropic (2)");
           expect(modelList?.body.text).toContain("Models (anthropic");
           expect(keyboardCallbackData(modelList!)).toContain(`mdl_sel_${boundRef}`);
@@ -914,6 +969,82 @@ process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" })
               }),
             ]),
           });
+          const refreshedModels = (await gateway.call("models.list", {
+            view: "default",
+            refresh: true,
+          })) as ModelsListResult;
+          expect(catalogChoices(refreshedModels)).toEqual(startupChoices);
+          await gateway.restartAfterStateMutation(async () => {});
+          const restartedModels = (await gateway.call("models.list", {
+            view: "default",
+            preparedOnly: true,
+          })) as ModelsListResult;
+          expect(catalogChoices(restartedModels)).toEqual(startupChoices);
+          expect(startupChoices.some((model) => model.provider === accountProvider)).toBe(false);
+          expect(catalogRequests).toBe(0);
+          const beforeLogin = gateway.markLogs();
+          const login = spawn(
+            process.execPath,
+            [
+              path.resolve(import.meta.dirname, "../../../../dist/entry.js"),
+              "models",
+              "auth",
+              "paste-token",
+              "--agent",
+              "qa",
+              "--provider",
+              accountProvider,
+              "--profile-id",
+              `${accountProvider}:fixture`,
+            ],
+            { env: gateway.runtimeEnv, stdio: ["pipe", "pipe", "pipe"] },
+          );
+          login.stdout.resume();
+          let loginError = "";
+          login.stderr.on("data", (chunk) => {
+            loginError += chunk;
+          });
+          login.stdin.end("fixture-account-token\n");
+          try {
+            const [code] = await withTestTimeout(
+              once(login, "close"),
+              30_000,
+              "Token login timed out",
+            );
+            expect(code, loginError).toBe(0);
+          } finally {
+            login.kill("SIGKILL");
+          }
+          await expect
+            .poll(() => gateway.readLogsSince(beforeLogin), { timeout: 30_000 })
+            .toContain(`config hot reload applied (auth.profiles.${accountProvider}:fixture)`);
+          const addedModels = await gateway.call("models.list", {
+            view: "default",
+            refresh: true,
+          });
+          // SAFETY: the real Gateway validates models.list replies against ModelsListResult.
+          const addedChoices = catalogChoices(addedModels as ModelsListResult);
+          expect(addedChoices).toContainEqual({
+            provider: accountProvider,
+            id: "account-model",
+            available: true,
+          });
+          expect(addedChoices.filter((model) => model.provider !== accountProvider)).toEqual(
+            startupChoices,
+          );
+          expect(catalogRequests).toBeGreaterThan(0);
+          await gateway.restartAfterStateMutation(async () => {});
+          for (const view of ["default", "configured"] as const) {
+            const result = await gateway.call("models.list", { view, preparedOnly: true });
+            // SAFETY: the real Gateway validates models.list replies against ModelsListResult.
+            expect(catalogChoices(result as ModelsListResult)).toEqual(addedChoices);
+          }
+          const cliCalls = (await fs.readFile(authCallsPath, "utf8"))
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line));
+          console.info("MODEL_INVENTORY_AUTH_PROOF", JSON.stringify(cliCalls));
+          expect(cliCalls.length).toBeGreaterThan(0);
           expect(
             cliCalls.every((args) => JSON.stringify(args) === '["auth","status","--json"]'),
           ).toBe(true);

--- a/test/fixtures/config-corpus/provider-admission-bedrock.json
+++ b/test/fixtures/config-corpus/provider-admission-bedrock.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "vars": {
+      "AWS_PROFILE": "default",
+      "AWS_SHARED_CREDENTIALS_FILE": "/home/fixture/.aws/credentials"
+    }
+  },
+  "models": {
+    "providers": {
+      "amazon-bedrock": { "auth": "aws-sdk" }
+    }
+  }
+}

--- a/test/fixtures/config-corpus/provider-admission-family.json
+++ b/test/fixtures/config-corpus/provider-admission-family.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "vars": {
+      "BYTEPLUS_API_KEY": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  }
+}

--- a/test/fixtures/config-corpus/provider-admission-generic.json
+++ b/test/fixtures/config-corpus/provider-admission-generic.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "vars": {
+      "GITHUB_TOKEN": "FAKE_CONFIG_CORPUS_CREDENTIAL",
+      "AWS_PROFILE": "default",
+      "AWS_SHARED_CREDENTIALS_FILE": "/home/fixture/.aws/credentials"
+    }
+  }
+}

--- a/test/fixtures/config-corpus/provider-admission-openai.json
+++ b/test/fixtures/config-corpus/provider-admission-openai.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "vars": {
+      "OPENAI_API_KEY": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  }
+}

--- a/test/fixtures/config-corpus/provider-admission-selected-plan.json
+++ b/test/fixtures/config-corpus/provider-admission-selected-plan.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "vars": {
+      "BYTEPLUS_API_KEY": "FAKE_CONFIG_CORPUS_CREDENTIAL"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": { "primary": "byteplus-plan/ark-code-latest" }
+    }
+  }
+}

--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -280,7 +280,7 @@ describe("Provider model discovery auth preparation", () => {
           },
         };
       } else {
-        config.models = { providers: { [providerId]: {} } };
+        config.models = { providers: { [providerId]: { baseUrl: "", models: [] } } };
         vi.stubEnv("XAI_API_KEY", keyB);
       }
       await state.writeAuthProfiles(store);
@@ -714,7 +714,7 @@ describe("Provider model discovery auth preparation", () => {
     "preserves a plugin-owned %s after probing exhausted OAuth",
     async (resultKind) => {
       const { config, store } = await createChutesCatalogFixture();
-      config.models = { providers: { chutes: {} } };
+      config.models = { providers: { chutes: { baseUrl: "", models: [] } } };
       const otherProfileId = "openai:other-source";
       store.profiles[otherProfileId] = {
         type: "api_key",
@@ -917,7 +917,9 @@ describe("provider catalog late-result finalization", () => {
           resolveImplicitProviders({
             config: {
               auth: { order: { [providerId]: [profileId] } },
-              ...(shape === "providers" ? { models: { providers: { [peerId]: {} } } } : {}),
+              ...(shape === "providers"
+                ? { models: { providers: { [peerId]: { baseUrl: "", models: [] } } } }
+                : {}),
             },
             agentDir: state.agentDir(),
             authStore: store,

--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -280,6 +280,7 @@ describe("Provider model discovery auth preparation", () => {
           },
         };
       } else {
+        config.models = { providers: { [providerId]: {} } };
         vi.stubEnv("XAI_API_KEY", keyB);
       }
       await state.writeAuthProfiles(store);
@@ -713,6 +714,7 @@ describe("Provider model discovery auth preparation", () => {
     "preserves a plugin-owned %s after probing exhausted OAuth",
     async (resultKind) => {
       const { config, store } = await createChutesCatalogFixture();
+      config.models = { providers: { chutes: {} } };
       const otherProfileId = "openai:other-source";
       store.profiles[otherProfileId] = {
         type: "api_key",
@@ -865,6 +867,7 @@ describe("provider catalog late-result finalization", () => {
         {
           id: providerId,
           label: "Catalog Fixture",
+          ...(shape === "providers" ? { hookAliases: [peerId] } : {}),
           auth: [
             {
               id: "oauth",
@@ -912,7 +915,10 @@ describe("provider catalog late-result finalization", () => {
       const discover = (timeoutMs?: number) =>
         withCatalogProviders(() =>
           resolveImplicitProviders({
-            config: { auth: { order: { [providerId]: [profileId] } } },
+            config: {
+              auth: { order: { [providerId]: [profileId] } },
+              ...(shape === "providers" ? { models: { providers: { [peerId]: {} } } } : {}),
+            },
             agentDir: state.agentDir(),
             authStore: store,
             env: {},
@@ -936,7 +942,14 @@ describe("provider catalog late-result finalization", () => {
       let accepted = first;
       const lateReads = reads;
       if (timedOut) {
-        expect(outcomes).toEqual([{ provider: providerId, status: "unavailable" }]);
+        expect(outcomes).toEqual(
+          shape === "providers"
+            ? [
+                { provider: providerId, status: "unavailable" },
+                { provider: peerId, status: "unavailable" },
+              ]
+            : [{ provider: providerId, status: "unavailable" }],
+        );
         outcomes.length = 0;
         accepted = await discover();
       }


### PR DESCRIPTION
Depends on #144768. This PR remains open on `feat/provider-use-admission` for integration review.

## Problem

A live Gateway report on September 11 described native CLI models disappearing and saved Copilot models appearing after `openclaw models list --refresh`; restart reversed the change. On pinned main `611dbf76b4ba897ab2ac3d7cf863257391e93fe6`, real CLI and browser captures showed 1 → 35 → 1 models. Scope drift reproduced; the older native-disappearance direction did not.

Preparing all catalogs before readiness also delayed an 11-agent, 400-model-per-agent fixture to 57.2 seconds.

## Change

Startup publishes admitted static and stored facts. Live discovery and native CLI synchronization run after readiness, once per agent through the existing bounded scheduler. Background acquisition and explicit refresh use one scope, consume #144768’s admission owner, and publish through the existing event.

The worker preserves source/runtime config provenance and combines synchronous native hooks with parent-captured asynchronous hooks. Rebuilt auth storage retains its captured OAuth provider hooks. Failed acquisition retains usable published rows; lifecycle cancellation still propagates. Telegram consumes shared visibility and session projection instead of adding separate native/default/fallback rows. No schema, protocol, or config-key changes.

## Validation

- Real CLI/browser: 37 → 37 → 37 after background completion, refresh, and restart. Public token-paste account addition: 19 → 37 → 37.
- Telegram Test Server userbot: seven provider pages cover the complete model set. A separate saved-family-account case reproduced a session-selected Plan missing only from Telegram. Final head fixes it: both Plan callbacks match the same-session Gateway response, while the unscoped agent catalog excludes them.
- An already-open picker receives publication events, reloads its catalog, and reconnects after restart. During account save its intermediate wire responses are **19 → 1 → 37**; completed refresh and restart retain 37. This is not a monotonic-publication claim.
- All 22 sanitized config shapes reached real Gateway readiness. Final browser controls cover five admission cases and a matching dependency-base control. Normal CLI, configured picker, and chat sets agree. Diagnostic `all` agrees with CLI `--all`; unavailable inventory and separate CLI-launch actions are not normal model rows.
- Same-box 11×400 comparison: readiness 10.50 seconds on `de090105` and 10.62 seconds on dependency `40622e9`. The difference is within run-to-run variation. All 4,400 rows remain after background acquisition and explicit refresh. The final-head native and OAuth fact corrections were included in this repeated measurement.
- 285 owner tests, 89 corpus/sibling tests including 45 prior-release state cases, and 95 dependency tests passed on the type-only successor. The session correction passed 169 focused tests. After CI exposed two auth-fact omissions and a fixture type error, the final owner correction passed 64 tests across three files, focused lint, build, and the unchanged native Gateway failure/recovery/account/restart regression.

Final corrective head: `de0901059c6ab163800789ee95c8a428dff98d20`. Fresh final-head captures cover CLI/browser 37 → 37 → 37, native failure/recovery, Telegram session scope, and 11×400 timing. Earlier minimal-corpus and open-picker captures retain their `4724225` identity; the complete older proof and all failures remain preserved.

Proof uses synthetic credentials and catalog endpoints with zero model inference. Isolated metadata failures remain visible as partial-refresh warnings.

## Review risks

The large fixture used 588 MiB at readiness and 4,084 MiB after background acquisition plus explicit refresh, versus 630 MiB at the base endpoint. This does not isolate background-only memory or measure peak memory. Existing generation-owned workers stay alive to prevent changed plugin code loading under old state; this change starts them automatically. Lower-memory deployment sizing and the brief static publication during account save remain review concerns.

The dependency branch advanced after the pinned proof. CI run `34626480709` tested merge `62568d6761ce7d853e156858a88ee286d3021972` against dependency `6e7c69e1afe4ec60c981a5d4f90a294e33884938` and finished with two substantive failures: migrated binding discovery and a startup timeout. A controlled dependency-delta experiment reproduces the binding failure; it is not a standalone run on the complete dependency base. The unchanged startup file passes all three tests on the branch head, but the CI timeout cause remains unclassified.

Ratchet and lint checks passed on that recorded merge tree. The current PR reports merge conflicts, and #144768 remains open, so the old merge ref is not accepted current integration proof. Structural checks, including line limits, unused exports, ratchets, and formatting, must be green on the accepted CI merge tree; none can be waived as unrelated. The branch remains open pending the instructed single rebase onto main after #144768 merges.

The census below records source consumers and test/proof gaps. This head is not yet ready for the independent census verdict or landing. No approval-grant or merge action has been performed.
## Consumers

This inventory uses head `de0901059c6ab163800789ee95c8a428dff98d20` against admission base `40622e9fc3767c94b7e7eb5a250dde1c421ce5db`. Source paths identify direct readers and writers. Shared response consumers are listed separately so callers outside the touched files remain visible. There are no schema, protocol, config-key, or status-value additions.

| Changed symbol or meaning | Writers, readers, and replacement owner |
| --- | --- |
| Removed internal `includeCredentialProviders` switch | The old call chain was auth-publication `enqueue`/`drain` → `drainPendingAuthMutations` → `publishPreparedModelRuntimeOwnerBatch` → `startSerializedSnapshotBuildBatch`/`buildSnapshotBatch` → `prepareWorkspaceBuildGroup`/`prepareAgentFacts` → `collectPreparedModelRuntimeProviderIds`. The switch is gone from all six owner modules: `prepared-model-runtime-auth-publication.ts`, `prepared-model-runtime.ts`, `.owner.ts`, `.build.ts`, `.facts.ts`, `.configured.ts`. Every build now uses the same admitted scope. Head has no remaining occurrence of this switch. |
| Removed transaction-only `profileSetChanged` accumulator | `PreparedModelRuntimeAuthPublicationOwner.enqueue` now records owner gates without accumulating this bit (`src/agents/prepared-model-runtime-auth-publication.ts:56`); `drain` calls the publication callback without a scope boolean (`:233`); its only production caller is `src/agents/prepared-model-runtime.ts:659`. The mutation-event field is retained: `invalidatePreparedModelRuntimeOwnersForAuthMutation` still marks the catalog stale at `prepared-model-runtime-auth-publication.ts:321`. Event producers/readers remain `auth-profiles/runtime-snapshots.ts:145,329,365,434,542`, `auth-profiles/store.ts:1160,2038`, `auth-profiles/mutation-lineage.ts:109`, and `gateway/server-methods/models-auth-refresh.ts:31`. The field was not removed from the event contract. |
| `providerIds` now means admitted configured, credential-bound, and native providers in static and full preparation | `resolvePreparedModelRuntimeProviderIds` (`src/agents/prepared-model-runtime.facts.ts:95`) calls the dependency's `resolveProviderUseAdmission`; it reads selected refs, profile facts, auth aliases, provider environment declarations, and native credential facts. Its only callers are initial agent facts (`:169`), merged ambient facts (`:395`), and the worker's refreshed exact-agent facts (`prepared-model-catalog.worker.ts:242`). `collectPreparedModelRuntimeProviderIds` (`.configured.ts:63`) has one production caller, this helper (`.facts.ts:126`). `prepareWorkspaceBuildGroup` callers are `.build.ts:449`, `.scoped-catalog.ts:43`, and `prepared-model-catalog.worker.ts:122`. Those callers retain explicit provider-scoped discovery where requested. No separate admission policy remains in the worker. |
| Static provider rows and configured registry-group identity | `.facts.ts:295` derives discovery scope from agent facts; `:409` passes admitted providers to static catalog loading; `groupConfiguredRegistrySources` includes normalized provider IDs in its key (`:621`); `prepareConfiguredRuntimeFactsBatch` filters static provider configs against each representative's scope (`:664`). The batch's only production consumer is `.build.ts:550`. Full preparation passes the same IDs at `.full-catalog.ts:90`; its callers are `.build.ts:541`, `.scoped-catalog.ts:62`, and `prepared-model-catalog.worker.ts:302`. Rows flow through the captured model registry to the published catalog and the consumers below. This key is ephemeral build grouping, not persisted state. |
| Local parameter `admittedProviderIds` renamed to `admittedProviders` | The positional parameter of `collectPreparedModelRuntimeProviderIds` in `.configured.ts:63` has one production caller, the facts scope resolver named above. Its shape remains `Iterable<string>`. The separate local `admittedProviderIds` in `models-config.providers.implicit.ts` is declared from that function's own `providerIds`/catalog refs and read in its runtime-catalog branch. Those three same-name references in merge62568 are not callers of the renamed parameter. |
| Removed local `prepareSyntheticAuth` helper; startup no longer awaits live/native preparation | The deleted helper was defined only in `src/agents/prepared-model-runtime.synthetic-auth.ts` and called only by `.facts.ts`. `.facts.ts:356` now selects synchronous `resolveAmbientAgentCredentialsForDiscovery` for static mode and existing asynchronous `prepareAmbientAgentCredentialsForDiscovery` for live mode. `prepareAgentFacts` reads stored profiles without external sync (`.facts.ts:142`). The public provider hook named `prepareSyntheticAuth` is retained: declarations in `src/plugins/provider-plugin.types.ts:631`; dispatch/cache in `provider-synthetic-auth.ts`, `provider-runtime.ts`, `provider-discovery.ts`, `provider-discovery.runtime.ts`, and `synthetic-auth.runtime.ts`; implementations in `extensions/anthropic/provider-discovery.ts`, `anthropic/register.runtime.ts`, `codex/provider-discovery.ts`, and `codex/src/app-server/native-auth.ts`. Its existing runtime-hook and compatibility docs remain valid. |
| Native facts in worker requests | The existing parent `createPreparedModelCatalogWorker` captures native facts before dispatch (`src/agents/prepared-model-catalog-worker.ts:289`); the worker restores request facts (`prepared-model-catalog.worker.ts:153`), includes their provider refs in synchronous native resolution (`:228`), merges current disk profiles, then reruns shared admission (`:242`). Async parent captures and synchronous native hooks both reach full catalog preparation (`:302`). The worker factory's only production caller is `.build.ts:248`; worker task registration is `.worker.ts:370`. No native account is synthesized from a UI label. |
| Rebuilt `templateAuthStorage` and OAuth provider object identity | `.facts.ts:386` rebuilds storage after ambient/profile credential merge and registers captured provider objects with the existing per-storage registry at `:388`. Readers are configured-source grouping (`:614`), captured model discovery (`:667`), and full discovery (`.full-catalog.ts:57`). The canonical auth storage reads that registry in `sessions/auth-storage.ts:777,853`, `sessions/auth-storage-oauth-registry.ts:32`, and `sessions/auth-storage-oauth-refresh.ts:37,67`. Provider object identity remains part of registry-group equivalence; the change does not replace the registry owner. |
| Worker source/runtime config provenance | `createPreparedModelCatalogWorkerInput` serializes runtime config facts and authored-source facts separately (`src/agents/prepared-model-catalog-worker.ts:165`), includes both in its fingerprint (`:135,179`) and payload (`:188`). `prepareWorkerGeneration` restores each separately (`prepared-model-catalog.worker.ts:95`) before setting the runtime/source pair and discovery; reconstruction fingerprints consume both (`:138`). The removed shared-object-identity shortcut had no other consumer. This transports existing resolution facts; it does not change config or persistence schema. |
| `PreparedModelCatalogGenerationMismatchError` classification | The internal class now extends `PreparedModelRuntimePublicationSupersededError` (`src/agents/prepared-model-catalog-worker.ts:91`). The parent constructs it for a worker `generation-mismatch` response (`:231`), fences the pool in validation, and catches it to retire that request's pool (`:342`). Existing caller handling for superseded publication now recognizes this lifecycle outcome. The worker result discriminants `ok`, `failed`, and `generation-mismatch` are unchanged; a response is checked before publication. |
| Startup hydration and full-catalog scheduling | `hydrateConfiguredExternalCliAuth` (`src/gateway/server-startup-post-attach.ts:297`) moves from the readiness path to `scheduleStartupModelCatalogs` (`:408`), its only production caller. Hydration stops before the next agent when the lifetime is no longer current. `startGatewaySidecars` publishes stored/static facts (`:590`). `startGatewayPostAttachRuntime` registers the new sidecar in Gateway lifetime handles (`:1475`); the sidecar waits on the existing post-ready barrier, checks lifetime before each agent, and calls `loadPreparedModelCatalogSnapshot({refreshFullCatalog:true})` (`:447`). It catches acquisition failure only while that owner/lifetime stays current; lifecycle errors propagate. Existing full-catalog publication drives `chat.metadata.changed` through `src/gateway/server-chat-metadata-lifecycle.ts:13`. Documentation is `docs/cli/models.md`. |
| Removed `ModelCatalogAuthChecker`, `isRetiredModelPickerProvider`, and command-side catalog additions | The checker type's only production use was the deleted command `hasAuth` closure. The retired-provider helper's only production readers were `createModelPickerVisibleProviderPredicate` and deleted `isModelsBrowseVisibleProvider`. The predicate still directly checks the existing retired-provider set (`src/agents/model-runtime-aliases.ts:41`), and its callers remain `src/flows/model-picker.ts:949,1189,1293,1584`. Deleted command locals are `isModelsBrowseVisibleProvider`, `hasAuth`, `incompatibleModelKeys`, `restrictToProviderWildcards`, `useUnfilteredCliCatalog`, `add`, `addRawModelRef`, and `addModelConfigEntries`. All were private to `commands-models.ts`. `projectPreparedModelsProviderData` now groups only shared projected visible rows (`src/auto-reply/reply/commands-models.ts:271`). Full searches find no remaining removed exported symbol. |
| `LogicalModelCatalogEntryState.syntheticAuthUnknown` and shared visibility | `resolveLogicalModelCatalogEntryState` writes this internal boolean from actual auth evidence (`src/agents/model-catalog-visibility.ts:51`). `prepareLogicalVisibleModelCatalog` reads it only for unmanaged non-OpenAI entries (`:177`), absorbing the former Gateway-only `syntheticLocal` rule. Direct state producers are `src/gateway/server-methods/models-list-result.ts:586`, `src/auto-reply/reply/commands-models.ts:263`, and `src/flows/model-picker.ts:210`; all use the same helper. Direct visibility readers are those same three modules. The boolean stays inside catalog preparation; it is not a new wire field or a credential-availability claim. |
| Bare configured refs and fallback retention | `createModelVisibilityPolicyWithFallbacks` now resolves a bare additional/exact/fallback ref against its real provider while retaining the known default provider for the default selection (`src/agents/model-selection-shared.ts:1631,1665`). Its only production caller is `createModelVisibilityPolicy` (`src/agents/model-visibility-policy.ts:55`). That wrapper's readers are `auto-reply/reply/{model-selection-directive.ts:180,commands-models.ts:239,model-selection.ts:184,284,299,533,session-reset-model.ts:156}`, `commands/models/list.status-command.ts:575`, `model-picker/apply-session-model-selection.ts:203`, `gateway/worker-environments/inference-runtime.ts:398`, `gateway/http-utils.ts:201`, `gateway/server-methods/models-list-result.ts:559`, `agents/tools/session-status-tool.ts:531`, `agents/model-catalog-visibility.ts:118`, `agents/model-catalog-view.ts:112`, `agents/command/model-selection.ts:150,173,568`, and `agents/command/run-embedded-attempt.ts:423`. These callers consume configured/retained key sets and policy; the config keys themselves are unchanged. |
| Session selection and `ModelsProviderData` row/variant contents | Telegram now supplies its stored session entry at `extensions/telegram/src/bot-handlers.callback-router.ts:527` through `TelegramBotDeps.buildModelsProviderData` (`bot-deps.ts:75,138`). `ModelsCommandSessionEntry` now includes existing override and route-origin fields (`src/auto-reply/reply/commands-models.ts:55`). `projectPreparedModelsProviderData` resolves that selected model (`:210`), passes it to the shared `createModelCatalogDecisions` (`:221`), and consumes `decisions.snapshot.entries` and `.routeVariants` (`:237,258,301`). That owner already projects session/provider rows without changing shared state. Result writers for `byProvider`, `modelNames`, `modelCatalog`, `runtimeChoicesByProvider`, and `runtimeChoicesByModel` remain this projection (`:271–331`). `resolvedDefault` remains the agent default. The SDK retains both the existing `ModelsProviderData` construction shape and the compatibility wrapper `buildModelsProviderData` (`src/plugin-sdk/models-provider-runtime.ts:22`, documented in `docs/plugins/sdk-migration/compatibility-policy.md:87`); `command-auth.ts` and `command-auth-native.ts` re-export the unchanged types. |

Direct final consumers of the changed shared command projection:

- Text/native `/models`: `resolveModelsCommandReply` (`src/auto-reply/reply/commands-models.ts:489`) groups, paginates, and produces the channel reply; `handleModelsCommand` dispatches it. Channel `commands.buildModelsMenuChannelData`, `buildModelsProviderChannelData`, and `buildModelsListChannelData` retain ownership of encoding the structured menu. The shared projection does not assemble a second client-specific row set.
- Telegram: `extensions/telegram/src/bot-handlers.callback-router.ts:534–665` renders provider/model buttons, verifies membership, and forwards `modelData.modelCatalog` to `applySessionModelSelection`; `:696` renders the observed apply result. Session storage is read before projection. The provider/model IDs remain typed values; presentation text never becomes a path or selected model.
- Discord: `extensions/discord/src/monitor/model-picker.state.ts:198` loads the shared builder; `:503–627` and `model-picker.view.ts:75–821` read names, provider membership, and runtime choices. `native-command-model-picker-interaction.ts:189,571,596,659` verifies selected membership, reads catalog capabilities, then calls `applyDiscordModelPickerSelection` in `native-command-model-picker-apply.ts`. The view and apply consumers both inherit the shared change.
- Mattermost: `extensions/mattermost/src/mattermost/slash-http.ts:797` and `monitor-model-picker.ts:212` call the shared builder with session state through `runtime-api.ts`; `model-picker.ts:144,225,238,301,324` derives menu rows and allowed selections. Slash delivery sends the rendered view at `slash-http.ts:831`; monitor selection dispatch consumes the allowed refs. Both runtime barrels preserve the public SDK boundary.
- Interactive setup/selection: `src/flows/model-picker.ts:191` consumes the shared logical visibility helper, and its provider predicate call sites listed above retain native/retired filtering for that surface. The shared visibility change therefore also affects this sibling, not only Gateway and Telegram.

Readers of the published Gateway `models.list` rows retain their existing request/result schema:

- Owner → `src/gateway/server-model-catalog.ts` → `src/gateway/server-methods/models-list-result.ts:559,570` → registered `modelsHandlers["models.list"]` (`src/gateway/server-methods/models.ts:21`). That handler validates `ModelsListParamsSchema`, resolves agent/session authority, and applies its existing session projection before responding. Schema definitions stay at `packages/gateway-protocol/src/schema/agents-models-skills.ts:289,362`; validator registration is `validator-registry.ts:406`. `default`, `configured`, `all`, and `provider-config` keep distinct documented meanings; diagnostic `all` is not normal picker membership.
- CLI: `src/commands/models/list.list-command.ts:38,78` requests and renders the published rows (or its existing local owner path). Terminal UI: `src/tui/gateway-chat.ts:453` reads the method; `src/tui/embedded-backend.ts` reads the local prepared owner. No renderer gets a separate provider admission rule.
- Control UI: `ui/src/lib/model-catalog-store.ts:52` is the shared request adapter and defaults to `configured`. Direct callers are `lib/gateway-diagnostics.ts:55`, `pages/config/config-page.ts:389`, `pages/model-providers/load.ts:85`, `pages/model-providers/catalog-discovery.ts:96`, `pages/cron/cron-page.ts:290`, `pages/new-session/model-control.ts:197`, `pages/agents/agents-page.ts:661`, `components/command-palette-catalog-search.ts:322`, `pages/chat/chat-state-refresh.ts:240`, and `pages/chat/chat-command-executor.ts:261,750`. Chat rendering ends in `pages/chat/components/chat-model-picker.ts` and its options/state components; runtime-launch actions are separate typed targets. Existing event readers are `lib/model-catalog-store.ts:68`, `app/app-host.ts:496`, `pages/cron/cron-page.ts:136`, and `components/command-palette.ts:338`.
- Shared Swift/macOS: `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayRequest.swift:100` constructs `models.list`; `ChatGatewayPayloadCodec.swift:158` maps catalog/config events; `ChatViewModel+ModelControls.swift:4` publishes choices; `ChatViewModel+TransportEvents.swift:33,47,82,194` reloads them. macOS `WebChatSwiftUI.swift:238,274` requests catalogs and `QuickChatModel.swift:296,1142` publishes choices/reloads. `GatewayConnection.swift:161` retains the method enum.
- Android: `apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt:7024,7056` requests catalogs and `:7027` publishes through its generation guard; `chat/ChatController.kt:5146` publishes chat choices; `ui/chat/ChatScreen.kt:396–656` consumes them for the picker and selected capabilities. `gateway/GatewayProtocol.kt:574,947` keeps method/event decoding; `NodeRuntime.kt:5918` and `ChatController.kt:4008` consume invalidation events. `MainViewModel.kt:524` exposes the state and `ui/HealthLogsSettingsScreen.kt:50` reads its count.
- Wear: Android `wear/WearProxyController.kt:223` forwards the method; `apps/android/wear-shared/src/main/java/ai/openclaw/wear/shared/WearProtocol.kt:119` retains the type; `apps/android/wear/src/main/java/ai/openclaw/wear/WearGatewayRepository.kt:310` decodes it and `WearViewModel.kt` consumes the catalog for selection. No native app wire shape changed.

Last-consumer evidence in this lane is the real CLI/browser row captures and Telegram Test Server message/callback captures recorded in the proof section. Shared owner/command regressions support the core change. This lane did not run a new live Discord, Mattermost, Swift, Android, or Wear device proof; these are source-traced indirect consumers, not claimed live passes. Stable-host/previous-release-state and final CI merge-tree census remain explicit landing gates until their results are recorded.


## Tests

This case ledger names the boundary actually exercised. A downstream production caller does not turn a helper test into a command or supervisor test. Entries marked internal-only are remaining corrections, not accepted gate passes. Unchanged tests are not reclassified merely because they share a file.

- `handleModelsCommand` is registered in `src/auto-reply/reply/commands-handlers.runtime.ts:91`.
- `models.list` is registered in `src/gateway/server-methods/models.ts:21`.
- `startGatewayPostAttachRuntime` is invoked by `src/gateway/server-startup-finish.ts:240`.
- The catalog worker supervisor uses `runtimeProcessEntrypoints.preparedModelCatalog` through `WorkerTaskPool` in `src/agents/prepared-model-catalog-worker.ts:237`.
### Visibility and aliases

| File and line | Exact case | Actual boundary | Verdict / minimum correction |
| --- | --- | --- | --- |
| `src/agents/model-catalog-visibility.test.ts:97` | retains a bare fallback under its unique catalog provider | `resolveLogicalVisibleModelCatalog` | NEW, internal-only. Move the bare fallback fixture to a real `/models` command or `models.list` request and assert the fallback provider/model is visible. |
| same, `:125` | keeps unverified local models without admitting failed or OpenAI auth in default browse | same, with handcrafted auth evaluation | NEW, internal-only. Exercise command or Gateway default view using the existing auth test fixture; preserve local-unknown, local-failed, and remote-unknown outcomes. |
| same, `:125` | keeps unverified local models without admitting failed or OpenAI auth in configured browse | same | NEW, internal-only. Same correction for configured view. |
| `src/agents/model-runtime-aliases.test.ts:364` | keeps standalone CLI backend provider refs visible | `createModelPickerVisibleProviderPredicate`, `isCliRuntimeProvider` | Existing helper case has three new retired-provider assertions. The predicate's production consumers are interactive pickers in `src/flows/model-picker.ts:949,1189,1293,1584`, not the chat handler. Remove the newly moved helper assertions only if equivalent actual interactive-command proof is retained or add that command-level proof. Existing chat alias case covers chat behavior but cannot certify this predicate's call path. |
| same, deleted case | recognizes retired picker providers without loading CLI backend metadata | deleted `isRetiredModelPickerProvider` helper | Removal is consistent with deleting that helper. No replacement direct predicate case should be presented as registered command proof. |

### Worker credential and native-auth cases

| File and line | Exact case | Actual boundary | Verdict / minimum correction |
| --- | --- | --- | --- |
| `src/agents/prepared-model-catalog-worker.integration.test.ts:423` | pairs full catalog native routes with exact-generation auth (async: false) | `startSerializedSnapshotBuildBatch` → snapshot full-catalog access → real worker supervisor and registered worker | Changed initial native-mode expectation. This genuinely crosses the worker boundary; name it in evidence. It does not run Gateway dispatch. |
| same | pairs full catalog native routes with exact-generation auth (async: true) | same | Changed expectation correctly distinguishes deferred parent-captured async auth from initial static auth. Real worker proof; not Gateway startup proof. |
| `src/agents/prepared-model-catalog-worker.secrets.test.ts:87` | preserves config literal bytes through discovery and the writable plan | direct worker request function | REWRITTEN, internal-only despite real fixture HTTP. |
| same | preserves config marker bytes through discovery and the writable plan | same | REWRITTEN, internal-only. |
| same | preserves config env-template bytes through discovery and the writable plan | same | REWRITTEN, internal-only. |
| same | preserves profile profile-only sibling through discovery and the writable plan | same | REWRITTEN, internal-only. |
| same | preserves config migrated binding through discovery and the writable plan | same | NEW parameter case, internal-only. |
| same | preserves config loader-substituted literal through discovery and the writable plan | same | REWRITTEN, internal-only. |
| same | preserves config loader-escaped literal through discovery and the writable plan | same | REWRITTEN, internal-only. |
| same | preserves config loader-pending shorthand through discovery and the writable plan | same | REWRITTEN, internal-only. |

- Minimum secrets correction: use `createPreparedModelCatalogWorker(...).loadCatalog()` with the existing isolated fixture and an owned `isCurrent`/shutdown lifecycle. Keep exact HTTP bearer checks and returned model assertions. That forces real structured cloning, worker generation restoration, and result validation. Remove direct cloned-object WeakMap assertions: they inspect the parent clone, which a real worker cannot mutate. Replace parent `planOpenClawModelsJsonSource` spying with a worker-observable fixture result or existing persisted/public contract proof. Do not lose the no-secret-in-plan contract by merely deleting its assertion; identify a real worker-visible observation first.
- Existing stronger sibling: `prepared-model-catalog-worker.integration.test.ts:1007`, “preserves ref-only api-key and token profiles through the real worker.” It uses the supervisor and provider-visible credential checks but does not cover all seven literal/provenance variants or the migrated binding. It is a harness to extend, not evidence that those variants already passed.

### Runtime scope and auth invalidation

| File and line | Exact case | Actual boundary | Verdict / minimum correction |
| --- | --- | --- | --- |
| `src/agents/prepared-model-runtime.sources.test.ts:255` | isolates admitted static scopes while sharing equal scopes and retaining authored rows | `prepareConfiguredRuntimeFactsBatch` | NEW, internal-only. Three agents are supplied as precomputed facts. It cannot detect wrong admission facts from the real supervisor. Move narrow/wider/equal agent scopes into the existing built Gateway fixture; request each agent before acquisition and assert allowed static/authored rows. Registry identity and `registryCount === 2` are implementation/performance assertions, not substitute behavior. |
| `src/agents/prepared-model-runtime.reload-auth.test.ts:367` | does not live-refresh a token rotation with the same profile set | mocked mutation callback → `prepareModelRuntimeSnapshot` | REWRITTEN auth assertion, internal-only. It now checks rotated store bytes instead of the worker's providerIds call shape, which is stronger locally but still bypasses mutation command/Gateway flow. Use token-paste/update command followed by public auth/catalog observation, keeping discovery request count unchanged for rotation. |
| `src/agents/prepared-model-runtime.startup-static.test.ts:468` | keeps explicit provider discovery scoped while preparing configured static rows | `prepareScopedReadOnlyModelCatalog` | REWRITTEN, internal-only and call-shape assertions. Drive the actual CLI list/probe command which owns this scoped read; fixture unrelated provider hook must stay uncalled, admitted selected rows must survive. |
| same, `:604` | publishes configured turn facts without eagerly building a full catalog | `refreshPreparedModelRuntimeSnapshots`, snapshot accessors; worker mocked | REWRITTEN, internal-only. Move the new sync-vs-async auth behavior to real startup/worker supervisor evidence; preserve old unrelated lifecycle assertions unless separately justified. |
| same, `:744` | publishes exact dynamic configured models without building a live catalog | same; configured model resolver mocked | Changed provider-scope expectation only. Internal-only. Replace the changed call-shape assertion with actual returned provider/model behavior at supervisor/command boundary; do not relabel the old helper test as Gateway proof. |
| same, `:877` | prepares admitted static rows when manifest facts already resolve the selected model | `refreshPreparedModelRuntimeSnapshots`, static hook mocked | REWRITTEN, internal-only. A real Gateway fixture should expose a nonselected admitted static row as well as the selected manifest row; the current test only counts configured models and hook arguments. |

### Chat command projection

| File and line | Exact case | Actual boundary | Verdict / minimum correction |
| --- | --- | --- | --- |
| `src/auto-reply/reply/commands-models.test.ts:287` | retains an unauthenticated default only when configured=false | `buildPreparedModelsProviderData` | NEW, internal-only. Call `handleModelsCommand(buildParams('/models', { agents: {} }), true)` with equivalent absent-primary config and assert no implicit default provider. |
| same | retains an unauthenticated default only when configured=true | same | NEW, internal-only. Same handler with explicit primary; assert its provider/model output. |
| same, `:458` | retains the published default alongside allowed provider models | `handleModelsCommand('/models')` | REWRITTEN, registered command reached. Checks visible provider counts. |
| same, `:524` | applies the same configured model restriction to CLI runtime providers | `buildPreparedModelsProviderData` | REWRITTEN, internal-only. Call handler with `/models claude-cli`; assert the two intended rows and all excluded rows. |
| same, `:626` | honors configured CLI primary retention under provider wildcards when listing CLI runtime models | `buildPreparedModelsProviderData` | Changed table expectation, internal-only. |
| same | honors configured CLI fallback retention under provider wildcards when listing CLI runtime models | same | Changed table expectation, internal-only. |
| same | honors an unrestricted agent override when listing CLI runtime models | same | Changed table expectation, internal-only. |
| same | honors an empty explicit allowlist when listing CLI runtime models | same | Changed table expectation, internal-only. |
| same | honors legacy provider wildcards when listing CLI runtime models | same | Changed table expectation, internal-only. |

- Minimum table correction: convert the shared callback at `:626-666` to `handleModelsCommand` using `/models claude-cli` and `all` where requested; assert the returned model lines and absence of unexpected rows. Keep the config-nonmutation assertion.
- The eight unchanged table rows are: provider wildcards; exact refs; an allowed CLI model; CLI provider wildcards; a pinned deprecated CLI model; configured CLI fallback retention under exact refs; an agent restriction; explicit all browse. A shared callback conversion strengthens these too. They are not eight newly added tests in this diff.
- Existing actual-command overlap: `:328` unauthenticated providers vs explicit all; `:458` published default retention; `:490` retired aliases and supported runtime providers. The last fixture lacks uppercase retired ids and does not reach the separate interactive picker predicate.

### Prior-release corpus

| File and line | Exact changed parameter cases | Actual boundary | Verdict / minimum correction |
| --- | --- | --- | --- |
| `src/config/state-startup-corpus.test.ts:167` | 2026.9.2 × provider-admission-selected-plan.json preserves state through Doctor and Gateway startup | Doctor/startup helpers, then `acquireReadOnlyPreparedModelRuntime` | Changed model assertion is below registered startup/method boundary. |
| same | 2026.9.3-95f3ed9 × provider-admission-selected-plan.json preserves state through Doctor and Gateway startup | same | Same limitation. |
| same | 2026.9.2 × provider-admission-family.json preserves state through Doctor and Gateway startup | same | Same limitation. |
| same | 2026.9.3-95f3ed9 × provider-admission-family.json preserves state through Doctor and Gateway startup | same | Same limitation. |

- The other table cases keep their prior behavior; local `entries` binding is mechanical. The new before/after environment capture affects fixture isolation, not a new behavior case.
- Preserve the released-state migration checks. Add or reuse a real Gateway startup plus models.list for these two changed admission shapes, with exact source identity. Existing private live corpus captures may qualify only after root verifies these precise inputs and head equivalence; this audit does not promote them automatically.

### Gateway startup and built-runtime cases

| File and line | Exact case | Actual boundary | Verdict / minimum correction |
| --- | --- | --- | --- |
| `src/gateway/server-startup-post-attach.test.ts:1869` | keeps catalog acquisition after readiness and stops at complete | `startGatewayPostAttachRuntime` | NEW supervisor case. Real scheduling; catalog dependency mocked. |
| same | keeps catalog acquisition after readiness and stops at before readiness | same | NEW supervisor case. Stops tracked sidecars before readiness barrier; no catalog call expected. |
| same | keeps catalog acquisition after readiness and stops at between agents | same | NEW supervisor case. Stops after first mocked agent call; no second call. Does not prove interrupting real provider work. |
| same, `:1915` | contains ordinary catalog failure after readiness | same | NEW supervisor case. Warning then second agent; catalog mocked. |
| same | contains abort catalog failure after readiness | same | NEW supervisor case. Loop stops and task warning recorded. |
| same | contains superseded catalog failure after readiness | same | NEW supervisor case. Same boundary/limit. |
| same | contains config replaced catalog failure after readiness | same | NEW supervisor case. Same boundary/limit. |
| same | contains retired owner catalog failure after readiness | same | NEW supervisor case. Same boundary/limit. |
| same, `:1992` | keeps transcripts auto-start alive when Gmail post-ready sidecars stop | same | Existing supervisor behavior; expected lifetime handle count 4→5 is mechanical. |
| same, `:3233` | emits a sidecar readiness summary in startup trace details | same | Existing supervisor behavior; summary count 3→4 is mechanical. |
| `src/gateway/server-startup.test.ts:97` | publishes readiness without acquiring the full catalog | `testing.prewarmConfiguredPrimaryModel` | NEW, helper-only. Already stronger coverage exists in the three new real-supervisor readiness cases above. Remove this added duplicate; do not rename it supervisor coverage. |
| same, `:104` | hydrates configured external CLI auth without republishing prepared owners | `testing.hydrateConfiguredExternalCliAuth` | Name-only rewrite; body unchanged. Its old wording did not match the existing assertion. Does not prove actual startup order; registered supervisor/native Gateway cases own that. |
| `src/gateway/gateway-auth-recovery.test.ts:337` | serves a large authenticated catalog for each agent through the built Gateway | real `dist/index.js` startup + authenticated models.list requests | REWRITTEN, registered Gateway reached. 11 agents × 400 rows checked in three phases. Requests are sequential. No held acquisition or concurrent health request. |
| `test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts:724` | keeps native model choices through Telegram browsing, refresh, and restart | real built Gateway, registered Telegram command/callback flow, models.list, real token-paste CLI | REWRITTEN, registered boundaries reached. Covers first failure, healthy sibling after completion, recovery, later failure retention, retry after endpoint correction, refresh/restart equality, and account addition. Mock Telegram transport is boundary proof, not a live Test Server claim. |

### Mechanical test-support edits

- `src/agents/prepared-model-runtime.test-harness.ts`: add the synchronous ambient-auth mock export needed by the production cutover. No test body or registered entry point added.
- `src/agents/tools/media-generate-tool.donor-resources.test.ts:193`: remove deleted `includeCredentialProviders: false` option in the shared five-case fixture (`managed`, `failure`, `primary-failure`, `rollback`, `raw`). This is fixture compatibility only.
- `src/agents/tools/media-generate-tool.resources.test.ts:255`: remove the same option in `prepareSnapshot`. Existing image/video resource cases are not newly written behaviors. Do not call this an integration run.
- `src/gateway/server-startup.test.ts`: new catalog mock, listAgentIds mock, and reset support the new helper-only test; remove unused added setup if that duplicate test is removed.
- Startup-static shared mocks and imported AuthStorage type are fixture-contract changes; they do not make every unchanged test a newly rewritten case.


## Contention

Held serialization: process-wide `pLimit(1)` full-catalog slot; per-agent `agentBuildCompletions`; the global config/auth publication tail and overlapping auth-publication component gates; one serial worker per captured generation; and the sequential startup agent loop. The existing models-config persist path also holds its per-target write queue across planning and writes when invoked. This diff adds no SQLite transaction or schema. It is not correct to say “none held.”

`prepared-model-runtime.build.ts:310–351` holds catalog/agent exclusion through discovery and projection. Config/auth replacement waits agent completion at `:637–707`. `prepared-model-runtime.ts:649–656` serializes publication. `prepared-model-catalog-worker.ts:237–276` owns worker serialization and capture shutdown. The existing models-config writer is `models-config.ts:286–356`.

Concurrent-responsiveness result: **not yet proven under active acquisition**. Existing real-worker tests prove deduplication with a held provider, and startup tests prove readiness ordering. The 4,400-row Gateway test issues sequential requests. The native failure fixture releases its provider barrier before calling `models.list`. Before the gate can pass, its healthy `health` and prepared `models.list` requests must complete with the acquisition barrier still held, within the named request-latency bound. Config/auth replacement contention also needs its explicit acceptance condition; background execution alone proves neither property.

## Invalidation
| Value | Owner, input, and invalidation | Existing coverage and gap |
| --- | --- | --- |
| admitted providerIds | `prepared-model-runtime.facts.ts:97-140,142-181,381-398`: derives selected providers, admission owner result, auth profiles, native credentials, provider environment bindings, and wildcard policy. Recomputed at each facts build; explicit scoped input overrides it. Worker recomputes after durable auth refresh (`prepared-model-catalog.worker.ts:215-248`). | New migrated-secret helper and existing real worker durable-auth additions exercise parts. Native Gateway account-addition case reaches real command and refresh. No new real supervisor narrow/wider/equal static-scope test. |
| configuredManifestModels map | `facts.ts:280-291`: local to one workspace preparation, keyed normalized provider and lowercased model id. Discarded after build. | Dynamic configured model helper checks case distinctions; this diff does not add a persistent cache or a new invalidation requirement. |
| preparedStaticProviderCatalog, providerStaticModels, inlineProviderModels, configuredCatalogEntries | `facts.ts:312-430`: plugin-generation owned; reused only with reusable generation. Workspace/config replacement normally rebuilds generation; auth publication deliberately reuses plugin facts. Worker clears `providerStaticModels` when materializing newly admitted runtime plugin owners (`worker.ts:284-290`). | Startup-static tests assert hook scope; real account-add and restart case checks new provider inclusion. Existing reuse means auth-triggered static publication can remain temporarily narrower until full refresh. Do not promise monotonic rows. |
| grouped configured registry | `facts.ts:608-713`: group lifetime is one batch. Key includes config, projected source models, credential bytes, normalized admitted providerIds, root models.json, plugin catalogs. Executable OAuth hook identities must also match. Static configs are filtered to representative's admitted provider set. | New sources helper checks narrow/wider/equal group isolation; final owner-selection sibling covers OAuth hook generation. Registered agent-scope behavior remains a gap unless exact real corpus evidence covers it. |
| captured root and plugin catalogs | `facts.ts:568-577,612-624`: read at preparation; plugin IDs derived from admitted provider owners at `:457-476`, empty in replace mode. No request-time filesystem poll added. | Real restart/account/full-refresh covers normal reconstruction. Added scope test explicitly keeps authored rows but is helper-only. |
| full catalog inventory and projection | `build.ts:186-234`: retained only when inventory key, installed-plugin fingerprint, and captured auth match. `facts.ts:582-599` inventory key covers model/auth/env/plugin config, input/environment, stored order and omits runtime selections intentionally; current runtime capability projection is rebuilt. `full-catalog.ts:127-147` removes native rows from retained provider inventory. | Native Gateway refresh/restart/account case proves stable keys+available and old-row retention after failure. Existing worker integration adds/updates/removes durable profiles. Unchanged reload-auth tests cover neutral reload retention and obsolete publication. Exact config-change cancellation through Gateway remains absent in changed cases. |
| authModes, auth store, credentials | `full-catalog.ts:346-424`: immutable generation snapshot with per-run in-memory auth/registry fork. `auth-publication.ts:299-345`: mutation increments owner generation; flags runtime stale; profile-set change additionally flags catalog stale. `prepared-model-runtime.ts:679-747` removes stale dispatch, enqueues/adopts rebuild, and commits dispatch before waiters. | Changed token-rotation case protects rotated bytes/no live discovery but calls mocked mutation directly. Native public account-addition covers profile-set growth, not rotation, deletion, order change, or inherited-store collision. Those have lower-level existing coverage; do not count them as newly run Gateway proof. |
| workerInput generation and source provenance | `catalog-worker.ts:127-195`: captures config/source config, both resolution-fact sets, auth store, providerIds, environment, metadata and artifact identity. Each request fingerprint additionally contains freshly captured synthetic auth. Worker restores both provenance sets at `worker.ts:109-112` and rejects reconstructed mismatch. | Secrets suite covers full provenance variants only via direct request function. Real worker integration covers cloning/native lifecycle and existing ref-only profiles. Supervisor conversion is required for the changed provenance suite. |
| worker prepared generation | `catalog.worker.ts` final `serveWorkerTasks` closure memoizes one `prepareWorkerGeneration`; new request refreshes durable credentials and recalculates admission. Parent mismatch retires only request pool; stopped lifecycle rejects reuse (`catalog-worker.ts:232-373`). | Existing worker scope/native login/logout and generation-mismatch tests are stronger than helper tests. This audit did not rerun them. |
| pending full catalog / pending auth | `build.ts:235-373`: one full-catalog promise; same auth scope deduplicates while pending; resource claims released in finally; full-catalog pending cleared after success/failure. Explicit refresh waits retained inventory projection before new acquisition. | Existing worker integration `:948` holds actual discovery, proves two callers share it, cached result, and explicit second refresh. It does not call Gateway health while held. |
| refreshFailed attempt state | `publication-events.ts:20-63`: reuses attempt only for same source, live getter exposes error/provider outcomes; success clears error; stale or superseded failure does not publish status. | Native Gateway case checks first failure, healthy sibling, recovery, later failure/retention/recovery. Existing reload-auth `:36,83,175,209` checks neutral reload, first attempt, obsolete generation using mocked worker. |
| /models projected byProvider and evaluations | `commands-models.ts:189-293`: request-local projection from owner, selected session model, prepared auth and visibility policy. No persistent projection cache added. | Changed command cases must use handler. Session-selected private proof is separate and must retain its exact head binding. |


Reload and restart rebuild generation-owned facts; account mutation invalidates auth, while profile-set changes also invalidate catalog contents. Session model changes rebuild the request-local projection. Existing real account-save, refresh, restart, and failure/recovery observations remain valid for their recorded heads. The table identifies missing boundary proof for other triggers; it is not a claim that every trigger has passed.

## Older host and previous-release state

The touched Telegram plugin requires this gate. The latest published stable tag is `v2026.9.4`. No candidate-plugin execution on that shipped host has been recorded. Source inspection shows no new plugin import, but that is not an execution result.

The retained prior-release corpus copies databases generated by released `v2026.9.2` (`3928bad9badfcb6c7d140530435e806fb8092190`) and frozen `2026.9.3-95f3ed9` (`95f3ed90285b73d50764ab6b670976fb7ca5d638`). Its 45 state cases passed within the 89-test corpus/sibling run on `576305080a3e1d6589d16ce7ece2fad07ba45fcc`. Those helper-level migration passes are not a real Gateway launch of the current candidate on a previous-release directory. That launch and stable-host plugin execution remain required before the census verdict.

## Status evidence

Publication and failure claims require observed Gateway replies; test success requires the completed test result and exit status. Intermediate inventory log markers precede later assertions and do not certify success. The large fixture's first catalog observation occurs after readiness without a barrier that excludes background completion; it must not be described as an isolated pre-acquisition static capture. Its memory endpoint also follows explicit refresh and does not establish background-only or peak memory.

## Census checker result

The required checker ran with original main baseline `611dbf76b4ba897ab2ac3d7cf863257391e93fe6` and head `de0901059c6ab163800789ee95c8a428dff98d20`: exit **1**, Consumers section present, search tree `62568d6761ce7d853e156858a88ee286d3021972`. Its complete output is retained in the lane report. That broad comparison also inventories changes imported since the original reproduction baseline; the remaining references have not all received semantic disposition.

A separate lane comparison against pinned admission base `40622e9fc3767c94b7e7eb5a250dde1c421ce5db` also exits **1**. The removed `includeCredentialProviders`, `isRetiredModelPickerProvider`, and `ModelCatalogAuthChecker` have no remaining reference. Its two remaining names are the unrelated local `admittedProviderIds` variable and the retained public `prepareSyntheticAuth` hook, distinguished in Consumers. This supplemental interpretation does not replace the required check, clear its exit status, or certify the current conflicted integration. No census readiness marker or merge request has been issued.
