### PR TITLE
refactor(matrix): share bounded context cache insertion

### DIFF
--- a/extensions/matrix/src/matrix/monitor/reply-context.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reply-context.test.ts
@@ -294,40 +294,42 @@ describe("matrix reply context", () => {
     });
   });
 
-  it("uses LRU eviction — recently accessed entries survive over older ones", async () => {
-    let callCount = 0;
-    const getEvent = vi.fn().mockImplementation((_roomId: string, eventId: string) => {
-      callCount++;
-      return Promise.resolve({
-        event_id: eventId,
-        sender: `@user${callCount}:example.org`,
-        type: "m.room.message",
-        origin_server_ts: Date.now(),
-        content: { msgtype: "m.text", body: `msg-${eventId}` },
-      });
-    });
+  it("retains recently accessed reply contexts when the cache exceeds 256 entries", async () => {
+    const getEvent = vi.fn(async (_roomId: string, eventId: string) => ({
+      event_id: eventId,
+      sender: "@alice:example.org",
+      type: "m.room.message",
+      origin_server_ts: Date.now(),
+      content: { msgtype: "m.text", body: `msg-${eventId}` },
+    }));
     const getMemberDisplayName = vi
       .fn()
       .mockImplementation((_r: string, userId: string) => Promise.resolve(userId));
-
-    // Use a small cache by testing the eviction pattern:
-    // The actual MAX_CACHED_REPLY_CONTEXTS is 256. We cannot override it easily,
-    // but we can verify that a cache hit reorders entries (delete + re-insert).
     const resolveReplyContext = createMatrixReplyContextResolver({
       client: { getEvent } as never,
       getMemberDisplayName,
       logVerboseMessage: () => {},
     });
+    const roomId = "!room:example.org";
+    const oldest = await resolveReplyContext({ roomId, eventId: "$event-0" });
+    const nextOldest = await resolveReplyContext({ roomId, eventId: "$event-1" });
+    for (let i = 2; i < 256; i += 1) {
+      await resolveReplyContext({ roomId, eventId: `$event-${i}` });
+    }
+    expect(await resolveReplyContext({ roomId, eventId: "$event-0" })).toBe(oldest);
+    expect(getEvent).toHaveBeenCalledTimes(256);
 
-    // Populate cache with two entries
-    await resolveReplyContext({ roomId: "!r:e", eventId: "$A" });
-    await resolveReplyContext({ roomId: "!r:e", eventId: "$B" });
-    expect(getEvent).toHaveBeenCalledTimes(2);
+    await resolveReplyContext({ roomId, eventId: "$event-256" });
 
-    // Access $A again — should be a cache hit (no new getEvent call)
-    // and should move $A to the end of the Map for LRU.
-    const hitResult = await resolveReplyContext({ roomId: "!r:e", eventId: "$A" });
-    expect(getEvent).toHaveBeenCalledTimes(2); // Still 2 — cache hit
-    expect(hitResult.replyToBody).toBe("msg-$A");
+    // Check the survivor before refetching the victim triggers another eviction.
+    expect(await resolveReplyContext({ roomId, eventId: "$event-0" })).toBe(oldest);
+    expect(getEvent).toHaveBeenCalledTimes(257);
+    expect(await resolveReplyContext({ roomId, eventId: "$event-1" })).not.toBe(nextOldest);
+    expect(getEvent).toHaveBeenCalledTimes(258);
+    for (let i = 0; i <= 256; i += 1) {
+      expect(getEvent.mock.calls.filter(([, eventId]) => eventId === `$event-${i}`)).toHaveLength(
+        i === 1 ? 2 : 1,
+      );
+    }
   });
 });

--- a/extensions/matrix/src/matrix/monitor/reply-context.ts
+++ b/extensions/matrix/src/matrix/monitor/reply-context.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixClient } from "../sdk.js";
+import { setBoundedMap } from "./bounded-cache.js";
 import { summarizeMatrixMessageContextEvent } from "./context-summary.js";
 import type { MatrixRawEvent } from "./types.js";
 
@@ -39,13 +40,7 @@ export function createMatrixReplyContextResolver(params: {
   const cache = new Map<string, MatrixReplyContext>();
 
   const remember = (key: string, value: MatrixReplyContext): MatrixReplyContext => {
-    cache.set(key, value);
-    if (cache.size > MAX_CACHED_REPLY_CONTEXTS) {
-      const oldest = cache.keys().next().value;
-      if (typeof oldest === "string") {
-        cache.delete(oldest);
-      }
-    }
+    setBoundedMap(cache, key, value, MAX_CACHED_REPLY_CONTEXTS);
     return value;
   };
 

--- a/extensions/matrix/src/matrix/monitor/thread-context.test.ts
+++ b/extensions/matrix/src/matrix/monitor/thread-context.test.ts
@@ -138,6 +138,42 @@ describe("matrix thread context", () => {
     expect(getMemberDisplayName).toHaveBeenCalledTimes(1);
   });
 
+  it("evicts the oldest thread context despite a cache hit when exceeding 256 entries", async () => {
+    const getEvent = vi.fn(async (_roomId: string, eventId: string) => ({
+      event_id: eventId,
+      sender: "@alice:example.org",
+      type: "m.room.message",
+      origin_server_ts: Date.now(),
+      content: { msgtype: "m.text", body: `msg-${eventId}` },
+    }));
+    const resolveThreadContext = createMatrixThreadContextResolver({
+      client: { getEvent } as never,
+      getMemberDisplayName: vi.fn(async () => "Alice"),
+      logVerboseMessage: () => {},
+    });
+    const roomId = "!room:example.org";
+    const oldest = await resolveThreadContext({ roomId, threadRootId: "$event-0" });
+    const nextOldest = await resolveThreadContext({ roomId, threadRootId: "$event-1" });
+    for (let i = 2; i < 256; i += 1) {
+      await resolveThreadContext({ roomId, threadRootId: `$event-${i}` });
+    }
+    expect(await resolveThreadContext({ roomId, threadRootId: "$event-0" })).toBe(oldest);
+    expect(getEvent).toHaveBeenCalledTimes(256);
+
+    await resolveThreadContext({ roomId, threadRootId: "$event-256" });
+
+    // Check the survivor before refetching the victim triggers another eviction.
+    expect(await resolveThreadContext({ roomId, threadRootId: "$event-1" })).toBe(nextOldest);
+    expect(getEvent).toHaveBeenCalledTimes(257);
+    expect(await resolveThreadContext({ roomId, threadRootId: "$event-0" })).not.toBe(oldest);
+    expect(getEvent).toHaveBeenCalledTimes(258);
+    for (let i = 0; i <= 256; i += 1) {
+      expect(getEvent.mock.calls.filter(([, eventId]) => eventId === `$event-${i}`)).toHaveLength(
+        i === 0 ? 2 : 1,
+      );
+    }
+  });
+
   it("does not cache thread starter fetch failures", async () => {
     const getEvent = vi
       .fn()

--- a/extensions/matrix/src/matrix/monitor/thread-context.ts
+++ b/extensions/matrix/src/matrix/monitor/thread-context.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixClient } from "../sdk.js";
+import { setBoundedMap } from "./bounded-cache.js";
 import { summarizeMatrixMessageContextEvent } from "./context-summary.js";
 import type { MatrixRawEvent } from "./types.js";
 
@@ -58,13 +59,7 @@ export function createMatrixThreadContextResolver(params: {
   const cache = new Map<string, MatrixThreadContext>();
 
   const remember = (key: string, value: MatrixThreadContext): MatrixThreadContext => {
-    cache.set(key, value);
-    if (cache.size > MAX_TRACKED_THREAD_STARTERS) {
-      const oldest = cache.keys().next().value;
-      if (typeof oldest === "string") {
-        cache.delete(oldest);
-      }
-    }
+    setBoundedMap(cache, key, value, MAX_TRACKED_THREAD_STARTERS);
     return value;
   };
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

The head branch is in openclaw/openclaw.

</details>

## What Problem This Solves

At maintainer request, consolidate duplicated bounded-cache insertion used by Matrix reply quotes and thread-root context. The existing reply test did not reach the cache limit, so it could not detect an eviction-policy regression.

## Why This Change Was Made

Both context resolvers now use the existing bounded-map helper for insertion and eviction. Their independent 256-entry caches retain distinct hit policies: reply context is LRU, while thread context remains FIFO.

## User Impact

No intended user-visible behavior change. Cached context identity, transient fetch retries, and the order of event fetching, message summarization, and display-name resolution remain unchanged.

## Evidence

- All four complete suites passed before and after extraction: 80 cases each, with identical test bytes and cases. Reply context: 25; thread context: 21; direct rooms: 26; room info: 8.
- Capacity tests fill 256 entries, touch the oldest, then insert the 257th. They check survivor identity before refetching the evicted entry and verify per-event fetch counts.
- All 25 selected changed-check components passed, including focused formatting, extension source/test typechecks, targeted lint, and the separately selected doctor contract tests (two files, six cases).
- Independent P2 review found no actionable issues in the final diff.
- This is passing before/after characterization, not a reproduced production bug. Live Matrix/Gateway behavior has not been run.
- Hosted CI [run 34603284189](https://github.com/openclaw/openclaw/actions/runs/34603284189) succeeded for exact head `8d2e3b9064dac787561bb33982e64560e5f9acf7`.
