### PR TITLE
test(macos): observe readiness cancellation and deadline ownership

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -1457,9 +1457,11 @@ struct GatewayProcessManagerTests {
 
     @Test func `transport cancellation does not publish readiness failure`() async throws {
         let url = try #require(URL(string: "ws://example.invalid"))
+        let cancellationThrows = Mutex(0)
         let (_, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
             GatewayTestWebSocketTask(
                 receiveHook: { _, _ in
+                    cancellationThrows.withLock { $0 += 1 }
                     throw URLError(.cancelled)
                 })
         }
@@ -1474,9 +1476,8 @@ struct GatewayProcessManagerTests {
             manager._testClearLaunchAgentReadinessFailure()
         }
 
-        let startedAt = Date()
         #expect(await manager.waitForGatewayReady(timeout: 0.5) == false)
-        #expect(Date().timeIntervalSince(startedAt) < 1.5)
+        #expect(cancellationThrows.withLock { $0 } > 0)
         #expect(manager.status == .running(details: "pid 4242"))
         #expect(manager.lastFailureReason == "keep current state")
         #expect(manager._testHasLaunchAgentReadinessCandidate())
@@ -1643,14 +1644,18 @@ struct GatewayProcessManagerTests {
 
     @Test func `readiness timeout includes a stalled socket connect`() async throws {
         let url = try #require(URL(string: "ws://example.invalid"))
+        let receiveGate = AsyncTestGate()
+        defer { receiveGate.open() }
+        let socket = GatewayTestWebSocketTask(
+            receiveHook: { _, receiveIndex in
+                if receiveIndex == 0 {
+                    await receiveGate.wait()
+                    try Task.checkCancellation()
+                }
+                return .data(GatewayWebSocketTestSupport.connectChallengeData())
+            })
         let (session, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
-            GatewayTestWebSocketTask(
-                receiveHook: { _, receiveIndex in
-                    if receiveIndex == 0 {
-                        try await Task.sleep(nanoseconds: 30 * 1_000_000_000)
-                    }
-                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
-                })
+            socket
         }
         manager.setTestingDesiredActive(true)
         manager.setTestingStatus(.attachedExisting(details: "pid 3131"))
@@ -1663,13 +1668,16 @@ struct GatewayProcessManagerTests {
             manager._testClearLaunchAgentReadinessFailure()
         }
 
-        let startedAt = Date()
         let ready = await manager.waitForGatewayReady(timeout: 0.1)
-        let elapsed = Date().timeIntervalSince(startedAt)
+        // The readiness deadline must return before the shared handshake's own timeout.
+        // Capture its state before shutdown supplies cancellation during cleanup.
+        let socketState = socket.state
+        let socketCancelCount = socket.snapshotCancelCount()
         await connection.shutdown()
 
         #expect(!ready)
-        #expect(elapsed < 1)
+        #expect(socketState == .running)
+        #expect(socketCancelCount == 0)
         #expect(session.snapshotMakeCount() == 1)
         #expect(manager.status == .failed("Gateway did not start in time"))
         #expect(manager.lastFailureReason == "gateway readiness timeout")


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/143615

## What Problem This Solves

Resolves a problem where macOS CI rejects two readiness lifecycle tests on host elapsed-time assertions even though their remaining state assertions pass. In [the failed Mac suite](https://github.com/openclaw/openclaw/actions/runs/34611173436/job/103314869122), transport cancellation took 1.51418s against a 1.5s ceiling, and stalled-connect readiness took 1.092115s against a 1s ceiling. The cause of those historical timing overruns is unproven.

## Why This Change Was Made

Replace only those two elapsed-time assertions with observations of the existing owners. The cancellation test records that the transport actually threw cancellation while retaining every original state assertion. The stalled-connect test holds the existing receive gate closed until readiness returns, checks cancellation after the gate, and snapshots the original socket state and cancellation count before shutdown can supply cleanup effects.

The socket must still be running and uncancelled when the outer readiness deadline returns. The existing false-result, single-socket, and failure-state assertions and cleanup remain. No production code, timeouts, configuration, scheduler, dependency, or ordinary CI settings change.

## User Impact

No product behavior changes. This makes two CI assertions check readiness deadline ownership and cancellation behavior instead of the host's elapsed time. Scope: one test file, **+20/-12; production +0/-0**.

## Evidence

- Candidate: `2ec6d8ad85d9fed83c26b620e4a7ee4608b03f75`, based on `cc0d3ca78ecf3b9f0933bea84e19cb26f89a9870`.
- **Ordinary CI PASS:** [run 34623060475](https://github.com/openclaw/openclaw/actions/runs/34623060475), attempt 1, completed September 11, 2026 at 16:59:17 UTC: 33 jobs, 7 passed and 26 skipped. Required `openclaw/ci-gate` job `103348208626` passed; all current PR checks have no nonpassing entries.
- Actual checkout: `38864fb8a5dfde25e35f63e721625faa0b9dadf9`, parents `5114fcdbd3402010e2b13fc2675e8025b30e1279` and the exact candidate; tree `9f7cc124253d1b044e55e776a66494fc5f0bccb4`. The first-parent diff is solely this test file, +20/-12.
- [Full Mac job 103341760063](https://github.com/openclaw/openclaw/actions/runs/34623060475/job/103341760063) passed: cancellation case 1.195s; stalled-connect case 0.629s; GatewayProcessManager suite 234.838s; full Mac 2179 tests/241 suites in 256.483s; isolated AppState two tests/one suite in 0.074s; shared kit 1695/132 in 59.985s; Swabble 10 XCTest passes. Xcode 26.6 / Swift 6.3.3. macOS Periphery, both shared-kit scans, and their intersection also passed.
- Local Swift frontend parsing and `git diff --check` passed. Independent source review found no blocking issues; a separate P0-scoped formal review reported no findings. These are source/static checks, not Swift runtime proof.
- Local registered Swift tests cannot run: this host has Command Line Tools but no full Xcode/Swift Testing module. SwiftFormat and SwiftLint are unavailable locally.
- **Hosted workflow FAILED:** [run 34620341158](https://github.com/openclaw/openclaw/actions/runs/34620341158), attempt 1, sole job `103332458876`, completed September 11, 2026 at 16:26:26 UTC. Workflow commit `d6b531dba817cc5b7fdd0bb1808f8e96df9b7023` verified and detached to the exact candidate before setup.
- **Retrospectively validated runtime proof:** offline validation of the complete joined log confirmed a **19/19 candidate baseline** in 0.832s, a compiled outer-timeout mutant with exactly two socket-state/count assertion failures, a compiled cancellation-to-terminal-failure mutant with exactly three status/reason/candidate assertion failures, and a **19/19 restored/rebuilt baseline** in 0.872s. The baseline covers both changed cases, `AsyncTimeoutTests`, and `GatewayChannelRequestTests`. Five builds succeeded, in 632.07s, 54.48s, 41.70s, 51.72s, and 48.42s.
- The original verifier expected contiguous `manager._testHasLaunchAgentReadinessCandidate`, while Swift expanded the receiver before the method name. Offline validation matched the exact receiver-expanded expression, all five named assertions and locations, identities, ordered build/test summaries, and the sole terminal matcher error. All nine synthetic wrong-receiver, wrong-method, extra-issue, missing-restoration, wrapper-error, resource/join, and filesystem-cleanup controls were rejected. Independent full-log review concurred. The workflow remains **failed**; no runtime retry, source change, or proof-payload change was made.
- Log SHA256: `1a2f4c512a843e47da66c28a892dfe672ea5d9db6cfbc72133d8f39ec20029a9` (665785 bytes). Restoration is supported by the reviewed restoration/hash guards and the actual rebuilt restored-baseline marker, not a final complete-hash receipt. Post-job cleanup completed.
- [ClawSweeper revision 4](https://github.com/openclaw/openclaw/pull/145056#issuecomment-5637325603), reviewed September 13, 2026 at 19:17:21 UTC, found no introduced defect. Its P1 risk is explicitly dispositioned: the historical timing-overrun cause remains unknown, with no runtime-cause claim; complete proof logs were independently verified, including the 19/19 candidate baseline, exact two/three controlled-negative failures, and guarded rebuild/restored 19/19 pass. The accepted mitigation is this lifecycle-observation test change, leaving production deadlines and shared-handshake ownership unchanged. The reviewer's download-allowlist limitation does not remove that retained evidence. The [single aged-review request](https://github.com/openclaw/openclaw/pull/145056#issuecomment-5655195688) completed through automatic recovery; no additional request or live Gateway claim is made.
- The proof-only workflow is isolated on a separate branch and is not part of this PR. Its failed status remains historical evidence; the unchanged ordinary full suite supplies separate qualification.

**Status on September 13, 2026: fresh CI and native preparation passed at unchanged `2ec6d8ad85d9fed83c26b620e4a7ee4608b03f75`.** Ordinary CI attempt 2 completed successfully at 18:51:05 UTC (7 passed, 26 skipped); Workflow Sanity attempt 2 passed at 18:57:55 UTC; native prepare passed at 18:58:47 UTC without a rebase or head change. The CI retry used the same historical checkout documented above; current-main composition was separately source-reviewed, not runtime-tested by that retry. The fresh review risk is dispositioned above. Manual squash landing is authorized but has not yet run; no automatic merge or historical timing-cause claim.
