### PR TITLE
refactor(tests): share provider auth runtime fixtures

### DIFF
--- a/extensions/cerebras/onboard.test.ts
+++ b/extensions/cerebras/onboard.test.ts
@@ -6,6 +6,7 @@ import {
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../test-support/runtime-spies.js";
 import { buildCerebrasCatalogModels } from "./api.js";
 import plugin from "./index.js";
 import { applyCerebrasConfig, CEREBRAS_DEFAULT_MODEL_REF } from "./onboard.js";
@@ -139,21 +140,24 @@ describe("Cerebras onboarding", () => {
       throw new Error("expected Cerebras non-interactive auth method");
     }
 
-    const result = await method.runNonInteractive({
-      authChoice: "cerebras-api-key",
-      config: {
-        agents: {
-          defaults: {
-            model: { primary: "anthropic/claude-sonnet-4-6" },
-            models: { "anthropic/claude-sonnet-4-6": { alias: "Existing" } },
-          },
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          models: { "anthropic/claude-sonnet-4-6": { alias: "Existing" } },
         },
       },
+    };
+
+    const result = await method.runNonInteractive({
+      authChoice: "cerebras-api-key",
+      config,
+      baseConfig: config,
       opts: {},
-      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
-      resolveApiKey: vi.fn(async () => ({ key: "fixture-value", source: "profile" })),
+      runtime: createRuntimeSpies(),
+      resolveApiKey: vi.fn(async () => ({ key: "fixture-value", source: "profile" as const })),
       toApiKeyCredential: vi.fn(() => null),
-    } as never);
+    });
 
     expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe(
       "anthropic/claude-sonnet-4-6",

--- a/extensions/litellm/index.test.ts
+++ b/extensions/litellm/index.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../test-support/runtime-spies.js";
 import plugin from "./index.js";
 
 const LITELLM_DEFAULT_MODEL = {
@@ -49,15 +50,11 @@ describe("litellm plugin", () => {
           litellmApiKey: "litellm-test-key",
           customBaseUrl: "https://litellm.example/v1/",
         },
-        runtime: {
-          error: vi.fn(),
-          exit: vi.fn(),
-          log: vi.fn(),
-        } as never,
+        runtime: createRuntimeSpies(),
         agentDir,
         resolveApiKey,
         toApiKeyCredential,
-      } as never);
+      });
 
       expect(result).toStrictEqual({
         auth: {

--- a/extensions/stepfun/index.test.ts
+++ b/extensions/stepfun/index.test.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../test-support/runtime-spies.js";
 import stepfunPlugin from "./index.js";
 import {
   STEPFUN_DEFAULT_MODEL_REF,
@@ -175,29 +176,31 @@ describe("stepfun provider registration", () => {
       });
       const provider = requireRegisteredProvider(providers, providerId);
       const method = provider.auth.find((entry) => entry.id === methodId);
-      if (!method?.runNonInteractive) {
+      if (!method?.runNonInteractive || !method.wizard?.choiceId) {
         throw new Error(`expected StepFun non-interactive auth method ${methodId}`);
       }
 
-      const result = await method.runNonInteractive({
-        authChoice: method.wizard?.choiceId,
-        config: {
-          agents: {
-            defaults: {
-              model: {
-                primary: "anthropic/claude-sonnet-4-6",
-                fallbacks: ["openai/gpt-5.6-luna"],
-              },
-              models: { "anthropic/claude-sonnet-4-6": { alias: "Existing" } },
+      const config = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+              fallbacks: ["openai/gpt-5.6-luna"],
             },
+            models: { "anthropic/claude-sonnet-4-6": { alias: "Existing" } },
           },
         },
+      };
+
+      const result = await method.runNonInteractive({
+        authChoice: method.wizard.choiceId,
+        config,
+        baseConfig: config,
         opts: {},
-        env: {},
-        runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
-        resolveApiKey: vi.fn(async () => ({ key: "fixture-value", source: "profile" })),
+        runtime: createRuntimeSpies(),
+        resolveApiKey: vi.fn(async () => ({ key: "fixture-value", source: "profile" as const })),
         toApiKeyCredential: vi.fn(() => null),
-      } as never);
+      });
 
       expect(result?.agents?.defaults?.model).toEqual({
         primary: "anthropic/claude-sonnet-4-6",

--- a/src/plugins/provider-api-key-auth.test.ts
+++ b/src/plugins/provider-api-key-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { loadAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-profiles/store-runtime.js";
-import type { RuntimeEnv } from "../runtime.js";
+import { createTestRuntime } from "../commands/test-runtime-config-helpers.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createProviderApiKeyAuthMethod } from "./provider-api-key-auth.js";
 
@@ -23,7 +23,7 @@ describe("createProviderApiKeyAuthMethod", () => {
         baseConfig: {},
         agentDir: state.agentDir(),
         opts: { exampleApiKey: "test-token" },
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as unknown as RuntimeEnv,
+        runtime: createTestRuntime(),
         resolveApiKey: vi.fn(async () => ({ key: "test-token", source: "flag" as const })),
         toApiKeyCredential: () => credential,
       });
@@ -54,7 +54,7 @@ describe("createProviderApiKeyAuthMethod", () => {
       config: {},
       baseConfig: {},
       opts: { exampleApiKey: "test-token" },
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as unknown as RuntimeEnv,
+      runtime: createTestRuntime(),
       resolveApiKey,
     });
 
@@ -86,7 +86,7 @@ describe("createProviderApiKeyAuthMethod", () => {
       config: {},
       baseConfig: {},
       opts: { exampleApiKey: "test-token" },
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as unknown as RuntimeEnv,
+      runtime: createTestRuntime(),
       resolveApiKey: vi.fn(async () => ({ key: "test-token", source: "profile" as const })),
       toApiKeyCredential: vi.fn(() => null),
     });
@@ -126,7 +126,7 @@ describe("createProviderApiKeyAuthMethod", () => {
       config: {},
       baseConfig: {},
       opts: { exampleApiKey: "test-token" },
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as unknown as RuntimeEnv,
+      runtime: createTestRuntime(),
       resolveApiKey: vi.fn(async () => ({ key: "test-token", source: "profile" as const })),
       toApiKeyCredential: vi.fn(() => null),
     });
@@ -153,7 +153,7 @@ describe("createProviderApiKeyAuthMethod", () => {
       env: {},
       opts: { exampleApiKey: "test-token" },
       prompter: { note: vi.fn() },
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      runtime: createTestRuntime(),
       secretInputMode: "plaintext",
     } as never);
 


### PR DESCRIPTION
## What Problem This Solves

API-key auth tests duplicate runtime mocks, while broad casts hide parts of the public auth-context contract.

## Why This Change Was Made

Reuse existing runtime fixtures in the StepFun, Cerebras, LiteLLM, and core API-key auth suites. Supply required noninteractive context fields where needed while preserving configuration identity, repeatable resolver answers, nonthrowing runtime methods, and the deliberately partial interactive fixture. Existing assertions and temporary-state cleanup remain intact; no production, SDK, or helper changes.

## User Impact

No user-facing behavior change. The test-only diff adds 42 lines and removes 38, replacing duplicated fixtures and unchecked casts with existing typed helpers.

## Evidence

All four complete suites passed before and after in separate fresh processes: the same 31 cases, order, and statuses. Source/dependency checks and owned temporary-root cleanup passed. Profile-source fixtures still use synthetic resolvers; the flag-source cases retain isolated credential persistence, including the core store readback. No live-provider behavior is claimed.

All 23 selected changed-file checks passed, including core and plugin test typechecking, boundary guards, dead-export scans, formatting, and lint. Independent review found no actionable issues through P2. No production build was run for this test-only change.
