### PR TITLE
fix(secrets): avoid unrelated reads during GitHub maintenance

### DIFF
--- a/src/secrets/store/secret-store-hidden-github.ts
+++ b/src/secrets/store/secret-store-hidden-github.ts
@@ -283,6 +283,9 @@ export function listHiddenGitHubSecretRecordNames(params: {
             .select(["name", "value", "created_at_ms", "updated_at_ms"])
             .where("scope_kind", "=", "team")
             .where("scope_id", "=", "")
+            // Bound the existing name index before materializing values; the classifier stays exact.
+            .where("name", ">=", `${params.prefix}-`)
+            .where("name", "<", `${params.prefix}.`)
             .where("kind", "=", "secret")
             .where("allowed_hosts", "is", null)
             .where("deleted_at_ms", "is", null)

--- a/src/secrets/store/secret-store.test.ts
+++ b/src/secrets/store/secret-store.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as kyselySync from "../../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../../infra/node-sqlite.js";
 import { isSecretValueRegisteredForRedaction } from "../../logging/secret-redaction-registry.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
@@ -288,6 +289,121 @@ describe("secret store", () => {
       });
     }
   });
+
+  it.each(["github-device", "github-oauth"] as const)(
+    "does not materialize unrelated secret values when listing %s records",
+    (prefix) => {
+      const database = createDatabaseOptions();
+      const { db } = openOpenClawStateDatabase(database);
+      const now = Date.now();
+      const insert = db.prepare(`
+        INSERT INTO secret_store_entries
+          (scope_kind, scope_id, name, kind, value, created_at_ms, updated_at_ms)
+        VALUES ('team', '', ?, 'secret', ?, ?, ?)
+      `);
+      // Seed persisted values directly so listing, rather than writing, owns redaction registration.
+      const names = [`${prefix}-${"f".repeat(32)}`, `${prefix}-${"0".repeat(32)}`];
+      for (const name of names) {
+        insert.run(name, `synthetic-value:${name}`, now, now);
+      }
+      const sibling = prefix === "github-device" ? "github-oauth" : "github-device";
+      insert.run(`${sibling}-${"a".repeat(32)}`, `synthetic-sibling:${prefix}`, now, now);
+      for (let index = 0; index < 64; index += 1) {
+        insert.run(`UNRELATED_${index}`, `synthetic-unrelated:${prefix}:${index}`, now, now);
+      }
+      const execute = vi.spyOn(kyselySync, "executeSqliteQuerySync");
+      try {
+        expect(listHiddenGitHubSecretRecordNames({ prefix, database })).toEqual(
+          [...names].toSorted(),
+        );
+        const materialized = execute.mock.results.flatMap((result) =>
+          result.type === "return" ? result.value.rows : [],
+        );
+        expect(materialized).not.toContainEqual(
+          expect.objectContaining({
+            value: expect.stringMatching(/^synthetic-(sibling|unrelated):/),
+          }),
+        );
+        for (const name of names) {
+          expect(materialized).toContainEqual(
+            expect.objectContaining({ value: `synthetic-value:${name}` }),
+          );
+          expect(isSecretValueRegisteredForRedaction(`synthetic-value:${name}`)).toBe(true);
+        }
+        expect(isSecretValueRegisteredForRedaction(`synthetic-sibling:${prefix}`)).toBe(false);
+        expect(isSecretValueRegisteredForRedaction(`synthetic-unrelated:${prefix}:0`)).toBe(false);
+      } finally {
+        execute.mockRestore();
+      }
+    },
+  );
+
+  it.each(["github-device", "github-oauth"] as const)(
+    "preserves exact names, liveness, scope, and redaction when listing %s records",
+    (prefix) => {
+      const database = createDatabaseOptions();
+      const { db } = openOpenClawStateDatabase(database);
+      const now = Date.parse("2026-01-01T00:00:00.000Z");
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+      const insert = db.prepare(`
+        INSERT INTO secret_store_entries
+          (scope_kind, scope_id, name, kind, value, allowed_hosts,
+           created_at_ms, updated_at_ms, deleted_at_ms)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      const cases = [
+        { accept: true },
+        { created: now - 15 * 60_000 + 1, accept: true },
+        { created: now - 15 * 60_000, accept: prefix === "github-oauth" },
+        { created: now + 1, accept: false },
+        { updated: now + 1, accept: true },
+        { scopeKind: "identity", scopeId: "other", accept: false },
+        { kind: "env", accept: false },
+        { allowedHosts: "[]", accept: false },
+        { deleted: now, accept: false },
+        { name: `${prefix}-${"A".repeat(32)}`, accept: false },
+        { name: `${prefix}-${"a".repeat(31)}`, accept: false },
+        { name: `${prefix}-${"a".repeat(33)}`, accept: false },
+        { name: `${prefix}-${"a".repeat(32)}\n`, accept: false },
+        { name: `${prefix}-${"a".repeat(32)}\0`, accept: false },
+        { name: `${prefix}.`, accept: false },
+        { name: `${prefix.toUpperCase()}-${"a".repeat(32)}`, accept: false },
+        { name: `${prefix}-é${"a".repeat(31)}`, accept: false },
+      ];
+      const fixtures = cases.map((entry, index) =>
+        Object.assign(
+          {
+            name: `${prefix}-${index.toString(16).padStart(32, "0")}`,
+            value: `synthetic-parity:${prefix}:${index}`,
+          },
+          entry,
+        ),
+      );
+      for (const entry of fixtures) {
+        insert.run(
+          entry.scopeKind ?? "team",
+          entry.scopeId ?? "",
+          entry.name,
+          entry.kind ?? "secret",
+          entry.value,
+          entry.allowedHosts ?? null,
+          entry.created ?? now,
+          entry.updated ?? now,
+          entry.deleted ?? null,
+        );
+      }
+      expect(listHiddenGitHubSecretRecordNames({ prefix, database })).toEqual(
+        fixtures
+          .filter((entry) => entry.accept)
+          .map((entry) => entry.name)
+          .toSorted(),
+      );
+      for (const entry of fixtures) {
+        expect(isSecretValueRegisteredForRedaction(entry.value)).toBe(entry.accept);
+      }
+    },
+  );
 
   it("purges transient GitHub records on their own deadlines and retains OAuth state", () => {
     const database = createDatabaseOptions();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where GitHub authorization maintenance repeatedly loads unrelated shared-secret values into memory as the secret store grows. Both device and OAuth reconciliation performed this work even without a configured GitHub identity.

## Why This Change Was Made

Narrow the existing indexed query to the requested GitHub name range before projecting values. Keep the exact JavaScript classifier, expiration and scope checks, matched-value redaction, name ordering, and fresh per-record reads. No schema or index change is needed.

## User Impact

GitHub maintenance allocates less memory and spends less synchronous time reading unrelated secrets. Authorization behavior stays the same.

## Evidence

- Real SQLite regression fails on the original code because unrelated value payloads cross the query boundary; it passes after the fix. Separate parity cases cover names, expiration, scope, and redaction.
- Focused coverage: 25 secret-store, 46 GitHub record, and 41 lifecycle tests passed.
- Local synthetic benchmark with 2,048 unrelated 256-byte values: one list materializes 2 records / 50 value bytes instead of 2,052 records / 524,386 bytes. A device+OAuth pair falls from median 3.83 ms to 0.48 ms across 15 samples after 5 warmups. With 512 unrelated 64 KiB values, the pair falls from 17.55 ms to 0.46 ms. These fixtures do not establish production stall attribution.
- Native query plans use the existing live index with a name range. Independent parity checks cover UTF-8 and both UTF-16 encodings; exact classification remains in JavaScript.
- Independent P2 autoreview found no actionable findings.
- Full `check:changed` passed.
- Linux Blacksmith owner-flow exercised actual SQLite and GitHub lifecycle maintenance: invalid device/OAuth rows were removed, a valid pending device and 64 unrelated secrets were retained, and a later exact read observed an updated record. The selected-source receipt and all assertions were retained. The wrapper exited 1 after a cleanup timeout; a separate native check confirmed the lease completed and its workflow ended. This is qualified owner-flow evidence, not a clean overall wrapper run or live GitHub authorization.
