### PR TITLE
refactor(cli): share ordinary parse error rendering

### DIFF
--- a/src/cli/program/error-output.test.ts
+++ b/src/cli/program/error-output.test.ts
@@ -705,6 +705,26 @@ describe("formatCliParseErrorOutput", () => {
     );
   });
 
+  it.each([
+    {
+      name: "missing mandatory option",
+      raw: "  ERROR: required option '--node <id>' not specified\n",
+      message: 'Missing required option "--node <id>".',
+    },
+    {
+      name: "unclassified Commander diagnostic",
+      raw: "error: option '--timeout <ms>' argument missing\n",
+      message: "OpenClaw could not parse this command: option '--timeout <ms>' argument missing",
+    },
+  ])("preserves the complete ordinary $name diagnostic", ({ raw, message }) => {
+    expect(
+      formatCliParseErrorOutput(raw, {
+        argv: ["node", "openclaw", "nodes", "invoke"],
+        commandPath: ["nodes", "invoke"],
+      }),
+    ).toBe(`${message}\nTry: openclaw nodes invoke --help\n`);
+  });
+
   it("prefers the parsed Commander path over option-like argv values", () => {
     const output = formatCliParseErrorOutput("error: unknown option '--wat'\n", {
       argv: ["node", "openclaw", "plugins", "--source", "install", "list", "--wat"],

--- a/src/cli/program/error-output.ts
+++ b/src/cli/program/error-output.ts
@@ -116,6 +116,32 @@ export function createCliUnknownCommandError(
   });
 }
 
+function formatOrdinaryCliParseErrorMessage(message: string): string {
+  const unknownOption = message.match(/^unknown option ['"`](.+?)['"`]/i);
+  if (unknownOption) {
+    const option = unknownOption[1] ?? "";
+    return `OpenClaw does not recognize option ${quote(option)}.`;
+  }
+
+  const missingArgument = message.match(/^missing required argument ['"`](.+?)['"`]/i);
+  if (missingArgument) {
+    const argument = missingArgument[1] ?? "";
+    return `Missing required argument ${quote(argument)}.`;
+  }
+
+  const missingOption = message.match(/^required option ['"`](.+?)['"`] not specified/i);
+  if (missingOption) {
+    const option = missingOption[1] ?? "";
+    return `Missing required option ${quote(option)}.`;
+  }
+
+  if (/^too many arguments\b/i.test(message)) {
+    return "Too many arguments for this command.";
+  }
+
+  return `OpenClaw could not parse this command: ${message}`;
+}
+
 /** Convert Commander parse errors into OpenClaw-specific help and docs guidance. */
 export function formatCliParseErrorOutput(
   raw: string,
@@ -127,45 +153,7 @@ export function formatCliParseErrorOutput(
     return formatCliUnknownCommandOutput(unknownCommand[1] ?? "", options);
   }
 
-  const unknownOption = message.match(/^unknown option ['"`](.+?)['"`]/i);
-  if (unknownOption) {
-    const option = unknownOption[1] ?? "";
-    const output = `OpenClaw does not recognize option ${quote(option)}.`;
-    return lines(
-      theme.error(output),
-      formatHelpHint(options.argv, { commandPath: options.commandPath }),
-    );
-  }
-
-  const missingArgument = message.match(/^missing required argument ['"`](.+?)['"`]/i);
-  if (missingArgument) {
-    const argument = missingArgument[1] ?? "";
-    const output = `Missing required argument ${quote(argument)}.`;
-    return lines(
-      theme.error(output),
-      formatHelpHint(options.argv, { commandPath: options.commandPath }),
-    );
-  }
-
-  const missingOption = message.match(/^required option ['"`](.+?)['"`] not specified/i);
-  if (missingOption) {
-    const option = missingOption[1] ?? "";
-    const output = `Missing required option ${quote(option)}.`;
-    return lines(
-      theme.error(output),
-      formatHelpHint(options.argv, { commandPath: options.commandPath }),
-    );
-  }
-
-  if (/^too many arguments\b/i.test(message)) {
-    const output = "Too many arguments for this command.";
-    return lines(
-      theme.error(output),
-      formatHelpHint(options.argv, { commandPath: options.commandPath }),
-    );
-  }
-
-  const output = `OpenClaw could not parse this command: ${message}`;
+  const output = formatOrdinaryCliParseErrorMessage(message);
   return lines(
     theme.error(output),
     formatHelpHint(options.argv, { commandPath: options.commandPath }),


### PR DESCRIPTION
## What Problem This Solves

The CLI's ordinary parse-error branches repeat the same diagnostic styling and command-specific help footer. This maintainer-requested cleanup removes that duplicated rendering responsibility without changing the diagnostics operators receive.

## Why This Change Was Made

A private, flat classifier retains the existing lazy match order and exact ordinary error text; the existing public formatter renders its result once. Unknown-command suggestions, plugin hints and documentation remain on their separate early-return path. Error construction, raw messages, JSON envelopes and option-reading order are unchanged.

Production: **+27/-39 (net -12 lines)**. Tests: **+20/-0**. No dependency, configuration, protocol, persistence or security-policy change is introduced by this patch.

## User Impact

No intended user-visible change. Invalid commands retain the same text, newline, help target, human/JSON output and exit behavior. Two complete-string regression cases protect missing mandatory options and unclassified Commander diagnostics.

## Evidence

- The original four-file CLI suite passed 216 cases. Adding the two regression cases passed all 218 on the original production code; the refactor retained every per-file ordered case and result. Separate output fault controls produced the intended assertion failures, and exact restoration returned the selected cases and full suite to green.
- On base `e1f6deaf` plus the exact two afterimages subsequently signed as `dad033ab`, the fresh four-file suite passed **218/218**, normal `pnpm build` passed, and the actual enforcing `pnpm ui:check-performance` passed: **352,927 startup gzip bytes / 353,107-byte limit**. This local build used Node 26.8.1; it is not a claim of hosted build parity.
- Four real built CLI invocations (`nodes describe`, `nodes describe --node`, and each with `--json`) returned the expected exit 1. Complete stdout/stderr matched the established human diagnostics and structured envelopes; the isolated fixture and owned process groups were removed.
- The normal required changed gate passed **all 29 checks** on the exact two-file tree, using configured Linux Node 24.19.0 / pnpm 12.3.4 [Testbox execution](https://github.com/openclaw/openclaw/actions/runs/34594952635). Its command and cleanup succeeded. A later runner-portal synchronization warning was retained; it was not treated as a test failure or silently retried.
- Fresh precommit Codex review was scoped-clean through P0. A separate raw-parent review of signed commit `dad033ab` was scoped-clean through P2.
- Read-only qualification through main `66c7fad0` found both owner preimages, parser callers, direct dependencies and lockfile unchanged. Upstream build/runtime changes were inspected separately; this branch was not rebased merely because main advanced.

[Exact-head CI run 34605678854](https://github.com/openclaw/openclaw/actions/runs/34605678854) passed on `dad033ab` (30 successful jobs, 17 skipped), including the required CI gate. [The completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/144948#issuecomment-5635368132) found no actionable issues. Native preparation and landing remain pending. Earlier no-product fixture-loader failure, metadata-only index/config successors of unknown origin, and sampled-process observation limits remain in the retained evidence; none is represented as a successful product execution or unexplained source restoration. No changelog edit or agent transcript is included.
