### PR TITLE
fix: keep Node fixtures portable under Bun

### DIFF
--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -17,6 +17,7 @@ import {
 import { buildSystemdUnit, parseSystemdExecStart } from "../../daemon/systemd-unit.js";
 import { makeTempWorkspace } from "../../test-helpers/workspace.js";
 import { captureEnv, withEnvAsync } from "../../test-utils/env.js";
+import { resolveTestNodeExecPath } from "../../test-utils/node-process.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
 const { runtimeLogs, runtimeErrors, defaultRuntime, resetRuntimeCapture } =
@@ -271,7 +272,7 @@ describe("runDaemonInstall integration", () => {
         if (!nodePath) {
           throw new Error("Missing repaired runtime");
         }
-        expect(await fs.realpath(nodePath)).toBe(await fs.realpath(process.execPath));
+        expect(await fs.realpath(nodePath)).toBe(await fs.realpath(resolveTestNodeExecPath()));
         expect(repaired?.programArguments).toContain(entry);
         expect(await fs.readFile(definitionPath, "utf8")).not.toContain(oldNode);
         expect(runtimeLogs.join("\n")).toContain(

--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -179,7 +179,15 @@ describe("runDaemonInstall integration", () => {
   )(
     "repairs $condition Node in the $platform definition (force=$force)",
     async ({ platform, force, condition }) => {
+      const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath")!;
+      const testNodeExecPath = resolveTestNodeExecPath();
       vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+      if (process.versions.bun) {
+        Object.defineProperty(process, "execPath", {
+          value: testNodeExecPath,
+          configurable: true,
+        });
+      }
       const entry = path.join(tempHome, "dist", "index.js");
       await fs.mkdir(path.dirname(entry), { recursive: true });
       await fs.writeFile(entry, "");
@@ -272,7 +280,7 @@ describe("runDaemonInstall integration", () => {
         if (!nodePath) {
           throw new Error("Missing repaired runtime");
         }
-        expect(await fs.realpath(nodePath)).toBe(await fs.realpath(resolveTestNodeExecPath()));
+        expect(await fs.realpath(nodePath)).toBe(await fs.realpath(testNodeExecPath));
         expect(repaired?.programArguments).toContain(entry);
         expect(await fs.readFile(definitionPath, "utf8")).not.toContain(oldNode);
         expect(runtimeLogs.join("\n")).toContain(
@@ -287,6 +295,9 @@ describe("runDaemonInstall integration", () => {
         }
       } finally {
         process.argv = originalArgv;
+        if (process.versions.bun) {
+          Object.defineProperty(process, "execPath", execPathDescriptor);
+        }
       }
     },
   );
@@ -1000,7 +1011,7 @@ describe("runDaemonInstall integration", () => {
         if (testCase.name === "operator heap cap") {
           const measure = (flags: string[]) => {
             const child = spawnSync(
-              process.execPath,
+              resolveTestNodeExecPath(),
               [
                 ...flags,
                 "-e",

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -4,6 +4,7 @@ import type { GatewayServiceCommandConfig } from "../../daemon/service.js";
 import { mockSystemAccountHome } from "../../daemon/service.test-helpers.js";
 import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
 import { captureFullEnv } from "../../test-utils/env.js";
+import { resolveTestNodeExecPath } from "../../test-utils/node-process.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 import { createInstallPlanFixture, nodeProbeOutput } from "./install.test-helpers.js";
 import type { createDaemonInstallActionContext } from "./shared.js";
@@ -764,7 +765,7 @@ describe("runDaemonInstall", () => {
     "refuses runtime repair on $failure without claiming success",
     async ({ failure, message }) => {
       service.isLoaded.mockResolvedValue(true);
-      const oldNode = failure === "probe" ? process.execPath : "/opt/old/bin/node";
+      const oldNode = failure === "probe" ? resolveTestNodeExecPath() : "/opt/old/bin/node";
       service.readCommand.mockResolvedValue({
         programArguments: [oldNode, "/opt/openclaw/dist/index.js", "gateway"],
       });

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -595,7 +595,8 @@ export async function listAgentSessionDirs(stateDir: string): Promise<string[]> 
     const entries = await fs.readdir(root, { withFileTypes: true });
     return entries
       .filter((entry) => entry.isDirectory())
-      .map((entry) => path.join(root, entry.name, "sessions"));
+      .map((entry) => path.join(root, entry.name, "sessions"))
+      .toSorted();
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return [];

--- a/src/commands/doctor-config-preflight.process.test-support.ts
+++ b/src/commands/doctor-config-preflight.process.test-support.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
 import { ensureOpenClawAgentDatabaseSchema } from "../state/openclaw-agent-db.js";
+import { resolveTestNodeExecPath } from "../test-utils/node-process.js";
 
 const execFileAsync = promisify(execFile);
+const isolatedRuntimeNodeExecPath = resolveTestNodeExecPath();
 // The fixture owns its package assets; resolving linked source back to the checkout
 // makes Doctor repair that checkout instead, including building its Control UI.
 // Dependency realpaths still own their transitive packages under isolated installs.
@@ -40,7 +42,7 @@ export function runBuiltRuntime(
   maxBuffer?: number,
 ) {
   return spawnSync(
-    process.execPath,
+    isolatedRuntimeNodeExecPath,
     [...ISOLATED_RUNTIME_NODE_ARGS, path.join(runtimeRoot, "dist", "entry.js"), ...args],
     {
       cwd: runtimeRoot,
@@ -59,13 +61,17 @@ export function runSourceRuntime(
   timeout: number,
   maxBuffer?: number,
 ) {
-  return spawnSync(process.execPath, [...ISOLATED_RUNTIME_NODE_ARGS, "--import", "tsx", ...args], {
-    cwd: runtimeRoot,
-    encoding: "utf8",
-    env,
-    timeout,
-    ...(maxBuffer === undefined ? {} : { maxBuffer }),
-  });
+  return spawnSync(
+    isolatedRuntimeNodeExecPath,
+    [...ISOLATED_RUNTIME_NODE_ARGS, "--import", "tsx", ...args],
+    {
+      cwd: runtimeRoot,
+      encoding: "utf8",
+      env,
+      timeout,
+      ...(maxBuffer === undefined ? {} : { maxBuffer }),
+    },
+  );
 }
 
 export function runIsolatedModuleScript(
@@ -74,7 +80,7 @@ export function runIsolatedModuleScript(
   options: { runtimeRoot?: string; timeoutMs?: number } = {},
 ) {
   return execFileAsync(
-    process.execPath,
+    isolatedRuntimeNodeExecPath,
     [
       ...(options.runtimeRoot ? ISOLATED_RUNTIME_NODE_ARGS : []),
       "--import",

--- a/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
@@ -124,7 +124,7 @@ describe("read-only Skill Workshop migration inspection", () => {
       closeOpenClawStateDatabaseForTest();
       const databasePath = resolveOpenClawStateSqlitePath(state.env);
       const databaseBefore = await snapshotDatabase(databasePath);
-      const filesBefore = await fs.readdir(state.stateDir, { recursive: true });
+      const filesBefore = (await fs.readdir(state.stateDir, { recursive: true })).toSorted();
       const destination = path.join(
         resolveWorkshopSkillsDir(config, "main", state.env),
         "relocated",
@@ -156,7 +156,9 @@ describe("read-only Skill Workshop migration inspection", () => {
         expect(find("condition", "payload.message")?.message).not.toContain("Private prose");
         expect(await loadCronJobsStoreWithConfigJobsReadOnly(storePath, state.env)).toEqual(before);
         expect(await snapshotDatabase(databasePath)).toEqual(databaseBefore);
-        expect(await fs.readdir(state.stateDir, { recursive: true })).toEqual(filesBefore);
+        expect((await fs.readdir(state.stateDir, { recursive: true })).toSorted()).toEqual(
+          filesBefore,
+        );
       }
     });
   });
@@ -271,7 +273,7 @@ describe("read-only Skill Workshop migration inspection", () => {
         closeOpenClawStateDatabaseForTest();
         const databasePath = resolveOpenClawStateSqlitePath(state.env);
         const databaseBefore = proposal ? await snapshotDatabase(databasePath) : undefined;
-        const filesBefore = await fs.readdir(state.stateDir, { recursive: true });
+        const filesBefore = (await fs.readdir(state.stateDir, { recursive: true })).toSorted();
 
         const result = await runDoctorLintChecks(
           { mode: "lint", runtime: { log() {}, error() {}, exit() {} }, cfg: config },
@@ -296,7 +298,9 @@ describe("read-only Skill Workshop migration inspection", () => {
             expect(finding.fixHint).toContain("manifests");
           }
         }
-        expect(await fs.readdir(state.stateDir, { recursive: true })).toEqual(filesBefore);
+        expect((await fs.readdir(state.stateDir, { recursive: true })).toSorted()).toEqual(
+          filesBefore,
+        );
         expect(await fs.readFile(state.configPath)).toEqual(configBefore);
         for (const manifest of manifests) {
           expect(await fs.readFile(manifest.file, "utf8")).toBe(manifest.contents);

--- a/src/infra/node-runtime-recovery.test.ts
+++ b/src/infra/node-runtime-recovery.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } fr
 import { isUsableNode, recoverNodeRuntime } from "../../node-runtime-recovery.mjs";
 import { SQLITE_CAPABILITY_PROBE } from "../../node-sqlite.mjs";
 import { buildTaskScript } from "../daemon/schtasks-layout.js";
+import { resolveTestNodeExecPath } from "../test-utils/node-process.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
 import { encodeWindowsLauncherScript } from "./windows-launcher-encoding.js";
@@ -63,6 +64,10 @@ vi.mock("./windows-encoding.js", async (importOriginal) => ({
 
 const originalArgv = process.argv;
 const originalExecArgv = process.execArgv;
+// Exercise the Node-only recovery branch when Bun owns Vitest; process-boundary cases still launch Node.
+const bunVersionDescriptor = Object.getOwnPropertyDescriptor(process.versions, "bun");
+const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath")!;
+const testNodeExecPath = resolveTestNodeExecPath();
 const hostPlatform = process.platform;
 const windowsPath = {
   isAbsolute: path.win32.isAbsolute.bind(path.win32),
@@ -76,6 +81,10 @@ let exitSpy: MockInstance<typeof process.exit>;
 let stderrSpy: MockInstance<typeof process.stderr.write>;
 
 beforeEach(() => {
+  if (bunVersionDescriptor) {
+    Object.defineProperty(process.versions, "bun", { value: undefined, configurable: true });
+    Object.defineProperty(process, "execPath", { value: testNodeExecPath, configurable: true });
+  }
   mockProcessPlatform("linux");
   mocks.currentAdmitted = false;
   mocks.encoding = "utf-8";
@@ -132,6 +141,10 @@ afterEach(() => {
   }
   process.argv = originalArgv;
   process.execArgv = originalExecArgv;
+  if (bunVersionDescriptor) {
+    Object.defineProperty(process.versions, "bun", bunVersionDescriptor);
+    Object.defineProperty(process, "execPath", execPathDescriptor);
+  }
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
@@ -319,7 +332,7 @@ describe("runtime recovery discovery", () => {
       );
       const { spawnSync } =
         await vi.importActual<typeof import("node:child_process")>("node:child_process");
-      const result = spawnSync(process.execPath, [driver, "doctor", "--fix", "--non-interactive"], {
+      const result = spawnSync(testNodeExecPath, [driver, "doctor", "--fix", "--non-interactive"], {
         cwd,
         env: {
           ...process.env,

--- a/src/test-utils/node-process.test.ts
+++ b/src/test-utils/node-process.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { withEnv } from "./env.js";
+import { resolveTestNodeExecPath } from "./node-process.js";
+import { withTempDir } from "./temp-dir.js";
+
+it.skipIf(process.platform === "win32")(
+  "skips a Bun node shim before the real Node executable",
+  async () => {
+    await withTempDir("openclaw-node-process-", async (tempDir) => {
+      const shimPath = path.join(tempDir, "node");
+      await fs.writeFile(shimPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+      const bunVersionDescriptor = Object.getOwnPropertyDescriptor(process.versions, "bun");
+      const nodeExecPath = resolveTestNodeExecPath();
+      Object.defineProperty(process.versions, "bun", { value: "test", configurable: true });
+      try {
+        const resolved = withEnv(
+          { PATH: [tempDir, path.dirname(nodeExecPath)].join(path.delimiter) },
+          () => resolveTestNodeExecPath(),
+        );
+        expect(resolved).toBe(nodeExecPath);
+      } finally {
+        if (bunVersionDescriptor) {
+          Object.defineProperty(process.versions, "bun", bunVersionDescriptor);
+        } else {
+          Reflect.deleteProperty(process.versions, "bun");
+        }
+      }
+    });
+  },
+);

--- a/src/test-utils/node-process.ts
+++ b/src/test-utils/node-process.ts
@@ -1,5 +1,6 @@
 // Test helpers for spawning Node processes and asserting their output.
 import { execFileSync, spawnSync, type SpawnSyncReturns } from "node:child_process";
+import path from "node:path";
 
 type NodeEvalArgsOptions = {
   evalFlag?: "--eval" | "-e";
@@ -16,6 +17,47 @@ type SpawnNodeEvalOptions = Omit<NonNullable<Parameters<typeof spawnSync>[2]>, "
     encoding?: BufferEncoding;
   };
 
+export function resolveTestNodeExecPath(): string {
+  if (!process.versions.bun) {
+    return process.execPath;
+  }
+
+  // Bun's --bun mode prepends a node shim that points back to Bun. Walk every
+  // PATH candidate and accept only a process that identifies itself as Node.
+  const executableNames =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+          .split(";")
+          .filter(Boolean)
+          .map((extension) => `node${extension.toLowerCase()}`)
+      : ["node"];
+  const candidates = (process.env.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .flatMap((directory) => executableNames.map((name) => path.join(directory, name)));
+
+  for (const candidate of new Set(candidates)) {
+    try {
+      const nodePath = execFileSync(
+        candidate,
+        ["-p", "process.versions.bun ? '' : process.execPath"],
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 5_000,
+        },
+      ).trim();
+      if (nodePath) {
+        return nodePath;
+      }
+    } catch {
+      // Missing, non-executable, and broken PATH entries are not Node candidates.
+    }
+  }
+
+  throw new Error("Unable to locate a Node executable while running tests under Bun");
+}
+
 /** Builds node args for ESM eval snippets used by subprocess boundary tests. */
 export function createNodeEvalArgs(source: string, options: NodeEvalArgsOptions = {}): string[] {
   const args = (options.imports ?? []).flatMap((specifier) => ["--import", specifier]);
@@ -25,11 +67,15 @@ export function createNodeEvalArgs(source: string, options: NodeEvalArgsOptions 
 
 export function execNodeEvalSync(source: string, options: ExecNodeEvalOptions = {}): string {
   const { evalFlag, imports, ...execOptions } = options;
-  return execFileSync(process.execPath, createNodeEvalArgs(source, { evalFlag, imports }), {
-    cwd: process.cwd(),
-    encoding: "utf8",
-    ...execOptions,
-  });
+  return execFileSync(
+    resolveTestNodeExecPath(),
+    createNodeEvalArgs(source, { evalFlag, imports }),
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      ...execOptions,
+    },
+  );
 }
 
 export function spawnNodeEvalSync(
@@ -37,7 +83,7 @@ export function spawnNodeEvalSync(
   options: SpawnNodeEvalOptions = {},
 ): SpawnSyncReturns<string> {
   const { evalFlag, imports, ...spawnOptions } = options;
-  return spawnSync(process.execPath, createNodeEvalArgs(source, { evalFlag, imports }), {
+  return spawnSync(resolveTestNodeExecPath(), createNodeEvalArgs(source, { evalFlag, imports }), {
     cwd: process.cwd(),
     encoding: "utf8",
     ...spawnOptions,


### PR DESCRIPTION
## Problem

When Vitest runs under Bun, Node-specific fixtures inherit Bun's `process.execPath`. That made isolated Node subprocess cases launch Bun and caused the Node runtime-recovery suite to exit through its intentional Bun guard before exercising any recovery behavior. Bun's `--bun` mode can also prepend a `node` shim that points back to Bun. Bun and Node return directory entries in different valid orders, making read-only Doctor assertions and multi-agent reset traversal order-dependent.

## Solution

Resolve an actual Node executable in shared test support whenever Bun owns Vitest. The resolver walks PATH candidates and rejects Bun-backed `node` shims before returning Node. Fixtures that explicitly exercise Node startup, service repair, and runtime admission use that executable. The recovery tests temporarily model the Node-only process fields under Bun, restore their original descriptors after every case, and keep all existing assertions active.

Sort recursive inventory snapshots before comparison so they continue to detect filesystem changes without depending on API enumeration order. Agent session cleanup now also sorts discovered directories before destructive reset, giving both runtimes the same stable sequence.

Production runtime behavior is unchanged apart from deterministic cleanup ordering. No dependency is added.

## Verification

- Custom Bun branch `steipete/bun:codex/openclaw-bun-compat`, containing the pending SQLite, realpath, and `fs.promises.access` fixes.
- Exact local release fork `1.4.3-canary.1+13bd48ed7`: 213 focused cases passed on the PR head (resolver 1, runtime recovery 73, install 99, cleanup 27, read-only Doctor 13).
- Earlier Bun portability sweep: 1,015 passed, 2 platform skips, 0 failed across 11 routed shards.
- Node focused replay: 244 passed before one load-sensitive Gateway readiness timeout; that exact case passed in isolation in 7.6 seconds.
- Node integration replay after the final fixture repair: 58 passed, 0 failed.
- Node and Bun `--bun` resolver regression: 1 passed under each runtime.
- `pnpm check:changed` passed after rebasing onto current `main`.
- Independent P0-P2 review found no actionable findings after both reported resolver/test issues were fixed.

Related Bun fixes: oven-sh/bun#40005, oven-sh/bun#42277, and oven-sh/bun#42279.
