### PR TITLE
refactor(tests): share model status runtime fixture

### DIFF
--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -8,6 +8,7 @@ import { setCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-m
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { expectObjectFields } from "../../test-utils/mock-call-assertions.js";
+import { createTestRuntime } from "../test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => {
   type MockAuthProfile = { provider: string; [key: string]: unknown };
@@ -346,19 +347,7 @@ const defaultResolveEnvApiKeyImpl:
   | ((provider: string) => { apiKey: string; source: string } | null)
   | undefined = mocks.resolveEnvApiKey.getMockImplementation();
 
-const runtime = {
-  log: vi.fn(),
-  error: vi.fn(),
-  exit: vi.fn(),
-};
-
-function createRuntime() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
-}
+const runtime = createTestRuntime();
 
 function parseFirstJsonLog(runtimeLike: { log: Mock }) {
   return JSON.parse(String(runtimeLike.log.mock.calls[0]?.[0]));
@@ -576,8 +565,8 @@ describe("modelsStatusCommand auth overview", () => {
     );
 
     try {
-      const jsonRuntime = createRuntime();
-      await modelsStatusCommand({ json: true }, jsonRuntime as never);
+      const jsonRuntime = createTestRuntime();
+      await modelsStatusCommand({ json: true }, jsonRuntime);
       expect(parseFirstJsonLog(jsonRuntime).auth.unusableProfiles).toEqual([
         expect.objectContaining({
           profileId: "anthropic:default",
@@ -588,9 +577,9 @@ describe("modelsStatusCommand auth overview", () => {
         }),
       ]);
 
-      const textRuntime = createRuntime();
-      await modelsStatusCommand({}, textRuntime as never);
-      const output = (textRuntime.log as Mock).mock.calls
+      const textRuntime = createTestRuntime();
+      await modelsStatusCommand({}, textRuntime);
+      const output = textRuntime.log.mock.calls
         .map((call: unknown[]) => String(call[0]))
         .join("\n");
       expect(output).toContain("Unavailable auth profiles");
@@ -626,8 +615,8 @@ describe("modelsStatusCommand auth overview", () => {
     );
 
     try {
-      const jsonRuntime = createRuntime();
-      await modelsStatusCommand({ json: true }, jsonRuntime as never);
+      const jsonRuntime = createTestRuntime();
+      await modelsStatusCommand({ json: true }, jsonRuntime);
       expect(parseFirstJsonLog(jsonRuntime).auth.unusableProfiles).toEqual([
         expect.objectContaining({
           profileId: "openai:default",
@@ -636,8 +625,8 @@ describe("modelsStatusCommand auth overview", () => {
         }),
       ]);
 
-      const textRuntime = createRuntime();
-      await modelsStatusCommand({}, textRuntime as never);
+      const textRuntime = createTestRuntime();
+      await modelsStatusCommand({}, textRuntime);
       expect(textRuntime.log.mock.calls.flat().join("\n")).toContain("cooldown:wham_token_expired");
     } finally {
       delete store.usageStats;
@@ -666,8 +655,8 @@ describe("modelsStatusCommand auth overview", () => {
     );
 
     try {
-      const statusRuntime = createRuntime();
-      await modelsStatusCommand({ json: true }, statusRuntime as never);
+      const statusRuntime = createTestRuntime();
+      await modelsStatusCommand({ json: true }, statusRuntime);
       const [unusable] = parseFirstJsonLog(statusRuntime).auth.unusableProfiles;
       expect(unusable).toMatchObject({
         profileId,
@@ -700,7 +689,7 @@ describe("modelsStatusCommand auth overview", () => {
       await releaseCatalog.promise;
       return [];
     });
-    const commandPromise = modelsStatusCommand({ json: true }, createRuntime() as never);
+    const commandPromise = modelsStatusCommand({ json: true }, createTestRuntime());
 
     try {
       await catalogStarted.promise;
@@ -747,7 +736,7 @@ describe("modelsStatusCommand auth overview", () => {
     [{ probeMaxTokens: "" }, "--probe-max-tokens"],
     [{ probeMaxTokens: "   " }, "--probe-max-tokens"],
   ])("rejects invalid probe numeric option %j", async (opts, label) => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     mocks.runAuthProbes.mockClear();
     await expect(
       modelsStatusCommand({ json: true, probe: true, ...opts }, localRuntime),
@@ -764,14 +753,14 @@ describe("modelsStatusCommand auth overview", () => {
     ],
   ])("forwards probe numeric options %j", async (opts, expected) => {
     mocks.runAuthProbes.mockClear();
-    await modelsStatusCommand({ json: true, probe: true, ...opts }, createRuntime());
+    await modelsStatusCommand({ json: true, probe: true, ...opts }, createTestRuntime());
     expect(mocks.runAuthProbes).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ options: expect.objectContaining(expected) }),
     );
   });
 
   it("includes masked auth sources in JSON output", async () => {
-    await modelsStatusCommand({ json: true }, runtime as never);
+    await modelsStatusCommand({ json: true }, runtime);
     const payload = parseFirstJsonLog(runtime);
 
     expect(mocks.loadModelsConfigArgs.mock.calls.at(-1)?.[0]).toMatchObject({
@@ -849,8 +838,8 @@ describe("modelsStatusCommand auth overview", () => {
         ],
       },
       async () => {
-        const localRuntime = createRuntime();
-        await modelsStatusCommand({ json: true }, localRuntime as never);
+        const localRuntime = createTestRuntime();
+        await modelsStatusCommand({ json: true }, localRuntime);
 
         expect(parseFirstJsonLog(localRuntime).allowed).toEqual([
           "clawrouter/anthropic/claude-haiku-4-5",
@@ -868,8 +857,8 @@ describe("modelsStatusCommand auth overview", () => {
         catalog: [{ provider: "openai", id: "gpt-5.6-sol", name: "GPT-5.6 Sol" }],
       },
       async () => {
-        const localRuntime = createRuntime();
-        await modelsStatusCommand({ json: true }, localRuntime as never);
+        const localRuntime = createTestRuntime();
+        await modelsStatusCommand({ json: true }, localRuntime);
 
         expect(parseFirstJsonLog(localRuntime).allowed).toEqual(["clawrouter/anthropic/*"]);
       },
@@ -894,8 +883,8 @@ describe("modelsStatusCommand auth overview", () => {
           defaults: { ...baseConfig.agents.defaults, utilityModel: "openai/gpt-5.6-luna" },
         },
       });
-      const explicitRuntime = createRuntime();
-      await modelsStatusCommand({ json: true }, explicitRuntime as never);
+      const explicitRuntime = createTestRuntime();
+      await modelsStatusCommand({ json: true }, explicitRuntime);
       expect(parseFirstJsonLog(explicitRuntime).utilityModel).toEqual({
         ref: "openai/gpt-5.6-luna",
         source: "config",
@@ -907,8 +896,8 @@ describe("modelsStatusCommand auth overview", () => {
           defaults: { ...baseConfig.agents.defaults, utilityModel: "" },
         },
       });
-      const disabledRuntime = createRuntime();
-      await modelsStatusCommand({ json: true }, disabledRuntime as never);
+      const disabledRuntime = createTestRuntime();
+      await modelsStatusCommand({ json: true }, disabledRuntime);
       expect(parseFirstJsonLog(disabledRuntime).utilityModel).toEqual({
         ref: null,
         source: "disabled",
@@ -923,8 +912,8 @@ describe("modelsStatusCommand auth overview", () => {
           defaults: { ...baseConfig.agents.defaults, utilityModel: "mistral/mistral-small" },
         },
       });
-      const missingAuthRuntime = createRuntime();
-      await modelsStatusCommand({ json: true }, missingAuthRuntime as never);
+      const missingAuthRuntime = createTestRuntime();
+      await modelsStatusCommand({ json: true }, missingAuthRuntime);
       const missingPayload = parseFirstJsonLog(missingAuthRuntime);
       expect(missingPayload.utilityModel).toEqual({
         ref: "mistral/mistral-small",
@@ -947,8 +936,8 @@ describe("modelsStatusCommand auth overview", () => {
           },
         },
       });
-      const aliasRuntime = createRuntime();
-      await modelsStatusCommand({ json: true }, aliasRuntime as never);
+      const aliasRuntime = createTestRuntime();
+      await modelsStatusCommand({ json: true }, aliasRuntime);
       expect(parseFirstJsonLog(aliasRuntime).utilityModel).toEqual({
         ref: "anthropic/claude-opus-4-6",
         source: "config",
@@ -961,10 +950,10 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("honors OPENCLAW_AGENT_DIR when no --agent override is provided", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     mocks.resolveAgentDir.mockClear();
     await withEnvAsync({ OPENCLAW_AGENT_DIR: "/tmp/openclaw-isolated-agent" }, async () => {
-      await modelsStatusCommand({ json: true }, localRuntime as never);
+      await modelsStatusCommand({ json: true }, localRuntime);
     });
 
     expectResolveAgentDirCalledFor("main");
@@ -975,7 +964,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("honors deprecated PI_CODING_AGENT_DIR when OPENCLAW_AGENT_DIR is unset", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     mocks.resolveAgentDir.mockClear();
     await withEnvAsync(
       {
@@ -983,7 +972,7 @@ describe("modelsStatusCommand auth overview", () => {
         PI_CODING_AGENT_DIR: "/tmp/openclaw-legacy-agent",
       },
       async () => {
-        await modelsStatusCommand({ json: true }, localRuntime as never);
+        await modelsStatusCommand({ json: true }, localRuntime);
       },
     );
 
@@ -994,7 +983,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("uses agent overrides and reports sources", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withAgentScopeOverrides(
       {
         primary: "openai/gpt-4",
@@ -1002,7 +991,7 @@ describe("modelsStatusCommand auth overview", () => {
         agentDir: "/tmp/openclaw-agent-custom",
       },
       async () => {
-        await modelsStatusCommand({ json: true, agent: "Jeremiah" }, localRuntime as never);
+        await modelsStatusCommand({ json: true, agent: "Jeremiah" }, localRuntime);
         expectResolveAgentDirCalledFor("jeremiah");
         const payload = parseFirstJsonLog(localRuntime);
         expect(payload.agentId).toBe("jeremiah");
@@ -1040,7 +1029,7 @@ describe("modelsStatusCommand auth overview", () => {
   }
 
   it("resolves a selected agent's bare alias from that agent's model scope", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withConfig(
       {
         agents: {
@@ -1055,7 +1044,7 @@ describe("modelsStatusCommand auth overview", () => {
       },
       async () => {
         await withAgentScopeOverrides({ primary: "jeremiah-choice" }, async () => {
-          await modelsStatusCommand({ json: true, agent: "jeremiah" }, localRuntime as never);
+          await modelsStatusCommand({ json: true, agent: "jeremiah" }, localRuntime);
           const payload = parseFirstJsonLog(localRuntime);
           expect(payload.defaultModel).toBe("jeremiah-choice");
           // Resolving the bare alias against global defaults reported
@@ -1071,7 +1060,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("prefers a per-agent alias row over the same alias in defaults", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withConfig(
       {
         agents: {
@@ -1089,7 +1078,7 @@ describe("modelsStatusCommand auth overview", () => {
       },
       async () => {
         await withAgentScopeOverrides({ primary: "shared" }, async () => {
-          await modelsStatusCommand({ json: true, agent: "jeremiah" }, localRuntime as never);
+          await modelsStatusCommand({ json: true, agent: "jeremiah" }, localRuntime);
           const payload = parseFirstJsonLog(localRuntime);
           // Per-agent rows are applied after defaults, so the agent's row owns
           // the alias and the displayed target must follow the same precedence.
@@ -1101,7 +1090,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("keeps unscoped status on global defaults when no agent is selected", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withConfig(
       {
         agents: {
@@ -1118,7 +1107,7 @@ describe("modelsStatusCommand auth overview", () => {
         },
       },
       async () => {
-        await modelsStatusCommand({ json: true }, localRuntime as never);
+        await modelsStatusCommand({ json: true }, localRuntime);
         const payload = parseFirstJsonLog(localRuntime);
         // No --agent still reports unscoped defaults; another agent's rows must
         // not leak into the global view.
@@ -1152,8 +1141,8 @@ describe("modelsStatusCommand auth overview", () => {
           fallbacks: ["openai/gpt-5.6-sol"],
         },
         async () => {
-          const localRuntime = createRuntime();
-          await modelsStatusCommand({ json: true }, localRuntime as never);
+          const localRuntime = createTestRuntime();
+          await modelsStatusCommand({ json: true }, localRuntime);
 
           expectResolveAgentDirCalledFor("jeremiah");
           expect(mocks.resolveAgentExplicitModelPrimary).not.toHaveBeenCalled();
@@ -1174,8 +1163,8 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("rejects API-key auth for subscription-only Codex Spark", async () => {
-    const localRuntime = createRuntime();
-    const textRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
+    const textRuntime = createTestRuntime();
     await withOpenAIStatusFixture(
       {
         primary: "openai/gpt-5.3-codex-spark",
@@ -1188,8 +1177,8 @@ describe("modelsStatusCommand auth overview", () => {
         },
       },
       async () => {
-        await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
-        await modelsStatusCommand({ check: true }, textRuntime as never);
+        await modelsStatusCommand({ json: true, check: true }, localRuntime);
+        await modelsStatusCommand({ check: true }, textRuntime);
       },
     );
     const payload = parseFirstJsonLog(localRuntime);
@@ -1208,8 +1197,8 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("reports usable Codex auth as unavailable when its harness plugin is quarantined", async () => {
-    const localRuntime = createRuntime();
-    const textRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
+    const textRuntime = createTestRuntime();
     const payloadFailure = {
       pluginId: "codex",
       installPath: "/private/plugin",
@@ -1248,8 +1237,8 @@ describe("modelsStatusCommand auth overview", () => {
         },
       },
       async () => {
-        await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
-        await modelsStatusCommand({ check: true }, textRuntime as never);
+        await modelsStatusCommand({ json: true, check: true }, localRuntime);
+        await modelsStatusCommand({ check: true }, textRuntime);
       },
     );
 
@@ -1292,7 +1281,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("evaluates mixed primary and fallback OpenAI routes independently", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withOpenAIStatusFixture(
       {
         primary: "openai/gpt-5.6",
@@ -1308,7 +1297,7 @@ describe("modelsStatusCommand auth overview", () => {
         },
       },
       async () => {
-        await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+        await modelsStatusCommand({ json: true, check: true }, localRuntime);
       },
     );
     const payload = parseFirstJsonLog(localRuntime);
@@ -1338,7 +1327,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("flags a utility model whose route needs api-key auth despite an OAuth-healthy primary", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withOpenAIStatusFixture(
       {
         primary: "openai/gpt-5.5",
@@ -1354,7 +1343,7 @@ describe("modelsStatusCommand auth overview", () => {
         },
       },
       async () => {
-        await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+        await modelsStatusCommand({ json: true, check: true }, localRuntime);
       },
     );
     const payload = parseFirstJsonLog(localRuntime);
@@ -1371,8 +1360,8 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("reports incompatible model routes separately in JSON and text", async () => {
-    const jsonRuntime = createRuntime();
-    const textRuntime = createRuntime();
+    const jsonRuntime = createTestRuntime();
+    const textRuntime = createTestRuntime();
     await withOpenAIStatusFixture(
       {
         primary: "openai/gpt-5.6",
@@ -1384,8 +1373,8 @@ describe("modelsStatusCommand auth overview", () => {
         }),
       },
       async () => {
-        await modelsStatusCommand({ json: true, check: true }, jsonRuntime as never);
-        await modelsStatusCommand({ check: true }, textRuntime as never);
+        await modelsStatusCommand({ json: true, check: true }, jsonRuntime);
+        await modelsStatusCommand({ check: true }, textRuntime);
       },
     );
     const payload = parseFirstJsonLog(jsonRuntime);
@@ -1408,7 +1397,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("reports missing static transport observation as indeterminate", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withOpenAIStatusFixture(
       {
         primary: "openai/gpt-5.4-nano",
@@ -1423,7 +1412,7 @@ describe("modelsStatusCommand auth overview", () => {
         },
       },
       async () => {
-        await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+        await modelsStatusCommand({ json: true, check: true }, localRuntime);
       },
     );
 
@@ -1440,7 +1429,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("uses static catalog transport observation for route readiness", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withOpenAIStatusFixture(
       {
         primary: "openai/gpt-5.4-nano",
@@ -1464,7 +1453,7 @@ describe("modelsStatusCommand auth overview", () => {
         ],
       },
       async () => {
-        await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+        await modelsStatusCommand({ json: true, check: true }, localRuntime);
       },
     );
 
@@ -1478,7 +1467,7 @@ describe("modelsStatusCommand auth overview", () => {
     ["ChatGPT first", false],
     ["Platform first", true],
   ])("selects ChatGPT nano from grouped physical routes with %s", async (_label, reverse) => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     const platform = {
       id: "gpt-5.4-nano",
       name: "Platform Nano",
@@ -1511,7 +1500,7 @@ describe("modelsStatusCommand auth overview", () => {
         routeVariants,
       },
       async () => {
-        await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+        await modelsStatusCommand({ json: true, check: true }, localRuntime);
       },
     );
 
@@ -1524,7 +1513,7 @@ describe("modelsStatusCommand auth overview", () => {
   it.each(["Writer", "rEaDeR"])(
     "keeps model status independent of %s routes",
     async (responsesId) => {
-      const localRuntime = createRuntime();
+      const localRuntime = createTestRuntime();
       const baseUrl = "https://models.example.test/v1";
       const model = (id: string, api?: ModelDefinitionConfig["api"]): ModelDefinitionConfig => ({
         id,
@@ -1556,7 +1545,7 @@ describe("modelsStatusCommand auth overview", () => {
           routeVariants: catalog,
         },
         async () => {
-          await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+          await modelsStatusCommand({ json: true, check: true }, localRuntime);
         },
       );
 
@@ -1571,7 +1560,7 @@ describe("modelsStatusCommand auth overview", () => {
   );
 
   it("keeps API-key SecretRef profiles usable for a concrete OpenAI route", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withOpenAIStatusFixture(
       {
         primary: "openai/gpt-5.6",
@@ -1585,7 +1574,7 @@ describe("modelsStatusCommand auth overview", () => {
       },
       async () =>
         await withEnvAsync({ OPENAI_API_KEY: "resolved-key" }, async () => {
-          await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+          await modelsStatusCommand({ json: true, check: true }, localRuntime);
         }),
     );
     const payload = parseFirstJsonLog(localRuntime);
@@ -1595,7 +1584,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("reports unresolved API-key SecretRef profiles as indeterminate", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     await withOpenAIStatusFixture(
       {
         primary: "openai/gpt-5.6",
@@ -1609,7 +1598,7 @@ describe("modelsStatusCommand auth overview", () => {
       },
       async () =>
         await withEnvAsync({ OPENAI_API_KEY: undefined }, async () => {
-          await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+          await modelsStatusCommand({ json: true, check: true }, localRuntime);
         }),
     );
     const payload = parseFirstJsonLog(localRuntime);
@@ -1626,7 +1615,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("preserves configured AWS SDK profiles for non-OpenAI providers", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();
     const originalProfiles = { ...mocks.store.profiles };
     const originalOrder = mocks.store.order ? { ...mocks.store.order } : undefined;
@@ -1656,7 +1645,7 @@ describe("modelsStatusCommand auth overview", () => {
     mocks.resolveEnvApiKey.mockImplementation(() => null);
 
     try {
-      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      await modelsStatusCommand({ json: true, check: true }, localRuntime);
       const payload = parseFirstJsonLog(localRuntime);
       expect(payload.auth.missingProvidersInUse).toEqual([]);
       expect(payload.auth.modelRouteIssues).toEqual([]);
@@ -1678,7 +1667,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("handles cli backend and exact provider auth summaries", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();
     const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
     mocks.loadConfig.mockReturnValue({
@@ -1694,12 +1683,12 @@ describe("modelsStatusCommand auth overview", () => {
     mocks.resolveEnvApiKey.mockImplementation(() => null);
 
     try {
-      await modelsStatusCommand({ json: true }, localRuntime as never);
+      await modelsStatusCommand({ json: true }, localRuntime);
       const payload = parseFirstJsonLog(localRuntime);
       expect(payload.defaultModel).toBe("claude-cli/claude-sonnet-4-6");
       expect(payload.auth.missingProvidersInUse).toStrictEqual([]);
 
-      const aliasRuntime = createRuntime();
+      const aliasRuntime = createTestRuntime();
       mocks.loadConfig.mockReturnValue({
         agents: {
           defaults: {
@@ -1719,7 +1708,7 @@ describe("modelsStatusCommand auth overview", () => {
         }
         return null;
       });
-      await modelsStatusCommand({ json: true }, aliasRuntime as never);
+      await modelsStatusCommand({ json: true }, aliasRuntime);
       const aliasPayload = parseFirstJsonLog(aliasRuntime);
       const providers = aliasPayload.auth.providers as Array<{ provider: string }>;
       expect(
@@ -1741,7 +1730,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("treats plugin-owned synthetic auth as usable for models in use", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();
     const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
     const originalSyntheticImpl =
@@ -1774,7 +1763,7 @@ describe("modelsStatusCommand auth overview", () => {
 
     try {
       const syntheticProbeStart = mocks.resolveProviderSyntheticAuthWithPlugin.mock.calls.length;
-      await modelsStatusCommand({ json: true }, localRuntime as never);
+      await modelsStatusCommand({ json: true }, localRuntime);
       const payload = parseFirstJsonLog(localRuntime);
       const providers = payload.auth.providers as Array<{
         provider: string;
@@ -1830,7 +1819,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("passes the canonical merged provider config to synthetic auth plugins", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();
     const originalSyntheticRefs =
       mocks.resolveRuntimeSyntheticAuthProviderRefs.getMockImplementation();
@@ -1859,7 +1848,7 @@ describe("modelsStatusCommand auth overview", () => {
     mocks.resolveProviderSyntheticAuthWithPlugin.mockReturnValue(undefined);
 
     try {
-      await modelsStatusCommand({ json: true }, localRuntime as never);
+      await modelsStatusCommand({ json: true }, localRuntime);
 
       expect(mocks.resolveProviderSyntheticAuthWithPlugin).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1895,7 +1884,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("does not treat declared but unresolved synthetic auth as usable", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();
     const originalProfiles = { ...mocks.store.profiles };
     const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
@@ -1919,7 +1908,7 @@ describe("modelsStatusCommand auth overview", () => {
     mocks.resolveProviderSyntheticAuthWithPlugin.mockReturnValue(undefined);
 
     try {
-      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      await modelsStatusCommand({ json: true, check: true }, localRuntime);
       const payload = parseFirstJsonLog(localRuntime);
       expect(payload.auth.missingProvidersInUse).toEqual([]);
       expect(payload.auth.modelRouteIssues).toEqual([
@@ -1954,7 +1943,7 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("includes auth-evidence-only providers in the auth overview", async () => {
-    const localRuntime = createRuntime();
+    const localRuntime = createTestRuntime();
     const originalKeysImpl = mocks.listProviderEnvAuthLookupKeys.getMockImplementation();
     const originalLookupImpl = mocks.resolveProviderEnvAuthLookupMaps.getMockImplementation();
     const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
@@ -1984,7 +1973,7 @@ describe("modelsStatusCommand auth overview", () => {
     );
 
     try {
-      await modelsStatusCommand({ json: true }, localRuntime as never);
+      await modelsStatusCommand({ json: true }, localRuntime);
       const payload = parseFirstJsonLog(localRuntime);
       const workspaceProvider = requireProvider(payload.auth.providers, "workspace-cloud");
       expect(requireRecord(workspaceProvider.effective, "workspace effective auth").kind).toBe(
@@ -2017,16 +2006,16 @@ describe("modelsStatusCommand auth overview", () => {
         fallbacks: undefined,
       },
       async () => {
-        const textRuntime = createRuntime();
-        await modelsStatusCommand({ agent: "main" }, textRuntime as never);
-        const output = (textRuntime.log as Mock).mock.calls
+        const textRuntime = createTestRuntime();
+        await modelsStatusCommand({ agent: "main" }, textRuntime);
+        const output = textRuntime.log.mock.calls
           .map((call: unknown[]) => String(call[0]))
           .join("\n");
         expect(output).toContain("Default (defaults)");
         expect(output).toContain("Fallbacks (0) (defaults)");
 
-        const jsonRuntime = createRuntime();
-        await modelsStatusCommand({ json: true, agent: "main" }, jsonRuntime as never);
+        const jsonRuntime = createTestRuntime();
+        await modelsStatusCommand({ json: true, agent: "main" }, jsonRuntime);
         const payload = parseFirstJsonLog(jsonRuntime);
         expect(payload.modelConfig).toEqual({
           defaultSource: "defaults",
@@ -2037,8 +2026,8 @@ describe("modelsStatusCommand auth overview", () => {
   });
 
   it("throws when agent id is unknown", async () => {
-    const localRuntime = createRuntime();
-    await expect(modelsStatusCommand({ agent: "unknown" }, localRuntime as never)).rejects.toThrow(
+    const localRuntime = createTestRuntime();
+    await expect(modelsStatusCommand({ agent: "unknown" }, localRuntime)).rejects.toThrow(
       'Unknown agent id "unknown".',
     );
   });
@@ -2046,7 +2035,7 @@ describe("modelsStatusCommand auth overview", () => {
     const originalProfiles = { ...mocks.store.profiles };
     mocks.store.profiles = {};
     const localRuntime = {
-      ...createRuntime(),
+      ...createTestRuntime(),
       writeStdout: vi.fn(),
       writeJson: vi.fn(),
     };
@@ -2054,7 +2043,7 @@ describe("modelsStatusCommand auth overview", () => {
     mocks.resolveEnvApiKey.mockImplementation(() => null);
 
     try {
-      await modelsStatusCommand({ check: true, plain: true }, localRuntime as never);
+      await modelsStatusCommand({ check: true, plain: true }, localRuntime);
       expect(localRuntime.writeStdout).toHaveBeenCalledOnce();
       expect(localRuntime.log).not.toHaveBeenCalled();
       expect(localRuntime.exit).toHaveBeenCalledWith(1);


### PR DESCRIPTION
## What Problem This Solves

Model-status tests duplicate the command runtime fixture and cast runtime values to `never`, obscuring the interface those tests exercise.

## Why This Change Was Made

Reuse the existing typed `createTestRuntime` helper at the same allocation sites. Keep the writer-less mocks and nonthrowing exit behavior, including the separate explicit stdout/JSON writer fixture. Remove 45 runtime casts and two unnecessary log casts without changing assertions or cleanup.

## User Impact

No runtime behavior changes. Test maintenance uses one existing fixture owner; production and helper code are unchanged. The test diff removes 11 lines overall and retains every case.

## Evidence

- Complete model-status and unchanged backup-command suites passed before and after: 48 + 9 = 57 cases in each phase, with identical case order and results and no skips or todos.
- All 20 selected changed-file checks passed, including command-test typechecking, formatting, lint, boundary guards, and dead-export scans.
- Independent review found no actionable issues through P2. Output selection, fresh mock allocation, exit-code assertions, credential-omission assertions, and cleanup remain intact.

This is test-fixture validation, not live-provider or authentication-runtime proof. No production build was required for the test-only change.
