### PR TITLE
refactor(tasks): separate flow record transformations

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -779,7 +779,6 @@ src/state/openclaw-state-db.test.ts
 src/status/status-message.ts
 src/system-agent/verified-inference.ts
 src/tasks/task-executor.test.ts
-src/tasks/task-flow-registry.ts
 src/tasks/task-registry.maintenance.ts
 src/tasks/task-registry.store.test.ts
 src/tasks/task-registry.test.ts

--- a/src/tasks/task-flow-registry.records.ts
+++ b/src/tasks/task-flow-registry.records.ts
@@ -1,0 +1,320 @@
+import crypto from "node:crypto";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type {
+  JsonValue,
+  TaskFlowRecord,
+  TaskFlowStatus,
+  TaskFlowSyncMode,
+} from "./task-flow-registry.types.js";
+import type { TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
+
+export type TaskFlowSyncInput = Pick<
+  TaskRecord,
+  | "parentFlowId"
+  | "status"
+  | "terminalOutcome"
+  | "notifyPolicy"
+  | "label"
+  | "task"
+  | "lastEventAt"
+  | "endedAt"
+  | "taskId"
+  | "terminalSummary"
+  | "progressSummary"
+>;
+
+export type FlowRecordPatch = Omit<
+  Partial<
+    Pick<
+      TaskFlowRecord,
+      | "status"
+      | "notifyPolicy"
+      | "goal"
+      | "currentStep"
+      | "blockedTaskId"
+      | "blockedSummary"
+      | "controllerId"
+      | "stateJson"
+      | "waitJson"
+      | "cancelRequestedAt"
+      | "updatedAt"
+      | "endedAt"
+    >
+  >,
+  | "currentStep"
+  | "blockedTaskId"
+  | "blockedSummary"
+  | "controllerId"
+  | "stateJson"
+  | "waitJson"
+  | "cancelRequestedAt"
+  | "endedAt"
+> & {
+  currentStep?: string | null;
+  blockedTaskId?: string | null;
+  blockedSummary?: string | null;
+  controllerId?: string | null;
+  stateJson?: JsonValue | null;
+  waitJson?: JsonValue | null;
+  cancelRequestedAt?: number | null;
+  endedAt?: number | null;
+};
+
+export type FlowRecordCreateFields = {
+  ownerKey: string;
+  requesterOrigin?: TaskFlowRecord["requesterOrigin"];
+  status?: TaskFlowStatus;
+  notifyPolicy?: TaskNotifyPolicy;
+  goal: string;
+  currentStep?: string | null;
+  blockedTaskId?: string | null;
+  blockedSummary?: string | null;
+  stateJson?: JsonValue | null;
+  waitJson?: JsonValue | null;
+  cancelRequestedAt?: number | null;
+  createdAt?: number;
+  updatedAt?: number;
+  endedAt?: number | null;
+};
+
+export type CreateFlowRecordParams = FlowRecordCreateFields & {
+  syncMode?: TaskFlowSyncMode;
+  controllerId?: string | null;
+  revision?: number;
+};
+
+export type PreparedTaskMirroredFlowSync = {
+  current: TaskFlowRecord;
+  next: TaskFlowRecord;
+};
+
+function cloneStructuredValue<T>(value: T | undefined): T | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return structuredClone(value);
+}
+
+export function cloneFlowRecord(record: TaskFlowRecord): TaskFlowRecord {
+  return {
+    ...record,
+    ...(record.requesterOrigin
+      ? { requesterOrigin: cloneStructuredValue(record.requesterOrigin)! }
+      : {}),
+    ...(record.stateJson !== undefined
+      ? { stateJson: cloneStructuredValue(record.stateJson)! }
+      : {}),
+    ...(record.waitJson !== undefined ? { waitJson: cloneStructuredValue(record.waitJson)! } : {}),
+  };
+}
+
+export function normalizeRestoredFlowRecord(record: TaskFlowRecord): TaskFlowRecord {
+  const syncMode = record.syncMode === "task_mirrored" ? "task_mirrored" : "managed";
+  const controllerId =
+    syncMode === "managed"
+      ? (normalizeOptionalString(record.controllerId) ?? "core/legacy-restored")
+      : undefined;
+  return {
+    ...record,
+    syncMode,
+    ownerKey: assertFlowOwnerKey(record.ownerKey),
+    ...(record.requesterOrigin
+      ? { requesterOrigin: cloneStructuredValue(record.requesterOrigin)! }
+      : {}),
+    ...(controllerId ? { controllerId } : {}),
+    currentStep: normalizeOptionalString(record.currentStep),
+    blockedTaskId: normalizeOptionalString(record.blockedTaskId),
+    blockedSummary: normalizeOptionalString(record.blockedSummary),
+    ...(record.stateJson !== undefined
+      ? { stateJson: cloneStructuredValue(record.stateJson)! }
+      : {}),
+    ...(record.waitJson !== undefined ? { waitJson: cloneStructuredValue(record.waitJson)! } : {}),
+    revision: Math.max(0, record.revision),
+    cancelRequestedAt: record.cancelRequestedAt ?? undefined,
+    endedAt: record.endedAt ?? undefined,
+  };
+}
+
+export function snapshotFlowRecords(source: ReadonlyMap<string, TaskFlowRecord>): TaskFlowRecord[] {
+  return [...source.values()].map((record) => cloneFlowRecord(record));
+}
+
+function ensureNotifyPolicy(notifyPolicy?: TaskNotifyPolicy): TaskNotifyPolicy {
+  return notifyPolicy ?? "done_only";
+}
+
+function normalizeJsonBlob(value: JsonValue | null | undefined): JsonValue | undefined {
+  return value === undefined ? undefined : cloneStructuredValue(value);
+}
+
+function assertFlowOwnerKey(ownerKey: string): string {
+  const normalized = normalizeOptionalString(ownerKey);
+  if (!normalized) {
+    throw new Error("Flow ownerKey is required.");
+  }
+  return normalized;
+}
+
+export function assertControllerId(controllerId?: string | null): string {
+  const normalized = normalizeOptionalString(controllerId);
+  if (!normalized) {
+    throw new Error("Managed flow controllerId is required.");
+  }
+  return normalized;
+}
+
+export function resolveFlowBlockedSummary(
+  task: Pick<TaskRecord, "status" | "terminalOutcome" | "terminalSummary" | "progressSummary">,
+): string | undefined {
+  if (task.status !== "succeeded" || task.terminalOutcome !== "blocked") {
+    return undefined;
+  }
+  return (
+    normalizeOptionalString(task.terminalSummary) ?? normalizeOptionalString(task.progressSummary)
+  );
+}
+
+export function deriveTaskFlowStatusFromTask(
+  task: Pick<TaskRecord, "status" | "terminalOutcome">,
+): TaskFlowStatus {
+  if (task.status === "queued") {
+    return "queued";
+  }
+  if (task.status === "running") {
+    return "running";
+  }
+  if (task.status === "succeeded") {
+    return task.terminalOutcome === "blocked" ? "blocked" : "succeeded";
+  }
+  if (task.status === "cancelled") {
+    return "cancelled";
+  }
+  if (task.status === "lost") {
+    return "lost";
+  }
+  return "failed";
+}
+
+export function isTerminalTaskFlowStatus(status: TaskFlowStatus): boolean {
+  return (
+    status === "succeeded" ||
+    status === "blocked" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "lost"
+  );
+}
+
+export function resolveTaskMirroredFlowTiming(
+  task: Pick<TaskRecord, "createdAt" | "lastEventAt" | "endedAt">,
+  isTerminal: boolean,
+): { updatedAt: number; endedAt?: number } {
+  if (!isTerminal) {
+    return { updatedAt: task.lastEventAt ?? task.createdAt };
+  }
+  const endedAt = task.endedAt ?? task.lastEventAt ?? task.createdAt;
+  return { updatedAt: endedAt, endedAt };
+}
+
+export function buildFlowRecord(params: CreateFlowRecordParams): TaskFlowRecord {
+  const now = params.createdAt ?? Date.now();
+  const syncMode = params.syncMode ?? "managed";
+  const controllerId = syncMode === "managed" ? assertControllerId(params.controllerId) : undefined;
+  return {
+    flowId: crypto.randomUUID(),
+    syncMode,
+    ownerKey: assertFlowOwnerKey(params.ownerKey),
+    ...(params.requesterOrigin
+      ? { requesterOrigin: cloneStructuredValue(params.requesterOrigin)! }
+      : {}),
+    ...(controllerId ? { controllerId } : {}),
+    revision: Math.max(0, params.revision ?? 0),
+    status: params.status ?? "queued",
+    notifyPolicy: ensureNotifyPolicy(params.notifyPolicy),
+    goal: params.goal,
+    currentStep: normalizeOptionalString(params.currentStep),
+    blockedTaskId: normalizeOptionalString(params.blockedTaskId),
+    blockedSummary: normalizeOptionalString(params.blockedSummary),
+    ...(normalizeJsonBlob(params.stateJson) !== undefined
+      ? { stateJson: normalizeJsonBlob(params.stateJson)! }
+      : {}),
+    ...(normalizeJsonBlob(params.waitJson) !== undefined
+      ? { waitJson: normalizeJsonBlob(params.waitJson)! }
+      : {}),
+    ...(params.cancelRequestedAt != null ? { cancelRequestedAt: params.cancelRequestedAt } : {}),
+    createdAt: now,
+    updatedAt: params.updatedAt ?? now,
+    ...(params.endedAt != null ? { endedAt: params.endedAt } : {}),
+  };
+}
+
+export function applyFlowPatch(current: TaskFlowRecord, patch: FlowRecordPatch): TaskFlowRecord {
+  const controllerId =
+    patch.controllerId === undefined
+      ? current.controllerId
+      : normalizeOptionalString(patch.controllerId);
+  if (current.syncMode === "managed") {
+    assertControllerId(controllerId);
+  }
+  return {
+    ...current,
+    ...(patch.status ? { status: patch.status } : {}),
+    ...(patch.notifyPolicy ? { notifyPolicy: patch.notifyPolicy } : {}),
+    ...(patch.goal ? { goal: patch.goal } : {}),
+    controllerId,
+    currentStep:
+      patch.currentStep === undefined
+        ? current.currentStep
+        : normalizeOptionalString(patch.currentStep),
+    blockedTaskId:
+      patch.blockedTaskId === undefined
+        ? current.blockedTaskId
+        : normalizeOptionalString(patch.blockedTaskId),
+    blockedSummary:
+      patch.blockedSummary === undefined
+        ? current.blockedSummary
+        : normalizeOptionalString(patch.blockedSummary),
+    stateJson:
+      patch.stateJson === undefined ? current.stateJson : normalizeJsonBlob(patch.stateJson),
+    waitJson: patch.waitJson === undefined ? current.waitJson : normalizeJsonBlob(patch.waitJson),
+    cancelRequestedAt:
+      patch.cancelRequestedAt === undefined
+        ? current.cancelRequestedAt
+        : (patch.cancelRequestedAt ?? undefined),
+    revision: current.revision + 1,
+    updatedAt: patch.updatedAt ?? Date.now(),
+    endedAt: patch.endedAt === undefined ? current.endedAt : (patch.endedAt ?? undefined),
+  };
+}
+
+export function prepareTaskMirroredFlowSyncFromCurrent(
+  task: TaskFlowSyncInput,
+  flow: TaskFlowRecord,
+): PreparedTaskMirroredFlowSync {
+  const terminalFlowStatus = deriveTaskFlowStatusFromTask(task);
+  const isTerminal = isTerminalTaskFlowStatus(terminalFlowStatus);
+  const timing = resolveTaskMirroredFlowTiming(
+    {
+      createdAt: flow.createdAt,
+      lastEventAt: task.lastEventAt,
+      endedAt: task.endedAt,
+    },
+    isTerminal,
+  );
+  const next = applyFlowPatch(flow, {
+    status: terminalFlowStatus,
+    notifyPolicy: task.notifyPolicy,
+    goal: normalizeOptionalString(task.label) ?? (task.task.trim() || "Background task"),
+    blockedTaskId: terminalFlowStatus === "blocked" ? task.taskId.trim() || null : null,
+    blockedSummary:
+      terminalFlowStatus === "blocked" ? (resolveFlowBlockedSummary(task) ?? null) : null,
+    waitJson: null,
+    updatedAt: timing.updatedAt,
+    ...(isTerminal
+      ? {
+          endedAt: timing.endedAt ?? timing.updatedAt,
+        }
+      : { endedAt: null }),
+  });
+  return { current: cloneFlowRecord(flow), next };
+}

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -1,8 +1,25 @@
 // Coordinates managed task-flow creation, updates, ownership, and snapshots.
-import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  applyFlowPatch,
+  assertControllerId,
+  buildFlowRecord,
+  cloneFlowRecord,
+  deriveTaskFlowStatusFromTask,
+  isTerminalTaskFlowStatus,
+  normalizeRestoredFlowRecord,
+  prepareTaskMirroredFlowSyncFromCurrent,
+  resolveFlowBlockedSummary,
+  resolveTaskMirroredFlowTiming,
+  snapshotFlowRecords,
+  type CreateFlowRecordParams,
+  type FlowRecordCreateFields,
+  type FlowRecordPatch,
+  type PreparedTaskMirroredFlowSync,
+  type TaskFlowSyncInput,
+} from "./task-flow-registry.records.js";
 import {
   getTaskFlowRegistryObservers,
   getTaskFlowRegistryStore,
@@ -14,9 +31,10 @@ import {
   type JsonValue,
   type TaskFlowRecord,
   type TaskFlowStatus,
-  type TaskFlowSyncMode,
 } from "./task-flow-registry.types.js";
-import type { TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+export type { PreparedTaskMirroredFlowSync } from "./task-flow-registry.records.js";
 
 const log = createSubsystemLogger("tasks/task-flow-registry");
 let flows = new Map<string, TaskFlowRecord>();
@@ -26,66 +44,6 @@ type TaskFlowRegistryRestoreState =
   | { status: "ready" }
   | { status: "failed"; error: Error; message: string };
 let taskFlowRegistryRestoreState: TaskFlowRegistryRestoreState = { status: "uninitialized" };
-
-type FlowRecordPatch = Omit<
-  Partial<
-    Pick<
-      TaskFlowRecord,
-      | "status"
-      | "notifyPolicy"
-      | "goal"
-      | "currentStep"
-      | "blockedTaskId"
-      | "blockedSummary"
-      | "controllerId"
-      | "stateJson"
-      | "waitJson"
-      | "cancelRequestedAt"
-      | "updatedAt"
-      | "endedAt"
-    >
-  >,
-  | "currentStep"
-  | "blockedTaskId"
-  | "blockedSummary"
-  | "controllerId"
-  | "stateJson"
-  | "waitJson"
-  | "cancelRequestedAt"
-  | "endedAt"
-> & {
-  currentStep?: string | null;
-  blockedTaskId?: string | null;
-  blockedSummary?: string | null;
-  controllerId?: string | null;
-  stateJson?: JsonValue | null;
-  waitJson?: JsonValue | null;
-  cancelRequestedAt?: number | null;
-  endedAt?: number | null;
-};
-
-type FlowRecordCreateFields = {
-  ownerKey: string;
-  requesterOrigin?: TaskFlowRecord["requesterOrigin"];
-  status?: TaskFlowStatus;
-  notifyPolicy?: TaskNotifyPolicy;
-  goal: string;
-  currentStep?: string | null;
-  blockedTaskId?: string | null;
-  blockedSummary?: string | null;
-  stateJson?: JsonValue | null;
-  waitJson?: JsonValue | null;
-  cancelRequestedAt?: number | null;
-  createdAt?: number;
-  updatedAt?: number;
-  endedAt?: number | null;
-};
-
-type CreateFlowRecordParams = FlowRecordCreateFields & {
-  syncMode?: TaskFlowSyncMode;
-  controllerId?: string | null;
-  revision?: number;
-};
 
 export type TaskFlowUpdateResult =
   | {
@@ -109,62 +67,6 @@ type TaskFlowSyncResult =
       current: TaskFlowRecord;
     };
 
-export type PreparedTaskMirroredFlowSync = {
-  current: TaskFlowRecord;
-  next: TaskFlowRecord;
-};
-
-function cloneStructuredValue<T>(value: T | undefined): T | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  return structuredClone(value);
-}
-
-function cloneFlowRecord(record: TaskFlowRecord): TaskFlowRecord {
-  return {
-    ...record,
-    ...(record.requesterOrigin
-      ? { requesterOrigin: cloneStructuredValue(record.requesterOrigin)! }
-      : {}),
-    ...(record.stateJson !== undefined
-      ? { stateJson: cloneStructuredValue(record.stateJson)! }
-      : {}),
-    ...(record.waitJson !== undefined ? { waitJson: cloneStructuredValue(record.waitJson)! } : {}),
-  };
-}
-
-function normalizeRestoredFlowRecord(record: TaskFlowRecord): TaskFlowRecord {
-  const syncMode = record.syncMode === "task_mirrored" ? "task_mirrored" : "managed";
-  const controllerId =
-    syncMode === "managed"
-      ? (normalizeOptionalString(record.controllerId) ?? "core/legacy-restored")
-      : undefined;
-  return {
-    ...record,
-    syncMode,
-    ownerKey: assertFlowOwnerKey(record.ownerKey),
-    ...(record.requesterOrigin
-      ? { requesterOrigin: cloneStructuredValue(record.requesterOrigin)! }
-      : {}),
-    ...(controllerId ? { controllerId } : {}),
-    currentStep: normalizeOptionalString(record.currentStep),
-    blockedTaskId: normalizeOptionalString(record.blockedTaskId),
-    blockedSummary: normalizeOptionalString(record.blockedSummary),
-    ...(record.stateJson !== undefined
-      ? { stateJson: cloneStructuredValue(record.stateJson)! }
-      : {}),
-    ...(record.waitJson !== undefined ? { waitJson: cloneStructuredValue(record.waitJson)! } : {}),
-    revision: Math.max(0, record.revision),
-    cancelRequestedAt: record.cancelRequestedAt ?? undefined,
-    endedAt: record.endedAt ?? undefined,
-  };
-}
-
-function snapshotFlowRecords(source: ReadonlyMap<string, TaskFlowRecord>): TaskFlowRecord[] {
-  return [...source.values()].map((record) => cloneFlowRecord(record));
-}
-
 function emitFlowRegistryObserverEvent(createEvent: () => TaskFlowRegistryObserverEvent): void {
   const observers = getTaskFlowRegistryObservers();
   if (!observers?.onEvent) {
@@ -175,83 +77,6 @@ function emitFlowRegistryObserverEvent(createEvent: () => TaskFlowRegistryObserv
   } catch {
     // Flow observers are best-effort only. They must not break registry writes.
   }
-}
-
-function ensureNotifyPolicy(notifyPolicy?: TaskNotifyPolicy): TaskNotifyPolicy {
-  return notifyPolicy ?? "done_only";
-}
-
-function normalizeJsonBlob(value: JsonValue | null | undefined): JsonValue | undefined {
-  return value === undefined ? undefined : cloneStructuredValue(value);
-}
-
-function assertFlowOwnerKey(ownerKey: string): string {
-  const normalized = normalizeOptionalString(ownerKey);
-  if (!normalized) {
-    throw new Error("Flow ownerKey is required.");
-  }
-  return normalized;
-}
-
-function assertControllerId(controllerId?: string | null): string {
-  const normalized = normalizeOptionalString(controllerId);
-  if (!normalized) {
-    throw new Error("Managed flow controllerId is required.");
-  }
-  return normalized;
-}
-
-function resolveFlowBlockedSummary(
-  task: Pick<TaskRecord, "status" | "terminalOutcome" | "terminalSummary" | "progressSummary">,
-): string | undefined {
-  if (task.status !== "succeeded" || task.terminalOutcome !== "blocked") {
-    return undefined;
-  }
-  return (
-    normalizeOptionalString(task.terminalSummary) ?? normalizeOptionalString(task.progressSummary)
-  );
-}
-
-function deriveTaskFlowStatusFromTask(
-  task: Pick<TaskRecord, "status" | "terminalOutcome">,
-): TaskFlowStatus {
-  if (task.status === "queued") {
-    return "queued";
-  }
-  if (task.status === "running") {
-    return "running";
-  }
-  if (task.status === "succeeded") {
-    return task.terminalOutcome === "blocked" ? "blocked" : "succeeded";
-  }
-  if (task.status === "cancelled") {
-    return "cancelled";
-  }
-  if (task.status === "lost") {
-    return "lost";
-  }
-  return "failed";
-}
-
-function isTerminalTaskFlowStatus(status: TaskFlowStatus): boolean {
-  return (
-    status === "succeeded" ||
-    status === "blocked" ||
-    status === "failed" ||
-    status === "cancelled" ||
-    status === "lost"
-  );
-}
-
-function resolveTaskMirroredFlowTiming(
-  task: Pick<TaskRecord, "createdAt" | "lastEventAt" | "endedAt">,
-  isTerminal: boolean,
-): { updatedAt: number; endedAt?: number } {
-  if (!isTerminal) {
-    return { updatedAt: task.lastEventAt ?? task.createdAt };
-  }
-  const endedAt = task.endedAt ?? task.lastEventAt ?? task.createdAt;
-  return { updatedAt: endedAt, endedAt };
 }
 
 function restoreTaskFlowRegistryOnce(): void {
@@ -343,77 +168,6 @@ function tryPersistFlowDelete(flowId: string): boolean {
     });
     return false;
   }
-}
-
-function buildFlowRecord(params: CreateFlowRecordParams): TaskFlowRecord {
-  const now = params.createdAt ?? Date.now();
-  const syncMode = params.syncMode ?? "managed";
-  const controllerId = syncMode === "managed" ? assertControllerId(params.controllerId) : undefined;
-  return {
-    flowId: crypto.randomUUID(),
-    syncMode,
-    ownerKey: assertFlowOwnerKey(params.ownerKey),
-    ...(params.requesterOrigin
-      ? { requesterOrigin: cloneStructuredValue(params.requesterOrigin)! }
-      : {}),
-    ...(controllerId ? { controllerId } : {}),
-    revision: Math.max(0, params.revision ?? 0),
-    status: params.status ?? "queued",
-    notifyPolicy: ensureNotifyPolicy(params.notifyPolicy),
-    goal: params.goal,
-    currentStep: normalizeOptionalString(params.currentStep),
-    blockedTaskId: normalizeOptionalString(params.blockedTaskId),
-    blockedSummary: normalizeOptionalString(params.blockedSummary),
-    ...(normalizeJsonBlob(params.stateJson) !== undefined
-      ? { stateJson: normalizeJsonBlob(params.stateJson)! }
-      : {}),
-    ...(normalizeJsonBlob(params.waitJson) !== undefined
-      ? { waitJson: normalizeJsonBlob(params.waitJson)! }
-      : {}),
-    ...(params.cancelRequestedAt != null ? { cancelRequestedAt: params.cancelRequestedAt } : {}),
-    createdAt: now,
-    updatedAt: params.updatedAt ?? now,
-    ...(params.endedAt != null ? { endedAt: params.endedAt } : {}),
-  };
-}
-
-function applyFlowPatch(current: TaskFlowRecord, patch: FlowRecordPatch): TaskFlowRecord {
-  const controllerId =
-    patch.controllerId === undefined
-      ? current.controllerId
-      : normalizeOptionalString(patch.controllerId);
-  if (current.syncMode === "managed") {
-    assertControllerId(controllerId);
-  }
-  return {
-    ...current,
-    ...(patch.status ? { status: patch.status } : {}),
-    ...(patch.notifyPolicy ? { notifyPolicy: patch.notifyPolicy } : {}),
-    ...(patch.goal ? { goal: patch.goal } : {}),
-    controllerId,
-    currentStep:
-      patch.currentStep === undefined
-        ? current.currentStep
-        : normalizeOptionalString(patch.currentStep),
-    blockedTaskId:
-      patch.blockedTaskId === undefined
-        ? current.blockedTaskId
-        : normalizeOptionalString(patch.blockedTaskId),
-    blockedSummary:
-      patch.blockedSummary === undefined
-        ? current.blockedSummary
-        : normalizeOptionalString(patch.blockedSummary),
-    stateJson:
-      patch.stateJson === undefined ? current.stateJson : normalizeJsonBlob(patch.stateJson),
-    waitJson: patch.waitJson === undefined ? current.waitJson : normalizeJsonBlob(patch.waitJson),
-    cancelRequestedAt:
-      patch.cancelRequestedAt === undefined
-        ? current.cancelRequestedAt
-        : (patch.cancelRequestedAt ?? undefined),
-    revision: current.revision + 1,
-    updatedAt: patch.updatedAt ?? Date.now(),
-    endedAt: patch.endedAt === undefined ? current.endedAt : (patch.endedAt ?? undefined),
-  };
 }
 
 function writeFlowRecord(next: TaskFlowRecord, previous?: TaskFlowRecord): TaskFlowRecord | null {
@@ -643,22 +397,7 @@ export function requestFlowCancel(params: {
   });
 }
 
-export function syncFlowFromTaskResult(
-  task: Pick<
-    TaskRecord,
-    | "parentFlowId"
-    | "status"
-    | "terminalOutcome"
-    | "notifyPolicy"
-    | "label"
-    | "task"
-    | "lastEventAt"
-    | "endedAt"
-    | "taskId"
-    | "terminalSummary"
-    | "progressSummary"
-  >,
-): TaskFlowSyncResult {
+export function syncFlowFromTaskResult(task: TaskFlowSyncInput): TaskFlowSyncResult {
   const flowId = task.parentFlowId?.trim();
   if (!flowId) {
     return { ok: true, flow: null };
@@ -680,38 +419,6 @@ export function syncFlowFromTaskResult(
     };
   }
   return { ok: true, flow: updated };
-}
-
-function prepareTaskMirroredFlowSyncFromCurrent(
-  task: Parameters<typeof syncFlowFromTaskResult>[0],
-  flow: TaskFlowRecord,
-): PreparedTaskMirroredFlowSync {
-  const terminalFlowStatus = deriveTaskFlowStatusFromTask(task);
-  const isTerminal = isTerminalTaskFlowStatus(terminalFlowStatus);
-  const timing = resolveTaskMirroredFlowTiming(
-    {
-      createdAt: flow.createdAt,
-      lastEventAt: task.lastEventAt,
-      endedAt: task.endedAt,
-    },
-    isTerminal,
-  );
-  const next = applyFlowPatch(flow, {
-    status: terminalFlowStatus,
-    notifyPolicy: task.notifyPolicy,
-    goal: normalizeOptionalString(task.label) ?? (task.task.trim() || "Background task"),
-    blockedTaskId: terminalFlowStatus === "blocked" ? task.taskId.trim() || null : null,
-    blockedSummary:
-      terminalFlowStatus === "blocked" ? (resolveFlowBlockedSummary(task) ?? null) : null,
-    waitJson: null,
-    updatedAt: timing.updatedAt,
-    ...(isTerminal
-      ? {
-          endedAt: timing.endedAt ?? timing.updatedAt,
-        }
-      : { endedAt: null }),
-  });
-  return { current: cloneFlowRecord(flow), next };
 }
 
 export function prepareTaskMirroredFlowSync(
@@ -818,4 +525,3 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
     resetTaskFlowRegistryForTests,
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Flow record construction and transformation live alongside registry restoration, persistence and observers, making it harder to separate database ownership from prepared data during the asynchronous storage refactor.

## Why This Change Was Made

Move the existing record transformations into their own internal module and keep registry reads, writes and observer publication together. Function bodies, public types and synchronous operation boundaries are preserved. Remove the registry file's now-obsolete size exemption.

## User Impact

No user-visible behavior or persisted format changes. This is a focused architectural prerequisite for the coordinated async task/flow conversion.

## Evidence

- All 19 existing flow registry and store cases passed.
- Full selected changed checks and fresh independent Codex review through P2 passed.
- The 15 extracted function bodies were checked against the original implementation; registry persistence and publication order are unchanged.
- No worker execution or event-loop performance improvement is claimed by this extraction.
