### PR TITLE
fix(anthropic): stop pulling CLI-bound channel sessions into the coding catalog

### DIFF
--- a/extensions/anthropic/session-catalog-adoption.ts
+++ b/extensions/anthropic/session-catalog-adoption.ts
@@ -14,3 +14,8 @@ export function adoptedSessionKey(hostId: string, threadId: string): string {
     hostId === CLAUDE_LOCAL_SESSION_HOST_ID ? threadId : adoptedSourceKey(hostId, threadId);
   return `${CLAUDE_ADOPTED_SESSION_KEY_PREFIX}${createHash("sha256").update(source).digest("hex")}`;
 }
+
+/** True for session keys minted by the catalog adoption flow (see adoptedSessionKey). */
+export function isClaudeAdoptedSessionKey(sessionKey: string | undefined): boolean {
+  return typeof sessionKey === "string" && sessionKey.startsWith(CLAUDE_ADOPTED_SESSION_KEY_PREFIX);
+}

--- a/extensions/anthropic/session-catalog-adoption.ts
+++ b/extensions/anthropic/session-catalog-adoption.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 export const CLAUDE_LOCAL_SESSION_HOST_ID = "gateway:local";
 const CLAUDE_ADOPTED_SESSION_KEY_PREFIX = "plugin:anthropic:catalog-adopt:claude:";
+const AGENT_SCOPED_KEY_PREFIX = "agent:";
 
 export function adoptedSourceKey(hostId: string, threadId: string): string {
   return `${hostId}\0${threadId}`;
@@ -17,5 +18,21 @@ export function adoptedSessionKey(hostId: string, threadId: string): string {
 
 /** True for session keys minted by the catalog adoption flow (see adoptedSessionKey). */
 export function isClaudeAdoptedSessionKey(sessionKey: string | undefined): boolean {
-  return typeof sessionKey === "string" && sessionKey.startsWith(CLAUDE_ADOPTED_SESSION_KEY_PREFIX);
+  if (typeof sessionKey !== "string" || sessionKey.length === 0) {
+    return false;
+  }
+  // Session creation persists the minted key agent-scoped
+  // (`agent:<agentId>:<minted>`); agent ids never contain colons, so stripping
+  // one scope restores the minted shape. Bound-session enumeration returns that
+  // persisted key, and the projector must keep recognizing adopted rows while
+  // every other binding stays unprojected.
+  let minted = sessionKey;
+  if (sessionKey.startsWith(AGENT_SCOPED_KEY_PREFIX)) {
+    const separator = sessionKey.indexOf(":", AGENT_SCOPED_KEY_PREFIX.length);
+    if (separator < 0) {
+      return false;
+    }
+    minted = sessionKey.slice(separator + 1);
+  }
+  return minted.startsWith(CLAUDE_ADOPTED_SESSION_KEY_PREFIX);
 }

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -1018,6 +1018,20 @@ describe("Claude session catalog", () => {
         pluginExtensions: { anthropic: { sessionCatalog: { sourceThreadId: sessionId } } },
       }),
     },
+    {
+      // Real adoption hands the minted key to session creation, which persists
+      // it agent-scoped (agent:<agentId>:<minted>); bound-session enumeration
+      // returns that canonical shape, so it must stay recognized here.
+      label: "canonical persisted key after session creation agent-scopes it",
+      sessionKey: (sessionId: string) =>
+        `agent:main:${adoptedSessionKey("gateway:local", sessionId)}`,
+      entry: (sessionId: string) => ({
+        cliSessionBindings: { "claude-cli": { sessionId } },
+        pluginOwnerId: "anthropic",
+        modelSelectionLocked: true,
+        pluginExtensions: { anthropic: { sessionCatalog: { sourceThreadId: sessionId } } },
+      }),
+    },
   ])(
     "links a catalog row to an existing OpenClaw session via $label",
     async ({ entry, sessionKey }) => {

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -11,7 +11,7 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { SessionCatalogProvider as RegisteredSessionCatalogProvider } from "openclaw/plugin-sdk/session-catalog";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { adoptedSourceKey } from "./session-catalog-adoption.js";
+import { adoptedSessionKey, adoptedSourceKey } from "./session-catalog-adoption.js";
 import { listClaudeSessions } from "./session-catalog-discovery.js";
 import {
   createClaudeSessionNodeInvokePolicies,
@@ -1009,13 +1009,8 @@ describe("Claude session catalog", () => {
 
   it.each([
     {
-      label: "CLI binding",
-      entry: (sessionId: string) => ({
-        cliSessionBindings: { "claude-cli": { sessionId } },
-      }),
-    },
-    {
       label: "catalog marker when the CLI binding is empty",
+      sessionKey: (sessionId: string) => adoptedSessionKey("gateway:local", sessionId),
       entry: (sessionId: string) => ({
         cliSessionBindings: { "claude-cli": { sessionId: "" } },
         pluginOwnerId: "anthropic",
@@ -1023,35 +1018,105 @@ describe("Claude session catalog", () => {
         pluginExtensions: { anthropic: { sessionCatalog: { sourceThreadId: sessionId } } },
       }),
     },
-  ])("links a catalog row to an existing OpenClaw session via $label", async ({ entry }) => {
+  ])(
+    "links a catalog row to an existing OpenClaw session via $label",
+    async ({ entry, sessionKey }) => {
+      const home = await createHome();
+      process.env.HOME = home;
+      const sessionId = "claude-bound-session";
+      await writeProject({
+        home,
+        entries: [
+          {
+            sessionId,
+            fullPath: path.join(home, ".claude", "projects", "-workspace", `${sessionId}.jsonl`),
+            summary: "Bound session",
+            projectPath: "/work/source",
+          },
+        ],
+        transcripts: { [sessionId]: [message(sessionId, "user", "source prompt", 1)] },
+      });
+      const provider = captureCatalogProvider({
+        config: { current: () => ({}) },
+        agent: {
+          session: {
+            listSessionEntries: () => [
+              { sessionKey: sessionKey(sessionId), entry: entry(sessionId) },
+            ],
+          },
+        },
+      } as unknown as PluginRuntime);
+
+      const hosts = await provider?.list({});
+      expect(hosts?.[0]?.sessions[0]?.sessionKey).toBe(sessionKey(sessionId));
+    },
+  );
+
+  it("keeps a categorized channel session out of the catalog's owned rows when it only ran the CLI", async () => {
     const home = await createHome();
     process.env.HOME = home;
-    const sessionId = "claude-bound-session";
+    const sessionId = "whatsapp-cli-run";
     await writeProject({
       home,
       entries: [
         {
           sessionId,
           fullPath: path.join(home, ".claude", "projects", "-workspace", `${sessionId}.jsonl`),
-          summary: "Bound session",
+          summary: "WhatsApp group run",
           projectPath: "/work/source",
         },
       ],
       transcripts: { [sessionId]: [message(sessionId, "user", "source prompt", 1)] },
     });
+    const whatsappKey = "agent:main:whatsapp:12025550123-987654321@g.us";
     const provider = captureCatalogProvider({
       config: { current: () => ({}) },
       agent: {
         session: {
           listSessionEntries: () => [
-            { sessionKey: "agent:main:claude-bound", entry: entry(sessionId) },
+            {
+              sessionKey: whatsappKey,
+              entry: {
+                chatType: "group",
+                category: "WhatsApp Gruppen",
+                cliSessionBindings: { "claude-cli": { sessionId } },
+              },
+            },
           ],
         },
       },
     } as unknown as PluginRuntime);
 
+    // The row stays continuable (continue affinity still resolves the binding
+    // to the WhatsApp session), but the row must not claim the session: the UI
+    // treats a projected sessionKey as "this catalog row owns the sidebar
+    // entry" and would pull a categorized session out of its custom group.
     const hosts = await provider?.list({});
-    expect(hosts?.[0]?.sessions[0]?.sessionKey).toBe("agent:main:claude-bound");
+    expect(hosts?.[0]?.sessions[0]?.sessionKey).toBeUndefined();
+    expect(hosts?.[0]?.sessions[0]?.canContinue).toBe(true);
+    expect(
+      listBoundClaudeSessions({
+        id: "anthropic",
+        config: {},
+        runtime: {
+          config: { current: () => ({}) },
+          agent: {
+            session: {
+              listSessionEntries: () => [
+                {
+                  sessionKey: whatsappKey,
+                  entry: {
+                    chatType: "group",
+                    category: "WhatsApp Gruppen",
+                    cliSessionBindings: { "claude-cli": { sessionId } },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawPluginApi),
+    ).toEqual(new Map([[adoptedSourceKey("gateway:local", sessionId), whatsappKey]]));
   });
 
   it("continues a local Desktop-app row and lists it as continuable", async () => {

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -7,7 +7,11 @@ import type {
 } from "openclaw/plugin-sdk/session-catalog";
 import { sessionCatalogPaging } from "openclaw/plugin-sdk/session-catalog";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { adoptedSourceKey, CLAUDE_LOCAL_SESSION_HOST_ID } from "./session-catalog-adoption.js";
+import {
+  adoptedSourceKey,
+  CLAUDE_LOCAL_SESSION_HOST_ID,
+  isClaudeAdoptedSessionKey,
+} from "./session-catalog-adoption.js";
 import { continueClaudeSession } from "./session-catalog-continue.js";
 import { isExactClaudeSessionCursor } from "./session-catalog-cursor.js";
 import { listClaudeSessions } from "./session-catalog-discovery.js";
@@ -114,6 +118,14 @@ function toGenericClaudeHost(
       const nodeCli =
         host.kind === "node" && host.canContinueClaude === true && session.source === "claude-cli";
       const existingSessionKey = adopted.get(adoptedSourceKey(host.hostId, session.threadId));
+      // Only sessions minted by the adoption flow may carry a sessionKey here:
+      // the UI treats that field as "this transcript row owns the regular
+      // sidebar entry" and hides the row from its category/pinned zones. A
+      // plain channel session that merely ran the CLI keeps its own sidebar
+      // row; its binding still feeds continue affinity in session-catalog-continue.
+      const projectedSessionKey = isClaudeAdoptedSessionKey(existingSessionKey)
+        ? existingSessionKey
+        : undefined;
       // Already-adopted rows stay continuable even if node policy later denies
       // the run command: continue only returns the existing session key, and
       // the turn itself still fails closed at invoke time.
@@ -134,7 +146,7 @@ function toGenericClaudeHost(
         ...(session.customGroup ? { customGroup: session.customGroup } : {}),
         ...(session.pullRequest ? { pullRequest: session.pullRequest } : {}),
         archived: session.archived,
-        ...(continuable && existingSessionKey ? { sessionKey: existingSessionKey } : {}),
+        ...(continuable && projectedSessionKey ? { sessionKey: projectedSessionKey } : {}),
         canContinue: continuable,
         canArchive: false,
         canOpenTerminal: terminal.canOpenTerminal,


### PR DESCRIPTION
## What Problem This Solves

#144877: a WhatsApp group session assigned to a custom category (via `sessions.patchMany`) fell back into the CODING zone on the sidebar after every incoming message triggered a claude-cli run, and returned to its custom group only when the CLI transcript file under `~/.claude/projects/<workspace>/` was removed. Per the documented sidebar contract, assigning a session to a custom group always wins over automatic zone classification, so curated channel sessions were effectively un-categorizable whenever they used the CLI backend.

## Solution

`boundClaudeSource` maps any session entry carrying a `claude-cli` CLI binding to a bound catalog source, and the catalog list projected that mapped session key onto the transcript's catalog row. The UI collects those `sessionKey`s as adopted rows and filters them out of the regular sidebar tree (`roots: orderedRootRows.filter((row) => !adopted.has(row.key))`), rendering them inside the coding catalog section instead — that is the "moved to CODING" the report describes. The projection had no adoption-source constraint, so a plain channel session that merely ran the CLI was silently pulled out of its curated zone.

The fix narrows the projection, not the binding map: only session keys minted by the adoption flow (`plugin:anthropic:catalog-adopt:claude:<sha256>`, now exposed by `isClaudeAdoptedSessionKey`) are projected onto catalog rows. `listBoundClaudeSessions` is unchanged — `session-catalog-continue` depends on the binding mapping to restore an existing session when a transcript's "continue" is used, and that affinity is exactly the binding branch's legitimate purpose. A bound-but-unadopted row stays continuable through `terminal.localResumable`, and the adopted-row behavior for genuinely minted sessions is unchanged. The Codex catalog already restricts its equivalent projection to adoption-minted keys (`extensions/codex/src/session-catalog-adoption.ts`), so this also removes the plugin asymmetry.

Session creation canonicalizes the minted key into the agent namespace: real adoption passes the unscoped key to `createSessionEntry`, the Gateway owner persists it as `agent:<agentId>:plugin:anthropic:catalog-adopt:claude:<hash>`, and bound-session enumeration returns that persisted shape. The predicate therefore strips one agent scope (`agent:` + agentId + `:`; agent ids never contain colons per `normalizeAgentId`) before testing the adoption prefix, and preserves the full persisted key in the catalog row so the UI keeps deduplicating the sidebar entry against the live row.

## Evidence

- Pre-fix red (narrowing defect): `session-catalog.test.ts` — a categorized group session entry carrying only `cliSessionBindings["claude-cli"]` produced a catalog row whose `sessionKey` claimed the session (`hosts[0].sessions[0].sessionKey === "agent:main:whatsapp:…"`) while `listBoundClaudeSessions` mapped the transcript to it; the UI-side contract (`app-sidebar-session-navigation.ts:694`) hides exactly those rows from category/pinned zones.
- Post-fix: the same scenario returns `sessionKey: undefined` on the row while `canContinue` stays `true` and `listBoundClaudeSessions` still maps the binding (continue affinity preserved); the genuinely adopted session (minted key + marker + model lock) still projects its `sessionKey`, pinning the marker-based link path.
- Pre-fix red (canonical-key regression, found in review): a persisted adopted entry shaped exactly as session creation mints it (`cliSessionBindings["claude-cli"].sessionId` set, `pluginOwnerId: "anthropic"`, `modelSelectionLocked: true`, catalog marker) whose enumeration key is the canonical `agent:main:plugin:anthropic:catalog-adopt:claude:<sha256>` failed the minted-shape-only predicate — the catalog row lost its `sessionKey` (`expected undefined to be 'agent:main:plugin:anthropic:catalog-a…'` on head `2fd4aad7d6d`), so an existing adopted session would have rendered twice: once as its live coding-catalog row and once as a regular sidebar thread.
- Post-fix: the same canonical persisted key projects through unchanged (`sessionKey === "agent:main:plugin:anthropic:catalog-adopt:claude:<sha256>"`), alongside the unscoped minted shape. Full file: `session-catalog.test.ts` 73/73 on head `198db79889c`; `tsgo` extensions + extension-test lanes exit 0 (fresh tsbuildinfo).

fixes #144877

🤖 Generated with [Claude Code](https://claude.com/claude-code)
