### PR TITLE
fix(ui): hide empty native CLI catalogs in the sessions sidebar

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -32,6 +32,7 @@ import {
 import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import {
+  catalogErrorMessages,
   formatSidebarTimestamp,
   normalizeCatalogTimestamp,
   type CatalogBackingSessionDisplay,
@@ -162,24 +163,6 @@ function renderCatalogHeaderStatus(hasActiveRun: boolean, hasUnread: boolean) {
     : nothing;
 }
 
-function catalogErrorMessages(catalog: SessionCatalog): string[] {
-  const messages = new Set<string>();
-  const add = (error: SessionCatalog["error"]) => {
-    if (error) {
-      messages.add(formatUiError(`[${error.code}] ${error.message}`));
-    }
-  };
-  add(catalog.error);
-  for (const host of catalog.hosts) {
-    // A disconnected empty host is normal fleet state, not a provider failure.
-    // Cached rows still expose the host-level offline badge when the host is visible.
-    if (host.error?.code !== "NODE_OFFLINE") {
-      add(host.error);
-    }
-  }
-  return [...messages];
-}
-
 export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
   // Adopted rows use canonical local labels and title snapshots; native catalog
   // refreshes must not rename them or replace the regular session presentation.
@@ -214,7 +197,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     const hasError = errorMessages.length > 0;
     // Keep provider failures distinguishable from successful empty results.
     // Hiding both states would silently mask unavailable session sources.
-    if (rows.length === 0 && !hasMore && !hasError && !canCreateSession) {
+    if (rows.length === 0 && !hasMore && !hasError) {
       return nothing;
     }
     const errorMessage = errorMessages.join("; ");

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../../packages/gateway-protocol/src/index.ts";
 import type { ApplicationNavigationOptions } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../lib/format.ts";
 import { repoName } from "../lib/session-display.ts";
 import type {
@@ -116,6 +117,37 @@ export function visibleSessionCatalogProjection(
   archivedFilter: boolean,
 ): SessionCatalog[] {
   return archivedFilter ? [] : catalogs.filter((catalog) => !hiddenCatalogIds.has(catalog.id));
+}
+
+export function catalogErrorMessages(catalog: SessionCatalog): string[] {
+  const messages = new Set<string>();
+  const add = (error: SessionCatalog["error"]) => {
+    if (error) {
+      messages.add(formatUiError(`[${error.code}] ${error.message}`));
+    }
+  };
+  add(catalog.error);
+  for (const host of catalog.hosts) {
+    // A disconnected empty host is normal fleet state, not a provider failure.
+    // Cached rows still expose the host-level offline badge when the host is visible.
+    if (host.error?.code !== "NODE_OFFLINE") {
+      add(host.error);
+    }
+  }
+  return [...messages];
+}
+
+/**
+ * A catalog earns a sidebar section through rows, further pages, or a provider
+ * failure. A successful empty catalog stays out of the sidebar even when it can
+ * start sessions: the new-session page still lists it as a target, and hiding
+ * it here keeps the zone peer list and the rendered sections in agreement.
+ */
+export function catalogSectionHasContent(catalog: SessionCatalog): boolean {
+  return (
+    catalog.hosts.some((host) => host.sessions.length > 0 || Boolean(host.nextCursor)) ||
+    catalogErrorMessages(catalog).length > 0
+  );
 }
 
 export function visibleCatalogHosts(

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -25,6 +25,7 @@ import { AppSidebarBase } from "./app-sidebar-base.ts";
 import { projectSidebarArchiveVisibility } from "./app-sidebar-session-archive-visibility.ts";
 import {
   adoptedCatalogSessionKeys,
+  catalogSectionHasContent,
   visibleSessionCatalogProjection,
 } from "./app-sidebar-session-catalogs.ts";
 import {
@@ -355,7 +356,9 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       catalogIds:
         this.sessionsStatusFilter === "archived"
           ? []
-          : this.visibleSessionCatalogs().map((catalog) => catalog.id),
+          : this.visibleSessionCatalogs()
+              .filter(catalogSectionHasContent)
+              .map((catalog) => catalog.id),
       collapsedSections: this.collapsedSessionSections,
       hideEmptyGroups: this.sessionsHideEmptyGroups || this.sessionOwnerFilterActive,
       visibleSessionLimits: this.sessionData.visibleSessionLimits,

--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -52,7 +52,24 @@ suite.define(() => {
                 archive: false,
                 startTerminal: true,
               },
-              hosts: [],
+              hosts: [
+                {
+                  hostId: "gateway:local",
+                  label: "Gateway Mac",
+                  kind: "gateway",
+                  connected: true,
+                  sessions: [
+                    {
+                      threadId: "cli-thread",
+                      name: "CLI plan",
+                      status: "stored",
+                      archived: false,
+                      canContinue: true,
+                      canArchive: false,
+                    },
+                  ],
+                },
+              ],
             },
           ],
         },

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -162,7 +162,24 @@ describe("AppSidebar new session navigation", () => {
           archive: false,
           startTerminal: true,
         },
-        hosts: [],
+        hosts: [
+          {
+            hostId: "gateway:local",
+            label: "Gateway Mac",
+            kind: "gateway",
+            connected: true,
+            sessions: [
+              {
+                threadId: "local-thread",
+                name: "Local plan",
+                status: "stored",
+                archived: false,
+                canContinue: true,
+                canArchive: false,
+              },
+            ],
+          },
+        ],
       },
     ];
     sidebar.sessionData.requestSessionDataUpdate();
@@ -179,6 +196,40 @@ describe("AppSidebar new session navigation", () => {
     link.click();
 
     expect(onOpenNewSession).toHaveBeenCalledWith("research", { catalogId: "claude" });
+  });
+
+  it("hides a successful empty catalog even when it can start sessions", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(
+      gateway,
+      createSessions("research", ["agent:research:main"]),
+    );
+    sidebar.connected = true;
+    sidebar.sessionData.sessionCatalogs = [
+      {
+        id: "claude",
+        label: "Claude Code",
+        capabilities: { continueSession: true, archive: false, startTerminal: true },
+        hosts: [
+          {
+            hostId: "gateway:local",
+            label: "Gateway Mac",
+            kind: "gateway",
+            connected: true,
+            sessions: [],
+          },
+        ],
+      },
+    ];
+    sidebar.sessionData.requestSessionDataUpdate();
+    await sidebar.updateComplete;
+
+    expect(sidebar.querySelector('[data-session-section="catalog:claude"]')).toBeNull();
+    expect(sidebar.querySelector(".sidebar-session-catalog-new")).toBeNull();
+    // Without a visible peer section the lone Other zone stays headerless.
+    expect(
+      sidebar.querySelector('[data-session-section="ungrouped"] .sidebar-recent-sessions__head'),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Control UI sessions sidebar would see permanently empty Claude Code or Codex sections on hosts without those CLIs or without any threads. An invisible catalog could also leave an orphan “Other” header above ordinary sessions.

## Why This Change Was Made

Successful empty catalogs no longer render sidebar sections merely because they can start terminal sessions. The renderer and the projection's zone peer list now use the same content criteria: session rows, further pages, or a provider error. The projection uses `catalogSectionHasContent`, with error handling shared with the renderer, so hidden catalogs no longer force an “Other” header.

## User Impact

The sessions sidebar omits empty native CLI catalogs. Provider errors and paginated catalogs remain visible. Starting a terminal session remains available from the new-session page, whose target picker lists every start-capable catalog. This is a UI-only change with no configuration or protocol changes.

## Evidence

Prior local proof run by the coordinator on commit `7bfe2334b85c1ccae573cfb692e1b2452756cc1e`:

- `node scripts/run-vitest.mjs run ui/src/components/app-sidebar.test.ts ui/src/components/app-sidebar-session-catalog-live.test.ts`: 2 files, 363 tests passed.
- `pnpm tsgo:ui`: passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-interactions.e2e.test.ts`: 7 tests passed.
- Codex autoreview: scoped-clean at P2.

Tests that relied on rendering an empty start-capable catalog were updated, and a new unit case covers the hidden-empty state.

Synthetic browser proof uses the same empty-catalog fixture against the parent source and this commit. The ordinary session stays visible; empty catalog headers and the orphan “Other” header disappear.

**Before**

![Before: sessions sidebar with empty native CLI catalogs](https://github.com/user-attachments/assets/015cc4ee-eb5f-4704-ade2-89fb93123b86)

**After**

![After: sessions sidebar with empty native CLI catalogs](https://github.com/user-attachments/assets/1afb1618-f5f0-40df-a459-7f8221346660)


### Known limitation from review

ClawSweeper identified a P3 follow-up for populated catalogs hidden entirely by an owner filter: the catalog section can disappear while the ordinary-session “Other” heading remains. This PR fixes successful catalogs that are empty before owner filtering. The requested landing preserves the reviewed commit; extending the predicate to effective-owner filtering is deferred. The remaining issue is presentation-only, with no session loss or loss of new-session targets.
