### PR TITLE
refactor(cli): centralize progress lifetime cleanup

### DIFF
--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -2,8 +2,9 @@ import { Writable } from "node:stream";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 // Progress tests cover CLI progress rendering and lifecycle cleanup.
 import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { supportsOscProgress } from "../../packages/terminal-core/src/osc-progress.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import { createCliProgress, shouldUseInteractiveProgressSpinner } from "./progress.js";
+import { createCliProgress, withProgress } from "./progress.js";
 
 const clackMocks = vi.hoisted(() => {
   const spinnerInstance = {
@@ -196,37 +197,29 @@ describe("cli progress", () => {
     }
   });
 
-  it("does not use readline-backed spinners while raw TUI input is active", () => {
-    expect(
-      shouldUseInteractiveProgressSpinner({
-        streamIsTty: true,
-        stdinIsRaw: true,
-      }),
-    ).toBe(false);
-  });
-
-  it("keeps the normal interactive spinner for regular tty commands", () => {
-    expect(
-      shouldUseInteractiveProgressSpinner({
-        streamIsTty: true,
-        stdinIsRaw: false,
-      }),
-    ).toBe(true);
-  });
-
   it("routes clack spinner output through the progress stream", () => {
     const stream = createOutput(true, vi.fn());
 
-    const progress = createCliProgress({
-      label: "Loading",
-      stream,
+    const fallbacks: Array<"spinner" | "none"> = ["spinner", "none"];
+    let fallbackReads = 0;
+    withStdinIsRaw(false, () => {
+      const progress = createCliProgress({
+        label: "Loading",
+        stream,
+        get fallback() {
+          return fallbacks[fallbackReads++];
+        },
+      });
+      try {
+        expect(clackMocks.spinner).toHaveBeenCalledWith({ output: stream });
+        expect(clackMocks.spinnerInstance.start).toHaveBeenCalledWith(
+          expect.stringContaining("Loading"),
+        );
+        expect(fallbackReads).toBe(2);
+      } finally {
+        progress.done();
+      }
     });
-    progress.done();
-
-    expect(clackMocks.spinner).toHaveBeenCalledWith({ output: stream });
-    expect(clackMocks.spinnerInstance.start).toHaveBeenCalledWith(
-      expect.stringContaining("Loading"),
-    );
   });
 
   it("does not write terminal controls when raw TUI input suppresses the default spinner", () => {
@@ -260,7 +253,8 @@ describe("cli progress", () => {
         firstWrites.push(chunk);
       }),
     );
-    const secondStream = createOutput(true, vi.fn());
+    const secondWrite = vi.fn();
+    const secondStream = createOutput(true, secondWrite);
 
     const delayed = createCliProgress({
       label: "Delayed",
@@ -278,7 +272,53 @@ describe("cli progress", () => {
     next.done();
 
     expect(firstWrites).toStrictEqual([]);
+    expect(secondWrite).toHaveBeenCalledWith(theme.accent("Next"));
   });
+
+  it.each(["resolve", "reject"] as const)(
+    "releases the line after work callbacks %s",
+    async (outcome) => {
+      const events: string[] = [];
+      const stream = createOutput(true, (chunk) => events.push(chunk));
+      const oscSupported = supportsOscProgress(process.env, true);
+      const error = new Error("work failed");
+      let owned: ReturnType<typeof createCliProgress> | undefined;
+      let next: ReturnType<typeof createCliProgress> | undefined;
+      try {
+        const work = withProgress({ label: "Work", stream, fallback: "line" }, async (progress) => {
+          owned = progress;
+          await Promise.resolve();
+          events.push("callback");
+          progress.setLabel("Updated");
+          if (outcome === "reject") {
+            throw error;
+          }
+          return "value";
+        });
+        if (outcome === "reject") {
+          await expect(work).rejects.toBe(error);
+        } else {
+          await expect(work).resolves.toBe("value");
+        }
+        expect(events).toEqual([
+          ...(oscSupported ? ["\x1b]9;4;3;0\x1b\\"] : []),
+          "\r\x1b[2K",
+          theme.accent("Work"),
+          "callback",
+          ...(oscSupported ? ["\x1b]9;4;3;0\x1b\\"] : []),
+          "\r\x1b[2K",
+          theme.accent("Updated"),
+          ...(oscSupported ? ["\x1b]9;4;0;0\x1b\\"] : []),
+          "\r\x1b[2K",
+        ]);
+        next = createCliProgress({ label: "Next", stream, fallback: "line" });
+        expect(events.at(-1)).toBe(theme.accent("Next"));
+      } finally {
+        owned?.done();
+        next?.done();
+      }
+    },
+  );
 
   it("clamps oversized delayed progress timers", () => {
     const stream = createOutput(true, vi.fn());

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -102,16 +102,6 @@ export type ProgressTotalsUpdate = {
   label?: string;
 };
 
-/** Decide whether the interactive spinner is safe for the current terminal state. */
-export function shouldUseInteractiveProgressSpinner(params: {
-  fallback?: ProgressOptions["fallback"];
-  streamIsTty?: boolean;
-  stdinIsRaw?: boolean;
-}): boolean {
-  const spinnerRequested = params.fallback === undefined || params.fallback === "spinner";
-  return spinnerRequested && params.streamIsTty === true && params.stdinIsRaw !== true;
-}
-
 const noopReporter: ProgressReporter = {
   setLabel: () => {},
   setPercent: () => {},
@@ -138,11 +128,8 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
   const delayMs = resolveTimerTimeoutMs(options.delayMs, DEFAULT_DELAY_MS, 0);
   const canOsc = isTty && supportsOscProgress(process.env, isTty);
   const stdinIsRaw = process.stdin.isRaw;
-  const allowSpinner = shouldUseInteractiveProgressSpinner({
-    fallback: options.fallback,
-    streamIsTty: isTty,
-    stdinIsRaw,
-  });
+  const fallback = options.fallback;
+  const allowSpinner = (fallback === undefined || fallback === "spinner") && isTty && !stdinIsRaw;
   const allowLine = isTty && options.fallback === "line";
   if (isTty && stdinIsRaw && (options.fallback === undefined || options.fallback === "spinner")) {
     // Raw stdin usually means an interactive prompt owns cursor movement.
@@ -270,18 +257,13 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
       clearTimeout(timer);
       timer = null;
     }
-    if (!started) {
-      if (isTty) {
-        unregisterActiveProgressLine(stream);
+    if (started) {
+      if (controller) {
+        controller.clear();
       }
-      activeProgress = Math.max(0, activeProgress - 1);
-      return;
+      spin?.stop("");
+      clearActiveProgressLine();
     }
-    if (controller) {
-      controller.clear();
-    }
-    spin?.stop("");
-    clearActiveProgressLine();
     if (isTty) {
       unregisterActiveProgressLine(stream);
     }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep maintainer edits enabled where GitHub exposes that control. This is a same-repository branch.

</details>

## What Problem This Solves

Long-running CLI commands share one terminal progress owner, but spinner eligibility was routed through a single-caller helper and completion repeated the same ownership-release tail in two branches. This is a maintenance cleanup, not a claim of a newly fixed user-visible defect.

## Why This Change Was Made

Keep those decisions inside the existing progress owner: inline the spinner decision while preserving the fallback option's read boundary, and share unregister/decrement cleanup between started and cancelled-before-start reporters. Started reporters still perform their existing display cleanup first. Timer cancellation, repeated completion, callback settlement, and the current exception ordering remain unchanged.

The removed function was source-exported, but no supported package/SDK export or additional production caller was found in the inspected source and stable tags. The supported reporter wrappers and the memory-host CLI facade remain unchanged. Production changes are **+7/-25, net -18 lines**; test changes are **+69/-29, net +40**.

## User Impact

No intended user-visible change. Normal/raw-input spinner selection, delayed cancellation, line ownership, callback results/errors, and wizard progress composition retain their supported behavior.

## Evidence

The refreshed candidate tree was verified byte-for-byte against signed commit `ab4faca2747acb088dd1fc82444dfcc9416357f4`, with raw parent `147695599f250a7c472dcf84e870502add52e315`. Its two reviewed afterimages and normalized -18-line production patch are unchanged by the mechanical refresh.

- The normal four-suite invocation passed **57 cases**: CLI progress, terminal OSC progress, terminal restoration, and the Clack prompter. Original, test-only, and candidate roles were recorded; the final boolean-expression correction received a fresh complete 57-case run. After the refresh, the same four suites passed all 57 cases again with the identical ordered per-file testcase inventory.
- Six real PTY scenarios ran through the existing PTY owner, plus one ordinary pipe scenario, against the original and corrected candidate. All exited naturally with the same ordered observed output/cleanup events: line updates, delayed cancellation, async resolution/rejection, real spinner cleanup, wizard composition, and piped output. The refreshed signed head received the same seven candidate executions again; their complete ordered events matched both retained references. No terminal, raw-mode, color, timer, worker, or resource override was added.
- Four isolated intentional controls detected repeated fallback reads, missing pre-start ownership release, missing repeated-completion protection, and returning work without awaiting it. Each expected assertion failure was inspected, the candidate restored, and its selected case returned green. These controls were on the earlier strict-comparison candidate, not relabeled as runs on the final correction.
- All **29 required changed checks** passed on the refreshed exact head, including the complete core-test type pass, all dead-export scans, and lint: [refreshed configured Linux proof](https://github.com/openclaw/openclaw/actions/runs/34625200311). The original candidate's [earlier full gate](https://github.com/openclaw/openclaw/actions/runs/34596422436) is retained separately. Both attributable leases stopped normally; local capsule/process cleanup and source/dependency preservation were verified.
- Independent precommit and separately requested exact-commit Codex reviews completed through **P0–P2**, with no actionable findings. A fresh one-pass exact-commit review of `ab4faca2747acb088dd1fc82444dfcc9416357f4` also completed through P0–P2 with no actionable findings.

The original head's [GitHub CI run](https://github.com/openclaw/openclaw/actions/runs/34610510421) failed in the unrelated hosted planner's 81/80 job-cap growth case. An earlier independent PR reproduced that failure with the original Progress files. The canonical repair landed in [#144965](https://github.com/openclaw/openclaw/pull/144965); this failure-justified refresh incorporates it through the base, without adding planner files, increasing the cap, or dropping coverage. [Exact-head GitHub CI](https://github.com/openclaw/openclaw/actions/runs/34644487914) completed successfully for `ab4faca2747acb088dd1fc82444dfcc9416357f4`; no old failed run was rerun as a substitute.

Normal focused command:

```sh
node scripts/run-vitest.mjs src/cli/progress.test.ts packages/terminal-core/src/osc-progress.test.ts packages/terminal-core/src/restore.test.ts src/wizard/clack-prompter.test.ts
node scripts/check-changed.mjs -- src/cli/progress.ts src/cli/progress.test.ts
```

### Limits and retained failures

Native terminal proof was on macOS/POSIX with Node 26.8.1; it is not Windows or packaged-install proof. OSC support was false in the inherited terminal environment, so real-terminal OSC output is not claimed; the existing OSC unit cases passed. The normal configured changed gate used Linux Node 24.19.0. The 26 consumer modules were source-reviewed, not all executed end to end.

The boolean simplification is qualified for supported boolean/undefined stream flags. Forged truthy nonboolean flags can differ and are not claimed equivalent. Existing synchronous cleanup exceptions retain their original behavior; this does not introduce finally-based exception recovery.

The first gate passed 20 checks before lint rejected unnecessary strict boolean comparisons; eight later checks were unrun. After the small correction and fresh local/native proof, one provider attempt returned HTTP 429 before sync or checks and left an ambiguous pending creation record. No resource was guessed, stopped, or deleted from an absent inventory match. A single subsequently authorized unchanged retry acquired a separate attributable lease and passed the full gate. A post-success external portal-sync timeout is retained as a warning, separate from the successful check/lease cleanup result.

The refreshed gate's native provider selected its built-in full sync after a targeted-reference lookup failed; the same admitted run then verified the exact source/tree and passed all checks. Its post-success external portal-sync timeout is likewise retained as telemetry warning, not hidden or treated as a failed check/lease cleanup.
