### PR TITLE
fix(agents): tell the model about restart-safe tool restriction in recovery prompt

### DIFF
--- a/src/agents/main-session-recovery/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-recovery/main-session-restart-dispatch.ts
@@ -54,6 +54,11 @@ const RESTART_RECOVERY_RESUME_MESSAGE = formatSystemTurnPrompt(
     `missing as having an unknown outcome. ${TOOL_FAILURE_INSTRUCTION}`,
 );
 
+const RESTART_SAFE_TOOLS_NOTICE =
+  "For this turn only, the tool surface has been narrowed to replay-safe tools as a " +
+  "recovery precaution. Use the tools that are available to report status or continue " +
+  "read-only work; the full tool surface restores on the next user turn.";
+
 type RestartRecoveryTerminalStatus = "error" | "ok" | "timeout";
 
 export function hasRestartRecoveryMessageActionAuthority(entry: SessionEntry): boolean {
@@ -72,15 +77,21 @@ export function requiresRestartRecoveryMessageActionAuthority(entry: SessionEntr
   );
 }
 
-function buildResumeMessage(pendingFinalDeliveryText?: string | null): string {
+function buildResumeMessage(
+  pendingFinalDeliveryText?: string | null,
+  forceRestartSafeTools?: boolean,
+): string {
   const sanitizedPendingText =
     typeof pendingFinalDeliveryText === "string"
       ? sanitizePendingFinalDeliveryText(pendingFinalDeliveryText)
       : "";
+  const base = forceRestartSafeTools
+    ? `${RESTART_RECOVERY_RESUME_MESSAGE}\n\n${RESTART_SAFE_TOOLS_NOTICE}`
+    : RESTART_RECOVERY_RESUME_MESSAGE;
   if (sanitizedPendingText) {
-    return `${RESTART_RECOVERY_RESUME_MESSAGE}\n\nNote: The interrupted final reply was captured: "${sanitizedPendingText}"`;
+    return `${base}\n\nNote: The interrupted final reply was captured: "${sanitizedPendingText}"`;
   }
-  return RESTART_RECOVERY_RESUME_MESSAGE;
+  return base;
 }
 
 export function resolveRestartRecoveryDeliveryContext(params: {
@@ -520,7 +531,7 @@ export async function resumeMainSession(params: {
     }
     const agentParams: AgentRunRequest = {
       agentId: params.agentId,
-      message: buildResumeMessage(sanitizedPendingText),
+      message: buildResumeMessage(sanitizedPendingText, params.forceRestartSafeTools),
       sessionKey: dispatchSessionKey,
       expectedExistingSessionId: params.entry.sessionId,
       ...(params.sessionWorkAdmissionHandoffId

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -5720,6 +5720,12 @@ describe("main-session-restart-recovery", () => {
       bestEffortDeliver: true,
       forceRestartSafeTools: true,
     });
+    expect(gatewayCall?.params?.message).toContain(
+      "the tool surface has been narrowed to replay-safe tools",
+    );
+    expect(gatewayCall?.params?.message).toContain(
+      "the full tool surface restores on the next user turn",
+    );
 
     const store = readStore(path.join(sessionsDir, "sessions.json"));
     expect(store["agent:main:demo-channel:room-1"]?.status).toBe("running");


### PR DESCRIPTION
Fixes #145029

## What Problem This Solves

When a gateway restart interrupts a turn, the resumed run is dispatched with `forceRestartSafeTools: true`, narrowing the tool surface to replay-safe tools. The restriction itself is correct — it prevents repeating a side effect whose outcome is unknown. But the recovery prompt tells the model to "continue from the existing transcript" without mentioning the tool surface was narrowed. The model sees ~9 read-only tools where its configured profile is `full`, infers its permissions were revoked, and asks the operator to "restore write access" that was never taken away.

- Problem: Recovery prompt is silent about the temporary tool restriction
- Solution: Append a generic notice to the recovery prompt when `forceRestartSafeTools` is active
- What changed: `buildResumeMessage` now accepts `forceRestartSafeTools` and appends a notice
- What did NOT change: The tool filtering logic, the flag semantics, or any other recovery behavior

## Why This Change Was Made

The model cannot distinguish a temporary restart-safe restriction from a genuine permissions change. The notice describes the restriction generically without assuming its cause — `forceRestartSafeTools` can be set for multiple reasons (unsafe tool call, replay-safe checkpoint, pending delivery, ambiguous reply hooks), so the notice avoids claiming the interrupted call was unsafe or listing specific unavailable tools.

## User Impact

A restart-safe recovery turn will no longer produce false "my write permissions were revoked" messages. The model will understand the restriction is temporary and act within available tools.

## Evidence

End-to-end recovery proof via `openclaw --dev gateway` with a configured live provider. A session was interrupted mid-execution, marked as aborted, then the gateway was restarted to trigger restart-safe recovery:

```
[main-session-restart-recovery] started interrupted main session: agent:main:recovery-proof
[main-session-restart-recovery] main-session restart recovery startup complete: started=1 settled=0 failed=0 skipped=0
[provider-transport-fetch] [model-fetch] request started (provider, model, and endpoint details omitted)
[provider-transport-fetch] [model-fetch] response status=200 elapsedMs=25766
The `sleep 60` command was interrupted by a gateway restart, and the tool result is missing—the outcome is unknown. There are no active exec sessions now, which is consistent with the process being terminated during the restart.
If you'd like, I can run it again.
[agents/agent-command] [agent] run [id omitted] ended with stopReason=stop
[main-session-restart-recovery] main-session restart recovery terminal: session=agent:main:recovery-proof status=ok reason=completed
```

The model received the recovery prompt, understood the interruption, and responded safely — offering to retry instead of reporting a false permissions blocker.

Before/after comparison via `node --import tsx/esm` (actual module import with real `formatSystemTurnPrompt`):
```
BEFORE (origin/main): No notice — model told to 'continue' with no explanation of tool restriction.
AFTER (this PR): Notice appended — "the tool surface has been narrowed to replay-safe tools as a recovery precaution. Use the tools that are available to report status or continue read-only work; the full tool surface restores on the next user turn."
```

Regression test (vitest, pre-fix fail / post-fix pass):
```
Pre-fix: Expected "the tool surface has been narrowed to replay-safe tools" → not found → 1 failed
Post-fix: Tests 1 passed | 201 skipped (202)
```

## AI Assistance

This PR is AI-assisted. Used code tracing to locate the recovery prompt construction in `main-session-restart-dispatch.ts` and applied the existing conditional-append pattern already used by `pendingFinalDeliveryText`. The implementer understands the restart-safe recovery path and the multiple conditions that set `forceRestartSafeTools`.

---

Contributor evidence above retains its reported result; private provider, model, endpoint, and run details have been omitted. The review addendum below qualifies the original user-impact claim.

## What Problem This Solves

Restart recovery can temporarily remove write tools without explaining why. The agent can mistake that smaller tool set for revoked permissions and ask the operator to restore access that was never removed.

## Fix and Impact

The recovery dispatcher now explains the restriction when it selects replay-safe tools. It preserves captured final replies and leaves tool policy, permissions, and ordinary-turn behavior unchanged.

The exact notice is:

> For this turn only, the tool surface has been narrowed to replay-safe tools as a recovery precaution. Use the tools that are available to report status or continue read-only work; the full tool surface restores on the next user turn.

“Full tool surface” means the normal configured tools, subject to current permissions and availability. The review suggested “normal configured tool set” as clearer wording; the contributor text remains unchanged.

## Evidence

Validated contributor head `fdf101285e39054de32e1a64a9394c1ba384a4c9`.

- A real Gateway restart on main produced 35 → 10 → 35 tools, with no explanation in the recovery request.
- The contributor head delivered the notice in the actual recovery request and restored its ordinary tool set afterward. Its older baseline includes two extra memory tools: 37 → 11 → 37.
- The same test after merging main `c92ce0278f4ad8eef8658350c5ba0165c62f53f2` produced 35 → 10 → 35 with the notice present during restricted recovery.
- Restricted pending-final recovery includes the notice and captured reply. Unrestricted recovery omits the notice, including when a final reply is pending.
- The recovery and tool-dispatch suites passed: 242 tests across four files. The three explicit prompt controls passed on both heads. Two test-routing checks passed. Changed-file lint passed, and the PR's CI gate is successful.

The provider fixture proves prompt delivery and tool selection. It does not prove that every model will avoid a false permission message.

## Consumers

The main-session recovery dispatcher is the sole caller of the private prompt builder. Restricted recovery receives the explanation; unrestricted recovery does not. Pending-final delivery retains its existing text. Tool filtering, replay-safe execution controls, and later ordinary turns keep their existing contracts. No configuration, schema, protocol, or dependency changes are introduced.

## Review addendum

Reviewed contributor head `fdf101285e39054de32e1a64a9394c1ba384a4c9`. No source or test correction is required.

### Behavior and wording

- Restricted main-session recovery now receives an explanation of its temporary tool set. The restriction decision and current permissions remain unchanged.
- Unrestricted recovery receives no notice. Pending-final recovery retains its captured text and receives the notice only when its existing restriction flag is active.
- “Full tool surface” means the normal configured tool set, subject to current permissions and availability. “Normal configured tool set applies on the next ordinary user turn; current permissions still apply” would be clearer wording, but is not a required source change.
- This qualifies the original claim that false permission messages “will no longer” occur: the change gives the model missing context. It does not guarantee the wording or correctness of every response.

### Evidence

- The real Gateway reproduction on main `46aa369b315196a0ec57f6e171e97defbe64e18e` showed 35 → 10 → 35 tools, with no explanation in the recovery request.
- The contributor head delivered the notice and restored its ordinary catalog afterward: 37 → 11 → 37 tools. Its older baseline includes two additional memory tools.
- Fresh merge `0566077d54f2c7fd96616fbcb45f01e812debb92`, with contributor parent `fdf101285e39054de32e1a64a9394c1ba384a4c9` and main parent `c92ce0278f4ad8eef8658350c5ba0165c62f53f2`, showed 35 → 10 → 35 tools with the notice during restricted recovery.
- These runs entered through a real Gateway, interrupted a harmless sleep command, recovered the session, and sent a subsequent ordinary `chat.send` turn. The deterministic provider fixture proves prompt delivery and tool selection. It does not measure false-permission response frequency.
- All 242 tests across the four recovery and replay-safety files passed on that merge. Three additional prompt controls passed on both contributor and merge checkouts. Two routing checks and changed-file lint passed. The prompt controls are dispatch-boundary tests, not additional live channel flows.

### Consumers

- The private prompt builder has one production caller in the main-session recovery dispatcher. The builder receives the same restriction flag that the request sends to tool preparation.
- Recovery policy and pending-delivery handling select the flag first. The dispatcher records it, builds the prompt, and submits the request. Tool construction then applies current permissions and the existing restart-safe filter.
- Gateway execution, command attempts, concrete tools, client tools, bundled tool servers, language-server tools, and Code Mode retain their existing policy contracts. Prompt assembly preserves the notice in the captured provider request.
- Existing recovery marking, reply checkpoints, claim adoption, settlement, and session cleanup keep their state ownership and ordering. This diff adds only local prompt values; it adds no shared-state writer.
- Queued generated-media completion, subagent recovery text, and channel resumption notifications have separate owners and remain unchanged. No configuration, schema, migration, protocol, SDK, or dependency change is introduced.
