### PR TITLE
fix(tasks): preserve ACP completion during cancellation

### DIFF
--- a/src/tasks/task-registry-cancel.ts
+++ b/src/tasks/task-registry-cancel.ts
@@ -174,6 +174,15 @@ export async function cancelTaskById(params: {
             ? { expectedInstanceId: managedBacking.instanceId, expectedOwnerKey: task.ownerKey }
             : {}),
         });
+        // The run owns terminal outcomes published while backend cancellation waits.
+        const current = tasks.get(task.taskId);
+        if (current && isTerminalTaskStatus(current.status)) {
+          return {
+            found: true,
+            cancelled: current.status === "cancelled",
+            task: cloneTaskRecord(current),
+          };
+        }
       } else if (task.runtime === "subagent") {
         const { killSubagentRunAdmin } = await loadTaskRegistryControlRuntime();
         const reconcile = (result: Awaited<ReturnType<typeof killSubagentRunAdmin>>) => {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -4715,6 +4715,42 @@ describe("task-registry", () => {
     });
   });
 
+  it.each(["succeeded", "failed", "timed_out", "lost", "cancelled"] as const)(
+    "preserves ACP %s recorded during cancellation",
+    async (status) => {
+      await withTaskRegistryTempDir(async () => {
+        const runId = "run-acp-cancel-race";
+        const task = createTaskFixture("acp", {
+          childSessionKey: "agent:codex:acp:cancel-race",
+          runId,
+          task: "Finish during cancellation",
+          notifyPolicy: "silent",
+        });
+        hoisted.cancelSessionMock.mockImplementationOnce(async () => {
+          updateTaskStateByRunId({
+            runId,
+            runtime: "acp",
+            status,
+            endedAt: 200,
+            terminalSummary: "Recorded terminal result",
+          });
+        });
+
+        const result = await cancelTask(task.taskId);
+
+        expectRecordFields(result, { found: true, cancelled: status === "cancelled" });
+        for (const record of [result.task, getTaskById(task.taskId)]) {
+          expectRecordFields(record, {
+            status,
+            endedAt: 200,
+            error: undefined,
+            terminalSummary: "Recorded terminal result",
+          });
+        }
+      });
+    },
+  );
+
   it("cancels subagent-backed tasks through subagent control", async () => {
     await withTaskRegistryTempDir(async () => {
       const silentTask = createTaskFixture("subagent", {


### PR DESCRIPTION
## What Problem This Solves

Cancelling an ACP background task could replace a completed result with cancellation if normal completion arrived while the backend cancellation call was still pending.

Original fix and regression: @Gabrielnkl, with co-author credit retained.

## Why This Change Was Made

The task cancellation owner used the earlier task state after waiting for the backend. It now rereads the task and returns any recorded final outcome before writing cancellation, preserving the result, error, and end time.

## User Impact

Completed work keeps its result when completion wins the race. Cancellation that wins still reports success. Existing task storage and Gateway response shapes remain compatible.

## Evidence

- Real Gateway `tasks.cancel` and `tasks.get` calls used the ACP session manager and stdio transport, with a backend storage read held while the task completed.
- Before the fix, releasing that read changed the completed task to cancelled; afterward, the task stayed completed with its original result and end time, and cancellation returned `cancelled: false`.
- When cancellation won, it returned `cancelled: true` and preserved the recorded cancellation end time.

## Consumers

- Background-task cancellation callers: receive the recorded final outcome without overwriting completed work.
- Task status readers: retain the original result and end time after a late cancellation request.
