### PR TITLE
fix: continue cloud provisioning after a Gateway restart

### DIFF
--- a/docs/gateway/cloud-workers/dispatching-a-session.md
+++ b/docs/gateway/cloud-workers/dispatching-a-session.md
@@ -19,6 +19,8 @@ In the Control UI, open **New Session** and use the unified **Place** picker to 
 
 With a GitHub repository selected, **Remote checkout** lets you choose the source ref without cloning on the Gateway. With a Gateway folder selected, cloud selection enables its managed worktree. The Gateway creates the session, finishes dispatch, and only then sends the first turn. The server badge in the session sidebar shows the durable placement state. Startup recovery retains the repository URL and ref along with the destination and first message.
 
+If the Gateway restarts during provisioning, the pending first message waits for recovery and continues automatically when its worker is ready. Temporary startup or suspension errors do not cancel setup. The first message stays before later recovery notices in the chat, including after reconnecting.
+
 Choosing **Stop cloud worker…** while the new session is still provisioning pauses its initial message before requesting teardown. A late dispatch response cannot send that message. The draft stays visible for **Retry** and is not resubmitted automatically. Regular session drafts survive reconnects and page reloads; incognito drafts remain only in the current page. If the first message was already sent, uncertain delivery remains **Check delivery** rather than starting another turn.
 
 While a placement is active, OpenClaw automatically samples available space on the remote workspace volume. Low-space warnings appear in the selected chat and on the session's cloud badge. They are advisory, clear automatically after space recovers, and do not stop or reclaim the worker.

--- a/src/gateway/server-worker-placement-reconcile-guard.ts
+++ b/src/gateway/server-worker-placement-reconcile-guard.ts
@@ -1,6 +1,30 @@
+import type { WorkerProvisioningDispatchPlacement } from "./worker-environments/placement-dispatch-failure.js";
 import type { WorkerPlacementDispatchService } from "./worker-environments/placement-dispatch.js";
+import { matchesWorkerPlacementTarget } from "./worker-environments/placement-reclaim-contract.js";
 import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import type { WorkerEnvironmentService } from "./worker-environments/service.js";
+
+export function createWorkerPlacementInitialRecovery(params: {
+  placements: WorkerSessionPlacementStore;
+  environments: WorkerEnvironmentService;
+  isStopping: () => boolean;
+}) {
+  return async (placement: WorkerProvisioningDispatchPlacement) => {
+    const current = params.placements.get(placement.sessionId);
+    if (
+      params.isStopping() ||
+      !placement.environmentId ||
+      !current ||
+      !matchesWorkerPlacementTarget(current, placement) ||
+      current.sessionKey !== placement.sessionKey ||
+      current.agentId !== placement.agentId ||
+      current.executionMode !== placement.executionMode
+    ) {
+      throw new Error("Worker placement changed before initial setup recovery");
+    }
+    await params.environments.reconcileEnvironment(placement.environmentId);
+  };
+}
 
 export function installWorkerPlacementReconcileGuard(params: {
   placements: WorkerSessionPlacementStore;

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -29,7 +29,10 @@ import { createGatewayWorkerDispatchAdmission } from "./server-worker-placement-
 import { createGatewayWorkerPlacementMoveBarrier } from "./server-worker-placement-move-barrier.js";
 import { createGatewayWorkerPlacementMoveDestinationResolver } from "./server-worker-placement-move-destination.js";
 import { createGatewayWorkerPlacementReclaimBarriers } from "./server-worker-placement-reclaim.js";
-import { installWorkerPlacementReconcileGuard } from "./server-worker-placement-reconcile-guard.js";
+import {
+  createWorkerPlacementInitialRecovery,
+  installWorkerPlacementReconcileGuard,
+} from "./server-worker-placement-reconcile-guard.js";
 import { createWorkerPlacementSessionEvidenceResolver } from "./server-worker-placement-session-evidence.js";
 import {
   createWorkerPlacementNodeWorkspaceBindingResolver,
@@ -433,6 +436,11 @@ export function createGatewayWorkerPlacementRuntime(
         )?.gitAuthor,
     }),
     createGatewayWorkerDispatchAdmission(loadWorkerPlacementSessionRuntimeModule),
+    createWorkerPlacementInitialRecovery({
+      ...params,
+      isStopping: () =>
+        stopped || params.environments.isStopping() || getGatewayRestartDrainSignal().aborted,
+    }),
   );
   const dispatchService = {
     ...rawDispatchService,

--- a/src/gateway/worker-environments/placement-dispatch-coordinator-admission.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator-admission.test.ts
@@ -14,6 +14,115 @@ import {
 import type { WorkerPlacementDispatchRequest } from "./service-contract.js";
 
 describe("worker placement maintenance admission", () => {
+  it.each(["ready", "provider-pending", "abort", "stop", "move", "replacement"] as const)(
+    "retains restarted input between provider passes until %s",
+    async (outcome) => {
+      const firstPass = createDeferredCore();
+      const providerSettled = createDeferredCore();
+      const controller = new AbortController();
+      const active = {
+        ...ACTIVE_PLACEMENT,
+        sessionId: PROVISIONING_PLACEMENT.sessionId,
+        generation: PROVISIONING_PLACEMENT.generation + 1,
+      };
+      let attempts = 0;
+      const coordinated = coordinateWorkerPlacementDispatch(
+        createCoordinatorTestService({
+          resumeProvisioning: async (placement, core, report, admit) => {
+            report?.(placement);
+            return await admit!(async (signal) => {
+              await core(signal);
+              if (++attempts === 1) {
+                return undefined;
+              }
+              report?.(active);
+              return active;
+            });
+          },
+        }),
+        (_request, run) => run(),
+        async (placement) => {
+          await coordinated.resumeProvisioning(placement, async (_signal, retain) => {
+            if (outcome === "provider-pending") {
+              retain?.(providerSettled.promise);
+            }
+          });
+          firstPass.resolve();
+        },
+      );
+      let held = true;
+      const waiting = coordinated.waitForInitialPlacement(
+        PROVISIONING_PLACEMENT,
+        controller.signal,
+      );
+      void waiting.then(
+        () => (held = false),
+        () => (held = false),
+      );
+      try {
+        await firstPass.promise;
+        await setImmediatePromise();
+        expect(held).toBe(true);
+        expect(coordinated.isPlacementOperationInFlight(PROVISIONING_PLACEMENT.sessionId)).toBe(
+          outcome === "provider-pending",
+        );
+        if (outcome === "provider-pending") {
+          // A timed-out provider still owns admission after its foreground pass ended.
+          await coordinated.resumeProvisioning(PROVISIONING_PLACEMENT, async () => {});
+          await setImmediatePromise();
+          expect(held).toBe(true);
+          expect(attempts).toBe(1);
+          providerSettled.resolve();
+          await setImmediatePromise();
+        }
+        if (outcome === "abort") {
+          controller.abort(new Error("input cancelled"));
+        } else if (outcome === "stop") {
+          await coordinated.reclaim(PROVISIONING_PLACEMENT).catch(() => undefined);
+        } else if (outcome === "move") {
+          await coordinated
+            .move({ ...MOVE_REQUEST, sessionId: PROVISIONING_PLACEMENT.sessionId })
+            .catch(() => undefined);
+        } else {
+          await coordinated.resumeProvisioning(
+            {
+              ...PROVISIONING_PLACEMENT,
+              generation: PROVISIONING_PLACEMENT.generation + (outcome === "replacement" ? 1 : 0),
+            },
+            async () => {},
+          );
+        }
+        if (outcome === "ready" || outcome === "provider-pending") {
+          await expect(waiting).resolves.toEqual(active);
+        } else {
+          await expect(waiting).rejects.toThrow();
+        }
+      } finally {
+        providerSettled.resolve();
+        controller.abort();
+        await waiting.catch(() => undefined);
+      }
+    },
+  );
+
+  it("reports failure to start guarded recovery and honors already-cancelled input", async () => {
+    const recover = vi.fn(async () => {
+      throw new Error("gateway is stopping");
+    });
+    const coordinated = coordinateWorkerPlacementDispatch(
+      createCoordinatorTestService({}),
+      (_request, run) => run(),
+      recover,
+    );
+    await expect(coordinated.waitForInitialPlacement(PROVISIONING_PLACEMENT)).rejects.toThrow(
+      "gateway is stopping",
+    );
+    await expect(
+      coordinated.waitForInitialPlacement(PROVISIONING_PLACEMENT, AbortSignal.abort()),
+    ).rejects.toThrow();
+    expect(recover).toHaveBeenCalledOnce();
+  });
+
   it.each(["active", "incomplete", "stale-generation"] as const)(
     "holds input for its exact recovery owner (%s)",
     async (outcome) => {

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
@@ -12,6 +12,7 @@ import {
   createCoordinatorTestService,
   MOVE_REQUEST,
   preparedReclaim,
+  PROVISIONING_PLACEMENT,
   REQUEST,
 } from "./placement-dispatch-coordinator.test-support.js";
 import type { WorkerPlacementDispatchService } from "./placement-dispatch.js";
@@ -959,7 +960,7 @@ describe("worker placement dispatch coordinator", () => {
     const fullSweep = coordinated.reconcile();
     await sweepStarted.promise;
     const destroying = coordinated.forceDestroyEnvironment("worker-exclusive");
-    const joinedRecovery = coordinated.resumeProvisioning({} as never, async () => {
+    const joinedRecovery = coordinated.resumeProvisioning(PROVISIONING_PLACEMENT, async () => {
       joinedRecoveryStarted.resolve();
       await releaseJoinedRecovery.promise;
     });
@@ -967,7 +968,15 @@ describe("worker placement dispatch coordinator", () => {
     releaseSweep.resolve();
     await setImmediatePromise();
 
-    const lateRecovery = coordinated.resumeProvisioning({} as never, async () => {});
+    const lateRecovery = coordinated.resumeProvisioning(
+      {
+        ...PROVISIONING_PLACEMENT,
+        sessionId: "late-session",
+        sessionKey: "agent:main:late-session",
+        environmentId: "worker-late",
+      },
+      async () => {},
+    );
     await setImmediatePromise();
     expect(resumeProvisioning).toHaveBeenCalledOnce();
     expect(forceDestroyEnvironment).not.toHaveBeenCalled();

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -454,6 +454,7 @@ export function coordinateWorkerPlacementDispatch(
           Awaited<ReturnType<WorkerPlacementDispatchService["resumeProvisioning"]>>
         >();
       let providerSettlement = Promise.resolve();
+      let providerPending = false;
       // Reserve the queue in this stack, before admission can yield to a newer sweep.
       // Only foreground recovery holds that fence; a timed-out provider retains admission.
       const recover = async () => {
@@ -477,47 +478,50 @@ export function coordinateWorkerPlacementDispatch(
       }
       void queued.catch(ready.reject);
       const tracked = trackPlacementOperation(async (report) => {
-        try {
-          // Recovery joins its captured sweep, never a later Stop which awaits that sweep.
-          const result = await service.resumeProvisioning(
-            placement,
-            async (signal) => {
-              await reconcileEnvironmentCore(signal, (settled) => {
-                providerSettlement = settled;
-              });
-            },
-            report,
-            (runRecovery) =>
-              admitDispatch(placement, async (signal) => {
-                try {
-                  await racePromiseWithAbortSignal(ready.promise, signal);
-                  signal?.throwIfAborted();
-                  const recovered = await runRecovery(signal);
-                  foreground.resolve(recovered);
-                  return recovered;
-                } catch (error) {
-                  foreground.reject(error);
-                  throw error;
-                } finally {
-                  // Caller timeouts finish the sweep, not the real provider or its Stop owner.
-                  await providerSettlement;
+        // Recovery joins its captured sweep, never a later Stop which awaits that sweep.
+        return await service.resumeProvisioning(
+          placement,
+          async (signal) => {
+            await reconcileEnvironmentCore(signal, (settled) => {
+              providerSettlement = settled;
+              providerPending = true;
+              const markSettled = () => {
+                if (providerSettlement === settled) {
+                  providerPending = false;
                 }
-              }).catch(async (error: unknown) => {
-                if (error instanceof WorkerPlacementAdmissionTargetError) {
-                  // The failed reservation is released. Cleanup still follows its captured
-                  // predecessor, never a later Stop or the sweep that this recovery joins.
-                  await ready.promise;
+              };
+              void settled.then(markSettled, markSettled);
+            });
+          },
+          report,
+          (runRecovery) =>
+            admitDispatch(placement, async (signal) => {
+              try {
+                await racePromiseWithAbortSignal(ready.promise, signal);
+                signal?.throwIfAborted();
+                const recovered = await runRecovery(signal);
+                if (providerPending) {
+                  foreground.resolve(recovered);
+                }
+                return recovered;
+              } catch (error) {
+                if (providerPending) {
+                  foreground.reject(error);
                 }
                 throw error;
-              }),
-          );
-          // Never-admitted invalid owners still settle their exact cleanup before returning.
-          foreground.resolve(result);
-          return result;
-        } catch (error) {
-          foreground.reject(error);
-          throw error;
-        }
+              } finally {
+                // Caller timeouts finish the sweep, not the real provider or its Stop owner.
+                await providerSettlement;
+              }
+            }).catch(async (error: unknown) => {
+              if (error instanceof WorkerPlacementAdmissionTargetError) {
+                // The failed reservation is released. Cleanup still follows its captured
+                // predecessor, never a later Stop or the sweep that this recovery joins.
+                await ready.promise;
+              }
+              throw error;
+            }),
+        );
       });
       registerOperation({
         kind: "recovery",
@@ -525,6 +529,9 @@ export function coordinateWorkerPlacementDispatch(
         ...tracked,
         foreground: foreground.promise,
       });
+      // Ordinary completion must release the old operation before a caller can retry it.
+      // Only a still-running provider may publish foreground completion ahead of that release.
+      void tracked.operation.then(foreground.resolve, foreground.reject);
       return foreground.promise;
     },
   };

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -1,7 +1,10 @@
 import { isDeepStrictEqual } from "node:util";
 import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import { createDeferredCore } from "../../shared/deferred.js";
-import type { WorkerDispatchPlacement } from "./placement-dispatch-failure.js";
+import type {
+  WorkerDispatchPlacement,
+  WorkerProvisioningDispatchPlacement,
+} from "./placement-dispatch-failure.js";
 import type { WorkerPlacementDispatchService } from "./placement-dispatch.js";
 import {
   matchesWorkerPlacementTarget,
@@ -49,6 +52,7 @@ function trackPlacementOperation<T extends WorkerDispatchPlacement | void>(
 export function coordinateWorkerPlacementDispatch(
   service: WorkerPlacementDispatchService,
   admitDispatch: WorkerPlacementDispatchAdmission,
+  recoverInitialPlacement?: (placement: WorkerProvisioningDispatchPlacement) => Promise<void>,
 ): WorkerPlacementDispatchService & {
   isPlacementOperationInFlight(sessionId: string): boolean;
   waitForInitialPlacement(
@@ -198,9 +202,13 @@ export function coordinateWorkerPlacementDispatch(
     [Kind in keyof OperationServices]: {
       kind: Kind;
       request: Parameters<OperationServices[Kind]>[0];
-    } & ReturnType<typeof trackPlacementOperation<Awaited<ReturnType<OperationServices[Kind]>>>>;
+    } & ReturnType<typeof trackPlacementOperation<Awaited<ReturnType<OperationServices[Kind]>>>> &
+      (Kind extends "recovery"
+        ? { foreground: ReturnType<WorkerPlacementDispatchService["resumeProvisioning"]> }
+        : unknown);
   }[keyof OperationServices];
   const operationsInFlight = new Map<string, Set<PlacementOperation>>();
+  const setupWaiters = new Map<string, Set<(operation: PlacementOperation) => void>>();
   const pendingOperations = (sessionId: string) => [...(operationsInFlight.get(sessionId) ?? [])];
   const registerOperation = (record: PlacementOperation) => {
     const pending = operationsInFlight.get(record.request.sessionId) ?? new Set();
@@ -213,6 +221,9 @@ export function coordinateWorkerPlacementDispatch(
     }
     pending.add(record);
     operationsInFlight.set(record.request.sessionId, pending);
+    for (const observe of setupWaiters.get(record.request.sessionId) ?? []) {
+      observe(record);
+    }
     const release = () => {
       pending.delete(record);
       if (pending.size === 0) {
@@ -233,34 +244,82 @@ export function coordinateWorkerPlacementDispatch(
     async waitForInitialPlacement(placement, signal) {
       signal?.throwIfAborted();
       const pending = pendingOperations(placement.sessionId);
-      const owner = pending.length === 1 ? pending[0] : undefined;
-      // The persisted state is not proof of a live setup owner. Only join the exact
-      // dispatch/recovery that published it, never a Move or Stop operation.
-      if (
-        !owner ||
-        (owner.kind !== "dispatch" && owner.kind !== "recovery") ||
-        owner.request.sessionKey !== placement.sessionKey ||
-        owner.request.agentId !== placement.agentId ||
-        !matchesWorkerPlacementTarget(
+      const matchesOwner = (owner: PlacementOperation) =>
+        (owner.kind === "dispatch" || owner.kind === "recovery") &&
+        owner.request.sessionKey === placement.sessionKey &&
+        owner.request.agentId === placement.agentId &&
+        matchesWorkerPlacementTarget(
           owner.currentPlacement() ?? (owner.kind === "recovery" ? owner.request : undefined),
           placement,
-        )
-      ) {
-        throw new Error(
+        );
+      const missingOwner = () =>
+        new Error(
           "Worker setup has no matching live dispatch owner. Wait for recovery or explicitly retry setup.",
         );
+      const initialOwner = pending.length === 1 ? pending[0] : undefined;
+      const recover =
+        recoverInitialPlacement && placement.state === "provisioning" && placement.environmentId
+          ? () => recoverInitialPlacement(placement)
+          : undefined;
+      if (pending.length ? !initialOwner || !matchesOwner(initialOwner) : !recover) {
+        throw missingOwner();
       }
-      const waitSignal = signal
-        ? AbortSignal.any([signal, owner.superseded.signal])
-        : owner.superseded.signal;
-      const completed = await racePromiseWithAbortSignal(owner.operation, waitSignal);
-      waitSignal.throwIfAborted();
-      if (!completed || !matchesWorkerPlacementTarget(owner.completedPlacement(), completed)) {
-        throw new Error(
-          "Worker setup did not publish a ready placement. Inspect the setup recovery error.",
-        );
+      const superseded = new AbortController();
+      let recoveryFailure: { error: unknown } | undefined;
+      const waitSignal = signal ? AbortSignal.any([signal, superseded.signal]) : superseded.signal;
+      let nextOwner = createDeferredCore<PlacementOperation>();
+      const observe = (owner: PlacementOperation) => {
+        // A restart can leave a gap between provider recovery passes. Stop, Move, or
+        // replacement during that gap still permanently invalidates the held input.
+        if (pendingOperations(placement.sessionId).length !== 1 || !matchesOwner(owner)) {
+          superseded.abort(missingOwner());
+        } else {
+          nextOwner.resolve(owner);
+        }
+      };
+      const waiters = setupWaiters.get(placement.sessionId) ?? new Set();
+      waiters.add(observe);
+      setupWaiters.set(placement.sessionId, waiters);
+      try {
+        if (initialOwner) {
+          nextOwner.resolve(initialOwner);
+        } else if (recover) {
+          // Subscribe before waking the existing guarded recovery owner. Its environment
+          // coordinator deduplicates concurrent waiters and owns subsequent provider passes.
+          void recover().catch((error: unknown) => {
+            recoveryFailure = { error };
+            superseded.abort(error);
+          });
+        }
+        for (;;) {
+          const owner = await racePromiseWithAbortSignal(nextOwner.promise, waitSignal);
+          nextOwner = createDeferredCore<PlacementOperation>();
+          const ownerSignal = AbortSignal.any([waitSignal, owner.superseded.signal]);
+          const completed = await racePromiseWithAbortSignal(owner.operation, ownerSignal);
+          ownerSignal.throwIfAborted();
+          if (completed && matchesWorkerPlacementTarget(owner.completedPlacement(), completed)) {
+            return completed;
+          }
+          if (
+            !completed &&
+            recover &&
+            owner.kind === "recovery" &&
+            matchesWorkerPlacementTarget(owner.currentPlacement(), placement)
+          ) {
+            continue;
+          }
+          throw new Error(
+            "Worker setup did not publish a ready placement. Inspect the setup recovery error.",
+          );
+        }
+      } catch (error) {
+        throw recoveryFailure ? recoveryFailure.error : error;
+      } finally {
+        waiters.delete(observe);
+        if (waiters.size === 0) {
+          setupWaiters.delete(placement.sessionId);
+        }
       }
-      return completed;
     },
     dispatch: async (request, onTransition, authorize) => {
       const inFlight = pendingOperations(request.sessionId).find(
@@ -378,6 +437,14 @@ export function coordinateWorkerPlacementDispatch(
         ? runReconciliation(() => service.reconcileActive())
         : runReconciliation(() => service.reconcileActive(environmentId), false),
     resumeProvisioning: (placement, reconcileEnvironmentCore) => {
+      const inFlight = pendingOperations(placement.sessionId).find(
+        (pending) => pending.kind === "recovery" && isDeepStrictEqual(pending.request, placement),
+      );
+      if (inFlight?.kind === "recovery") {
+        // A timed-out provider retains admission after foreground recovery has finished.
+        // Reuse that pass until it settles; a later sweep can then resume the same owner.
+        return inFlight.foreground;
+      }
       // Insertion order matters: a later queued sweep must not steal a provisioning join
       // from the earlier sweep already awaiting that environment pass.
       const sweep = [...reconciliationSweeps].find((candidate) => candidate.acceptingJoins);
@@ -452,7 +519,12 @@ export function coordinateWorkerPlacementDispatch(
           throw error;
         }
       });
-      registerOperation({ kind: "recovery", request: placement, ...tracked });
+      registerOperation({
+        kind: "recovery",
+        request: placement,
+        ...tracked,
+        foreground: foreground.promise,
+      });
       return foreground.promise;
     },
   };

--- a/src/gateway/worker-environments/placement-dispatch-shutdown.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-shutdown.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { createDeferredCore } from "../../shared/deferred.js";
+import {
+  createWorkerPlacementInitialRecovery,
+  installWorkerPlacementReconcileGuard,
+} from "../server-worker-placement-reconcile-guard.js";
 import { WorkerDispatchTargetChangedError } from "../server-worker-placement-session-target.js";
+import { coordinateWorkerPlacementDispatch } from "./placement-dispatch-coordinator.js";
 import {
   MANIFEST_REF,
   REQUEST,
@@ -87,12 +92,34 @@ describe("worker placement shutdown replay", () => {
       stop: vi.fn(),
     }));
     const attach = vi.spyOn(restarted, "attachSession");
-    const recovery = createRecoveryService(placements, restarted);
+    const recovery = coordinateWorkerPlacementDispatch(
+      createRecoveryService(placements, restarted),
+      (_request, run) => run(),
+      createWorkerPlacementInitialRecovery({
+        placements,
+        environments: restarted,
+        isStopping: () => false,
+      }),
+    );
+    const uninstallGuard = installWorkerPlacementReconcileGuard({
+      placements,
+      environments: restarted,
+      dispatch: recovery,
+      isStopping: () => false,
+    });
     const owner = placements.get(REQUEST.sessionId)!;
     if (owner.state !== "provisioning") {
       throw new Error("restart lost its provisioning owner");
     }
-    await recovery.resumeProvisioning(owner, () => restarted.reconcileEnvironment(environmentId));
+    try {
+      const ready = await Promise.all([
+        recovery.waitForInitialPlacement(owner),
+        recovery.waitForInitialPlacement(owner),
+      ]);
+      expect(ready).toEqual([placements.get(REQUEST.sessionId), placements.get(REQUEST.sessionId)]);
+    } finally {
+      await uninstallGuard();
+    }
 
     expect(placements.get(REQUEST.sessionId)).toMatchObject({ state: "active", environmentId });
     expect(support.testState.store.get(environmentId)).toMatchObject({

--- a/ui/src/app/session-placement-startup.disconnect.test.ts
+++ b/ui/src/app/session-placement-startup.disconnect.test.ts
@@ -71,6 +71,7 @@ describe("initial turn ownership through disconnect", () => {
       await flushStartupMicrotasks();
       expect(startup.get(input.recovery.sessionKey)).toMatchObject({
         phase: "failed",
+        startedAt: input.createdAt,
         initialTurn: { text: input.recovery.message, sendRunId: input.recovery.messageId },
         action: "retry",
       });
@@ -241,6 +242,7 @@ describe("initial turn ownership through disconnect", () => {
     expect(request).toHaveBeenCalledTimes(1);
     client.recoveryScopeReady = true;
     transition(gateway, { ...gateway.snapshot, phase: "connected" });
+    expect(startup.get(input.recovery.sessionKey)?.startedAt).toBe(input.createdAt);
     await vi.waitFor(() => expect(startup.hasPendingTurn(input.recovery.sessionKey)).toBe(false));
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "sessions.dispatch",

--- a/ui/src/app/session-placement-startup.runtime.ts
+++ b/ui/src/app/session-placement-startup.runtime.ts
@@ -292,7 +292,8 @@ export default function createApplicationPlacementStartupRuntime(
       // Status reads must not rescan payloads or mint new attachment identities.
       attachments: restoreChatApiAttachments(input.recovery.attachments),
       persistRecovery: input.persistRecovery,
-      createdAt: input.createdAt,
+      createdAt:
+        existing?.owner.messageId === owner.messageId ? existing.createdAt : input.createdAt,
       scope,
       retainsConnection: capturePlacementStartupConnection(params.gateway, owner),
     };

--- a/ui/src/lib/sessions/session-placement-startup.test.ts
+++ b/ui/src/lib/sessions/session-placement-startup.test.ts
@@ -292,6 +292,40 @@ describe("session placement startup", () => {
     expect(request).toHaveBeenCalledTimes(6);
   });
 
+  it.each(["gateway-suspending", "gateway-restarting"])(
+    "continues provisioning automatically after %s without reclaiming the worker",
+    async (reason) => {
+      vi.useFakeTimers();
+      try {
+        let unavailableReads = 0;
+        const request = vi.fn(async (method: string) => {
+          if (method === "sessions.dispatch") {
+            return { placement: { state: "provisioning" } };
+          }
+          if (method === "sessions.describe") {
+            if (unavailableReads++ < 8) {
+              throw new GatewayRequestError({
+                code: "UNAVAILABLE",
+                message: "Gateway temporarily unavailable",
+                retryable: true,
+                details: { reason },
+              });
+            }
+            return { session: { placement: { state: "active" } } };
+          }
+          return { status: "started" };
+        });
+        const outcome = startSessionPlacementInitialTurn(clientWith(request), params, () => true);
+        await vi.runAllTimersAsync();
+        await expect(outcome).resolves.toMatchObject({ status: "started" });
+        expect(request).not.toHaveBeenCalledWith("sessions.reclaim", expect.anything());
+        expect(request.mock.calls.filter(([method]) => method === "sessions.send")).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it.each([
     {
       name: "reclaims the session placement",

--- a/ui/src/lib/sessions/session-placement-startup.ts
+++ b/ui/src/lib/sessions/session-placement-startup.ts
@@ -8,6 +8,7 @@ import {
   type GatewayBrowserClient,
 } from "../../api/gateway.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import { isAwaitingGatewayFailure } from "../../lib/gateway-availability.ts";
 import { generateUUID } from "../../lib/uuid.ts";
 import {
   isTerminalFailureChatSendAck,
@@ -32,6 +33,7 @@ type PlacementReadResult =
   | { status: "read"; placement?: SessionPlacement; sessionId?: string }
   | { status: "missing" }
   | { status: "rejected"; error: string }
+  | { status: "awaiting-gateway" }
   | { status: "unavailable" };
 type PlacementResolution =
   | { status: "active"; placement: SessionPlacement }
@@ -98,6 +100,9 @@ async function readPlacement(
       ...(typeof sessionId === "string" && sessionId.trim() ? { sessionId } : {}),
     };
   } catch (error) {
+    if (isAwaitingGatewayFailure(error, null)) {
+      return { status: "awaiting-gateway" };
+    }
     if (!isAmbiguousDispatchError(error)) {
       return {
         status: "rejected",
@@ -143,8 +148,9 @@ async function resolveActivePlacement(
     if (result.status === "rejected") {
       return { status: "cleanup-rejected", error: result.error };
     }
-    if (result.status === "unavailable") {
-      lookupFailures += 1;
+    if (result.status === "unavailable" || result.status === "awaiting-gateway") {
+      // A planned Gateway interruption says nothing about the worker's health.
+      lookupFailures = result.status === "awaiting-gateway" ? 0 : lookupFailures + 1;
       const submissionCancelled = !isCurrent();
       if (submissionCancelled || lookupFailures >= PLACEMENT_LOOKUP_FAILURE_LIMIT) {
         if (!params.cleanupOnCancellation() && submissionCancelled) {
@@ -239,7 +245,7 @@ export async function deleteSessionPlacementDraft(
   if (existing.status === "rejected") {
     return existing.error;
   }
-  if (existing.status === "unavailable") {
+  if (existing.status === "unavailable" || existing.status === "awaiting-gateway") {
     return "placement draft session could not be verified";
   }
   if (!existing.sessionId) {
@@ -309,7 +315,7 @@ export async function deleteRecoveredSessionPlacementDraft(
   if (existing.status === "rejected") {
     return existing.error;
   }
-  if (existing.status === "unavailable") {
+  if (existing.status === "unavailable" || existing.status === "awaiting-gateway") {
     return "session placement could not be verified";
   }
   if (existing.placement) {

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -93,6 +93,7 @@ export type BuildChatItemsProps = {
   stream: string | null;
   streamStartedAt: number | null;
   queue?: ChatQueueItem[];
+  initialTurnId?: string;
   pendingInputs?: ChatPendingInputsPage["items"];
   workspaceSyncPendingRunIds?: readonly string[];
   workerSetupPending?: boolean;
@@ -368,7 +369,10 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         (identity?.role === "assistant" && !identity.isImported && identity.runId === runId)
       );
     });
-    items.splice(insertionIndex < 0 ? items.length : insertionIndex, 0, {
+    // The retained New Session prompt predates all recovery output, including
+    // after a reload when its original browser timestamp is unavailable.
+    const position = queued.id === props.initialTurnId ? 0 : insertionIndex;
+    items.splice(position < 0 ? items.length : position, 0, {
       kind: "message",
       key: queued.sendRunId ? buildMessageItems([message])[0]!.key : `pending-send:${queued.id}`,
       message,

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -5377,6 +5377,26 @@ describe("user message expansion state", () => {
 });
 
 describe("thread item cache", () => {
+  it("repositions an initial placement prompt when recovery identifies its existing queue row", () => {
+    const queued = queuedSend("initial", "Original request", 10_000, "failed", {
+      sendRunId: "initial",
+      sendAttempts: 1,
+    });
+    const input = createProps({
+      messages: [assistantMessage("Gateway recovery", 2)],
+      queue: [queued],
+    });
+    const roles = (items: ReturnType<typeof buildCachedChatItems>) =>
+      items.filter((item) => item.kind === "group").map((item) => item.role);
+
+    expect(roles(buildCachedChatItems(input))).toEqual(["assistant", "user"]);
+    expect(roles(buildCachedChatItems({ ...input, initialTurnId: queued.id }))).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(roles(buildCachedChatItems(input))).toEqual(["assistant", "user"]);
+  });
+
   it("sender provenance refreshes reply display without changing the person", () => {
     resetChatThreadState();
     const alice = userMessage("first", 1, {

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -263,6 +263,7 @@ function sameChatItemsStructuralInput(
     previous.streamSegments === next.streamSegments &&
     previous.streamStartedAt === next.streamStartedAt &&
     previous.queue === next.queue &&
+    previous.initialTurnId === next.initialTurnId &&
     previous.pendingInputs === next.pendingInputs &&
     previous.workspaceSyncPendingRunIds === next.workspaceSyncPendingRunIds &&
     previous.workerSetupPending === next.workerSetupPending &&

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1085,6 +1085,10 @@ describe("chat run error", () => {
       const onQueueRetry = vi.fn();
       const container = renderChatView({
         canSend: false,
+        messages: [
+          { role: "user", content: "[System] Gateway restarted", timestamp: 3 },
+          { role: "assistant", content: "Worker recovery is pending", timestamp: 4 },
+        ],
         queue: [
           {
             id: "ordinary",
@@ -1104,6 +1108,7 @@ describe("chat run error", () => {
           error: "Retained initial turn",
           initialTurn: {
             id: "initial",
+            sendRunId: "initial",
             text: "original prompt",
             createdAt: 1,
             sendAttempts: 1,
@@ -1115,6 +1120,13 @@ describe("chat run error", () => {
       });
       expect(container.querySelector(".chat-thread")?.textContent).toContain("original prompt");
       expect(container.querySelector(".chat-thread")?.textContent).toContain("later draft");
+      const transcript = container.querySelector(".chat-thread")?.textContent ?? "";
+      expect(transcript.indexOf("original prompt")).toBeLessThan(
+        transcript.indexOf("Gateway restarted"),
+      );
+      expect(transcript.indexOf("Worker recovery is pending")).toBeLessThan(
+        transcript.indexOf("later draft"),
+      );
       const buttons = container.querySelectorAll<HTMLButtonElement>(".chat-send-status__retry");
       expect(buttons).toHaveLength(1);
       expect(buttons[0]?.textContent?.trim()).toBe(action === "retry" ? "Retry" : "Check delivery");

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -184,6 +184,7 @@ export function renderChat(props: ChatProps) {
         loading: props.loading && !placementStartup,
         streamStartedAt: placementStartup?.startedAt ?? props.streamStartedAt,
         queue,
+        initialTurnId: props.placementStartup?.initialTurn?.id,
         pendingInputs: pendingInputs?.page.items,
         runActive: props.runActive === true,
         runWorking,

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -102,6 +102,7 @@ export type ChatThreadProps = ChatSendStatusActions & {
   runUsageById?: ReadonlyMap<string, RunOutputUsage>;
   runStatus?: ChatRunUiStatus | null;
   queue: ChatQueueItem[];
+  initialTurnId?: string;
   pendingInputs?: ChatPendingInputsPage["items"];
   showThinking: boolean;
   showToolCalls: boolean;

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -129,6 +129,7 @@ export function projectChatTranscript(
     stream: displayStream,
     streamStartedAt: props.streamStartedAt,
     queue: props.queue,
+    initialTurnId: props.initialTurnId,
     pendingInputs: props.pendingInputs,
     workerSetupPending: ["requested", "provisioning", "syncing", "starting"].includes(
       activeSession?.placement?.state ?? "",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a cloud session could remain stuck when the Gateway restarted during worker provisioning. Its initial message could become permanently marked “Not sent,” while the restart recovery notice appeared above the message that prompted it.

## Why This Change Was Made

Pending turns now rejoin the exact provisioning operation through the existing environment recovery owner, including gaps between provider recovery attempts. Identical recovery requests share their existing operation. Normal completion releases that operation before accepting a retry; only an unresolved provider may publish an early foreground result. Stop, Move, replacement, and caller cancellation still invalidate held input.

The Control UI keeps reconciling through planned restart/suspension errors, retains the initial message's timestamp across reconnects, and anchors that message before later recovery output. Receipt deduplication and ordinary queued-message ordering remain intact. No configuration or persistence changes are needed.

## User Impact

A Gateway restart during provisioning no longer requires users to resend the initial message. Setup resumes on the intended worker without duplicate allocation, and the conversation remains in the correct order.

## Evidence

- Reproduced the missing-dispatch-owner failure through a real placement-store shutdown/reopen regression before the fix; two concurrent waiters now reach the same recovered worker, with one attachment and workspace sync.
- Reproduced the retained-provider overlap failure and verified that a later recovery pass preserves the original owner.
- [The first hosted CI run](https://github.com/openclaw/openclaw/actions/runs/34622104403/job/103338454138) caught an immediate-retry completion race. It reproduced locally and was fixed in the completion owner; all 112 affected recovery/cancellation tests now pass, including the original failing Stop test with unchanged assertions.
- 871 targeted tests pass across provisioning, cancellation, restart recovery, initial-message delivery, receipt deduplication, and chat rendering. The final recovery-helper extraction was rerun through 45 affected tests.
- Core, test, and UI type checks; changed-file lint; formatting; lifecycle/import guards; and unused-export checks pass. Independent review found no actionable P0–P2 defects.
- Message ordering was verified with synthetic data in Chrome. Validation uses local synthetic provider/transport fixtures; this has not been deployed to a live Gateway.

### Message ordering: before and after

Synthetic retained-message fixture rendered with the pre-fix chat view and the current chat view. These images demonstrate ordering and the retained Retry action; the provisioning-recovery behavior is covered by the shutdown/reopen and delivery tests above.

| Before | After |
| --- | --- |
| ![Recovery notice appears before the initial prompt](https://github.com/user-attachments/assets/5c2ea12b-f720-4e7e-88b0-7ec60aa22c12) | ![Initial prompt appears before recovery notices](https://github.com/user-attachments/assets/11389413-4d00-48d6-8008-256700326dd2) |
