### PR TITLE
refactor(transcripts): await reads and retain snapshot ownership

### DIFF
--- a/src/agents/tools/transcripts-tool-read.ts
+++ b/src/agents/tools/transcripts-tool-read.ts
@@ -2,6 +2,7 @@ import type { TranscriptSessionSummary } from "../../../packages/gateway-protoco
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import {
   isTranscriptSelectionCurrent,
+  isTranscriptSelectionOwned,
   isTranscriptSessionActive,
   resolveSourceProvider,
   type TranscriptsRuntimeContext,
@@ -32,7 +33,8 @@ export async function listPastTranscripts({ ctx, store, rawParams }: ReadParams)
   // Page before authorization, but limit after it: hidden meetings must not crowd
   // accessible captures out of the result. No per-meeting database queries.
   for (let offset = 0; sessions.length < limit; offset += 200) {
-    const entries = store.listReadEntries({ limit: 200, offset });
+    const entries = await store.listReadEntries({ limit: 200, offset });
+    ctx.assertCallerActive?.();
     for (const entry of entries) {
       if (!(await canAccessTranscriptSession(ctx, entry.session, "list"))) {
         continue;
@@ -73,13 +75,15 @@ export async function listPastTranscripts({ ctx, store, rawParams }: ReadParams)
 export async function showPastTranscript(params: ReadParams) {
   const { ctx, store } = params;
   const selection = await resolveTranscriptToolSession({ ...params, action: "show" });
-  const entry = store.listReadEntries({ limit: 1, session: selection.session })[0];
+  const entry = (await store.listReadEntries({ limit: 1, session: selection.session }))[0];
+  ctx.assertCallerActive?.();
   if (!entry) {
     throw new Error(`transcripts session not found: ${selection.selector}`);
   }
   const notes = await readTranscriptNotes(store, selection.session);
+  const current = await isTranscriptSelectionCurrent(selection, store);
   ctx.assertCallerActive?.();
-  if (!isTranscriptSelectionCurrent(selection, store)) {
+  if (!current || !isTranscriptSelectionOwned(selection)) {
     const text = "Transcript changed while reading. Retry show to read the current notes.";
     return toolText(text, {
       text,

--- a/src/agents/tools/transcripts-tool-selection.ts
+++ b/src/agents/tools/transcripts-tool-selection.ts
@@ -76,8 +76,11 @@ export async function resolveTranscriptToolSession(params: {
   params.ctx.assertCallerActive?.();
   const durableRead = params.action === "show";
   const exactActive = explicit || durableRead ? undefined : activeSessions.get(value);
-  const { qualified, unqualified } = params.store.matchSessionEntries(value);
-  let entry: { session: TranscriptSessionDescriptor; selector: string } | undefined;
+  const { qualified, unqualified } = await params.store.matchSessionEntries(value);
+  params.ctx.assertCallerActive?.();
+  let entry:
+    | { session: TranscriptSessionDescriptor; selector: string; inputRevision?: string }
+    | undefined;
   // Current raw handles can span historical dates, but never another raw ID
   // or a conflicting qualified meaning. Authorization cannot break a tie.
   const preferActive =
@@ -116,10 +119,8 @@ export async function resolveTranscriptToolSession(params: {
   // Reads authorize the durable descriptor that owns the notes. Mutations keep
   // the admitted capture's authority even after a same-tuple durable rewrite.
   const session = durableRead ? entry?.session : (selectedActive?.session ?? entry?.session);
-  // Historical authorization and inference can outlive an entire reopen/stop.
-  // Capture the durable input revision before either awaited operation.
-  const historicalRevision =
-    session && !selectedActive ? params.store.readSummaryInputRevision(session) : undefined;
+  // The revision belongs to the matched descriptor, even if its row changes while matching waits.
+  const historicalRevision = !selectedActive ? entry?.inputRevision : undefined;
   if (
     !entry ||
     !session ||
@@ -127,6 +128,7 @@ export async function resolveTranscriptToolSession(params: {
   ) {
     throw new Error(`transcripts session not found: ${value}`);
   }
+  params.ctx.assertCallerActive?.();
   return { session, selector: entry.selector, activeCandidate, selectedActive, historicalRevision };
 }
 

--- a/src/agents/tools/transcripts-tool.lifecycle.test.ts
+++ b/src/agents/tools/transcripts-tool.lifecycle.test.ts
@@ -9,7 +9,8 @@ import type {
   TranscriptSourceProvider,
   TranscriptStartRequest,
 } from "../../transcripts/provider-types.js";
-import { TranscriptsStore } from "../../transcripts/store.js";
+import { TranscriptsStore, TranscriptsSummaryChangedError } from "../../transcripts/store.js";
+import { summarizeTranscripts } from "../../transcripts/summary.js";
 import { createTranscriptsTool } from "./transcripts-tool.js";
 
 const { getProvider } = vi.hoisted(() => ({ getProvider: vi.fn() }));
@@ -78,6 +79,156 @@ function harness() {
 }
 
 describe("transcript capture ownership", () => {
+  it.each(["stop", "summarize", "show"] as const)(
+    "does not adopt a replacement revision after a delayed %s match",
+    async (action) => {
+      const h = harness();
+      await h.start();
+      await h.execute({ action: "stop", sessionId: "notes" });
+      const original = await h.session();
+      const entered = createDeferred();
+      const release = createDeferred();
+      const match = h.store.matchSessionEntries.bind(h.store);
+      vi.spyOn(TranscriptsStore.prototype, "matchSessionEntries").mockImplementationOnce(
+        async (...args) => {
+          const entries = await match(...args);
+          entered.resolve();
+          await release.promise;
+          return entries;
+        },
+      );
+      const pending = h.execute({ action, sessionId: "notes" });
+      const replacement = {
+        ...original,
+        title: "Replacement capture",
+        source: { ...original.source, accountId: "replacement-account" },
+        metadata: { ...original.metadata, agentId: "replacement-agent" },
+      };
+      const utterance = { text: "replacement-only note" };
+      const summary = summarizeTranscripts({ session: replacement, utterances: [utterance] });
+      try {
+        await Promise.race([entered.promise, pending]);
+        await h.store.writeSession(replacement);
+        await h.store.appendUtteranceForSession(replacement, utterance);
+        await h.store.writeSummary(summary, replacement);
+      } finally {
+        release.resolve();
+      }
+      const result = await pending;
+      expect(result).toMatchObject({ details: { skipped: true } });
+      expect(JSON.stringify(result)).not.toContain(utterance.text);
+      expect(await h.session()).toEqual(replacement);
+      expect((await h.store.readSummary(replacement)).summary).toEqual(summary);
+      expect(await h.store.readUtterancesForSession(replacement)).toMatchObject([utterance]);
+    },
+  );
+
+  it.each(["selection-read", "summary-write"] as const)(
+    "refuses a summary when its caller closes during %s",
+    async (boundary) => {
+      const h = harness();
+      await h.start();
+      const session = await h.session();
+      let callerActive = true;
+      const tool = h.createTool(() => {
+        if (!callerActive) {
+          throw new Error("caller ended");
+        }
+      });
+      const entered = createDeferred();
+      const release = createDeferred();
+      if (boundary === "selection-read") {
+        const read = h.store.matchSessionEntries.bind(h.store);
+        vi.spyOn(TranscriptsStore.prototype, "matchSessionEntries").mockImplementationOnce(
+          async (...args) => {
+            const result = await read(...args);
+            entered.resolve();
+            await release.promise;
+            return result;
+          },
+        );
+      } else {
+        const write = h.store.writeSummary.bind(h.store);
+        vi.spyOn(TranscriptsStore.prototype, "writeSummary").mockImplementationOnce(
+          async (...args) => {
+            entered.resolve();
+            await release.promise;
+            return write(...args);
+          },
+        );
+      }
+      const pending = tool.execute("closing-summary", { action: "summarize", sessionId: "notes" });
+      const rejected = expect(pending).rejects.toThrow("caller ended");
+      try {
+        await Promise.race([entered.promise, pending]);
+        callerActive = false;
+      } finally {
+        release.resolve();
+        await rejected;
+      }
+      expect(await h.store.readSummary(session)).toEqual({});
+      expect(h.provider.stop).not.toHaveBeenCalled();
+      expect((await h.session()).stoppedAt).toBeUndefined();
+      await h.execute({ action: "stop", sessionId: "notes" });
+    },
+  );
+
+  it.each([
+    { boundary: "revision-read", alreadyStopped: false },
+    { boundary: "session-write", alreadyStopped: false },
+    { boundary: "revision-read", alreadyStopped: true },
+  ] as const)(
+    "preserves a changed historical transcript when stop waits during $boundary (stopped=$alreadyStopped)",
+    async ({ boundary, alreadyStopped }) => {
+      const h = harness();
+      await h.start();
+      await h.execute({ action: "stop", sessionId: "notes" });
+      const stoppedSession = await h.session();
+      const session = alreadyStopped ? stoppedSession : { ...stoppedSession, stoppedAt: undefined };
+      await h.store.writeSession(session);
+      const summary = await h.store.readSummary(session);
+      const entered = createDeferred();
+      const release = createDeferred();
+      if (boundary === "revision-read") {
+        const read = h.store.readSummaryInputRevision.bind(h.store);
+        vi.spyOn(TranscriptsStore.prototype, "readSummaryInputRevision").mockImplementationOnce(
+          async (...args) => {
+            const revision = await read(...args);
+            entered.resolve();
+            await release.promise;
+            return revision;
+          },
+        );
+      } else {
+        const write = h.store.writeSession.bind(h.store);
+        vi.spyOn(TranscriptsStore.prototype, "writeSession").mockImplementationOnce(
+          async (...args) => {
+            entered.resolve();
+            await release.promise;
+            return write(...args);
+          },
+        );
+      }
+      const pending = h.execute({ action: "stop", sessionId: "notes" });
+      try {
+        await Promise.race([entered.promise, pending]);
+        await h.store.appendUtteranceForSession(session, { text: "Saved during historical stop" });
+      } finally {
+        release.resolve();
+      }
+      if (alreadyStopped) {
+        await expect(pending).rejects.toBeInstanceOf(TranscriptsSummaryChangedError);
+      } else {
+        await expect(pending).resolves.toMatchObject({ details: { skipped: true } });
+      }
+      expect(await h.session()).toEqual(session);
+      expect(await h.store.readSummary(session)).toEqual(summary);
+      expect(await h.store.readUtterancesForSession(session)).toMatchObject([
+        { text: "Saved during historical stop" },
+      ]);
+    },
+  );
+
   it.each(["revision-read", "restore-write"] as const)(
     "does not grant retry authority when failed startup encounters %s failure",
     async (fault) => {
@@ -92,9 +243,9 @@ describe("transcript capture ownership", () => {
           .mockImplementationOnce(originalWrite)
           .mockRejectedValueOnce(new Error("restore unavailable"));
       } else {
-        vi.spyOn(h.store, "readSummaryInputRevision").mockImplementationOnce(() => {
-          throw new Error("revision unavailable");
-        });
+        vi.spyOn(h.store, "readSummaryInputRevision").mockRejectedValueOnce(
+          new Error("revision unavailable"),
+        );
       }
       h.provider.start = vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async () => ({
         ok: false,
@@ -135,17 +286,19 @@ describe("transcript capture ownership", () => {
       });
       const originalWrite = h.store.writeSession.bind(h.store);
       let blocked = false;
-      vi.spyOn(TranscriptsStore.prototype, "writeSession").mockImplementation(async (session) => {
-        if (session.title === "Room" && !blocked) {
-          blocked = true;
-          entered.resolve();
-          await release.promise;
-          if (fault === "write failure") {
-            throw new Error("title write unavailable");
+      vi.spyOn(TranscriptsStore.prototype, "writeSession").mockImplementation(
+        async (session, condition) => {
+          if (session.title === "Room" && !blocked) {
+            blocked = true;
+            entered.resolve();
+            await release.promise;
+            if (fault === "write failure") {
+              throw new Error("title write unavailable");
+            }
           }
-        }
-        await originalWrite(session);
-      });
+          await originalWrite(session, condition);
+        },
+      );
       const start = h
         .createTool()
         .execute(

--- a/src/agents/tools/transcripts-tool.occupancy.test.ts
+++ b/src/agents/tools/transcripts-tool.occupancy.test.ts
@@ -104,6 +104,65 @@ function harness() {
 }
 
 describe("occupancy-driven transcript lifecycle", () => {
+  it("refuses a stale occupancy reopen after its recent read is delayed", async () => {
+    const h = harness();
+    const original = {
+      sessionId: "recent-capture",
+      title: "Original meeting",
+      source: {
+        providerId: h.provider.id,
+        accountId: "default",
+        guildId: "guild",
+        channelId: "voice",
+      },
+      startedAt: "2026-08-01T11:50:00.000Z",
+      stoppedAt: "2026-08-01T11:59:00.000Z",
+      metadata: { sessionIdOrigin: "generated" },
+    };
+    await h.store.writeSession(original);
+    await h.store.appendUtteranceForSession(original, { text: "Archived speech" });
+    const entered = createDeferred();
+    const release = createDeferred();
+    const read = h.store.readRecentStoppedSession.bind(h.store);
+    const delayedRead = vi
+      .spyOn(TranscriptsStore.prototype, "readRecentStoppedSession")
+      .mockImplementationOnce(async (...args) => {
+        const recent = await read(...args);
+        expect(recent).toBeDefined();
+        entered.resolve();
+        await release.promise;
+        return recent;
+      });
+    await withPluginRuntimeRegistryScope(h.registry, async () => {
+      const service = h.service();
+      try {
+        service.start();
+        await vi.waitFor(() => expect(h.watches).toHaveLength(1));
+        h.watches[0]!.onOccupied();
+        await entered.promise;
+        const replacement = { ...original, title: "Changed by another writer" };
+        await h.store.writeSession(replacement);
+        await h.store.appendUtteranceForSession(replacement, { text: "Saved during recent read" });
+        release.resolve();
+        await vi.waitFor(() => {
+          expect(
+            h.logger.warn.mock.calls.length + vi.mocked(h.provider.start!).mock.calls.length,
+          ).toBeGreaterThan(0);
+        });
+        expect.soft(h.provider.start).not.toHaveBeenCalled();
+        expect.soft(await h.store.readSession(original.sessionId)).toEqual(replacement);
+        expect(await h.store.readUtterancesForSession(original)).toMatchObject([
+          { text: "Archived speech" },
+          { text: "Saved during recent read" },
+        ]);
+      } finally {
+        release.resolve();
+        await service.stop();
+        delayedRead.mockRestore();
+      }
+    });
+  });
+
   it.each([undefined, null, "invalid", "supplied", "generated"])(
     "reopens only a newest capture with recorded generated origin (%s)",
     async (origin) => {
@@ -303,7 +362,7 @@ describe("occupancy-driven transcript lifecycle", () => {
             expect((await h.store.readSession(request.session.sessionId))?.stoppedAt).toBeDefined(),
           );
           const restored = await h.store.readSession(request.session.sessionId);
-          const revision = h.store.readSummaryInputRevision(request.session);
+          const revision = await h.store.readSummaryInputRevision(request.session);
           if (stop !== "omitted") {
             if (stop === "denied") {
               h.provider.accessControl!.authorize = async () => ({ ok: false, error: "denied" });
@@ -321,7 +380,7 @@ describe("occupancy-driven transcript lifecycle", () => {
           // Historical stop preserves stoppedAt and summary inputs, even when it
           // cancels a pending retry. The real stop must still revoke that attempt.
           expect(await h.store.readSession(request.session.sessionId)).toEqual(restored);
-          expect(h.store.readSummaryInputRevision(request.session)).toBe(revision);
+          expect(await h.store.readSummaryInputRevision(request.session)).toBe(revision);
           const summary = await h.store.readSummary(request.session);
           h.provider.start = vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async (next) => {
             h.requests.push(next);

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -22,6 +22,7 @@ import {
   authorizeTranscriptSource,
   createTranscriptSessionId,
   isTranscriptSelectionCurrent,
+  isTranscriptSelectionOwned,
   readTranscriptStringParam,
   resolveTranscriptSourceOwnership,
   resolveSourceProvider,
@@ -151,6 +152,7 @@ async function importTranscripts(params: {
     cfg: params.ctx.config,
     store: params.store,
     session,
+    assertCurrent: params.ctx.assertCallerActive,
   });
   const { summaryPath, intendedSummaryPath, summary, summaryExportError } =
     await exportTranscriptSummary(params.store, session, persisted);
@@ -178,12 +180,17 @@ async function summarizeExisting(params: {
   params.ctx.assertCallerActive?.();
   // Finalization owns notes through export. Older model results must not
   // overwrite it, even while the same capture reservation is still held.
-  const canWriteSummary = () =>
-    isTranscriptSelectionCurrent(selection, params.store) &&
+  const ownsSummary = () =>
+    isTranscriptSelectionOwned(selection) &&
     (!selection.selectedActive || selection.selectedActive.session === selection.session) &&
     !selection.selectedActive?.stopping &&
     !selection.selectedActive?.finalization;
-  if (!canWriteSummary()) {
+  const canWriteSummary = async () => {
+    const current = await isTranscriptSelectionCurrent(selection, params.store);
+    params.ctx.assertCallerActive?.();
+    return current && ownsSummary();
+  };
+  if (!(await canWriteSummary())) {
     return transcriptSelectionNoLongerActive(selection);
   }
   const { session, selector } = selection;
@@ -191,12 +198,22 @@ async function summarizeExisting(params: {
   const summary = await readTranscriptSummary({ ...params, cfg: params.ctx.config, session });
   // Reading yields; a retired capture cannot write into its same-tuple replacement.
   params.ctx.assertCallerActive?.();
-  if (!canWriteSummary()) {
+  if (!(await canWriteSummary())) {
     return transcriptSelectionNoLongerActive(selection);
   }
   let intendedPath: string;
   try {
-    intendedPath = await params.store.writeSummary(summary, session, selection.historicalRevision);
+    intendedPath = await params.store.writeSummary(
+      summary,
+      session,
+      selection.historicalRevision,
+      () => {
+        params.ctx.assertCallerActive?.();
+        if (!ownsSummary()) {
+          throw new TranscriptsSummaryChangedError();
+        }
+      },
+    );
   } catch (error) {
     if (error instanceof TranscriptsSummaryChangedError) {
       return transcriptSelectionNoLongerActive(selection);
@@ -204,7 +221,7 @@ async function summarizeExisting(params: {
     throw error;
   }
   params.ctx.assertCallerActive?.();
-  if (!canWriteSummary()) {
+  if (!(await canWriteSummary())) {
     return transcriptSelectionNoLongerActive(selection);
   }
   const { summaryPath, intendedSummaryPath, summaryExportError } = await exportTranscriptSummary(

--- a/src/gateway/server-methods/transcripts.ts
+++ b/src/gateway/server-methods/transcripts.ts
@@ -27,7 +27,7 @@ import { assertValidParams, type Validator } from "./validation.js";
 function transcriptReadMethod<T>(
   method: string,
   validate: Validator<T>,
-  read: (store: TranscriptsStore, params: T, cfg: OpenClawConfig) => unknown,
+  read: (store: TranscriptsStore, params: T, cfg: OpenClawConfig) => Promise<unknown>,
 ): GatewayRequestHandler {
   return async ({ params, context, client, respond }) => {
     if (!assertValidParams(params, validate, method, respond)) {

--- a/src/infra/state-migrations.meeting-transcripts-projections.test.ts
+++ b/src/infra/state-migrations.meeting-transcripts-projections.test.ts
@@ -152,7 +152,7 @@ describe("meeting transcript Doctor oversized projections", () => {
       const readListedCapture = async (expectedSelector: string) => {
         closeOpenClawStateDatabaseForTest();
         const reopened = new TranscriptsStore(harness.root, { env: harness.env });
-        const listed = listTranscriptLibrary(reopened, {}).sessions.find(
+        const listed = (await listTranscriptLibrary(reopened, {})).sessions.find(
           (entry) => entry.sessionId === sessionId,
         );
         expect(listed?.selector).toBe(expectedSelector);

--- a/src/state/openclaw-state-db-handle.ts
+++ b/src/state/openclaw-state-db-handle.ts
@@ -11,13 +11,14 @@ const handleLeases = resolveGlobalSingleton(
 
 export function openTrackedStateDatabase(
   pathname: string,
-  options?: { existingOnly?: boolean },
+  options?: { existingOnly?: boolean; readOnly?: boolean; timeout?: number },
 ): DatabaseSync {
   const lease = acquireStateDatabaseHandleLease({ databasePath: pathname, busyTimeoutMs: 0 });
   try {
-    const database = openNodeSqliteDatabase(
-      options?.existingOnly ? resolveExistingSqliteFileUri(pathname) : pathname,
-    );
+    const location = options?.existingOnly ? resolveExistingSqliteFileUri(pathname) : pathname;
+    const database = options?.readOnly
+      ? openNodeSqliteDatabase(location, { readOnly: true, timeout: options.timeout })
+      : openNodeSqliteDatabase(location);
     handleLeases.set(database, lease);
     return database;
   } catch (error) {

--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./openclaw-state-db-cache.js";
 import {
   isArtifactPreservingStateRead,
+  iterateOpenClawStateDatabaseReadOnly,
   withExistingOpenClawStateDatabaseArtifactPreservingReadOnly,
   withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync,
   withExistingOpenClawStateDatabaseReadOnly,
@@ -42,6 +43,129 @@ function createOptions(stateDir: string) {
 afterEach(() => {
   vi.restoreAllMocks();
   closeOpenClawStateDatabaseForTest();
+});
+
+it("keeps fresh synchronous read callbacks from returning asynchronous work", async () => {
+  await withTempDir("openclaw-state-sync-read-", async (root) => {
+    const options = createOptions(root);
+    openOpenClawStateDatabase(options);
+    closeOpenClawStateDatabaseForTest();
+    expect(() =>
+      withExistingOpenClawStateDatabaseReadOnly(() => Promise.resolve(1), options),
+    ).toThrow("SQLite source read must remain synchronous");
+    const exclusion = acquireOpenClawStateDatabaseFileExclusion(options.path);
+    exclusion.release();
+  });
+});
+
+it.each(["complete", "return", "throw"] as const)(
+  "ends the native stream snapshot before close on %s",
+  async (ending) => {
+    await withTempDir("openclaw-state-stream-snapshot-", async (root) => {
+      const source = openOpenClawStateDatabase(createOptions(root));
+      let reader: DatabaseSync | undefined;
+      let finalized = false;
+      let transactionAtClose: boolean | undefined;
+      // oxlint-disable-next-line typescript/unbound-method -- Called below with the intercepted native database receiver.
+      const close = DatabaseSync.prototype.close;
+      vi.spyOn(DatabaseSync.prototype, "close").mockImplementation(function (this: DatabaseSync) {
+        if (this === reader) {
+          transactionAtClose = this.isTransaction;
+        }
+        close.call(this);
+      });
+      const rows = iterateOpenClawStateDatabaseReadOnly(source, function* ({ db }) {
+        reader = db;
+        try {
+          yield db.prepare("SELECT 1 AS value").get()?.value;
+        } finally {
+          expect(db.isOpen).toBe(true);
+          expect(db.isTransaction).toBe(true);
+          finalized = true;
+        }
+      });
+      try {
+        expect((await rows.next()).value).toBe(1);
+        if (ending === "complete") {
+          expect((await rows.next()).done).toBe(true);
+        } else if (ending === "return") {
+          await rows.return();
+        } else {
+          const failure = new Error("stream consumer failed");
+          await expect(rows.throw(failure)).rejects.toBe(failure);
+        }
+        expect(finalized).toBe(true);
+        expect(transactionAtClose).toBe(false);
+        expect(reader?.isOpen).toBe(false);
+      } finally {
+        await rows.return();
+      }
+    });
+  },
+);
+
+it("retains stream handle custody when native close fails until explicit close succeeds", async () => {
+  await withTempDir("openclaw-state-stream-close-", async (root) => {
+    const source = openOpenClawStateDatabase(createOptions(root));
+    const failure = new Error("reader close failed");
+    let refuseClose = true;
+    let reader: DatabaseSync | undefined;
+    // oxlint-disable-next-line typescript/unbound-method -- Called below with the intercepted native database receiver.
+    const close = DatabaseSync.prototype.close;
+    const closeSpy = vi.spyOn(DatabaseSync.prototype, "close");
+    closeSpy.mockImplementation(function (this: DatabaseSync) {
+      if (this === reader && refuseClose) {
+        throw failure;
+      }
+      close.call(this);
+    });
+    const rows = iterateOpenClawStateDatabaseReadOnly(source, function* ({ db }) {
+      reader = db;
+      yield db.prepare("SELECT 1 AS value").get()?.value;
+      yield 2;
+    });
+    try {
+      expect((await rows.next()).value).toBe(1);
+      await expect(rows.return()).rejects.toBe(failure);
+      expect(reader?.isOpen).toBe(true);
+      expect(() => acquireOpenClawStateDatabaseFileExclusion(source.path)).toThrow(
+        "reader close failed",
+      );
+      expect(reader?.isOpen).toBe(true);
+      refuseClose = false;
+      closeOpenClawStateDatabaseForTest();
+      expect(reader?.isOpen).toBe(false);
+      const exclusion = acquireOpenClawStateDatabaseFileExclusion(source.path);
+      exclusion.release();
+    } finally {
+      refuseClose = false;
+      await rows.return();
+      closeOpenClawStateDatabaseForTest();
+      closeSpy.mockRestore();
+    }
+  });
+});
+
+it("rejects non-filesystem stream sources without interpreting their logical path as a file", async () => {
+  await withTempDir("openclaw-state-memory-stream-", async (root) => {
+    const db = new DatabaseSync(":memory:");
+    const pathname = path.join(root, "logical-state.sqlite");
+    const rows = iterateOpenClawStateDatabaseReadOnly(
+      { db, path: pathname, walMaintenance: { checkpoint: () => false, close: () => false } },
+      function* () {
+        yield "unreachable";
+      },
+    );
+    try {
+      await expect(rows.next()).rejects.toThrow(
+        "Streaming shared-state reads require a filesystem-backed database",
+      );
+      expect(fs.readdirSync(root)).toEqual([]);
+    } finally {
+      await rows.return();
+      db.close();
+    }
+  });
 });
 
 it("waits for a transient database lock before a fresh read-only schema inspection", async () => {

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -2,20 +2,23 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync-cache-state.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { SqliteCoordinatorError } from "../infra/sqlite-coordinator.js";
 import {
   prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationSync,
 } from "../infra/sqlite-snapshot-source.js";
-import { withSqliteSourceHandle } from "../infra/sqlite-source-handle.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   type OpenClawStateDatabaseOptions,
+  type OpenClawStateDatabase,
 } from "./openclaw-state-db-contract.js";
 import { openDanglingWorkshopIndexReadAdmission } from "./openclaw-state-db-dangling-workshop-index.js";
+import { openTrackedStateDatabase } from "./openclaw-state-db-handle.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
@@ -112,35 +115,96 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
   }
 }
 
+function openOpenClawStateReadOnlyLocation(pathname: string, location: string) {
+  // Install the busy handler before legacy catalog admission reads sqlite_schema.
+  const options = { readOnly: true, timeout: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS };
+  const liveSource = location === pathname;
+  const db = liveSource
+    ? openTrackedStateDatabase(pathname, options)
+    : openNodeSqliteDatabase(location, options);
+  let closeSchemaReadAdmission: (() => void) | undefined;
+  const close = () => {
+    const errors: unknown[] = [];
+    try {
+      closeSchemaReadAdmission?.();
+    } catch (error) {
+      errors.push(error);
+    }
+    if (liveSource) {
+      errors.push(
+        ...openClawStateDatabaseCache.closeOpenClawStateDatabaseHandle({ db, path: pathname }),
+      );
+    } else {
+      try {
+        clearNodeSqliteKyselyCacheForDatabase(db);
+        db.close();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "Shared-state reader cleanup failed.");
+    }
+  };
+  try {
+    closeSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(db);
+    assertSupportedStateSchemaVersion(db, pathname);
+  } catch (error) {
+    close();
+    throw error;
+  }
+  return { database: { db, path: pathname }, close };
+}
+
 function withOpenClawStateReadOnlyLocation<T>(
   operation: (database: OpenClawStateReadOnlyDatabase) => T,
   pathname: string,
   location: string,
 ): T {
-  const read = () => {
-    // node:sqlite opens without a busy handler, so a timeout installed by a
-    // later PRAGMA leaves the first statement — legacy catalog admission's
-    // sqlite_schema read — failing outright on any transient lock.
-    const db = openNodeSqliteDatabase(location, {
-      readOnly: true,
-      timeout: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-    });
-    let closeSchemaReadAdmission: (() => void) | undefined;
-    try {
-      closeSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(db);
-      assertSupportedStateSchemaVersion(db, pathname);
-      return operation({ db, path: pathname });
-    } finally {
-      try {
-        closeSchemaReadAdmission?.();
-      } finally {
-        clearNodeSqliteKyselyCacheForDatabase(db);
-        db.close();
-      }
+  const opened = openOpenClawStateReadOnlyLocation(pathname, location);
+  try {
+    const result = operation(opened.database);
+    if (location === pathname && isPromiseLike(result)) {
+      throw new SqliteCoordinatorError("SQLite source read must remain synchronous");
     }
-  };
-  // Only live-source descriptors join handle custody; snapshots remain private.
-  return location === pathname ? withSqliteSourceHandle(pathname, read) : read();
+    return result;
+  } finally {
+    opened.close();
+  }
+}
+
+/** Keep streamed rows on one private reader while callers yield or close the shared writer. */
+export async function* iterateOpenClawStateDatabaseReadOnly<Row, Result>(
+  source: OpenClawStateDatabase,
+  operation: (database: OpenClawStateReadOnlyDatabase) => Generator<Row, Result>,
+  env: NodeJS.ProcessEnv = process.env,
+): AsyncGenerator<Row, Result> {
+  const pathname = source.db.location();
+  if (!pathname) {
+    throw new Error("Streaming shared-state reads require a filesystem-backed database.");
+  }
+  openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
+  const opened = openOpenClawStateReadOnlyLocation(pathname, pathname);
+  try {
+    // sqlite-allow-raw -- Keep composite streamed reads in one native read-only snapshot.
+    opened.database.db.exec("BEGIN");
+    return yield* operation(opened.database);
+  } catch (error) {
+    openClawStateDatabaseCache.evictOpenClawStateDatabaseAfterCorruption(source, error);
+    throw error;
+  } finally {
+    try {
+      // Bun can retain statements after close; end the snapshot before releasing handle custody.
+      if (opened.database.db.isTransaction) {
+        opened.database.db.exec("ROLLBACK"); // sqlite-allow-raw -- End this owner's read-only snapshot.
+      }
+    } finally {
+      opened.close();
+    }
+  }
 }
 
 /** Read shared state without joining writers; admission inherits artifact preservation. */

--- a/src/transcripts/auto-start.ts
+++ b/src/transcripts/auto-start.ts
@@ -174,6 +174,7 @@ export function createTranscriptsAutoStartService(
       | "rawParams"
       | "abortSignal"
       | "existingSession"
+      | "existingSessionCondition"
       | "onCaptureEnded"
       | "sessionIdOrigin"
     >,
@@ -181,12 +182,12 @@ export function createTranscriptsAutoStartService(
     diagnostics?.record(index, capture.lifecycleToken, "starting");
     try {
       const retry = retries.get(index);
-      // Both modes validate the exact failed attempt immediately before the
-      // configured start's synchronous existing-tuple write.
-      retry?.assertCurrent(params.store);
       const result = await startTranscripts({
         ...params,
         existingSession: retry?.session ?? params.existingSession,
+        existingSessionCondition: retry
+          ? { expectedInputRevision: retry.revision, assertCurrent: retry.assertCurrent }
+          : params.existingSessionCondition,
         ctx,
         startupWaitMs: AUTO_START_PROVIDER_READY_TIMEOUT_MS,
         configuredLifecycle: true,
@@ -337,25 +338,29 @@ export function createTranscriptsAutoStartService(
             return;
           }
           const now = Date.now();
-          const recent =
-            retries.get(index)?.session ??
-            store.readRecentStoppedSession(
-              sanitizeTranscriptSourceLocator(source),
-              new Date(now - AUTO_START_OCCUPANCY_REOPEN_WINDOW_MS).toISOString(),
-              new Date(now).toISOString(),
-            );
+          const retained = retries.get(index);
+          const recent = retained
+            ? { session: retained.session, inputRevision: retained.revision }
+            : await store.readRecentStoppedSession(
+                sanitizeTranscriptSourceLocator(source),
+                new Date(now - AUTO_START_OCCUPANCY_REOPEN_WINDOW_MS).toISOString(),
+                new Date(now).toISOString(),
+              );
+          if (stopped || !occupied || controller.signal.aborted) {
+            return;
+          }
           const candidate =
             recent &&
-            recent.metadata?.sessionIdOrigin === "generated" &&
+            recent.session.metadata?.sessionIdOrigin === "generated" &&
             (!(source.agentId ?? ctx.agentId) ||
-              (recent.metadata?.agentId ?? "main") === (source.agentId ?? ctx.agentId)) &&
-            !activeSessions.has(recent.sessionId) &&
-            !isTranscriptSessionStarting(recent.sessionId) &&
-            !startedSessions.has(recent.sessionId)
+              (recent.session.metadata?.agentId ?? "main") === (source.agentId ?? ctx.agentId)) &&
+            !activeSessions.has(recent.session.sessionId) &&
+            !isTranscriptSessionStarting(recent.session.sessionId) &&
+            !startedSessions.has(recent.session.sessionId)
               ? recent
               : undefined;
           const owned = {
-            sessionId: candidate?.sessionId ?? createTranscriptSessionId(),
+            sessionId: candidate?.session.sessionId ?? createTranscriptSessionId(),
             lifecycleToken: Symbol(label),
           };
           diagnosticToken = owned.lifecycleToken;
@@ -364,7 +369,20 @@ export function createTranscriptsAutoStartService(
             store,
             sessionIdOrigin: "generated",
             abortSignal: controller.signal,
-            existingSession: candidate,
+            existingSession: candidate?.session,
+            existingSessionCondition: candidate
+              ? {
+                  expectedInputRevision: candidate.inputRevision,
+                  assertCurrent: () => {
+                    if (stopped || !occupied || controller.signal.aborted || capture !== owned) {
+                      throw new TranscriptStartError(
+                        "id-conflict",
+                        new Error("transcript occupancy changed before reopening"),
+                      );
+                    }
+                  },
+                }
+              : undefined,
             rawParams: {
               ...entry,
               ...source,

--- a/src/transcripts/capture-operations.ts
+++ b/src/transcripts/capture-operations.ts
@@ -4,6 +4,7 @@ import {
   activeSessions,
   finalizeTranscriptCapture,
   isTranscriptSelectionCurrent,
+  isTranscriptSelectionOwned,
   isTranscriptSessionStarting,
   revokeTranscriptStartRetries,
   stopTranscriptProviderCapture,
@@ -12,7 +13,7 @@ import {
 } from "./capture.js";
 import { resolveTranscriptsConfig } from "./config.js";
 import type { TranscriptSessionDescriptor } from "./provider-types.js";
-import { TranscriptsStore } from "./store.js";
+import { TranscriptsStore, TranscriptsSummaryChangedError } from "./store.js";
 
 export function createTranscriptsStore(ctx: TranscriptsRuntimeContext): TranscriptsStore {
   return new TranscriptsStore(path.join(ctx.stateDir, "transcripts"), {
@@ -50,7 +51,9 @@ export async function stopTranscriptCapture(params: {
     selector,
   });
   // Authorization may await native policy while the provider retires this owner.
-  if (!isTranscriptSelectionCurrent(selection, params.store)) {
+  const current = await isTranscriptSelectionCurrent(selection, params.store);
+  params.ctx.assertCallerActive?.();
+  if (!current || !isTranscriptSelectionOwned(selection)) {
     return skip("inactive");
   }
   if (isTranscriptSessionStarting(sessionId)) {
@@ -88,15 +91,33 @@ export async function stopTranscriptCapture(params: {
       stoppedSession = selectedActive.session;
       finalized = true;
     } else {
+      const assertCurrent = () => {
+        params.ctx.assertCallerActive?.();
+        if (!isTranscriptSelectionOwned(selection) || isTranscriptSessionStarting(sessionId)) {
+          throw new TranscriptsSummaryChangedError();
+        }
+      };
       stoppedSession = { ...session, stoppedAt: session.stoppedAt ?? new Date().toISOString() };
       if (!session.stoppedAt) {
-        await params.store.writeSession(stoppedSession);
+        try {
+          await params.store.writeSession(stoppedSession, {
+            expectedInputRevision: selection.historicalRevision,
+            assertCurrent,
+          });
+        } catch (error) {
+          if (error instanceof TranscriptsSummaryChangedError) {
+            return skip("inactive");
+          }
+          throw error;
+        }
       }
       persisted = await persistTranscriptSummary({
         config: resolveTranscriptsConfig(params.ctx.config?.transcripts),
         cfg: params.ctx.config,
         store: params.store,
         session: stoppedSession,
+        expectedInputRevision: session.stoppedAt ? selection.historicalRevision : undefined,
+        assertCurrent,
       });
     }
     const { summaryPath, intendedSummaryPath, summary, summaryExportError } =

--- a/src/transcripts/capture-summary.ts
+++ b/src/transcripts/capture-summary.ts
@@ -40,13 +40,25 @@ export async function readTranscriptSummary(params: {
 }
 
 export async function persistTranscriptSummary(
-  params: Parameters<typeof readTranscriptSummary>[0],
+  params: Parameters<typeof readTranscriptSummary>[0] & {
+    expectedInputRevision?: string;
+    assertCurrent?: () => void;
+  },
 ) {
-  const revision = params.store.readSummaryInputRevision(params.session);
-  if (revision === undefined) {
+  const revision = await params.store.readSummaryInputRevision(params.session);
+  params.assertCurrent?.();
+  if (
+    revision === undefined ||
+    (params.expectedInputRevision !== undefined && revision !== params.expectedInputRevision)
+  ) {
     throw new TranscriptsSummaryChangedError();
   }
   const summary = await readTranscriptSummary(params);
-  const intendedSummaryPath = await params.store.writeSummary(summary, params.session, revision);
+  const intendedSummaryPath = await params.store.writeSummary(
+    summary,
+    params.session,
+    params.expectedInputRevision ?? revision,
+    params.assertCurrent,
+  );
   return { summary, intendedSummaryPath };
 }

--- a/src/transcripts/capture.ts
+++ b/src/transcripts/capture.ts
@@ -15,7 +15,7 @@ import type {
   TranscriptsStartResult,
 } from "./provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "./source-locator.js";
-import type { TranscriptsStore } from "./store.js";
+import { TranscriptsSummaryChangedError, type TranscriptsStore } from "./store.js";
 
 const ACCOUNT_ID_OUTPUT_MAX_CHARS = 64;
 
@@ -70,16 +70,25 @@ export type TranscriptCaptureSelection = {
   historicalRevision: string | undefined;
 };
 
-export function isTranscriptSelectionCurrent(
+export function isTranscriptSelectionOwned(selection: TranscriptCaptureSelection): boolean {
+  return activeSessions.get(selection.session.sessionId) === selection.activeCandidate;
+}
+
+export async function isTranscriptSelectionCurrent(
   selection: TranscriptCaptureSelection,
   store: TranscriptsStore,
-): boolean {
-  return (
-    activeSessions.get(selection.session.sessionId) === selection.activeCandidate &&
-    (selection.selectedActive !== undefined ||
-      (selection.historicalRevision !== undefined &&
-        store.readSummaryInputRevision(selection.session) === selection.historicalRevision))
-  );
+): Promise<boolean> {
+  if (!isTranscriptSelectionOwned(selection)) {
+    return false;
+  }
+  if (selection.selectedActive) {
+    return true;
+  }
+  if (selection.historicalRevision === undefined) {
+    return false;
+  }
+  const revision = await store.readSummaryInputRevision(selection.session);
+  return isTranscriptSelectionOwned(selection) && revision === selection.historicalRevision;
 }
 
 /** Read-only process facts; a retained stop/cleanup owner does not prove capture is armed. */
@@ -129,16 +138,13 @@ export function retainTranscriptStartRetry(
   pendingStartRetries.add(owner);
   return {
     session: retry.session,
-    assertCurrent(store: TranscriptsStore) {
-      try {
-        if (
-          !pendingStartRetries.has(owner) ||
-          store.readSummaryInputRevision(retry.session) !== retry.revision
-        ) {
-          throw new Error("transcript changed or stopped before startup retry");
-        }
-      } catch (error) {
-        throw new TranscriptStartError("id-conflict", error);
+    revision: retry.revision,
+    assertCurrent: () => {
+      if (!pendingStartRetries.has(owner)) {
+        throw new TranscriptStartError(
+          "id-conflict",
+          new Error("transcript changed or stopped before startup retry"),
+        );
       }
     },
     release: () => pendingStartRetries.delete(owner),
@@ -176,12 +182,18 @@ export function finalizeTranscriptCapture(params: {
     stoppedAt: entry.session.stoppedAt ?? new Date().toISOString(),
   };
   entry.finalization ??= (async () => {
-    await params.store.writeSession(entry.session);
+    const assertCurrent = () => {
+      if (activeSessions.get(entry.session.sessionId) !== entry) {
+        throw new TranscriptsSummaryChangedError();
+      }
+    };
+    await params.store.writeSession(entry.session, { assertCurrent });
     return await persistTranscriptSummary({
       config: resolveTranscriptsConfig(params.ctx.config?.transcripts),
       cfg: params.ctx.config,
       store: params.store,
       session: entry.session,
+      assertCurrent,
     });
   })()
     .then((result) => {
@@ -448,6 +460,7 @@ export async function startTranscripts(params: {
   configuredLifecycle?: true;
   lifecycleToken?: symbol;
   existingSession?: TranscriptSessionDescriptor;
+  existingSessionCondition?: Parameters<TranscriptsStore["writeSession"]>[1];
   /** Configured capture retains the original choice before supplying its selected ID. */
   sessionIdOrigin?: "generated" | "supplied";
   onCaptureEnded?: () => void;
@@ -538,7 +551,14 @@ export async function startTranscripts(params: {
   let retry: TranscriptStartError["retry"];
   const startupAbort = createStartupAbortScope(params.abortSignal);
   try {
-    await params.store.writeSession(session);
+    try {
+      await params.store.writeSession(session, params.existingSessionCondition);
+    } catch (error) {
+      if (error instanceof TranscriptsSummaryChangedError) {
+        throw new TranscriptStartError("id-conflict", error);
+      }
+      throw error;
+    }
     admitted = true;
     let result: TranscriptsStartResult;
     try {
@@ -656,7 +676,7 @@ export async function startTranscripts(params: {
         await params.store.writeSession(restored);
         // Authority describes the durable tuple after restoration, including its
         // original stop time. A failed restoration or revision read grants none.
-        const revision = params.store.readSummaryInputRevision(restored);
+        const revision = await params.store.readSummaryInputRevision(restored);
         if (revision !== undefined) {
           retry = { session: restored, revision };
         }

--- a/src/transcripts/library.async.test.ts
+++ b/src/transcripts/library.async.test.ts
@@ -1,0 +1,231 @@
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { activeSessions } from "./capture.js";
+import { exportTranscriptLibrary, getTranscriptLibrary, listTranscriptLibrary } from "./library.js";
+import type { TranscriptSessionDescriptor } from "./provider-types.js";
+import { TranscriptsStore, transcriptSessionSelector } from "./store.js";
+import { summarizeTranscripts } from "./summary.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => {
+  vi.restoreAllMocks();
+  activeSessions.clear();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function fixture() {
+  const stateDir = tempDirs.make("transcript-library-async-");
+  return {
+    store: new TranscriptsStore(path.join(stateDir, "transcripts"), {
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    }),
+  };
+}
+
+function session(
+  sessionId: string,
+  overrides: Partial<TranscriptSessionDescriptor> = {},
+): TranscriptSessionDescriptor {
+  return {
+    sessionId,
+    title: sessionId,
+    source: { providerId: "manual-transcript" },
+    startedAt: "2026-08-20T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("transcript library asynchronous reads", () => {
+  it.each(["get", "export"] as const)(
+    "keeps a delayed composed %s response coherent after a peer update",
+    async (kind) => {
+      const { store } = fixture();
+      const target = session("delayed-read", { title: "Original meeting" });
+      const utterance = { text: "Original saved note" };
+      await store.writeSession(target);
+      await store.appendUtteranceForSession(target, utterance);
+      await store.writeSummary(
+        summarizeTranscripts({ session: target, utterances: [utterance] }),
+        target,
+      );
+      const selector = transcriptSessionSelector(target);
+      const gate = createDeferred();
+      const reading = createDeferred();
+      if (kind === "get") {
+        const read = store.readLibraryEntry.bind(store);
+        vi.spyOn(store, "readLibraryEntry").mockImplementationOnce(async (...args) => {
+          const snapshot = await read(...args);
+          reading.resolve();
+          await gate.promise;
+          return snapshot;
+        });
+      } else {
+        const iterate = store.iterateExport.bind(store);
+        vi.spyOn(store, "iterateExport").mockImplementationOnce(async function* (...args) {
+          const snapshot = yield* iterate(...args);
+          reading.resolve();
+          await gate.promise;
+          return snapshot;
+        });
+      }
+      const read = async () =>
+        kind === "get"
+          ? JSON.stringify(
+              await getTranscriptLibrary(store, { selector, includeUtterances: true, limit: 1 }),
+            )
+          : Buffer.from(
+              (await exportTranscriptLibrary(store, { selector, format: "markdown" })).data,
+              "base64",
+            ).toString("utf8");
+      let settled = false;
+      const result = read();
+      const settlement = result.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      const replacement = { ...target, title: "Replacement meeting" };
+      const added = { text: "Peer saved note" };
+      try {
+        await reading.promise;
+        await setImmediate();
+        expect(settled).toBe(false);
+        await store.writeSession(replacement);
+        await store.appendUtteranceForSession(replacement, added);
+        await store.writeSummary(
+          summarizeTranscripts({ session: replacement, utterances: [utterance, added] }),
+          replacement,
+        );
+      } finally {
+        gate.resolve();
+        await settlement;
+      }
+      const text = await result;
+      expect(text).toContain("## Overview");
+      expect(text).toContain(target.title);
+      expect(text).toContain(utterance.text);
+      expect(text).not.toContain(replacement.title);
+      expect(text).not.toContain(added.text);
+      expect((await store.readSession(selector))?.title).toBe(replacement.title);
+      expect(await store.readUtterancesForSession(replacement)).toMatchObject([utterance, added]);
+    },
+  );
+
+  it.each(["get", "export"] as const)(
+    "propagates a failed composed %s without returning partial content",
+    async (kind) => {
+      const { store } = fixture();
+      const target = session("rejected-read");
+      await store.writeSession(target);
+      const failure = new Error("archive read failed");
+      const selector = transcriptSessionSelector(target);
+      if (kind === "get") {
+        vi.spyOn(store, "readLibraryEntry").mockRejectedValueOnce(failure);
+        await expect(
+          getTranscriptLibrary(store, { selector, includeUtterances: true, limit: 1 }),
+        ).rejects.toBe(failure);
+      } else {
+        vi.spyOn(store, "iterateExport").mockImplementationOnce(async function* () {
+          yield { sequence: 0, text: "Partial content" };
+          throw failure;
+        });
+        await expect(exportTranscriptLibrary(store, { selector, format: "jsonl" })).rejects.toBe(
+          failure,
+        );
+      }
+    },
+  );
+
+  it("rejects an export canceled before its completion result", async () => {
+    const { store } = fixture();
+    vi.spyOn(store, "iterateExport").mockImplementationOnce(async function* () {
+      yield { sequence: 0, text: "Partial content" };
+      return undefined;
+    });
+    await expect(
+      exportTranscriptLibrary(store, { selector: "canceled", format: "jsonl" }),
+    ).rejects.toThrow("export ended before completion");
+  });
+
+  it("awaits asynchronous page cleanup when public projection fails", async () => {
+    const { store } = fixture();
+    await store.writeSession(session("projection-failure"));
+    const iterateReadEntries = store.iterateReadEntries.bind(store);
+    const cleanup = createDeferred();
+    const closing = createDeferred();
+    let closed = false;
+    vi.spyOn(store, "iterateReadEntries").mockImplementation(async function* (options) {
+      try {
+        return yield* iterateReadEntries(options);
+      } finally {
+        closing.resolve();
+        await cleanup.promise;
+        closed = true;
+      }
+    });
+    const failure = new Error("provider projection failed");
+    const result = listTranscriptLibrary(store, {}, () => {
+      throw failure;
+    });
+    let settled = false;
+    const settlement = result.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    try {
+      await closing.promise;
+      await setImmediate();
+      expect(settled).toBe(false);
+      expect(closed).toBe(false);
+    } finally {
+      cleanup.resolve();
+      await settlement;
+    }
+    await expect(result).rejects.toBe(failure);
+    expect(closed).toBe(true);
+  });
+
+  it("distinguishes historical unstopped rows from exact live subscriptions and stopping captures", async () => {
+    const { store } = fixture();
+    const old = session("reused");
+    const current = session("reused", { startedAt: "2026-08-21T10:00:00.000Z" });
+    await store.writeSession(old);
+    await store.writeSession(current);
+    activeSessions.set(current.sessionId, {
+      session: current,
+      phase: "active",
+      provider: {},
+      providerId: current.source.providerId,
+    });
+    const first = await listTranscriptLibrary(store, {});
+    expect(first.sessions.map((entry) => entry.activeSubscription)).toEqual([true, false]);
+    activeSessions.get(current.sessionId)!.stopping = true;
+    expect(
+      (await getTranscriptLibrary(store, { selector: transcriptSessionSelector(current) })).session
+        .activeSubscription,
+    ).toBe(false);
+    const capture = activeSessions.get(current.sessionId)!;
+    delete capture.stopping;
+    capture.phase = "terminal";
+    expect(
+      (await listTranscriptLibrary(store, {})).sessions.every((entry) => !entry.activeSubscription),
+    ).toBe(true);
+    activeSessions.clear();
+    expect(
+      (await listTranscriptLibrary(store, {})).sessions.every(
+        (entry) => !entry.activeSubscription && entry.stoppedAt === undefined,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/transcripts/library.test.ts
+++ b/src/transcripts/library.test.ts
@@ -12,6 +12,7 @@ import {
   clearNodeSqliteKyselyCacheForDatabase,
   executeSqliteQuerySync,
 } from "../infra/kysely-sync.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -21,6 +22,7 @@ import { activeSessions } from "./capture.js";
 import { exportTranscriptLibrary, getTranscriptLibrary, listTranscriptLibrary } from "./library.js";
 import type { TranscriptSessionDescriptor } from "./provider-types.js";
 import { readTranscriptLibraryStatus } from "./status.js";
+import { cursorScope, encodeCursor } from "./store-read.js";
 import { meetingTranscriptDb } from "./store-sqlite.js";
 import { TranscriptsStore, transcriptSessionSelector } from "./store.js";
 import { summarizeTranscripts } from "./summary.js";
@@ -51,10 +53,18 @@ function observeArchiveReads(database: DatabaseSync) {
     maxRowBytes: number;
     closed: boolean;
   }> = [];
-  const prepare = database.prepare.bind(database);
-  vi.spyOn(database, "prepare").mockImplementation((sql) => {
-    const statement = prepare(sql);
-    if (!/^select\b/iu.test(sql) || !sql.includes("meeting_transcript_")) {
+  const location = database.location();
+  const prototype = requireNodeSqlite().DatabaseSync.prototype;
+  // oxlint-disable-next-line typescript/unbound-method -- Called below with the intercepted native database receiver.
+  const prepare = prototype.prepare;
+  const prepareSpy = vi.spyOn(prototype, "prepare");
+  prepareSpy.mockImplementation(function (this: DatabaseSync, sql) {
+    const statement = prepare.call(this, sql);
+    if (
+      this.location() !== location ||
+      !/^select\b/iu.test(sql) ||
+      !sql.includes("meeting_transcript_")
+    ) {
       return statement;
     }
     const record = { sql, rows: 0, bytes: 0, maxRowBytes: 0, closed: false };
@@ -115,7 +125,7 @@ describe("transcript library SQLite reads", () => {
     for (const row of rows) {
       await store.writeSession(row);
     }
-    const result = listTranscriptLibrary(store, { startedAfter: "2026-08-20T09:00:00Z" });
+    const result = await listTranscriptLibrary(store, { startedAfter: "2026-08-20T09:00:00Z" });
     expect(result.sessions.map(({ sessionId }) => sessionId)).toEqual([
       "utc-at-1030",
       "offset-at-1000",
@@ -146,7 +156,7 @@ describe("transcript library SQLite reads", () => {
     const seen: Array<{ sessionId: string; startedAt: string; selector: string }> = [];
     let cursor: string | undefined;
     for (let index = 0; index < ordered.length; index++) {
-      const page = listTranscriptLibrary(store, { limit: 1, cursor });
+      const page = await listTranscriptLibrary(store, { limit: 1, cursor });
       expect(page.sessions).toHaveLength(1);
       const { sessionId, startedAt, selector } = page.sessions[0]!;
       seen.push({ sessionId, startedAt, selector });
@@ -161,10 +171,12 @@ describe("transcript library SQLite reads", () => {
       })),
     );
     expect(
-      listTranscriptLibrary(store, {
-        startedAfter: "2026-08-20T06:00:00.0005Z",
-        startedBefore: "2026-08-20T06:00:00.001Z",
-      }).sessions.map(({ sessionId }) => sessionId),
+      (
+        await listTranscriptLibrary(store, {
+          startedAfter: "2026-08-20T06:00:00.0005Z",
+          startedBefore: "2026-08-20T06:00:00.001Z",
+        })
+      ).sessions.map(({ sessionId }) => sessionId),
     ).toEqual(["basic", "fraction", "same", "same"]);
   });
 
@@ -186,20 +198,20 @@ describe("transcript library SQLite reads", () => {
         try {
           await store.writeSession(local);
           await store.writeSession(${JSON.stringify(earlier)});
-          const first = listTranscriptLibrary(store, { limit: 1 });
+          const first = await listTranscriptLibrary(store, { limit: 1 });
           assert.deepEqual(first.sessions.map(row => row.sessionId), ["local"]);
           assert.equal(typeof first.nextCursor, "string");
-          const next = listTranscriptLibrary(store, { limit: 1, cursor: first.nextCursor });
+          const next = await listTranscriptLibrary(store, { limit: 1, cursor: first.nextCursor });
           assert.deepEqual(next.sessions.map(row => row.sessionId), ["earlier"]);
           assert.equal(next.nextCursor, null);
-          assert.deepEqual(listTranscriptLibrary(store, {
+          assert.deepEqual((await listTranscriptLibrary(store, {
             startedAfter: "2026-08-20T06:00:00",
             startedBefore: "2026-08-20T13:00:00.001Z",
-          }).sessions.map(row => row.sessionId), ["local"]);
-          assert.deepEqual(listTranscriptLibrary(store, {
+          })).sessions.map(row => row.sessionId), ["local"]);
+          assert.deepEqual((await listTranscriptLibrary(store, {
             startedAfter: "2026-08-20T13:00:00.000Z",
             startedBefore: "2026-08-20T13:00:00.001Z",
-          }).sessions.map(row => row.sessionId), ["local"]);
+          })).sessions.map(row => row.sessionId), ["local"]);
           assert.deepEqual(await store.readSession(transcriptSessionSelector(local)), local);
         } finally {
           closeOpenClawStateDatabaseForTest();
@@ -233,7 +245,7 @@ describe("transcript library SQLite reads", () => {
           : "x".repeat(remaining + Number(kind === "oversized-ascii")));
       await store.writeSession(session(kind, { startedAt }));
       const parse = vi.spyOn(Date, "parse");
-      expect(() => listTranscriptLibrary(store, {})).toThrow(
+      await expect(listTranscriptLibrary(store, {})).rejects.toThrow(
         expect.objectContaining({ type: "transcript_result_too_large" }),
       );
       expect(parse.mock.calls.some(([value]) => value === startedAt)).toBe(kind === "at-cap");
@@ -256,7 +268,7 @@ describe("transcript library SQLite reads", () => {
     for (const id of ["b", "a"]) {
       await store.writeSession(session(id));
     }
-    const result = listTranscriptLibrary(store, { limit: 1 });
+    const result = await listTranscriptLibrary(store, { limit: 1 });
     expect(result.sessions.map(({ sessionId }) => sessionId)).toEqual(["a"]);
     expect(result.nextCursor).toEqual(expect.any(String));
   });
@@ -266,11 +278,11 @@ describe("transcript library SQLite reads", () => {
     await store.writeSession(session("one"));
     const db = database();
     const schema = db.prepare("SELECT type, name, sql FROM sqlite_schema ORDER BY name").all();
-    expect(listTranscriptLibrary(store, {}).sessions).toHaveLength(1);
+    expect((await listTranscriptLibrary(store, {})).sessions).toHaveLength(1);
     const held = db.prepare("SELECT 1 UNION ALL SELECT 2").iterate();
     held.next();
     try {
-      expect(listTranscriptLibrary(store, {}).sessions).toHaveLength(1);
+      expect((await listTranscriptLibrary(store, {})).sessions).toHaveLength(1);
     } finally {
       held.return?.();
     }
@@ -279,7 +291,7 @@ describe("transcript library SQLite reads", () => {
     );
     closeOpenClawStateDatabaseForTest();
     expect(database() === db).toBe(false);
-    expect(listTranscriptLibrary(store, {}).sessions).toHaveLength(1);
+    expect((await listTranscriptLibrary(store, {})).sessions).toHaveLength(1);
   });
 
   it("stops active status descriptor reads when the public result budget is consumed", async () => {
@@ -346,6 +358,7 @@ describe("transcript library SQLite reads", () => {
   it("stops a cumulative page before consuming the remaining rows and releases its iterator", async () => {
     const { store, database } = fixture();
     const target = session("cumulative");
+    const selector = transcriptSessionSelector(target);
     await store.writeSession(target);
     for (let index = 0; index < 6; index++) {
       await store.appendUtteranceForSession(target, {
@@ -353,17 +366,24 @@ describe("transcript library SQLite reads", () => {
       });
     }
     const reads = observeArchiveReads(database());
-    expect(() => store.readUtterancePage(target, { limit: 6 })).toThrow(
-      expect.objectContaining({ type: "transcript_result_too_large" }),
-    );
-    const page = reads.find((read) => read.sql.includes('"sequence"'))!;
+    await expect(
+      getTranscriptLibrary(store, { selector, includeUtterances: true, limit: 6 }),
+    ).rejects.toThrow(expect.objectContaining({ type: "transcript_result_too_large" }));
+    const page = reads.find(
+      (read) =>
+        read.sql.includes("meeting_transcript_utterances") &&
+        !read.sql.includes("meeting_transcript_sessions"),
+    )!;
     expect(page.rows).toBeLessThanOrEqual(3);
     expect(page.bytes).toBeLessThanOrEqual(2 * TRANSCRIPTS_RESULT_MAX_BYTES);
     expect(page.closed).toBe(true);
     await store.appendUtteranceForSession(target, { text: "after rejection" });
-    expect(store.readUtterancePage(target, { after: 5 }).utterances).toMatchObject([
-      { text: "after rejection", sequence: 6 },
-    ]);
+    const recovered = await getTranscriptLibrary(store, {
+      selector,
+      includeUtterances: true,
+      cursor: encodeCursor(cursorScope(["get", selector, undefined]), [5]),
+    });
+    expect(recovered.utterances).toMatchObject([{ text: "after rejection", sequence: 6 }]);
   });
 
   it("uses oversized lookahead only for pagination, then rejects that requested row", async () => {
@@ -418,19 +438,19 @@ describe("transcript library SQLite reads", () => {
           : {}),
       });
       const reads = observeArchiveReads(database());
-      expect(() => listTranscriptLibrary(store, {})).toThrow(
+      await expect(listTranscriptLibrary(store, {})).rejects.toThrow(
         expect.objectContaining({ type: "transcript_result_too_large" }),
       );
-      expect(() => store.readLatestEntry()).toThrow(
+      await expect(store.readLatestEntry()).rejects.toThrow(
         expect.objectContaining({ type: "transcript_result_too_large" }),
       );
-      expect(() => store.readEntry(transcriptSessionSelector(target))).toThrow(
+      await expect(store.readEntry(transcriptSessionSelector(target))).rejects.toThrow(
         expect.objectContaining({ type: "transcript_result_too_large" }),
       );
       expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
         TRANSCRIPTS_RESULT_MAX_BYTES,
       );
-      expect(store.readEntry(target.sessionId)).toBeUndefined();
+      expect(await store.readEntry(target.sessionId)).toBeUndefined();
       expect(await store.readSession(target.sessionId)).toEqual(target);
     },
   );
@@ -442,20 +462,20 @@ describe("transcript library SQLite reads", () => {
     await store.writeSession(first);
     await store.writeSession(second);
     const reads = observeArchiveReads(database());
-    const page = listTranscriptLibrary(store, { limit: 1 });
+    const page = await listTranscriptLibrary(store, { limit: 1 });
     expect(page.sessions.map((entry) => entry.sessionId)).toEqual(["a"]);
     expect(page.nextCursor).not.toBeNull();
     expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
       TRANSCRIPTS_RESULT_MAX_BYTES,
     );
-    expect(() => listTranscriptLibrary(store, { cursor: page.nextCursor! })).toThrow(
+    await expect(listTranscriptLibrary(store, { cursor: page.nextCursor! })).rejects.toThrow(
       expect.objectContaining({ type: "transcript_result_too_large" }),
     );
     for (const id of ["b", "c", "d"]) {
       await store.writeSession(session(id, { title: "x".repeat(600_000) }));
     }
     reads.length = 0;
-    expect(() => listTranscriptLibrary(store, { query: "x" })).toThrow(
+    await expect(listTranscriptLibrary(store, { query: "x" })).rejects.toThrow(
       expect.objectContaining({ type: "transcript_result_too_large" }),
     );
     expect(reads[0]?.rows).toBe(2);
@@ -463,12 +483,9 @@ describe("transcript library SQLite reads", () => {
     for (const id of ["b", "c", "d"]) {
       await store.writeSession(session(id, { metadata: { private: "x".repeat(600_000) } }));
     }
-    expect(listTranscriptLibrary(store, {}).sessions.map((entry) => entry.sessionId)).toEqual([
-      "a",
-      "b",
-      "c",
-      "d",
-    ]);
+    expect(
+      (await listTranscriptLibrary(store, {})).sessions.map((entry) => entry.sessionId),
+    ).toEqual(["a", "b", "c", "d"]);
   });
 
   it("bounds summary transfer after omitting duplicated history and keeps the larger export budget", async () => {
@@ -640,10 +657,10 @@ describe("transcript library SQLite reads", () => {
     for (let index = 0; index < 103; index++) {
       await store.writeSession(session(`session-${String(index).padStart(3, "0")}`));
     }
-    const first = listTranscriptLibrary(store, {});
+    const first = await listTranscriptLibrary(store, {});
     expect(first.sessions).toHaveLength(50);
-    const second = listTranscriptLibrary(store, { cursor: first.nextCursor! });
-    const third = listTranscriptLibrary(store, { cursor: second.nextCursor! });
+    const second = await listTranscriptLibrary(store, { cursor: first.nextCursor! });
+    const third = await listTranscriptLibrary(store, { cursor: second.nextCursor! });
     expect(second.sessions).toHaveLength(50);
     expect(third.sessions).toHaveLength(3);
     expect(third.nextCursor).toBeNull();
@@ -652,15 +669,15 @@ describe("transcript library SQLite reads", () => {
     ).toEqual(
       Array.from({ length: 103 }, (_, index) => `session-${String(index).padStart(3, "0")}`),
     );
-    expect(listTranscriptLibrary(store, { limit: 100 }).sessions).toHaveLength(100);
-    expect(listTranscriptLibrary(store, { limit: 200 }).sessions).toHaveLength(103);
+    expect((await listTranscriptLibrary(store, { limit: 100 })).sessions).toHaveLength(100);
+    expect((await listTranscriptLibrary(store, { limit: 200 })).sessions).toHaveLength(103);
     for (const limit of [0, 201, 1.5]) {
-      expect(() => listTranscriptLibrary(store, { limit })).toThrow("between 1 and 200");
+      await expect(listTranscriptLibrary(store, { limit })).rejects.toThrow("between 1 and 200");
     }
     await store.writeSession(session("newer", { startedAt: "2026-08-21T10:00:00.000Z" }));
-    expect(listTranscriptLibrary(store, { cursor: first.nextCursor! }).sessions[0]?.sessionId).toBe(
-      "session-050",
-    );
+    expect(
+      (await listTranscriptLibrary(store, { cursor: first.nextCursor! })).sessions[0]?.sessionId,
+    ).toBe("session-050");
   });
 
   it("combines literal title/source search, exact owner/account/provider filters and inclusive/exclusive dates", async () => {
@@ -690,32 +707,37 @@ describe("transcript library SQLite reads", () => {
       startedBefore: "2026-08-21T10:00:00Z",
     };
     expect(
-      listTranscriptLibrary(store, { ...filters, query: "% LAUNCH_" }).sessions.map(
+      (await listTranscriptLibrary(store, { ...filters, query: "% LAUNCH_" })).sessions.map(
         (entry) => entry.sessionId,
       ),
     ).toEqual(["one"]);
     expect(
-      listTranscriptLibrary(store, { ...filters, query: "ROOM-A" }).sessions.map(
+      (await listTranscriptLibrary(store, { ...filters, query: "ROOM-A" })).sessions.map(
         (entry) => entry.sessionId,
       ),
     ).toEqual(["one"]);
-    expect(listTranscriptLibrary(store, { ...filters, accountId: "personal" }).sessions).toEqual(
-      [],
-    );
-    expect(listTranscriptLibrary(store, { ...filters, providerId: "different" }).sessions).toEqual(
-      [],
-    );
     expect(
-      listTranscriptLibrary(store, { agentId: "main" }).sessions.map((entry) => entry.sessionId),
+      (await listTranscriptLibrary(store, { ...filters, accountId: "personal" })).sessions,
+    ).toEqual([]);
+    expect(
+      (await listTranscriptLibrary(store, { ...filters, providerId: "different" })).sessions,
+    ).toEqual([]);
+    expect(
+      (await listTranscriptLibrary(store, { agentId: "main" })).sessions.map(
+        (entry) => entry.sessionId,
+      ),
     ).toEqual(["two"]);
     expect(
-      listTranscriptLibrary(store, {}).sessions.find((entry) => entry.sessionId === "legacy")
-        ?.agentId,
+      (await listTranscriptLibrary(store, {})).sessions.find(
+        (entry) => entry.sessionId === "legacy",
+      )?.agentId,
     ).toBeNull();
-    expect(() => listTranscriptLibrary(store, { startedAfter: "bad date" })).toThrow("date filter");
-    expect(() =>
+    await expect(listTranscriptLibrary(store, { startedAfter: "bad date" })).rejects.toThrow(
+      "date filter",
+    );
+    await expect(
       listTranscriptLibrary(store, { startedAfter: "2026-08-22", startedBefore: "2026-08-21" }),
-    ).toThrow("range");
+    ).rejects.toThrow("range");
   });
 
   it("preserves full canonical handles and pages/searches durable utterances without reading exports", async () => {
@@ -764,7 +786,7 @@ describe("transcript library SQLite reads", () => {
     await store.writeSummary(summarizeTranscripts({ session: target, utterances }), target);
     // Reopen a raw legacy-shaped URL row without Doctor or read-time normalization.
     closeOpenClawStateDatabaseForTest();
-    const selector = listTranscriptLibrary(store, {}).sessions[0]!.selector;
+    const selector = (await listTranscriptLibrary(store, {})).sessions[0]!.selector;
     for (const query of [
       "PLANNING",
       "opaque",
@@ -776,7 +798,7 @@ describe("transcript library SQLite reads", () => {
       "public-file",
     ]) {
       expect(
-        listTranscriptLibrary(store, { query }).sessions.map((entry) => entry.selector),
+        (await listTranscriptLibrary(store, { query })).sessions.map((entry) => entry.selector),
         query,
       ).toEqual([selector]);
     }
@@ -785,11 +807,12 @@ describe("transcript library SQLite reads", () => {
       "invite",
       "example.test",
     ]) {
-      expect(
-        [...store.iterateReadEntries({ query })].map((entry) => entry.selector),
-        query,
-      ).toEqual([]);
-      expect(listTranscriptLibrary(store, { query }).sessions, query).toEqual([]);
+      const selectors: string[] = [];
+      for await (const entry of store.iterateReadEntries({ query })) {
+        selectors.push(entry.selector);
+      }
+      expect(selectors, query).toEqual([]);
+      expect((await listTranscriptLibrary(store, { query })).sessions, query).toEqual([]);
     }
     const first = await getTranscriptLibrary(store, {
       selector,
@@ -829,7 +852,10 @@ describe("transcript library SQLite reads", () => {
     ]);
     expect(last.nextCursor).toBeNull();
     expect(JSON.stringify(first)).not.toContain("private");
-    const publicOutputs = [JSON.stringify(first), JSON.stringify(listTranscriptLibrary(store, {}))];
+    const publicOutputs = [
+      JSON.stringify(first),
+      JSON.stringify(await listTranscriptLibrary(store, {})),
+    ];
     for (const format of ["markdown", "jsonl"] as const) {
       const exported = await exportTranscriptLibrary(store, { selector, format });
       const content = Buffer.from(exported.data, "base64").toString("utf8");
@@ -857,13 +883,15 @@ describe("transcript library SQLite reads", () => {
       await store.appendUtteranceForSession(target, { text: "a" });
       await store.appendUtteranceForSession(target, { text: "b" });
     }
-    const listed = listTranscriptLibrary(store, { limit: 1 });
+    const listed = await listTranscriptLibrary(store, { limit: 1 });
     const selector = listed.sessions[0]!.selector;
     const read = await getTranscriptLibrary(store, { selector, includeUtterances: true, limit: 1 });
-    expect(() => listTranscriptLibrary(store, { cursor: "not-a-cursor" })).toThrow("cursor");
-    expect(() =>
+    await expect(listTranscriptLibrary(store, { cursor: "not-a-cursor" })).rejects.toThrow(
+      "cursor",
+    );
+    await expect(
       listTranscriptLibrary(store, { cursor: listed.nextCursor!, agentId: "other" }),
-    ).toThrow("cursor");
+    ).rejects.toThrow("cursor");
     await expect(
       getTranscriptLibrary(store, { selector, cursor: listed.nextCursor! }),
     ).rejects.toThrow("cursor");
@@ -989,39 +1017,6 @@ describe("transcript library SQLite reads", () => {
       );
     }
     expect(fs.existsSync(path.join(stateDir, "transcripts"))).toBe(false);
-    expect(store.readNotes(target)).toEqual({});
-  });
-
-  it("distinguishes historical unstopped rows from exact live subscriptions and stopping captures", async () => {
-    const { store } = fixture();
-    const old = session("reused");
-    const current = session("reused", { startedAt: "2026-08-21T10:00:00.000Z" });
-    await store.writeSession(old);
-    await store.writeSession(current);
-    activeSessions.set(current.sessionId, {
-      session: current,
-      phase: "active",
-      provider: {},
-      providerId: current.source.providerId,
-    });
-    const first = listTranscriptLibrary(store, {});
-    expect(first.sessions.map((entry) => entry.activeSubscription)).toEqual([true, false]);
-    activeSessions.get(current.sessionId)!.stopping = true;
-    expect(
-      (await getTranscriptLibrary(store, { selector: transcriptSessionSelector(current) })).session
-        .activeSubscription,
-    ).toBe(false);
-    const capture = activeSessions.get(current.sessionId)!;
-    delete capture.stopping;
-    capture.phase = "terminal";
-    expect(
-      listTranscriptLibrary(store, {}).sessions.every((entry) => !entry.activeSubscription),
-    ).toBe(true);
-    activeSessions.clear();
-    expect(
-      listTranscriptLibrary(store, {}).sessions.every(
-        (entry) => !entry.activeSubscription && entry.stoppedAt === undefined,
-      ),
-    ).toBe(true);
+    expect(await store.readNotes(target)).toEqual({});
   });
 });

--- a/src/transcripts/library.ts
+++ b/src/transcripts/library.ts
@@ -1,8 +1,5 @@
 import { createHash } from "node:crypto";
-import {
-  asSafeIntegerInRange,
-  parseDateStringTimestampMs,
-} from "@openclaw/normalization-core/number-coercion";
+import { parseDateStringTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   TRANSCRIPTS_EXPORT_MAX_BYTES,
@@ -21,48 +18,22 @@ import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text
 import { readTranscriptCaptureSnapshot } from "./capture.js";
 import {
   projectTranscriptMarkdown,
+  projectTranscriptNotes,
   projectTranscriptSession,
   projectTranscriptUtterance,
-  readTranscriptNotes,
 } from "./read.js";
 import {
   assertTranscriptByteLimit,
   assertTranscriptByteCount,
+  cursorScope,
+  decodeCursor,
+  encodeCursor,
   TranscriptLibraryError,
+  type TranscriptExportRead,
   type TranscriptReadOptions,
-  type TranscriptReadPurpose,
 } from "./store-read.js";
 import { safeTranscriptPathSegment, type TranscriptsStore } from "./store.js";
 import { renderTranscriptsMarkdown } from "./summary.js";
-
-function cursorScope(values: unknown[]): string {
-  return createHash("sha256").update(JSON.stringify(values)).digest("hex");
-}
-
-function encodeCursor(scope: string, position: [string, string] | [number]): string {
-  return Buffer.from(JSON.stringify([1, scope, ...position])).toString("base64url");
-}
-
-function decodeCursor(cursor: string | undefined, scope: string): unknown[] | undefined {
-  if (cursor === undefined) {
-    return undefined;
-  }
-  try {
-    if (cursor.length > TRANSCRIPTS_RESULT_MAX_BYTES || !/^[A-Za-z0-9_-]+$/u.test(cursor)) {
-      throw new Error();
-    }
-    const value: unknown = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
-    if (Array.isArray(value) && value[0] === 1 && value[1] === scope) {
-      return value.slice(2);
-    }
-  } catch {
-    /* Invalid or cross-query cursors are never used as selectors. */
-  }
-  throw new TranscriptLibraryError(
-    "transcript_invalid_cursor",
-    "Invalid transcript cursor; restart pagination with the current filters.",
-  );
-}
 
 function normalizeDate(value: string | undefined): string | undefined {
   if (value === undefined) {
@@ -78,26 +49,11 @@ function normalizeDate(value: string | undefined): string | undefined {
   return new Date(time).toISOString();
 }
 
-function requireEntry(
-  store: TranscriptsStore,
-  selector: string,
-  purpose: TranscriptReadPurpose = "page",
-) {
-  const entry = store.readEntry(selector, purpose);
-  if (!entry) {
-    throw new TranscriptLibraryError(
-      "transcript_session_not_found",
-      "Transcript not found; refresh the library and use its full selector.",
-    );
-  }
-  return entry;
-}
-
-export function listTranscriptLibrary(
+export async function listTranscriptLibrary(
   store: TranscriptsStore,
   params: TranscriptsListParams,
   providerName?: (providerId: string) => string | undefined,
-): TranscriptsListResult {
+): Promise<TranscriptsListResult> {
   const { cursor, ...filters } = params;
   const startedAfter = normalizeDate(filters.startedAfter);
   const startedBefore = normalizeDate(filters.startedBefore);
@@ -134,7 +90,7 @@ export function listTranscriptLibrary(
   let bytes = 0;
   let hasMore = false;
   try {
-    for (let step = page.next(); ; step = page.next()) {
+    for (let step = await page.next(); ; step = await page.next()) {
       if (step.done) {
         hasMore = step.value;
         break;
@@ -150,7 +106,7 @@ export function listTranscriptLibrary(
       sessions.push(entry);
     }
   } finally {
-    page.return(false);
+    await page.return(false);
   }
   const last = sessions.at(-1);
   const result = {
@@ -166,27 +122,7 @@ export async function getTranscriptLibrary(
   params: TranscriptsGetParams,
   providerName?: (providerId: string) => string | undefined,
 ): Promise<TranscriptsGetResult> {
-  const purpose =
-    params.limit === undefined && params.cursor === undefined && params.query === undefined
-      ? "legacy"
-      : "page";
-  const entry = requireEntry(store, params.selector, purpose);
-  const scope = cursorScope(["get", entry.selector, params.query]);
-  const position = decodeCursor(params.cursor, scope);
-  const after = asSafeIntegerInRange(position?.[0], { min: 0 });
-  if (position && (position.length !== 1 || after === undefined)) {
-    throw new TranscriptLibraryError(
-      "transcript_invalid_cursor",
-      "Invalid transcript reader cursor.",
-    );
-  }
-  const page = params.includeUtterances
-    ? store.readUtterancePage(
-        entry.session,
-        { limit: params.limit, query: params.query, after },
-        purpose,
-      )
-    : undefined;
+  const { entry, page, notes, purpose, scope } = await store.readLibraryEntry(params);
   const utterances = page?.utterances.map((utterance) => {
     const projected = projectTranscriptUtterance(utterance);
     if (purpose === "legacy") {
@@ -203,7 +139,7 @@ export async function getTranscriptLibrary(
     ),
     ...(utterances ? { utterances } : {}),
     nextCursor: page?.hasMore && last ? encodeCursor(scope, [last.sequence]) : null,
-    summary: await readTranscriptNotes(store, entry.session, purpose),
+    summary: projectTranscriptNotes(notes),
   };
   assertTranscriptByteLimit(
     JSON.stringify(result),
@@ -216,22 +152,35 @@ export async function exportTranscriptLibrary(
   store: TranscriptsStore,
   params: TranscriptsExportParams,
 ): Promise<TranscriptsExportResult> {
-  const entry = requireEntry(store, params.selector, "export");
+  const rows = store.iterateExport(params.selector, params.format === "markdown");
   const parts: string[] = [];
   let sizeBytes = 0;
-  for (const utterance of store.iterateUtterances(entry.session)) {
-    const text =
-      params.format === "jsonl"
-        ? `${JSON.stringify(projectTranscriptUtterance(utterance))}\n`
-        : sanitizeTerminalText(utterance.text).trim();
-    const speaker = sanitizeTerminalText(utterance.speakerLabel ?? "").trim();
-    const line = params.format === "markdown" && speaker ? `${speaker}: ${text}` : text;
-    // Include Markdown list/newline overhead while accumulating, before rendering the body.
-    sizeBytes += Buffer.byteLength(line, "utf8") + (params.format === "markdown" ? 3 : 0);
-    assertTranscriptByteCount(sizeBytes, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
-    parts.push(line);
+  let completed: TranscriptExportRead | undefined;
+  try {
+    for (let step = await rows.next(); ; step = await rows.next()) {
+      if (step.done) {
+        completed = step.value;
+        break;
+      }
+      const utterance = step.value;
+      const text =
+        params.format === "jsonl"
+          ? `${JSON.stringify(projectTranscriptUtterance(utterance))}\n`
+          : sanitizeTerminalText(utterance.text).trim();
+      const speaker = sanitizeTerminalText(utterance.speakerLabel ?? "").trim();
+      const line = params.format === "markdown" && speaker ? `${speaker}: ${text}` : text;
+      // Include Markdown list/newline overhead while accumulating, before rendering the body.
+      sizeBytes += Buffer.byteLength(line, "utf8") + (params.format === "markdown" ? 3 : 0);
+      assertTranscriptByteCount(sizeBytes, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
+      parts.push(line);
+    }
+  } finally {
+    await rows.return(undefined);
   }
-  const notes = params.format === "markdown" ? store.readNotes(entry.session, "export") : undefined;
+  if (!completed) {
+    throw new Error("Transcript export ended before completion.");
+  }
+  const { entry, notes } = completed;
   const summary = notes?.summary;
   const title = sanitizeTerminalText(entry.session.title ?? "").trim() || "Transcript";
   const body =

--- a/src/transcripts/read.ts
+++ b/src/transcripts/read.ts
@@ -82,7 +82,12 @@ export async function readTranscriptNotes(
   session: TranscriptSessionDescriptor,
   purpose: TranscriptReadPurpose = "page",
 ): Promise<TranscriptsGetResult["summary"]> {
-  const stored = store.readNotes(session, purpose);
+  return projectTranscriptNotes(await store.readNotes(session, purpose));
+}
+
+export function projectTranscriptNotes(
+  stored: Awaited<ReturnType<TranscriptsStore["readNotes"]>>,
+): TranscriptsGetResult["summary"] {
   if (stored.markdown === undefined) {
     return undefined;
   }

--- a/src/transcripts/status.producer.test.ts
+++ b/src/transcripts/status.producer.test.ts
@@ -307,16 +307,18 @@ describe("configured transcript source provenance", () => {
       const originalWrite = f.store.writeSession.bind(f.store);
       let titleFailed = false;
       let cleanupFails = true;
-      vi.spyOn(TranscriptsStore.prototype, "writeSession").mockImplementation(async (session) => {
-        if (session.title === "Room title" && !titleFailed) {
-          titleFailed = true;
-          throw new Error("title write unavailable");
-        }
-        if (session.stoppedAt && fault === "session-write" && cleanupFails) {
-          throw new Error("final session write unavailable");
-        }
-        await originalWrite(session);
-      });
+      vi.spyOn(TranscriptsStore.prototype, "writeSession").mockImplementation(
+        async (session, condition) => {
+          if (session.title === "Room title" && !titleFailed) {
+            titleFailed = true;
+            throw new Error("title write unavailable");
+          }
+          if (session.stoppedAt && fault === "session-write" && cleanupFails) {
+            throw new Error("final session write unavailable");
+          }
+          await originalWrite(session, condition);
+        },
+      );
       const originalSummary = f.store.writeSummary.bind(f.store);
       vi.spyOn(TranscriptsStore.prototype, "writeSummary").mockImplementation(async (...args) => {
         if (fault === "summary-write" && cleanupFails) {
@@ -440,12 +442,14 @@ describe("configured transcript source provenance", () => {
         return { ok: true, sessionId };
       });
       const writeSession = f.store.writeSession.bind(f.store);
-      vi.spyOn(TranscriptsStore.prototype, "writeSession").mockImplementation(async (session) => {
-        if (cleanupFails && fault === "session-write" && session.stoppedAt) {
-          throw new Error("final session unavailable");
-        }
-        await writeSession(session);
-      });
+      vi.spyOn(TranscriptsStore.prototype, "writeSession").mockImplementation(
+        async (session, condition) => {
+          if (cleanupFails && fault === "session-write" && session.stoppedAt) {
+            throw new Error("final session unavailable");
+          }
+          await writeSession(session, condition);
+        },
+      );
       const writeSummary = f.store.writeSummary.bind(f.store);
       vi.spyOn(TranscriptsStore.prototype, "writeSummary").mockImplementation(async (...args) => {
         if (cleanupFails && fault === "summary-write") {
@@ -668,7 +672,7 @@ describe("configured transcript source provenance", () => {
       expect(session.stoppedAt).toEqual(expect.any(String));
       const notes = await f.store.readSummary(session);
       expect(notes.summary?.transcript).toEqual(["Saved before the duplicate retry"]);
-      const revision = f.store.readSummaryInputRevision(session);
+      const revision = await f.store.readSummaryInputRevision(session);
       vi.mocked(providerRegistry.getTranscriptSourceProvider).mockImplementation((id) =>
         id === delayedId ? delayedProvider : f.provider,
       );
@@ -687,7 +691,7 @@ describe("configured transcript source provenance", () => {
       expect(await f.store.listSessionEntries()).toHaveLength(1);
       expect(await f.store.readSession(entry.sessionId)).toEqual(session);
       expect(await f.store.readSummary(session)).toEqual(notes);
-      expect(f.store.readSummaryInputRevision(session)).toBe(revision);
+      expect(await f.store.readSummaryInputRevision(session)).toBe(revision);
     } finally {
       await service.stop();
     }

--- a/src/transcripts/status.ts
+++ b/src/transcripts/status.ts
@@ -110,7 +110,7 @@ export async function readTranscriptLibraryStatus(
   let activeBytes = 0;
   // Project each bounded row before reading the next to avoid retaining private descriptors.
   for (const capture of selectedCaptures) {
-    const entry = store.readEntry(transcriptSessionSelector(capture.session));
+    const entry = await store.readEntry(transcriptSessionSelector(capture.session));
     if (entry) {
       const projected = projectTranscriptSession(entry, undefined, undefined, captures);
       activeBytes += Buffer.byteLength(JSON.stringify(projected), "utf8");
@@ -191,7 +191,7 @@ export async function readTranscriptLibraryStatus(
       }
       return result;
     });
-  const latest = store.readLatestEntry();
+  const latest = await store.readLatestEntry();
   const result: TranscriptsStatusResult = {
     enabled: config.enabled,
     providers: allProviders.slice(0, TRANSCRIPTS_PAGE_MAX),

--- a/src/transcripts/store-read.ts
+++ b/src/transcripts/store-read.ts
@@ -1,5 +1,9 @@
+import { createHash } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
-import { parseDateStringTimestampMs } from "@openclaw/normalization-core/number-coercion";
+import {
+  asSafeIntegerInRange,
+  parseDateStringTimestampMs,
+} from "@openclaw/normalization-core/number-coercion";
 import { expressionBuilder, type Expression, type SqlBool } from "kysely";
 import {
   TRANSCRIPTS_EXPORT_MAX_BYTES,
@@ -10,6 +14,7 @@ import {
   TRANSCRIPTS_RESULT_MAX_BYTES,
   type TranscriptUtterance,
   type TranscriptsListParams,
+  type TranscriptsGetParams,
 } from "../../packages/gateway-protocol/src/schema/transcripts.js";
 import { executeSqliteQueryTakeFirstSync, iterateSqliteQuerySync } from "../infra/kysely-sync.js";
 import type { TranscriptSessionDescriptor } from "./provider-types.js";
@@ -34,6 +39,35 @@ export class TranscriptLibraryError extends Error {
   ) {
     super(message);
   }
+}
+
+export function cursorScope(values: unknown[]): string {
+  return createHash("sha256").update(JSON.stringify(values)).digest("hex");
+}
+
+export function encodeCursor(scope: string, position: [string, string] | [number]): string {
+  return Buffer.from(JSON.stringify([1, scope, ...position])).toString("base64url");
+}
+
+export function decodeCursor(cursor: string | undefined, scope: string): unknown[] | undefined {
+  if (cursor === undefined) {
+    return undefined;
+  }
+  try {
+    if (cursor.length > TRANSCRIPTS_RESULT_MAX_BYTES || !/^[A-Za-z0-9_-]+$/u.test(cursor)) {
+      throw new Error();
+    }
+    const value: unknown = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+    if (Array.isArray(value) && value[0] === 1 && value[1] === scope) {
+      return value.slice(2);
+    }
+  } catch {
+    /* Invalid or cross-query cursors are never used as selectors. */
+  }
+  throw new TranscriptLibraryError(
+    "transcript_invalid_cursor",
+    "Invalid transcript cursor; restart pagination with the current filters.",
+  );
 }
 
 function transcriptPageLimit(limit = TRANSCRIPTS_PAGE_DEFAULT, max = TRANSCRIPTS_PAGE_MAX): number {
@@ -491,7 +525,7 @@ function transcriptReadUtteranceFromRow(
   };
 }
 
-export function readTranscriptUtterancePage(
+function readTranscriptUtterancePage(
   database: DatabaseSync,
   session: TranscriptSessionDescriptor,
   options: { limit?: number; after?: number; query?: string },
@@ -574,7 +608,7 @@ export function readStoredTranscriptNotes(
 }
 
 /** Iterate canonical rows for downloads without materializing export files or an unbounded array. */
-export function* iterateTranscriptUtterances(
+function* iterateTranscriptUtterances(
   database: DatabaseSync,
   session: TranscriptSessionDescriptor,
 ): Generator<TranscriptUtterance> {
@@ -585,4 +619,64 @@ export function* iterateTranscriptUtterances(
     assertTranscriptByteCount(row.payload_bytes, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
     yield transcriptReadUtteranceFromRow(row);
   }
+}
+
+function requireTranscriptReadEntry(
+  database: DatabaseSync,
+  selector: string,
+  purpose: TranscriptReadPurpose,
+) {
+  const entry = readTranscriptEntry(database, selector, purpose);
+  if (!entry) {
+    throw new TranscriptLibraryError(
+      "transcript_session_not_found",
+      "Transcript not found; refresh the library and use its full selector.",
+    );
+  }
+  return entry;
+}
+
+export function readTranscriptLibraryEntry(database: DatabaseSync, params: TranscriptsGetParams) {
+  const purpose: "legacy" | "page" =
+    params.limit === undefined && params.cursor === undefined && params.query === undefined
+      ? "legacy"
+      : "page";
+  const entry = requireTranscriptReadEntry(database, params.selector, purpose);
+  const scope = cursorScope(["get", entry.selector, params.query]);
+  const position = decodeCursor(params.cursor, scope);
+  const after = asSafeIntegerInRange(position?.[0], { min: 0 });
+  if (position && (position.length !== 1 || after === undefined)) {
+    throw new TranscriptLibraryError(
+      "transcript_invalid_cursor",
+      "Invalid transcript reader cursor.",
+    );
+  }
+  const page = params.includeUtterances
+    ? readTranscriptUtterancePage(
+        database,
+        entry.session,
+        { limit: params.limit, query: params.query, after },
+        purpose,
+      )
+    : undefined;
+  const notes = readStoredTranscriptNotes(database, entry.session, purpose);
+  return { entry, page, notes, purpose, scope };
+}
+
+export type TranscriptExportRead = {
+  entry: TranscriptReadEntry;
+  notes: ReturnType<typeof readStoredTranscriptNotes> | undefined;
+};
+
+export function* iterateTranscriptExport(
+  database: DatabaseSync,
+  selector: string,
+  includeNotes: boolean,
+): Generator<TranscriptUtterance, TranscriptExportRead> {
+  const entry = requireTranscriptReadEntry(database, selector, "export");
+  yield* iterateTranscriptUtterances(database, entry.session);
+  const notes = includeNotes
+    ? readStoredTranscriptNotes(database, entry.session, "export")
+    : undefined;
+  return { entry, notes };
 }

--- a/src/transcripts/store-sqlite.ts
+++ b/src/transcripts/store-sqlite.ts
@@ -43,6 +43,21 @@ export function meetingTranscriptSessionQuery(
     .where("started_at", "=", session.startedAt);
 }
 
+export function transcriptSummaryInputRevisionFromRow(
+  row: Pick<
+    MeetingTranscriptSessionRow,
+    "next_utterance_seq" | "title" | "source_json" | "metadata_json" | "stopped_at"
+  >,
+): string {
+  return JSON.stringify({
+    next_utterance_seq: row.next_utterance_seq,
+    title: row.title,
+    source_json: row.source_json,
+    metadata_json: row.metadata_json,
+    stopped_at: row.stopped_at,
+  });
+}
+
 export function readTranscriptSummaryInputRevision(
   database: DatabaseSync,
   session: Pick<TranscriptSessionDescriptor, "sessionId" | "startedAt">,
@@ -58,7 +73,7 @@ export function readTranscriptSummaryInputRevision(
     ]),
   );
   // Export bookkeeping is not summary input and must not invalidate a reader.
-  return row ? JSON.stringify(row) : undefined;
+  return row ? transcriptSummaryInputRevisionFromRow(row) : undefined;
 }
 
 export function readTranscriptSummaryKeys(database: DatabaseSync): Set<string> {
@@ -76,7 +91,7 @@ export function readRecentStoppedTranscriptSession(
   source: TranscriptSourceLocator,
   stoppedAfter: string,
   stoppedBefore: string,
-): TranscriptSessionDescriptor | undefined {
+): { session: TranscriptSessionDescriptor; inputRevision: string } | undefined {
   const row = executeSqliteQueryTakeFirstSync(
     database,
     meetingTranscriptDb(database)
@@ -102,7 +117,9 @@ export function readRecentStoppedTranscriptSession(
       .orderBy("session_id", "asc")
       .limit(1),
   );
-  return row ? sessionFromRow(row) : undefined;
+  return row
+    ? { session: sessionFromRow(row), inputRevision: transcriptSummaryInputRevisionFromRow(row) }
+    : undefined;
 }
 
 export function meetingTranscriptUtteranceQuery(

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -2,12 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { StateDatabaseCoordinatorContentionError } from "../infra/state-database-coordinator.js";
+import { acquireOpenClawStateDatabaseFileExclusion } from "../state/openclaw-state-db-cache.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import type { TranscriptSessionDescriptor } from "./provider-types.js";
-import { safeTranscriptPathSegment, TranscriptsStore } from "./store.js";
+import { safeTranscriptPathSegment, transcriptSessionSelector, TranscriptsStore } from "./store.js";
 import { summarizeTranscripts } from "./summary.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -36,6 +38,84 @@ function session(
 }
 
 describe("TranscriptsStore", () => {
+  it("keeps a streamed page stable across writes and shared writer closure", async () => {
+    const { store, stateDir } = createStore();
+    for (const id of ["a", "b", "c"]) {
+      await store.writeSession({ ...session(id), title: id });
+    }
+    const writer = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    const rows = store.iterateReadEntries({ limit: 3 });
+    try {
+      const first = await rows.next();
+      expect(first.done).toBe(false);
+      if (first.done) {
+        throw new Error("Expected first transcript row");
+      }
+      expect(first.value.session.title).toBe("a");
+      await store.writeSession({ ...session("c"), title: "changed" });
+      closeOpenClawStateDatabaseForTest();
+      expect(writer.db.isOpen).toBe(false);
+      expect(() => acquireOpenClawStateDatabaseFileExclusion(writer.path)).toThrow(
+        StateDatabaseCoordinatorContentionError,
+      );
+      const remaining: string[] = [];
+      for await (const entry of rows) {
+        remaining.push(entry.session.title ?? "");
+      }
+      expect(remaining).toEqual(["b", "c"]);
+    } finally {
+      await rows.return(false);
+    }
+    const exclusion = acquireOpenClawStateDatabaseFileExclusion(writer.path);
+    exclusion.release();
+    expect((await store.readSession("c"))?.title).toBe("changed");
+  });
+
+  it.each(["return", "consumer-error"] as const)(
+    "releases its streamed utterance reader after %s",
+    async (finish) => {
+      const { store, stateDir } = createStore();
+      const target = session();
+      await store.writeSession(target);
+      await store.appendUtteranceForSession(target, { text: "first" });
+      await store.appendUtteranceForSession(target, { text: "second" });
+      const writer = openOpenClawStateDatabase({
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      });
+      const rows = store.iterateExport(transcriptSessionSelector(target), false);
+      try {
+        const first = await rows.next();
+        expect(first.done).toBe(false);
+        expect(() => acquireOpenClawStateDatabaseFileExclusion(writer.path)).toThrow(
+          StateDatabaseCoordinatorContentionError,
+        );
+        if (finish === "return") {
+          expect((await rows.return(undefined)).done).toBe(true);
+        } else {
+          const failure = new Error("consumer stopped reading");
+          await expect(
+            (async () => {
+              for await (const row of rows) {
+                expect(row.text).toBe("second");
+                throw failure;
+              }
+            })(),
+          ).rejects.toBe(failure);
+        }
+      } finally {
+        await rows.return(undefined);
+      }
+      const exclusion = acquireOpenClawStateDatabaseFileExclusion(writer.path);
+      exclusion.release();
+      expect((await store.readUtterancesForSession(target)).map((row) => row.text)).toEqual([
+        "first",
+        "second",
+      ]);
+    },
+  );
+
   it.each([undefined, null, "invalid", "generated", "supplied"])(
     "retains the admitted ID origin %s across updates, reopen, and Doctor restoration",
     async (origin) => {

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -2,9 +2,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveOptionalIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import type { TranscriptUtterance as ProjectedTranscriptUtterance } from "../../packages/gateway-protocol/src/schema/transcripts.js";
 import { sha256File, sha256Hex } from "../infra/crypto-digest.js";
 import { ensureAbsoluteDirectory } from "../infra/fs-safe.js";
 import { executeSqliteQuerySync, executeSqliteQueryTakeFirstSync } from "../infra/kysely-sync.js";
+import { iterateOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -44,6 +46,7 @@ import {
   readRecentStoppedTranscriptSession,
   readTranscriptSummaryKeys,
   readTranscriptSummaryInputRevision,
+  transcriptSummaryInputRevisionFromRow,
   sessionFromRow,
   summaryFromRow,
   utteranceFromRow,
@@ -61,11 +64,16 @@ export class TranscriptsSummaryChangedError extends Error {
   }
 }
 
+type TranscriptSessionMatchEntry = StoreTypes.TranscriptsSessionEntry & { inputRevision: string };
+
 /** Canonical meeting-capture transcript store. Files are explicit exports only. */
 export class TranscriptsStore {
   constructor(
     private readonly exportRootDir: string,
-    private readonly databaseOptions: OpenClawStateDatabaseOptions = {},
+    private readonly databaseOptions: Pick<
+      OpenClawStateDatabaseOptions,
+      "env" | "path" | "readOnly"
+    > = {},
   ) {}
 
   private database() {
@@ -294,35 +302,45 @@ export class TranscriptsStore {
     );
   }
 
-  iterateReadEntries(options: read.TranscriptReadOptions = {}) {
-    return read.iterateTranscriptReadEntries(this.database().db, options);
+  async *iterateReadEntries(options: read.TranscriptReadOptions = {}) {
+    return yield* iterateOpenClawStateDatabaseReadOnly(
+      this.database(),
+      ({ db }) => read.iterateTranscriptReadEntries(db, options),
+      this.databaseOptions.env,
+    );
   }
 
-  readEntry(selector: string, purpose: read.TranscriptReadPurpose = "page") {
+  async readEntry(selector: string, purpose: read.TranscriptReadPurpose = "page") {
     return read.readTranscriptEntry(this.database().db, selector, purpose);
   }
 
-  readLatestEntry() {
+  async readLatestEntry() {
     return read.readLatestTranscriptEntry(this.database().db);
   }
 
-  readNotes(session: TranscriptSessionDescriptor, purpose: read.TranscriptReadPurpose = "page") {
+  async readNotes(
+    session: TranscriptSessionDescriptor,
+    purpose: read.TranscriptReadPurpose = "page",
+  ) {
     return read.readStoredTranscriptNotes(this.database().db, session, purpose);
   }
 
-  readUtterancePage(
-    session: TranscriptSessionDescriptor,
-    options: { limit?: number; after?: number; query?: string } = {},
-    purpose: "page" | "legacy" = "page",
-  ) {
-    return read.readTranscriptUtterancePage(this.database().db, session, options, purpose);
+  async readLibraryEntry(params: Parameters<typeof read.readTranscriptLibraryEntry>[1]) {
+    return read.readTranscriptLibraryEntry(this.database().db, params);
   }
 
-  iterateUtterances(session: TranscriptSessionDescriptor) {
-    return read.iterateTranscriptUtterances(this.database().db, session);
+  async *iterateExport(
+    selector: string,
+    includeNotes: boolean,
+  ): AsyncGenerator<ProjectedTranscriptUtterance, read.TranscriptExportRead | undefined> {
+    return yield* iterateOpenClawStateDatabaseReadOnly(
+      this.database(),
+      ({ db }) => read.iterateTranscriptExport(db, selector, includeNotes),
+      this.databaseOptions.env,
+    );
   }
 
-  readRecentStoppedSession(
+  async readRecentStoppedSession(
     source: TranscriptSourceLocator,
     stoppedAfter: string,
     stoppedBefore: string,
@@ -335,15 +353,20 @@ export class TranscriptsStore {
     );
   }
 
-  readSummaryInputRevision(session: TranscriptSessionDescriptor): string | undefined {
+  async readSummaryInputRevision(
+    session: TranscriptSessionDescriptor,
+  ): Promise<string | undefined> {
     return readTranscriptSummaryInputRevision(this.database().db, session);
   }
 
-  listReadEntries(options: read.TranscriptReadOptions) {
+  async listReadEntries(options: read.TranscriptReadOptions) {
     return read.queryTranscriptReadEntries(this.database().db, options);
   }
 
-  async writeSession(session: TranscriptSessionDescriptor): Promise<void> {
+  async writeSession(
+    session: TranscriptSessionDescriptor,
+    condition?: { expectedInputRevision?: string; assertCurrent?: () => void },
+  ): Promise<void> {
     ensureMeetingTranscriptsSchema(this.databaseOptions);
     if (
       !this.readSessionByIdentity(session) &&
@@ -357,7 +380,7 @@ export class TranscriptsStore {
       const legacySelector = legacyTranscriptSessionSelector(session);
       if (legacySelector !== undefined) {
         const legacySessionDir = path.join(this.exportRootDir, legacySelector);
-        const legacyRow = this.readCanonicalSelectorRow(legacySelector);
+        const legacyRow = this.readCanonicalSelectorRow(this.database(), legacySelector);
         const legacyOwner = legacyRow ? sessionFromRow(legacyRow) : undefined;
         const legacyPathIsCanonical =
           legacyOwner !== undefined &&
@@ -382,6 +405,13 @@ export class TranscriptsStore {
     };
     const now = Date.now();
     this.transaction("meeting-transcripts.session.write", ({ db: database }) => {
+      condition?.assertCurrent?.();
+      if (
+        condition?.expectedInputRevision !== undefined &&
+        readTranscriptSummaryInputRevision(database, session) !== condition.expectedInputRevision
+      ) {
+        throw new TranscriptsSummaryChangedError();
+      }
       const previous = executeSqliteQueryTakeFirstSync(
         database,
         meetingTranscriptSessionQuery(database, session).selectAll(),
@@ -428,7 +458,7 @@ export class TranscriptsStore {
   async readSessionEntry(
     sessionSelector: string,
   ): Promise<StoreTypes.TranscriptsSessionEntry | undefined> {
-    const { qualified, unqualified } = this.matchSessionEntries(sessionSelector);
+    const { qualified, unqualified } = await this.matchSessionEntries(sessionSelector);
     const entries = qualified.length ? qualified : unqualified;
     if (entries.length > 1) {
       throw new Error(
@@ -437,11 +467,15 @@ export class TranscriptsStore {
           .join(", ")}`,
       );
     }
-    return entries[0];
+    const matched = entries[0];
+    if (!matched) {
+      return undefined;
+    }
+    const { inputRevision: _inputRevision, ...entry } = matched;
+    return entry;
   }
 
-  private readCanonicalSelectorRow(selector: string) {
-    const database = this.database();
+  private readCanonicalSelectorRow(database: OpenClawStateDatabase, selector: string) {
     return executeSqliteQueryTakeFirstSync(
       database.db,
       meetingTranscriptDb(database.db)
@@ -453,24 +487,26 @@ export class TranscriptsStore {
 
   // Return bounded evidence, not a selection policy: operators prefer qualified
   // matches, while legacy tool handles must also account for raw-ID collisions.
-  matchSessionEntries(value: string): {
-    qualified: StoreTypes.TranscriptsSessionEntry[];
-    unqualified: StoreTypes.TranscriptsSessionEntry[];
-  } {
+  async matchSessionEntries(value: string): Promise<{
+    qualified: TranscriptSessionMatchEntry[];
+    unqualified: TranscriptSessionMatchEntry[];
+  }> {
     const database = this.database();
     const query = meetingTranscriptDb(database.db)
       .selectFrom("meeting_transcript_sessions")
       .selectAll()
       .orderBy("started_at", "desc")
       .limit(2);
+    const matchedEntry = (row: MeetingTranscriptSessionRow): TranscriptSessionMatchEntry => ({
+      ...this.entryFromRow(row, this.hasSummary(database, row)),
+      inputRevision: transcriptSummaryInputRevisionFromRow(row),
+    });
     const entries = (selection: typeof query) =>
-      executeSqliteQuerySync(database.db, selection).rows.map((row) =>
-        this.entryFromRow(row, this.hasSummary(database, row)),
-      );
-    const canonical = this.readCanonicalSelectorRow(value);
+      executeSqliteQuerySync(database.db, selection).rows.map(matchedEntry);
+    const canonical = this.readCanonicalSelectorRow(database, value);
     const date = value.match(/^(\d{4}-\d{2}-\d{2})\//u)?.[1];
     const qualified = canonical
-      ? [this.entryFromRow(canonical, this.hasSummary(database, canonical))]
+      ? [matchedEntry(canonical)]
       : date
         ? entries(
             query
@@ -525,6 +561,7 @@ export class TranscriptsStore {
     summary: TranscriptsSummary,
     session: TranscriptSessionDescriptor,
     expectedInputRevision?: string,
+    assertCurrent?: () => void,
   ): Promise<string> {
     const summaryJson = JSON.stringify(summary);
     const markdown = renderTranscriptsMarkdown(summary);
@@ -536,6 +573,7 @@ export class TranscriptsStore {
     };
     ensureMeetingTranscriptsSchema(this.databaseOptions);
     this.transaction("meeting-transcripts.summary.write", ({ db: database }) => {
+      assertCurrent?.();
       // Recheck under the writer lock; a concurrent writer can change the
       // transcript after the caller's pre-check but before this commit.
       if (


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Meeting-transcript readers and their tool/capture callers assume database reads finish synchronously. Delayed reads can pair a descriptor with a different input revision or let cleanup close a shared writer while an export is still reading. On Bun, closing an unfinished reader can leave its SQLite snapshot pinned.

## Why This Change Was Made

Await complete transcript reads and their actual callers. Carry the descriptor and its input revision together, and revalidate current authority/revision inside guarded writes. Stream composed exports from one privately owned read-only snapshot, retaining it until iteration finishes, returns or throws.

Finalize the iterator, explicitly roll back its read transaction, then close through the existing tracked handle owner. A failed close retains file-exclusion custody until a successful retry. Existing limits, storage schema and exported formats remain unchanged.

## User Impact

Transcript tools, capture, summaries and exports wait for the selected store operation and reject stale results before writing. Exports preserve a coherent snapshot during concurrent updates or shared-writer closure. Stopping a reader releases its read transaction on supported Node and Bun runtimes.

## Evidence

- 226 focused native/caller cases passed on the current-main composition. After the snapshot repair, 67 owner/library/store cases passed, including failed-close custody; final test-only lint correction passed its two affected cases.
- Three snapshot completion/return/throw regressions failed on the prior owner and passed after repair.
- Actual Bun 1.4.2 early return left a peer WAL checkpoint at busy=1/log=365 before the fix. Early return and completion now both produce busy=0/log=0.
- A production-source SQLite probe exercised list/get/export, peer-update snapshot consistency, shared-writer close, stale revision refusal, early return, exclusion and reopen. All created processes joined.
- All selected checks and a fresh independent whole-candidate Codex review through P2 passed. One test-only lint failure was repaired and the affected checks plus remaining gate tail completed; no checks or assertions were weakened.

No full build or worker responsiveness claim is included. This is awaited API and cursor ownership groundwork; the canonical worker cutover remains tracked separately.
