### PR TITLE
feat(cli): read the resolved approval ledger from the terminal

### DIFF
--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -4,6 +4,7 @@ read_when:
   - You want to edit exec approvals from the CLI
   - You need to manage allowlists on gateway or node hosts
   - You need to list or resolve a pending approval without a chat surface
+  - You need the recorded outcome of past approval decisions from a terminal
 title: "Approvals"
 ---
 
@@ -23,6 +24,7 @@ openclaw approvals get --node <id|name|ip>
 openclaw approvals get --gateway
 openclaw approvals pending
 openclaw approvals resolve <id> <allow-once|allow-always|deny>
+openclaw approvals history
 ```
 
 `get` shows the effective exec policy for the target: the requested `tools.exec` policy, the host approvals-file policy, and the merged effective result. Nodes with a host-native policy, such as the Windows companion, show that policy directly instead of applying OpenClaw approvals-file policy math.
@@ -77,6 +79,24 @@ default:
 ```bash
 openclaw approvals resolve <id> allow-always --expires-in-days 30
 ```
+
+## Approval history
+
+Resolved approvals stay readable from the Gateway's rolling 30-day ledger without opening the Control UI:
+
+```bash
+openclaw approvals history
+openclaw approvals history --kind exec
+openclaw approvals history --limit 100
+openclaw approvals history --cursor <nextCursor>
+openclaw approvals history --json
+```
+
+The table shows the resolution time in UTC, the approval kind, the recorded decision, the resolution reason, the source agent/session, the resolver attribution (`device`, `channel`, `runtime`, or `system`), and the reviewer-safe command or summary. Rows that failed closed without a reviewer decision show their terminal status (`expired` or `cancelled`) in the decision column, so a timeout is never mistaken for an approval.
+
+`--kind` accepts `exec`, `plugin`, and `system-agent`; `--limit` accepts 1-100. Both filters are applied by the Gateway, and malformed values are rejected before any request is sent. Paging is cursor-based: when more rows remain, the output ends with the `nextCursor` value and the command that continues from it. `--json` returns the Gateway result unchanged (`items`, `nextCursor`) for audit scripts.
+
+The read requests the `operator.approvals` scope only — no admin scope is needed — and the Gateway applies the same per-reviewer session-access filtering it applies to every other approval surface, so a restricted operator sees only the rows it may review. History is read-only: decisions are recorded by `openclaw approvals resolve`, the Control UI, or channel surfaces.
 
 ## Standing grants
 

--- a/src/cli/exec-approvals-cli.history.test.ts
+++ b/src/cli/exec-approvals-cli.history.test.ts
@@ -1,0 +1,344 @@
+import { Command } from "commander";
+// Approval history CLI coverage stays separate from pending/resolve and policy-management tests.
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerExecApprovalsCli } from "./exec-approvals-cli.js";
+
+const mocks = vi.hoisted(() => {
+  const runtimeErrors: string[] = [];
+  const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");
+  const defaultRuntime = {
+    log: vi.fn(),
+    error: vi.fn((...args: unknown[]) => {
+      runtimeErrors.push(stringifyArgs(args));
+    }),
+    writeStdout: vi.fn((value: string) => {
+      defaultRuntime.log(value.endsWith("\n") ? value.slice(0, -1) : value);
+    }),
+    writeJson: vi.fn((value: unknown, space = 2) => {
+      defaultRuntime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+    }),
+    exit: vi.fn((code: number) => {
+      throw new Error(`__exit__:${code}`);
+    }),
+  };
+  return {
+    callGatewayFromCli: vi.fn(),
+    defaultRuntime,
+    runtimeErrors,
+  };
+});
+
+const { callGatewayFromCli, defaultRuntime, runtimeErrors } = mocks;
+
+const requireRecord = createRequireRecord("record", "expected-label-capitalized");
+
+function firstMockArg(mock: { mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> } }): unknown {
+  const call = mock.mock.calls[0];
+  if (!call) {
+    throw new Error("Expected mock to have at least one call");
+  }
+  return call[0];
+}
+
+function writtenJson(): Record<string, unknown> {
+  return requireRecord(firstMockArg(vi.mocked(defaultRuntime.writeJson)), "written json");
+}
+
+function runtimeOutput(): string {
+  return defaultRuntime.log.mock.calls.map(([line]) => String(line ?? "")).join("\n");
+}
+
+const RESOLVED_AT_MS = Date.UTC(2026, 8, 10, 12, 0, 0);
+
+function allowedExecApproval(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "approval-allowed-1",
+    status: "allowed",
+    decision: "allow-always",
+    reason: "user",
+    urlPath: "/approve/approval-allowed-1",
+    createdAtMs: RESOLVED_AT_MS - 60_000,
+    expiresAtMs: RESOLVED_AT_MS + 60_000,
+    resolvedAtMs: RESOLVED_AT_MS,
+    presentation: {
+      kind: "exec",
+      commandText: "echo ready",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    },
+    source: { agentId: "main", sessionKey: "agent:main:dm" },
+    resolver: { kind: "device", id: "device-1" },
+    ...overrides,
+  };
+}
+
+function deniedPluginApproval() {
+  return {
+    id: "approval-denied-1",
+    status: "denied",
+    decision: "deny",
+    reason: "user",
+    urlPath: "/approve/approval-denied-1",
+    createdAtMs: RESOLVED_AT_MS - 60_000,
+    expiresAtMs: RESOLVED_AT_MS + 60_000,
+    resolvedAtMs: RESOLVED_AT_MS,
+    presentation: {
+      kind: "plugin",
+      title: "Send message",
+      description: "Post to #general",
+      severity: "info",
+      allowedDecisions: ["allow-once", "deny"],
+    },
+    source: { agentId: "helper", sessionKey: "agent:helper:group" },
+    resolver: { kind: "channel", id: "telegram:1" },
+  };
+}
+
+function expiredExecApproval() {
+  return {
+    id: "approval-expired-1",
+    status: "expired",
+    reason: "timeout",
+    urlPath: "/approve/approval-expired-1",
+    createdAtMs: RESOLVED_AT_MS - 60_000,
+    expiresAtMs: RESOLVED_AT_MS,
+    resolvedAtMs: RESOLVED_AT_MS,
+    presentation: {
+      kind: "exec",
+      commandText: "sleep 1",
+      allowedDecisions: ["allow-once", "deny"],
+    },
+    resolver: { kind: "system" },
+  };
+}
+
+function cancelledSystemAgentApproval() {
+  return {
+    id: "approval-cancelled-1",
+    status: "cancelled",
+    reason: "gateway-restart",
+    urlPath: "/approve/approval-cancelled-1",
+    createdAtMs: RESOLVED_AT_MS - 60_000,
+    expiresAtMs: RESOLVED_AT_MS + 60_000,
+    resolvedAtMs: RESOLVED_AT_MS,
+    presentation: {
+      kind: "system-agent",
+      title: "Config change",
+      description: "Update gateway config",
+      proposalHash: "a".repeat(64),
+      allowedDecisions: ["allow-once", "deny"],
+    },
+  };
+}
+
+vi.mock("./gateway-rpc.js", () => ({
+  callGatewayFromCli: (method: string, opts: unknown, params?: unknown, extra?: unknown) =>
+    mocks.callGatewayFromCli(method, opts, params, extra),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.defaultRuntime,
+}));
+
+describe("exec approvals history CLI", () => {
+  // Wide terminal so table cells stay on one line: these assertions cover cell
+  // content, and the table renderer wraps by design on narrow terminals.
+  const originalColumns = process.stdout.columns;
+  const setWideTerminal = () => {
+    Object.defineProperty(process.stdout, "columns", { value: 220, configurable: true });
+  };
+
+  const createProgram = () => {
+    const program = new Command();
+    program.exitOverride();
+    registerExecApprovalsCli(program);
+    return program;
+  };
+
+  const runApprovalsCommand = async (args: string[]) => {
+    const program = createProgram();
+    await program.parseAsync(args, { from: "user" });
+  };
+
+  beforeEach(() => {
+    setWideTerminal();
+    runtimeErrors.length = 0;
+    callGatewayFromCli.mockReset();
+    defaultRuntime.log.mockClear();
+    defaultRuntime.error.mockClear();
+    defaultRuntime.writeStdout.mockClear();
+    defaultRuntime.writeJson.mockClear();
+    defaultRuntime.exit.mockClear();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, "columns", {
+      value: originalColumns,
+      configurable: true,
+    });
+  });
+
+  it.each(["tool", "EXEC", "exec ", ""])(
+    "rejects an unknown history kind before the Gateway request (%s)",
+    async (kind) => {
+      await expect(
+        runApprovalsCommand(["approvals", "history", "--kind", kind, "--json"]),
+      ).rejects.toThrow("--kind must be one of: exec, plugin, system-agent.");
+
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["0", "101", "1.5", "10junk", "-1", "1e2"])(
+    "rejects an out-of-range history limit before the Gateway request (%s)",
+    async (limit) => {
+      await expect(
+        runApprovalsCommand(["approvals", "history", "--limit", limit, "--json"]),
+      ).rejects.toThrow("--limit must be an integer between 1 and 100.");
+
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects a blank history cursor before the Gateway request", async () => {
+    await expect(
+      runApprovalsCommand(["approvals", "history", "--cursor", "   ", "--json"]),
+    ).rejects.toThrow("--cursor must not be empty.");
+
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+  });
+
+  it("requests the ledger with the approvals scope and no params by default", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({ items: [] });
+
+    await runApprovalsCommand(["approvals", "history"]);
+
+    const call = callGatewayFromCli.mock.calls[0];
+    expect(call?.[0]).toBe("approval.history");
+    expect(call?.[2]).toEqual({});
+    expect(call?.[3]).toEqual({ scopes: ["operator.approvals"] });
+  });
+
+  it("forwards kind, limit, and cursor exactly as given", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({ items: [] });
+
+    await runApprovalsCommand([
+      "approvals",
+      "history",
+      "--kind",
+      "system-agent",
+      "--limit",
+      "100",
+      "--cursor",
+      "cursor-2",
+    ]);
+
+    const call = callGatewayFromCli.mock.calls[0];
+    expect(call?.[0]).toBe("approval.history");
+    expect(call?.[2]).toEqual({ kind: "system-agent", limit: 100, cursor: "cursor-2" });
+  });
+
+  it("writes the Gateway ledger result unchanged with --json", async () => {
+    const result = { items: [allowedExecApproval()], nextCursor: "cursor-2" };
+    callGatewayFromCli.mockResolvedValueOnce(result);
+
+    await runApprovalsCommand(["approvals", "history", "--json"]);
+
+    expect(writtenJson()).toEqual(result);
+  });
+
+  it("renders resolved rows with decision, reason, source, and resolver", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      items: [allowedExecApproval(), deniedPluginApproval()],
+    });
+
+    await runApprovalsCommand(["approvals", "history"]);
+
+    const output = runtimeOutput();
+    expect(output).toContain("2026-09-10T12:00:00Z");
+    expect(output).toContain("echo ready");
+    expect(output).toContain("exec");
+    expect(output).toContain("allow-always");
+    expect(output).toContain("main / agent:main:dm");
+    expect(output).toContain("device:device-1");
+    expect(output).toContain("Send message: Post to #general");
+    expect(output).toContain("plugin");
+    expect(output).toContain("deny");
+    expect(output).toContain("channel:telegram:1");
+  });
+
+  it("shows the terminal status when no reviewer decision was recorded", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      items: [expiredExecApproval(), cancelledSystemAgentApproval()],
+    });
+
+    await runApprovalsCommand(["approvals", "history"]);
+
+    const output = runtimeOutput();
+    expect(output).toContain("expired");
+    expect(output).toContain("timeout");
+    expect(output).toContain("cancelled");
+    expect(output).toContain("gateway-restart");
+    expect(output).toContain("Config change: Update gateway config");
+    expect(output).toContain("system-agent");
+  });
+
+  it("prints the next cursor so callers can page further back", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      items: [allowedExecApproval()],
+      nextCursor: "cursor-page-2",
+    });
+
+    await runApprovalsCommand(["approvals", "history"]);
+
+    expect(runtimeOutput()).toContain("cursor-page-2");
+  });
+
+  it("keeps the paging cursor when session-access filtering empties the page", async () => {
+    // Visibility filtering runs after pagination, so an empty visible page can
+    // still have retained rows behind it; dropping the cursor would dead-end paging.
+    callGatewayFromCli.mockResolvedValueOnce({ items: [], nextCursor: "cursor-filtered-page" });
+
+    await runApprovalsCommand(["approvals", "history"]);
+
+    const output = runtimeOutput();
+    expect(output).toMatch(/rolling 30-day/);
+    expect(output).toContain("cursor-filtered-page");
+  });
+
+  it("names the retention window when the ledger has no rows", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({ items: [] });
+
+    await runApprovalsCommand(["approvals", "history"]);
+
+    expect(runtimeOutput()).toMatch(/rolling 30-day/);
+  });
+
+  it("escapes terminal-unsafe request text instead of emitting raw control bytes", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      items: [
+        allowedExecApproval({
+          presentation: {
+            kind: "exec",
+            commandText: "\u001b[31mrm -rf /tmp/x\u001b[0m",
+            allowedDecisions: ["allow-once", "deny"],
+          },
+        }),
+      ],
+    });
+
+    await runApprovalsCommand(["approvals", "history"]);
+
+    const output = runtimeOutput();
+    expect(output).not.toContain("\u001b[31m");
+    expect(output).toContain("rm -rf /tmp/x");
+  });
+
+  it("rejects an invalid history response", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({ items: [{ id: "approval-bogus" }] });
+
+    await expect(runApprovalsCommand(["approvals", "history", "--json"])).rejects.toThrow(
+      "Invalid approval history response.",
+    );
+  });
+});

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -10,11 +10,14 @@ import type { Command } from "commander";
 import JSON5 from "json5";
 import {
   isWellFormedApprovalId,
+  validateApprovalHistoryResult,
   type ApprovalDecision,
   type ApprovalGetResult,
+  type ApprovalHistoryResult,
   type ApprovalKind,
   type ApprovalResolveResult,
   type ApprovalSnapshot,
+  type TerminalApprovalSnapshot,
 } from "../../packages/gateway-protocol/src/index.js";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
@@ -647,6 +650,156 @@ function renderPendingApprovals(entries: PendingApprovalCliEntry[]): void {
 
 function approvalRecordedDecision(approval: ApprovalSnapshot): ApprovalDecision | null {
   return "decision" in approval && isApprovalDecision(approval.decision) ? approval.decision : null;
+}
+
+// Ledger filters mirror ApprovalHistoryParamsSchema so the Gateway validator stays
+// authoritative; local parsing only keeps malformed input from making a round trip.
+const APPROVAL_HISTORY_KINDS = [
+  "exec",
+  "plugin",
+  "system-agent",
+] as const satisfies readonly ApprovalKind[];
+const APPROVAL_HISTORY_MAX_LIMIT = 100;
+const APPROVAL_HISTORY_RETENTION_NOTE = "Approval history is a rolling 30-day window.";
+
+type ApprovalHistoryCliOpts = ExecApprovalsCliOpts & {
+  kind?: string;
+  limit?: string;
+  cursor?: string;
+};
+
+type ApprovalHistoryQuery = {
+  kind?: ApprovalKind;
+  limit?: number;
+  cursor?: string;
+};
+
+function isApprovalHistoryKind(value: string): value is ApprovalKind {
+  return (APPROVAL_HISTORY_KINDS as readonly string[]).includes(value);
+}
+
+function readApprovalHistoryQuery(opts: ApprovalHistoryCliOpts): ApprovalHistoryQuery {
+  const query: ApprovalHistoryQuery = {};
+  if (opts.kind !== undefined) {
+    if (!isApprovalHistoryKind(opts.kind)) {
+      exitWithError(`--kind must be one of: ${APPROVAL_HISTORY_KINDS.join(", ")}.`);
+    }
+    query.kind = opts.kind;
+  }
+  if (opts.limit !== undefined) {
+    const limit = parseStrictPositiveInteger(opts.limit);
+    if (limit === undefined || limit > APPROVAL_HISTORY_MAX_LIMIT) {
+      exitWithError(`--limit must be an integer between 1 and ${APPROVAL_HISTORY_MAX_LIMIT}.`);
+    }
+    query.limit = limit;
+  }
+  if (opts.cursor !== undefined) {
+    if (!opts.cursor.trim()) {
+      exitWithError("--cursor must not be empty.");
+    }
+    // Cursors are opaque signed tokens: forward verbatim so paging never depends on trimming.
+    query.cursor = opts.cursor;
+  }
+  return query;
+}
+
+async function loadApprovalHistory(opts: ApprovalHistoryCliOpts): Promise<ApprovalHistoryResult> {
+  // approval.history declares operator.approvals; unlike the owner-specific pending
+  // lists it needs no admin scope, so request only what the ledger read requires.
+  const result = await callGatewayFromCli(
+    "approval.history",
+    opts,
+    readApprovalHistoryQuery(opts),
+    {
+      scopes: [APPROVALS_SCOPE] as OperatorScope[],
+    },
+  );
+  if (!validateApprovalHistoryResult(result)) {
+    throw new Error("Invalid approval history response.");
+  }
+  return result;
+}
+
+function formatApprovalHistoryRequest(item: TerminalApprovalSnapshot): string {
+  const presentation = item.presentation;
+  // System-agent rows stay on their reviewer-safe presentation: the exact
+  // operation is host-local by contract and must not leak into terminals.
+  const text =
+    presentation.kind === "exec"
+      ? presentation.commandText
+      : `${presentation.title}: ${presentation.description}`;
+  return escapeApprovalTextForTerminal(text);
+}
+
+function formatApprovalHistorySource(item: TerminalApprovalSnapshot): string {
+  const parts = [item.source?.agentId, item.source?.sessionKey].filter((value): value is string =>
+    Boolean(value),
+  );
+  return parts.length > 0 ? escapeApprovalTextForTerminal(parts.join(" / ")) : "-";
+}
+
+function formatApprovalHistoryDecision(item: TerminalApprovalSnapshot): string {
+  // Expired and cancelled rows failed closed without a reviewer decision; the
+  // terminal status is the honest answer for an audit trail.
+  return approvalRecordedDecision(item) ?? item.status;
+}
+
+function formatApprovalHistoryResolvedAt(resolvedAtMs: number): string {
+  // Absolute UTC timestamps: an audit trail must not shift with the reader's clock.
+  // Second precision keeps the column narrow enough to survive small terminals.
+  return new Date(resolvedAtMs).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Prints the store cursor that continues this listing.
+ *
+ * Session-access filtering runs after pagination, so a page can come back empty
+ * while more retained rows sit behind it. Callers must therefore surface the
+ * cursor on every page, or a restricted reviewer's paging dead-ends on the
+ * first fully filtered page.
+ */
+function logApprovalHistoryCursor(nextCursor: string | undefined): void {
+  if (!nextCursor) {
+    return;
+  }
+  const cursor = sanitizeForLog(nextCursor);
+  defaultRuntime.log(theme.muted(`Next cursor: ${cursor}`));
+  defaultRuntime.log(theme.muted(`Page with: openclaw approvals history --cursor ${cursor}`));
+}
+
+function renderApprovalHistory(result: ApprovalHistoryResult): void {
+  const items = result.items;
+  if (items.length === 0) {
+    defaultRuntime.log(theme.muted(`No resolved approvals. ${APPROVAL_HISTORY_RETENTION_NOTE}`));
+    logApprovalHistoryCursor(result.nextCursor);
+    return;
+  }
+  defaultRuntime.log(`${theme.heading("Resolved approvals")} ${theme.muted(`(${items.length})`)}`);
+  defaultRuntime.log(
+    renderTerminalSafeTable({
+      width: getTerminalTableWidth(),
+      columns: [
+        { key: "Resolved", header: "Resolved", minWidth: 20 },
+        { key: "Kind", header: "Kind", minWidth: 12 },
+        { key: "Decision", header: "Decision", minWidth: 12 },
+        { key: "Reason", header: "Reason", minWidth: 12 },
+        { key: "Source", header: "Agent / Session", minWidth: 16, flex: true },
+        { key: "Resolver", header: "Resolver", minWidth: 12 },
+        { key: "Request", header: "Command / Summary", minWidth: 20, flex: true },
+      ],
+      rows: items.map((item) => ({
+        Resolved: formatApprovalHistoryResolvedAt(item.resolvedAtMs),
+        Kind: item.presentation.kind,
+        Decision: formatApprovalHistoryDecision(item),
+        Reason: item.reason,
+        Source: formatApprovalHistorySource(item),
+        Resolver: formatResolver(item),
+        Request: formatApprovalHistoryRequest(item),
+      })),
+    }).trimEnd(),
+  );
+  defaultRuntime.log(theme.muted(APPROVAL_HISTORY_RETENTION_NOTE));
+  logApprovalHistoryCursor(result.nextCursor);
 }
 
 function formatResolver(approval: ApprovalResolveResult["approval"]): string {
@@ -1309,6 +1462,26 @@ export function registerExecApprovalsCli(program: Command) {
       }
     });
   nodesCallOpts(grantsRevokeCmd);
+
+  const historyCmd = approvals
+    .command("history")
+    .description("List resolved approvals from the rolling 30-day gateway ledger")
+    .option("--kind <kind>", "Filter by approval kind (exec, plugin, system-agent)")
+    .option("--limit <n>", `Maximum rows to return (1-${APPROVAL_HISTORY_MAX_LIMIT})`)
+    .option("--cursor <token>", "Resume from the nextCursor printed by a previous page")
+    .action(async (opts: ApprovalHistoryCliOpts) => {
+      try {
+        const result = await loadApprovalHistory(opts);
+        if (opts.json) {
+          defaultRuntime.writeJson(result, 0);
+          return;
+        }
+        renderApprovalHistory(result);
+      } catch (err) {
+        failApprovalsCommand(err, opts);
+      }
+    });
+  nodesCallOpts(historyCmd);
 
   const getCmd = approvals
     .command("get")


### PR DESCRIPTION
Closes #144950

## What Problem This Solves

Operators who reach a gateway over SSH, inside a container, or from a CI/audit job cannot read the recorded outcome of approval decisions from the terminal. `openclaw approvals` covers pending requests, resolution, standing grants, and the allowlist, but the gateway's durable resolved-approval ledger — a rolling 30-day window of every allowed, denied, expired, and cancelled exec, plugin, and system-agent approval, with resolver attribution — is only reachable through the Control UI approvals page.

So an ordinary review question ("which exec commands were allowed this week, and which resolver decided them?") needs an interactive browser session against the gateway host, and there is no machine-readable route for audit reporting. The only terminal fallback is the raw escape hatch `openclaw gateway call approval.history`, which returns protocol JSON with no table, no paging affordance, no scope guidance, and no discovery from `openclaw approvals --help`.

## Why This Change Was Made

Adds a read-only `openclaw approvals history` subcommand that forwards to the already-shipped `approval.history` gateway method, mirroring the sibling `approvals grants list` shape (`--limit`, `--json`, dedicated renderer) so the command group reads as one consistent surface.

Design decisions and boundaries:

- Filters map 1:1 onto `ApprovalHistoryParamsSchema` (`kind`, `limit` 1-100, `cursor`), keeping the gateway validator authoritative. Local parsing only rejects malformed values before a round trip, which is how `grants list --limit` already behaves.
- The read requests `operator.approvals` — the scope the method declares — instead of the `operator.admin` scope the pending lists need for full enumeration, so a restricted reviewer is not pushed toward admin.
- Rows that failed closed without a reviewer decision (`expired`, `cancelled`) show their terminal status in the decision column, so a timeout can never be mistaken for an approval in an audit read.
- Response shape is validated with the shared protocol validator before rendering, and all reviewer text goes through the same terminal-escaping path the rest of this CLI uses.
- Paging is explicit: when the gateway returns `nextCursor`, the output prints it plus the command that continues from it. Session-access filtering runs *after* pagination server-side, so a page can come back empty while retained rows remain behind it — the cursor is therefore printed on empty pages too, and a unit test pins that boundary so a restricted reviewer's paging cannot dead-end.

Compared with the existing raw route (`openclaw gateway call approval.history --params '{"limit":100}' --json`, which already exports protocol JSON), this adds the parts an audit read needs in a terminal: a discoverable subcommand under `approvals --help`, a human table with the same columns the Control UI shows, terminal-safe escaping of reviewer text, local rejection of malformed `--kind`/`--limit` before a round trip, the correct `operator.approvals` scope request, an empty state that names the retention window, and a printed continuation cursor. `--json` keeps the raw export path intact for scripts.

Non-goals: no protocol, schema, gateway, storage, or scope change; no change to how decisions are recorded or resolved; the Control UI's missing `kind` filter is deliberately left out of this PR.

## User Impact

`openclaw approvals history` now prints the resolved-approval audit trail in the terminal: resolution time in UTC, approval kind, recorded decision, resolution reason, source agent/session, resolver attribution (`device` / `channel` / `runtime` / `system`), and the reviewer-safe command or summary.

```bash
openclaw approvals history
openclaw approvals history --kind exec          # exec | plugin | system-agent
openclaw approvals history --limit 100          # 1-100
openclaw approvals history --cursor <nextCursor>
openclaw approvals history --json               # gateway result unchanged, for audit scripts
```

An empty ledger says so and names the rolling 30-day window, so "no rows" is not mistaken for "no access"; when the gateway still returns a cursor for that page, the continuation command is printed as well. Restricted operators see only the rows the gateway already permits them to review, because filtering stays server-side. No existing command changes behavior; `openclaw approvals --help` now lists `history` alongside `pending`, `resolve`, and `grants`.

## Evidence

Real environment tested: yes — a real gateway server (loopback bind, token auth, Control UI disabled, sidecar startup deferred) booted in-process from this branch, a real exec approval raised over RPC with `exec.approval.request`, resolved to a terminal decision with `approval.resolve` (`allowed` / `allow-once`), and then read back by the real CLI running as a separate subprocess against that live gateway. No mocks, no fixtures, no stubbed gateway method; isolated temp `HOME`/`OPENCLAW_STATE_DIR`, removed after the run.

Exact steps or commands run after this patch: run from the worktree root at this branch head, in this order.

```text
# 1. zero-mock proof script (boots the gateway, records a real decision, drives the CLI)
cd <worktree>
node --import ./scripts/tsx.mjs <evidence-dir>/proof-approvals-history.mts

# 2. CLI invocations the script made against the live gateway
openclaw approvals --help
openclaw approvals history --url ws://127.0.0.1:<port> --token <redacted-local-proof-token> --timeout 180000
openclaw approvals history --url ws://127.0.0.1:<port> --token <redacted-local-proof-token> --timeout 180000 --json
openclaw approvals history --url ws://127.0.0.1:<port> --token <redacted-local-proof-token> --timeout 180000 --kind plugin
openclaw approvals history --url ws://127.0.0.1:<port> --token <redacted-local-proof-token> --timeout 180000 --kind tool
openclaw approvals history --url ws://127.0.0.1:<port> --token <redacted-local-proof-token> --timeout 180000 --limit 101

# 3. focused tests + format + lint + type check
node scripts/run-vitest.mjs run src/cli/exec-approvals-cli.history.test.ts src/cli/exec-approvals-cli.test.ts
pnpm exec oxfmt --check src/cli/exec-approvals-cli.ts src/cli/exec-approvals-cli.history.test.ts
pnpm exec oxlint src/cli/exec-approvals-cli.ts src/cli/exec-approvals-cli.history.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental
```

Evidence after fix: verbatim terminal output from the live-gateway run above, with the unpatched `main` behavior first for contrast.

```text
# before this patch (main @ 66c7fad, OpenClaw 2026.9.4) — no history surface at all
$ node --import ./scripts/tsx.mjs src/entry.ts approvals --help | grep -i history
(no output; grep exit status 1)

# after this patch — real gateway, real recorded decision, real CLI subprocess
$ openclaw approvals --help
Commands:
  allowlist   Edit the per-agent allowlist
  get         Fetch exec approvals snapshot
  grants      Standing grants minted by allow-always on automation approvals
  history     List resolved approvals from the rolling 30-day gateway ledger
  pending     List pending exec, plugin, and system-agent approvals
  resolve     Resolve a pending approval
  set         Replace exec approvals with a JSON file

$ openclaw approvals history --url ws://127.0.0.1:44801 --token <redacted> --timeout 180000
# exit=0
Resolved approvals (1)
┌────────────────────┬────────────┬────────────┬────────────┬─────────────────┬────────────────────┬───────────────────┐
│ Resolved           │ Kind       │ Decision   │ Reason     │ Agent / Session │ Resolver           │ Command / Summary │
├────────────────────┼────────────┼────────────┼────────────┼─────────────────┼────────────────────┼───────────────────┤
│ 2026-09-           │ exec       │ allow-once │ user       │ -               │ device:b667bcaed94 │ printf hist-proof │
│ 11T14:29:29Z       │            │            │            │                 │ 51b0ca2c2fee2cdad7 │                   │
│                    │            │            │            │                 │ 25379c9b2a1ea966fc │                   │
│                    │            │            │            │                 │ c08613a5268974c63  │                   │
└────────────────────┴────────────┴────────────┴────────────┴─────────────────┴────────────────────┴───────────────────┘
Approval history is a rolling 30-day window.

$ openclaw approvals history ... --json
# exit=0
{"items":[{"id":"proof-exec-approval","status":"allowed","presentation":{"kind":"exec","commandText":"printf hist-proof","commandPreview":null,"warningText":null,"host":"local","nodeId":null,"agentId":null,"allowedDecisions":["allow-once","deny"]},"urlPath":"/approve/proof-exec-approval","createdAtMs":1789136969168,"expiresAtMs":1789137029168,"resolvedAtMs":1789136969287,"reason":"user","decision":"allow-once","source":{},"resolver":{"kind":"device","id":"b667bcaed9451b0ca2c2fee2cdad725379c9b2a1ea966fcc08613a5268974c63"}}]}

$ openclaw approvals history ... --kind plugin
# exit=0
No resolved approvals. Approval history is a rolling 30-day window.

$ openclaw approvals history ... --kind tool
# exit=1
--kind must be one of: exec, plugin, system-agent.

$ openclaw approvals history ... --limit 101
# exit=1
--limit must be an integer between 1 and 100.

# proof script summary (22 assertions, 0 failures)
PASS  approval request accepted — status=accepted
PASS  approval reached a terminal decision — status=allowed
PASS  approvals --help lists history
PASS  history exits 0 — exit=0
PASS  history shows the resolved command
PASS  history shows kind exec
PASS  history shows the recorded decision
PASS  history shows resolver attribution
PASS  history names the retention window
PASS  history --json exits 0 — exit=0
PASS  history --json returns the ledger row
PASS  ledger row id matches — id=proof-exec-approval
PASS  ledger row is terminal — status=allowed
PASS  ledger row keeps the reviewer-safe exec command — commandText=printf hist-proof
PASS  ledger row carries resolver attribution
PASS  history --kind plugin exits 0 — exit=0
PASS  kind filter is applied by the gateway (no exec row)
PASS  history rejects an unknown kind — exit=1
PASS  unknown kind error names the accepted values
PASS  history rejects an out-of-range limit — exit=1
PASS  limit error names the accepted range
# ALL CHECKS PASSED
```

Observed result after fix: the CLI reads the real ledger end to end. The recorded decision from the live gateway appears as one row with its UTC resolution time, kind, decision, reason, and `device:` resolver attribution; `--json` returns the gateway result unchanged (durable id, `resolvedAtMs`, reviewer-safe `commandText`); the `--kind plugin` filter is applied server-side and correctly returns no exec row; malformed `--kind`/`--limit` are rejected locally with exit 1 before any request is sent. Focused tests: 21 new cases in `src/cli/exec-approvals-cli.history.test.ts` plus the 47 pre-existing cases in `src/cli/exec-approvals-cli.test.ts` — 68/68 passing; `oxfmt --check`, `oxlint`, and `tsgo -p tsconfig.core.json` all clean. The new tests were written first and failed against unpatched `main` (20/20 failing at the RED run: Commander reported the unknown `history` command), then passed with this change; the 21st case pins the empty-page-plus-`nextCursor` boundary described above.

What was not tested: a multi-page ledger against a live gateway — `nextCursor` paging and the "Page with:" hint are covered by unit tests with a mocked RPC only, because producing more than 100 terminal approvals needs a long-running real workload; plugin and system-agent rows against a live gateway (unit-tested with schema-exact fixtures for `denied`, `expired`, and `cancelled`, including rows with no resolver); a live restricted-role scope denial (the `operator.approvals` requirement is asserted in the unit test and enforced by the gateway method descriptor, not re-verified end to end here); Windows/PowerShell terminal rendering and narrow-terminal wrapping beyond the 120-column fallback shown above; and the Control UI approvals page, which this PR does not touch. Full CI lanes were pending at submission time.
