### PR TITLE
fix: claude-cli backend fails with spawn ENAMETOOLONG on Windows multi-MCP installs

### DIFF
--- a/extensions/anthropic/cli-runtime-args.test.ts
+++ b/extensions/anthropic/cli-runtime-args.test.ts
@@ -1,0 +1,174 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { CliBackendExecuteContext } from "openclaw/plugin-sdk/cli-backend";
+import { describe, expect, it } from "vitest";
+import { prepareClaudeCliTransportArgs } from "./cli-runtime-args.js";
+
+const BASE_ARGS = [
+  "-p",
+  "--output-format",
+  "stream-json",
+  "--include-partial-messages",
+  "--verbose",
+  "--setting-sources",
+  "user",
+  "--allowedTools",
+  "mcp__openclaw__*",
+  "--disallowedTools",
+  "ScheduleWakeup,CronCreate",
+] as const;
+
+function createContext(
+  overrides: Partial<CliBackendExecuteContext> = {},
+): CliBackendExecuteContext {
+  return {
+    command: "claude",
+    args: [...BASE_ARGS],
+    cwd: process.cwd(),
+    env: {},
+    prompt: "hi",
+    modelId: "claude-sonnet-4-5",
+    systemPrompt: "system",
+    useResume: false,
+    timeoutMs: 1000,
+    requestToolPermission: async () => ({ behavior: "deny", message: "nope" }),
+    requestUserInput: async () => ({ status: "cancelled", message: "nope" }),
+    ...overrides,
+  };
+}
+
+function manyToolNames(count: number): string[] {
+  // ~48 characters per name keeps the joined list well past the inline budget.
+  return Array.from(
+    { length: count },
+    (_, index) => `server-with-a-long-name__tool_with_a_long_name_${index}`,
+  );
+}
+
+function settingsArgValue(args: string[]): string | undefined {
+  const index = args.indexOf("--settings");
+  return index < 0 ? undefined : args[index + 1];
+}
+
+describe("prepareClaudeCliTransportArgs", () => {
+  it("keeps a small allow list inline without a settings file", () => {
+    const result = prepareClaudeCliTransportArgs(createContext());
+    const allowedIndex = result.args.indexOf("--allowedTools");
+    expect(allowedIndex).toBeGreaterThanOrEqual(0);
+    expect(result.args[allowedIndex + 1]).toBe("mcp__openclaw__*");
+    expect(result.args).not.toContain("--settings");
+    expect(result.cleanup).toBeUndefined();
+  });
+
+  it("relocates an oversized allow list into a temporary settings file", () => {
+    const toolNames = manyToolNames(400);
+    const result = prepareClaudeCliTransportArgs(
+      createContext({
+        toolAvailability: { native: ["read", "bash"], openClaw: toolNames },
+      }),
+    );
+    try {
+      expect(result.args).not.toContain("--allowedTools");
+      const settingsPath = settingsArgValue(result.args);
+      expect(settingsPath).toBeDefined();
+      expect(existsSync(settingsPath!)).toBe(true);
+      const settings = JSON.parse(readFileSync(settingsPath!, "utf8")) as {
+        permissions?: { allow?: string[] };
+      };
+      expect(settings.permissions?.allow).toEqual(
+        toolNames.map((name) => `mcp__openclaw__${name}`),
+      );
+      expect(result.cleanup).toBeDefined();
+    } finally {
+      result.cleanup?.();
+    }
+    const settingsPath = settingsArgValue(result.args)!;
+    expect(existsSync(settingsPath)).toBe(false);
+    expect(existsSync(path.dirname(settingsPath))).toBe(false);
+  });
+
+  it("merges the relocated allow list into existing inline settings JSON", () => {
+    const inlineSettings = JSON.stringify({
+      disableAllHooks: true,
+      enabledPlugins: {},
+      permissions: { deny: ["mcp__*"] },
+    });
+    const toolNames = manyToolNames(400);
+    const result = prepareClaudeCliTransportArgs(
+      createContext({
+        args: [...BASE_ARGS, "--settings", inlineSettings],
+        toolAvailability: { native: ["read"], openClaw: toolNames },
+      }),
+    );
+    try {
+      // Exactly one --settings flag survives; the inline JSON moved into the file.
+      expect(result.args.filter((arg) => arg === "--settings")).toHaveLength(1);
+      expect(result.args).not.toContain(inlineSettings);
+      expect(result.args).not.toContain("--allowedTools");
+      const settings = JSON.parse(readFileSync(settingsArgValue(result.args)!, "utf8")) as {
+        disableAllHooks?: boolean;
+        enabledPlugins?: Record<string, unknown>;
+        permissions?: { allow?: string[]; deny?: string[] };
+      };
+      expect(settings.disableAllHooks).toBe(true);
+      expect(settings.enabledPlugins).toEqual({});
+      expect(settings.permissions?.deny).toEqual(["mcp__*"]);
+      expect(settings.permissions?.allow).toEqual(
+        toolNames.map((name) => `mcp__openclaw__${name}`),
+      );
+    } finally {
+      result.cleanup?.();
+    }
+  });
+
+  it("merges the relocated allow list into --settings=<json> form", () => {
+    const inlineSettings = JSON.stringify({ disableAllHooks: true });
+    const toolNames = manyToolNames(400);
+    const result = prepareClaudeCliTransportArgs(
+      createContext({
+        args: [...BASE_ARGS, `--settings=${inlineSettings}`],
+        toolAvailability: { native: ["read"], openClaw: toolNames },
+      }),
+    );
+    try {
+      expect(result.args.some((arg) => arg.startsWith("--settings="))).toBe(false);
+      const settings = JSON.parse(readFileSync(settingsArgValue(result.args)!, "utf8")) as {
+        disableAllHooks?: boolean;
+        permissions?: { allow?: string[] };
+      };
+      expect(settings.disableAllHooks).toBe(true);
+      expect(settings.permissions?.allow).toHaveLength(toolNames.length);
+    } finally {
+      result.cleanup?.();
+    }
+  });
+
+  it("keeps the allow list inline when existing --settings is a file path", () => {
+    const toolNames = manyToolNames(400);
+    const result = prepareClaudeCliTransportArgs(
+      createContext({
+        args: [...BASE_ARGS, "--settings", "C:\\claude\\team-settings.json"],
+        toolAvailability: { native: ["read"], openClaw: toolNames },
+      }),
+    );
+    const settingsIndex = result.args.indexOf("--settings");
+    expect(result.args[settingsIndex + 1]).toBe("C:\\claude\\team-settings.json");
+    const allowedIndex = result.args.indexOf("--allowedTools");
+    expect(allowedIndex).toBeGreaterThanOrEqual(0);
+    expect(result.args[allowedIndex + 1]).toBe(
+      toolNames.map((name) => `mcp__openclaw__${name}`).join(","),
+    );
+    result.cleanup?.();
+  });
+
+  it("keeps --settings JSON inline when the allow list stays small", () => {
+    const inlineSettings = JSON.stringify({ disableAllHooks: true });
+    const result = prepareClaudeCliTransportArgs(
+      createContext({ args: [...BASE_ARGS, "--settings", inlineSettings] }),
+    );
+    const settingsIndex = result.args.indexOf("--settings");
+    expect(result.args[settingsIndex + 1]).toBe(inlineSettings);
+    expect(result.args).toContain("--allowedTools");
+    expect(result.cleanup).toBeUndefined();
+  });
+});

--- a/extensions/anthropic/cli-runtime-args.ts
+++ b/extensions/anthropic/cli-runtime-args.ts
@@ -1,4 +1,6 @@
 import type { CliBackendExecuteContext } from "openclaw/plugin-sdk/cli-backend";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolvePreferredOpenClawTmpDir, tempWorkspaceSync } from "openclaw/plugin-sdk/temp-path";
 
 const PROTOCOL_FLAGS = new Set([
   "-p",
@@ -23,14 +25,119 @@ const PROTOCOL_VALUE_FLAGS = new Set([
   "--system-prompt",
 ]);
 const TOOL_FLAGS = new Set(["--tools", "--allowedTools", "--allowed-tools"]);
+const CLAUDE_SETTINGS_ARG = "--settings";
+// Windows caps a spawned command line near 32,767 characters; a large
+// tool-availability allow list overflows that budget inline and surfaces as
+// spawn ENAMETOOLONG. Past this size, carry the allow list in a temporary
+// Claude settings file instead: permissions.allow is the native settings
+// equivalent of --allowedTools, and the file path keeps argv short on every
+// platform.
+const ALLOWED_TOOLS_INLINE_CHAR_BUDGET = 8 * 1024;
+
+type PreparedClaudeCliTransportArgs = {
+  args: string[];
+  excludeDynamicSections: boolean;
+  /** Releases the temporary settings file once the transport process closes. */
+  cleanup?: () => void;
+};
+
+function parseInlineClaudeSettings(raw: string | undefined): Record<string, unknown> | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Move an oversized allow list off argv into a temporary settings file. */
+function relocateApprovedToolsToSettingsFile(
+  args: string[],
+  approvedTools: string[],
+): { cleanup: () => void } {
+  // Claude Code honors a single --settings value, so merge into the inline
+  // settings the restricted execution projection already passed instead of
+  // appending a second flag that would shadow them.
+  let settingsIndex = -1;
+  let settingsConsumesValue = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === CLAUDE_SETTINGS_ARG && typeof args[index + 1] === "string") {
+      settingsIndex = index;
+      settingsConsumesValue = true;
+      break;
+    }
+    if (arg.startsWith(CLAUDE_SETTINGS_ARG + "=")) {
+      settingsIndex = index;
+      break;
+    }
+  }
+  let baseSettings: Record<string, unknown> = {};
+  let splicedSettings: string[] = [];
+  if (settingsIndex >= 0) {
+    const raw = settingsConsumesValue
+      ? args[settingsIndex + 1]
+      : args[settingsIndex]!.slice(CLAUDE_SETTINGS_ARG.length + 1);
+    const parsed = parseInlineClaudeSettings(raw);
+    if (parsed === undefined) {
+      // A --settings file path or unrecognized value stays authoritative;
+      // keep the historical inline allow list for that configuration.
+      args.push("--allowedTools", approvedTools.join(","));
+      return { cleanup: () => {} };
+    }
+    baseSettings = parsed;
+    splicedSettings = args.splice(settingsIndex, settingsConsumesValue ? 2 : 1);
+  }
+  let settingsPath: string;
+  let cleanup: () => void;
+  try {
+    const workspace = tempWorkspaceSync({
+      rootDir: resolvePreferredOpenClawTmpDir(),
+      prefix: "openclaw-claude-cli-settings-",
+    });
+    const basePermissions = isRecord(baseSettings.permissions) ? baseSettings.permissions : {};
+    settingsPath = workspace.writeJson("settings.json", {
+      ...baseSettings,
+      permissions: { ...basePermissions, allow: approvedTools },
+    });
+    let cleaned = false;
+    cleanup = () => {
+      if (cleaned) {
+        return;
+      }
+      cleaned = true;
+      try {
+        workspace.cleanup();
+      } catch {
+        // Temp cleanup is best effort; the OS sweeps the temp root eventually.
+      }
+    };
+  } catch {
+    // If the temp file cannot be written, restore the historical inline argv
+    // rather than failing the run in a new way.
+    if (splicedSettings.length > 0) {
+      args.splice(settingsIndex, 0, ...splicedSettings);
+    }
+    args.push("--allowedTools", approvedTools.join(","));
+    return { cleanup: () => {} };
+  }
+  args.push(CLAUDE_SETTINGS_ARG, settingsPath);
+  return { cleanup };
+}
 
 /** Keep prepared CLI arguments, replacing only transport and admission-owned policy. */
-export function prepareClaudeCliTransportArgs(context: CliBackendExecuteContext) {
+export function prepareClaudeCliTransportArgs(
+  context: CliBackendExecuteContext,
+): PreparedClaudeCliTransportArgs {
   const args: string[] = [];
   const allowedTools: string[] = [];
   let tools: string[] | undefined;
   let settingSources = "user";
   let excludeDynamicSections = false;
+  let cleanup: (() => void) | undefined;
   for (let index = 0; index < context.args.length; index += 1) {
     const raw = context.args[index]!;
     const equals = raw.indexOf("=");
@@ -107,10 +214,17 @@ export function prepareClaudeCliTransportArgs(context: CliBackendExecuteContext)
     args.push("--tools", tools.join(","));
   }
   if (approvedTools.length) {
-    args.push("--allowedTools", approvedTools.join(","));
+    const inlineAllowedTools = approvedTools.join(",");
+    if (inlineAllowedTools.length <= ALLOWED_TOOLS_INLINE_CHAR_BUDGET) {
+      args.push("--allowedTools", inlineAllowedTools);
+    } else {
+      cleanup = relocateApprovedToolsToSettingsFile(args, approvedTools).cleanup;
+    }
   }
   if (context.sessionId) {
     args.push(context.useResume ? "--resume" : "--session-id", context.sessionId);
   }
-  return { args, excludeDynamicSections };
+  return cleanup === undefined
+    ? { args, excludeDynamicSections }
+    : { args, excludeDynamicSections, cleanup };
 }

--- a/extensions/anthropic/cli-runtime.test.ts
+++ b/extensions/anthropic/cli-runtime.test.ts
@@ -119,6 +119,84 @@ function resultDetail(records: Record<string, unknown>[]): Record<string, unknow
 }
 
 describe("Claude native stdio boundary", () => {
+  it("relocates an oversized tool allowlist into a settings file reused across turns", async () => {
+    const liveSession = createLiveSession();
+    const toolNames = Array.from(
+      { length: 600 },
+      (_, index) => `heavy-mcp-server__tool_with_a_long_name_${index}`,
+    );
+    const context = await createContext("normal", {
+      liveSession,
+      toolAvailability: { native: ["read", "bash"], openClaw: toolNames },
+    });
+    context.args = [...context.args, "--allowedTools", "mcp__openclaw__*"];
+    const expectedAllow = toolNames.map((name) => `mcp__openclaw__${name}`);
+
+    // Fresh turn: the allowlist travels in a temporary settings file, not inline argv.
+    const first = resultDetail(await collect(context));
+    expect(first.turn).toBe(1);
+    const argv = first.argv as string[];
+    expect(argv).not.toContain("--allowedTools");
+    const settingsPath = argv[argv.indexOf("--settings") + 1];
+    expect(typeof settingsPath).toBe("string");
+    const settings = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      permissions?: { allow?: string[] };
+    };
+    expect(settings.permissions?.allow).toEqual(expectedAllow);
+
+    // Reused turn: the warm session keeps the same process, argv, and settings file.
+    const second = resultDetail(await collect(context));
+    expect(second.turn).toBe(2);
+    expect(second.argv).toEqual(argv);
+
+    // Closing the session releases the temporary settings file.
+    const handle = liveSession.current();
+    expect(handle).toBeDefined();
+    handle!.close("idle");
+    await handle!.waitForExit();
+    await expect(access(settingsPath)).rejects.toThrow();
+  });
+
+  it("merges a relocated allowlist into inline settings the projection already passed", async () => {
+    const liveSession = createLiveSession();
+    const toolNames = Array.from(
+      { length: 600 },
+      (_, index) => `heavy-mcp-server__tool_with_a_long_name_${index}`,
+    );
+    const inlineSettings = JSON.stringify({
+      disableAllHooks: true,
+      enabledPlugins: {},
+      permissions: { deny: ["mcp__*"] },
+    });
+    const context = await createContext("normal", {
+      liveSession,
+      toolAvailability: { native: ["read"], openClaw: toolNames },
+    });
+    context.args = [
+      ...context.args,
+      "--allowedTools",
+      "mcp__openclaw__*",
+      "--settings",
+      inlineSettings,
+    ];
+
+    const first = resultDetail(await collect(context));
+    const argv = first.argv as string[];
+    expect(argv).not.toContain("--allowedTools");
+    expect(argv).not.toContain(inlineSettings);
+    expect(argv.filter((arg) => arg === "--settings")).toHaveLength(1);
+    const settingsPath = argv[argv.indexOf("--settings") + 1];
+    const settings = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      disableAllHooks?: boolean;
+      enabledPlugins?: Record<string, unknown>;
+      permissions?: { allow?: string[]; deny?: string[] };
+    };
+    expect(settings.disableAllHooks).toBe(true);
+    expect(settings.enabledPlugins).toEqual({});
+    expect(settings.permissions?.deny).toEqual(["mcp__*"]);
+    expect(settings.permissions?.allow).toEqual(toolNames.map((name) => `mcp__openclaw__${name}`));
+  });
+
   it.each([
     { scenario: "shutdown-ignore", name: "native parent and child ignore EOF and SIGTERM" },
     { scenario: "shutdown-eof", name: "native parent exits immediately on EOF" },

--- a/extensions/anthropic/cli-runtime.test.ts
+++ b/extensions/anthropic/cli-runtime.test.ts
@@ -138,7 +138,9 @@ describe("Claude native stdio boundary", () => {
     const argv = first.argv as string[];
     expect(argv).not.toContain("--allowedTools");
     const settingsPath = argv[argv.indexOf("--settings") + 1];
-    expect(typeof settingsPath).toBe("string");
+    if (typeof settingsPath !== "string") {
+      throw new Error("Relocated transport argv is missing the --settings file path.");
+    }
     const settings = JSON.parse(await readFile(settingsPath, "utf8")) as {
       permissions?: { allow?: string[] };
     };
@@ -186,6 +188,9 @@ describe("Claude native stdio boundary", () => {
     expect(argv).not.toContain(inlineSettings);
     expect(argv.filter((arg) => arg === "--settings")).toHaveLength(1);
     const settingsPath = argv[argv.indexOf("--settings") + 1];
+    if (typeof settingsPath !== "string") {
+      throw new Error("Relocated transport argv is missing the --settings file path.");
+    }
     const settings = JSON.parse(await readFile(settingsPath, "utf8")) as {
       disableAllHooks?: boolean;
       enabledPlugins?: Record<string, unknown>;

--- a/extensions/anthropic/cli.runtime.ts
+++ b/extensions/anthropic/cli.runtime.ts
@@ -33,6 +33,7 @@ type ClaudeCliSession = {
   handle: CliBackendLiveSessionHandle;
   capability?: CliBackendLiveSessionCapability;
   transport?: ReturnType<typeof createClaudeCliTransport>;
+  transportCleanup?: () => void;
   currentTurn?: ClaudeCliTurn;
   idleTimer?: ReturnType<typeof setTimeout>;
   hasBackgroundTasks: boolean;
@@ -175,6 +176,9 @@ function closeSession(
     turn.events.end();
   }
   session.transport?.close();
+  const transportCleanup = session.transportCleanup;
+  session.transportCleanup = undefined;
+  transportCleanup?.();
 }
 
 function completeTurn(session: ClaudeCliSession, turn: ClaudeCliTurn) {
@@ -298,50 +302,58 @@ export async function* executeClaudeCli(
     // Adopt the process's exact MCP capture before prompt dispatch or native tool callbacks.
     capability?.activate(session.handle);
     if (!session.transport) {
-      const { args, excludeDynamicSections } = prepareClaudeCliTransportArgs(context);
-      session.transport = createClaudeCliTransport({
-        context,
-        args,
-        secretInput,
-        currentContext: () => session.currentTurn?.context,
-        initialize: {
-          appendSystemPrompt: context.systemPrompt,
-          excludeDynamicSections,
-          hooks: {
-            UserPromptSubmit: [{ hookCallbackIds: ["UserPromptSubmit"] }],
-            PreToolUse: [{ hookCallbackIds: ["PreToolUse"] }],
+      const { args, excludeDynamicSections, cleanup } = prepareClaudeCliTransportArgs(context);
+      session.transportCleanup = cleanup;
+      try {
+        session.transport = createClaudeCliTransport({
+          context,
+          args,
+          secretInput,
+          currentContext: () => session.currentTurn?.context,
+          initialize: {
+            appendSystemPrompt: context.systemPrompt,
+            excludeDynamicSections,
+            hooks: {
+              UserPromptSubmit: [{ hookCallbackIds: ["UserPromptSubmit"] }],
+              PreToolUse: [{ hookCallbackIds: ["PreToolUse"] }],
+            },
           },
-        },
-        onMessage: (message) => acceptMessage(session, message),
-        onRequest: async (request, signal) => {
-          // No interactive MCP elicitation handler is registered; preserve its declined outcome.
-          if (request.subtype === "elicitation") {
-            return () => ({ action: "decline" });
-          }
-          const admittedTurn = activeTurn(session);
-          const response = await handleRequest(session, request, signal);
-          // The transport invokes this synchronously at its final write, after all awaits.
-          return () => {
-            if (admittedTurn && activeTurn(session) === admittedTurn && !signal.aborted) {
-              return response;
+          onMessage: (message) => acceptMessage(session, message),
+          onRequest: async (request, signal) => {
+            // No interactive MCP elicitation handler is registered; preserve its declined outcome.
+            if (request.subtype === "elicitation") {
+              return () => ({ action: "decline" });
             }
-            const message = "The OpenClaw run is no longer active.";
-            if (request.subtype === "can_use_tool") {
-              return { behavior: "deny", message, toolUseID: request.tool_use_id };
-            }
-            return request.callback_id === "PreToolUse"
-              ? {
-                  hookSpecificOutput: {
-                    hookEventName: "PreToolUse",
-                    permissionDecision: "deny",
-                    permissionDecisionReason: message,
-                  },
-                }
-              : {};
-          };
-        },
-        onError: (error) => session.handle.close("abort", error),
-      });
+            const admittedTurn = activeTurn(session);
+            const response = await handleRequest(session, request, signal);
+            // The transport invokes this synchronously at its final write, after all awaits.
+            return () => {
+              if (admittedTurn && activeTurn(session) === admittedTurn && !signal.aborted) {
+                return response;
+              }
+              const message = "The OpenClaw run is no longer active.";
+              if (request.subtype === "can_use_tool") {
+                return { behavior: "deny", message, toolUseID: request.tool_use_id };
+              }
+              return request.callback_id === "PreToolUse"
+                ? {
+                    hookSpecificOutput: {
+                      hookEventName: "PreToolUse",
+                      permissionDecision: "deny",
+                      permissionDecisionReason: message,
+                    },
+                  }
+                : {};
+            };
+          },
+          onError: (error) => session.handle.close("abort", error),
+        });
+      } catch (error) {
+        const transportCleanup = session.transportCleanup;
+        session.transportCleanup = undefined;
+        transportCleanup?.();
+        throw error;
+      }
       await session.transport.initialize();
     }
     context.assertCurrent?.();


### PR DESCRIPTION
Closes #144792

## What Problem This Solves

Fixes an issue where users on Windows running the `claude-cli` backend with many MCP servers would have every agent turn fail immediately with `spawn ENAMETOOLONG` (often surfaced misleadingly as `reason=auth-profile` / `FailoverError`), because the full tool-availability allow list is passed inline as `--allowedTools tool_1,tool_2,…` and overflows the Windows command-line limit. The earlier prompt relocation moved the system prompt off the command line, but the allowed-tools list — the largest remaining argument on multi-MCP installs — was still inline.

## Why This Change Was Made

When the joined allow list exceeds an 8 KiB inline budget (well below the ~32,767-character CreateProcess limit; a known-good 139-tool install measures ~6.5K characters, a failing 559-tool install ~27K), the transport arg builder now writes `{ "permissions": { "allow": [...] } }` to a private temp file and passes `--settings <path>` instead of `--allowedTools ...`. `permissions.allow` is the native settings equivalent of `--allowedTools`, so enforcement is unchanged — only the transport moves off the command line.

Key boundaries:

- Small allow lists stay inline; nothing changes for installs that work today.
- Claude Code honors a single `--settings` value, so when the restricted execution projection already passed inline settings JSON, the allow list is merged into that JSON (both `--settings` and `--settings=<json>` forms) rather than shadowing it with a second flag.
- An existing `--settings` file path (or non-JSON value) stays authoritative and the allow list falls back to inline, as does any failure to write the temp file — the fix never introduces a new failure mode.
- The temp file lives for the life of the long-lived stdio session and is removed when the session closes or if process spawn fails.

## User Impact

Heavy-MCP Windows installs can run current releases with the Claude subscription backend again instead of being pinned to 6.34: agent turns start and respond instead of dying at spawn. Non-Windows hosts and small tool lists see no behavior change.

## Evidence

**Real behavior proof through the actual `executeClaudeCli` agent path** (new tests in `extensions/anthropic/cli-runtime.test.ts`, driving the real stdio transport against a protocol-speaking Claude fixture subprocess):

- *Fresh turn with 600 tools (~29K characters of allowlist):* the spawned process argv contains no `--allowedTools`; it carries a single `--settings <path>` whose JSON holds every `mcp__openclaw__*` entry verbatim under `permissions.allow`. The full turn completes through the real protocol: initialize, UserPromptSubmit hook, PreToolUse hook, and `can_use_tool` authorization all still function with the file-based settings.
- *Reused turn:* a second turn on the warm session reuses the same process and argv (`turn: 2`, identical argv) — the settings file stays valid for the life of the session.
- *Session cleanup:* closing the live session removes the temporary settings file (`access()` rejects after `waitForExit()`).
- *Preserved settings:* when the restricted projection already passed inline `--settings` JSON, the relocated file keeps `disableAllHooks`, `enabledPlugins`, and the existing `permissions.deny` alongside the merged `permissions.allow`, and exactly one `--settings` flag survives.

**Real Windows run with actual Claude Code (2.1.233) through this branch's `executeClaudeCli` agent path**, 600 synthetic OpenClaw tools (inline `--allowedTools` would be 35,289 characters — over the Windows limit):

```
PROOF inline --allowedTools length would be: 35289 chars
PROOF spawned argv total length: 316 chars
PROOF argv contains --allowedTools: false
PROOF --settings file bytes: 40737
PROOF permissions.allow entries: 600
PROOF settings file removed after cleanup: true
PROOF real fresh turn result: "PROOF_TURN_1_OK"
PROOF settings workspace alive during session: true openclaw-claude-cli-settings-gLeWpq
PROOF real reused turn result: "PROOF_TURN_2_OK"
PROOF settings workspace removed after session close: true
```

The fresh and reused turns are real Claude Code agent turns interpreting the relocated settings file; the session holds the temp workspace while warm and releases it on close. (Synthetic tool names; no private endpoints, keys, or paths beyond the OS temp dir.)
Focused unit tests in `extensions/anthropic/cli-runtime-args.test.ts` (6 tests) additionally cover the inline small-list path, the `--settings=<json>` form, the file-path fallback, and the write-failure fallback.

Existing suites pass: `extensions/anthropic/cli-runtime.test.ts` + `extensions/anthropic/cli-shared.test.ts` + `cli-runtime-args.test.ts` (77 tests), full `pnpm test:extension anthropic` (592 passed; the only 3 failures are pre-existing `session-catalog.test.ts` symlink tests that require Windows developer mode and fail identically on clean `main`).
`scripts/check-src-extension-import-boundary.mts --json` clean; `node scripts/check-changed.mjs` lanes pass (typecheck, lint, format, boundary guards).
