### PR TITLE
chore(doctor): reproduce historical Workshop setup migration refusal

### DIFF
--- a/src/commands/doctor-config-preflight.historical-workspace.process.test.ts
+++ b/src/commands/doctor-config-preflight.historical-workspace.process.test.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { LegacyStateMigrationStepReceipt } from "../infra/state-migrations.types.js";
+import {
+  createSourceRuntime,
+  runIsolatedModuleScript,
+} from "./doctor-config-preflight.process.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("Doctor preflight historical Workshop workspace", () => {
+  it.each([
+    { historical: false, status: "pending" },
+    { historical: false, status: "applied" },
+    { historical: true, status: "pending" },
+    { historical: true, status: "applied" },
+  ] as const)(
+    "settles setup before relocating a $status create (historical=$historical)",
+    async ({ historical, status }) => {
+      const root = fs.realpathSync(tempDirs.make("openclaw-doctor-historical-workspace-"));
+      const stateDir = path.join(root, "state");
+      const oldWorkspace = path.join(root, "workspace");
+      const currentWorkspace = historical ? path.join(oldWorkspace, "current") : oldWorkspace;
+      const configPath = path.join(root, "openclaw.json");
+      const configRaw = JSON.stringify({
+        agents: { defaults: { workspace: currentWorkspace }, entries: { main: {} } },
+      });
+      fs.mkdirSync(currentWorkspace, { recursive: true });
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.writeFileSync(configPath, configRaw);
+      const sourcePath = path.join(oldWorkspace, "openclaw-workspace-state.json");
+      const setup = {
+        version: 1,
+        bootstrapSeededAt: "2026-07-05T17:21:38.000Z",
+        setupCompletedAt: "2026-07-05T17:29:02.000Z",
+      };
+      const setupRaw = JSON.stringify(setup);
+      fs.writeFileSync(sourcePath, setupRaw);
+      const runtimeRoot = createSourceRuntime(root);
+      const { stdout } = await runIsolatedModuleScript(
+        {
+          PATH: process.env.PATH,
+          HOME: root,
+          USERPROFILE: root,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+          NO_COLOR: "1",
+        },
+        `
+        import fs from "node:fs";
+        import path from "node:path";
+        import assert from "node:assert/strict";
+        import { runDoctorConfigPreflight } from "./src/commands/doctor-config-preflight.ts";
+        import { readWorkspaceStateSnapshot } from "./src/agents/workspace-state-store.ts";
+        import { hashSkillProposalContent, importLegacySkillProposal, readSkillProposalRecord } from "./src/skills/workshop/store.ts";
+        import { SKILL_WORKSHOP_SCHEMA } from "./src/skills/workshop/types.ts";
+        import { resolveWorkshopSkillsDir } from "./src/skills/workshop/skills-root.ts";
+        import { openOpenClawStateDatabase } from "./src/state/openclaw-state-db.ts";
+        const config = ${configRaw};
+        const oldWorkspace = ${JSON.stringify(oldWorkspace)};
+        const stateDir = ${JSON.stringify(stateDir)};
+        const status = ${JSON.stringify(status)};
+        const skillDir = path.join(oldWorkspace, "skills", "retained-procedure");
+        const content = "---\\nname: retained-procedure\\ndescription: Retained procedure\\n---\\n\\n# Retained procedure\\n";
+        const now = "2026-09-01T00:00:00.000Z";
+        const record = {
+          schema: SKILL_WORKSHOP_SCHEMA,
+          id: "retained-procedure-20260901-1234567890",
+          kind: "create", status,
+          title: "Create retained procedure", description: "Retained procedure",
+          createdAt: now, updatedAt: now, createdBy: "skill-workshop",
+          proposedVersion: "v1", draftFile: "PROPOSAL.md",
+          draftHash: hashSkillProposalContent(content),
+          target: {
+            skillKey: "retained-procedure", skillName: "retained-procedure",
+            skillDir, skillFile: path.join(skillDir, "SKILL.md"), source: "openclaw-workspace",
+          },
+          scan: { state: "clean", scannedAt: now, critical: 0, warn: 0, info: 0, findings: [] },
+          ...(status === "applied" ? { appliedAt: now } : {}),
+        };
+        importLegacySkillProposal({ record, ownerAgentId: "main", store: { config, env: process.env } });
+        // Doctor retires missing pending drafts before relocation. Keep a valid
+        // bundle so this fixture reaches the historical setup gate instead.
+        const draftDir = path.join(stateDir, "skill-workshop", "proposals", record.id);
+        fs.mkdirSync(draftDir, { recursive: true });
+        fs.writeFileSync(path.join(draftDir, record.draftFile), content);
+        if (status === "applied") {
+          fs.mkdirSync(skillDir, { recursive: true });
+          fs.writeFileSync(record.target.skillFile, content);
+        }
+        let result;
+        try {
+          await runDoctorConfigPreflight({ doctorOnlyStateMigrations: true, migrateLegacyConfig: false });
+          result = { completed: true };
+        } catch (error) {
+          result = { completed: false, name: error.name, stepReceipts: error.stepReceipts, message: error.message };
+        }
+        const options = { config, env: process.env };
+        const readRecord = () => readSkillProposalRecord(record.id, options, {}, { config });
+        if (!result.completed) {
+          assert.equal(fs.readFileSync(${JSON.stringify(sourcePath)}, "utf8"), ${JSON.stringify(setupRaw)});
+          assert.equal(fs.existsSync(${JSON.stringify(sourcePath)} + ".doctor-importing"), false);
+          assert.deepEqual(await readRecord(), record);
+        } else {
+          const snapshot = await readWorkspaceStateSnapshot(oldWorkspace, { env: process.env });
+          assert.equal(snapshot.setup.bootstrapSeededAt, ${JSON.stringify(setup.bootstrapSeededAt)});
+          assert.equal(snapshot.setup.setupCompletedAt, ${JSON.stringify(setup.setupCompletedAt)});
+          assert.equal(fs.existsSync(${JSON.stringify(sourcePath)}), false);
+          const archives = fs.readdirSync(oldWorkspace).filter(name => name.startsWith("openclaw-workspace-state.json.migrated."));
+          assert.equal(archives.length, 1);
+          assert.equal(fs.readFileSync(path.join(oldWorkspace, archives[0]), "utf8"), ${JSON.stringify(setupRaw)});
+          const db = openOpenClawStateDatabase({ env: process.env }).db;
+          const receipt = db.prepare("SELECT report_json, removed_source FROM migration_sources WHERE source_path = ?").get(${JSON.stringify(sourcePath)});
+          assert.equal(receipt.removed_source, 1);
+          assert.equal(JSON.parse(receipt.report_json).archivePath, path.join(oldWorkspace, archives[0]));
+          const migrated = await readRecord();
+          const destination = path.join(resolveWorkshopSkillsDir(config, "main", process.env), record.target.skillKey);
+          assert.deepEqual(migrated, { ...record, target: { ...record.target, skillDir: destination, skillFile: path.join(destination, "SKILL.md"), source: "openclaw-workshop" } });
+          if (status === "applied") assert.equal(fs.readFileSync(migrated.target.skillFile, "utf8"), content);
+          else assert.equal(fs.existsSync(migrated.target.skillFile), false);
+          await runDoctorConfigPreflight({ doctorOnlyStateMigrations: true, migrateLegacyConfig: false });
+          assert.deepEqual(await readRecord(), migrated);
+          assert.deepEqual(db.prepare("SELECT report_json, removed_source FROM migration_sources WHERE source_path = ?").get(${JSON.stringify(sourcePath)}), receipt);
+          assert.deepEqual(fs.readdirSync(oldWorkspace).filter(name => name.startsWith("openclaw-workspace-state.json.migrated.")), archives);
+        }
+        assert.equal(fs.readFileSync(path.join(draftDir, record.draftFile), "utf8"), content);
+        console.log("HISTORICAL_WORKSPACE_RESULT:" + JSON.stringify(result));
+        `,
+        { runtimeRoot, timeoutMs: 60_000 },
+      );
+      const result = JSON.parse(stdout.split("HISTORICAL_WORKSPACE_RESULT:").at(-1) ?? "null") as {
+        completed: boolean;
+        stepReceipts?: LegacyStateMigrationStepReceipt[];
+      };
+      expect(fs.readFileSync(configPath, "utf8")).toBe(configRaw);
+      // Keep the full first-refusal receipt in the failure output: an unrelated
+      // fixture/setup error is not evidence for the historical discovery bug.
+      expect(
+        result,
+        JSON.stringify(
+          result.stepReceipts?.find((receipt) => receipt.refusal?.code === "step-refused"),
+        ),
+      ).toMatchObject({ completed: true });
+    },
+    60_000,
+  );
+});


### PR DESCRIPTION
Related: #145050

**Draft — red-phase regression and migration design for owner review. No production fix is implemented, and this must not merge in its current state.**

## What Problem This Solves

Tracks the repair for an upgrade/Doctor failure when retained Workshop proposals reference a former workspace that is no longer configured. Doctor skips that root's valid setup file, then Workshop refuses because setup migration is still required there. The shipped 2026.9.4 incident and recovery are documented in #145050.

## Why This Change Was Made

This draft makes the actual Doctor preflight path executable with synthetic historical-workspace state, rather than relying only on source inspection. It deliberately asserts successful repair and retains the failing cases as the red phase; it does not hide them behind skip or expected-failure annotations.

The [storage checkpoint](https://github.com/openclaw/openclaw/blob/main/docs/reference/database-schemas/storage-changes.md#review-checkpoint-for-material-changes) and [issue review](https://github.com/openclaw/openclaw/issues/145050#issuecomment-5637131147) require recorded migration-owner acceptance before implementing historical-root admission. That acceptance is still outstanding. The following is a proposal, not an accepted contract:

- **Owner and order:** Doctor remains the only setup importer. Reuse Workshop's retained-record classification to identify pending or applied-create candidates, then pass explicitly admitted roots to the existing setup importer before Workshop relocation. Do not derive a second set of runtime workspaces or mutate configuration to force discovery.
- **Admission decision:** A retained target path is provenance, not sufficient authorization. Validate the owning agent and the historical root/path relationship using existing ownership and canonical-path rules. Record the exact evidence that permits each root; ambiguous or unverifiable roots remain untouched and receive actionable Doctor recovery guidance. Whether explicit operator selection is required for those roots remains a maintainer decision.
- **Persistence:** No new store or schema bump. Existing SQLite setup state and proposal rows remain authoritative. Preserve setup timestamps, proposal status/history, archive bytes, migration receipts, and verified source retirement. This changes discovery scope, not import format or canonical conflict resolution.
- **Lifecycle and recovery:** Keep the existing maintenance locks, claim/identity revalidation, archive-before-retirement, and interrupted-import retry behavior. Revalidate admission before writes; discovery cannot itself create, move, or delete historical files.
- **Boundaries and cost:** Inspect retained Workshop records once and deduplicate admitted roots. No recursive filesystem scan or per-record repeated import. Automatic startup and copied-state read-only planning must not gain access to external historical targets.
- **Alternatives:** Explicit operator-selected recovery through Doctor is an alternative if bounded automatic admission cannot be justified. A new importer, weakening Workshop readiness, or making the old root a persistent configured workspace is not proposed.
- **Rollback:** Reverting the discovery change must leave the existing canonical schema readable. Preserve archives/receipts for recovery; do not automatically restore retired sources and recreate the original gate.

## User Impact

None yet: this draft changes tests only. Live installations are not patched. A completed fix would let normal Doctor repair converge for admitted historical roots without private-API workarounds.

## Evidence

Baseline: upstream main `5114fcdbd3402010e2b13fc2675e8025b30e1279`, Ubuntu 24.04.4 LTS, Node 24.18.0, pnpm 12.3.4. Source dependencies installed with the frozen lockfile in a dedicated checkout, separate from the live installation.

Command:

```sh
node scripts/run-vitest.mjs run src/commands/doctor-config-preflight.historical-workspace.process.test.ts --maxWorkers=1
```

Initial run: **2 passed, 2 failed**, exit 1. Both configured-root controls passed; both historical-root cases failed with the first `step-refused` receipt at `skill-workshop`, naming the intact historical setup source. No current-main production code was changed. This is now a runtime reproduction on main, not only the original shipped-release observation.

Final committed test (`1d7607f0`) rerun with the receipt assertions: **2 passed, 2 failed**, exit 1, 216.24 seconds. Configured-root pending/applied controls passed (54.96/51.00 seconds); historical pending/applied cases again failed at the same `skill-workshop` setup gate. Formatting (`pnpm exec oxfmt --check <test-file>`) and `git diff --cached --check` passed. No test timeout was raised or bypassed.

Review: independent read-only source/fixture review found no blocking defect. The repository autoreview helper was invoked but returned `reviewer_unavailable` / `engine_failed`, exit 1, with no report. This is **not** a clean autoreview verdict. Full build, broad suites, independent second-host verification, and green/refactor proof are not claimed for this test-only red draft.

The fixture covers pending creates and applied creates, each with a configured-root control and an unconfigured historical-root case. It invokes real `runDoctorConfigPreflight` in a child with an explicit environment allowlist and fixture-owned state/package assets. No migration decision is mocked. Draft bytes are present so missing-draft retirement cannot mask the bug.

Success assertions cover both setup timestamps, preserved archive bytes, source retirement, the migration receipt, unchanged configuration, proposal retargeting without unintended application, applied skill content, and a second Doctor run that preserves the same proposal/archive/receipt. Failures retain the first refused receipt and verify that setup bytes and proposal record fields were not silently discarded.

Before ready-for-review: obtain design acceptance, implement the admitted-root path, turn the historical cases green without changing their success expectations, add admission rejection/revalidation coverage, run the existing copied-state planning and interrupted-setup recovery tests, and complete fresh review. This draft does not claim green/refactor completion or close #145050.
