### PR TITLE
fix(sqlite): retain Bun worker library and handle ownership

### DIFF
--- a/docs/install/bun-compatibility.md
+++ b/docs/install/bun-compatibility.md
@@ -40,6 +40,8 @@ Before opening databases, OpenClaw selects a library in this order:
 
 Candidates must meet the WAL safety floor and support extension loading before selection. If automatic discovery finds no qualifying library, Bun keeps its runtime library; ordinary agent databases can open if that library meets the WAL floor. The memory KNN child uses the same selected library.
 
+SQLite storage workers inherit the main process's selected library. Opening another database or restarting a storage worker reuses that selection without repeating Bun's one-shot library initialization.
+
 Set `OPENCLAW_SQLITE_LIBRARY` in the process environment before starting OpenClaw to override discovery:
 
 ```sh
@@ -69,6 +71,7 @@ When the KNN child cannot load extensions, memory search falls back to a batched
 - **Lifecycle scripts:** Bun blocks dependency lifecycle scripts unless explicitly trusted with `bun pm trust`.
 - **Package scripts:** Some scripts hardcode pnpm, so `bun run` still invokes pnpm internally.
 - **SQLite handles:** Bun 1.4.2 can retain statement handles and WAL/shared-memory files after `DatabaseSync.close()` or `Symbol.dispose()`; OpenClaw cannot finalize them through Bun's public `node:sqlite` API. See the [upstream close fix](https://github.com/oven-sh/bun/pull/40005); use Node when prompt file release matters.
+- **SQLite storage workers:** Bun uses one worker per distinct database, up to four open databases. Clients of the same database share its worker. Closing the last client waits for worker exit to release native handles; opening a fifth distinct database fails without interrupting existing stores. Node workers can share multiple databases. This temporary Bun limit can be revisited after the upstream close fix ships and repeated close/reopen tests prove native handles and locks are released.
 - **Workspace installation:** `bun install` cannot resolve this repository's pnpm workspace layout. Use `pnpm install`.
 
 See [Bun](/install/bun) for the workflow and lifecycle trust commands.

--- a/src/infra/bun-sqlite-library.ts
+++ b/src/infra/bun-sqlite-library.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { posix } from "node:path";
+import { getEnvironmentData, isMainThread, setEnvironmentData } from "node:worker_threads";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { isSqliteWalResetSafeVersion } from "./sqlite-runtime-version.js";
 
@@ -15,6 +17,7 @@ export type SqliteLibrarySelection =
 
 type SelectionOptions = { explicitPath?: string };
 type LibraryProbe = { version: string; extensionLoadingSupported: boolean };
+const WORKER_SELECTION_KEY = "openclaw.bunSqliteLibrarySelection";
 type SelectionDependencies = {
   isBun: boolean;
   platform: string;
@@ -150,6 +153,59 @@ function selectionError(path: string, error: unknown): Error {
   );
 }
 
+function inheritedSelection(): SqliteLibrarySelection | undefined {
+  const value: unknown = getEnvironmentData(WORKER_SELECTION_KEY);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (isRecord(value)) {
+    if (value.source === "runtime") {
+      return { source: "runtime" };
+    }
+    if (
+      (value.source === "env" || value.source === "discovered") &&
+      typeof value.path === "string" &&
+      typeof value.version === "string" &&
+      value.extensionLoadingSupported === true
+    ) {
+      return {
+        source: value.source,
+        path: value.path,
+        version: value.version,
+        extensionLoadingSupported: true,
+      };
+    }
+  }
+  throw new Error("Invalid inherited SQLite library selection");
+}
+
+function createRuntimeSelector(): ReturnType<typeof createSelector> {
+  const isBun = Boolean(process.versions.bun);
+  const sharedLibrary = isBun && process.platform === "darwin";
+  const inherited = sharedLibrary && !isMainThread ? inheritedSelection() : undefined;
+  if (inherited) {
+    return () => inherited;
+  }
+  const select = createSelector({
+    isBun,
+    platform: process.platform,
+    env: process.env,
+    exists: existsSync,
+    probe: probeLibrary,
+    select: selectLibrary,
+  });
+  let published = false;
+  return (options) => {
+    const selection = select(options);
+    if (sharedLibrary && isMainThread && !published) {
+      // Bun's library hook is process-wide; new workers inherit the completed owner's fact.
+      setEnvironmentData(WORKER_SELECTION_KEY, Object.freeze({ ...selection }));
+      published = true;
+    }
+    return selection;
+  };
+}
+
 /** Select once, before any SQLite open; shared across CLI and bundled SDK module graphs. */
 export function ensureSqliteLibrarySelected(
   options?: SelectionOptions & {
@@ -160,15 +216,9 @@ export function ensureSqliteLibrarySelected(
   const dependencies = options?.internals;
   const select = dependencies
     ? (dependencies.selector ??= createSelector(dependencies))
-    : resolveGlobalSingleton(Symbol.for("openclaw.bunSqliteLibrarySelection"), () =>
-        createSelector({
-          isBun: Boolean(process.versions.bun),
-          platform: process.platform,
-          env: process.env,
-          exists: existsSync,
-          probe: probeLibrary,
-          select: selectLibrary,
-        }),
+    : resolveGlobalSingleton(
+        Symbol.for("openclaw.bunSqliteLibrarySelection"),
+        createRuntimeSelector,
       );
   return select(options);
 }

--- a/src/infra/bun-sqlite-library.worker.test.ts
+++ b/src/infra/bun-sqlite-library.worker.test.ts
@@ -1,0 +1,328 @@
+import { existsSync } from "node:fs";
+import * as fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import type { SqliteWorkerStore } from "./sqlite-worker-contract.js";
+import type { FixtureOperations } from "./sqlite-worker-store.test-support.js";
+
+const runtime = vi.hoisted(() => ({
+  mainThread: true,
+  environment: new Map<unknown, unknown>(),
+  selectedPath: undefined as string | undefined,
+  launches: 0,
+  dlopen: vi.fn(),
+  select: vi.fn<(path: string) => void>(),
+  getEnvironmentData: vi.fn<(key: unknown) => unknown>(),
+  setEnvironmentData: vi.fn<(key: unknown, value: unknown) => void>(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, stat: vi.fn(actual.stat) };
+});
+
+vi.mock("node:module", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:module")>();
+  return {
+    createRequire: (...args: Parameters<typeof actual.createRequire>) => {
+      const require = actual.createRequire(...args);
+      return Object.assign((specifier: string) => {
+        if (specifier === "bun:ffi") {
+          return { dlopen: runtime.dlopen, FFIType: { cstring: 0, i32: 1 } };
+        }
+        if (specifier === "bun:sqlite") {
+          return { Database: { setCustomSQLite: runtime.select } };
+        }
+        return require(specifier);
+      }, require);
+    },
+  };
+});
+
+vi.mock("node:worker_threads", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:worker_threads")>();
+  return {
+    ...actual,
+    get isMainThread() {
+      return runtime.mainThread;
+    },
+    getEnvironmentData: runtime.getEnvironmentData,
+    setEnvironmentData: runtime.setEnvironmentData,
+    Worker: class extends actual.Worker {
+      constructor(...args: ConstructorParameters<typeof actual.Worker>) {
+        runtime.launches += 1;
+        if (!runtime.selectedPath || runtime.environment.size === 0) {
+          throw new Error("Worker started before its SQLite library owner completed selection");
+        }
+        super(...args);
+      }
+    },
+  };
+});
+
+const selectionKey = Symbol.for("openclaw.bunSqliteLibrarySelection");
+const stores = new Set<SqliteWorkerStore<FixtureOperations>>();
+let previousSelection: PropertyDescriptor | undefined;
+let previousVersions: PropertyDescriptor | undefined;
+let previousPlatform: PropertyDescriptor | undefined;
+
+function restoreProperty(
+  target: object,
+  key: PropertyKey,
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+  } else {
+    Reflect.deleteProperty(target, key);
+  }
+}
+
+function setRuntime(bun: boolean, platform: string) {
+  Object.defineProperty(process, "versions", {
+    configurable: true,
+    value: { ...process.versions, bun: bun ? "fixture" : undefined },
+  });
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+beforeEach(() => {
+  previousSelection = Object.getOwnPropertyDescriptor(globalThis, selectionKey);
+  previousVersions = Object.getOwnPropertyDescriptor(process, "versions");
+  previousPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  Reflect.deleteProperty(globalThis, selectionKey);
+  vi.resetModules();
+  runtime.mainThread = true;
+  runtime.environment.clear();
+  runtime.selectedPath = undefined;
+  runtime.launches = 0;
+  runtime.dlopen.mockReset().mockImplementation(() => ({
+    symbols: {
+      sqlite3_libversion: () => "3.53.4",
+      sqlite3_compileoption_used: () => 0,
+    },
+    close() {},
+  }));
+  runtime.select.mockReset().mockImplementation((selectedPath) => {
+    if (runtime.selectedPath) {
+      throw new Error("SQLite library selection is process-wide and cannot repeat");
+    }
+    runtime.selectedPath = selectedPath;
+  });
+  runtime.getEnvironmentData
+    .mockReset()
+    .mockImplementation((key) => structuredClone(runtime.environment.get(key)));
+  runtime.setEnvironmentData.mockReset().mockImplementation((key, value) => {
+    runtime.environment.set(key, value);
+  });
+  vi.stubEnv("OPENCLAW_SQLITE_LIBRARY", "/fixture/sqlite.dylib");
+  setRuntime(true, "darwin");
+});
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    try {
+      await Promise.all([...stores].map((store) => store.close()));
+    } finally {
+      stores.clear();
+      restoreProperty(globalThis, selectionKey, previousSelection);
+      restoreProperty(process, "versions", previousVersions);
+      restoreProperty(process, "platform", previousPlatform);
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+      runtime.environment.clear();
+      cleanup();
+    }
+  }),
+);
+
+async function enterWorkerHeap() {
+  runtime.mainThread = false;
+  Reflect.deleteProperty(globalThis, selectionKey);
+  vi.resetModules();
+  return await import("./bun-sqlite-library.js");
+}
+
+async function openStore(databasePath: string) {
+  const { openSqliteWorkerStore } = await import("./sqlite-worker-store.js");
+  const store = await openSqliteWorkerStore<FixtureOperations>({
+    moduleUrl: new URL("./sqlite-worker-store.test-support.ts", import.meta.url),
+    databasePath,
+    input: undefined,
+  });
+  stores.add(store);
+  return store;
+}
+
+describe("Bun SQLite process selection and worker inheritance", () => {
+  it("inherits the completed custom selection without repeating Bun's one-shot native hook", async () => {
+    const parent = await import("./bun-sqlite-library.js");
+    const selected = parent.ensureSqliteLibrarySelected();
+    expect(selected).toMatchObject({
+      source: "env",
+      path: "/fixture/sqlite.dylib",
+      version: "3.53.4",
+    });
+    expect([...runtime.environment.values()]).toEqual([selected]);
+    const worker = await enterWorkerHeap();
+    expect(worker.ensureSqliteLibrarySelected({ explicitPath: "/worker/different.dylib" })).toEqual(
+      selected,
+    );
+    expect(worker.ensureSqliteLibrarySelected()).toEqual(selected);
+    expect(runtime.select).toHaveBeenCalledExactlyOnceWith("/fixture/sqlite.dylib");
+    expect(runtime.dlopen).toHaveBeenCalledTimes(1);
+    expect(runtime.setEnvironmentData).toHaveBeenCalledTimes(1);
+  });
+
+  it("inherits the parent's runtime fallback without independently probing or applying an override", async () => {
+    vi.stubEnv("OPENCLAW_SQLITE_LIBRARY", "");
+    runtime.dlopen.mockImplementation(() => {
+      throw new Error("No custom library available");
+    });
+    const parent = await import("./bun-sqlite-library.js");
+    expect(parent.ensureSqliteLibrarySelected()).toEqual({ source: "runtime" });
+    expect([...runtime.environment.values()]).toEqual([{ source: "runtime" }]);
+    runtime.dlopen.mockClear();
+    const worker = await enterWorkerHeap();
+    expect(worker.ensureSqliteLibrarySelected({ explicitPath: "/worker/different.dylib" })).toEqual(
+      { source: "runtime" },
+    );
+    expect(runtime.dlopen).not.toHaveBeenCalled();
+    expect(runtime.select).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { bun: false, platform: "darwin" },
+    { bun: true, platform: "linux" },
+  ])(
+    "leaves worker environment facts and native selection untouched on $platform (Bun: $bun)",
+    async ({ bun, platform }) => {
+      setRuntime(bun, platform);
+      runtime.getEnvironmentData.mockImplementation(() => {
+        throw new Error("Unrelated worker data must not be read");
+      });
+      const worker = await enterWorkerHeap();
+      expect(worker.ensureSqliteLibrarySelected()).toMatchObject({ source: "runtime" });
+      expect(runtime.getEnvironmentData).not.toHaveBeenCalled();
+      expect(runtime.setEnvironmentData).not.toHaveBeenCalled();
+      expect(runtime.dlopen).not.toHaveBeenCalled();
+      expect(runtime.select).not.toHaveBeenCalled();
+    },
+  );
+
+  it("prepares dedicated workers, bounds distinct databases, and retains ownership until termination joins", async () => {
+    const directory = tempDirs.make("bun-sqlite-worker-selection-");
+    const paths = Array.from({ length: 5 }, (_, index) => path.join(directory, `${index}.sqlite`));
+    const active: SqliteWorkerStore<FixtureOperations>[] = [];
+    for (let index = 0; index < 4; index += 1) {
+      const store = await openStore(paths[index]!);
+      active.push(store);
+      await store.execute({ type: "append", input: { value: `database ${index}` } });
+    }
+    const [overflow] = await Promise.allSettled([openStore(paths[4]!)]);
+    if (overflow.status === "fulfilled") {
+      await overflow.value.close();
+    }
+    expect(overflow).toMatchObject({ status: "rejected", reason: { code: "overloaded" } });
+    expect(existsSync(paths[4]!)).toBe(false);
+    expect(runtime.launches).toBe(4);
+    for (const [index, store] of active.entries()) {
+      expect(await store.execute({ type: "read", input: undefined })).toEqual([
+        `database ${index}`,
+      ]);
+    }
+    const aliasPath = path.join(directory, "alias.sqlite");
+    await fs.link(paths[0]!, aliasPath);
+    const alias = await openStore(aliasPath);
+    await alias.execute({ type: "append", input: { value: "shared alias" } });
+    expect(runtime.launches).toBe(4);
+    await active[0]!.close();
+    expect(await alias.execute({ type: "read", input: undefined })).toEqual([
+      "database 0",
+      "shared alias",
+    ]);
+
+    const terminating = createDeferredCore();
+    const release = createDeferredCore();
+    const termination = vi
+      .spyOn(Worker.prototype, "terminate")
+      .mockImplementationOnce(async function (this: Worker) {
+        terminating.resolve();
+        await release.promise;
+        termination.mockRestore();
+        return this.terminate();
+      });
+    const closing = alias.close();
+    let reopening: Promise<SqliteWorkerStore<FixtureOperations>> | undefined;
+    try {
+      await terminating.promise;
+      // Leave room for a replacement so the database owner, not the worker cap, must block it.
+      await active[3]!.close();
+      const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+      const backendPath = await fs.realpath(
+        fileURLToPath(new URL("./sqlite-worker-store.test-support.ts", import.meta.url)),
+      );
+      const inspected = createDeferredCore();
+      vi.mocked(fs.stat).mockImplementation(async (pathname, options) => {
+        const result = await actualFs.stat(pathname, options);
+        if (pathname === backendPath) {
+          inspected.resolve();
+        }
+        return result;
+      });
+      let reopenSettled = false;
+      reopening = openStore(paths[0]!);
+      void reopening.then(
+        () => {
+          reopenSettled = true;
+        },
+        () => {
+          reopenSettled = true;
+        },
+      );
+      await inspected.promise;
+      // Resume the admission continuation after its last filesystem inspection.
+      await Promise.resolve();
+      expect(runtime.launches).toBe(4);
+      expect(reopenSettled).toBe(false);
+      vi.mocked(fs.stat).mockImplementation(actualFs.stat);
+      release.resolve();
+      await closing;
+      const reopened = await reopening;
+      expect(await reopened.execute({ type: "read", input: undefined })).toEqual([
+        "database 0",
+        "shared alias",
+      ]);
+      expect(runtime.launches).toBe(5);
+      expect(await active[1]!.execute({ type: "read", input: undefined })).toEqual(["database 1"]);
+      expect(await active[2]!.execute({ type: "read", input: undefined })).toEqual(["database 2"]);
+    } finally {
+      release.resolve();
+      termination.mockRestore();
+      const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+      vi.mocked(fs.stat).mockImplementation(actualFs.stat);
+      await Promise.allSettled([closing, ...(reopening ? [reopening] : [])]);
+    }
+    expect(runtime.select).toHaveBeenCalledExactlyOnceWith("/fixture/sqlite.dylib");
+    expect(runtime.setEnvironmentData).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes no successful selection and starts no worker after the native hook fails", async () => {
+    runtime.select.mockImplementation(() => {
+      throw new Error("Native selection failed");
+    });
+    const databasePath = path.join(tempDirs.make("bun-sqlite-selection-failure-"), "store.sqlite");
+    await expect(openStore(databasePath)).rejects.toThrow("Native selection failed");
+    const { ensureSqliteLibrarySelected } = await import("./bun-sqlite-library.js");
+    expect(() => ensureSqliteLibrarySelected()).toThrow("Native selection failed");
+    expect(runtime.select).toHaveBeenCalledTimes(1);
+    expect(runtime.environment.size).toBe(0);
+    expect(runtime.setEnvironmentData).not.toHaveBeenCalled();
+    expect(runtime.launches).toBe(0);
+    expect(existsSync(databasePath)).toBe(false);
+  });
+});

--- a/src/infra/sqlite-worker-store.ts
+++ b/src/infra/sqlite-worker-store.ts
@@ -9,6 +9,7 @@ import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { INCOGNITO_AGENT_SQLITE_BASENAME } from "../state/openclaw-agent-db.paths.js";
+import { ensureSqliteLibrarySelected } from "./bun-sqlite-library.js";
 import { hasErrnoCode } from "./errno.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
@@ -419,11 +420,20 @@ class SqliteWorkerBroker {
         await Promise.race([...this.slots].map((slot) => slot.exit));
         return this.acquireSlot();
       }
+      if (process.versions.bun) {
+        throw new SqliteWorkerError(
+          "Bun SQLite workers support at most four distinct open databases; close a store or use Node",
+          "overloaded",
+        );
+      }
       const selected = available.reduce((left, right) =>
         left.actors.size <= right.actors.size ? left : right,
       );
       selected.pendingOpens += 1;
       return selected;
+    }
+    if (process.versions.bun && process.platform === "darwin") {
+      ensureSqliteLibrarySelected();
     }
     const url = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteStore);
     const worker = runOutsideCaller(
@@ -610,6 +620,10 @@ class SqliteWorkerBroker {
         await actor.slot.exit;
         throw error;
       } finally {
+        if (process.versions.bun) {
+          // Bun retains native statements after close; keep pathname ownership until VM exit.
+          await this.retire(actor.slot);
+        }
         this.forget(actor);
         await this.retireEmpty(actor.slot);
       }


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

On supported Bun, a second SQLite worker or a restarted store repeats the process-wide native library selector and fails. Bun also retains native statements after database close, so sharing a worker between databases can leave a closed store's file handles and SQLite lock alive.

## Why This Change Was Made

Keep selection in the existing library owner and pass its completed fact to new workers. Selection policy, capability checks and failure memoization stay intact.

On Bun, use one worker per distinct database within the existing four-worker cap. Alias clients share the same actor; final close retains pathname ownership until worker exit. A fifth distinct database is refused explicitly without disturbing the existing stores. Node retains shared slots.

## User Impact

Bun worker stores can start after main-process selection, open concurrently, close and reopen without repeated initialization or leaked native ownership. Bun temporarily supports four distinct open worker databases; users needing more can use Node. The limit can be revisited after the upstream native-close fix ships and release tests prove it safe.

## Evidence

- 82 selected Node tests passed, with six affected cases rerun after a test-only lint cleanup. Full selected checks and fresh independent Codex P2 review passed.
- Actual Bun 1.4.2 reproduced repeated library selection failure and native-handle growth across 20 shared-slot close/reopen cycles.
- With dedicated slots, four stores remain healthy after capacity refusal. Alias clients preserve ownership; final close leaves zero descriptors while three peers stay live. Independent SQLite writes, checkpoints and exclusive journal-mode changes succeed afterward. Every one of 20 reopen/close cycles leaves zero descriptors.
- Reversing only retirement-before-forgetting ownership makes the close-order regression fail.
- A separately pinned compiled union of the Logbook worker candidate and these exact repair files passed a full build and actual Bun Logbook/Team Reports startup, concurrent use, restart and fresh-process persistence checks. Source and artifact hashes stayed unchanged; all created resources joined.

The compiled union is recorded separately from later mechanical PR rebases; no full rebuild of those later graphs is claimed. Bun's pre-existing tsconfig diagnostic was reproduced without OpenClaw and retained in the proof. No dependency patch or version change is included.
