### PR TITLE
refactor(agents): separate subagent registration records

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-public-api.ts
+++ b/src/agents/subagents/registry/subagent-registry-public-api.ts
@@ -7,6 +7,7 @@ import type { SubagentLifecycleController } from "./subagent-registry-lifecycle.
 import { getSubagentRunsForChildSession } from "./subagent-registry-memory.js";
 import {
   countActiveRunsForSessionFromRuns,
+  listSwarmRunsForGroupFromRuns,
   getLatestSubagentRunByChildSessionKeyFromRuns,
 } from "./subagent-registry-queries.js";
 import { markRequesterTurnYieldedInRuns } from "./subagent-registry-requester-yield.js";
@@ -146,15 +147,11 @@ export function createSubagentRegistryPublicApi(config: {
     requesterSessionKey?: string,
     requesterAgentId?: string,
   ): SubagentRunRecord[] {
-    const key = groupId.trim();
-    const requesterKey = requesterSessionKey?.trim();
-    return [...readRuns().values()].filter(
-      (entry) =>
-        entry.collect === true &&
-        entry.groupId === key &&
-        (!requesterKey ||
-          (entry.swarmRequesterSessionKey ?? entry.requesterSessionKey) === requesterKey) &&
-        (!requesterAgentId || entry.requesterAgentId === requesterAgentId),
+    return listSwarmRunsForGroupFromRuns(
+      readRuns(),
+      groupId,
+      requesterSessionKey,
+      requesterAgentId,
     );
   }
 

--- a/src/agents/subagents/registry/subagent-registry-queries.ts
+++ b/src/agents/subagents/registry/subagent-registry-queries.ts
@@ -429,6 +429,24 @@ export function shouldIgnorePostCompletionAnnounceForSessionFromRuns(
   );
 }
 
+export function listSwarmRunsForGroupFromRuns(
+  runs: Map<string, SubagentRunRecord>,
+  groupId: string,
+  requesterSessionKey?: string,
+  requesterAgentId?: string,
+): SubagentRunRecord[] {
+  const key = groupId.trim();
+  const requesterKey = requesterSessionKey?.trim();
+  return [...runs.values()].filter(
+    (entry) =>
+      entry.collect === true &&
+      entry.groupId === key &&
+      (!requesterKey ||
+        (entry.swarmRequesterSessionKey ?? entry.requesterSessionKey) === requesterKey) &&
+      (!requesterAgentId || entry.requesterAgentId === requesterAgentId),
+  );
+}
+
 /** Counts active direct child runs plus completed children that still have pending descendants. */
 export function countActiveRunsForSessionFromRuns(
   runs: Map<string, SubagentRunRecord>,

--- a/src/agents/subagents/registry/subagent-registry-run-launch-record.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-launch-record.ts
@@ -1,0 +1,79 @@
+import { normalizeSubagentRunState } from "./subagent-delivery-state.js";
+import type { RegisterSubagentRunParams, SubagentRunRecord } from "./subagent-registry.types.js";
+
+export function createSubagentRegistrationRecord(
+  registerParams: RegisterSubagentRunParams,
+  prepared: {
+    now: number;
+    generation: number;
+    lifecycleGeneration: string;
+    requesterAgentId?: string;
+    requesterOrigin?: SubagentRunRecord["requesterOrigin"];
+    swarmWaitOwnerSessionKeys?: string[];
+  },
+): SubagentRunRecord {
+  const { now, generation, requesterOrigin } = prepared;
+  const runId = registerParams.runId.trim();
+  const childSessionKey = registerParams.childSessionKey.trim();
+  const requesterSessionKey = registerParams.requesterSessionKey.trim();
+  const requesterTurnRunId = registerParams.requesterTurnRunId?.trim();
+  const controllerSessionKey = registerParams.controllerSessionKey?.trim() || requesterSessionKey;
+  const spawnMode = registerParams.spawnMode === "session" ? "session" : "run";
+  const runTimeoutSeconds = registerParams.runTimeoutSeconds ?? 0;
+  const queued = registerParams.queued === true;
+  return normalizeSubagentRunState({
+    runId,
+    taskRunId: runId,
+    ...(requesterTurnRunId ? { requesterTurnRunId } : {}),
+    childSessionKey,
+    controllerSessionKey,
+    requesterSessionKey,
+    requesterOrigin,
+    progressOrigin: registerParams.progressOrigin,
+    requesterDisplayKey: registerParams.requesterDisplayKey,
+    requesterAgentId: prepared.requesterAgentId,
+    task: registerParams.task,
+    taskName: registerParams.taskName,
+    cleanup: registerParams.cleanup,
+    expectsCompletionMessage: registerParams.expectsCompletionMessage,
+    spawnMode,
+    label: registerParams.label,
+    model: registerParams.model,
+    agentDir: registerParams.agentDir,
+    workspaceDir: registerParams.workspaceDir,
+    runTimeoutSeconds,
+    collect: registerParams.collect,
+    swarmRequesterSessionKey: registerParams.swarmRequesterSessionKey,
+    swarmWaitOwnerSessionKeys: prepared.swarmWaitOwnerSessionKeys,
+    swarmRunId: registerParams.collect ? runId : undefined,
+    schedulerSlotId: registerParams.collect ? runId : undefined,
+    swarmLaunchIdempotencyKey: registerParams.swarmLaunchIdempotencyKey,
+    swarmLaunchReplayKey: registerParams.swarmLaunchReplayKey,
+    swarmLaunchRequestFingerprint: registerParams.swarmLaunchRequestFingerprint,
+    swarmLaunchPending: registerParams.collect === true,
+    groupId: registerParams.groupId,
+    outputSchema: registerParams.outputSchema,
+    queuedLaunch: registerParams.queuedLaunch,
+    generation,
+    createdAt: now,
+    execution: {
+      status: queued ? "queued" : "running",
+      startedAt: queued ? undefined : now,
+      lifecycleGeneration: prepared.lifecycleGeneration,
+    },
+    completion: {
+      required: registerParams.expectsCompletionMessage === true,
+    },
+    delivery: {
+      status: registerParams.expectsCompletionMessage === false ? "not_required" : "pending",
+    },
+    sessionStartedAt: queued ? undefined : now,
+    accumulatedRuntimeMs: 0,
+    cleanupHandled: false,
+    wakeOnDescendantSettle: undefined,
+    requesterSettleWake: undefined,
+    attachmentsDir: registerParams.attachmentsDir,
+    attachmentsRootDir: registerParams.attachmentsRootDir,
+    retainAttachmentsOnKeep: registerParams.retainAttachmentsOnKeep,
+  });
+}

--- a/src/agents/subagents/registry/subagent-registry-run-launch.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-launch.ts
@@ -15,19 +15,14 @@ import {
 } from "../../../tasks/detached-task-runtime.js";
 import { createSubagentTaskBackingDetail } from "../../../tasks/task-backing-authority.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
-import type { DeliveryContext } from "../../../utils/delivery-context.types.js";
 import { resolveSubagentRequesterAgentId } from "../../subagent-requester-owner.js";
 import { updateSwarmCollectorCompletion } from "../swarm/swarm-collector.js";
 import { bindSwarmRunReservation } from "../swarm/swarm-scheduler.js";
-import { normalizeSubagentRunState } from "./subagent-delivery-state.js";
 import { SUBAGENT_ENDED_REASON_ERROR } from "./subagent-lifecycle-events.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
+import { createSubagentRegistrationRecord } from "./subagent-registry-run-launch-record.js";
 import { SubagentRecoveryManager } from "./subagent-registry-run-recovery.js";
-import type {
-  SubagentProgressOrigin,
-  SubagentRunRecord,
-  SwarmQueuedLaunch,
-} from "./subagent-registry.types.js";
+import type { RegisterSubagentRunParams, SubagentRunRecord } from "./subagent-registry.types.js";
 import {
   compareSubagentRunGeneration,
   nextSubagentRunGeneration,
@@ -57,44 +52,7 @@ function resolveSwarmWaitOwnerSessionKeys(
   return ownerSessionKeys;
 }
 
-export type RegisterSubagentRunParams = {
-  runId: string;
-  requesterTurnRunId?: string;
-  childSessionKey: string;
-  controllerSessionKey?: string;
-  requesterSessionKey: string;
-  requesterOrigin?: DeliveryContext;
-  progressOrigin?: SubagentProgressOrigin;
-  requesterDisplayKey: string;
-  task: string;
-  taskName?: string;
-  agentId?: string;
-  requesterAgentId?: string;
-  cleanup: "delete" | "keep";
-  label?: string;
-  model?: string;
-  agentDir?: string;
-  workspaceDir?: string;
-  runTimeoutSeconds?: number;
-  expectsCompletionMessage?: boolean;
-  spawnMode?: "run" | "session";
-  attachmentsDir?: string;
-  attachmentsRootDir?: string;
-  retainAttachmentsOnKeep?: boolean;
-  collect?: boolean;
-  swarmRequesterSessionKey?: string;
-  swarmLaunchIdempotencyKey?: string;
-  swarmLaunchReplayKey?: string;
-  swarmLaunchRequestFingerprint?: string;
-  groupId?: string;
-  outputSchema?: Record<string, unknown>;
-  queuedLaunch?: SwarmQueuedLaunch;
-  queued?: boolean;
-  /** Required when direct dispatch suppresses Gateway tracking. Out-of-process launches keep
-      Gateway's existing best-effort CLI policy; other callers create a best-effort row here. */
-  taskRowOwnership?: "required" | "gateway_best_effort";
-  gatewayContextResolver?: GatewayContextResolver;
-};
+export type { RegisterSubagentRunParams } from "./subagent-registry.types.js";
 
 export class SubagentLaunchManager extends SubagentRecoveryManager {
   private findRunByIdentity(runId: string): SubagentRunRecord | undefined {
@@ -108,8 +66,6 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
     const runId = registerParams.runId.trim();
     const childSessionKey = registerParams.childSessionKey.trim();
     const requesterSessionKey = registerParams.requesterSessionKey.trim();
-    const requesterTurnRunId = registerParams.requesterTurnRunId?.trim();
-    const controllerSessionKey = registerParams.controllerSessionKey?.trim() || requesterSessionKey;
     if (!runId || !childSessionKey || !requesterSessionKey) {
       return;
     }
@@ -119,34 +75,16 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
       childSessionKey,
     );
     const cfg = this.options.getRuntimeConfig();
-    const spawnMode = registerParams.spawnMode === "session" ? "session" : "run";
     const runTimeoutSeconds = registerParams.runTimeoutSeconds ?? 0;
     const waitTimeoutMs = this.options.resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
     const requesterOrigin = normalizeDeliveryContext(registerParams.requesterOrigin);
     const queued = registerParams.queued === true;
-    const entry: SubagentRunRecord = normalizeSubagentRunState({
-      runId,
-      taskRunId: runId,
-      ...(requesterTurnRunId ? { requesterTurnRunId } : {}),
-      childSessionKey,
-      controllerSessionKey,
-      requesterSessionKey,
-      requesterOrigin,
-      progressOrigin: registerParams.progressOrigin,
-      requesterDisplayKey: registerParams.requesterDisplayKey,
+    const entry = createSubagentRegistrationRecord(registerParams, {
+      now,
+      generation,
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
       requesterAgentId: resolveSubagentRequesterAgentId(cfg, registerParams),
-      task: registerParams.task,
-      taskName: registerParams.taskName,
-      cleanup: registerParams.cleanup,
-      expectsCompletionMessage: registerParams.expectsCompletionMessage,
-      spawnMode,
-      label: registerParams.label,
-      model: registerParams.model,
-      agentDir: registerParams.agentDir,
-      workspaceDir: registerParams.workspaceDir,
-      runTimeoutSeconds,
-      collect: registerParams.collect,
-      swarmRequesterSessionKey: registerParams.swarmRequesterSessionKey,
+      requesterOrigin,
       swarmWaitOwnerSessionKeys:
         registerParams.collect && registerParams.swarmRequesterSessionKey
           ? resolveSwarmWaitOwnerSessionKeys(
@@ -154,36 +92,6 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
               registerParams.swarmRequesterSessionKey,
             )
           : undefined,
-      swarmRunId: registerParams.collect ? runId : undefined,
-      schedulerSlotId: registerParams.collect ? runId : undefined,
-      swarmLaunchIdempotencyKey: registerParams.swarmLaunchIdempotencyKey,
-      swarmLaunchReplayKey: registerParams.swarmLaunchReplayKey,
-      swarmLaunchRequestFingerprint: registerParams.swarmLaunchRequestFingerprint,
-      swarmLaunchPending: registerParams.collect === true,
-      groupId: registerParams.groupId,
-      outputSchema: registerParams.outputSchema,
-      queuedLaunch: registerParams.queuedLaunch,
-      generation,
-      createdAt: now,
-      execution: {
-        status: queued ? "queued" : "running",
-        startedAt: queued ? undefined : now,
-        lifecycleGeneration: getAgentEventLifecycleGeneration(),
-      },
-      completion: {
-        required: registerParams.expectsCompletionMessage === true,
-      },
-      delivery: {
-        status: registerParams.expectsCompletionMessage === false ? "not_required" : "pending",
-      },
-      sessionStartedAt: queued ? undefined : now,
-      accumulatedRuntimeMs: 0,
-      cleanupHandled: false,
-      wakeOnDescendantSettle: undefined,
-      requesterSettleWake: undefined,
-      attachmentsDir: registerParams.attachmentsDir,
-      attachmentsRootDir: registerParams.attachmentsRootDir,
-      retainAttachmentsOnKeep: registerParams.retainAttachmentsOnKeep,
     });
     this.options.runs.set(runId, entry);
     bindGatewayContextResolver(entry, registerParams.gatewayContextResolver);

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -1,4 +1,5 @@
 import type { SubagentEndReason } from "../../../context-engine/types.js";
+import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 /** Persisted execution, completion, delivery, and attachment state for child runs. */
 import type { DeliveryContext } from "../../../utils/delivery-context.types.js";
 import type { AgentRunTerminalReplySnapshot } from "../../agent-run-terminal-reply.js";
@@ -32,7 +33,7 @@ export type ContextEngineSubagentEndedParams = {
   workspaceDir?: string;
 };
 
-export type SubagentProgressOrigin = {
+type SubagentProgressOrigin = {
   channel?: string;
   accountId?: string;
   to?: string;
@@ -116,7 +117,7 @@ export type SwarmStructuredOutputState = {
   invalidAttempts: number;
 };
 
-export type SwarmQueuedLaunch = {
+type SwarmQueuedLaunch = {
   request: Record<string, unknown>;
   /** Exact trusted launch capability, persisted so restart replay cannot lose it. */
   authorization?: SubagentLaunchAuthorization;
@@ -339,4 +340,43 @@ export type SubagentRunReadRecord = Pick<
 > & {
   execution: Pick<SubagentExecutionState, "status" | "startedAt" | "endedAt" | "outcome">;
   collectorCompletion?: Pick<SwarmCollectorCompletion, "status">;
+};
+
+export type RegisterSubagentRunParams = {
+  runId: string;
+  requesterTurnRunId?: string;
+  childSessionKey: string;
+  controllerSessionKey?: string;
+  requesterSessionKey: string;
+  requesterOrigin?: DeliveryContext;
+  progressOrigin?: SubagentProgressOrigin;
+  requesterDisplayKey: string;
+  task: string;
+  taskName?: string;
+  agentId?: string;
+  requesterAgentId?: string;
+  cleanup: "delete" | "keep";
+  label?: string;
+  model?: string;
+  agentDir?: string;
+  workspaceDir?: string;
+  runTimeoutSeconds?: number;
+  expectsCompletionMessage?: boolean;
+  spawnMode?: "run" | "session";
+  attachmentsDir?: string;
+  attachmentsRootDir?: string;
+  retainAttachmentsOnKeep?: boolean;
+  collect?: boolean;
+  swarmRequesterSessionKey?: string;
+  swarmLaunchIdempotencyKey?: string;
+  swarmLaunchReplayKey?: string;
+  swarmLaunchRequestFingerprint?: string;
+  groupId?: string;
+  outputSchema?: Record<string, unknown>;
+  queuedLaunch?: SwarmQueuedLaunch;
+  queued?: boolean;
+  /** Required when direct dispatch suppresses Gateway tracking. Out-of-process launches keep
+      Gateway's existing best-effort CLI policy; other callers create a best-effort row here. */
+  taskRowOwnership?: "required" | "gateway_best_effort";
+  gatewayContextResolver?: GatewayContextResolver;
 };


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Subagent registration mixes record construction with lifecycle, persistence and swarm publication. The group query also embeds its filtering in the public registry adapter. Those boundaries need to be clear before database operations become asynchronous.

## Why This Change Was Made

Extract registration record construction from already-prepared facts and move the group projection beside the existing registry queries. Keep normalization, owner checks, persistence and publication in their existing synchronous order. The constructor retains the already-normalized requester origin object.

## User Impact

No user-visible behavior, storage format or public API changes. The smaller owner modules make the coordinated async conversion easier to review.

## Evidence

- All 225 existing registry, resume and query cases passed.
- Full selected checks and fresh independent Codex review through P2 passed.
- No test-only exports or compatibility wrappers were added. Existing public type re-exports are preserved.
- This is preparation; it does not move SQLite off the main thread.
