### PR TITLE
feat(ui): choose where to start suggested tasks

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -98,7 +98,9 @@ The Place picker's **Projects** section can start the same worktree flow from a 
 
 Agents can also call `suggest_task` when they discover confirmed follow-up work outside the current task. The Control UI and Gateway-backed TUI offer **Start in a new session**. This starts the task directly in the suggested folder without creating a worktree or requiring Git. The new session is instructed to explain the need and ask the user before creating or switching to a worktree later. Dismissing a suggestion starts nothing. Suggestions and their IDs are ephemeral and do not survive a Gateway restart.
 
-Both clients send `taskSuggestions.accept` with `mode: "local"`. Existing RPC clients retain the explicit `worktree`, `local`, `cloud`, and `session` modes. Omitted mode still means `worktree` for callers that used the original worktree action; the current Control UI and TUI never omit it. These compatibility modes are not launch choices in the suggestion UI.
+In the Control UI, the arrow beside **Start in a new session** offers two additional actions: **Start in a new worktree** creates an isolated session from the suggested Git checkout, and **Start in this session** sends the task to the current conversation. If the current session is running, the task follows its normal steering behavior. Worktree creation requires a usable Git checkout; a failed start displays an error and keeps the suggestion available to retry.
+
+The primary action and the Gateway-backed TUI send `taskSuggestions.accept` with `mode: "local"`. The Control UI menu sends explicit `worktree` or `session` modes for those choices. RPC clients also retain `cloud` mode. Omitted mode still means `worktree` for callers that used the original worktree action; the Control UI and TUI never omit it.
 
 OpenClaw exposes these tools only to operator sessions with an actionable Gateway UI. Channel sessions and local/embedded TUI sessions do not receive them, because those surfaces have no portable typed task-action contract.
 

--- a/ui/src/e2e/chat-flow.task-suggestions.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.task-suggestions.e2e.test.ts
@@ -14,8 +14,15 @@ import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-su
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
-  it("starts a model-suggested follow-up in a new session before workspace decisions", async () => {
-    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
+  it.each([
+    { mode: "local", label: "Start in a new session" },
+    { mode: "worktree", label: "Start in a new worktree" },
+    { mode: "session", label: "Start in this session" },
+  ])("starts a suggested task with $mode placement", async ({ mode, label }) => {
+    const context = await suite.newBrowserContext({
+      ...createControlUiE2eContextOptions(),
+      colorScheme: mode === "worktree" ? "dark" : "light",
+    });
     const page = await context.newPage();
     const suggestion = {
       id: "task_123",
@@ -42,7 +49,7 @@ suite.define(() => {
         "taskSuggestions.list": { suggestions: [suggestion] },
         "taskSuggestions.accept": {
           taskId: "task_123",
-          key: "agent:main:dashboard:suggested",
+          key: mode === "session" ? "main" : "agent:main:dashboard:suggested",
         },
       },
     });
@@ -59,10 +66,24 @@ suite.define(() => {
       const startButton = page.getByRole("button", { name: "Start in a new session" });
       await startButton.waitFor({ state: "visible", timeout: 10_000 });
       const card = page.locator(`.task-suggestion[data-task-id="${suggestion.id}"]`);
-      expect(await card.locator("wa-dropdown").count()).toBe(0);
+      const options = card.getByRole("button", { name: "Choose where to start the task" });
+      expect(
+        await startButton.evaluate((element) => getComputedStyle(element).borderTopRightRadius),
+      ).toBe("0px");
+      expect(
+        await options.evaluate((element) => getComputedStyle(element).borderTopLeftRadius),
+      ).toBe("0px");
+      await options.click();
+      await card.getByRole("menuitem", { name: "Start in a new worktree" }).waitFor();
+      expect(await gateway.getRequests("taskSuggestions.accept")).toHaveLength(0);
+      await captureUiProof(suite, page, "task-suggestions", `${mode}-menu.png`);
+      await page.keyboard.press("Escape");
+      await expect
+        .poll(() => options.evaluate((element) => element === document.activeElement))
+        .toBe(true);
       expect(await card.getByRole("button", { name: "Copy prompt" }).isEnabled()).toBe(true);
       expect(await gateway.getRequests("environments.list")).toHaveLength(0);
-      await captureUiProof(suite, page, "task-suggestions", "session-first.png");
+      await captureUiProof(suite, page, "task-suggestions", `${mode}-split-button.png`);
       await page.getByText("Show instructions", { exact: true }).click();
       await page
         .getByText("/projects/example", { exact: true })
@@ -72,13 +93,34 @@ suite.define(() => {
           exact: true,
         })
         .waitFor({ state: "visible", timeout: 10_000 });
-      await startButton.click();
+      const sourceUrl = page.url();
+      await gateway.deferNext("taskSuggestions.accept");
+      if (mode === "local") {
+        await startButton.click();
+      } else {
+        await options.click();
+        await card.getByRole("menuitem", { name: label, exact: true }).click();
+      }
+      await gateway.waitForRequest("taskSuggestions.accept");
+      expect(await card.getByRole("button", { name: "Starting…", exact: true }).isDisabled()).toBe(
+        true,
+      );
+      expect(await options.isDisabled()).toBe(true);
+      await gateway.resolveDeferred("taskSuggestions.accept", {
+        taskId: suggestion.id,
+        key: mode === "session" ? "main" : "agent:main:dashboard:suggested",
+      });
 
       const acceptRequest = await gateway.waitForRequest("taskSuggestions.accept");
-      expect(acceptRequest.params).toEqual({ taskId: "task_123", mode: "local" });
-      await expect
-        .poll(() => new URL(page.url()).pathname)
-        .toBe(controlUiSessionPath("agent:main:dashboard:suggested"));
+      expect(acceptRequest.params).toEqual({ taskId: "task_123", mode });
+      if (mode === "session") {
+        await card.waitFor({ state: "hidden" });
+        expect(page.url()).toBe(sourceUrl);
+      } else {
+        await expect
+          .poll(() => new URL(page.url()).pathname)
+          .toBe(controlUiSessionPath("agent:main:dashboard:suggested"));
+      }
     } finally {
       await suite.closeBrowserContext(context);
     }
@@ -180,6 +222,9 @@ suite.define(() => {
       expect(await card.getByRole("button", { name: "Start in a new session" }).isDisabled()).toBe(
         true,
       );
+      expect(
+        await card.getByRole("button", { name: "Choose where to start the task" }).isDisabled(),
+      ).toBe(true);
       expect(await card.getByRole("button", { name: "Copy prompt" }).isEnabled()).toBe(true);
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4999,6 +4999,9 @@ export const en: TranslationMap & {
     taskSuggestions: {
       eyebrow: "Suggested task · in {repo}",
       startSession: "Start in a new session",
+      startOptions: "Choose where to start the task",
+      startWorktree: "Start in a new worktree",
+      startCurrentSession: "Start in this session",
       copyPrompt: "Copy prompt",
       copyPromptFailed: "Couldn't copy the prompt to the clipboard",
       promptCopied: "Copied",

--- a/ui/src/pages/chat/chat-pane-task-suggestions.ts
+++ b/ui/src/pages/chat/chat-pane-task-suggestions.ts
@@ -12,6 +12,7 @@ import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import { ChatPaneSharing } from "./chat-pane-sharing.ts";
 import { resolveChatAgentId } from "./chat-state-route.ts";
+import type { TaskSuggestionStartMode } from "./components/chat-task-suggestions.ts";
 
 export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
   protected taskSuggestions: TaskSuggestion[] = [];
@@ -120,8 +121,10 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
     void this.refreshTaskSuggestions();
   }
 
-  protected readonly acceptTaskSuggestion = (suggestion: TaskSuggestion): Promise<void> =>
-    this.resolveTaskSuggestion(suggestion, "accept");
+  protected readonly acceptTaskSuggestion = (
+    suggestion: TaskSuggestion,
+    mode: TaskSuggestionStartMode = "local",
+  ): Promise<void> => this.resolveTaskSuggestion(suggestion, "accept", mode);
 
   protected readonly dismissTaskSuggestion = (suggestion: TaskSuggestion): Promise<void> =>
     this.resolveTaskSuggestion(suggestion, "dismiss");
@@ -188,6 +191,7 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
   protected async resolveTaskSuggestion(
     suggestion: TaskSuggestion,
     action: "accept" | "dismiss",
+    mode: TaskSuggestionStartMode = "local",
   ): Promise<void> {
     const scope = this.captureConnectionScope();
     if (
@@ -211,7 +215,7 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
       if (action === "accept") {
         const result = await scope.client.request<TaskSuggestionsAcceptResult>(
           "taskSuggestions.accept",
-          { taskId: suggestion.id, mode: "local" },
+          { taskId: suggestion.id, mode },
         );
         acceptedKey = result.key;
       } else {
@@ -221,7 +225,7 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
         return;
       }
       this.setTaskSuggestions(this.taskSuggestions.filter((item) => item.id !== suggestion.id));
-      if (acceptedKey) {
+      if (acceptedKey && mode !== "session") {
         this.onPaneSessionChange?.(this.paneId, acceptedKey);
       }
     } catch (error) {

--- a/ui/src/pages/chat/chat-task-suggestions.test.ts
+++ b/ui/src/pages/chat/chat-task-suggestions.test.ts
@@ -42,13 +42,12 @@ function renderSuggestion(overrides: Partial<ChatTaskSuggestionTrayProps> = {}) 
 }
 
 describe("chat task suggestions", () => {
-  it("starts a new session without asking for an execution mode", () => {
+  it("starts a new session from the primary action", () => {
     const { container, onAccept, onDismiss } = renderSuggestion();
 
     expect(container.querySelector(".task-suggestion__start")?.textContent).toContain(
       "Start in a new session",
     );
-    expect(container.querySelector("wa-dropdown")).toBeNull();
 
     expect(container.querySelector(".task-suggestion__eyebrow")?.textContent).toContain(
       "Suggested task · in project",
@@ -71,7 +70,7 @@ describe("chat task suggestions", () => {
 
     container.querySelector<HTMLButtonElement>(".task-suggestion__start")?.click();
     container.querySelector<HTMLButtonElement>(".task-suggestion__dismiss")?.click();
-    expect(onAccept).toHaveBeenCalledWith(suggestion);
+    expect(onAccept).toHaveBeenCalledWith(suggestion, "local");
     expect(onDismiss).toHaveBeenCalledWith(suggestion);
   });
 

--- a/ui/src/pages/chat/components/chat-task-suggestions.ts
+++ b/ui/src/pages/chat/components/chat-task-suggestions.ts
@@ -2,10 +2,19 @@
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import { ref } from "lit/directives/ref.js";
-import type { TaskSuggestion } from "../../../../../packages/gateway-protocol/src/index.js";
+import type {
+  TaskSuggestion,
+  TaskSuggestionsAcceptParams,
+} from "../../../../../packages/gateway-protocol/src/index.js";
 import { icons } from "../../../components/icons.ts";
+import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 import { repoName } from "../../../lib/session-display.ts";
+
+export type TaskSuggestionStartMode = Extract<
+  TaskSuggestionsAcceptParams["mode"],
+  "local" | "worktree" | "session"
+>;
 
 export type ChatTaskSuggestionTrayProps = {
   taskSuggestions?: TaskSuggestion[];
@@ -18,7 +27,7 @@ export type ChatTaskSuggestionTrayProps = {
   onCopyTaskSuggestionPrompt?: (suggestion: TaskSuggestion) => void;
   canAcceptTaskSuggestions?: boolean;
   canDismissTaskSuggestions?: boolean;
-  onAcceptTaskSuggestion?: (suggestion: TaskSuggestion) => void;
+  onAcceptTaskSuggestion?: (suggestion: TaskSuggestion, mode: TaskSuggestionStartMode) => void;
   onDismissTaskSuggestion?: (suggestion: TaskSuggestion) => void;
 };
 
@@ -33,7 +42,7 @@ export function renderChatTaskSuggestionTray(props: ChatTaskSuggestionTrayProps)
     onCopyPrompt: (suggestion) => props.onCopyTaskSuggestionPrompt?.(suggestion),
     canAccept: props.canAcceptTaskSuggestions === true,
     canDismiss: props.canDismissTaskSuggestions === true,
-    onAccept: (suggestion) => props.onAcceptTaskSuggestion?.(suggestion),
+    onAccept: (suggestion, mode) => props.onAcceptTaskSuggestion?.(suggestion, mode),
     onDismiss: (suggestion) => props.onDismissTaskSuggestion?.(suggestion),
     onNavigate: (taskId, direction) => props.onNavigateTaskSuggestion?.(taskId, direction),
   });
@@ -58,7 +67,7 @@ function renderChatTaskSuggestions(props: {
   busyIds: ReadonlySet<string>;
   canAccept: boolean;
   canDismiss: boolean;
-  onAccept: (suggestion: TaskSuggestion) => void;
+  onAccept: (suggestion: TaskSuggestion, mode: TaskSuggestionStartMode) => void;
   onDismiss: (suggestion: TaskSuggestion) => void;
   onCopyPrompt: (suggestion: TaskSuggestion) => void;
   copiedIds: ReadonlySet<string>;
@@ -87,9 +96,9 @@ function renderChatTaskSuggestions(props: {
         const copyLabel = copied
           ? t("chat.taskSuggestions.promptCopied")
           : t("chat.taskSuggestions.copyPrompt");
-        const accept = () => {
+        const accept = (mode: TaskSuggestionStartMode) => {
           if (!busy && props.canAccept) {
-            props.onAccept(suggestion);
+            props.onAccept(suggestion, mode);
           }
         };
         const active = suggestion.id === activeId;
@@ -194,17 +203,47 @@ function renderChatTaskSuggestions(props: {
             </div>
             <div class="task-suggestion__actions">
               <button
-                class="btn task-suggestion__start"
+                class="btn task-suggestion__start task-suggestion__start--primary"
                 type="button"
                 ?disabled=${busy || !props.canAccept}
                 title=${props.canAccept ? "" : t("chat.taskSuggestions.adminRequired")}
-                @click=${accept}
+                @click=${() => accept("local")}
               >
                 ${icons.play}
                 ${
                   busy ? t("chat.taskSuggestions.starting") : t("chat.taskSuggestions.startSession")
                 }
               </button>
+              <wa-dropdown
+                placement="top-end"
+                ?disabled=${busy || !props.canAccept}
+                @wa-select=${(event: CustomEvent<{ item: { value: string } }>) => {
+                  const mode = event.detail.item.value;
+                  if (mode === "local" || mode === "worktree" || mode === "session") {
+                    accept(mode);
+                  }
+                }}
+              >
+                <button
+                  slot="trigger"
+                  class="btn task-suggestion__start task-suggestion__start--options"
+                  type="button"
+                  ?disabled=${busy || !props.canAccept}
+                  aria-label=${t("chat.taskSuggestions.startOptions")}
+                  title=${props.canAccept ? "" : t("chat.taskSuggestions.adminRequired")}
+                >
+                  ${icons.chevronDown}
+                </button>
+                <wa-dropdown-item value="local" ?disabled=${busy || !props.canAccept}>
+                  ${t("chat.taskSuggestions.startSession")}
+                </wa-dropdown-item>
+                <wa-dropdown-item value="worktree" ?disabled=${busy || !props.canAccept}>
+                  ${t("chat.taskSuggestions.startWorktree")}
+                </wa-dropdown-item>
+                <wa-dropdown-item value="session" ?disabled=${busy || !props.canAccept}>
+                  ${t("chat.taskSuggestions.startCurrentSession")}
+                </wa-dropdown-item>
+              </wa-dropdown>
             </div>
           </article>
         `;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1892,7 +1892,7 @@ openclaw-chat-video-player {
   justify-self: end;
 }
 
-.task-suggestion__start,
+.task-suggestion__actions .task-suggestion__start,
 :root[data-theme-mode="light"] .task-suggestion__start {
   display: inline-flex;
   align-items: center;
@@ -1900,7 +1900,7 @@ openclaw-chat-video-player {
   height: 34px;
   padding: 0 12px;
   border: 1px solid color-mix(in srgb, var(--text) 12%, transparent);
-  border-radius: 11px;
+  border-radius: var(--task-suggestion-start-radius, 11px);
   corner-shape: superellipse(1.5);
   background: var(--task-suggestion-action-bg);
   color: var(--task-suggestion-action-fg);
@@ -1908,6 +1908,16 @@ openclaw-chat-video-player {
   line-height: 1;
   white-space: nowrap;
   user-select: none;
+}
+
+.task-suggestion__start--primary {
+  --task-suggestion-start-radius: 11px 0 0 11px;
+}
+
+.task-suggestion__start--options {
+  --task-suggestion-start-radius: 0 11px 11px 0;
+
+  border-inline-start: 0;
 }
 
 .task-suggestion__start svg {


### PR DESCRIPTION
## What Problem This Solves

Suggested-task cards in the Control UI only offered **Start in a new session**. Users could not choose an isolated worktree or send the suggested task to the conversation they were already using.

## Why This Change Was Made

Replace the single launch button with a split button: keep a new local session as the primary action and expose all three choices through the arrow. Reuse the Gateway's existing `local`, `worktree`, and `session` acceptance modes. Starting in the current session uses its existing steering behavior and does not navigate away.

The split control uses the shared dropdown for keyboard interaction and keeps its inner corners joined in both light and dark themes. The managed-worktree documentation now describes the available choices.

## User Impact

Users can start a suggested task in a new session, in a new worktree, or in the current session. The default still works in plain folders; explicitly choosing a worktree requires a usable Git checkout. Both button segments are disabled while starting or when acceptance is unavailable, and failed requests retain the existing visible error and retry behavior.

## Evidence

All captures below use synthetic mocked-Gateway data.

| Before | After — light theme |
| --- | --- |
| ![Before: single new-session button](https://github.com/user-attachments/assets/9341582e-e1a4-401f-a64c-a92db6b14412) | ![After: split button with all three launch choices](https://github.com/user-attachments/assets/9f51712c-5c92-4942-a906-d8fe701d306d) |

<details>
<summary>After — dark theme</summary>

![After: joined split button and launch menu in dark theme](https://github.com/user-attachments/assets/ff7a77f1-3674-40ea-a49c-be7e8761b012)

</details>

- 11 focused UI tests passed: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-task-suggestions.test.ts ui/src/pages/chat/chat-pane-task-suggestions.test.ts`.
- 6 mocked-Gateway browser scenarios passed, covering all three explicit launch modes, current-session URL preservation, Escape focus return, busy and unavailable controls, session switching, and light/dark joined corners: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.task-suggestions.e2e.test.ts`.
- Changed-file checks passed, including core-test and UI typechecks, i18n validation, formatting, lint, and dead-export scans. The browser suite also built the production UI bundle.
- Independent final review found no actionable P0–P2 issues.

The browser scenarios verify the UI-to-Gateway requests; they do not create live worktrees or run a model task.
