### PR TITLE
fix(goals): preserve objectives and optional budgets

### DIFF
--- a/docs/tools/goal.md
+++ b/docs/tools/goal.md
@@ -40,6 +40,10 @@ a separate sandbox policy session.
 OpenClaw treats any text after `/goal` that is not a known action word as a
 new objective.
 
+Explicit actions such as `start` and `edit` preserve line breaks, indentation,
+and repeated spaces inside the objective. Leading and trailing whitespace is
+trimmed.
+
 ## What goals are for
 
 Use a goal when a session has a concrete outcome that should stay visible
@@ -104,7 +108,8 @@ with `Goal error: goal already exists` until the current one is cleared.
 - `usage_limited`: reserved for a future usage-limit stop state. `/goal
 resume` restarts pursuit the same way.
 - `complete`: the goal was achieved. Complete goals are terminal. Use `/goal
-clear` before starting another goal.
+clear` before starting another goal. Repeating completion preserves the original
+  completion time, including when you add a status note.
 
 `/new` and `/reset` clear the current session goal, since they intentionally
 start fresh session context.
@@ -117,6 +122,9 @@ session's fresh token count at goal-creation time. If the session only has a
 stale or unknown token snapshot when the goal starts, OpenClaw waits for the
 next fresh snapshot and uses that as the baseline, so tokens spent before the
 goal existed are not charged to it.
+
+The model should omit `token_budget` unless you explicitly request a budget.
+Transports that require every tool argument can pass `null` for no budget.
 
 When usage reaches the budget, the goal moves to `budget_limited`. This does
 not delete the goal or erase the objective. It tells the operator and the
@@ -144,10 +152,14 @@ can report achievement or a genuine blocker without quietly moving the
 target.
 
 `update_goal` should mark a goal `complete` only when the objective is
-actually achieved. It should mark a goal `blocked` only after the same
-blocking condition recurs for at least three consecutive goal turns, not for
-ordinary difficulty or missing polish. Updating goal status does not send a
-chat reply. The agent must still provide the user's requested final response.
+verified against the full objective with no required work remaining. It should
+mark a goal `blocked` only after the same blocking condition recurs for at least
+three consecutive goal turns, not for ordinary difficulty or missing polish.
+Resuming a blocked goal starts a fresh count of three consecutive turns. Earlier
+blocked turns do not count toward it.
+A nearly exhausted budget does not justify marking unfinished work complete.
+Updating goal status does not send a chat reply. The agent must still provide
+the user's requested final response.
 
 ## Goal context on every turn
 

--- a/src/agents/tools/goal-tools.test.ts
+++ b/src/agents/tools/goal-tools.test.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import {
@@ -85,7 +86,7 @@ describe("goal tools", () => {
     expect(getSessionEntry({ storePath, sessionKey: "global" })?.goal?.status).toBe("active");
   });
 
-  it("uses the resolved session agent for global session stores", async () => {
+  it.each([undefined, null, 100])("creates a scoped goal with token_budget=%s", async (budget) => {
     const { config, template } = await createStoreConfig();
     const tool = createCreateGoalTool({
       agentSessionKey: "global",
@@ -100,12 +101,20 @@ describe("goal tools", () => {
       sessionKey: "global",
       entry: { sessionId: "sess-global", updatedAt: 1 },
     });
-    await tool.execute("call-1", { objective: "ship global work" });
+    const args = {
+      objective: "ship global work",
+      ...(budget !== undefined ? { token_budget: budget } : {}),
+    };
+    expect(Value.Check(tool.parameters, args)).toBe(true);
+    await tool.execute("call-1", args);
 
     const mainStorePath = resolveSessionStorePathCore(template, { agentId: "main" });
     expect(
       getSessionEntry({ storePath: researchStorePath, sessionKey: "global" })?.goal?.objective,
     ).toBe("ship global work");
+    expect(
+      getSessionEntry({ storePath: researchStorePath, sessionKey: "global" })?.goal?.tokenBudget,
+    ).toBe(budget ?? undefined);
     expect(
       getSessionEntry({ storePath: mainStorePath, sessionKey: "global" })?.goal,
     ).toBeUndefined();

--- a/src/agents/tools/goal-tools.ts
+++ b/src/agents/tools/goal-tools.ts
@@ -1,8 +1,3 @@
-/**
- * Model-facing thread goal tools.
- *
- * Provides create/get/update goal operations scoped to the current session store.
- */
 import { Type } from "typebox";
 import { SessionGoalTransitionError } from "../../config/sessions/goals-transitions.js";
 import {
@@ -41,9 +36,8 @@ const CreateGoalToolSchema = Type.Object({
     description: "Concrete objective; explicit request only.",
   }),
   token_budget: Type.Optional(
-    Type.Integer({
-      minimum: 1,
-      description: "Optional positive token budget.",
+    Type.Union([Type.Integer({ minimum: 1 }), Type.Null()], {
+      description: "Positive token budget. Omit or pass null unless explicitly requested.",
     }),
   ),
 });
@@ -75,13 +69,13 @@ function resolveGoalSessionScope(options: GoalToolOptions): GoalSessionScope {
   };
 }
 
-/** Creates the read-only tool that returns the current thread goal snapshot. */
 export function createGetGoalTool(options: GoalToolOptions): AnyAgentTool {
   return {
     label: "Get Goal",
     name: "get_goal",
     displaySummary: "Get the current thread goal",
-    description: "Get thread goal, status, token usage.",
+    description:
+      "Get the current session goal, including its full objective, status, token usage, and optional budget.",
     parameters: Type.Object({}),
     execute: async () => {
       const snapshot = await getSessionGoal({
@@ -93,14 +87,13 @@ export function createGetGoalTool(options: GoalToolOptions): AnyAgentTool {
   };
 }
 
-/** Creates the tool that starts a new thread goal when explicitly requested. */
 export function createCreateGoalTool(options: GoalToolOptions): AnyAgentTool {
   return {
     label: "Create Goal",
     name: "create_goal",
     displaySummary: "Create a thread goal",
     description:
-      "Create goal only explicit user/system request. Optional token_budget caps goal token usage. Existing goal => fail; user-facing controls clear it.",
+      "Create a goal only when explicitly requested by the user or system instructions. Set a positive token_budget only when a budget is explicitly requested; otherwise omit it or pass null. Fails if a goal already exists; the user must clear it before starting another.",
     parameters: CreateGoalToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -120,14 +113,13 @@ export function createCreateGoalTool(options: GoalToolOptions): AnyAgentTool {
   };
 }
 
-/** Creates the tool that marks the current thread goal complete or blocked. */
 export function createUpdateGoalTool(options: GoalToolOptions): AnyAgentTool {
   return {
     label: "Update Goal",
     name: "update_goal",
     displaySummary: "Complete or block a thread goal",
     description:
-      "Update the session goal status (complete | blocked) with an optional note. complete only achieved. blocked only same blocker 3+ consecutive goal turns; never ordinary difficulty/polish. Updating a goal does not reply to the user; provide the requested final response afterward.",
+      "Mark the session goal complete only when the full objective is verified and no required work remains. Mark it blocked only when the same blocker has recurred for at least three consecutive goal turns and no meaningful progress is possible without user input or an external change. After the user resumes a blocked goal, count those turns from the resume. Difficulty, incomplete work, or a nearly exhausted budget do not justify completion or blocking. Updating a goal does not reply to the user; provide the requested final response afterward.",
     parameters: UpdateGoalToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/auto-reply/commands-registry-normalize.ts
+++ b/src/auto-reply/commands-registry-normalize.ts
@@ -90,7 +90,12 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
     return trimmed;
   }
 
-  const newline = options?.preserveArguments ? -1 : trimmed.indexOf("\n");
+  const commandAlias = trimmed.match(/^\/[^\s@:]+/u)?.[0]?.toLowerCase();
+  const preserveArguments =
+    options?.preserveArguments ||
+    (commandAlias !== undefined &&
+      getCommandRegistryLookup().aliases.get(commandAlias)?.command.key === "goal");
+  const newline = preserveArguments ? -1 : trimmed.indexOf("\n");
   const singleLine = newline === -1 ? trimmed : trimmed.slice(0, newline).trim();
   const multilineTail = newline === -1 ? undefined : trimmed.slice(newline + 1).trimStart();
 
@@ -100,7 +105,7 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
     ? (() => {
         const [, command, rest] = colonMatch;
         const commandRest = expectDefined(rest, "commands registry normalize rest");
-        const normalizedRest = options?.preserveArguments ? commandRest : commandRest.trimStart();
+        const normalizedRest = preserveArguments ? commandRest : commandRest.trimStart();
         return normalizedRest
           ? `/${command}${/^\s/.test(normalizedRest) ? "" : " "}${normalizedRest}`
           : `/${command}`;
@@ -140,7 +145,7 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
     return commandBody;
   }
   const normalizedRest = rest?.trimStart();
-  const normalizedHead = options?.preserveArguments
+  const normalizedHead = preserveArguments
     ? `${tokenSpec.canonical}${commandBody.slice(tokenKey.length)}`
     : normalizedRest
       ? `${tokenSpec.canonical} ${normalizedRest}`

--- a/src/auto-reply/reply/commands-goal.test.ts
+++ b/src/auto-reply/reply/commands-goal.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { normalizeCommandBody } from "../commands-registry-normalize.js";
 import { takeCommandSessionMetadataChanges } from "./command-session-metadata.js";
 import { handleGoalCommand, parseGoalCommand } from "./commands-goal.js";
 import type { HandleCommandsParams } from "./commands-types.js";
@@ -131,32 +132,39 @@ describe("goal commands", () => {
     });
   });
 
-  it("starts a goal from Codex-style bare /goal objective text", async () => {
-    const storePath = await createStorePath();
-    await upsertSessionEntry({
-      storePath,
-      sessionKey,
-      entry: {
-        sessionId: "sess-main",
-        updatedAt: 1,
-        totalTokens: 0,
-        totalTokensFresh: true,
-        totalTokensVersion: 1,
-      },
-    });
+  it.each(["", "start ", "set ", "create "])(
+    "preserves the objective when starting with /goal %s",
+    async (action) => {
+      const storePath = await createStorePath();
+      await upsertSessionEntry({
+        storePath,
+        sessionKey,
+        entry: {
+          sessionId: "sess-main",
+          updatedAt: 1,
+          totalTokens: 0,
+          totalTokensFresh: true,
+          totalTokensVersion: 1,
+        },
+      });
 
-    const params = buildGoalParams("/goal build a 3d game", storePath);
-    const result = await handleGoalCommand(params, true);
+      const objective = "build a 3d game\n\nKeep this exact label: a  b\n\tThen verify it.";
+      const params = buildGoalParams(
+        normalizeCommandBody(`/goal ${action}${objective}`),
+        storePath,
+      );
+      const result = await handleGoalCommand(params, true);
 
-    expect(result?.shouldContinue).toBe(true);
-    expect(result?.reply).toBeUndefined();
-    expect(params.command.commandBodyNormalized).toBe("build a 3d game");
-    expect((params.ctx as { BodyForAgent?: string }).BodyForAgent).toBe("build a 3d game");
-    expect(getSessionEntry({ storePath, sessionKey })?.goal?.objective).toBe("build a 3d game");
-    expect(takeCommandSessionMetadataChanges(params.ctx)).toEqual([
-      { sessionKey, reason: "command-metadata" },
-    ]);
-  });
+      expect(result?.shouldContinue).toBe(true);
+      expect(result?.reply).toBeUndefined();
+      expect(params.command.commandBodyNormalized).toBe(objective);
+      expect((params.ctx as { BodyForAgent?: string }).BodyForAgent).toBe(objective);
+      expect(getSessionEntry({ storePath, sessionKey })?.goal?.objective).toBe(objective);
+      expect(takeCommandSessionMetadataChanges(params.ctx)).toEqual([
+        { sessionKey, reason: "command-metadata" },
+      ]);
+    },
+  );
 
   it("wraps command-prefixed goal objectives before continuing", async () => {
     const storePath = await createStorePath();

--- a/src/auto-reply/reply/commands-goal.ts
+++ b/src/auto-reply/reply/commands-goal.ts
@@ -54,14 +54,15 @@ export function parseGoalCommand(raw: string): { action: string; text: string } 
   if (!argText) {
     return { action: "status", text: "" };
   }
-  const [actionRaw = "", ...rest] = argText.split(/\s+/);
+  const actionEnd = argText.search(/\s/);
+  const actionRaw = actionEnd === -1 ? argText : argText.slice(0, actionEnd);
   const action = normalizeOptionalLowercaseString(actionRaw) ?? "status";
   if (!GOAL_ACTIONS.has(action)) {
     return { action: "start", text: argText };
   }
   return {
     action,
-    text: rest.join(" ").trim(),
+    text: actionEnd === -1 ? "" : argText.slice(actionEnd).trim(),
   };
 }
 

--- a/src/config/sessions/goals-transitions.ts
+++ b/src/config/sessions/goals-transitions.ts
@@ -9,8 +9,6 @@ export class SessionGoalTransitionError extends Error {
   }
 }
 
-const TERMINAL_GOAL_STATUSES = new Set<SessionGoalStatus>(["complete"]);
-
 function normalizeTokenCount(value: number | undefined): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value >= 0
     ? Math.floor(value)
@@ -39,8 +37,6 @@ export function accountSessionGoalUsage(
   now: number,
   options?: { adoptFreshBaseline?: boolean },
 ): SessionGoal | undefined {
-  // `goal` is introduced here as a core-owned slot; no shipped plugin-owned
-  // goal state exists to migrate, and plugin slot registration now reserves it.
   const goal = entry.goal;
   if (!goal) {
     return undefined;
@@ -118,7 +114,7 @@ export function buildUpdatedSessionGoalStatus(
   if (!accounted) {
     throw new SessionGoalTransitionError("goal not found");
   }
-  if (TERMINAL_GOAL_STATUSES.has(accounted.status) && accounted.status !== options.status) {
+  if (accounted.status === "complete" && accounted.status !== options.status) {
     throw new SessionGoalTransitionError(`goal is already ${accounted.status}`);
   }
   const resetsBudgetWindow =
@@ -135,7 +131,7 @@ export function buildUpdatedSessionGoalStatus(
     ...(options.note ? { lastStatusNote: options.note } : {}),
     ...(options.status === "paused" ? { pausedAt: now } : {}),
     ...(options.status === "blocked" ? { blockedAt: now } : {}),
-    ...(options.status === "complete" ? { completedAt: now } : {}),
+    ...(options.status === "complete" ? { completedAt: accounted.completedAt ?? now } : {}),
   };
   if (resetsBudgetWindow) {
     next.tokenStart = freshTokenStart ?? 0;
@@ -167,7 +163,7 @@ export function buildUpdatedSessionGoalObjective(
   if (!accounted) {
     throw new SessionGoalTransitionError("goal not found");
   }
-  if (TERMINAL_GOAL_STATUSES.has(accounted.status)) {
+  if (accounted.status === "complete") {
     throw new SessionGoalTransitionError(`goal is already ${accounted.status}`);
   }
   // Rewording keeps status and token accounting; only the target moves.

--- a/src/config/sessions/goals.test.ts
+++ b/src/config/sessions/goals.test.ts
@@ -289,6 +289,18 @@ describe("session goals", () => {
 
     expect(completed.status).toBe("complete");
     expect(completed.lastStatusNote).toBe("done");
+    const repeated = await updateSessionGoalStatus({
+      storePath: fixture.storePath(),
+      sessionKey,
+      status: "complete",
+      note: "verified",
+      now: 30,
+    });
+    expect(repeated.completedAt).toBe(completed.completedAt);
+    expect(repeated.lastStatusNote).toBe("verified");
+    expect(getSessionEntry({ storePath: fixture.storePath(), sessionKey })?.goal?.completedAt).toBe(
+      completed.completedAt,
+    );
     await expect(
       updateSessionGoalStatus({
         storePath: fixture.storePath(),


### PR DESCRIPTION
## What Problem This Solves

Fixes goal commands losing multiline requirements and significant whitespace before the objective reaches the session store or agent. Repeating completion also used to move the completion timestamp, making finished elapsed time grow.

The goal tool schema exposed no explicit no-budget value for transports that require all arguments. A live ChatGPT-backed run supplied a one-token budget even though the user requested none.

## Why This Change Was Made

Preserve goal arguments through slash-command normalization and action parsing, and retain the first completion timestamp while allowing later status notes. Let `create_goal` accept `token_budget: null`, which the existing parameter reader already treats as absent. Clarify explicit budget requests, full-objective completion, and counting blocker turns anew after resume. Remove redundant goal comments and the single-value terminal-status set.

Compared directly with [Codex OSS goal tools](https://github.com/openai/codex/blob/c77c34ed33877a6e5b3759703d01d3b223274cbf/codex-rs/ext/goal/src/spec.rs) and its [continuation instructions](https://github.com/openai/codex/blob/c77c34ed33877a6e5b3759703d01d3b223274cbf/codex-rs/ext/goal/templates/goals/continuation.md). OpenClaw retains its existing operator-owned clear/resume controls.

## User Impact

Goal objectives keep their line breaks, indentation, and repeated spaces. Completing a goal again preserves the original finished time. Models can explicitly leave a goal unbudgeted, and receive clearer completion/blocking instructions.

## Evidence

- 101 focused tests passed across goal storage/transitions, operation receipts, model tools, goal commands, and the shared command registry. Regressions failed before the repairs: explicit actions flattened whitespace, shared normalization dropped multiline tails, repeated completion changed the timestamp, and the schema rejected an explicit null budget.
- Final `check:changed` passed locally, including core and test types, lint, dead exports, and owner guards. Full `pnpm build` passed.
- Independent Codex review: no actionable P0–P2 findings.
- After an explicit rebuild, isolated real-model `agent exec` runs passed on both ChatGPT-backed and OpenAI API-key transports using `openai/gpt-5.6-sol`. Each called `create_goal`, `get_goal`, and `update_goal` once with zero tool failures. SQLite readback verified the exact multiline objective, no token budget, completed state, and the visible final `GOAL  VERIFIED`.
- The first native Codex harness attempt failed at client cleanup and is not counted as passing proof. The successful runs used the embedded OpenClaw runtime whose tools this PR changes.

## Follow-up

Codex accounts consumed tokens; OpenClaw currently derives goal usage from context snapshots. Compaction and post-completion accounting need a separate owner-level repair. This PR does not change that persistent accounting contract or add automatic goal continuations.
