### PR TITLE
refactor(sqlite): support existing-only worker acquisition

### DIFF
--- a/docs/plugins/sdk-overview/infrastructure.md
+++ b/docs/plugins/sdk-overview/infrastructure.md
@@ -96,6 +96,24 @@ Declare private build entries with
 [`openclaw.build.workerEntries`](/plugins/dependency-resolution#native-imports-from-a-standalone-source-build)
 and derive their locations from the loader's `api.runtimeSource` fact.
 
+Pass `existingOnly: true` when acquisition must preserve a missing database.
+The call returns `undefined` without starting a worker or invoking a factory
+when the file is absent and no active actor retains that path. A cold existing
+open requires the module's explicit
+`openExistingSqliteWorkerBackend(input, { databasePath })` export. The host
+never substitutes the ordinary creation factory. The existing factory must
+use SQLite's native read-only or existing-file opening mode and validate the
+current schema without creating or migrating it. A filesystem existence check
+followed by ordinary create-if-missing opening does not satisfy this contract.
+
+The host checks physical identity before dispatching the existing factory and
+again before returning the store. Disappearance or replacement after admission
+rejects acquisition. Existing-only and ordinary clients share the same physical
+actor when their module and initialization input match; changing open intent
+does not rerun a factory or create another connection. Domain commands still
+own write permission and any later schema initialization. Existing-only
+acquisition provides no read-only capability for subsequent commands.
+
 Abort signals remove operations that are still queued. Once dispatched, an
 operation retains its result or failure; cancellation does not prove rollback.
 `close()` rejects new work and drains that client's accepted operations. The

--- a/src/infra/sqlite-store.worker.ts
+++ b/src/infra/sqlite-store.worker.ts
@@ -9,6 +9,7 @@ import {
   type SqliteWorkerReply,
   type SqliteWorkerRequest,
 } from "./sqlite-worker-contract.js";
+import { assertExistingDatabaseIdentity } from "./sqlite-worker-identity.js";
 
 const port = parentPort;
 if (!port) {
@@ -27,6 +28,9 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
       if (actors.has(request.actor)) {
         throw new Error("SQLite worker actor is already open");
       }
+      if (request.existingIdentity) {
+        assertExistingDatabaseIdentity(request.databasePath, request.existingIdentity);
+      }
       if (!sourceLoaderRegistered && request.sourceLoaderUrl) {
         const loader: unknown = await import(request.sourceLoaderUrl);
         if (!isRecord(loader) || typeof loader.register !== "function") {
@@ -36,10 +40,17 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
         sourceLoaderRegistered = true;
       }
       const module: unknown = await import(request.moduleUrl);
-      if (!isRecord(module) || typeof module.createSqliteWorkerBackend !== "function") {
-        throw new Error("SQLite worker module must export createSqliteWorkerBackend");
+      const factoryName = request.existingIdentity
+        ? "openExistingSqliteWorkerBackend"
+        : "createSqliteWorkerBackend";
+      if (!isRecord(module) || typeof module[factoryName] !== "function") {
+        throw new Error(`SQLite worker module must export ${factoryName}`);
       }
-      const backend: unknown = await module.createSqliteWorkerBackend(deserialize(request.input), {
+      // Module loading can yield before the factory opens native state.
+      if (request.existingIdentity) {
+        assertExistingDatabaseIdentity(request.databasePath, request.existingIdentity);
+      }
+      const backend: unknown = await module[factoryName](deserialize(request.input), {
         databasePath: request.databasePath,
       });
       if (

--- a/src/infra/sqlite-worker-contract.ts
+++ b/src/infra/sqlite-worker-contract.ts
@@ -25,6 +25,7 @@ export type SqliteWorkerRequest = {
       moduleUrl: string;
       sourceLoaderUrl?: string;
       databasePath: string;
+      existingIdentity?: string;
       input: Uint8Array;
     }
   | { type: "execute"; input: Uint8Array }

--- a/src/infra/sqlite-worker-identity.ts
+++ b/src/infra/sqlite-worker-identity.ts
@@ -1,0 +1,53 @@
+import { statSync } from "node:fs";
+import { realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import { hasErrnoCode } from "./errno.js";
+
+export async function readDatabasePathIdentity(databasePath: string): Promise<{
+  key: string;
+  canonicalPath: string;
+}> {
+  const file = await stat(databasePath, { bigint: true }).catch((error: unknown) => {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return undefined;
+    }
+    throw error;
+  });
+  if (file) {
+    if (!file.isFile()) {
+      throw new Error("SQLite worker database path must identify a regular file");
+    }
+    const canonicalPath = await realpath(databasePath);
+    const canonicalFile = await stat(canonicalPath, { bigint: true });
+    if (file.dev !== canonicalFile.dev || file.ino !== canonicalFile.ino) {
+      throw new Error("SQLite database pathname changed during admission");
+    }
+    return { key: `file:${file.dev}:${file.ino}`, canonicalPath };
+  }
+  // Resolve the existing ancestor before a first open so directory aliases share admission.
+  const missing: string[] = [];
+  let ancestor = databasePath;
+  while (true) {
+    try {
+      const canonicalPath = path.join(await realpath(ancestor), ...missing);
+      return { key: `path:${canonicalPath}`, canonicalPath };
+    } catch (error) {
+      if (!hasErrnoCode(error, "ENOENT")) {
+        throw error;
+      }
+      missing.unshift(path.basename(ancestor));
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) {
+        throw error;
+      }
+      ancestor = parent;
+    }
+  }
+}
+
+export function assertExistingDatabaseIdentity(databasePath: string, expected: string): void {
+  const file = statSync(databasePath, { bigint: true });
+  if (!file.isFile() || `file:${file.dev}:${file.ino}` !== expected) {
+    throw new Error("SQLite database file identity changed before existing-only open");
+  }
+}

--- a/src/infra/sqlite-worker-store.existing.test.ts
+++ b/src/infra/sqlite-worker-store.existing.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { copyFileSync, renameSync, unlinkSync } from "node:fs";
+import { link, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { SqliteWorkerRequest } from "./sqlite-worker-contract.js";
+import { openSqliteWorkerStore, type SqliteWorkerStore } from "./sqlite-worker-store.js";
+import type { FixtureOpenInput, FixtureOperations } from "./sqlite-worker-store.test-support.js";
+
+const stores = new Set<SqliteWorkerStore<FixtureOperations>>();
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    try {
+      await Promise.all([...stores].map((store) => store.close()));
+    } finally {
+      stores.clear();
+      cleanup();
+    }
+  }),
+);
+
+function databasePath(): string {
+  return path.join(tempDirs.make("openclaw-sqlite-worker-existing-"), "store.sqlite");
+}
+
+async function open(file: string, existingOnly = false, input?: FixtureOpenInput) {
+  const store = await openSqliteWorkerStore<FixtureOperations>({
+    moduleUrl: new URL("./sqlite-worker-store.test-support.ts", import.meta.url),
+    databasePath: file,
+    input,
+    existingOnly,
+  });
+  if (store) {
+    stores.add(store);
+  }
+  return store;
+}
+
+async function seed(file: string, value: string): Promise<void> {
+  const store = await open(file);
+  assert.ok(store);
+  await store.execute({ type: "append", input: { value } });
+  await store.close();
+}
+
+describe("existing-only SQLite worker admission", () => {
+  it("returns missing without worker dispatch, filesystem creation, or retained client capacity", async () => {
+    const file = databasePath();
+    const requests = vi.spyOn(Worker.prototype, "postMessage");
+    try {
+      for (let index = 0; index < 80; index += 1) {
+        expect(await open(file, true)).toBeUndefined();
+      }
+      expect(requests).not.toHaveBeenCalled();
+      expect(await readdir(path.dirname(file))).toEqual([]);
+    } finally {
+      requests.mockRestore();
+    }
+    await seed(file, "ordinary creation remains available");
+  });
+
+  it("does not initialize an existing empty file", async () => {
+    const file = databasePath();
+    await writeFile(file, "");
+    const store = await open(file, true);
+    assert.ok(store);
+    await store.close();
+    expect(await readFile(file)).toEqual(Buffer.alloc(0));
+  });
+
+  it("requires explicit backend support instead of invoking the ordinary factory", async () => {
+    const file = databasePath();
+    await writeFile(file, "");
+    const modulePath = path.join(path.dirname(file), "ordinary-only.mjs");
+    await writeFile(
+      modulePath,
+      'export function createSqliteWorkerBackend() { throw new Error("ordinary factory ran"); }\n',
+    );
+    await expect(
+      openSqliteWorkerStore({
+        moduleUrl: pathToFileURL(modulePath),
+        databasePath: file,
+        input: undefined,
+        existingOnly: true,
+      }),
+    ).rejects.toThrow("must export openExistingSqliteWorkerBackend");
+    expect(await readFile(file)).toEqual(Buffer.alloc(0));
+  });
+
+  it("shares ordinary write intent with an existing actor across aliases and drains accepted work", async () => {
+    const file = databasePath();
+    await seed(file, "seed");
+    const existing = await open(file, true);
+    assert.ok(existing);
+    const alias = path.join(path.dirname(file), "alias.sqlite");
+    await link(file, alias);
+    const ordinary = await open(alias);
+    assert.ok(ordinary);
+    let settled = false;
+    const pending = ordinary
+      .execute({ type: "append", input: { value: "ordinary" } })
+      .then((receipt) => {
+        settled = true;
+        return receipt;
+      });
+    await ordinary.close();
+    expect(settled).toBe(true);
+    const first = await pending;
+    const second = await existing.execute({ type: "append", input: { value: "existing" } });
+    expect(second).toEqual({ ...first, writes: 2 });
+    expect(first.threadId).toBeGreaterThan(0);
+    expect(await existing.execute({ type: "read", input: undefined })).toEqual([
+      "seed",
+      "ordinary",
+      "existing",
+    ]);
+  });
+
+  it.each(["deleted", "replaced"] as const)(
+    "rejects a file %s after parent admission before dispatching its factory",
+    async (kind) => {
+      const file = databasePath();
+      const replacement = path.join(path.dirname(file), "replacement.sqlite");
+      const displaced = path.join(path.dirname(file), "displaced.sqlite");
+      const markerPath = path.join(path.dirname(file), "factory-called");
+      await seed(file, "original");
+      await seed(replacement, "replacement");
+      const replacementBytes = await readFile(replacement);
+      const messages = vi.spyOn(Worker.prototype, "postMessage").mockImplementationOnce(function (
+        this: Worker,
+        request: SqliteWorkerRequest,
+        transferList,
+      ) {
+        messages.mockRestore();
+        expect(request).toMatchObject({ type: "open", databasePath: file });
+        expect("existingIdentity" in request && request.existingIdentity).toMatch(/^file:/);
+        if (kind === "deleted") {
+          unlinkSync(file);
+        } else {
+          renameSync(file, displaced);
+          copyFileSync(replacement, file);
+        }
+        return this.postMessage(request, transferList);
+      });
+      try {
+        await expect(open(file, true, { type: "observe", markerPath })).rejects.toThrow();
+      } finally {
+        messages.mockRestore();
+      }
+      await expect(readFile(markerPath)).rejects.toMatchObject({ code: "ENOENT" });
+      if (kind === "deleted") {
+        await expect(readFile(file)).rejects.toMatchObject({ code: "ENOENT" });
+      } else {
+        expect(await readFile(file)).toEqual(replacementBytes);
+      }
+      const recovered = await open(replacement, true);
+      assert.ok(recovered);
+      expect(await recovered.execute({ type: "read", input: undefined })).toEqual(["replacement"]);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "retains a vanished alias until its admitted client closes",
+    async () => {
+      const file = databasePath();
+      await seed(file, "original");
+      const original = await open(file, true);
+      assert.ok(original);
+      const alias = path.join(path.dirname(file), "alias.sqlite");
+      await link(file, alias);
+      const aliasClient = await open(alias, true);
+      assert.ok(aliasClient);
+      unlinkSync(alias);
+      await expect(open(alias, true)).rejects.toThrow("pathname changed");
+      await aliasClient.close();
+      expect(await open(alias, true)).toBeUndefined();
+      expect(await original.execute({ type: "read", input: undefined })).toEqual(["original"]);
+    },
+  );
+
+  it("rechecks file identity after loading the existing backend module", async () => {
+    const file = databasePath();
+    const displaced = path.join(path.dirname(file), "displaced.sqlite");
+    const marker = path.join(path.dirname(file), "factory-called");
+    await seed(file, "original");
+    const modulePath = path.join(path.dirname(file), "delayed-entry.mjs");
+    await writeFile(
+      modulePath,
+      `
+      import { renameSync, writeFileSync } from "node:fs";
+      renameSync(${JSON.stringify(file)}, ${JSON.stringify(displaced)});
+      writeFileSync(${JSON.stringify(file)}, "");
+      export function openExistingSqliteWorkerBackend() {
+        writeFileSync(${JSON.stringify(marker)}, "factory called");
+        throw new Error("existing factory ran");
+      }
+    `,
+    );
+    await expect(
+      openSqliteWorkerStore({
+        moduleUrl: pathToFileURL(modulePath),
+        databasePath: file,
+        input: undefined,
+        existingOnly: true,
+      }),
+    ).rejects.toThrow("identity changed");
+    await expect(readFile(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(file)).toEqual(Buffer.alloc(0));
+    const original = await open(displaced, true);
+    assert.ok(original);
+    expect(await original.execute({ type: "read", input: undefined })).toEqual(["original"]);
+  });
+
+  it.each([false, true])(
+    "preserves native no-create and no-migration after a factory race (replacement: %s)",
+    async (replace) => {
+      const file = databasePath();
+      const backupPath = path.join(path.dirname(file), "backup.sqlite");
+      const replacementPath = path.join(path.dirname(file), "replacement.sqlite");
+      await seed(file, "original");
+      await seed(replacementPath, "replacement");
+      const replacementBytes = await readFile(replacementPath);
+      await expect(
+        open(file, true, {
+          type: "replace",
+          backupPath,
+          ...(replace ? { replacementPath } : {}),
+        }),
+      ).rejects.toThrow();
+      if (replace) {
+        expect(await readFile(file)).toEqual(replacementBytes);
+      } else {
+        await expect(readFile(file)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      const original = await open(backupPath, true);
+      assert.ok(original);
+      expect(await original.execute({ type: "read", input: undefined })).toEqual(["original"]);
+    },
+  );
+});

--- a/src/infra/sqlite-worker-store.test-support.ts
+++ b/src/infra/sqlite-worker-store.test-support.ts
@@ -5,7 +5,7 @@ import { parentPort, threadId } from "node:worker_threads";
 import type { Generated } from "kysely";
 import { clearNodeSqliteKyselyCacheForDatabase } from "./kysely-sync-cache-state.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
-import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { openNodeSqliteDatabase, resolveExistingSqliteFileUri } from "./node-sqlite.js";
 import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
 import type { SqliteWorkerBackend } from "./sqlite-worker-contract.js";
 
@@ -22,7 +22,8 @@ if (parentPort) {
 
 export type FixtureOpenInput =
   | { type: "link"; existingPath: string }
-  | { type: "replace"; backupPath: string };
+  | { type: "observe"; markerPath: string }
+  | { type: "replace"; backupPath: string; replacementPath?: string };
 
 type Receipt = { actor: string; writes: number; threadId: number };
 export type FixtureOperations = {
@@ -56,15 +57,39 @@ function waitForFile(file: string): Promise<void> {
 
 export function createSqliteWorkerBackend(
   input: FixtureOpenInput | undefined,
-  { databasePath }: { databasePath: string },
+  context: { databasePath: string },
+): SqliteWorkerBackend<FixtureOperations> {
+  return createFixtureBackend(input, context.databasePath, false);
+}
+
+export function openExistingSqliteWorkerBackend(
+  input: FixtureOpenInput | undefined,
+  context: { databasePath: string },
+): SqliteWorkerBackend<FixtureOperations> {
+  return createFixtureBackend(input, context.databasePath, true);
+}
+
+function createFixtureBackend(
+  input: FixtureOpenInput | undefined,
+  databasePath: string,
+  existingOnly: boolean,
 ): SqliteWorkerBackend<FixtureOperations> {
   if (input?.type === "link") {
     linkSync(input.existingPath, databasePath);
+  } else if (input?.type === "observe") {
+    writeFileSync(input.markerPath, "factory called");
   } else if (input?.type === "replace") {
     renameSync(databasePath, input.backupPath);
+    if (input.replacementPath) {
+      renameSync(input.replacementPath, databasePath);
+    }
   }
-  const db = openNodeSqliteDatabase(databasePath);
-  db.exec("CREATE TABLE IF NOT EXISTS entries (id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+  const db = openNodeSqliteDatabase(
+    existingOnly ? resolveExistingSqliteFileUri(databasePath) : databasePath,
+  );
+  if (!existingOnly) {
+    db.exec("CREATE TABLE IF NOT EXISTS entries (id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+  }
   const query = getNodeSqliteKysely<{ entries: { id: Generated<number>; value: string } }>(db);
   const actor = randomUUID();
   let writes = 0;

--- a/src/infra/sqlite-worker-store.ts
+++ b/src/infra/sqlite-worker-store.ts
@@ -10,7 +10,6 @@ import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { INCOGNITO_AGENT_SQLITE_BASENAME } from "../state/openclaw-agent-db.paths.js";
 import { ensureSqliteLibrarySelected } from "./bun-sqlite-library.js";
-import { hasErrnoCode } from "./errno.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import {
@@ -20,6 +19,7 @@ import {
   type SqliteWorkerRequest,
   type SqliteWorkerStore,
 } from "./sqlite-worker-contract.js";
+import { readDatabasePathIdentity } from "./sqlite-worker-identity.js";
 
 export type {
   SqliteWorkerBackend,
@@ -33,6 +33,13 @@ const MAX_STORES = 64;
 const MAX_REQUESTS = 128;
 const MAX_QUEUED_BYTES = 64 * 1024 * 1024;
 const runOutsideCaller = AsyncLocalStorage.snapshot();
+
+type SqliteWorkerStoreOptions = {
+  moduleUrl: URL;
+  databasePath: string;
+  input: unknown;
+  existingOnly?: boolean;
+};
 
 type RequestBody = SqliteWorkerRequest extends infer Request
   ? Request extends SqliteWorkerRequest
@@ -82,48 +89,6 @@ export class SqliteWorkerError extends Error {
   }
 }
 
-async function readDatabasePathIdentity(databasePath: string): Promise<{
-  key: string;
-  canonicalPath: string;
-}> {
-  const file = await stat(databasePath, { bigint: true }).catch((error: unknown) => {
-    if (hasErrnoCode(error, "ENOENT")) {
-      return undefined;
-    }
-    throw error;
-  });
-  if (file) {
-    if (!file.isFile()) {
-      throw new Error("SQLite worker database path must identify a regular file");
-    }
-    const canonicalPath = await realpath(databasePath);
-    const canonicalFile = await stat(canonicalPath, { bigint: true });
-    if (file.dev !== canonicalFile.dev || file.ino !== canonicalFile.ino) {
-      throw new Error("SQLite database pathname changed during admission");
-    }
-    return { key: `file:${file.dev}:${file.ino}`, canonicalPath };
-  }
-  // Resolve the existing ancestor before a first open so directory aliases share admission.
-  const missing: string[] = [];
-  let ancestor = databasePath;
-  while (true) {
-    try {
-      const canonicalPath = path.join(await realpath(ancestor), ...missing);
-      return { key: `path:${canonicalPath}`, canonicalPath };
-    } catch (error) {
-      if (!hasErrnoCode(error, "ENOENT")) {
-        throw error;
-      }
-      missing.unshift(path.basename(ancestor));
-      const parent = path.dirname(ancestor);
-      if (parent === ancestor) {
-        throw error;
-      }
-      ancestor = parent;
-    }
-  }
-}
-
 class SqliteWorkerBroker {
   private readonly actors = new Map<string, Actor>();
   private readonly slots = new Set<Slot>();
@@ -136,11 +101,9 @@ class SqliteWorkerBroker {
   private admissionTail: Promise<void> = Promise.resolve();
   private draining?: Promise<void>;
 
-  open<Operations extends SqliteWorkerOperations>(options: {
-    moduleUrl: URL;
-    databasePath: string;
-    input: unknown;
-  }): Promise<SqliteWorkerStore<Operations>> {
+  open<Operations extends SqliteWorkerOperations>(
+    options: SqliteWorkerStoreOptions,
+  ): Promise<SqliteWorkerStore<Operations> | undefined> {
     const basename = path.basename(options.databasePath);
     if (
       !options.databasePath ||
@@ -164,12 +127,18 @@ class SqliteWorkerBroker {
     }
     const client = {};
     this.clients.add(client);
-    let snapshot: { moduleUrl: URL; databasePath: string; input: Buffer };
+    let snapshot: {
+      moduleUrl: URL;
+      databasePath: string;
+      input: Buffer;
+      existingOnly: boolean;
+    };
     try {
       snapshot = {
         moduleUrl: new URL(options.moduleUrl),
         databasePath: path.resolve(options.databasePath),
         input: serialize(options.input),
+        existingOnly: options.existingOnly === true,
       };
     } catch (error) {
       this.clients.delete(client);
@@ -207,9 +176,10 @@ class SqliteWorkerBroker {
       moduleUrl: URL;
       databasePath: string;
       input: Buffer;
+      existingOnly: boolean;
     },
     client: object,
-  ): Promise<SqliteWorkerStore<Operations>> {
+  ): Promise<SqliteWorkerStore<Operations> | undefined> {
     if (
       options.moduleUrl.protocol !== "file:" ||
       options.moduleUrl.search ||
@@ -220,16 +190,9 @@ class SqliteWorkerBroker {
     const databasePath = path.resolve(options.databasePath);
     const input = options.input;
     const inputHash = createHash("sha256").update(input).digest("hex");
-    const [identity, modulePath] = await Promise.all([
-      readDatabasePathIdentity(databasePath),
-      realpath(fileURLToPath(options.moduleUrl)),
-    ]);
+    const identity = await readDatabasePathIdentity(databasePath);
     const { key, canonicalPath } = identity;
     const admittedPaths = new Set([databasePath, canonicalPath]);
-    const moduleUrl = pathToFileURL(modulePath).href;
-    if (!/\.[cm]?[jt]s$/.test(modulePath) || !(await stat(modulePath)).isFile()) {
-      throw new Error("SQLite worker backend must identify a JavaScript or TypeScript file");
-    }
     if (
       [...this.actors.values()].some(
         (entry) =>
@@ -240,6 +203,15 @@ class SqliteWorkerBroker {
       throw new Error(
         "SQLite database pathname changed while its worker owner is active; close the existing store first",
       );
+    }
+    if (options.existingOnly && !key.startsWith("file:")) {
+      this.clients.delete(client);
+      return undefined;
+    }
+    const modulePath = await realpath(fileURLToPath(options.moduleUrl));
+    const moduleUrl = pathToFileURL(modulePath).href;
+    if (!/\.[cm]?[jt]s$/.test(modulePath) || !(await stat(modulePath)).isFile()) {
+      throw new Error("SQLite worker backend must identify a JavaScript or TypeScript file");
     }
     let actor = this.actors.get(key);
     if (actor?.closing) {
@@ -280,6 +252,7 @@ class SqliteWorkerBroker {
           actor: actor.id,
           moduleUrl,
           databasePath,
+          ...(options.existingOnly ? { existingIdentity: key } : {}),
           input,
           ...(/\.[cm]?ts$/.test(modulePath)
             ? { sourceLoaderUrl: import.meta.resolve("tsx/esm/api") }
@@ -672,11 +645,18 @@ class SqliteWorkerBroker {
   }
 }
 
-export function openSqliteWorkerStore<Operations extends SqliteWorkerOperations>(options: {
-  moduleUrl: URL;
-  databasePath: string;
-  input: unknown;
-}): Promise<SqliteWorkerStore<Operations>> {
+export function openSqliteWorkerStore<Operations extends SqliteWorkerOperations>(
+  options: SqliteWorkerStoreOptions & { existingOnly: true },
+): Promise<SqliteWorkerStore<Operations> | undefined>;
+export function openSqliteWorkerStore<Operations extends SqliteWorkerOperations>(
+  options: SqliteWorkerStoreOptions & { existingOnly?: false },
+): Promise<SqliteWorkerStore<Operations>>;
+export function openSqliteWorkerStore<Operations extends SqliteWorkerOperations>(
+  options: SqliteWorkerStoreOptions,
+): Promise<SqliteWorkerStore<Operations> | undefined>;
+export function openSqliteWorkerStore<Operations extends SqliteWorkerOperations>(
+  options: SqliteWorkerStoreOptions,
+): Promise<SqliteWorkerStore<Operations> | undefined> {
   if (!isMainThread) {
     return Promise.reject(
       new SqliteWorkerError(
@@ -689,5 +669,5 @@ export function openSqliteWorkerStore<Operations extends SqliteWorkerOperations>
     Symbol.for("openclaw.sqliteWorkerBroker"),
     () => new SqliteWorkerBroker(),
     (broker) => broker.close(),
-  ).open(options);
+  ).open<Operations>(options);
 }


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

The worker broker always starts a creation factory. Canonical cache and discovery reads must preserve a missing database and must not initialize an existing file merely to check its contents.

## Why This Change Was Made

Add explicit existing-only acquisition to the same broker. An unowned missing path returns undefined without starting a worker or calling a factory. Cold existing acquisition requires an explicit backend factory that uses native no-create opening and avoids migrations; the creation factory is never substituted.

Check physical identity before and after backend-module loading, retaining the existing parent post-open check. Open intent stays outside actor identity, so aliases and ordinary/existing clients reuse the same owner and drainage.

## User Impact

Future canonical reads can use workers while preserving missing files and existing storage. Existing-only controls acquisition, not subsequent command permissions. The current ordinary worker stores keep their existing behavior.

## Evidence

- All 92 affected Node tests passed, covering ordinary/existing broker behavior, native SQLite wrappers, and Bun ownership fixtures; full selected checks and fresh independent Codex review through P2 passed.
- Rebased onto the landed Bun library/retirement repair. Every authored addition and deletion is unchanged; the sole conflict was import context.
- Fresh normal build and actual Node 24.20.0/Bun 1.4.2 source and compiled probes passed on the combined graph. Positive controls verify SQL/worker instrumentation and compiled-source refusal.
- All four modes record zero main-thread SQLite calls, no missing-path broker worker/factory/database, byte-preserving existing reads, native no-create races, alias reuse, and accepted-write drainage. Target descriptors return to zero with peer stores live and through 20 close/reopen cycles.
- Source and all generated artifact hashes stayed unchanged and every process joined. Build: 274.30s. Node source/compiled probes: 12.63s/5.48s; Bun source/compiled: 22.61s/3.69s. These are smoke timings, not throughput comparisons.

This supplies an acquisition prerequisite. Canonical shared-state execution, agent affinity, incognito lifetime and final-use admission remain part of the coordinated worker migration.
