### PR TITLE
refactor: simplify CLI child listener registration

### DIFF
--- a/scripts/run-node.mts
+++ b/scripts/run-node.mts
@@ -1181,13 +1181,8 @@ const waitForSpawnedProcess = async (childProcess: RunNodeChild, deps: RunNodeDe
         }
         settle({ exitCode, exitSignal, forwardedSignal });
       };
-      if ("once" in childProcess) {
-        childProcess.on("error", handleError);
-        childProcess.on("exit", handleExit);
-      } else {
-        childProcess.on("error", handleError);
-        childProcess.on("exit", handleExit);
-      }
+      childProcess.on("error", handleError);
+      childProcess.on("exit", handleExit);
     });
   } finally {
     cleanupSignals();


### PR DESCRIPTION
## What Problem This Solves

The CLI runner checks whether a spawned child exposes `once`, but both branches register the same `error` and `exit` listeners with `on`. The redundant condition obscures the existing child-process contract.

## Why This Change Was Made

Register the listeners directly through the `on` method already required and validated by the runner. This removes five lines while preserving listener ordering, settlement, signal forwarding, and cleanup.

## User Impact

No user-visible behavior change. CLI and build children retain the same error, exit, and interruption handling.

## Evidence

All 118 existing runner unit and isolated lifecycle tests pass. The selected canonical checks pass, including script typing, lint, erasability, and dead exports. No new tests or dependencies were added. Independent P2 review found no actionable findings.
