### PR TITLE
fix(system-agent): re-admit fallback agent runtime

### DIFF
--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -1,5 +1,10 @@
 import "./chat-engine.mocks.test-support.js";
 import { describe, expect, it, vi } from "vitest";
+import {
+  getPreparedModelRuntimePluginGeneration,
+  withPreparedModelRuntimePluginGenerationScope,
+} from "../agents/prepared-model-runtime-generation-scope.js";
+import type { PreparedModelRuntimePluginGeneration } from "../agents/prepared-model-runtime.types.js";
 import type { SystemAgentSession } from "./agent-turn.js";
 import type { SystemAgentTurnDeps } from "./agent-turn.test-support.js";
 import {
@@ -18,6 +23,55 @@ import {
 import { loadSystemAgentOverview } from "./overview.js";
 
 describe("SystemAgentChatEngine facade", () => {
+  it("keeps alternate-agent turns and planners outside the requester generation", async () => {
+    useTempStateDir();
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: { model: "openai/gpt-5.5" },
+        list: [{ id: "alternate", default: true, model: "openai/gpt-5.5" }],
+      },
+    };
+    const inference = await createSystemAgentVerifiedInferenceTestFixture(config);
+    expect(inference.binding.execution.agentId).toBe("alternate");
+    const inheritedGeneration = {} as PreparedModelRuntimePluginGeneration;
+    const observedGenerations: Array<PreparedModelRuntimePluginGeneration | undefined> = [];
+    const runEmbeddedAgent = vi.fn(async () => {
+      observedGenerations.push(getPreparedModelRuntimePluginGeneration());
+      return { meta: { finalAssistantVisibleText: "ready" } };
+    });
+    const planGreeting = vi.fn(async () => {
+      observedGenerations.push(getPreparedModelRuntimePluginGeneration());
+      return null;
+    });
+    const engine = new SystemAgentChatEngine({
+      requesterAgentId: "requester",
+      verifiedInference: inference.binding,
+      planGreeting,
+      runAgentTurn: (params) =>
+        runSystemAgentTurnWithDeps(params, {
+          ...inference.deps,
+          readConfigFileSnapshot: async () => configSnapshot(config),
+          runEmbeddedAgent: runEmbeddedAgent as never,
+        }),
+      deps: {
+        ...inference.deps,
+        readConfigFileSnapshot: async () => configSnapshot(config),
+        loadOverview: fakeOverviewLoader(),
+      },
+    });
+    try {
+      await withPreparedModelRuntimePluginGenerationScope(inheritedGeneration, () =>
+        engine.handle("continue setup"),
+      );
+      await withPreparedModelRuntimePluginGenerationScope(inheritedGeneration, () =>
+        engine.planGreeting({ overview: {} as never, facts: {} as never, timeoutMs: 10 }),
+      );
+      expect(observedGenerations).toEqual([undefined, undefined]);
+    } finally {
+      await engine.dispose();
+    }
+  });
+
   it("ends a partial timed-out agent turn without starting a second planner inference", async () => {
     useTempStateDir();
     const config: OpenClawConfig = {

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -3,6 +3,7 @@ import type {
   SystemAgentWizardCancel,
   WizardAnswer,
 } from "../../packages/gateway-protocol/src/index.js";
+import { runOutsidePreparedModelRuntimePluginGenerationScope } from "../agents/prepared-model-runtime-generation-scope.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   cleanupSystemAgentSession,
@@ -231,16 +232,23 @@ export class SystemAgentChatEngine {
     facts: SystemAgentGreetingFacts;
     timeoutMs: number;
   }): Promise<SystemAgentGreetingPlan | null> {
-    const planner = this.options.planGreeting;
-    const plan = planner
-      ? await planner(params)
-      : await import("./assistant.js").then(({ planSystemAgentGreetingWithConfiguredModel }) =>
-          planSystemAgentGreetingWithConfiguredModel({
-            ...params,
-            verifiedInference: this.verifiedInference,
-            deps: this.options.deps,
-          }),
-        );
+    const runPlanner = async () => {
+      const planner = this.options.planGreeting;
+      return planner
+        ? await planner(params)
+        : await import("./assistant.js").then(({ planSystemAgentGreetingWithConfiguredModel }) =>
+            planSystemAgentGreetingWithConfiguredModel({
+              ...params,
+              verifiedInference: this.verifiedInference,
+              deps: this.options.deps,
+            }),
+          );
+    };
+    const requesterAgentId = this.options.requesterAgentId?.trim();
+    const plan =
+      requesterAgentId && requesterAgentId !== this.verifiedInference.execution.agentId
+        ? await runOutsidePreparedModelRuntimePluginGenerationScope(runPlanner)
+        : await runPlanner();
     if (plan) {
       await this.requireVerifiedInference();
     }

--- a/src/system-agent/chat-turn-router.ts
+++ b/src/system-agent/chat-turn-router.ts
@@ -1,3 +1,4 @@
+import { runOutsidePreparedModelRuntimePluginGenerationScope } from "../agents/prepared-model-runtime-generation-scope.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type {
   SystemAgentSession,
@@ -342,14 +343,20 @@ export class ChatTurnRouter {
         : text
     }`;
     // The runtime already owns recovery; a terminal failure must not start another inference turn.
-    const loopReply = await agentTurn({
-      input: loopInput,
-      overview,
-      surface: this.options.surface ?? "cli",
-      approvalArmed,
-      ...(this.options.operatorApprovalOnly ? { operatorApprovalOnly: true } : {}),
-      session: this.agentSession,
-    });
+    const runTurn = () =>
+      agentTurn({
+        input: loopInput,
+        overview,
+        surface: this.options.surface ?? "cli",
+        approvalArmed,
+        ...(this.options.operatorApprovalOnly ? { operatorApprovalOnly: true } : {}),
+        session: this.agentSession,
+      });
+    const requesterAgentId = this.options.requesterAgentId?.trim();
+    const loopReply =
+      requesterAgentId && requesterAgentId !== this.agentSession.verifiedInference.execution.agentId
+        ? await runOutsidePreparedModelRuntimePluginGenerationScope(runTurn)
+        : await runTurn();
     if (!loopReply?.text) {
       throw new SystemAgentInferenceUnavailableError("agent-turn");
     }


### PR DESCRIPTION
## What Problem This Solves

A delegated OpenClaw system-agent conversation can verify a fallback route owned by a different configured agent, then execute the actual chat turn under the requester's inherited prepared-runtime generation. The alternate agent does not own that generation, so the real turn can fail with `prepared model runtime plugin generation was superseded` even though verification succeeded.

This also leads to misleading provider/onboarding guidance because the failure occurs before the alternate provider is actually exercised.

Addresses #139710.

## Implementation

- Leave setup verification unchanged; isolated verification probes already avoid inherited prepared generations.
- At the actual assistant-turn boundary, run an alternate-agent turn outside the requester's prepared-runtime generation scope.
- Apply the same boundary to configured greeting planners.
- Preserve inherited scope when requester and execution owner are the same agent.

## Evidence

The original mocked verifier-only patch was removed after review because it duplicated existing probe isolation and did not cover the real conversation.

The amended regression drives `SystemAgentChatEngine.handle()` through the real `runSystemAgentTurnWithDeps()` path and observes the scope inside the embedded runner. It also exercises the configured greeting planner.

After the amendment:

- Alternate-agent real turn observes no requester generation.
- Alternate-agent greeting planner observes no requester generation.
- `inference-fallback.test.ts`, `chat-engine.test.ts`, and `chat-turn-router.operations.test.ts`: 58/58 passed.
- `node scripts/check-changed.mjs`: passed all changed-file gates.
- Rebased onto `origin/main` at `1846735b5d4` before the final focused run.

### Live isolated Gateway canary

Run on September 11, 2026 against exact head `6c9c46613126051f20bf33b9419c2978b60d3cfa`, using a unique loopback port, isolated config/state/workspaces, channels disabled, and the real Gateway agent RPC.

Production path exercised:

`agent` RPC for requester -> real requester model turn -> model-visible `openclaw` tool -> in-process `openclaw.chat` with host delegation -> deliberately failing requester inference route -> authenticated fallback-agent verification -> actual fallback-owned system-agent turn -> requester result.

Observed:

- The requester route `dead/canary` failed its real setup-inference probe with a network error.
- Fallback agent `fallback` was selected and completed a real `ollama/qwen3.5:cloud` verification probe with `OK`.
- The actual system-agent turn then ran on `ollama/qwen3.5:cloud` and completed successfully.
- The `openclaw` tool returned normally to the requester.
- The requester produced the exact terminal result `FALLBACK_CANARY_OK`.
- Gateway run completed successfully after 75.9 seconds; no superseded-generation error occurred.
- Secrets, hostnames, local paths, and endpoint details are omitted from this evidence.

This is runtime proof of the exact cross-agent production boundary fixed by the PR. It is not a live-installation deployment qualification.

## Relationship to Other Work

Draft PR #142218 applies a similar scope-exit rule to detached `sessions_send` A2A follow-ups. This PR fixes the system-agent conversation and planner boundaries instead.
