### PR TITLE
fix(test): avoid MCP OAuth fixture port collisions

### DIFF
--- a/src/cli/mcp-cli.oauth-integration.test.ts
+++ b/src/cli/mcp-cli.oauth-integration.test.ts
@@ -34,8 +34,8 @@ async function readBody(request: IncomingMessage): Promise<string> {
   return Buffer.concat(chunks).toString("utf8");
 }
 
-async function startOAuthFixture(port: number) {
-  const issuer = `http://127.0.0.1:${port}`;
+async function startOAuthFixture() {
+  let issuer = "";
   let codeChallenge: string | undefined;
   let tokenRedirectUri: string | undefined;
   let tokenVerifier: string | undefined;
@@ -188,14 +188,21 @@ async function startOAuthFixture(port: number) {
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
-    server.listen(port, "127.0.0.1", resolve);
+    server.listen(0, "127.0.0.1", resolve);
   });
+  const close = () =>
+    new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await close();
+    throw new Error("OAuth fixture did not bind a TCP address");
+  }
+  issuer = `http://127.0.0.1:${address.port}`;
   return {
     issuer,
-    close: () =>
-      new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      }),
+    close,
     exchange: () => ({ tokenRedirectUri, tokenVerifier }),
     mcpRequests: () => mcpRequests,
   };
@@ -315,22 +322,21 @@ describe("mcp login OAuth integration", () => {
 
   it("logs in and probes an OAuth MCP server through the CLI", async () => {
     await withTempHome(`openclaw-mcp-login-${randomUUID()}-`, async () => {
-      const oauthPort = await getFreePort();
-      const callbackPort = await getFreePort();
-      const fixture = await startOAuthFixture(oauthPort);
-      const redirectUrl = `http://127.0.0.1:${callbackPort}/oauth/callback`;
-      const logs: string[] = [];
-      const authorizationUrl = createDeferred<string>();
-      vi.spyOn(defaultRuntime, "log").mockImplementation((line) => {
-        const text = String(line);
-        logs.push(text);
-        if (text.startsWith(`${fixture.issuer}/authorize`)) {
-          authorizationUrl.resolve(text);
-        }
-      });
-      const program = new Command().exitOverride();
-      registerMcpCli(program);
+      const fixture = await startOAuthFixture();
       try {
+        const callbackPort = await getFreePort();
+        const redirectUrl = `http://127.0.0.1:${callbackPort}/oauth/callback`;
+        const logs: string[] = [];
+        const authorizationUrl = createDeferred<string>();
+        vi.spyOn(defaultRuntime, "log").mockImplementation((line) => {
+          const text = String(line);
+          logs.push(text);
+          if (text.startsWith(`${fixture.issuer}/authorize`)) {
+            authorizationUrl.resolve(text);
+          }
+        });
+        const program = new Command().exitOverride();
+        registerMcpCli(program);
         await program.parseAsync(
           [
             "mcp",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/144236

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

This is a same-repository branch; maintainers can update it through repository permissions.

</details>

## What Problem This Solves

Resolves a problem where the MCP OAuth CLI integration fixture can fail with
`EADDRINUSE` when another listener takes a probed port before the fixture binds it.
This is a maintainer-requested, test-only follow-up to a failure observed during
release-validation PR CI, not a production OAuth change.

## Why This Change Was Made

The fixture now lets the OS allocate its port while binding and derives its issuer
from that live listener. Setup after binding is covered by cleanup, including
callback-port selection. The explicit callback port, OAuth assertions, real HTTP
calls, and timeouts are unchanged.

## User Impact

Developers get a fixture that owns its advertised port throughout the test.
There is no production behavior, authentication, or persistent-data change.

## Evidence

- Controlled real-socket reproduction: the original fixture failed `EADDRINUSE`
  when another listener occupied its requested port. With the repair and the
  same interceptor, it served HTTP 200 with its actual issuer while the competing
  listener remained bound; every original login assertion passed and cleanup
  was observed.
- The clean full owner passed all 3 tests without the private interceptor.
- All selected changed-file gates passed, including CLI test typechecking,
  formatting, lint, and the export scans.
- Independent review completed with no actionable findings.

The reproduction does not identify the listener involved in the historical CI
failure. Local proof is not hosted CI or live FRV acceptance; no release, registry,
or external OAuth-provider operation was performed.
