### PR TITLE
fix(update): keep updating core when a plugin target is unavailable

### DIFF
--- a/docs/cli/update/how-updates-run.md
+++ b/docs/cli/update/how-updates-run.md
@@ -439,9 +439,11 @@ Before mutation, an installed plugin whose declared `openclaw.compat.pluginApi`
 range or `openclaw.install.minHostVersion` excludes the target core can block the
 update if the requested replacement is unavailable or also incompatible. The
 `plugin-incompatible` refusal names the installed version and requirement.
-Install a compatible plugin version, explicitly disable the plugin, or wait for
-a compatible release. A registry outage alone never establishes this refusal;
-candidate validation and post-core convergence still check activation safety.
+When the installed plugin is known to be incompatible, a registry outage also
+blocks the update because a compatible replacement cannot be resolved. Retry
+when the registry is reachable, pin a compatible plugin version, explicitly
+disable the plugin, or wait for a compatible release. Compatible installed
+plugins still follow the advisory path described above.
 
 Older updaters may still refuse with `plugin-target-unavailable` before candidate
 code runs. Use your installation's [manual update method](/install/updating/update-methods),

--- a/docs/cli/update/how-updates-run.md
+++ b/docs/cli/update/how-updates-run.md
@@ -396,9 +396,8 @@ the sentinel.
 
 On stable updates, a configured OpenClaw-owned official plugin with no install
 record is repaired from the selected core release cohort. This also applies to
-`doctor --fix` after an earlier upgrade lost a formerly bundled plugin. Admission
-checks that package target before stopping the Gateway; post-core reconciliation
-installs it before restart. Existing install records retain their source and
+`doctor --fix` after an earlier upgrade lost a formerly bundled plugin. Post-core
+reconciliation installs it before restart. Existing install records retain their source and
 selector policy. Verified official packages use the existing
 [capability-consent exemption](/plugins/manage-plugins#capability-consent).
 
@@ -428,6 +427,25 @@ advisory and reports `postUpdate.plugins.status: "warning"` in JSON. The warning
 includes the observed installed and available versions and an explicit command
 to replace the pin. Keep the pin if intentional. This advisory does not establish
 incompatibility, change the pin, or fail an otherwise successful core update.
+
+An unavailable npm target or unreachable registry does not block the core update
+when a compatible, runnable plugin is already installed. Plugin sync retains that
+installed version and its recorded selector. The summary, warning log, and run
+history name the plugin, requested target, resolution failure, and
+`openclaw plugins update <id>` next action. JSON keeps top-level `status: "ok"`
+with a `plugin-target-unavailable` advisory under `postUpdate.plugins.warnings`.
+
+Before mutation, an installed plugin whose declared `openclaw.compat.pluginApi`
+range or `openclaw.install.minHostVersion` excludes the target core can block the
+update if the requested replacement is unavailable or also incompatible. The
+`plugin-incompatible` refusal names the installed version and requirement.
+Install a compatible plugin version, explicitly disable the plugin, or wait for
+a compatible release. A registry outage alone never establishes this refusal;
+candidate validation and post-core convergence still check activation safety.
+
+Older updaters may still refuse with `plugin-target-unavailable` before candidate
+code runs. Use your installation's [manual update method](/install/updating/update-methods),
+then run `openclaw update repair` from the updated installation.
 
 <Warning>
 If an exact pinned npm plugin update resolves to an artifact whose integrity differs from the stored install record, `openclaw update` aborts that plugin artifact update instead of installing it. Reinstall or update the plugin explicitly only after verifying you trust the new artifact.

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -44,6 +44,7 @@ import { cleanupStaleManagedServiceUpdateHandoffs } from "../infra/update-manage
 import type { UpdateRunRecord } from "../infra/update-run-record.js";
 import type { UpdateRunResult } from "../infra/update-runner.js";
 import * as windowsPrivateDirectory from "../infra/windows-private-directory.js";
+import { flushLogger, resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub-error-codes.js";
 import { ManagedPluginLifecycleError } from "../plugins/management-lifecycle-error.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
@@ -5181,6 +5182,12 @@ describe("update-cli", () => {
         version,
       };
       const records = { demo: record };
+      const warningLogPath = path.join(installPath, "update-warning.log");
+      setLoggerOverride({ level: "warn", file: warningLogPath });
+      onTestFinished(async () => {
+        await flushLogger();
+        resetLogger();
+      });
       loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
       mockNpmPluginOutcomes(
         [
@@ -5203,6 +5210,22 @@ describe("update-cli", () => {
       await updateCommand({ yes: true, json, restart: false });
 
       expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+      await flushLogger();
+      const logEntries = fsSync.existsSync(warningLogPath)
+        ? (await fs.readFile(warningLogPath, "utf8"))
+            .trim()
+            .split("\n")
+            .map((line): unknown => JSON.parse(line))
+        : [];
+      const retainedWarning = expect.objectContaining({
+        message,
+        _meta: expect.objectContaining({ logLevelName: "WARN" }),
+      });
+      if (repaired) {
+        expect(logEntries).not.toContainEqual(retainedWarning);
+      } else {
+        expect(logEntries).toContainEqual(retainedWarning);
+      }
       if (json) {
         const result = lastWriteJsonCall();
         if (repaired) {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5158,6 +5158,89 @@ describe("update-cli", () => {
     expect(pluginOutcome(jsonOutput)?.status).toBe("skipped");
   });
 
+  it.each([
+    { json: false, repaired: false, version: "1.0.0" },
+    { json: true, repaired: false, version: "1.0.0" },
+    { json: true, repaired: true, version: "1.0.0" },
+    { json: true, repaired: false, version: undefined },
+  ])(
+    "reports unavailable retained plugin targets without failing core ($json, repaired=$repaired, version=$version)",
+    async ({ json, repaired, version }) => {
+      const message =
+        'Retained plugin "demo" at 1.0.0: requested @example/demo@2.0.0 for core 9999.0.0 could not be resolved: No matching version found. Run `openclaw plugins update demo` when the package or registry is available.';
+      const installPath = createCaseDir("unavailable-target");
+      await fs.mkdir(installPath, { recursive: true });
+      await writeJsonFixture(path.join(installPath, "package.json"), {
+        name: "@example/demo",
+        version: "1.0.0",
+      });
+      const record: PluginInstallRecord = {
+        source: "npm",
+        spec: "@example/demo@2.0.0",
+        installPath,
+        version,
+      };
+      const records = { demo: record };
+      loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      mockNpmPluginOutcomes(
+        [
+          {
+            pluginId: "demo",
+            status: "unchanged",
+            code: "plugin-target-unavailable",
+            currentVersion: "1.0.0",
+            message,
+          },
+        ],
+        false,
+        { ...baseConfig, plugins: { ...baseConfig.plugins, installs: records } },
+      );
+      runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+        ...postCoreConvergenceResult(),
+        installRecords: repaired ? { demo: { ...record, version: "2.0.0" } } : records,
+      });
+
+      await updateCommand({ yes: true, json, restart: false });
+
+      expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+      if (json) {
+        const result = lastWriteJsonCall();
+        if (repaired) {
+          expect(result).toMatchObject({ status: "ok", postUpdate: { plugins: { warnings: [] } } });
+          return;
+        }
+        expect(result).toMatchObject({
+          status: "ok",
+          postUpdate: {
+            plugins: {
+              status: "warning",
+              warnings: [
+                expect.objectContaining({
+                  pluginId: "demo",
+                  reason: "plugin-target-unavailable",
+                  message,
+                }),
+              ],
+            },
+          },
+          run: {
+            status: "succeeded",
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                step: expect.stringMatching(/^warning:/),
+                status: "completed",
+                detail: expect.stringContaining(message),
+              }),
+            ]),
+          },
+        });
+        expect(result).not.toHaveProperty("reason", "plugin-target-unavailable");
+      } else {
+        expect(stripAnsi(getLogOutput())).toContain(message);
+      }
+    },
+  );
+
   it("marks blocked ClawHub update skips as post-update warnings", async () => {
     const trustWarning =
       "╭─ BLOCKED - ClawHub flagged this release as malicious ─╮\n" +
@@ -6836,18 +6919,18 @@ describe("update-cli", () => {
     },
   );
 
-  it.each(["unavailable plugin", "changed service owner"])(
+  it.each(["incompatible plugin", "changed service owner"])(
     "refuses %s before already-current convergence",
     async (failure) => {
       const root = await mockPackageInstallAtCaseDir();
       readPackageVersion.mockResolvedValue("2026.9.3");
       primeNpmChannelTag("latest", "2026.9.3");
       mockRunningManagedGateway(["node", path.join(root, "dist", "index.js"), "gateway", "run"]);
-      if (failure === "unavailable plugin") {
+      if (failure === "incompatible plugin") {
         pluginAvailabilityPreflight.mockRejectedValueOnce(
           new updateCliShared.UpdatePreMutationError(
-            "plugin-target-unavailable",
-            "Plugin target unavailable",
+            "plugin-incompatible",
+            "Installed plugin incompatible",
           ),
         );
       } else {
@@ -6859,9 +6942,7 @@ describe("update-cli", () => {
       expect(lastWriteJsonCall()).toMatchObject({
         status: "error",
         reason:
-          failure === "unavailable plugin"
-            ? "plugin-target-unavailable"
-            : "managed-service-preflight",
+          failure === "incompatible plugin" ? "plugin-incompatible" : "managed-service-preflight",
       });
       expectNoSideEffects(
         updateNpmInstalledPlugins,
@@ -12714,7 +12795,7 @@ describe("update-cli", () => {
     "reports plugin admission refusal without changing the serving install (dryRun=%s)",
     async (dryRun) => {
       const detail =
-        'Plugin "example" requires @openclaw/example@1.0.1: Package not found on npm. Retry later.';
+        'Plugin "example" (installed 1.0.0) requires plugin API <1.0.1: no compatible replacement. Disable the plugin or wait.';
       const sentinel = await runControlPlaneUpdate({
         expectedExitCode: 1,
         meta: {
@@ -12726,14 +12807,14 @@ describe("update-cli", () => {
           await mockPackageInstallAtCaseDir();
           const { UpdatePreMutationError } = await import("./update-cli/shared.js");
           pluginAvailabilityPreflight.mockRejectedValue(
-            new UpdatePreMutationError("plugin-target-unavailable", detail),
+            new UpdatePreMutationError("plugin-incompatible", detail),
           );
         },
       });
 
       expect(lastWriteJsonCall()).toMatchObject({
         status: "error",
-        reason: "plugin-target-unavailable",
+        reason: "plugin-incompatible",
       });
       expect(getErrorOutput()).toContain(detail);
       expectNoSideEffects(serviceStop, serviceStart, serviceRestart, replaceConfigFile);
@@ -12742,7 +12823,7 @@ describe("update-cli", () => {
       if (dryRun) {
         expect(sentinel).toBeNull();
       } else {
-        expect(sentinel?.payload.stats?.reason).toBe("plugin-target-unavailable");
+        expect(sentinel?.payload.stats?.reason).toBe("plugin-incompatible");
       }
     },
   );

--- a/src/cli/update-cli/update-command-convergence.ts
+++ b/src/cli/update-cli/update-command-convergence.ts
@@ -203,6 +203,23 @@ export async function convergeUpdatePlugins(params: {
           ],
         };
       }
+      const pluginAdvisories = (postCorePluginUpdate?.warnings ?? []).filter(
+        (warning) => warning.reason === "plugin-target-unavailable",
+      );
+      resultWithPostUpdate = {
+        ...resultWithPostUpdate,
+        steps: [
+          ...resultWithPostUpdate.steps,
+          ...pluginAdvisories.map((warning, index) => ({
+            name: `finalize:plugins:${index}`,
+            command: "openclaw plugins update",
+            cwd: postUpdateRoot,
+            durationMs: 0,
+            exitCode: 0,
+            advisory: { kind: "recoverable-maintenance" as const, message: warning.message },
+          })),
+        ],
+      };
       if (
         params.coreAlreadyCurrent &&
         resultWithPostUpdate.status !== "error" &&

--- a/src/cli/update-cli/update-command-execution.test.ts
+++ b/src/cli/update-cli/update-command-execution.test.ts
@@ -329,34 +329,46 @@ describe("mutable update execution", () => {
   });
 
   it.each([
-    { category: undefined, range: ">=1.0.0", refused: false },
-    { category: "metadata-env", range: ">=1.0.0", refused: false },
-    { category: undefined, range: ">=1.0.0 <1.0.1", refused: true },
-    { category: "metadata-env", range: ">=1.0.0 <1.0.1", refused: false },
+    { failure: "missing", contract: "api", range: ">=1.0.0", refused: false },
+    { failure: "metadata", contract: "api", range: ">=1.0.0", refused: false },
+    { failure: "throw", contract: "api", range: ">=1.0.0", refused: false },
+    { failure: "missing", contract: "api", range: ">=1.0.0 <1.0.1", refused: true },
+    { failure: "metadata", contract: "api", range: ">=1.0.0 <1.0.1", refused: true },
+    { failure: "throw", contract: "api", range: ">=1.0.0 <1.0.1", refused: true },
+    { failure: "metadata", contract: "host", range: ">=1.0.2", refused: true },
+    { failure: "throw", contract: "host", range: ">=1.0.2", refused: true },
   ])(
-    "admits only known plugin compatibility risks ($category, $range)",
-    async ({ category, range, refused }) => {
+    "refuses unresolved incompatible plugins before mutation ($failure, $contract, $range)",
+    async ({ failure, contract, range, refused }) => {
       await withTestDir({ prefix: "openclaw-plugin-admission-" }, async (installPath) => {
         await fs.writeFile(
           path.join(installPath, "package.json"),
           JSON.stringify({
             name: "@example/demo",
             version: "1.0.0",
-            openclaw: { compat: { pluginApi: range } },
+            openclaw:
+              contract === "api"
+                ? { compat: { pluginApi: range } }
+                : { install: { minHostVersion: range } },
           }),
         );
         mocks.pluginRecords.mockResolvedValue({
           demo: { source: "npm", spec: "@example/demo@1.0.1", version: "1.0.0", installPath },
         });
         mocks.pluginTargets.mockResolvedValue([{ pluginId: "demo", spec: "@example/demo@1.0.1" }]);
-        mocks.npmMetadata.mockResolvedValue({
-          ok: false,
-          category,
-          error:
-            category === "metadata-env"
-              ? "registry unreachable: ECONNRESET"
-              : "No matching version found",
-        });
+        const error =
+          failure === "missing"
+            ? "No matching version found"
+            : "registry connection failed: ECONNRESET";
+        if (failure === "throw") {
+          mocks.npmMetadata.mockRejectedValue(new Error(error));
+        } else {
+          mocks.npmMetadata.mockResolvedValue({
+            ok: false,
+            category: failure === "metadata" ? "metadata-env" : undefined,
+            error,
+          });
+        }
         const actual = await vi.importActual<typeof import("./update-command-plugin-preflight.js")>(
           "./update-command-plugin-preflight.js",
         );
@@ -369,7 +381,13 @@ describe("mutable update execution", () => {
           expect(execution?.result.reason).toBe("plugin-incompatible");
           expect(execution?.failure?.detail).toContain('Plugin "demo" (installed 1.0.0)');
           expect(execution?.failure?.detail).toContain(range);
+          expect(execution?.failure?.detail).toContain("core 1.0.1");
           expect(execution?.failure?.detail).toContain("@example/demo@1.0.1");
+          expect(execution?.failure?.detail).toContain(error);
+          if (failure !== "missing") {
+            expect(execution?.failure?.detail).toContain("registry could not be reached");
+            expect(execution?.failure?.detail).toContain("Retry when the registry is reachable");
+          }
           expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
           expect(mocks.runPackageUpdate).not.toHaveBeenCalled();
           expect(mocks.serviceStopped).toBe(false);

--- a/src/cli/update-cli/update-command-execution.test.ts
+++ b/src/cli/update-cli/update-command-execution.test.ts
@@ -23,6 +23,9 @@ const mocks = vi.hoisted(() => ({
   maybeStopService: vi.fn(),
   prepareMutableUpdate: vi.fn<(env?: NodeJS.ProcessEnv) => Promise<void>>(),
   pluginPreflight: vi.fn(),
+  pluginTargets: vi.fn(),
+  pluginRecords: vi.fn(),
+  npmMetadata: vi.fn(),
   readGitRecovery: vi.fn(),
   runGitUpdate: vi.fn(),
   runPackageUpdate: vi.fn(),
@@ -45,6 +48,18 @@ vi.mock("../../infra/update-candidate-canary.js", () => ({
 
 vi.mock("./update-command-plugin-preflight.js", () => ({
   preflightConfiguredNpmPluginTargets: mocks.pluginPreflight,
+}));
+
+vi.mock("../../commands/doctor/shared/missing-configured-plugin-install.targets.js", () => ({
+  collectConfiguredNpmPluginTargets: mocks.pluginTargets,
+}));
+vi.mock("../../plugins/installed-plugin-index-records.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/installed-plugin-index-records.js")>()),
+  loadInstalledPluginIndexInstallRecords: mocks.pluginRecords,
+}));
+vi.mock("../../infra/install-source-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/install-source-utils.js")>()),
+  resolveNpmSpecMetadata: mocks.npmMetadata,
 }));
 
 vi.mock("../../infra/update-runner-git-recovery.js", () => ({
@@ -229,7 +244,7 @@ describe("mutable update execution", () => {
     expect(mocks.serviceStopped).toBe(false);
   });
 
-  it.each(["available", "unavailable", "changed-owner"] as const)(
+  it.each(["available", "incompatible", "changed-owner"] as const)(
     "admits local artifacts from the staged version before rehearsal: %s",
     async (outcome) => {
       await withTestDir({ prefix: "openclaw-staged-plugin-admission-" }, async (stage) => {
@@ -242,10 +257,10 @@ describe("mutable update execution", () => {
           events.push("preflight");
           expect(targetVersion).toBe("1.0.7");
           expect(mocks.serviceStopped).toBe(false);
-          if (outcome === "unavailable") {
+          if (outcome === "incompatible") {
             throw new UpdatePreMutationError(
-              "plugin-target-unavailable",
-              "fixture plugin is unavailable",
+              "plugin-incompatible",
+              "fixture installed plugin is incompatible",
             );
           }
         });
@@ -288,7 +303,7 @@ describe("mutable update execution", () => {
           expect(mocks.validateCanary).not.toHaveBeenCalled();
           expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
           expect(execution?.result.reason).toBe(
-            outcome === "unavailable" ? "plugin-target-unavailable" : "database-schema-preflight",
+            outcome === "incompatible" ? "plugin-incompatible" : "database-schema-preflight",
           );
         }
       });
@@ -314,27 +329,57 @@ describe("mutable update execution", () => {
   });
 
   it.each([
-    "@openclaw/example@1.0.1: Package not found on npm",
-    "@openclaw/example@1.0.1: npm view failed: ECONNRESET",
-  ])("keeps the serving package unchanged when plugin admission fails: %s", async (detail) => {
-    mocks.pluginPreflight.mockRejectedValue(
-      new UpdatePreMutationError("plugin-target-unavailable", detail),
-    );
+    { category: undefined, range: ">=1.0.0", refused: false },
+    { category: "metadata-env", range: ">=1.0.0", refused: false },
+    { category: undefined, range: ">=1.0.0 <1.0.1", refused: true },
+    { category: "metadata-env", range: ">=1.0.0 <1.0.1", refused: false },
+  ])(
+    "admits only known plugin compatibility risks ($category, $range)",
+    async ({ category, range, refused }) => {
+      await withTestDir({ prefix: "openclaw-plugin-admission-" }, async (installPath) => {
+        await fs.writeFile(
+          path.join(installPath, "package.json"),
+          JSON.stringify({
+            name: "@example/demo",
+            version: "1.0.0",
+            openclaw: { compat: { pluginApi: range } },
+          }),
+        );
+        mocks.pluginRecords.mockResolvedValue({
+          demo: { source: "npm", spec: "@example/demo@1.0.1", version: "1.0.0", installPath },
+        });
+        mocks.pluginTargets.mockResolvedValue([{ pluginId: "demo", spec: "@example/demo@1.0.1" }]);
+        mocks.npmMetadata.mockResolvedValue({
+          ok: false,
+          category,
+          error:
+            category === "metadata-env"
+              ? "registry unreachable: ECONNRESET"
+              : "No matching version found",
+        });
+        const actual = await vi.importActual<typeof import("./update-command-plugin-preflight.js")>(
+          "./update-command-plugin-preflight.js",
+        );
+        mocks.pluginPreflight.mockImplementation(actual.preflightConfiguredNpmPluginTargets);
 
-    const execution = await executeMutableUpdate(executionParams("package"));
+        const execution = await executeMutableUpdate(executionParams("package"));
 
-    expect(execution).toMatchObject({
-      mutationStarted: false,
-      result: {
-        status: "error",
-        reason: "plugin-target-unavailable",
-        steps: [expect.objectContaining({ stderrTail: detail })],
-      },
-    });
-    expect(mocks.serviceStopped).toBe(false);
-    expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
-    expect(mocks.runPackageUpdate).not.toHaveBeenCalled();
-  });
+        expect(execution?.result.status).toBe(refused ? "error" : "ok");
+        if (refused) {
+          expect(execution?.result.reason).toBe("plugin-incompatible");
+          expect(execution?.failure?.detail).toContain('Plugin "demo" (installed 1.0.0)');
+          expect(execution?.failure?.detail).toContain(range);
+          expect(execution?.failure?.detail).toContain("@example/demo@1.0.1");
+          expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
+          expect(mocks.runPackageUpdate).not.toHaveBeenCalled();
+          expect(mocks.serviceStopped).toBe(false);
+        } else {
+          expect(execution?.result.reason).toBeUndefined();
+          expect(mocks.runPackageUpdate).toHaveBeenCalledOnce();
+        }
+      });
+    },
+  );
 
   it("waits for plugin availability before preparing a package update", async () => {
     const available = createDeferred();

--- a/src/cli/update-cli/update-command-finalize.ts
+++ b/src/cli/update-cli/update-command-finalize.ts
@@ -266,6 +266,12 @@ async function updateFinalizeCommandInternal(
     (result) => pluginOutcome(result.pluginUpdate),
   );
   const pluginUpdate = completedPluginUpdate.pluginUpdate;
+  lifecycle.recordWarnings(
+    (pluginUpdate.warnings ?? [])
+      .filter((warning) => warning.reason === "plugin-target-unavailable")
+      .map((warning) => warning.message),
+    "plugins",
+  );
   configSnapshot = completedPluginUpdate.configSnapshot;
   const completionBudget = lifecycle.budget("completionCache");
   // Leave shutdown time inside the phase deadline so optional cache failures can settle.

--- a/src/cli/update-cli/update-command-plugin-preflight.ts
+++ b/src/cli/update-cli/update-command-plugin-preflight.ts
@@ -1,6 +1,7 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { collectConfiguredNpmPluginTargets } from "../../commands/doctor/shared/missing-configured-plugin-install.targets.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveNpmSpecMetadata } from "../../infra/install-source-utils.js";
 import { readInstalledPackageManifest } from "../../infra/package-update-utils.js";
 import { resolveRegistryUpdateChannel, type UpdateChannel } from "../../infra/update-channels.js";
@@ -65,7 +66,7 @@ export async function preflightConfiguredNpmPluginTargets(params: {
       if (!requirement || typeof manifest?.version !== "string") {
         continue;
       }
-      let requiredSpec: string;
+      let requiredSpec = target.spec;
       let failure: string;
       try {
         const selected = await resolveNpmInstallSpecsForUpdateChannel({
@@ -77,10 +78,10 @@ export async function preflightConfiguredNpmPluginTargets(params: {
           ? { ok: true as const, metadata: selected.npmResolution }
           : await resolveNpmSpecMetadata({ spec: requiredSpec, timeoutMs: params.timeoutMs });
         if (!resolution.ok) {
-          if (resolution.category === "metadata-env") {
-            continue;
-          }
-          failure = resolution.error;
+          failure =
+            resolution.category === "metadata-env"
+              ? `registry could not be reached: ${resolution.error}`
+              : resolution.error;
         } else {
           const candidateRequirement = incompatibleRequirement(
             resolution.metadata.packageOpenClaw,
@@ -91,13 +92,12 @@ export async function preflightConfiguredNpmPluginTargets(params: {
           }
           failure = `resolved plugin requires ${candidateRequirement}`;
         }
-      } catch {
-        // A registry outage is not evidence that a compatible release does not exist.
-        continue;
+      } catch (error) {
+        failure = `registry could not be reached: ${formatErrorMessage(error)}`;
       }
       throw new UpdatePreMutationError(
         "plugin-incompatible",
-        `Update refused: Plugin "${target.pluginId}" (installed ${manifest.version}) requires ${requirement} and would not load on core ${targetVersion}. Cannot resolve a compatible ${requiredSpec}: ${failure}. Install a compatible plugin version with \`openclaw plugins update <package>@<compatible-version>\`, disable it with \`openclaw plugins disable ${target.pluginId}\`, or wait for a compatible release.`,
+        `Update refused: Plugin "${target.pluginId}" (installed ${manifest.version}) requires ${requirement} and would not load on core ${targetVersion}. Cannot resolve a compatible ${requiredSpec}: ${failure}. Retry when the registry is reachable, pin a compatible plugin version with \`openclaw plugins update <package>@<compatible-version>\`, disable it with \`openclaw plugins disable ${target.pluginId}\`, or wait for a compatible release.`,
       );
     }
   });

--- a/src/cli/update-cli/update-command-plugin-preflight.ts
+++ b/src/cli/update-cli/update-command-plugin-preflight.ts
@@ -1,13 +1,38 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { collectConfiguredNpmPluginTargets } from "../../commands/doctor/shared/missing-configured-plugin-install.targets.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveNpmSpecMetadata } from "../../infra/install-source-utils.js";
+import { readInstalledPackageManifest } from "../../infra/package-update-utils.js";
 import { resolveRegistryUpdateChannel, type UpdateChannel } from "../../infra/update-channels.js";
 import { resolveNpmInstallSpecsForUpdateChannel } from "../../plugins/install-channel-specs.js";
+import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
+import { checkMinHostVersion } from "../../plugins/min-host-version.js";
+import {
+  resolvePackagePluginApiRange,
+  satisfiesPluginApiRange,
+} from "../../plugins/package-compat.js";
 import { UpdatePreMutationError } from "./shared.js";
 import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 
-/** Admit configured npm targets without installing plugins or changing live state. */
+function incompatibleRequirement(
+  metadata: unknown,
+  targetVersion: string,
+  installed = false,
+): string | undefined {
+  const api = resolvePackagePluginApiRange(metadata);
+  if (api.ok && api.range && !satisfiesPluginApiRange(targetVersion, api.range)) {
+    return `plugin API ${api.range}`;
+  }
+  const install = isRecord(metadata) && isRecord(metadata.install) ? metadata.install : undefined;
+  const host = checkMinHostVersion({
+    currentVersion: targetVersion,
+    minHostVersion: install?.minHostVersion,
+    allowLegacyBareSemver: installed,
+  });
+  return !host.ok && host.kind === "incompatible" ? `OpenClaw ${host.requirement.raw}` : undefined;
+}
+
+/** Block only a declared incompatibility that an available plugin update cannot repair. */
 export async function preflightConfiguredNpmPluginTargets(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -15,61 +40,65 @@ export async function preflightConfiguredNpmPluginTargets(params: {
   channel: UpdateChannel;
   timeoutMs: number;
 }): Promise<void> {
-  const failures: string[] = [];
-  try {
-    await withOwnedManagedUpdateEnv(params.env, async () => {
-      const targets = await collectConfiguredNpmPluginTargets({
-        config: params.config,
-        env: params.env,
-        targetVersion: params.targetVersion ?? "",
-        channel: resolveRegistryUpdateChannel({
-          configChannel: params.channel,
-          currentVersion: params.targetVersion,
-        }),
-      });
-      for (const target of targets) {
-        if (!params.targetVersion) {
-          failures.push(
-            `Plugin "${target.pluginId}" (${target.spec}): cannot determine the required version because the target core version is unknown. Select an exact registry target.`,
-          );
-          continue;
-        }
-        let requiredSpec = target.spec;
-        try {
-          const selected = await resolveNpmInstallSpecsForUpdateChannel({
-            ...target,
-            timeoutMs: params.timeoutMs,
-          });
-          requiredSpec = selected.installSpec;
-          const resolution = selected.npmResolution
-            ? { ok: true as const, metadata: selected.npmResolution }
-            : await resolveNpmSpecMetadata({ spec: requiredSpec, timeoutMs: params.timeoutMs });
-          if (!resolution.ok) {
-            failures.push(
-              `Plugin "${target.pluginId}" requires ${requiredSpec} for core ${params.targetVersion}: ${resolution.error}`,
-            );
-          }
-        } catch (error) {
-          failures.push(
-            `Plugin "${target.pluginId}" requires ${requiredSpec} for core ${params.targetVersion}: ${formatErrorMessage(error)}`,
-          );
-        }
-      }
+  const targetVersion = params.targetVersion;
+  if (!targetVersion) {
+    return;
+  }
+  await withOwnedManagedUpdateEnv(params.env, async () => {
+    const installRecords = await loadInstalledPluginIndexInstallRecords({ env: params.env });
+    const targets = await collectConfiguredNpmPluginTargets({
+      ...params,
+      targetVersion,
+      installRecords,
+      channel: resolveRegistryUpdateChannel({
+        configChannel: params.channel,
+        currentVersion: targetVersion,
+      }),
     });
-  } catch (error) {
-    failures.push(`Could not inspect configured npm plugins: ${formatErrorMessage(error)}`);
-  }
-  if (failures.length > 0) {
-    throw new UpdatePreMutationError(
-      "plugin-target-unavailable",
-      [
-        "Update refused: configured npm plugin targets are unavailable.",
-        ...failures,
-        "Retry after the packages or registry are available, use `openclaw update --tag <older-version>`, or disable the affected plugin and retry.",
-        ...(params.channel === "extended-stable"
-          ? ["Extended-stable does not accept --tag; retry later or explicitly switch channels."]
-          : []),
-      ].join("\n"),
-    );
-  }
+    for (const target of targets) {
+      const record = installRecords[target.pluginId];
+      const manifest = record?.installPath
+        ? readInstalledPackageManifest(record.installPath)
+        : undefined;
+      const requirement = incompatibleRequirement(manifest?.openclaw, targetVersion, true);
+      // Availability and retention belong to post-core sync; a healthy plugin needs no network gate.
+      if (!requirement || typeof manifest?.version !== "string") {
+        continue;
+      }
+      let requiredSpec: string;
+      let failure: string;
+      try {
+        const selected = await resolveNpmInstallSpecsForUpdateChannel({
+          ...target,
+          timeoutMs: params.timeoutMs,
+        });
+        requiredSpec = selected.installSpec;
+        const resolution = selected.npmResolution
+          ? { ok: true as const, metadata: selected.npmResolution }
+          : await resolveNpmSpecMetadata({ spec: requiredSpec, timeoutMs: params.timeoutMs });
+        if (!resolution.ok) {
+          if (resolution.category === "metadata-env") {
+            continue;
+          }
+          failure = resolution.error;
+        } else {
+          const candidateRequirement = incompatibleRequirement(
+            resolution.metadata.packageOpenClaw,
+            targetVersion,
+          );
+          if (!candidateRequirement) {
+            continue;
+          }
+          failure = `resolved plugin requires ${candidateRequirement}`;
+        }
+      } catch {
+        // A registry outage is not evidence that a compatible release does not exist.
+        continue;
+      }
+      throw new UpdatePreMutationError(
+        "plugin-incompatible",
+        `Update refused: Plugin "${target.pluginId}" (installed ${manifest.version}) requires ${requirement} and would not load on core ${targetVersion}. Cannot resolve a compatible ${requiredSpec}: ${failure}. Install a compatible plugin version with \`openclaw plugins update <package>@<compatible-version>\`, disable it with \`openclaw plugins disable ${target.pluginId}\`, or wait for a compatible release.`,
+      );
+    }
+  });
 }

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -278,11 +278,11 @@ export async function updatePluginsAfterCoreUpdate(params: {
   // Convergence checks activation before restart. Seed it from the current
   // sync/npm records so repair cannot overwrite them with an older disk snapshot.
   const convergenceBaselineRecords = pluginConfig.plugins?.installs ?? {};
-  // Keep the observed selectors stable if convergence replaces their records.
-  const probedNpmSpecs = new Map(
+  // Keep the observed records stable if convergence replaces them.
+  const probedNpmRecords = new Map(
     cohort.updateOutcomes.map(({ pluginId }) => {
       const record = convergenceBaselineRecords[pluginId];
-      return [pluginId, record?.source === "npm" ? record.spec : undefined];
+      return [pluginId, record?.source === "npm" ? { ...record } : undefined];
     }),
   );
   const convergence = await runPostCorePluginConvergence({
@@ -320,35 +320,50 @@ export async function updatePluginsAfterCoreUpdate(params: {
   // Repair already persisted this authoritative map; the commit below must not
   // restore the pre-convergence records and discard successful repairs.
   pluginConfig = withPluginInstallRecords(pluginConfig, convergence.installRecords);
-  // An unchanged npm outcome can report a newer registry release without replacing
-  // its pin. Do not retain that advisory if convergence repaired or removed the pin.
+  // Report retention only while the probed install survives convergence.
   for (const outcome of cohort.updateOutcomes) {
     const record = convergence.installRecords[outcome.pluginId];
+    const probed = probedNpmRecords.get(outcome.pluginId);
     if (
       outcome.status !== "unchanged" ||
       !outcome.currentVersion ||
-      !outcome.nextVersion ||
-      comparePackageUpdateVersions(outcome.nextVersion, outcome.currentVersion) <= 0 ||
       record?.source !== "npm" ||
-      (record.resolvedVersion ?? record.version) !== outcome.currentVersion ||
-      record.spec !== probedNpmSpecs.get(outcome.pluginId) ||
-      resolveExactNpmSpecVersion(record.spec) !== outcome.currentVersion ||
-      !isTrustedOfficialPluginInstallRecord({
-        pluginId: outcome.pluginId,
-        packageName: resolveNpmSpecPackageName(record.spec),
-        record,
-      })
+      record.spec !== probed?.spec
     ) {
       continue;
     }
-    const message = `Plugin update retained an official plugin pin: ${outcome.message}`;
+    const unavailable = outcome.code === "plugin-target-unavailable";
+    if (
+      unavailable
+        ? record.installPath !== probed?.installPath ||
+          record.version !== probed?.version ||
+          record.resolvedVersion !== probed?.resolvedVersion
+        : !outcome.nextVersion ||
+          comparePackageUpdateVersions(outcome.nextVersion, outcome.currentVersion) <= 0 ||
+          (record.resolvedVersion ?? record.version) !== outcome.currentVersion ||
+          resolveExactNpmSpecVersion(record.spec) !== outcome.currentVersion ||
+          !isTrustedOfficialPluginInstallRecord({
+            pluginId: outcome.pluginId,
+            packageName: resolveNpmSpecPackageName(record.spec),
+            record,
+          })
+    ) {
+      continue;
+    }
+    const message = unavailable
+      ? outcome.message
+      : `Plugin update retained an official plugin pin: ${outcome.message}`;
     warnings.push({
       pluginId: outcome.pluginId,
-      reason: "retained-plugin-pin",
+      reason: unavailable ? "plugin-target-unavailable" : "retained-plugin-pin",
       message,
-      guidance: ["Keep the pin if intentional; replacing it is an explicit operator choice."],
+      guidance: [
+        unavailable
+          ? `Run openclaw plugins update ${outcome.pluginId} when the target is available.`
+          : "Keep the pin if intentional; replacing it is an explicit operator choice.",
+      ],
     });
-    if (!params.json) {
+    if (!params.json && !loggedPluginWarnings.has(stripAnsi(message))) {
       runtime.log(theme.warn(message));
     }
   }

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { comparePackageUpdateVersions } from "../../infra/package-update-utils.js";
 import { resolveRegistryUpdateChannel, type UpdateChannel } from "../../infra/update-channels.js";
+import { getLogger } from "../../logging/logger.js";
 import type { PluginCapabilityConsentHandler } from "../../plugins/capability-consent.js";
 import { commitPluginInstallRecordsWithConfig } from "../../plugins/install-record-commit.js";
 import {
@@ -363,6 +364,9 @@ export async function updatePluginsAfterCoreUpdate(params: {
           : "Keep the pin if intentional; replacing it is an explicit operator choice.",
       ],
     });
+    if (unavailable) {
+      getLogger().warn(message);
+    }
     if (!params.json && !loggedPluginWarnings.has(stripAnsi(message))) {
       runtime.log(theme.warn(message));
     }

--- a/src/cli/update-cli/update-finalization-lifecycle.ts
+++ b/src/cli/update-cli/update-finalization-lifecycle.ts
@@ -99,10 +99,10 @@ export class UpdateFinalizationLifecycle {
     }
   }
 
-  recordWarnings(warnings: readonly string[]): void {
+  recordWarnings(warnings: readonly string[], phase: "doctor" | "plugins" = "doctor"): void {
     warnings.forEach((detail, index) => {
       this.record(
-        { phase: "doctor", step: `warning:finalize:doctor:${index}` },
+        { phase, step: `warning:finalize:${phase}:${index}` },
         "completed",
         Date.now(),
         detail,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -12,7 +12,10 @@ import { resolveRegistryUpdateChannel } from "../../../infra/update-channels.js"
 import { resolvePluginArtifactDeclaredSurface } from "../../../plugins/capability-artifact.js";
 import type { PluginCapabilityConsentHandler } from "../../../plugins/capability-consent.js";
 import { computeDeclaredSurfaceHash } from "../../../plugins/capability-summary.js";
-import { resolveClawHubInstallSpecsForUpdateChannel } from "../../../plugins/install-channel-specs.js";
+import {
+  resolveClawHubInstallSpecsForUpdateChannel,
+  resolveNpmInstallSpecsForUpdateChannel,
+} from "../../../plugins/install-channel-specs.js";
 import type { PluginInstallArtifactConsentHandler } from "../../../plugins/install-types.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../../../plugins/installed-plugin-index-policy.js";
 import { isTrustedOfficialPluginInstallRecord } from "../../../plugins/official-external-install-records.js";
@@ -23,6 +26,7 @@ import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db
 import { expectObjectFields } from "../../../test-utils/mock-call-assertions.js";
 import { VERSION } from "../../../version.js";
 import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
+import { collectConfiguredNpmPluginTargets } from "./missing-configured-plugin-install.targets.js";
 import {
   brokenPluginSnapshot,
   channelPluginEntry,
@@ -873,7 +877,6 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     // The doctor module owns a broad install/catalog graph. Its cold import is
     // suite setup; individual cases measure detection and repair behavior.
     await import("./missing-configured-plugin-install.js");
-    await import("../../../cli/update-cli/update-command-plugin-preflight.js");
   });
 
   beforeEach(() => {
@@ -1754,21 +1757,17 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       mocks.installPluginFromNpmSpec.mockImplementation(async ({ spec }: { spec: string }) =>
         successfulInstall({ pluginId, npmSpec: packageName, version: versionForSpec(spec) }),
       );
-      const { preflightConfiguredNpmPluginTargets } =
-        await import("../../../cli/update-cli/update-command-plugin-preflight.js");
-      await preflightConfiguredNpmPluginTargets({
+      const targets = await collectConfiguredNpmPluginTargets({
         config,
         env,
         targetVersion: coreVersion,
         channel: "stable",
-        timeoutMs: 1000,
       });
       const expectedSpec =
         source === "external" ? packageName : `${packageName}@${expectedVersion}`;
-      expect(mocks.resolveNpmSpecMetadata).toHaveBeenCalledWith({
-        spec: expectedSpec,
-        timeoutMs: 1000,
-      });
+      expect(await Promise.all(targets.map(resolveNpmInstallSpecsForUpdateChannel))).toEqual([
+        expect.objectContaining({ installSpec: expectedSpec }),
+      ]);
       expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
       expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
 
@@ -3224,119 +3223,8 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result.warnings).toStrictEqual([]);
   });
 
-  it.each([
-    {
-      availability: "missing version",
-      channel: "stable",
-      error: "Package not found on npm: @openclaw/codex@2026.9.3.",
-    },
-    { availability: "registry outage", channel: "stable", error: "registry connection timed out" },
-    { availability: "published version", channel: "stable" },
-    { availability: "already-current floating package", channel: "stable" },
-    { availability: "beta-only package", channel: "beta" },
-    { availability: "unknown core version", channel: "stable" },
-  ] as const)(
-    "preflights Codex with $availability before any plugin mutation",
-    async ({ availability, channel, ...outcome }) => {
-      const alreadyCurrent = availability === "already-current floating package";
-      const installedVersion = alreadyCurrent ? "2026.9.3" : "2026.9.1";
-      if (alreadyCurrent) {
-        useManifestCatalogResolvers();
-      }
-      const installDir = tempDirs.make("openclaw-plugin-availability-");
-      createColdPluginFixture({
-        rootDir: installDir,
-        pluginId: "codex",
-        packageName: "@openclaw/codex",
-        packageVersion: installedVersion,
-      });
-      const packageFile = path.join(installDir, "package.json");
-      const originalPackage = fs.readFileSync(packageFile, "utf8");
-      const records = installedRecords("codex", {
-        spec: alreadyCurrent ? "@openclaw/codex" : "@openclaw/codex@2026.9.1",
-        resolvedVersion: installedVersion,
-        installPath: installDir,
-      });
-      const config: OpenClawConfig = { plugins: { entries: { codex: { enabled: true } } } };
-      const originalConfig = structuredClone(config);
-      const originalRecords = structuredClone(records);
-      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
-      mocks.loadPluginMetadataSnapshot.mockReturnValue({
-        plugins: [{ id: "codex", packageVersion: installedVersion, channels: [] }],
-        diagnostics: [],
-      });
-      mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
-        officialPluginEntry({ id: "codex", npmSpec: "@openclaw/codex" }),
-      ]);
-      mocks.resolveNpmSpecMetadata.mockImplementation(async ({ spec }: { spec: string }) => {
-        if (spec === "@openclaw/codex@2026.9.3" && "error" in outcome) {
-          return { ok: false, error: outcome.error };
-        }
-        if (availability === "beta-only package" && spec === "@openclaw/codex@latest") {
-          return { ok: false, error: "No latest release for @openclaw/codex." };
-        }
-        const version =
-          spec === "@openclaw/codex"
-            ? "2026.9.2"
-            : spec.endsWith("@beta")
-              ? "2026.9.3-beta.1"
-              : spec.split("@").at(-1);
-        return {
-          ok: true,
-          metadata: {
-            name: "@openclaw/codex",
-            version,
-            resolvedSpec: `@openclaw/codex@${version}`,
-          },
-        };
-      });
-      const { preflightConfiguredNpmPluginTargets } =
-        await import("../../../cli/update-cli/update-command-plugin-preflight.js");
-      const result = preflightConfiguredNpmPluginTargets({
-        config,
-        env: testEnv,
-        targetVersion: availability === "unknown core version" ? null : "2026.9.3",
-        channel,
-        timeoutMs: 1000,
-      });
-      if (availability === "unknown core version") {
-        await expect(result).rejects.toMatchObject({
-          reason: "plugin-target-unavailable",
-          message: expect.stringContaining("target core version is unknown"),
-        });
-      } else if ("error" in outcome) {
-        await expect(result).rejects.toMatchObject({
-          reason: "plugin-target-unavailable",
-          message: expect.stringContaining(
-            `Plugin "codex" requires @openclaw/codex@2026.9.3 for core 2026.9.3: ${outcome.error}`,
-          ),
-        });
-      } else {
-        await expect(result).resolves.toBeUndefined();
-      }
-      expect(
-        mocks.resolveNpmSpecMetadata.mock.calls
-          .map(([params]) => params.spec)
-          .toSorted((left, right) => left.localeCompare(right)),
-      ).toEqual(
-        availability === "unknown core version"
-          ? []
-          : channel === "beta"
-            ? ["@openclaw/codex@beta", "@openclaw/codex@latest"]
-            : ["@openclaw/codex@2026.9.3"],
-      );
-      expect(config).toEqual(originalConfig);
-      expect(records).toEqual(originalRecords);
-      expect(fs.readFileSync(packageFile, "utf8")).toBe(originalPackage);
-      expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
-      expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
-      expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
-      expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
-    },
-  );
-
   it.each(["disabled", "path", "bundled", "local npm archive"] as const)(
-    "does not query npm while preflighting a %s configured plugin",
+    "does not select npm targets for a %s configured plugin",
     async (kind) => {
       const records = installedRecords("fixture", {
         source: kind === "path" ? "path" : "npm",
@@ -3351,17 +3239,14 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       if (kind === "bundled") {
         mockCurrentBundledPlugin("fixture", "@example/fixture");
       }
-      const { preflightConfiguredNpmPluginTargets } =
-        await import("../../../cli/update-cli/update-command-plugin-preflight.js");
       await expect(
-        preflightConfiguredNpmPluginTargets({
+        collectConfiguredNpmPluginTargets({
           config: { plugins: { entries: { fixture: { enabled: kind !== "disabled" } } } },
           env: testEnv,
           targetVersion: "2026.9.3",
           channel: "stable",
-          timeoutMs: 1000,
         }),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual([]);
       expect(mocks.resolveNpmSpecMetadata).not.toHaveBeenCalled();
       expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
       expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -16,6 +16,7 @@ import {
 import { buildClawHubPluginInstallRecordFields } from "./clawhub-install-records.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import {
+  isUnavailablePluginSource,
   NpmChannelResolutionError,
   resolveNpmInstallSpecsForUpdateChannel,
 } from "./install-channel-specs.js";
@@ -109,6 +110,7 @@ export async function updateNpmInstalledPlugins(params: {
   packagePluginIds?: Readonly<Record<string, readonly string[]>>;
 }): Promise<PluginUpdateSummary> {
   const logger = params.logger ?? {};
+  const coreSync = params.syncOfficialPluginInstalls && params.disableOnFailure;
   const consentCallbacks = capturePluginCapabilityConsentHandlerErrors(params.onCapabilityConsent);
   const installs = params.config.plugins?.installs ?? {};
   const targets = new Set(params.pluginIds?.length ? params.pluginIds : Object.keys(installs));
@@ -226,6 +228,7 @@ export async function updateNpmInstalledPlugins(params: {
     }
 
     let npmSpecs: Awaited<ReturnType<typeof resolveNpmInstallSpecsForUpdateChannel>> | undefined;
+    let npmResolutionError: NpmChannelResolutionError | undefined;
     try {
       npmSpecs =
         record.source === "npm" && npmTarget
@@ -235,9 +238,12 @@ export async function updateNpmInstalledPlugins(params: {
       if (!(error instanceof NpmChannelResolutionError)) {
         throw error;
       }
-      outcomes.push({ pluginId, status: "error", code: error.code, message: error.message });
-      logger.warn?.(error.message);
-      continue;
+      if (!coreSync) {
+        outcomes.push({ pluginId, status: "error", code: error.code, message: error.message });
+        logger.warn?.(error.message);
+        continue;
+      }
+      npmResolutionError = error;
     }
     const clawhubSpecs =
       record.source === "clawhub"
@@ -252,7 +258,7 @@ export async function updateNpmInstalledPlugins(params: {
         : undefined;
     const effectiveSpec =
       record.source === "npm"
-        ? npmSpecs?.installSpec
+        ? (npmSpecs?.installSpec ?? npmTarget?.spec)
         : record.source === "clawhub"
           ? clawhubSpecs?.installSpec
           : record.spec;
@@ -344,24 +350,50 @@ export async function updateNpmInstalledPlugins(params: {
     if (!params.dryRun && record.source === "npm" && currentVersion) {
       changed = (await repairRegisteredOpenClawHostLink({ pluginId, record, logger })) || changed;
     }
-    // Payload validation is filesystem work needed only to preserve state after metadata failures.
-    // Every failure path below ends this plugin iteration, so the result cannot be reused.
-    const hasRunnableInstalledPayloadForFailure = async (code?: string): Promise<boolean> => {
+    const recordNpmFailure = async (message: string, code?: string): Promise<void> => {
+      let installedPayloadRunnable = false;
       if (
-        code !== PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE ||
-        !params.disableOnFailure ||
-        params.dryRun ||
-        currentVersion === undefined
+        (code === PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE ||
+          (coreSync && isUnavailablePluginSource("npm", { ok: false, code }))) &&
+        params.disableOnFailure &&
+        !params.dryRun &&
+        currentVersion
       ) {
-        return false;
+        const compatible =
+          !coreSync ||
+          isNpmMetadataCompatibleWithCurrentHost(
+            { packageOpenClaw: installedManifest?.openclaw },
+            { hostVersion: params.coreVersion, allowLegacyBareSemver: true },
+          );
+        try {
+          installedPayloadRunnable =
+            compatible &&
+            (await hasRunnableInstalledNpmPayload({ installPath, manifest: installedManifest }));
+        } catch {
+          // Damaged or unreadable payloads do not qualify for retention.
+        }
       }
-      try {
-        return await hasRunnableInstalledNpmPayload({ installPath, manifest: installedManifest });
-      } catch {
-        // Damaged or unreadable payloads fail closed without aborting the remaining plugin sweep.
-        return false;
+      if (coreSync && installedPayloadRunnable) {
+        const retainedMessage =
+          `Retained "${pluginId}" at ${currentVersion}: target ${effectiveSpec}` +
+          `${params.coreVersion ? ` for OpenClaw ${params.coreVersion}` : ""} is unavailable. ${message} ` +
+          `Retry "openclaw plugins update ${pluginId}" after the target is published or registry access recovers.`;
+        logger.warn?.(retainedMessage);
+        outcomes.push({
+          pluginId,
+          status: "unchanged",
+          code: "plugin-target-unavailable",
+          currentVersion,
+          message: retainedMessage,
+        });
+        return;
       }
+      recordFailure(pluginId, message, { code, installedPayloadRunnable });
     };
+    if (npmResolutionError) {
+      await recordNpmFailure(npmResolutionError.message, npmResolutionError.code);
+      continue;
+    }
     const extensionsDir = resolveRecordedExtensionsDir({
       pluginId,
       installPath,
@@ -445,15 +477,12 @@ export async function updateNpmInstalledPlugins(params: {
           continue;
         }
       } else {
-        if (!parseRegistryNpmSpec(effectiveSpec!)) {
+        if (coreSync || !parseRegistryNpmSpec(effectiveSpec!)) {
           const code =
             metadataResult.category === "metadata-env"
               ? PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
-              : undefined;
-          recordFailure(pluginId, `Failed to check ${pluginId}: ${metadataResult.error}`, {
-            code,
-            installedPayloadRunnable: await hasRunnableInstalledPayloadForFailure(code),
-          });
+              : PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND;
+          await recordNpmFailure(`Failed to check ${pluginId}: ${metadataResult.error}`, code);
           continue;
         }
         logger.warn?.(
@@ -568,10 +597,7 @@ export async function updateNpmInstalledPlugins(params: {
                   phase,
                   error: result.error,
                 });
-      recordFailure(pluginId, message, {
-        code,
-        installedPayloadRunnable: await hasRunnableInstalledPayloadForFailure(code),
-      });
+      await recordNpmFailure(message, code);
       continue;
     }
     if (params.dryRun) {

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -370,12 +370,16 @@ export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
     : undefined;
 }
 
-export function isNpmMetadataCompatibleWithCurrentHost(metadata: NpmSpecResolution): boolean {
-  const hostVersion = resolveCompatibilityHostVersion();
+export function isNpmMetadataCompatibleWithCurrentHost(
+  metadata: NpmSpecResolution,
+  options: { hostVersion?: string; allowLegacyBareSemver?: boolean } = {},
+): boolean {
+  const hostVersion = options.hostVersion ?? resolveCompatibilityHostVersion();
   const installMetadata = metadata.packageOpenClaw?.install;
   const minHostVersionCheck = checkMinHostVersion({
     currentVersion: hostVersion,
     minHostVersion: isRecord(installMetadata) ? installMetadata.minHostVersion : undefined,
+    allowLegacyBareSemver: options.allowLegacyBareSemver,
   });
   if (!minHostVersionCheck.ok) {
     return false;

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2829,6 +2829,129 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it.each([
+    { spec: "@acme/demo@2.0.0", updateChannel: "stable", stderr: "E404 No matching version" },
+    { spec: "@acme/demo@^2.0.0", updateChannel: "stable", stderr: "E404 No matching version" },
+    { spec: "@acme/demo", updateChannel: "stable", stderr: "ECONNREFUSED registry unreachable" },
+    { spec: "@acme/demo", updateChannel: "beta", stderr: "ECONNREFUSED registry unreachable" },
+  ] as const)(
+    "retains the installed plugin during core sync when $spec on $updateChannel fails: $stderr",
+    async ({ spec, updateChannel, stderr }) => {
+      const warn = vi.fn();
+      const installPath = createInstalledPackageDir({
+        name: "@acme/demo",
+        version: "1.0.0",
+        runnable: true,
+      });
+      const config: OpenClawConfig = {
+        plugins: {
+          allow: ["demo"],
+          entries: { demo: { enabled: true, config: { preserved: true } } },
+          slots: { memory: "demo" },
+          installs: {
+            demo: {
+              source: "npm",
+              spec,
+              installPath,
+              version: "1.0.0",
+              resolvedName: "@acme/demo",
+              resolvedSpec: "@acme/demo@1.0.0",
+              resolvedVersion: "1.0.0",
+            },
+          },
+        },
+      };
+      runCommandWithTimeoutMock.mockResolvedValue({ code: 1, stdout: "", stderr });
+      installPluginFromNpmSpecMock.mockResolvedValue({
+        ok: false,
+        code: stderr.startsWith("E404") ? "npm_package_not_found" : "npm_metadata_failure",
+        error: stderr,
+      });
+
+      const result = await updateNpmInstalledPlugins({
+        config,
+        pluginIds: ["demo"],
+        syncOfficialPluginInstalls: true,
+        disableOnFailure: true,
+        updateChannel,
+        coreVersion: "2026.9.4",
+        logger: { warn },
+      });
+
+      expect(result.outcomes).toEqual([
+        {
+          pluginId: "demo",
+          status: "unchanged",
+          code: "plugin-target-unavailable",
+          currentVersion: "1.0.0",
+          message: expect.stringContaining('Retained "demo" at 1.0.0'),
+        },
+      ]);
+      const message = result.outcomes[0]?.message ?? "";
+      expect(message).toContain(spec);
+      expect(message).toContain("2026.9.4");
+      expect(message).toContain(stderr.startsWith("E404") ? "Package not found" : "ECONNREFUSED");
+      expect(message).toContain("openclaw plugins update demo");
+      expect(warn).toHaveBeenCalledWith(message);
+      expect(result.config).toBe(config);
+      expect(result.changed).toBe(false);
+      expect(fs.readFileSync(path.join(installPath, "index.js"), "utf8")).toBe(
+        "export default function register() {}\n",
+      );
+      expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["damaged", "incompatible"] as const)(
+    "does not retain a %s installed plugin when a core-sync target is unavailable",
+    async (payload) => {
+      const installPath = createInstalledPackageDir({
+        name: "@acme/demo",
+        version: "1.0.0",
+        runnable: true,
+      });
+      if (payload === "damaged") {
+        fs.rmSync(path.join(installPath, "index.js"));
+      } else {
+        fs.writeFileSync(
+          path.join(installPath, "package.json"),
+          JSON.stringify({
+            name: "@acme/demo",
+            version: "1.0.0",
+            openclaw: { extensions: ["./index.js"], compat: { pluginApi: "<2020.1.1" } },
+          }),
+        );
+      }
+      runCommandWithTimeoutMock.mockResolvedValue({
+        code: 1,
+        stdout: "",
+        stderr: "E404 No matching version",
+      });
+      installPluginFromNpmSpecMock.mockResolvedValue({
+        ok: false,
+        code: "npm_package_not_found",
+        error: "Package not found",
+      });
+      const config: OpenClawConfig = {
+        plugins: {
+          entries: { demo: { enabled: true } },
+          installs: { demo: { source: "npm", spec: "@acme/demo@2.0.0", installPath } },
+        },
+      };
+
+      const result = await updateNpmInstalledPlugins({
+        config,
+        pluginIds: ["demo"],
+        syncOfficialPluginInstalls: true,
+        disableOnFailure: true,
+        coreVersion: "2026.9.4",
+      });
+
+      expect(result.config.plugins?.entries?.demo?.enabled).toBe(false);
+      expect(result.outcomes[0]?.status).toBe("skipped");
+    },
+  );
+
   it("disables a corrupt installed payload when metadata probing also fails", async () => {
     const warn = vi.fn();
     const installPath = createInstalledPackageDir({


### PR DESCRIPTION
Fixes #144973
Fixes #145027
Refs #144732

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers can edit it directly.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw update` could not update core when one configured npm plugin had no resolvable target or its registry was unreachable, even though the installed plugin could continue working.

## Why This Change Was Made

Preflight uses the loader's existing `openclaw.compat.pluginApi` and `openclaw.install.minHostVersion` contracts. Compatible installed plugins need no registry admission gate. Post-core sync retains their runnable installed version on resolution failures, preserves selectors, and records an advisory in the summary, ledger, and application WARN log, including JSON mode.

If the installed plugin is already incompatible with the target core, a compatible replacement must be resolvable before mutation. Missing targets, returned registry failures, and thrown resolution errors refuse with `plugin-incompatible`, naming the plugin, installed version, requirement, target core, failure, and retry/pin/disable actions. Final-record checks prevent stale retained-version advisories after later repair.

## User Impact

Working plugins can remain installed while core updates finish with `status: "ok"` and a `plugin-target-unavailable` advisory. Known incompatibilities cannot proceed on the assumption that an unreachable registry will repair them later. No new configuration, dependencies, manifest fields, or skip switch is introduced.

Release-note context: keep core updates moving when compatible npm plugins have unavailable targets; retain working plugins with actionable warnings and refuse unresolved incompatible replacements before mutation. Thanks to @blaekmajik, @noma-marketplacedb, and @zhangmianzhong-glitch for the reports.

## Evidence

- New outage regressions failed on 6915: four API-range/host-floor cases returned `ok` instead of the required pre-mutation refusal. After the fix, 245 focused admission, finalization, and plugin-owner tests passed.
- `node scripts/check-changed.mjs`, the full build, and canonical package tarball validation passed. Fresh P1 autoreview of this correction returned `scoped-clean` with no accepted findings. Earlier retention, JSON/ledger/WARN logging, and Doctor tests remain recorded in the worker handoff.
- Candidate head: `1b2fc9626068577595e3d328ff17a0236c560903`; tarball SHA-256: `21e7c99c7960602b49d2172da1dd2ba540d7db94a243e8233b1a80bfcb538b04`. Exact-head CI passed after refreshing the merge snapshot to include #145115; details are recorded below.

Older published 2026.9.3/2026.9.4 updaters execute their old preflight before candidate code. They may still need the documented manual bootstrap followed by `openclaw update repair`; this change does not retroactively replace an already-running updater.

## ClawSweeper review

**Skipped — Add data-model compatibility proof:** No persisted store, schema, config key, or on-disk format changes are introduced. Retained pins and advisories use the existing ledger and install-record shapes. The real compatible-plugin retention and incompatible-plugin refusal upgrade results below cover the changed behavior.

**P1 fixed:** both `metadata-env` failures and thrown registry errors now reach the pre-mutation `plugin-incompatible` refusal when an installed requirement excludes the target. Compatible-plugin admission remains permissive. Regression failure/pass evidence and the fresh P1 review cover both branches.

**P2 upgrade results:** both real Docker artifact-update cells passed on the candidate above (Linux arm64, Node 24.19.0):

| Installed plugin / registry | Result and boundary proof |
| --- | --- |
| `minHostVersion >=2026.9.5`, target `2026.9.4`; socket resets | Exit 1, `plugin-incompatible` with `ECONNRESET` and retry/pin/disable guidance. Gateway PID 1338 and manager PID 1331/start identities, HTTP, unit, core/build-info/inventory identities, and plugin record unchanged. No service mutation, activation, restart, publication, swap, or rollback; only private staging preceded refusal. |
| `minHostVersion >=2026.9.3`, target `2026.9.4`; HTTP 404 | Exit 0, `status: "ok"`, ledger `succeeded`. Plugin 1.0.0 selector/path/resolved identity/integrity retained; one matching application WARN record; real Gateway HTTP confirms activation. |

The negative fixture uses the existing compatibility-host override (`2026.9.5`) for initial plugin installation and the task-owned managed Gateway. The update CLI invocation has no override; admission evaluates target `2026.9.4`. This does not claim a published `2026.9.5` binary. Preparation proved that the real manager stop path closes the endpoint. Existing time limits stayed unchanged, and all owned containers were removed.

## CI status

[Run 34632689117](https://github.com/openclaw/openclaw/actions/runs/34632689117) passed for exact head `1b2fc9626068577595e3d328ff17a0236c560903`. Its checked-out merge `cd66f822372c438c0f5ec945e7c4667f751e0626` includes #145115. Both `check-lint-core-1` and `checks-node-compact-small-6` passed without a job rerun. The exact-head watcher reported `GREEN`; older failed checks were verified as superseded.

The first close/reopen refresh still ran the previous merge snapshot; a second cycle selected the corrected snapshot. Earlier failures are retained below for provenance.

[Run 34629690606](https://github.com/openclaw/openclaw/actions/runs/34629690606) finished with 128 passing and 45 skipped checks. Two jobs failed, and the aggregate `openclaw/ci-gate` failed with them:

- [check-lint-core-1](https://github.com/openclaw/openclaw/actions/runs/34629690606/job/103363431859): `src/cli/daemon-cli/install.test.ts:1126` exceeds max-lines (1001). CI checked merge `e6c6417d` of this head into main `160dee82f740a9951be86972ff1577092d22e407`. This file is unchanged across this PR head, 6915, and the original branch base (blob `be4b3d2503bdd8391e66b4c025b3d75072629c12`); the CI merge has different blob `d293d2792f0f16ea5dad2c6523807a10bdd23e43`.
- [checks-node-compact-small-6](https://github.com/openclaw/openclaw/actions/runs/34629690606/job/103363433926): `doctor-update.ledger.test.ts` failed “waits for an outstanding real child before rejecting without terminal history” with “Doctor child did not settle normally” at `doctor-update.executor.test-support.ts:54`. Neither test nor its support file exists in this PR head; both come from the newer-main merge. The test exercises delegated Doctor child ownership, without the plugin preflight.

These unrelated failures are recorded without changing their files, limits, assertions, or timeouts. The scoped local checks, requested P1 autoreview, and both candidate Docker cells passed.
