### PR TITLE
refactor: retire Workboard's legacy card-store fallback

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1352,7 +1352,7 @@ extensions/workboard/src/gateway-helpers.ts	1
 extensions/workboard/src/sqlite-store.ts	36
 extensions/workboard/src/store-automation.ts	1
 extensions/workboard/src/store-card-helpers.ts	1
-extensions/workboard/src/store-core.ts	5
+extensions/workboard/src/store-core.ts	2
 extensions/workboard/src/store-normalizers.ts	11
 extensions/workboard/src/store-workflow.ts	2
 extensions/workboard/src/store.ts	1

--- a/extensions/workboard/doctor-contract-api.test.ts
+++ b/extensions/workboard/doctor-contract-api.test.ts
@@ -13,6 +13,7 @@ import { stateMigrations } from "./doctor-contract-api.js";
 import type { PersistedWorkboardCard } from "./src/persistence-types.js";
 import { createWorkboardSqliteStores } from "./src/sqlite-store.js";
 import { WorkboardStore } from "./src/store.js";
+import { sqliteTestAuxStores } from "./src/test/sqlite-store.js";
 
 function createDoctorContext(env: NodeJS.ProcessEnv): PluginDoctorStateMigrationContext {
   return {
@@ -451,7 +452,7 @@ describe("workboard doctor contract", () => {
       expect(await attachmentStore.entries()).toHaveLength(1);
 
       const reopenedStores = createWorkboardSqliteStores({ env });
-      const store = new WorkboardStore(reopenedStores.cards);
+      const store = new WorkboardStore(reopenedStores.cards, sqliteTestAuxStores(reopenedStores));
       expect(await store.get("card-1")).toMatchObject({ title: "Current card" });
       expect(await reopenedStores.attachments.lookup("attachment-1")).toBeUndefined();
       reopenedStores.close();

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -2,8 +2,8 @@
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerWorkboardCli } from "./cli.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
-import { WorkboardStore } from "./store.js";
+import type { WorkboardStore } from "./store.js";
+import { createWorkboardSqliteTestStore } from "./test/sqlite-store.js";
 
 const gatewayRuntime = vi.hoisted(() => ({
   callGatewayFromCli: vi.fn(),
@@ -23,24 +23,6 @@ vi.mock("openclaw/plugin-sdk/gateway-runtime", async () => {
 vi.mock("openclaw/plugin-sdk/runtime-config-snapshot", () => ({
   getRuntimeConfig: gatewayRuntime.getRuntimeConfig,
 }));
-
-function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
-  const entries = new Map<string, T>();
-  return {
-    async register(key, value) {
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].flatMap(([key, value]) => (value ? [{ key, value }] : []));
-    },
-  };
-}
 
 function createProgram(store: WorkboardStore): Command {
   const program = new Command();
@@ -89,7 +71,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("records full-host authority on locally created cards", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const program = createProgram(store);
 
     await program.parseAsync(["workboard", "create", "Host card"], { from: "user" });
@@ -104,7 +86,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("redacts claim tokens from card JSON output", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Claimed worker", status: "running" });
     await store.claim(card.id, { ownerId: "worker", token: "secret-token" });
     const program = createProgram(store);
@@ -123,7 +105,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("hides archived cards from text output by default and reveals them with --include-archived", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.create({ title: "Active card" });
     const archived = await store.create({ title: "Archived card" });
     await store.archive(archived.id, true);
@@ -144,7 +126,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("marks archived cards in show output", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const archived = await store.create({ title: "Archived card", status: "ready" });
     await store.archive(archived.id, true);
     const program = createProgram(store);
@@ -157,7 +139,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("preserves archived cards in JSON list output by default", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const archived = await store.create({ title: "Archived card" });
     await store.archive(archived.id, true);
     const program = createProgram(store);
@@ -171,7 +153,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("does not fall back to local dispatch for explicit gateway targets", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Remote target", status: "ready" });
     const program = createProgram(store);
     gatewayRuntime.callGatewayFromCli.mockRejectedValueOnce(
@@ -188,7 +170,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("does not fall back to local dispatch for configured remote gateways", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Configured remote target", status: "ready" });
     const program = createProgram(store);
     gatewayRuntime.getRuntimeConfig.mockReturnValue({
@@ -208,7 +190,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("forwards --max-starts to the dispatch gateway call", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const program = createProgram(store);
     gatewayRuntime.callGatewayFromCli.mockResolvedValueOnce({ started: [], startFailures: [] });
 
@@ -223,7 +205,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("requests minimum scopes unless full-host access is explicit", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const program = createProgram(store);
     gatewayRuntime.callGatewayFromCli.mockResolvedValue({ started: [], startFailures: [] });
 
@@ -241,7 +223,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("omits maxStarts from the dispatch gateway call when the flag is absent", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const program = createProgram(store);
     gatewayRuntime.callGatewayFromCli.mockResolvedValueOnce({ started: [], startFailures: [] });
 
@@ -256,7 +238,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("does not fall back when an older gateway lacks max-starts dispatch", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Bounded dispatch", status: "ready" });
     const program = createProgram(store);
     gatewayRuntime.callGatewayFromCli.mockRejectedValueOnce(
@@ -273,7 +255,7 @@ describe("registerWorkboardCli", () => {
   it.each(["0", "-1", "1e3", "0x10", "5.5"])(
     "rejects invalid --max-starts value %s",
     async (value) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const program = createProgram(store);
 
       await expect(
@@ -284,7 +266,7 @@ describe("registerWorkboardCli", () => {
   );
 
   it("rejects ambiguous card id prefixes", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const prefix = await createAmbiguousPrefix(store);
     const program = createProgram(store);
 
@@ -294,7 +276,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("moves claimed cards with operator authority and redacts JSON output", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Claimed card", status: "todo" });
     await store.claim(card.id, { ownerId: "worker", token: "secret-token" });
     const program = createProgram(store);
@@ -313,7 +295,7 @@ describe("registerWorkboardCli", () => {
   });
 
   it("rejects an invalid move status", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Invalid move" });
     const program = createProgram(store);
 

--- a/extensions/workboard/src/command.test.ts
+++ b/extensions/workboard/src/command.test.ts
@@ -4,30 +4,12 @@ import type { OpenClawPluginCommandDefinition } from "openclaw/plugin-sdk/core";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../api.js";
 import { registerWorkboardCommand } from "./command.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
-import { WorkboardStore } from "./store.js";
+import type { WorkboardStore } from "./store.js";
+import { createWorkboardSqliteTestStore } from "./test/sqlite-store.js";
 import {
   resolveAgentWorkboardWorkspaceRuntime,
   resolveCommandWorkboardWorkspaceAccess,
 } from "./workspace-access.js";
-
-function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
-  const entries = new Map<string, T>();
-  return {
-    async register(key, value) {
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].flatMap(([key, value]) => (value ? [{ key, value }] : []));
-    },
-  };
-}
 
 function createApi(run = vi.fn().mockResolvedValue({ runId: "run-1" })): OpenClawPluginApi {
   return {
@@ -162,7 +144,7 @@ describe("handleWorkboardCommand", () => {
   });
 
   it("attests the default agent for an unassigned slash-command card", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.create({
       title: "Unassigned slash card",
       status: "ready",
@@ -227,7 +209,7 @@ describe("handleWorkboardCommand", () => {
   });
 
   it("creates, lists, and dispatches workboard cards", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const api = createApi();
 
     await expect(
@@ -260,7 +242,7 @@ describe("handleWorkboardCommand", () => {
   });
 
   it("requires write access for slash mutations", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const api = createApi();
     const card = await store.create({ title: "Ready worker", status: "ready" });
 
@@ -292,7 +274,7 @@ describe("handleWorkboardCommand", () => {
   });
 
   it("shows when an archived card is excluded from dispatch", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const api = createApi();
     const card = await store.create({ title: "Archived slash card", status: "ready" });
     await store.archive(card.id, true);
@@ -305,7 +287,7 @@ describe("handleWorkboardCommand", () => {
   });
 
   it("moves claimed cards for operators on slash-command surfaces", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const api = createApi();
     const card = await store.create({ title: "Claimed slash card", status: "todo" });
     await store.claim(card.id, { ownerId: "worker", token: "secret-token" });
@@ -325,7 +307,7 @@ describe("handleWorkboardCommand", () => {
   });
 
   it("rejects invalid slash-command move statuses", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const api = createApi();
     const card = await store.create({ title: "Invalid slash move" });
 
@@ -342,8 +324,11 @@ describe("handleWorkboardCommand", () => {
   });
 
   it("uses the slash caller's workspace access for worktree materialization", async () => {
-    const store = new WorkboardStore(createMemoryStore());
-    const api = createApi();
+    const store = createWorkboardSqliteTestStore();
+    const run = vi.fn(async (input: { idempotencyKey: string }) => ({
+      runId: `accepted:${input.idempotencyKey}`,
+    }));
+    const api = createApi(run);
     const createWorktree = vi.mocked(api.runtime.worktrees.create);
     createWorktree.mockResolvedValue({
       id: "managed-id",
@@ -448,10 +433,23 @@ describe("handleWorkboardCommand", () => {
         ownerId: allowed.id,
       }),
     );
+    expect(run).toHaveBeenCalledTimes(2);
+    for (const [index, id] of [restricted.id, allowed.id].entries()) {
+      const runId = `accepted:${run.mock.calls[index]?.[0].idempotencyKey}`;
+      await expect(store.get(id)).resolves.toMatchObject({
+        status: "running",
+        runId,
+        execution: { runId },
+        metadata: {
+          automation: { launch: { phase: "accepted", acceptedRunId: runId } },
+          attempts: [expect.objectContaining({ id: runId, runId })],
+        },
+      });
+    }
   });
 
   it("rejects ambiguous card id prefixes", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const api = createApi();
     const prefix = await createAmbiguousPrefix(store);
 

--- a/extensions/workboard/src/dispatcher-compensation.test.ts
+++ b/extensions/workboard/src/dispatcher-compensation.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import { WorkboardStore } from "./store.js";
+import { sqliteTestAuxStores } from "./test/sqlite-store.js";
 
 describe("Workboard dispatcher compensation", () => {
   it.each([
@@ -35,8 +36,8 @@ describe("Workboard dispatcher compensation", () => {
     const dbPath = path.join(dir, "workboard.sqlite");
     const dispatchStores = createWorkboardSqliteStores({ dbPath });
     const hostStores = createWorkboardSqliteStores({ dbPath });
-    const store = new WorkboardStore(dispatchStores.cards);
-    const host = new WorkboardStore(hostStores.cards);
+    const store = new WorkboardStore(dispatchStores.cards, sqliteTestAuxStores(dispatchStores));
+    const host = new WorkboardStore(hostStores.cards, sqliteTestAuxStores(hostStores));
     try {
       const card = await store.create({
         title: "Isolated worker",

--- a/extensions/workboard/src/dispatcher-ownership.test.ts
+++ b/extensions/workboard/src/dispatcher-ownership.test.ts
@@ -1,31 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
-import { WorkboardStore } from "./store.js";
+import {
+  createWorkboardSqliteTestHarness,
+  createWorkboardSqliteTestStore,
+} from "./test/sqlite-store.js";
 
 const CLAIM_RECLAIM_MS = 5 * 60 * 1000;
 
-function createMemoryStore(): WorkboardKeyedStore {
-  const entries = new Map<string, PersistedWorkboardCard>();
-  return {
-    async register(key, value) {
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].map(([key, value]) => ({ key, value }));
-    },
-  };
-}
-
 describe("Workboard dispatcher ownership", () => {
   it("dispatches a card whose create input tried to inject archivedAt", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const now = 10;
     const card = await store.create({
       title: "Injected archive",
@@ -48,8 +32,8 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("falls back to one default owner for persisted blank and unassigned agents", async () => {
-    const keyed = createMemoryStore();
-    const store = new WorkboardStore(keyed);
+    const { store, stores } = createWorkboardSqliteTestHarness();
+    const keyed = stores.cards;
     const blankAgent = await store.create({
       title: "Blank agent worker",
       status: "ready",
@@ -85,8 +69,8 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("keeps an active blank-assignment card in the default worker slot", async () => {
-    const keyed = createMemoryStore();
-    const store = new WorkboardStore(keyed);
+    const { store, stores } = createWorkboardSqliteTestHarness();
+    const keyed = stores.cards;
     const active = await store.create({
       title: "Active default worker",
       status: "running",
@@ -115,7 +99,7 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("bounds failed worker attempts without draining the ready queue", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const cards = [];
     for (let index = 0; index < 5; index += 1) {
       cards.push(
@@ -158,7 +142,7 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("does not spend worker attempts on cards that fail workspace preflight", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const inaccessible = [];
     for (const [index, priority] of (["urgent", "high"] as const).entries()) {
       inaccessible.push(
@@ -198,7 +182,7 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("tries a healthy owner before retrying a failed owner's queued cards", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const failed = await store.create({
       title: "Failing urgent worker",
       status: "ready",
@@ -243,7 +227,7 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("preserves priority order among available owners when workers start successfully", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const urgent = await store.create({
       title: "Urgent primary worker",
       status: "ready",
@@ -294,79 +278,85 @@ describe("Workboard dispatcher ownership", () => {
   ])(
     "keeps a cross-board running worker slot for a $name assigned agent until its heartbeat grace expires",
     async ({ agentId }) => {
-      const store = new WorkboardStore(createMemoryStore());
-      const stale = await store.create({
-        title: "Abandoned product worker",
-        status: "running",
-        agentId,
-        boardId: "product",
-        execution: {
-          id: "stale-execution",
-          kind: "agent-session",
-          mode: "autonomous",
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(10_000);
+        const store = createWorkboardSqliteTestStore();
+        const stale = await store.create({
+          title: "Abandoned product worker",
           status: "running",
-          startedAt: 1,
-          updatedAt: 1,
-        },
-      });
-      const claimed = await store.claim(stale.id, {
-        ownerId: "shared-worker",
-        token: "stale-token",
-        ttlSeconds: 1,
-      });
-      const ready = await store.create({
-        title: "Ready operations recovery",
-        status: "ready",
-        agentId: "shared-worker",
-        boardId: "ops",
-        workspaceAccess: { unrestricted: true },
-      });
-      const run = vi.fn().mockResolvedValue({ runId: "run-after-grace" });
-      const expiresAt = claimed.card.metadata?.claim?.expiresAt;
-      expect(expiresAt).toBeDefined();
-
-      const withinGrace = await dispatchAndStartWorkboardCards({
-        store,
-        subagent: { run },
-        options: {
-          now: expiresAt! + CLAIM_RECLAIM_MS,
-          maxStarts: 1,
+          agentId,
+          boardId: "product",
+          execution: {
+            id: "stale-execution",
+            kind: "agent-session",
+            mode: "autonomous",
+            status: "running",
+            startedAt: 1,
+            updatedAt: 1,
+          },
+        });
+        const claimed = await store.claim(stale.id, {
+          ownerId: "shared-worker",
+          token: "stale-token",
+          ttlSeconds: 1,
+        });
+        const ready = await store.create({
+          title: "Ready operations recovery",
+          status: "ready",
+          agentId: "shared-worker",
           boardId: "ops",
-        },
-      });
+          workspaceAccess: { unrestricted: true },
+        });
+        const run = vi.fn().mockResolvedValue({ runId: "run-after-grace" });
+        const expiresAt = claimed.card.metadata?.claim?.expiresAt;
+        expect(expiresAt).toBeDefined();
 
-      expect(withinGrace.started).toEqual([]);
-      expect(run).not.toHaveBeenCalled();
-      await expect(store.get(stale.id)).resolves.toMatchObject({
-        status: "running",
-        execution: { status: "running" },
-        metadata: { claim: { ownerId: "shared-worker" } },
-      });
+        vi.setSystemTime(expiresAt! + CLAIM_RECLAIM_MS);
+        const withinGrace = await dispatchAndStartWorkboardCards({
+          store,
+          subagent: { run },
+          options: {
+            maxStarts: 1,
+            boardId: "ops",
+          },
+        });
 
-      const reclaimed = await dispatchAndStartWorkboardCards({
-        store,
-        subagent: { run },
-        options: {
-          now: expiresAt! + CLAIM_RECLAIM_MS + 1,
-          maxStarts: 1,
-          boardId: "ops",
-        },
-      });
+        expect(withinGrace.started).toEqual([]);
+        expect(run).not.toHaveBeenCalled();
+        await expect(store.get(stale.id)).resolves.toMatchObject({
+          status: "running",
+          execution: { status: "running" },
+          metadata: { claim: { ownerId: "shared-worker" } },
+        });
 
-      expect(reclaimed.started).toEqual([
-        expect.objectContaining({ cardId: ready.id, runId: "run-after-grace" }),
-      ]);
-      expect(run).toHaveBeenCalledOnce();
-      await expect(store.get(stale.id)).resolves.toMatchObject({
-        status: "running",
-        execution: { status: "running" },
-        metadata: { claim: { ownerId: "shared-worker" } },
-      });
+        vi.setSystemTime(expiresAt! + CLAIM_RECLAIM_MS + 1);
+        const reclaimed = await dispatchAndStartWorkboardCards({
+          store,
+          subagent: { run },
+          options: {
+            maxStarts: 1,
+            boardId: "ops",
+          },
+        });
+
+        expect(reclaimed.started).toEqual([
+          expect.objectContaining({ cardId: ready.id, runId: "run-after-grace" }),
+        ]);
+        expect(run).toHaveBeenCalledOnce();
+        await expect(store.get(stale.id)).resolves.toMatchObject({
+          status: "running",
+          execution: { status: "running" },
+          metadata: { claim: { ownerId: "shared-worker" } },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
     },
   );
 
   it("does not let an expired review claim consume worker capacity", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const now = Date.now();
     await store.create({
       title: "Expired review claim",
@@ -403,16 +393,16 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it.each([
-    { wallClock: 10_000, dispatchNow: 50_000, expectedStarts: 1 },
-    { wallClock: 50_000, dispatchNow: 10_000, expectedStarts: 0 },
+    { wallClock: 10_000, dispatchNow: 50_000, expectedClaimAttempts: 1 },
+    { wallClock: 50_000, dispatchNow: 10_000, expectedClaimAttempts: 0 },
   ])(
-    "evaluates claim capacity at dispatch time instead of wall time ($wallClock, $dispatchNow)",
-    async ({ wallClock, dispatchNow, expectedStarts }) => {
+    "selects at the dispatch snapshot while claiming at current time ($wallClock, $dispatchNow)",
+    async ({ wallClock, dispatchNow, expectedClaimAttempts }) => {
       vi.useFakeTimers();
       try {
         vi.setSystemTime(wallClock);
-        const store = new WorkboardStore(createMemoryStore());
-        await store.create({
+        const store = createWorkboardSqliteTestStore();
+        const review = await store.create({
           title: "Review claim with a deterministic expiry",
           status: "review",
           agentId: "shared-worker",
@@ -433,6 +423,7 @@ describe("Workboard dispatcher ownership", () => {
           workspaceAccess: { unrestricted: true },
         });
         const run = vi.fn().mockResolvedValue({ runId: "run-at-dispatch-time" });
+        const claim = vi.spyOn(store, "claim");
 
         const result = await dispatchAndStartWorkboardCards({
           store,
@@ -440,14 +431,28 @@ describe("Workboard dispatcher ownership", () => {
           options: { now: dispatchNow, maxStarts: 1 },
         });
 
-        expect(run).toHaveBeenCalledTimes(expectedStarts);
-        expect(result.started).toHaveLength(expectedStarts);
-        if (expectedStarts === 1) {
-          expect(result.started[0]).toMatchObject({
-            cardId: ready.id,
-            runId: "run-at-dispatch-time",
-          });
-        }
+        expect(claim.mock.calls.map(([id]) => id)).toEqual(
+          expectedClaimAttempts === 1 ? [ready.id] : [],
+        );
+        expect(run).not.toHaveBeenCalled();
+        expect(result.started).toEqual([]);
+        expect(result.startFailures).toEqual(
+          expectedClaimAttempts === 1
+            ? [
+                expect.objectContaining({
+                  cardId: ready.id,
+                  error: "Owner shared-worker already has active Workboard work.",
+                }),
+              ]
+            : [],
+        );
+        const unchangedReady = await store.get(ready.id);
+        expect(unchangedReady?.status).toBe("ready");
+        expect(unchangedReady?.metadata?.claim).toBeUndefined();
+        await expect(store.get(review.id)).resolves.toMatchObject({
+          status: "review",
+          metadata: { claim: review.metadata?.claim },
+        });
       } finally {
         vi.useRealTimers();
       }
@@ -460,7 +465,7 @@ describe("Workboard dispatcher ownership", () => {
   ])(
     "replaces an expired ready-card claim with the $ownerId slot",
     async ({ agentId, ownerId }) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const now = Date.now();
       const card = await store.create({
         title: "Ready with an expired lease",
@@ -499,7 +504,7 @@ describe("Workboard dispatcher ownership", () => {
   );
 
   it("serializes concurrent board dispatches for the same worker", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const ops = await store.create({
       title: "Ops shared worker",
       status: "ready",
@@ -564,7 +569,7 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("keeps one worker slot across 25 concurrent board dispatches", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const cards = await Promise.all(
       Array.from({ length: 25 }, (_, index) =>
         store.create({
@@ -598,7 +603,7 @@ describe("Workboard dispatcher ownership", () => {
   it.each(["scheduled dispatch", "dashboard exact-card start"] as const)(
     "persists launch association before %s and keeps accepted runs visible",
     async (origin) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({
         title: "Worker with unavailable execution persistence",
         status: "ready",
@@ -690,7 +695,7 @@ describe("Workboard dispatcher ownership", () => {
   );
 
   it("marks a prepared launch accepted after Gateway acceptance", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Worker with durable acceptance",
       status: "ready",
@@ -742,7 +747,7 @@ describe("Workboard dispatcher ownership", () => {
   it.each(["backlog", "todo", "ready"] as const)(
     "starts an exact dashboard card from %s",
     async (status) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({
         title: `Exact ${status}`,
         status,
@@ -766,7 +771,7 @@ describe("Workboard dispatcher ownership", () => {
   it.each(["review", "blocked", "done"] as const)(
     "rejects an exact dashboard card in %s",
     async (status) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({
         title: `Invalid exact ${status}`,
         status,
@@ -800,7 +805,7 @@ describe("Workboard dispatcher ownership", () => {
     { label: "due", offsetMs: -1_000, starts: true },
     { label: "future", offsetMs: 60_000, starts: false },
   ])("handles a $label scheduled exact dashboard card", async ({ offsetMs, starts }) => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const now = Date.now();
     const card = await store.create({
       title: "Scheduled exact",
@@ -826,7 +831,7 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("keeps global owner capacity for exact dashboard starts across boards", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const active = await store.create({
       title: "Active owner",
       status: "ready",
@@ -858,7 +863,7 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("starts the exact lower-priority card without selecting a sibling", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const urgent = await store.create({
       title: "Urgent sibling",
       status: "ready",
@@ -886,7 +891,7 @@ describe("Workboard dispatcher ownership", () => {
   });
 
   it("keeps an accepted worker running when its worker log cannot be recorded", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Worker with unavailable logging",
       status: "ready",

--- a/extensions/workboard/src/dispatcher.races.test.ts
+++ b/extensions/workboard/src/dispatcher.races.test.ts
@@ -3,26 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
-import { WorkboardStore } from "./store.js";
-
-function createMemoryStore(): WorkboardKeyedStore {
-  const entries = new Map<string, PersistedWorkboardCard>();
-  return {
-    async register(key, value) {
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].map(([key, value]) => ({ key, value }));
-    },
-  };
-}
+import { createWorkboardSqliteTestStore } from "./test/sqlite-store.js";
 
 describe("Workboard dispatcher lifecycle races", () => {
   it.each([
@@ -32,7 +13,7 @@ describe("Workboard dispatcher lifecycle races", () => {
     { name: "under review", status: "review" as const },
     { name: "moved to another board", boardId: "product" },
   ])("does not start a card $name during dispatch preflight", async (transition) => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Concurrent dispatch transition",
       status: "ready",
@@ -78,7 +59,7 @@ describe("Workboard dispatcher lifecycle races", () => {
   });
 
   it("does not spend worker attempts on cards that change before they can be claimed", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const first = await store.create({
       title: "First stale dispatch",
       status: "ready",
@@ -131,7 +112,7 @@ describe("Workboard dispatcher lifecycle races", () => {
 
   it("retains a managed worktree when pre-start lossless cleanup declines", async () => {
     const managedPath = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-retained-"));
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Retain failed worker checkout",
       status: "ready",

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -1,30 +1,11 @@
 // Workboard tests cover dispatcher plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
-import { WorkboardStore } from "./store.js";
-
-function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
-  const entries = new Map<string, T>();
-  return {
-    async register(key, value) {
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].flatMap(([key, value]) => (value ? [{ key, value }] : []));
-    },
-  };
-}
+import { createWorkboardSqliteTestStore } from "./test/sqlite-store.js";
 
 describe("dispatchAndStartWorkboardCards", () => {
   it("persists the resolved subagent runtime on new executions", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Claude worker",
       status: "ready",
@@ -56,7 +37,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("omits unresolved runtime metadata instead of labeling it codex", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Unknown runtime worker",
       status: "ready",
@@ -79,7 +60,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("materializes managed worktrees, supplies cwd, and persists them", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Isolated worker",
       status: "ready",
@@ -138,7 +119,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("requires explicit reauthorization for legacy cards under full-host dispatch", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Legacy worker",
       status: "ready",
@@ -172,7 +153,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("adopts current authority for a legacy card without a host workspace path", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Legacy scratch worker", status: "ready" });
     const run = vi.fn().mockResolvedValue({ runId: "run-legacy-scratch" });
 
@@ -190,7 +171,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("does not claim a card whose workspace authority changed after preflight", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Racing authority update",
       status: "ready",
@@ -227,7 +208,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("rejects worktree sources outside the dispatcher's workspace boundary", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Protected checkout",
       status: "ready",
@@ -262,7 +243,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("leaves inaccessible directory workspaces ready and unclaimed", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Protected directory",
       status: "ready",
@@ -294,7 +275,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("does not launch a mutable nested directory for a workspace-bound caller", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Mutable nested directory",
       status: "ready",
@@ -322,7 +303,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("does not let an implicit target agent workspace widen caller access", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Other agent scratch",
       status: "ready",
@@ -352,7 +333,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("pins an allowed implicit worker to the caller's workspace root", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Workspace scratch",
       status: "ready",
@@ -393,7 +374,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("rejects a restricted card when the target agent is not sandboxed", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Restricted worker",
       status: "ready",
@@ -431,7 +412,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("rejects a restricted card when the target workspace is read-only", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Read-only worker",
       status: "ready",
@@ -468,7 +449,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("keeps read-only card authority after a later full-host dispatch", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Persisted read-only worker",
       status: "ready",
@@ -493,7 +474,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("rejects a target sandbox root broader than the card authority", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Broader target worker",
       status: "ready",
@@ -534,7 +515,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("rejects a restricted card when the target sandbox has an escape path", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Escaping worker",
       status: "ready",
@@ -572,7 +553,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("rejects a restricted workspace nested inside a broader Git checkout", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Nested checkout worker",
       status: "ready",
@@ -614,7 +595,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("keeps a card's persisted workspace ceiling during a later admin dispatch", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Persisted restricted worker",
       status: "ready",
@@ -659,7 +640,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("runs an authorized worktree request directly in a workspace-bound caller's root", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Workspace-bound worker",
       status: "ready",
@@ -698,7 +679,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("rejects linked-worktree metadata outside a restricted workspace mount", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Linked worktree worker",
       status: "ready",
@@ -737,7 +718,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("does not reuse a generated branch as an omitted source base", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Branchless retry",
       status: "ready",
@@ -774,7 +755,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("claims ready cards and starts bounded subagent worker runs", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const first = await store.create({
       title: "First worker",
       status: "ready",
@@ -842,7 +823,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("shares one worker slot across cards dispatched with the same explicit owner", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const first = await store.create({
       title: "First shared worker",
       status: "ready",
@@ -876,7 +857,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("counts the active claim owner when checking worker capacity", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const running = await store.create({
       title: "Already claimed worker",
       status: "running",
@@ -906,7 +887,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   it.each(["worker", "other-worker"])(
     "starts recoverable work after a higher-priority worker fails (next owner: %s)",
     async (nextOwner) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const failed = await store.create({
         title: "Unavailable urgent worker",
         status: "ready",
@@ -944,7 +925,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   );
 
   it("does not let review cards consume an agent running slot", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.create({
       title: "Waiting for operator review",
       status: "review",
@@ -976,7 +957,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("starts workers only for the selected board", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const ops = await store.create({
       title: "Ops worker",
       status: "ready",
@@ -1012,7 +993,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("keeps claimed review cards in the owner running slot", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const review = await store.create({
       title: "Claimed operator review",
       status: "review",
@@ -1039,7 +1020,7 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("blocks a card when worker start fails after claim", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Fail worker",
       status: "ready",

--- a/extensions/workboard/src/gateway.test.ts
+++ b/extensions/workboard/src/gateway.test.ts
@@ -2,26 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../api.js";
 import { registerWorkboardGatewayMethods } from "./gateway.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
-import { WorkboardStore } from "./store.js";
-
-function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
-  const entries = new Map<string, T>();
-  return {
-    async register(key, value) {
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].flatMap(([key, value]) => (value ? [{ key, value }] : []));
-    },
-  };
-}
+import { createWorkboardSqliteTestStore } from "./test/sqlite-store.js";
 
 describe("workboard gateway methods", () => {
   it("registers CRUD methods with read/write scopes", async () => {
@@ -33,7 +14,7 @@ describe("workboard gateway methods", () => {
     const api = {
       runtime: {
         state: {
-          openKeyedStore: vi.fn(() => createMemoryStore()),
+          openKeyedStore: vi.fn(),
         },
       },
       registerGatewayMethod: vi.fn(
@@ -43,7 +24,7 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
 
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     registerWorkboardGatewayMethods({ api, store });
 
     expect([...methods.keys()]).toEqual([
@@ -194,7 +175,7 @@ describe("workboard gateway methods", () => {
       opts: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2];
     };
     const methods = new Map<string, RegisteredMethod>();
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const api = {
       runtime: {
         agent: {
@@ -316,7 +297,7 @@ describe("workboard gateway methods", () => {
     const api = {
       runtime: {
         state: {
-          openKeyedStore: vi.fn(() => createMemoryStore()),
+          openKeyedStore: vi.fn(),
         },
       },
       registerGatewayMethod: vi.fn(
@@ -326,7 +307,7 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
 
-    registerWorkboardGatewayMethods({ api, store: new WorkboardStore(createMemoryStore()) });
+    registerWorkboardGatewayMethods({ api, store: createWorkboardSqliteTestStore() });
 
     const createRespond = vi.fn();
     await methods.get("workboard.cards.create")?.handler({
@@ -372,7 +353,7 @@ describe("workboard gateway methods", () => {
     const api = {
       runtime: {
         state: {
-          openKeyedStore: vi.fn(() => createMemoryStore()),
+          openKeyedStore: vi.fn(),
         },
       },
       registerGatewayMethod: vi.fn(
@@ -382,7 +363,7 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
 
-    registerWorkboardGatewayMethods({ api, store: new WorkboardStore(createMemoryStore()) });
+    registerWorkboardGatewayMethods({ api, store: createWorkboardSqliteTestStore() });
 
     const createHandler = methods.get("workboard.cards.create")?.handler;
     const respond = vi.fn();
@@ -407,7 +388,7 @@ describe("workboard gateway methods", () => {
     const api = {
       runtime: {
         state: {
-          openKeyedStore: vi.fn(() => createMemoryStore()),
+          openKeyedStore: vi.fn(),
         },
         subagent: { run },
       },
@@ -417,7 +398,7 @@ describe("workboard gateway methods", () => {
         },
       ),
     } as unknown as OpenClawPluginApi;
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Ready worker",
       status: "ready",
@@ -450,7 +431,7 @@ describe("workboard gateway methods", () => {
     const run = vi.fn();
     const api = {
       runtime: {
-        state: { openKeyedStore: vi.fn(() => createMemoryStore()) },
+        state: { openKeyedStore: vi.fn() },
         subagent: { run },
       },
       registerGatewayMethod: vi.fn(
@@ -459,7 +440,7 @@ describe("workboard gateway methods", () => {
         },
       ),
     } as unknown as OpenClawPluginApi;
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Blocked exact start",
       status: "blocked",
@@ -491,10 +472,12 @@ describe("workboard gateway methods", () => {
       opts: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2];
     };
     const methods = new Map<string, RegisteredMethod>();
-    const run = vi.fn().mockResolvedValue({ runId: "run-card" });
+    const run = vi.fn(async (input: { idempotencyKey: string }) => ({
+      runId: `accepted:${input.idempotencyKey}`,
+    }));
     const api = {
       runtime: {
-        state: { openKeyedStore: vi.fn(() => createMemoryStore()) },
+        state: { openKeyedStore: vi.fn() },
         subagent: { run },
       },
       registerGatewayMethod: vi.fn(
@@ -503,7 +486,7 @@ describe("workboard gateway methods", () => {
         },
       ),
     } as unknown as OpenClawPluginApi;
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await Promise.all(
       Array.from({ length: 5 }, (_, index) =>
         store.create({
@@ -544,6 +527,21 @@ describe("workboard gateway methods", () => {
       ?.handler({ params: { boardId: "legacy" }, respond: defaultRespond } as never);
     expect(defaultRespond.mock.calls[0]?.[1]?.started).toHaveLength(3);
     expect(run).toHaveBeenCalledTimes(7);
+    const startedCards = (await store.list()).filter((card) => card.status === "running");
+    expect(startedCards).toHaveLength(7);
+    const expectedRunIds = run.mock.calls.map(([input]) => `accepted:${input.idempotencyKey}`);
+    expect(startedCards.map((card) => card.runId)).toEqual(expect.arrayContaining(expectedRunIds));
+    for (const card of startedCards) {
+      const runId = card.runId;
+      expect(card).toMatchObject({
+        runId,
+        execution: { runId },
+        metadata: {
+          automation: { launch: { phase: "accepted", acceptedRunId: runId } },
+          attempts: [expect.objectContaining({ id: runId, runId })],
+        },
+      });
+    }
 
     const legacyRespond = vi.fn();
     await methods
@@ -607,7 +605,7 @@ describe("workboard gateway methods", () => {
         },
       ),
     } as unknown as OpenClawPluginApi;
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const denied = await store.create({
       title: "Denied checkout",
       status: "ready",
@@ -691,7 +689,7 @@ describe("workboard gateway methods", () => {
     const api = {
       runtime: {
         state: {
-          openKeyedStore: vi.fn(() => createMemoryStore()),
+          openKeyedStore: vi.fn(),
         },
       },
       registerGatewayMethod: vi.fn(
@@ -701,7 +699,7 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
 
-    registerWorkboardGatewayMethods({ api, store: new WorkboardStore(createMemoryStore()) });
+    registerWorkboardGatewayMethods({ api, store: createWorkboardSqliteTestStore() });
 
     const createRespond = vi.fn();
     await methods.get("workboard.cards.create")?.handler({

--- a/extensions/workboard/src/lifecycle-sync.cleanup-recovery.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.cleanup-recovery.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createWorkboardLifecycleService, syncWorkboardSubagentEnded } from "./lifecycle-sync.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import { WorkboardStore } from "./store.js";
+import { sqliteTestAuxStores } from "./test/sqlite-store.js";
 
 const SESSION_KEY = "agent:main:subagent:workboard-cleanup-recovery";
 const RUN_ID = "run-cleanup-recovery";
@@ -14,7 +15,7 @@ const SOURCE_PATH = "/repo";
 
 function openStore(dbPath: string) {
   const stores = createWorkboardSqliteStores({ dbPath });
-  return { store: new WorkboardStore(stores.cards), stores };
+  return { store: new WorkboardStore(stores.cards, sqliteTestAuxStores(stores)), stores };
 }
 
 function execution(

--- a/extensions/workboard/src/lifecycle-sync.restart.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.restart.test.ts
@@ -1,26 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
 import { createWorkboardLifecycleService, syncWorkboardSubagentEnded } from "./lifecycle-sync.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
 import { WorkboardStore } from "./store.js";
-
-function createMemoryStore(): WorkboardKeyedStore {
-  const entries = new Map<string, PersistedWorkboardCard>();
-  return {
-    async register(key, value) {
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].map(([key, value]) => ({ key, value }));
-    },
-  };
-}
+import { createWorkboardSqliteTestHarness, sqliteTestAuxStores } from "./test/sqlite-store.js";
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
@@ -33,8 +15,7 @@ function createDeferred<T>() {
 }
 
 async function beginPreparedDispatch() {
-  const keyed = createMemoryStore();
-  const dispatchStore = new WorkboardStore(keyed);
+  const { store: dispatchStore, stores } = createWorkboardSqliteTestHarness();
   const card = await dispatchStore.create({
     title: "Prepared across restart",
     status: "ready",
@@ -60,7 +41,7 @@ async function beginPreparedDispatch() {
     dispatch,
     prepared,
     runResult,
-    replacementStore: new WorkboardStore(keyed),
+    replacementStore: new WorkboardStore(stores.cards, sqliteTestAuxStores(stores)),
   };
 }
 
@@ -98,264 +79,326 @@ async function stopLifecycleSweep(
   await lifecycle.service.stop?.(lifecycle.context);
 }
 
+async function cleanupInterruptedDispatch(
+  interrupted: Awaited<ReturnType<typeof beginPreparedDispatch>>,
+  lifecycle: Awaited<ReturnType<typeof startLifecycleSweep>> | undefined,
+): Promise<void> {
+  try {
+    if (lifecycle) {
+      await stopLifecycleSweep(lifecycle);
+    }
+  } finally {
+    try {
+      await rejectInterruptedDispatch(interrupted);
+    } finally {
+      await interrupted.replacementStore.close();
+    }
+  }
+}
+
 describe("Workboard prepared launch restart recovery", () => {
   it("fails a prepared launch absent from the first complete post-restart snapshot", async () => {
     const interrupted = await beginPreparedDispatch();
-    const lifecycle = await startLifecycleSweep({
-      store: interrupted.replacementStore,
-      sessions: [],
-      complete: true,
-    });
+    let lifecycle: Awaited<ReturnType<typeof startLifecycleSweep>> | undefined;
+    try {
+      lifecycle = await startLifecycleSweep({
+        store: interrupted.replacementStore,
+        sessions: [],
+        complete: true,
+      });
 
-    await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
-      status: "running",
-      sessionKey: interrupted.prepared.sessionKey,
-      runId: interrupted.prepared.provisionalRunId,
-      execution: { status: "running", runId: interrupted.prepared.provisionalRunId },
-      metadata: {
-        claim: { ownerId: "workboard-dispatcher" },
-        attempts: [{ status: "running", runId: interrupted.prepared.provisionalRunId }],
-        automation: { launch: { phase: "prepared" } },
-      },
-    });
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    expect(lifecycle.readSessions).not.toHaveBeenCalled();
-
-    lifecycle.service.onGatewayStart();
-    await vi.waitFor(async () => {
-      expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe("blocked");
-    });
-    await stopLifecycleSweep(lifecycle);
-
-    const recovered = await interrupted.replacementStore.get(interrupted.card.id);
-    expect(recovered).toMatchObject({
-      status: "blocked",
-      metadata: {
-        automation: {
-          launch: {
-            phase: "failed",
-            requestedSessionKey: interrupted.prepared.sessionKey,
-            provisionalRunId: interrupted.prepared.provisionalRunId,
-            reason: expect.stringContaining("Gateway"),
-          },
+      await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
+        status: "running",
+        sessionKey: interrupted.prepared.sessionKey,
+        runId: interrupted.prepared.provisionalRunId,
+        execution: { status: "running", runId: interrupted.prepared.provisionalRunId },
+        metadata: {
+          claim: { ownerId: "workboard-dispatcher" },
+          attempts: [{ status: "running", runId: interrupted.prepared.provisionalRunId }],
+          automation: { launch: { phase: "prepared" } },
         },
-        attempts: [
-          expect.objectContaining({
-            status: "blocked",
-            runId: interrupted.prepared.provisionalRunId,
-            endedAt: expect.any(Number),
-          }),
-        ],
-      },
-    });
-    expect(recovered?.metadata?.claim).toBeUndefined();
-    expect(recovered?.sessionKey).toBeUndefined();
-    expect(recovered?.runId).toBeUndefined();
-    expect(recovered?.execution).toBeUndefined();
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      expect(lifecycle.readSessions).not.toHaveBeenCalled();
 
-    await rejectInterruptedDispatch(interrupted);
-    expect(
-      (await interrupted.replacementStore.get(interrupted.card.id))?.metadata?.automation?.launch,
-    ).toMatchObject({ phase: "failed" });
+      lifecycle.service.onGatewayStart();
+      await vi.waitFor(async () => {
+        expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe(
+          "blocked",
+        );
+      });
+      await stopLifecycleSweep(lifecycle);
+      lifecycle = undefined;
+
+      const recovered = await interrupted.replacementStore.get(interrupted.card.id);
+      expect(recovered).toMatchObject({
+        status: "blocked",
+        metadata: {
+          automation: {
+            launch: {
+              phase: "failed",
+              requestedSessionKey: interrupted.prepared.sessionKey,
+              provisionalRunId: interrupted.prepared.provisionalRunId,
+              reason: expect.stringContaining("Gateway"),
+            },
+          },
+          attempts: [
+            expect.objectContaining({
+              status: "blocked",
+              runId: interrupted.prepared.provisionalRunId,
+              endedAt: expect.any(Number),
+            }),
+          ],
+        },
+      });
+      expect(recovered?.metadata?.claim).toBeUndefined();
+      expect(recovered?.sessionKey).toBeUndefined();
+      expect(recovered?.runId).toBeUndefined();
+      expect(recovered?.execution).toBeUndefined();
+
+      await rejectInterruptedDispatch(interrupted);
+      expect(
+        (await interrupted.replacementStore.get(interrupted.card.id))?.metadata?.automation?.launch,
+      ).toMatchObject({ phase: "failed" });
+    } finally {
+      await cleanupInterruptedDispatch(interrupted, lifecycle);
+    }
   });
 
   it("fails a prepared launch when its persisted session has no active run", async () => {
     const interrupted = await beginPreparedDispatch();
-    const lifecycle = await startLifecycleSweep({
-      store: interrupted.replacementStore,
-      sessions: [
-        {
-          key: `agent:worker:${interrupted.prepared.sessionKey}`,
-          status: "running",
-          hasActiveRun: false,
-        },
-      ],
-      complete: true,
-    });
+    let lifecycle: Awaited<ReturnType<typeof startLifecycleSweep>> | undefined;
+    try {
+      lifecycle = await startLifecycleSweep({
+        store: interrupted.replacementStore,
+        sessions: [
+          {
+            key: `agent:worker:${interrupted.prepared.sessionKey}`,
+            status: "running",
+            hasActiveRun: false,
+          },
+        ],
+        complete: true,
+      });
 
-    lifecycle.service.onGatewayStart();
-    await vi.waitFor(async () => {
-      expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe("blocked");
-    });
-    await stopLifecycleSweep(lifecycle);
+      lifecycle.service.onGatewayStart();
+      await vi.waitFor(async () => {
+        expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe(
+          "blocked",
+        );
+      });
+      await stopLifecycleSweep(lifecycle);
+      lifecycle = undefined;
 
-    await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
-      status: "blocked",
-      metadata: { automation: { launch: { phase: "failed" } } },
-    });
-    expect(
-      (await interrupted.replacementStore.get(interrupted.card.id))?.metadata?.claim,
-    ).toBeUndefined();
-    await rejectInterruptedDispatch(interrupted);
+      await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
+        status: "blocked",
+        metadata: { automation: { launch: { phase: "failed" } } },
+      });
+      expect(
+        (await interrupted.replacementStore.get(interrupted.card.id))?.metadata?.claim,
+      ).toBeUndefined();
+      await rejectInterruptedDispatch(interrupted);
+    } finally {
+      await cleanupInterruptedDispatch(interrupted, lifecycle);
+    }
   });
 
   it("accepts a prepared launch found under its canonical post-restart session", async () => {
     const interrupted = await beginPreparedDispatch();
-    const canonicalSessionKey = `agent:worker:${interrupted.prepared.sessionKey}`;
-    const lifecycle = await startLifecycleSweep({
-      store: interrupted.replacementStore,
-      sessions: [{ key: canonicalSessionKey, status: "running", hasActiveRun: true }],
-      complete: true,
-    });
+    let lifecycle: Awaited<ReturnType<typeof startLifecycleSweep>> | undefined;
+    try {
+      const canonicalSessionKey = `agent:worker:${interrupted.prepared.sessionKey}`;
+      lifecycle = await startLifecycleSweep({
+        store: interrupted.replacementStore,
+        sessions: [{ key: canonicalSessionKey, status: "running", hasActiveRun: true }],
+        complete: true,
+      });
 
-    expect(lifecycle.readSessions).not.toHaveBeenCalled();
-    lifecycle.service.onGatewayStart();
-    await vi.waitFor(async () => {
-      expect(
-        (await interrupted.replacementStore.get(interrupted.card.id))?.metadata?.automation?.launch
-          ?.phase,
-      ).toBe("accepted");
-    });
+      expect(lifecycle.readSessions).not.toHaveBeenCalled();
+      lifecycle.service.onGatewayStart();
+      await vi.waitFor(async () => {
+        expect(
+          (await interrupted.replacementStore.get(interrupted.card.id))?.metadata?.automation
+            ?.launch?.phase,
+        ).toBe("accepted");
+      });
 
-    const accepted = await interrupted.replacementStore.get(interrupted.card.id);
-    expect(accepted).toMatchObject({
-      status: "running",
-      sessionKey: canonicalSessionKey,
-      runId: interrupted.prepared.provisionalRunId,
-      metadata: {
-        claim: { ownerId: "workboard-dispatcher" },
-        attempts: [
-          expect.objectContaining({
-            status: "running",
-            sessionKey: canonicalSessionKey,
-            runId: interrupted.prepared.provisionalRunId,
-          }),
-        ],
-        automation: {
-          launch: {
-            phase: "accepted",
-            acceptedSessionKey: canonicalSessionKey,
+      const accepted = await interrupted.replacementStore.get(interrupted.card.id);
+      expect(accepted).toMatchObject({
+        status: "running",
+        sessionKey: canonicalSessionKey,
+        runId: interrupted.prepared.provisionalRunId,
+        metadata: {
+          claim: { ownerId: "workboard-dispatcher" },
+          attempts: [
+            expect.objectContaining({
+              status: "running",
+              sessionKey: canonicalSessionKey,
+              runId: interrupted.prepared.provisionalRunId,
+            }),
+          ],
+          automation: {
+            launch: {
+              phase: "accepted",
+              acceptedSessionKey: canonicalSessionKey,
+            },
           },
         },
-      },
-    });
-    expect(accepted?.metadata?.automation?.launch).not.toHaveProperty("acceptedRunId");
+      });
+      expect(accepted?.metadata?.automation?.launch).not.toHaveProperty("acceptedRunId");
 
-    await syncWorkboardSubagentEnded({
-      store: interrupted.replacementStore,
-      event: {
-        targetSessionKey: canonicalSessionKey,
+      await syncWorkboardSubagentEnded({
+        store: interrupted.replacementStore,
+        event: {
+          targetSessionKey: canonicalSessionKey,
+          runId: "accepted-run",
+          outcome: "ok",
+        },
+      });
+      const terminal = await interrupted.replacementStore.get(interrupted.card.id);
+      expect(terminal).toMatchObject({
+        status: "review",
+        sessionKey: canonicalSessionKey,
         runId: "accepted-run",
-        outcome: "ok",
-      },
-    });
-    const terminal = await interrupted.replacementStore.get(interrupted.card.id);
-    expect(terminal).toMatchObject({
-      status: "review",
-      sessionKey: canonicalSessionKey,
-      runId: "accepted-run",
-      metadata: {
-        automation: { launch: { phase: "accepted", acceptedRunId: "accepted-run" } },
-        attempts: [
-          expect.objectContaining({
-            id: "accepted-run",
-            status: "succeeded",
-            runId: "accepted-run",
-          }),
-        ],
-      },
-    });
-    expect(terminal?.metadata?.attempts).toHaveLength(1);
+        metadata: {
+          automation: { launch: { phase: "accepted", acceptedRunId: "accepted-run" } },
+          attempts: [
+            expect.objectContaining({
+              id: "accepted-run",
+              status: "succeeded",
+              runId: "accepted-run",
+            }),
+          ],
+        },
+      });
+      expect(terminal?.metadata?.attempts).toHaveLength(1);
 
-    await stopLifecycleSweep(lifecycle);
-    await rejectInterruptedDispatch(interrupted);
-    expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe("review");
+      await stopLifecycleSweep(lifecycle);
+      lifecycle = undefined;
+      await rejectInterruptedDispatch(interrupted);
+      expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe("review");
+    } finally {
+      await cleanupInterruptedDispatch(interrupted, lifecycle);
+    }
   });
 
   it("accepts a prepared launch from an explicit terminal session snapshot", async () => {
     const interrupted = await beginPreparedDispatch();
-    const canonicalSessionKey = `agent:worker:${interrupted.prepared.sessionKey}`;
-    const launch = (await interrupted.replacementStore.get(interrupted.card.id))?.metadata
-      ?.automation?.launch;
-    if (launch?.phase !== "prepared") {
-      throw new Error("expected prepared launch");
+    let lifecycle: Awaited<ReturnType<typeof startLifecycleSweep>> | undefined;
+    try {
+      const canonicalSessionKey = `agent:worker:${interrupted.prepared.sessionKey}`;
+      const launch = (await interrupted.replacementStore.get(interrupted.card.id))?.metadata
+        ?.automation?.launch;
+      if (launch?.phase !== "prepared") {
+        throw new Error("expected prepared launch");
+      }
+      lifecycle = await startLifecycleSweep({
+        store: interrupted.replacementStore,
+        sessions: [
+          {
+            key: canonicalSessionKey,
+            status: "done",
+            hasActiveRun: false,
+            updatedAt: launch.preparedAt + 1,
+          },
+        ],
+        complete: true,
+      });
+
+      lifecycle.service.onGatewayStart();
+      await vi.waitFor(async () => {
+        expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe(
+          "review",
+        );
+      });
+      await stopLifecycleSweep(lifecycle);
+      lifecycle = undefined;
+
+      await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
+        status: "review",
+        sessionKey: canonicalSessionKey,
+        metadata: {
+          automation: {
+            launch: { phase: "accepted", acceptedSessionKey: canonicalSessionKey },
+          },
+          attempts: [expect.objectContaining({ status: "succeeded" })],
+        },
+      });
+      await rejectInterruptedDispatch(interrupted);
+    } finally {
+      await cleanupInterruptedDispatch(interrupted, lifecycle);
     }
-    const lifecycle = await startLifecycleSweep({
-      store: interrupted.replacementStore,
-      sessions: [
-        {
-          key: canonicalSessionKey,
-          status: "done",
-          hasActiveRun: false,
-          updatedAt: launch.preparedAt + 1,
-        },
-      ],
-      complete: true,
-    });
-
-    lifecycle.service.onGatewayStart();
-    await vi.waitFor(async () => {
-      expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe("review");
-    });
-    await stopLifecycleSweep(lifecycle);
-
-    await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
-      status: "review",
-      sessionKey: canonicalSessionKey,
-      metadata: {
-        automation: {
-          launch: { phase: "accepted", acceptedSessionKey: canonicalSessionKey },
-        },
-        attempts: [expect.objectContaining({ status: "succeeded" })],
-      },
-    });
-    await rejectInterruptedDispatch(interrupted);
   });
 
   it("does not accept a terminal session without durable timing evidence", async () => {
     const interrupted = await beginPreparedDispatch();
-    const canonicalSessionKey = `agent:worker:${interrupted.prepared.sessionKey}`;
-    const lifecycle = await startLifecycleSweep({
-      store: interrupted.replacementStore,
-      sessions: [
-        {
-          key: canonicalSessionKey,
-          status: "done",
-          hasActiveRun: false,
-        },
-      ],
-      complete: true,
-    });
+    let lifecycle: Awaited<ReturnType<typeof startLifecycleSweep>> | undefined;
+    try {
+      const canonicalSessionKey = `agent:worker:${interrupted.prepared.sessionKey}`;
+      lifecycle = await startLifecycleSweep({
+        store: interrupted.replacementStore,
+        sessions: [
+          {
+            key: canonicalSessionKey,
+            status: "done",
+            hasActiveRun: false,
+          },
+        ],
+        complete: true,
+      });
 
-    lifecycle.service.onGatewayStart();
-    await vi.waitFor(async () => {
-      expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe("blocked");
-    });
-    await stopLifecycleSweep(lifecycle);
+      lifecycle.service.onGatewayStart();
+      await vi.waitFor(async () => {
+        expect((await interrupted.replacementStore.get(interrupted.card.id))?.status).toBe(
+          "blocked",
+        );
+      });
+      await stopLifecycleSweep(lifecycle);
+      lifecycle = undefined;
 
-    await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
-      status: "blocked",
-      metadata: { automation: { launch: { phase: "failed" } } },
-    });
-    await rejectInterruptedDispatch(interrupted);
+      await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
+        status: "blocked",
+        metadata: { automation: { launch: { phase: "failed" } } },
+      });
+      await rejectInterruptedDispatch(interrupted);
+    } finally {
+      await cleanupInterruptedDispatch(interrupted, lifecycle);
+    }
   });
 
   it("keeps a prepared launch running when the post-restart snapshot is incomplete", async () => {
     const interrupted = await beginPreparedDispatch();
-    const lifecycle = await startLifecycleSweep({
-      store: interrupted.replacementStore,
-      sessions: [],
-      complete: false,
-    });
+    let lifecycle: Awaited<ReturnType<typeof startLifecycleSweep>> | undefined;
+    try {
+      lifecycle = await startLifecycleSweep({
+        store: interrupted.replacementStore,
+        sessions: [],
+        complete: false,
+      });
 
-    lifecycle.service.onGatewayStart();
-    await vi.waitFor(() => expect(lifecycle.readSessions).toHaveBeenCalledOnce());
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
-      status: "running",
-      sessionKey: interrupted.prepared.sessionKey,
-      runId: interrupted.prepared.provisionalRunId,
-      metadata: {
-        claim: { ownerId: "workboard-dispatcher" },
-        automation: { launch: { phase: "prepared" } },
-      },
-    });
+      lifecycle.service.onGatewayStart();
+      const readSessions = lifecycle.readSessions;
+      await vi.waitFor(() => expect(readSessions).toHaveBeenCalledOnce());
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      await expect(interrupted.replacementStore.get(interrupted.card.id)).resolves.toMatchObject({
+        status: "running",
+        sessionKey: interrupted.prepared.sessionKey,
+        runId: interrupted.prepared.provisionalRunId,
+        metadata: {
+          claim: { ownerId: "workboard-dispatcher" },
+          automation: { launch: { phase: "prepared" } },
+        },
+      });
 
-    await stopLifecycleSweep(lifecycle);
-    await rejectInterruptedDispatch(interrupted);
+      await stopLifecycleSweep(lifecycle);
+      lifecycle = undefined;
+      await rejectInterruptedDispatch(interrupted);
+    } finally {
+      await cleanupInterruptedDispatch(interrupted, lifecycle);
+    }
   });
 });

--- a/extensions/workboard/src/lifecycle-sync.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.test.ts
@@ -1,5 +1,5 @@
 import type { WorkboardExecution, WorkboardStatus } from "@openclaw/workboard-contract";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createWorkboardAutomationNudgeService } from "./automation-nudge.js";
 import {
   createWorkboardLifecycleService,
@@ -7,27 +7,9 @@ import {
   syncWorkboardAgentEnded,
   syncWorkboardSubagentEnded,
 } from "./lifecycle-sync.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
 import { workboardSessionKeyForCard } from "./session-link.js";
-import { WorkboardStore } from "./store.js";
-
-function createMemoryStore(): WorkboardKeyedStore {
-  const entries = new Map<string, PersistedWorkboardCard>();
-  return {
-    async register(key, value) {
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].map(([key, value]) => ({ key, value }));
-    },
-  };
-}
+import type { WorkboardStore } from "./store.js";
+import { createWorkboardSqliteTestStore } from "./test/sqlite-store.js";
 
 function execution(
   sessionKey: string,
@@ -100,13 +82,9 @@ async function runSessionSweep(params: {
   await service.stop?.({ logger: { warn: vi.fn() } } as never);
 }
 
-afterEach(() => {
-  vi.useRealTimers();
-});
-
 describe("Workboard gateway lifecycle sync", () => {
   it("nudges the attached board automation when a matching subagent ends", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
     const sessionKey = "agent:main:subagent:workboard-planning-card-1";
     const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
@@ -134,7 +112,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("uses the active service owner from a prepared plugin generation", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
     const sessionKey = "agent:main:subagent:workboard-planning-card-generation";
     const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
@@ -167,7 +145,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("does not nudge a matching card whose board has no automation", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({ id: "planning" });
     const sessionKey = "agent:main:subagent:workboard-planning-card-2";
     const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
@@ -189,7 +167,7 @@ describe("Workboard gateway lifecycle sync", () => {
   it.each(["cron:job-categorize-planning", "agent:main:cron:job-categorize-planning:run:run-1"])(
     "does not nudge from cron-originated session %s",
     async (sessionKey) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
       const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
       const request = vi.fn();
@@ -209,7 +187,7 @@ describe("Workboard gateway lifecycle sync", () => {
   );
 
   it("coalesces repeated board nudges within the debounce window", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
     const sessionKey = "agent:main:subagent:workboard-planning-card-3";
     const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
@@ -239,7 +217,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("swallows nudge failures without affecting lifecycle sync", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
     const sessionKey = "agent:main:subagent:workboard-planning-card-4";
     const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
@@ -263,7 +241,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("logs disabled automation skips without affecting lifecycle sync", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
     const sessionKey = "agent:main:subagent:workboard-planning-card-disabled";
     const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
@@ -289,7 +267,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("moves a linked running card to review from the subagent hook without UI involvement", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = "agent:main:subagent:workboard-default-card-1";
     const card = await createLinkedCard(store, {
       sessionKey,
@@ -316,7 +294,7 @@ describe("Workboard gateway lifecycle sync", () => {
   it.each(["error", "timeout", "killed"] as const)(
     "moves a linked running card to blocked for subagent outcome %s",
     async (outcome) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const sessionKey = `agent:main:subagent:workboard-default-${outcome}`;
       const card = await createLinkedCard(store, {
         sessionKey,
@@ -343,7 +321,7 @@ describe("Workboard gateway lifecycle sync", () => {
   );
 
   it("updates execution attempts once when duplicate failure hooks arrive", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = "agent:main:subagent:workboard-default-failure";
     const card = await createLinkedCard(store, {
       sessionKey,
@@ -368,7 +346,7 @@ describe("Workboard gateway lifecycle sync", () => {
   it.each(["review", "blocked", "done"] as const)(
     "keeps a manually moved %s card in place",
     async (status) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const sessionKey = `agent:main:subagent:workboard-default-${status}`;
       const card = await createLinkedCard(store, { status, sessionKey, runId: `run-${status}` });
 
@@ -396,7 +374,7 @@ describe("Workboard gateway lifecycle sync", () => {
     ["blocked", "blocked"],
     ["done", "done"],
   ] as const)("applies the running source-status guard from %s", async (status, expected) => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = `agent:main:dashboard:${status}`;
     const card = await createLinkedCard(store, { status, sessionKey });
 
@@ -421,7 +399,7 @@ describe("Workboard gateway lifecycle sync", () => {
     ["blocked", "blocked"],
     ["done", "done"],
   ] as const)("applies the terminal source-status guard from %s", async (status, expected) => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = `agent:main:dashboard:terminal-${status}`;
     const card = await createLinkedCard(store, { status, sessionKey });
 
@@ -435,18 +413,22 @@ describe("Workboard gateway lifecycle sync", () => {
 
   it("does not apply a terminal status older than the latest manual move", async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(3000);
-    const store = new WorkboardStore(createMemoryStore());
-    const sessionKey = "agent:main:dashboard:manual-newer";
-    const card = await createLinkedCard(store, { status: "running", sessionKey });
+    try {
+      vi.setSystemTime(3000);
+      const store = createWorkboardSqliteTestStore();
+      const sessionKey = "agent:main:dashboard:manual-newer";
+      const card = await createLinkedCard(store, { status: "running", sessionKey });
 
-    await syncWorkboardSubagentEnded({
-      store,
-      event: { targetSessionKey: sessionKey, endedAt: 2000, outcome: "ok" },
-      now: 4000,
-    });
+      await syncWorkboardSubagentEnded({
+        store,
+        event: { targetSessionKey: sessionKey, endedAt: 2000, outcome: "ok" },
+        now: 4000,
+      });
 
-    expect((await store.get(card.id))?.status).toBe("running");
+      expect((await store.get(card.id))?.status).toBe("running");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([
@@ -473,7 +455,7 @@ describe("Workboard gateway lifecycle sync", () => {
       },
     },
   ])("matches cards by $name", async ({ prepare }) => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const { card, sessionKey, runId } = await prepare(store);
 
     await syncWorkboardSubagentEnded({
@@ -485,7 +467,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("does not let a stale dispatcher event override an explicit session link", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await createLinkedCard(store, {
       sessionKey: "agent:main:dashboard:replacement",
       agentId: "worker",
@@ -505,7 +487,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("uses agent_end context to reconcile non-subagent linked sessions", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = "agent:main:dashboard:agent-end";
     const card = await createLinkedCard(store, {
       sessionKey,
@@ -527,7 +509,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("marks an inactive running session stale and clears it after recovery", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = "agent:main:dashboard:stale";
     const card = await createLinkedCard(store, { status: "todo", sessionKey });
     const staleUpdatedAt = card.updatedAt + 1;
@@ -560,7 +542,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("skips session discovery for an empty board", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const readSessions = vi.fn().mockResolvedValue({ sessions: [], complete: true });
     const warn = vi.fn();
     const context = { logger: { warn } } as never;
@@ -579,7 +561,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("skips session discovery when no unarchived card needs lifecycle reconciliation", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await store.create({ title: "Not dispatched", status: "ready" });
     const archived = await createLinkedCard(store, {
       sessionKey: "agent:retired:subagent:workboard-default-archived",
@@ -601,7 +583,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("reconciles a captured unknown session when agent ownership is unambiguous", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await createLinkedCard(store, { sessionKey: "unknown" });
     const request = vi.fn().mockImplementation(async (method: string) => {
       if (method === "agents.list") {
@@ -642,7 +624,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("reconciles an agent-prefixed Workboard session when discovery is relevant", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await createLinkedCard(store, { agentId: "worker", boardId: "ops" });
     const sessionKey = workboardSessionKeyForCard(card);
     const suffix = sessionKey.slice(sessionKey.indexOf("subagent:workboard-"));
@@ -664,7 +646,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("does not suffix-match a uniquely wrong agent for an explicit target", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await createLinkedCard(store, { agentId: "worker", boardId: "ops" });
     const sessionKey = workboardSessionKeyForCard(card);
     const suffix = sessionKey.slice(sessionKey.indexOf("subagent:workboard-"));
@@ -685,7 +667,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("suffix-matches an accepted agentless run whose link could not be persisted", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Accepted without link", status: "ready" });
     const acceptedSessionKey = workboardSessionKeyForCard(card);
     const claimed = await store.claim(card.id, { ownerId: "workboard-dispatcher" });
@@ -726,7 +708,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("backfills the exact terminal run identity without duplicating its attempt", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const provisionalSessionKey = "subagent:workboard-default-terminal-backfill";
     const canonicalSessionKey = `agent:worker:${provisionalSessionKey}`;
     const created = await createLinkedCard(store, { sessionKey: provisionalSessionKey });
@@ -768,7 +750,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("does not backfill over a newer attempt after lifecycle matching", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const provisionalSessionKey = "subagent:workboard-default-match-race";
     const created = await createLinkedCard(store, { sessionKey: provisionalSessionKey });
     const provisionalRunId = `workboard:${created.id}:${created.updatedAt}`;
@@ -806,7 +788,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("does not apply a delayed terminal event from an older accepted run", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = "agent:worker:subagent:workboard-default-retried";
     const card = await createLinkedCard(store, {
       sessionKey,
@@ -833,7 +815,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("does not suffix-match an agentless card when configured-agent sessions are ambiguous", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Ambiguous accepted run", status: "ready" });
     const acceptedSessionKey = workboardSessionKeyForCard(card);
     const claimed = await store.claim(card.id, { ownerId: "workboard-dispatcher" });
@@ -858,7 +840,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("suffix-matches an agentless linked card to an agent-prefixed Workboard session", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await createLinkedCard(store, { boardId: "ops" });
     const sessionKey = `agent:worker:${workboardSessionKeyForCard(card)}`;
 
@@ -873,7 +855,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("waits for gateway startup before beginning the lifecycle sweep", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = "agent:main:dashboard:startup-ready";
     const card = await createLinkedCard(store, { status: "todo", sessionKey });
     let gatewayReady = false;
@@ -909,7 +891,7 @@ describe("Workboard gateway lifecycle sync", () => {
   });
 
   it("begins immediately when the lifecycle service reloads after gateway startup", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = "agent:main:dashboard:plugin-reload";
     const card = await createLinkedCard(store, { status: "todo", sessionKey });
     const readSessions = vi
@@ -945,38 +927,48 @@ describe("Workboard gateway lifecycle sync", () => {
 
   it("runs the bounded session reconciliation from the lifecycle-owned service interval", async () => {
     vi.useFakeTimers();
-    const store = new WorkboardStore(createMemoryStore());
-    const sessionKey = "agent:main:dashboard:service";
-    const card = await createLinkedCard(store, { status: "todo", sessionKey });
-    const readSessions = vi
-      .fn()
-      .mockResolvedValueOnce({
-        sessions: [
-          { key: sessionKey, status: "running", hasActiveRun: true, updatedAt: card.updatedAt + 1 },
-        ],
-        complete: true,
-      })
-      .mockResolvedValueOnce({
-        sessions: [
-          { key: sessionKey, status: "done", hasActiveRun: false, updatedAt: card.updatedAt + 2 },
-        ],
-        complete: true,
+    let service: ReturnType<typeof createWorkboardLifecycleService> | undefined;
+    try {
+      const store = createWorkboardSqliteTestStore();
+      const sessionKey = "agent:main:dashboard:service";
+      const card = await createLinkedCard(store, { status: "todo", sessionKey });
+      const readSessions = vi
+        .fn()
+        .mockResolvedValueOnce({
+          sessions: [
+            {
+              key: sessionKey,
+              status: "running",
+              hasActiveRun: true,
+              updatedAt: card.updatedAt + 1,
+            },
+          ],
+          complete: true,
+        })
+        .mockResolvedValueOnce({
+          sessions: [
+            { key: sessionKey, status: "done", hasActiveRun: false, updatedAt: card.updatedAt + 2 },
+          ],
+          complete: true,
+        });
+      service = createWorkboardLifecycleService({ store, readSessions });
+      await service.start({ logger: { warn: vi.fn() } } as never);
+      service.onGatewayStart();
+      await vi.waitFor(async () => {
+        expect((await store.get(card.id))?.status).toBe("running");
       });
-    const service = createWorkboardLifecycleService({ store, readSessions });
-    await service.start({ logger: { warn: vi.fn() } } as never);
-    service.onGatewayStart();
-    await vi.waitFor(async () => {
-      expect((await store.get(card.id))?.status).toBe("running");
-    });
 
-    await vi.advanceTimersByTimeAsync(60_000);
-    await vi.waitFor(async () => {
-      expect((await store.get(card.id))?.status).toBe("review");
-    });
-    service.onGatewayStop();
-    await service.stop?.({ logger: { warn: vi.fn() } } as never);
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.waitFor(async () => {
+        expect((await store.get(card.id))?.status).toBe("review");
+      });
 
-    expect(readSessions).toHaveBeenCalledTimes(2);
+      expect(readSessions).toHaveBeenCalledTimes(2);
+    } finally {
+      service?.onGatewayStop();
+      await service?.stop?.({ logger: { warn: vi.fn() } } as never);
+      vi.useRealTimers();
+    }
   });
 
   it("federates configured agents without ownerless sentinels", async () => {

--- a/extensions/workboard/src/persistence-types.ts
+++ b/extensions/workboard/src/persistence-types.ts
@@ -34,7 +34,7 @@ export type WorkboardKeyedStore<T = PersistedWorkboardCard> = {
   entries(): Promise<Array<{ key: string; value: T }>>;
 };
 
-export type WorkboardBoardCardAggregate = {
+type WorkboardBoardCardAggregate = {
   boardId: string;
   status: WorkboardCard["status"];
   total: number;
@@ -61,18 +61,3 @@ export type WorkboardCardStore = WorkboardKeyedStore & {
   ): Promise<WorkboardOwnerClaimResult>;
   listBoardAggregates(): Promise<WorkboardBoardCardAggregate[]>;
 };
-
-export function isWorkboardCardStore(store: WorkboardKeyedStore): store is WorkboardCardStore {
-  return (
-    "listBoardAggregates" in store &&
-    typeof store.listBoardAggregates === "function" &&
-    "registerIfAbsent" in store &&
-    typeof store.registerIfAbsent === "function" &&
-    "registerIfUpdatedAt" in store &&
-    typeof store.registerIfUpdatedAt === "function" &&
-    "claimIfOwnerAvailable" in store &&
-    typeof store.claimIfOwnerAvailable === "function" &&
-    "deleteIfUpdatedAt" in store &&
-    typeof store.deleteIfUpdatedAt === "function"
-  );
-}

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -8,13 +8,11 @@ import type {
   WorkboardStatus,
 } from "@openclaw/workboard-contract";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { isWorkboardCardStore } from "./persistence-types.js";
 import type {
   PersistedWorkboardAttachment,
   PersistedWorkboardBoard,
   PersistedWorkboardCard,
   PersistedWorkboardNotificationSubscription,
-  WorkboardBoardCardAggregate,
   WorkboardCardStore,
   WorkboardKeyedStore,
 } from "./persistence-types.js";
@@ -96,42 +94,27 @@ const WORKBOARD_CAS_ATTEMPTS = 3;
 
 export class WorkboardCoreStore extends WorkboardStoreRuntime {
   private lastNotificationSequence = 0;
-  private readonly cardStore?: WorkboardCardStore;
   private compensationJournal?: WorkboardMutationJournalEntry[];
-  protected readonly store: WorkboardKeyedStore;
+  protected readonly store: WorkboardCardStore;
   protected readonly boardStore: WorkboardKeyedStore<PersistedWorkboardBoard>;
   protected readonly subscriptionStore: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
   protected readonly attachmentStore: WorkboardKeyedStore<PersistedWorkboardAttachment>;
 
   constructor(
-    store: WorkboardKeyedStore,
+    store: WorkboardCardStore,
     stores: {
-      boards?: WorkboardKeyedStore<PersistedWorkboardBoard>;
-      subscriptions?: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
-      attachments?: WorkboardKeyedStore<PersistedWorkboardAttachment>;
+      boards: WorkboardKeyedStore<PersistedWorkboardBoard>;
+      subscriptions: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
+      attachments: WorkboardKeyedStore<PersistedWorkboardAttachment>;
       dataVersion?: () => number;
       close?: () => void;
-    } = {},
+    },
   ) {
     super(stores.dataVersion, stores.close);
-    if (isWorkboardCardStore(store)) {
-      this.cardStore = this.trackCardStore(store);
-      this.store = this.cardStore;
-    } else {
-      this.store = this.track(store);
-    }
-    this.boardStore = this.track(
-      stores.boards ?? (store as unknown as WorkboardKeyedStore<PersistedWorkboardBoard>),
-    );
-    this.subscriptionStore = this.track(
-      stores.subscriptions ??
-        (store as unknown as WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>),
-      { notifyChanges: false },
-    );
-    this.attachmentStore = this.track(
-      stores.attachments ?? (store as unknown as WorkboardKeyedStore<PersistedWorkboardAttachment>),
-      { notifyChanges: false },
-    );
+    this.store = this.trackCardStore(store);
+    this.boardStore = this.track(stores.boards);
+    this.subscriptionStore = this.track(stores.subscriptions, { notifyChanges: false });
+    this.attachmentStore = this.track(stores.attachments, { notifyChanges: false });
   }
 
   protected async withCardCompensation<T>(run: () => Promise<T>): Promise<T> {
@@ -233,28 +216,11 @@ export class WorkboardCoreStore extends WorkboardStoreRuntime {
     card: WorkboardCard,
     expectedUpdatedAt: number,
   ): Promise<boolean> {
-    if (this.cardStore) {
-      return await this.cardStore.registerIfUpdatedAt(
-        card.id,
-        { version: 1, card },
-        expectedUpdatedAt,
-      );
-    }
-    if ((await this.get(card.id))?.updatedAt !== expectedUpdatedAt) {
-      return false;
-    }
-    await this.store.register(card.id, { version: 1, card });
-    return true;
+    return await this.store.registerIfUpdatedAt(card.id, { version: 1, card }, expectedUpdatedAt);
   }
 
   private async deleteCardIfUpdatedAt(id: string, expectedUpdatedAt: number): Promise<boolean> {
-    if (this.cardStore) {
-      return await this.cardStore.deleteIfUpdatedAt(id, expectedUpdatedAt);
-    }
-    if ((await this.get(id))?.updatedAt !== expectedUpdatedAt) {
-      return false;
-    }
-    return await this.store.delete(id);
+    return await this.store.deleteIfUpdatedAt(id, expectedUpdatedAt);
   }
 
   protected async updateLatestCard(
@@ -367,15 +333,7 @@ export class WorkboardCoreStore extends WorkboardStoreRuntime {
         byStatus: {},
       });
     }
-    const cardAggregates: WorkboardBoardCardAggregate[] = this.cardStore
-      ? await this.cardStore.listBoardAggregates()
-      : (await this.list()).map((card) => ({
-          boardId: cardBoardId(card),
-          status: card.status,
-          total: 1,
-          archived: card.metadata?.archivedAt ? 1 : 0,
-          updatedAt: card.updatedAt,
-        }));
+    const cardAggregates = await this.store.listBoardAggregates();
     for (const aggregate of cardAggregates) {
       const boardId = aggregate.boardId;
       const summary =
@@ -615,8 +573,8 @@ export class WorkboardCoreStore extends WorkboardStoreRuntime {
       ...(completedAt ? { completedAt } : {}),
       ...(!metadataIsEmpty(syncedMetadata) ? { metadata: syncedMetadata } : {}),
     };
-    if (options.insertIfAbsent && this.cardStore) {
-      const inserted = await this.cardStore.registerIfAbsent(card.id, { version: 1, card });
+    if (options.insertIfAbsent) {
+      const inserted = await this.store.registerIfAbsent(card.id, { version: 1, card });
       if (!inserted) {
         const winner = await this.get(card.id);
         if (!winner) {
@@ -871,45 +829,35 @@ export class WorkboardCoreStore extends WorkboardStoreRuntime {
     if (metadataIsEmpty(next.metadata)) {
       delete next.metadata;
     }
-    if (this.cardStore) {
-      const expectedUpdatedAt = options.expectedUpdatedAt ?? existing.updatedAt;
-      if (options.ownerSlot) {
-        const result = await this.cardStore.claimIfOwnerAvailable(
-          next.id,
-          { version: 1, card: next },
-          expectedUpdatedAt,
-          options.ownerSlot.ownerId,
-          options.ownerSlot.now,
-        );
-        if (result === "owner_busy") {
-          throw new Error(`Owner ${options.ownerSlot.ownerId} already has active Workboard work.`);
-        }
-        if (result === "updated") {
-          this.recordCardMutation(existing, next);
-          await this.deleteDetachedAttachments(existing, next);
-          return next;
-        }
-      } else if (
-        await this.cardStore.registerIfUpdatedAt(
-          next.id,
-          { version: 1, card: next },
-          expectedUpdatedAt,
-        )
-      ) {
+    const expectedUpdatedAt = options.expectedUpdatedAt ?? existing.updatedAt;
+    if (options.ownerSlot) {
+      const result = await this.store.claimIfOwnerAvailable(
+        next.id,
+        { version: 1, card: next },
+        expectedUpdatedAt,
+        options.ownerSlot.ownerId,
+        options.ownerSlot.now,
+      );
+      if (result === "owner_busy") {
+        throw new Error(`Owner ${options.ownerSlot.ownerId} already has active Workboard work.`);
+      }
+      if (result === "updated") {
         this.recordCardMutation(existing, next);
         await this.deleteDetachedAttachments(existing, next);
         return next;
       }
-      const current = await this.get(next.id);
-      if (!current) {
-        throw new Error(`card not found: ${id}`);
-      }
-      throw new WorkboardCardConflictError(current);
+    } else if (
+      await this.store.registerIfUpdatedAt(next.id, { version: 1, card: next }, expectedUpdatedAt)
+    ) {
+      this.recordCardMutation(existing, next);
+      await this.deleteDetachedAttachments(existing, next);
+      return next;
     }
-    await this.store.register(next.id, { version: 1, card: next });
-    this.recordCardMutation(existing, next);
-    await this.deleteDetachedAttachments(existing, next);
-    return next;
+    const current = await this.get(next.id);
+    if (!current) {
+      throw new Error(`card not found: ${id}`);
+    }
+    throw new WorkboardCardConflictError(current);
   }
 
   private async assertActiveStatusAllowed(

--- a/extensions/workboard/src/store-lifecycle.test.ts
+++ b/extensions/workboard/src/store-lifecycle.test.ts
@@ -1,48 +1,26 @@
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import { createWorkboardLifecycleService } from "./lifecycle-sync.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
-import { WorkboardStore } from "./store.js";
+import {
+  createWorkboardSqliteTestHarness,
+  createWorkboardSqliteTestStore,
+} from "./test/sqlite-store.js";
 import { createWorkboardTools } from "./tools.js";
-
-function memoryStore(
-  options: {
-    beforeRegister?: () => Promise<void>;
-    beforeLookup?: () => Promise<void>;
-  } = {},
-): WorkboardKeyedStore {
-  const rows = new Map<string, PersistedWorkboardCard>();
-  return {
-    async register(key, value) {
-      await options.beforeRegister?.();
-      rows.set(key, value);
-    },
-    async lookup(key) {
-      await options.beforeLookup?.();
-      return rows.get(key);
-    },
-    async delete(key) {
-      return rows.delete(key);
-    },
-    async entries() {
-      return [...rows].map(([key, value]) => ({ key, value }));
-    },
-  };
-}
 
 describe("Workboard store lifetime", () => {
   it("joins queued mutations before closing and rejects new work", async () => {
     const entered = createDeferred<void>();
     const resume = createDeferred<void>();
-    const persistence = memoryStore({
-      beforeRegister: async () => {
+    let closes = 0;
+    const {
+      store,
+      stores: { cards: persistence },
+    } = createWorkboardSqliteTestHarness({
+      beforeCardWrite: async () => {
         entered.resolve();
         await resume.promise;
       },
-    });
-    let closes = 0;
-    const store = new WorkboardStore(persistence, {
-      close: () => {
+      onStoreClose: () => {
         closes += 1;
       },
     });
@@ -50,33 +28,35 @@ describe("Workboard store lifetime", () => {
     await entered.promise;
     const queued = store.create({ title: "Queued" });
     const closing = store.close();
-    expect(store.close()).toBe(closing);
-    await expect(store.create({ title: "Late" })).rejects.toThrow("workboard store is closed.");
-    expect(closes).toBe(0);
-    resume.resolve();
-    await expect(first).resolves.toMatchObject({ title: "First" });
-    await expect(queued).resolves.toMatchObject({ title: "Queued" });
-    await closing;
-    expect(closes).toBe(1);
-    expect(await persistence.entries()).toHaveLength(2);
-    await expect(store.list()).rejects.toThrow("workboard store is closed.");
+    try {
+      expect(store.close()).toBe(closing);
+      await expect(store.create({ title: "Late" })).rejects.toThrow("workboard store is closed.");
+      expect(closes).toBe(0);
+      resume.resolve();
+      await expect(first).resolves.toMatchObject({ title: "First" });
+      await expect(queued).resolves.toMatchObject({ title: "Queued" });
+      await closing;
+      expect(closes).toBe(1);
+      expect(await persistence.entries()).toHaveLength(2);
+      await expect(store.list()).rejects.toThrow("workboard store is closed.");
+    } finally {
+      resume.resolve();
+    }
   });
 
   it("keeps a whole admitted tool call alive across its reads", async () => {
     const entered = createDeferred<void>();
     const resume = createDeferred<void>();
     let pause = false;
-    const store = new WorkboardStore(
-      memoryStore({
-        beforeLookup: async () => {
-          if (pause) {
-            pause = false;
-            entered.resolve();
-            await resume.promise;
-          }
-        },
-      }),
-    );
+    const store = createWorkboardSqliteTestStore({
+      beforeCardLookup: async () => {
+        if (pause) {
+          pause = false;
+          entered.resolve();
+          await resume.promise;
+        }
+      },
+    });
     const card = await store.create({ title: "Read context", notes: "Keep the full result." });
     const tool = createWorkboardTools({ store }).find((entry) => entry.name === "workboard_read");
     if (!tool) {
@@ -100,8 +80,8 @@ describe("Workboard store lifetime", () => {
   });
 
   it("does not let another store or a detached continuation revive a closed owner", async () => {
-    const first = new WorkboardStore(memoryStore());
-    const second = new WorkboardStore(memoryStore());
+    const first = createWorkboardSqliteTestStore();
+    const second = createWorkboardSqliteTestStore();
     const resume = createDeferred<void>();
     const { detached } = await first.runOperation(() => ({
       detached: resume.promise.then(() => first.create({ title: "Detached" })),
@@ -125,9 +105,11 @@ describe("Workboard store lifetime", () => {
     const entered = createDeferred<void>();
     const resume = createDeferred<void>();
     let closes = 0;
-    const persistence = memoryStore();
-    const store = new WorkboardStore(persistence, {
-      close: () => {
+    const {
+      store,
+      stores: { cards: persistence },
+    } = createWorkboardSqliteTestHarness({
+      onStoreClose: () => {
         closes += 1;
       },
     });
@@ -177,8 +159,8 @@ describe("Workboard store lifetime", () => {
   it("retains the same cleanup failure without retrying it", async () => {
     const failure = new Error("native close failed");
     let closes = 0;
-    const store = new WorkboardStore(memoryStore(), {
-      close: () => {
+    const store = createWorkboardSqliteTestStore({
+      onStoreClose: () => {
         closes += 1;
         throw failure;
       },

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -7,38 +7,16 @@ import { type WorkboardCard, WORKBOARD_STATUSES } from "@openclaw/workboard-cont
 import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type {
-  PersistedWorkboardAttachment,
-  PersistedWorkboardBoard,
-  PersistedWorkboardCard,
-  PersistedWorkboardNotificationSubscription,
-  WorkboardCardStore,
-  WorkboardKeyedStore,
-} from "./persistence-types.js";
+import type { PersistedWorkboardCard, WorkboardCardStore } from "./persistence-types.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
+import { secondsToDurationMs } from "./store-constants.js";
 import { normalizeExecution } from "./store-normalizers.js";
 import { WorkboardCardConflictError, WorkboardStore } from "./store.js";
-
-function createMemoryStore<T = PersistedWorkboardCard>(options?: {
-  beforeRegister?: (key: string, value: T) => Promise<void> | void;
-}): WorkboardKeyedStore<T> {
-  const entries = new Map<string, T>();
-  return {
-    async register(key, value) {
-      await options?.beforeRegister?.(key, value);
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].flatMap(([key, value]) => (value ? [{ key, value }] : []));
-    },
-  };
-}
+import {
+  createWorkboardSqliteTestHarness,
+  createWorkboardSqliteTestStore,
+  sqliteTestAuxStores,
+} from "./test/sqlite-store.js";
 
 function createSignal() {
   let resolve = () => {};
@@ -177,8 +155,8 @@ function createConcurrentSqliteHarness(prefix: string) {
   const hostStores = createWorkboardSqliteStores({ dbPath });
   const paused = createPausedCardStore(operationStores.cards);
   return {
-    operation: new WorkboardStore(paused.store),
-    host: new WorkboardStore(hostStores.cards),
+    operation: new WorkboardStore(paused.store, sqliteTestAuxStores(operationStores)),
+    host: new WorkboardStore(hostStores.cards, sqliteTestAuxStores(hostStores)),
     paused,
     close() {
       hostStores.close();
@@ -242,7 +220,7 @@ function withWorkboardSqliteDatabase(prefix: string, run: (db: DatabaseSync) => 
 
 describe("WorkboardStore", () => {
   it("emits one monotonic change after each visible mutation", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const changes = vi.fn();
     store.subscribeChanges(changes);
 
@@ -256,7 +234,7 @@ describe("WorkboardStore", () => {
   });
 
   it("does not emit for no-op commands and isolates listener failures", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const changes = vi.fn(() => {
       throw new Error("listener failed");
     });
@@ -271,11 +249,13 @@ describe("WorkboardStore", () => {
   });
 
   it("announces an epoch and reports failed commands that partially committed", async () => {
-    const subscriptions = createMemoryStore<PersistedWorkboardNotificationSubscription>();
+    const {
+      store,
+      stores: { subscriptions },
+    } = createWorkboardSqliteTestHarness();
     subscriptions.entries = async () => {
       throw new Error("subscription cleanup failed");
     };
-    const store = new WorkboardStore(createMemoryStore(), { subscriptions });
     const changes = vi.fn();
     store.subscribeChanges(changes);
     store.announceChangeEpoch();
@@ -328,8 +308,8 @@ describe("WorkboardStore", () => {
     const dbPath = path.join(dir, "workboard.sqlite");
     const firstStores = createWorkboardSqliteStores({ dbPath });
     const secondStores = createWorkboardSqliteStores({ dbPath });
-    const first = new WorkboardStore(firstStores.cards);
-    const second = new WorkboardStore(secondStores.cards);
+    const first = new WorkboardStore(firstStores.cards, sqliteTestAuxStores(firstStores));
+    const second = new WorkboardStore(secondStores.cards, sqliteTestAuxStores(secondStores));
     try {
       const base = await first.create({ title: "Original", status: "todo" });
       const moved = await second.move(base.id, "blocked", 2000);
@@ -368,8 +348,8 @@ describe("WorkboardStore", () => {
     const dbPath = path.join(dir, "workboard.sqlite");
     const firstStores = createWorkboardSqliteStores({ dbPath });
     const secondStores = createWorkboardSqliteStores({ dbPath });
-    const first = new WorkboardStore(firstStores.cards);
-    const second = new WorkboardStore(secondStores.cards);
+    const first = new WorkboardStore(firstStores.cards, sqliteTestAuxStores(firstStores));
+    const second = new WorkboardStore(secondStores.cards, sqliteTestAuxStores(secondStores));
     try {
       const created = await first.create({ title: "Delete fence" });
       const edited = await second.update(created.id, { notes: "Concurrent edit" });
@@ -476,8 +456,8 @@ describe("WorkboardStore", () => {
     const dbPath = path.join(dir, "workboard.sqlite");
     const firstStores = createWorkboardSqliteStores({ dbPath });
     const secondStores = createWorkboardSqliteStores({ dbPath });
-    const first = new WorkboardStore(firstStores.cards);
-    const second = new WorkboardStore(secondStores.cards);
+    const first = new WorkboardStore(firstStores.cards, sqliteTestAuxStores(firstStores));
+    const second = new WorkboardStore(secondStores.cards, sqliteTestAuxStores(secondStores));
     try {
       const sessionKey = `agent:main:dashboard:${"x".repeat(480)}`;
       const [left, right] = await Promise.all([
@@ -505,8 +485,8 @@ describe("WorkboardStore", () => {
     const firstStores = createWorkboardSqliteStores({ dbPath });
     const secondStores = createWorkboardSqliteStores({ dbPath });
     const paused = createPausedCardStore(firstStores.cards);
-    const first = new WorkboardStore(paused.store);
-    const second = new WorkboardStore(secondStores.cards);
+    const first = new WorkboardStore(paused.store, sqliteTestAuxStores(firstStores));
+    const second = new WorkboardStore(secondStores.cards, sqliteTestAuxStores(secondStores));
     try {
       const sessionKey = "agent:main:dashboard:archived-race";
       const captured = await second.captureSession({ title: "Captured", sessionKey });
@@ -534,8 +514,8 @@ describe("WorkboardStore", () => {
     const dbPath = path.join(dir, "workboard.sqlite");
     const firstStores = createWorkboardSqliteStores({ dbPath });
     const secondStores = createWorkboardSqliteStores({ dbPath });
-    const first = new WorkboardStore(firstStores.cards);
-    const second = new WorkboardStore(secondStores.cards);
+    const first = new WorkboardStore(firstStores.cards, sqliteTestAuxStores(firstStores));
+    const second = new WorkboardStore(secondStores.cards, sqliteTestAuxStores(secondStores));
     try {
       const firstCard = await first.create({ title: "First", status: "ready", agentId: "worker" });
       const secondCard = await first.create({
@@ -560,7 +540,7 @@ describe("WorkboardStore", () => {
   });
 
   it("reuses the active captured session across boards and archived duplicates", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const sessionKey = "agent:main:dashboard:captured";
     const active = await store.create({ title: "Active", sessionKey, boardId: "default" });
     const historical = await store.create({ title: "Historical", sessionKey, boardId: "ops" });
@@ -968,13 +948,13 @@ describe("WorkboardStore", () => {
     ["", "non-empty string"],
     ["x".repeat(129), "128 characters or fewer"],
   ])("rejects invalid automation job ids", async (automationJobId, message) => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
 
     await expect(store.upsertBoard({ id: "planning", automationJobId })).rejects.toThrow(message);
   });
 
   it("creates and lists cards by status order and position", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
 
     const review = await store.create({
       title: "Review release notes",
@@ -991,8 +971,8 @@ describe("WorkboardStore", () => {
   });
 
   it("does not persist empty metadata for default cards", async () => {
-    const keyed = createMemoryStore();
-    const store = new WorkboardStore(keyed);
+    const { store, stores } = createWorkboardSqliteTestHarness();
+    const keyed = stores.cards;
 
     const card = await store.create({ title: "Plain card" });
 
@@ -1002,7 +982,7 @@ describe("WorkboardStore", () => {
   });
 
   it("preserves open execution engine identifiers without rewriting historical labels", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const runtimeCard = await store.create({
       title: "Runtime identity",
       execution: {
@@ -1040,7 +1020,7 @@ describe("WorkboardStore", () => {
   });
 
   it("preserves explicit zero positions", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
 
     const card = await store.create({ title: "Top card", status: "todo", position: 0 });
 
@@ -1048,7 +1028,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps initial session, run, and task links when creating cards", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
 
     const card = await store.create({
       title: "Follow up",
@@ -1093,7 +1073,7 @@ describe("WorkboardStore", () => {
   });
 
   it("ignores dependency links from generic metadata writes", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Parent" });
     const child = await store.create({
       title: "Child",
@@ -1113,8 +1093,8 @@ describe("WorkboardStore", () => {
   });
 
   it("stores card templates and metadata in the card record", async () => {
-    const keyed = createMemoryStore();
-    const store = new WorkboardStore(keyed);
+    const { store, stores } = createWorkboardSqliteTestHarness();
+    const keyed = stores.cards;
 
     const card = await store.create({
       title: "Fix flaky lane",
@@ -1140,7 +1120,7 @@ describe("WorkboardStore", () => {
   });
 
   it("updates automation metadata from top-level patch fields", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Tune automation" });
 
     const updated = await store.update(card.id, {
@@ -1181,7 +1161,7 @@ describe("WorkboardStore", () => {
   });
 
   it("only accepts workspace authority from trusted top-level provenance", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Restricted card",
       workspaceAccess: { unrestricted: false, roots: ["/workspace"], writable: true },
@@ -1213,7 +1193,7 @@ describe("WorkboardStore", () => {
   });
 
   it("only accepts launch state from store-owned transitions", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Trusted launch",
       status: "ready",
@@ -1255,7 +1235,7 @@ describe("WorkboardStore", () => {
   });
 
   it("does not let a delayed launch failure overwrite a newer retry", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Retried launch", status: "ready" });
     const firstClaim = await store.claim(card.id, { ownerId: "worker" });
     const first = await store.prepareExecutionLaunch(card.id, {
@@ -1302,7 +1282,7 @@ describe("WorkboardStore", () => {
   });
 
   it("moves cards and records lifecycle timestamps", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Ship workboard" });
 
     const running = await store.move(card.id, "running", 500);
@@ -1328,7 +1308,7 @@ describe("WorkboardStore", () => {
   });
 
   it("tracks lifecycle status provenance and clears it on manual status changes", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Sync status provenance" });
 
     const zeroSourceLifecycle = await store.update(card.id, {
@@ -1385,7 +1365,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(2000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({
         title: "Initial running status",
         status: "running",
@@ -1414,7 +1394,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const staleCard = await store.create({ title: "Stale bulk target" });
       const freshCard = await store.create({ title: "Fresh bulk target" });
       vi.setSystemTime(3000);
@@ -1443,7 +1423,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps non-status fields from stale lifecycle patches", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Keep stale sync details",
       execution: {
@@ -1511,7 +1491,7 @@ describe("WorkboardStore", () => {
   });
 
   it("clears copied lifecycle provenance on manual status patches", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Clear copied provenance" });
     const lifecycleMoved = await store.update(card.id, {
       status: "review",
@@ -1546,7 +1526,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps execution session links aligned with edited card links", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Relink me",
       sessionKey: "agent:main:dashboard:1",
@@ -1580,7 +1560,7 @@ describe("WorkboardStore", () => {
   });
 
   it("tracks execution attempts as card metadata", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Run worker" });
 
     const running = await store.update(card.id, {
@@ -1658,7 +1638,7 @@ describe("WorkboardStore", () => {
   });
 
   it("adds comments, links, proof, and archive metadata", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Track proof" });
 
     const commented = await store.addComment(card.id, { body: "Reviewer asked for screenshots." });
@@ -1712,7 +1692,7 @@ describe("WorkboardStore", () => {
   });
 
   it("ignores caller-supplied archivedAt on create so no card is born archived", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Injected archive",
       metadata: { archivedAt: Date.now() },
@@ -1733,7 +1713,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({ title: "Resolve worker proof", status: "running" });
       const claimed = await store.claim(card.id, { ownerId: "main", token: "token-1" });
       const proofInput = {
@@ -1775,7 +1755,7 @@ describe("WorkboardStore", () => {
   });
 
   it("retains the correlated proof when metadata budget trimming is required", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Keep proof under metadata pressure",
       status: "running",
@@ -1821,7 +1801,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps identical completion proof append-only without an explicit proof id", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const proofInput = { command: "pnpm test extensions/workboard", note: "94 tests" };
     const card = await store.create({
       title: "Preserve historical proof",
@@ -1842,7 +1822,7 @@ describe("WorkboardStore", () => {
   });
 
   it("resolves only the explicitly correlated proof across identical retries", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const proofInput = { command: "review poem", note: "Checked each line." };
     const card = await store.create({
       title: "Keep unresolved proof history",
@@ -1867,7 +1847,7 @@ describe("WorkboardStore", () => {
   });
 
   it("reuses an explicitly correlated terminal proof with the same status", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const proof = {
       id: "proof-passed",
       status: "passed" as const,
@@ -1889,7 +1869,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rejects an explicitly correlated terminal proof with a different status", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Reject terminal status rewrite",
       metadata: {
@@ -1910,7 +1890,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rejects a completion proof id when its evidence does not match", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Reject mismatched proof",
       metadata: {
@@ -1937,9 +1917,8 @@ describe("WorkboardStore", () => {
     });
   });
 
-  it("stores attachments in the plugin kv namespace and adds worker context", async () => {
-    const attachments = createMemoryStore<PersistedWorkboardAttachment>();
-    const store = new WorkboardStore(createMemoryStore(), { attachments });
+  it("stores attachments in SQLite and adds worker context", async () => {
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Review attached log" });
 
     const attached = await store.addAttachment(card.id, {
@@ -2001,8 +1980,7 @@ describe("WorkboardStore", () => {
   });
 
   it("removes attachment blobs when the card attachment index prunes old entries", async () => {
-    const attachments = createMemoryStore<PersistedWorkboardAttachment>();
-    const store = new WorkboardStore(createMemoryStore(), { attachments });
+    const { store, dbPath } = createWorkboardSqliteTestHarness();
     const card = await store.create({ title: "Many attachments" });
     let firstAttachmentId = "";
 
@@ -2017,13 +1995,26 @@ describe("WorkboardStore", () => {
     const saved = await store.get(card.id);
     expect(saved?.metadata?.attachments).toHaveLength(20);
     expect(await store.getAttachment(firstAttachmentId)).toBeUndefined();
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      expect(
+        db
+          .prepare("SELECT attachment_id FROM workboard_attachment_blobs WHERE attachment_id = ?")
+          .get(firstAttachmentId),
+      ).toBeUndefined();
+      expect(db.prepare("SELECT COUNT(*) AS count FROM workboard_attachment_blobs").get()).toEqual({
+        count: 20,
+      });
+    } finally {
+      db.close();
+    }
     const exported = await store.exportCards();
     expect(exported.attachments).toHaveLength(20);
     expect(exported.attachments[0]).not.toHaveProperty("contentBase64");
   });
 
   it("records worker logs and protocol violations on cards", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Protocol card",
       status: "running",
@@ -2080,7 +2071,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps concurrent metadata appends from dropping siblings", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Collect notes" });
 
     await Promise.all([
@@ -2096,7 +2087,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps metadata under the keyed-store value budget", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Collect a lot of notes" });
 
     for (let index = 0; index < 50; index += 1) {
@@ -2114,7 +2105,7 @@ describe("WorkboardStore", () => {
   });
 
   it("records append events when metadata retention drops old comments", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Track retained comments" });
 
     let updated = card;
@@ -2128,7 +2119,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps queued metadata when lifecycle updates add stale state", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Sync stale state" });
 
     await Promise.all([
@@ -2152,7 +2143,7 @@ describe("WorkboardStore", () => {
   });
 
   it("exports card records with metadata", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Export me", templateId: "docs" });
 
     await expect(store.exportCards()).resolves.toMatchObject({
@@ -2162,7 +2153,7 @@ describe("WorkboardStore", () => {
   });
 
   it("claims cards, heartbeats, and releases the claim", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Coordinate worker", status: "todo" });
 
     const claimed = await store.claim(card.id, { ownerId: "main", ttlSeconds: 60 });
@@ -2208,7 +2199,7 @@ describe("WorkboardStore", () => {
   });
 
   it("atomically guards and adopts dispatcher workspace authority", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Legacy dispatch", status: "ready" });
     const expectedAuthority = {
       boardId: "default",
@@ -2261,7 +2252,7 @@ describe("WorkboardStore", () => {
   });
 
   it("reports an active claim after a dependency-backed card starts running", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Parent", status: "done" });
     const child = await store.create({ title: "Child", parents: [parent.id] });
 
@@ -2276,7 +2267,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({ title: "Grace-protected worker", status: "ready" });
       const claimed = await store.claim(card.id, { ownerId: "original", ttlSeconds: 1 });
       const expiresAt = claimed.card.metadata?.claim?.expiresAt;
@@ -2314,7 +2305,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const scheduled = await store.create({ title: "Scheduled", status: "ready" });
       await store.claim(scheduled.id, { ownerId: "main", ttlSeconds: 60 });
       await store.update(scheduled.id, { status: "scheduled", scheduledAt: 10_000 });
@@ -2325,7 +2316,7 @@ describe("WorkboardStore", () => {
         maxRetries: 1,
         metadata: { failureCount: 1 },
       });
-      await store.claim(exhausted.id, { ownerId: "main", ttlSeconds: 60 });
+      await store.claim(exhausted.id, { ownerId: "exhausted-worker", ttlSeconds: 60 });
       await store.update(exhausted.id, { metadata: { failureCount: 2 } });
 
       await expect(store.claim(scheduled.id, { ownerId: "other" })).rejects.toThrow(
@@ -2343,7 +2334,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({ title: "Bound claim", status: "todo" });
 
       const claimed = await store.claim(card.id, {
@@ -2358,7 +2349,7 @@ describe("WorkboardStore", () => {
   });
 
   it("does not let invalid stored claim expiry block a fresh claim", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Invalid claim expiry",
       status: "todo",
@@ -2382,7 +2373,7 @@ describe("WorkboardStore", () => {
   });
 
   it("creates idempotent child cards and promotes them when parents finish", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Parent", status: "running" });
     const child = await store.create({
       title: "Child",
@@ -2437,7 +2428,7 @@ describe("WorkboardStore", () => {
   });
 
   it("returns an idempotent child retry when its original parent was deleted", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Ephemeral parent" });
     const child = await store.create({
       title: "Retryable child",
@@ -2459,7 +2450,7 @@ describe("WorkboardStore", () => {
   });
 
   it("accepts POSIX and Windows absolute directory workspaces", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
 
     await expect(
       store.create({
@@ -2498,7 +2489,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(0);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({
         title: "Later",
         status: "scheduled",
@@ -2565,7 +2556,7 @@ describe("WorkboardStore", () => {
   });
 
   it("holds dependent cards out of runnable statuses until parents finish", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Parent", status: "running" });
     const child = await store.create({
       title: "Child",
@@ -2642,9 +2633,8 @@ describe("WorkboardStore", () => {
   });
 
   it("resolves parent dependency status with targeted lookups instead of a full-corpus scan", async () => {
-    const cardStore = createMemoryStore();
-    const entriesSpy = vi.spyOn(cardStore, "entries");
-    const store = new WorkboardStore(cardStore);
+    const { store, stores } = createWorkboardSqliteTestHarness();
+    const entriesSpy = vi.spyOn(stores.cards, "entries");
 
     const parent = await store.create({ title: "Parent" });
     const children = await Promise.all(
@@ -2670,7 +2660,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rejects terminal children with incomplete dependency parents", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const runningParent = await store.create({ title: "Running parent", status: "running" });
     const doneChild = await store.create({ title: "Done child", status: "done" });
 
@@ -2687,7 +2677,7 @@ describe("WorkboardStore", () => {
   });
 
   it("preserves dependency links across link caps and parent deletion", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Parent", status: "running" });
     const child = await store.create({ title: "Child", parents: [parent.id] });
 
@@ -2710,7 +2700,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rolls back card creation when dependency link capacity rejects the parent", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Fanout parent" });
     for (let index = 0; index < 50; index += 1) {
       await store.create({ title: `Child ${index}`, parents: [parent.id] });
@@ -2728,7 +2718,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rejects invalid parent creates without persisting partial cards", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parents: string[] = [];
     for (let index = 0; index < 21; index += 1) {
       parents.push((await store.create({ title: `Parent ${index}` })).id);
@@ -2761,7 +2751,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rejects dependency cycles", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const first = await store.create({ title: "First" });
     const second = await store.create({ title: "Second", parents: [first.id] });
 
@@ -2769,7 +2759,7 @@ describe("WorkboardStore", () => {
   });
 
   it("completes and blocks claimed cards with structured handoff metadata", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Ship child",
       status: "running",
@@ -2860,7 +2850,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps long lifecycle handoffs in comments while capping notifications", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const completeCard = await store.create({ title: "Long complete" });
     const blockCard = await store.create({ title: "Long block" });
     const longSummary = "x".repeat(1000);
@@ -2880,7 +2870,7 @@ describe("WorkboardStore", () => {
     const dbPath = path.join(dir, "workboard.sqlite");
     const stores = createWorkboardSqliteStores({ dbPath });
     try {
-      const store = new WorkboardStore(stores.cards);
+      const store = new WorkboardStore(stores.cards, sqliteTestAuxStores(stores));
       const poisoned = await store.create({ title: "Oversized notification", status: "ready" });
       const sibling = await store.create({ title: "Unaffected sibling", status: "ready" });
       const oversized = `${"x".repeat(238)}🦞${" tail".repeat(60)}`;
@@ -2923,7 +2913,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const ready = await store.create({ title: "Ready", status: "ready" });
       const readyUpdatedAt = ready.updatedAt;
       const expired = await store.create({ title: "Expired", status: "running" });
@@ -2948,7 +2938,11 @@ describe("WorkboardStore", () => {
         status: "ready",
         maxRuntimeSeconds: 1,
       });
-      await store.claim(claimedTimed.id, { ownerId: "main", token: "token-2", ttlSeconds: 60 });
+      await store.claim(claimedTimed.id, {
+        ownerId: "timed-worker",
+        token: "token-2",
+        ttlSeconds: 60,
+      });
       const createdRunningTimed = await store.create({
         title: "Created running timed",
         status: "running",
@@ -2996,31 +2990,15 @@ describe("WorkboardStore", () => {
     }
   });
 
-  it("caps oversized max runtime seconds during dispatch timeout checks", async () => {
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
-      const card = await store.create({
-        title: "Bound runtime",
-        status: "running",
-        maxRuntimeSeconds: Number.MAX_SAFE_INTEGER,
-      });
-      if (card.startedAt === undefined) {
-        throw new Error("expected running card to have startedAt");
-      }
-
-      const result = await store.dispatch(card.startedAt + Number.MAX_SAFE_INTEGER + 1);
-
-      expect(result.blocked).toEqual([expect.objectContaining({ id: card.id })]);
-      await expect(store.get(card.id)).resolves.toMatchObject({ status: "blocked" });
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+  it.each([Number.MAX_SAFE_INTEGER, Number.MAX_VALUE])(
+    "caps oversized runtime seconds %s to the maximum Date duration",
+    (seconds) => {
+      expect(secondsToDurationMs(seconds)).toBe(MAX_DATE_TIMESTAMP_MS);
+    },
+  );
 
   it("lets in-flight retries finish before enforcing the retry budget", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const retrying = await store.create({
       title: "Retrying",
       status: "ready",
@@ -3091,7 +3069,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({ title: "Long run" });
       await store.claim(card.id, { ownerId: "main", ttlSeconds: 60 });
 
@@ -3120,7 +3098,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(MAX_DATE_TIMESTAMP_MS - 30_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({ title: "Near date limit" });
       await store.claim(card.id, { ownerId: "main", ttlSeconds: 60 });
 
@@ -3134,7 +3112,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps the claim when release status validation fails", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Keep claim" });
     await store.claim(card.id, { ownerId: "main", token: "token-1" });
 
@@ -3148,7 +3126,7 @@ describe("WorkboardStore", () => {
   });
 
   it("checks mutation claim scope inside queued card writes", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Scoped mutation" });
     await store.claim(card.id, { ownerId: "main", token: "token-1" });
 
@@ -3167,7 +3145,7 @@ describe("WorkboardStore", () => {
   });
 
   it("lets operators override claims while enforcing agent-scoped moves", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Scoped move", status: "todo" });
     await store.claim(card.id, { ownerId: "agent-a", token: "test-auth-token" });
 
@@ -3182,7 +3160,7 @@ describe("WorkboardStore", () => {
   });
 
   it("checks matching claim tokens inside queued card writes", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Token-scoped mutation" });
     await store.claim(card.id, { ownerId: "main", token: "test-auth-token" });
 
@@ -3205,7 +3183,7 @@ describe("WorkboardStore", () => {
   });
 
   it("clears resolved proof diagnostics when adding proof", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Needs proof",
       status: "done",
@@ -3230,7 +3208,7 @@ describe("WorkboardStore", () => {
   });
 
   it("clears resolved proof diagnostics when adding an artifact", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Needs artifact",
       status: "done",
@@ -3255,7 +3233,7 @@ describe("WorkboardStore", () => {
   });
 
   it("does not commit proof when proof artifact validation fails", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Atomic proof" });
 
     await expect(
@@ -3272,7 +3250,7 @@ describe("WorkboardStore", () => {
   });
 
   it("computes and refreshes card diagnostics", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const ready = await store.create({
       title: "Ready too long",
       agentId: "main",
@@ -3287,17 +3265,10 @@ describe("WorkboardStore", () => {
     const doneWithAttachment = await store.create({
       title: "Done with attachment",
       status: "done",
-      metadata: {
-        attachments: [
-          {
-            id: "attachment-proof",
-            cardId: "attachment-card",
-            fileName: "result.log",
-            byteSize: 1,
-            createdAt: 10,
-          },
-        ],
-      },
+    });
+    await store.addAttachment(doneWithAttachment.id, {
+      fileName: "result.log",
+      contentBase64: Buffer.from("x").toString("base64"),
     });
 
     const now = Date.now() + 2 * 24 * 60 * 60 * 1000;
@@ -3333,7 +3304,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps archived cards out of diagnostics without rewriting their history", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Archived completed work", status: "done" });
     const now = Date.now();
 
@@ -3376,7 +3347,7 @@ describe("WorkboardStore", () => {
   it.each(WORKBOARD_STATUSES)(
     "reports archived %s cards according to terminal state",
     async (status) => {
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({ title: `Archived ${status}`, status });
 
       await store.archive(card.id, true);
@@ -3405,7 +3376,7 @@ describe("WorkboardStore", () => {
   );
 
   it("keeps archived-card diagnostics transient across lifecycle changes", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Archived but ready", status: "ready" });
     const now = Date.now();
 
@@ -3429,8 +3400,8 @@ describe("WorkboardStore", () => {
   it("does not drop concurrent updates while refreshing diagnostics", async () => {
     let proofPromise: Promise<unknown> | undefined;
     let triggered = false;
-    const keyed = createMemoryStore({
-      async beforeRegister(_key, value) {
+    const store: WorkboardStore = createWorkboardSqliteTestStore({
+      async beforeCardWrite(_key, value) {
         if (triggered || !value.card.metadata?.diagnostics?.length) {
           return;
         }
@@ -3441,7 +3412,6 @@ describe("WorkboardStore", () => {
         });
       },
     });
-    const store: WorkboardStore = new WorkboardStore(keyed);
     const card = await store.create({ title: "Ready too long", agentId: "main" });
 
     await store.refreshDiagnostics(Date.now() + 2 * 24 * 60 * 60 * 1000);
@@ -3456,7 +3426,7 @@ describe("WorkboardStore", () => {
   });
 
   it("builds bounded worker context from card metadata", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Write docs",
       notes: "Acceptance:\n- mention tools",
@@ -3476,7 +3446,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps worker-context text bounds UTF-16 safe", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Bound context",
       metadata: {
@@ -3494,7 +3464,7 @@ describe("WorkboardStore", () => {
   });
 
   it("scopes idempotent creates and stats by board", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const ops = await store.create({
       title: "Ops work",
       boardId: "ops",
@@ -3552,7 +3522,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const oldReady = await store.create({
         title: "Archived ready work",
         boardId: "ops",
@@ -3590,7 +3560,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rejects completed manifests for cards not created from the parent", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Parent", status: "running" });
     const unrelated = await store.create({ title: "Unrelated" });
 
@@ -3617,7 +3587,7 @@ describe("WorkboardStore", () => {
   });
 
   it("promotes, reassigns, and reclaims cards for operator recovery", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Recover me",
       status: "blocked",
@@ -3668,7 +3638,7 @@ describe("WorkboardStore", () => {
   });
 
   it("includes parent results and recent assignee work in worker context", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({
       title: "Design",
       status: "running",
@@ -3705,11 +3675,11 @@ describe("WorkboardStore", () => {
     );
   });
 
-  it("persists board metadata and notification subscriptions in separate stores", async () => {
-    const cards = createMemoryStore();
-    const boards = createMemoryStore<PersistedWorkboardBoard>();
-    const subscriptions = createMemoryStore<PersistedWorkboardNotificationSubscription>();
-    const store = new WorkboardStore(cards, { boards, subscriptions });
+  it("persists board metadata and notification subscriptions in separate SQLite tables", async () => {
+    const {
+      store,
+      stores: { cards, boards, subscriptions },
+    } = createWorkboardSqliteTestHarness();
 
     const board = await store.upsertBoard({
       id: "ops",
@@ -3753,8 +3723,10 @@ describe("WorkboardStore", () => {
   });
 
   it("excludes archived cards from notification replay without discarding their history", async () => {
-    const subscriptions = createMemoryStore<PersistedWorkboardNotificationSubscription>();
-    const store = new WorkboardStore(createMemoryStore(), { subscriptions });
+    const {
+      store,
+      stores: { subscriptions },
+    } = createWorkboardSqliteTestHarness();
     const historical = await store.create({
       title: "Archived notifications",
       boardId: "ops",
@@ -3811,8 +3783,10 @@ describe("WorkboardStore", () => {
   });
 
   it("replays notification events with subscription cursors", async () => {
-    const subscriptions = createMemoryStore<PersistedWorkboardNotificationSubscription>();
-    const store = new WorkboardStore(createMemoryStore(), { subscriptions });
+    const {
+      store,
+      stores: { subscriptions },
+    } = createWorkboardSqliteTestHarness();
     const card = await store.create({ title: "Notify me", boardId: "ops" });
     const subscription = await store.subscribeNotifications({
       boardId: "ops",
@@ -3864,16 +3838,18 @@ describe("WorkboardStore", () => {
     const cursorWriteReleased = new Promise<void>((resolve) => {
       releaseCursorWrite = resolve;
     });
-    const subscriptions = createMemoryStore<PersistedWorkboardNotificationSubscription>({
-      async beforeRegister(_key, value) {
-        if (!value.subscription.lastEventId) {
-          return;
-        }
+    const {
+      store,
+      stores: { subscriptions },
+    } = createWorkboardSqliteTestHarness();
+    const registerSubscription = subscriptions.register.bind(subscriptions);
+    subscriptions.register = async (key, value) => {
+      if (value.subscription.lastEventId) {
         markCursorWriteStarted();
         await cursorWriteReleased;
-      },
-    });
-    const store = new WorkboardStore(createMemoryStore(), { subscriptions });
+      }
+      await registerSubscription(key, value);
+    };
     const card = await store.create({ title: "Delete in-flight notification", boardId: "ops" });
     const subscription = await store.subscribeNotifications({
       boardId: "ops",
@@ -3898,9 +3874,7 @@ describe("WorkboardStore", () => {
   });
 
   it("does not skip same-millisecond notification events after cursor advancement", async () => {
-    const store = new WorkboardStore(createMemoryStore(), {
-      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
-    });
+    const store = createWorkboardSqliteTestStore();
     await store.create({
       title: "First same-ms event",
       boardId: "ops",
@@ -3948,9 +3922,7 @@ describe("WorkboardStore", () => {
   });
 
   it("does not skip unsequenced notifications after a sequenced same-millisecond event", async () => {
-    const store = new WorkboardStore(createMemoryStore(), {
-      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
-    });
+    const store = createWorkboardSqliteTestStore();
     await store.create({
       title: "Sequenced notification",
       boardId: "ops",
@@ -4004,9 +3976,7 @@ describe("WorkboardStore", () => {
   });
 
   it("drains large same-millisecond notification batches without replaying delivered ids", async () => {
-    const store = new WorkboardStore(createMemoryStore(), {
-      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
-    });
+    const store = createWorkboardSqliteTestStore();
     for (let index = 0; index < 205; index += 1) {
       await store.create({
         title: `Same-ms event ${index}`,
@@ -4044,9 +4014,7 @@ describe("WorkboardStore", () => {
   });
 
   it("filters replayed notification events by session and run subscriptions", async () => {
-    const store = new WorkboardStore(createMemoryStore(), {
-      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
-    });
+    const store = createWorkboardSqliteTestStore();
     const matching = await store.create({
       title: "Matching session",
       boardId: "ops",
@@ -4095,9 +4063,7 @@ describe("WorkboardStore", () => {
   });
 
   it("replays card-scoped subscriptions without requiring the board id", async () => {
-    const store = new WorkboardStore(createMemoryStore(), {
-      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
-    });
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Ops card", boardId: "ops" });
     const subscription = await store.subscribeNotifications({
       cardId: card.id,
@@ -4114,9 +4080,7 @@ describe("WorkboardStore", () => {
   });
 
   it("replays stale metadata as stale notification events", async () => {
-    const store = new WorkboardStore(createMemoryStore(), {
-      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
-    });
+    const store = createWorkboardSqliteTestStore();
     await store.create({
       title: "Stale card",
       boardId: "ops",
@@ -4146,8 +4110,7 @@ describe("WorkboardStore", () => {
   });
 
   it("marks triage cards as orchestration candidates during dispatch", async () => {
-    const boards = createMemoryStore<PersistedWorkboardBoard>();
-    const store = new WorkboardStore(createMemoryStore(), { boards });
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({
       id: "planning",
       orchestration: { autoDecompose: true, autoDecomposePerDispatch: 1 },
@@ -4194,7 +4157,7 @@ describe("WorkboardStore", () => {
   });
 
   it("does not mutate archived ready cards during repeated dispatch", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({
       title: "Archived ready work",
       status: "ready",
@@ -4221,7 +4184,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const card = await store.create({
         title: "Archived scheduled work",
         status: "scheduled",
@@ -4255,7 +4218,7 @@ describe("WorkboardStore", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = new WorkboardStore(createMemoryStore());
+      const store = createWorkboardSqliteTestStore();
       const timedOut = await store.create({
         title: "Archived timed-out work",
         status: "running",
@@ -4297,8 +4260,7 @@ describe("WorkboardStore", () => {
   });
 
   it("applies auto orchestration dispatch caps per board", async () => {
-    const boards = createMemoryStore<PersistedWorkboardBoard>();
-    const store = new WorkboardStore(createMemoryStore(), { boards });
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({
       id: "ops",
       orchestration: { autoDecompose: true, autoDecomposePerDispatch: 1 },
@@ -4322,8 +4284,7 @@ describe("WorkboardStore", () => {
   });
 
   it("scopes dispatch mutations by board", async () => {
-    const boards = createMemoryStore<PersistedWorkboardBoard>();
-    const store = new WorkboardStore(createMemoryStore(), { boards });
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({
       id: "ops",
       orchestration: { autoDecompose: true, autoDecomposePerDispatch: 1 },
@@ -4351,10 +4312,7 @@ describe("WorkboardStore", () => {
   });
 
   it("deletes board notification subscriptions with empty board metadata", async () => {
-    const store = new WorkboardStore(createMemoryStore(), {
-      boards: createMemoryStore<PersistedWorkboardBoard>(),
-      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
-    });
+    const store = createWorkboardSqliteTestStore();
     await store.upsertBoard({ id: "ops", name: "Ops" });
     await store.subscribeNotifications({
       boardId: "ops",
@@ -4369,9 +4327,7 @@ describe("WorkboardStore", () => {
   });
 
   it("deletes card notification subscriptions with the card", async () => {
-    const store = new WorkboardStore(createMemoryStore(), {
-      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
-    });
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Notify me" });
     await store.subscribeNotifications({
       cardId: card.id,
@@ -4386,7 +4342,7 @@ describe("WorkboardStore", () => {
   });
 
   it("specifies and decomposes rough cards into linked children", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({
       title: "Rough idea",
       status: "triage",
@@ -4455,7 +4411,7 @@ describe("WorkboardStore", () => {
   });
 
   it("keeps specify as a todo-only clarification step", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const card = await store.create({ title: "Rough idea", status: "triage" });
     const blocked = await store.create({ title: "Blocked idea", status: "blocked" });
 
@@ -4473,7 +4429,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rolls back newly created children when decomposition fails", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Parent", status: "todo" });
 
     await expect(
@@ -4487,7 +4443,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rolls back links added to reused idempotent children when decomposition fails", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Parent" });
     const existingChild = await store.create({
       title: "Existing child",
@@ -4519,7 +4475,7 @@ describe("WorkboardStore", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-decompose-control-"));
     const dbPath = path.join(dir, "workboard.sqlite");
     const stores = createWorkboardSqliteStores({ dbPath });
-    const store = new WorkboardStore(stores.cards);
+    const store = new WorkboardStore(stores.cards, sqliteTestAuxStores(stores));
     try {
       const parent = await store.create({ title: "Parent" });
       const reusedChild = await store.create({
@@ -4728,11 +4684,13 @@ describe("WorkboardStore", () => {
   });
 
   it("preserves a linked-create failure when card compensation also fails", async () => {
-    const cards = createMemoryStore();
-    const store = new WorkboardStore(cards);
+    const {
+      store,
+      stores: { cards },
+    } = createWorkboardSqliteTestHarness();
     const parent = await store.create({ title: "Claimed parent", status: "ready" });
     await store.claim(parent.id, { ownerId: "worker" });
-    cards.delete = async () => {
+    cards.deleteIfUpdatedAt = async () => {
       throw new Error("card compensation failed");
     };
 
@@ -4752,7 +4710,7 @@ describe("WorkboardStore", () => {
   });
 
   it("preserves parent child links when decomposition leaves the parent open", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({ title: "Parent", status: "triage" });
     await store.addLink(parent.id, { type: "relates_to", url: "https://example.com/context" });
 
@@ -4778,7 +4736,7 @@ describe("WorkboardStore", () => {
   });
 
   it("omits derived child idempotency keys when the parent key is already at the limit", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const parent = await store.create({
       title: "Parent",
       idempotencyKey: "p".repeat(160),
@@ -4792,7 +4750,7 @@ describe("WorkboardStore", () => {
   });
 
   it("links an idempotent existing child before completing decomposition", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const existingChild = await store.create({
       title: "Existing child",
       idempotencyKey: "child-key",
@@ -4816,7 +4774,7 @@ describe("WorkboardStore", () => {
   });
 
   it("rejects invalid status values", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     await expect(store.create({ title: "Bad card", status: "later" })).rejects.toThrow(
       /status must be one of/,
     );

--- a/extensions/workboard/src/test/sqlite-store.ts
+++ b/extensions/workboard/src/test/sqlite-store.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach } from "vitest";
+import type { PersistedWorkboardCard, WorkboardCardStore } from "../persistence-types.js";
+import { createWorkboardSqliteStores } from "../sqlite-store.js";
+import { WorkboardStore } from "../store.js";
+
+type WorkboardSqliteTestOptions = {
+  beforeCardWrite?: (key: string, value: PersistedWorkboardCard) => void | Promise<void>;
+  beforeCardLookup?: (key: string) => void | Promise<void>;
+  onStoreClose?: () => void;
+};
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  const results = await Promise.allSettled(cleanups.splice(0).map((cleanup) => cleanup()));
+  const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "Workboard SQLite test cleanup failed");
+  }
+});
+
+function withCardHooks(
+  cards: WorkboardCardStore,
+  options: WorkboardSqliteTestOptions,
+): WorkboardCardStore {
+  return {
+    async register(key, value) {
+      await options.beforeCardWrite?.(key, value);
+      await cards.register(key, value);
+    },
+    async registerIfAbsent(key, value) {
+      await options.beforeCardWrite?.(key, value);
+      return cards.registerIfAbsent(key, value);
+    },
+    async registerIfUpdatedAt(key, value, expectedUpdatedAt) {
+      await options.beforeCardWrite?.(key, value);
+      return cards.registerIfUpdatedAt(key, value, expectedUpdatedAt);
+    },
+    async claimIfOwnerAvailable(key, value, expectedUpdatedAt, ownerId, now) {
+      await options.beforeCardWrite?.(key, value);
+      return cards.claimIfOwnerAvailable(key, value, expectedUpdatedAt, ownerId, now);
+    },
+    async lookup(key) {
+      await options.beforeCardLookup?.(key);
+      return cards.lookup(key);
+    },
+    delete: (key) => cards.delete(key),
+    deleteIfUpdatedAt: (key, expectedUpdatedAt) => cards.deleteIfUpdatedAt(key, expectedUpdatedAt),
+    entries: () => cards.entries(),
+    listBoardAggregates: () => cards.listBoardAggregates(),
+  };
+}
+
+export function createWorkboardSqliteTestHarness(options: WorkboardSqliteTestOptions = {}) {
+  // openclaw-temp-dir: allow closes the SQLite owner before removing database files.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-test-"));
+  const dbPath = path.join(dir, "workboard.sqlite");
+  let sqlite: ReturnType<typeof createWorkboardSqliteStores>;
+  try {
+    sqlite = createWorkboardSqliteStores({ dbPath });
+  } catch (error) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    throw error;
+  }
+  let databaseClosed = false;
+  const closeDatabase = () => {
+    if (!databaseClosed) {
+      databaseClosed = true;
+      sqlite.close();
+    }
+  };
+  const stores = {
+    ...sqlite,
+    cards:
+      options.beforeCardWrite || options.beforeCardLookup
+        ? withCardHooks(sqlite.cards, options)
+        : sqlite.cards,
+    close: closeDatabase,
+  };
+  let storeCloseObserved = false;
+  const store = new WorkboardStore(stores.cards, {
+    ...stores,
+    close: () => {
+      storeCloseObserved = true;
+      (options.onStoreClose ?? closeDatabase)();
+    },
+  });
+  cleanups.push(async () => {
+    try {
+      if (!storeCloseObserved) {
+        await store.close();
+      }
+    } finally {
+      try {
+        closeDatabase();
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+  return { store, stores, dbPath };
+}
+
+export function createWorkboardSqliteTestStore(options: WorkboardSqliteTestOptions = {}) {
+  return createWorkboardSqliteTestHarness(options).store;
+}
+
+export function sqliteTestAuxStores(stores: ReturnType<typeof createWorkboardSqliteStores>) {
+  const { boards, subscriptions, attachments } = stores;
+  return { boards, subscriptions, attachments };
+}

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -3,28 +3,12 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { isToolResultError } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
-import { WorkboardStore } from "./store.js";
+import {
+  createWorkboardSqliteTestHarness,
+  createWorkboardSqliteTestStore,
+} from "./test/sqlite-store.js";
 import { createWorkboardTools } from "./tools.js";
 import { guardWorkboardToolsForWorkspaceAccess } from "./workspace-access.js";
-
-function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
-  const entries = new Map<string, T>();
-  return {
-    async register(key, value) {
-      entries.set(key, value);
-    },
-    async lookup(key) {
-      return entries.get(key);
-    },
-    async delete(key) {
-      return entries.delete(key);
-    },
-    async entries() {
-      return [...entries].flatMap(([key, value]) => (value ? [{ key, value }] : []));
-    },
-  };
-}
 
 function readPayload(result: unknown): Record<string, unknown> {
   return (result as { details?: Record<string, unknown> }).details ?? {};
@@ -32,7 +16,7 @@ function readPayload(result: unknown): Record<string, unknown> {
 
 describe("workboard tools", () => {
   it("inherits the active tool filesystem boundary for workspace metadata", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const restrictedContext = {
       agentId: "main",
       workspaceDir: "/workspace",
@@ -109,7 +93,7 @@ describe("workboard tools", () => {
   });
 
   it("preserves read-only sandbox authority while allowing manual card movement", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const context: NonNullable<Parameters<typeof guardWorkboardToolsForWorkspaceAccess>[1]> = {
       agentId: "main",
       sessionKey: "agent:main:subagent:readonly",
@@ -147,8 +131,8 @@ describe("workboard tools", () => {
   });
 
   it("lists, claims, heartbeats, and reads worker context", async () => {
-    const keyed = createMemoryStore();
-    const workboardStore = new WorkboardStore(keyed);
+    const { store: workboardStore, stores } = createWorkboardSqliteTestHarness();
+    const keyed = stores.cards;
     const tools = createWorkboardTools({
       store: workboardStore,
       context: { agentId: "main", sessionKey: "session-1" },
@@ -228,9 +212,10 @@ describe("workboard tools", () => {
   });
 
   it("keeps blocked-card mutations out of the host tool failure contract", async () => {
-    const keyed = createMemoryStore();
+    const { store, stores } = createWorkboardSqliteTestHarness();
+    const keyed = stores.cards;
     const tools = createWorkboardTools({
-      store: new WorkboardStore(keyed),
+      store,
       context: { agentId: "main" },
     });
     const byName = new Map(tools.map((tool) => [tool.name, tool]));
@@ -284,8 +269,7 @@ describe("workboard tools", () => {
   });
 
   it("can share one store across tool instances for claim coordination", async () => {
-    const keyed = createMemoryStore();
-    const store = new WorkboardStore(keyed);
+    const store = createWorkboardSqliteTestStore();
     const mainTools = new Map(
       createWorkboardTools({
         store,
@@ -308,8 +292,7 @@ describe("workboard tools", () => {
   });
 
   it("requires claim scope before creating or linking dependencies against claimed cards", async () => {
-    const keyed = createMemoryStore();
-    const store = new WorkboardStore(keyed);
+    const store = createWorkboardSqliteTestStore();
     const mainTools = new Map(
       createWorkboardTools({
         store,
@@ -352,7 +335,7 @@ describe("workboard tools", () => {
       token: claimed.token,
     });
     const child = await store.create({ title: "Claimed child" });
-    await store.claim(child.id, { ownerId: "main", token: "child-token" });
+    await store.claim(child.id, { ownerId: "child-worker", token: "child-token" });
     await expect(
       otherTools.get("workboard_link")?.execute("call-3", {
         parentId: parent.id,
@@ -379,8 +362,7 @@ describe("workboard tools", () => {
   });
 
   it("creates dependent cards and completes claimed work through tools", async () => {
-    const keyed = createMemoryStore();
-    const store = new WorkboardStore(keyed);
+    const store = createWorkboardSqliteTestStore();
     const tools = new Map(
       createWorkboardTools({
         store,
@@ -457,8 +439,7 @@ describe("workboard tools", () => {
   });
 
   it("redacts claim tokens from dispatch tool results", async () => {
-    const keyed = createMemoryStore();
-    const store = new WorkboardStore(keyed);
+    const store = createWorkboardSqliteTestStore();
     const tools = new Map(
       createWorkboardTools({
         store,
@@ -493,8 +474,7 @@ describe("workboard tools", () => {
   });
 
   it("exposes board lifecycle, decomposition, runs, and notification tools", async () => {
-    const keyed = createMemoryStore();
-    const store = new WorkboardStore(keyed);
+    const store = createWorkboardSqliteTestStore();
     const tools = new Map(
       createWorkboardTools({
         store,
@@ -627,7 +607,7 @@ describe("workboard tools", () => {
   });
 
   it("moves cards with agent claim scope", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = createWorkboardSqliteTestStore();
     const tools = new Map(
       createWorkboardTools({ store, context: { agentId: "agent-b" } }).map((tool) => [
         tool.name,


### PR DESCRIPTION
Closes #144995

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Workboard's shipped plugin already stores cards in SQLite, but its core still accepts a legacy keyed-card backend and most backend tests use Map fixtures through that path. Those fixtures do not enforce the SQLite ownership, identity, and durability contracts that the application uses.

Controlled tests exposed the gap: the original SQLite fixture migration failed five cases, while three other tests passed despite an orphaned attachment BLOB or worker starts whose accepted associations were not persisted. Joined attachment reads can hide an orphan after metadata pruning, and repeated mock run IDs can force the dispatcher's intentional acceptance-persistence fallback without failing the old assertions.

## Why This Change Was Made

Require the existing full card-store contract with explicit auxiliary stores, remove the private keyed-card fallback paths, and migrate backend tests to an owned SQLite fixture. The fixture drains admitted work before closing its database and removing its directory; restart and fake-timer cases retain explicit failure-path cleanup.

The tests now check physical BLOB deletion independently of joined metadata and verify durable accepted associations using distinct mock run IDs. The clock-skew cases preserve snapshot selection while exercising the unchanged current claim authority. Duration saturation uses the existing production arithmetic owner alongside ordinary SQLite timeout/readback proof. The `.28` Doctor migration and existing SQLite algorithms remain intact.

## User Impact

This is an internal persistence and test refactor with no intended user-visible behavior change. Workboard retains its existing UI, CLI, tool, stored-data, and claim-admission contracts. Maintainers gain regression coverage that exercises the persistence behavior used by the shipped plugin.

## Evidence

Validated on macOS 27.0 with Node 24.20.0 and an independent frozen pnpm 12.3.4 installation, against source baseline `bc21739e1d5e8961277d4775068255fe58f19e3c`:

- **359 tests passed across 18 Workboard backend and Doctor files**, including the SQLite policy/batch-read siblings, conditional writes, ownership, compensation, notification cursors, lifecycle, and restart cases. The suite was rerun on the final formatted source.
- The complete `node scripts/check-changed.mjs --base bc21739e1d5e8961277d4775068255fe58f19e3c --timed` gate passed, including production/test typechecks, lint, dead exports, Doctor declaration/closure tests, storage guards, and import cycles. The assertion-safety baseline only shrinks for the removed Workboard casts.
- An isolated P2 review found no actionable P0–P2 defects; the final source was reverified afterward.
- Before correction, five selected SQLite cases failed and both unused-binding lint errors were reproduced. The original three false-green controls passed with 21 BLOB rows, six of seven Gateway launches still `prepared`, and the second slash launch still `prepared`.
- Corrected negative controls fail on physical BLOB retention and durable `prepared` versus `accepted` state. Nine deliberate lifecycle failures complete with all nine fixture directories removed and no hook timeout or unhandled rejection. Temporary fault controls are excluded from this patch.

The final local patch is bound by SHA-256 `92f3119cdbbe94fc14e48be18f0bc3e1107341c6f4a1d9530543c8d57667f6b5`. Published head `1a7bd245b050cab84eb6e5d8ea1cfd5e13b57309` is a mechanical rebase onto `c1a7a205daa122c601238e01994150fd219258d1`: all 17 Workboard file bytes and patch sections match the tested candidate, and the assertion baseline preserves current-main entries except the approved five-to-two reduction. Hosted exact-head CI is required before native preparation.

The final backend run took 19.07 seconds wall in this environment. A separate five-database synthetic sample with 14 logical writes per database observed mean startup/operation/close times of 21.84/17.11/12.12 ms, a 976,256-byte database/WAL/SHM footprint before close, and a 200,704-byte database after sidecar removal. These are local sample observations, not production benchmarks, cumulative disk-write measurements, or a before/after speedup claim.

Validation limits: Linux, Windows, packaged-release, and live Gateway/provider tests were not run. Runtime tests used synthetic data and mocked worker entry points, without live Gateway/provider credentials. The duration proof covers arithmetic saturation plus ordinary SQLite timeout persistence; it does not run enormous timestamps through SQLite or dynamically cover a hypothetical dispatch-only bypass affecting only enormous inputs. No new public clock, schema, concurrency policy, numeric persistence interpretation, or test-only production export is introduced.
