### PR TITLE
fix: local infer image, embedding, audio, and video commands fail for saved accounts stored as SecretRefs

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -330,10 +330,11 @@ vi.mock("./command-secret-targets.js", () => ({
 }));
 
 // Account-secret snapshot preparation is covered by dedicated
-// model.account-secrets.* tests; keep this command-wiring suite on the
-// pre-existing mocked world instead of loading the real secrets runtime.
-vi.mock("./capability-cli/model-local-secrets.js", () => ({
-  prepareLocalModelRunAccountSecrets: vi.fn(async () => {}),
+// model.account-secrets.* and local-runners.account-secrets tests; keep this
+// command-wiring suite on the pre-existing mocked world instead of loading the
+// real secrets runtime.
+vi.mock("./capability-cli/local-account-secrets.js", () => ({
+  prepareLocalCapabilityAccountSecrets: vi.fn(async () => {}),
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({

--- a/src/cli/capability-cli/audio.ts
+++ b/src/cli/capability-cli/audio.ts
@@ -8,6 +8,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { getProviderEnvVars } from "../../secrets/provider-env-vars.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
+import { prepareLocalCapabilityAccountSecrets } from "./local-account-secrets.js";
 import { isMissingMediaUnderstandingProvider } from "./media-understanding-result.js";
 import type { CapabilityEnvelope } from "./metadata.js";
 import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
@@ -31,10 +32,9 @@ async function runAudioTranscribe(params: {
     commandName: "infer audio transcribe",
     targetIds: getModelsCommandSecretTargetIds(),
   });
-  const agentDir = resolveAgentDir(
-    cfg,
-    resolveCapabilityProviderAgentId(cfg, params.agent, "infer audio transcribe"),
-  );
+  const agentId = resolveCapabilityProviderAgentId(cfg, params.agent, "infer audio transcribe");
+  await prepareLocalCapabilityAccountSecrets({ cfg, agentId });
+  const agentDir = resolveAgentDir(cfg, agentId);
   const activeModel = requireProviderModelOverride(params.model);
   const result = await transcribeAudioFile({
     filePath: path.resolve(params.file),

--- a/src/cli/capability-cli/embedding.ts
+++ b/src/cli/capability-cli/embedding.ts
@@ -9,6 +9,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getMemoryEmbeddingCommandSecretTargetIds } from "../command-secret-targets.js";
 import { collectOption } from "../program/helpers.js";
+import { prepareLocalCapabilityAccountSecrets } from "./local-account-secrets.js";
 import type { CapabilityEnvelope } from "./metadata.js";
 import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
 import {
@@ -49,6 +50,7 @@ async function runMemoryEmbeddingCreate(params: {
   const requestedProvider =
     normalizeOptionalString(params.provider) || modelRef?.provider || "auto";
   const agentId = resolveCapabilityProviderAgentId(cfg, params.agent, "infer embedding create");
+  await prepareLocalCapabilityAccountSecrets({ cfg, agentId });
   const result = await createEmbeddingProvider({
     config: cfg,
     agentDir: resolveAgentDir(cfg, agentId),

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -27,6 +27,7 @@ import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
 import { readInputFiles, writeOutputAsset } from "../media-output.js";
 import { collectOption } from "../program/helpers.js";
+import { prepareLocalCapabilityAccountSecrets } from "./local-account-secrets.js";
 import { isMissingMediaUnderstandingProvider } from "./media-understanding-result.js";
 import type { CapabilityEnvelope } from "./metadata.js";
 import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
@@ -72,6 +73,7 @@ async function runImageGenerate(params: {
     targetIds: getModelsCommandSecretTargetIds(),
   });
   const agentId = resolveCapabilityProviderAgentId(cfg, params.agent, `infer ${params.capability}`);
+  await prepareLocalCapabilityAccountSecrets({ cfg, agentId });
   const agentDir = resolveAgentDir(cfg, agentId);
   const inputImages =
     params.file && params.file.length > 0
@@ -153,6 +155,7 @@ async function runImageDescribe(params: {
     targetIds: getModelsCommandSecretTargetIds(),
   });
   const agentId = resolveCapabilityProviderAgentId(cfg, params.agent, `infer ${params.capability}`);
+  await prepareLocalCapabilityAccountSecrets({ cfg, agentId });
   const agentDir = resolveAgentDir(cfg, agentId);
   const activeModel = requireProviderModelOverride(params.model);
   const prompt = normalizeOptionalString(params.prompt);

--- a/src/cli/capability-cli/local-account-secrets.test.ts
+++ b/src/cli/capability-cli/local-account-secrets.test.ts
@@ -28,9 +28,9 @@ vi.mock("../../secrets/runtime.js", () => ({
   activateSecretsRuntimeSnapshot: mocks.activateSecretsRuntimeSnapshot,
 }));
 
-import { prepareLocalModelRunAccountSecrets } from "./model-local-secrets.js";
+import { prepareLocalCapabilityAccountSecrets } from "./local-account-secrets.js";
 
-describe("prepareLocalModelRunAccountSecrets", () => {
+describe("prepareLocalCapabilityAccountSecrets", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getRuntimeConfigSourceSnapshot.mockReturnValue(null);
@@ -42,7 +42,7 @@ describe("prepareLocalModelRunAccountSecrets", () => {
     const sourceConfig: OpenClawConfig = { secrets: { providers: {} } };
     mocks.getRuntimeConfigSourceSnapshot.mockReturnValue(sourceConfig);
 
-    await prepareLocalModelRunAccountSecrets({ cfg, agentId: "ops" });
+    await prepareLocalCapabilityAccountSecrets({ cfg, agentId: "ops" });
 
     expect(mocks.resolveAgentDir).toHaveBeenCalledWith(cfg, "ops");
     expect(mocks.prepareSecretsRuntimeSnapshot).toHaveBeenCalledWith({
@@ -63,7 +63,7 @@ describe("prepareLocalModelRunAccountSecrets", () => {
       configRefsPrepared: true,
     });
 
-    await prepareLocalModelRunAccountSecrets({ cfg, agentId: "main" });
+    await prepareLocalCapabilityAccountSecrets({ cfg, agentId: "main" });
 
     expect(mocks.resolveAgentDir).not.toHaveBeenCalled();
     expect(mocks.prepareSecretsRuntimeSnapshot).not.toHaveBeenCalled();

--- a/src/cli/capability-cli/local-account-secrets.ts
+++ b/src/cli/capability-cli/local-account-secrets.ts
@@ -3,8 +3,11 @@ import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../../secrets/runtime-state.js";
 
-/** Prepare account-owned SecretRefs for one standalone local model run. */
-export async function prepareLocalModelRunAccountSecrets(params: {
+/**
+ * Prepare the selected agent's account-owned SecretRefs for one standalone local
+ * capability run. Every agent-scoped local runner calls this before provider auth.
+ */
+export async function prepareLocalCapabilityAccountSecrets(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): Promise<void> {

--- a/src/cli/capability-cli/local-runners.account-secrets.test.ts
+++ b/src/cli/capability-cli/local-runners.account-secrets.test.ts
@@ -1,0 +1,175 @@
+/** Local capability runners must materialize the selected agent's saved-account SecretRefs. */
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { updateAuthProfileStoreWithLock } from "../../agents/auth-profiles/store-runtime.js";
+import { resolveApiKeyForProviderCore } from "../../agents/model-auth.js";
+import { setRuntimeConfigSnapshot } from "../../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { clearSecretsRuntimeSnapshotState } from "../../secrets/runtime-state.js";
+import { setupSecretsRuntimeSnapshotTestHooks } from "../../secrets/runtime.test-support.ts";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+
+setupSecretsRuntimeSnapshotTestHooks();
+
+type ProviderEgressParams = { cfg?: OpenClawConfig; config?: OpenClawConfig; agentDir?: string };
+
+const hoisted = vi.hoisted(() => {
+  const rawCfg: OpenClawConfig = {};
+  const egressAuth: Array<{ source?: string; apiKey?: string }> = [];
+  return { rawCfg, egressAuth };
+});
+
+// Stands in for the provider plugin at its egress boundary: it performs the same
+// saved-account auth lookup a real provider runs before sending a request.
+async function resolveEgressAuth(params: ProviderEgressParams): Promise<void> {
+  const auth = await resolveApiKeyForProviderCore({
+    provider: "customacct",
+    cfg: params.cfg ?? params.config,
+    agentDir: params.agentDir,
+  });
+  hoisted.egressAuth.push({ source: auth.source, apiKey: auth.apiKey });
+}
+
+vi.mock("../../image-generation/runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../image-generation/runtime.js")>()),
+  generateImage: vi.fn(async (params: ProviderEgressParams) => {
+    await resolveEgressAuth(params);
+    return { provider: "customacct", model: "test-model", attempts: [], images: [] };
+  }),
+}));
+
+vi.mock("../../video-generation/runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../video-generation/runtime.js")>()),
+  generateVideo: vi.fn(async (params: ProviderEgressParams) => {
+    await resolveEgressAuth(params);
+    return { provider: "customacct", model: "test-model", attempts: [], videos: [] };
+  }),
+}));
+
+vi.mock("../../media-understanding/runtime.js", async (importOriginal) => {
+  const describe = async (params: ProviderEgressParams) => {
+    await resolveEgressAuth(params);
+    return { text: "synthetic-ok", provider: "customacct", model: "test-model" };
+  };
+  return {
+    ...(await importOriginal<typeof import("../../media-understanding/runtime.js")>()),
+    describeImageFile: vi.fn(describe),
+    describeVideoFile: vi.fn(describe),
+    transcribeAudioFile: vi.fn(describe),
+  };
+});
+
+vi.mock("../../plugin-sdk/memory-core-bundled-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugin-sdk/memory-core-bundled-runtime.js")>()),
+  createEmbeddingProvider: vi.fn(async (params: ProviderEgressParams) => {
+    await resolveEgressAuth(params);
+    return {
+      provider: {
+        id: "customacct",
+        model: "test-model",
+        embedBatch: async (texts: string[]) => texts.map(() => [0.5]),
+      },
+    };
+  }),
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/config.js")>()),
+  getRuntimeConfig: () => hoisted.rawCfg,
+}));
+
+vi.mock("../cli-utils.js", () => ({
+  runCommandWithRuntime: vi.fn(async (_runtime: unknown, run: () => Promise<void>) => await run()),
+}));
+
+vi.mock("./output.js", () => ({
+  emitJsonOrText: vi.fn(),
+  formatEnvelopeForText: vi.fn(),
+  providerSummaryText: vi.fn(),
+}));
+
+import { registerAudioCapabilityCommands } from "./audio.js";
+import { registerEmbeddingCapabilityCommands } from "./embedding.js";
+import { registerImageCapabilityCommands } from "./image.js";
+import { registerVideoCapabilityCommands } from "./video.js";
+
+// Synthetic-only credential for local-path proof. Never a real key or endpoint.
+const ENV_ACCOUNT_KEY = "OPENCLAW_TEST_CAPABILITY_ACCOUNT_KEY";
+const ACCOUNT_KEY_VALUE = "synthetic-capability-account-key"; // pragma: allowlist secret
+
+function buildRawCfg(agentDir: string): OpenClawConfig {
+  return {
+    agents: {
+      defaults: { workspace: join(agentDir, "workspace") },
+      entries: { ops: { agentDir } },
+    },
+    models: {
+      providers: {
+        customacct: { api: "openai-completions", baseUrl: "http://127.0.0.1:1/v1", models: [] },
+      },
+    },
+  };
+}
+
+async function runLocalCapability(argv: string[]): Promise<void> {
+  const capability = new Command();
+  registerImageCapabilityCommands(capability);
+  registerEmbeddingCapabilityCommands(capability);
+  registerAudioCapabilityCommands(capability);
+  registerVideoCapabilityCommands(capability);
+  await capability.parseAsync([...argv, "--agent", "ops", "--json"], { from: "user" });
+}
+
+describe("local capability runners saved-account SecretRefs", () => {
+  let state: OpenClawTestState;
+
+  beforeEach(async () => {
+    state = await createOpenClawTestState({
+      prefix: "openclaw-capability-account-",
+      env: { [ENV_ACCOUNT_KEY]: ACCOUNT_KEY_VALUE },
+    });
+    const agentDir = state.agentDir("ops");
+    hoisted.rawCfg = buildRawCfg(agentDir);
+    // Production CLI boot pins the authored config as the runtime source first.
+    setRuntimeConfigSnapshot(structuredClone(hoisted.rawCfg), structuredClone(hoisted.rawCfg));
+    hoisted.egressAuth.length = 0;
+    const seeded = await updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (store) => {
+        store.profiles["customacct:saved"] = {
+          type: "api_key",
+          provider: "customacct",
+          keyRef: { source: "env", provider: "default", id: ENV_ACCOUNT_KEY },
+        };
+        return true;
+      },
+    });
+    expect(seeded).not.toBeNull();
+  });
+
+  afterEach(async () => {
+    clearSecretsRuntimeSnapshotState();
+    await state.cleanup();
+  });
+
+  it.each([
+    ["image generate", ["image", "generate", "--prompt", "a red square"]],
+    ["image describe", ["image", "describe", "--file", "input.png"]],
+    ["embedding create", ["embedding", "create", "--text", "hello", "--provider", "customacct"]],
+    ["audio transcribe", ["audio", "transcribe", "--file", "input.wav"]],
+    ["video generate", ["video", "generate", "--prompt", "a red square"]],
+    ["video describe", ["video", "describe", "--file", "input.mp4"]],
+  ])("%s resolves the saved account credential", async (_name, argv) => {
+    await runLocalCapability(argv);
+
+    expect(hoisted.egressAuth).toHaveLength(1);
+    expect(hoisted.egressAuth[0]).toEqual({
+      source: "profile:customacct:saved",
+      apiKey: ACCOUNT_KEY_VALUE,
+    });
+  });
+});

--- a/src/cli/capability-cli/local-runners.account-secrets.test.ts
+++ b/src/cli/capability-cli/local-runners.account-secrets.test.ts
@@ -51,15 +51,15 @@ vi.mock("../../video-generation/runtime.js", async (importOriginal) => ({
 }));
 
 vi.mock("../../media-understanding/runtime.js", async (importOriginal) => {
-  const describe = async (params: ProviderEgressParams) => {
+  const understandMedia = async (params: ProviderEgressParams) => {
     await resolveEgressAuth(params);
     return { text: "synthetic-ok", provider: "customacct", model: "test-model" };
   };
   return {
     ...(await importOriginal<typeof import("../../media-understanding/runtime.js")>()),
-    describeImageFile: vi.fn(describe),
-    describeVideoFile: vi.fn(describe),
-    transcribeAudioFile: vi.fn(describe),
+    describeImageFile: vi.fn(understandMedia),
+    describeVideoFile: vi.fn(understandMedia),
+    transcribeAudioFile: vi.fn(understandMedia),
   };
 });
 

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -38,8 +38,8 @@ import { createDeferredCore } from "../../shared/deferred.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
 import { collectOption } from "../program/helpers.js";
+import { prepareLocalCapabilityAccountSecrets } from "./local-account-secrets.js";
 import type { CapabilityEnvelope, CapabilityTransport } from "./metadata.js";
-import { prepareLocalModelRunAccountSecrets } from "./model-local-secrets.js";
 import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
 import {
   providerHasGenericConfig,
@@ -200,7 +200,7 @@ async function runModelRun(params: {
     const trackOwner = captureAsyncWorkTracker();
     // Command completion can precede response callbacks and cancellation drainage.
     void trackOwner(async () => {
-      await prepareLocalModelRunAccountSecrets({ cfg, agentId });
+      await prepareLocalCapabilityAccountSecrets({ cfg, agentId });
       const prepared = await acquireSimpleCompletionModelForAgent({
         cfg,
         agentId,

--- a/src/cli/capability-cli/video.ts
+++ b/src/cli/capability-cli/video.ts
@@ -30,6 +30,7 @@ import type { VideoGenerationResolution } from "../../video-generation/types.js"
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
 import { publishOutputFileAtomically, writeOutputAsset } from "../media-output.js";
+import { prepareLocalCapabilityAccountSecrets } from "./local-account-secrets.js";
 import type { CapabilityEnvelope } from "./metadata.js";
 import { emitJsonOrText, formatEnvelopeForText } from "./output.js";
 import {
@@ -125,6 +126,7 @@ async function runVideoGenerate(params: {
     targetIds: getModelsCommandSecretTargetIds(),
   });
   const agentId = resolveCapabilityProviderAgentId(cfg, params.agent, "infer video.generate");
+  await prepareLocalCapabilityAccountSecrets({ cfg, agentId });
   const agentDir = resolveAgentDir(cfg, agentId);
   const result = await generateVideo({
     cfg,
@@ -239,10 +241,9 @@ async function runVideoDescribe(params: { file: string; model?: string; agent?: 
     commandName: "infer video.describe",
     targetIds: getModelsCommandSecretTargetIds(),
   });
-  const agentDir = resolveAgentDir(
-    cfg,
-    resolveCapabilityProviderAgentId(cfg, params.agent, "infer video describe"),
-  );
+  const agentId = resolveCapabilityProviderAgentId(cfg, params.agent, "infer video describe");
+  await prepareLocalCapabilityAccountSecrets({ cfg, agentId });
+  const agentDir = resolveAgentDir(cfg, agentId);
   const activeModel = requireProviderModelOverride(params.model);
   const result = await describeVideoFile({
     filePath: path.resolve(params.file),


### PR DESCRIPTION
## What Problem This Solves

Local image, embedding, audio, and video commands failed before sending a request when the selected agent's saved credential was a SecretRef, a reference to a stored secret.

Closes #144930.

Credit: @masatohoshino for the repair and @Bruce-Yii for the existing shared account-secret preparation from #141569.

## Why This Change Was Made

Only local model inference prepared saved account secrets before authentication. The local media and embedding runners now use the same preparation owner, whose name was updated to reflect its shared scope.

## User Impact

Local media and embedding commands can use the selected agent's saved secret reference. Existing credentials and account-selection rules stay compatible; a missing selected secret still fails before any request.

## Evidence

- Real command-line runs used saved secret references and local HTTP fixtures: embedding creation, image generation, audio transcription, and video generation failed before requests on the base and returned expected outputs with the selected credential after the fix.
- Image and video description commands likewise failed before requests on the base and returned descriptions after the fix, using real media runtimes and a sole-agent setup.
- Missing selected secrets still prevented requests despite another agent having a usable account. Fresh command-line processes used the updated secret after rotation.
- Local model inference continued to work. The separate multi-agent image-option forwarding defect remained on both versions.
- Local fixtures establish credential routing and output handling; external generation quality and generated-video playback were not verified.

## Consumers

- Embedding creation: prepares the selected account's secret before authentication.
- Image generation, editing, and description: use the shared account-secret preparation before authentication.
- Audio transcription: prepares the selected account's secret before the media runtime.
- Video generation and description: prepare the selected account's secret before their runtimes.
