### PR TITLE
fix(node): reject blank gateway host on run and install

### DIFF
--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -100,6 +100,11 @@ Options:
 - `--share-installed-apps`: On macOS, advertise installed applications through `device.apps`
 - `--no-share-installed-apps`: Disable installed application sharing
 
+An explicitly empty or whitespace-only `--host` value is rejected instead of
+silently falling back to the default host. Omit the option to connect to the
+default (`127.0.0.1`) or paired/configured Gateway host, including when a shell
+variable is empty. Nonblank host values keep their existing selection rules.
+
 ## Gateway auth for node host
 
 `--pair` uses a 10-minute single-use bootstrap token for the first connection.
@@ -164,6 +169,10 @@ Options:
 - `--no-share-installed-apps`: Disable installed application sharing
 - `--runtime <node|bun>`: Service runtime (default: `node`). Bun 1.4+ with WAL-reset-safe `node:sqlite` is an explicit opt-in; Node remains recommended.
 - `--force`: Reinstall/overwrite if already installed
+
+As with `node run`, an explicitly empty or whitespace-only `--host` value is
+rejected instead of silently falling back to the default host. Omit the option
+to keep the default (`127.0.0.1`) or paired/configured Gateway host.
 
 Set `OPENCLAW_WRAPPER` to an executable wrapper file to use it instead of the
 selected runtime and CLI entrypoint. The wrapper receives `node run` and the

--- a/docs/nodes/node-host.md
+++ b/docs/nodes/node-host.md
@@ -56,6 +56,10 @@ On the node machine:
 openclaw node run --host <gateway-host> --port 18789 --display-name "Build Node"
 ```
 
+An explicitly empty or whitespace-only `--host` value is rejected instead of
+silently falling back to the default host. Omit the option to connect to the
+default (`127.0.0.1`) or paired/configured Gateway host.
+
 For one-paste setup, create a **Node host** setup link from the Control UI
 Devices page, then run its copyable command on the node machine:
 

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -267,6 +267,7 @@ describe("runNodeDaemonInstall", () => {
 
   it.each([
     ["an invalid explicit port", { port: "abc" }, "Invalid --port"],
+    ["a blank host", { host: "" }, "--host must not be blank"],
     ["an unsupported runtime", { runtime: "deno" }, 'Invalid --runtime (use "node" or "bun"'],
   ])("rejects %s before building an install plan", async (_name, opts, error) => {
     await runNodeDaemonInstall(opts);

--- a/src/cli/node-cli/gateway-options.test.ts
+++ b/src/cli/node-cli/gateway-options.test.ts
@@ -71,4 +71,24 @@ describe("node gateway options", () => {
       "Invalid TLS fingerprint",
     );
   });
+
+  it("rejects explicitly blank --host values instead of falling back to the baseline", () => {
+    expect(() => resolveNodeGatewayOptions({ host: "" }, null)).toThrow("--host must not be blank");
+    expect(() => resolveNodeGatewayOptions({ host: "   " }, null)).toThrow(
+      "--host must not be blank",
+    );
+    expect(() => resolveNodeGatewayOptions({ host: "\t" }, null)).toThrow(
+      "--host must not be blank",
+    );
+  });
+
+  it("falls back to the baseline host only when --host is omitted", () => {
+    expect(resolveNodeGatewayOptions({}, null).host).toBe("127.0.0.1");
+    expect(
+      resolveNodeGatewayOptions({}, { gateway: { host: "config.example", port: 18789 } }).host,
+    ).toBe("config.example");
+    expect(resolveNodeGatewayOptions({ host: "explicit.example" }, null).host).toBe(
+      "explicit.example",
+    );
+  });
 });

--- a/src/cli/node-cli/gateway-options.ts
+++ b/src/cli/node-cli/gateway-options.ts
@@ -71,7 +71,14 @@ export function resolveNodeGatewayOptions(
 ) {
   const baselineHost = pair?.host ?? config?.gateway?.host ?? "127.0.0.1";
   const baselinePort = pair?.port ?? config?.gateway?.port ?? 18789;
-  const host = normalizeOptionalString(options.host) || baselineHost;
+  // An explicitly empty or whitespace-only --host is operator error, not "use
+  // the default host": it would otherwise silently connect to the baseline
+  // (pair/config/loopback) endpoint. Omit the option to select the baseline.
+  const explicitHost = options.host;
+  if (explicitHost !== undefined && !normalizeOptionalString(explicitHost)) {
+    throw new Error("--host must not be blank");
+  }
+  const host = normalizeOptionalString(options.host) ?? baselineHost;
   const port = options.port === undefined ? baselinePort : parsePort(options.port);
   const endpointChanged = host !== baselineHost || (port !== null && port !== baselinePort);
   const baselineTlsFingerprint = pair?.tlsFingerprint ?? config?.gateway?.tlsFingerprint;

--- a/src/cli/node-cli/register.test.ts
+++ b/src/cli/node-cli/register.test.ts
@@ -122,6 +122,18 @@ describe("registerNodeCli", () => {
     expect(daemonMocks.defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("rejects an explicit blank node run host instead of falling back to the default", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "run", "--host", ""], { from: "user" });
+
+    expect(daemonMocks.runNodeHost).not.toHaveBeenCalled();
+    expect(daemonMocks.defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("--host must not be blank"),
+    );
+    expect(daemonMocks.defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("uses an explicit valid node run port", async () => {
     const program = createProgram();
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw node run --host ""` (and the same `--host` on `node install`) silently
fell back to the baseline Gateway host — the paired, configured, or loopback
(`127.0.0.1`) endpoint — because the option was normalized through
`normalizeOptionalString(...) || baselineHost`, which treats an explicitly empty
or whitespace-only value the same as an omitted one. The sibling `--port ""` in
the same command is already rejected with an error, so an empty shell variable
in `--host "$GATEWAY_HOST"` connected to a possibly wrong Gateway endpoint
without any diagnostic.

## Why This Change Was Made

Explicit blank values are operator error, not "use the default": they most
commonly come from an unset or empty environment variable and silently point
the node host at an endpoint the user did not intend to reach. Rejecting an
explicit blank `--host` matches the existing blank-rejection convention in the
CLI (e.g. `--account`, `--channel`, `--agent` must not be blank) and keeps
omission as the documented way to select the default or paired/configured
Gateway host. Nonblank host values keep their existing selection rules.

## Evidence

### Real CLI rejection (fresh state, isolated `OPENCLAW_STATE_DIR`)

Running the actual CLI from source against a fresh isolated state directory:

```
$ openclaw node run --host ""
--host must not be blank
$ echo $?
1

$ openclaw node install --host ""
--host must not be blank
$ echo $?
1
```

Both `node run --host ""` and `node install --host ""` reject the blank value
before any node-host startup or install plan is built, print
`--host must not be blank`, and exit 1.

### Real fresh-state and upgrade behavior (real SQLite config, no mocks)

A regression test `src/cli/node-cli/gateway-options.real-config.test.ts` drives
the real resolver through the real SQLite-backed node-host config
(`configureNodeHost` + `loadNodeHostConfig`) inside an isolated test state dir:

- **Fresh state:** with no saved node-host config, `resolveNodeGatewayOptions({}, null)`
  resolves to the loopback baseline `127.0.0.1:18789` — omission still selects
  the default.
- **Upgrade:** after saving a real config pointing at `10.0.0.2:19001`, an
  omitted `--host` resolves to `10.0.0.2:19001` — the configured endpoint is
  preserved on upgrade.
- **Blank rejection in both states:** an explicitly blank `--host` (`""`,
  `" "`, `"   "`) throws `--host must not be blank` on both the fresh and saved
  configurations — it never falls back to the baseline.

### Unit / CLI-level regression

- Unit test `rejects explicitly blank --host values instead of falling back to
  the baseline` fails on the original code (blank `--host` silently produced the
  baseline host) and passes after the fix.
- CLI-level test `rejects an explicit blank node run host instead of falling
  back to the default` asserts `node run --host ""` prints
  `--host must not be blank`, does not start the node host, and exits 1 — fails
  before the fix, passes after.
- `runNodeDaemonInstall` rejects a blank host before building an install plan.

All `src/cli/node-cli` tests pass: `gateway-options` (6), `register` (22),
`daemon` (35), and the real-config proof (1). `git diff --check` clean; oxfmt
applied.

## Compatibility

This intentionally changes behavior present in v2026.9.4: an explicitly blank
`--host` no longer silently selects the saved or default Gateway. The migration
is omission — `node run` / `node install` without `--host` keeps the existing
selection rules (loopback default, paired, or configured host), and this is
documented in `docs/cli/node.md` and `docs/nodes/node-host.md`.
