### PR TITLE
refactor(secrets): remove unused scope parameter from normalizeScope

### DIFF
--- a/src/secrets/store/secret-store.ts
+++ b/src/secrets/store/secret-store.ts
@@ -95,7 +95,7 @@ type SecretStoreReadError =
 
 const SECRET_STORE_RETENTION_MS = 30 * 24 * 60 * 60_000;
 
-function normalizeScope(_scope: SecretStoreScope): { scopeKind: "team"; scopeId: "" } {
+function normalizeScope(): { scopeKind: "team"; scopeId: "" } {
   return { scopeKind: "team", scopeId: "" };
 }
 
@@ -203,7 +203,7 @@ export function listSecretStoreEntries(params: {
   includeDeleted?: boolean;
   database?: OpenClawStateDatabaseOptions;
 }): SecretStoreEntryMetadata[] {
-  const { scopeKind, scopeId } = normalizeScope(params.scope);
+  const { scopeKind, scopeId } = normalizeScope();
   try {
     return (
       withExistingOpenClawStateDatabaseReadOnly(({ db: sqlite }) => {
@@ -359,7 +359,7 @@ export function readSecretStoreValue(params: {
 }): Result<string, SecretStoreReadError> {
   try {
     assertSecretStoreEnvName(params.name);
-    const { scopeKind, scopeId } = normalizeScope(params.scope);
+    const { scopeKind, scopeId } = normalizeScope();
     const row = withExistingOpenClawStateDatabaseReadOnly(({ db: sqlite }) => {
       const db = getNodeSqliteKysely<SecretStoreDatabase>(sqlite);
       return executeSqliteQueryTakeFirstSync(
@@ -418,7 +418,7 @@ function writeSecretStoreEntryInternal(
       ? normalizeSecretAllowedHosts(params.allowedHosts)
       : undefined;
   const allowedHostsJson = allowedHosts?.length ? JSON.stringify(allowedHosts) : null;
-  const { scopeKind, scopeId } = normalizeScope(params.scope);
+  const { scopeKind, scopeId } = normalizeScope();
   const now = Date.now();
   return runOpenClawStateWriteTransaction(
     ({ db: sqlite }) => {
@@ -494,7 +494,7 @@ function rollbackSecretStoreEntryWrite(params: {
   database?: OpenClawStateDatabaseOptions;
 }): boolean {
   assertSecretStoreMutationName(params.name);
-  const { scopeKind, scopeId } = normalizeScope(params.scope);
+  const { scopeKind, scopeId } = normalizeScope();
   const now = Date.now();
   try {
     return runOpenClawStateWriteTransaction(
@@ -572,7 +572,7 @@ export function updateSecretStoreAllowedHosts(params: {
 }): void {
   assertSecretStoreEnvName(params.name);
   const allowedHosts = normalizeSecretAllowedHosts(params.allowedHosts);
-  const { scopeKind, scopeId } = normalizeScope(params.scope);
+  const { scopeKind, scopeId } = normalizeScope();
   const now = Date.now();
   runOpenClawStateWriteTransaction(
     ({ db: sqlite }) => {
@@ -611,7 +611,7 @@ export function deleteSecretStoreEntry(params: {
   database?: OpenClawStateDatabaseOptions;
 }): void {
   assertSecretStoreMutationName(params.name);
-  const { scopeKind, scopeId } = normalizeScope(params.scope);
+  const { scopeKind, scopeId } = normalizeScope();
   const state = openOpenClawStateDatabase(params.database);
   const now = Date.now();
   try {


### PR DESCRIPTION
## What Problem This Solves

`normalizeScope` in `src/secrets/store/secret-store.ts` declares a `_scope: SecretStoreScope` parameter that is never read. Its body always returns the same constant `{ scopeKind: "team", scopeId: "" }`, regardless of the argument. The underscore prefix exists only because the repository's `noUnusedParameters` compile setting (`tsconfig.core.json:8`) otherwise rejects an unused parameter — a compiler-acknowledged sign that the parameter is dead.

## Why This Change Was Made

This removes the unused parameter so the helper's signature reflects what it actually computes, and updates its six call sites to call `normalizeScope()` with no argument. `SecretStoreScope` (the module-private, single-value `{ kind: "team" }` type) is retained because the public entry points (`listSecretStoreEntries`, `readSecretStoreValue`, `writeSecretStoreEntry*`, `updateSecretStoreAllowedHosts`, `deleteSecretStoreEntry`) still accept `scope` in their own params and forward its shape elsewhere. No behavior changes: the function's return value was already independent of its input.

## User Impact

None. This is an internal, behavior-preserving cleanup with no user-visible or API-visible effect.

## Evidence

- **Typecheck:** `tsgo -p tsconfig.core.json --noEmit` reports no errors for `src/secrets/store/secret-store.ts` (pre-existing unrelated missing-module errors in `packages/markdown-core` etc. are a local-environment artifact, not caused by this change).
- **Tests:** the dedicated secrets suite covering every `normalizeScope` call site passes on Node 26.8.1 (which embeds the required SQLite 3.51.3+):

  ```
  Test Files  1 passed (1)
       Tests  21 passed (21)
  ```

  (`src/secrets/store/secret-store.test.ts`, via `test/vitest/vitest.secrets.config.ts`.)

- **Correctness argument:** `normalizeScope` previously returned the constant `{ scopeKind: "team", scopeId: "" }` for the only possible `SecretStoreScope` value (`{ kind: "team" }`); removing the argument cannot change any caller's outcome. `git diff --check` is clean.

## Real CLI behavior proof

The real `openclaw secrets store` CLI was exercised end-to-end against a fresh
isolated state directory (`OPENCLAW_STATE_DIR`), driving every secret-store
operation whose call site was changed by this refactor — through the actual CLI
entry point, not a test harness:

```
$ openclaw secrets store set DEPLOY_ENV_VALUE --kind env --value "env-value-144984"
Stored DEPLOY_ENV_VALUE (env).            # writeSecretStoreEntry

$ openclaw secrets store list --json
[ { "name": "DEPLOY_ENV_VALUE", "kind": "env", "valuePreview": "env-value-144984", ... } ]   # listSecretStoreEntries

$ openclaw secrets store get DEPLOY_ENV_VALUE --json
{ "name": "DEPLOY_ENV_VALUE", "kind": "env", "value": "env-value-144984" }                   # readSecretStoreValue

$ printf 'shh-secret-144984' | openclaw secrets store set API_KEY --kind secret --allow-host example.com --value-file -
Stored API_KEY (secret).                  # writeSecretStoreEntry (secret kind, stdin)

$ openclaw secrets store set API_KEY --allow-host other.example
Allowed API_KEY for other.example.        # updateSecretStoreAllowedHosts (policy-only path)

$ openclaw secrets store rm DEPLOY_ENV_VALUE --yes
Removed 1 team store entry.               # deleteSecretStoreEntry

$ openclaw secrets store list --json
[ { "name": "API_KEY", "kind": "secret", "allowedHosts": ["other.example"], ... } ]
                                          # deletion persisted; the secret entry
                                          # remains live and still lists (write-only)
```

All commands exited 0. This demonstrates the refactored call sites behave
identically through the real CLI: values write, list, and read back correctly
for both env and secret kinds, allowed-host policies update, and entries delete
as expected — confirming the removed parameter was truly unused. The final
`list --json` shows the still-live `API_KEY` secret (with its updated allowed-host
policy); only the deleted `DEPLOY_ENV_VALUE` env entry is gone. The SQLite store
behind this sequence was re-inspected directly (`SELECT name, kind, deleted_at_ms
FROM secret_store_entries`) and confirms exactly one live entry, `API_KEY`, and
one deleted entry, `DEPLOY_ENV_VALUE`, matching the transcript above.

The sequence was re-executed in one fresh state directory to produce this
corrected transcript. An earlier draft of this proof ended with `[]` because the
final listing had been captured against a separate state directory after the
entries had been cleaned up; re-running the full sequence in a single isolated
state makes the list reflect the live `API_KEY` entry as shown.


