### PR TITLE
refactor(state): defer repository database opening until use

### DIFF
--- a/src/state/session-repository-workspaces.test.ts
+++ b/src/state/session-repository-workspaces.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   ensureRepositoryWorkspacePendingResultSchema,
   hasRepositoryWorkspacePendingResultSchema,
@@ -9,9 +10,11 @@ import {
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import {
   closeOpenClawStateDatabaseByPath,
+  isOpenClawStateDatabaseOpen,
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "./openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import { createSessionRepositoryWorkspaceStore } from "./session-repository-workspaces.js";
 
 const roots: string[] = [];
@@ -39,6 +42,39 @@ async function fixture() {
   const database = openOpenClawStateDatabase({ path: path.join(root, "openclaw.sqlite") });
   return { database, store: createSessionRepositoryWorkspaceStore({ database }) };
 }
+
+it("captures a lazy store location and retains it across environment changes and reopen", async () => {
+  await withOpenClawTestState({ scenario: "empty" }, async (state) => {
+    const firstPath = resolveOpenClawStateSqlitePath();
+    const secondPath = resolveOpenClawStateSqlitePath({
+      ...process.env,
+      OPENCLAW_STATE_DIR: state.statePath("second"),
+    });
+    try {
+      const store = createSessionRepositoryWorkspaceStore();
+      expect(store.path).toBe(firstPath);
+      const workspaceId = "00000000-0000-4000-8000-000000000000";
+      expect(store.artifactPath(workspaceId)).toBe(
+        path.join(path.dirname(firstPath), "repository-workspaces", `${workspaceId}.git`),
+      );
+      expect.soft(isOpenClawStateDatabaseOpen(firstPath)).toBe(false);
+      await expect.soft(fs.stat(firstPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+      vi.stubEnv("OPENCLAW_STATE_DIR", state.statePath("second"));
+      const initial = store.create(source);
+      expect(store.get(initial.workspaceId)).toEqual(initial);
+      expect(isOpenClawStateDatabaseOpen(firstPath)).toBe(true);
+      closeOpenClawStateDatabaseByPath(firstPath);
+      expect(store.find(source)).toEqual(initial);
+      expect(isOpenClawStateDatabaseOpen(secondPath)).toBe(false);
+      await expect(fs.stat(secondPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      closeOpenClawStateDatabaseByPath(firstPath);
+      closeOpenClawStateDatabaseByPath(secondPath);
+      vi.unstubAllEnvs();
+    }
+  });
+});
 
 it("retries rolled-back first-use pending owner DDL and preserves the committed column on reopen", async () => {
   const { database } = await fixture();

--- a/src/state/session-repository-workspaces.ts
+++ b/src/state/session-repository-workspaces.ts
@@ -12,6 +12,7 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabase,
 } from "./openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 export type SessionRepositoryWorkspaceRecord = {
   workspaceId: string;
@@ -69,10 +70,42 @@ function project(row: Selectable<SessionRepositoryWorkspaces>): SessionRepositor
   };
 }
 
+function readWorkspace(
+  db: DatabaseSync,
+  workspaceId: string,
+): SessionRepositoryWorkspaceRecord | undefined {
+  if (!tableExists(db, table)) {
+    return undefined;
+  }
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    query(db).selectFrom(table).selectAll().where("workspace_id", "=", workspaceId),
+  );
+  return row ? project(row) : undefined;
+}
+
+function findWorkspace(
+  db: DatabaseSync,
+  owner: WorkspaceOwner,
+): SessionRepositoryWorkspaceRecord | undefined {
+  if (!tableExists(db, table)) {
+    return undefined;
+  }
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    query(db)
+      .selectFrom(table)
+      .selectAll()
+      .where("agent_id", "=", owner.agentId)
+      .where("session_key", "=", owner.sessionKey),
+  );
+  return row ? project(row) : undefined;
+}
+
 export function createSessionRepositoryWorkspaceStore(
   options: { database?: OpenClawStateDatabase; now?: () => number } = {},
 ) {
-  const databasePath = (options.database ?? openOpenClawStateDatabase()).path;
+  const databasePath = options.database?.path ?? path.resolve(resolveOpenClawStateSqlitePath());
   const now = options.now ?? Date.now;
   const read = () => openOpenClawStateDatabase({ path: databasePath }).db;
   const write = <T>(operation: (db: DatabaseSync) => T) =>
@@ -88,38 +121,14 @@ export function createSessionRepositoryWorkspaceStore(
       }
     }
   };
-  const get = (workspaceId: string): SessionRepositoryWorkspaceRecord | undefined => {
-    const db = read();
-    if (!tableExists(db, table)) {
-      return undefined;
-    }
-    const row = executeSqliteQueryTakeFirstSync(
-      db,
-      query(db).selectFrom(table).selectAll().where("workspace_id", "=", workspaceId),
-    );
-    return row ? project(row) : undefined;
-  };
-  const find = (owner: WorkspaceOwner): SessionRepositoryWorkspaceRecord | undefined => {
-    const db = read();
-    if (!tableExists(db, table)) {
-      return undefined;
-    }
-    const row = executeSqliteQueryTakeFirstSync(
-      db,
-      query(db)
-        .selectFrom(table)
-        .selectAll()
-        .where("agent_id", "=", owner.agentId)
-        .where("session_key", "=", owner.sessionKey),
-    );
-    return row ? project(row) : undefined;
-  };
+  const get = (workspaceId: string) => readWorkspace(read(), workspaceId);
+  const find = (owner: WorkspaceOwner) => findWorkspace(read(), owner);
   const mutate = (
     input: WorkspaceMutation,
     values: (current: SessionRepositoryWorkspaceRecord) => Updateable<SessionRepositoryWorkspaces>,
   ): SessionRepositoryWorkspaceRecord =>
     write((db) => {
-      const current = get(input.workspaceId);
+      const current = readWorkspace(db, input.workspaceId);
       if (!current || current.revision !== input.expectedRevision) {
         throw new Error("Repository workspace revision changed");
       }
@@ -172,7 +181,7 @@ export function createSessionRepositoryWorkspaceStore(
       ensure();
       return write((db) => {
         input.assertCurrent();
-        const existing = find({ agentId, sessionKey });
+        const existing = findWorkspace(db, { agentId, sessionKey });
         if (existing) {
           if (
             existing.url !== url ||


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Constructing a repository-workspace store opens SQLite even when the caller only needs an artifact path. Transaction helpers also reacquire their store through public read methods instead of using the connection already admitted to the transaction.

## Why This Change Was Made

Capture the canonical absolute path without opening the database. Open on actual data access, retaining that captured path through environment changes and reopen. Reuse private native read helpers inside the existing transaction owner.

## User Impact

Artifact-path planning no longer creates or reopens SQLite. Existing synchronous operations, revision checks, stored formats and artifact cleanup behavior remain unchanged.

## Evidence

- All 24 store, checkpoint and deletion cases passed; the lazy-opening regression failed on original source for the intended reason.
- Actual artifact-consumer and SQLite before/after proof preserved create/checkpoint/reopen, stale-revision refusal and sibling artifacts. Construction and artifact-only lookup no longer open the database.
- Full selected checks and fresh independent Codex review through P2 passed. All created processes joined and the broader recovery candidate remained untouched.
- No compiled build or worker execution is claimed by this focused prerequisite.
