### PR TITLE
refactor(gateway): target wake and lineage session reads

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -18,6 +18,8 @@ import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "../agents/internal-runtime-context.js";
+import { createSubagentRunRecord } from "../agents/subagent-test-fixtures.test-helpers.js";
+import { subagentRuns } from "../agents/subagents/registry/subagent-registry-memory.js";
 import { createAgentLifecycleTerminalBackstop } from "../auto-reply/reply/agent-lifecycle-terminal.js";
 import { formatChannelProgressDraftLine } from "../channels/streaming.js";
 import {
@@ -6806,6 +6808,10 @@ describe("agent event handler", () => {
 
   describe("spawnedBy enrichment in chat and agent broadcasts", () => {
     function mockSessionLineage(key: string, spawnedBy?: string) {
+      mockSessionEntry(
+        { sessionId: "lineage", updatedAt: 1, ...(spawnedBy ? { spawnedBy } : {}) },
+        key,
+      );
       vi.mocked(loadGatewaySessionRow).mockReturnValue({
         key,
         kind: "direct",
@@ -6813,6 +6819,50 @@ describe("agent event handler", () => {
         ...(spawnedBy ? { spawnedBy } : {}),
       });
     }
+
+    it.each([false, true])(
+      "requires a stored session before projecting registry lineage (stored=%s)",
+      (stored) => {
+        const key = "agent:main:subagent:lineage-presence";
+        const runId = "lineage-presence-run";
+        const controller = "agent:main:controller";
+        mockSessionEntry(
+          stored
+            ? {
+                sessionId: "lineage-session",
+                updatedAt: 1,
+                spawnedBy: "agent:main:former-controller",
+              }
+            : undefined,
+          key,
+        );
+        subagentRuns.set(
+          runId,
+          createSubagentRunRecord({
+            runId,
+            childSessionKey: key,
+            requesterSessionKey: controller,
+            controllerSessionKey: controller,
+          }),
+        );
+        const { handler, broadcast } = createHarness({ resolveSessionKeyForRun: () => key });
+        try {
+          emitAgentEvent(handler, runId, "assistant", { text: "Child response" });
+          expect(broadcast).toHaveBeenCalled();
+          for (const [, payload] of broadcast.mock.calls) {
+            if (stored) {
+              expect(payload.spawnedBy).toBe(controller);
+            } else {
+              expect(payload).not.toHaveProperty("spawnedBy");
+            }
+          }
+          expect(loadGatewaySessionLifecycleSnapshotMock).not.toHaveBeenCalled();
+        } finally {
+          handler.dispose();
+          subagentRuns.delete(runId);
+        }
+      },
+    );
 
     it.each([
       {
@@ -7116,7 +7166,7 @@ describe("agent event handler", () => {
       expectPayloadDataFields(gapError[1], { reason: "seq gap", expected: 2, received: 5 });
     });
 
-    it("caches spawnedBy lookup so repeated events for the same subagent session only load the row once", () => {
+    it("projects repeated subagent lineage without loading full session rows", () => {
       vi.mocked(loadGatewaySessionRow).mockClear();
       mockSessionLineage("agent:coder:subagent:cache-test", "agent:conductor:task:parent-cache");
 
@@ -7132,9 +7182,7 @@ describe("agent event handler", () => {
         ["lifecycle", { phase: "end" }],
       ]);
 
-      // Key assertion: loadGatewaySessionRow called exactly once despite 3 events
-      expect(loadGatewaySessionRow).toHaveBeenCalledTimes(1);
-      expect(loadGatewaySessionRow).toHaveBeenCalledWith("agent:coder:subagent:cache-test");
+      expect(loadGatewaySessionRow).not.toHaveBeenCalled();
 
       // All broadcasts still have correct spawnedBy
       const chatCalls = chatBroadcastCalls(broadcast);
@@ -7160,8 +7208,8 @@ describe("agent event handler", () => {
         ["assistant", { text: "chunk 2" }],
       ]);
 
-      // null result is cached — only one DB call despite two events
-      expect(loadGatewaySessionRow).toHaveBeenCalledTimes(1);
+      expect(loadGatewaySessionRow).not.toHaveBeenCalled();
+      expect(loadSessionEntry).toHaveBeenCalledOnce();
 
       const chatCalls = chatBroadcastCalls(broadcast);
       for (const [, payload] of chatCalls) {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -75,6 +75,7 @@ import {
 } from "./session-lifecycle-state.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "./session-request-agent.js";
 import { resolveSessionSubscriptionKeys } from "./session-subscription-keys.js";
+import { projectGatewaySessionRunState } from "./session-utils-display.js";
 import {
   loadGatewaySessionEntryReadOnly,
   loadGatewaySessionLifecycleSnapshot,
@@ -581,7 +582,14 @@ export function createAgentEventHandler({
     }
     let result: string | null = null;
     try {
-      result = loadGatewaySessionLifecycleSnapshotForEvent(sessionKey).row?.spawnedBy ?? null;
+      const { entry, canonicalKey } = loadGatewaySessionEntryReadOnly(sessionKey, { clone: false });
+      if (entry) {
+        result =
+          projectGatewaySessionRunState({ key: canonicalKey, entry, now: Date.now() })
+            .subagentOwner ||
+          entry.spawnedBy ||
+          null;
+      }
     } catch {
       // result stays null
     }

--- a/src/gateway/server-methods/system-event-routing.test.ts
+++ b/src/gateway/server-methods/system-event-routing.test.ts
@@ -13,7 +13,7 @@ import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
   requestHeartbeat: vi.fn(),
-  loadGatewaySessionRow: vi.fn(),
+  loadGatewaySessionEntryReadOnly: vi.fn(),
 }));
 
 vi.mock("../../infra/heartbeat-wake.js", async (importOriginal) => ({
@@ -23,7 +23,7 @@ vi.mock("../../infra/heartbeat-wake.js", async (importOriginal) => ({
 
 vi.mock("../session-utils.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../session-utils.js")>()),
-  loadGatewaySessionRow: mocks.loadGatewaySessionRow,
+  loadGatewaySessionEntryReadOnly: mocks.loadGatewaySessionEntryReadOnly,
 }));
 
 import { systemHandlers } from "./system.js";
@@ -36,13 +36,13 @@ describe("system-event routing", () => {
   afterEach(() => {
     resetSystemEventsForTest();
     mocks.requestHeartbeat.mockReset();
-    mocks.loadGatewaySessionRow.mockReset();
+    mocks.loadGatewaySessionEntryReadOnly.mockReset();
   });
 
   it("queues and immediately wakes the requested session", async () => {
     const respond = vi.fn();
     const sessionKey = "agent:main:main";
-    mocks.loadGatewaySessionRow.mockReturnValue({ key: sessionKey, archived: false });
+    mocks.loadGatewaySessionEntryReadOnly.mockReturnValue({ entry: { sessionId: "session" } });
     const request = {
       params: {
         text: "OpenClaw updated. Welcome the user back.",
@@ -76,7 +76,9 @@ describe("system-event routing", () => {
 
   it("routes a bare targeted wake through the persisted fixed-store owner", async () => {
     const respond = vi.fn();
-    mocks.loadGatewaySessionRow.mockReturnValue({ key: "global", archived: false });
+    mocks.loadGatewaySessionEntryReadOnly.mockReturnValue({
+      entry: { sessionId: "global-session" },
+    });
     const request = {
       params: { text: "Wake the retained session.", sessionKey: "global", wake: true },
       respond,
@@ -100,7 +102,9 @@ describe("system-event routing", () => {
       'systemHandlers["system-event"] test invariant',
     )(request);
 
-    expect(mocks.loadGatewaySessionRow).toHaveBeenCalledWith("global", { agentId: "ops" });
+    expect(mocks.loadGatewaySessionEntryReadOnly).toHaveBeenCalledWith("global", {
+      agentId: "ops",
+    });
     expect(mocks.requestHeartbeat).toHaveBeenCalledWith(
       expect.objectContaining({ sessionKey: "global" }),
     );
@@ -176,38 +180,43 @@ describe("system-event routing", () => {
     );
   });
 
-  it("rejects immediate wakes for missing sessions", async () => {
-    const respond = vi.fn();
-    const sessionKey = "agent:main:missing";
-    mocks.loadGatewaySessionRow.mockReturnValue(null);
-    const request = {
-      params: {
-        text: "OpenClaw updated. Welcome the user back.",
-        sessionKey,
-        wake: true,
-      },
-      respond,
-      context: {
-        broadcast: vi.fn(),
-        incrementPresenceVersion: vi.fn(() => 1),
-        getHealthVersion: vi.fn(() => 1),
-        getRuntimeConfig: vi.fn(() => ({ agents: { list: [{ id: "main" }] } })),
-      },
-    } as unknown as GatewayRequestHandlerOptions;
+  it.each([undefined, 0, 1])(
+    "rejects immediate wakes for missing or archived sessions (%s)",
+    async (archivedAt) => {
+      const respond = vi.fn();
+      const sessionKey = "agent:main:missing";
+      mocks.loadGatewaySessionEntryReadOnly.mockReturnValue({
+        entry: archivedAt === undefined ? undefined : { sessionId: "archived-session", archivedAt },
+      });
+      const request = {
+        params: {
+          text: "OpenClaw updated. Welcome the user back.",
+          sessionKey,
+          wake: true,
+        },
+        respond,
+        context: {
+          broadcast: vi.fn(),
+          incrementPresenceVersion: vi.fn(() => 1),
+          getHealthVersion: vi.fn(() => 1),
+          getRuntimeConfig: vi.fn(() => ({ agents: { list: [{ id: "main" }] } })),
+        },
+      } as unknown as GatewayRequestHandlerOptions;
 
-    await expectDefined(
-      systemHandlers["system-event"],
-      'systemHandlers["system-event"] test invariant',
-    )(request);
+      await expectDefined(
+        systemHandlers["system-event"],
+        'systemHandlers["system-event"] test invariant',
+      )(request);
 
-    expect(peekSystemEvents(sessionKey)).toEqual([]);
-    expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({ message: `Unknown or archived session "${sessionKey}"` }),
-    );
-  });
+      expect(peekSystemEvents(sessionKey)).toEqual([]);
+      expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ message: `Unknown or archived session "${sessionKey}"` }),
+      );
+    },
+  );
 
   it("rejects wake requests mixed with node presence events", async () => {
     const respond = vi.fn();
@@ -234,7 +243,7 @@ describe("system-event routing", () => {
     )(request);
 
     expect(peekSystemEvents(sessionKey)).toEqual([]);
-    expect(mocks.loadGatewaySessionRow).not.toHaveBeenCalled();
+    expect(mocks.loadGatewaySessionEntryReadOnly).not.toHaveBeenCalled();
     expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
     expect(respond).toHaveBeenCalledWith(
       false,

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -43,7 +43,7 @@ import { createPresenceRecipientProjection } from "../presence-projection.js";
 import { getGatewayProcessInstanceId } from "../process-instance.js";
 import { broadcastPresenceSnapshot } from "../server/presence-events.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
-import { loadGatewaySessionRow } from "../session-utils.js";
+import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -214,10 +214,10 @@ export const systemHandlers: GatewayRequestHandlers = {
       }
       // A targeted wake starts a model run. Require a live persisted session
       // so malformed keys cannot create phantom work under agent defaults.
-      const targetSession = loadGatewaySessionRow(requestedSessionKey, {
+      const { entry: targetSession } = loadGatewaySessionEntryReadOnly(requestedSessionKey, {
         agentId: requestedAgentId,
       });
-      if (!targetSession || targetSession.archived) {
+      if (!targetSession || targetSession.archivedAt !== undefined) {
         respond(
           false,
           undefined,


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Targeted wakes and chat lineage lookups build full session projections even though they need only entry existence, archive state and lineage. That unnecessarily reads repository metadata on event paths.

## Why This Change Was Made

Read the existing canonical session entry directly and reuse the current run-state projector for lineage. Preserve archive rejection, missing-entry behavior, controller precedence, caching and synchronous delivery timing.

## User Impact

Wake and lineage behavior stays the same with less database work. This is a small cleanup prerequisite for the broader asynchronous repository-store conversion.

## Evidence

- 235 focused tests, full selected changed checks and fresh independent Codex P2 review passed.
- Real synthetic handler/SQLite proof counted one repository query for the full-row positive control and old wake/lineage paths; both targeted paths now execute zero repository queries. Native close and reopen checks passed.
- Wake also avoids opening shared state. Lineage retains necessary subagent-registry reads; it is not claimed to be entirely memory-only or worker-backed.
- Individual busy-host samples observed wake 67.99→6.77 ms and lineage 38.65→33.65 ms. These are observations, not a benchmark or throughput claim.
- No full build or production Gateway deployment was performed for this synchronous four-file cleanup.
