### PR TITLE
refactor(voice-call): await call persistence and lifecycle work

### DIFF
--- a/docs/plugins/voice-call/troubleshooting.md
+++ b/docs/plugins/voice-call/troubleshooting.md
@@ -14,10 +14,16 @@ Fixes for setup, webhook exposure, credentials, signature verification, Google M
 
 ### Call placement fails to save its initial record
 
-Voice Call saves the initial record before reserving a concurrency slot or
-contacting the carrier. If that write fails, the placement reports the storage
-error without dialing. Restore access to the state directory, then retry; the
-failed placement does not consume `maxConcurrentCalls` capacity.
+Voice Call reserves pending capacity while saving the initial record, then publishes
+the active call and contacts the carrier only after the write succeeds. If the write
+fails, placement reports the storage error without dialing and releases the reservation.
+Restore access to the state directory, then retry; a failed placement does not consume
+`maxConcurrentCalls` capacity.
+
+Webhook acknowledgments and transcript-driven replies wait for call-record persistence.
+Token-bound realtime streams wait for pending call updates before matching the carrier ID.
+Failed event writes remain retryable, and shutdown drains admitted call work after
+closing webhook and stream producers.
 
 ### Setup fails webhook exposure
 

--- a/extensions/voice-call/doctor-contract-api.test.ts
+++ b/extensions/voice-call/doctor-contract-api.test.ts
@@ -6,7 +6,6 @@ import { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
   createPluginStateKeyedStoreForTests,
-  createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type {
@@ -38,11 +37,8 @@ function installStateRuntime(): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
-      openKeyedStore: (() => {
-        throw new Error("openKeyedStore is not used by voice-call doctor tests");
-      }) as never,
-      openSyncKeyedStore: (options: OpenKeyedStoreOptions) =>
-        createPluginStateSyncKeyedStoreForTests("voice-call", options),
+      openKeyedStore: (options: OpenKeyedStoreOptions) =>
+        createPluginStateKeyedStoreForTests("voice-call", options),
       openChannelIngressQueue: (() => {
         throw new Error("openChannelIngressQueue is not used by voice-call doctor tests");
       }) as never,
@@ -102,7 +98,7 @@ describe("voice-call doctor state migration", () => {
         oauthDir: path.join(warmStateDir, "oauth"),
         context: createDoctorContext(warmEnv),
       });
-      const restored = loadActiveCallsFromStore(warmStorePath);
+      const restored = await loadActiveCallsFromStore(warmStorePath);
       const history = await getCallHistoryFromStore(warmStorePath, 1000);
       overCapacityMigration = {
         warnings: result.warnings,
@@ -222,7 +218,7 @@ describe("voice-call doctor state migration", () => {
     await expect(fs.access(sourcePath)).rejects.toThrow();
     await fs.access(`${sourcePath}.migrated`);
 
-    const restored = loadActiveCallsFromStore(storePath);
+    const restored = await loadActiveCallsFromStore(storePath);
     expect(restored.activeCalls.get("call-doctor")?.providerCallId).toBe("provider-doctor");
     expect(restored.processedEventIds.has("evt-doctor")).toBe(true);
 
@@ -265,9 +261,9 @@ describe("voice-call doctor state migration", () => {
       warnings: [],
     });
 
-    expect(loadActiveCallsFromStore(defaultStorePath).activeCalls.has("call-isolated-state")).toBe(
-      true,
-    );
+    expect(
+      (await loadActiveCallsFromStore(defaultStorePath)).activeCalls.has("call-isolated-state"),
+    ).toBe(true);
   });
 
   it("keeps literal $ patterns in home when resolving a tilde-configured store", async () => {
@@ -365,7 +361,7 @@ describe("voice-call doctor state migration", () => {
       warnings: [],
     });
     await expect(migration.detectLegacyState(params)).resolves.toBeNull();
-    expect(loadActiveCallsFromStore(storePath).activeCalls.size).toBe(0);
+    expect((await loadActiveCallsFromStore(storePath)).activeCalls.size).toBe(0);
   });
 
   it("imports the newest legacy call records when the JSONL log is over capacity", () => {
@@ -422,6 +418,6 @@ describe("voice-call doctor state migration", () => {
     ]);
     await fs.access(sourcePath);
     await expect(fs.access(`${sourcePath}.migrated`)).rejects.toThrow();
-    expect(loadActiveCallsFromStore(storePath).activeCalls.has("call-valid")).toBe(true);
+    expect((await loadActiveCallsFromStore(storePath)).activeCalls.has("call-valid")).toBe(true);
   });
 });

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -156,7 +156,7 @@ describe("voice-call CLI status fallback", () => {
     args?: string[];
   }): Promise<unknown> {
     callGatewayFromCliMock.mockRejectedValue(params.error ?? gatewayTransportError());
-    findCallInStoreMock.mockReturnValue(params.persisted);
+    findCallInStoreMock.mockResolvedValue(params.persisted);
     const ensureRuntime = vi.fn(async () => {
       throw new Error("status fallback must not initialize the telephony runtime");
     });
@@ -201,7 +201,7 @@ describe("voice-call CLI status fallback", () => {
   });
 
   it("lists persisted active calls without initializing the telephony runtime", async () => {
-    loadActiveCallsFromStoreMock.mockReturnValue({
+    loadActiveCallsFromStoreMock.mockResolvedValue({
       activeCalls: new Map([["call-1", { callId: "call-1", state: "ringing" }]]),
     });
     expect(await runStatusWithUnavailableGateway({ args: [] })).toEqual({

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -389,13 +389,13 @@ export function registerVoiceCallCli(params: {
       ensureHistoryStateRuntime();
       const storePath = path.dirname(resolveDefaultStorePath(config));
       if (options.callId) {
-        const call = findCallInStore(storePath, options.callId);
+        const call = await findCallInStore(storePath, options.callId);
         writeCliJson(call ?? { found: false });
         return;
       }
       writeCliJson({
         found: true,
-        calls: Array.from(loadActiveCallsFromStore(storePath).activeCalls.values()),
+        calls: Array.from((await loadActiveCallsFromStore(storePath)).activeCalls.values()),
       });
     });
 

--- a/extensions/voice-call/src/manager.async-store.test.ts
+++ b/extensions/voice-call/src/manager.async-store.test.ts
@@ -1,0 +1,531 @@
+import fs from "node:fs";
+import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type { RealtimeVoiceProviderPlugin } from "openclaw/plugin-sdk/realtime-voice";
+import { expect, it, vi } from "vitest";
+import { VoiceCallConfigSchema, type VoiceCallConfig } from "./config.js";
+import { CallManager } from "./manager.js";
+import { createTestStorePath, FakeProvider, makePersistedCall } from "./manager.test-harness.js";
+import { CALL_RECORD_EVENTS_NAMESPACE, findCallInStore } from "./manager/store.js";
+import * as callStore from "./manager/store.js";
+import { setVoiceCallStateRuntime } from "./runtime-state.js";
+import { CallRecordSchema, type InitiateCallInput } from "./types.js";
+import { RealtimeCallHandler } from "./webhook/realtime-handler.js";
+import { connectWs, startUpgradeWsServer, waitForClose } from "./websocket-test-support.js";
+import type { WebSocket } from "./websocket.js";
+
+async function withDelayedStore(
+  run: (fixture: {
+    manager: CallManager;
+    config: VoiceCallConfig;
+    provider: FakeProvider;
+    storePath: string;
+    holdNextWrite: () => {
+      entered: Promise<void>;
+      release: () => void;
+      fail: () => void;
+    };
+  }) => Promise<void>,
+  fixtureOptions: { initialize?: boolean; provider?: FakeProvider; realtime?: boolean } = {},
+) {
+  const storePath = createTestStorePath();
+  const writes: Promise<void>[] = [];
+  const persist = callStore.persistCallRecord;
+  const persistence = vi.spyOn(callStore, "persistCallRecord").mockImplementation((...args) => {
+    const work = persist(...args);
+    writes.push(work);
+    return work;
+  });
+  const gates: ReturnType<typeof createDeferred<void>>[] = [];
+  let nextWrite: (() => Promise<void>) | undefined;
+  setVoiceCallStateRuntime({
+    state: {
+      resolveStateDir: () => storePath,
+      openKeyedStore: <T>(options: OpenKeyedStoreOptions) => {
+        const store = createPluginStateKeyedStoreForTests<T>("voice-call", options);
+        return {
+          ...store,
+          async register(...args: Parameters<typeof store.register>) {
+            if (options.namespace === CALL_RECORD_EVENTS_NAMESPACE && nextWrite) {
+              const hold = nextWrite;
+              nextWrite = undefined;
+              await hold();
+            }
+            await store.register(...args);
+          },
+        };
+      },
+      openChannelIngressQueue: () => {
+        throw new Error("Unused ingress queue");
+      },
+      openChannelIngressDrain: () => {
+        throw new Error("Unused ingress drain");
+      },
+    },
+  });
+  const provider = fixtureOptions.provider ?? new FakeProvider();
+  const config = VoiceCallConfigSchema.parse({
+    provider: provider.name,
+    realtime: { enabled: fixtureOptions.realtime ?? false },
+    fromNumber: "+15550000000",
+    maxConcurrentCalls: 1,
+  });
+  const manager = new CallManager(config, storePath);
+  if (fixtureOptions.initialize !== false) {
+    await manager.initialize(provider, "https://fixture.invalid/voice/webhook");
+  }
+  try {
+    await run({
+      manager,
+      config,
+      provider,
+      storePath,
+      holdNextWrite() {
+        const entered = createDeferred<void>();
+        const release = createDeferred<void>();
+        gates.push(release);
+        let fail = false;
+        nextWrite = async () => {
+          entered.resolve();
+          await release.promise;
+          if (fail) {
+            throw new Error("Synthetic delayed persistence failure");
+          }
+        };
+        return {
+          entered: entered.promise,
+          release: () => release.resolve(),
+          fail: () => {
+            fail = true;
+            release.resolve();
+          },
+        };
+      },
+    });
+  } finally {
+    for (const gate of gates) {
+      gate.resolve();
+    }
+    await manager.stop();
+    await Promise.allSettled(writes);
+    persistence.mockRestore();
+    resetPluginStateStoreForTests();
+    fs.rmSync(storePath, { recursive: true, force: true });
+  }
+}
+
+it("reserves pending capacity without publishing or dialing an uncommitted call", async () => {
+  await withDelayedStore(async ({ manager, provider, holdNextWrite }) => {
+    const dial = vi.spyOn(provider, "initiateCall");
+    const gate = holdNextWrite();
+    const first = manager.initiateCall("+15550000001");
+    void first.catch(() => {});
+    await gate.entered;
+    expect(manager.getActiveCalls()).toHaveLength(0);
+    expect(dial).not.toHaveBeenCalled();
+    await expect(manager.initiateCall("+15550000002")).resolves.toMatchObject({
+      success: false,
+      error: "Maximum concurrent calls (1) reached",
+    });
+    gate.fail();
+    await expect(first).rejects.toThrow("Synthetic delayed persistence failure");
+    expect(manager.getActiveCalls()).toHaveLength(0);
+    await expect(manager.initiateCall("+15550000002")).resolves.toMatchObject({ success: true });
+    expect(dial).toHaveBeenCalledOnce();
+  });
+});
+
+it.each(["committed", "failed", "retired"] as const)(
+  "waits for the outbound provider binding before admitting a token-bound stream (%s)",
+  async (outcome) => {
+    await withDelayedStore(
+      async ({ manager, config, provider, storePath, holdNextWrite }) => {
+        const providerCallId = "native-provider-binding";
+        const dialed = createDeferred<InitiateCallInput>();
+        const bridgeCreated = createDeferred<void>();
+        const frameReceived = createDeferred<void>();
+        let bindingWrite: ReturnType<typeof holdNextWrite> | undefined;
+        const initiate = vi.spyOn(provider, "initiateCall").mockImplementation(async (input) => {
+          bindingWrite = holdNextWrite();
+          dialed.resolve(input);
+          return { providerCallId, status: "initiated" };
+        });
+        const createBridge = vi.fn<RealtimeVoiceProviderPlugin["createBridge"]>(() => {
+          bridgeCreated.resolve();
+          return {
+            connect: async () => {},
+            sendAudio: () => {},
+            setMediaTimestamp: () => {},
+            submitToolResult: () => {},
+            acknowledgeMark: () => {},
+            close: () => {},
+            isConnected: () => true,
+            triggerGreeting: () => {},
+          };
+        });
+        const handler = new RealtimeCallHandler(
+          config.realtime,
+          manager,
+          () => ({
+            agentId: "main",
+            instructions: "Synthetic realtime fixture.",
+            provider: {
+              id: "test-realtime",
+              label: "Test realtime",
+              isConfigured: () => true,
+              createBridge,
+            },
+            providerConfig: {},
+          }),
+          config.serve.path,
+          { connect: () => {}, disconnect: () => {}, retire: () => {} },
+        );
+        manager.streamSessionIssuer = (request) => handler.issueStreamSession(request);
+        let server: Awaited<ReturnType<typeof startUpgradeWsServer>> | undefined;
+        let ws: WebSocket | undefined;
+        const placement = manager.initiateCall("+15550000001", undefined, { mode: "conversation" });
+        let retirement: ReturnType<CallManager["processEvent"]> | undefined;
+        try {
+          const input = await dialed.promise;
+          const write = expectDefined(bindingWrite, "pending provider binding write");
+          await write.entered;
+          expect(manager.getCall(input.callId)?.providerCallId).toBeUndefined();
+          if (outcome === "retired") {
+            retirement = manager.processEvent({
+              id: "terminal-before-stream-admission",
+              type: "call.ended",
+              callId: input.callId,
+              providerCallId,
+              timestamp: Date.now(),
+              reason: "hangup-user",
+            });
+          }
+          server = await startUpgradeWsServer({
+            urlPath: new URL(expectDefined(input.streamUrl, "issued Telnyx stream URL")).pathname,
+            onUpgrade: (request, socket, head) => {
+              socket.once("data", () => frameReceived.resolve());
+              handler.handleWebSocketUpgrade(request, socket, head);
+            },
+          });
+          ws = await connectWs(server.url);
+          const closed = waitForClose(ws);
+          const admitted = Promise.race([
+            bridgeCreated.promise.then(() => "bridge" as const),
+            closed.then(() => "closed" as const),
+          ]);
+          ws.send(
+            JSON.stringify({
+              event: "start",
+              stream_id: "native-binding-stream",
+              start: { call_control_id: providerCallId },
+            }),
+          );
+          await frameReceived.promise;
+          expect(createBridge).not.toHaveBeenCalled();
+          if (outcome === "failed") {
+            write.fail();
+          } else {
+            write.release();
+          }
+          expect((await placement).success).toBe(outcome !== "failed");
+          await retirement;
+          expect(await admitted).toBe(outcome === "committed" ? "bridge" : "closed");
+          if (outcome === "committed") {
+            expect(createBridge).toHaveBeenCalledOnce();
+            expect((await findCallInStore(storePath, input.callId))?.providerCallId).toBe(
+              providerCallId,
+            );
+          } else {
+            expect(createBridge).not.toHaveBeenCalled();
+            expect(manager.getCall(input.callId)).toBeUndefined();
+          }
+          ws.terminate();
+          await closed;
+        } finally {
+          bindingWrite?.release();
+          ws?.terminate();
+          await handler.close();
+          await server?.close();
+          await placement;
+          await retirement;
+          initiate.mockRestore();
+        }
+      },
+      { provider: new FakeProvider("telnyx"), realtime: true },
+    );
+  },
+);
+
+it("keeps failed event drafts private and admits a duplicate only after rollback", async () => {
+  await withDelayedStore(async ({ manager, storePath, holdNextWrite }) => {
+    const placement = await manager.initiateCall("+15550000001");
+    const call = manager.getCall(placement.callId)!;
+    const gate = holdNextWrite();
+    const event = {
+      id: "answered-replay",
+      type: "call.answered" as const,
+      callId: call.callId,
+      providerCallId: call.providerCallId,
+      timestamp: Date.now(),
+    };
+    const first = manager.processEvent(event);
+    void first.catch(() => {});
+    await gate.entered;
+    const second = manager.processEvent({ ...event });
+    expect(manager.getCall(call.callId) === call).toBe(true);
+    expect(call.state).toBe("initiated");
+    expect(call.answeredAt).toBeUndefined();
+    expect(call.processedEventIds).not.toContain(event.id);
+    gate.fail();
+    await expect(first).rejects.toThrow("Synthetic delayed persistence failure");
+    await expect(second).resolves.toMatchObject({ kind: "processed" });
+    expect(manager.getCall(call.callId) === call).toBe(true);
+    expect(call.state).toBe("answered");
+    expect(call.processedEventIds.filter((id) => id === event.id)).toHaveLength(1);
+    resetPluginStateStoreForTests();
+    expect((await findCallInStore(storePath, call.callId))?.state).toBe("answered");
+  });
+});
+
+it("drains an admitted event on stop without starting late playback or accepting new events", async () => {
+  await withDelayedStore(async ({ manager, provider, storePath, holdNextWrite }) => {
+    const placement = await manager.initiateCall("+15550000001", undefined, {
+      mode: "notify",
+      message: "Synthetic notification",
+    });
+    const call = manager.getCall(placement.callId)!;
+    const gate = holdNextWrite();
+    const event = manager.processEvent({
+      id: "stop-during-answered",
+      type: "call.answered",
+      callId: call.callId,
+      providerCallId: call.providerCallId,
+      timestamp: Date.now(),
+    });
+    await gate.entered;
+    let stopped = false;
+    const stop = manager.stop().then(() => {
+      stopped = true;
+    });
+    await expect(
+      manager.processEvent({
+        id: "late-event",
+        type: "call.active",
+        callId: call.callId,
+        timestamp: Date.now(),
+      }),
+    ).rejects.toThrow("manager is stopping");
+    expect(stopped).toBe(false);
+    expect(provider.playTtsCalls).toHaveLength(0);
+    gate.release();
+    await event;
+    await stop;
+    expect(provider.playTtsCalls).toHaveLength(0);
+    resetPluginStateStoreForTests();
+    expect((await findCallInStore(storePath, call.callId))?.state).toBe("answered");
+  });
+});
+
+it("does not hang up a rejected inbound call after stop begins during persistence", async () => {
+  await withDelayedStore(async ({ manager, provider, holdNextWrite }) => {
+    const gate = holdNextWrite();
+    const event = manager.processEvent({
+      id: "rejected-during-stop",
+      type: "call.initiated",
+      callId: "unknown-inbound",
+      providerCallId: "provider-rejected",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15550000001",
+      to: "+15550000000",
+    });
+    await gate.entered;
+    const stopping = manager.stop();
+    gate.release();
+    await event;
+    await stopping;
+    expect(provider.hangupCalls).toHaveLength(0);
+  });
+});
+
+it("joins admitted restore checks without starting carrier work after a delayed expiry write", async () => {
+  await withDelayedStore(
+    async ({ manager, provider, storePath, holdNextWrite }) => {
+      await callStore.persistCallRecord(
+        storePath,
+        CallRecordSchema.parse(
+          makePersistedCall({
+            callId: "restored-active",
+            providerCallId: "provider-active",
+            startedAt: Date.now(),
+          }),
+        ),
+      );
+      await callStore.persistCallRecord(
+        storePath,
+        CallRecordSchema.parse(
+          makePersistedCall({
+            callId: "restored-expired",
+            providerCallId: "provider-expired",
+            startedAt: Date.now() - 400_000,
+          }),
+        ),
+      );
+      const status = createDeferred<{ isTerminal: boolean; status: string }>();
+      vi.spyOn(provider, "getCallStatus").mockImplementation(() => status.promise);
+      const gate = holdNextWrite();
+      const initialization = manager.initialize(provider, "https://fixture.invalid/voice/webhook");
+      await gate.entered;
+      let stopped = false;
+      const stopping = manager.stop().then(() => {
+        stopped = true;
+      });
+      gate.release();
+      try {
+        await expect
+          .poll(async () => (await findCallInStore(storePath, "restored-expired"))?.state)
+          .toBe("timeout");
+        expect(stopped).toBe(false);
+        expect(provider.hangupCalls).toHaveLength(0);
+      } finally {
+        status.resolve({ isTerminal: false, status: "in-progress" });
+      }
+      await initialization;
+      await stopping;
+      expect(provider.hangupCalls).toHaveLength(0);
+      expect((await findCallInStore(storePath, "restored-expired"))?.state).toBe("timeout");
+    },
+    { initialize: false },
+  );
+});
+
+it("publishes restored calls only after their missing live anchor is persisted", async () => {
+  await withDelayedStore(
+    async ({ manager, provider, storePath, holdNextWrite }) => {
+      await callStore.persistCallRecord(
+        storePath,
+        CallRecordSchema.parse(
+          makePersistedCall({
+            callId: "restored-unanchored",
+            providerCallId: "provider-unanchored",
+            startedAt: Date.now(),
+            answeredAt: undefined,
+            state: "speaking",
+          }),
+        ),
+      );
+      const gate = holdNextWrite();
+      const initialization = manager.initialize(provider, "https://fixture.invalid/voice/webhook");
+      try {
+        await gate.entered;
+        expect(manager.getActiveCalls()).toHaveLength(0);
+        expect(manager.getCallByProviderCallId("provider-unanchored")).toBeUndefined();
+      } finally {
+        gate.release();
+        await initialization;
+      }
+      expect(manager.getActiveCalls()).toHaveLength(1);
+      expect((await findCallInStore(storePath, "restored-unanchored"))?.answeredAt).toBeTypeOf(
+        "number",
+      );
+    },
+    { initialize: false },
+  );
+});
+
+it("rejects restore when terminal-state persistence fails instead of reporting a provider failure", async () => {
+  await withDelayedStore(
+    async ({ manager, provider, storePath, holdNextWrite }) => {
+      await callStore.persistCallRecord(
+        storePath,
+        CallRecordSchema.parse(
+          makePersistedCall({
+            callId: "restored-terminal",
+            providerCallId: "provider-terminal",
+            startedAt: Date.now(),
+          }),
+        ),
+      );
+      provider.getCallStatusResult = { isTerminal: true, status: "completed" };
+      const gate = holdNextWrite();
+      const initialization = manager.initialize(provider, "https://fixture.invalid/voice/webhook");
+      void initialization.catch(() => {});
+      await gate.entered;
+      gate.fail();
+      await expect(initialization).rejects.toThrow("Synthetic delayed persistence failure");
+      expect(manager.getActiveCalls()).toHaveLength(0);
+      expect((await findCallInStore(storePath, "restored-terminal"))?.state).toBe("answered");
+    },
+    { initialize: false },
+  );
+});
+
+it("observes restore write failures while awaiting another carrier", async () => {
+  await withDelayedStore(
+    async ({ manager, provider, storePath }) => {
+      await callStore.persistCallRecord(
+        storePath,
+        CallRecordSchema.parse(
+          makePersistedCall({
+            callId: "restore-terminal-first",
+            providerCallId: "provider-terminal-first",
+            startedAt: Date.now(),
+          }),
+        ),
+      );
+      await callStore.persistCallRecord(
+        storePath,
+        CallRecordSchema.parse(
+          makePersistedCall({
+            callId: "restore-expired-second",
+            providerCallId: "provider-expired-second",
+            startedAt: Date.now() - 400_000,
+          }),
+        ),
+      );
+      const persist = expectDefined(
+        vi.mocked(callStore.persistCallRecord).getMockImplementation(),
+        "native persistence observer",
+      );
+      vi.mocked(callStore.persistCallRecord).mockImplementation((directory, call) =>
+        call.callId === "restore-terminal-first" && call.state === "completed"
+          ? Promise.reject(new Error("Synthetic terminal write failed"))
+          : persist(directory, call),
+      );
+      provider.getCallStatusResult = { isTerminal: true, status: "completed" };
+      const carrierStarted = createDeferred<void>();
+      const releaseCarrier = createDeferred<void>();
+      vi.spyOn(provider, "hangupCall").mockImplementation(async () => {
+        carrierStarted.resolve();
+        await releaseCarrier.promise;
+      });
+      const unhandled: unknown[] = [];
+      const capture = (error: unknown) => {
+        unhandled.push(error);
+      };
+      process.on("unhandledRejection", capture);
+      const initialization = manager.initialize(provider, "https://fixture.invalid/voice/webhook");
+      void initialization.catch(() => {});
+      try {
+        await carrierStarted.promise;
+        // Node reports unobserved rejections between event-loop turns, before the carrier resolves.
+        await nextEventLoopTurn();
+        expect(unhandled).toEqual([]);
+      } finally {
+        releaseCarrier.resolve();
+        try {
+          await expect(initialization).rejects.toThrow("Synthetic terminal write failed");
+        } finally {
+          process.off("unhandledRejection", capture);
+        }
+      }
+    },
+    { initialize: false },
+  );
+});

--- a/extensions/voice-call/src/manager.closed-loop.test.ts
+++ b/extensions/voice-call/src/manager.closed-loop.test.ts
@@ -32,7 +32,7 @@ describe("CallManager closed-loop turns", () => {
     const started = await manager.initiateCall("+15550000003");
     expect(started.success).toBe(true);
 
-    markCallAnswered(manager, started.callId, "evt-closed-loop-answered");
+    await markCallAnswered(manager, started.callId, "evt-closed-loop-answered");
 
     const turnPromise = manager.continueCall(started.callId, "How can I help?");
     await vi.waitFor(() => {
@@ -40,7 +40,7 @@ describe("CallManager closed-loop turns", () => {
       expectTranscriptWaiter(manager, started.callId);
     });
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-closed-loop-speech",
       type: "call.speech",
       callId: started.callId,
@@ -75,14 +75,18 @@ describe("CallManager closed-loop turns", () => {
     const started = await manager.initiateCall("+15550000004");
     expect(started.success).toBe(true);
 
-    markCallAnswered(manager, started.callId, "evt-overlap-answered");
+    await markCallAnswered(manager, started.callId, "evt-overlap-answered");
 
     const first = manager.continueCall(started.callId, "First prompt");
     const second = await manager.continueCall(started.callId, "Second prompt");
     expect(second.success).toBe(false);
     expect(second.error).toBe("Already waiting for transcript");
+    await vi.waitFor(() => {
+      expect(provider.startListeningCalls).toHaveLength(1);
+      expectTranscriptWaiter(manager, started.callId);
+    });
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-overlap-speech",
       type: "call.speech",
       callId: started.callId,
@@ -110,7 +114,7 @@ describe("CallManager closed-loop turns", () => {
     const started = await manager.initiateCall("+15550000004");
     expect(started.success).toBe(true);
 
-    markCallAnswered(manager, started.callId, "evt-turn-token-answered");
+    await markCallAnswered(manager, started.callId, "evt-turn-token-answered");
 
     const turnPromise = manager.continueCall(started.callId, "Prompt");
     await vi.waitFor(() => {
@@ -120,7 +124,7 @@ describe("CallManager closed-loop turns", () => {
 
     const expectedTurnToken = requireTurnToken(provider);
 
-    const staleResult = manager.processEvent({
+    const staleResult = await manager.processEvent({
       id: "evt-turn-token-bad",
       type: "call.speech",
       callId: started.callId,
@@ -134,7 +138,7 @@ describe("CallManager closed-loop turns", () => {
 
     expectTranscriptWaiter(manager, started.callId);
 
-    const finalResult = manager.processEvent({
+    const finalResult = await manager.processEvent({
       id: "evt-turn-token-good",
       type: "call.speech",
       callId: started.callId,
@@ -166,14 +170,14 @@ describe("CallManager closed-loop turns", () => {
     const started = await manager.initiateCall("+15550000005");
     expect(started.success).toBe(true);
 
-    markCallAnswered(manager, started.callId, "evt-multi-answered");
+    await markCallAnswered(manager, started.callId, "evt-multi-answered");
 
     const firstTurn = manager.continueCall(started.callId, "First question");
     await vi.waitFor(() => {
       expect(provider.startListeningCalls).toHaveLength(1);
       expectTranscriptWaiter(manager, started.callId);
     });
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-multi-speech-1",
       type: "call.speech",
       callId: started.callId,
@@ -189,7 +193,7 @@ describe("CallManager closed-loop turns", () => {
       expect(provider.startListeningCalls).toHaveLength(2);
       expectTranscriptWaiter(manager, started.callId);
     });
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-multi-speech-2",
       type: "call.speech",
       callId: started.callId,
@@ -225,7 +229,7 @@ describe("CallManager closed-loop turns", () => {
     const started = await manager.initiateCall("+15550000006");
     expect(started.success).toBe(true);
 
-    markCallAnswered(manager, started.callId, "evt-loop-answered");
+    await markCallAnswered(manager, started.callId, "evt-loop-answered");
 
     for (let i = 1; i <= 5; i++) {
       const turnPromise = manager.continueCall(started.callId, `Prompt ${i}`);
@@ -233,7 +237,7 @@ describe("CallManager closed-loop turns", () => {
         expect(provider.startListeningCalls).toHaveLength(i);
         expectTranscriptWaiter(manager, started.callId);
       });
-      manager.processEvent({
+      await manager.processEvent({
         id: `evt-loop-speech-${i}`,
         type: "call.speech",
         callId: started.callId,

--- a/extensions/voice-call/src/manager.inbound-allowlist.test.ts
+++ b/extensions/voice-call/src/manager.inbound-allowlist.test.ts
@@ -9,7 +9,7 @@ describe("CallManager inbound allowlist", () => {
       allowFrom: ["+15550001234"],
     });
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-allowlist-missing",
       type: "call.initiated",
       callId: "call-missing",
@@ -30,7 +30,7 @@ describe("CallManager inbound allowlist", () => {
       allowFrom: ["+15550001234"],
     });
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-allowlist-anon",
       type: "call.initiated",
       callId: "call-anon",
@@ -52,7 +52,7 @@ describe("CallManager inbound allowlist", () => {
       allowFrom: ["+15550001234"],
     });
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-allowlist-suffix",
       type: "call.initiated",
       callId: "call-suffix",
@@ -73,7 +73,7 @@ describe("CallManager inbound allowlist", () => {
       inboundPolicy: "disabled",
     });
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-reject-init",
       type: "call.initiated",
       callId: "provider-dup",
@@ -84,7 +84,7 @@ describe("CallManager inbound allowlist", () => {
       to: "+15550000000",
     });
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-reject-ring",
       type: "call.ringing",
       callId: "provider-dup",
@@ -121,7 +121,7 @@ describe("CallManager inbound allowlist", () => {
       provider,
     );
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-reject-fail-init",
       type: "call.initiated",
       callId: "provider-flaky",
@@ -133,7 +133,7 @@ describe("CallManager inbound allowlist", () => {
     });
     await Promise.resolve();
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-reject-fail-ring",
       type: "call.ringing",
       callId: "provider-flaky",
@@ -158,7 +158,7 @@ describe("CallManager inbound allowlist", () => {
       allowFrom: ["+15550001234"],
     });
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-allowlist-exact",
       type: "call.initiated",
       callId: "call-exact",

--- a/extensions/voice-call/src/manager.lifecycle.test.ts
+++ b/extensions/voice-call/src/manager.lifecycle.test.ts
@@ -56,10 +56,10 @@ describe("CallManager termination lifecycle", () => {
         new FakeProvider(providerName),
       );
       const managers = [manager];
-      onTestFinished(() => {
+      onTestFinished(async () => {
         try {
           for (const owner of managers) {
-            finalizeTestManagerCalls(owner);
+            await finalizeTestManagerCalls(owner);
           }
         } finally {
           resetPluginStateStoreForTests();
@@ -104,7 +104,7 @@ describe("CallManager termination lifecycle", () => {
         }
         return event;
       };
-      manager.processEvent(callback(initialProviderId, "in-progress", true));
+      await manager.processEvent(callback(initialProviderId, "in-progress", true));
       await expect(
         manager.speak(started.callId, "Preserve this call transcript."),
       ).resolves.toEqual({
@@ -136,7 +136,7 @@ describe("CallManager termination lifecycle", () => {
         providerName === "plivo" ? "ringing" : "completed",
         providerName === "twilio",
       );
-      expect(current.processEvent(late).kind).not.toBe("final-speech");
+      expect((await current.processEvent(late)).kind).not.toBe("final-speech");
 
       const history = await current.getCallHistory();
       expect(new Set(history.map((call) => call.callId))).toEqual(new Set([started.callId]));
@@ -159,7 +159,7 @@ describe("CallManager termination lifecycle", () => {
     try {
       expect(provider.attempts).toHaveLength(1);
 
-      manager.processEvent({
+      await manager.processEvent({
         id: "provider-terminal",
         type: "call.ended",
         callId: call.callId,

--- a/extensions/voice-call/src/manager.notify.test.ts
+++ b/extensions/voice-call/src/manager.notify.test.ts
@@ -107,7 +107,7 @@ async function answerCall(
   eventId: string,
   providerCallId = "call-uuid",
 ) {
-  manager.processEvent({
+  await manager.processEvent({
     id: eventId,
     type: "call.answered",
     callId,
@@ -147,7 +147,7 @@ describe("CallManager notify and mapping", () => {
       );
       const callId = await initiateCallWithMessage(manager, "+15550000014", "Notify", "notify");
 
-      manager.processEvent({
+      await manager.processEvent({
         id: "evt-notify-failed-hangup",
         type: "call.answered",
         callId,
@@ -178,7 +178,7 @@ describe("CallManager notify and mapping", () => {
     expect(requireCall(manager, callId).providerCallId).toBe("request-uuid");
     expect(requireMappedCall(manager, "request-uuid").callId).toBe(callId);
 
-    manager.processEvent({
+    await manager.processEvent({
       id: "evt-1",
       type: "call.answered",
       callId,

--- a/extensions/voice-call/src/manager.restore.test.ts
+++ b/extensions/voice-call/src/manager.restore.test.ts
@@ -1,6 +1,6 @@
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
-  createPluginStateSyncKeyedStoreForTests,
+  createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 // Voice Call tests cover manager.restore plugin behavior.
@@ -23,11 +23,8 @@ function installStateRuntime(): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
-      openKeyedStore: (() => {
-        throw new Error("openKeyedStore is not used by voice-call restore tests");
-      }) as never,
-      openSyncKeyedStore: (options: OpenKeyedStoreOptions) =>
-        createPluginStateSyncKeyedStoreForTests("voice-call", options),
+      openKeyedStore: (options: OpenKeyedStoreOptions) =>
+        createPluginStateKeyedStoreForTests("voice-call", options),
       openChannelIngressQueue: (() => {
         throw new Error("openChannelIngressQueue is not used by voice-call restore tests");
       }) as never,
@@ -76,7 +73,7 @@ describe("CallManager verification on restore", () => {
   }) {
     const storePath = createTestStorePath();
     const call = makePersistedCall(params?.callOverrides);
-    writeCallsToStore(storePath, [call]);
+    await writeCallsToStore(storePath, [call]);
 
     const provider = new FakeProvider();
     if (params?.providerResult) {
@@ -122,7 +119,7 @@ describe("CallManager verification on restore", () => {
 
   it("prefers active provider state before persisted fallback", async () => {
     const storePath = createTestStorePath();
-    writeCallsToStore(storePath, [
+    await writeCallsToStore(storePath, [
       makePersistedCall({
         callId: "call-target",
         providerCallId: "provider-completed",
@@ -183,7 +180,7 @@ describe("CallManager verification on restore", () => {
     const hangupCall = requireSingleHangupCall(provider);
     expect(hangupCall.reason).toBe("timeout");
 
-    expect(loadActiveCallsFromStore(storePath).activeCalls.size).toBe(0);
+    expect((await loadActiveCallsFromStore(storePath)).activeCalls.size).toBe(0);
   });
 
   it("skips calls without providerCallId", async () => {
@@ -269,7 +266,7 @@ describe("CallManager verification on restore", () => {
         answeredAt: undefined,
       }),
     ];
-    writeCallsToStore(storePath, calls);
+    await writeCallsToStore(storePath, calls);
 
     const provider = new FakeProvider();
     provider.getCallStatus = async ({ providerCallId }) => {
@@ -374,7 +371,7 @@ describe("CallManager verification on restore", () => {
       expect(activeCall.state).toBe(state);
       expect(activeCall.answeredAt).toBe(startedAt);
       expect(
-        loadActiveCallsFromStore(storePath).activeCalls.get(activeCall.callId)?.answeredAt,
+        (await loadActiveCallsFromStore(storePath)).activeCalls.get(activeCall.callId)?.answeredAt,
       ).toBe(startedAt);
 
       await vi.advanceTimersByTimeAsync(9_000);
@@ -400,7 +397,7 @@ describe("CallManager verification on restore", () => {
       endReason: "completed",
       processedEventIds: replayKeys,
     });
-    writeCallsToStore(storePath, [persisted]);
+    await writeCallsToStore(storePath, [persisted]);
 
     const provider = new FakeProvider();
     const config = VoiceCallConfigSchema.parse({
@@ -411,7 +408,7 @@ describe("CallManager verification on restore", () => {
     const manager = registerTestManagerCleanup(new CallManager(config, storePath));
     await manager.initialize(provider, "https://example.com/voice/webhook");
 
-    manager.processEvent({
+    await manager.processEvent({
       id: replayKeys.at(-1) as string,
       type: "call.initiated",
       callId: String(persisted.providerCallId),
@@ -424,7 +421,7 @@ describe("CallManager verification on restore", () => {
 
     expect(manager.getActiveCalls()).toHaveLength(0);
 
-    manager.processEvent({
+    await manager.processEvent({
       id: replayKeys[0] as string,
       type: "call.initiated",
       callId: String(persisted.providerCallId),

--- a/extensions/voice-call/src/manager.test-harness.test.ts
+++ b/extensions/voice-call/src/manager.test-harness.test.ts
@@ -64,9 +64,9 @@ it("finalizes each fixture's calls and destroys its real duration and transcript
     const started = await fixture.manager.initiateCall("+15550000001");
     expect(started.success).toBe(true);
     callIds.push(started.callId);
-    ownership.run("duration", () => {
-      markCallAnswered(fixture.manager, started.callId, `answered-${index}`);
-    });
+    await ownership.run("duration", () =>
+      markCallAnswered(fixture.manager, started.callId, `answered-${index}`),
+    );
     if (index === 0) {
       turns.push(
         ownership.run("transcript", () =>

--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -3,9 +3,10 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
-  createPluginStateSyncKeyedStoreForTests,
+  createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { onTestFinished } from "vitest";
@@ -89,11 +90,8 @@ export function createTestStorePath(): string {
 function createVoiceCallStateRuntimeForTests(): VoiceCallStateRuntime["state"] {
   return {
     resolveStateDir: () => "",
-    openKeyedStore: (() => {
-      throw new Error("openKeyedStore is not used by voice-call manager tests");
-    }) as VoiceCallStateRuntime["state"]["openKeyedStore"],
-    openSyncKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
-      createPluginStateSyncKeyedStoreForTests<T>("voice-call", options),
+    openKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
+      createPluginStateKeyedStoreForTests<T>("voice-call", options),
     openChannelIngressQueue: (() => {
       throw new Error("openChannelIngressQueue is not used by voice-call manager tests");
     }) as VoiceCallStateRuntime["state"]["openChannelIngressQueue"],
@@ -107,13 +105,13 @@ function installVoiceCallStateRuntimeForTests(): void {
   setVoiceCallStateRuntime({ state: createVoiceCallStateRuntimeForTests() });
 }
 
-export function finalizeTestManagerCalls(manager: CallManager): void {
+export async function finalizeTestManagerCalls(manager: CallManager): Promise<void> {
   const errors: unknown[] = [];
   for (const call of manager.getActiveCalls()) {
     try {
       // Synthetic carrier completion retires fixture timers/waiters even when
       // its fake hangup deliberately fails. Provider work must be joined first.
-      manager.processEvent({
+      await manager.processEvent({
         id: randomUUID(),
         type: "call.ended",
         callId: call.callId,
@@ -158,8 +156,12 @@ export async function createManagerHarness(
   return { manager, provider, storePath };
 }
 
-export function markCallAnswered(manager: CallManager, callId: string, eventId: string): void {
-  manager.processEvent({
+export async function markCallAnswered(
+  manager: CallManager,
+  callId: string,
+  eventId: string,
+): Promise<void> {
+  await manager.processEvent({
     id: eventId,
     type: "call.answered",
     callId,
@@ -168,10 +170,13 @@ export function markCallAnswered(manager: CallManager, callId: string, eventId: 
   });
 }
 
-export function writeCallsToStore(storePath: string, calls: Record<string, unknown>[]): void {
+export async function writeCallsToStore(
+  storePath: string,
+  calls: Record<string, unknown>[],
+): Promise<void> {
   fs.mkdirSync(storePath, { recursive: true });
   for (const call of calls) {
-    persistCallRecord(storePath, CallRecordSchema.parse(call));
+    await persistCallRecord(storePath, CallRecordSchema.parse(call));
   }
 }
 
@@ -205,19 +210,17 @@ export const EVENT_MANAGER_REPLAY_KEY_LIMIT = 10_000;
 
 export function createEventManagerHarness() {
   const contexts: CallManagerContext[] = [];
+  const pendingWork = new Set<Promise<unknown>>();
 
   function installStateRuntime(shouldFail?: () => boolean): void {
     setVoiceCallStateRuntime({
       state: {
         resolveStateDir: () => "",
-        openKeyedStore: (() => {
-          throw new Error("openKeyedStore is not used by voice-call event tests");
-        }) as never,
-        openSyncKeyedStore: (options: OpenKeyedStoreOptions) => {
+        openKeyedStore: (options: OpenKeyedStoreOptions) => {
           if (shouldFail?.()) {
             throw new Error("synthetic SQLite persistence failure");
           }
-          return createPluginStateSyncKeyedStoreForTests("voice-call", options);
+          return createPluginStateKeyedStoreForTests("voice-call", options);
         },
         openChannelIngressQueue: (() => {
           throw new Error("openChannelIngressQueue is not used by voice-call event tests");
@@ -234,16 +237,27 @@ export function createEventManagerHarness() {
     installStateRuntime();
   }
 
-  function cleanup(): void {
-    for (const ctx of contexts.splice(0)) {
+  async function cleanup(): Promise<void> {
+    const ownedContexts = contexts.splice(0);
+    for (const ctx of ownedContexts) {
       for (const timer of ctx.maxDurationTimers.values()) {
         clearTimeout(timer);
       }
       ctx.maxDurationTimers.clear();
+      for (const timer of ctx.notifyHangupTimers.values()) {
+        clearTimeout(timer);
+      }
+      ctx.notifyHangupTimers.clear();
       for (const waiter of ctx.transcriptWaiters.values()) {
         clearTimeout(waiter.timeout);
+        waiter.reject(new Error("Voice-call test finished"));
       }
       ctx.transcriptWaiters.clear();
+    }
+    while (pendingWork.size > 0) {
+      await Promise.allSettled(pendingWork);
+    }
+    for (const ctx of ownedContexts) {
       fs.rmSync(ctx.storePath, { recursive: true, force: true });
     }
     resetPluginStateStoreForTests();
@@ -269,6 +283,15 @@ export function createEventManagerHarness() {
       transcriptWaiters: new Map(),
       maxDurationTimers: new Map(),
       initialMessageInFlight: new Set(),
+      notifyHangupTimers: new Map(),
+      isStopping: () => false,
+      mutationQueue: new KeyedAsyncQueue(),
+      pendingCallAdmissions: new Set(),
+      trackCallWork(work) {
+        pendingWork.add(work);
+        const remove = () => pendingWork.delete(work);
+        void work.then(remove, remove);
+      },
       ...overrides,
     };
     contexts.push(ctx);

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -1,6 +1,7 @@
 // Voice Call plugin module implements manager behavior.
 import fs from "node:fs";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { VoiceCallConfig, VoiceCallCoreSessionConfig } from "./config.js";
 import type { CallEndResult, CallManagerContext, StreamSessionIssuer } from "./manager/context.js";
@@ -90,6 +91,89 @@ export class CallManager {
   private maxDurationTimers = new Map<CallId, NodeJS.Timeout>();
   private initialMessageInFlight = new Set<CallId>();
   private autoResponseOwners = new WeakMap<CallRecord, symbol>();
+  private readonly mutationQueue = new KeyedAsyncQueue();
+  private readonly pendingCallAdmissions = new Set<CallId>();
+  private readonly pendingWork = new Set<Promise<unknown>>();
+  private readonly notifyHangupTimers = new Map<CallId, NodeJS.Timeout>();
+  private initialization: Promise<void> | null = null;
+  private closing = false;
+  private stopPromise: Promise<void> | null = null;
+
+  private trackCallWork = (work: Promise<unknown>): void => {
+    this.pendingWork.add(work);
+    const settled = () => this.pendingWork.delete(work);
+    void work.then(settled, settled);
+  };
+
+  private runOperation<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.closing) {
+      return Promise.reject(new Error("Voice Call manager is stopping"));
+    }
+    const pending = this.initialization
+      ? this.initialization.then(() => {
+          if (this.closing) {
+            throw new Error("Voice Call manager is stopping");
+          }
+          return operation();
+        })
+      : operation();
+    this.trackCallWork(pending);
+    return pending;
+  }
+
+  /** Stop is owned by runtime shutdown, after webhook and stream producers have closed. */
+  stop(): Promise<void> {
+    if (this.stopPromise) {
+      return this.stopPromise;
+    }
+    this.closing = true;
+    for (const timers of [this.maxDurationTimers, this.notifyHangupTimers]) {
+      for (const timer of timers.values()) {
+        clearTimeout(timer);
+      }
+      timers.clear();
+    }
+    for (const waiter of this.transcriptWaiters.values()) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(new Error("Voice Call runtime stopped"));
+    }
+    this.transcriptWaiters.clear();
+    this.stopPromise = (async () => {
+      const failures: unknown[] = [];
+      while (this.pendingWork.size > 0) {
+        const results = await Promise.allSettled(this.pendingWork);
+        for (const result of results) {
+          if (result.status === "rejected") {
+            failures.push(result.reason);
+          }
+        }
+      }
+      for (const timers of [this.maxDurationTimers, this.notifyHangupTimers]) {
+        for (const timer of timers.values()) {
+          clearTimeout(timer);
+        }
+        timers.clear();
+      }
+      if (failures.length > 0) {
+        throw new AggregateError(failures, "Voice Call work failed during shutdown");
+      }
+    })();
+    return this.stopPromise;
+  }
+
+  /** Serialize transient metadata with persisted updates without adding event-store writes. */
+  updateCallMetadata(
+    call: CallRecord,
+    update: (metadata: CallRecord["metadata"]) => CallRecord["metadata"],
+  ): Promise<void> {
+    return this.runOperation(() =>
+      this.mutationQueue.enqueue("state", async () => {
+        if (this.activeCalls.get(call.callId) === call && !TerminalStates.has(call.state)) {
+          call.metadata = update(call.metadata ? { ...call.metadata } : undefined);
+        }
+      }),
+    );
+  }
 
   /**
    * Carrier-side stream session issuer. Wired by the runtime when realtime is
@@ -112,28 +196,45 @@ export class CallManager {
    * Initialize the call manager with a provider.
    * Verifies persisted calls with the provider and restarts timers.
    */
-  async initialize(provider: VoiceCallProvider, webhookUrl: string): Promise<void> {
+  initialize(provider: VoiceCallProvider, webhookUrl: string): Promise<void> {
+    if (this.closing) {
+      return Promise.reject(new Error("Voice Call manager is stopping"));
+    }
+    const pending = this.initializeFromStore(provider, webhookUrl);
+    this.initialization = pending;
+    this.trackCallWork(pending);
+    void pending.then(
+      () => {
+        if (this.initialization === pending) {
+          this.initialization = null;
+        }
+      },
+      () => {},
+    );
+    return pending;
+  }
+
+  private async initializeFromStore(
+    provider: VoiceCallProvider,
+    webhookUrl: string,
+  ): Promise<void> {
     this.provider = provider;
     this.webhookUrl = webhookUrl;
 
     fs.mkdirSync(this.storePath, { recursive: true });
 
-    const persisted = loadActiveCallsFromStore(this.storePath);
+    const persisted = await loadActiveCallsFromStore(this.storePath);
+    if (this.closing) {
+      return;
+    }
     this.processedEventIds = persisted.processedEventIds;
     this.rejectedProviderCallIds = new Map();
 
     const verified = await this.verifyRestoredCalls(provider, persisted.activeCalls);
-    this.activeCalls = verified;
-
-    // Rebuild providerCallIdMap from verified calls only
-    this.providerCallIdMap = new Map();
-    for (const [callId, call] of verified) {
-      if (call.providerCallId) {
-        this.providerCallIdMap.set(call.providerCallId, callId);
-      }
+    if (this.closing) {
+      return;
     }
-
-    // Restart max-duration timers for restored calls that are past the answered/live state.
+    const timers: Array<{ callId: CallId; deadline: number }> = [];
     let skippedAlreadyElapsedTimers = 0;
     for (const [callId, call] of verified) {
       const maxDurationAnchor = resolveRestoredMaxDurationAnchor(call);
@@ -143,9 +244,6 @@ export class CallManager {
         if (elapsed >= maxDurationMs) {
           // Already expired — remove instead of keeping
           verified.delete(callId);
-          if (call.providerCallId) {
-            this.providerCallIdMap.delete(call.providerCallId);
-          }
           skippedAlreadyElapsedTimers += 1;
           continue;
         }
@@ -153,16 +251,30 @@ export class CallManager {
           // Twilio streams can restore directly in speaking/listening without an
           // answered webhook; anchoring at startedAt preserves bounded duration.
           call.answeredAt = maxDurationAnchor;
-          persistCallRecord(this.storePath, call);
+          await persistCallRecord(this.storePath, call);
         }
-        startMaxDurationTimer({
-          ctx: this.getContext(),
-          callId,
-          timeoutMs: maxDurationMs - elapsed,
-          onTimeout: (id) => this.endCall(id, { reason: "timeout" }),
-        });
-        console.log(`[voice-call] Restarted max-duration timer for restored call ${callId}`);
+        if (this.closing) {
+          return;
+        }
+        timers.push({ callId, deadline: maxDurationAnchor + maxDurationMs });
       }
+    }
+    // Publish one restored view after every required write has completed.
+    this.activeCalls = verified;
+    this.providerCallIdMap = new Map();
+    for (const [callId, call] of verified) {
+      if (call.providerCallId) {
+        this.providerCallIdMap.set(call.providerCallId, callId);
+      }
+    }
+    for (const { callId, deadline } of timers) {
+      startMaxDurationTimer({
+        ctx: this.getContext(),
+        callId,
+        timeoutMs: Math.max(0, deadline - Date.now()),
+        onTimeout: (id) => this.endCall(id, { reason: "timeout" }),
+      });
+      console.log(`[voice-call] Restarted max-duration timer for restored call ${callId}`);
     }
     if (skippedAlreadyElapsedTimers > 0) {
       console.log(
@@ -191,7 +303,7 @@ export class CallManager {
     const maxAgeMs = resolveVoiceCallSecondsTimerDelayMs(this.config.maxDurationSeconds);
     const now = Date.now();
     const verified = new Map<CallId, CallRecord>();
-    const verifyTasks: Array<{ callId: CallId; call: CallRecord; promise: Promise<void> }> = [];
+    const verifyTasks: Promise<void>[] = [];
     let skippedNoProviderCallId = 0;
     let skippedOlderThanMaxDuration = 0;
     const skippedTerminalStatuses = new Map<string, number>();
@@ -199,43 +311,47 @@ export class CallManager {
     let keptUnknownProviderStatus = 0;
     let keptVerificationFailures = 0;
 
-    for (const [callId, call] of candidates) {
-      // Skip calls without a provider ID — can't verify
-      if (!call.providerCallId) {
-        skippedNoProviderCallId += 1;
-        continue;
-      }
+    let admissionFailure: { error: unknown } | undefined;
+    try {
+      for (const [callId, call] of candidates) {
+        if (this.closing) {
+          break;
+        }
+        // Skip calls without a provider ID — can't verify
+        if (!call.providerCallId) {
+          skippedNoProviderCallId += 1;
+          continue;
+        }
 
-      // Skip calls older than maxDurationSeconds (time-based fallback)
-      if (now - call.startedAt > maxAgeMs) {
-        skippedOlderThanMaxDuration += 1;
-        markRestoredCallSkipped(call, "timeout");
-        persistCallRecord(this.storePath, call);
-        await provider
-          .hangupCall({
-            callId,
-            providerCallId: call.providerCallId,
-            reason: "timeout",
-          })
-          .catch((err: unknown) => {
-            console.warn(
-              `[voice-call] Failed to hang up expired restored call ${callId}:`,
-              err instanceof Error ? err.message : String(err),
-            );
-          });
-        continue;
-      }
+        // Skip calls older than maxDurationSeconds (time-based fallback)
+        if (now - call.startedAt > maxAgeMs) {
+          skippedOlderThanMaxDuration += 1;
+          markRestoredCallSkipped(call, "timeout");
+          await persistCallRecord(this.storePath, call);
+          if (this.closing) {
+            break;
+          }
+          await provider
+            .hangupCall({
+              callId,
+              providerCallId: call.providerCallId,
+              reason: "timeout",
+            })
+            .catch((err: unknown) => {
+              console.warn(
+                `[voice-call] Failed to hang up expired restored call ${callId}:`,
+                err instanceof Error ? err.message : String(err),
+              );
+            });
+          continue;
+        }
 
-      const task = {
-        callId,
-        call,
-        promise: provider
-          .getCallStatus({ providerCallId: call.providerCallId })
-          .then((result) => {
+        const task = provider.getCallStatus({ providerCallId: call.providerCallId }).then(
+          async (result) => {
             if (result.isTerminal) {
               incrementRestoreStatusCount(skippedTerminalStatuses, result.status);
               markRestoredCallSkipped(call, "completed");
-              persistCallRecord(this.storePath, call);
+              await persistCallRecord(this.storePath, call);
             } else if (result.isUnknown) {
               keptUnknownProviderStatus += 1;
               verified.set(callId, call);
@@ -243,17 +359,29 @@ export class CallManager {
               keptVerifiedActive += 1;
               verified.set(callId, call);
             }
-          })
-          .catch(() => {
-            // Verification failed entirely — keep the call, rely on timer
+          },
+          () => {
+            // A failed provider check keeps the call; failed persistence still rejects restore.
             keptVerificationFailures += 1;
             verified.set(callId, call);
-          }),
-      };
-      verifyTasks.push(task);
+          },
+        );
+        // Later calls can await carrier work before the final drain observes this task.
+        void task.catch(() => {});
+        verifyTasks.push(task);
+      }
+    } catch (error) {
+      admissionFailure = { error };
     }
-
-    await Promise.allSettled(verifyTasks.map((t) => t.promise));
+    const outcomes = await Promise.allSettled(verifyTasks);
+    if (admissionFailure) {
+      throw admissionFailure.error;
+    }
+    for (const outcome of outcomes) {
+      if (outcome.status === "rejected") {
+        throw outcome.reason;
+      }
+    }
     if (skippedNoProviderCallId > 0) {
       console.log(
         `[voice-call] Skipped ${skippedNoProviderCallId} restored call(s) with no providerCallId`,
@@ -302,7 +430,9 @@ export class CallManager {
     sessionKey?: string,
     options?: OutboundCallOptions | string,
   ): Promise<{ callId: CallId; success: boolean; error?: string }> {
-    return initiateCallWithContext(this.getContext(), to, sessionKey, options);
+    return this.runOperation(() =>
+      initiateCallWithContext(this.getContext(), to, sessionKey, options),
+    );
   }
 
   /**
@@ -313,21 +443,23 @@ export class CallManager {
     text: string,
     options?: SpeakOptions,
   ): Promise<{ success: boolean; error?: string }> {
-    return speakWithContext(this.getContext(), callId, text, options);
+    return this.runOperation(() => speakWithContext(this.getContext(), callId, text, options));
   }
 
   /**
    * Send DTMF digits to an active call.
    */
   async sendDtmf(callId: CallId, digits: string): Promise<{ success: boolean; error?: string }> {
-    return sendDtmfWithContext(this.getContext(), callId, digits);
+    return this.runOperation(() => sendDtmfWithContext(this.getContext(), callId, digits));
   }
 
   /**
    * Speak the initial message for a call (called when media stream connects).
    */
   async speakInitialMessage(providerCallId: string): Promise<void> {
-    return speakInitialMessageWithContext(this.getContext(), providerCallId);
+    return this.runOperation(() =>
+      speakInitialMessageWithContext(this.getContext(), providerCallId),
+    );
   }
 
   /**
@@ -337,18 +469,23 @@ export class CallManager {
     callId: CallId,
     prompt: string,
   ): Promise<{ success: boolean; transcript?: string; error?: string }> {
-    return continueCallWithContext(this.getContext(), callId, prompt);
+    return this.runOperation(() => continueCallWithContext(this.getContext(), callId, prompt));
   }
 
   /**
    * End an active call.
    */
   endCall(callId: CallId, options?: { reason?: EndReason }): Promise<CallEndResult> {
-    return endCallWithContext(this.getContext(), callId, options);
+    return this.runOperation(() => endCallWithContext(this.getContext(), callId, options));
   }
 
   private getContext(): CallManagerContext {
     return {
+      mutationQueue: this.mutationQueue,
+      pendingCallAdmissions: this.pendingCallAdmissions,
+      trackCallWork: this.trackCallWork,
+      isStopping: () => this.closing,
+      notifyHangupTimers: this.notifyHangupTimers,
       activeCalls: this.activeCalls,
       providerCallIdMap: this.providerCallIdMap,
       processedEventIds: this.processedEventIds,
@@ -374,8 +511,8 @@ export class CallManager {
   /**
    * Process a webhook event.
    */
-  processEvent(event: NormalizedEvent): ProcessEventResult {
-    return processManagerEvent(this.getContext(), event);
+  processEvent(event: NormalizedEvent): Promise<ProcessEventResult> {
+    return this.runOperation(() => processManagerEvent(this.getContext(), event));
   }
 
   createAutoResponseGuard(call: CallRecord): { isCurrent: () => boolean; release: () => void } {
@@ -385,6 +522,7 @@ export class CallManager {
     this.autoResponseOwners.set(call, owner);
     return {
       isCurrent: () =>
+        !this.closing &&
         this.activeCalls.get(call.callId) === call &&
         !TerminalStates.has(call.state) &&
         this.autoResponseOwners.get(call) === owner,
@@ -457,6 +595,15 @@ export class CallManager {
     return this.activeCalls.get(callId);
   }
 
+  /** Await admitted identity updates before resolving a token-bound stream's active call. */
+  getCallForStream(callId: CallId): Promise<CallRecord | undefined> {
+    return this.runOperation(() =>
+      this.mutationQueue.enqueue("state", async () =>
+        this.closing ? undefined : this.activeCalls.get(callId),
+      ),
+    );
+  }
+
   /**
    * Get an active call by provider call ID (e.g., Twilio CallSid).
    */
@@ -481,13 +628,13 @@ export class CallManager {
     if (active) {
       return active;
     }
-    return findCallInStore(this.storePath, callId);
+    return this.runOperation(() => findCallInStore(this.storePath, callId));
   }
 
   /**
    * Get call history (from persisted logs).
    */
   async getCallHistory(limit = 50): Promise<CallRecord[]> {
-    return getCallHistoryFromStore(this.storePath, limit);
+    return this.runOperation(() => getCallHistoryFromStore(this.storePath, limit));
   }
 }

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -1,3 +1,4 @@
+import type { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 // Voice Call plugin module implements context behavior.
 import type { VoiceCallConfig, VoiceCallCoreSessionConfig } from "../config.js";
 import type { VoiceCallProvider } from "../providers/base.js";
@@ -29,10 +30,15 @@ type CallManagerRuntimeDeps = {
 };
 
 type CallManagerTransientState = {
+  mutationQueue: KeyedAsyncQueue;
+  pendingCallAdmissions: Set<CallId>;
+  trackCallWork: (work: Promise<unknown>) => void;
+  isStopping: () => boolean;
   activeTurnCalls: Set<CallId>;
   endCallOperations: Map<CallId, Promise<CallEndResult>>;
   transcriptWaiters: Map<CallId, TranscriptWaiter>;
   maxDurationTimers: Map<CallId, NodeJS.Timeout>;
+  notifyHangupTimers: Map<CallId, NodeJS.Timeout>;
   initialMessageInFlight: Set<CallId>;
 };
 

--- a/extensions/voice-call/src/manager/events.inbound.test.ts
+++ b/extensions/voice-call/src/manager/events.inbound.test.ts
@@ -24,14 +24,12 @@ beforeEach(() => {
   setup();
 });
 
-afterEach(() => {
-  cleanup();
-});
+afterEach(cleanup);
 
 describe("processEvent (functional inbound calls)", () => {
   it.each(["created", "rejected"] as const)(
     "does not publish %s inbound calls before SQLite persistence succeeds",
-    (kind) => {
+    async (kind) => {
       let failPersistence = true;
       installStateRuntime(() => failPersistence);
       const { ctx, hangupCalls } = createRejectingInboundContext();
@@ -42,7 +40,9 @@ describe("processEvent (functional inbound calls)", () => {
         from: "+15550000002",
       });
 
-      expect(() => processEvent(ctx, event)).toThrow("synthetic SQLite persistence failure");
+      await expect(processEvent(ctx, event)).rejects.toThrow(
+        "synthetic SQLite persistence failure",
+      );
       expect(ctx.activeCalls.size).toBe(0);
       expect(ctx.providerCallIdMap.size).toBe(0);
       expect(ctx.rejectedProviderCallIds.size).toBe(0);
@@ -50,13 +50,13 @@ describe("processEvent (functional inbound calls)", () => {
       expect(hangupCalls).toHaveLength(0);
 
       failPersistence = false;
-      expect(processEvent(ctx, event)).toEqual({ kind: "processed" });
+      expect(await processEvent(ctx, event)).toEqual({ kind: "processed" });
       expect(ctx.activeCalls.size).toBe(kind === "created" ? 1 : 0);
       expect(hangupCalls).toHaveLength(kind === "rejected" ? 1 : 0);
     },
   );
 
-  it("calls provider hangup when rejecting inbound call", () => {
+  it("calls provider hangup when rejecting inbound call", async () => {
     const { ctx, hangupCalls } = createRejectingInboundContext();
     const event = createInboundInitiatedEvent({
       id: "evt-1",
@@ -64,7 +64,7 @@ describe("processEvent (functional inbound calls)", () => {
       from: "+15559999999",
     });
 
-    processEvent(ctx, event);
+    await processEvent(ctx, event);
 
     expect(ctx.activeCalls.size).toBe(0);
     expect(hangupCalls).toHaveLength(1);
@@ -75,7 +75,7 @@ describe("processEvent (functional inbound calls)", () => {
     });
   });
 
-  it("does not call hangup when provider is null", () => {
+  it("does not call hangup when provider is null", async () => {
     const ctx = createContext({
       config: createInboundDisabledConfig(),
       provider: null,
@@ -86,12 +86,12 @@ describe("processEvent (functional inbound calls)", () => {
       from: "+15551111111",
     });
 
-    processEvent(ctx, event);
+    await processEvent(ctx, event);
 
     expect(ctx.activeCalls.size).toBe(0);
   });
 
-  it("calls hangup only once for duplicate events for same rejected call", () => {
+  it("calls hangup only once for duplicate events for same rejected call", async () => {
     const { ctx, hangupCalls } = createRejectingInboundContext();
     const event1 = createInboundInitiatedEvent({
       id: "evt-init",
@@ -109,8 +109,8 @@ describe("processEvent (functional inbound calls)", () => {
       to: "+15550000000",
     };
 
-    processEvent(ctx, event1);
-    processEvent(ctx, event2);
+    await processEvent(ctx, event1);
+    await processEvent(ctx, event2);
 
     expect(ctx.activeCalls.size).toBe(0);
     expect(hangupCalls).toEqual([
@@ -122,7 +122,7 @@ describe("processEvent (functional inbound calls)", () => {
     ]);
   });
 
-  it("answers accepted inbound calls when the provider requires an answer command", () => {
+  it("answers accepted inbound calls when the provider requires an answer command", async () => {
     const answerCalls: AnswerCallInput[] = [];
     const provider = createProvider({
       answerCall: async (input: AnswerCallInput): Promise<void> => {
@@ -149,7 +149,7 @@ describe("processEvent (functional inbound calls)", () => {
       from: "+15552222222",
     });
 
-    processEvent(ctx, event);
+    await processEvent(ctx, event);
 
     const call = requireFirstActiveCall(ctx);
     expect(answerCalls).toEqual([
@@ -160,7 +160,7 @@ describe("processEvent (functional inbound calls)", () => {
     ]);
   });
 
-  it("removes active call even when hangup rejects", () => {
+  it("removes active call even when hangup rejects", async () => {
     const provider = createProvider({
       hangupCall: async (): Promise<void> => {
         throw new Error("provider down");
@@ -176,11 +176,11 @@ describe("processEvent (functional inbound calls)", () => {
       from: "+15553333333",
     });
 
-    processEvent(ctx, event);
+    await processEvent(ctx, event);
     expect(ctx.activeCalls.size).toBe(0);
   });
 
-  it("preserves inbound direction for auto-registered inbound calls", () => {
+  it("preserves inbound direction for auto-registered inbound calls", async () => {
     const ctx = createContext({
       config: VoiceCallConfigSchema.parse({
         enabled: true,
@@ -200,7 +200,7 @@ describe("processEvent (functional inbound calls)", () => {
       to: "+15550000000",
     };
 
-    processEvent(ctx, event);
+    await processEvent(ctx, event);
 
     expect(ctx.activeCalls.size).toBe(1);
     const call = requireFirstActiveCall(ctx);
@@ -220,7 +220,7 @@ describe("processEvent (functional inbound calls)", () => {
     },
   ])(
     "assigns $sessionScope session keys to inbound calls",
-    ({ sessionScope, coreSession, expectedSessionKey }) => {
+    async ({ sessionScope, coreSession, expectedSessionKey }) => {
       const ctx = createContext({
         config: VoiceCallConfigSchema.parse({
           enabled: true,
@@ -242,14 +242,14 @@ describe("processEvent (functional inbound calls)", () => {
         to: "+15550000000",
       };
 
-      processEvent(ctx, event);
+      await processEvent(ctx, event);
 
       const call = requireFirstActiveCall(ctx);
       expect(call.sessionKey).toBe(expectedSessionKey(call));
     },
   );
 
-  it("applies per-number inbound greeting and stores the matched route key", () => {
+  it("applies per-number inbound greeting and stores the matched route key", async () => {
     const ctx = createContext({
       config: VoiceCallConfigSchema.parse({
         enabled: true,
@@ -276,7 +276,7 @@ describe("processEvent (functional inbound calls)", () => {
       to: "+1 (555) 000-2222",
     };
 
-    processEvent(ctx, event);
+    await processEvent(ctx, event);
 
     const call = requireFirstActiveCall(ctx);
     expect(call.metadata?.initialMessage).toBe("Silver Fox Cards, how can I help?");
@@ -284,7 +284,7 @@ describe("processEvent (functional inbound calls)", () => {
     expect(call.agentId).toBe("cards");
   });
 
-  it("bounds rejected provider calls while retaining hangup-once behavior", () => {
+  it("bounds rejected provider calls while retaining hangup-once behavior", async () => {
     const rejectedProviderCallIds = new Map<string, symbol>(
       Array.from(
         { length: EVENT_MANAGER_REPLAY_KEY_LIMIT },
@@ -294,7 +294,7 @@ describe("processEvent (functional inbound calls)", () => {
     const { ctx, hangupCalls } = createRejectingInboundContext();
     ctx.rejectedProviderCallIds = rejectedProviderCallIds;
 
-    processEvent(
+    await processEvent(
       ctx,
       createInboundInitiatedEvent({
         id: "evt-rejected-new",
@@ -302,7 +302,7 @@ describe("processEvent (functional inbound calls)", () => {
         from: "+15552222222",
       }),
     );
-    processEvent(
+    await processEvent(
       ctx,
       createInboundInitiatedEvent({
         id: "evt-rejected-new-replay",

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 // Voice Call tests cover events plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,6 +15,8 @@ import { processEvent } from "./events.js";
 import { speakInitialMessage } from "./outbound.js";
 import { MAX_CALL_REPLAY_KEYS } from "./replay-keys.js";
 import { persistCallRecord } from "./store.js";
+import * as callStore from "./store.js";
+import { waitForFinalTranscript } from "./timers.js";
 
 const logSpy = vi.hoisted(() => {
   const logEntries: string[] = [];
@@ -59,8 +62,8 @@ beforeEach(() => {
   logSpy.clearLogEntries();
 });
 
-afterEach(() => {
-  cleanup();
+afterEach(async () => {
+  await cleanup();
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -68,7 +71,7 @@ afterEach(() => {
 describe("processEvent (functional)", () => {
   it.each(["speech", "answered", "terminal"] as const)(
     "publishes %s side effects only after SQLite persistence succeeds",
-    (kind) => {
+    async (kind) => {
       let failPersistence = true;
       installStateRuntime(() => failPersistence);
       const onCallAnswered = vi.fn();
@@ -111,7 +114,9 @@ describe("processEvent (functional)", () => {
             ? { ...base, type: "call.answered", providerCallId: "provider-after" }
             : { ...base, type: "call.ended", reason: "hangup-user" };
 
-      expect(() => processEvent(ctx, event)).toThrow("synthetic SQLite persistence failure");
+      await expect(processEvent(ctx, event)).rejects.toThrow(
+        "synthetic SQLite persistence failure",
+      );
       expect(ctx.processedEventIds.has(event.id)).toBe(false);
       expect(call.processedEventIds).toEqual([]);
       expect(call.transcript).toEqual([]);
@@ -123,7 +128,7 @@ describe("processEvent (functional)", () => {
       expect(logSpy.logEntries).not.toContain(terminalLog);
 
       failPersistence = false;
-      processEvent(ctx, event);
+      await processEvent(ctx, event);
       expect(ctx.processedEventIds.has(event.id)).toBe(true);
       expect(resolve).toHaveBeenCalledTimes(kind === "speech" ? 1 : 0);
       expect(reject).toHaveBeenCalledTimes(kind === "terminal" ? 1 : 0);
@@ -139,7 +144,7 @@ describe("processEvent (functional)", () => {
 
   it.each(["request-uuid", "call-1"])(
     "upgrades provider identity without downgrading a known alias via %s",
-    (aliasCallId) => {
+    async (aliasCallId) => {
       const now = Date.now();
       const ctx = createContext();
       ctx.activeCalls.set("call-1", {
@@ -160,9 +165,9 @@ describe("processEvent (functional)", () => {
       if (!initialCall) {
         throw new Error("expected the initial call");
       }
-      persistCallRecord(ctx.storePath, initialCall);
+      await persistCallRecord(ctx.storePath, initialCall);
 
-      processEvent(ctx, {
+      await processEvent(ctx, {
         id: "evt-provider-id-change",
         type: "call.answered",
         callId: "call-1",
@@ -178,7 +183,7 @@ describe("processEvent (functional)", () => {
       expect(ctx.providerCallIdMap.get("call-uuid")).toBe("call-1");
       expect(ctx.providerCallIdMap.has("request-uuid")).toBe(false);
 
-      const result = processEvent(ctx, {
+      const result = await processEvent(ctx, {
         id: "evt-old-provider-alias",
         type: "call.speech",
         callId: aliasCallId,
@@ -210,12 +215,12 @@ describe("processEvent (functional)", () => {
       if (!state) {
         throw new Error("expected the fixture state runtime");
       }
-      const openStore = state.openSyncKeyedStore.bind(state);
+      const openStore = state.openKeyedStore.bind(state);
       const fault = vi
-        .spyOn(state, "openSyncKeyedStore")
+        .spyOn(state, "openKeyedStore")
         .mockImplementation(<T>(options: OpenKeyedStoreOptions) => {
           const store = openStore<T>(options);
-          store.entries = () => {
+          store.entries = async () => {
             throw new Error("synthetic call history read failure");
           };
           return store;
@@ -226,7 +231,7 @@ describe("processEvent (functional)", () => {
             "synthetic call history read failure",
           );
         } else {
-          expect(() =>
+          await expect(
             manager.processEvent({
               ...createInboundInitiatedEvent({
                 id: "event-unreadable-history",
@@ -235,7 +240,7 @@ describe("processEvent (functional)", () => {
               }),
               direction: "outbound",
             }),
-          ).toThrow("synthetic call history read failure");
+          ).rejects.toThrow("synthetic call history read failure");
         }
       } finally {
         fault.mockRestore();
@@ -245,7 +250,7 @@ describe("processEvent (functional)", () => {
     },
   );
 
-  it("does not burn replay keys for unknown calls before a later replay can resolve them", () => {
+  it("does not burn replay keys for unknown calls before a later replay can resolve them", async () => {
     const now = Date.now();
     const ctx = createContext();
     const event: NormalizedEvent = {
@@ -257,7 +262,7 @@ describe("processEvent (functional)", () => {
       timestamp: now + 1,
     };
 
-    expect(processEvent(ctx, event)).toEqual({ kind: "ignored", replayable: true });
+    expect(await processEvent(ctx, event)).toEqual({ kind: "ignored", replayable: true });
 
     expect(ctx.processedEventIds.size).toBe(0);
 
@@ -276,7 +281,7 @@ describe("processEvent (functional)", () => {
     });
     ctx.providerCallIdMap.set("provider-late", "call-late");
 
-    processEvent(ctx, event);
+    await processEvent(ctx, event);
 
     const call = ctx.activeCalls.get("call-late");
     if (!call) {
@@ -287,7 +292,7 @@ describe("processEvent (functional)", () => {
     expect(Array.from(ctx.processedEventIds)).toEqual(["stable-late-call"]);
   });
 
-  it("invokes onCallAnswered hook for answered events", () => {
+  it("invokes onCallAnswered hook for answered events", async () => {
     const now = Date.now();
     let answeredCallId: string | null = null;
     const ctx = createContext({
@@ -310,7 +315,7 @@ describe("processEvent (functional)", () => {
     });
     ctx.providerCallIdMap.set("call-2-provider", "call-2");
 
-    processEvent(ctx, {
+    await processEvent(ctx, {
       id: "evt-answered-hook",
       type: "call.answered",
       callId: "call-2",
@@ -398,7 +403,7 @@ describe("processEvent (functional)", () => {
       ctx.providerCallIdMap.set("provider-live", "call-live");
       const liveTimestamp = now + 250;
 
-      processEvent(ctx, createEvent(liveTimestamp));
+      await processEvent(ctx, createEvent(liveTimestamp));
 
       const call = ctx.activeCalls.get("call-live");
       if (!call) {
@@ -488,7 +493,7 @@ describe("processEvent (functional)", () => {
     vi.useRealTimers();
   });
 
-  it("auto-registers externally-initiated outbound-api calls with correct direction", () => {
+  it("auto-registers externally-initiated outbound-api calls with correct direction", async () => {
     const ctx = createContext();
     const event: NormalizedEvent = {
       id: "evt-external-1",
@@ -501,7 +506,7 @@ describe("processEvent (functional)", () => {
       to: "+15559876543",
     };
 
-    processEvent(ctx, event);
+    await processEvent(ctx, event);
 
     // Call should be registered in activeCalls and providerCallIdMap
     expect(ctx.activeCalls.size).toBe(1);
@@ -513,7 +518,7 @@ describe("processEvent (functional)", () => {
     expect(call.to).toBe("+15559876543");
   });
 
-  it("does not reject externally-initiated outbound calls even with disabled inbound policy", () => {
+  it("does not reject externally-initiated outbound calls even with disabled inbound policy", async () => {
     const { ctx, hangupCalls } = createRejectingInboundContext();
     const event: NormalizedEvent = {
       id: "evt-external-2",
@@ -526,7 +531,7 @@ describe("processEvent (functional)", () => {
       to: "+15559876543",
     };
 
-    processEvent(ctx, event);
+    await processEvent(ctx, event);
 
     // External outbound calls bypass inbound policy — they should be accepted
     expect(ctx.activeCalls.size).toBe(1);
@@ -535,7 +540,7 @@ describe("processEvent (functional)", () => {
     expect(call.direction).toBe("outbound");
   });
 
-  it("deduplicates by dedupeKey even when event IDs differ", () => {
+  it("deduplicates by dedupeKey even when event IDs differ", async () => {
     const now = Date.now();
     const ctx = createContext();
     ctx.activeCalls.set("call-dedupe", {
@@ -553,7 +558,7 @@ describe("processEvent (functional)", () => {
     });
     ctx.providerCallIdMap.set("provider-dedupe", "call-dedupe");
 
-    const firstResult = processEvent(ctx, {
+    const firstResult = await processEvent(ctx, {
       id: "evt-1",
       dedupeKey: "stable-key-1",
       type: "call.speech",
@@ -564,7 +569,7 @@ describe("processEvent (functional)", () => {
       isFinal: true,
     });
 
-    const replayResult = processEvent(ctx, {
+    const replayResult = await processEvent(ctx, {
       id: "evt-2",
       dedupeKey: "stable-key-1",
       type: "call.speech",
@@ -594,7 +599,7 @@ describe("processEvent (functional)", () => {
     { label: "whitespace", transcript: " \t\n", withWaiter: false },
     { label: "empty with a waiter", transcript: "", withWaiter: true },
     { label: "whitespace with a waiter", transcript: " \t\n", withWaiter: true },
-  ])("records $label final speech as a processed non-turn", ({ transcript, withWaiter }) => {
+  ])("records $label final speech as a processed non-turn", async ({ transcript, withWaiter }) => {
     const now = Date.now();
     const ctx = createContext();
     const callId = `call-blank-${withWaiter ? "waiter" : "direct"}-${transcript.length}`;
@@ -618,7 +623,7 @@ describe("processEvent (functional)", () => {
       ctx.transcriptWaiters.set(callId, { resolve, reject, timeout });
     }
 
-    const result = processEvent(ctx, {
+    const result = await processEvent(ctx, {
       id: `evt-${callId}`,
       dedupeKey: `dedupe-${callId}`,
       type: "call.speech",
@@ -638,7 +643,7 @@ describe("processEvent (functional)", () => {
     expect(ctx.transcriptWaiters.has(callId)).toBe(withWaiter);
   });
 
-  it("bounds committed replay keys in both manager and persisted call owners", () => {
+  it("bounds committed replay keys in both manager and persisted call owners", async () => {
     const now = Date.now();
     const managerKeys = Array.from(
       { length: EVENT_MANAGER_REPLAY_KEY_LIMIT },
@@ -661,7 +666,7 @@ describe("processEvent (functional)", () => {
     });
     ctx.providerCallIdMap.set("provider-bounded", "call-bounded");
 
-    const result = processEvent(ctx, {
+    const result = await processEvent(ctx, {
       id: "evt-bounded-new",
       type: "call.dtmf",
       callId: "call-bounded",
@@ -679,7 +684,7 @@ describe("processEvent (functional)", () => {
     expect(call?.processedEventIds[0]).toBe("call-1");
     expect(call?.processedEventIds.at(-1)).toBe("evt-bounded-new");
     expect(
-      processEvent(ctx, {
+      await processEvent(ctx, {
         id: "evt-bounded-new",
         type: "call.dtmf",
         callId: "call-bounded",
@@ -690,7 +695,7 @@ describe("processEvent (functional)", () => {
     ).toEqual({ kind: "ignored" });
   });
 
-  it("keeps retryable call.error events replayable", () => {
+  it("keeps retryable call.error events replayable", async () => {
     const now = Date.now();
     const ctx = createContext();
     ctx.activeCalls.set("call-retryable-error", {
@@ -719,8 +724,8 @@ describe("processEvent (functional)", () => {
       retryable: true,
     };
 
-    expect(processEvent(ctx, event)).toEqual({ kind: "processed", replayable: true });
-    processEvent(ctx, event);
+    expect(await processEvent(ctx, event)).toEqual({ kind: "processed", replayable: true });
+    await processEvent(ctx, event);
 
     const call = ctx.activeCalls.get("call-retryable-error");
     if (!call) {
@@ -759,31 +764,34 @@ describe("processEvent privacy assertions", () => {
       allowFrom: ["+15550001111"],
       allowed: false,
     },
-  ])("redacts caller phone numbers in allowlist $label logs", ({ phone, allowFrom, allowed }) => {
-    const ctx = createContext({
-      config: VoiceCallConfigSchema.parse({
-        enabled: true,
-        provider: "plivo",
-        fromNumber: "+15550000000",
-        inboundPolicy: "allowlist",
-        allowFrom,
-      }),
-      provider: createProvider(),
-    });
+  ])(
+    "redacts caller phone numbers in allowlist $label logs",
+    async ({ phone, allowFrom, allowed }) => {
+      const ctx = createContext({
+        config: VoiceCallConfigSchema.parse({
+          enabled: true,
+          provider: "plivo",
+          fromNumber: "+15550000000",
+          inboundPolicy: "allowlist",
+          allowFrom,
+        }),
+        provider: createProvider(),
+      });
 
-    processEvent(
-      ctx,
-      createInboundInitiatedEvent({
-        id: `evt-privacy-${allowed ? "accept" : "reject"}`,
-        providerCallId: `prov-privacy-${allowed ? "accept" : "reject"}`,
-        from: phone,
-      }),
-    );
+      await processEvent(
+        ctx,
+        createInboundInitiatedEvent({
+          id: `evt-privacy-${allowed ? "accept" : "reject"}`,
+          providerCallId: `prov-privacy-${allowed ? "accept" : "reject"}`,
+          from: phone,
+        }),
+      );
 
-    expectCallerRedacted(phone, `allowlisted=${allowed}`);
-  });
+      expectCallerRedacted(phone, `allowlisted=${allowed}`);
+    },
+  );
 
-  it("redacts caller phone numbers in call record creation logs", () => {
+  it("redacts caller phone numbers in call record creation logs", async () => {
     const ctx = createContext({
       config: VoiceCallConfigSchema.parse({
         enabled: true,
@@ -793,7 +801,7 @@ describe("processEvent privacy assertions", () => {
       }),
     });
     const phone = "+15554444444";
-    processEvent(
+    await processEvent(
       ctx,
       createInboundInitiatedEvent({
         id: "evt-privacy-create",
@@ -806,7 +814,7 @@ describe("processEvent privacy assertions", () => {
     expectCallerRedacted(phone, call.callId);
   });
 
-  it("redacts caller phone numbers when rejection cannot reach a provider", () => {
+  it("redacts caller phone numbers when rejection cannot reach a provider", async () => {
     const ctx = createContext({
       config: VoiceCallConfigSchema.parse({
         enabled: true,
@@ -818,7 +826,7 @@ describe("processEvent privacy assertions", () => {
       provider: null,
     });
     const phone = "+15559999999";
-    processEvent(
+    await processEvent(
       ctx,
       createInboundInitiatedEvent({
         id: "evt-privacy-no-provider",
@@ -830,3 +838,71 @@ describe("processEvent privacy assertions", () => {
     expectCallerRedacted(phone, "prov-privacy-no-provider");
   });
 });
+
+it.each([false, true])(
+  "reports unconsumed speech after its waiter expires (replacement=%s)",
+  async (replacement) => {
+    vi.useFakeTimers();
+    const ctx = createContext();
+    ctx.config.transcriptTimeoutMs = 30;
+    const call: CallRecord = {
+      callId: "call-expiring-waiter",
+      providerCallId: "provider-expiring-waiter",
+      provider: "plivo",
+      direction: "inbound",
+      state: "listening",
+      from: "+15550000001",
+      to: "+15550000000",
+      startedAt: Date.now(),
+      answeredAt: Date.now(),
+      transcript: [],
+      processedEventIds: [],
+    };
+    ctx.activeCalls.set(call.callId, call);
+    ctx.providerCallIdMap.set(call.providerCallId!, call.callId);
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const persist = callStore.persistCallRecord;
+    vi.spyOn(callStore, "persistCallRecord").mockImplementationOnce(async (...args) => {
+      entered.resolve();
+      await release.promise;
+      await persist(...args);
+    });
+    const waiting = waitForFinalTranscript(ctx, call.callId);
+    const timedOut = expect(waiting).rejects.toThrow("Timed out waiting for transcript");
+    const pending = processEvent(ctx, {
+      id: "speech-before-timeout",
+      type: "call.speech",
+      callId: call.callId,
+      timestamp: Date.now(),
+      transcript: "Persist this utterance",
+      isFinal: true,
+    });
+    let replacementSettled = false;
+    try {
+      await entered.promise;
+      await vi.advanceTimersByTimeAsync(30);
+      await timedOut;
+      if (replacement) {
+        const next = waitForFinalTranscript(ctx, call.callId);
+        ctx.trackCallWork(
+          next.then(
+            () => {
+              replacementSettled = true;
+            },
+            () => {},
+          ),
+        );
+      }
+      release.resolve();
+      await expect(pending).resolves.toMatchObject({ kind: "final-speech", waiterResolved: false });
+      expect(replacementSettled).toBe(false);
+      expect(ctx.transcriptWaiters.has(call.callId)).toBe(replacement);
+      expect(call.transcript.at(-1)?.text).toBe("Persist this utterance");
+      expect(ctx.processedEventIds.has("speech-before-timeout")).toBe(true);
+    } finally {
+      release.resolve();
+      await pending;
+    }
+  },
+);

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -17,7 +17,7 @@ import {
   rememberManagerReplayKey,
   reserveRejectedProviderCall,
 } from "./replay-keys.js";
-import { addTranscriptEntry, transitionState } from "./state.js";
+import { addTranscriptEntry, copyCallRecord, transitionState } from "./state.js";
 import { findCallInStore, persistCallRecord } from "./store.js";
 import { resolveTranscriptWaiter, startMaxDurationTimer } from "./timers.js";
 
@@ -35,10 +35,14 @@ type EventContext = Pick<
   | "storePath"
   | "transcriptWaiters"
   | "maxDurationTimers"
+  | "notifyHangupTimers"
   | "endCallOperations"
   | "onCallAnswered"
   | "onCallerSpeech"
   | "streamSessionIssuer"
+  | "mutationQueue"
+  | "trackCallWork"
+  | "isStopping"
 >;
 
 export type ProcessEventResult =
@@ -81,13 +85,13 @@ function shouldAcceptInbound(config: EventContext["config"], from: string | unde
   }
 }
 
-function createWebhookCall(params: {
+async function createWebhookCall(params: {
   ctx: EventContext;
   providerCallId: string;
   direction: "inbound" | "outbound";
   from: string;
   to: string;
-}): CallRecord {
+}): Promise<CallRecord> {
   const callId = crypto.randomUUID();
   const effective = resolveVoiceCallEffectiveConfig(
     params.ctx.config,
@@ -122,7 +126,7 @@ function createWebhookCall(params: {
     },
   };
 
-  persistCallRecord(params.ctx.storePath, callRecord);
+  await persistCallRecord(params.ctx.storePath, callRecord);
   params.ctx.activeCalls.set(callId, callRecord);
   params.ctx.providerCallIdMap.set(params.providerCallId, callId);
 
@@ -132,12 +136,12 @@ function createWebhookCall(params: {
   return callRecord;
 }
 
-function persistRejectedInboundCall(params: {
+async function persistRejectedInboundCall(params: {
   ctx: EventContext;
   event: NormalizedEvent;
   dedupeKey: string;
   providerCallId: string;
-}): void {
+}): Promise<void> {
   const callId = params.event.callId || params.providerCallId;
   const now = Date.now();
   const rejectedCall: CallRecord = {
@@ -155,10 +159,20 @@ function persistRejectedInboundCall(params: {
     processedEventIds: [params.dedupeKey],
     metadata: { rejectionReason: "inbound-policy" },
   };
-  persistCallRecord(params.ctx.storePath, rejectedCall);
+  await persistCallRecord(params.ctx.storePath, rejectedCall);
 }
 
-export function processEvent(ctx: EventContext, event: NormalizedEvent): ProcessEventResult {
+export function processEvent(
+  ctx: EventContext,
+  event: NormalizedEvent,
+): Promise<ProcessEventResult> {
+  return ctx.mutationQueue.enqueue("state", () => processEventInQueue(ctx, event));
+}
+
+async function processEventInQueue(
+  ctx: EventContext,
+  event: NormalizedEvent,
+): Promise<ProcessEventResult> {
   const dedupeKey = event.dedupeKey || event.id;
   if (ctx.processedEventIds.has(dedupeKey)) {
     return { kind: "ignored" };
@@ -173,9 +187,9 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
   let providerCallId = event.providerCallId;
   let retained: CallRecord | undefined;
   if (!call) {
-    retained = findCallInStore(ctx.storePath, event.callId);
+    retained = await findCallInStore(ctx.storePath, event.callId);
     if (!retained && providerCallId && providerCallId !== event.callId) {
-      retained = findCallInStore(ctx.storePath, providerCallId);
+      retained = await findCallInStore(ctx.storePath, providerCallId);
     }
     // A policy rejection records an attempt, not confirmed carrier termination.
     if (retained && retained.metadata?.rejectionReason !== "inbound-policy") {
@@ -191,7 +205,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     const providerOwner =
       providerCallId === event.callId && retained
         ? retained
-        : findCallInStore(ctx.storePath, providerCallId);
+        : await findCallInStore(ctx.storePath, providerCallId);
     // Known aliases cannot replace the live owner's newer provider ID.
     if (providerOwner?.callId === call.callId) {
       providerCallId = call.providerCallId;
@@ -218,28 +232,33 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
         return { kind: "ignored" };
       }
       const callId = event.callId ?? pid;
-      persistRejectedInboundCall({ ctx, event, dedupeKey, providerCallId: pid });
+      await persistRejectedInboundCall({ ctx, event, dedupeKey, providerCallId: pid });
+      if (ctx.isStopping()) {
+        return { kind: "processed" };
+      }
       const rejectionReservation = reserveRejectedProviderCall(ctx.rejectedProviderCallIds, pid);
       if (rejectionReservation === undefined) {
         return { kind: "ignored" };
       }
       rememberManagerReplayKey(ctx.processedEventIds, dedupeKey);
       log.info(`Rejecting inbound call by policy: ${pid}`);
-      void ctx.provider
-        .hangupCall({
-          callId,
-          providerCallId: pid,
-          reason: "hangup-bot",
-        })
-        .catch((err: unknown) => {
-          releaseRejectedProviderCall(ctx.rejectedProviderCallIds, pid, rejectionReservation);
-          const message = formatErrorMessage(err);
-          log.warn(`Failed to reject inbound call ${pid}: ${message}`);
-        });
+      ctx.trackCallWork(
+        ctx.provider
+          .hangupCall({
+            callId,
+            providerCallId: pid,
+            reason: "hangup-bot",
+          })
+          .catch((err: unknown) => {
+            releaseRejectedProviderCall(ctx.rejectedProviderCallIds, pid, rejectionReservation);
+            const message = formatErrorMessage(err);
+            log.warn(`Failed to reject inbound call ${pid}: ${message}`);
+          }),
+      );
       return { kind: "processed" };
     }
 
-    call = createWebhookCall({
+    call = await createWebhookCall({
       ctx,
       providerCallId,
       direction: eventDirection === "outbound" ? "outbound" : "inbound",
@@ -255,16 +274,8 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     return { kind: "ignored", replayable: true };
   }
 
-  const activeCall = call;
-  const previousCall = {
-    state: activeCall.state,
-    providerCallId: activeCall.providerCallId,
-    answeredAt: activeCall.answeredAt,
-    endedAt: activeCall.endedAt,
-    endReason: activeCall.endReason,
-    transcriptLength: activeCall.transcript.length,
-    processedEventIds: [...activeCall.processedEventIds],
-  };
+  const activeCall = copyCallRecord(call);
+  const previousCall = { providerCallId: call.providerCallId };
   const shouldCommitReplayKey = !(event.type === "call.error" && event.retryable);
   const effects: Array<() => void> = [];
   let result: ProcessEventResult = { kind: "processed" };
@@ -296,35 +307,35 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     }
   };
 
-  try {
-    if (providerCallId && providerCallId !== activeCall.providerCallId) {
-      activeCall.providerCallId = providerCallId;
-    }
-    if (shouldCommitReplayKey) {
-      appendCallReplayKey(activeCall.processedEventIds, dedupeKey);
-    }
+  if (providerCallId && providerCallId !== activeCall.providerCallId) {
+    activeCall.providerCallId = providerCallId;
+  }
+  if (shouldCommitReplayKey) {
+    appendCallReplayKey(activeCall.processedEventIds, dedupeKey);
+  }
 
-    switch (event.type) {
-      case "call.initiated": {
-        transitionState(activeCall, "initiated");
-        const inboundProvider = ctx.provider;
-        const inboundProviderCallId = activeCall.providerCallId;
-        const answerInboundCall = inboundProvider?.answerCall?.bind(inboundProvider);
-        if (activeCall.direction === "inbound" && inboundProviderCallId && answerInboundCall) {
-          effects.push(() => {
-            const inboundStreamSession =
-              ctx.config.realtime?.enabled &&
-              inboundProvider?.name === "telnyx" &&
-              ctx.streamSessionIssuer
-                ? ctx.streamSessionIssuer({
-                    providerName: "telnyx",
-                    callId: activeCall.callId,
-                    from: activeCall.from,
-                    to: activeCall.to,
-                    direction: "inbound",
-                  })
-                : undefined;
-            void answerInboundCall({
+  switch (event.type) {
+    case "call.initiated": {
+      transitionState(activeCall, "initiated");
+      const inboundProvider = ctx.provider;
+      const inboundProviderCallId = activeCall.providerCallId;
+      const answerInboundCall = inboundProvider?.answerCall?.bind(inboundProvider);
+      if (activeCall.direction === "inbound" && inboundProviderCallId && answerInboundCall) {
+        effects.push(() => {
+          const inboundStreamSession =
+            ctx.config.realtime?.enabled &&
+            inboundProvider?.name === "telnyx" &&
+            ctx.streamSessionIssuer
+              ? ctx.streamSessionIssuer({
+                  providerName: "telnyx",
+                  callId: activeCall.callId,
+                  from: activeCall.from,
+                  to: activeCall.to,
+                  direction: "inbound",
+                })
+              : undefined;
+          ctx.trackCallWork(
+            answerInboundCall({
               callId: activeCall.callId,
               providerCallId: inboundProviderCallId,
               ...(inboundStreamSession
@@ -336,120 +347,118 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
             }).catch((err: unknown) => {
               const message = formatErrorMessage(err);
               log.warn(`Failed to answer inbound call ${activeCall.providerCallId}: ${message}`);
-            });
+            }),
+          );
+        });
+      }
+      break;
+    }
+
+    case "call.ringing":
+      transitionState(activeCall, "ringing");
+      break;
+
+    case "call.answered":
+      activeCall.answeredAt = event.timestamp;
+      transitionState(activeCall, "answered");
+      effects.push(startDurationTimer, () => ctx.onCallAnswered?.(call));
+      break;
+
+    case "call.active":
+      transitionState(activeCall, "active");
+      break;
+
+    case "call.speaking":
+    case "call.assistant-speech":
+      prepareLiveDurationTimer();
+      transitionState(activeCall, "speaking");
+      if (event.type === "call.assistant-speech" && event.transcript.trim()) {
+        addTranscriptEntry(activeCall, "bot", event.transcript);
+      }
+      break;
+
+    case "call.speech":
+      if (event.isFinal && event.transcript.trim()) {
+        const waiter = ctx.transcriptWaiters.get(activeCall.callId);
+        if (waiter?.turnToken && waiter.turnToken !== event.turnToken) {
+          log.warn(`Ignoring speech event with mismatched turn token for ${activeCall.callId}`);
+          result = { kind: "ignored" };
+          break;
+        }
+        addTranscriptEntry(activeCall, "user", event.transcript);
+        const speechResult: Extract<ProcessEventResult, { kind: "final-speech" }> = {
+          kind: "final-speech",
+          call,
+          transcript: event.transcript,
+          waiterResolved: false,
+        };
+        result = speechResult;
+        if (waiter) {
+          effects.push(() => {
+            if (ctx.transcriptWaiters.get(activeCall.callId) === waiter) {
+              speechResult.waiterResolved = resolveTranscriptWaiter(
+                ctx,
+                activeCall.callId,
+                event.transcript,
+                event.turnToken,
+              );
+            }
           });
         }
-        break;
       }
+      if (event.transcript.trim()) {
+        effects.push(() => ctx.onCallerSpeech?.(call));
+      }
+      prepareLiveDurationTimer();
+      transitionState(activeCall, "listening");
+      break;
 
-      case "call.ringing":
-        transitionState(activeCall, "ringing");
-        break;
+    case "call.silence":
+    case "call.dtmf":
+      break;
 
-      case "call.answered":
-        activeCall.answeredAt = event.timestamp;
-        transitionState(activeCall, "answered");
-        effects.push(startDurationTimer, () => ctx.onCallAnswered?.(activeCall));
-        break;
+    case "call.ended":
+      await finalizeCall({
+        ctx,
+        call,
+        preparedCall: activeCall,
+        endReason: event.reason,
+        endedAt: event.timestamp,
+      });
+      publishProviderCallId(true);
+      rememberManagerReplayKey(ctx.processedEventIds, dedupeKey);
+      return { kind: "processed" };
 
-      case "call.active":
-        transitionState(activeCall, "active");
-        break;
-
-      case "call.speaking":
-      case "call.assistant-speech":
-        prepareLiveDurationTimer();
-        transitionState(activeCall, "speaking");
-        if (event.type === "call.assistant-speech" && event.transcript.trim()) {
-          addTranscriptEntry(activeCall, "bot", event.transcript);
-        }
-        break;
-
-      case "call.speech":
-        if (event.isFinal && event.transcript.trim()) {
-          const waiter = ctx.transcriptWaiters.get(activeCall.callId);
-          if (waiter?.turnToken && waiter.turnToken !== event.turnToken) {
-            log.warn(`Ignoring speech event with mismatched turn token for ${activeCall.callId}`);
-            result = { kind: "ignored" };
-            break;
-          }
-          addTranscriptEntry(activeCall, "user", event.transcript);
-          result = {
-            kind: "final-speech",
-            call: activeCall,
-            transcript: event.transcript,
-            waiterResolved: Boolean(waiter),
-          };
-          if (waiter) {
-            effects.push(() => {
-              resolveTranscriptWaiter(ctx, activeCall.callId, event.transcript, event.turnToken);
-            });
-          }
-        }
-        if (event.transcript.trim()) {
-          effects.push(() => ctx.onCallerSpeech?.(activeCall));
-        }
-        prepareLiveDurationTimer();
-        transitionState(activeCall, "listening");
-        break;
-
-      case "call.silence":
-      case "call.dtmf":
-        break;
-
-      case "call.ended":
-        finalizeCall({
+    case "call.error":
+      if (!event.retryable) {
+        await finalizeCall({
           ctx,
-          call: activeCall,
-          endReason: event.reason,
+          call,
+          preparedCall: activeCall,
+          endReason: "error",
           endedAt: event.timestamp,
+          transcriptRejectReason: `Call error: ${event.error}`,
         });
         publishProviderCallId(true);
         rememberManagerReplayKey(ctx.processedEventIds, dedupeKey);
         return { kind: "processed" };
-
-      case "call.error":
-        if (!event.retryable) {
-          finalizeCall({
-            ctx,
-            call: activeCall,
-            endReason: "error",
-            endedAt: event.timestamp,
-            transcriptRejectReason: `Call error: ${event.error}`,
-          });
-          publishProviderCallId(true);
-          rememberManagerReplayKey(ctx.processedEventIds, dedupeKey);
-          return { kind: "processed" };
-        }
-        // Retryable provider errors remain uncommitted for a later redelivery.
-        result = { kind: "processed", replayable: true };
-        break;
-    }
-
-    // Persist reversible call mutations before publishing dedupe, timers, or waiters.
-    persistCallRecord(ctx.storePath, activeCall);
-    publishProviderCallId();
-    if (shouldCommitReplayKey) {
-      rememberManagerReplayKey(ctx.processedEventIds, dedupeKey);
-    }
-  } catch (err) {
-    Object.assign(activeCall, {
-      state: previousCall.state,
-      providerCallId: previousCall.providerCallId,
-      answeredAt: previousCall.answeredAt,
-      endedAt: previousCall.endedAt,
-      endReason: previousCall.endReason,
-    });
-    activeCall.transcript.length = previousCall.transcriptLength;
-    activeCall.processedEventIds.splice(
-      0,
-      activeCall.processedEventIds.length,
-      ...previousCall.processedEventIds,
-    );
-    throw err;
+      }
+      // Retryable provider errors remain uncommitted for a later redelivery.
+      result = { kind: "processed", replayable: true };
+      break;
   }
-  for (const effect of effects) {
-    effect();
+
+  // Persist reversible call mutations before publishing dedupe, timers, or waiters.
+  await persistCallRecord(ctx.storePath, activeCall);
+  Object.assign(call, activeCall);
+  publishProviderCallId();
+  if (shouldCommitReplayKey) {
+    rememberManagerReplayKey(ctx.processedEventIds, dedupeKey);
+  }
+  if (!ctx.isStopping()) {
+    for (const effect of effects) {
+      effect();
+    }
   }
   return result;
 }

--- a/extensions/voice-call/src/manager/lifecycle.ts
+++ b/extensions/voice-call/src/manager/lifecycle.ts
@@ -2,7 +2,7 @@
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { TerminalStates, type CallRecord, type EndReason } from "../types.js";
 import type { CallManagerContext } from "./context.js";
-import { transitionState } from "./state.js";
+import { copyCallRecord, transitionState } from "./state.js";
 import { persistCallRecord } from "./store.js";
 import { clearMaxDurationTimer, rejectTranscriptWaiter } from "./timers.js";
 
@@ -14,7 +14,9 @@ type CallLifecycleContext = Pick<
   CallManagerContext,
   "activeCalls" | "providerCallIdMap" | "storePath"
 > &
-  Partial<Pick<CallManagerContext, "transcriptWaiters" | "maxDurationTimers">>;
+  Partial<
+    Pick<CallManagerContext, "transcriptWaiters" | "maxDurationTimers" | "notifyHangupTimers">
+  >;
 
 /** Remove a provider-call mapping only when it still points at this call. */
 function removeProviderCallMapping(
@@ -30,22 +32,28 @@ function removeProviderCallMapping(
   }
 }
 
-/** Persist terminal state, clean timers/waiters, and remove active call indexes. */
-export function finalizeCall(params: {
+/** Finalize under the manager mutation queue, publishing cleanup only after persistence. */
+export async function finalizeCall(params: {
   ctx: CallLifecycleContext;
   call: CallRecord;
+  preparedCall?: CallRecord;
   endReason: EndReason;
   endedAt?: number;
   transcriptRejectReason?: string;
-}): void {
+}): Promise<void> {
   const { ctx, call, endReason } = params;
+  if (ctx.activeCalls.get(call.callId) !== call) {
+    return;
+  }
   const previousState = call.state;
 
   if (!TerminalStates.has(previousState)) {
-    call.endedAt = params.endedAt ?? Date.now();
-    call.endReason = endReason;
-    transitionState(call, endReason);
-    persistCallRecord(ctx.storePath, call);
+    const next = copyCallRecord(params.preparedCall ?? call);
+    next.endedAt = params.endedAt ?? Date.now();
+    next.endReason = endReason;
+    transitionState(next, endReason);
+    await persistCallRecord(ctx.storePath, next);
+    Object.assign(call, next);
     log.info(
       `[voice-call] Call finalized callId=${call.callId} providerCallId=${call.providerCallId ?? "unknown"} endReason=${endReason}`,
     );
@@ -53,6 +61,11 @@ export function finalizeCall(params: {
 
   if (ctx.maxDurationTimers) {
     clearMaxDurationTimer({ maxDurationTimers: ctx.maxDurationTimers }, call.callId);
+  }
+  const notifyTimer = ctx.notifyHangupTimers?.get(call.callId);
+  if (notifyTimer) {
+    clearTimeout(notifyTimer);
+    ctx.notifyHangupTimers?.delete(call.callId);
   }
   if (ctx.transcriptWaiters) {
     rejectTranscriptWaiter(

--- a/extensions/voice-call/src/manager/mutations.ts
+++ b/extensions/voice-call/src/manager/mutations.ts
@@ -1,0 +1,29 @@
+import { TerminalStates, type CallRecord } from "../types.js";
+import type { CallManagerContext } from "./context.js";
+import { copyCallRecord } from "./state.js";
+import { persistCallRecord } from "./store.js";
+
+type CallMutationContext = Pick<CallManagerContext, "activeCalls" | "storePath" | "mutationQueue">;
+
+/** Commit one live call update while preserving the call identity held by its callbacks. */
+export function updateCall(
+  ctx: CallMutationContext,
+  call: CallRecord,
+  update: (next: CallRecord) => void,
+  isCurrent?: () => boolean,
+): Promise<boolean> {
+  return ctx.mutationQueue.enqueue("state", async () => {
+    if (
+      ctx.activeCalls.get(call.callId) !== call ||
+      TerminalStates.has(call.state) ||
+      (isCurrent && !isCurrent())
+    ) {
+      return false;
+    }
+    const next = copyCallRecord(call);
+    update(next);
+    await persistCallRecord(ctx.storePath, next);
+    Object.assign(call, next);
+    return true;
+  });
+}

--- a/extensions/voice-call/src/manager/outbound.persistence.test.ts
+++ b/extensions/voice-call/src/manager/outbound.persistence.test.ts
@@ -21,19 +21,27 @@ it.each([
   "preserves callback-owned identity when initiation settles after the call is $phase ($payload)",
   async ({ phase, requestUuid }) => {
     const placement = createDeferred<InitiateCallResult>();
+    const placementStarted = createDeferred<void>();
     const playback = vi.fn(async () => {});
     const ctx = createContext({
-      provider: createProvider({ initiateCall: () => placement.promise, playTts: playback }),
+      provider: createProvider({
+        initiateCall: () => {
+          placementStarted.resolve();
+          return placement.promise;
+        },
+        playTts: playback,
+      }),
       webhookUrl: "https://example.com/voice/webhook",
     });
     const parser = new PlivoProvider({ authId: "MA-fixture", authToken: "synthetic-token" });
     const pending = initiateCall(ctx, "+15550000001");
     try {
+      await Promise.race([placementStarted.promise, pending]);
       const call = [...ctx.activeCalls.values()][0];
       if (!call) {
         throw new Error("expected the pending outbound call");
       }
-      const deliver = (fields: Record<string, string>) => {
+      const deliver = async (fields: Record<string, string>) => {
         const parsed = parser.parseWebhookEvent({
           headers: {},
           method: "POST",
@@ -48,13 +56,13 @@ it.each([
         });
         expect(parsed.events).toHaveLength(1);
         for (const event of parsed.events) {
-          processEvent(ctx, event);
+          await processEvent(ctx, event);
         }
       };
-      deliver({ CallStatus: "in-progress" });
+      await deliver({ CallStatus: "in-progress" });
       expect(call.providerCallId).toBe("canonical-call-uuid");
       if (phase === "ended") {
-        deliver({ CallStatus: "completed" });
+        await deliver({ CallStatus: "completed" });
       }
       const beforeResult = await getCallHistoryFromStore(ctx.storePath);
 
@@ -63,7 +71,7 @@ it.each([
       expect(call.providerCallId).toBe("canonical-call-uuid");
 
       if (phase === "active") {
-        deliver({ CallStatus: "in-progress", Speech: "Continue the connected call." });
+        await deliver({ CallStatus: "in-progress", Speech: "Continue the connected call." });
         await expect(speak(ctx, call.callId, "Still connected.")).resolves.toEqual({
           success: true,
         });
@@ -85,7 +93,11 @@ it.each([
 
 it("keeps outbound capacity available after storage failure without dialing", async () => {
   const placement = createDeferred<InitiateCallResult>();
-  const dial = vi.fn(() => placement.promise);
+  const placementStarted = createDeferred<void>();
+  const dial = vi.fn(() => {
+    placementStarted.resolve();
+    return placement.promise;
+  });
   const ctx = createContext({
     provider: createProvider({ initiateCall: dial }),
     webhookUrl: "https://example.com/voice/webhook",
@@ -108,6 +120,7 @@ it("keeps outbound capacity available after storage failure without dialing", as
       success: false,
       error: "Maximum concurrent calls (1) reached",
     });
+    await Promise.race([placementStarted.promise, recovered]);
     expect(dial).toHaveBeenCalledOnce();
   } finally {
     placement.resolve({ providerCallId: "provider-recovered", status: "initiated" });
@@ -117,8 +130,77 @@ it("keeps outbound capacity available after storage failure without dialing", as
   expect(result.success).toBe(true);
   expect(ctx.activeCalls.size).toBe(1);
   expect(ctx.providerCallIdMap.get("provider-recovered")).toBe(result.callId);
-  expect(loadActiveCallsFromStore(ctx.storePath).activeCalls.get(result.callId)).toMatchObject({
+  expect(
+    (await loadActiveCallsFromStore(ctx.storePath)).activeCalls.get(result.callId),
+  ).toMatchObject({
     providerCallId: "provider-recovered",
     state: "initiated",
   });
 });
+
+it.each([
+  { phase: "terminal", playbackFails: false },
+  { phase: "terminal", playbackFails: true },
+  { phase: "replaced", playbackFails: false },
+  { phase: "replaced", playbackFails: true },
+] as const)(
+  "does not rewrite a $phase call after delayed playback (failure=$playbackFails)",
+  async ({ phase, playbackFails }) => {
+    const playbackStarted = createDeferred<void>();
+    const playback = createDeferred<void>();
+    const ctx = createContext({
+      provider: createProvider({
+        playTts: () => {
+          playbackStarted.resolve();
+          return playback.promise;
+        },
+      }),
+      webhookUrl: "https://example.com/voice/webhook",
+    });
+    const started = await initiateCall(ctx, "+15550000001");
+    expect(started.success).toBe(true);
+    const call = ctx.activeCalls.get(started.callId);
+    if (!call) {
+      throw new Error("expected the connected outbound call");
+    }
+    const pending = speak(ctx, call.callId, "Pending playback");
+    const replacement = { ...structuredClone(call), state: "active" as const };
+    let historyBeforeSettlement: Awaited<ReturnType<typeof getCallHistoryFromStore>>;
+    try {
+      await Promise.race([playbackStarted.promise, pending]);
+      if (phase === "terminal") {
+        await processEvent(ctx, {
+          id: "ended-during-playback",
+          type: "call.ended",
+          callId: call.callId,
+          providerCallId: call.providerCallId,
+          timestamp: Date.now(),
+          reason: "completed",
+        });
+      } else {
+        ctx.activeCalls.set(call.callId, replacement);
+      }
+      historyBeforeSettlement = await getCallHistoryFromStore(ctx.storePath);
+    } finally {
+      if (playbackFails) {
+        playback.reject(new Error("playback interrupted"));
+      } else {
+        playback.resolve();
+      }
+      await pending;
+    }
+    await expect(pending).resolves.toEqual({
+      success: false,
+      error: playbackFails ? "playback interrupted" : "Call has ended",
+    });
+    expect(await getCallHistoryFromStore(ctx.storePath)).toEqual(historyBeforeSettlement);
+    if (phase === "terminal") {
+      expect(ctx.activeCalls.has(call.callId)).toBe(false);
+      expect(call.state).toBe("completed");
+    } else {
+      expect(ctx.activeCalls.get(call.callId)).toBe(replacement);
+      expect(replacement.state).toBe("active");
+      expect(replacement.transcript).toEqual([]);
+    }
+  },
+);

--- a/extensions/voice-call/src/manager/outbound.test.ts
+++ b/extensions/voice-call/src/manager/outbound.test.ts
@@ -1,38 +1,27 @@
 // Voice Call tests cover outbound plugin behavior.
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CallRecordSchema, type CallRecord } from "../types.js";
 
 const {
-  addTranscriptEntryMock,
   clearMaxDurationTimerMock,
-  ensureMaxDurationTimerForLiveCallMock,
+  startMaxDurationTimerMock,
   generateDtmfRedirectTwimlMock,
   generateNotifyTwimlMock,
   getCallByProviderCallIdMock,
   mapVoiceToPollyMock,
   persistCallRecordMock,
   rejectTranscriptWaiterMock,
-  transitionStateMock,
 } = vi.hoisted(() => ({
-  addTranscriptEntryMock: vi.fn(),
   clearMaxDurationTimerMock: vi.fn(),
-  ensureMaxDurationTimerForLiveCallMock: vi.fn(
-    (params: { call: { answeredAt?: number }; liveAt: number }) => {
-      params.call.answeredAt ??= params.liveAt;
-    },
-  ),
+  startMaxDurationTimerMock: vi.fn(),
   generateDtmfRedirectTwimlMock: vi.fn(),
   generateNotifyTwimlMock: vi.fn(),
   getCallByProviderCallIdMock: vi.fn(),
   mapVoiceToPollyMock: vi.fn(),
   persistCallRecordMock: vi.fn(),
   rejectTranscriptWaiterMock: vi.fn(),
-  transitionStateMock: vi.fn(),
-}));
-
-vi.mock("./state.js", () => ({
-  addTranscriptEntry: addTranscriptEntryMock,
-  transitionState: transitionStateMock,
 }));
 
 vi.mock("./store.js", () => ({
@@ -42,7 +31,7 @@ vi.mock("./store.js", () => ({
 vi.mock("./timers.js", () => ({
   clearMaxDurationTimer: clearMaxDurationTimerMock,
   clearTranscriptWaiter: vi.fn(),
-  ensureMaxDurationTimerForLiveCall: ensureMaxDurationTimerForLiveCallMock,
+  startMaxDurationTimer: startMaxDurationTimerMock,
   rejectTranscriptWaiter: rejectTranscriptWaiterMock,
   waitForFinalTranscript: vi.fn(),
 }));
@@ -69,10 +58,31 @@ import {
   speakInitialMessage,
 } from "./outbound.js";
 
+function createCall(overrides: Partial<CallRecord> = {}): CallRecord {
+  return CallRecordSchema.parse({
+    callId: "call-1",
+    providerCallId: "provider-1",
+    provider: "plivo",
+    direction: "outbound",
+    state: "active",
+    from: "+15550000000",
+    to: "+15550000001",
+    startedAt: Date.now(),
+    transcript: [],
+    processedEventIds: [],
+    ...overrides,
+  });
+}
+
 function createActiveCallContext(params: { hangupCall?: ReturnType<typeof vi.fn> } = {}) {
-  const call = { callId: "call-1", providerCallId: "provider-1", state: "active" };
+  const call = createCall();
   const hangupCall = params.hangupCall ?? vi.fn(async () => {});
   const ctx = {
+    mutationQueue: new KeyedAsyncQueue(),
+    isStopping: () => false,
+    trackCallWork: vi.fn(),
+    notifyHangupTimers: new Map(),
+    pendingCallAdmissions: new Set<string>(),
     activeCalls: new Map([["call-1", call]]),
     providerCallIdMap: new Map([["provider-1", "call-1"]]),
     provider: { hangupCall },
@@ -88,6 +98,7 @@ function createActiveCallContext(params: { hangupCall?: ReturnType<typeof vi.fn>
 describe("voice-call outbound helpers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    persistCallRecordMock.mockReset().mockResolvedValue(undefined);
     mapVoiceToPollyMock.mockReturnValue("Polly.Joanna");
     generateDtmfRedirectTwimlMock.mockReturnValue("<DtmfRedirect />");
     generateNotifyTwimlMock.mockReturnValue("<Response />");
@@ -95,6 +106,11 @@ describe("voice-call outbound helpers", () => {
 
   it("guards initiateCall when provider, webhook, capacity, or fromNumber are missing", async () => {
     const base = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       config: {
@@ -126,6 +142,11 @@ describe("voice-call outbound helpers", () => {
 
     const saturated = {
       ...base,
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map([["existing", {}]]),
       provider: { name: "twilio" },
     };
@@ -154,6 +175,11 @@ describe("voice-call outbound helpers", () => {
   it("initiates notify-mode calls with inline TwiML and records provider ids", async () => {
     const initiateProviderCall = vi.fn(async () => ({ providerCallId: "provider-1" }));
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       provider: { name: "twilio", initiateCall: initiateProviderCall },
@@ -194,6 +220,11 @@ describe("voice-call outbound helpers", () => {
   it("persists the configured agent on outbound call records", async () => {
     const initiateProviderCall = vi.fn(async () => ({ providerCallId: "provider-1" }));
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       provider: { name: "twilio", initiateCall: initiateProviderCall },
@@ -221,6 +252,11 @@ describe("voice-call outbound helpers", () => {
 
   it("uses the per-call agent for explicit session normalization", async () => {
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       provider: {
@@ -253,6 +289,11 @@ describe("voice-call outbound helpers", () => {
   it("initiates conversation calls with pre-connect DTMF TwiML", async () => {
     const initiateProviderCall = vi.fn(async () => ({ providerCallId: "provider-1" }));
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       provider: { name: "twilio", initiateCall: initiateProviderCall },
@@ -298,6 +339,11 @@ describe("voice-call outbound helpers", () => {
   it("rejects DTMF sequences outside conversation mode", async () => {
     const initiateProviderCall = vi.fn(async () => ({ providerCallId: "provider-1" }));
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       provider: { name: "twilio", initiateCall: initiateProviderCall },
@@ -327,6 +373,11 @@ describe("voice-call outbound helpers", () => {
 
   it("fails initiateCall cleanly when provider initiation throws", async () => {
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       provider: {
@@ -352,9 +403,14 @@ describe("voice-call outbound helpers", () => {
   });
 
   it("speaks through connected calls and rolls back to listening on provider errors", async () => {
-    const call = { callId: "call-1", providerCallId: "provider-1", state: "active" };
+    const call = createCall();
     const playTts = vi.fn(async () => {});
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map([["call-1", call]]),
       providerCallIdMap: new Map(),
       provider: { name: "twilio", playTts },
@@ -365,7 +421,7 @@ describe("voice-call outbound helpers", () => {
     await expect(
       speak(ctx as never, "call-1", "hello", { listenAfterPlayback: true }),
     ).resolves.toEqual({ success: true });
-    expect(transitionStateMock).toHaveBeenCalledWith(call, "speaking");
+    expect(call.state).toBe("speaking");
     expect(playTts).toHaveBeenCalledWith({
       callId: "call-1",
       providerCallId: "provider-1",
@@ -373,7 +429,7 @@ describe("voice-call outbound helpers", () => {
       voice: "alloy",
       listenAfterPlayback: true,
     });
-    expect(addTranscriptEntryMock).toHaveBeenCalledWith(call, "bot", "hello");
+    expect(call.transcript).toEqual([expect.objectContaining({ speaker: "bot", text: "hello" })]);
 
     playTts.mockImplementationOnce(async () => {
       throw new Error("tts failed");
@@ -382,17 +438,22 @@ describe("voice-call outbound helpers", () => {
       success: false,
       error: "tts failed",
     });
-    expect(transitionStateMock).toHaveBeenLastCalledWith(call, "listening");
+    expect(call.state).toBe("listening");
   });
 
   it("reports telephony queue overflow without starting a silent listening turn", async () => {
-    const call = { callId: "call-1", providerCallId: "provider-1", state: "active" };
+    const call = createCall();
     const playTts = vi.fn(async () => {
       throw new Error("Telephony TTS queue is full for stream; maxPending=8");
     });
     const startListening = vi.fn(async () => {});
     const activeTurnCalls = new Set<string>();
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map([["call-1", call]]),
       providerCallIdMap: new Map([["provider-1", "call-1"]]),
       provider: {
@@ -417,13 +478,18 @@ describe("voice-call outbound helpers", () => {
     expect(playTts).toHaveBeenCalledOnce();
     expect(startListening).not.toHaveBeenCalled();
     expect(activeTurnCalls.size).toBe(0);
-    expect(transitionStateMock).toHaveBeenLastCalledWith(call, "listening");
+    expect(call.state).toBe("listening");
   });
 
   it("passes configured voice ids through to Telnyx speak", async () => {
-    const call = { callId: "call-1", providerCallId: "provider-1", state: "active" };
+    const call = createCall();
     const playTts = vi.fn(async () => {});
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map([["call-1", call]]),
       providerCallIdMap: new Map(),
       provider: { name: "telnyx", playTts },
@@ -451,18 +517,18 @@ describe("voice-call outbound helpers", () => {
   });
 
   it("caps notify-mode auto-hangup delay before scheduling", async () => {
-    const call = {
-      callId: "call-1",
-      providerCallId: "provider-1",
-      state: "active",
-      metadata: { initialMessage: "hello", mode: "notify" },
-    };
+    const call = createCall({ metadata: { initialMessage: "hello", mode: "notify" } });
     const playTts = vi.fn(async () => {});
     const timeoutSpy = vi
       .spyOn(globalThis, "setTimeout")
       .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
     getCallByProviderCallIdMock.mockReturnValue(call);
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map([["call-1", call]]),
       providerCallIdMap: new Map([["provider-1", "call-1"]]),
       provider: { name: "twilio", playTts },
@@ -483,16 +549,18 @@ describe("voice-call outbound helpers", () => {
   });
 
   it("uses per-number route TTS voice for routed inbound calls", async () => {
-    const call = {
-      callId: "call-1",
-      providerCallId: "provider-1",
+    const call = createCall({
       direction: "inbound",
-      state: "active",
       to: "+15550002222",
       metadata: { numberRouteKey: "+15550002222" },
-    };
+    });
     const playTts = vi.fn(async () => {});
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map([["call-1", call]]),
       providerCallIdMap: new Map(),
       provider: { name: "twilio", playTts },
@@ -522,15 +590,14 @@ describe("voice-call outbound helpers", () => {
   });
 
   it("keeps top-level TTS for outbound calls to a number with an inbound route", async () => {
-    const call = {
-      callId: "call-1",
-      providerCallId: "provider-1",
-      direction: "outbound",
-      state: "active",
-      to: "+15550002222",
-    };
+    const call = createCall({ direction: "outbound", to: "+15550002222" });
     const playTts = vi.fn(async () => {});
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map([["call-1", call]]),
       providerCallIdMap: new Map(),
       provider: { name: "twilio", playTts },
@@ -556,9 +623,14 @@ describe("voice-call outbound helpers", () => {
   });
 
   it("sends DTMF through connected provider calls", async () => {
-    const call = { callId: "call-1", providerCallId: "provider-1", state: "active" };
+    const call = createCall();
     const sendDtmfProvider = vi.fn(async () => {});
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map([["call-1", call]]),
       providerCallIdMap: new Map(),
       provider: { name: "twilio", sendDtmf: sendDtmfProvider },
@@ -577,8 +649,13 @@ describe("voice-call outbound helpers", () => {
   });
 
   it("rejects invalid or unsupported outbound DTMF", async () => {
-    const call = { callId: "call-1", providerCallId: "provider-1", state: "active" };
+    const call = createCall();
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map([["call-1", call]]),
       providerCallIdMap: new Map(),
       provider: { name: "telnyx" },
@@ -614,7 +691,7 @@ describe("voice-call outbound helpers", () => {
       expect(endedAt).toBeGreaterThanOrEqual(beforeEndMs);
       expect(endedAt).toBeLessThanOrEqual(afterEndMs);
     }
-    expect(transitionStateMock).toHaveBeenCalledWith(call, "hangup-bot");
+    expect(call.state).toBe("hangup-bot");
     expect(clearMaxDurationTimerMock).toHaveBeenCalledWith(
       { maxDurationTimers: ctx.maxDurationTimers },
       "call-1",
@@ -648,7 +725,7 @@ describe("voice-call outbound helpers", () => {
       expect(endedAt).toBeGreaterThanOrEqual(beforeEndMs);
       expect(endedAt).toBeLessThanOrEqual(afterEndMs);
     }
-    expect(transitionStateMock).toHaveBeenCalledWith(call, "timeout");
+    expect(call.state).toBe("timeout");
     expect(rejectTranscriptWaiterMock).toHaveBeenCalledWith(
       { transcriptWaiters: ctx.transcriptWaiters },
       "call-1",
@@ -660,6 +737,11 @@ describe("voice-call outbound helpers", () => {
     await expect(
       speak(
         {
+          mutationQueue: new KeyedAsyncQueue(),
+          isStopping: () => false,
+          trackCallWork: vi.fn(),
+          notifyHangupTimers: new Map(),
+          pendingCallAdmissions: new Set<string>(),
           activeCalls: new Map(),
           providerCallIdMap: new Map(),
           provider: { name: "twilio", playTts: vi.fn() },
@@ -674,6 +756,11 @@ describe("voice-call outbound helpers", () => {
     await expect(
       endCall(
         {
+          mutationQueue: new KeyedAsyncQueue(),
+          isStopping: () => false,
+          trackCallWork: vi.fn(),
+          notifyHangupTimers: new Map(),
+          pendingCallAdmissions: new Set<string>(),
           activeCalls: new Map([
             ["call-1", { callId: "call-1", state: "completed", providerCallId: "provider-1" }],
           ]),
@@ -696,6 +783,11 @@ describe("voice-call outbound helpers", () => {
       streamUrl: "wss://example.test/voice/stream/realtime/token-xyz",
     }));
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       provider: { name: "telnyx", initiateCall: initiateProviderCall },
@@ -738,6 +830,11 @@ describe("voice-call outbound helpers", () => {
       streamUrl: "wss://example.test/should-not-be-used",
     }));
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       provider: { name: "twilio", initiateCall: initiateProviderCall },
@@ -767,6 +864,11 @@ describe("voice-call outbound helpers", () => {
     const initiateProviderCall = vi.fn(async () => ({ providerCallId: "call-control-1" }));
     const streamSessionIssuer = vi.fn();
     const ctx = {
+      mutationQueue: new KeyedAsyncQueue(),
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
+      notifyHangupTimers: new Map(),
+      pendingCallAdmissions: new Set<string>(),
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       provider: { name: "telnyx", initiateCall: initiateProviderCall },

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -19,14 +19,11 @@ import { mapVoiceToPolly } from "../voice-mapping.js";
 import type { CallEndResult, CallManagerContext } from "./context.js";
 import { finalizeCall } from "./lifecycle.js";
 import { getCallByProviderCallId } from "./lookup.js";
-import { addTranscriptEntry, transitionState } from "./state.js";
+import { updateCall } from "./mutations.js";
+import { addTranscriptEntry, copyCallRecord, transitionState } from "./state.js";
 import { persistCallRecord } from "./store.js";
 import { resolveVoiceCallSecondsTimerDelayMs } from "./timer-delays.js";
-import {
-  clearTranscriptWaiter,
-  ensureMaxDurationTimerForLiveCall,
-  waitForFinalTranscript,
-} from "./timers.js";
+import { clearTranscriptWaiter, startMaxDurationTimer, waitForFinalTranscript } from "./timers.js";
 import { generateDtmfRedirectTwiml, generateNotifyTwiml } from "./twiml.js";
 
 type InitiateContext = Pick<
@@ -39,6 +36,9 @@ type InitiateContext = Pick<
   | "storePath"
   | "webhookUrl"
   | "streamSessionIssuer"
+  | "mutationQueue"
+  | "pendingCallAdmissions"
+  | "isStopping"
 >;
 
 type SpeakContext = Pick<
@@ -51,6 +51,9 @@ type SpeakContext = Pick<
   | "transcriptWaiters"
   | "maxDurationTimers"
   | "endCallOperations"
+  | "mutationQueue"
+  | "trackCallWork"
+  | "isStopping"
 >;
 
 type ConversationContext = Pick<
@@ -64,7 +67,11 @@ type ConversationContext = Pick<
   | "transcriptWaiters"
   | "maxDurationTimers"
   | "initialMessageInFlight"
+  | "notifyHangupTimers"
   | "endCallOperations"
+  | "mutationQueue"
+  | "trackCallWork"
+  | "isStopping"
 >;
 
 type EndCallContext = Pick<
@@ -76,6 +83,7 @@ type EndCallContext = Pick<
   | "transcriptWaiters"
   | "maxDurationTimers"
   | "endCallOperations"
+  | "mutationQueue"
 >;
 
 type ConnectedCallContext = Pick<CallManagerContext, "activeCalls" | "provider">;
@@ -129,6 +137,10 @@ function requireConnectedCall(ctx: ConnectedCallContext, callId: CallId): Connec
   };
 }
 
+function isCurrentCall(ctx: Pick<CallManagerContext, "activeCalls">, call: CallRecord): boolean {
+  return ctx.activeCalls.get(call.callId) === call && !TerminalStates.has(call.state);
+}
+
 function validateDtmfDigits(digits: string): string | null {
   return /^[0-9*#wWpP,]+$/.test(digits)
     ? null
@@ -169,7 +181,7 @@ export async function initiateCall(
     return { callId: "", success: false, error: "Webhook URL not configured" };
   }
 
-  if (ctx.activeCalls.size >= ctx.config.maxConcurrentCalls) {
+  if (ctx.activeCalls.size + ctx.pendingCallAdmissions.size >= ctx.config.maxConcurrentCalls) {
     return {
       callId: "",
       success: false,
@@ -209,11 +221,21 @@ export async function initiateCall(
     },
   };
 
-  // Persist before reserving capacity so storage failures cannot strand undialed calls.
-  persistCallRecord(ctx.storePath, callRecord);
-  ctx.activeCalls.set(callId, callRecord);
+  ctx.pendingCallAdmissions.add(callId);
+  try {
+    await ctx.mutationQueue.enqueue("state", async () => {
+      await persistCallRecord(ctx.storePath, callRecord);
+      ctx.activeCalls.set(callId, callRecord);
+      ctx.pendingCallAdmissions.delete(callId);
+    });
+  } finally {
+    ctx.pendingCallAdmissions.delete(callId);
+  }
 
   try {
+    if (ctx.isStopping()) {
+      throw new Error("Voice Call manager is stopping");
+    }
     // For notify mode with a message, use inline TwiML with <Say>.
     let inlineTwiml: string | undefined;
     let preConnectTwiml: string | undefined;
@@ -252,22 +274,29 @@ export async function initiateCall(
     });
 
     // A callback may establish the canonical ID or finalize the call while dialing awaits.
-    if (ctx.activeCalls.get(callId) === callRecord && !callRecord.providerCallId) {
-      callRecord.providerCallId = result.providerCallId;
+    await ctx.mutationQueue.enqueue("state", async () => {
+      if (!isCurrentCall(ctx, callRecord) || callRecord.providerCallId) {
+        return;
+      }
+      const next = copyCallRecord(callRecord);
+      next.providerCallId = result.providerCallId;
+      await persistCallRecord(ctx.storePath, next);
+      Object.assign(callRecord, next);
       ctx.providerCallIdMap.set(result.providerCallId, callId);
-      persistCallRecord(ctx.storePath, callRecord);
-    }
+    });
     console.log(
       `[voice-call] Outbound call initiated: callId=${callId} providerCallId=${callRecord.providerCallId ?? result.providerCallId} mode=${mode} preConnectDtmf=${preConnectTwiml ? "yes" : "no"} initialMessage=${initialMessage ? "yes" : "no"}`,
     );
 
     return { callId, success: true };
   } catch (err) {
-    finalizeCall({
-      ctx,
-      call: callRecord,
-      endReason: "failed",
-    });
+    await ctx.mutationQueue.enqueue("state", () =>
+      finalizeCall({
+        ctx,
+        call: callRecord,
+        endReason: "failed",
+      }),
+    );
 
     return {
       callId,
@@ -279,6 +308,7 @@ export async function initiateCall(
 
 export type SpeakOptions = {
   listenAfterPlayback?: boolean;
+  isCurrent?: () => boolean;
 };
 
 export async function speak(
@@ -293,15 +323,41 @@ export async function speak(
   }
   const { call, providerCallId, provider } = connected;
 
+  let speakingCommitted = false;
   try {
-    ensureMaxDurationTimerForLiveCall({
+    let startTimer = false;
+    speakingCommitted = await updateCall(
       ctx,
       call,
-      liveAt: Date.now(),
-      onTimeout: (id) => endCall(ctx, id, { reason: "timeout" }),
-    });
-    transitionState(call, "speaking");
-    persistCallRecord(ctx.storePath, call);
+      (next) => {
+        if (!next.answeredAt) {
+          next.answeredAt = Date.now();
+          startTimer = true;
+        }
+        transitionState(next, "speaking");
+      },
+      options?.isCurrent,
+    );
+    if (options?.isCurrent) {
+      // Speech admitted during the write must finish its replay/turn checks before playback.
+      await ctx.mutationQueue.enqueue("state", async () => undefined);
+      if (!options.isCurrent()) {
+        throw new Error("Automatic reply superseded");
+      }
+    }
+    if (!speakingCommitted || !isCurrentCall(ctx, call)) {
+      return { success: false, error: "Call has ended" };
+    }
+    if (ctx.isStopping()) {
+      throw new Error("Voice Call manager is stopping");
+    }
+    if (startTimer) {
+      startMaxDurationTimer({
+        ctx,
+        callId,
+        onTimeout: (id) => endCall(ctx, id, { reason: "timeout" }),
+      });
+    }
 
     const numberRouteKey = resolveVoiceCallNumberRouteKeyForCall(call);
     const voice = resolvePreferredTtsVoice(
@@ -310,20 +366,25 @@ export async function speak(
     const playbackOptions = options?.listenAfterPlayback ? { listenAfterPlayback: true } : {};
     await provider.playTts({
       callId,
-      providerCallId,
+      providerCallId: call.providerCallId ?? providerCallId,
       text,
       voice,
       ...playbackOptions,
     });
 
-    addTranscriptEntry(call, "bot", text);
-    persistCallRecord(ctx.storePath, call);
+    if (!(await updateCall(ctx, call, (next) => addTranscriptEntry(next, "bot", text)))) {
+      return { success: false, error: "Call has ended" };
+    }
 
     return { success: true };
   } catch (err) {
-    // A failed playback should not leave the call stuck in speaking state.
-    transitionState(call, "listening");
-    persistCallRecord(ctx.storePath, call);
+    if (speakingCommitted) {
+      await updateCall(ctx, call, (next) => {
+        if (next.state === "speaking") {
+          transitionState(next, "listening");
+        }
+      });
+    }
     return { success: false, error: formatErrorMessage(err) };
   }
 }
@@ -409,39 +470,70 @@ export async function speakInitialMessage(
     }
 
     // Clear only after successful playback so transient provider failures can retry.
-    if (call.metadata) {
-      delete call.metadata.initialMessage;
-      persistCallRecord(ctx.storePath, call);
+    if (
+      !(await updateCall(ctx, call, (next) => {
+        if (next.metadata?.initialMessage === initialMessage) {
+          delete next.metadata.initialMessage;
+        }
+      })) ||
+      !isCurrentCall(ctx, call)
+    ) {
+      return;
     }
 
+    if (ctx.isStopping()) {
+      throw new Error("Voice Call manager is stopping");
+    }
     if (mode === "notify") {
       const delaySec = ctx.config.outbound.notifyHangupDelaySec;
       const delayMs = resolveVoiceCallSecondsTimerDelayMs(delaySec, 0);
       console.log(`[voice-call] Notify mode: auto-hangup in ${delaySec}s for call ${call.callId}`);
-      setTimeout(() => {
-        void (async () => {
-          const currentCall = ctx.activeCalls.get(call.callId);
-          if (currentCall && !TerminalStates.has(currentCall.state)) {
+      const previousTimer = ctx.notifyHangupTimers.get(call.callId);
+      if (previousTimer) {
+        clearTimeout(previousTimer);
+      }
+      const timer = setTimeout(() => {
+        if (ctx.notifyHangupTimers.get(call.callId) !== timer) {
+          return;
+        }
+        ctx.notifyHangupTimers.delete(call.callId);
+        const work = (async () => {
+          if (!ctx.isStopping() && isCurrentCall(ctx, call)) {
             console.log(`[voice-call] Notify mode: hanging up call ${call.callId}`);
-            const endResult = await endCall(ctx, call.callId);
-            if (!endResult.success) {
+            try {
+              const endResult = await endCall(ctx, call.callId);
+              if (!endResult.success) {
+                console.warn(
+                  `[voice-call] Notify mode failed to hang up call ${call.callId}: ${endResult.error ?? "unknown error"}`,
+                );
+              }
+            } catch (error) {
               console.warn(
-                `[voice-call] Notify mode failed to hang up call ${call.callId}: ${endResult.error ?? "unknown error"}`,
+                `[voice-call] Notify mode failed to hang up call ${call.callId}: ${formatErrorMessage(error)}`,
               );
             }
           }
         })();
+        ctx.trackCallWork(work);
       }, delayMs);
+      ctx.notifyHangupTimers.set(call.callId, timer);
     } else if (
       mode === "conversation" &&
       ctx.provider &&
       shouldStartListeningAfterInitialMessage(ctx)
     ) {
-      transitionState(call, "listening");
-      persistCallRecord(ctx.storePath, call);
+      if (
+        !(await updateCall(ctx, call, (next) => transitionState(next, "listening"))) ||
+        !isCurrentCall(ctx, call)
+      ) {
+        return;
+      }
+      if (ctx.isStopping()) {
+        throw new Error("Voice Call manager is stopping");
+      }
       await ctx.provider.startListening({
         callId: call.callId,
-        providerCallId,
+        providerCallId: call.providerCallId ?? providerCallId,
       });
     }
   } finally {
@@ -474,11 +566,28 @@ export async function continueCall(
       return speakResult;
     }
 
-    transitionState(call, "listening");
-    persistCallRecord(ctx.storePath, call);
+    if (
+      !(await updateCall(ctx, call, (next) => transitionState(next, "listening"))) ||
+      !isCurrentCall(ctx, call)
+    ) {
+      return { success: false, error: "Call has ended" };
+    }
 
+    if (ctx.isStopping()) {
+      throw new Error("Voice Call manager is stopping");
+    }
     const listenStartedAt = Date.now();
-    await provider.startListening({ callId, providerCallId, turnToken });
+    await provider.startListening({
+      callId,
+      providerCallId: call.providerCallId ?? providerCallId,
+      turnToken,
+    });
+    if (ctx.isStopping()) {
+      throw new Error("Voice Call manager is stopping");
+    }
+    if (!isCurrentCall(ctx, call)) {
+      return { success: false, error: "Call has ended" };
+    }
 
     const transcript = await waitForFinalTranscript(ctx, callId, turnToken);
     const transcriptReceivedAt = Date.now();
@@ -488,19 +597,21 @@ export async function continueCall(
 
     const lastTurnLatencyMs = transcriptReceivedAt - turnStartedAt;
     const lastTurnListenWaitMs = transcriptReceivedAt - listenStartedAt;
-    const turnCount =
-      call.metadata && typeof call.metadata.turnCount === "number"
-        ? call.metadata.turnCount + 1
-        : 1;
-
-    call.metadata = {
-      ...call.metadata,
-      turnCount,
-      lastTurnLatencyMs,
-      lastTurnListenWaitMs,
-      lastTurnCompletedAt: transcriptReceivedAt,
-    };
-    persistCallRecord(ctx.storePath, call);
+    if (
+      !(await updateCall(ctx, call, (next) => {
+        const turnCount =
+          typeof next.metadata?.turnCount === "number" ? next.metadata.turnCount + 1 : 1;
+        next.metadata = {
+          ...next.metadata,
+          turnCount,
+          lastTurnLatencyMs,
+          lastTurnListenWaitMs,
+          lastTurnCompletedAt: transcriptReceivedAt,
+        };
+      }))
+    ) {
+      return { success: false, error: "Call has ended" };
+    }
 
     console.log(
       "[voice-call] continueCall latency call=" +
@@ -547,11 +658,13 @@ export function endCall(
         reason,
       });
 
-      finalizeCall({
-        ctx,
-        call,
-        endReason: reason,
-      });
+      await ctx.mutationQueue.enqueue("state", () =>
+        finalizeCall({
+          ctx,
+          call,
+          endReason: reason,
+        }),
+      );
 
       return { success: true };
     } catch (err) {

--- a/extensions/voice-call/src/manager/state.ts
+++ b/extensions/voice-call/src/manager/state.ts
@@ -47,3 +47,13 @@ export function addTranscriptEntry(call: CallRecord, speaker: "bot" | "user", te
   };
   call.transcript.push(entry);
 }
+
+/** Stage persisted changes without exposing uncommitted state through active-call getters. */
+export function copyCallRecord(call: CallRecord): CallRecord {
+  return {
+    ...call,
+    transcript: [...call.transcript],
+    processedEventIds: [...call.processedEventIds],
+    ...(call.metadata ? { metadata: { ...call.metadata } } : {}),
+  };
+}

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -2,9 +2,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Command } from "commander";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
-  createPluginStateSyncKeyedStoreForTests,
+  createPluginStateKeyedStoreForTests,
   openOpenClawStateDatabase,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
@@ -20,6 +22,7 @@ import { CallRecordSchema } from "../types.js";
 import { MAX_CALL_REPLAY_KEYS } from "./replay-keys.js";
 import {
   CALL_RECORD_EVENT_CHUNKS_NAMESPACE,
+  CALL_RECORD_EVENTS_NAMESPACE,
   CALL_RECORD_CHUNK_MAX_ENTRIES,
   findCallInStore,
   getCallHistoryFromStore,
@@ -35,15 +38,35 @@ vi.mock("../../api.js", async (importOriginal) => ({
 
 const MANAGER_REPLAY_KEY_LIMIT = 10_000;
 
-function installStateRuntime(bulkReads = true): void {
+function installStateRuntime({
+  bulkReads = true,
+  beforeOperation,
+}: {
+  bulkReads?: boolean;
+  beforeOperation?: (
+    namespace: string,
+    operation: "register" | "entries",
+    key?: string,
+  ) => Promise<void>;
+} = {}): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
-      openKeyedStore: (() => {
-        throw new Error("openKeyedStore is not used by voice-call store tests");
-      }) as never,
-      openSyncKeyedStore: <T>(options: OpenKeyedStoreOptions) => {
-        const store = createPluginStateSyncKeyedStoreForTests<T>("voice-call", options);
+      openKeyedStore: <T>(options: OpenKeyedStoreOptions) => {
+        const backingStore = createPluginStateKeyedStoreForTests<T>("voice-call", options);
+        const store = beforeOperation
+          ? {
+              ...backingStore,
+              async register(...args: Parameters<typeof backingStore.register>) {
+                await beforeOperation(options.namespace, "register", args[0]);
+                await backingStore.register(...args);
+              },
+              async entries() {
+                await beforeOperation(options.namespace, "entries");
+                return backingStore.entries();
+              },
+            }
+          : backingStore;
         if (bulkReads) {
           return store;
         }
@@ -78,14 +101,14 @@ describe("voice-call call record store", () => {
     );
     const added = CallRecordSchema.parse(makePersistedCall({ callId: "new" }));
     for (const call of calls) {
-      persistCallRecord(storePath, call);
+      await persistCallRecord(storePath, call);
     }
     const stopped = new Error("SQLite tail test finished");
     sleepMock
       .mockReset()
       .mockRejectedValue(stopped)
       .mockImplementationOnce(async () => {
-        persistCallRecord(storePath, added);
+        await persistCallRecord(storePath, added);
       });
     let output = "";
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
@@ -121,7 +144,7 @@ describe("voice-call call record store", () => {
     );
     writeLegacyCallsJsonl(storePath, [call]);
 
-    const restored = loadActiveCallsFromStore(storePath);
+    const restored = await loadActiveCallsFromStore(storePath);
     expect(restored.activeCalls.has("call-legacy")).toBe(false);
     expect(restored.processedEventIds.has("evt-1")).toBe(false);
     expect(fs.existsSync(path.join(storePath, "calls.jsonl"))).toBe(true);
@@ -136,14 +159,14 @@ describe("voice-call call record store", () => {
       makePersistedCall({ callId: "call-sqlite", transcript: [] }),
     );
 
-    persistCallRecord(storePath, call);
+    await persistCallRecord(storePath, call);
 
     expect(fs.existsSync(path.join(storePath, "calls.jsonl"))).toBe(false);
-    const restored = loadActiveCallsFromStore(storePath);
+    const restored = await loadActiveCallsFromStore(storePath);
     expect(restored.activeCalls.get("call-sqlite")?.providerCallId).toBe(call.providerCallId);
   });
 
-  it("does not read the JSONL fallback when SQLite state cannot open", () => {
+  it("does not read the JSONL fallback when SQLite state cannot open", async () => {
     const storePath = createTestStorePath();
     const call = CallRecordSchema.parse(makePersistedCall({ callId: "call-jsonl" }));
     writeLegacyCallsJsonl(storePath, [call]);
@@ -151,9 +174,6 @@ describe("voice-call call record store", () => {
       state: {
         resolveStateDir: () => "",
         openKeyedStore: (() => {
-          throw new Error("openKeyedStore is not used by voice-call store tests");
-        }) as never,
-        openSyncKeyedStore: (() => {
           throw new Error("sqlite unavailable");
         }) as never,
         openChannelIngressQueue: (() => {
@@ -165,7 +185,7 @@ describe("voice-call call record store", () => {
       },
     });
 
-    const restored = loadActiveCallsFromStore(storePath);
+    const restored = await loadActiveCallsFromStore(storePath);
     expect(restored.activeCalls.has("call-jsonl")).toBe(false);
     expect(fs.existsSync(path.join(storePath, "calls.jsonl"))).toBe(true);
   });
@@ -173,7 +193,7 @@ describe("voice-call call record store", () => {
   it.each([true, false])(
     "restores complete chunked call transcripts (bulk: %s)",
     async (bulkReads) => {
-      installStateRuntime(bulkReads);
+      installStateRuntime({ bulkReads });
       const storePath = createTestStorePath();
       const call = CallRecordSchema.parse(
         makePersistedCall({
@@ -183,14 +203,14 @@ describe("voice-call call record store", () => {
           ],
         }),
       );
-      persistCallRecord(storePath, call);
+      await persistCallRecord(storePath, call);
       resetPluginStateStoreForTests();
-      expect(loadActiveCallsFromStore(storePath).activeCalls.get(call.callId)?.transcript).toEqual(
-        call.transcript,
-      );
+      expect(
+        (await loadActiveCallsFromStore(storePath)).activeCalls.get(call.callId)?.transcript,
+      ).toEqual(call.transcript);
       await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([call]);
       const env = { ...process.env, OPENCLAW_STATE_DIR: storePath };
-      const chunks = createPluginStateSyncKeyedStoreForTests<{ index: number; dataBase64: string }>(
+      const chunks = createPluginStateKeyedStoreForTests<{ index: number; dataBase64: string }>(
         "voice-call",
         {
           namespace: CALL_RECORD_EVENT_CHUNKS_NAMESPACE,
@@ -198,7 +218,7 @@ describe("voice-call call record store", () => {
           env,
         },
       );
-      const rows = chunks.entries();
+      const rows = await chunks.entries();
       const first = rows.find((row) => row.value.index === 0);
       const later = rows.find((row) => row.value.index === 1);
       if (!first || !later) {
@@ -207,19 +227,19 @@ describe("voice-call call record store", () => {
       const good = CallRecordSchema.parse(
         makePersistedCall({ callId: "good-call", transcript: [] }),
       );
-      persistCallRecord(storePath, good);
+      await persistCallRecord(storePath, good);
       const { db } = openOpenClawStateDatabase({ env });
       db.prepare("UPDATE plugin_state_entries SET value_json = ? WHERE entry_key = ?").run(
         "invalid JSON",
         later.key,
       );
-      chunks.register(first.key, { ...first.value, index: -1 });
+      await chunks.register(first.key, { ...first.value, index: -1 });
       await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([good]);
-      expect(findCallInStore(storePath, good.callId)).toEqual(good);
-      chunks.delete(first.key);
+      expect(await findCallInStore(storePath, good.callId)).toEqual(good);
+      await chunks.delete(first.key);
       await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([good]);
-      chunks.register(first.key, first.value);
-      expect(() => findCallInStore(storePath, good.callId)).toThrowError(
+      await chunks.register(first.key, first.value);
+      await expect(findCallInStore(storePath, good.callId)).rejects.toThrowError(
         expect.objectContaining({ code: "PLUGIN_STATE_CORRUPT" }),
       );
     },
@@ -242,9 +262,9 @@ describe("voice-call call record store", () => {
       }),
     );
 
-    persistCallRecord(storePath, call);
+    await persistCallRecord(storePath, call);
 
-    const restored = loadActiveCallsFromStore(storePath);
+    const restored = await loadActiveCallsFromStore(storePath);
     const restoredCall = restored.activeCalls.get("call-large");
     expect(restoredCall?.providerCallId).toBe(call.providerCallId);
     expect(restoredCall?.transcript).toEqual([]);
@@ -256,7 +276,7 @@ describe("voice-call call record store", () => {
     expect(fs.existsSync(path.join(storePath, "calls.jsonl"))).toBe(false);
   });
 
-  it("replays same-millisecond snapshots in write order", () => {
+  it("replays same-millisecond snapshots in write order", async () => {
     vi.useFakeTimers({ now: new Date("2026-05-31T10:00:00.000Z") });
     const storePath = createTestStorePath();
     const first = CallRecordSchema.parse(
@@ -266,14 +286,116 @@ describe("voice-call call record store", () => {
       makePersistedCall({ callId: "call-order", state: "answered" }),
     );
 
-    persistCallRecord(storePath, first);
-    persistCallRecord(storePath, second);
+    await persistCallRecord(storePath, first);
+    await persistCallRecord(storePath, second);
 
-    const restored = loadActiveCallsFromStore(storePath);
+    const restored = await loadActiveCallsFromStore(storePath);
     expect(restored.activeCalls.get("call-order")?.state).toBe("answered");
   });
 
-  it("persists and restores only the newest per-call replay keys", () => {
+  it("captures call bytes and write order before a delayed chunk publishes", async () => {
+    vi.useFakeTimers({ now: new Date("2026-05-31T10:00:00.000Z") });
+    const storePath = createTestStorePath();
+    const blocked = createDeferred<void>();
+    const release = createDeferred<void>();
+    let delayed = false;
+    installStateRuntime({
+      beforeOperation: async (namespace, operation) => {
+        if (
+          !delayed &&
+          namespace === CALL_RECORD_EVENT_CHUNKS_NAMESPACE &&
+          operation === "register"
+        ) {
+          delayed = true;
+          blocked.resolve();
+          await release.promise;
+        }
+      },
+    });
+    const first = CallRecordSchema.parse(
+      makePersistedCall({
+        callId: "call-delayed",
+        state: "ringing",
+        transcript: [
+          { timestamp: Date.now(), speaker: "user", text: "🦞".repeat(30_000), isFinal: true },
+        ],
+      }),
+    );
+    const expectedFirst = structuredClone(first);
+    const pending = persistCallRecord(storePath, first);
+    try {
+      await blocked.promise;
+      await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([]);
+      expectDefined(first.transcript[0], "first transcript entry").text =
+        "mutated after persistence started";
+      first.state = "answered";
+      await persistCallRecord(storePath, first);
+      await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([first]);
+    } finally {
+      release.resolve();
+      await pending;
+    }
+    resetPluginStateStoreForTests();
+    await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([expectedFirst, first]);
+    expect((await loadActiveCallsFromStore(storePath)).activeCalls.get(first.callId)?.state).toBe(
+      "answered",
+    );
+  });
+
+  it.each([CALL_RECORD_EVENT_CHUNKS_NAMESPACE, CALL_RECORD_EVENTS_NAMESPACE])(
+    "does not publish a call after a rejected %s write",
+    async (failedNamespace) => {
+      const storePath = createTestStorePath();
+      const failure = new Error("delayed SQLite write rejected");
+      installStateRuntime({
+        beforeOperation: async (namespace, operation, key) => {
+          await Promise.resolve();
+          if (
+            operation === "register" &&
+            namespace === failedNamespace &&
+            (namespace === CALL_RECORD_EVENTS_NAMESPACE || key?.endsWith(":chunk:0001"))
+          ) {
+            throw failure;
+          }
+        },
+      });
+      const call = CallRecordSchema.parse(
+        makePersistedCall({
+          transcript: [
+            { timestamp: Date.now(), speaker: "user", text: "🦞".repeat(30_000), isFinal: true },
+          ],
+        }),
+      );
+      await expect(persistCallRecord(storePath, call)).rejects.toBe(failure);
+      installStateRuntime();
+      resetPluginStateStoreForTests();
+      await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([]);
+      await expect(findCallInStore(storePath, call.callId)).resolves.toBeUndefined();
+    },
+  );
+
+  it("propagates pruning rejection and preserves restore versus status read errors", async () => {
+    const storePath = createTestStorePath();
+    const call = CallRecordSchema.parse(makePersistedCall({ callId: "call-read-error" }));
+    const failure = new Error("delayed SQLite listing rejected");
+    installStateRuntime({
+      beforeOperation: async (_namespace, operation) => {
+        await Promise.resolve();
+        if (operation === "entries") {
+          throw failure;
+        }
+      },
+    });
+    await expect(persistCallRecord(storePath, call)).rejects.toBe(failure);
+    await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([]);
+    expect((await loadActiveCallsFromStore(storePath)).activeCalls.size).toBe(0);
+    await expect(findCallInStore(storePath, call.callId)).rejects.toBe(failure);
+    installStateRuntime();
+    resetPluginStateStoreForTests();
+    await expect(findCallInStore(storePath, call.callId)).resolves.toEqual(call);
+  });
+
+  it("persists and restores only the newest per-call replay keys", async () => {
     const storePath = createTestStorePath();
     const replayKeys = Array.from(
       { length: MAX_CALL_REPLAY_KEYS + 2 },
@@ -286,17 +408,17 @@ describe("voice-call call record store", () => {
       }),
     );
 
-    persistCallRecord(storePath, call);
+    await persistCallRecord(storePath, call);
 
-    const restored = loadActiveCallsFromStore(storePath);
+    const restored = await loadActiveCallsFromStore(storePath);
     const expected = replayKeys.slice(-MAX_CALL_REPLAY_KEYS);
     expect(restored.activeCalls.get("call-bounded-replay")?.processedEventIds).toEqual(expected);
     expect([...restored.processedEventIds]).toEqual(expected);
   });
 
-  it("hydrates manager replay keys in latest-snapshot call order", () => {
+  it("hydrates manager replay keys in latest-snapshot call order", async () => {
     const storePath = createTestStorePath();
-    persistCallRecord(
+    await persistCallRecord(
       storePath,
       CallRecordSchema.parse(
         makePersistedCall({
@@ -311,7 +433,7 @@ describe("voice-call call record store", () => {
       callIndex < MANAGER_REPLAY_KEY_LIMIT / MAX_CALL_REPLAY_KEYS;
       callIndex++
     ) {
-      persistCallRecord(
+      await persistCallRecord(
         storePath,
         CallRecordSchema.parse(
           makePersistedCall({
@@ -325,7 +447,7 @@ describe("voice-call call record store", () => {
         ),
       );
     }
-    persistCallRecord(
+    await persistCallRecord(
       storePath,
       CallRecordSchema.parse(
         makePersistedCall({
@@ -336,7 +458,7 @@ describe("voice-call call record store", () => {
       ),
     );
 
-    const restored = loadActiveCallsFromStore(storePath);
+    const restored = await loadActiveCallsFromStore(storePath);
 
     expect(restored.processedEventIds.size).toBe(MANAGER_REPLAY_KEY_LIMIT);
     expect(restored.processedEventIds.has("evt-latest-old")).toBe(true);
@@ -347,13 +469,13 @@ describe("voice-call call record store", () => {
 
   it("finds retained snapshots outside recent history and preserves internal-id precedence", async () => {
     const storePath = createTestStorePath();
-    persistCallRecord(
+    await persistCallRecord(
       storePath,
       CallRecordSchema.parse(
         makePersistedCall({ callId: "call-target", providerCallId: "provider-target" }),
       ),
     );
-    persistCallRecord(
+    await persistCallRecord(
       storePath,
       CallRecordSchema.parse(
         makePersistedCall({
@@ -364,7 +486,7 @@ describe("voice-call call record store", () => {
       ),
     );
     for (let index = 0; index < 101; index += 1) {
-      persistCallRecord(
+      await persistCallRecord(
         storePath,
         CallRecordSchema.parse(
           makePersistedCall({
@@ -375,11 +497,11 @@ describe("voice-call call record store", () => {
       );
     }
     expect(await getCallHistoryFromStore(storePath, 100)).toHaveLength(100);
-    expect(findCallInStore(storePath, "call-target")).toMatchObject({
+    expect(await findCallInStore(storePath, "call-target")).toMatchObject({
       callId: "call-target",
       state: "completed",
     });
-    expect(findCallInStore(storePath, "provider-target")).toMatchObject({
+    expect(await findCallInStore(storePath, "provider-target")).toMatchObject({
       callId: "call-target",
       state: "completed",
     });

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -1,7 +1,7 @@
 // Voice Call plugin module implements store behavior.
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
-import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getOptionalVoiceCallStateRuntime } from "../runtime-state.js";
 import { CallRecordSchema, TerminalStates, type CallId, type CallRecord } from "../types.js";
 import {
@@ -52,8 +52,8 @@ type PersistedCallRecord = {
 
 /** Pair of plugin state stores used for call record events. */
 type CallRecordStateStores = {
-  events: PluginStateSyncKeyedStore<CallRecordEventMeta>;
-  chunks: PluginStateSyncKeyedStore<CallRecordEventChunk>;
+  events: PluginStateKeyedStore<CallRecordEventMeta>;
+  chunks: PluginStateKeyedStore<CallRecordEventChunk>;
 };
 
 /** Return the pre-SQLite JSONL call log path for migration/compat checks. */
@@ -74,12 +74,12 @@ function createCallRecordStateStores(storePath: string): CallRecordStateStores {
   }
   const env = resolvePluginStateEnv(storePath);
   return {
-    events: runtime.state.openSyncKeyedStore<CallRecordEventMeta>({
+    events: runtime.state.openKeyedStore<CallRecordEventMeta>({
       namespace: CALL_RECORD_EVENTS_NAMESPACE,
       maxEntries: CALL_RECORD_EVENT_META_MAX_ENTRIES,
       env,
     }),
-    chunks: runtime.state.openSyncKeyedStore<CallRecordEventChunk>({
+    chunks: runtime.state.openKeyedStore<CallRecordEventChunk>({
       namespace: CALL_RECORD_EVENT_CHUNKS_NAMESPACE,
       maxEntries: CALL_RECORD_CHUNK_MAX_ENTRIES,
       env,
@@ -220,12 +220,13 @@ export function prepareVoiceCallRecordForStorage(call: CallRecord): CallRecord {
 }
 
 /** Register a serialized call record event and its chunks, then prune old events. */
-function registerCallRecordEvent(
+async function registerCallRecordEvent(
   stores: CallRecordStateStores,
   eventKey: string,
   call: CallRecord,
-  order?: { persistedAt: number; sequence: number },
-): void {
+  order: { persistedAt: number; sequence: number },
+): Promise<void> {
+  // Capture the snapshot before chunk writes yield to later call mutations.
   const serialized = JSON.stringify(prepareVoiceCallRecordForStorage(call));
   const buffer = Buffer.from(serialized, "utf8");
   const chunkCount = Math.max(1, Math.ceil(buffer.byteLength / RAW_CALL_RECORD_CHUNK_BYTES));
@@ -239,50 +240,53 @@ function registerCallRecordEvent(
       index * RAW_CALL_RECORD_CHUNK_BYTES,
       (index + 1) * RAW_CALL_RECORD_CHUNK_BYTES,
     );
-    stores.chunks.register(buildChunkKey(eventKey, index), {
+    await stores.chunks.register(buildChunkKey(eventKey, index), {
       index,
       dataBase64: chunk.toString("base64"),
     });
   }
-  stores.events.register(eventKey, {
+  await stores.events.register(eventKey, {
     chunkCount,
     byteLength: buffer.byteLength,
-    persistedAt: order?.persistedAt,
-    sequence: order?.sequence,
+    persistedAt: order.persistedAt,
+    sequence: order.sequence,
   });
-  pruneCallRecordEvents(stores);
+  await pruneCallRecordEvents(stores);
 }
 
 /** Delete metadata and all chunk rows for one call record event. */
-function deleteCallRecordEventRows(stores: CallRecordStateStores, eventKey: string): void {
-  const meta = stores.events.lookup(eventKey);
-  stores.events.delete(eventKey);
+async function deleteCallRecordEventRows(
+  stores: CallRecordStateStores,
+  eventKey: string,
+): Promise<void> {
+  const meta = await stores.events.lookup(eventKey);
+  await stores.events.delete(eventKey);
   if (!meta) {
     return;
   }
   for (let index = 0; index < meta.chunkCount; index += 1) {
-    stores.chunks.delete(buildChunkKey(eventKey, index));
+    await stores.chunks.delete(buildChunkKey(eventKey, index));
   }
 }
 
 /** Keep only the newest bounded call record events. */
-function pruneCallRecordEvents(stores: CallRecordStateStores): void {
-  const rows = stores.events.entries();
+async function pruneCallRecordEvents(stores: CallRecordStateStores): Promise<void> {
+  const rows = await stores.events.entries();
   if (rows.length <= MAX_CALL_RECORD_EVENTS) {
     return;
   }
   const sorted = rows.toSorted((a, b) => a.createdAt - b.createdAt || a.key.localeCompare(b.key));
   for (const row of sorted.slice(0, rows.length - MAX_CALL_RECORD_EVENTS)) {
-    deleteCallRecordEventRows(stores, row.key);
+    await deleteCallRecordEventRows(stores, row.key);
   }
 }
 
 /** Read and reassemble one chunked call record event. */
-function readCallRecordEvent(
+async function readCallRecordEvent(
   stores: CallRecordStateStores,
   eventKey: string,
   meta: CallRecordEventMeta,
-): CallRecord | null {
+): Promise<CallRecord | null> {
   if (
     !Number.isSafeInteger(meta.chunkCount) ||
     meta.chunkCount < 1 ||
@@ -291,7 +295,7 @@ function readCallRecordEvent(
     return null;
   }
   // Preserve compatibility with published hosts exposing point reads only.
-  const records = stores.chunks.lookupMany?.(
+  const records = await stores.chunks.lookupMany?.(
     Array.from({ length: meta.chunkCount }, (_, index) => buildChunkKey(eventKey, index)),
   );
   const chunks: Buffer[] = [];
@@ -300,7 +304,9 @@ function readCallRecordEvent(
     if (result && !result.ok) {
       throw result.error;
     }
-    const chunk = records ? result?.value : stores.chunks.lookup(buildChunkKey(eventKey, index));
+    const chunk = records
+      ? result?.value
+      : await stores.chunks.lookup(buildChunkKey(eventKey, index));
     if (!chunk || chunk.index !== index) {
       return null;
     }
@@ -311,22 +317,22 @@ function readCallRecordEvent(
 }
 
 /** Read all persisted call records in stable persisted order. */
-function readCallRecordEvents(stores: CallRecordStateStores): CallRecord[] {
-  const sqliteCalls: PersistedCallRecord[] = stores.events
-    .entries()
-    .toSorted((a, b) => a.createdAt - b.createdAt || a.key.localeCompare(b.key))
-    .map((entry) => {
-      const call = readCallRecordEvent(stores, entry.key, entry.value);
-      return call
-        ? {
-            call,
-            persistedAt: entry.value.persistedAt ?? entry.createdAt,
-            sequence: entry.value.sequence ?? parseEventKeySequence(entry.key),
-            orderKey: entry.key,
-          }
-        : null;
-    })
-    .filter((entry): entry is PersistedCallRecord => entry !== null);
+async function readCallRecordEvents(stores: CallRecordStateStores): Promise<CallRecord[]> {
+  const entries = (await stores.events.entries()).toSorted(
+    (a, b) => a.createdAt - b.createdAt || a.key.localeCompare(b.key),
+  );
+  const sqliteCalls: PersistedCallRecord[] = [];
+  for (const entry of entries) {
+    const call = await readCallRecordEvent(stores, entry.key, entry.value);
+    if (call) {
+      sqliteCalls.push({
+        call,
+        persistedAt: entry.value.persistedAt ?? entry.createdAt,
+        sequence: entry.value.sequence ?? parseEventKeySequence(entry.key),
+        orderKey: entry.key,
+      });
+    }
+  }
   return sqliteCalls
     .toSorted(
       (a, b) =>
@@ -338,11 +344,11 @@ function readCallRecordEvents(stores: CallRecordStateStores): CallRecord[] {
 }
 
 /** Persist one call record event to plugin state. */
-export function persistCallRecord(storePath: string, call: CallRecord): void {
+export async function persistCallRecord(storePath: string, call: CallRecord): Promise<void> {
   try {
     const stores = createCallRecordStateStores(storePath);
     const order = nextCallRecordOrder();
-    registerCallRecordEvent(stores, buildNewEventKey(order), call, order);
+    await registerCallRecordEvent(stores, buildNewEventKey(order), call, order);
   } catch (err) {
     console.error("[voice-call] Failed to persist call record:", err);
     throw err;
@@ -350,15 +356,15 @@ export function persistCallRecord(storePath: string, call: CallRecord): void {
 }
 
 /** Restore nonterminal active calls and provider/event indexes from persisted records. */
-export function loadActiveCallsFromStore(storePath: string): {
+export async function loadActiveCallsFromStore(storePath: string): Promise<{
   activeCalls: Map<CallId, CallRecord>;
   providerCallIdMap: Map<string, CallId>;
   processedEventIds: Set<string>;
-} {
+}> {
   const stores = tryCreateCallRecordStateStores(storePath);
   let calls: CallRecord[] = [];
   try {
-    calls = stores ? readCallRecordEvents(stores) : [];
+    calls = stores ? await readCallRecordEvents(stores) : [];
   } catch (err) {
     console.error("[voice-call] Failed to read SQLite call records:", err);
   }
@@ -397,11 +403,11 @@ export function loadActiveCallsFromStore(storePath: string): {
   return { activeCalls, providerCallIdMap, processedEventIds };
 }
 
-function readCallHistoryFromStore(storePath: string): CallRecord[] {
+async function readCallHistoryFromStore(storePath: string): Promise<CallRecord[]> {
   const stores = tryCreateCallRecordStateStores(storePath);
   if (stores) {
     try {
-      return readCallRecordEvents(stores);
+      return await readCallRecordEvents(stores);
     } catch (err) {
       console.error("[voice-call] Failed to read SQLite call history:", err);
     }
@@ -410,9 +416,12 @@ function readCallHistoryFromStore(storePath: string): CallRecord[] {
 }
 
 /** Resolve an internal ID or retained provider alias to its newest logical call snapshot. */
-export function findCallInStore(storePath: string, callId: string): CallRecord | undefined {
+export async function findCallInStore(
+  storePath: string,
+  callId: string,
+): Promise<CallRecord | undefined> {
   // Admission and status must distinguish unavailable history from an absent call.
-  const calls = readCallRecordEvents(createCallRecordStateStores(storePath));
+  const calls = await readCallRecordEvents(createCallRecordStateStores(storePath));
   const match =
     calls.findLast((call) => call.callId === callId) ??
     calls.findLast((call) => call.providerCallId === callId);
@@ -427,5 +436,5 @@ export async function getCallHistoryFromStore(
   if (limit <= 0) {
     return [];
   }
-  return readCallHistoryFromStore(storePath).slice(-limit);
+  return (await readCallHistoryFromStore(storePath)).slice(-limit);
 }

--- a/extensions/voice-call/src/manager/timers.test.ts
+++ b/extensions/voice-call/src/manager/timers.test.ts
@@ -23,6 +23,8 @@ describe("voice-call manager timers", () => {
   it("delegates max-duration termination and logs typed failure", async () => {
     const call = { id: "call-1", state: "active" };
     const ctx = {
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
       activeCalls: new Map([["call-1", call]]),
       maxDurationTimers: new Map(),
       config: { maxDurationSeconds: 5 },
@@ -58,6 +60,8 @@ describe("voice-call manager timers", () => {
 
   it("does not time out terminal calls", async () => {
     const ctx = {
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
       activeCalls: new Map([["call-1", { id: "call-1", state: "completed" }]]),
       maxDurationTimers: new Map(),
       config: { maxDurationSeconds: 5 },
@@ -78,6 +82,8 @@ describe("voice-call manager timers", () => {
   it("caps oversized max duration and transcript timers", () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const ctx = {
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
       activeCalls: new Map([["call-1", { id: "call-1", state: "active" }]]),
       maxDurationTimers: new Map(),
       transcriptWaiters: new Map(),
@@ -108,6 +114,8 @@ describe("voice-call manager timers", () => {
 
   it("waits for transcripts, resolves matching tokens, rejects mismatches and timeouts", async () => {
     const ctx = {
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
       transcriptWaiters: new Map(),
       config: { transcriptTimeoutMs: 1_000 },
     };
@@ -139,6 +147,8 @@ describe("voice-call manager timers", () => {
 
   it("rejects duplicate transcript waiters for the same call", async () => {
     const ctx = {
+      isStopping: () => false,
+      trackCallWork: vi.fn(),
       transcriptWaiters: new Map(),
       config: { transcriptTimeoutMs: 1_000 },
     };

--- a/extensions/voice-call/src/manager/timers.ts
+++ b/extensions/voice-call/src/manager/timers.ts
@@ -1,6 +1,6 @@
 // Voice Call plugin module implements timers behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { TerminalStates, type CallId, type CallRecord } from "../types.js";
+import { TerminalStates, type CallId } from "../types.js";
 import type { CallEndResult, CallManagerContext } from "./context.js";
 import {
   resolveVoiceCallSecondsTimerDelayMs,
@@ -11,9 +11,17 @@ import {
 
 type TimerContext = Pick<
   CallManagerContext,
-  "activeCalls" | "maxDurationTimers" | "config" | "transcriptWaiters"
+  | "activeCalls"
+  | "maxDurationTimers"
+  | "config"
+  | "transcriptWaiters"
+  | "trackCallWork"
+  | "isStopping"
 >;
-type MaxDurationTimerContext = Pick<TimerContext, "activeCalls" | "maxDurationTimers" | "config">;
+type MaxDurationTimerContext = Pick<
+  TimerContext,
+  "activeCalls" | "maxDurationTimers" | "config" | "trackCallWork" | "isStopping"
+>;
 type TranscriptWaiterContext = Pick<TimerContext, "transcriptWaiters">;
 
 /** Clear and forget the max-duration timer for a call. */
@@ -46,10 +54,10 @@ export function startMaxDurationTimer(params: {
   );
 
   const timer = setTimeout(() => {
-    void (async () => {
+    const work = (async () => {
       params.ctx.maxDurationTimers.delete(params.callId);
       const call = params.ctx.activeCalls.get(params.callId);
-      if (call && !TerminalStates.has(call.state)) {
+      if (!params.ctx.isStopping() && call && !TerminalStates.has(call.state)) {
         console.log(
           `[voice-call] Max duration reached (${Math.ceil(maxDurationMs / 1000)}s), ending call ${params.callId}`,
         );
@@ -67,31 +75,10 @@ export function startMaxDurationTimer(params: {
         }
       }
     })();
+    params.ctx.trackCallWork(work);
   }, maxDurationMs);
 
   params.ctx.maxDurationTimers.set(params.callId, timer);
-}
-
-/** Backfill max-duration enforcement from the first live conversation signal. */
-export function ensureMaxDurationTimerForLiveCall(params: {
-  ctx: MaxDurationTimerContext;
-  call: CallRecord;
-  liveAt: number;
-  onTimeout: (callId: CallId) => Promise<CallEndResult>;
-}): void {
-  if (params.call.answeredAt) {
-    return;
-  }
-
-  // Realtime streams can prove the call is live before an answered callback;
-  // use that first live signal so stale cleanup can skip it without losing
-  // maxDurationSeconds enforcement.
-  params.call.answeredAt = params.liveAt;
-  startMaxDurationTimer({
-    ctx: params.ctx,
-    callId: params.call.callId,
-    onTimeout: params.onTimeout,
-  });
 }
 
 /** Clear and forget a pending final-transcript waiter. */

--- a/extensions/voice-call/src/runtime-state.ts
+++ b/extensions/voice-call/src/runtime-state.ts
@@ -7,11 +7,7 @@ import { createPluginRuntimeStore, type PluginRuntime } from "openclaw/plugin-sd
 export type VoiceCallStateRuntime = {
   state: Pick<
     PluginRuntime["state"],
-    | "resolveStateDir"
-    | "openKeyedStore"
-    | "openSyncKeyedStore"
-    | "openChannelIngressQueue"
-    | "openChannelIngressDrain"
+    "resolveStateDir" | "openKeyedStore" | "openChannelIngressQueue" | "openChannelIngressDrain"
   >;
 };
 

--- a/extensions/voice-call/src/runtime.realtime-routing.test.ts
+++ b/extensions/voice-call/src/runtime.realtime-routing.test.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
-  createPluginStateSyncKeyedStoreForTests,
+  createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type {
@@ -12,7 +12,6 @@ import type {
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
-import { finalizeTestManagerCalls } from "./manager.test-harness.js";
 import type { VoiceCallStateRuntime } from "./runtime-state.js";
 import { createVoiceCallRuntime, type VoiceCallRuntime } from "./runtime.js";
 import { createVoiceCallBaseConfig } from "./test-fixtures.js";
@@ -33,11 +32,8 @@ vi.mock("./realtime-voice.runtime.js", async (importOriginal) => {
 function createStateRuntime(): VoiceCallStateRuntime["state"] {
   return {
     resolveStateDir: () => "",
-    openKeyedStore: (() => {
-      throw new Error("openKeyedStore is not used by realtime routing tests");
-    }) as VoiceCallStateRuntime["state"]["openKeyedStore"],
-    openSyncKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
-      createPluginStateSyncKeyedStoreForTests<T>("voice-call", options),
+    openKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
+      createPluginStateKeyedStoreForTests<T>("voice-call", options),
     openChannelIngressQueue: (() => {
       throw new Error("openChannelIngressQueue is not used by realtime routing tests");
     }) as VoiceCallStateRuntime["state"]["openChannelIngressQueue"],
@@ -234,20 +230,17 @@ describe("voice-call realtime route ownership", () => {
         ]),
       );
     } finally {
-      await runtime?.stop();
-      for (const ws of sockets) {
-        if (ws.readyState !== WebSocket.CLOSED) {
-          const closed = waitForClose(ws);
-          ws.terminate();
-          await closed;
-        }
-      }
-      await Promise.all(servers.map((server) => server.close()));
       try {
-        if (runtime) {
-          finalizeTestManagerCalls(runtime.manager);
-        }
+        await runtime?.stop();
       } finally {
+        for (const ws of sockets) {
+          if (ws.readyState !== WebSocket.CLOSED) {
+            const closed = waitForClose(ws);
+            ws.terminate();
+            await closed;
+          }
+        }
+        await Promise.all(servers.map((server) => server.close()));
         resetPluginStateStoreForTests();
       }
     }

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 // Voice Call tests cover runtime plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   resolveTwilioAuthToken: vi.fn(),
   validateProviderConfig: vi.fn(),
   managerInitialize: vi.fn(),
+  managerStop: vi.fn(),
   managerGetCall: vi.fn(),
   webhookStart: vi.fn(),
   webhookStop: vi.fn(),
@@ -76,6 +78,7 @@ vi.mock("./config.js", () => ({
 vi.mock("./manager.js", () => ({
   CallManager: class {
     initialize = mocks.managerInitialize;
+    stop = mocks.managerStop;
     getCall = mocks.managerGetCall;
   },
 }));
@@ -234,6 +237,7 @@ describe("createVoiceCallRuntime lifecycle", () => {
     );
     mocks.validateProviderConfig.mockReturnValue({ valid: true, errors: [] });
     mocks.managerInitialize.mockResolvedValue(undefined);
+    mocks.managerStop.mockResolvedValue(undefined);
     mocks.managerGetCall.mockReset();
     mocks.webhookStart.mockResolvedValue("http://127.0.0.1:3334/voice/webhook");
     mocks.webhookStop.mockResolvedValue(undefined);
@@ -377,14 +381,37 @@ describe("createVoiceCallRuntime lifecycle", () => {
       expect(mocks.webhookStop).toHaveBeenCalledTimes(1);
     });
     expect(stopped).toBe(false);
+    expect(mocks.managerStop).not.toHaveBeenCalled();
 
     releaseWebhookStop?.();
     await firstStop;
     expect(stopped).toBe(true);
+    expect(mocks.managerStop).toHaveBeenCalledOnce();
 
     expect(tunnelStop).toHaveBeenCalledTimes(1);
     expect(mocks.cleanupTailscaleExposure).toHaveBeenCalledTimes(1);
     expect(mocks.webhookStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("drains the manager after transport cleanup fails and preserves the first error", async () => {
+    const transportFailure = new Error("webhook shutdown failed");
+    const drain = createDeferred<void>();
+    mocks.webhookStop.mockRejectedValue(transportFailure);
+    mocks.managerStop.mockReturnValue(drain.promise);
+    const runtime = await createVoiceCallRuntime({
+      config: createBaseConfig(),
+      coreConfig: {},
+      agentRuntime: {} as never,
+    });
+    let settled = false;
+    const stopped = runtime.stop().catch((error: unknown) => {
+      settled = true;
+      return error;
+    });
+    await vi.waitFor(() => expect(mocks.managerStop).toHaveBeenCalledOnce());
+    expect(settled).toBe(false);
+    drain.reject(new Error("manager drain failed"));
+    expect(await stopped).toBe(transportFailure);
   });
 
   it("passes fullConfig to the webhook server for streaming provider resolution", async () => {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -124,20 +124,13 @@ function mapVoiceCallConsultTranscript(
 function createRuntimeResourceLifecycle(params: {
   config: VoiceCallConfig;
   webhookServer: VoiceCallWebhookServer;
+  manager: CallManager;
 }): {
   setTunnelResult: (result: TunnelResult | null) => void;
   stop: (opts?: { suppressErrors?: boolean }) => Promise<void>;
 } {
   let tunnelResult: TunnelResult | null = null;
   let stopPromise: Promise<void> | null = null;
-
-  const runStep = async (step: () => Promise<void>, suppressErrors: boolean) => {
-    if (suppressErrors) {
-      await step().catch(() => {});
-      return;
-    }
-    await step();
-  };
 
   return {
     setTunnelResult: (result) => {
@@ -149,17 +142,24 @@ function createRuntimeResourceLifecycle(params: {
       }
       const suppressErrors = opts?.suppressErrors ?? false;
       stopPromise = (async () => {
-        await runStep(async () => {
-          if (tunnelResult) {
-            await tunnelResult.stop();
+        let failure: { error: unknown } | undefined;
+        for (const step of [
+          async () => {
+            await tunnelResult?.stop();
+          },
+          () => cleanupTailscaleExposure(params.config),
+          () => params.webhookServer.stop(),
+          () => params.manager.stop(),
+        ]) {
+          try {
+            await step();
+          } catch (error) {
+            failure ??= { error };
           }
-        }, suppressErrors);
-        await runStep(async () => {
-          await cleanupTailscaleExposure(params.config);
-        }, suppressErrors);
-        await runStep(async () => {
-          await params.webhookServer.stop();
-        }, suppressErrors);
+        }
+        if (failure && !suppressErrors) {
+          throw failure.error;
+        }
       })();
       return stopPromise;
     },
@@ -462,7 +462,7 @@ export async function createVoiceCallRuntime(params: {
     }
     webhookServer.setRealtimeHandler(realtimeHandler);
   }
-  const lifecycle = createRuntimeResourceLifecycle({ config, webhookServer });
+  const lifecycle = createRuntimeResourceLifecycle({ config, webhookServer, manager });
 
   const localUrl = await webhookServer.start();
 

--- a/extensions/voice-call/src/webhook.auto-response.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.auto-response.lifecycle.test.ts
@@ -8,12 +8,13 @@ import {
   FakeProvider,
   finalizeTestManagerCalls,
 } from "./manager.test-harness.js";
+import * as callStore from "./manager/store.js";
 import { TwilioProvider } from "./providers/twilio.js";
 import type { NormalizedEvent, WebhookContext } from "./types.js";
 import { VoiceCallWebhookServer } from "./webhook.js";
 import { connectWs, waitForClose } from "./websocket-test-support.js";
 
-type ResponseParams = { onEarlyText?: (text: string) => Promise<boolean> };
+type ResponseParams = { userMessage: string; onEarlyText?: (text: string) => Promise<boolean> };
 type ResponseResult = { text: string; deliveredEarly: boolean };
 const mocks = vi.hoisted(() => ({
   generate: vi.fn<(params: ResponseParams) => Promise<ResponseResult>>(),
@@ -164,9 +165,9 @@ afterEach(async () => {
     await server.stop();
   }
   for (const manager of managers.splice(0)) {
-    finalizeTestManagerCalls(manager);
+    await finalizeTestManagerCalls(manager);
   }
-  state.cleanup();
+  await state.cleanup();
 });
 
 describe("automatic phone reply ownership", () => {
@@ -189,6 +190,162 @@ describe("automatic phone reply ownership", () => {
       await second.finish("current reply");
       expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["current reply"]);
       expect(call.provider.clearTtsQueue).toHaveBeenCalled();
+    },
+  );
+
+  it.each(["native", "partial", "final"] as const)(
+    "revokes a reply waiting for persistence when %s stream speech arrives",
+    async (signal) => {
+      const call = await startCall(true);
+      const { callbacks } = await call.openStream("stream-pending-write");
+      callbacks.onTranscript?.("first question");
+      const first = await responseAt(0);
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const persist = callStore.persistCallRecord;
+      const persistence = vi
+        .spyOn(callStore, "persistCallRecord")
+        .mockImplementationOnce(async (...args) => {
+          entered.resolve();
+          await release.promise;
+          await persist(...args);
+        });
+      try {
+        const delivery = first.early("obsolete early reply");
+        await entered.promise;
+        expect(call.provider.playTtsCalls).toEqual([]);
+        if (signal === "native") {
+          callbacks.onSpeechStart?.();
+        } else if (signal === "partial") {
+          callbacks.onPartial?.("wait");
+        } else {
+          callbacks.onTranscript?.("replacement question");
+        }
+        release.resolve();
+        expect(await delivery).toBe(false);
+        expect(call.provider.playTtsCalls).toEqual([]);
+        await first.finish("obsolete final reply");
+        if (signal !== "final") {
+          callbacks.onTranscript?.("replacement question");
+        }
+        const second = await responseAt(1);
+        await second.finish("current reply");
+        expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["current reply"]);
+      } finally {
+        release.resolve();
+        persistence.mockRestore();
+      }
+    },
+  );
+
+  it.each(["native", "partial", "final"] as const)(
+    "does not revive a pending transcript reply after newer %s stream speech",
+    async (signal) => {
+      const call = await startCall(true);
+      const { callbacks } = await call.openStream("stream-pending-transcript");
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const persist = callStore.persistCallRecord;
+      const persistence = vi
+        .spyOn(callStore, "persistCallRecord")
+        .mockImplementationOnce(async (...args) => {
+          entered.resolve();
+          await release.promise;
+          await persist(...args);
+        });
+      const processEvent = vi.spyOn(call.manager, "processEvent");
+      try {
+        callbacks.onTranscript?.("obsolete question");
+        await entered.promise;
+        const firstEvent = processEvent.mock.results.at(0);
+        if (!firstEvent || firstEvent.type !== "return") {
+          throw new Error("Expected admitted transcript persistence");
+        }
+        if (signal === "native") {
+          callbacks.onSpeechStart?.();
+        } else if (signal === "partial") {
+          callbacks.onPartial?.("wait");
+        } else {
+          // Stream transcript IDs use milliseconds; keep these two fixture events distinct.
+          const firstTimestamp = processEvent.mock.calls.at(0)?.[0].timestamp;
+          if (firstTimestamp === undefined) {
+            throw new Error("Expected first transcript timestamp");
+          }
+          await vi.waitFor(() => expect(Date.now()).toBeGreaterThan(firstTimestamp));
+          callbacks.onTranscript?.("replacement question");
+        }
+        release.resolve();
+        await firstEvent.value;
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        if (signal !== "final") {
+          callbacks.onTranscript?.("replacement question");
+        }
+        await vi.waitFor(() =>
+          expect(
+            mocks.generate.mock.calls.some(
+              ([params]) => params.userMessage === "replacement question",
+            ),
+          ).toBe(true),
+        );
+        expect(mocks.generate.mock.calls.map(([params]) => params.userMessage)).toEqual([
+          "replacement question",
+        ]);
+        expect(call.manager.getCall(call.callId)?.transcript.map((entry) => entry.text)).toEqual([
+          "obsolete question",
+          "replacement question",
+        ]);
+        const current = await responseAt(0);
+        await current.finish("current reply");
+        expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["current reply"]);
+      } finally {
+        release.resolve();
+        persistence.mockRestore();
+        processEvent.mockRestore();
+      }
+    },
+  );
+
+  it.each(["partial", "final"] as const)(
+    "orders automatic playback behind queued carrier %s speech",
+    async (signal) => {
+      const call = await startCall();
+      await call.speech("first question");
+      const first = await responseAt(0);
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const persist = callStore.persistCallRecord;
+      const persistence = vi
+        .spyOn(callStore, "persistCallRecord")
+        .mockImplementationOnce(async (...args) => {
+          entered.resolve();
+          await release.promise;
+          await persist(...args);
+        });
+      const processEvent = vi.spyOn(call.manager, "processEvent");
+      try {
+        const delivery = first.early("obsolete reply");
+        await entered.promise;
+        const speech = call.speech("replacement question", signal === "final");
+        await vi.waitFor(() => expect(processEvent).toHaveBeenCalledOnce());
+        expect(call.provider.playTtsCalls).toEqual([]);
+        release.resolve();
+        await speech;
+        expect(await delivery).toBe(false);
+        expect(call.provider.playTtsCalls).toEqual([]);
+        await first.finish("");
+        if (signal === "partial") {
+          await call.speech("replacement question");
+        }
+        const replacement = await responseAt(1);
+        await replacement.finish("current reply");
+        expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["current reply"]);
+      } finally {
+        release.resolve();
+        persistence.mockRestore();
+        processEvent.mockRestore();
+      }
     },
   );
 
@@ -250,25 +407,71 @@ describe("automatic phone reply ownership", () => {
     if (!turnToken) {
       throw new Error("Expected explicit turn token");
     }
-    await call.speech("obsolete input", true, "mismatched-event", "old-token");
-    await first.finish("current reply");
-    expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual([
-      "explicit prompt",
-      "current reply",
-    ]);
-    expect(await first.early("late callback after completion")).toBe(false);
-    await call.speech("accepted input", true, "accepted-event", turnToken);
-    expect(await waiting).toMatchObject({ success: true, transcript: "accepted input" });
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const persist = callStore.persistCallRecord;
+    const persistence = vi
+      .spyOn(callStore, "persistCallRecord")
+      .mockImplementationOnce(async (...args) => {
+        entered.resolve();
+        await release.promise;
+        await persist(...args);
+      });
+    const processEvent = vi.spyOn(call.manager, "processEvent");
+    try {
+      const delivery = first.early("current reply");
+      await entered.promise;
+      const rejectedSpeech = call.speech("obsolete input", true, "mismatched-event", "old-token");
+      await vi.waitFor(() => expect(processEvent).toHaveBeenCalledOnce());
+      release.resolve();
+      await rejectedSpeech;
+      expect(await delivery).toBe(true);
+      await first.finish("");
+      expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual([
+        "explicit prompt",
+        "current reply",
+      ]);
+      expect(await first.early("late callback after completion")).toBe(false);
+      await call.speech("accepted input", true, "accepted-event", turnToken);
+      expect(await waiting).toMatchObject({ success: true, transcript: "accepted input" });
+    } finally {
+      release.resolve();
+      persistence.mockRestore();
+      processEvent.mockRestore();
+    }
   });
 
   it("does not invalidate on a replayed transcript", async () => {
     const call = await startCall();
     await call.speech("first question", true, "same-event");
     const first = await responseAt(0);
-    await call.speech("first question", true, "same-event");
-    await first.finish("current reply");
-    expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["current reply"]);
-    expect(mocks.generate).toHaveBeenCalledTimes(1);
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const persist = callStore.persistCallRecord;
+    const persistence = vi
+      .spyOn(callStore, "persistCallRecord")
+      .mockImplementationOnce(async (...args) => {
+        entered.resolve();
+        await release.promise;
+        await persist(...args);
+      });
+    const processEvent = vi.spyOn(call.manager, "processEvent");
+    try {
+      const delivery = first.early("current reply");
+      await entered.promise;
+      const replay = call.speech("first question", true, "same-event");
+      await vi.waitFor(() => expect(processEvent).toHaveBeenCalledOnce());
+      release.resolve();
+      await replay;
+      expect(await delivery).toBe(true);
+      await first.finish("");
+      expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["current reply"]);
+      expect(mocks.generate).toHaveBeenCalledTimes(1);
+    } finally {
+      release.resolve();
+      persistence.mockRestore();
+      processEvent.mockRestore();
+    }
   });
 
   it.each(["native", "partial", "final"] as const)(

--- a/extensions/voice-call/src/webhook.hangup-once.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.hangup-once.lifecycle.test.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
-  createPluginStateSyncKeyedStoreForTests,
+  createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { postRawWebhook } from "openclaw/plugin-sdk/test-env";
@@ -24,11 +24,8 @@ function installStateRuntime(): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
-      openKeyedStore: (() => {
-        throw new Error("openKeyedStore is not used by voice-call webhook lifecycle tests");
-      }) as never,
-      openSyncKeyedStore: (options: OpenKeyedStoreOptions) =>
-        createPluginStateSyncKeyedStoreForTests("voice-call", options),
+      openKeyedStore: (options: OpenKeyedStoreOptions) =>
+        createPluginStateKeyedStoreForTests("voice-call", options),
       openChannelIngressQueue: (() => {
         throw new Error(
           "openChannelIngressQueue is not used by voice-call webhook lifecycle tests",
@@ -242,12 +239,12 @@ describe("Voice-call webhook hangup-once lifecycle", () => {
       if (!state) {
         throw new Error("expected fixture SQLite runtime");
       }
-      const openStore = state.openSyncKeyedStore.bind(state);
+      const openStore = state.openKeyedStore.bind(state);
       const fault = vi
-        .spyOn(state, "openSyncKeyedStore")
+        .spyOn(state, "openKeyedStore")
         .mockImplementation(<T>(options: OpenKeyedStoreOptions) => {
           const store = openStore<T>(options);
-          store.entries = () => {
+          store.entries = async () => {
             throw new Error("synthetic signed callback history failure");
           };
           return store;
@@ -267,7 +264,7 @@ describe("Voice-call webhook hangup-once lifecycle", () => {
       try {
         await server.stop();
       } finally {
-        finalizeTestManagerCalls(manager);
+        await finalizeTestManagerCalls(manager);
         resetPluginStateStoreForTests();
         fs.rmSync(storePath, { recursive: true, force: true });
       }

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -131,13 +131,19 @@ const createCall = (startedAt: number): CallRecord => ({
 });
 
 const automaticReplyManagerStub = {
+  updateCallMetadata: async (
+    call: CallRecord,
+    update: (metadata: CallRecord["metadata"]) => CallRecord["metadata"],
+  ) => {
+    call.metadata = update(call.metadata);
+  },
   createAutoResponseGuard: () => ({ isCurrent: () => true, release: () => {} }),
   invalidateAutoResponse: () => {},
 };
 
 const createManager = (calls: CallRecord[]) => {
   const endCall = vi.fn(async () => ({ success: true }));
-  const processEvent = vi.fn<CallManager["processEvent"]>(() => ({ kind: "processed" }));
+  const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
   const manager = {
     ...automaticReplyManagerStub,
     getActiveCalls: () => calls,
@@ -1012,7 +1018,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
   it("keeps retryable provider errors replayable through the actual webhook owner", async () => {
     const mockProvider = new MockProvider();
     const { manager, processEvent } = createManager([]);
-    processEvent.mockReturnValue({ kind: "processed", replayable: true });
+    processEvent.mockResolvedValue({ kind: "processed", replayable: true });
     const server = new VoiceCallWebhookServer(
       createConfig({ provider: "mock" }),
       manager,
@@ -1047,7 +1053,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
     const twilioProvider = new TwilioProvider({ accountSid: "AC123", authToken });
     const registeredCalls: CallRecord[] = [];
     const { manager, processEvent } = createManager(registeredCalls);
-    processEvent.mockImplementation((event) =>
+    processEvent.mockImplementation(async (event) =>
       registeredCalls.some((call) => call.providerCallId === event.providerCallId)
         ? { kind: "processed" }
         : { kind: "ignored", replayable: true },
@@ -1079,13 +1085,45 @@ describe("VoiceCallWebhookServer replay handling", () => {
     }
   });
 
+  it("holds a signed webhook response until event persistence finishes", async () => {
+    const authToken = "signed-delayed-store-token";
+    const twilioProvider = new TwilioProvider({ accountSid: "AC123", authToken });
+    const { manager, processEvent } = createManager([]);
+    const persistence = createDeferred<Awaited<ReturnType<CallManager["processEvent"]>>>();
+    processEvent.mockReturnValueOnce(persistence.promise);
+    const server = new VoiceCallWebhookServer(
+      createConfig({ provider: "twilio", twilio: { accountSid: "AC123", authToken } }),
+      manager,
+      twilioProvider,
+    );
+    try {
+      const baseUrl = await server.start();
+      twilioProvider.setPublicUrl(requireBoundRequestUrl(server, baseUrl).toString());
+      let answered = false;
+      const response = postSignedTwilioWebhook({
+        server,
+        baseUrl,
+        authToken,
+        body: "CallSid=CA-delayed-store&CallStatus=in-progress&Direction=outbound-api",
+      }).then((result) => {
+        answered = true;
+        return result;
+      });
+      await vi.waitFor(() => expect(processEvent).toHaveBeenCalledOnce());
+      expect(answered).toBe(false);
+      persistence.resolve({ kind: "processed" });
+      expect((await response).status).toBe(200);
+    } finally {
+      persistence.resolve({ kind: "processed" });
+      await server.stop();
+    }
+  });
+
   it("retries an identical signed Twilio callback after event processing fails", async () => {
     const authToken = "signed-retry-auth-token";
     const twilioProvider = new TwilioProvider({ accountSid: "AC123", authToken });
     const { manager, processEvent } = createManager([]);
-    processEvent.mockImplementationOnce(() => {
-      throw new Error("synthetic SQLite persistence failure");
-    });
+    processEvent.mockRejectedValueOnce(new Error("synthetic SQLite persistence failure"));
     const config = createConfig({
       provider: "twilio",
       twilio: { accountSid: "AC123", authToken },
@@ -1201,9 +1239,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
       { skipVerification: true },
     );
     const { manager, processEvent } = createManager([]);
-    processEvent.mockImplementationOnce(() => {
-      throw new Error("synthetic SQLite persistence failure");
-    });
+    processEvent.mockRejectedValueOnce(new Error("synthetic SQLite persistence failure"));
     const config = createConfig({
       provider: "plivo",
       skipSignatureVerification: true,
@@ -2224,6 +2260,7 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     expect(params).toHaveProperty("senderIsOwner", undefined);
     expect(speak).toHaveBeenCalledWith(call.callId, "Hello back", {
       listenAfterPlayback: true,
+      isCurrent: expect.any(Function),
     });
   });
 
@@ -2259,7 +2296,11 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     ).handleInboundResponse(call.callId, "hello");
 
     expect(speak.mock.calls).toEqual([
-      [call.callId, "Spoken before compaction. Final detail.", { listenAfterPlayback: true }],
+      [
+        call.callId,
+        "Spoken before compaction. Final detail.",
+        { listenAfterPlayback: true, isCurrent: expect.any(Function) },
+      ],
     ]);
     expect(mocks.generateVoiceResponse.mock.calls[0]?.[0]).toHaveProperty("senderIsOwner", false);
   });
@@ -2579,7 +2620,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
     };
 
     const clearTtsQueue = vi.fn<TwilioProviderTestDouble["clearTtsQueue"]>();
-    const processEvent = vi.fn<CallManager["processEvent"]>((event) => {
+    const processEvent = vi.fn<CallManager["processEvent"]>(async (event) => {
       if (event.type === "call.speech") {
         // Mirrors manager behavior: call.speech transitions to listening.
         call.state = "listening";
@@ -2646,7 +2687,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       media.config.onSpeechStart?.("CA-barge", "MZ-barge");
       media.config.onTranscript?.("CA-barge", "hello after greeting", "MZ-barge");
       expect(clearTtsQueue).toHaveBeenCalledTimes(2);
-      expect(handleInboundResponse).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(handleInboundResponse).toHaveBeenCalledTimes(1));
       expect(processEvent).toHaveBeenCalledTimes(1);
       const [calledCallId, calledTranscript] = expectDefined<unknown[]>(
         handleInboundResponse.mock.calls.at(0),
@@ -2669,7 +2710,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
     };
 
     const clearTtsQueue = vi.fn<TwilioProviderTestDouble["clearTtsQueue"]>();
-    const processEvent = vi.fn<CallManager["processEvent"]>((event) =>
+    const processEvent = vi.fn<CallManager["processEvent"]>(async (event) =>
       event.type === "call.speech"
         ? {
             kind: "final-speech",
@@ -2728,7 +2769,9 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       expect(event.providerCallId).toBe("CA-inbound");
       expect(event.transcript).toBe("hello");
       expect(event.isFinal).toBe(true);
-      expect(handleInboundResponse).toHaveBeenCalledWith("call-inbound", "hello");
+      await vi.waitFor(() =>
+        expect(handleInboundResponse).toHaveBeenCalledWith("call-inbound", "hello"),
+      );
     } finally {
       await server.stop();
     }
@@ -2768,9 +2811,12 @@ describe("VoiceCallWebhookServer webhook event path auto-response (#79118)", () 
     parseWebhookEvent: () => ({ events: [event], statusCode: 200 }),
   });
 
-  const buildManagerWith = (call: CallRecord, result?: ReturnType<CallManager["processEvent"]>) => {
+  const buildManagerWith = (
+    call: CallRecord,
+    result?: Awaited<ReturnType<CallManager["processEvent"]>>,
+  ) => {
     const managerResult = createManager([call]);
-    managerResult.processEvent.mockReturnValue(
+    managerResult.processEvent.mockResolvedValue(
       result ?? {
         kind: "final-speech",
         call,

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -77,10 +77,13 @@ type WebhookHeaderGateResult =
       reason: string;
     };
 
-function appendRecentTalkEventMetadata(call: CallRecord, event: TalkEvent): void {
-  const metadata = call.metadata ?? {};
-  const recent = Array.isArray(metadata.recentTalkEvents)
-    ? metadata.recentTalkEvents.filter(
+function appendRecentTalkEventMetadata(
+  metadata: CallRecord["metadata"],
+  event: TalkEvent,
+): CallRecord["metadata"] {
+  const previous = metadata ?? {};
+  const recent = Array.isArray(previous.recentTalkEvents)
+    ? previous.recentTalkEvents.filter(
         (entry): entry is { at: string; type: string; sessionId: string; turnId?: string } =>
           Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
       )
@@ -91,8 +94,8 @@ function appendRecentTalkEventMetadata(call: CallRecord, event: TalkEvent): void
     sessionId: event.sessionId,
     turnId: event.turnId,
   });
-  call.metadata = {
-    ...metadata,
+  return {
+    ...previous,
     lastTalkEventAt: event.timestamp,
     lastTalkEventType: event.type,
     recentTalkEvents: recent.slice(-10),
@@ -198,6 +201,8 @@ export class VoiceCallWebhookServer {
   /** Media stream handler for bidirectional audio (when streaming enabled) */
   private mediaStreamHandler: MediaStreamHandler | null = null;
   private readonly streamDisconnectGrace: StreamDisconnectGrace;
+  // Revoke pending transcript replies before persistence has created a response guard.
+  private readonly streamSpeechGenerations = new WeakMap<CallRecord, symbol>();
   /** Realtime voice handler for duplex provider bridges. */
   private realtimeHandler: RealtimeCallHandler | null = null;
   private replayResponses = new Map<string, CachedWebhookResponse>();
@@ -341,13 +346,16 @@ export class VoiceCallWebhookServer {
       : undefined;
   }
 
-  private interruptStreamReply(providerCallId: string, streamSid: string): void {
+  private interruptStreamReply(providerCallId: string, streamSid: string): symbol | undefined {
     const current = this.getCurrentStream(providerCallId, streamSid);
     if (!current || this.shouldSuppressBargeInForInitialMessage(current.call)) {
-      return;
+      return undefined;
     }
+    const generation = Symbol("stream speech");
+    this.streamSpeechGenerations.set(current.call, generation);
     this.manager.invalidateAutoResponse(current.call);
     current.provider.clearTtsQueue(providerCallId);
+    return generation;
   }
 
   /**
@@ -430,7 +438,7 @@ export class VoiceCallWebhookServer {
           );
           return;
         }
-        const { call, provider: streamProvider } = current;
+        const { call } = current;
         const suppressBargeIn = this.shouldSuppressBargeInForInitialMessage(call);
         if (suppressBargeIn) {
           this.logger.info(
@@ -439,7 +447,7 @@ export class VoiceCallWebhookServer {
           return;
         }
 
-        streamProvider.clearTtsQueue(providerCallId);
+        const generation = this.interruptStreamReply(providerCallId, streamSid);
 
         // Create a speech event and process it through the manager
         const event: NormalizedEvent = {
@@ -451,7 +459,14 @@ export class VoiceCallWebhookServer {
           transcript,
           isFinal: true,
         };
-        this.processEventWithAutoResponse(event);
+        void this.processEventWithAutoResponse(
+          event,
+          () =>
+            this.streamSpeechGenerations.get(call) === generation &&
+            this.getCurrentStream(providerCallId, streamSid)?.call === call,
+        ).catch((err: unknown) => {
+          this.logger.error(`Error processing stream transcript: ${String(err)}`);
+        });
       },
       onSpeechStart: (providerCallId, streamSid) =>
         this.interruptStreamReply(providerCallId, streamSid),
@@ -462,7 +477,15 @@ export class VoiceCallWebhookServer {
       onTalkEvent: (providerCallId, streamSid, event) => {
         const current = this.getCurrentStream(providerCallId, streamSid);
         if (current) {
-          appendRecentTalkEventMetadata(current.call, event);
+          void this.manager
+            .updateCallMetadata(current.call, (metadata) =>
+              this.getCurrentStream(providerCallId, streamSid)
+                ? appendRecentTalkEventMetadata(metadata, event)
+                : metadata,
+            )
+            .catch((error: unknown) => {
+              this.logger.warn(`Failed to update stream call metadata: ${String(error)}`);
+            });
         }
       },
       onConnect: (callId, streamSid) => {
@@ -817,7 +840,7 @@ export class VoiceCallWebhookServer {
         const parsed = this.provider.parseWebhookEvent(ctx, {
           verifiedRequestKey: verification.verifiedRequestKey,
         });
-        if (!isReplay && this.processParsedEvents(parsed.events)) {
+        if (!isReplay && (await this.processParsedEvents(parsed.events))) {
           verification.releaseReplay?.();
         }
 
@@ -1012,11 +1035,11 @@ export class VoiceCallWebhookServer {
     }
   }
 
-  private processParsedEvents(events: NormalizedEvent[]): boolean {
+  private async processParsedEvents(events: NormalizedEvent[]): Promise<boolean> {
     let replayable = false;
     for (const event of events) {
       try {
-        replayable = this.processEventWithAutoResponse(event) || replayable;
+        replayable = (await this.processEventWithAutoResponse(event)) || replayable;
       } catch (err) {
         this.logger.error(`Error processing event ${event.type}: ${String(err)}`);
         throw err;
@@ -1025,12 +1048,15 @@ export class VoiceCallWebhookServer {
     return replayable;
   }
 
-  private processEventWithAutoResponse(event: NormalizedEvent): boolean {
-    const result = this.manager.processEvent(event);
+  private async processEventWithAutoResponse(
+    event: NormalizedEvent,
+    isCurrent?: () => boolean,
+  ): Promise<boolean> {
+    const result = await this.manager.processEvent(event);
     if (result.kind !== "final-speech") {
       return result.replayable === true;
     }
-    if (result.waiterResolved) {
+    if (result.waiterResolved || (isCurrent && !isCurrent())) {
       return false;
     }
     const callMode = result.call.metadata?.mode as string | undefined;
@@ -1098,7 +1124,10 @@ export class VoiceCallWebhookServer {
         return false;
       }
       this.logger.info(`AI response queued ${callId} chars=${text.length}`);
-      const result = await this.manager.speak(callId, text, { listenAfterPlayback: true });
+      const result = await this.manager.speak(callId, text, {
+        listenAfterPlayback: true,
+        isCurrent: response.isCurrent,
+      });
       return result.success;
     };
     try {

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -5,38 +5,22 @@ import type {
 } from "openclaw/plugin-sdk/realtime-voice";
 import { describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
-import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
+import { createVoiceCallBaseConfig } from "../test-fixtures.js";
 import type { CallRecord, HangupCallInput } from "../types.js";
 import { connectWs, startUpgradeWsServer, waitForClose } from "../websocket-test-support.js";
 import { RealtimeCallHandler, type ResolveRealtimeCallRegistration } from "./realtime-handler.js";
 import type { StreamDisconnectLifecycle } from "./stream-disconnect-grace.js";
 
-function createRealtimeConfig(): VoiceCallRealtimeConfig {
-  return {
-    enabled: true,
-    streamPath: "/voice/stream/realtime",
-    instructions: "Be helpful.",
-    toolPolicy: "safe-read-only",
-    consultPolicy: "auto",
-    tools: [],
-    fastContext: {
-      enabled: false,
-      timeoutMs: 800,
-      maxResults: 3,
-      sources: ["memory", "sessions"],
-      fallbackToConsult: false,
-    },
-    agentContext: {
-      enabled: false,
-      maxChars: 6000,
-      includeIdentity: true,
-      includeWorkspaceFiles: true,
-      files: ["SOUL.md", "IDENTITY.md", "USER.md"],
-    },
-    providers: {},
-  };
-}
+const updateCallMetadata: CallManager["updateCallMetadata"] = async (call, update) => {
+  call.metadata = update(call.metadata);
+};
+
+const createRealtimeConfig = () => ({
+  ...createVoiceCallBaseConfig().realtime,
+  enabled: true,
+  instructions: "Be helpful.",
+});
 
 const noOpStreamDisconnectLifecycle: StreamDisconnectLifecycle = {
   connect: () => {},
@@ -106,7 +90,7 @@ function createCarrierLifecycleHarness(
     processedEventIds: [],
     ...(options.initialMessage ? { metadata: { initialMessage: options.initialMessage } } : {}),
   };
-  const processEvent = vi.fn();
+  const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
   const hangupCall = vi.fn(async (_input: HangupCallInput) => {});
   const endCall = vi.fn(
     options.endCall ??
@@ -114,7 +98,7 @@ function createCarrierLifecycleHarness(
         const reason = endOptions?.reason ?? "hangup-bot";
         try {
           await hangupCall({ callId, providerCallId: call.providerCallId!, reason });
-          processEvent({
+          await processEvent({
             id: `manager-ended-${call.providerCallId}`,
             type: "call.ended",
             callId,
@@ -132,6 +116,7 @@ function createCarrierLifecycleHarness(
     createRealtimeConfig(),
     {
       processEvent,
+      updateCallMetadata,
       endCall,
       getCallByProviderCallId: vi.fn(() => call),
     } as unknown as CallManager,
@@ -154,6 +139,54 @@ async function connectCarrierStream(handler: RealtimeCallHandler) {
 }
 
 describe("RealtimeCallHandler lifecycle", () => {
+  it.each(["continue", "shutdown"] as const)(
+    "waits for carrier admission persistence before bridge creation (%s)",
+    async (outcome) => {
+      const persistence = createDeferred<Awaited<ReturnType<CallManager["processEvent"]>>>();
+      const sendAudio = vi.fn();
+      const createBridgeForCall = vi.fn<RealtimeVoiceProviderPlugin["createBridge"]>(() =>
+        createBridge(() => {}, { sendAudio }),
+      );
+      const { call, handler, processEvent, hangupCall } =
+        createCarrierLifecycleHarness(createBridgeForCall);
+      processEvent.mockReturnValueOnce(persistence.promise);
+      const { server, ws } = await connectCarrierStream(handler);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-pending-store", callSid: call.providerCallId },
+          }),
+        );
+        const audio = Buffer.from([0xff, 0xfe, 0xfd]);
+        ws.send(JSON.stringify({ event: "media", media: { payload: audio.toString("base64") } }));
+        await vi.waitFor(() => expect(processEvent).toHaveBeenCalledOnce());
+        expect(createBridgeForCall).not.toHaveBeenCalled();
+        if (outcome === "shutdown") {
+          let closed = false;
+          const closing = handler.close().then(() => {
+            closed = true;
+          });
+          await waitForClose(ws);
+          expect(closed).toBe(false);
+          persistence.resolve({ kind: "processed" });
+          await closing;
+          expect(createBridgeForCall).not.toHaveBeenCalled();
+          expect(hangupCall).toHaveBeenCalledOnce();
+        } else {
+          persistence.resolve({ kind: "processed" });
+          await vi.waitFor(() => expect(sendAudio).toHaveBeenCalledWith(audio));
+          expect(createBridgeForCall).toHaveBeenCalledOnce();
+        }
+      } finally {
+        persistence.resolve({ kind: "processed" });
+        ws.terminate();
+        await handler.close();
+        await server.close();
+      }
+    },
+  );
+
   it.each(["completed", "error"] as const)(
     "ends the carrier call when the provider closes with %s",
     async (reason) => {
@@ -848,7 +881,8 @@ describe("RealtimeCallHandler lifecycle", () => {
     const handler = new RealtimeCallHandler(
       createRealtimeConfig(),
       {
-        processEvent: vi.fn(),
+        processEvent: vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" })),
+        updateCallMetadata,
         endCall: vi.fn(async () => ({ success: true })),
         getCallByProviderCallId: vi.fn(() => call),
       } as unknown as CallManager,
@@ -954,7 +988,8 @@ describe("RealtimeCallHandler lifecycle", () => {
     const handler = new RealtimeCallHandler(
       createRealtimeConfig(),
       {
-        processEvent: vi.fn(),
+        processEvent: vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" })),
+        updateCallMetadata,
         endCall: vi.fn(async () => ({ success: true })),
         getCallByProviderCallId: vi.fn(() => call),
       } as unknown as CallManager,

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -41,6 +41,10 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+const updateCallMetadata: CallManager["updateCallMetadata"] = async (call, update) => {
+  call.metadata = update(call.metadata);
+};
+
 function makeRequest(url: string, host = "gateway.ts.net"): http.IncomingMessage {
   const req = new http.IncomingMessage(null as never);
   req.url = url;
@@ -148,9 +152,10 @@ function makeHandler(
   const handler = new RealtimeCallHandler(
     config,
     {
-      processEvent: vi.fn(),
+      processEvent: vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" })),
+      updateCallMetadata,
       endCall: vi.fn(async () => ({ success: true })),
-      getCall: vi.fn(),
+      getCallForStream: vi.fn<CallManager["getCallForStream"]>(async () => undefined),
       getCallByProviderCallId: vi.fn(),
       ...deps?.manager,
     } as unknown as CallManager,
@@ -233,12 +238,25 @@ function makeCallRecord(providerCallId: string): CallRecord {
   };
 }
 
-function createFinalizingStreamGrace(
-  processEvent: (event: NormalizedEvent) => void,
-  eventId: string,
-) {
+function createCallRecordLookup() {
+  const calls = new Map<string, CallRecord>();
+  return vi.fn((providerCallId: string) => {
+    let call = calls.get(providerCallId);
+    if (!call) {
+      call = makeCallRecord(providerCallId);
+      calls.set(providerCallId, call);
+    }
+    return call;
+  });
+}
+
+function createFinalizingStreamGrace(processEvent: CallManager["processEvent"], eventId: string) {
+  let finalization: ReturnType<CallManager["processEvent"]> | undefined;
+  onTestFinished(async () => {
+    await finalization;
+  });
   return new StreamDisconnectGrace(({ providerCallId }) => {
-    processEvent({
+    finalization = processEvent({
       id: eventId,
       type: "call.ended",
       callId: "call-1",
@@ -246,6 +264,7 @@ function createFinalizingStreamGrace(
       timestamp: Date.now(),
       reason: "completed",
     });
+    void finalization.catch(() => {});
   });
 }
 
@@ -272,6 +291,7 @@ async function withBargeInHarness(
     handleBargeIn: ReturnType<typeof vi.fn>;
     outboundMessages: Array<Record<string, unknown>>;
     processEvent: ReturnType<typeof vi.fn>;
+    handler: RealtimeCallHandler;
     sendAudio: ReturnType<typeof vi.fn>;
     ws: WebSocket;
   }) => Promise<void>,
@@ -279,7 +299,7 @@ async function withBargeInHarness(
   let callbacks: RealtimeBridgeRequest | undefined;
   const sendAudio = vi.fn();
   const handleBargeIn = vi.fn();
-  const processEvent = vi.fn();
+  const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
   const call = makeCallRecord(params.providerCallId);
   const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
     callbacks = request;
@@ -334,6 +354,7 @@ async function withBargeInHarness(
         handleBargeIn,
         outboundMessages,
         processEvent,
+        handler,
         sendAudio,
         ws,
       });
@@ -422,6 +443,41 @@ describe("RealtimeCallHandler path routing", () => {
     );
   });
 
+  it("persists a final transcript before consulting without blocking carrier audio", async () => {
+    await withBargeInHarness(
+      { providerCallId: "CA-pending-transcript" },
+      async ({ callbacks, processEvent, handler, sendAudio, ws }) => {
+        const consult = vi.fn(async () => ({ text: "Deployment is healthy." }));
+        handler.registerToolHandler("openclaw_agent_consult", consult);
+        const persistence = createDeferred<Awaited<ReturnType<CallManager["processEvent"]>>>();
+        processEvent.mockReturnValueOnce(persistence.promise);
+        callbacks.onTranscript?.("user", "Check the deployment.", true);
+        callbacks.onToolCall?.({
+          itemId: "item-pending-store",
+          callId: "consult-pending-store",
+          name: "openclaw_agent_consult",
+          args: { question: "Check the deployment." },
+        });
+        const audio = Buffer.from([0xff, 0xfe]);
+        ws.send(JSON.stringify({ event: "media", media: { payload: audio.toString("base64") } }));
+        try {
+          await waitForRealtimeTest(() => expect(sendAudio).toHaveBeenCalledWith(audio));
+          expect(consult).not.toHaveBeenCalled();
+          expect(processEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+              type: "call.speech",
+              transcript: "Check the deployment.",
+            }),
+          );
+          persistence.resolve({ kind: "processed" });
+          await waitForRealtimeTest(() => expect(consult).toHaveBeenCalledOnce());
+        } finally {
+          persistence.resolve({ kind: "processed" });
+        }
+      },
+    );
+  });
+
   it("uses the request host and stream path in TwiML", () => {
     const handler = makeHandler();
     const payload = handler.buildTwiMLPayload(makeRequest("/voice/webhook", "gateway.ts.net"));
@@ -455,8 +511,8 @@ describe("RealtimeCallHandler path routing", () => {
         return makeBridge();
       },
     );
-    const processEvent = vi.fn();
-    const getCallByProviderCallId = vi.fn((): CallRecord => ({
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
+    const getCallByProviderCallId = vi.fn<() => CallRecord>().mockReturnValue({
       callId: "call-1",
       providerCallId: "CA-outbound",
       provider: "twilio",
@@ -468,7 +524,7 @@ describe("RealtimeCallHandler path routing", () => {
       transcript: [],
       processedEventIds: [],
       metadata: {},
-    }));
+    });
     const handler = makeHandler(undefined, {
       manager: {
         processEvent,
@@ -535,9 +591,9 @@ describe("RealtimeCallHandler path routing", () => {
 
   it("joins Telnyx realtime streams to the token-bound call", async () => {
     let callbacks: RealtimeBridgeRequest | undefined;
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const resolveInstructions = vi.fn((call: CallRecord) => `instructions:${call.agentId}`);
-    const getCall = vi.fn((): CallRecord => ({
+    const getCall = vi.fn<() => CallRecord>().mockReturnValue({
       callId: "call-1",
       agentId: "support",
       providerCallId: "v3:call-1",
@@ -550,7 +606,7 @@ describe("RealtimeCallHandler path routing", () => {
       transcript: [],
       processedEventIds: [],
       metadata: { initialMessage: "hello" },
-    }));
+    });
     const triggerGreeting = vi.fn();
     const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
       callbacks = request;
@@ -559,7 +615,8 @@ describe("RealtimeCallHandler path routing", () => {
     const handler = makeHandler(undefined, {
       manager: {
         processEvent,
-        getCall,
+        getCallForStream: async () => getCall(),
+        getCallByProviderCallId: getCall,
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
       resolveInstructions,
@@ -622,7 +679,7 @@ describe("RealtimeCallHandler path routing", () => {
   });
 
   it("rejects stream sessions when token expiry would exceed the Date range", async () => {
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const createBridge = vi.fn(() => makeBridge());
     const handler = makeHandler(undefined, {
       manager: {
@@ -650,7 +707,7 @@ describe("RealtimeCallHandler path routing", () => {
   });
 
   it("rejects Telnyx stream starts that do not match the token-bound call", async () => {
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const getCall = vi.fn((): CallRecord => ({
       callId: "call-1",
       providerCallId: "v3:call-1",
@@ -668,7 +725,7 @@ describe("RealtimeCallHandler path routing", () => {
     const handler = makeHandler(undefined, {
       manager: {
         processEvent,
-        getCall,
+        getCallForStream: async () => getCall(),
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
@@ -712,7 +769,7 @@ describe("RealtimeCallHandler path routing", () => {
         return makeBridge({ triggerGreeting });
       },
     );
-    const getCallByProviderCallId = vi.fn((): CallRecord => ({
+    const getCallByProviderCallId = vi.fn<() => CallRecord>().mockReturnValue({
       callId: "call-1",
       providerCallId: "CA-silent",
       provider: "twilio",
@@ -724,7 +781,7 @@ describe("RealtimeCallHandler path routing", () => {
       transcript: [],
       processedEventIds: [],
       metadata: {},
-    }));
+    });
     const handler = makeHandler(undefined, {
       manager: {
         getCallByProviderCallId,
@@ -762,7 +819,7 @@ describe("RealtimeCallHandler path routing", () => {
   it("speaks through the active outbound realtime bridge by call id", async () => {
     const triggerGreeting = vi.fn();
     const createBridge = vi.fn(() => makeBridge({ triggerGreeting }));
-    const getCallByProviderCallId = vi.fn((): CallRecord => ({
+    const getCallByProviderCallId = vi.fn<() => CallRecord>().mockReturnValue({
       callId: "call-1",
       providerCallId: "CA-speak",
       provider: "twilio",
@@ -774,7 +831,7 @@ describe("RealtimeCallHandler path routing", () => {
       transcript: [],
       processedEventIds: [],
       metadata: {},
-    }));
+    });
     const handler = makeHandler(undefined, {
       manager: {
         getCallByProviderCallId,
@@ -817,7 +874,7 @@ describe("RealtimeCallHandler path routing", () => {
           onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
         }
       | undefined;
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const endCall = vi.fn(async () => ({ success: true }));
     const close = vi.fn(() => {
       callbacks?.onTranscript?.("user", "last words", true);
@@ -830,7 +887,7 @@ describe("RealtimeCallHandler path routing", () => {
         return makeBridge({ close });
       },
     );
-    const getCallByProviderCallId = vi.fn((): CallRecord => makeCallRecord("CA-complete"));
+    const getCallByProviderCallId = createCallRecordLookup();
     const streamDisconnectLifecycle = createFinalizingStreamGrace(
       processEvent,
       "disconnect-grace-expired",
@@ -914,7 +971,7 @@ describe("RealtimeCallHandler path routing", () => {
   });
 
   it("delays finalization after an abnormal realtime WebSocket disconnect", async () => {
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const close = vi.fn();
     const createBridge = vi.fn(() => makeBridge({ close }));
     const providerCallId = "CA-abnormal-disconnect";
@@ -934,7 +991,7 @@ describe("RealtimeCallHandler path routing", () => {
     const handler = makeHandler(undefined, {
       manager: {
         processEvent,
-        getCallByProviderCallId: vi.fn(() => makeCallRecord(providerCallId)),
+        getCallByProviderCallId: createCallRecordLookup(),
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
       streamDisconnectLifecycle,
@@ -992,7 +1049,7 @@ describe("RealtimeCallHandler path routing", () => {
         }
       | undefined;
     const sendAudio = vi.fn();
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const call: CallRecord = makeCallRecord("CA-talk-events");
     const createBridge = vi.fn(
       (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
@@ -1703,12 +1760,6 @@ describe("RealtimeCallHandler path routing", () => {
           args: { question: "Are the basement lights on?" },
         });
         expect(receivedPartialTranscript).toBeUndefined();
-        resolveWorkingSubmission?.();
-        await vi.advanceTimersByTimeAsync(350);
-        await waitForRealtimeTest(() => {
-          expect(receivedPartialTranscript).toBe("Are the basement");
-        });
-
         await waitForRealtimeTest(() => {
           const workingCall = submitToolResult.mock.calls.find(
             ([callId]) => callId === "consult-call",
@@ -1722,6 +1773,12 @@ describe("RealtimeCallHandler path routing", () => {
           expect(typeof payload?.message).toBe("string");
           expect(workingCall[2]).toEqual({ willContinue: true });
         });
+        expectDefined(resolveWorkingSubmission, "pending provider working submission")();
+        await vi.advanceTimersByTimeAsync(350);
+        await waitForRealtimeTest(() => {
+          expect(receivedPartialTranscript).toBe("Are the basement");
+        });
+
         expect(
           submitToolResult.mock.calls.filter(
             ([, result]) =>
@@ -1778,14 +1835,21 @@ describe("RealtimeCallHandler path routing", () => {
           args: { question: "Do not run this twice" },
         });
         await waitForRealtimeTest(() => {
-          expect(submitToolResult).toHaveBeenCalledTimes(1);
+          expect(recentTalkEvents(call).some((event) => event.type === "tool.error")).toBe(true);
         });
-        await vi.advanceTimersByTimeAsync(0);
         expect(consultHandler).toHaveBeenCalledTimes(1);
-        expect(submitToolResult).toHaveBeenCalledWith(
+        expect(submitToolResult).toHaveBeenCalledTimes(2);
+        expect(submitToolResult).toHaveBeenNthCalledWith(
+          1,
           "consult-rejected",
           expect.objectContaining({ status: "working" }),
           { willContinue: true },
+        );
+        expect(submitToolResult).toHaveBeenNthCalledWith(
+          2,
+          "consult-rejected",
+          { error: "working result rejected" },
+          undefined,
         );
       } finally {
         vi.useRealTimers();
@@ -2044,7 +2108,7 @@ describe("RealtimeCallHandler path routing", () => {
       { consultPolicy: "always" },
       {
         manager: {
-          getCallByProviderCallId: vi.fn((): CallRecord => makeCallRecord("CA-force")),
+          getCallByProviderCallId: createCallRecordLookup(),
         },
         realtimeProvider: makeRealtimeProvider(createBridge),
       },
@@ -2113,7 +2177,7 @@ describe("RealtimeCallHandler path routing", () => {
     });
     const handler = makeHandler(undefined, {
       manager: {
-        getCallByProviderCallId: vi.fn((providerCallId: string) => makeCallRecord(providerCallId)),
+        getCallByProviderCallId: createCallRecordLookup(),
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
@@ -2200,7 +2264,7 @@ describe("RealtimeCallHandler path routing", () => {
       { consultPolicy: "always" },
       {
         manager: {
-          getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-forced-close")),
+          getCallByProviderCallId: createCallRecordLookup(),
         },
         realtimeProvider: makeRealtimeProvider(createBridge),
       },
@@ -2297,9 +2361,7 @@ describe("RealtimeCallHandler path routing", () => {
       { consultPolicy: "always" },
       {
         manager: {
-          getCallByProviderCallId: vi.fn((providerCallId: string) =>
-            makeCallRecord(providerCallId),
-          ),
+          getCallByProviderCallId: createCallRecordLookup(),
         },
         realtimeProvider: makeRealtimeProvider(createBridge),
       },
@@ -2446,7 +2508,7 @@ describe("RealtimeCallHandler path routing", () => {
       }
       return bridge;
     });
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const endCall = vi.fn(async () => ({ success: true }));
     const sharedCallSid = "CA-continuity-shared";
     const call = makeCallRecord(sharedCallSid);
@@ -2598,7 +2660,7 @@ describe("RealtimeCallHandler path routing", () => {
         }
         return makeBridge({ connect: replacementConnect, close: replacementClose });
       });
-      const processEvent = vi.fn();
+      const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
       const endCall = vi.fn(async () => ({ success: true }));
       const sharedCallSid = "CA-transcript-rollback";
       const call = makeCallRecord(sharedCallSid);
@@ -2735,7 +2797,7 @@ describe("RealtimeCallHandler path routing", () => {
       request.onClose?.("completed");
       return makeBridge();
     });
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const call = makeCallRecord("CA-transcript-synchronous-close");
     const handler = makeHandler(undefined, {
       manager: {
@@ -2795,7 +2857,7 @@ describe("RealtimeCallHandler path routing", () => {
     });
     const handler = makeHandler(undefined, {
       manager: {
-        getCallByProviderCallId: vi.fn((providerCallId: string) => makeCallRecord(providerCallId)),
+        getCallByProviderCallId: createCallRecordLookup(),
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
@@ -2895,7 +2957,7 @@ describe("RealtimeCallHandler path routing", () => {
           onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
         }
       | undefined;
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const createBridge = vi.fn(
       (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
         callbacks = request;
@@ -2905,7 +2967,7 @@ describe("RealtimeCallHandler path routing", () => {
     const handler = makeHandler(undefined, {
       manager: {
         processEvent,
-        getCallByProviderCallId: vi.fn((): CallRecord => makeCallRecord("CA-direct-turns")),
+        getCallByProviderCallId: createCallRecordLookup(),
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
@@ -2981,7 +3043,7 @@ describe("RealtimeCallHandler path routing", () => {
     );
     const handler = makeHandler(undefined, {
       manager: {
-        getCallByProviderCallId: vi.fn((): CallRecord => makeCallRecord("CA-settle")),
+        getCallByProviderCallId: createCallRecordLookup(),
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
@@ -3073,7 +3135,7 @@ describe("RealtimeCallHandler path routing", () => {
       { consultPolicy: "always" },
       {
         manager: {
-          getCallByProviderCallId: vi.fn((): CallRecord => makeCallRecord("CA-native")),
+          getCallByProviderCallId: createCallRecordLookup(),
         },
         realtimeProvider: makeRealtimeProvider(createBridge),
       },
@@ -3153,7 +3215,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       {
         manager: {
-          getCallByProviderCallId: vi.fn((): CallRecord => makeCallRecord("CA-fast")),
+          getCallByProviderCallId: createCallRecordLookup(),
         },
         realtimeProvider: makeRealtimeProvider(createBridge),
       },
@@ -3211,7 +3273,7 @@ describe("RealtimeCallHandler websocket hardening", () => {
     );
     const handler = makeHandler(undefined, {
       manager: {
-        getCallByProviderCallId: vi.fn((): CallRecord => makeCallRecord("CA-backpressure")),
+        getCallByProviderCallId: createCallRecordLookup(),
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
@@ -3252,7 +3314,7 @@ describe("RealtimeCallHandler websocket hardening", () => {
 
   it("rejects oversized pre-start frames before bridge setup", async () => {
     const createBridge = vi.fn(() => makeBridge());
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" }));
     const getCallByProviderCallId = vi.fn();
     const handler = makeHandler(undefined, {
       manager: {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -336,33 +336,32 @@ async function waitForNativeConsult(state: NativeConsultState): Promise<NativeCo
 }
 
 function appendRecentTalkEventMetadata(
-  call: CallRecord | null | undefined,
+  metadata: CallRecord["metadata"],
   event: TalkEvent,
-): void {
-  if (!call) {
-    return;
-  }
-  const metadata = call.metadata ?? {};
-  const previous = Array.isArray(metadata.recentTalkEvents) ? metadata.recentTalkEvents : [];
-  metadata.lastTalkEventAt = event.timestamp;
-  metadata.lastTalkEventType = event.type;
-  metadata.recentTalkEvents = [
+): CallRecord["metadata"] {
+  const previous = metadata ?? {};
+  const recent = Array.isArray(previous.recentTalkEvents) ? previous.recentTalkEvents : [];
+  return {
     ...previous,
-    {
-      id: event.id,
-      brain: event.brain,
-      mode: event.mode,
-      provider: event.provider,
-      seq: event.seq,
-      sessionId: event.sessionId,
-      timestamp: event.timestamp,
-      transport: event.transport,
-      type: event.type,
-      ...(event.turnId ? { turnId: event.turnId } : {}),
-      ...(event.final !== undefined ? { final: event.final } : {}),
-    },
-  ].slice(-12);
-  call.metadata = metadata;
+    lastTalkEventAt: event.timestamp,
+    lastTalkEventType: event.type,
+    recentTalkEvents: [
+      ...recent,
+      {
+        id: event.id,
+        brain: event.brain,
+        mode: event.mode,
+        provider: event.provider,
+        seq: event.seq,
+        sessionId: event.sessionId,
+        timestamp: event.timestamp,
+        transport: event.transport,
+        type: event.type,
+        ...(event.turnId ? { turnId: event.turnId } : {}),
+        ...(event.final !== undefined ? { final: event.final } : {}),
+      },
+    ].slice(-12),
+  };
 }
 
 // The declared 2026.9.2 host has no WebSocket SDK subpath. Keep these two
@@ -390,6 +389,7 @@ export class RealtimeCallHandler {
   private readonly consultSessionsByCallId = new Map<string, RealtimeConsultSession>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
   private readonly terminationAttempts = new Set<Promise<void>>();
+  private readonly admissions = new Set<Promise<void>>();
   private closePromise: Promise<void> | null = null;
   private closing = false;
   private publicOrigin: string | null = null;
@@ -482,7 +482,19 @@ export class RealtimeCallHandler {
       let lastMediaTimestamp: number | undefined;
       let lastMediaGapWarnAt = 0;
 
-      ws.on("message", (data: Buffer) => {
+      let admitting = false;
+      const pendingFrames: Buffer[] = [];
+      let pendingBytes = 0;
+      const handleMessage = (data: Buffer) => {
+        if (admitting) {
+          pendingBytes += Math.max(1, data.byteLength);
+          if (pendingBytes > MAX_REALTIME_WS_BUFFERED_BYTES) {
+            ws.terminate();
+            return;
+          }
+          pendingFrames.push(data);
+          return;
+        }
         try {
           const frame = adapter.parseInbound(data.toString());
           if (frame.kind === "ignored") {
@@ -495,18 +507,46 @@ export class RealtimeCallHandler {
             initialized = true;
             activeCallSid = frame.providerCallId;
             activeStreamSid = frame.streamId;
-            const nextBinding = this.handleCall(
+            admitting = true;
+            // pause() stops socket reads, but ws can still emit frames already in its receiver.
+            ws.pause();
+            const admission = this.handleCall(
               frame.streamId,
               frame.providerCallId,
               ws,
               callerMeta,
               adapter,
-            );
-            if (!nextBinding) {
-              return;
-            }
-            telephonyBinding = nextBinding;
-            this.streamDisconnectLifecycle.connect(activeCallSid, activeStreamSid);
+            )
+              .then(async (nextBinding) => {
+                telephonyBinding = nextBinding;
+                if (!nextBinding) {
+                  return;
+                }
+                if (this.closing || ws.readyState !== WebSocket.OPEN) {
+                  await nextBinding.close(
+                    this.serverClosingSockets.has(ws) ? "shutdown" : "disconnect",
+                  );
+                  return;
+                }
+                this.streamDisconnectLifecycle.connect(activeCallSid, activeStreamSid);
+              })
+              .catch((error: unknown) => {
+                console.error("[voice-call] realtime admission failed:", error);
+                ws.close(1011, "Failed to persist call");
+              })
+              .finally(() => {
+                admitting = false;
+                if (ws.readyState === WebSocket.OPEN && !this.closing) {
+                  for (const pending of pendingFrames) {
+                    handleMessage(pending);
+                  }
+                }
+                ws.resume();
+                pendingFrames.length = 0;
+                pendingBytes = 0;
+                this.admissions.delete(admission);
+              });
+            this.admissions.add(admission);
             return;
           }
           if (!telephonyBinding) {
@@ -549,7 +589,8 @@ export class RealtimeCallHandler {
         } catch (error) {
           console.error("[voice-call] realtime WS parse failed:", error);
         }
-      });
+      };
+      ws.on("message", handleMessage);
 
       ws.on("close", () => {
         this.activeSockets.delete(ws);
@@ -579,7 +620,7 @@ export class RealtimeCallHandler {
     this.closing = true;
     this.pendingStreamTokens.clear();
     const sockets = [...this.activeSockets];
-    this.closePromise = Promise.all([
+    this.closePromise = Promise.allSettled([
       shutdownBarrier,
       ...sockets.map(
         (ws) =>
@@ -594,9 +635,14 @@ export class RealtimeCallHandler {
           }),
       ),
     ])
-      .then(async () => {
-        await Promise.all(this.terminationAttempts);
+      .then(async (results) => {
+        results.push(...(await Promise.allSettled(this.admissions)));
+        results.push(...(await Promise.allSettled(this.terminationAttempts)));
         this.pendingStreamTokens.clear();
+        const failure = results.find((result) => result.status === "rejected");
+        if (failure?.status === "rejected") {
+          throw failure.reason;
+        }
       })
       .finally(() => {
         this.closing = false;
@@ -683,14 +729,14 @@ export class RealtimeCallHandler {
     };
   }
 
-  private handleCall(
+  private async handleCall(
     streamSid: string,
     callSid: string,
     ws: WebSocket,
     callerMeta: Omit<PendingStreamToken, "expiry">,
     adapter: StreamFrameAdapter,
-  ): RealtimeTelephonyBinding | null {
-    const preparedCall = this.prepareCallInManager(callSid, callerMeta);
+  ): Promise<RealtimeTelephonyBinding | null> {
+    const preparedCall = await this.prepareCallInManager(callSid, callerMeta);
     if (!preparedCall) {
       ws.close(1008, "Caller rejected by policy");
       return null;
@@ -699,7 +745,6 @@ export class RealtimeCallHandler {
     const { callRecord } = preparedCall;
     const callId = callRecord.callId;
     const hadPredecessorOnAdmission = this.activeBridgesByCallId.has(callId);
-    const previousTelephonyBinding = this.activeTelephonyBindingsByCallId.get(callId);
     let callEndPromise: Promise<void> | undefined;
     const emitCallEnd = (cause: RealtimeCallEndCause): Promise<void> => {
       if (callEndPromise) {
@@ -725,6 +770,22 @@ export class RealtimeCallHandler {
       return attempt;
     };
 
+    const admissionAbandoned = () => this.closing || ws.readyState !== WebSocket.OPEN;
+    const abandonAdmission = async (): Promise<void> => {
+      if (!this.activeBridgesByCallId.has(callId)) {
+        if (this.closing || this.serverClosingSockets.has(ws)) {
+          await emitCallEnd("shutdown");
+        } else {
+          this.streamDisconnectLifecycle.connect(callSid, streamSid);
+          this.streamDisconnectLifecycle.disconnect(callSid, streamSid);
+        }
+      }
+    };
+    if (admissionAbandoned()) {
+      await abandonAdmission();
+      return null;
+    }
+
     let registration: RealtimeCallRegistration;
     try {
       registration = this.resolveCallRegistration(callRecord);
@@ -732,23 +793,38 @@ export class RealtimeCallHandler {
       console.error(
         `[voice-call] Failed to resolve realtime call registration callId=${callId} providerCallId=${callSid}: ${formatErrorMessage(error)}`,
       );
-      if (!hadPredecessorOnAdmission) {
+      if (!this.activeBridgesByCallId.has(callId)) {
         void emitCallEnd("error");
       }
       ws.close(1011, "Check realtime configuration for routed agent");
       return null;
     }
 
-    const { baseFields, initialGreeting } = preparedCall;
-    if (callRecord.metadata) {
-      delete callRecord.metadata.initialMessage;
-    }
-    this.manager.processEvent({
+    const { baseFields } = preparedCall;
+    let initialGreeting: string | undefined;
+    await this.manager.updateCallMetadata(callRecord, (metadata) => {
+      if (metadata) {
+        initialGreeting =
+          typeof metadata.initialMessage === "string" ? metadata.initialMessage : undefined;
+        delete metadata.initialMessage;
+      }
+      return metadata;
+    });
+    await this.manager.processEvent({
       id: `realtime-answered-${callSid}`,
       callId,
       type: "call.answered",
       ...baseFields,
     });
+    if (admissionAbandoned()) {
+      await abandonAdmission();
+      return null;
+    }
+    if (this.manager.getCallByProviderCallId(callSid) !== callRecord) {
+      ws.close(1008, "Call is no longer active");
+      return null;
+    }
+    const previousTelephonyBinding = this.activeTelephonyBindingsByCallId.get(callId);
     const { agentId, instructions, provider: realtimeProvider, providerConfig } = registration;
     const initialGreetingInstructions = buildGreetingInstructions(instructions, initialGreeting);
     const harness = createRealtimeVoiceSessionHarness({
@@ -767,7 +843,15 @@ export class RealtimeCallHandler {
         outputAudioDelta: (audio) => ({ byteLength: audio.byteLength }),
         outputAudioDone: (reason) => ({ callId, providerCallId: callSid, reason }),
       },
-      onTalkEvent: (event) => appendRecentTalkEventMetadata(callRecord, event),
+      onTalkEvent: (event) => {
+        void this.manager
+          .updateCallMetadata(callRecord, (metadata) =>
+            appendRecentTalkEventMetadata(metadata, event),
+          )
+          .catch((error: unknown) => {
+            console.warn("[voice-call] Failed to update realtime call metadata:", error);
+          });
+      },
     });
     let providerHandlesInputAudioBargeIn =
       realtimeProvider.capabilities?.handlesInputAudioBargeIn === true;
@@ -871,6 +955,8 @@ export class RealtimeCallHandler {
     // retires the predecessor only after creation succeeds; failure restores it.
     const userTranscriptAdoption = this.beginUserTranscriptOwnerAdoption(callId);
     const userTranscriptOwner = userTranscriptAdoption.owner;
+    let transcriptPersistence = Promise.resolve();
+    let continuityGeneration = 0;
     const bridgeParams: Parameters<typeof harness.createBridge>[0] = {
       provider: realtimeProvider,
       cfg: this.coreConfig,
@@ -980,33 +1066,60 @@ export class RealtimeCallHandler {
             transcript,
             isFinal: true,
           };
-          this.manager.processEvent(event);
-          this.scheduleForcedAgentConsult({
-            harness,
-            session,
-            callId,
-            callSid,
-            transcript,
-            userTranscriptOwner,
-            clearAudio: () => {
-              const clearedBytes = audioPacer.clearAudio();
-              console.log(
-                `[voice-call] realtime forced consult cleared outbound audio callId=${callId} providerCallId=${callSid} queuedBytes=${clearedBytes}`,
-              );
-            },
+          const generation = continuityGeneration;
+          transcriptPersistence = this.manager.processEvent(event).then(() => {
+            if (
+              sessionClosed ||
+              generation !== continuityGeneration ||
+              !this.getUserTranscriptState(callId, userTranscriptOwner) ||
+              !this.isActiveBridgeOwner(callId, session)
+            ) {
+              return;
+            }
+            this.scheduleForcedAgentConsult({
+              harness,
+              session,
+              callId,
+              callSid,
+              transcript,
+              userTranscriptOwner,
+              clearAudio: () => {
+                const clearedBytes = audioPacer.clearAudio();
+                console.log(
+                  `[voice-call] realtime forced consult cleared outbound audio callId=${callId} providerCallId=${callSid} queuedBytes=${clearedBytes}`,
+                );
+              },
+            });
+          });
+          void transcriptPersistence.catch((error: unknown) => {
+            console.error("[voice-call] Failed to persist realtime transcript:", error);
           });
           return;
         }
-        this.manager.processEvent({
-          id: `realtime-bot-${callSid}-${Date.now()}`,
-          type: "call.assistant-speech",
-          callId,
-          providerCallId: callSid,
-          timestamp: Date.now(),
-          transcript: text,
+        transcriptPersistence = this.manager
+          .processEvent({
+            id: `realtime-bot-${callSid}-${Date.now()}`,
+            type: "call.assistant-speech",
+            callId,
+            providerCallId: callSid,
+            timestamp: Date.now(),
+            transcript: text,
+          })
+          .then(() => {});
+        void transcriptPersistence.catch((error: unknown) => {
+          console.error("[voice-call] Failed to persist realtime transcript:", error);
         });
       },
-      onToolCall: (toolEvent, sessionLocal) => {
+      onToolCall: async (toolEvent, sessionLocal) => {
+        const generation = continuityGeneration;
+        await transcriptPersistence;
+        if (
+          sessionClosed ||
+          generation !== continuityGeneration ||
+          !this.isActiveBridgeOwner(callId, sessionLocal)
+        ) {
+          return;
+        }
         const turnId = harness.ensureTurn();
         harness.emit({
           type: "tool.call",
@@ -1031,6 +1144,7 @@ export class RealtimeCallHandler {
       },
       onEvent: (event) => {
         if (event.direction === "client" && event.type === "session.continuity.reset") {
+          continuityGeneration += 1;
           // A fresh provider session cannot complete the prior session's text,
           // audio, tool work, or Talk turn.
           const turnId = harness.talk.activeTurnId;
@@ -1739,7 +1853,7 @@ export class RealtimeCallHandler {
     }
   }
 
-  private prepareCallInManager(
+  private async prepareCallInManager(
     callSid: string,
     callerMeta: Omit<PendingStreamToken, "expiry"> = {},
   ) {
@@ -1752,19 +1866,15 @@ export class RealtimeCallHandler {
       ...(callerMeta.to ? { to: callerMeta.to } : {}),
     };
 
-    const callRecord = this.resolveRealtimeCall(callSid, callerMeta, baseFields);
+    const callRecord = await this.resolveRealtimeCall(callSid, callerMeta, baseFields);
     if (!callRecord) {
       return null;
     }
 
-    const initialGreeting = this.extractInitialGreeting(callRecord);
-    console.log(
-      `[voice-call] Realtime call ${callRecord.callId} initial greeting ${initialGreeting ? "queued" : "absent"}`,
-    );
-    return { callRecord, baseFields, initialGreeting };
+    return { callRecord, baseFields };
   }
 
-  private resolveRealtimeCall(
+  private async resolveRealtimeCall(
     callSid: string,
     callerMeta: Omit<PendingStreamToken, "expiry">,
     baseFields: {
@@ -1774,13 +1884,13 @@ export class RealtimeCallHandler {
       from?: string;
       to?: string;
     },
-  ): CallRecord | null {
+  ): Promise<CallRecord | null> {
     if (callerMeta.callId) {
-      const call = this.manager.getCall(callerMeta.callId);
+      const call = await this.manager.getCallForStream(callerMeta.callId);
       return call?.providerCallId === callSid ? call : null;
     }
 
-    this.manager.processEvent({
+    await this.manager.processEvent({
       id: `realtime-initiated-${callSid}`,
       callId: callSid,
       type: "call.initiated",
@@ -1788,12 +1898,6 @@ export class RealtimeCallHandler {
     });
 
     return this.manager.getCallByProviderCallId(callSid) ?? null;
-  }
-
-  private extractInitialGreeting(call: CallRecord): string | undefined {
-    return typeof call.metadata?.initialMessage === "string"
-      ? call.metadata.initialMessage
-      : undefined;
   }
 
   private async executeEndCallTool(params: {

--- a/extensions/voice-call/src/webhook/stale-call-reaper.transport.test.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.transport.test.ts
@@ -1,6 +1,7 @@
 // Voice Call tests cover stale-call reaping through a real provider HTTP boundary.
 import type { ServerResponse } from "node:http";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { withFetchPreconnect, withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { endCall } from "../manager/outbound.js";
@@ -86,6 +87,7 @@ describe("stale-call reaper provider transport", () => {
           processedEventIds: [],
         } satisfies CallRecord;
         const context: Parameters<typeof endCall>[0] = {
+          mutationQueue: new KeyedAsyncQueue(),
           activeCalls: new Map([[call.callId, call]]),
           providerCallIdMap: new Map([[call.providerCallId, call.callId]]),
           provider,


### PR DESCRIPTION
## What Problem This Solves

Prepares Voice Call to use asynchronous call-record persistence without acknowledging callbacks, publishing active calls, or starting replies before their records are saved. Delayed writes must preserve capacity limits, speech interruption, transcript timeouts, and shutdown ordering.

## Why This Change Was Made

Call history, restore, lookup, and persistence use the existing asynchronous plugin-state contract. The manager serializes state and persistence decisions through the existing keyed queue, keeps uncommitted drafts private, and reserves capacity for pending outbound admissions. Carrier, playback, listening, and transcript waits remain outside that queue.

HTTP and streaming callbacks await persistence, startup joins required restore writes, and runtime stop drains admitted work. Automatic playback lets admitted speech finish its replay and turn-token checks. Expired transcript waiters cannot consume speech or steal replacement waiters. Token-bound realtime streams wait for pending identity updates before matching the carrier ID, avoiding rejection while the provider-ID write is still pending.

## User Impact

Call records retain their existing format, chunk limits, retention, metadata-last publication, replay behavior, and aliases. Failed persistence does not publish an active record or begin outbound playback. Existing synchronous map getters and telephony policies remain.

This is groundwork for moving SQLite execution off the main event loop. It does not itself move SQL to a worker or claim a performance improvement; that cutover must preserve the canonical shared-state owner, including configured store paths and aliases.

## Evidence

- All 896 Voice Call tests passed, including real SQLite delayed/rejected-write, capacity, replay, startup, shutdown, and speech-ordering tests. Real loopback WebSocket tests reproduce token-bound stream rejection before the fix and cover committed, failed, and retired-call outcomes.
- The complete changed-path gate passed; affected type, format, typed-lint, and ratchet checks passed again after the stream-admission fix. Fresh full-candidate Codex review found no actionable P0–P2 defects.
- Normal build passed in 319.40 seconds. Compiled public runtime proof passed through loopback HTTP and SDK-bound SQLite: held writes delay acknowledgment and shutdown, replay preserves history, and a fresh process reopens records and aliases. Write phase: 5.98 seconds; reopen: 2.91 seconds. Source and artifacts stayed unchanged, with no TypeScript fallback.

The compiled proof uses a programmatic full Plugin API host and mock provider, not normal Gateway activation or vendor telephony. Timings are smoke observations including normal shutdown grace, not benchmarks. Original counterexamples and prior proof remain preserved.
