### PR TITLE
fix(doctor): contain MCP child cleanup failures

### DIFF
--- a/docs/gateway/doctor/checks.md
+++ b/docs/gateway/doctor/checks.md
@@ -18,6 +18,7 @@ full behavior and rationale of each numbered check, follow the links under
     - UI protocol freshness check (rebuilds Control UI when the protocol schema is newer).
     - Health check + restart prompt.
     - Problem-only skill and plugin notes; healthy inventory stays in `openclaw skills check` and `openclaw plugins list`.
+    - Runtime tool schema checks report failing MCP servers and continue with the remaining checks. If subprocess cleanup cannot be confirmed, Doctor retains the server findings and adds a cleanup diagnostic; inspect or stop the affected MCP processes before rerunning Doctor.
 
   </Accordion>
   <Accordion title="Config and migrations">

--- a/src/agents/mcp-client-lifecycle.ts
+++ b/src/agents/mcp-client-lifecycle.ts
@@ -50,11 +50,26 @@ export async function connectMcpClient(params: {
   });
   try {
     await Promise.race([
-      params.client.connect(params.transport, {
-        signal,
-        timeout: params.timeoutMs,
-        maxTotalTimeout: params.timeoutMs,
-      }),
+      (async () => {
+        const { client } = params;
+        const close = client.close;
+        client.close = () => {
+          const closing = close.call(client);
+          // SDK initialization discards this promise; preserve rejection for awaited callers.
+          void closing.catch(() => recordAgentCleanupFailure());
+          return closing;
+        };
+        try {
+          await client.connect(params.transport, {
+            signal,
+            timeout: params.timeoutMs,
+            maxTotalTimeout: params.timeoutMs,
+          });
+        } finally {
+          // A deadline can win the outer race before SDK initialization actually settles.
+          client.close = close;
+        }
+      })(),
       aborted,
     ]);
   } catch (error) {

--- a/src/agents/mcp-stdio-transport.test.ts
+++ b/src/agents/mcp-stdio-transport.test.ts
@@ -8,7 +8,7 @@ import { EmptyResultSchema, JSONRPCRequestSchema } from "@modelcontextprotocol/s
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { OwnedStdioCleanupError, type OwnedStdioProcess } from "../process/owned-stdio.js";
-import { disposeMcpClient } from "./mcp-client-lifecycle.js";
+import { connectMcpClient, disposeMcpClient } from "./mcp-client-lifecycle.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 import { createAgentCleanupScope } from "./run-cleanup-timeout.js";
 
@@ -292,6 +292,56 @@ describe("OpenClawStdioClientTransport", () => {
     });
     expect(cleanupScope.outcome).toBe("uncertain");
   });
+
+  it.each(["initialize-error", "aborted"] as const)(
+    "contains SDK %s cleanup rejection without certifying closure",
+    async (trigger) => {
+      const fixture = createChild();
+      const failure = new Error(
+        "service child cleanup identity lost: anchor channel closed without a matching closing receipt",
+      );
+      const transport = createTransport({ command: "node" });
+      const client = new Client({ name: "doctor-mcp-proof", version: "1" });
+      const cleanupScope = createAgentCleanupScope();
+      await cleanupScope.run(async () => {
+        const controller = new AbortController();
+        const connecting = connectMcpClient({
+          client,
+          transport,
+          timeoutMs: 5_000,
+          signal: controller.signal,
+        });
+        const rejected = expect(connecting).rejects.toThrow("fixture initialization failed");
+        await vi.waitFor(() => expect(fixture.stdin.readableLength).toBeGreaterThan(0));
+        const initialize = JSONRPCRequestSchema.parse(
+          JSON.parse(fixture.stdin.read().toString("utf8")),
+        );
+        if (trigger === "aborted") {
+          controller.abort(new Error("fixture initialization failed"));
+        } else {
+          fixture.stdout.write(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: initialize.id,
+              error: { code: -32603, message: "fixture initialization failed" },
+            }) + "\n",
+          );
+        }
+        await rejected;
+        fixture.root.resolve({ code: 1, signal: null });
+        fixture.extinction.reject(failure);
+        // Let the SDK's discarded close promise settle before explicit disposal.
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        await expect(disposeMcpClient({ client, transport, transportType: "stdio" })).resolves.toBe(
+          "uncertain",
+        );
+        await expect(transport.close()).rejects.toBe(failure);
+      });
+      expect(cleanupScope.outcome).toBe("uncertain");
+    },
+  );
 
   it.each([
     { confirmed: true, outcome: "closed" },

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -241,40 +241,57 @@ describe("doctor runtime tool schema checks", () => {
     );
   });
 
-  it("reports bundle MCP runtime diagnostics when tool listing fails schema validation", async () => {
-    mocks.createBundleMcpToolRuntime.mockReturnValueOnce({
-      tools: [],
-      diagnostics: [
-        {
-          serverName: "fuzzplugin",
-          safeServerName: "fuzzplugin",
-          launchSummary: "node fuzzplugin-mcp.mjs",
-          message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
-        },
-      ],
-      dispose: mocks.disposeBundleRuntime,
-    });
+  it.each([false, true])(
+    "preserves MCP schema diagnostics with cleanup failure=%s",
+    async (cleanupFails) => {
+      if (cleanupFails) {
+        mocks.disposeBundleRuntime.mockRejectedValueOnce(
+          new Error("MCP runtime cleanup could not confirm closure"),
+        );
+      }
+      mocks.createBundleMcpToolRuntime.mockReturnValueOnce({
+        tools: [],
+        diagnostics: [
+          {
+            serverName: "fuzzplugin",
+            safeServerName: "fuzzplugin",
+            launchSummary: "node fuzzplugin-mcp.mjs",
+            message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
+          },
+        ],
+        dispose: mocks.disposeBundleRuntime,
+      });
 
-    await expect(
-      collectRuntimeToolSchemaFindings({
+      const findings = await collectRuntimeToolSchemaFindings({
         mcp: {
           servers: {
             fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
-      }),
-    ).resolves.toContainEqual({
-      checkId: "core/doctor/runtime-tool-schemas",
-      severity: "error",
-      message:
-        'Configured MCP server "fuzzplugin" could not expose runtime tools for schema validation.',
-      path: "mcp.servers.fuzzplugin",
-      requirement: 'tools[0].inputSchema.type: Invalid input: expected "object"',
-      fixHint:
-        "Fix or disable the offending MCP server, then rerun doctor before relying on assistant tool startup.",
-    });
-    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
-  });
+      });
+      expect(findings).toContainEqual({
+        checkId: "core/doctor/runtime-tool-schemas",
+        severity: "error",
+        message:
+          'Configured MCP server "fuzzplugin" could not expose runtime tools for schema validation.',
+        path: "mcp.servers.fuzzplugin",
+        requirement: 'tools[0].inputSchema.type: Invalid input: expected "object"',
+        fixHint:
+          "Fix or disable the offending MCP server, then rerun doctor before relying on assistant tool startup.",
+      });
+      if (cleanupFails) {
+        expect(findings).toContainEqual(
+          expect.objectContaining({
+            checkId: "core/doctor/runtime-tool-schemas",
+            path: "mcp.servers",
+            requirement: "MCP runtime cleanup could not confirm closure",
+            fixHint: "Inspect or stop the configured MCP server processes, then rerun doctor.",
+          }),
+        );
+      }
+      expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("reports bundle MCP runtime diagnostics for exact MCP tool allowlists", async () => {
     mocks.createBundleMcpToolRuntime.mockReturnValueOnce({

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -1327,7 +1327,21 @@ export async function collectRuntimeToolSchemaFindings(
       }
     }
   } finally {
-    await Promise.all([...bundleRuntimeByContext.values()].map((runtime) => runtime.dispose()));
+    const cleanup = await Promise.allSettled(
+      [...bundleRuntimeByContext.values()].map(async (runtime) => await runtime.dispose()),
+    );
+    for (const outcome of cleanup) {
+      if (outcome.status === "rejected") {
+        findings.push({
+          checkId: "core/doctor/runtime-tool-schemas",
+          severity: "error",
+          message: "Configured MCP tool schema inspection could not confirm child-process cleanup.",
+          path: "mcp.servers",
+          requirement: formatErrorMessage(outcome.reason),
+          fixHint: "Inspect or stop the configured MCP server processes, then rerun doctor.",
+        });
+      }
+    }
   }
   return findings;
 }


### PR DESCRIPTION
Fixes #144919
Refs #144911

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users running Doctor against a failing stdio MCP server could lose the CLI to an unhandled child-cleanup rejection. A subsequent cleanup failure could also erase the server-specific findings and repair instructions that Doctor had already collected.

Thanks to @LibraHo for reporting the Docker Compose Doctor failure and distinguishing it from the related Gateway MCP timeout report.

## Why This Change Was Made

The MCP SDK discards an async `close()` promise when initialization fails. Observing the transport's cleanup promise does not observe that separate SDK promise. The shared connection lifecycle now observes the SDK close promise during actual initialization, returns its original rejection to awaited callers, and restores the original method when initialization settles, including when the outer deadline wins first.

Doctor records each failed cleanup as an error finding while preserving its existing server findings. The service-child receipt, lineage, and extinction protocol remains unchanged. These subprocesses are also used outside service managers; skipping MCP checks in containers would skip useful diagnostics.

## User Impact

Doctor can continue its remaining checks while reporting the failed MCP inspection and the next cleanup step. Cleanup uncertainty remains an error rather than being reported as successful closure. The shared SDK containment also covers node-host and Gateway MCP connections.

## Evidence

- New real-SDK regression failed before the fix: The finalized two-case regression reported two unhandled rejections with `service child cleanup identity lost: anchor channel closed without a matching closing receipt` and exited 1. Afterward, all 21 transport tests passed, including initialization-error and aborted-initialization cases, with cleanup still reported as uncertain.
- Extended Doctor regression failed before its fix with `MCP runtime cleanup could not confirm closure`; afterward, the Doctor runtime/contribution suites passed all 198 tests, retaining both the server finding and cleanup diagnostic.
- MCP client/runtime and node-host sibling tests passed; service-child lifecycle/relay tests passed all 66 cases, and both real stdio process-group tests passed.
- `pnpm build` passed.
- `node scripts/check-changed.mjs` and `git diff --check` passed.
- Independent Codex review: no actionable P0/P1 findings.
- Exact-head [CI run 34615562249](https://github.com/openclaw/openclaw/actions/runs/34615562249) passed. The CI watcher reported `GREEN` for `4b2b903c2dfd6edfee78b6a88e6cb34c44d26738`, including the previously failing planner shard. Earlier failures used a stale merge ref without the independent planner fix in #144965; the refreshed merge ref contains that fix. No rebase or CI-policy change was made in this PR.

Known proof gaps: the published 2026.9.4 image did not finish pulling after 25 minutes and was stopped; a candidate build using the repository Dockerfile failed fetching pinned Bun (`unexpected EOF`, 1,506,722 of 49,673,846 bytes). Consequently, neither the original Compose reproduction nor a repaired Compose run is claimed. Native managed-service validation also remains unrun. The repository's real process lifecycle tests are supplemental proof, not a substitute for that cell.

The reporter's exact NAS configuration and child operation remain unverified. Source and regressions establish the configured-MCP Doctor path; 2026.9.4's forced-anchor retirement lacks the newer strict receipt repair already present on main in #144069.

## ClawSweeper review

Maintainer decision: land the scoped MCP cleanup repair and retain `Fixes #144919`. The deployment-proof rank-up request is intentionally deferred: the exact NAS/Compose trigger remains unverified, and the source-supported MCP fix is the accepted landing scope. This PR does not change restart-health/startup-delay behavior, and no such proof is claimed here. Data-model compatibility proof is not applicable because this diff changes neither stored data nor migrations. The current-head review identified no actionable code or security finding.
