### PR TITLE
refactor(chat): keep one setup action on empty chats

### DIFF
--- a/ui/src/e2e/inference-setup-gate.e2e.test.ts
+++ b/ui/src/e2e/inference-setup-gate.e2e.test.ts
@@ -56,17 +56,10 @@ suite.define(() => {
       const textarea = page.locator(".agent-chat__composer-combobox textarea");
       await expect.poll(() => textarea.isDisabled()).toBe(false);
       const welcome = page.locator(".agent-chat__welcome--setup");
-      const welcomeAction = welcome.getByRole("button", { name: "Connect an AI provider" });
-      const composerAction = page
-        .locator(".agent-chat__disabled-banner")
-        .getByRole("button", { name: "Connect an AI provider" });
-      await expect.poll(() => welcomeAction.count()).toBe(1);
-      await expect.poll(() => composerAction.count()).toBe(1);
+      const setupAction = page.getByRole("button", { name: "Connect an AI provider", exact: true });
+      await expect.poll(() => setupAction.count()).toBe(1);
       await captureProof(page, "chat-home-desktop.png");
-      await welcomeAction.click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-setup");
-      await page.goBack();
-      await composerAction.click();
+      await setupAction.click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-setup");
       await page.goBack();
       const sendButton = page.getByRole("button", { name: "Send message", exact: true });
@@ -76,7 +69,11 @@ suite.define(() => {
       await page.getByText("Available Commands", { exact: true }).waitFor();
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
       await expect.poll(() => welcome.count()).toBe(0);
-      await expect.poll(() => composerAction.count()).toBe(1);
+      await expect.poll(() => setupAction.count()).toBe(1);
+      await captureProof(page, "chat-help-desktop.png");
+      await setupAction.click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-setup");
+      await page.goBack();
       await textarea.fill("Start a conversation.");
       await expect.poll(() => sendButton.isDisabled()).toBe(true);
       expect(await textarea.inputValue()).toBe("Start a conversation.");

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -77,7 +77,11 @@ function renderTranscriptShell(
                   ? renderPanelLoadingSkeleton("chat", t("chat.thread.loading"))
                   : nothing
               }
-              ${projection.isEmpty && !projection.searchOpen ? renderWelcomeState(props) : nothing}
+              ${
+                projection.isEmpty && !projection.searchOpen
+                  ? renderWelcomeState({ ...props, onModelSetup: undefined })
+                  : nothing
+              }
               ${
                 projection.isEmpty && projection.searchOpen
                   ? html` <div class="agent-chat__empty">${t("chat.thread.noMatches")}</div> `

--- a/ui/src/pages/chat/components/chat-welcome.ts
+++ b/ui/src/pages/chat/components/chat-welcome.ts
@@ -192,9 +192,13 @@ export function renderWelcomeState(props: ChatWelcomeProps) {
         ${renderWelcomeClawd()}
         <h2>${t("modelSetup.required.title")}</h2>
         <p class="agent-chat__hint">${t("modelSetup.required.body")}</p>
-        <button class="btn primary" type="button" @click=${props.onModelSetup}>
-          ${t("modelSetup.required.action")}
-        </button>
+        ${
+          props.onModelSetup
+            ? html`<button class="btn primary" type="button" @click=${props.onModelSetup}>
+                ${t("modelSetup.required.action")}
+              </button>`
+            : nothing
+        }
       </div>
     `;
   }


### PR DESCRIPTION
## What Problem This Solves

An empty-chat test fixture displayed duplicate setup actions. Later checks found that the current Gateway did not produce that state, so this is a renderer cleanup with no reproduced product defect.

## Why This Change Was Made

Chat omits the optional welcome setup action and retains the persistent composer action. The welcome explanation and New Session setup action remain.

## User Impact

No duplicate was observed in real product states: no configured provider, a provider missing credentials, or a working connection. No configuration, storage, or protocol behavior changes.

## Evidence

A real Gateway and browser showed zero, one, and zero setup buttons for those three states. The missing-credential action opened Model Setup, and a working connection completed a reply. The earlier fixture regression failed before the change; 19 welcome tests, two browser flows, and CI passed. Those fixture results establish rendering behavior, not product reachability.

Consumers: Chat omits the welcome action; New Session retains its supplied action.

Related: #144967.
