### PR TITLE
perf(reply): reduce cold imports during heartbeat preflight

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1809,7 +1809,7 @@ src/agents/harness/lifecycle-hook-helpers.ts	1
 src/agents/harness/native-hook-relay-client.ts	2
 src/agents/harness/native-hook-relay-codec.ts	2
 src/agents/harness/native-hook-relay-state.ts	1
-src/agents/harness/selection.ts	5
+src/agents/harness/selection.ts	4
 src/agents/harness/support.ts	1
 src/agents/harness/tool-result-middleware.ts	1
 src/agents/identity.ts	8

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -43,12 +43,12 @@ import { resolveEmbeddedAgentStream } from "./embedded-agent-runner/stream-resol
 import { createAgentHarnessHostCapabilities } from "./harness/host-capability.js";
 import { resolveAgentHarnessOwnerPluginId } from "./harness/registry.js";
 import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
+import type { AgentHarnessPreparedModelProvider } from "./harness/selection-decision.js";
 import {
   resolveAvailableAgentHarnessPolicy,
   resolvePluginHarnessPolicyToolsAllow,
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
-  type AgentHarnessPreparedModelProvider,
 } from "./harness/selection.js";
 import {
   resolveAgentHarnessPreparedAuthSupport,

--- a/src/agents/embedded-agent-runner/run/model-harness.ts
+++ b/src/agents/embedded-agent-runner/run/model-harness.ts
@@ -2,10 +2,10 @@ import type { Model } from "../../../llm/types.js";
 import { OPENCLAW_AGENT_RUNTIME_ID } from "../../agent-runtime-id.js";
 import { resolveAuthoredModelContextTokens } from "../../context-resolution.js";
 import { AgentHarnessPreflightError } from "../../harness/errors.js";
+import type { AgentHarnessPreparedModelProvider } from "../../harness/selection-decision.js";
 import {
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
-  type AgentHarnessPreparedModelProvider,
 } from "../../harness/selection.js";
 import {
   resolveAgentHarnessPreparedAuthSupport,

--- a/src/agents/harness/builtin-openclaw-metadata.ts
+++ b/src/agents/harness/builtin-openclaw-metadata.ts
@@ -1,0 +1,13 @@
+import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host-compat.js";
+import type { AgentHarnessV2 } from "./types.js";
+
+/** Shared descriptor facts; invocation and built-in identity stay with the factory. */
+export const BUILTIN_AGENT_HARNESS_METADATA: Pick<
+  AgentHarnessV2,
+  "id" | "label" | "contextEngineHostCapabilities" | "supports" | "deliveryDefaults"
+> = {
+  id: "openclaw",
+  label: "OpenClaw embedded agent",
+  contextEngineHostCapabilities: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST.capabilities,
+  supports: () => ({ supported: true, priority: 0 }),
+};

--- a/src/agents/harness/builtin-openclaw.ts
+++ b/src/agents/harness/builtin-openclaw.ts
@@ -4,10 +4,10 @@
  * Harness selection uses this factory to expose the embedded OpenClaw runtime
  * through the same AgentHarness contract as external harness plugins.
  */
-import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host-compat.js";
 import { runEmbeddedAttempt } from "../embedded-agent-runner/run/attempt.js";
 import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
 import { runHostPreparedIsolatedCompletion } from "../host-prepared-isolated-completion.js";
+import { BUILTIN_AGENT_HARNESS_METADATA } from "./builtin-openclaw-metadata.js";
 import { projectSettledTurnFinalizationAttemptResult } from "./settled-turn-finalization-result.js";
 import type {
   AgentHarness,
@@ -86,10 +86,7 @@ function buildRestrictedFinalizationAttempt(
 /** Creates the built-in harness backed by the embedded OpenClaw agent runner. */
 export function createOpenClawAgentHarness(): AgentHarnessV2 {
   const harness: AgentHarnessV2 = {
-    id: "openclaw",
-    label: "OpenClaw embedded agent",
-    contextEngineHostCapabilities: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST.capabilities,
-    supports: () => ({ supported: true, priority: 0 }),
+    ...BUILTIN_AGENT_HARNESS_METADATA,
     runAttempt: (params) => runEmbeddedAttempt(params as EmbeddedRunAttemptParams),
     runIsolatedCompletionV2: runHostPreparedIsolatedCompletion,
     finalizeSettledTurn: async ({ attempt }) => {

--- a/src/agents/harness/selection-decision.ts
+++ b/src/agents/harness/selection-decision.ts
@@ -1,0 +1,271 @@
+/** Synchronous harness selection facts, without loading invocation machinery. */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveProviderRefOwnership } from "../../plugins/providers.js";
+import { isCliRuntimeAliasForProvider } from "../model-runtime-aliases.js";
+import { resolveAgentHarnessAutoSelectionHint } from "./auto-selection.js";
+import { resolveAgentHarnessAvailabilityDecision } from "./availability.js";
+import { BUILTIN_AGENT_HARNESS_METADATA } from "./builtin-openclaw-metadata.js";
+import { MissingAgentHarnessError } from "./errors.js";
+import type { AgentHarnessPolicy } from "./policy.js";
+import { listRegisteredAgentHarnesses, resolveAgentHarnessOwnerPluginId } from "./registry.js";
+import { buildAgentHarnessSupportContext, compareHarnessSupport } from "./support.js";
+import type { AgentHarness, AgentHarnessSupport, AgentHarnessSupportContext } from "./types.js";
+
+const log = createSubsystemLogger("agents/harness");
+
+export type AgentHarnessSelectionParams = {
+  provider: string;
+  modelId?: string;
+  modelProvider?: AgentHarnessSupportContext["modelProvider"];
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  agentHarnessId?: string;
+  agentHarnessRuntimeOverride?: string;
+};
+
+export type AgentHarnessSelectionDecisionParams = AgentHarnessSelectionParams & {
+  /** Finalized route/auth facts must always pass harness support, including persisted pins. */
+  preparedModelProvider?: boolean;
+};
+
+export type AgentHarnessPreparedModelProvider = NonNullable<
+  AgentHarnessSupportContext["modelProvider"]
+>;
+
+export type AgentHarnessSelectionCandidate = {
+  id: string;
+  label: string;
+  pluginId?: string;
+  supported?: boolean;
+  priority?: number;
+  reason?: string;
+};
+
+export type AgentHarnessSelectionDecision = {
+  policy: AgentHarnessPolicy;
+  selectedHarnessId: string;
+  selectedReason:
+    | "forced_openclaw"
+    | "forced_plugin"
+    // Implicit Codex preference found no registered Codex harness, so OpenClaw handled the run.
+    | "implicit_plugin_unavailable_openclaw"
+    // Implicit Codex preference cannot reproduce the prepared transport, so OpenClaw handled it.
+    | "implicit_plugin_unsupported_openclaw"
+    // The requested plugin declared OpenClaw as a lossless fallback for this prepared request.
+    | "plugin_declared_fallback_openclaw"
+    // Provider-owned CLI runtime aliases have no agent harness plugin counterpart.
+    | "cli_runtime_passthrough_openclaw"
+    // Auto mode chose a registered plugin harness that supports the provider/model.
+    | "auto_plugin"
+    // Auto mode found no supporting plugin harness, so OpenClaw handled the run.
+    | "auto_openclaw";
+  candidates: AgentHarnessSelectionCandidate[];
+} & (
+  | { builtIn: true; harness?: never; ownerPluginId?: never }
+  | { builtIn: false; harness: AgentHarness; ownerPluginId: string }
+);
+
+/** Reads delivery policy from the same validated decision used for execution. */
+export function resolveAgentHarnessDeliveryDefaults(
+  params: AgentHarnessSelectionParams,
+): AgentHarness["deliveryDefaults"] {
+  const selection = resolveAgentHarnessSelectionDecision(params);
+  return selection.builtIn
+    ? BUILTIN_AGENT_HARNESS_METADATA.deliveryDefaults
+    : selection.harness.deliveryDefaults;
+}
+
+function listPluginAgentHarnesses(): AgentHarness[] {
+  return listRegisteredAgentHarnesses().map((entry) => entry.harness);
+}
+
+export function resolveAgentHarnessSelectionDecision(
+  params: AgentHarnessSelectionDecisionParams,
+): AgentHarnessSelectionDecision {
+  // Keep the probed instance: owner validation must reject replacement during supports().
+  const pluginHarnesses = listPluginAgentHarnesses();
+  const availability = resolveAgentHarnessAvailabilityDecision({
+    ...params,
+    resolveProviderOwnership: () =>
+      resolveProviderRefOwnership({
+        provider: params.provider,
+        config: params.config,
+      }),
+  });
+  const policy = availability.policy;
+  // OpenClaw's built-in harness is intentionally not part of the plugin candidate list. Explicit plugin
+  // runtimes fail closed unless the selected plugin declares OpenClaw as a lossless fallback.
+  const runtime = policy.runtime;
+  if (runtime === "openclaw") {
+    const selectedReason =
+      availability.kind === "implicit-unavailable"
+        ? "implicit_plugin_unavailable_openclaw"
+        : availability.kind === "implicit-unsupported"
+          ? "implicit_plugin_unsupported_openclaw"
+          : availability.kind === "declared-fallback"
+            ? "plugin_declared_fallback_openclaw"
+            : "forced_openclaw";
+    return buildAgentHarnessSelectionDecision({
+      policy,
+      selectedReason,
+      candidates: listHarnessCandidates(pluginHarnesses),
+    });
+  }
+  if (runtime !== "auto") {
+    const forced = pluginHarnesses.find((entry) => entry.id === runtime);
+    if (forced) {
+      const support = availability.support;
+      if (!support || support.supported || support.fallbackRuntime === "openclaw") {
+        if (support && !support.supported) {
+          log.info(
+            `agent harness selected requested=${runtime} selected=${forced.id} reason=private_qa_forced_runtime`,
+          );
+        }
+        return buildAgentHarnessSelectionDecision({
+          harness: forced,
+          policy,
+          selectedReason: "forced_plugin",
+          candidates: listHarnessCandidates(pluginHarnesses),
+        });
+      }
+      if (isCliRuntimeAliasForProvider({ runtime, provider: params.provider })) {
+        return buildAgentHarnessSelectionDecision({
+          policy: {
+            ...policy,
+            runtime: "openclaw",
+          },
+          selectedReason: "cli_runtime_passthrough_openclaw",
+          candidates: listHarnessCandidates(pluginHarnesses),
+        });
+      }
+      throw new Error(
+        `Requested agent harness "${runtime}" does not support ${formatProviderModel(params)}${
+          support.reason ? ` (${support.reason})` : ""
+        }.`,
+      );
+    }
+    if (
+      isCliRuntimeAliasForProvider({
+        runtime,
+        provider: params.provider,
+        cfg: params.config,
+      })
+    ) {
+      return buildAgentHarnessSelectionDecision({
+        policy: {
+          ...policy,
+          runtime: "openclaw",
+        },
+        selectedReason: "cli_runtime_passthrough_openclaw",
+        candidates: listHarnessCandidates(pluginHarnesses),
+      });
+    }
+    throw new MissingAgentHarnessError(runtime);
+  }
+
+  const hintedCandidates = pluginHarnesses.map((harness) => ({
+    harness,
+    support: resolveAgentHarnessAutoSelectionHint({ harness, provider: params.provider }),
+  }));
+  const candidates = hintedCandidates.some((entry) => entry.support === undefined)
+    ? (() => {
+        const supportContext = buildAgentHarnessSupportContext({
+          provider: params.provider,
+          modelId: params.modelId,
+          modelProvider: params.modelProvider,
+          requestedRuntime: runtime,
+          config: params.config,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          preparedModelProvider: params.preparedModelProvider,
+          providerOwnership: resolveProviderRefOwnership({
+            provider: params.provider,
+            config: params.config,
+          }),
+        });
+        return hintedCandidates.map(({ harness, support }) => ({
+          harness,
+          support: support ?? harness.supports(supportContext),
+        }));
+      })()
+    : hintedCandidates.map(({ harness, support }) => ({
+        harness,
+        // SAFETY: The preceding some() check established that every hint has support.
+        support: support as AgentHarnessSupport,
+      }));
+  const supported = candidates
+    .filter(
+      (
+        entry,
+      ): entry is {
+        harness: AgentHarness;
+        support: AgentHarnessSupport & { supported: true };
+      } => entry.support.supported,
+    )
+    .toSorted(compareHarnessSupport);
+
+  const selected = supported[0]?.harness;
+  if (selected) {
+    return buildAgentHarnessSelectionDecision({
+      harness: selected,
+      policy,
+      selectedReason: "auto_plugin",
+      candidates: candidates.map(toSelectionCandidate),
+    });
+  }
+  return buildAgentHarnessSelectionDecision({
+    policy,
+    selectedReason: "auto_openclaw",
+    candidates: candidates.map(toSelectionCandidate),
+  });
+}
+
+function listHarnessCandidates(harnesses: AgentHarness[]): AgentHarnessSelectionCandidate[] {
+  return harnesses.map((harness) => ({
+    id: harness.id,
+    label: harness.label,
+    pluginId: harness.pluginId,
+  }));
+}
+
+function toSelectionCandidate(entry: {
+  harness: AgentHarness;
+  support: AgentHarnessSupport;
+}): AgentHarnessSelectionCandidate {
+  return {
+    id: entry.harness.id,
+    label: entry.harness.label,
+    pluginId: entry.harness.pluginId,
+    supported: entry.support.supported,
+    priority: entry.support.supported ? entry.support.priority : undefined,
+    reason: entry.support.reason,
+  };
+}
+
+export function buildAgentHarnessSelectionDecision(params: {
+  harness?: AgentHarness;
+  policy: AgentHarnessPolicy;
+  selectedReason: AgentHarnessSelectionDecision["selectedReason"];
+  candidates: AgentHarnessSelectionCandidate[];
+}): AgentHarnessSelectionDecision {
+  const common = {
+    policy: params.policy,
+    selectedHarnessId: params.harness?.id ?? BUILTIN_AGENT_HARNESS_METADATA.id,
+    selectedReason: params.selectedReason,
+    candidates: params.candidates,
+  };
+  return params.harness
+    ? {
+        ...common,
+        builtIn: false,
+        harness: params.harness,
+        ownerPluginId: resolveAgentHarnessOwnerPluginId(params.harness),
+      }
+    : { ...common, builtIn: true };
+}
+
+function formatProviderModel(params: { provider: string; modelId?: string }): string {
+  return params.modelId ? `${params.provider}/${params.modelId}` : params.provider;
+}

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -77,6 +77,7 @@ import type { ContextEngineLogicalTurnLease } from "./context-engine-logical-tur
 import { resolveAgentHarnessPolicy } from "./policy.js";
 import { clearAgentHarnesses, registerAgentHarness } from "./registry.js";
 import { ensureSelectedAgentHarnessPlugin } from "./runtime-plugin.js";
+import { resolveAgentHarnessDeliveryDefaults } from "./selection-decision.js";
 import {
   agentHarnessBuildsOpenClawTools,
   agentHarnessExposesOpenClawTools,
@@ -2178,29 +2179,34 @@ describe("runAgentHarnessAttempt", () => {
 });
 
 describe("selectAgentHarness", () => {
-  it("rejects a harness replaced during its support probe", () => {
-    const replacement: AgentHarness = {
-      id: "codex",
-      label: "Replacement",
-      supports: () => ({ supported: true }),
-      runAttempt: async () => createAttemptResult("replacement"),
-    };
-    registerAgentHarness({
-      ...replacement,
-      supports: () => {
-        registerAgentHarness(replacement);
-        return { supported: true };
-      },
-    });
+  it.each(["runtime", "delivery"] as const)(
+    "rejects a harness replaced during its %s support probe",
+    (surface) => {
+      const replacement: AgentHarness = {
+        id: "codex",
+        label: "Replacement",
+        supports: () => ({ supported: true }),
+        runAttempt: async () => createAttemptResult("replacement"),
+      };
+      registerAgentHarness({
+        ...replacement,
+        supports: () => {
+          registerAgentHarness(replacement);
+          return { supported: true };
+        },
+      });
 
-    expect(() =>
-      selectAgentHarness({
-        provider: "openai",
-        modelId: "gpt-5.6-sol",
-        agentHarnessRuntimeOverride: "codex",
-      }),
-    ).toThrow("changed during owner resolution");
-  });
+      const select =
+        surface === "runtime" ? selectAgentHarness : resolveAgentHarnessDeliveryDefaults;
+      expect(() =>
+        select({
+          provider: "openai",
+          modelId: "gpt-5.6-sol",
+          agentHarnessRuntimeOverride: "codex",
+        }),
+      ).toThrow("changed during owner resolution");
+    },
+  );
 
   it("does not select Codex from a non-OpenAI model name", () => {
     registerSuccessfulCodexHarness();

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -1,7 +1,6 @@
 /**
  * Selects and invokes native agent harnesses for embedded run attempts.
  */
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   createChildDiagnosticTraceContext,
   createDiagnosticTraceContext,
@@ -12,7 +11,6 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { claimHeartbeatContextForUserRun } from "../../infra/heartbeat-outcome-store.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { resolveProviderRefOwnership } from "../../plugins/providers.js";
 import { resolveAdmittedRunActiveAssertion } from "../admitted-run-context.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import { resolveGroupToolPolicy } from "../agent-tools.policy.js";
@@ -28,7 +26,6 @@ import type {
   EmbeddedRunAttemptParams,
   EmbeddedRunAttemptResult,
 } from "../embedded-agent-runner/run/types.js";
-import { isCliRuntimeAliasForProvider } from "../model-runtime-aliases.js";
 import {
   unwrapModelHeaderSentinelsForProviderEgress,
   unwrapSecretSentinelsForProviderEgress,
@@ -43,49 +40,37 @@ import {
 } from "../tool-policy.js";
 import type { SystemAgentToolOptions } from "../tools/system-agent-tool.js";
 import { copyCoreTtsAttemptResultProvenance } from "../tools/tts-tool-result-provenance.js";
-import { resolveAgentHarnessAutoSelectionHint } from "./auto-selection.js";
-import { resolveAgentHarnessAvailabilityDecision } from "./availability.js";
 import { createOpenClawAgentHarness, isBuiltInOpenClawAgentHarness } from "./builtin-openclaw.js";
 import { selectContextEngineForTranscriptHost } from "./context-engine-logical-turn.js";
 import { drainPendingContextEngineTurnsBeforeRun } from "./context-engine-turn-attempt.js";
-import { AgentHarnessPreflightError, MissingAgentHarnessError } from "./errors.js";
+import { AgentHarnessPreflightError } from "./errors.js";
 import { createAgentHarnessHostCapabilities } from "./host-capability.js";
 import {
   runAgentHarnessLifecycleAttempt,
   runAgentHarnessLifecycleFinalization,
 } from "./lifecycle.js";
 import type { AgentHarnessPolicy } from "./policy.js";
-import { listRegisteredAgentHarnesses, resolveAgentHarnessOwnerPluginId } from "./registry.js";
 import {
-  buildAgentHarnessSupportContext,
-  compareHarnessSupport,
+  buildAgentHarnessSelectionDecision,
+  resolveAgentHarnessSelectionDecision,
+  type AgentHarnessSelectionParams,
+  type AgentHarnessSelectionDecisionParams,
+  type AgentHarnessSelectionCandidate,
+  type AgentHarnessSelectionDecision as AgentHarnessSelectionFact,
+  type AgentHarnessPreparedModelProvider,
+} from "./selection-decision.js";
+import {
   resolveAgentHarnessPreparedAuthSupport,
   resolveAgentHarnessPreparedRouteSupport,
 } from "./support.js";
-import type { AgentHarness, AgentHarnessSupport, AgentHarnessSupportContext } from "./types.js";
+import type { AgentHarness } from "./types.js";
 
 const log = createSubsystemLogger("agents/harness");
 export { resolveAvailableAgentHarnessPolicy } from "./availability.js";
 
-type AgentHarnessSelectionParams = {
-  provider: string;
-  modelId?: string;
-  modelProvider?: AgentHarnessSupportContext["modelProvider"];
-  config?: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-  agentHarnessId?: string;
-  agentHarnessRuntimeOverride?: string;
+type AgentHarnessSelectionDecision = Omit<AgentHarnessSelectionFact, "harness"> & {
+  harness: AgentHarness;
 };
-
-type AgentHarnessSelectionDecisionParams = AgentHarnessSelectionParams & {
-  /** Finalized route/auth facts must always pass harness support, including persisted pins. */
-  preparedModelProvider?: boolean;
-};
-
-export type AgentHarnessPreparedModelProvider = NonNullable<
-  AgentHarnessSupportContext["modelProvider"]
->;
 
 const PLUGIN_HARNESS_SENDER_DENY_ALL_PROMPT =
   "Tool and file actions are disabled for this sender by chat policy. If asked to edit files or use tools, say this sender is not allowed by policy; do not imply retrying will help.";
@@ -93,40 +78,6 @@ const PLUGIN_HARNESS_GROUP_DENY_ALL_PROMPT =
   "Tool and file actions are disabled for this chat by policy. If asked to edit files or use tools, say this chat is not allowed by policy.";
 const PLUGIN_HARNESS_RUNTIME_DENY_ALL_PROMPT =
   "Tool and file actions are disabled by runtime policy. If asked to edit files or use tools, say tools are disabled by policy.";
-
-type AgentHarnessSelectionCandidate = {
-  id: string;
-  label: string;
-  pluginId?: string;
-  supported?: boolean;
-  priority?: number;
-  reason?: string;
-};
-
-type AgentHarnessSelectionDecision = {
-  harness: AgentHarness;
-  builtIn: boolean;
-  /** Registry-owned identity; absent only for the built-in runtime. */
-  ownerPluginId?: string;
-  policy: AgentHarnessPolicy;
-  selectedHarnessId: string;
-  selectedReason:
-    | "forced_openclaw"
-    | "forced_plugin"
-    // Implicit Codex preference found no registered Codex harness, so OpenClaw handled the run.
-    | "implicit_plugin_unavailable_openclaw"
-    // Implicit Codex preference cannot reproduce the prepared transport, so OpenClaw handled it.
-    | "implicit_plugin_unsupported_openclaw"
-    // The requested plugin declared OpenClaw as a lossless fallback for this prepared request.
-    | "plugin_declared_fallback_openclaw"
-    // Provider-owned CLI runtime aliases have no agent harness plugin counterpart.
-    | "cli_runtime_passthrough_openclaw"
-    // Auto mode chose a registered plugin harness that supports the provider/model.
-    | "auto_plugin"
-    // Auto mode found no supporting plugin harness, so OpenClaw handled the run.
-    | "auto_openclaw";
-  candidates: AgentHarnessSelectionCandidate[];
-};
 
 type PluginHarnessToolPolicyContext = Pick<
   EmbeddedRunAttemptParams,
@@ -171,10 +122,6 @@ type ResolvedPluginHarnessToolPolicies = {
   safeDeniedToolNames: string[];
   toolPolicyRestricted: boolean;
 };
-
-function listPluginAgentHarnesses(): AgentHarness[] {
-  return listRegisteredAgentHarnesses().map((entry) => entry.harness);
-}
 
 export function selectAgentHarness(params: AgentHarnessSelectionParams): AgentHarness {
   return selectAgentHarnessDecision(params).harness;
@@ -225,146 +172,11 @@ export function agentHarnessExposesOpenClawTools(harnessId: string): boolean {
 function selectAgentHarnessDecision(
   params: AgentHarnessSelectionDecisionParams,
 ): AgentHarnessSelectionDecision {
-  // Keep the probed instance: owner validation must reject replacement during supports().
-  const pluginHarnesses = listPluginAgentHarnesses();
-  const availability = resolveAgentHarnessAvailabilityDecision({
-    ...params,
-    resolveProviderOwnership: () =>
-      resolveProviderRefOwnership({
-        provider: params.provider,
-        config: params.config,
-      }),
-  });
-  const policy = availability.policy;
-  // OpenClaw's built-in harness is intentionally not part of the plugin candidate list. Explicit plugin
-  // runtimes fail closed unless the selected plugin declares OpenClaw as a lossless fallback.
-  const openClawHarness = createOpenClawAgentHarness();
-  const runtime = policy.runtime;
-  if (runtime === "openclaw") {
-    const selectedReason =
-      availability.kind === "implicit-unavailable"
-        ? "implicit_plugin_unavailable_openclaw"
-        : availability.kind === "implicit-unsupported"
-          ? "implicit_plugin_unsupported_openclaw"
-          : availability.kind === "declared-fallback"
-            ? "plugin_declared_fallback_openclaw"
-            : "forced_openclaw";
-    return buildSelectionDecision({
-      harness: openClawHarness,
-      policy,
-      selectedReason,
-      candidates: listHarnessCandidates(pluginHarnesses),
-    });
-  }
-  if (runtime !== "auto") {
-    const forced = pluginHarnesses.find((entry) => entry.id === runtime);
-    if (forced) {
-      const support = availability.support;
-      if (!support || support.supported || support.fallbackRuntime === "openclaw") {
-        if (support && !support.supported) {
-          log.info(
-            `agent harness selected requested=${runtime} selected=${forced.id} reason=private_qa_forced_runtime`,
-          );
-        }
-        return buildSelectionDecision({
-          harness: forced,
-          policy,
-          selectedReason: "forced_plugin",
-          candidates: listHarnessCandidates(pluginHarnesses),
-        });
-      }
-      if (isCliRuntimeAliasForProvider({ runtime, provider: params.provider })) {
-        return buildSelectionDecision({
-          harness: openClawHarness,
-          policy: {
-            ...policy,
-            runtime: "openclaw",
-          },
-          selectedReason: "cli_runtime_passthrough_openclaw",
-          candidates: listHarnessCandidates(pluginHarnesses),
-        });
-      }
-      throw new Error(
-        `Requested agent harness "${runtime}" does not support ${formatProviderModel(params)}${
-          support.reason ? ` (${support.reason})` : ""
-        }.`,
-      );
-    }
-    if (
-      isCliRuntimeAliasForProvider({
-        runtime,
-        provider: params.provider,
-        cfg: params.config,
-      })
-    ) {
-      return buildSelectionDecision({
-        harness: openClawHarness,
-        policy: {
-          ...policy,
-          runtime: "openclaw",
-        },
-        selectedReason: "cli_runtime_passthrough_openclaw",
-        candidates: listHarnessCandidates(pluginHarnesses),
-      });
-    }
-    throw new MissingAgentHarnessError(runtime);
-  }
-
-  const hintedCandidates = pluginHarnesses.map((harness) => ({
-    harness,
-    support: resolveAgentHarnessAutoSelectionHint({ harness, provider: params.provider }),
-  }));
-  const candidates = hintedCandidates.some((entry) => entry.support === undefined)
-    ? (() => {
-        const supportContext = buildAgentHarnessSupportContext({
-          provider: params.provider,
-          modelId: params.modelId,
-          modelProvider: params.modelProvider,
-          requestedRuntime: runtime,
-          config: params.config,
-          agentId: params.agentId,
-          sessionKey: params.sessionKey,
-          preparedModelProvider: params.preparedModelProvider,
-          providerOwnership: resolveProviderRefOwnership({
-            provider: params.provider,
-            config: params.config,
-          }),
-        });
-        return hintedCandidates.map(({ harness, support }) => ({
-          harness,
-          support: support ?? harness.supports(supportContext),
-        }));
-      })()
-    : hintedCandidates.map(({ harness, support }) => ({
-        harness,
-        support: support as AgentHarnessSupport,
-      }));
-  const supported = candidates
-    .filter(
-      (
-        entry,
-      ): entry is {
-        harness: AgentHarness;
-        support: AgentHarnessSupport & { supported: true };
-      } => entry.support.supported,
-    )
-    .toSorted(compareHarnessSupport);
-
-  const selected = supported[0]?.harness;
-  if (selected) {
-    return buildSelectionDecision({
-      harness: selected,
-      policy,
-      selectedReason: "auto_plugin",
-      candidates: candidates.map(toSelectionCandidate),
-    });
-  }
-  return buildSelectionDecision({
-    harness: openClawHarness,
-    policy,
-    selectedReason: "auto_openclaw",
-    candidates: candidates.map(toSelectionCandidate),
-  });
+  const selection = resolveAgentHarnessSelectionDecision(params);
+  return {
+    ...selection,
+    harness: selection.builtIn ? createOpenClawAgentHarness() : selection.harness,
+  };
 }
 
 /** Runs the selected harness's fail-closed settled-turn finalization operation. */
@@ -1050,43 +862,18 @@ function policyDeniesAllTools(policy?: { deny?: string[] }): boolean {
   );
 }
 
-function listHarnessCandidates(harnesses: AgentHarness[]): AgentHarnessSelectionCandidate[] {
-  return harnesses.map((harness) => ({
-    id: harness.id,
-    label: harness.label,
-    pluginId: harness.pluginId,
-  }));
-}
-
-function toSelectionCandidate(entry: {
-  harness: AgentHarness;
-  support: AgentHarnessSupport;
-}): AgentHarnessSelectionCandidate {
-  return {
-    id: entry.harness.id,
-    label: entry.harness.label,
-    pluginId: entry.harness.pluginId,
-    supported: entry.support.supported,
-    priority: entry.support.supported ? entry.support.priority : undefined,
-    reason: entry.support.reason,
-  };
-}
-
 function buildSelectionDecision(params: {
   harness: AgentHarness;
   policy: AgentHarnessPolicy;
   selectedReason: AgentHarnessSelectionDecision["selectedReason"];
   candidates: AgentHarnessSelectionCandidate[];
 }): AgentHarnessSelectionDecision {
-  const builtIn = isBuiltInOpenClawAgentHarness(params.harness);
   return {
+    ...buildAgentHarnessSelectionDecision({
+      ...params,
+      harness: isBuiltInOpenClawAgentHarness(params.harness) ? undefined : params.harness,
+    }),
     harness: params.harness,
-    builtIn,
-    ...(!builtIn ? { ownerPluginId: resolveAgentHarnessOwnerPluginId(params.harness) } : {}),
-    policy: params.policy,
-    selectedHarnessId: params.harness.id,
-    selectedReason: params.selectedReason,
-    candidates: params.candidates,
   };
 }
 
@@ -1107,9 +894,5 @@ function logAgentHarnessSelection(
     runtime: selection.policy.runtime,
     candidates: selection.candidates,
   });
-}
-
-function formatProviderModel(params: { provider: string; modelId?: string }): string {
-  return params.modelId ? `${params.provider}/${params.modelId}` : params.provider;
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/subagents/registry/subagent-control.test.ts
+++ b/src/agents/subagents/registry/subagent-control.test.ts
@@ -5,10 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import {
-  tryFastAbortFromMessage,
-  stopSubagentsForRequester,
-} from "../../../auto-reply/reply/abort.js";
+import { stopSubagentsForRequester } from "../../../auto-reply/reply/abort-operation.js";
+import { tryFastAbortFromMessage } from "../../../auto-reply/reply/abort.js";
 import { createReplyOperation } from "../../../auto-reply/reply/reply-run-registry.js";
 import { buildTestCtx } from "../../../auto-reply/reply/test-ctx.js";
 import {

--- a/src/auto-reply/reply/abort-operation.ts
+++ b/src/auto-reply/reply/abort-operation.ts
@@ -1,0 +1,389 @@
+// Handles abort requests and active reply run cancellation.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
+import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-manager-api.js";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveActiveEmbeddedRunSessionId } from "../../agents/embedded-agent-runner/active-run-projections.js";
+import { abortEmbeddedAgentRun } from "../../agents/embedded-agent-runner/runs.js";
+import { killAllControlledSubagentRuns } from "../../agents/subagents/registry/subagent-control.js";
+import { listSubagentRunsForController } from "../../agents/subagents/registry/subagent-registry-read.js";
+import {
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "../../agents/tools/sessions-helpers.js";
+import { resolveSessionStorePathCore } from "../../config/sessions.js";
+import {
+  loadSessionEntry,
+  markSessionAbortTarget,
+  resolveSessionAbortTarget,
+  type SessionAbortTargetContext,
+  type SessionAbortTargetIdentity,
+  type SessionAbortTargetResult,
+} from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { logVerbose } from "../../globals.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { isAcpSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
+import { resolveCommandAuthorization } from "../command-auth.js";
+import type { FinalizedRuntimeMsgContext } from "../templating.js";
+import {
+  type AbortCutoff,
+  resolveAbortCutoffFromContext,
+  shouldPersistAbortCutoff,
+} from "./abort-cutoff.js";
+import { setAbortMemory } from "./abort-primitives.js";
+import type { FastAbortRequestParams, FastAbortResult, PreparedFastAbortRequest } from "./abort.js";
+import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
+import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
+import { clearSessionQueues } from "./queue.js";
+import { replyRunRegistry } from "./reply-run-registry.js";
+
+export function abortSessionRunTargetWithOutcome(params: { key?: string; sessionId?: string }): {
+  active: boolean;
+  aborted: boolean;
+  retirement?: Promise<void>;
+} {
+  const sessionIds = new Set<string>();
+  const key = normalizeOptionalString(params.key);
+  let active = key ? replyRunRegistry.isActive(key) : false;
+  if (key) {
+    const activeSessionId = resolveActiveEmbeddedRunSessionId(key);
+    if (activeSessionId) {
+      active = true;
+      sessionIds.add(activeSessionId);
+    }
+  }
+  const explicitSessionId = normalizeOptionalString(params.sessionId);
+  if (explicitSessionId) {
+    sessionIds.add(explicitSessionId);
+  }
+
+  let aborted = key ? replyRunRegistry.abort(key) : false;
+  for (const sessionId of sessionIds) {
+    aborted = abortEmbeddedAgentRun(sessionId) || aborted;
+  }
+  // Stop owns these captured IDs; a later turn may rebind the session key.
+  const retirement =
+    !active || aborted
+      ? Promise.all(
+          [...sessionIds].map((sessionId) =>
+            retireSessionMcpRuntime({
+              sessionId,
+              reason: "session-stop",
+            }),
+          ),
+        ).then(() => undefined)
+      : undefined;
+  return { active, aborted, retirement };
+}
+
+function resolveStoredSessionId(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+}): string | undefined {
+  const agentId = resolveSessionAgentId({
+    sessionKey: params.sessionKey,
+    config: params.cfg,
+  });
+  const storePath = resolveSessionStorePathCore(params.cfg.session?.store, { agentId });
+  try {
+    return loadSessionEntry({
+      agentId,
+      clone: false,
+      sessionKey: params.sessionKey,
+      storePath,
+    })?.sessionId;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveBoundAcpAbortTargetSessionKey(params: {
+  ctx: FinalizedRuntimeMsgContext;
+  cfg: OpenClawConfig;
+  activeSessionKey: string;
+}): string | undefined {
+  const bindingContext = resolveConversationBindingContextFromMessage({
+    cfg: params.cfg,
+    ctx: params.ctx,
+  });
+  if (!bindingContext) {
+    return undefined;
+  }
+  return resolveEffectiveResetTargetSessionKey({
+    cfg: params.cfg,
+    channel: bindingContext.channel,
+    accountId: bindingContext.accountId,
+    conversationId: bindingContext.conversationId,
+    parentConversationId: bindingContext.parentConversationId,
+    activeSessionKey: params.activeSessionKey,
+    skipConfiguredFallbackWhenActiveSessionNonAcp: false,
+    fallbackToActiveAcpWhenUnbound: false,
+  });
+}
+
+function normalizeRequesterSessionKey(
+  cfg: OpenClawConfig,
+  key: string | undefined,
+): string | undefined {
+  const cleaned = normalizeOptionalString(key);
+  if (!cleaned) {
+    return undefined;
+  }
+  const { mainKey, alias } = resolveMainSessionAlias(cfg);
+  return resolveInternalSessionKey({ key: cleaned, alias, mainKey });
+}
+
+export async function stopSubagentsForRequester(params: {
+  cfg: OpenClawConfig;
+  requesterSessionKey?: string;
+  requesterAgentId?: string;
+  beforeKill?: Parameters<typeof killAllControlledSubagentRuns>[0]["beforeKill"];
+}): Promise<{ stopped: number; failed: number }> {
+  const requesterKey = normalizeRequesterSessionKey(params.cfg, params.requesterSessionKey);
+  if (!requesterKey) {
+    await params.beforeKill?.();
+    return { stopped: 0, failed: 0 };
+  }
+  const controllerAgentId = resolveSessionAgentId({
+    config: params.cfg,
+    sessionKey: requesterKey,
+    fallbackAgentId: params.requesterAgentId,
+  });
+  const result = await killAllControlledSubagentRuns({
+    cfg: params.cfg,
+    controller: {
+      controllerSessionKey: requesterKey,
+      controllerAgentId,
+      callerSessionKey: requesterKey,
+      callerIsSubagent: isSubagentSessionKey(requesterKey),
+      controlScope: "children",
+    },
+    runs: listSubagentRunsForController(requesterKey),
+    suppressTaskDelivery: true,
+    beforeKill: params.beforeKill,
+  });
+  if (result.status === "error") {
+    logVerbose(`abort: failed to stop subagents for ${requesterKey}: ${result.error}`);
+  }
+  if (result.killed > 0) {
+    logVerbose(`abort: stopped ${result.killed} subagent run(s) for ${requesterKey}`);
+  }
+  return { stopped: result.killed, failed: result.status === "error" ? result.failed : 0 };
+}
+
+export async function executeFastAbortRequest(
+  params: FastAbortRequestParams,
+  request: PreparedFastAbortRequest,
+): Promise<FastAbortResult> {
+  const { ctx, cfg } = params;
+  const { commandSessionKey, targetKey, resolveTargetAgentId } = request;
+
+  const commandAuthorized = ctx.CommandAuthorized;
+  const auth = resolveCommandAuthorization({
+    ctx,
+    cfg,
+    commandAuthorized,
+  });
+  if (!auth.isAuthorizedSender) {
+    return { handled: false, aborted: false };
+  }
+
+  const agentId = resolveTargetAgentId();
+  const abortKey = targetKey ?? auth.from ?? auth.to;
+  const requesterSessionKey = targetKey ?? ctx.SessionKey ?? abortKey;
+
+  if (targetKey) {
+    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
+    const abortCutoffForTarget = (target: SessionAbortTargetContext): AbortCutoff | undefined =>
+      shouldPersistAbortCutoff({
+        commandSessionKey,
+        targetSessionKey: target.sessionKey,
+      })
+        ? resolveAbortCutoffFromContext(ctx)
+        : undefined;
+    let resolvedAbortTarget: SessionAbortTargetIdentity | null = null;
+    try {
+      resolvedAbortTarget = resolveSessionAbortTarget({
+        agentId,
+        sessionKey: targetKey,
+        storePath,
+      });
+    } catch (error) {
+      logVerbose(
+        `abort: failed to resolve abort metadata for ${targetKey}: ${formatErrorMessage(error)}`,
+      );
+    }
+    const resolvedTargetKey = resolvedAbortTarget?.sessionKey ?? targetKey;
+    const conversationBoundAcpTargetKey = commandSessionKey
+      ? resolveBoundAcpAbortTargetSessionKey({
+          ctx,
+          cfg,
+          activeSessionKey: commandSessionKey,
+        })
+      : undefined;
+    const boundAcpTargetKey = !isAcpSessionKey(resolvedTargetKey)
+      ? conversationBoundAcpTargetKey
+      : undefined;
+    const abortTargetKeys = [resolvedTargetKey];
+    if (boundAcpTargetKey && boundAcpTargetKey !== resolvedTargetKey) {
+      abortTargetKeys.push(boundAcpTargetKey);
+    }
+    let aborted = false;
+    let activeAbortRejected = false;
+    const acpCancellations: Promise<void>[] = [];
+    try {
+      const { stopped, failed } = await stopSubagentsForRequester({
+        cfg,
+        requesterSessionKey,
+        requesterAgentId: agentId,
+        beforeKill: () => {
+          if (params.isCommandTargetCurrent?.() === false) {
+            throw new Error("The selected session changed before it could be stopped.");
+          }
+          try {
+            const sourceAbortKey =
+              commandSessionKey &&
+              !abortTargetKeys.includes(commandSessionKey) &&
+              conversationBoundAcpTargetKey &&
+              abortTargetKeys.includes(conversationBoundAcpTargetKey)
+                ? commandSessionKey
+                : undefined;
+            const sessionIdsByKey = new Map<string, string | undefined>(
+              abortTargetKeys.map((abortTargetKey) => [
+                abortTargetKey,
+                replyRunRegistry.resolveSessionId(abortTargetKey) ??
+                  (abortTargetKey === resolvedTargetKey
+                    ? resolvedAbortTarget?.sessionId
+                    : resolveStoredSessionId({ cfg, sessionKey: abortTargetKey })),
+              ]),
+            );
+            for (const abortTargetKey of abortTargetKeys) {
+              const outcome = abortSessionRunTargetWithOutcome({
+                key: abortTargetKey,
+                sessionId: sessionIdsByKey.get(abortTargetKey),
+              });
+              if (outcome.retirement) {
+                acpCancellations.push(outcome.retirement);
+              }
+              activeAbortRejected ||= outcome.active && !outcome.aborted;
+              aborted = outcome.aborted || aborted;
+            }
+            const sourceSessionId = sourceAbortKey
+              ? (replyRunRegistry.resolveSessionId(sourceAbortKey) ??
+                resolveStoredSessionId({ cfg, sessionKey: sourceAbortKey }))
+              : undefined;
+            if (sourceAbortKey) {
+              const outcome = abortSessionRunTargetWithOutcome({
+                key: sourceAbortKey,
+                sessionId: sourceSessionId,
+              });
+              if (outcome.retirement) {
+                acpCancellations.push(outcome.retirement);
+              }
+              activeAbortRejected ||= outcome.active && !outcome.aborted;
+              aborted = outcome.aborted || aborted;
+            }
+            const cleared = clearSessionQueues(
+              abortTargetKeys
+                .flatMap((abortTargetKey) => [abortTargetKey, sessionIdsByKey.get(abortTargetKey)])
+                .concat(sourceAbortKey, sourceSessionId),
+            );
+            if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
+              logVerbose(
+                `abort: cleared followups=${cleared.followupCleared} lane=${cleared.laneCleared} keys=${cleared.keys.join(",")}`,
+              );
+            }
+          } finally {
+            // The tree already holds queued reservations. Initiate ACP without awaiting
+            // either backend so native cleanup cannot delay signal-less ACP steer turns.
+            const acpManager = getAcpSessionManager();
+            for (const acpTargetKey of abortTargetKeys) {
+              const resolution = acpManager.resolveSession({
+                cfg,
+                sessionKey: acpTargetKey,
+                agentId: acpTargetKey === resolvedTargetKey ? agentId : undefined,
+              });
+              if (resolution.kind === "none") {
+                continue;
+              }
+              acpCancellations.push(
+                acpManager
+                  .cancelSession({
+                    cfg,
+                    sessionKey: resolution.sessionKey,
+                    agentId: resolution.agentId,
+                    reason: "fast-abort",
+                  })
+                  .catch((error: unknown) => {
+                    logVerbose(
+                      `abort: ACP cancel failed for ${acpTargetKey}: ${formatErrorMessage(error)}`,
+                    );
+                  }),
+              );
+            }
+          }
+          return true;
+        },
+      });
+      const rejectionReason = activeAbortRejected && !aborted ? "finalizing" : undefined;
+      if (!rejectionReason) {
+        let persistedAbortTarget: SessionAbortTargetResult | null = null;
+        try {
+          persistedAbortTarget = await markSessionAbortTarget({
+            isCurrent: params.isCommandTargetCurrent,
+            scope: {
+              agentId,
+              sessionKey: targetKey,
+              storePath,
+            },
+            resolveAbortCutoff: abortCutoffForTarget,
+          });
+        } catch (error) {
+          logVerbose(
+            `abort: failed to persist abort metadata for ${targetKey}: ${formatErrorMessage(error)}`,
+          );
+        }
+        if (persistedAbortTarget?.persisted === false) {
+          logVerbose(
+            `abort: failed to persist abort metadata for ${targetKey}: ${persistedAbortTarget.persistenceError ?? "unknown error"}`,
+          );
+        }
+        const abortMemoryKey =
+          persistedAbortTarget?.sessionKey ?? resolvedAbortTarget?.sessionKey ?? abortKey;
+        const hasAbortTargetEntry = Boolean(
+          persistedAbortTarget?.entry ?? resolvedAbortTarget?.entry,
+        );
+        if (
+          persistedAbortTarget?.persisted !== true &&
+          abortMemoryKey &&
+          !hasAbortTargetEntry &&
+          params.isCommandTargetCurrent?.() !== false
+        ) {
+          setAbortMemory(abortMemoryKey, true);
+        }
+      }
+      return {
+        handled: true,
+        aborted,
+        ...(rejectionReason ? { rejectionReason } : {}),
+        stoppedSubagents: stopped,
+        failedSubagents: failed,
+      };
+    } finally {
+      // Join even when native signaling or metadata exits exceptionally.
+      await Promise.all(acpCancellations);
+    }
+  }
+
+  if (abortKey) {
+    setAbortMemory(abortKey, true);
+  }
+  const { stopped, failed } = await stopSubagentsForRequester({ cfg, requesterSessionKey });
+  return {
+    handled: true,
+    aborted: false,
+    stoppedSubagents: stopped,
+    failedSubagents: failed,
+  };
+}

--- a/src/auto-reply/reply/abort.lazy.test.ts
+++ b/src/auto-reply/reply/abort.lazy.test.ts
@@ -1,0 +1,19 @@
+import { expect, it, vi } from "vitest";
+import { buildTestCtx } from "./test-ctx.js";
+
+vi.mock("../../agents/subagents/registry/subagent-control.js", () => {
+  throw new Error("ordinary messages must not initialize cancellation owners");
+});
+
+it.each(["direct", "group"])(
+  "keeps %s ordinary messages outside cancellation runtime",
+  async (chatType) => {
+    const { tryFastAbortFromMessage } = await import("./abort.js");
+    await expect(
+      tryFastAbortFromMessage({
+        ctx: buildTestCtx({ CommandBody: "continue the conversation", ChatType: chatType }),
+        cfg: {},
+      }),
+    ).resolves.toEqual({ handled: false, aborted: false });
+  },
+);

--- a/src/auto-reply/reply/abort.target-owner.test.ts
+++ b/src/auto-reply/reply/abort.target-owner.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, onTestFinished } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   loadSessionEntry,
@@ -280,8 +280,26 @@ describe.each(["fast", "command"] as const)("%s Stop current owner", (pathKind) 
       resetTriggered: false,
     });
     operation.attachBackend({ kind: "embedded", cancel: () => {}, isStreaming: () => true });
+    const aborted = createDeferred();
+    const onAbort = () => aborted.resolve();
+    operation.abortSignal.addEventListener("abort", onAbort, { once: true });
     const stopping =
       pathKind === "fast" ? tryFastAbortFromMessage(state) : handleStopCommand(state.params, true);
+    onTestFinished(async () => {
+      operation.abortSignal.removeEventListener("abort", onAbort);
+      release.resolve();
+      await Promise.allSettled([writer, stopping]);
+      operation.complete();
+    });
+    void stopping.then(
+      () => {
+        if (!operation.abortSignal.aborted) {
+          aborted.reject(new Error("Stop completed without aborting the active operation"));
+        }
+      },
+      (error: unknown) => aborted.reject(error),
+    );
+    await aborted.promise;
     expect(operation.abortSignal.aborted).toBe(true);
     release.resolve();
     await writer;
@@ -292,7 +310,6 @@ describe.each(["fast", "command"] as const)("%s Stop current owner", (pathKind) 
     expect(loadSessionEntry({ storePath: state.storePath, sessionKey })?.abortedLastRun).toBe(
       false,
     );
-    operation.complete();
   });
 
   it("completes cancellation when its own abort releases the live publisher", async () => {

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -21,16 +21,16 @@ import {
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import { resolveAbortCutoffFromContext, shouldSkipMessageByAbortCutoff } from "./abort-cutoff.js";
-import { getAbortMemory } from "./abort-primitives.js";
+import { stopSubagentsForRequester } from "./abort-operation.js";
 import {
-  formatAbortReplyText,
+  getAbortMemory,
   isAbortRequestText,
   isAbortTrigger,
   setAbortMemory,
-  stopSubagentsForRequester,
-  tryFastAbortFromMessage,
-} from "./abort.js";
+} from "./abort-primitives.js";
+import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
 import { enqueueFollowupRun, getFollowupQueueDepth, type FollowupRun } from "./queue.js";
+import { clearFollowupQueue } from "./queue/state.js";
 import { createReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
 import { testing as replyRunRegistryTesting } from "./reply-run-registry.test-support.js";
 import { buildTestCtx } from "./test-ctx.js";
@@ -266,6 +266,7 @@ describe("abort detection", () => {
   afterEach(async () => {
     for (const key of trackedAbortMemoryKeys) {
       setAbortMemory(key, false);
+      clearFollowupQueue(key);
     }
     trackedAbortMemoryKeys.clear();
     vi.restoreAllMocks();
@@ -475,6 +476,27 @@ describe("abort detection", () => {
     });
 
     expect(result.handled).toBe(true);
+  });
+
+  it("resolves owner authorization after loading cancellation runtime", async () => {
+    const sessionKey = "telegram:123";
+    const sessionId = "session-123";
+    const { root, cfg } = await createAbortConfig({
+      sessionIdsByKey: { [sessionKey]: sessionId },
+    });
+    cfg.commands = { ownerAllowFrom: ["telegram:123"] };
+    enqueueQueuedFollowupRun({ root, cfg, sessionId, sessionKey });
+    const pending = runStopCommand({
+      cfg,
+      sessionKey,
+      from: "telegram:123",
+      to: "telegram:123",
+      senderId: "123",
+    });
+    cfg.commands.ownerAllowFrom = ["telegram:other-owner"];
+
+    await expect(pending).resolves.toEqual({ handled: false, aborted: false });
+    expect(getFollowupQueueDepth(sessionKey)).toBe(1);
   });
 
   it("fast-aborts authorized text slash stop commands before they queue", async () => {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -1,86 +1,27 @@
-// Handles abort requests and active reply run cancellation.
+// Recognizes stop requests before loading active-run cancellation machinery.
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
-import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-manager-api.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { resolveActiveEmbeddedRunSessionId } from "../../agents/embedded-agent-runner/active-run-projections.js";
-import { abortEmbeddedAgentRun } from "../../agents/embedded-agent-runner/runs.js";
-import { killAllControlledSubagentRuns } from "../../agents/subagents/registry/subagent-control.js";
-import { listSubagentRunsForController } from "../../agents/subagents/registry/subagent-registry-read.js";
-import {
-  resolveInternalSessionKey,
-  resolveMainSessionAlias,
-} from "../../agents/tools/sessions-helpers.js";
-import { resolveSessionStorePathCore } from "../../config/sessions.js";
-import {
-  loadSessionEntry,
-  markSessionAbortTarget,
-  resolveSessionAbortTarget,
-  type SessionAbortTargetContext,
-  type SessionAbortTargetIdentity,
-  type SessionAbortTargetResult,
-} from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { logVerbose } from "../../globals.js";
-import { formatErrorMessage } from "../../infra/errors.js";
-import { isAcpSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
-import { resolveCommandAuthorization } from "../command-auth.js";
 import type { FinalizedRuntimeMsgContext } from "../templating.js";
-import {
-  type AbortCutoff,
-  resolveAbortCutoffFromContext,
-  shouldPersistAbortCutoff,
-} from "./abort-cutoff.js";
-import { isAbortRequestText, isAbortTrigger, setAbortMemory } from "./abort-primitives.js";
-import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
-import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
+import { isAbortRequestText } from "./abort-primitives.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
-import { clearSessionQueues } from "./queue.js";
-import { replyRunRegistry } from "./reply-run-registry.js";
 
-export { isAbortRequestText, isAbortTrigger, setAbortMemory };
+export type FastAbortRequestParams = {
+  ctx: FinalizedRuntimeMsgContext;
+  cfg: OpenClawConfig;
+  isCommandTargetCurrent?: () => boolean;
+};
 
-export function abortSessionRunTargetWithOutcome(params: { key?: string; sessionId?: string }): {
-  active: boolean;
+export type FastAbortResult = {
+  handled: boolean;
   aborted: boolean;
-  retirement?: Promise<void>;
-} {
-  const sessionIds = new Set<string>();
-  const key = normalizeOptionalString(params.key);
-  let active = key ? replyRunRegistry.isActive(key) : false;
-  if (key) {
-    const activeSessionId = resolveActiveEmbeddedRunSessionId(key);
-    if (activeSessionId) {
-      active = true;
-      sessionIds.add(activeSessionId);
-    }
-  }
-  const explicitSessionId = normalizeOptionalString(params.sessionId);
-  if (explicitSessionId) {
-    sessionIds.add(explicitSessionId);
-  }
-
-  let aborted = key ? replyRunRegistry.abort(key) : false;
-  for (const sessionId of sessionIds) {
-    aborted = abortEmbeddedAgentRun(sessionId) || aborted;
-  }
-  // Stop owns these captured IDs; a later turn may rebind the session key.
-  const retirement =
-    !active || aborted
-      ? Promise.all(
-          [...sessionIds].map((sessionId) =>
-            retireSessionMcpRuntime({
-              sessionId,
-              reason: "session-stop",
-            }),
-          ),
-        ).then(() => undefined)
-      : undefined;
-  return { active, aborted, retirement };
-}
+  rejectionReason?: "finalizing";
+  stoppedSubagents?: number;
+  failedSubagents?: number;
+};
 
 export function formatAbortReplyText(
   stoppedSubagents?: number,
@@ -106,112 +47,8 @@ export function formatAbortReplyText(
   return `⚙️ Agent was aborted. Stopped ${stoppedSubagents} ${label}.${failureSuffix}`;
 }
 
-function resolveStoredSessionId(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-}): string | undefined {
-  const agentId = resolveSessionAgentId({
-    sessionKey: params.sessionKey,
-    config: params.cfg,
-  });
-  const storePath = resolveSessionStorePathCore(params.cfg.session?.store, { agentId });
-  try {
-    return loadSessionEntry({
-      agentId,
-      clone: false,
-      sessionKey: params.sessionKey,
-      storePath,
-    })?.sessionId;
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveBoundAcpAbortTargetSessionKey(params: {
-  ctx: FinalizedRuntimeMsgContext;
-  cfg: OpenClawConfig;
-  activeSessionKey: string;
-}): string | undefined {
-  const bindingContext = resolveConversationBindingContextFromMessage({
-    cfg: params.cfg,
-    ctx: params.ctx,
-  });
-  if (!bindingContext) {
-    return undefined;
-  }
-  return resolveEffectiveResetTargetSessionKey({
-    cfg: params.cfg,
-    channel: bindingContext.channel,
-    accountId: bindingContext.accountId,
-    conversationId: bindingContext.conversationId,
-    parentConversationId: bindingContext.parentConversationId,
-    activeSessionKey: params.activeSessionKey,
-    skipConfiguredFallbackWhenActiveSessionNonAcp: false,
-    fallbackToActiveAcpWhenUnbound: false,
-  });
-}
-
-function normalizeRequesterSessionKey(
-  cfg: OpenClawConfig,
-  key: string | undefined,
-): string | undefined {
-  const cleaned = normalizeOptionalString(key);
-  if (!cleaned) {
-    return undefined;
-  }
-  const { mainKey, alias } = resolveMainSessionAlias(cfg);
-  return resolveInternalSessionKey({ key: cleaned, alias, mainKey });
-}
-
-export async function stopSubagentsForRequester(params: {
-  cfg: OpenClawConfig;
-  requesterSessionKey?: string;
-  requesterAgentId?: string;
-  beforeKill?: Parameters<typeof killAllControlledSubagentRuns>[0]["beforeKill"];
-}): Promise<{ stopped: number; failed: number }> {
-  const requesterKey = normalizeRequesterSessionKey(params.cfg, params.requesterSessionKey);
-  if (!requesterKey) {
-    await params.beforeKill?.();
-    return { stopped: 0, failed: 0 };
-  }
-  const controllerAgentId = resolveSessionAgentId({
-    config: params.cfg,
-    sessionKey: requesterKey,
-    fallbackAgentId: params.requesterAgentId,
-  });
-  const result = await killAllControlledSubagentRuns({
-    cfg: params.cfg,
-    controller: {
-      controllerSessionKey: requesterKey,
-      controllerAgentId,
-      callerSessionKey: requesterKey,
-      callerIsSubagent: isSubagentSessionKey(requesterKey),
-      controlScope: "children",
-    },
-    runs: listSubagentRunsForController(requesterKey),
-    suppressTaskDelivery: true,
-    beforeKill: params.beforeKill,
-  });
-  if (result.status === "error") {
-    logVerbose(`abort: failed to stop subagents for ${requesterKey}: ${result.error}`);
-  }
-  if (result.killed > 0) {
-    logVerbose(`abort: stopped ${result.killed} subagent run(s) for ${requesterKey}`);
-  }
-  return { stopped: result.killed, failed: result.status === "error" ? result.failed : 0 };
-}
-
-export async function tryFastAbortFromMessage(params: {
-  ctx: FinalizedRuntimeMsgContext;
-  cfg: OpenClawConfig;
-  isCommandTargetCurrent?: () => boolean;
-}): Promise<{
-  handled: boolean;
-  aborted: boolean;
-  rejectionReason?: "finalizing";
-  stoppedSubagents?: number;
-  failedSubagents?: number;
-}> {
+/** Normalize ingress once; current authorization belongs to the loaded operation. */
+function resolveFastAbortRequest(params: FastAbortRequestParams) {
   const { ctx, cfg } = params;
   const commandSessionKey =
     normalizeOptionalString(ctx.SessionKey) ?? normalizeOptionalString(ctx.ParentSessionKey);
@@ -227,214 +64,23 @@ export async function tryFastAbortFromMessage(params: {
   const stripped = isGroup ? stripMentions(raw, ctx, cfg, resolveTargetAgentId()) : raw;
   const abortRequested = isAbortRequestText(stripped);
   if (!abortRequested) {
+    return undefined;
+  }
+
+  return { commandSessionKey, targetKey, resolveTargetAgentId };
+}
+
+export type PreparedFastAbortRequest = NonNullable<ReturnType<typeof resolveFastAbortRequest>>;
+
+export async function tryFastAbortFromMessage(
+  params: FastAbortRequestParams,
+): Promise<FastAbortResult> {
+  const request = resolveFastAbortRequest(params);
+  if (!request) {
     return { handled: false, aborted: false };
   }
-
-  const commandAuthorized = ctx.CommandAuthorized;
-  const auth = resolveCommandAuthorization({
-    ctx,
-    cfg,
-    commandAuthorized,
-  });
-  if (!auth.isAuthorizedSender) {
-    return { handled: false, aborted: false };
-  }
-
-  const agentId = resolveTargetAgentId();
-  const abortKey = targetKey ?? auth.from ?? auth.to;
-  const requesterSessionKey = targetKey ?? ctx.SessionKey ?? abortKey;
-
-  if (targetKey) {
-    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
-    const abortCutoffForTarget = (target: SessionAbortTargetContext): AbortCutoff | undefined =>
-      shouldPersistAbortCutoff({
-        commandSessionKey,
-        targetSessionKey: target.sessionKey,
-      })
-        ? resolveAbortCutoffFromContext(ctx)
-        : undefined;
-    let resolvedAbortTarget: SessionAbortTargetIdentity | null = null;
-    try {
-      resolvedAbortTarget = resolveSessionAbortTarget({
-        agentId,
-        sessionKey: targetKey,
-        storePath,
-      });
-    } catch (error) {
-      logVerbose(
-        `abort: failed to resolve abort metadata for ${targetKey}: ${formatErrorMessage(error)}`,
-      );
-    }
-    const resolvedTargetKey = resolvedAbortTarget?.sessionKey ?? targetKey;
-    const conversationBoundAcpTargetKey = commandSessionKey
-      ? resolveBoundAcpAbortTargetSessionKey({
-          ctx,
-          cfg,
-          activeSessionKey: commandSessionKey,
-        })
-      : undefined;
-    const boundAcpTargetKey = !isAcpSessionKey(resolvedTargetKey)
-      ? conversationBoundAcpTargetKey
-      : undefined;
-    const abortTargetKeys = [resolvedTargetKey];
-    if (boundAcpTargetKey && boundAcpTargetKey !== resolvedTargetKey) {
-      abortTargetKeys.push(boundAcpTargetKey);
-    }
-    let aborted = false;
-    let activeAbortRejected = false;
-    const acpCancellations: Promise<void>[] = [];
-    try {
-      const { stopped, failed } = await stopSubagentsForRequester({
-        cfg,
-        requesterSessionKey,
-        requesterAgentId: agentId,
-        beforeKill: () => {
-          if (params.isCommandTargetCurrent?.() === false) {
-            throw new Error("The selected session changed before it could be stopped.");
-          }
-          try {
-            const sourceAbortKey =
-              commandSessionKey &&
-              !abortTargetKeys.includes(commandSessionKey) &&
-              conversationBoundAcpTargetKey &&
-              abortTargetKeys.includes(conversationBoundAcpTargetKey)
-                ? commandSessionKey
-                : undefined;
-            const sessionIdsByKey = new Map<string, string | undefined>(
-              abortTargetKeys.map((abortTargetKey) => [
-                abortTargetKey,
-                replyRunRegistry.resolveSessionId(abortTargetKey) ??
-                  (abortTargetKey === resolvedTargetKey
-                    ? resolvedAbortTarget?.sessionId
-                    : resolveStoredSessionId({ cfg, sessionKey: abortTargetKey })),
-              ]),
-            );
-            for (const abortTargetKey of abortTargetKeys) {
-              const outcome = abortSessionRunTargetWithOutcome({
-                key: abortTargetKey,
-                sessionId: sessionIdsByKey.get(abortTargetKey),
-              });
-              if (outcome.retirement) {
-                acpCancellations.push(outcome.retirement);
-              }
-              activeAbortRejected ||= outcome.active && !outcome.aborted;
-              aborted = outcome.aborted || aborted;
-            }
-            const sourceSessionId = sourceAbortKey
-              ? (replyRunRegistry.resolveSessionId(sourceAbortKey) ??
-                resolveStoredSessionId({ cfg, sessionKey: sourceAbortKey }))
-              : undefined;
-            if (sourceAbortKey) {
-              const outcome = abortSessionRunTargetWithOutcome({
-                key: sourceAbortKey,
-                sessionId: sourceSessionId,
-              });
-              if (outcome.retirement) {
-                acpCancellations.push(outcome.retirement);
-              }
-              activeAbortRejected ||= outcome.active && !outcome.aborted;
-              aborted = outcome.aborted || aborted;
-            }
-            const cleared = clearSessionQueues(
-              abortTargetKeys
-                .flatMap((abortTargetKey) => [abortTargetKey, sessionIdsByKey.get(abortTargetKey)])
-                .concat(sourceAbortKey, sourceSessionId),
-            );
-            if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
-              logVerbose(
-                `abort: cleared followups=${cleared.followupCleared} lane=${cleared.laneCleared} keys=${cleared.keys.join(",")}`,
-              );
-            }
-          } finally {
-            // The tree already holds queued reservations. Initiate ACP without awaiting
-            // either backend so native cleanup cannot delay signal-less ACP steer turns.
-            const acpManager = getAcpSessionManager();
-            for (const acpTargetKey of abortTargetKeys) {
-              const resolution = acpManager.resolveSession({
-                cfg,
-                sessionKey: acpTargetKey,
-                agentId: acpTargetKey === resolvedTargetKey ? agentId : undefined,
-              });
-              if (resolution.kind === "none") {
-                continue;
-              }
-              acpCancellations.push(
-                acpManager
-                  .cancelSession({
-                    cfg,
-                    sessionKey: resolution.sessionKey,
-                    agentId: resolution.agentId,
-                    reason: "fast-abort",
-                  })
-                  .catch((error: unknown) => {
-                    logVerbose(
-                      `abort: ACP cancel failed for ${acpTargetKey}: ${formatErrorMessage(error)}`,
-                    );
-                  }),
-              );
-            }
-          }
-          return true;
-        },
-      });
-      const rejectionReason = activeAbortRejected && !aborted ? "finalizing" : undefined;
-      if (!rejectionReason) {
-        let persistedAbortTarget: SessionAbortTargetResult | null = null;
-        try {
-          persistedAbortTarget = await markSessionAbortTarget({
-            isCurrent: params.isCommandTargetCurrent,
-            scope: {
-              agentId,
-              sessionKey: targetKey,
-              storePath,
-            },
-            resolveAbortCutoff: abortCutoffForTarget,
-          });
-        } catch (error) {
-          logVerbose(
-            `abort: failed to persist abort metadata for ${targetKey}: ${formatErrorMessage(error)}`,
-          );
-        }
-        if (persistedAbortTarget?.persisted === false) {
-          logVerbose(
-            `abort: failed to persist abort metadata for ${targetKey}: ${persistedAbortTarget.persistenceError ?? "unknown error"}`,
-          );
-        }
-        const abortMemoryKey =
-          persistedAbortTarget?.sessionKey ?? resolvedAbortTarget?.sessionKey ?? abortKey;
-        const hasAbortTargetEntry = Boolean(
-          persistedAbortTarget?.entry ?? resolvedAbortTarget?.entry,
-        );
-        if (
-          persistedAbortTarget?.persisted !== true &&
-          abortMemoryKey &&
-          !hasAbortTargetEntry &&
-          params.isCommandTargetCurrent?.() !== false
-        ) {
-          setAbortMemory(abortMemoryKey, true);
-        }
-      }
-      return {
-        handled: true,
-        aborted,
-        ...(rejectionReason ? { rejectionReason } : {}),
-        stoppedSubagents: stopped,
-        failedSubagents: failed,
-      };
-    } finally {
-      // Join even when native signaling or metadata exits exceptionally.
-      await Promise.all(acpCancellations);
-    }
-  }
-
-  if (abortKey) {
-    setAbortMemory(abortKey, true);
-  }
-  const { stopped, failed } = await stopSubagentsForRequester({ cfg, requesterSessionKey });
-  return {
-    handled: true,
-    aborted: false,
-    stoppedSubagents: stopped,
-    failedSubagents: failed,
-  };
+  // Normalized ingress is not authority. The operation resolves authorization
+  // and retains current-target validation after loading cancellation machinery.
+  const { executeFastAbortRequest } = await import("./abort-operation.js");
+  return executeFastAbortRequest(params, request);
 }

--- a/src/auto-reply/reply/commands-abort-trigger.test.ts
+++ b/src/auto-reply/reply/commands-abort-trigger.test.ts
@@ -34,12 +34,18 @@ vi.mock("./abort-cutoff.js", () => ({
   shouldPersistAbortCutoff: vi.fn(() => false),
 }));
 
-vi.mock("./abort.js", () => ({
+vi.mock("./abort-operation.js", () => ({
   abortSessionRunTargetWithOutcome: abortSessionRunTargetWithOutcomeMock,
-  formatAbortReplyText: formatAbortReplyTextMock,
+  stopSubagentsForRequester: vi.fn(async () => ({ stopped: 0, failed: 0 })),
+}));
+
+vi.mock("./abort-primitives.js", () => ({
   isAbortTrigger: vi.fn((raw: string) => raw === "stop"),
   setAbortMemory: setAbortMemoryMock,
-  stopSubagentsForRequester: vi.fn(async () => ({ stopped: 0, failed: 0 })),
+}));
+
+vi.mock("./abort.js", () => ({
+  formatAbortReplyText: formatAbortReplyTextMock,
 }));
 
 vi.mock("./commands-session-store.js", () => ({

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -8,13 +8,9 @@ import {
   shouldPersistAbortCutoff,
   type AbortCutoff,
 } from "./abort-cutoff.js";
-import {
-  abortSessionRunTargetWithOutcome,
-  formatAbortReplyText,
-  isAbortTrigger,
-  setAbortMemory,
-  stopSubagentsForRequester,
-} from "./abort.js";
+import { abortSessionRunTargetWithOutcome, stopSubagentsForRequester } from "./abort-operation.js";
+import { isAbortTrigger, setAbortMemory } from "./abort-primitives.js";
+import { formatAbortReplyText } from "./abort.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import {
   persistAbortTargetEntry,

--- a/src/auto-reply/reply/commands-stop-target.test.ts
+++ b/src/auto-reply/reply/commands-stop-target.test.ts
@@ -50,12 +50,18 @@ vi.mock("./abort-cutoff.js", () => ({
   shouldPersistAbortCutoff: vi.fn(() => false),
 }));
 
-vi.mock("./abort.js", () => ({
+vi.mock("./abort-operation.js", () => ({
   abortSessionRunTargetWithOutcome: abortSessionRunTargetWithOutcomeMock,
-  formatAbortReplyText: formatAbortReplyTextMock,
+  stopSubagentsForRequester: stopSubagentsForRequesterMock,
+}));
+
+vi.mock("./abort-primitives.js", () => ({
   isAbortTrigger: vi.fn(() => false),
   setAbortMemory: vi.fn(),
-  stopSubagentsForRequester: stopSubagentsForRequesterMock,
+}));
+
+vi.mock("./abort.js", () => ({
+  formatAbortReplyText: formatAbortReplyTextMock,
 }));
 
 vi.mock("./commands-session-store.js", () => ({

--- a/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
+++ b/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
@@ -1,6 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { selectAgentHarness } from "../../agents/harness/selection.js";
+import { resolveAgentHarnessDeliveryDefaults } from "../../agents/harness/selection-decision.js";
 import {
   buildModelAliasIndex,
   resolveDefaultModelForAgent,
@@ -301,7 +301,7 @@ function resolveHarnessSourceVisibleRepliesDefault(params: {
         entry: params.entry,
         cfg: params.cfg,
       });
-      const harness = selectAgentHarness({
+      const defaults = resolveAgentHarnessDeliveryDefaults({
         provider: candidate.provider,
         modelId: candidate.model,
         config: params.cfg,
@@ -310,9 +310,7 @@ function resolveHarnessSourceVisibleRepliesDefault(params: {
         agentHarnessId: resolveSessionPinnedHarnessId(params.entry),
         agentHarnessRuntimeOverride,
       });
-      return (
-        harness.deliveryDefaults?.visibleReplies ?? harness.deliveryDefaults?.sourceVisibleReplies
-      );
+      return defaults?.visibleReplies ?? defaults?.sourceVisibleReplies;
     };
     const selectedModelCandidate =
       turnModelCandidate ?? storedModelCandidate ?? channelModelCandidate;

--- a/src/auto-reply/reply/dispatch-from-config.turn-model-selection-differential.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-model-selection-differential.test.ts
@@ -20,8 +20,8 @@ import { buildTestCtx } from "./test-ctx.js";
 
 const selectAgentHarnessMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../../agents/harness/selection.js", () => ({
-  selectAgentHarness: (...args: unknown[]) => selectAgentHarnessMock(...args),
+vi.mock("../../agents/harness/selection-decision.js", () => ({
+  resolveAgentHarnessDeliveryDefaults: (...args: unknown[]) => selectAgentHarnessMock(...args),
 }));
 
 const { resolveVisibleRepliesPolicy } = await import("./dispatch-from-config.harness-defaults.js");
@@ -89,7 +89,7 @@ describe("turn model selection harness-path differential", () => {
   beforeEach(() => {
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createSessionConversationTestRegistry());
-    selectAgentHarnessMock.mockImplementation(() => recorderHarness);
+    selectAgentHarnessMock.mockImplementation(() => recorderHarness.deliveryDefaults);
   });
 
   afterEach(() => {

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -65,7 +65,7 @@ vi.mock("../../agents/harness/hook-helpers.js", () => ({
 }));
 
 // Harness selection and built-in execution are owned by their focused suites. These tests keep
-// the real visible-reply policy resolver while supplying its default OpenClaw harness leaf.
+// the real visible-reply policy resolver while supplying its default delivery metadata.
 const preparedReplyMockState = vi.hoisted(() => ({
   unexpectedCalls: [] as string[],
 }));
@@ -120,7 +120,7 @@ vi.mock("../../agents/subagents/spawn/subagent-capabilities.js", () => ({
   resolveSubagentCapabilityStore: vi.fn().mockReturnValue(undefined),
 }));
 
-const selectAgentHarnessMock = vi.hoisted(() =>
+const resolveAgentHarnessDeliveryDefaultsMock = vi.hoisted(() =>
   vi.fn(
     (params: {
       provider: string;
@@ -136,14 +136,14 @@ const selectAgentHarnessMock = vi.hoisted(() =>
         params.agentHarnessId ||
         params.agentHarnessRuntimeOverride
       ) {
-        preparedReplyMockState.unexpectedCalls.push("selectAgentHarness");
+        preparedReplyMockState.unexpectedCalls.push("resolveAgentHarnessDeliveryDefaults");
       }
-      return { id: "openclaw", deliveryDefaults: {} };
+      return {};
     },
   ),
 );
-vi.mock("../../agents/harness/selection.js", () => ({
-  selectAgentHarness: selectAgentHarnessMock,
+vi.mock("../../agents/harness/selection-decision.js", () => ({
+  resolveAgentHarnessDeliveryDefaults: resolveAgentHarnessDeliveryDefaultsMock,
 }));
 
 vi.mock("../../agents/model-selection.js", () => ({
@@ -4282,7 +4282,7 @@ describe("runPreparedReply media-only handling", () => {
 
   it("resolves origin-less sessions as internal for synthetic stable facts", async () => {
     vi.mocked(buildDirectChatContext).mockReturnValue("direct-context");
-    selectAgentHarnessMock.mockClear();
+    resolveAgentHarnessDeliveryDefaultsMock.mockClear();
     // An entry with no persisted delivery origin has only ever been driven
     // internally; its wake source must not leak into the
     // stable context as a non-internal surface or the fact diverges from
@@ -4315,7 +4315,7 @@ describe("runPreparedReply media-only handling", () => {
     const run = requireRunReplyAgentCall(0).followupRun.run;
     expect(run.cliSessionBindingFacts?.sourceReplyDeliveryMode).toBe("automatic");
     expect(
-      selectAgentHarnessMock.mock.calls.map(([params]) => ({
+      resolveAgentHarnessDeliveryDefaultsMock.mock.calls.map(([params]) => ({
         provider: params.provider,
         modelId: params.modelId,
       })),

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -29,7 +29,7 @@ export {
 export { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 export { getReplyFromConfig } from "../auto-reply/reply/get-reply.js";
 export { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-export { isAbortRequestText } from "../auto-reply/reply/abort.js";
+export { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 export { isBtwRequestText } from "../auto-reply/reply/btw-command.js";
 export { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
 export { finalizeInboundContextForSdk as finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";


### PR DESCRIPTION
## What Problem This Solves

Heartbeat and reply preflight paid for cold execution-runtime imports even when they only needed delivery metadata or were handling an ordinary message. The complete 428-test heartbeat cohort spent about 11–12 seconds on avoidable work in a controlled Linux comparison.

## Why This Change Was Made

Share one synchronous harness-selection decision between metadata and runtime callers. Metadata reads delivery defaults without constructing the embedded harness; runtime callers retain the genuine selected harness and registry-owner validation.

Normalize stop-request ingress once, then load the cancellation operation for an eligible request. Authorization and current-target checks remain inside that operation after loading. The existing cancellation, queue, persistence, and cleanup body moves intact to its owner. Internal callers use that owner or the existing primitives; the public SDK export is preserved.

## User Impact

Ordinary messages and heartbeat preflight avoid initializing execution and cancellation machinery just to make lightweight decisions. This reduces cold startup work without changing shard counts, worker limits, configuration, or runtime routing policy.

## Evidence

On one isolated Linux runner with four available CPUs, two workers, fresh caches, and matching source/dependencies, all 25 files and 428 cases passed in every arm:

| Arm | Whole cohort | Maximum RSS (KiB) |
| --- | ---: | ---: |
| Original A | 138.177 s | 2,154,772 |
| Candidate | 127.179 s | 2,191,572 |
| Original B | 139.523 s | 2,173,004 |

The candidate is 8.0–8.8% faster than both controls; the controls differ by 1.35 seconds. No cases were removed or skipped. The single-case comparison was 20.138 / 16.828 / 19.578 seconds. These measurements do not establish whole-CI savings. RSS comes from the retained GNU `/usr/bin/time -v` output for those same arms: the largest individual-process high-water mark, not summed concurrent process-tree memory or a leak measurement. Candidate RSS is 27.04 MiB (1.28%) above the control mean; this is a time improvement, with no demonstrated memory reduction. This supplies the before/after RSS requested in the latest review and its rank-up move.

The original abort entry fails the new ordinary-message import-boundary regression, and the candidate passes. Another 341 focused cases cover selection identity, authorization, cancellation/persistence ordering, and sibling dispatch. Full build and isolated built Discord entrypoint profiling passed.

Every selected changed-check component passed through composite validation. The earlier full invocation failed on a test callback annotation; after that mechanical fix, the remaining 11 canonical checks passed. Final independent P2 review found no actionable issues. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34620973404) is green on `10434c57c3f8e564797c95e4f7a887cde56e0889`. The initial CI run exposed a stale test mock after moving delivery metadata to its owner; the reply itself still ran. Updating that mock preserved the provider/model and stable-facts assertions. The original 63-file/1,549-case CI cohort then passed locally, and the correction received a clean independent P2 review.

The test changes clean tracked fixture queues and observe cancellation while a replacement writer remains blocked, preserving the original ordering and replacement-state assertions.

## Scope

Production grows by 93 net lines for typed metadata/request boundaries and their adapters after moving the existing owners; tests grow by 74 lines. The old-path assertion debt ratchet tightens from 5 to 4. No dependency or persistence-schema change is included.
