### PR TITLE
fix(mcp): reject directory commands in doctor

### DIFF
--- a/src/cli/mcp-cli.doctor-directory-command.test.ts
+++ b/src/cli/mcp-cli.doctor-directory-command.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome } from "../config/home-env.test-harness.js";
+import {
+  cleanupMcpCliTestState,
+  createWorkspace,
+  lastLogLine,
+  mockLog,
+  resetMcpCliTestState,
+  runMcpCommand,
+} from "./mcp-cli.test-harness.js";
+
+describe("MCP doctor stdio commands that resolve to directories", () => {
+  beforeEach(() => {
+    resetMcpCliTestState();
+  });
+
+  afterEach(async () => {
+    await cleanupMcpCliTestState();
+  });
+
+  it("reports directories and continues past them on PATH", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      const serverDir = path.join(workspaceDir, "docs-mcp-repo");
+      const shadowDir = path.join(workspaceDir, "shadow");
+      const binDir = path.join(workspaceDir, "bin");
+      await fs.mkdir(serverDir, { recursive: true });
+      await fs.mkdir(path.join(shadowDir, "docs-mcp"), { recursive: true });
+      await fs.mkdir(binDir, { recursive: true });
+      await fs.writeFile(path.join(binDir, "docs-mcp"), "#!/bin/sh\nexit 0\n", "utf-8");
+      await fs.chmod(path.join(binDir, "docs-mcp"), 0o755);
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      const servers = {
+        "explicit-dir": { command: serverDir },
+        "path-dir-only": { command: "docs-mcp", env: { PATH: shadowDir } },
+        "path-dir-then-file": {
+          command: "docs-mcp",
+          env: { PATH: [shadowDir, binDir].join(path.delimiter) },
+        },
+      };
+      for (const [name, server] of Object.entries(servers)) {
+        await runMcpCommand(["mcp", "set", name, JSON.stringify(server)]);
+      }
+      mockLog.mockClear();
+
+      await expect(runMcpCommand(["mcp", "doctor", "--json"])).rejects.toThrow("__exit__:1");
+
+      expect(JSON.parse(lastLogLine())).toMatchObject({
+        ok: false,
+        servers: [
+          {
+            name: "explicit-dir",
+            ok: false,
+            issues: [
+              {
+                level: "error",
+                message: `stdio command not found or not executable: ${serverDir}`,
+              },
+            ],
+          },
+          {
+            name: "path-dir-only",
+            ok: false,
+            issues: [
+              { level: "error", message: "stdio command not found or not executable: docs-mcp" },
+            ],
+          },
+          { name: "path-dir-then-file", ok: true, issues: [] },
+        ],
+      });
+    });
+  });
+});

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -884,56 +884,6 @@ describe("mcp cli", () => {
     });
   });
 
-  it("reports MCP stdio commands that resolve to directories", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
-      const workspaceDir = await createWorkspace();
-      const serverDir = path.join(workspaceDir, "docs-mcp-repo");
-      const shadowDir = path.join(workspaceDir, "shadow");
-      const binDir = path.join(workspaceDir, "bin");
-      await fs.mkdir(serverDir, { recursive: true });
-      await fs.mkdir(path.join(shadowDir, "docs-mcp"), { recursive: true });
-      await fs.mkdir(binDir, { recursive: true });
-      await fs.writeFile(path.join(binDir, "docs-mcp"), "#!/bin/sh\nexit 0\n", "utf-8");
-      await fs.chmod(path.join(binDir, "docs-mcp"), 0o755);
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      await writeMcpDoctorServers(home, {
-        "explicit-dir": { command: serverDir },
-        "path-dir-only": { command: "docs-mcp", env: { PATH: shadowDir } },
-        "path-dir-then-file": {
-          command: "docs-mcp",
-          env: { PATH: [shadowDir, binDir].join(path.delimiter) },
-        },
-      });
-      mockLog.mockClear();
-
-      await expect(runMcpCommand(["mcp", "doctor", "--json"])).rejects.toThrow("__exit__:1");
-
-      expect(JSON.parse(lastLogLine())).toMatchObject({
-        ok: false,
-        servers: [
-          {
-            name: "explicit-dir",
-            ok: false,
-            issues: [
-              {
-                level: "error",
-                message: `stdio command not found or not executable: ${serverDir}`,
-              },
-            ],
-          },
-          {
-            name: "path-dir-only",
-            ok: false,
-            issues: [
-              { level: "error", message: "stdio command not found or not executable: docs-mcp" },
-            ],
-          },
-          { name: "path-dir-then-file", ok: true, issues: [] },
-        ],
-      });
-    });
-  });
-
   it("removes pure disabled tombstones when enabling MCP servers", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -884,6 +884,56 @@ describe("mcp cli", () => {
     });
   });
 
+  it("reports MCP stdio commands that resolve to directories", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+      const workspaceDir = await createWorkspace();
+      const serverDir = path.join(workspaceDir, "docs-mcp-repo");
+      const shadowDir = path.join(workspaceDir, "shadow");
+      const binDir = path.join(workspaceDir, "bin");
+      await fs.mkdir(serverDir, { recursive: true });
+      await fs.mkdir(path.join(shadowDir, "docs-mcp"), { recursive: true });
+      await fs.mkdir(binDir, { recursive: true });
+      await fs.writeFile(path.join(binDir, "docs-mcp"), "#!/bin/sh\nexit 0\n", "utf-8");
+      await fs.chmod(path.join(binDir, "docs-mcp"), 0o755);
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await writeMcpDoctorServers(home, {
+        "explicit-dir": { command: serverDir },
+        "path-dir-only": { command: "docs-mcp", env: { PATH: shadowDir } },
+        "path-dir-then-file": {
+          command: "docs-mcp",
+          env: { PATH: [shadowDir, binDir].join(path.delimiter) },
+        },
+      });
+      mockLog.mockClear();
+
+      await expect(runMcpCommand(["mcp", "doctor", "--json"])).rejects.toThrow("__exit__:1");
+
+      expect(JSON.parse(lastLogLine())).toMatchObject({
+        ok: false,
+        servers: [
+          {
+            name: "explicit-dir",
+            ok: false,
+            issues: [
+              {
+                level: "error",
+                message: `stdio command not found or not executable: ${serverDir}`,
+              },
+            ],
+          },
+          {
+            name: "path-dir-only",
+            ok: false,
+            issues: [
+              { level: "error", message: "stdio command not found or not executable: docs-mcp" },
+            ],
+          },
+          { name: "path-dir-then-file", ok: true, issues: [] },
+        ],
+      });
+    });
+  });
+
   it("removes pure disabled tombstones when enabling MCP servers", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -246,7 +246,8 @@ async function directoryExists(filePath: string): Promise<boolean> {
 async function isExecutable(filePath: string): Promise<boolean> {
   try {
     await fs.access(filePath, process.platform === "win32" ? fsConstants.F_OK : fsConstants.X_OK);
-    return true;
+    // X_OK also succeeds for searchable directories; follow symlinks to check the target type.
+    return (await fs.stat(filePath)).isFile();
   } catch {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

`openclaw mcp doctor` reported a server as healthy when its command was a directory, so operators discovered the invalid command only when trying to launch it.

Closes #144997.

Reported and fixed by @masatohoshino; both contributor commits retain their authorship.

## Why This Change Was Made

The shared command check tested permissions without checking the file type. It now requires a regular file, follows symlinks, and continues searching PATH after a directory match.

## User Impact

Directory commands fail the setup check with the existing executable error and exit code 1. Executable files and symlinks to them still pass.

## Evidence

- Real macOS `mcp set` and `mcp doctor --json` runs reported explicit directories and directory-only PATH matches as healthy before the fix; the same commands now report `ok: false` and exit 1.
- A symlink to a directory now fails; executable files, executable symlinks, and a later executable on PATH still pass.
- Files without execute permission still fail. Windows execution was not verified.

## Consumers

- `openclaw mcp doctor`: rejects directories during its static command check.
