### PR TITLE
fix(synology-chat): stop one account's send burst from delaying other accounts

### DIFF
--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -427,6 +427,34 @@ describe("sendHostedFileUrl", () => {
     expect(vi.mocked(https.request)).toHaveBeenCalledTimes(1);
   });
 
+  it("paces each incoming webhook endpoint independently", async () => {
+    mockSuccessResponse();
+    const accountA = "https://nas-a.example.com/incoming";
+    const accountB = "https://nas-b.example.com/incoming";
+    const requestedUrls = () =>
+      vi.mocked(https.request).mock.calls.map(([url]) => (url instanceof URL ? url.href : url));
+
+    const sends = [
+      sendMessage(accountA, "a1"),
+      sendMessage(accountA, "a2"),
+      sendMessage(accountA, "a3"),
+      sendMessage(accountB, "b1"),
+    ];
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(requestedUrls()).toEqual([accountA, accountB]);
+
+    await vi.advanceTimersByTimeAsync(498);
+    expect(requestedUrls()).toEqual([accountA, accountB]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(requestedUrls()).toEqual([accountA, accountB, accountA]);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(requestedUrls()).toEqual([accountA, accountB, accountA, accountA]);
+    await expect(Promise.all(sends)).resolves.toEqual([true, true, true, true]);
+  });
+
   it("rejects malformed file URLs before making a request", async () => {
     const result = await settleTimers(
       sendHostedFileUrl("https://nas.example.com/incoming", hostedUrl("not-a-url")),

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -25,8 +25,16 @@ const USER_LIST_RESPONSE_MAX_BYTES = 1 * 1024 * 1024;
 const USER_LIST_REQUEST_TIMEOUT_MS = 15_000;
 /** Wall-clock budget for outgoing webhook requests including response body. */
 const POST_REQUEST_TIMEOUT_MS = 30_000;
-let lastSendTime = 0;
-let sendQueue: Promise<void> = Promise.resolve();
+
+type SendSlotState = {
+  tail: Promise<void>;
+  lastSendTime: number;
+  waiters: number;
+};
+
+// Pace sends per incoming webhook endpoint so a burst on one account cannot
+// head-of-line block an independent account's webhook.
+const sendSlots = new Map<string, SendSlotState>();
 
 const UNPROVEN_TRANSPORT_ERROR_BRANCH = "unproven transport error branch";
 
@@ -147,7 +155,7 @@ export async function sendMessage(
     // Synology Chat API requires numeric user_ids to specify the recipient.
     const body = buildWebhookBody({ text: chunk }, userId);
     // Retry only proven pre-connect failures; ambiguous webhook replays can duplicate messages.
-    await waitForSendSlot();
+    await waitForSendSlot(incomingUrl);
     await onPlatformSendDispatch?.();
     let result: SynologyHostedFileSendResult["status"];
     try {
@@ -158,7 +166,7 @@ export async function sendMessage(
         delayMs: ({ attempt }) => 300 * 2 ** (attempt - 1),
         sleep: async (delayMs) => {
           await sleepWithAbort(delayMs);
-          await waitForSendSlot();
+          await waitForSendSlot(incomingUrl);
           await onPlatformSendDispatch?.();
         },
       });
@@ -189,7 +197,7 @@ export async function sendHostedFileUrl(
     return { status: "not-dispatched" };
   }
 
-  await waitForSendSlot();
+  await waitForSendSlot(incomingUrl);
   await onPlatformSendDispatch?.();
 
   try {
@@ -310,16 +318,39 @@ async function fetchChatUsers(
   });
 }
 
-async function waitForSendSlot(): Promise<void> {
-  const next = sendQueue.then(async () => {
-    const elapsed = Date.now() - lastSendTime;
+async function waitForSendSlot(incomingUrl: string): Promise<void> {
+  pruneIdleSendSlots();
+  const slot = sendSlots.get(incomingUrl) ?? {
+    tail: Promise.resolve(),
+    lastSendTime: 0,
+    waiters: 0,
+  };
+  sendSlots.set(incomingUrl, slot);
+  slot.waiters += 1;
+  const next = slot.tail.then(async () => {
+    const elapsed = Date.now() - slot.lastSendTime;
     if (elapsed < MIN_SEND_INTERVAL_MS) {
       await sleep(MIN_SEND_INTERVAL_MS - elapsed);
     }
-    lastSendTime = Date.now();
+    slot.lastSendTime = Date.now();
   });
-  sendQueue = next.catch(() => {});
-  await next;
+  slot.tail = next.catch(() => {});
+  try {
+    await next;
+  } finally {
+    slot.waiters -= 1;
+  }
+}
+
+function pruneIdleSendSlots(): void {
+  const now = Date.now();
+  for (const [incomingUrl, slot] of sendSlots) {
+    // Retire a slot only after its cooldown elapses so a follow-up send to the
+    // same endpoint still honors the minimum interval.
+    if (slot.waiters === 0 && now - slot.lastSendTime >= MIN_SEND_INTERVAL_MS) {
+      sendSlots.delete(incomingUrl);
+    }
+  }
 }
 
 function assertHostedMediaUrl(fileUrl: SynologyHostedMediaUrl): string {


### PR DESCRIPTION
Closes #127491

## What Problem This Solves

Fixes an issue where operators running more than one Synology Chat account would see messages on one account delayed whenever another account was sending a burst (long chunked replies, hosted media, pairing notices). Every account shared a single process-wide 500 ms send slot, so account B waited behind every queued send for account A even though the two post to independent incoming webhooks.

## Why This Change Was Made

The outbound send slot is now keyed by the incoming webhook URL. Sends to the same endpoint keep the existing 500 ms spacing and FIFO order (text chunks, pre-connect retries, and hosted media still share one slot per endpoint), while different endpoints no longer block each other. Idle per-endpoint state is pruned on the next send once its cooldown has elapsed, so the map stays bounded by active endpoints and a quick follow-up send to the same endpoint still honors the interval.

## User Impact

Multi-account Synology Chat setups deliver messages for each account independently. Single-account behavior is unchanged.

## Evidence

### Real transport, before and after (no mocks, no fake timers)

A standalone script imported the production `extensions/synology-chat/src/client.ts` from source (`node --import ./scripts/tsx.mjs`, Node 26.5.0). It called `sendMessage` over real `node:http` against two local listeners that stand in for two accounts' incoming webhooks (`http://127.0.0.1:<port>/webapi/entry.cgi?...&token=REDACTED`).

- Three messages were queued for account A and one for account B at the same moment.
- Each listener recorded the arrival time and the decoded `payload.text`, and answered `200 {"success":true}`.
- Each variant ran twice in a fresh process. Ordering was identical, and timings matched within 3 ms.

| Arrival at webhook | main `c1a7a205daa1` (before) | this PR `54ae24381edd` (after) |
|---|---|---|
| A-1 | 5 ms | 4 ms |
| A-2 | 503 ms | 502 ms |
| A-3 | 1003 ms | 1003 ms |
| **B-1** | **1503 ms**, behind all of A | **5 ms**, immediately |
| `sendMessage` results | all `true`, done at 1504 ms | all `true`, done at 1003 ms |

Before the fix, account B's message waits behind every queued account A send. After it, B is delivered immediately while A keeps its 500 ms spacing.

<details>
<summary>Raw output (both runs)</summary>

```text
node v26.5.0
## run 1: main c1a7a205daa1 (before)
sendMessage results: [true,true,true,true] (all sends finished after 1504ms)
arrival at webhook | endpoint | text
               5ms | A        | A-1
             503ms | A        | A-2
            1003ms | A        | A-3
            1503ms | B        | B-1
## run 1: candidate 54ae24381edd (after)
sendMessage results: [true,true,true,true] (all sends finished after 1003ms)
arrival at webhook | endpoint | text
               4ms | A        | A-1
               5ms | B        | B-1
             502ms | A        | A-2
            1003ms | A        | A-3
## run 2: main c1a7a205daa1 (before)
sendMessage results: [true,true,true,true] (all sends finished after 1504ms)
arrival at webhook | endpoint | text
               4ms | A        | A-1
             501ms | A        | A-2
            1002ms | A        | A-3
            1504ms | B        | B-1
## run 2: candidate 54ae24381edd (after)
sendMessage results: [true,true,true,true] (all sends finished after 1002ms)
arrival at webhook | endpoint | text
               4ms | A        | A-1
               5ms | B        | B-1
             502ms | A        | A-2
            1002ms | A        | A-3
```

</details>

<details>
<summary>Proof script</summary>

Run from the repository root with `SYNOLOGY_CLIENT_PATH` pointing at the client under test. For the baseline, `git show upstream/main:extensions/synology-chat/src/client.ts` was written beside the patched client so relative imports resolve identically.

```ts
import http from "node:http";
import type { AddressInfo } from "node:net";

const clientPath = process.env.SYNOLOGY_CLIENT_PATH;
const label = process.env.PROOF_LABEL ?? "client";
if (!clientPath) {
  throw new Error("SYNOLOGY_CLIENT_PATH is required");
}
const { sendMessage } = await import(clientPath);

type Arrival = { endpoint: string; text: string; atMs: number };
const arrivals: Arrival[] = [];
let t0 = 0;

async function startWebhook(endpoint: string) {
  const server = http.createServer((req, res) => {
    let body = "";
    req.setEncoding("utf8");
    req.on("data", (chunk: string) => {
      body += chunk;
    });
    req.on("end", () => {
      const payload = JSON.parse(new URLSearchParams(body).get("payload") ?? "{}");
      arrivals.push({ endpoint, text: payload.text ?? "", atMs: Date.now() - t0 });
      res.writeHead(200, { "content-type": "application/json" });
      res.end('{"success":true}');
    });
  });
  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
  const { port } = server.address() as AddressInfo;
  return {
    url: `http://127.0.0.1:${port}/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=2&token=REDACTED`,
    close: () =>
      new Promise<void>((resolve) => {
        server.closeAllConnections();
        server.close(() => resolve());
      }),
  };
}

const accountA = await startWebhook("A");
const accountB = await startWebhook("B");

t0 = Date.now();
const results = await Promise.all([
  sendMessage(accountA.url, "A-1"),
  sendMessage(accountA.url, "A-2"),
  sendMessage(accountA.url, "A-3"),
  sendMessage(accountB.url, "B-1"),
]);
const totalMs = Date.now() - t0;
await Promise.all([accountA.close(), accountB.close()]);

console.log(`## ${label}`);
console.log(`sendMessage results: ${JSON.stringify(results)} (all sends finished after ${totalMs}ms)`);
console.log("arrival at webhook | endpoint | text");
for (const arrival of arrivals.toSorted((left, right) => left.atMs - right.atMs)) {
  console.log(`${`${arrival.atMs}ms`.padStart(18)} | ${arrival.endpoint.padEnd(8)} | ${arrival.text}`);
}
```

</details>

### Regression tests and checks

- The new test `paces each incoming webhook endpoint independently` fails on current `main` with `expected [ Array(1) ] to deeply equal [ …(2) ]`, and passes with this change.
- `extensions/synology-chat/src/client.test.ts` passes 48/48 on this branch, rebased on `c1a7a205daa1`.
- `tsgo -p tsconfig.extensions.json` and `oxfmt --check` are clean, and hosted CI is green.

**Scope:** the listeners are local stand-ins for Synology NAS incoming webhooks, not a physical NAS. The proof covers the client's outbound pacing and delivery order, which is the only behavior this change touches.

AI-assisted. Fully tested with the real-transport run and unit tests above, and I have reviewed and understand the change.
