### PR TITLE
fix(update): avoid reporting rollback before activation

### DIFF
--- a/src/gateway/server-methods/update-report-run.test.ts
+++ b/src/gateway/server-methods/update-report-run.test.ts
@@ -219,7 +219,7 @@ describe("Report action from the authoritative update ledger", () => {
       expect(result.body).toContain("build");
       expect(result.body).toContain("2026.9.1");
       expect(result.body).toContain("2026.9.2");
-      expect(result.body).toContain("Rollback outcome: not recorded");
+      expect(result.body).toContain("Recovery outcome: not recorded");
       expect(result.body).not.toContain("private-");
       expect(Buffer.byteLength(result.body)).toBeLessThan(16_000);
       expect(await reportFiles()).toEqual([]);

--- a/src/infra/update-failure-report-prepare.test.ts
+++ b/src/infra/update-failure-report-prepare.test.ts
@@ -14,6 +14,39 @@ function prepareDiagnosticReport(reason: string) {
 }
 
 describe("update report diagnostic command boundary", () => {
+  it("does not imply rollback when candidate repair stops before activation", async () => {
+    const report = await prepareUpdateFailureReport(
+      {
+        attemptId: "candidate-repair-refused",
+        target: "version 2026.9.4",
+        result: {
+          mode: "npm",
+          status: "error",
+          reason: "repair-requires-config-change",
+          before: { version: "2026.9.3" },
+          after: { version: "2026.9.3" },
+          steps: [
+            {
+              name: "repairing",
+              command: "repair staged candidate",
+              cwd: "/candidate",
+              durationMs: 1,
+              exitCode: 1,
+            },
+          ],
+          recovery: { serviceRestartSafe: false, reason: "runtime-verification-failed" },
+          durationMs: 1,
+        },
+      },
+      context,
+    );
+
+    expect(report.body).toContain("Failed phase: repairing");
+    expect(report.body).toContain("After version: 2026.9.3");
+    expect(report.body).toContain("Recovery outcome: not verified (runtime-verification-failed)");
+    expect(report.body.toLowerCase()).not.toContain("rollback");
+  });
+
   it("records the running Node version in the reviewed report", async () => {
     const report = await prepareDiagnosticReport("node-runtime-preflight");
     expect(report.body).toContain(`- Node version: ${process.versions.node}\n`);
@@ -90,7 +123,7 @@ describe("update report diagnostic command boundary", () => {
     expect(report.body).not.toContain("private-customer-text");
     expect(report.body).toContain("exit 7");
     expect(report.body).toContain("Update mode: npm");
-    expect(report.body).toContain("Rollback outcome: not verified");
+    expect(report.body).toContain("Recovery outcome: not verified");
   });
 
   it.each([

--- a/src/infra/update-failure-report-prepare.ts
+++ b/src/infra/update-failure-report-prepare.ts
@@ -122,7 +122,7 @@ function resolveUpdateTarget(
   );
 }
 
-function resolveRollbackOutcome(
+function resolveRecoveryOutcome(
   result: UpdateRunResult,
   context: UpdateFailureReportContext,
 ): string {
@@ -209,7 +209,7 @@ export async function prepareUpdateFailureReport(
   const platform = sanitizeReportField(`${process.platform}/${process.arch}`, context);
   const target = resolveUpdateTarget(input, context);
   const phase = resolveFailedPhase(input.result, context);
-  const rollback = resolveRollbackOutcome(input.result, context);
+  const recovery = resolveRecoveryOutcome(input.result, context);
   const bodyWithoutMarker = [
     "# OpenClaw update failure report",
     "",
@@ -220,7 +220,7 @@ export async function prepareUpdateFailureReport(
     `- Node version: ${sanitizeReportField(process.versions.node ?? "unknown", context)}`,
     `- Update target: ${target}`,
     `- Failed phase: ${phase}`,
-    `- Rollback outcome: ${rollback}`,
+    `- Recovery outcome: ${recovery}`,
     "",
     "## Bounded diagnostics",
     "",

--- a/src/infra/update-failure-report.test.ts
+++ b/src/infra/update-failure-report.test.ts
@@ -166,7 +166,7 @@ describe("update failure report", () => {
     const saved = await fs.readFile(result.savedReportPath, "utf8");
     expect(saved).toBe(prepared.body);
     expect(Buffer.byteLength(saved, "utf8")).toBeLessThanOrEqual(16_000);
-    expect(saved).toContain("Rollback outcome: verified safe to restart");
+    expect(saved).toContain("Recovery outcome: verified safe to restart");
     expect(saved).toContain("Failed phase:");
     expect(saved).toContain("Update target:");
     expect(saved).toContain("🦞");
@@ -216,7 +216,7 @@ describe("update failure report", () => {
     );
 
     expect(prepared.body).toContain(
-      "Rollback outcome: package rollback verified; service restart not verified (runtime-verification-failed)",
+      "Recovery outcome: package rollback verified; service restart not verified (runtime-verification-failed)",
     );
   });
 


### PR DESCRIPTION
Refs #145005

<details>
<summary>Additional instructions</summary>

This uses a same-repository branch for maintainer updates.

</details>

## What Problem This Solves

Fixes an issue where users reporting a failed update would see “Rollback outcome” even when candidate validation or repair stopped before activation. That label suggested the previous package had been restored, although the recorded fact could instead be verification of the untouched installation.

## Why This Change Was Made

The shared report now labels this field “Recovery outcome.” It retains “package rollback verified” only when that explicit fact is recorded. The report continues to use the existing recovery result and sanitization.

## User Impact

Operators and maintainers can read pre-activation failure reports without mistaking an installation verification failure for a failed rollback. Thanks to @BodegaClaw for the report that exposed this ambiguity.

This change does not alter config-promotion policy or make an unverified installation pass verification. The reporter’s specific config changes and integrity failure remain unconfirmed without the local run ledger.

## Evidence

- Regression before the fix: `node scripts/run-vitest.mjs src/infra/update-failure-report-prepare.test.ts -t 'does not imply rollback'` failed: expected `Recovery outcome`, received `Rollback outcome` for a pre-activation `repair-requires-config-change` result.
- After the fix: `node scripts/run-vitest.mjs src/infra/update-failure-report-prepare.test.ts src/infra/update-failure-report.test.ts` passed 55 tests, including explicit verified-rollback reporting and report submission/consent behavior.
- Gateway consumer: `node scripts/run-vitest.mjs src/gateway/server-methods/update-report-run.test.ts` passed 23 tests.
- `node scripts/check-changed.mjs` passed; the Gateway expectation also passed targeted formatting and lint. `git diff --check` passed.
- Existing policy boundary: `node scripts/run-vitest.mjs src/cli/update-cli/update-command-repair-isolation.e2e.test.ts` passed both cases, preserving serving-file isolation and the config-change refusal.
- Exact-head [CI run 34616829148](https://github.com/openclaw/openclaw/actions/runs/34616829148) completed successfully. `node scripts/watch-pr-ci.mjs 145039 d2ea815269a2cf2d413a24582568a27e2d24b241` finished `GREEN` with zero pending checks; it excluded 85 superseded checks from the raw GitHub rollup.
