### PR TITLE
refactor(whatsapp): centralize fixed plugin wiring

### DIFF
--- a/extensions/whatsapp/src/channel.runtime.ts
+++ b/extensions/whatsapp/src/channel.runtime.ts
@@ -3,99 +3,42 @@ import {
   startWebLoginWithQr as startWebLoginWithQrImpl,
   waitForWebLogin as waitForWebLoginImpl,
 } from "../login-qr-runtime.js";
-import { getActiveWebListener as getActiveWebListenerImpl } from "./active-listener.js";
+import { getActiveWebListener } from "./active-listener.js";
 import {
-  getWebAuthAgeMs as getWebAuthAgeMsImpl,
-  logWebSelfId as logWebSelfIdImpl,
-  logoutWeb as logoutWebImpl,
-  readWebAuthSnapshot as readWebAuthSnapshotImpl,
-  readWebAuthState as readWebAuthStateImpl,
-  readWebAuthExistsBestEffort as readWebAuthExistsBestEffortImpl,
-  readWebAuthExistsForDecision as readWebAuthExistsForDecisionImpl,
-  readWebAuthSnapshotBestEffort as readWebAuthSnapshotBestEffortImpl,
-  readWebSelfId as readWebSelfIdImpl,
-  webAuthExists as webAuthExistsImpl,
+  getWebAuthAgeMs,
+  logWebSelfId,
+  logoutWeb,
+  readWebAuthSnapshot,
+  readWebAuthState,
+  readWebAuthExistsBestEffort,
+  readWebAuthExistsForDecision,
+  readWebAuthSnapshotBestEffort,
+  readWebSelfId,
+  webAuthExists,
 } from "./auth-store.js";
-import { monitorWebChannel as monitorWebChannelImpl } from "./auto-reply/monitor.js";
-import { loginWeb as loginWebImpl } from "./login.js";
+import { monitorWebChannel } from "./auto-reply/monitor.js";
+import { loginWeb } from "./login.js";
 import { whatsappSetupWizard as whatsappSetupWizardImpl } from "./setup-surface.js";
 
-type GetActiveWebListener = typeof import("./active-listener.js").getActiveWebListener;
-type GetWebAuthAgeMs = typeof import("./auth-store.js").getWebAuthAgeMs;
-type LogWebSelfId = typeof import("./auth-store.js").logWebSelfId;
-type LogoutWeb = typeof import("./auth-store.js").logoutWeb;
-type ReadWebAuthSnapshot = typeof import("./auth-store.js").readWebAuthSnapshot;
-type ReadWebAuthState = typeof import("./auth-store.js").readWebAuthState;
-type ReadWebAuthExistsBestEffort = typeof import("./auth-store.js").readWebAuthExistsBestEffort;
-type ReadWebAuthExistsForDecision = typeof import("./auth-store.js").readWebAuthExistsForDecision;
-type ReadWebAuthSnapshotBestEffort = typeof import("./auth-store.js").readWebAuthSnapshotBestEffort;
-type ReadWebSelfId = typeof import("./auth-store.js").readWebSelfId;
-type WebAuthExists = typeof import("./auth-store.js").webAuthExists;
-type LoginWeb = typeof import("./login.js").loginWeb;
+export {
+  getActiveWebListener,
+  getWebAuthAgeMs,
+  logWebSelfId,
+  logoutWeb,
+  readWebAuthSnapshot,
+  readWebAuthState,
+  readWebAuthExistsBestEffort,
+  readWebAuthExistsForDecision,
+  readWebAuthSnapshotBestEffort,
+  readWebSelfId,
+  webAuthExists,
+  loginWeb,
+  monitorWebChannel,
+};
+
 type StartWebLoginWithQr = typeof import("../login-qr-runtime.js").startWebLoginWithQr;
 type WaitForWebLogin = typeof import("../login-qr-runtime.js").waitForWebLogin;
 type WhatsAppSetupWizard = typeof import("./setup-surface.js").whatsappSetupWizard;
-type MonitorWebChannel = typeof import("./auto-reply/monitor.js").monitorWebChannel;
-
-export function getActiveWebListener(
-  ...args: Parameters<GetActiveWebListener>
-): ReturnType<GetActiveWebListener> {
-  return getActiveWebListenerImpl(...args);
-}
-
-export function getWebAuthAgeMs(...args: Parameters<GetWebAuthAgeMs>): ReturnType<GetWebAuthAgeMs> {
-  return getWebAuthAgeMsImpl(...args);
-}
-
-export function logWebSelfId(...args: Parameters<LogWebSelfId>): ReturnType<LogWebSelfId> {
-  return logWebSelfIdImpl(...args);
-}
-
-export function logoutWeb(...args: Parameters<LogoutWeb>): ReturnType<LogoutWeb> {
-  return logoutWebImpl(...args);
-}
-
-export function readWebAuthSnapshot(
-  ...args: Parameters<ReadWebAuthSnapshot>
-): ReturnType<ReadWebAuthSnapshot> {
-  return readWebAuthSnapshotImpl(...args);
-}
-
-export function readWebAuthState(
-  ...args: Parameters<ReadWebAuthState>
-): ReturnType<ReadWebAuthState> {
-  return readWebAuthStateImpl(...args);
-}
-
-export function readWebAuthExistsBestEffort(
-  ...args: Parameters<ReadWebAuthExistsBestEffort>
-): ReturnType<ReadWebAuthExistsBestEffort> {
-  return readWebAuthExistsBestEffortImpl(...args);
-}
-
-export function readWebAuthExistsForDecision(
-  ...args: Parameters<ReadWebAuthExistsForDecision>
-): ReturnType<ReadWebAuthExistsForDecision> {
-  return readWebAuthExistsForDecisionImpl(...args);
-}
-
-export function readWebAuthSnapshotBestEffort(
-  ...args: Parameters<ReadWebAuthSnapshotBestEffort>
-): ReturnType<ReadWebAuthSnapshotBestEffort> {
-  return readWebAuthSnapshotBestEffortImpl(...args);
-}
-
-export function readWebSelfId(...args: Parameters<ReadWebSelfId>): ReturnType<ReadWebSelfId> {
-  return readWebSelfIdImpl(...args);
-}
-
-export function webAuthExists(...args: Parameters<WebAuthExists>): ReturnType<WebAuthExists> {
-  return webAuthExistsImpl(...args);
-}
-
-export function loginWeb(...args: Parameters<LoginWeb>): ReturnType<LoginWeb> {
-  return loginWebImpl(...args);
-}
 
 export async function startWebLoginWithQr(
   ...args: Parameters<StartWebLoginWithQr>
@@ -110,9 +53,3 @@ export async function waitForWebLogin(
 }
 
 export const whatsappSetupWizard: WhatsAppSetupWizard = { ...whatsappSetupWizardImpl };
-
-export function monitorWebChannel(
-  ...args: Parameters<MonitorWebChannel>
-): ReturnType<MonitorWebChannel> {
-  return monitorWebChannelImpl(...args);
-}

--- a/extensions/whatsapp/src/channel.setup.ts
+++ b/extensions/whatsapp/src/channel.setup.ts
@@ -1,23 +1,8 @@
 // Whatsapp plugin module implements channel.setup behavior.
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import type { ResolvedWhatsAppAccount } from "./accounts.js";
-import { readWhatsAppAccountLinkState } from "./channel-runtime-loader.js";
-import {
-  resolveWhatsAppGroupRequireMention,
-  resolveWhatsAppGroupToolPolicy,
-} from "./group-policy.js";
-import { whatsappSetupContract } from "./setup-core.js";
-import { createWhatsAppPluginBase, whatsappSetupWizardProxy } from "./shared.js";
+import { createWhatsAppPluginBase } from "./shared.js";
 
 export const whatsappSetupPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
-  ...createWhatsAppPluginBase({
-    groups: {
-      resolveRequireMention: resolveWhatsAppGroupRequireMention,
-      resolveToolPolicy: resolveWhatsAppGroupToolPolicy,
-    },
-    setupWizard: whatsappSetupWizardProxy,
-    setupContract: whatsappSetupContract,
-    isConfigured: (account) => Boolean(account.authDir),
-    isLinked: async (account) => await readWhatsAppAccountLinkState(account.authDir),
-  }),
+  ...createWhatsAppPluginBase(),
 };

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -15,17 +15,10 @@ import {
   resolveWhatsAppAgentReactionGuidance,
 } from "./channel-actions.js";
 import { whatsappChannelOutbound, whatsappMessageAdapter } from "./channel-outbound.js";
-import {
-  loadWhatsAppChannelRuntime,
-  readWhatsAppAccountLinkState,
-} from "./channel-runtime-loader.js";
+import { loadWhatsAppChannelRuntime } from "./channel-runtime-loader.js";
 import { whatsappCommandPolicy } from "./command-policy.js";
 import { formatWhatsAppConfigAllowFromEntries } from "./config-accessors.js";
 import { resolveWhatsAppMentionStripRegexes } from "./group-intro.js";
-import {
-  resolveWhatsAppGroupRequireMention,
-  resolveWhatsAppGroupToolPolicy,
-} from "./group-policy.js";
 import { checkWhatsAppHeartbeatReady } from "./heartbeat.js";
 import {
   isWhatsAppGroupJid,
@@ -38,8 +31,7 @@ import {
 import { getWhatsAppRuntime } from "./runtime.js";
 import { sendTypingWhatsApp } from "./send.js";
 import { resolveWhatsAppOutboundSessionRoute } from "./session-route.js";
-import { whatsappSetupContract } from "./setup-core.js";
-import { createWhatsAppPluginBase, whatsappSetupWizardProxy } from "./shared.js";
+import { createWhatsAppPluginBase } from "./shared.js";
 import { collectWhatsAppStatusIssues } from "./status-issues.js";
 
 const loadWhatsAppDirectoryConfig = createLazyRuntimeModule(() => import("./directory-config.js"));
@@ -81,16 +73,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
       },
     },
     base: {
-      ...createWhatsAppPluginBase({
-        groups: {
-          resolveRequireMention: resolveWhatsAppGroupRequireMention,
-          resolveToolPolicy: resolveWhatsAppGroupToolPolicy,
-        },
-        setupWizard: whatsappSetupWizardProxy,
-        setupContract: whatsappSetupContract,
-        isConfigured: (account) => Boolean(account.authDir),
-        isLinked: async (account) => await readWhatsAppAccountLinkState(account.authDir),
-      }),
+      ...createWhatsAppPluginBase(),
       allowlist: buildDmGroupAccountAllowlistAdapter({
         channelId: "whatsapp",
         resolveAccount: resolveWhatsAppAccount,

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -24,10 +24,15 @@ import {
   resolveWhatsAppAccount,
   type ResolvedWhatsAppAccount,
 } from "./accounts.js";
+import { readWhatsAppAccountLinkState } from "./channel-runtime-loader.js";
 import { formatWhatsAppConfigAllowFromEntries } from "./config-accessors.js";
 import { WhatsAppChannelConfigSchema } from "./config-schema.js";
 import { whatsappDoctor } from "./doctor.js";
 import { resolveWhatsAppConfigPath } from "./group-config-path.js";
+import {
+  resolveWhatsAppGroupRequireMention,
+  resolveWhatsAppGroupToolPolicy,
+} from "./group-policy.js";
 import { resolveLegacyGroupSessionKey } from "./group-session-contract.js";
 import {
   collectUnsupportedSecretRefConfigCandidates,
@@ -39,6 +44,7 @@ import {
   deriveLegacySessionChatType,
   isLegacyGroupSessionKey,
 } from "./session-contract.js";
+import { whatsappSetupContract } from "./setup-core.js";
 
 const WHATSAPP_CHANNEL = "whatsapp" as const;
 
@@ -46,7 +52,7 @@ async function loadWhatsAppSetupSurface() {
   return await import("./setup-surface.js");
 }
 
-export const whatsappSetupWizardProxy = createWhatsAppSetupWizardProxy(
+const whatsappSetupWizardProxy = createWhatsAppSetupWizardProxy(
   async () => (await loadWhatsAppSetupSurface()).whatsappSetupWizard,
 );
 
@@ -95,13 +101,7 @@ function createWhatsAppSetupWizardProxy(
   });
 }
 
-export function createWhatsAppPluginBase(params: {
-  groups: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["groups"]>;
-  setupWizard: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["setupWizard"]>;
-  setupContract: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["setupContract"]>;
-  isConfigured: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["config"]>["isConfigured"];
-  isLinked: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["config"]>["isLinked"];
-}) {
+export function createWhatsAppPluginBase() {
   const collectWhatsAppSecurityWarnings = createAllowlistProviderGroupPolicyWarningCollector<{
     account: ResolvedWhatsAppAccount;
     cfg: Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
@@ -158,7 +158,7 @@ export function createWhatsAppPluginBase(params: {
       forceAccountBinding: true,
       preferSessionLookupForAnnounceTarget: true,
     },
-    setupWizard: params.setupWizard,
+    setupWizard: whatsappSetupWizardProxy,
     capabilities: {
       chatTypes: ["direct", "group", "channel"],
       polls: true,
@@ -189,8 +189,8 @@ export function createWhatsAppPluginBase(params: {
       ...whatsappConfigAdapter,
       isEnabled: (account) => account.enabled,
       disabledReason: () => "disabled",
-      isConfigured: params.isConfigured,
-      isLinked: params.isLinked,
+      isConfigured: (account) => Boolean(account.authDir),
+      isLinked: async (account) => await readWhatsAppAccountLinkState(account.authDir),
       hasPersistedAuthState: ({ cfg }) => hasAnyWhatsAppAuth(cfg),
       unconfiguredReason: () => "not configured",
       unlinkedReason: () => "not linked",
@@ -210,16 +210,15 @@ export function createWhatsAppPluginBase(params: {
       collectWarnings: collectWhatsAppOpenGroupFindings,
     },
     doctor: whatsappDoctor,
-    setupContract: params.setupContract,
-    groups: params.groups,
+    setupContract: whatsappSetupContract,
+    groups: {
+      resolveRequireMention: resolveWhatsAppGroupRequireMention,
+      resolveToolPolicy: resolveWhatsAppGroupToolPolicy,
+    },
   });
   return {
     ...base,
-    setupWizard: base.setupWizard!,
     capabilities: base.capabilities!,
-    reload: base.reload!,
-    gatewayMethodDescriptors: base.gatewayMethodDescriptors!,
-    configSchema: base.configSchema!,
     config: base.config!,
     messaging: {
       defaultMarkdownTableMode: "bullets",
@@ -233,8 +232,6 @@ export function createWhatsAppPluginBase(params: {
       unsupportedSecretRefSurfacePatterns,
       collectUnsupportedSecretRefConfigCandidates,
     },
-    security: base.security!,
-    groups: base.groups!,
   } satisfies Pick<
     ChannelPlugin<ResolvedWhatsAppAccount>,
     | "id"

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -526,21 +526,7 @@ type CreatedChannelPluginBase<TResolvedAccount> = Pick<
   Partial<
     Pick<
       ChannelPlugin<TResolvedAccount>,
-      | "setupWizard"
-      | "setup"
-      | "setupContract"
-      | "capabilities"
-      | "commands"
-      | "doctor"
-      | "agentPrompt"
-      | "streaming"
-      | "reload"
-      | "gatewayMethods"
-      | "gatewayMethodDescriptors"
-      | "configSchema"
-      | "config"
-      | "security"
-      | "groups"
+      Exclude<keyof CreateChannelPluginBaseOptions<TResolvedAccount>, "id" | "meta">
     >
   >;
 


### PR DESCRIPTION
Closes #144956

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Maintaining WhatsApp setup and full registration currently requires keeping the same fixed wiring synchronized in two callers, alongside thirteen private runtime functions that only forward to existing owners. This maintainer-requested change removes that duplication. It does not claim to fix a user-visible malfunction.

## Why This Change Was Made

The existing private WhatsApp factory now owns the fixed setup, group-policy and link-state wiring; the SDK return type derives its optional key set from existing options, and redundant copies of base properties are removed. Thirteen private non-async forwarders become named imports in the original dependency order plus an export block, while the async QR wrappers, wizard clone/proxy, auth preload, shared runtime Promise and provider policies remain.

## User Impact

No user-visible behavior change is intended. The five-file change removes **100 production code lines, 112 physical lines and 4,806 bytes**, with no new maintained tests, support code, dependencies or configuration. Setup and full registration use one owner for their fixed wiring.

Direct bindings expose the underlying function objects, changing private function identity and reflection. Current consumers were inspected for dependence on those properties, and the proof records this change separately from equivalent call results and ordering. No memory reduction or live WhatsApp reliability improvement is claimed.

## Evidence

The integration refresh at `d219ffe1fe15e3f0105780223de1224cb6e7e8cc` is based on main `3b2dbc82f1bab7d42872413411e8c6fe345eb7ec`, including the CI planner repair in #144965. The five-file patch and all five final source hashes are unchanged.

Fresh candidate integration checks passed on this head: full and cold source-loader/Jiti probes, one canonical `qaRuntime` build, then full and cold native built-ESM probes. The same denied-network/home harness and synthetic fixtures were used without modification. This refresh did not repeat the original control runs, full typed build or focused tests; their source-bound results are retained below. New-head hosted CI remains required.

The previous CI failure was the inherited planner inventory-growth test producing 81 jobs against an 80-job cap; this refresh uses the independently landed repair rather than rerunning the old merge. The [previous hosted review](https://github.com/openclaw/openclaw/pull/144957#issuecomment-5635472413) found no correctness/security defect. Its stored-data compatibility flag is rejected for this diff: the SDK change only rewrites an erased type alias, with no schema, storage or runtime-factory change.

Local validation covered this complete five-file change against source base `bc21739e1d5e8961277d4775068255fe58f19e3c`:

- **Real loader behavior:** four original/candidate comparisons passed: actual Jiti/source loading and native built ESM, each with full and cold initialization. The same hardened probes produced matching observable checks and events. Every candidate run matched the final source hashes.
- **Isolated real operations:** fresh processes used synthetic state with network, operator-home contents and Keychain access denied; denied-read and loopback-connect canaries checked enforcement. The facade and operation owners were not mocked. The probes covered lazy setup, shared runtime loading, all 15 callable exports initialized, real synthetic-auth reads, synchronous errors, asynchronous rejection ordering, account projection, group/wizard behavior, login/logout guards and an already-aborted monitor.
- **Build and existing tests:** original and final full builds passed; 11 focused SDK/WhatsApp tests passed. The full explicit-five-file changed gate passed, including six Doctor declaration/closure tests, core and plugin type checks, formatting, lint, SDK exports/surface, boundaries, dead exports and runtime-cycle guards.
- **Review:** fresh managed review of the complete final diff through P2 found no accepted/actionable findings.
- **Entrypoint:** the canonical built WhatsApp index loaded successfully in isolation. Its profiler baseline is an empty Node process, so it is not evidence of an old/new memory improvement.

Focused existing tests and the changed gate used:

```sh
node scripts/run-vitest.mjs \
  extensions/whatsapp/src/channel-runtime-loader.test.ts \
  extensions/whatsapp/src/channel.status.test.ts \
  src/plugin-sdk/core.test.ts

node scripts/check-changed.mjs \
  --base bc21739e1d5e8961277d4775068255fe58f19e3c -- \
  src/plugin-sdk/core.ts \
  extensions/whatsapp/src/shared.ts \
  extensions/whatsapp/src/channel.runtime.ts \
  extensions/whatsapp/src/channel.ts \
  extensions/whatsapp/src/channel.setup.ts
```

The first sandbox attempts failed during bootstrap; the final profile permits required filesystem metadata while retaining content/network denial. An early built probe expected a private export that the compiler had internalized; the corrected probe exercises the actual setup link-state callback, and both original and candidate were rerun with it. Knip and import-order checks also caught an unused export and the draft export layout; both were fixed without weakening checks. A nonfatal reviewer catalog-refresh timeout preceded a completed, validated P2 result.

The proof did not contact WhatsApp or run a live login/message roundtrip. It establishes the targeted loader, type and safe-operation boundaries; it does not prove behavior for hypothetical external users of private deep imports.

