### PR TITLE
refactor(tests): share command field assertions

### DIFF
--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { createColdPluginFixture } from "../../plugins/test-helpers/cold-plugin-fixtures.js";
 import { invokePluginArtifactInstallMock } from "../../plugins/test-helpers/install-fixtures.js";
+import { expectObjectFields } from "../../test-utils/mock-call-assertions.js";
 
 const installPluginFromNpmSpec = vi.fn();
 const resolveNpmSpecMetadata = vi.hoisted(() => vi.fn());
@@ -283,10 +284,7 @@ function requireArray(value: unknown, label: string): unknown[] {
 }
 
 function expectRecordFields(value: unknown, label: string, expected: Record<string, unknown>) {
-  const record = requireRecord(value, label);
-  for (const [key, expectedValue] of Object.entries(expected)) {
-    expect(record[key]).toEqual(expectedValue);
-  }
+  expectObjectFields(requireRecord(value, label), expected);
 }
 
 type MockWithCalls = { mock: { calls: unknown[][] } };

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -20,6 +20,7 @@ import type { BundledProviderPolicySurface } from "../../../plugins/provider-pol
 import { createColdPluginFixture } from "../../../plugins/test-helpers/cold-plugin-fixtures.js";
 import { closeOpenClawStateDatabaseByPath } from "../../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
+import { expectObjectFields } from "../../../test-utils/mock-call-assertions.js";
 import { VERSION } from "../../../version.js";
 import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
 import {
@@ -66,9 +67,7 @@ function expectRecordFields(record: unknown, expected: Record<string, unknown>) 
     throw new Error("Expected record");
   }
   const actual = record as Record<string, unknown>;
-  for (const [key, value] of Object.entries(expected)) {
-    expect(actual[key]).toEqual(value);
-  }
+  expectObjectFields(actual, expected);
   return actual;
 }
 

--- a/src/commands/doctor/shared/plugin-registry-migration.test.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../../plugins/test-helpers/fs-fixtures.js";
 import * as stateDbReadOnly from "../../../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
+import { expectObjectFields } from "../../../test-utils/mock-call-assertions.js";
 import { migratePluginRegistryForDoctor } from "./plugin-registry-migration.js";
 const tempDirs: string[] = [];
 
@@ -91,12 +92,6 @@ function createCurrentIndex(): InstalledPluginIndex {
 }
 
 const requireRecord = createRequireRecord("record", "expected-label-object-capitalized");
-function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
-  for (const [key, value] of Object.entries(fields)) {
-    expect(record[key]).toEqual(value);
-  }
-}
-
 function expectSha256(value: unknown) {
   expect(typeof value).toBe("string");
   expect(value).toMatch(/^[a-f0-9]{64}$/u);
@@ -205,11 +200,11 @@ describe("doctor plugin registry migration", () => {
       readConfig,
       env: hermeticEnv(),
     });
-    expectRecordFields(requireRecord(result, "migration result"), {
+    expectObjectFields(requireRecord(result, "migration result"), {
       status: "skip-existing",
       migrated: false,
     });
-    expectRecordFields(requireRecord(result.preflight, "migration preflight"), {
+    expectObjectFields(requireRecord(result.preflight, "migration preflight"), {
       action: "skip-existing",
       filePath,
     });
@@ -228,14 +223,14 @@ describe("doctor plugin registry migration", () => {
       readConfig: async () => ({}),
       env: hermeticEnv(),
     });
-    expectRecordFields(requireRecord(result, "migration result"), {
+    expectObjectFields(requireRecord(result, "migration result"), {
       status: "migrated",
     });
     expect(result.preflight.action).toBe("migrate");
 
     const persisted = await readPersistedInstalledPluginIndex({ stateDir });
     expect(persisted?.migrationVersion).toBe(1);
-    expectRecordFields(requirePlugin(persisted, "demo") as unknown as Record<string, unknown>, {
+    expectObjectFields(requirePlugin(persisted, "demo"), {
       pluginId: "demo",
     });
   });
@@ -321,7 +316,7 @@ describe("doctor plugin registry migration", () => {
       }),
       env: hermeticEnv(),
     });
-    expectRecordFields(requireRecord(result, "migration result"), {
+    expectObjectFields(requireRecord(result, "migration result"), {
       status: "migrated",
     });
     const current = requireMigratedIndex(result);
@@ -355,7 +350,7 @@ describe("doctor plugin registry migration", () => {
       readConfig: async () => ({}),
       env: hermeticEnv(),
     });
-    expectRecordFields(requireRecord(result, "migration result"), {
+    expectObjectFields(requireRecord(result, "migration result"), {
       status: "migrated",
     });
     const current = requireMigratedIndex(result);
@@ -432,7 +427,7 @@ describe("doctor plugin registry migration", () => {
       readConfig: async () => ({}),
       env: hermeticEnv(),
     });
-    expectRecordFields(requireRecord(result, "migration result"), {
+    expectObjectFields(requireRecord(result, "migration result"), {
       status: "migrated",
     });
     const current = requireMigratedIndex(result);
@@ -455,7 +450,7 @@ describe("doctor plugin registry migration", () => {
       readConfig,
       env: hermeticEnv(),
     });
-    expectRecordFields(requireRecord(result, "migration result"), {
+    expectObjectFields(requireRecord(result, "migration result"), {
       status: "dry-run",
       migrated: false,
     });
@@ -476,7 +471,7 @@ describe("doctor plugin registry migration", () => {
       config: {},
       env: hermeticEnv(),
     });
-    expectRecordFields(requireRecord(result, "migration result"), {
+    expectObjectFields(requireRecord(result, "migration result"), {
       status: "migrated",
       migrated: true,
     });
@@ -513,7 +508,7 @@ describe("doctor plugin registry migration", () => {
       }),
       env: hermeticEnv(),
     });
-    expectRecordFields(requireRecord(result, "migration result"), {
+    expectObjectFields(requireRecord(result, "migration result"), {
       status: "migrated",
     });
     const current = requireMigratedIndex(result);
@@ -556,7 +551,7 @@ describe("doctor plugin registry migration", () => {
       }),
       env: hermeticEnv(),
     });
-    expectRecordFields(requireRecord(result, "migration result"), {
+    expectObjectFields(requireRecord(result, "migration result"), {
       status: "migrated",
     });
     const current = requireMigratedIndex(result);

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -7,6 +7,7 @@ import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-m
 import { setCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata.test-support.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { expectObjectFields } from "../../test-utils/mock-call-assertions.js";
 
 const mocks = vi.hoisted(() => {
   type MockAuthProfile = { provider: string; [key: string]: unknown };
@@ -364,12 +365,6 @@ function parseFirstJsonLog(runtimeLike: { log: Mock }) {
 }
 
 const requireRecord = createRequireRecord("object", "label-not-object");
-
-function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
-  for (const [key, value] of Object.entries(fields)) {
-    expect(record[key]).toEqual(value);
-  }
-}
 
 function requireArray(value: unknown, label: string): unknown[] {
   expect(Array.isArray(value)).toBe(true);
@@ -1791,7 +1786,7 @@ describe("modelsStatusCommand auth overview", () => {
         .map(([arg]) => (arg as { provider: string }).provider);
       expect(payload.auth.missingProvidersInUse).toStrictEqual([]);
       const codexProvider = requireProvider(providers, "codex");
-      expectRecordFields(requireRecord(codexProvider.syntheticAuth, "codex synthetic auth"), {
+      expectObjectFields(requireRecord(codexProvider.syntheticAuth, "codex synthetic auth"), {
         value: "plugin-owned",
         source: "codex-app-server",
       });
@@ -1802,7 +1797,7 @@ describe("modelsStatusCommand auth overview", () => {
         Object.keys(requireRecord(codexProvider.syntheticAuth, "codex synthetic auth")),
       ).toStrictEqual(["value", "source"]);
       expect(JSON.stringify(payload)).not.toContain("codex-runtime-token");
-      expectRecordFields(requireRecord(codexProvider.effective, "codex effective auth"), {
+      expectObjectFields(requireRecord(codexProvider.effective, "codex effective auth"), {
         kind: "synthetic",
         detail: "codex-app-server",
       });


### PR DESCRIPTION
## What Problem This Solves

Command tests repeat field-by-field assertion loops across Doctor repair, channel setup, and model status coverage.

## Why This Change Was Made

Reuse the existing field-assertion helper in four test files. Keep the adapters that own labeled object guards or return the original record, along with every expected value and scenario assertion. Tests shrink by 13 lines (19 added, 32 removed); no production or shared-helper changes.

## User Impact

No user-facing behavior change. Test assertions have one shared implementation while preserving their existing guard and return contracts.

## Evidence

Five complete suites passed in separate fresh processes before and after: the same 247 cases and statuses, including the existing commands-btw helper consumer. Source and dependency checks passed, with joined processes and task-owned temporary roots removed. Independent source review found no P0–P2 issues. This is local test-fixture proof, not a live repair or provider claim.

All 20 checks selected by the normal `check-changed` command for these four files passed, including the affected command-test type graph, formatting, lint, boundary guards, and dead-export scans.
