### PR TITLE
refactor(logbook): run SQLite operations in owned workers

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -609,7 +609,6 @@ extensions/logbook/src/analyze.ts	8
 extensions/logbook/src/config.ts	1
 extensions/logbook/src/node-host.ts	1
 extensions/logbook/src/service.ts	6
-extensions/logbook/src/store.ts	4
 extensions/matrix/src/actions.ts	2
 extensions/matrix/src/approval-auth.ts	1
 extensions/matrix/src/approval-handler.runtime.ts	8

--- a/docs/plugins/logbook.md
+++ b/docs/plugins/logbook.md
@@ -109,7 +109,9 @@ browser's timezone. Frames and the SQLite timeline database live under
 
 Startup completes storage recovery and pruning before capture begins. Shutdown
 stops new work and waits for admitted database and model operations before closing
-storage.
+storage. SQLite opening, queries, transactions, maintenance, and closing run in
+host-owned workers. Frame reads and pruning share admission, so previews and
+analysis finish reading their files before retention can remove them.
 
 ## Model and data flow
 

--- a/docs/plugins/sdk-overview/infrastructure.md
+++ b/docs/plugins/sdk-overview/infrastructure.md
@@ -70,6 +70,12 @@ same transaction diagnostics as `runSqliteImmediateTransactionSync`. Keep the
 database handle and its owning operation alive until the returned promise settles.
 The callback and SQLite calls still run synchronously on the caller's thread.
 
+For a repeated fixed query, `prepareSqliteQuerySync(db, build)` compiles its
+Kysely shape once and binds fresh parameters on each call. It uses the normal
+synchronous executor and the connection's bounded statement cache when enabled.
+Keep the prepared function with its database owner and discard it when closing
+the connection; transaction callbacks must remain synchronous.
+
 ### SQLite worker stores
 
 Use `openSqliteWorkerStore<Operations>` from

--- a/extensions/logbook/index.test.ts
+++ b/extensions/logbook/index.test.ts
@@ -1,52 +1,71 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type {
-  OpenClawPluginApi,
   OpenClawPluginNodeInvokePolicy,
+  OpenClawPluginService,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { describe, expect, it, vi } from "vitest";
+import { createCapturedPluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
+import { LogbookStore } from "./src/store.js";
 
 type PolicyContext = Parameters<OpenClawPluginNodeInvokePolicy["handle"]>[0];
 
-function registerLogbookPolicies(): OpenClawPluginNodeInvokePolicy[] {
+function registerLogbook(runtimeSource = fileURLToPath(new URL("./index.ts", import.meta.url))) {
+  const captured = createCapturedPluginRegistration({ id: "logbook" });
+  captured.api.pluginConfig = { captureEnabled: false };
   const policies: OpenClawPluginNodeInvokePolicy[] = [];
-  plugin.register({
-    pluginConfig: {},
-    lifecycle: { registerRuntimeLifecycle() {} },
-    session: { controls: { registerControlUiDescriptor: () => {} } },
-    registerNodeInvokePolicy: (policy: OpenClawPluginNodeInvokePolicy) => policies.push(policy),
-    registerService: () => {},
-    registerGatewayMethod: () => {},
-  } as unknown as OpenClawPluginApi);
-  return policies;
+  const services: OpenClawPluginService[] = [];
+  const methods: Array<{ method: string; options: unknown }> = [];
+  captured.api.registerNodeInvokePolicy = (policy) => policies.push(policy);
+  captured.api.registerService = (service) => services.push(service);
+  captured.api.registerGatewayMethod = (method, _handler, options) => {
+    methods.push({ method, options });
+  };
+  plugin.register({ ...captured.api, runtimeSource });
+  return { policies, services, methods };
 }
+
+afterEach(() => vi.restoreAllMocks());
 
 describe("logbook gateway methods", () => {
   it("keeps only process-wide status independent of the authenticated profile", () => {
-    const registrations: Array<{ method: string; options: unknown }> = [];
-    plugin.register({
-      pluginConfig: {},
-      lifecycle: { registerRuntimeLifecycle() {} },
-      session: { controls: { registerControlUiDescriptor: () => {} } },
-      registerNodeInvokePolicy: () => {},
-      registerService: () => {},
-      registerGatewayMethod: (method: string, _handler: unknown, options: unknown) => {
-        registrations.push({ method, options });
-      },
-    } as unknown as OpenClawPluginApi);
-
-    expect(registrations.find((entry) => entry.method === "logbook.status")?.options).toEqual({
+    const { methods } = registerLogbook();
+    expect(methods.find((entry) => entry.method === "logbook.status")?.options).toEqual({
       scope: "operator.read",
       profileAccess: "independent",
     });
-    for (const registration of registrations.filter((entry) => entry.method !== "logbook.status")) {
+    for (const registration of methods.filter((entry) => entry.method !== "logbook.status")) {
       expect(registration.options).not.toHaveProperty("profileAccess");
     }
   });
+
+  it.each([
+    ["source", "extensions/logbook/index.ts", "extensions/logbook/src/store.worker.ts"],
+    ["standalone", "plugins/logbook/dist/index.js", "plugins/logbook/dist/src/store.worker.js"],
+    ["bundled", "dist/extensions/logbook/index.js", "dist/extensions/logbook/src/store.worker.js"],
+  ] as const)(
+    "locates its %s worker from the selected runtime entry",
+    async (_layout, entry, worker) => {
+      const { services } = registerLogbook(path.resolve(entry));
+      const stopBeforeOpening = new Error("worker location captured");
+      const open = vi.spyOn(LogbookStore, "open").mockRejectedValueOnce(stopBeforeOpening);
+      await expect(
+        services[0]!.start({ config: {}, stateDir: "/unused", logger: console }),
+      ).rejects.toBe(stopBeforeOpening);
+      expect(open).toHaveBeenCalledExactlyOnceWith(
+        path.join("/unused", "logbook"),
+        pathToFileURL(path.resolve(worker)),
+      );
+    },
+  );
 });
 
 describe("logbook snapshot invoke policy", () => {
   it("blocks logbook.snapshot when gateway.nodes.commands.deny lists screen.snapshot", async () => {
-    const [policy] = registerLogbookPolicies();
+    const {
+      policies: [policy],
+    } = registerLogbook();
     expect(policy?.commands).toEqual(["logbook.snapshot"]);
     const invokeNode = vi.fn();
     const result = await policy!.handle({
@@ -61,7 +80,9 @@ describe("logbook snapshot invoke policy", () => {
   });
 
   it("invokes the node when screen.snapshot is not denied", async () => {
-    const [policy] = registerLogbookPolicies();
+    const {
+      policies: [policy],
+    } = registerLogbook();
     const invokeNode = vi.fn().mockResolvedValue({ ok: true, payloadJSON: null });
     const result = await policy!.handle({
       nodeId: "node-1",

--- a/extensions/logbook/index.ts
+++ b/extensions/logbook/index.ts
@@ -1,6 +1,6 @@
 // Logbook plugin entrypoint: automatic work journal built from screen snapshots.
-import { readFileSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   ErrorCodes,
@@ -13,8 +13,8 @@ import {
   type OpenClawPluginNodeHostCommand,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { resolveLogbookConfig } from "./src/config.js";
+import { dayKeyFor } from "./src/day.js";
 import { LogbookService } from "./src/service.js";
-import { dayKeyFor } from "./src/store.js";
 
 const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -149,11 +149,18 @@ export default definePluginEntry({
           return;
         }
         stopping = undefined;
+        if (!api.runtimeSource) {
+          throw new Error("Logbook requires an OpenClaw host with runtime entrypoint metadata");
+        }
         const next = new LogbookService(config, {
           runtime: api.runtime,
           fullConfig: ctx.config,
           logger: ctx.logger,
           dataDir: path.join(ctx.stateDir, "logbook"),
+          workerModuleUrl: new URL(
+            `./src/store.worker${path.extname(api.runtimeSource)}`,
+            pathToFileURL(api.runtimeSource),
+          ),
         });
         opening = next;
         try {
@@ -228,18 +235,11 @@ export default definePluginEntry({
 
     registerWrite("logbook.frame", async (params) => {
       const frameId = readNumberParam(params, "frameId");
-      const frame = await requireService().frameById(frameId);
+      const frame = await requireService().framePayload(frameId);
       if (!frame) {
         throw new Error(`frame ${frameId} not found`);
       }
-      return {
-        frameId: frame.id,
-        capturedAtMs: frame.capturedAtMs,
-        width: frame.width,
-        height: frame.height,
-        format: "jpeg",
-        base64: readFileSync(frame.path).toString("base64"),
-      };
+      return frame;
     });
 
     // Standup and ask spend model tokens; capture/analyze mutate runtime state.

--- a/extensions/logbook/package.json
+++ b/extensions/logbook/package.json
@@ -17,6 +17,11 @@
     }
   },
   "openclaw": {
+    "build": {
+      "workerEntries": [
+        "./src/store.worker.ts"
+      ]
+    },
     "extensions": [
       "./index.ts"
     ]

--- a/extensions/logbook/src/analyze.ts
+++ b/extensions/logbook/src/analyze.ts
@@ -1,8 +1,8 @@
 // Logbook analysis pipeline: frames -> observations -> revised timeline cards.
 // Pure parsing/validation lives here so tests can cover it without the SDK.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import { dayKeyFor } from "./day.js";
 import { CARD_CATEGORIES } from "./prompts.js";
-import { dayKeyFor } from "./store.js";
 import type { LogbookCard, LogbookCardDraft, LogbookDistraction } from "./types.js";
 
 /** Cards within this window before a batch are treated as a revisable draft. */

--- a/extensions/logbook/src/card-reads.test.ts
+++ b/extensions/logbook/src/card-reads.test.ts
@@ -1,57 +1,21 @@
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
 import type { OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
 import { afterEach, expect, it, vi } from "vitest";
 import plugin from "../index.js";
 import { LogbookStore } from "./store.js";
 
-const cardReads = vi.hoisted(() => ({ queries: 0, payloadRows: 0 }));
-
-vi.mock("openclaw/plugin-sdk/sqlite-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/sqlite-runtime")>();
-  return {
-    ...actual,
-    openNodeSqliteDatabase: (...args: Parameters<typeof actual.openNodeSqliteDatabase>) => {
-      const db = actual.openNodeSqliteDatabase(...args);
-      const prepare = db.prepare.bind(db);
-      vi.spyOn(db, "prepare").mockImplementation((sql) => {
-        const statement = prepare(sql);
-        if (!/\bfrom\s+"?cards\b/i.test(sql)) {
-          return statement;
-        }
-        const all = statement.all.bind(statement);
-        vi.spyOn(statement, "all").mockImplementation((...bindings) => {
-          cardReads.queries++;
-          const rows = all(...bindings);
-          cardReads.payloadRows += rows.filter((row) => "distractions" in row).length;
-          return rows;
-        });
-        const iterate = statement.iterate.bind(statement);
-        vi.spyOn(statement, "iterate").mockImplementation(function* (...bindings) {
-          cardReads.queries++;
-          for (const row of iterate(...bindings)) {
-            if ("distractions" in row) {
-              cardReads.payloadRows++;
-            }
-            yield row;
-          }
-          return undefined;
-        });
-        return statement;
-      });
-      return db;
-    },
-  };
-});
+const workerModuleUrl = new URL("./store.worker.ts", import.meta.url);
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
-it("hydrates a timeline once and counts status without reading card payloads", async () => {
+it("serves timeline and status through their bounded store operations", async () => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-07-03T12:00:00"));
   const stateDir = realpathSync(mkdtempSync(path.join(tmpdir(), "logbook-card-reads-")));
@@ -62,7 +26,7 @@ it("hydrates a timeline once and counts status without reading card payloads", a
     config: {},
     logger: { info() {}, warn() {}, error() {}, debug() {} },
   };
-  const store = await LogbookStore.open(path.join(stateDir, "logbook"));
+  const store = await LogbookStore.open(path.join(stateDir, "logbook"), workerModuleUrl);
   const day = "2026-07-03";
   const startMs = new Date(`${day}T09:00:00`).getTime();
   const drafts = Array.from({ length: 8 }, (_, index) => ({
@@ -80,6 +44,7 @@ it("hydrates a timeline once and counts status without reading card payloads", a
   await store.close();
 
   plugin.register({
+    runtimeSource: fileURLToPath(new URL("../index.ts", import.meta.url)),
     pluginConfig: { captureEnabled: false },
     lifecycle: { registerRuntimeLifecycle() {} },
     runtime: {},
@@ -100,8 +65,9 @@ it("hydrates a timeline once and counts status without reading card payloads", a
       expect(respond.mock.calls[0]?.[0]).toBe(true);
       return respond.mock.calls[0]?.[1];
     };
-    cardReads.queries = 0;
-    cardReads.payloadRows = 0;
+    const timeline = vi.spyOn(LogbookStore.prototype, "timelineForDay");
+    const cardPayloads = vi.spyOn(LogbookStore.prototype, "cardsForDay");
+    const cardCount = vi.spyOn(LogbookStore.prototype, "countCardsForDay");
     expect(await call("logbook.timeline", { day })).toEqual({
       day,
       cards,
@@ -112,13 +78,11 @@ it("hydrates a timeline once and counts status without reading card payloads", a
         apps: [],
       },
     });
-    expect.soft(cardReads.queries).toBe(1);
-    expect.soft(cardReads.payloadRows).toBe(cards.length);
+    expect(timeline).toHaveBeenCalledExactlyOnceWith(day);
 
-    cardReads.queries = 0;
-    cardReads.payloadRows = 0;
     expect(await call("logbook.status")).toMatchObject({ today: day, todayCards: 8 });
-    expect.soft(cardReads.payloadRows).toBe(0);
+    expect(cardCount).toHaveBeenCalledExactlyOnceWith(day);
+    expect(cardPayloads).not.toHaveBeenCalled();
   } finally {
     await service.stop?.(context);
     rmSync(stateDir, { recursive: true, force: true });

--- a/extensions/logbook/src/day.ts
+++ b/extensions/logbook/src/day.ts
@@ -1,0 +1,7 @@
+/** Formats an epoch-ms timestamp as a local-time YYYY-MM-DD day key. */
+export function dayKeyFor(ms: number): string {
+  const date = new Date(ms);
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const dayOfMonth = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${dayOfMonth}`;
+}

--- a/extensions/logbook/src/frame-io.ts
+++ b/extensions/logbook/src/frame-io.ts
@@ -1,0 +1,41 @@
+import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+
+const MAX_FRAME_OPERATIONS = 128;
+
+/** Frame reads and pruning share admission while SQLite remains owned by the worker. */
+export function acquireLogbookFrameIo(root: string) {
+  const state = resolveGlobalSingleton(Symbol.for("openclaw.logbookFrameIo"), () => ({
+    queue: new KeyedAsyncQueue(),
+    pending: 0,
+  }));
+  const accepted = new Set<Promise<unknown>>();
+  let closing: Promise<void> | undefined;
+  return {
+    run<T>(operation: () => Promise<T>): Promise<T> {
+      if (closing) {
+        return Promise.reject(new Error("Logbook frame I/O is closed"));
+      }
+      if (state.pending >= MAX_FRAME_OPERATIONS) {
+        return Promise.reject(
+          Object.assign(new Error("Logbook frame I/O queue capacity reached"), {
+            code: "overloaded",
+          }),
+        );
+      }
+      state.pending += 1;
+      const result = state.queue.enqueue(root, operation);
+      accepted.add(result);
+      const settle = () => {
+        state.pending -= 1;
+        accepted.delete(result);
+      };
+      void result.then(settle, settle);
+      return result;
+    },
+    close(): Promise<void> {
+      closing ??= Promise.allSettled(accepted).then(() => undefined);
+      return closing;
+    },
+  };
+}

--- a/extensions/logbook/src/observation-reads.test.ts
+++ b/extensions/logbook/src/observation-reads.test.ts
@@ -9,40 +9,7 @@ import { buildAskPrompt } from "./prompts.js";
 import { LogbookService } from "./service.js";
 import { LogbookStore } from "./store.js";
 
-const reads = vi.hoisted(() => ({ rows: 0 }));
-
-vi.mock("openclaw/plugin-sdk/sqlite-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/sqlite-runtime")>();
-  return {
-    ...actual,
-    openNodeSqliteDatabase: (...args: Parameters<typeof actual.openNodeSqliteDatabase>) => {
-      const db = actual.openNodeSqliteDatabase(...args);
-      const prepare = db.prepare.bind(db);
-      vi.spyOn(db, "prepare").mockImplementation((sql) => {
-        const statement = prepare(sql);
-        if (!/\bfrom\s+"?observations\b/i.test(sql)) {
-          return statement;
-        }
-        const all = statement.all.bind(statement);
-        vi.spyOn(statement, "all").mockImplementation((...bindings) => {
-          const rows = all(...bindings);
-          reads.rows += rows.length;
-          return rows;
-        });
-        const iterate = statement.iterate.bind(statement);
-        vi.spyOn(statement, "iterate").mockImplementation(function* (...bindings) {
-          for (const row of iterate(...bindings)) {
-            reads.rows++;
-            yield row;
-          }
-          return undefined;
-        });
-        return statement;
-      });
-      return db;
-    },
-  };
-});
+const workerModuleUrl = new URL("./store.worker.ts", import.meta.url);
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -50,13 +17,13 @@ afterEach(() => {
 });
 
 it.each([0, 199, 200, 201])(
-  "asks with the same latest observations while reading at most 200 of %i rows",
+  "asks with the same latest observations using a bounded read of %i rows",
   async (count) => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-03T12:00:00"));
     const dataDir = mkdtempSync(path.join(tmpdir(), "logbook-observation-reads-"));
     const day = "2026-07-03";
-    const store = await LogbookStore.open(dataDir);
+    const store = await LogbookStore.open(dataDir, workerModuleUrl);
     const segments = Array.from({ length: count }, (_, index) => ({
       startMs: 1 + Math.floor(index / 3) * 1000,
       endMs: 1001 + Math.floor(index / 3) * 1000,
@@ -106,13 +73,14 @@ it.each([0, 199, 200, 201])(
     runtime.llm.complete = complete;
     const service = new LogbookService(resolveLogbookConfig({ captureEnabled: false }), {
       dataDir,
+      workerModuleUrl,
       runtime,
       fullConfig: {},
       logger: { info() {}, warn() {}, error() {}, debug() {} },
     });
     await service.start();
     try {
-      reads.rows = 0;
+      const observations = vi.spyOn(LogbookStore.prototype, "observationsInRange");
       expect(await service.ask(day, "What happened?")).toBe("Synthetic answer");
       expect(complete).toHaveBeenCalledTimes(1);
       expect(complete.mock.calls[0]?.[0].messages).toEqual([
@@ -128,7 +96,7 @@ it.each([0, 199, 200, 201])(
           }),
         },
       ]);
-      expect(reads.rows).toBe(Math.min(count, 200));
+      expect(observations).toHaveBeenCalledExactlyOnceWith(day, 0, Number.MAX_SAFE_INTEGER, 200);
     } finally {
       await Promise.resolve(service.stop());
       rmSync(dataDir, { recursive: true, force: true });

--- a/extensions/logbook/src/service-lifecycle.test.ts
+++ b/extensions/logbook/src/service-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { setImmediate } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
 import {
@@ -13,9 +14,12 @@ import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import plugin from "../index.js";
 import { resolveLogbookConfig } from "./config.js";
+import { dayKeyFor } from "./day.js";
 import { LogbookService } from "./service.js";
-import { dayKeyFor, LogbookStore } from "./store.js";
+import { LogbookStore } from "./store.js";
 
+const workerModuleUrl = new URL("./store.worker.ts", import.meta.url);
+const runtimeSource = fileURLToPath(new URL("../index.ts", import.meta.url));
 const quietLogger = { info() {}, warn() {}, error() {}, debug() {} };
 const snapshot = { payload: { base64: Buffer.from("synthetic image").toString("base64") } };
 
@@ -39,7 +43,7 @@ function completion(
 describe("Logbook service disposal", () => {
   it("joins a pending database open and asynchronous close when the runtime retires", async () => {
     const stateDir = tempDirs.make("logbook-opening-");
-    const store = await LogbookStore.open(path.join(stateDir, "logbook"));
+    const store = await LogbookStore.open(path.join(stateDir, "logbook"), workerModuleUrl);
     const opened = createDeferred<void>();
     const releaseOpen = createDeferred<void>();
     const closing = createDeferred<void>();
@@ -59,7 +63,7 @@ describe("Logbook service disposal", () => {
     captured.api.pluginConfig = { captureEnabled: false };
     const services: OpenClawPluginService[] = [];
     captured.api.registerService = (service) => services.push(service);
-    plugin.register(captured.api);
+    plugin.register({ ...captured.api, runtimeSource });
     const service = services[0]!;
     const context = { config: {}, stateDir, logger: quietLogger };
     const starting = service.start(context);
@@ -91,6 +95,7 @@ describe("Logbook service disposal", () => {
     );
     const service = new LogbookService(resolveLogbookConfig({ captureEnabled: false }), {
       dataDir,
+      workerModuleUrl,
       runtime: createPluginRuntimeMock(),
       fullConfig: {},
       logger: quietLogger,
@@ -110,6 +115,7 @@ describe("Logbook service disposal", () => {
       resolveLogbookConfig({ captureEnabled: false, visionModel: "synthetic/vision" }),
       {
         dataDir,
+        workerModuleUrl,
         runtime: createPluginRuntimeMock(),
         fullConfig: {},
         logger: quietLogger,
@@ -153,6 +159,7 @@ describe("Logbook service disposal", () => {
     "standup-write",
     "status-read",
     "ask-read",
+    "frame-read",
   ])("drains %s before closing SQLite", async (kind) => {
     const dataDir = realpathSync(mkdtempSync(path.join(tmpdir(), "logbook-service-drain-")));
     const entered = createDeferred<void>();
@@ -209,7 +216,7 @@ describe("Logbook service disposal", () => {
       );
     });
     if (kind.startsWith("vision")) {
-      const seed = await LogbookStore.open(dataDir);
+      const seed = await LogbookStore.open(dataDir, workerModuleUrl);
       try {
         for (let index = 0; index < 2; index++) {
           const time = startMs + index * 120_000;
@@ -236,14 +243,28 @@ describe("Logbook service disposal", () => {
         await seed.close();
       }
     }
-    const activeStore = await LogbookStore.open(dataDir);
+    const activeStore = await LogbookStore.open(dataDir, workerModuleUrl);
     vi.spyOn(LogbookStore, "open").mockResolvedValueOnce(activeStore);
-    if (kind === "capture-write") {
-      const insertFrame = activeStore.insertFrame.bind(activeStore);
-      vi.spyOn(activeStore, "insertFrame").mockImplementation(async (frame) => {
+    if (kind === "frame-read") {
+      await activeStore.captureFrame({
+        capturedAtMs: Date.now(),
+        day,
+        screenIndex: 0,
+        buffer: Buffer.from("synthetic frame payload"),
+      });
+      const framePayload = activeStore.framePayload.bind(activeStore);
+      vi.spyOn(activeStore, "framePayload").mockImplementation(async (id) => {
         entered.resolve();
         await release.promise;
-        return await insertFrame(frame);
+        return await framePayload(id);
+      });
+    }
+    if (kind === "capture-write") {
+      const captureFrame = activeStore.captureFrame.bind(activeStore);
+      vi.spyOn(activeStore, "captureFrame").mockImplementation(async (frame) => {
+        entered.resolve();
+        await release.promise;
+        return await captureFrame(frame);
       });
     }
     if (kind === "standup-write") {
@@ -276,7 +297,7 @@ describe("Logbook service disposal", () => {
         captureIntervalSeconds: 600,
         visionModel: "synthetic/vision",
       }),
-      { runtime, fullConfig: {}, logger, dataDir },
+      { runtime, fullConfig: {}, logger, dataDir, workerModuleUrl },
     );
     await service.start();
     const ticks = service as unknown as {
@@ -291,7 +312,9 @@ describe("Logbook service disposal", () => {
           ? service.status()
           : kind === "ask-read"
             ? service.ask(day, "What happened?")
-            : service.standup(day, true);
+            : kind === "frame-read"
+              ? service.framePayload(1)
+              : service.standup(day, true);
     void active.catch(() => {});
     await entered.promise;
     const stopped = vi.fn();
@@ -304,10 +327,16 @@ describe("Logbook service disposal", () => {
       await expect(service.standup(day, true)).rejects.toThrow("not running");
       await expect(service.analyzeNow()).rejects.toThrow("not running");
       release.resolve();
-      await active;
+      const result = await active;
+      if (kind === "frame-read") {
+        expect(result).toMatchObject({
+          frameId: 1,
+          base64: Buffer.from("synthetic frame payload").toString("base64"),
+        });
+      }
       await settled;
       expect(logger.error).not.toHaveBeenCalled();
-      const reopened = await LogbookStore.open(dataDir);
+      const reopened = await LogbookStore.open(dataDir, workerModuleUrl);
       try {
         if (kind.startsWith("capture")) {
           expect(await reopened.countUnbatchedActiveFrames()).toBe(1);
@@ -360,7 +389,7 @@ describe("Logbook service disposal", () => {
         await release.promise;
         return completion("Accepted standup");
       };
-      plugin.register(captured.api);
+      plugin.register({ ...captured.api, runtimeSource });
       const service = services[0]!;
       const context = { config: {}, stateDir, logger: quietLogger };
       await service.start(context);
@@ -399,7 +428,7 @@ describe("Logbook service disposal", () => {
         release.resolve();
         expect((await standup)?.[0]).toBe(true);
         await Promise.all([retiring, stopping, cleanup({ reason })]);
-        const reopened = await LogbookStore.open(path.join(stateDir, "logbook"));
+        const reopened = await LogbookStore.open(path.join(stateDir, "logbook"), workerModuleUrl);
         try {
           expect((await reopened.getStandup(dayKeyFor(Date.now())))?.text).toBe("Accepted standup");
         } finally {
@@ -419,7 +448,7 @@ describe("Logbook service disposal", () => {
     captured.api.pluginConfig = { captureEnabled: false };
     const services: OpenClawPluginService[] = [];
     captured.api.registerService = (service) => services.push(service);
-    plugin.register(captured.api);
+    plugin.register({ ...captured.api, runtimeSource });
     const context = { config: {}, stateDir, logger: quietLogger };
     try {
       for (const lifecycle of captured.runtimeLifecycles) {

--- a/extensions/logbook/src/service-lifecycle.test.ts
+++ b/extensions/logbook/src/service-lifecycle.test.ts
@@ -41,6 +41,92 @@ function completion(
 }
 
 describe("Logbook service disposal", () => {
+  it.each([false, true])(
+    "publishes synthesized cards with queued retention (prune=%s)",
+    async (prune) => {
+      const dataDir = tempDirs.make("logbook-publication-retention-");
+      const day = dayKeyFor(Date.now());
+      const startMs = new Date(`${day}T10:00:00`).getTime();
+      const endMs = startMs + 10 * 60_000;
+      const runtime = createPluginRuntimeMock();
+      runtime.mediaUnderstanding.extractStructuredWithModel = vi.fn(async () => ({
+        text: JSON.stringify([
+          { start: "10:00:00", end: "10:10:00", description: "Synthetic activity" },
+        ]),
+      }));
+      const synthesized = createDeferred<void>();
+      let pruning: Promise<PromiseSettledResult<number>> = Promise.resolve({
+        status: "fulfilled",
+        value: 0,
+      });
+      runtime.llm.complete = vi.fn(async () => {
+        if (prune) {
+          // Let synthesis enqueue its next worker command, then queue retention before its reply.
+          queueMicrotask(() =>
+            queueMicrotask(() => {
+              pruning = peer.pruneFrames(endMs).then(
+                (value) => ({ status: "fulfilled", value }),
+                (reason: unknown) => ({ status: "rejected", reason }),
+              );
+            }),
+          );
+        }
+        synthesized.resolve();
+        return completion(
+          JSON.stringify([
+            {
+              startTime: "10:00:00",
+              endTime: "10:10:00",
+              title: "Retained synthesis",
+              summary: "Published through retention",
+              category: "coding",
+            },
+          ]),
+        );
+      });
+      const logger = { ...quietLogger, warn: vi.fn(), error: vi.fn() };
+      const service = new LogbookService(
+        resolveLogbookConfig({ captureEnabled: false, visionModel: "codex/gpt-5.6-sol" }),
+        { dataDir, workerModuleUrl, runtime, fullConfig: {}, logger },
+      );
+      const peer = await LogbookStore.open(dataDir, workerModuleUrl);
+      try {
+        const frameId = await peer.captureFrame({
+          day,
+          capturedAtMs: startMs + 5 * 60_000,
+          screenIndex: 0,
+          buffer: Buffer.from("synthetic keyframe"),
+        });
+        await peer.createBatch({ day, startMs, endMs, frameIds: [frameId] });
+        await service.start();
+        expect(await service.analyzeNow()).toEqual({ started: true });
+        await synthesized.promise;
+        await setImmediate();
+        expect(await pruning).toEqual({ status: "fulfilled", value: prune ? 1 : 0 });
+        await service.stop();
+        expect(await peer.latestBatch()).toMatchObject({ status: "done", error: undefined });
+        expect(logger.warn).not.toHaveBeenCalled();
+        const cards = await peer.cardsForDay(day);
+        expect(cards).toHaveLength(1);
+        expect(cards[0]).toMatchObject({
+          title: "Retained synthesis",
+          keyframeId: prune ? undefined : frameId,
+        });
+        await peer.close();
+        const reopened = await LogbookStore.open(dataDir, workerModuleUrl);
+        try {
+          expect(await reopened.cardsForDay(day)).toEqual(cards);
+        } finally {
+          await reopened.close();
+        }
+      } finally {
+        await pruning;
+        await service.stop();
+        await peer.close();
+      }
+    },
+  );
+
   it("joins a pending database open and asynchronous close when the runtime retires", async () => {
     const stateDir = tempDirs.make("logbook-opening-");
     const store = await LogbookStore.open(path.join(stateDir, "logbook"), workerModuleUrl);

--- a/extensions/logbook/src/service.test.ts
+++ b/extensions/logbook/src/service.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { resolveLogbookConfig } from "./config.js";
 import { LogbookService } from "./service.js";
 
+const workerModuleUrl = new URL("./store.worker.ts", import.meta.url);
+
 type NodeRecord = { nodeId: string; displayName?: string; commands: string[] };
 
 const quietLogger = {
@@ -38,6 +40,7 @@ async function makeService(params: {
       fullConfig: (params.fullConfig ?? {}) as never,
       logger: quietLogger as never,
       dataDir,
+      workerModuleUrl,
     },
   );
   await service.start();

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -1,6 +1,4 @@
 // Logbook background service: snapshot capture loop, batch analysis, retention.
-import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import type {
@@ -10,16 +8,15 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
   CARD_LOOKBACK_MS,
-  MAX_FRAMES_PER_CALL,
   parseCardsJson,
   parseObservationSegments,
   pickKeyframeId,
   revisionWindow,
-  sampleFrames,
   selectBatchFrames,
   validateCardCoverage,
 } from "./analyze.js";
 import { parseModelRef, type LogbookConfig } from "./config.js";
+import { dayKeyFor } from "./day.js";
 import {
   buildAskPrompt,
   buildCardsCorrectionPrompt,
@@ -28,7 +25,7 @@ import {
   buildStandupPrompt,
   OBSERVATION_JSON_SCHEMA,
 } from "./prompts.js";
-import { dayKeyFor, LogbookStore } from "./store.js";
+import { LogbookStore } from "./store.js";
 import type { LogbookBatch, LogbookStatus } from "./types.js";
 
 const ANALYSIS_TICK_MS = 60 * 1000;
@@ -101,6 +98,7 @@ export class LogbookService {
       fullConfig: OpenClawConfig;
       logger: PluginLogger;
       dataDir: string;
+      workerModuleUrl: URL;
     },
   ) {}
 
@@ -109,7 +107,7 @@ export class LogbookService {
       throw new Error("Logbook service cannot be started again");
     }
     this.starting = this.trackOperation(async () => {
-      const store = await LogbookStore.open(this.deps.dataDir);
+      const store = await LogbookStore.open(this.deps.dataDir, this.deps.workerModuleUrl);
       this.store = store;
       try {
         if (this.stopping) {
@@ -297,24 +295,13 @@ export class LogbookService {
         const buffer = Buffer.from(base64, "base64");
         const capturedAtMs = Date.now();
         const day = dayKeyFor(capturedAtMs);
-        const contentHash = createHash("sha256").update(buffer).digest("hex");
-        // Unchanged consecutive frames mean the user is idle (or away); they are
-        // stored for the filmstrip but excluded from analysis batches.
-        const idle = (await store.lastFrame())?.contentHash === contentHash;
-        const filePath = store.frameFilePath(day, capturedAtMs);
-        // Screen captures can contain secrets; keep them owner-only.
-        mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
-        writeFileSync(filePath, buffer, { mode: 0o600 });
-        await store.insertFrame({
+        await store.captureFrame({
           capturedAtMs,
           day,
-          path: filePath,
           screenIndex: this.config.screenIndex,
           width: raw?.width,
           height: raw?.height,
-          byteSize: buffer.byteLength,
-          contentHash,
-          idle,
+          buffer,
         });
         this.lastCaptureAtMs = capturedAtMs;
         this.lastCaptureError = undefined;
@@ -489,11 +476,10 @@ export class LogbookService {
       `${vision.ref.provider}/${vision.ref.model}`,
     );
     try {
-      const frames = await store.batchFrames(batch.id);
-      const sampled = sampleFrames(frames, MAX_FRAMES_PER_CALL);
-      const images = sampled.map((frame) => ({
+      const sampled = await store.batchImages(batch.id);
+      const images = sampled.map(({ frame, buffer }) => ({
         type: "image" as const,
-        buffer: readFileSync(frame.path),
+        buffer,
         fileName: path.basename(frame.path),
         mime: "image/jpeg",
       }));
@@ -505,7 +491,7 @@ export class LogbookService {
           preferredProfile: vision.ref.preferredProfile,
           input: images,
           instructions: buildObservationInstructions({
-            frameTimes: sampled.map((frame) => frame.capturedAtMs),
+            frameTimes: sampled.map(({ frame }) => frame.capturedAtMs),
             startMs: batch.startMs,
             endMs: batch.endMs,
           }),
@@ -681,9 +667,9 @@ export class LogbookService {
     return this.trackOperation(() => store.listDays());
   }
 
-  async frameById(id: number): ReturnType<LogbookStore["frameById"]> {
+  async framePayload(id: number): ReturnType<LogbookStore["framePayload"]> {
     const store = this.requireStore();
-    return this.trackOperation(() => store.frameById(id));
+    return this.trackOperation(() => store.framePayload(id));
   }
 
   async framesInRange(startMs: number, endMs: number): ReturnType<LogbookStore["framesInRange"]> {

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -10,7 +10,6 @@ import {
   CARD_LOOKBACK_MS,
   parseCardsJson,
   parseObservationSegments,
-  pickKeyframeId,
   revisionWindow,
   selectBatchFrames,
   validateCardCoverage,
@@ -588,14 +587,9 @@ export class LogbookService {
     if (!parsed.ok) {
       throw new Error(`card synthesis failed validation: ${parsed.error}`);
     }
-    const windowFrames = (await store.framesInRange(window.startMs, window.endMs)).map((frame) => ({
-      id: frame.id,
-      capturedAtMs: frame.capturedAtMs,
-    }));
-    const drafts = parsed.drafts.map((draft) =>
-      Object.assign(draft, { keyframeId: pickKeyframeId(draft, windowFrames) }),
-    );
-    await store.replaceCardsInWindow(batch.day, window.startMs, window.endMs, drafts);
+    await store.replaceCardsInWindow(batch.day, window.startMs, window.endMs, parsed.drafts, {
+      selectKeyframes: true,
+    });
   }
 
   async standup(

--- a/extensions/logbook/src/store-contract.ts
+++ b/extensions/logbook/src/store-contract.ts
@@ -53,7 +53,13 @@ export type LogbookOperations = {
   >;
   countCardsForDay: Operation<{ day: string }, number>;
   replaceCardsInWindow: Operation<
-    { day: string; startMs: number; endMs: number; drafts: LogbookCardDraft[] },
+    {
+      day: string;
+      startMs: number;
+      endMs: number;
+      drafts: LogbookCardDraft[];
+      selectKeyframes?: boolean;
+    },
     void
   >;
   listDays: Operation<undefined, LogbookDay[]>;

--- a/extensions/logbook/src/store-contract.ts
+++ b/extensions/logbook/src/store-contract.ts
@@ -1,0 +1,64 @@
+import type {
+  LogbookBatch,
+  LogbookBatchStatus,
+  LogbookCard,
+  LogbookCardDraft,
+  LogbookDayStats,
+  LogbookFrame,
+  LogbookObservation,
+} from "./types.js";
+
+export type LogbookFrameInput = Omit<LogbookFrame, "id"> & { contentHash: string };
+export type LogbookBatchInput = {
+  day: string;
+  startMs: number;
+  endMs: number;
+  frameIds: number[];
+};
+export type LogbookObservationInput = Pick<LogbookObservation, "startMs" | "endMs" | "text">;
+export type LogbookTimeline = { day: string; cards: LogbookCard[]; stats: LogbookDayStats };
+export type LogbookStandup = { day: string; text: string; updatedMs: number };
+export type LogbookDay = { day: string; cards: number; firstMs: number; lastMs: number };
+
+type Operation<Input, Output> = { input: Input; output: Output };
+
+export type LogbookOperations = {
+  insertFrame: Operation<LogbookFrameInput, number>;
+  lastFrame: Operation<undefined, { capturedAtMs: number; contentHash: string } | null>;
+  unbatchedActiveFrames: Operation<{ limit: number }, LogbookFrame[]>;
+  countUnbatchedActiveFrames: Operation<undefined, number>;
+  frameById: Operation<{ id: number }, LogbookFrame | null>;
+  framesInRange: Operation<{ startMs: number; endMs: number }, LogbookFrame[]>;
+  createBatch: Operation<LogbookBatchInput, number>;
+  setBatchStatus: Operation<
+    { batchId: number; status: LogbookBatchStatus; error?: string; model?: string },
+    void
+  >;
+  latestBatch: Operation<undefined, LogbookBatch | null>;
+  resetRunningBatches: Operation<undefined, void>;
+  resetErrorBatches: Operation<undefined, number>;
+  nextPendingBatch: Operation<undefined, LogbookBatch | null>;
+  batchFrames: Operation<{ batchId: number }, LogbookFrame[]>;
+  replaceObservations: Operation<
+    { batchId: number; day: string; segments: LogbookObservationInput[] },
+    void
+  >;
+  observationsInRange: Operation<
+    { day: string; startMs: number; endMs: number; tailLimit?: number },
+    LogbookObservation[]
+  >;
+  cardsForDay: Operation<
+    { day: string; window?: { startMs: number; endMs: number } },
+    LogbookCard[]
+  >;
+  countCardsForDay: Operation<{ day: string }, number>;
+  replaceCardsInWindow: Operation<
+    { day: string; startMs: number; endMs: number; drafts: LogbookCardDraft[] },
+    void
+  >;
+  listDays: Operation<undefined, LogbookDay[]>;
+  timelineForDay: Operation<{ day: string }, LogbookTimeline>;
+  getStandup: Operation<{ day: string }, LogbookStandup | null>;
+  saveStandup: Operation<{ day: string; text: string }, void>;
+  pruneFrames: Operation<{ olderThanMs: number }, number>;
+};

--- a/extensions/logbook/src/store-frame-io.test.ts
+++ b/extensions/logbook/src/store-frame-io.test.ts
@@ -1,0 +1,220 @@
+import * as fs from "node:fs/promises";
+import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dayKeyFor } from "./day.js";
+import { LogbookStore } from "./store.js";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, readFile: vi.fn(actual.readFile) };
+});
+vi.mock("openclaw/plugin-sdk/sqlite-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/sqlite-runtime")>();
+  return {
+    ...actual,
+    openNodeSqliteDatabase: vi.fn(() => {
+      throw new Error("Logbook must not open SQLite in the application thread");
+    }),
+  };
+});
+
+const workerModuleUrl = new URL("./store.worker.ts", import.meta.url);
+const stores = new Set<LogbookStore>();
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    try {
+      await Promise.all([...stores].map((store) => store.close()));
+    } finally {
+      stores.clear();
+      vi.restoreAllMocks();
+      cleanup();
+    }
+  }),
+);
+
+async function open(dataDir: string) {
+  const store = await LogbookStore.open(dataDir, workerModuleUrl);
+  stores.add(store);
+  return store;
+}
+
+describe("Logbook worker and frame I/O ownership", () => {
+  it("bootstraps and reopens durable state without opening SQLite in the application thread", async () => {
+    const directory = tempDirs.make("logbook-worker-bootstrap-");
+    const store = await open(directory);
+    await store.saveStandup("2026-07-03", "Persisted through the worker");
+    await store.close();
+    const reopened = await open(directory);
+    expect(await reopened.getStandup("2026-07-03")).toMatchObject({
+      text: "Persisted through the worker",
+    });
+    expect(openNodeSqliteDatabase).not.toHaveBeenCalled();
+  });
+
+  it.each(["frame", "batch"] as const)(
+    "drains an admitted %s read before pruning through a directory alias or closing its client",
+    async (kind) => {
+      const directory = tempDirs.make("logbook-frame-drain-");
+      const dataDir = path.join(directory, "data");
+      const aliasDir = path.join(directory, "alias");
+      const owner = await open(dataDir);
+      await fs.symlink(dataDir, aliasDir, process.platform === "win32" ? "junction" : "dir");
+      const reader = await open(aliasDir);
+      const day = dayKeyFor(1);
+      const bytes = Buffer.from("synthetic frame before pruning");
+      const frameId = await owner.captureFrame({
+        capturedAtMs: 1,
+        day,
+        screenIndex: 0,
+        buffer: bytes,
+      });
+      const batchId = await owner.createBatch({ day, startMs: 1, endMs: 2, frameIds: [frameId] });
+      const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      vi.mocked(fs.readFile).mockImplementationOnce(async (file) => {
+        entered.resolve();
+        await release.promise;
+        return await actualFs.readFile(file);
+      });
+      const reading = kind === "frame" ? reader.framePayload(frameId) : reader.batchImages(batchId);
+      await entered.promise;
+      let pruned = false;
+      let closed = false;
+      const pruning = owner.pruneFrames(2).then((count) => {
+        pruned = true;
+        return count;
+      });
+      const closing = reader.close().then(() => {
+        closed = true;
+      });
+      try {
+        // Two real worker replies put any incorrectly dispatched prune ahead of the metadata read.
+        await owner.countCardsForDay(day);
+        expect(await owner.frameById(frameId)).not.toBeNull();
+        expect(pruned).toBe(false);
+        expect(closed).toBe(false);
+        release.resolve();
+        if (kind === "frame") {
+          expect(await reading).toMatchObject({ frameId, base64: bytes.toString("base64") });
+        } else {
+          expect(await reading).toEqual([
+            { frame: expect.objectContaining({ id: frameId }), buffer: bytes },
+          ]);
+        }
+        expect(await pruning).toBe(1);
+        await closing;
+        expect(await owner.frameById(frameId)).toBeNull();
+        await expect(fs.stat(owner.frameFilePath(day, 1))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      } finally {
+        release.resolve();
+        await Promise.allSettled([reading, pruning, closing]);
+      }
+    },
+  );
+
+  it("bounds pending frame reads and keeps admitted reads alive through close", async () => {
+    const directory = tempDirs.make("logbook-frame-capacity-");
+    const dataDir = path.join(directory, "data");
+    const aliasDir = path.join(directory, "alias");
+    const owner = await open(dataDir);
+    await fs.symlink(dataDir, aliasDir, process.platform === "win32" ? "junction" : "dir");
+    const reader = await open(aliasDir);
+    const bytes = Buffer.from("bounded frame queue");
+    const day = "2026-07-03";
+    const frameId = await owner.captureFrame({
+      capturedAtMs: 1,
+      day,
+      screenIndex: 0,
+      buffer: bytes,
+    });
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    vi.mocked(fs.readFile).mockImplementationOnce(async (file) => {
+      entered.resolve();
+      await release.promise;
+      return await actualFs.readFile(file);
+    });
+    const reads = Array.from({ length: 128 }, () => reader.framePayload(frameId));
+    const accepted = Promise.allSettled(reads);
+    await entered.promise;
+    let overflowResult:
+      | { status: "fulfilled" }
+      | { status: "rejected"; reason: unknown }
+      | undefined;
+    const overflow = reader.framePayload(frameId).then(
+      () => {
+        overflowResult = { status: "fulfilled" };
+      },
+      (reason: unknown) => {
+        overflowResult = { status: "rejected", reason };
+      },
+    );
+    let closed = false;
+    const closing = reader.close().then(() => {
+      closed = true;
+    });
+    try {
+      await owner.countCardsForDay(day);
+      expect(overflowResult).toMatchObject({ status: "rejected", reason: { code: "overloaded" } });
+      expect(closed).toBe(false);
+      release.resolve();
+      const outcomes = await accepted;
+      expect(outcomes.find((result) => result.status === "rejected")).toBeUndefined();
+      expect(
+        outcomes.every(
+          (result) =>
+            result.status === "fulfilled" && result.value?.base64 === bytes.toString("base64"),
+        ),
+      ).toBe(true);
+      await closing;
+      expect(await owner.framePayload(frameId)).toMatchObject({ base64: bytes.toString("base64") });
+    } finally {
+      release.resolve();
+      await Promise.allSettled([accepted, overflow, closing]);
+    }
+  });
+
+  it("loads a sampled batch larger than the worker result limit without transporting image buffers", async () => {
+    const dataDir = tempDirs.make("logbook-large-images-");
+    const store = await open(dataDir);
+    const day = "2026-07-03";
+    const bytes = Buffer.alloc(8 * 1024 * 1024, 0x61);
+    const frameIds: number[] = [];
+    for (let index = 0; index < 9; index += 1) {
+      const file = store.frameFilePath(day, index + 1);
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, bytes);
+      frameIds.push(
+        await store.insertFrame({
+          capturedAtMs: index + 1,
+          day,
+          path: file,
+          screenIndex: 0,
+          byteSize: bytes.byteLength,
+          contentHash: `synthetic-${index}`,
+          idle: false,
+        }),
+      );
+    }
+    const batchId = await store.createBatch({ day, startMs: 1, endMs: 10, frameIds });
+    const images = await store.batchImages(batchId);
+    expect(images).toHaveLength(9);
+    expect(images.reduce((total, image) => total + image.buffer.byteLength, 0)).toBe(
+      72 * 1024 * 1024,
+    );
+    expect(images.map((image) => image.frame.id)).toEqual(frameIds);
+    for (const image of images) {
+      expect(Buffer.isBuffer(image.buffer)).toBe(true);
+      expect(image.buffer.byteLength).toBe(bytes.byteLength);
+      expect(image.buffer[0]).toBe(0x61);
+      expect(image.buffer.at(-1)).toBe(0x61);
+    }
+  });
+});

--- a/extensions/logbook/src/store-read-budgets.test.ts
+++ b/extensions/logbook/src/store-read-budgets.test.ts
@@ -1,0 +1,274 @@
+import path from "node:path";
+import type { SqliteWorkerBackend } from "openclaw/plugin-sdk/sqlite-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LogbookOperations } from "./store-contract.js";
+import { createSqliteWorkerBackend } from "./store.worker.js";
+
+const reads = vi.hoisted(() => ({ cardQueries: 0, cardRows: 0, observationRows: 0 }));
+const preparations = vi.hoisted(() => new Map<string, number>());
+vi.mock("openclaw/plugin-sdk/sqlite-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/sqlite-runtime")>();
+  return {
+    ...actual,
+    openNodeSqliteDatabase: (...args: Parameters<typeof actual.openNodeSqliteDatabase>) => {
+      const db = actual.openNodeSqliteDatabase(...args);
+      const prepare = db.prepare.bind(db);
+      vi.spyOn(db, "prepare").mockImplementation((sql) => {
+        const statement = prepare(sql);
+        if (/^\s*(?:insert into "(?:frames|standups)"|update "batches")/i.test(sql)) {
+          preparations.set(sql, (preparations.get(sql) ?? 0) + 1);
+        }
+        const table = /\bfrom\s+"?(cards|observations)\b/i.exec(sql)?.[1];
+        if (!table) {
+          return statement;
+        }
+        const record = (row: Record<string, unknown>) => {
+          if (table === "cards") {
+            reads.cardRows += Number("distractions" in row);
+          } else {
+            reads.observationRows += 1;
+          }
+        };
+        const get = statement.get.bind(statement);
+        vi.spyOn(statement, "get").mockImplementation((...bindings) => {
+          reads.cardQueries += Number(table === "cards");
+          const row = get(...bindings);
+          if (row) {
+            record(row);
+          }
+          return row;
+        });
+        const all = statement.all.bind(statement);
+        vi.spyOn(statement, "all").mockImplementation((...bindings) => {
+          reads.cardQueries += Number(table === "cards");
+          const rows = all(...bindings);
+          rows.forEach(record);
+          return rows;
+        });
+        const iterate = statement.iterate.bind(statement);
+        vi.spyOn(statement, "iterate").mockImplementation(function* (...bindings) {
+          reads.cardQueries += Number(table === "cards");
+          for (const row of iterate(...bindings)) {
+            record(row);
+            yield row;
+          }
+          return undefined;
+        });
+        return statement;
+      });
+      return db;
+    },
+  };
+});
+
+const backends: SqliteWorkerBackend<LogbookOperations>[] = [];
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    try {
+      await Promise.all(backends.splice(0).map((backend) => Promise.resolve(backend.close())));
+    } finally {
+      vi.restoreAllMocks();
+      preparations.clear();
+      cleanup();
+    }
+  }),
+);
+const day = "2026-07-03";
+
+function openBackend() {
+  const dataDir = tempDirs.make("logbook-read-budget-");
+  const backend = createSqliteWorkerBackend(
+    { dataDir },
+    { databasePath: path.join(dataDir, "logbook.sqlite") },
+  );
+  backends.push(backend);
+  return backend;
+}
+
+describe("Logbook native statement and read budgets", () => {
+  it("reuses native write statements with fresh optional values and model coalescing", () => {
+    const backend = openBackend();
+    const firstFrame = {
+      capturedAtMs: 1,
+      day,
+      path: "first.jpg",
+      screenIndex: 0,
+      width: 640,
+      height: 480,
+      byteSize: 10,
+      contentHash: "first",
+      idle: false,
+    };
+    expect(backend.execute({ type: "insertFrame", input: firstFrame })).toBe(1);
+    expect(
+      backend.execute({
+        type: "createBatch",
+        input: { day, startMs: 1, endMs: 2, frameIds: [1] },
+      }),
+    ).toBe(1);
+    backend.execute({ type: "saveStandup", input: { day, text: "Initial standup" } });
+    backend.execute({
+      type: "setBatchStatus",
+      input: { batchId: 1, status: "error", error: "First failure", model: "synthetic/first" },
+    });
+    // The native cache retains a query on its second execution.
+    expect(
+      backend.execute({
+        type: "insertFrame",
+        input: { ...firstFrame, path: "warmup.jpg", contentHash: "warmup" },
+      }),
+    ).toBe(2);
+    backend.execute({ type: "saveStandup", input: { day, text: "Warmup standup" } });
+    backend.execute({
+      type: "setBatchStatus",
+      input: { batchId: 1, status: "running", error: "Warmup status" },
+    });
+    const warmed = new Map(preparations);
+    expect([...warmed.values()]).toEqual([2, 2, 2]);
+
+    expect(
+      backend.execute({
+        type: "insertFrame",
+        input: {
+          capturedAtMs: 2,
+          day,
+          path: "second.jpg",
+          screenIndex: 1,
+          byteSize: 20,
+          contentHash: "second",
+          idle: true,
+        },
+      }),
+    ).toBe(3);
+    backend.execute({ type: "saveStandup", input: { day, text: "Revised standup 🦞" } });
+    backend.execute({ type: "saveStandup", input: { day: "2026-07-04", text: "Another day" } });
+    backend.execute({ type: "setBatchStatus", input: { batchId: 1, status: "pending" } });
+    expect(backend.execute({ type: "latestBatch", input: undefined })).toMatchObject({
+      status: "pending",
+      error: undefined,
+      model: "synthetic/first",
+    });
+    backend.execute({
+      type: "setBatchStatus",
+      input: { batchId: 1, status: "done", model: "synthetic/second" },
+    });
+
+    expect(preparations).toEqual(warmed);
+    expect(backend.execute({ type: "frameById", input: { id: 1 } })).toMatchObject({
+      path: "first.jpg",
+      width: 640,
+      height: 480,
+      screenIndex: 0,
+      byteSize: 10,
+      idle: false,
+    });
+    expect(backend.execute({ type: "frameById", input: { id: 2 } })).toMatchObject({
+      path: "warmup.jpg",
+      width: 640,
+      height: 480,
+    });
+    expect(backend.execute({ type: "frameById", input: { id: 3 } })).toMatchObject({
+      path: "second.jpg",
+      width: undefined,
+      height: undefined,
+      screenIndex: 1,
+      byteSize: 20,
+      idle: true,
+    });
+    expect(backend.execute({ type: "lastFrame", input: undefined })).toEqual({
+      capturedAtMs: 2,
+      contentHash: "second",
+    });
+    expect(backend.execute({ type: "getStandup", input: { day } })).toMatchObject({
+      text: "Revised standup 🦞",
+    });
+    expect(backend.execute({ type: "getStandup", input: { day: "2026-07-04" } })).toMatchObject({
+      text: "Another day",
+    });
+    expect(backend.execute({ type: "latestBatch", input: undefined })).toMatchObject({
+      status: "done",
+      error: undefined,
+      model: "synthetic/second",
+    });
+  });
+
+  it("hydrates timeline cards once and counts cards without hydrating their payloads", () => {
+    const backend = openBackend();
+    const drafts = Array.from({ length: 8 }, (_, index) => ({
+      day,
+      startMs: index * 60_000,
+      endMs: (index + 1) * 60_000,
+      title: `Card ${index} 🦞`,
+      summary: "Summary",
+      detail: "Detailed activity",
+      category: "coding",
+      distractions: [],
+    }));
+    backend.execute({
+      type: "replaceCardsInWindow",
+      input: { day, startMs: 0, endMs: Number.MAX_SAFE_INTEGER, drafts },
+    });
+    reads.cardQueries = 0;
+    reads.cardRows = 0;
+    expect(backend.execute({ type: "timelineForDay", input: { day } })).toMatchObject({
+      cards: drafts.map((draft) => expect.objectContaining(draft)),
+      stats: { trackedMs: 8 * 60_000 },
+    });
+    expect(reads.cardQueries).toBe(1);
+    expect(reads.cardRows).toBe(8);
+
+    reads.cardQueries = 0;
+    reads.cardRows = 0;
+    expect(backend.execute({ type: "countCardsForDay", input: { day } })).toBe(8);
+    expect(reads.cardQueries).toBe(1);
+    expect(reads.cardRows).toBe(0);
+  });
+
+  it.each([0, 199, 200, 201])(
+    "reads at most 200 of %i observations with stable timestamp ties",
+    (count) => {
+      const backend = openBackend();
+      const frameId = backend.execute({
+        type: "insertFrame",
+        input: {
+          capturedAtMs: 1,
+          day,
+          path: "synthetic.jpg",
+          screenIndex: 0,
+          byteSize: 0,
+          contentHash: "synthetic",
+          idle: false,
+        },
+      });
+      if (typeof frameId !== "number") {
+        throw new Error("Expected a frame id from the native backend");
+      }
+      const batchId = backend.execute({
+        type: "createBatch",
+        input: { day, startMs: 0, endMs: Number.MAX_SAFE_INTEGER, frameIds: [frameId] },
+      });
+      if (typeof batchId !== "number") {
+        throw new Error("Expected a batch id from the native backend");
+      }
+      const segments = Array.from({ length: count }, (_, index) => ({
+        startMs: 1 + Math.floor(index / 3) * 1000,
+        endMs: 1001 + Math.floor(index / 3) * 1000,
+        text: `Observation ${index} 🦞`,
+      }));
+      backend.execute({ type: "replaceObservations", input: { batchId, day, segments } });
+      reads.observationRows = 0;
+      expect(
+        backend.execute({
+          type: "observationsInRange",
+          input: { day, startMs: 0, endMs: Number.MAX_SAFE_INTEGER, tailLimit: 200 },
+        }),
+      ).toEqual(
+        segments
+          .map((segment, index) => Object.assign({ id: index + 1, batchId, day }, segment))
+          .slice(-200),
+      );
+      expect(reads.observationRows).toBe(Math.min(count, 200));
+    },
+  );
+});

--- a/extensions/logbook/src/store-schema.ts
+++ b/extensions/logbook/src/store-schema.ts
@@ -1,0 +1,195 @@
+import type { Generated, Selectable } from "openclaw/plugin-sdk/sqlite-runtime";
+import { asOptionalObjectRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type {
+  LogbookBatch,
+  LogbookBatchStatus,
+  LogbookCard,
+  LogbookDistraction,
+  LogbookFrame,
+} from "./types.js";
+
+export const LOGBOOK_SCHEMA_VERSION = 1;
+
+export type LogbookDatabase = {
+  frames: {
+    id: Generated<number>;
+    captured_at_ms: number;
+    day: string;
+    path: string;
+    screen_index: number;
+    width: number | null;
+    height: number | null;
+    byte_size: number;
+    content_hash: string;
+    idle: number;
+    batch_id: number | null;
+  };
+  batches: {
+    id: Generated<number>;
+    day: string;
+    start_ms: number;
+    end_ms: number;
+    status: LogbookBatchStatus;
+    error: string | null;
+    frame_count: number;
+    model: string | null;
+    created_ms: number;
+    updated_ms: number;
+  };
+  observations: {
+    id: Generated<number>;
+    batch_id: number;
+    day: string;
+    start_ms: number;
+    end_ms: number;
+    text: string;
+  };
+  cards: {
+    id: Generated<number>;
+    day: string;
+    start_ms: number;
+    end_ms: number;
+    title: string;
+    summary: string;
+    detail: string;
+    category: string;
+    app_primary: string | null;
+    app_secondary: string | null;
+    distractions: string;
+    keyframe_id: number | null;
+    updated_ms: number;
+  };
+  standups: { day: string; text: string; updated_ms: number };
+};
+
+export const SCHEMA = `
+CREATE TABLE IF NOT EXISTS batches (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  day TEXT NOT NULL,
+  start_ms INTEGER NOT NULL,
+  end_ms INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'done', 'error')),
+  error TEXT,
+  frame_count INTEGER NOT NULL DEFAULT 0,
+  model TEXT,
+  created_ms INTEGER NOT NULL,
+  updated_ms INTEGER NOT NULL
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_logbook_batches_day ON batches (day, start_ms);
+CREATE TABLE IF NOT EXISTS frames (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  captured_at_ms INTEGER NOT NULL,
+  day TEXT NOT NULL,
+  path TEXT NOT NULL,
+  screen_index INTEGER NOT NULL DEFAULT 0,
+  width INTEGER,
+  height INTEGER,
+  byte_size INTEGER NOT NULL DEFAULT 0,
+  content_hash TEXT NOT NULL,
+  idle INTEGER NOT NULL DEFAULT 0 CHECK (idle IN (0, 1)),
+  batch_id INTEGER REFERENCES batches(id) ON DELETE SET NULL
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_logbook_frames_day ON frames (day, captured_at_ms);
+CREATE INDEX IF NOT EXISTS idx_logbook_frames_captured_at ON frames (captured_at_ms);
+CREATE INDEX IF NOT EXISTS idx_logbook_frames_unbatched ON frames (batch_id) WHERE batch_id IS NULL;
+CREATE INDEX IF NOT EXISTS idx_logbook_frames_batch ON frames (batch_id, captured_at_ms) WHERE batch_id IS NOT NULL;
+CREATE TABLE IF NOT EXISTS observations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  batch_id INTEGER NOT NULL REFERENCES batches(id) ON DELETE CASCADE,
+  day TEXT NOT NULL,
+  start_ms INTEGER NOT NULL,
+  end_ms INTEGER NOT NULL,
+  text TEXT NOT NULL
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_logbook_observations_day ON observations (day, start_ms);
+CREATE INDEX IF NOT EXISTS idx_logbook_observations_batch ON observations (batch_id);
+CREATE TABLE IF NOT EXISTS cards (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  day TEXT NOT NULL,
+  start_ms INTEGER NOT NULL,
+  end_ms INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  detail TEXT NOT NULL DEFAULT '',
+  category TEXT NOT NULL DEFAULT 'other',
+  app_primary TEXT,
+  app_secondary TEXT,
+  distractions TEXT NOT NULL DEFAULT '[]',
+  keyframe_id INTEGER REFERENCES frames(id) ON DELETE SET NULL,
+  updated_ms INTEGER NOT NULL
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_logbook_cards_day ON cards (day, start_ms);
+CREATE INDEX IF NOT EXISTS idx_logbook_cards_keyframe ON cards (keyframe_id) WHERE keyframe_id IS NOT NULL;
+CREATE TABLE IF NOT EXISTS standups (
+  day TEXT PRIMARY KEY,
+  text TEXT NOT NULL,
+  updated_ms INTEGER NOT NULL
+) STRICT;
+`;
+
+type FrameRow = Omit<Selectable<LogbookDatabase["frames"]>, "content_hash" | "batch_id">;
+type BatchRow = Omit<Selectable<LogbookDatabase["batches"]>, "created_ms" | "updated_ms">;
+
+export function toFrame(row: FrameRow): LogbookFrame {
+  return {
+    id: row.id,
+    capturedAtMs: row.captured_at_ms,
+    day: row.day,
+    path: row.path,
+    screenIndex: row.screen_index,
+    width: row.width ?? undefined,
+    height: row.height ?? undefined,
+    byteSize: row.byte_size,
+    idle: row.idle === 1,
+  };
+}
+
+export function toBatch(row: BatchRow): LogbookBatch {
+  return {
+    id: row.id,
+    day: row.day,
+    startMs: row.start_ms,
+    endMs: row.end_ms,
+    status: row.status,
+    error: row.error ?? undefined,
+    frameCount: row.frame_count,
+    model: row.model ?? undefined,
+  };
+}
+
+function parseDistractions(raw: string): LogbookDistraction[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((entry: unknown): entry is LogbookDistraction => {
+      const record = asOptionalObjectRecord(entry);
+      return (
+        record !== undefined &&
+        typeof record.title === "string" &&
+        typeof record.startMs === "number" &&
+        typeof record.endMs === "number"
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+export function toCard(row: Selectable<LogbookDatabase["cards"]>): LogbookCard {
+  return {
+    id: row.id,
+    day: row.day,
+    startMs: row.start_ms,
+    endMs: row.end_ms,
+    title: row.title,
+    summary: row.summary,
+    detail: row.detail,
+    category: row.category,
+    appPrimary: row.app_primary ?? undefined,
+    appSecondary: row.app_secondary ?? undefined,
+    distractions: parseDistractions(row.distractions),
+    keyframeId: row.keyframe_id ?? undefined,
+  };
+}

--- a/extensions/logbook/src/store.test.ts
+++ b/extensions/logbook/src/store.test.ts
@@ -1,12 +1,22 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { LogbookStore, dayKeyFor } from "./store.js";
+import { dayKeyFor } from "./day.js";
+import { LogbookStore } from "./store.js";
 import type { LogbookCardDraft } from "./types.js";
 
+const workerModuleUrl = new URL("./store.worker.ts", import.meta.url);
 const DAY = "2026-07-03";
 
 function queryPlanDetails(database: DatabaseSync, sql: string): string[] {
@@ -41,7 +51,7 @@ describe("LogbookStore", () => {
 
   beforeEach(async () => {
     dir = mkdtempSync(path.join(tmpdir(), "logbook-store-"));
-    store = await LogbookStore.open(dir);
+    store = await LogbookStore.open(dir, workerModuleUrl);
   });
 
   afterEach(async () => {
@@ -79,6 +89,32 @@ describe("LogbookStore", () => {
     });
     expect(await store.countUnbatchedActiveFrames()).toBe(0);
     expect(await store.batchFrames(batchId)).toHaveLength(2);
+  });
+
+  it("refuses a hardlinked database with another frame root before bootstrapping that root", async () => {
+    const capturedAtMs = Date.now();
+    const frameId = await insertFrame(capturedAtMs);
+    const otherRoot = path.join(dir, "another-root");
+    mkdirSync(otherRoot);
+    linkSync(path.join(dir, "logbook.sqlite"), path.join(otherRoot, "logbook.sqlite"));
+    const [result] = await Promise.allSettled([LogbookStore.open(otherRoot, workerModuleUrl)]);
+    try {
+      expect(existsSync(path.join(otherRoot, "frames"))).toBe(false);
+      expect(result).toMatchObject({
+        status: "rejected",
+        reason: { message: "SQLite database already belongs to another worker backend" },
+      });
+      expect(await store.frameById(frameId)).toMatchObject({
+        id: frameId,
+        capturedAtMs,
+        path: store.frameFilePath(dayKeyFor(capturedAtMs), capturedAtMs),
+      });
+      expect(await store.countUnbatchedActiveFrames()).toBe(1);
+    } finally {
+      if (result.status === "fulfilled") {
+        await result.value.close();
+      }
+    }
   });
 
   it("creates every owned table as STRICT with foreign keys enabled", () => {
@@ -182,7 +218,7 @@ describe("LogbookStore", () => {
     expect(database.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
     database.close();
 
-    store = await LogbookStore.open(dir);
+    store = await LogbookStore.open(dir, workerModuleUrl);
 
     const reopened = new DatabaseSync(databasePath, { readOnly: true });
     try {
@@ -511,7 +547,7 @@ describe("LogbookStore", () => {
     `);
     legacy.close();
 
-    store = await LogbookStore.open(dir);
+    store = await LogbookStore.open(dir, workerModuleUrl);
 
     expect((await store.batchFrames(7)).map((frame) => frame.id)).toEqual([11]);
     const migrated = new DatabaseSync(databasePath, { readOnly: true });
@@ -536,6 +572,28 @@ describe("LogbookStore", () => {
     }
   });
 
+  it("refuses a newer schema without changing its stored data", async () => {
+    await store.saveStandup(DAY, "Preserved future-version fixture");
+    await store.close();
+    const databasePath = path.join(dir, "logbook.sqlite");
+    const future = new DatabaseSync(databasePath);
+    future.exec("PRAGMA user_version = 2");
+    future.close();
+
+    await expect(LogbookStore.open(dir, workerModuleUrl)).rejects.toThrow(
+      "Logbook database uses newer schema version 2; this build supports 1",
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(preserved.prepare("PRAGMA user_version").get()).toEqual({ user_version: 2 });
+      expect(preserved.prepare("SELECT day, text FROM standups").all()).toEqual([
+        { day: DAY, text: "Preserved future-version fixture" },
+      ]);
+    } finally {
+      preserved.close();
+    }
+  });
+
   it("rolls back a legacy STRICT migration when stored data has the wrong type", async () => {
     const legacyDir = path.join(dir, "invalid-legacy");
     mkdirSync(legacyDir);
@@ -547,7 +605,7 @@ describe("LogbookStore", () => {
     `);
     legacy.close();
 
-    await expect(LogbookStore.open(legacyDir)).rejects.toThrow(
+    await expect(LogbookStore.open(legacyDir, workerModuleUrl)).rejects.toThrow(
       "Failed migrating SQLite table standups to STRICT",
     );
 

--- a/extensions/logbook/src/store.test.ts
+++ b/extensions/logbook/src/store.test.ts
@@ -481,6 +481,26 @@ describe("LogbookStore", () => {
     expect((await store.cardsForDay(DAY)).map((card) => card.title)).toEqual(["kept"]);
   });
 
+  it.each([false, true])(
+    "selects current keyframes after pruning instead of retaining a stale draft id (survivor=%s)",
+    async (survivor) => {
+      const startMs = new Date(`${DAY}T10:00:00`).getTime();
+      const expiredId = await insertFrame(startMs + 10 * 60_000);
+      const remainingId = survivor ? await insertFrame(startMs + 25 * 60_000) : undefined;
+      expect(await store.pruneFrames(startMs + 20 * 60_000)).toBe(1);
+      await store.replaceCardsInWindow(
+        DAY,
+        startMs,
+        startMs + 30 * 60_000,
+        [draft({ keyframeId: expiredId })],
+        { selectKeyframes: true },
+      );
+      const cards = await store.cardsForDay(DAY);
+      expect(cards).toHaveLength(1);
+      expect(cards[0]?.keyframeId).toBe(remainingId);
+    },
+  );
+
   it("requeues errored batches for explicit retry", async () => {
     const t0 = Date.now();
     const frameId = await insertFrame(t0);

--- a/extensions/logbook/src/store.ts
+++ b/extensions/logbook/src/store.ts
@@ -1,759 +1,219 @@
-// Logbook SQLite store: frames on disk, everything else in one plugin-owned DB.
-import { chmodSync, mkdirSync, rmdirSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import { canonicalPathFromExistingAncestor } from "openclaw/plugin-sdk/file-access-runtime";
 import {
-  configureSqliteConnectionPragmas,
-  migrateSqliteSchemaToStrict,
-} from "openclaw/plugin-sdk/plugin-state-runtime";
-import {
-  compileSqliteQueryBindings,
-  executeSqliteQuerySync,
-  executeSqliteQueryTakeFirstSync,
-  getNodeSqliteKysely,
-  openNodeSqliteDatabase,
-  runSqliteImmediateTransactionSync,
-  type Selectable,
+  openSqliteWorkerStore,
+  SqliteWorkerError,
+  type SqliteWorkerStore,
 } from "openclaw/plugin-sdk/sqlite-runtime";
+import { MAX_FRAMES_PER_CALL, sampleFrames } from "./analyze.js";
+import { acquireLogbookFrameIo } from "./frame-io.js";
 import type {
-  LogbookBatch,
-  LogbookBatchStatus,
-  LogbookCard,
-  LogbookCardDraft,
-  LogbookDatabase,
-  LogbookDayStats,
-  LogbookDistraction,
-  LogbookFrame,
-  LogbookObservation,
-} from "./types.js";
+  LogbookBatchInput,
+  LogbookFrameInput,
+  LogbookObservationInput,
+  LogbookOperations,
+} from "./store-contract.js";
+import type { LogbookBatchStatus, LogbookCardDraft } from "./types.js";
 
-type Database = import("node:sqlite").DatabaseSync;
-
-const LOGBOOK_SCHEMA_VERSION = 1;
-const LOGBOOK_SQLITE_BUSY_TIMEOUT_MS = 5_000;
-const SCHEMA = `
-CREATE TABLE IF NOT EXISTS batches (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  day TEXT NOT NULL,
-  start_ms INTEGER NOT NULL,
-  end_ms INTEGER NOT NULL,
-  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'done', 'error')),
-  error TEXT,
-  frame_count INTEGER NOT NULL DEFAULT 0,
-  model TEXT,
-  created_ms INTEGER NOT NULL,
-  updated_ms INTEGER NOT NULL
-) STRICT;
-CREATE INDEX IF NOT EXISTS idx_logbook_batches_day ON batches (day, start_ms);
-CREATE TABLE IF NOT EXISTS frames (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  captured_at_ms INTEGER NOT NULL,
-  day TEXT NOT NULL,
-  path TEXT NOT NULL,
-  screen_index INTEGER NOT NULL DEFAULT 0,
-  width INTEGER,
-  height INTEGER,
-  byte_size INTEGER NOT NULL DEFAULT 0,
-  content_hash TEXT NOT NULL,
-  idle INTEGER NOT NULL DEFAULT 0 CHECK (idle IN (0, 1)),
-  batch_id INTEGER REFERENCES batches(id) ON DELETE SET NULL
-) STRICT;
-CREATE INDEX IF NOT EXISTS idx_logbook_frames_day ON frames (day, captured_at_ms);
-CREATE INDEX IF NOT EXISTS idx_logbook_frames_captured_at ON frames (captured_at_ms);
-CREATE INDEX IF NOT EXISTS idx_logbook_frames_unbatched ON frames (batch_id) WHERE batch_id IS NULL;
-CREATE INDEX IF NOT EXISTS idx_logbook_frames_batch ON frames (batch_id, captured_at_ms) WHERE batch_id IS NOT NULL;
-CREATE TABLE IF NOT EXISTS observations (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  batch_id INTEGER NOT NULL REFERENCES batches(id) ON DELETE CASCADE,
-  day TEXT NOT NULL,
-  start_ms INTEGER NOT NULL,
-  end_ms INTEGER NOT NULL,
-  text TEXT NOT NULL
-) STRICT;
-CREATE INDEX IF NOT EXISTS idx_logbook_observations_day ON observations (day, start_ms);
-CREATE INDEX IF NOT EXISTS idx_logbook_observations_batch ON observations (batch_id);
-CREATE TABLE IF NOT EXISTS cards (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  day TEXT NOT NULL,
-  start_ms INTEGER NOT NULL,
-  end_ms INTEGER NOT NULL,
-  title TEXT NOT NULL,
-  summary TEXT NOT NULL,
-  detail TEXT NOT NULL DEFAULT '',
-  category TEXT NOT NULL DEFAULT 'other',
-  app_primary TEXT,
-  app_secondary TEXT,
-  distractions TEXT NOT NULL DEFAULT '[]',
-  keyframe_id INTEGER REFERENCES frames(id) ON DELETE SET NULL,
-  updated_ms INTEGER NOT NULL
-) STRICT;
-CREATE INDEX IF NOT EXISTS idx_logbook_cards_day ON cards (day, start_ms);
-CREATE INDEX IF NOT EXISTS idx_logbook_cards_keyframe ON cards (keyframe_id) WHERE keyframe_id IS NOT NULL;
-CREATE TABLE IF NOT EXISTS standups (
-  day TEXT PRIMARY KEY,
-  text TEXT NOT NULL,
-  updated_ms INTEGER NOT NULL
-) STRICT;
-`;
-
-type FrameRow = Omit<Selectable<LogbookDatabase["frames"]>, "content_hash" | "batch_id">;
-type BatchRow = Omit<Selectable<LogbookDatabase["batches"]>, "created_ms" | "updated_ms">;
-
-function toFrame(row: FrameRow): LogbookFrame {
-  return {
-    id: row.id,
-    capturedAtMs: row.captured_at_ms,
-    day: row.day,
-    path: row.path,
-    screenIndex: row.screen_index,
-    width: row.width ?? undefined,
-    height: row.height ?? undefined,
-    byteSize: row.byte_size,
-    idle: row.idle === 1,
-  };
-}
-
-function toBatch(row: BatchRow): LogbookBatch {
-  return {
-    id: row.id,
-    day: row.day,
-    startMs: row.start_ms,
-    endMs: row.end_ms,
-    status: row.status,
-    error: row.error ?? undefined,
-    frameCount: row.frame_count,
-    model: row.model ?? undefined,
-  };
-}
-
-function parseDistractions(raw: string): LogbookDistraction[] {
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-    return parsed.filter(
-      (entry): entry is LogbookDistraction =>
-        entry !== null &&
-        typeof entry === "object" &&
-        typeof (entry as LogbookDistraction).title === "string" &&
-        typeof (entry as LogbookDistraction).startMs === "number" &&
-        typeof (entry as LogbookDistraction).endMs === "number",
-    );
-  } catch {
-    return [];
-  }
-}
-
-function toCard(row: Selectable<LogbookDatabase["cards"]>): LogbookCard {
-  return {
-    id: row.id,
-    day: row.day,
-    startMs: row.start_ms,
-    endMs: row.end_ms,
-    title: row.title,
-    summary: row.summary,
-    detail: row.detail,
-    category: row.category,
-    appPrimary: row.app_primary ?? undefined,
-    appSecondary: row.app_secondary ?? undefined,
-    distractions: parseDistractions(row.distractions),
-    keyframeId: row.keyframe_id ?? undefined,
-  };
-}
-
-/** Formats an epoch-ms timestamp as a local-time YYYY-MM-DD day key. */
-export function dayKeyFor(ms: number): string {
-  const date = new Date(ms);
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const dayOfMonth = String(date.getDate()).padStart(2, "0");
-  return `${date.getFullYear()}-${month}-${dayOfMonth}`;
-}
+type CapturedFrame = Omit<LogbookFrameInput, "path" | "byteSize" | "contentHash" | "idle"> & {
+  buffer: Buffer;
+};
 
 export class LogbookStore {
-  private readonly db: Database;
-  private readonly query;
-  private readonly framesQuery;
-  private readonly batchesQuery;
-  private readonly cardsQuery;
-  private readonly walMaintenance: ReturnType<typeof configureSqliteConnectionPragmas>;
   readonly framesDir: string;
+  private closing: Promise<void> | undefined;
 
-  static async open(dataDir: string): Promise<LogbookStore> {
-    return new LogbookStore(dataDir);
+  static async open(dataDir: string, workerModuleUrl: URL): Promise<LogbookStore> {
+    if (!dataDir) {
+      throw new Error("Logbook data directory is required");
+    }
+    const root = await canonicalPathFromExistingAncestor(path.resolve(dataDir));
+    const worker = await openSqliteWorkerStore<LogbookOperations>({
+      moduleUrl: workerModuleUrl,
+      databasePath: path.join(dataDir, "logbook.sqlite"),
+      input: { dataDir: root },
+    });
+    return new LogbookStore(dataDir, worker, acquireLogbookFrameIo(root));
   }
 
-  private constructor(readonly dataDir: string) {
-    // Frames and the DB hold raw screen contents; keep everything owner-only
-    // even when the surrounding state dir is more permissive.
-    mkdirSync(dataDir, { recursive: true, mode: 0o700 });
-    chmodSync(dataDir, 0o700);
+  private constructor(
+    readonly dataDir: string,
+    private readonly worker: SqliteWorkerStore<LogbookOperations>,
+    private readonly frameIo: ReturnType<typeof acquireLogbookFrameIo>,
+  ) {
     this.framesDir = path.join(dataDir, "frames");
-    mkdirSync(this.framesDir, { recursive: true, mode: 0o700 });
-    chmodSync(this.framesDir, 0o700);
-    const dbPath = path.join(dataDir, "logbook.sqlite");
-    const db = openNodeSqliteDatabase(dbPath);
-    let walMaintenance: ReturnType<typeof configureSqliteConnectionPragmas> | undefined;
-    try {
-      // WAL/SHM sidecars inherit the main DB file's permissions.
-      chmodSync(dbPath, 0o600);
-      walMaintenance = configureSqliteConnectionPragmas(db, {
-        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
-        databaseLabel: "logbook",
-        databasePath: dbPath,
-        foreignKeys: true,
-        synchronous: "NORMAL",
-      });
-      const versionRow = db.prepare("PRAGMA user_version").get() as
-        | { user_version?: unknown }
-        | undefined;
-      const schemaVersion = Number(versionRow?.user_version ?? 0);
-      if (schemaVersion > LOGBOOK_SCHEMA_VERSION) {
-        throw new Error(
-          `Logbook database uses newer schema version ${schemaVersion}; this build supports ${LOGBOOK_SCHEMA_VERSION}`,
-        );
-      }
-      db.exec(SCHEMA);
-      if (schemaVersion < LOGBOOK_SCHEMA_VERSION) {
-        migrateSqliteSchemaToStrict(db, SCHEMA, { databaseLabel: dbPath });
-        db.exec(`PRAGMA user_version = ${LOGBOOK_SCHEMA_VERSION};`);
-      }
-    } catch (error) {
-      walMaintenance?.close();
-      db.close();
-      throw error;
-    }
-    if (!walMaintenance) {
-      db.close();
-      throw new Error("Logbook SQLite maintenance failed to initialize");
-    }
-    this.db = db;
-    this.walMaintenance = walMaintenance;
-    this.query = getNodeSqliteKysely<LogbookDatabase>(db);
-    // Timestamp ties follow insertion ids, matching existing SQLite reads.
-    this.framesQuery = this.query
-      .selectFrom("frames")
-      .select([
-        "id",
-        "captured_at_ms",
-        "day",
-        "path",
-        "screen_index",
-        "width",
-        "height",
-        "byte_size",
-        "idle",
-      ])
-      .orderBy("captured_at_ms", "asc")
-      .orderBy("id", "asc");
-    this.batchesQuery = this.query
-      .selectFrom("batches")
-      .select(["id", "day", "start_ms", "end_ms", "status", "error", "frame_count", "model"]);
-    this.cardsQuery = this.query.selectFrom("cards");
   }
 
-  async close(): Promise<void> {
-    this.walMaintenance.close();
-    this.db.close();
+  close(): Promise<void> {
+    this.closing ??= (async () => {
+      await this.frameIo.close();
+      await this.worker.close();
+    })();
+    return this.closing;
+  }
+
+  private execute<Key extends keyof LogbookOperations>(
+    type: Key,
+    input: LogbookOperations[Key]["input"],
+  ): Promise<LogbookOperations[Key]["output"]> {
+    if (this.closing) {
+      return Promise.reject(new SqliteWorkerError("Logbook store is closed", "closed"));
+    }
+    return this.worker.execute({ type, input });
   }
 
   frameFilePath(day: string, capturedAtMs: number): string {
     return path.join(this.framesDir, day, `${capturedAtMs}.jpg`);
   }
 
-  async insertFrame(params: {
-    capturedAtMs: number;
-    day: string;
-    path: string;
-    screenIndex: number;
-    width?: number;
-    height?: number;
-    byteSize: number;
-    contentHash: string;
-    idle: boolean;
-  }): Promise<number> {
-    const { compiled, bind } = compileSqliteQueryBindings<typeof params>((p) =>
-      this.query.insertInto("frames").values({
-        captured_at_ms: p((row) => row.capturedAtMs),
-        day: p((row) => row.day),
-        path: p((row) => row.path),
-        screen_index: p((row) => row.screenIndex),
-        width: p((row) => row.width ?? null),
-        height: p((row) => row.height ?? null),
-        byte_size: p((row) => row.byteSize),
-        content_hash: p((row) => row.contentHash),
-        idle: p((row) => (row.idle ? 1 : 0)),
-      }),
-    );
-    const result = this.db.prepare(compiled.sql).run(...bind(params));
-    return Number(result.lastInsertRowid);
+  insertFrame(params: LogbookFrameInput) {
+    return this.execute("insertFrame", params);
   }
 
-  async lastFrame(): Promise<{ capturedAtMs: number; contentHash: string } | null> {
-    const row = executeSqliteQueryTakeFirstSync(
-      this.db,
-      this.query
-        .selectFrom("frames")
-        .select(["captured_at_ms", "content_hash"])
-        .orderBy("captured_at_ms", "desc")
-        .orderBy("id", "desc")
-        .limit(1),
-    );
-    return row ? { capturedAtMs: row.captured_at_ms, contentHash: row.content_hash } : null;
+  lastFrame() {
+    return this.execute("lastFrame", undefined);
   }
 
-  async unbatchedActiveFrames(limit: number): Promise<LogbookFrame[]> {
-    return executeSqliteQuerySync(
-      this.db,
-      this.framesQuery.where("batch_id", "is", null).where("idle", "=", 0).limit(limit),
-    ).rows.map(toFrame);
+  unbatchedActiveFrames(limit: number) {
+    return this.execute("unbatchedActiveFrames", { limit });
   }
 
-  async countUnbatchedActiveFrames(): Promise<number> {
-    const row = executeSqliteQueryTakeFirstSync(
-      this.db,
-      this.query
-        .selectFrom("frames")
-        .select((eb) => eb.fn.countAll<number>().as("n"))
-        .where("batch_id", "is", null)
-        .where("idle", "=", 0),
-    );
-    return expectDefined(row, "Logbook unbatched frame count").n;
+  countUnbatchedActiveFrames() {
+    return this.execute("countUnbatchedActiveFrames", undefined);
   }
 
-  async frameById(id: number): Promise<LogbookFrame | null> {
-    const row = executeSqliteQueryTakeFirstSync(this.db, this.framesQuery.where("id", "=", id));
-    return row ? toFrame(row) : null;
+  frameById(id: number) {
+    return this.execute("frameById", { id });
   }
 
-  async framesInRange(startMs: number, endMs: number): Promise<LogbookFrame[]> {
-    return executeSqliteQuerySync(
-      this.db,
-      this.framesQuery.where("captured_at_ms", ">=", startMs).where("captured_at_ms", "<", endMs),
-    ).rows.map(toFrame);
+  framesInRange(startMs: number, endMs: number) {
+    return this.execute("framesInRange", { startMs, endMs });
   }
 
-  async createBatch(params: {
-    day: string;
-    startMs: number;
-    endMs: number;
-    frameIds: number[];
-  }): Promise<number> {
-    if (params.frameIds.length === 0) {
-      throw new Error("Logbook batch requires at least one frame");
-    }
-    const now = Date.now();
-    const batch = compileSqliteQueryBindings<typeof params>((p) =>
-      this.query.insertInto("batches").values({
-        day: p((row) => row.day),
-        start_ms: p((row) => row.startMs),
-        end_ms: p((row) => row.endMs),
-        status: "pending",
-        frame_count: p((row) => row.frameIds.length),
-        created_ms: now,
-        updated_ms: now,
-      }),
-    );
-    const insertBatch = this.db.prepare(batch.compiled.sql);
-    const assignment = compileSqliteQueryBindings<{ batchId: number; frameId: number }>((p) =>
-      this.query
-        .updateTable("frames")
-        .set({ batch_id: p((row) => row.batchId) })
-        .where(
-          "id",
-          "=",
-          p((row) => row.frameId),
-        )
-        .where("batch_id", "is", null),
-    );
-    const assignFrame = this.db.prepare(assignment.compiled.sql);
-    return runSqliteImmediateTransactionSync(
-      this.db,
-      () => {
-        const result = insertBatch.run(...batch.bind(params));
-        const batchId = Number(result.lastInsertRowid);
-        for (const frameId of params.frameIds) {
-          const assigned = assignFrame.run(...assignment.bind({ batchId, frameId }));
-          if (assigned.changes !== 1) {
-            throw new Error(`Logbook frame ${frameId} is missing or already batched`);
-          }
-        }
-        return batchId;
-      },
-      {
-        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
-        databaseLabel: "logbook",
-        operationLabel: "logbook.batch.create",
-      },
-    );
+  createBatch(params: LogbookBatchInput) {
+    return this.execute("createBatch", params);
   }
 
-  async setBatchStatus(
-    batchId: number,
-    status: LogbookBatchStatus,
-    error?: string,
-    model?: string,
-  ): Promise<void> {
-    const { compiled, bind } = compileSqliteQueryBindings<void>((p) =>
-      this.query
-        .updateTable("batches")
-        .set((eb) => ({
-          status,
-          error: error ?? null,
-          model: eb.fn.coalesce(eb.val(model ?? null), "model"),
-          updated_ms: p(() => Date.now()),
-        }))
-        .where("id", "=", batchId),
-    );
-    this.db.prepare(compiled.sql).run(...bind());
+  setBatchStatus(batchId: number, status: LogbookBatchStatus, error?: string, model?: string) {
+    return this.execute("setBatchStatus", { batchId, status, error, model });
   }
 
-  async latestBatch(): Promise<LogbookBatch | null> {
-    const row = executeSqliteQueryTakeFirstSync(
-      this.db,
-      this.batchesQuery.orderBy("id", "desc").limit(1),
-    );
-    return row ? toBatch(row) : null;
+  latestBatch() {
+    return this.execute("latestBatch", undefined);
   }
 
-  /** Requeues batches stuck in `running` after a crash so frames are not orphaned. */
-  async resetRunningBatches(): Promise<void> {
-    const { compiled, bind } = compileSqliteQueryBindings<void>((p) =>
-      this.query
-        .updateTable("batches")
-        .set({ status: "pending", updated_ms: p(() => Date.now()) })
-        .where("status", "=", "running"),
-    );
-    this.db.prepare(compiled.sql).run(...bind());
+  resetRunningBatches() {
+    return this.execute("resetRunningBatches", undefined);
   }
 
-  /** Requeues failed batches for an explicit user-driven retry (analyze now). */
-  async resetErrorBatches(): Promise<number> {
-    const { compiled, bind } = compileSqliteQueryBindings<void>((p) =>
-      this.query
-        .updateTable("batches")
-        .set({ status: "pending", error: null, updated_ms: p(() => Date.now()) })
-        .where("status", "=", "error"),
-    );
-    const result = this.db.prepare(compiled.sql).run(...bind());
-    return Number(result.changes);
+  resetErrorBatches() {
+    return this.execute("resetErrorBatches", undefined);
   }
 
-  async nextPendingBatch(): Promise<LogbookBatch | null> {
-    const row = executeSqliteQueryTakeFirstSync(
-      this.db,
-      this.batchesQuery
-        .where("status", "=", "pending")
-        .orderBy("start_ms", "asc")
-        .orderBy("id", "asc")
-        .limit(1),
-    );
-    return row ? toBatch(row) : null;
+  nextPendingBatch() {
+    return this.execute("nextPendingBatch", undefined);
   }
 
-  async batchFrames(batchId: number): Promise<LogbookFrame[]> {
-    return executeSqliteQuerySync(
-      this.db,
-      this.framesQuery.where("batch_id", "=", batchId),
-    ).rows.map(toFrame);
+  batchFrames(batchId: number) {
+    return this.execute("batchFrames", { batchId });
   }
 
-  /**
-   * Replaces a batch's observations atomically. Batch retries (analyze now
-   * after an error) rerun the vision stage, so appending would duplicate
-   * evidence into card synthesis, standups, and ask answers.
-   */
-  async replaceObservations(
-    batchId: number,
-    day: string,
-    segments: Array<{ startMs: number; endMs: number; text: string }>,
-  ): Promise<void> {
-    const deletion = compileSqliteQueryBindings<void>(() =>
-      this.query.deleteFrom("observations").where("batch_id", "=", batchId),
-    );
-    const deleteBatch = this.db.prepare(deletion.compiled.sql);
-    const observation = compileSqliteQueryBindings<(typeof segments)[number]>((p) =>
-      this.query.insertInto("observations").values({
-        batch_id: batchId,
-        day,
-        start_ms: p((row) => row.startMs),
-        end_ms: p((row) => row.endMs),
-        text: p((row) => row.text),
-      }),
-    );
-    const insert = this.db.prepare(observation.compiled.sql);
-    runSqliteImmediateTransactionSync(
-      this.db,
-      () => {
-        deleteBatch.run(...deletion.bind());
-        for (const segment of segments) {
-          insert.run(...observation.bind(segment));
-        }
-      },
-      {
-        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
-        databaseLabel: "logbook",
-        operationLabel: "logbook.observations.replace",
-      },
-    );
+  replaceObservations(batchId: number, day: string, segments: LogbookObservationInput[]) {
+    return this.execute("replaceObservations", { batchId, day, segments });
   }
 
-  async observationsInRange(
-    day: string,
-    startMs: number,
-    endMs: number,
-    tailLimit?: number,
-  ): Promise<LogbookObservation[]> {
-    const direction = tailLimit === undefined ? "asc" : "desc";
-    let query = this.query
-      .selectFrom("observations")
-      .selectAll()
-      .where("day", "=", day)
-      .where("end_ms", ">", startMs)
-      .where("start_ms", "<", endMs)
-      .orderBy("start_ms", direction)
-      .orderBy("id", direction);
-    if (tailLimit !== undefined) {
-      query = query.limit(tailLimit);
-    }
-    const rows = executeSqliteQuerySync(this.db, query).rows;
-    // Reverse the stable timestamp/id tail so prompts keep their original chronology.
-    if (tailLimit !== undefined) {
-      rows.reverse();
-    }
-    return rows.map((row) => ({
-      id: row.id,
-      batchId: row.batch_id,
-      day: row.day,
-      startMs: row.start_ms,
-      endMs: row.end_ms,
-      text: row.text,
-    }));
+  observationsInRange(day: string, startMs: number, endMs: number, tailLimit?: number) {
+    return this.execute("observationsInRange", { day, startMs, endMs, tailLimit });
   }
 
-  async cardsForDay(
-    day: string,
-    window?: { startMs: number; endMs: number },
-  ): Promise<LogbookCard[]> {
-    let query = this.cardsQuery
-      .selectAll()
-      .where("day", "=", day)
-      .orderBy("start_ms", "asc")
-      .orderBy("id", "asc");
-    if (window) {
-      query = query.where("end_ms", ">", window.startMs).where("start_ms", "<", window.endMs);
-    }
-    return executeSqliteQuerySync(this.db, query).rows.map(toCard);
+  cardsForDay(day: string, window?: { startMs: number; endMs: number }) {
+    return this.execute("cardsForDay", { day, window });
   }
 
-  async countCardsForDay(day: string): Promise<number> {
-    const row = executeSqliteQueryTakeFirstSync(
-      this.db,
-      this.cardsQuery.select((eb) => eb.fn.countAll<number>().as("count")).where("day", "=", day),
-    );
-    return expectDefined(row, "Logbook card count").count;
+  countCardsForDay(day: string) {
+    return this.execute("countCardsForDay", { day });
   }
 
-  /**
-   * Replaces cards overlapping [startMs, endMs) for a day in one transaction.
-   * The analysis lookback treats recent cards as a revisable draft, so partial
-   * writes here would surface as duplicated or missing timeline segments.
-   */
-  async replaceCardsInWindow(
-    day: string,
-    startMs: number,
-    endMs: number,
-    drafts: LogbookCardDraft[],
-  ): Promise<void> {
-    const now = Date.now();
-    const deletion = compileSqliteQueryBindings<void>(() =>
-      this.query
-        .deleteFrom("cards")
-        .where("day", "=", day)
-        .where("end_ms", ">", startMs)
-        .where("start_ms", "<", endMs),
-    );
-    const deleteWindow = this.db.prepare(deletion.compiled.sql);
-    const card = compileSqliteQueryBindings<LogbookCardDraft>((p) =>
-      this.query.insertInto("cards").values({
-        day: p((row) => row.day),
-        start_ms: p((row) => row.startMs),
-        end_ms: p((row) => row.endMs),
-        title: p((row) => row.title),
-        summary: p((row) => row.summary),
-        detail: p((row) => row.detail),
-        category: p((row) => row.category),
-        app_primary: p((row) => row.appPrimary ?? null),
-        app_secondary: p((row) => row.appSecondary ?? null),
-        distractions: p((row) => JSON.stringify(row.distractions)),
-        keyframe_id: p((row) => row.keyframeId ?? null),
-        updated_ms: now,
-      }),
-    );
-    const insert = this.db.prepare(card.compiled.sql);
-    runSqliteImmediateTransactionSync(
-      this.db,
-      () => {
-        deleteWindow.run(...deletion.bind());
-        for (const draft of drafts) {
-          insert.run(...card.bind(draft));
-        }
-      },
-      {
-        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
-        databaseLabel: "logbook",
-        operationLabel: "logbook.cards.replace",
-      },
-    );
+  replaceCardsInWindow(day: string, startMs: number, endMs: number, drafts: LogbookCardDraft[]) {
+    return this.execute("replaceCardsInWindow", { day, startMs, endMs, drafts });
   }
 
-  async listDays(): Promise<
-    Array<{ day: string; cards: number; firstMs: number; lastMs: number }>
-  > {
-    return executeSqliteQuerySync(
-      this.db,
-      this.cardsQuery
-        .select((eb) => [
-          "day",
-          eb.fn.countAll<number>().as("cards"),
-          eb.fn.min<number>("start_ms").as("first_ms"),
-          eb.fn.max<number>("end_ms").as("last_ms"),
-        ])
-        .groupBy("day")
-        .orderBy("day", "desc"),
-    ).rows.map((row) => ({
-      day: row.day,
-      cards: row.cards,
-      firstMs: row.first_ms,
-      lastMs: row.last_ms,
-    }));
+  listDays() {
+    return this.execute("listDays", undefined);
   }
 
-  async timelineForDay(
-    day: string,
-  ): Promise<{ day: string; cards: LogbookCard[]; stats: LogbookDayStats }> {
-    const cards = await this.cardsForDay(day);
-    const categories = new Map<string, number>();
-    const apps = new Map<string, number>();
-    let trackedMs = 0;
-    let distractionMs = 0;
-    for (const card of cards) {
-      const duration = Math.max(0, card.endMs - card.startMs);
-      trackedMs += duration;
-      categories.set(card.category, (categories.get(card.category) ?? 0) + duration);
-      if (card.appPrimary) {
-        apps.set(card.appPrimary, (apps.get(card.appPrimary) ?? 0) + duration);
+  timelineForDay(day: string) {
+    return this.execute("timelineForDay", { day });
+  }
+
+  getStandup(day: string) {
+    return this.execute("getStandup", { day });
+  }
+
+  saveStandup(day: string, text: string) {
+    return this.execute("saveStandup", { day, text });
+  }
+
+  captureFrame(params: CapturedFrame): Promise<number> {
+    // Snapshot before admission so a queued caller cannot mutate the capture bytes.
+    const buffer = Buffer.from(params.buffer);
+    const input = { ...params, buffer };
+    return this.frameIo.run(async () => {
+      const contentHash = createHash("sha256").update(buffer).digest("hex");
+      const previous = await this.worker.execute({ type: "lastFrame", input: undefined });
+      const filePath = this.frameFilePath(input.day, input.capturedAtMs);
+      await mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+      await writeFile(filePath, buffer, { mode: 0o600 });
+      return await this.worker.execute({
+        type: "insertFrame",
+        input: {
+          capturedAtMs: input.capturedAtMs,
+          day: input.day,
+          path: filePath,
+          screenIndex: input.screenIndex,
+          width: input.width,
+          height: input.height,
+          byteSize: buffer.byteLength,
+          contentHash,
+          idle: previous?.contentHash === contentHash,
+        },
+      });
+    });
+  }
+
+  framePayload(id: number) {
+    return this.frameIo.run(async () => {
+      const frame = await this.worker.execute({ type: "frameById", input: { id } });
+      if (!frame) {
+        return null;
       }
-      for (const distraction of card.distractions) {
-        distractionMs += Math.max(0, distraction.endMs - distraction.startMs);
+      return {
+        frameId: frame.id,
+        capturedAtMs: frame.capturedAtMs,
+        width: frame.width,
+        height: frame.height,
+        format: "jpeg" as const,
+        base64: (await readFile(frame.path)).toString("base64"),
+      };
+    });
+  }
+
+  batchImages(batchId: number) {
+    return this.frameIo.run(async () => {
+      const frames = await this.worker.execute({ type: "batchFrames", input: { batchId } });
+      const images = [];
+      for (const frame of sampleFrames(frames, MAX_FRAMES_PER_CALL)) {
+        images.push({ frame, buffer: await readFile(frame.path) });
       }
-    }
-    const byMsDesc = (a: { ms: number }, b: { ms: number }) => b.ms - a.ms;
-    return {
-      day,
-      cards,
-      stats: {
-        trackedMs,
-        distractionMs,
-        categories: [...categories.entries()]
-          .map(([category, ms]) => ({ category, ms }))
-          .toSorted(byMsDesc),
-        apps: [...apps.entries()].map(([domain, ms]) => ({ domain, ms })).toSorted(byMsDesc),
-      },
-    };
+      return images;
+    });
   }
 
-  async getStandup(day: string): Promise<{ day: string; text: string; updatedMs: number } | null> {
-    const row = executeSqliteQueryTakeFirstSync(
-      this.db,
-      this.query.selectFrom("standups").selectAll().where("day", "=", day),
+  pruneFrames(olderThanMs: number) {
+    return this.frameIo.run(() =>
+      this.worker.execute({ type: "pruneFrames", input: { olderThanMs } }),
     );
-    return row ? { day: row.day, text: row.text, updatedMs: row.updated_ms } : null;
-  }
-
-  async saveStandup(day: string, text: string): Promise<void> {
-    const { compiled, bind } = compileSqliteQueryBindings<void>((p) =>
-      this.query
-        .insertInto("standups")
-        .values({ day, text, updated_ms: p(() => Date.now()) })
-        .onConflict((conflict) =>
-          conflict.column("day").doUpdateSet((eb) => ({
-            text: eb.ref("excluded.text"),
-            updated_ms: eb.ref("excluded.updated_ms"),
-          })),
-        ),
-    );
-    this.db.prepare(compiled.sql).run(...bind());
-  }
-
-  /** Deletes frame rows and files older than the retention window. */
-  async pruneFrames(olderThanMs: number): Promise<number> {
-    const rows = executeSqliteQuerySync(
-      this.db,
-      this.query
-        .selectFrom("frames")
-        .select(["id", "path", "day"])
-        .where("captured_at_ms", "<", olderThanMs),
-    ).rows;
-    if (rows.length === 0) {
-      return 0;
-    }
-    const days = new Set<string>();
-    for (const row of rows) {
-      // Keep metadata until every file operation succeeds. A later retry can
-      // then find rows whose earlier files were already removed with force.
-      rmSync(row.path, { force: true });
-      days.add(row.day);
-    }
-    const currentPath = compileSqliteQueryBindings<number>((p) =>
-      this.query
-        .selectFrom("frames")
-        .select("path")
-        .where(
-          "id",
-          "=",
-          p((id) => id),
-        ),
-    );
-    const selectCurrent = this.db.prepare(currentPath.compiled.sql);
-    const deletion = compileSqliteQueryBindings<number>((p) =>
-      this.query.deleteFrom("frames").where(
-        "id",
-        "=",
-        p((id) => id),
-      ),
-    );
-    const deleteById = this.db.prepare(deletion.compiled.sql);
-    const deleted = runSqliteImmediateTransactionSync(
-      this.db,
-      () => {
-        let count = 0;
-        for (const row of rows) {
-          const current = selectCurrent.get(...currentPath.bind(row.id));
-          if (!current) {
-            continue;
-          }
-          if (current.path !== row.path) {
-            throw new Error(`Logbook frame ${row.id} changed path while pruning`);
-          }
-          // keyframe_id uses ON DELETE SET NULL, so the same commit cannot
-          // leave surviving cards pointed at removed frame rows.
-          count += Number(deleteById.run(...deletion.bind(row.id)).changes);
-        }
-        return count;
-      },
-      {
-        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
-        databaseLabel: "logbook",
-        operationLabel: "logbook.frames.prune",
-      },
-    );
-    for (const day of days) {
-      // Best-effort: removes now-empty day directories, keeps non-empty ones.
-      try {
-        rmdirSync(path.join(this.framesDir, day));
-      } catch {}
-    }
-    return deleted;
   }
 }

--- a/extensions/logbook/src/store.ts
+++ b/extensions/logbook/src/store.ts
@@ -136,8 +136,20 @@ export class LogbookStore {
     return this.execute("countCardsForDay", { day });
   }
 
-  replaceCardsInWindow(day: string, startMs: number, endMs: number, drafts: LogbookCardDraft[]) {
-    return this.execute("replaceCardsInWindow", { day, startMs, endMs, drafts });
+  replaceCardsInWindow(
+    day: string,
+    startMs: number,
+    endMs: number,
+    drafts: LogbookCardDraft[],
+    options?: { selectKeyframes: boolean },
+  ) {
+    return this.execute("replaceCardsInWindow", {
+      day,
+      startMs,
+      endMs,
+      drafts,
+      selectKeyframes: options?.selectKeyframes,
+    });
   }
 
   listDays() {

--- a/extensions/logbook/src/store.worker.ts
+++ b/extensions/logbook/src/store.worker.ts
@@ -15,6 +15,7 @@ import {
   runSqliteImmediateTransactionSync,
   type SqliteWorkerBackend,
 } from "openclaw/plugin-sdk/sqlite-runtime";
+import { pickKeyframeId } from "./analyze.js";
 import type {
   LogbookBatchInput,
   LogbookDay,
@@ -484,14 +485,17 @@ class LogbookDatabaseStore {
     startMs: number,
     endMs: number,
     drafts: LogbookCardDraft[],
+    selectKeyframes = false,
   ): void {
     const now = Date.now();
     runSqliteImmediateTransactionSync(
       this.db,
       () => {
+        const frames = selectKeyframes ? this.framesInRange(startMs, endMs) : undefined;
         this.statements.deleteCards({ day, startMs, endMs });
         for (const draft of drafts) {
-          this.statements.insertCard({ ...draft, now });
+          const keyframeId = frames ? pickKeyframeId(draft, frames) : draft.keyframeId;
+          this.statements.insertCard({ ...draft, keyframeId, now });
         }
       },
       {
@@ -679,6 +683,7 @@ export function createSqliteWorkerBackend(
             command.input.startMs,
             command.input.endMs,
             command.input.drafts,
+            command.input.selectKeyframes,
           );
         case "listDays":
           return store.listDays();

--- a/extensions/logbook/src/store.worker.ts
+++ b/extensions/logbook/src/store.worker.ts
@@ -1,0 +1,697 @@
+import { chmodSync, mkdirSync, rmdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import {
+  configureSqliteConnectionPragmas,
+  migrateSqliteSchemaToStrict,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  enableNodeSqliteKyselyStatementCache,
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+  openNodeSqliteDatabase,
+  prepareSqliteQuerySync,
+  runSqliteImmediateTransactionSync,
+  type SqliteWorkerBackend,
+} from "openclaw/plugin-sdk/sqlite-runtime";
+import type {
+  LogbookBatchInput,
+  LogbookDay,
+  LogbookFrameInput,
+  LogbookObservationInput,
+  LogbookOperations,
+  LogbookStandup,
+  LogbookTimeline,
+} from "./store-contract.js";
+import {
+  LOGBOOK_SCHEMA_VERSION,
+  SCHEMA,
+  toBatch,
+  toCard,
+  toFrame,
+  type LogbookDatabase,
+} from "./store-schema.js";
+import type {
+  LogbookBatch,
+  LogbookBatchStatus,
+  LogbookCard,
+  LogbookCardDraft,
+  LogbookFrame,
+  LogbookObservation,
+} from "./types.js";
+
+type Database = import("node:sqlite").DatabaseSync;
+
+const LOGBOOK_SQLITE_BUSY_TIMEOUT_MS = 5_000;
+class LogbookDatabaseStore {
+  private readonly db: Database;
+  private readonly query;
+  private readonly framesQuery;
+  private readonly batchesQuery;
+  private readonly cardsQuery;
+  private readonly statements;
+  private readonly walMaintenance: ReturnType<typeof configureSqliteConnectionPragmas>;
+  readonly framesDir: string;
+
+  constructor(dataDir: string, dbPath: string) {
+    // Screen captures and their database remain owner-only even in a permissive state directory.
+    mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+    chmodSync(dataDir, 0o700);
+    this.framesDir = path.join(dataDir, "frames");
+    mkdirSync(this.framesDir, { recursive: true, mode: 0o700 });
+    chmodSync(this.framesDir, 0o700);
+    const db = openNodeSqliteDatabase(dbPath);
+    let walMaintenance: ReturnType<typeof configureSqliteConnectionPragmas> | undefined;
+    try {
+      enableNodeSqliteKyselyStatementCache(db);
+      // WAL/SHM sidecars inherit the main DB file's permissions.
+      chmodSync(dbPath, 0o600);
+      walMaintenance = configureSqliteConnectionPragmas(db, {
+        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
+        databaseLabel: "logbook",
+        databasePath: dbPath,
+        foreignKeys: true,
+        synchronous: "NORMAL",
+      });
+      const versionRow = db.prepare("PRAGMA user_version").get();
+      const schemaVersion = Number(versionRow?.user_version ?? 0);
+      if (schemaVersion > LOGBOOK_SCHEMA_VERSION) {
+        throw new Error(
+          `Logbook database uses newer schema version ${schemaVersion}; this build supports ${LOGBOOK_SCHEMA_VERSION}`,
+        );
+      }
+      db.exec(SCHEMA);
+      if (schemaVersion < LOGBOOK_SCHEMA_VERSION) {
+        migrateSqliteSchemaToStrict(db, SCHEMA, { databaseLabel: dbPath });
+        db.exec(`PRAGMA user_version = ${LOGBOOK_SCHEMA_VERSION};`);
+      }
+      this.db = db;
+      this.walMaintenance = walMaintenance;
+      this.query = getNodeSqliteKysely<LogbookDatabase>(db);
+      // Timestamp ties follow insertion ids, matching existing SQLite reads.
+      this.framesQuery = this.query
+        .selectFrom("frames")
+        .select([
+          "id",
+          "captured_at_ms",
+          "day",
+          "path",
+          "screen_index",
+          "width",
+          "height",
+          "byte_size",
+          "idle",
+        ])
+        .orderBy("captured_at_ms", "asc")
+        .orderBy("id", "asc");
+      this.batchesQuery = this.query
+        .selectFrom("batches")
+        .select(["id", "day", "start_ms", "end_ms", "status", "error", "frame_count", "model"]);
+      this.cardsQuery = this.query.selectFrom("cards");
+      this.statements = {
+        insertFrame: prepareSqliteQuerySync<LogbookFrameInput>(db, (p) =>
+          this.query.insertInto("frames").values({
+            captured_at_ms: p((row) => row.capturedAtMs),
+            day: p((row) => row.day),
+            path: p((row) => row.path),
+            screen_index: p((row) => row.screenIndex),
+            width: p((row) => row.width ?? null),
+            height: p((row) => row.height ?? null),
+            byte_size: p((row) => row.byteSize),
+            content_hash: p((row) => row.contentHash),
+            idle: p((row) => (row.idle ? 1 : 0)),
+          }),
+        ),
+        insertBatch: prepareSqliteQuerySync<LogbookBatchInput & { now: number }>(db, (p) =>
+          this.query.insertInto("batches").values({
+            day: p((row) => row.day),
+            start_ms: p((row) => row.startMs),
+            end_ms: p((row) => row.endMs),
+            status: "pending",
+            frame_count: p((row) => row.frameIds.length),
+            created_ms: p((row) => row.now),
+            updated_ms: p((row) => row.now),
+          }),
+        ),
+        assignFrame: prepareSqliteQuerySync<{ batchId: number; frameId: number }>(db, (p) =>
+          this.query
+            .updateTable("frames")
+            .set({ batch_id: p((row) => row.batchId) })
+            .where(
+              "id",
+              "=",
+              p((row) => row.frameId),
+            )
+            .where("batch_id", "is", null),
+        ),
+        setBatchStatus: prepareSqliteQuerySync<
+          LogbookOperations["setBatchStatus"]["input"] & { now: number }
+        >(db, (p) =>
+          this.query
+            .updateTable("batches")
+            .set((eb) => ({
+              status: p((row) => row.status),
+              error: p((row) => row.error ?? null),
+              model: eb.fn.coalesce(
+                p((row) => row.model ?? null),
+                "model",
+              ),
+              updated_ms: p((row) => row.now),
+            }))
+            .where(
+              "id",
+              "=",
+              p((row) => row.batchId),
+            ),
+        ),
+        resetRunningBatches: prepareSqliteQuerySync<number>(db, (p) =>
+          this.query
+            .updateTable("batches")
+            .set({ status: "pending", updated_ms: p((now) => now) })
+            .where("status", "=", "running"),
+        ),
+        resetErrorBatches: prepareSqliteQuerySync<number>(db, (p) =>
+          this.query
+            .updateTable("batches")
+            .set({ status: "pending", error: null, updated_ms: p((now) => now) })
+            .where("status", "=", "error"),
+        ),
+        deleteObservations: prepareSqliteQuerySync<number>(db, (p) =>
+          this.query.deleteFrom("observations").where(
+            "batch_id",
+            "=",
+            p((batchId) => batchId),
+          ),
+        ),
+        insertObservation: prepareSqliteQuerySync<
+          LogbookObservationInput & { batchId: number; day: string }
+        >(db, (p) =>
+          this.query.insertInto("observations").values({
+            batch_id: p((row) => row.batchId),
+            day: p((row) => row.day),
+            start_ms: p((row) => row.startMs),
+            end_ms: p((row) => row.endMs),
+            text: p((row) => row.text),
+          }),
+        ),
+        deleteCards: prepareSqliteQuerySync<{ day: string; startMs: number; endMs: number }>(
+          db,
+          (p) =>
+            this.query
+              .deleteFrom("cards")
+              .where(
+                "day",
+                "=",
+                p((window) => window.day),
+              )
+              .where(
+                "end_ms",
+                ">",
+                p((window) => window.startMs),
+              )
+              .where(
+                "start_ms",
+                "<",
+                p((window) => window.endMs),
+              ),
+        ),
+        insertCard: prepareSqliteQuerySync<LogbookCardDraft & { now: number }>(db, (p) =>
+          this.query.insertInto("cards").values({
+            day: p((row) => row.day),
+            start_ms: p((row) => row.startMs),
+            end_ms: p((row) => row.endMs),
+            title: p((row) => row.title),
+            summary: p((row) => row.summary),
+            detail: p((row) => row.detail),
+            category: p((row) => row.category),
+            app_primary: p((row) => row.appPrimary ?? null),
+            app_secondary: p((row) => row.appSecondary ?? null),
+            distractions: p((row) => JSON.stringify(row.distractions)),
+            keyframe_id: p((row) => row.keyframeId ?? null),
+            updated_ms: p((row) => row.now),
+          }),
+        ),
+        saveStandup: prepareSqliteQuerySync<{ day: string; text: string; now: number }>(db, (p) =>
+          this.query
+            .insertInto("standups")
+            .values({
+              day: p((row) => row.day),
+              text: p((row) => row.text),
+              updated_ms: p((row) => row.now),
+            })
+            .onConflict((conflict) =>
+              conflict.column("day").doUpdateSet((eb) => ({
+                text: eb.ref("excluded.text"),
+                updated_ms: eb.ref("excluded.updated_ms"),
+              })),
+            ),
+        ),
+        currentFramePath: prepareSqliteQuerySync<number, { path: string }>(db, (p) =>
+          this.query
+            .selectFrom("frames")
+            .select("path")
+            .where(
+              "id",
+              "=",
+              p((id) => id),
+            ),
+        ),
+        deleteFrame: prepareSqliteQuerySync<number>(db, (p) =>
+          this.query.deleteFrom("frames").where(
+            "id",
+            "=",
+            p((id) => id),
+          ),
+        ),
+      };
+    } catch (error) {
+      // Preserve the opening failure while attempting both resource cleanups.
+      try {
+        walMaintenance?.close();
+      } catch {}
+      try {
+        db.close();
+      } catch {}
+      throw error;
+    }
+  }
+
+  close(): void {
+    try {
+      this.walMaintenance.close();
+    } finally {
+      this.db.close();
+    }
+  }
+
+  insertFrame(params: LogbookFrameInput): number {
+    const result = this.statements.insertFrame(params);
+    return Number(expectDefined(result.insertId, "Logbook inserted frame ID"));
+  }
+
+  lastFrame(): { capturedAtMs: number; contentHash: string } | null {
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.query
+        .selectFrom("frames")
+        .select(["captured_at_ms", "content_hash"])
+        .orderBy("captured_at_ms", "desc")
+        .orderBy("id", "desc")
+        .limit(1),
+    );
+    return row ? { capturedAtMs: row.captured_at_ms, contentHash: row.content_hash } : null;
+  }
+
+  unbatchedActiveFrames(limit: number): LogbookFrame[] {
+    return executeSqliteQuerySync(
+      this.db,
+      this.framesQuery.where("batch_id", "is", null).where("idle", "=", 0).limit(limit),
+    ).rows.map(toFrame);
+  }
+
+  countUnbatchedActiveFrames(): number {
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.query
+        .selectFrom("frames")
+        .select((eb) => eb.fn.countAll<number>().as("n"))
+        .where("batch_id", "is", null)
+        .where("idle", "=", 0),
+    );
+    return expectDefined(row, "Logbook unbatched frame count").n;
+  }
+
+  frameById(id: number): LogbookFrame | null {
+    const row = executeSqliteQueryTakeFirstSync(this.db, this.framesQuery.where("id", "=", id));
+    return row ? toFrame(row) : null;
+  }
+
+  framesInRange(startMs: number, endMs: number): LogbookFrame[] {
+    return executeSqliteQuerySync(
+      this.db,
+      this.framesQuery.where("captured_at_ms", ">=", startMs).where("captured_at_ms", "<", endMs),
+    ).rows.map(toFrame);
+  }
+
+  createBatch(params: LogbookBatchInput): number {
+    if (params.frameIds.length === 0) {
+      throw new Error("Logbook batch requires at least one frame");
+    }
+    const now = Date.now();
+    return runSqliteImmediateTransactionSync(
+      this.db,
+      () => {
+        const result = this.statements.insertBatch({ ...params, now });
+        const batchId = Number(expectDefined(result.insertId, "Logbook inserted batch ID"));
+        for (const frameId of params.frameIds) {
+          const assigned = this.statements.assignFrame({ batchId, frameId });
+          if (expectDefined(assigned.numAffectedRows, "Logbook assigned frame count") !== 1n) {
+            throw new Error(`Logbook frame ${frameId} is missing or already batched`);
+          }
+        }
+        return batchId;
+      },
+      {
+        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
+        databaseLabel: "logbook",
+        operationLabel: "logbook.batch.create",
+      },
+    );
+  }
+
+  setBatchStatus(
+    batchId: number,
+    status: LogbookBatchStatus,
+    error?: string,
+    model?: string,
+  ): void {
+    this.statements.setBatchStatus({ batchId, status, error, model, now: Date.now() });
+  }
+
+  latestBatch(): LogbookBatch | null {
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.batchesQuery.orderBy("id", "desc").limit(1),
+    );
+    return row ? toBatch(row) : null;
+  }
+
+  /** Requeues batches stuck in `running` after a crash so frames are not orphaned. */
+  resetRunningBatches(): void {
+    this.statements.resetRunningBatches(Date.now());
+  }
+
+  /** Requeues failed batches for an explicit user-driven retry (analyze now). */
+  resetErrorBatches(): number {
+    const result = this.statements.resetErrorBatches(Date.now());
+    return Number(expectDefined(result.numAffectedRows, "Logbook reset batch count"));
+  }
+
+  nextPendingBatch(): LogbookBatch | null {
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.batchesQuery
+        .where("status", "=", "pending")
+        .orderBy("start_ms", "asc")
+        .orderBy("id", "asc")
+        .limit(1),
+    );
+    return row ? toBatch(row) : null;
+  }
+
+  batchFrames(batchId: number): LogbookFrame[] {
+    return executeSqliteQuerySync(
+      this.db,
+      this.framesQuery.where("batch_id", "=", batchId),
+    ).rows.map(toFrame);
+  }
+
+  // Replace batch evidence atomically so manual retries cannot duplicate it.
+  replaceObservations(batchId: number, day: string, segments: LogbookObservationInput[]): void {
+    runSqliteImmediateTransactionSync(
+      this.db,
+      () => {
+        this.statements.deleteObservations(batchId);
+        for (const segment of segments) {
+          this.statements.insertObservation({ ...segment, batchId, day });
+        }
+      },
+      {
+        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
+        databaseLabel: "logbook",
+        operationLabel: "logbook.observations.replace",
+      },
+    );
+  }
+
+  observationsInRange(
+    day: string,
+    startMs: number,
+    endMs: number,
+    tailLimit?: number,
+  ): LogbookObservation[] {
+    const direction = tailLimit === undefined ? "asc" : "desc";
+    let query = this.query
+      .selectFrom("observations")
+      .selectAll()
+      .where("day", "=", day)
+      .where("end_ms", ">", startMs)
+      .where("start_ms", "<", endMs)
+      .orderBy("start_ms", direction)
+      .orderBy("id", direction);
+    if (tailLimit !== undefined) {
+      query = query.limit(tailLimit);
+    }
+    const rows = executeSqliteQuerySync(this.db, query).rows;
+    // Reverse the stable timestamp/id tail so prompts keep their original chronology.
+    if (tailLimit !== undefined) {
+      rows.reverse();
+    }
+    return rows.map((row) => ({
+      id: row.id,
+      batchId: row.batch_id,
+      day: row.day,
+      startMs: row.start_ms,
+      endMs: row.end_ms,
+      text: row.text,
+    }));
+  }
+
+  cardsForDay(day: string, window?: { startMs: number; endMs: number }): LogbookCard[] {
+    let query = this.cardsQuery
+      .selectAll()
+      .where("day", "=", day)
+      .orderBy("start_ms", "asc")
+      .orderBy("id", "asc");
+    if (window) {
+      query = query.where("end_ms", ">", window.startMs).where("start_ms", "<", window.endMs);
+    }
+    return executeSqliteQuerySync(this.db, query).rows.map(toCard);
+  }
+
+  countCardsForDay(day: string): number {
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.cardsQuery.select((eb) => eb.fn.countAll<number>().as("count")).where("day", "=", day),
+    );
+    return expectDefined(row, "Logbook card count").count;
+  }
+
+  // Replace the overlapping window atomically so revision cannot expose partial timeline spans.
+  replaceCardsInWindow(
+    day: string,
+    startMs: number,
+    endMs: number,
+    drafts: LogbookCardDraft[],
+  ): void {
+    const now = Date.now();
+    runSqliteImmediateTransactionSync(
+      this.db,
+      () => {
+        this.statements.deleteCards({ day, startMs, endMs });
+        for (const draft of drafts) {
+          this.statements.insertCard({ ...draft, now });
+        }
+      },
+      {
+        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
+        databaseLabel: "logbook",
+        operationLabel: "logbook.cards.replace",
+      },
+    );
+  }
+
+  listDays(): LogbookDay[] {
+    return executeSqliteQuerySync(
+      this.db,
+      this.cardsQuery
+        .select((eb) => [
+          "day",
+          eb.fn.countAll<number>().as("cards"),
+          eb.fn.min<number>("start_ms").as("first_ms"),
+          eb.fn.max<number>("end_ms").as("last_ms"),
+        ])
+        .groupBy("day")
+        .orderBy("day", "desc"),
+    ).rows.map((row) => ({
+      day: row.day,
+      cards: row.cards,
+      firstMs: row.first_ms,
+      lastMs: row.last_ms,
+    }));
+  }
+
+  timelineForDay(day: string): LogbookTimeline {
+    const cards = this.cardsForDay(day);
+    const categories = new Map<string, number>();
+    const apps = new Map<string, number>();
+    let trackedMs = 0;
+    let distractionMs = 0;
+    for (const card of cards) {
+      const duration = Math.max(0, card.endMs - card.startMs);
+      trackedMs += duration;
+      categories.set(card.category, (categories.get(card.category) ?? 0) + duration);
+      if (card.appPrimary) {
+        apps.set(card.appPrimary, (apps.get(card.appPrimary) ?? 0) + duration);
+      }
+      for (const distraction of card.distractions) {
+        distractionMs += Math.max(0, distraction.endMs - distraction.startMs);
+      }
+    }
+    const byMsDesc = (a: { ms: number }, b: { ms: number }) => b.ms - a.ms;
+    return {
+      day,
+      cards,
+      stats: {
+        trackedMs,
+        distractionMs,
+        categories: [...categories.entries()]
+          .map(([category, ms]) => ({ category, ms }))
+          .toSorted(byMsDesc),
+        apps: [...apps.entries()].map(([domain, ms]) => ({ domain, ms })).toSorted(byMsDesc),
+      },
+    };
+  }
+
+  getStandup(day: string): LogbookStandup | null {
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.query.selectFrom("standups").selectAll().where("day", "=", day),
+    );
+    return row ? { day: row.day, text: row.text, updatedMs: row.updated_ms } : null;
+  }
+
+  saveStandup(day: string, text: string): void {
+    this.statements.saveStandup({ day, text, now: Date.now() });
+  }
+
+  pruneFrames(olderThanMs: number): number {
+    const rows = executeSqliteQuerySync(
+      this.db,
+      this.query
+        .selectFrom("frames")
+        .select(["id", "path", "day"])
+        .where("captured_at_ms", "<", olderThanMs),
+    ).rows;
+    if (rows.length === 0) {
+      return 0;
+    }
+    const days = new Set<string>();
+    for (const row of rows) {
+      // Keep metadata until every file is removed; force makes interrupted passes retryable.
+      rmSync(row.path, { force: true });
+      days.add(row.day);
+    }
+    const deleted = runSqliteImmediateTransactionSync(
+      this.db,
+      () => {
+        let count = 0;
+        for (const row of rows) {
+          const current = this.statements.currentFramePath(row.id).rows[0];
+          if (!current) {
+            continue;
+          }
+          if (current.path !== row.path) {
+            throw new Error(`Logbook frame ${row.id} changed path while pruning`);
+          }
+          // ON DELETE SET NULL clears surviving cards' keyframes in the same commit.
+          const result = this.statements.deleteFrame(row.id);
+          count += Number(expectDefined(result.numAffectedRows, "Logbook pruned frame count"));
+        }
+        return count;
+      },
+      {
+        busyTimeoutMs: LOGBOOK_SQLITE_BUSY_TIMEOUT_MS,
+        databaseLabel: "logbook",
+        operationLabel: "logbook.frames.prune",
+      },
+    );
+    for (const day of days) {
+      // Best-effort: removes now-empty day directories, keeps non-empty ones.
+      try {
+        rmdirSync(path.join(this.framesDir, day));
+      } catch {}
+    }
+    return deleted;
+  }
+}
+
+export function createSqliteWorkerBackend(
+  input: { dataDir: string },
+  context: { databasePath: string },
+): SqliteWorkerBackend<LogbookOperations> {
+  const store = new LogbookDatabaseStore(input.dataDir, context.databasePath);
+  return {
+    execute(command) {
+      switch (command.type) {
+        case "insertFrame":
+          return store.insertFrame(command.input);
+        case "lastFrame":
+          return store.lastFrame();
+        case "unbatchedActiveFrames":
+          return store.unbatchedActiveFrames(command.input.limit);
+        case "countUnbatchedActiveFrames":
+          return store.countUnbatchedActiveFrames();
+        case "frameById":
+          return store.frameById(command.input.id);
+        case "framesInRange":
+          return store.framesInRange(command.input.startMs, command.input.endMs);
+        case "createBatch":
+          return store.createBatch(command.input);
+        case "setBatchStatus":
+          return store.setBatchStatus(
+            command.input.batchId,
+            command.input.status,
+            command.input.error,
+            command.input.model,
+          );
+        case "latestBatch":
+          return store.latestBatch();
+        case "resetRunningBatches":
+          return store.resetRunningBatches();
+        case "resetErrorBatches":
+          return store.resetErrorBatches();
+        case "nextPendingBatch":
+          return store.nextPendingBatch();
+        case "batchFrames":
+          return store.batchFrames(command.input.batchId);
+        case "replaceObservations":
+          return store.replaceObservations(
+            command.input.batchId,
+            command.input.day,
+            command.input.segments,
+          );
+        case "observationsInRange":
+          return store.observationsInRange(
+            command.input.day,
+            command.input.startMs,
+            command.input.endMs,
+            command.input.tailLimit,
+          );
+        case "cardsForDay":
+          return store.cardsForDay(command.input.day, command.input.window);
+        case "countCardsForDay":
+          return store.countCardsForDay(command.input.day);
+        case "replaceCardsInWindow":
+          return store.replaceCardsInWindow(
+            command.input.day,
+            command.input.startMs,
+            command.input.endMs,
+            command.input.drafts,
+          );
+        case "listDays":
+          return store.listDays();
+        case "timelineForDay":
+          return store.timelineForDay(command.input.day);
+        case "getStandup":
+          return store.getStandup(command.input.day);
+        case "saveStandup":
+          return store.saveStandup(command.input.day, command.input.text);
+        case "pruneFrames":
+          return store.pruneFrames(command.input.olderThanMs);
+      }
+    },
+    close: () => store.close(),
+  };
+}

--- a/extensions/logbook/src/types.ts
+++ b/extensions/logbook/src/types.ts
@@ -1,5 +1,4 @@
 // Shared Logbook domain shapes used by the store, pipeline, and gateway methods.
-import type { Generated } from "openclaw/plugin-sdk/sqlite-runtime";
 
 export type LogbookFrame = {
   id: number;
@@ -83,56 +82,4 @@ export type LogbookStatus = {
   today: string;
   todayCards: number;
   timeZone: string;
-};
-
-export type LogbookDatabase = {
-  frames: {
-    id: Generated<number>;
-    captured_at_ms: number;
-    day: string;
-    path: string;
-    screen_index: number;
-    width: number | null;
-    height: number | null;
-    byte_size: number;
-    content_hash: string;
-    idle: number;
-    batch_id: number | null;
-  };
-  batches: {
-    id: Generated<number>;
-    day: string;
-    start_ms: number;
-    end_ms: number;
-    status: LogbookBatchStatus;
-    error: string | null;
-    frame_count: number;
-    model: string | null;
-    created_ms: number;
-    updated_ms: number;
-  };
-  observations: {
-    id: Generated<number>;
-    batch_id: number;
-    day: string;
-    start_ms: number;
-    end_ms: number;
-    text: string;
-  };
-  cards: {
-    id: Generated<number>;
-    day: string;
-    start_ms: number;
-    end_ms: number;
-    title: string;
-    summary: string;
-    detail: string;
-    category: string;
-    app_primary: string | null;
-    app_secondary: string | null;
-    distractions: string;
-    keyframe_id: number | null;
-    updated_ms: number;
-  };
-  standups: { day: string; text: string; updated_ms: number };
 };

--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -7,6 +7,7 @@ import { isActiveMemoryExtensionRoot } from "../../test/vitest/vitest.extension-
 import { isBrowserExtensionRoot } from "../../test/vitest/vitest.extension-browser-paths.mjs";
 import { resolveSplitChannelExtensionShard } from "../../test/vitest/vitest.extension-channel-split-paths.mjs";
 import { isCodexExtensionRoot } from "../../test/vitest/vitest.extension-codex-paths.mjs";
+import { isDatabaseWorkerExtensionRoot } from "../../test/vitest/vitest.extension-database-workers-paths.mjs";
 import { isDiffsExtensionRoot } from "../../test/vitest/vitest.extension-diffs-paths.mjs";
 import { isFeishuExtensionRoot } from "../../test/vitest/vitest.extension-feishu-paths.mjs";
 import { isIrcExtensionRoot } from "../../test/vitest/vitest.extension-irc-paths.mjs";
@@ -22,7 +23,6 @@ import {
   isProviderOpenAiExtensionRoot,
 } from "../../test/vitest/vitest.extension-provider-paths.mjs";
 import { isQaExtensionRoot } from "../../test/vitest/vitest.extension-qa-paths.mjs";
-import { isTeamReportsExtensionRoot } from "../../test/vitest/vitest.extension-team-reports-paths.mjs";
 import { isTelegramExtensionRoot } from "../../test/vitest/vitest.extension-telegram-paths.mjs";
 import { isVoiceCallExtensionRoot } from "../../test/vitest/vitest.extension-voice-call-paths.mjs";
 import { isWhatsAppExtensionRoot } from "../../test/vitest/vitest.extension-whatsapp-paths.mjs";
@@ -146,7 +146,7 @@ const EXTENSION_TEST_CONFIG_ROUTES: Array<[(root: string) => boolean, string]> =
   [isMiscExtensionRoot, "test/vitest/vitest.extension-misc.config.ts"],
   [isMsTeamsExtensionRoot, "test/vitest/vitest.extension-msteams.config.ts"],
   [isQaExtensionRoot, "test/vitest/vitest.extension-qa.config.ts"],
-  [isTeamReportsExtensionRoot, "test/vitest/vitest.extension-team-reports.config.ts"],
+  [isDatabaseWorkerExtensionRoot, "test/vitest/vitest.extension-database-workers.config.ts"],
   [isTelegramExtensionRoot, "test/vitest/vitest.extension-telegram.config.ts"],
   [isVoiceCallExtensionRoot, "test/vitest/vitest.extension-voice-call.config.ts"],
   [isWhatsAppExtensionRoot, "test/vitest/vitest.extension-whatsapp.config.ts"],

--- a/scripts/pr-lib/wrapper-components.txt
+++ b/scripts/pr-lib/wrapper-components.txt
@@ -62,7 +62,7 @@ test/vitest/vitest.extension-misc-paths.mjs
 test/vitest/vitest.extension-msteams-paths.mjs
 test/vitest/vitest.extension-provider-paths.mjs
 test/vitest/vitest.extension-qa-paths.mjs
-test/vitest/vitest.extension-team-reports-paths.mjs
+test/vitest/vitest.extension-database-workers-paths.mjs
 test/vitest/vitest.extension-telegram-paths.mjs
 test/vitest/vitest.extension-voice-call-paths.mjs
 test/vitest/vitest.extension-whatsapp-paths.mjs

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -249,7 +249,8 @@ const EXTENSION_PROVIDERS_VITEST_CONFIG = "test/vitest/vitest.extension-provider
 const EXTENSION_QA_VITEST_CONFIG = "test/vitest/vitest.extension-qa.config.ts";
 const EXTENSION_SIGNAL_VITEST_CONFIG = "test/vitest/vitest.extension-signal.config.ts";
 const EXTENSION_SLACK_VITEST_CONFIG = "test/vitest/vitest.extension-slack.config.ts";
-const EXTENSION_TEAM_REPORTS_VITEST_CONFIG = "test/vitest/vitest.extension-team-reports.config.ts";
+const EXTENSION_DATABASE_WORKERS_VITEST_CONFIG =
+  "test/vitest/vitest.extension-database-workers.config.ts";
 const EXTENSION_TELEGRAM_VITEST_CONFIG = "test/vitest/vitest.extension-telegram.config.ts";
 const EXTENSION_VOICE_CALL_VITEST_CONFIG = "test/vitest/vitest.extension-voice-call.config.ts";
 const EXTENSION_WHATSAPP_VITEST_CONFIG = "test/vitest/vitest.extension-whatsapp.config.ts";
@@ -539,7 +540,7 @@ const VITEST_CONFIG_BY_KIND: Record<string, string> = {
   extensionIrc: EXTENSION_IRC_VITEST_CONFIG,
   extensionLine: EXTENSION_LINE_VITEST_CONFIG,
   extensionMattermost: EXTENSION_MATTERMOST_VITEST_CONFIG,
-  extensionTeamReports: EXTENSION_TEAM_REPORTS_VITEST_CONFIG,
+  extensionDatabaseWorkers: EXTENSION_DATABASE_WORKERS_VITEST_CONFIG,
   extensionTelegram: EXTENSION_TELEGRAM_VITEST_CONFIG,
   extensionVoiceCall: EXTENSION_VOICE_CALL_VITEST_CONFIG,
   extensionWhatsApp: EXTENSION_WHATSAPP_VITEST_CONFIG,

--- a/src/plugin-sdk/sqlite-runtime.ts
+++ b/src/plugin-sdk/sqlite-runtime.ts
@@ -27,6 +27,7 @@ export {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
   iterateSqliteQuerySync,
+  prepareSqliteQuerySync,
   sqliteStringSet,
 } from "../infra/kysely-sync.js";
 export { openNodeSqliteDatabase } from "../infra/node-sqlite.js";

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -32,7 +32,7 @@ import {
   createContractsVitestConfig,
   pluginContractPatterns,
 } from "./vitest/vitest.contracts-shared.ts";
-import { createExtensionTeamReportsVitestConfig } from "./vitest/vitest.extension-team-reports.config.ts";
+import { createExtensionDatabaseWorkersVitestConfig } from "./vitest/vitest.extension-database-workers.config.ts";
 import { createExtensionsVitestConfig } from "./vitest/vitest.extensions.config.ts";
 import { createGatewayMethodsIsolatedVitestConfig } from "./vitest/vitest.gateway-methods-isolated.config.ts";
 import { createGatewayMethodsVitestConfig } from "./vitest/vitest.gateway-methods.config.ts";
@@ -495,24 +495,29 @@ describe("projects vitest config", () => {
     expect(testConfig.sequence).toMatchObject({ groupOrder: 1 });
   });
 
-  it("runs Team Reports database owners in main-thread hosts across focused and full suites", () => {
-    const project = "test/vitest/vitest.extension-team-reports.config.ts";
-    const testConfig = requireTestConfig(createExtensionTeamReportsVitestConfig({}));
-    expect(resolveExtensionTestConfig("extensions/team-reports")).toBe(project);
-    expect(
-      buildVitestRunPlans(["extensions/team-reports/src/store.test.ts"]).map((plan) => plan.config),
-    ).toEqual([project]);
-    expect(rootVitestProjects).toContain(project);
-    expect(fullSuiteVitestShards.find((shard) => shard.name === "extensions")?.projects).toContain(
-      project,
-    );
-    expect(testConfig.pool).toBe("forks");
-    expect(testConfig.isolate).toBe(true);
-    expect(testConfig.include).toEqual(["team-reports/**/*.test.ts"]);
-    expect(requireTestConfig(createExtensionsVitestConfig({})).exclude).toContain(
-      "team-reports/**",
-    );
-  });
+  it.each(["logbook", "team-reports"])(
+    "runs %s database owners in main-thread hosts across focused and full suites",
+    (pluginId) => {
+      const project = "test/vitest/vitest.extension-database-workers.config.ts";
+      const testConfig = requireTestConfig(createExtensionDatabaseWorkersVitestConfig({}));
+      expect(resolveExtensionTestConfig(`extensions/${pluginId}`)).toBe(project);
+      expect(
+        buildVitestRunPlans([`extensions/${pluginId}/src/store.test.ts`]).map(
+          (plan) => plan.config,
+        ),
+      ).toEqual([project]);
+      expect(rootVitestProjects).toContain(project);
+      expect(
+        fullSuiteVitestShards.find((shard) => shard.name === "extensions")?.projects,
+      ).toContain(project);
+      expect(testConfig.pool).toBe("forks");
+      expect(testConfig.isolate).toBe(true);
+      expect(testConfig.include).toEqual(["logbook/**/*.test.ts", "team-reports/**/*.test.ts"]);
+      expect(requireTestConfig(createExtensionsVitestConfig({})).exclude).toContain(
+        `${pluginId}/**`,
+      );
+    },
+  );
 
   it("keeps the bundled lane on thread workers with the non-isolated runner", () => {
     const testConfig = requireTestConfig(bundledConfig);

--- a/test/vitest/vitest.config.ts
+++ b/test/vitest/vitest.config.ts
@@ -71,7 +71,7 @@ const rootVitestProjects = [
   "test/vitest/vitest.extension-providers.config.ts",
   "test/vitest/vitest.extension-signal.config.ts",
   "test/vitest/vitest.extension-slack.config.ts",
-  "test/vitest/vitest.extension-team-reports.config.ts",
+  "test/vitest/vitest.extension-database-workers.config.ts",
   "test/vitest/vitest.extension-telegram.config.ts",
   "test/vitest/vitest.extension-voice-call.config.ts",
   "test/vitest/vitest.extension-whatsapp.config.ts",

--- a/test/vitest/vitest.extension-database-workers-paths.d.mts
+++ b/test/vitest/vitest.extension-database-workers-paths.d.mts
@@ -1,0 +1,2 @@
+export const databaseWorkerExtensionTestRoots: string[];
+export function isDatabaseWorkerExtensionRoot(root: string): boolean;

--- a/test/vitest/vitest.extension-database-workers-paths.mjs
+++ b/test/vitest/vitest.extension-database-workers-paths.mjs
@@ -1,0 +1,5 @@
+export const databaseWorkerExtensionTestRoots = ["extensions/logbook", "extensions/team-reports"];
+
+export function isDatabaseWorkerExtensionRoot(root) {
+  return databaseWorkerExtensionTestRoots.includes(root);
+}

--- a/test/vitest/vitest.extension-database-workers.config.ts
+++ b/test/vitest/vitest.extension-database-workers.config.ts
@@ -1,16 +1,16 @@
-import { teamReportsExtensionTestRoots } from "./vitest.extension-team-reports-paths.mjs";
+import { databaseWorkerExtensionTestRoots } from "./vitest.extension-database-workers-paths.mjs";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 import { pluginControlUiPathGlob } from "./vitest.ui-paths.mjs";
 
-export function createExtensionTeamReportsVitestConfig(
+export function createExtensionDatabaseWorkersVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(
-    teamReportsExtensionTestRoots.map((root) => `${root}/**/*.test.ts`),
+    databaseWorkerExtensionTestRoots.map((root) => `${root}/**/*.test.ts`),
     {
       dir: "extensions",
       env,
-      name: "extension-team-reports",
+      name: "extension-database-workers",
       // The database broker runs in the application main thread and owns its SQLite workers.
       pool: "forks",
       isolate: true,
@@ -21,4 +21,4 @@ export function createExtensionTeamReportsVitestConfig(
   );
 }
 
-export default createExtensionTeamReportsVitestConfig();
+export default createExtensionDatabaseWorkersVitestConfig();

--- a/test/vitest/vitest.extension-team-reports-paths.d.mts
+++ b/test/vitest/vitest.extension-team-reports-paths.d.mts
@@ -1,2 +1,0 @@
-export const teamReportsExtensionTestRoots: string[];
-export function isTeamReportsExtensionRoot(root: string): boolean;

--- a/test/vitest/vitest.extension-team-reports-paths.mjs
+++ b/test/vitest/vitest.extension-team-reports-paths.mjs
@@ -1,5 +1,0 @@
-export const teamReportsExtensionTestRoots = ["extensions/team-reports"];
-
-export function isTeamReportsExtensionRoot(root) {
-  return teamReportsExtensionTestRoots.includes(root);
-}

--- a/test/vitest/vitest.extensions.config.ts
+++ b/test/vitest/vitest.extensions.config.ts
@@ -5,6 +5,7 @@ import { acpxExtensionTestRoots } from "./vitest.extension-acpx-paths.mjs";
 import { activeMemoryExtensionTestRoots } from "./vitest.extension-active-memory-paths.mjs";
 import { browserExtensionTestRoots } from "./vitest.extension-browser-paths.mjs";
 import { codexExtensionTestRoots } from "./vitest.extension-codex-paths.mjs";
+import { databaseWorkerExtensionTestRoots } from "./vitest.extension-database-workers-paths.mjs";
 import { diffsExtensionTestRoots } from "./vitest.extension-diffs-paths.mjs";
 import { feishuExtensionTestRoots } from "./vitest.extension-feishu-paths.mjs";
 import { ircExtensionTestRoots } from "./vitest.extension-irc-paths.mjs";
@@ -20,7 +21,6 @@ import {
   providerOpenAiExtensionTestRoots,
 } from "./vitest.extension-provider-paths.mjs";
 import { qaExtensionTestRoots } from "./vitest.extension-qa-paths.mjs";
-import { teamReportsExtensionTestRoots } from "./vitest.extension-team-reports-paths.mjs";
 import { telegramExtensionTestRoots } from "./vitest.extension-telegram-paths.mjs";
 import { voiceCallExtensionTestRoots } from "./vitest.extension-voice-call-paths.mjs";
 import { whatsAppExtensionTestRoots } from "./vitest.extension-whatsapp-paths.mjs";
@@ -46,7 +46,7 @@ export const extensionCatchAllExcludedTestRoots = [
   providerOpenAiExtensionTestRoots,
   providerExtensionTestRoots,
   qaExtensionTestRoots,
-  teamReportsExtensionTestRoots,
+  databaseWorkerExtensionTestRoots,
   telegramExtensionTestRoots,
   voiceCallExtensionTestRoots,
   whatsAppExtensionTestRoots,

--- a/test/vitest/vitest.scoped-config.ts
+++ b/test/vitest/vitest.scoped-config.ts
@@ -110,7 +110,7 @@ const SCOPED_PROJECT_GROUP_ORDER_BY_NAME = new Map(
     "extension-providers",
     "extension-signal",
     "extension-slack",
-    "extension-team-reports",
+    "extension-database-workers",
     "extension-telegram",
     "extension-voice-call",
     "extension-whatsapp",

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -165,7 +165,7 @@ export const fullSuiteVitestShards = [
       "test/vitest/vitest.extension-providers.config.ts",
       "test/vitest/vitest.extension-signal.config.ts",
       "test/vitest/vitest.extension-slack.config.ts",
-      "test/vitest/vitest.extension-team-reports.config.ts",
+      "test/vitest/vitest.extension-database-workers.config.ts",
       "test/vitest/vitest.extension-telegram.config.ts",
       "test/vitest/vitest.extension-voice-call.config.ts",
       "test/vitest/vitest.extension-whatsapp.config.ts",


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Logbook's awaitable store still executes SQLite on the application event loop. Database startup, lock contention, timeline queries and retention can stall Gateway work. Moving metadata reads to workers also requires preserving their relationship with frame files while capture and pruning continue.

## Why This Change Was Made

Move Logbook's complete typed database operations, connection setup, schema handling, prepared statements, transactions, WAL maintenance and close into the shared bounded SQLite worker broker. Reuse fixed Kysely plans for repeated writes and reads.

A bounded queue for each canonical frame directory owns capture, preview, batch-image reading and pruning through completion. File payloads use asynchronous file I/O; metadata queries stay in the worker. This preserves valid multi-image analysis without imposing a new aggregate image limit. Service shutdown retains accepted operations before closing its worker client. Automatic keyframe selection now runs inside the existing card-replacement transaction, so retention cannot invalidate a selected frame between lookup and publication. Explicit caller-supplied keyframes retain their original atomic rollback behavior.

## User Impact

SQLite work no longer blocks the application's event loop. Previews and analysis finish reading their frame files before retention removes them. Existing database placement, schema, retention policy, query order, file permissions and RPC payloads stay compatible.

## Evidence

- All 443 selected cases across 27 files passed, including broker/routing, Logbook lifecycle, frame/pruning races and read budgets.
- Full selected changed checks and a full Logbook-selected build passed. Fresh independent Codex review through P2 was clean; current-main integration preserved the reviewed runtime changes and all supplied owner/dependency context byte-for-byte.
- Source and emitted-JavaScript proofs exercised all 9 registered RPCs and all 23 store commands. Native instrumentation recorded zero parent-thread SQLite calls in four writer/reopen processes. Compiled proof used canonical emitted SDK/worker entries without TypeScript fallback.
- Capture stop/drain, service restart and fresh-process reopen preserved the expected frames, card and standup. Source/artifact hashes remained unchanged; all created children joined and synthetic state was removed.
- During a 753 ms SQLite write lock, the compiled application handled 125 timer ticks and 30 WebSocket pongs; event-loop p99 was 6.64 ms. Across 25 warm samples, read RPC median/p95 was 0.198/0.270 ms and write RPC was 0.444/0.675 ms. These describe the synthetic probe, not a comparative speedup.

The proof uses the registered plugin RPC boundary and a real WebSocket/SQLite harness; it does not claim full Gateway authentication, real screen capture or model inference. The existing canonical-path helper still uses synchronous filesystem metadata probes; SQLite execution and frame payload I/O are the migrated paths.

Release context: this plugin needs the new worker-capable host. The normal release workflow must publish its compatible host floor with that host; this PR does not publish a standalone plugin or change release versions.

## Concurrent retention and card publication

The worker cutover exposed a gap between the service's frame-range read and its later card replacement: the broker could dispatch queued retention before the read continuation enqueued publication. The original registered service flow reproduced a foreign-key failure and errored batch; its unpruned control passed.

Commit `20082d0cf728d8e42a9b71426b4a43c03b0b0442` sends automatic keyframe selection through the existing typed `replaceCardsInWindow` operation. The worker applies the existing midpoint selector within the existing replacement transaction. Retention can run before selection or after committed publication, where the existing `ON DELETE SET NULL` relationship clears a removed preview. No schema, migration, retention/preview limit, host SDK, broker, configuration, or Bun behavior changes in this repair.

The following proof was run on `ce0049d9` plus this six-file repair; all six source hashes match committed `20082d0c`:

- All 107 Logbook tests across ten files passed, including queued retention, already-pruned IDs with remaining-frame and empty-frame controls, and unchanged explicit-keyframe rollback. The two service cases passed again after fixture cleanup ownership was finalized.
- The complete changed-file gate passed, including plugin types/tests, lint/format, Knip, selected native checks, and runtime import-cycle checks. Fresh independent Codex review through P2 returned zero actionable findings. The ordinary full build passed.
- Sixteen stages passed across source and compiled layouts: queued retention, pruning before publication with no remaining frame, unpruned control, and original writer flow, each followed by a separate fresh-process reopen. These used registered Logbook callbacks, real loopback WebSockets, and real SQLite workers, with zero parent-thread SQLite calls. Publication completed with a durable card and no batch error; the unpruned control retained its keyframe.
- Compiled proof rejected source/TypeScript loading. It used the real registered capture flow with synthetic node bytes and invoked the observed production retention callback with a temporary synthetic cutoff clock, restored when the prune command dispatched. This does not claim elapsed hourly scheduling, real screen capture/model inference, full Gateway authentication, or npm installation proof.
- Both layouts handled 29 WebSocket pongs during approximately 752 ms of an independently held SQLite write lock. Compiled warm standup RPC median was 0.346 ms over 25 samples; these are local synthetic transport/scheduling observations, not SQL CPU timing or comparative benchmarks.

The initial combined proof's source stages passed; compiled preflight then exposed an incorrect external-fixture assumption about emitted module layout. Only that fixture was corrected to follow the actual inlined plugin and shared analyzer graph. Product sources and build outputs stayed unchanged. All owned proof jobs joined.

Previous CI on `ce0049d9` does not cover this repair; final-head CI and native landing gates apply to the published `20082d0c` head. Storage compatibility remains the existing database layout and schema with worker-owned execution; the repair adds no migration. The worker-capable host floor remains a release-workflow requirement, and this PR publishes no standalone plugin version.
