### PR TITLE
fix(plugins): evaluate SDK runtime before plugin bundles can require it

### DIFF
--- a/docs/plugins/architecture-internals/load-pipeline.md
+++ b/docs/plugins/architecture-internals/load-pipeline.md
@@ -27,6 +27,11 @@ At startup, OpenClaw does roughly this:
 7. call native `register(api)` hooks and collect registrations into the plugin registry
 8. expose the registry to commands/runtime surfaces
 
+Native plugin imports evaluate each requested SDK entry synchronously before
+linking the plugin's asynchronous module graph. This lets CommonJS bundles
+`require()` the same SDK entry during concurrent channel startup without seeing
+an unfinished ESM module. Unused SDK entries remain unloaded.
+
 Safety gates run **before** runtime execution. Discovery blocks a candidate
 when:
 
@@ -202,8 +207,10 @@ reuse the same checked bytes rather than reopening a file at each stage.
 
 Actual code imports retain their boundary and file-identity checks before first
 execution. Consent checks use a fresh inspection after an awaited approval so
-changed artifacts cannot inherit approval for older capabilities. Failed module
-evaluation remains retryable; a successful import is shared across consumers.
+changed artifacts cannot inherit approval for older capabilities. The plugin
+cache releases failed loads, but Node retains failed native ESM evaluations for
+the process lifetime; restarting an account cannot repair that module graph.
+A successful import is shared across consumers.
 
 The CLI invocation owns one operation cache across config reads, output metadata,
 command ownership, nested registration, and actions. Standalone registration uses

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -2,7 +2,7 @@
  * Server channel lifecycle tests.
  */
 import fs from "node:fs";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
@@ -27,6 +27,7 @@ import {
   runtimeForLogger,
 } from "../logging/subsystem.js";
 import { registerPluginHttpRoute } from "../plugins/http-registry.js";
+import { createPluginModuleLoader } from "../plugins/loader-module-runtime.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "../plugins/registry.js";
 import {
   getActivePluginRegistry,
@@ -717,6 +718,113 @@ describe("server-channels auto restart", () => {
     // (e.g. a reconnect loop). The replacement must never overlap that lifetime.
     expect(signals[0]?.aborted).toBe(true);
     expect(signals[1]?.aborted).toBe(false);
+  });
+
+  it("binds and rebinds a channel port after concurrent native SDK imports", async () => {
+    const root = channelTempDirs.make("openclaw-channel-sdk-restart-");
+    const files = {
+      "package.json": JSON.stringify({
+        name: "openclaw",
+        type: "module",
+        bin: { openclaw: "./openclaw.mjs" },
+        exports: { "./plugin-sdk/used": "./dist/plugin-sdk/used.js" },
+      }),
+      "dist/plugin-sdk/leaf.js": 'export const value = "ready";',
+      "dist/plugin-sdk/used.js": 'export { value } from "./leaf.js";',
+      "dist/extensions/demo/esm-plugin.mjs": 'export { value } from "openclaw/plugin-sdk/used";',
+      "dist/extensions/demo/cjs-plugin.cjs":
+        'module.exports = require("openclaw/plugin-sdk/used");',
+      "dist/extensions/demo/index.cjs": `module.exports = { load: () => Promise.all([
+        import("./esm-plugin.mjs"), import("./cjs-plugin.cjs")
+      ]).then(([esm, cjs]) => esm.value + ":" + cjs.default.value) };`,
+    };
+    for (const [relative, contents] of Object.entries(files)) {
+      const target = path.join(root, relative);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, contents);
+    }
+    fs.mkdirSync(path.join(root, "extensions"));
+    const load = createPluginModuleLoader({ devSourceRoot: root });
+    const plugin = load(path.join(root, "dist/extensions/demo/index.cjs")) as {
+      load: () => Promise<string>;
+    };
+    const firstStarted = createDeferred<Server>();
+    const secondStarted = createDeferred<Server>();
+    const crash = createDeferred();
+    const closed = createDeferred();
+    let generation = 0;
+    let port = 0;
+    installTestRegistry(
+      createTestPlugin({
+        startAccount: async ({ abortSignal }) => {
+          const current = generation++;
+          const ready = current === 0 ? firstStarted : secondStarted;
+          let server: Server | undefined;
+          try {
+            const value = await plugin.load();
+            server = createServer((_req, res) => res.end(`${value}:${current + 1}`));
+            const listener = server;
+            await new Promise<void>((resolve, reject) => {
+              listener.once("error", reject);
+              listener.listen(port, "127.0.0.1", resolve);
+            });
+            const address = listener.address();
+            if (!address || typeof address === "string") {
+              throw new Error("expected channel TCP listener");
+            }
+            port = address.port;
+            ready.resolve(listener);
+            await new Promise<void>((resolve, reject) => {
+              abortSignal.addEventListener("abort", () => resolve(), { once: true });
+              if (current === 0) {
+                void crash.promise.then(() => reject(new Error("channel worker crashed")));
+              }
+            });
+          } catch (error) {
+            // Surface native import failures directly instead of waiting for a port timeout.
+            ready.reject(error);
+            throw error;
+          } finally {
+            const listener = server;
+            if (listener) {
+              await new Promise<void>((resolve) => {
+                listener.close(() => resolve());
+              });
+            }
+            if (current === 0) {
+              closed.resolve();
+            }
+          }
+        },
+      }),
+    );
+    const manager = createManager();
+    const read = async () => {
+      const response = await fetch(`http://127.0.0.1:${port}`, {
+        headers: { Connection: "close" },
+      });
+      return response.text();
+    };
+    try {
+      await manager.startChannels();
+      const first = await firstStarted.promise;
+      const firstPort = port;
+      expect(await read()).toBe("ready:ready:1");
+      crash.resolve();
+      await closed.promise;
+      expect(first.listening).toBe(false);
+      await waitForMicrotaskCondition(
+        () => manager.isAutoRestartScheduled("discord", DEFAULT_ACCOUNT_ID),
+        "expected automatic channel restart after worker crash",
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      const second = await secondStarted.promise;
+      expect(second).not.toBe(first);
+      expect(port).toBe(firstPort);
+      expect(await read()).toBe("ready:ready:2");
+    } finally {
+      await manager.stopChannel("discord");
+    }
   });
 
   it.each(["resolve", "reject"] as const)(

--- a/src/plugins/loader.lazy-alias.test.ts
+++ b/src/plugins/loader.lazy-alias.test.ts
@@ -134,6 +134,26 @@ describe("native plugin alias preparation", () => {
     },
   );
 
+  it("evaluates shared SDK imports before concurrent lazy CJS plugins require them", async () => {
+    const f = fixture();
+    writeFile(f.root, "dist/plugin-sdk/leaf.js", 'export const value = "dist";');
+    writeFile(f.root, "dist/plugin-sdk/used.js", 'export { value } from "./leaf.js";');
+    const pluginDir = path.dirname(f.entry);
+    writeFile(pluginDir, "esm-plugin.mjs", 'export { value } from "openclaw/plugin-sdk/used";');
+    writeFile(pluginDir, "cjs-plugin.cjs", 'module.exports = require("openclaw/plugin-sdk/used");');
+    const entry = writeFile(
+      pluginDir,
+      "index.cjs",
+      `module.exports = { start: () => Promise.all([
+        import("./esm-plugin.mjs"), import("./cjs-plugin.cjs")
+      ]).then(modules => modules.map(module => module.value ?? module.default.value)) };`,
+    );
+    const load = createPluginModuleLoader({ devSourceRoot: f.root });
+    const plugin = load(entry) as { start: () => Promise<string[]> };
+    await expect(plugin.start()).resolves.toEqual(["dist", "dist"]);
+    await expect(plugin.start()).resolves.toEqual(["dist", "dist"]);
+  });
+
   it.each([
     { specifier: "@openclaw/retry", target: "dist/retry/index.js" },
     {

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -27,7 +27,7 @@ type ModuleWithResolver = typeof Module & {
   registerHooks?: (options: {
     resolve?: (
       specifier: string,
-      context: { parentURL?: string | undefined },
+      context: { parentURL?: string | undefined; conditions: readonly string[] },
       nextResolve: (
         specifier: string,
         context?: { parentURL?: string | undefined },
@@ -363,6 +363,11 @@ function installResolver(): void {
     resolve(specifier, context, nextResolve) {
       const aliasTarget = resolveAliasTargetForParentUrl(specifier, context.parentURL);
       if (aliasTarget) {
+        if (isPluginSdkAliasSpecifier(specifier) && context.conditions.includes("import")) {
+          // Finish the SDK graph before async linking caches an uninstantiated job
+          // that a concurrently activated CJS plugin cannot require.
+          Module.createRequire(import.meta.url)(aliasTarget);
+        }
         return {
           shortCircuit: true,
           url: pathToFileURL(aliasTarget).href,


### PR DESCRIPTION
Refs #144966

## What Problem This Solves

Fixes an issue where users starting mixed CommonJS and ESM channel plugins could lose channel startup when a CommonJS bundle required an SDK entry whose asynchronous import had not finished linking. A failed native module evaluation can also remain cached across account restarts.

## Why This Change Was Made

The native SDK resolver now synchronously evaluates each requested SDK graph before returning its URL to an asynchronous plugin import. Both plugin formats then consume the same evaluated Node module. SDK discovery remains lazy and plugin startup remains concurrent.

Node 24.19 throws the reported `ERR_REQUIRE_ESM_RACE_CONDITION` for a cached, uninstantiated module job; top-level await and evaluating cycles have different errors ([Node source](https://github.com/nodejs/node/blob/v24.19.0/lib/internal/modules/esm/loader.js#L282-L330)).

The channel supervisor, Teams account starter, and Teams listener owner are byte-identical between v2026.9.2 and v2026.9.3. This change leaves those owners intact and verifies their existing restart flow through a real TCP listener.

## User Impact

Channels can start while another plugin imports the same SDK entry. Teams starts its webhook listener without the require(ESM) error, and the supervisor can rebind the same port after an unexpected listener exit.

## Evidence

- Both new regressions fail on the original resolver with `ERR_REQUIRE_ESM_RACE_CONDITION`, then pass with this change. The supervisor regression verifies an HTTP response, a worker rejection, completed listener close, and a second HTTP response on the same port.
- `node scripts/run-vitest.mjs src/plugins/loader.lazy-alias.test.ts src/plugins/plugin-sdk-native-resolver.test.ts src/plugins/loader.native-module-loader.test.ts src/gateway/server-channels.test.ts src/plugin-sdk/channel-lifecycle.test.ts extensions/msteams/src/monitor.lifecycle.test.ts`: 227 tests passed across the focused runs, including all 153 supervisor tests after the final regression change.
- `pnpm build` passed; no `INEFFECTIVE_DYNAMIC_IMPORT` warnings.
- `node scripts/check-changed.mjs` passed, including core/test typechecks, lint, dependency guards, and runtime cycle checks.
- The isolated Teams entrypoint profile passed at approximately 90 MB peak RSS.
- Node 24.19 Docker proof used the real six-plugin set from the report, `@openclaw/msteams@2026.9.2`, and `@openclaw/discord@2026.9.3`, installed through the official CLI with synthetic credentials. Released OpenClaw 2026.9.3 reproduced the require(ESM) error immediately after HTTP startup, targeting `approval-gateway-runtime.js` in this run. The fixed source build and its built workspace packages started cleanly. Closing the real Teams listener produced an automatic restart after five seconds and a successful TCP connection to port 3978 again. An in-process Gateway restart also rebound the listener.

Known gaps: the released-package reproduction recovered on its first retry, so the reporter's permanent 2026.9.3 outage and exact `collection-runtime.js` target remain unconfirmed. The fixed Docker proof uses build artifacts with the released image's third-party dependencies; it is a startup/listener proof, not full package acceptance or authenticated Teams messaging. Synthetic Discord credentials produced expected authentication failures. Registry installation initially hit an idle timeout; the unchanged installation command succeeded on one cache-backed retry.

Thanks to @MeAjuda365 (Tomas Aiza) for the report and repeated deployment evidence.

## ClawSweeper review

No code findings on this head. The maintainer accepts the demonstrated startup race fix and listener recovery; reproducing the permanent 2026.9.3 outage, the exact failing SDK target, authenticated Teams messaging, and full package acceptance is deferred. The released 2026.9.3 Docker run self-healed, and the channel/supervisor owners are unchanged between 9.2 and 9.3. Issue #144966 stays open for the unresolved permanent-outage report.
