### PR TITLE
fix(voice-call): keep releasing resources when one cleanup step fails

### DIFF
--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -387,6 +387,60 @@ describe("createVoiceCallRuntime lifecycle", () => {
     expect(mocks.webhookStop).toHaveBeenCalledTimes(1);
   });
 
+  it("still cleans up tailscale and the webhook server when tunnel stop fails", async () => {
+    const tunnelError = new Error("tunnel cleanup failed");
+    const tunnelStop = vi.fn().mockRejectedValue(tunnelError);
+    mocks.startTunnel.mockResolvedValue({
+      publicUrl: "https://public.example/voice/webhook",
+      provider: "ngrok",
+      stop: tunnelStop,
+    });
+
+    const runtime = await createVoiceCallRuntime({
+      config: createBaseConfig(),
+      coreConfig: {} as OpenClawConfig,
+      agentRuntime: {} as never,
+    });
+
+    await expect(runtime.stop()).rejects.toBe(tunnelError);
+    expect(tunnelStop).toHaveBeenCalledTimes(1);
+    expect(mocks.cleanupTailscaleExposure).toHaveBeenCalledTimes(1);
+    expect(mocks.webhookStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("aggregates every cleanup failure in disposer order", async () => {
+    const tunnelError = new Error("tunnel cleanup failed");
+    const tailscaleError = new Error("tailscale cleanup failed");
+    const webhookError = new Error("webhook stop failed");
+    const tunnelStop = vi.fn().mockRejectedValue(tunnelError);
+    mocks.startTunnel.mockResolvedValue({
+      publicUrl: "https://public.example/voice/webhook",
+      provider: "ngrok",
+      stop: tunnelStop,
+    });
+    mocks.cleanupTailscaleExposure.mockRejectedValue(tailscaleError);
+    mocks.webhookStop.mockRejectedValue(webhookError);
+
+    const runtime = await createVoiceCallRuntime({
+      config: createBaseConfig(),
+      coreConfig: {} as OpenClawConfig,
+      agentRuntime: {} as never,
+    });
+
+    const firstStop = runtime.stop();
+    expect(runtime.stop()).toBe(firstStop);
+    const error = await firstStop.then(
+      () => undefined,
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([tunnelError, tailscaleError, webhookError]);
+    expect(tunnelStop).toHaveBeenCalledTimes(1);
+    expect(mocks.cleanupTailscaleExposure).toHaveBeenCalledTimes(1);
+    expect(mocks.webhookStop).toHaveBeenCalledTimes(1);
+  });
+
   it("passes fullConfig to the webhook server for streaming provider resolution", async () => {
     const coreConfig = { tts: { provider: "openai" } } as OpenClawConfig;
     const fullConfig = {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -131,14 +131,6 @@ function createRuntimeResourceLifecycle(params: {
   let tunnelResult: TunnelResult | null = null;
   let stopPromise: Promise<void> | null = null;
 
-  const runStep = async (step: () => Promise<void>, suppressErrors: boolean) => {
-    if (suppressErrors) {
-      await step().catch(() => {});
-      return;
-    }
-    await step();
-  };
-
   return {
     setTunnelResult: (result) => {
       tunnelResult = result;
@@ -149,17 +141,37 @@ function createRuntimeResourceLifecycle(params: {
       }
       const suppressErrors = opts?.suppressErrors ?? false;
       stopPromise = (async () => {
-        await runStep(async () => {
-          if (tunnelResult) {
-            await tunnelResult.stop();
+        const steps: Array<() => Promise<void>> = [
+          async () => {
+            if (tunnelResult) {
+              await tunnelResult.stop();
+            }
+          },
+          async () => {
+            await cleanupTailscaleExposure(params.config);
+          },
+          async () => {
+            await params.webhookServer.stop();
+          },
+        ];
+        // Attempt every owner even when an earlier one fails: the coordinator
+        // releases the runtime slot once stop settles, so a skipped disposer
+        // would leave the webhook port or public exposure live with no owner.
+        const errors: unknown[] = [];
+        for (const step of steps) {
+          try {
+            await step();
+          } catch (err) {
+            errors.push(err);
           }
-        }, suppressErrors);
-        await runStep(async () => {
-          await cleanupTailscaleExposure(params.config);
-        }, suppressErrors);
-        await runStep(async () => {
-          await params.webhookServer.stop();
-        }, suppressErrors);
+        }
+        if (suppressErrors || errors.length === 0) {
+          return;
+        }
+        if (errors.length === 1) {
+          throw errors[0];
+        }
+        throw new AggregateError(errors, "Voice call runtime cleanup failed");
       })();
       return stopPromise;
     },


### PR DESCRIPTION
Closes #127490

## What Problem This Solves

Resolves a problem where stopping the voice-call runtime could leave its webhook listener bound when an earlier cleanup step rejected. Normal shutdown stopped at the first rejecting disposer (the order is tunnel, then Tailscale exposure, then webhook server), but the plugin's runtime coordinator still released the runtime slot. The skipped webhook server kept its port open with no owner left to close it, and a replacement runtime could be admitted.

The built-in ngrok and Tailscale disposers currently absorb their own process and command failures, so an ordinary failed `tailscale` or ngrok shutdown does not trigger this. It applies whenever an earlier disposer rejects for any other reason. It also aligns normal stop with partial-start rollback, which already attempts every owner.

## Why This Change Was Made

Normal stop now attempts the tunnel, Tailscale exposure, and webhook server in the same order regardless of earlier failures. It then rejects with the single failure, or with an ordered `AggregateError` when several steps fail. Partial-start rollback still suppresses errors as before, and concurrent `stop()` calls still share one promise, so each disposer runs exactly once.

## User Impact

If a cleanup step rejects during voice-call shutdown, the webhook listener is still closed and its port released, and the failure is still reported. Behavior is unchanged when every step succeeds. This does not make Tailscale cleanup succeed when the `tailscale` command itself fails.

## Evidence

### Real webhook listener, before and after

A focused harness (run with `vitest run`, not committed) drove the production `createVoiceCallRuntime` on Node 26.5.0 with real timers. These parts were the real implementations: config resolution, the built-in `mock` telephony provider, `CallManager`, `VoiceCallWebhookServer`, and Tailscale cleanup (mode `off`).

- The only substitution was the tunnel module: `startTunnel` returns a tunnel whose `stop()` rejects with `injected tunnel stop failure`.
- The webhook server bound a real loopback port.
- A real TCP connect probed that port before and after `runtime.stop()`.

| Observation | main `c1a7a205daa1` (before) | this PR `ba5549b92b9f` (after) |
|---|---|---|
| Probe before `stop()` | accepting connections | accepting connections |
| `runtime.stop()` | rejects with `injected tunnel stop failure` | rejects with `injected tunnel stop failure` |
| **Probe after `stop()`** | **accepting connections**, listener leaked | **connection refused**, listener closed |

<details>
<summary>Raw output</summary>

```text
## main c1a7a205daa1 (before)
[voice-call] Failed to open SQLite call record store: Error: Voice Call state runtime not initialized
log: [voice-call] Webhook server listening on http://127.0.0.1:54214/voice/webhook
log: [voice-call] Runtime initialized
log: [voice-call] Webhook URL: https://tunnel.example.invalid/voice/webhook
probe before stop: 127.0.0.1:54214 accepting connections
runtime.stop(): rejected with Error: injected tunnel stop failure
probe after stop:  127.0.0.1:54214 accepting connections

## candidate ba5549b92b9f (after)
[voice-call] Failed to open SQLite call record store: Error: Voice Call state runtime not initialized
log: [voice-call] Webhook server listening on http://127.0.0.1:54232/voice/webhook
log: [voice-call] Runtime initialized
log: [voice-call] Webhook URL: https://tunnel.example.invalid/voice/webhook
probe before stop: 127.0.0.1:54232 accepting connections
runtime.stop(): rejected with Error: injected tunnel stop failure
probe after stop:  127.0.0.1:54232 connection refused
```

</details>

<details>
<summary>Harness</summary>

The baseline run replaced `extensions/voice-call/src/runtime.ts` with `git show upstream/main:extensions/voice-call/src/runtime.ts`. The patched file was restored and checksum-verified before the candidate run.

```ts
import fs from "node:fs";
import net from "node:net";
import os from "node:os";
import path from "node:path";
import { it, vi } from "vitest";
import { createVoiceCallRuntime } from "./runtime.js";
import { createVoiceCallBaseConfig } from "./test-fixtures.js";

vi.mock("./tunnel.js", () => ({
  startTunnel: async () => ({
    publicUrl: "https://tunnel.example.invalid/voice/webhook",
    provider: "ngrok",
    stop: async () => {
      throw new Error("injected tunnel stop failure");
    },
  }),
}));

function probe(port: number): Promise<"accepting connections" | "connection refused"> {
  return new Promise((resolve) => {
    const socket = net.connect({ host: "127.0.0.1", port });
    socket.once("connect", () => {
      socket.destroy();
      resolve("accepting connections");
    });
    socket.once("error", () => resolve("connection refused"));
  });
}

async function findFreePort(): Promise<number> {
  const server = net.createServer();
  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
  const address = server.address();
  const port = typeof address === "object" && address ? address.port : 0;
  await new Promise<void>((resolve) => server.close(() => resolve()));
  return port;
}

it("records webhook listener state around a failing runtime stop", async () => {
  const lines: string[] = [];
  const record = (line: string) => lines.push(line);
  const store = fs.mkdtempSync(path.join(os.tmpdir(), "voice-call-proof-"));
  const port = await findFreePort();
  const base = createVoiceCallBaseConfig({ tunnelProvider: "ngrok" });
  const config = { ...base, store, serve: { ...base.serve, port } };

  const runtime = await createVoiceCallRuntime({
    config,
    coreConfig: {} as never,
    agentRuntime: {} as never,
    logger: {
      info: (message: string) => record(`log: ${message}`),
      warn: (message: string) => record(`warn: ${message}`),
      error: (message: string) => record(`error: ${message}`),
      debug: () => {},
    },
  });

  record(`probe before stop: 127.0.0.1:${port} ${await probe(port)}`);
  try {
    await runtime.stop();
    record("runtime.stop(): resolved");
  } catch (err) {
    const detail =
      err instanceof AggregateError
        ? `AggregateError [${err.errors.map((e: Error) => e.message).join(", ")}]`
        : `${(err as Error).name}: ${(err as Error).message}`;
    record(`runtime.stop(): rejected with ${detail}`);
  }
  record(`probe after stop:  127.0.0.1:${port} ${await probe(port)}`);

  // Harness cleanup only, so a leaked listener cannot keep the worker alive.
  await runtime.webhookServer.stop().catch(() => {});
  fs.rmSync(store, { recursive: true, force: true });
  fs.writeFileSync(process.env.PROOF_OUT ?? path.join(os.tmpdir(), "voice-call-proof.txt"), `${lines.join("\n")}\n`);
});
```

</details>

### Regression tests and checks

- `still cleans up tailscale and the webhook server when tunnel stop fails`
  - On current `main` it fails: `expected "vi.fn()" to be called 1 times, but got 0 times`.
  - It passes with this change.
- `aggregates every cleanup failure in disposer order`
  - On current `main` it rejects with only the tunnel error.
  - It now rejects with an `AggregateError` holding the tunnel, Tailscale, and webhook errors in order, and a second `stop()` returns the same promise.
- `extensions/voice-call/src/runtime.test.ts` passes 26/26 on this branch, rebased on `c1a7a205daa1`.
- `tsgo -p tsconfig.extensions.json` and `oxfmt --check` are clean, and hosted CI is green.

**Scope:**

- The tunnel stop failure is injected, because the built-in disposers that run before the webhook server do not currently reject on their own. Everything else on the shutdown path is the real implementation, including the listener and the TCP probes.
- The harness did not provide the Gateway plugin state runtime, so both runs log `Failed to open SQLite call record store: ... state runtime not initialized`. No calls were placed, and this does not affect the lifecycle under test.

AI-assisted. Fully tested with the real-listener run and unit tests above, and I have reviewed and understand the change.
