### PR TITLE
fix: macOS packaging fails during private worker integrity checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
   "bin": {
     "openclaw": "openclaw.mjs"
   },
+  "publishConfig": {
+    "executableFiles": [
+      "dist/crabbox-wrapper.js",
+      "dist/entry.js",
+      "dist/index.js",
+      "dist/native-hook-relay/entry.js"
+    ]
+  },
   "directories": {
     "doc": "docs",
     "test": "test"

--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -792,13 +792,9 @@ export async function prepareBundledAiRuntimePackage(
 }
 
 async function normalizeOpenClawTarballModes(tarballPath: string) {
-  // npm/pnpm pack copy on-disk modes into the tarball (node-tar's portable
-  // mode-fix never adds read bits), so a restrictive-umask build host ships
-  // owner-only 0600/0700 entries that leave a root-installed CLI unreadable
-  // for non-root users under system tar and mode-preserving installers.
-  // Rewrite every entry to 0644/0755 the way a umask-022 host would have
-  // packed it, keeping executable bits. Stays on the system tar contract like
-  // the bundled AI runtime extraction above.
+  // npm can retain restrictive source read bits. Normalize those for non-root
+  // installers while preserving the archive's executable intent. pnpm derives
+  // that intent from bin and publishConfig.executableFiles, not source modes.
   const stageDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-package-modes-"));
   try {
     await runPackageTar("extract", tarballPath, stageDir);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where building the macOS app stops while packaging its private worker because the package integrity check finds missing executable permissions. The same failure affects the canonical package helper when using its pnpm pack path.

## Why This Change Was Made

pnpm preserves executable permissions only for `bin` entries and files named in `publishConfig.executableFiles`. Declare the four existing generated executable entrypoints in the root package manifest. Correct the mode normalizer's comment to reflect that dependency contract; leave the integrity checks and normalization behavior unchanged.

Regenerating the inventory after packing would conceal the lost permissions. This change preserves the executable intent at the package producer instead.

## User Impact

macOS app and pnpm package builds can finish with the expected executable files and all integrity checks enabled. No Gateway configuration, runtime logic, dependency versions, or release publication changes.

## Evidence

- A full macOS build at `f2ce199238e974b1d4caff8f11112aa51eb00d9e` failed its real private-worker package gate: `dist/index.js`, `dist/entry.js`, `dist/crabbox-wrapper.js`, and `dist/native-hook-relay/entry.js` were `0755` in source/inventory but `0644` in the pnpm archive. Every content hash and size matched.
- Native pnpm 12.3.4 minimal fixture: a non-bin executable loses its executable bit before this declaration and retains it with the supported declaration.
- Repacked the same retained build in an isolated copy with only the candidate manifest declaration: the unmodified package integrity/import-graph gate passed, and all four archive entries retained `0755`.
- Existing inventory collection/writer tests: 23 passed. The real package gate already catches this regression, so no test merely restating manifest values was added.
- Independent Codex review: no actionable P0–P2 findings.
- Dependency contract: [pnpm executableFiles documentation](https://pnpm.io/package_json#publishconfigexecutablefiles).

Production/tooling delta: eight package metadata lines added; comment-only change +3/-7. No runtime code or test growth. Exact introduction was not attributed; the failure above is directly reproduced on current build inputs.
