### PR TITLE
refactor(ai): simplify Responses endpoint policy

### DIFF
--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -31,27 +31,11 @@ type OpenAIResponsesPayloadPolicyOptions = {
 
 type OpenAIResponsesEndpointClass =
   | "default"
-  | "anthropic-public"
-  | "cerebras-native"
-  | "chutes-native"
-  | "deepseek-native"
-  | "github-copilot-native"
-  | "groq-native"
-  | "mistral-public"
-  | "moonshot-native"
-  | "modelstudio-native"
   | "openai-public"
   | "openai"
-  | "opencode-native"
   | "azure-openai"
-  | "openrouter"
   | "xai-native"
-  | "zai-native"
-  | "google-generative-ai"
-  | "google-vertex"
-  | "local"
-  | "custom"
-  | "invalid";
+  | "custom";
 
 type OpenAIResponsesPayloadPolicy = {
   allowsServiceTier: boolean;
@@ -75,39 +59,6 @@ type OpenAIResponsesPayloadCapabilities = {
 };
 
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
-const LOCAL_ENDPOINT_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
-const MODELSTUDIO_NATIVE_BASE_URLS = new Set([
-  "https://coding-intl.dashscope.aliyuncs.com/v1",
-  "https://coding.dashscope.aliyuncs.com/v1",
-  "https://dashscope.aliyuncs.com/compatible-mode/v1",
-  "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-]);
-const MOONSHOT_NATIVE_BASE_URLS = new Set([
-  "https://api.moonshot.ai/v1",
-  "https://api.moonshot.cn/v1",
-]);
-
-function normalizeComparableBaseUrl(value: unknown): string | undefined {
-  const trimmed = readStringValue(value)?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const parsedValue = /^[a-z0-9.[\]-]+(?::\d+)?(?:[/?#].*)?$/i.test(trimmed)
-    ? `https://${trimmed}`
-    : trimmed;
-  try {
-    const url = new URL(parsedValue);
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-      return undefined;
-    }
-    url.hash = "";
-    url.search = "";
-    return url.toString().replace(/\/+$/, "").toLowerCase();
-  } catch {
-    return undefined;
-  }
-}
-
 function resolveUrlHostname(value: unknown): string | undefined {
   const trimmed = readStringValue(value)?.trim();
   if (!trimmed) {
@@ -124,63 +75,22 @@ function resolveUrlHostname(value: unknown): string | undefined {
   }
 }
 
-function hostMatchesSuffix(host: string, suffix: string): boolean {
-  return suffix.startsWith(".") || suffix.startsWith("-")
-    ? host.endsWith(suffix)
-    : host === suffix || host.endsWith(`.${suffix}`);
-}
-
-function isLocalEndpointHost(host: string): boolean {
-  return (
-    LOCAL_ENDPOINT_HOSTS.has(host) ||
-    host.endsWith(".localhost") ||
-    host.endsWith(".local") ||
-    host.endsWith(".internal")
-  );
-}
-
-function resolveBundledOpenAIResponsesEndpointClass(
-  baseUrl: unknown,
-): OpenAIResponsesEndpointClass {
+function resolveOpenAIResponsesEndpointClass(baseUrl: unknown): OpenAIResponsesEndpointClass {
   const trimmed = readStringValue(baseUrl)?.trim();
   if (!trimmed) {
     return "default";
   }
   const host = resolveUrlHostname(trimmed);
   if (!host) {
-    return "invalid";
+    return "custom";
   }
-  const comparableBaseUrl = normalizeComparableBaseUrl(trimmed);
-
   switch (host) {
-    case "api.anthropic.com":
-      return "anthropic-public";
-    case "api.cerebras.ai":
-      return "cerebras-native";
-    case "llm.chutes.ai":
-      return "chutes-native";
-    case "api.deepseek.com":
-      return "deepseek-native";
-    case "api.groq.com":
-      return "groq-native";
-    case "api.mistral.ai":
-      return "mistral-public";
     case "api.openai.com":
       return "openai-public";
     case "chatgpt.com":
       return "openai";
-    case "generativelanguage.googleapis.com":
-      return "google-generative-ai";
-    case "aiplatform.googleapis.com":
-      return "google-vertex";
     case "api.x.ai":
       return "xai-native";
-    case "api.z.ai":
-      return "zai-native";
-  }
-
-  if (hostMatchesSuffix(host, ".githubcopilot.com")) {
-    return "github-copilot-native";
   }
   if (
     [
@@ -188,27 +98,9 @@ function resolveBundledOpenAIResponsesEndpointClass(
       ".cognitiveservices.azure.com",
       ".services.ai.azure.com",
       ".api.cognitive.microsoft.com",
-    ].some((suffix) => hostMatchesSuffix(host, suffix))
+    ].some((suffix) => host.endsWith(suffix))
   ) {
     return "azure-openai";
-  }
-  if (hostMatchesSuffix(host, "openrouter.ai")) {
-    return "openrouter";
-  }
-  if (hostMatchesSuffix(host, "opencode.ai")) {
-    return "opencode-native";
-  }
-  if (hostMatchesSuffix(host, "-aiplatform.googleapis.com")) {
-    return "google-vertex";
-  }
-  if (comparableBaseUrl && MOONSHOT_NATIVE_BASE_URLS.has(comparableBaseUrl)) {
-    return "moonshot-native";
-  }
-  if (comparableBaseUrl && MODELSTUDIO_NATIVE_BASE_URLS.has(comparableBaseUrl)) {
-    return "modelstudio-native";
-  }
-  if (isLocalEndpointHost(host)) {
-    return "local";
   }
   return "custom";
 }
@@ -234,7 +126,7 @@ function resolveOpenAIResponsesPayloadCapabilities(
   const provider = normalizeOptionalLowercaseString(model.provider);
   const api = normalizeOptionalLowercaseString(model.api);
   const isOpenAIProvider = provider === "openai";
-  const endpointClass = resolveBundledOpenAIResponsesEndpointClass(model.baseUrl);
+  const endpointClass = resolveOpenAIResponsesEndpointClass(model.baseUrl);
   const isResponsesApi = isOpenAIResponsesApi(api);
   const usesConfiguredBaseUrl = endpointClass !== "default";
   const usesKnownNativeOpenAIEndpoint =
@@ -244,23 +136,9 @@ function resolveOpenAIResponsesPayloadCapabilities(
   const usesKnownNativeOpenAIRoute =
     endpointClass === "default" ? provider === "openai" : usesKnownNativeOpenAIEndpoint;
   const usesExplicitProxyLikeEndpoint = usesConfiguredBaseUrl && !usesKnownNativeOpenAIEndpoint;
-  // Recognizing a hostname (routing it to a named endpointClass) is not the
-  // same as having confirmed that host's Responses API honors `instructions`
-  // -- OpenClaw bundles many named classes (Cerebras, Groq, Mistral,
-  // OpenCode, GitHub Copilot, ...) purely for SSRF/base-URL matching and
-  // other unrelated capability detection, with no contract proof either way
-  // for `instructions` specifically. Only two routes are actually verified:
-  // native OpenAI (definitionally, it's OpenAI's own API) and xAI's main
-  // route (confirmed via direct testing -- see the xAI compact-endpoint
-  // opt-out carve-out below, discovered by testing the real API). Every
-  // other named class defaults the same as an explicit custom/local proxy;
-  // `compat.supportsInstructions: true` opts a confirmed-working route in.
-  // Deliberately narrower than usesKnownNativeOpenAIRoute (used above for
-  // reasoning/service-tier/input-status policy): that boolean also covers
-  // azure-openai, which has never been verified for `instructions`
-  // specifically -- Azure mirrors OpenAI's API closely, but "closely" isn't
-  // a contract, and this file's whole point is not assuming one without
-  // evidence.
+  // Only native OpenAI and xAI's main route have verified instructions support.
+  // Azure remains distinct from native OpenAI for this capability; other routes
+  // require compat.supportsInstructions to opt in after contract verification.
   const usesVerifiedNativeOpenAIRoute =
     endpointClass === "default"
       ? provider === "openai"
@@ -351,7 +229,7 @@ export function resolveOpenAIResponsesCompactEndpointPlan(
       (configured === true ||
         (configured !== false &&
           (provider === "xai" || provider === "x-ai") &&
-          resolveBundledOpenAIResponsesEndpointClass(model.baseUrl) === "xai-native")),
+          resolveOpenAIResponsesEndpointClass(model.baseUrl) === "xai-native")),
   };
 }
 


### PR DESCRIPTION
Closes #144961

## What Problem This Solves

Maintainers have to keep a larger endpoint catalog in sync when updating Responses payload handling, even though most entries produce identical behavior. This is a bounded part of the requested reduction in unnecessary production code while preserving functionality.

## Why This Change Was Made

Collapse 22 private endpoint classes into the six policy outcomes their consumers actually distinguish, removing unused vendor/local URL tables and matching helpers. Keep the existing URL parser, OpenAI, ChatGPT, Azure, and xAI boundaries, and explicit compatibility overrides.

## User Impact

No user-visible behavior changes. Prompt delivery, continuation, storage, and compaction retain their existing behavior, while the production policy shrinks by 102 code lines and 122 physical lines.

## Evidence

- All 59 existing tests in six selected suites pass on both the original and final candidate, including real SDK HTTP requests and loopback SSE/WebSocket flows for prompt delivery, continuation, and compaction.
- Finite exported-policy and caller comparisons cover the former endpoint categories, malformed URLs, provider/API combinations, and compatibility/options states. Six deliberate regressions were detected.
- The local full changed-source gate and fresh independent P2 review pass with no actionable findings. No maintained tests were added or weakened.
