### PR TITLE
ci: avoid duplicate startup corpus runs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3066,7 +3066,6 @@ jobs:
               pnpm check:assertion-safety --base "$base_ref"
               pnpm config:docs:check
               pnpm plugins:inventory:check
-              node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/config-startup-corpus.test.ts src/config/state-startup-corpus.test.ts
               ;;
             release-lint-core-*)
               stripe="${TASK#release-lint-core-}"
@@ -3084,6 +3083,12 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Check startup corpus
+        # Full main Node coverage owns these files on the same checkout. PRs may
+        # select only changed tests; release gates also validate a separate merge tree.
+        if: matrix.task == 'baseline-ratchets' && !(github.repository == 'openclaw/openclaw' && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.preflight.outputs.run_check == 'true')
+        run: node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/config-startup-corpus.test.ts src/config/state-startup-corpus.test.ts
 
   qa-smoke-ci-profile:
     permissions:

--- a/docs/ci/pipeline.md
+++ b/docs/ci/pipeline.md
@@ -74,6 +74,13 @@ the job's uploaded artifacts.
 | `openclaw-performance`           | Separate workflow: daily/on-demand Kova runtime performance reports with mock-provider, deep-profile, and GPT 5.6 live lanes                                                                                                                                                                             | Scheduled and manual dispatch                          |
 | `docs-external-links`            | Separate workflow: Docs External Link Audit checks external documentation links with lychee and uploads a report; it reports findings without failing, so it never blocks a pull request                                                                                                                 | Scheduled and manual dispatch                          |
 
+Full canonical `main` pushes run the operator config and prior-release state
+startup corpora once through the Node `runtime-config` owner. Other runs that
+select baseline-ratchets retain its explicit **Check startup corpus** step:
+pull requests may select only changed tests, and release-gate dispatches
+also validate a separate merge tree. Both state repair passes and the static
+baseline ratchets remain unchanged.
+
 Ordinary pull requests that change only independent Control UI unit-test entries
 keep all three UI unit rows, performance checks, and existing type/lint gates,
 without repeating dedicated UI E2E jobs. Browser and Node test entries, shared

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -44,6 +44,7 @@ import {
   BOUNDARY_CHECKS,
   selectChecksForShard,
 } from "../../scripts/run-additional-boundary-checks.mts";
+import { buildVitestRunPlans } from "../../scripts/test-projects.test-support.mts";
 import { createTempDirTracker, useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { sharedVitestConfig } from "../vitest/vitest.shared.config.ts";
 import {
@@ -11866,6 +11867,70 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     },
     55_000,
   );
+
+  it("runs the startup corpus once on full canonical main pushes", () => {
+    const files = [
+      "src/config/config-startup-corpus.test.ts",
+      "src/config/state-startup-corpus.test.ts",
+    ];
+    const groups = createNodeTestShardBundles({
+      compactMode: "push",
+      includeReleaseOnlyPluginShards: false,
+    }).flatMap((shard) => shard.groups);
+    const steps: WorkflowStep[] = readCiWorkflow().jobs["checks-fast-core"].steps;
+    for (const file of files) {
+      expect(
+        buildVitestRunPlans([file]).map((plan) => plan.config),
+        file,
+      ).toEqual(["test/vitest/vitest.runtime-config.config.ts"]);
+      const nodeOwners = groups.filter(
+        (group) =>
+          group.configs.includes("test/vitest/vitest.runtime-config.config.ts") &&
+          (!group.includePatterns ||
+            group.includePatterns.some((pattern) => minimatch(file, pattern))),
+      );
+      expect(nodeOwners, file).toHaveLength(1);
+      const extraOwners = steps.filter(
+        (step) =>
+          step.run?.includes(file) &&
+          (!step.if ||
+            evaluateWorkflowExpression(`\${{ ${step.if} }}`, {
+              eventName: "push",
+              repository: "openclaw/openclaw",
+              ref: "refs/heads/main",
+              matrix: { task: "baseline-ratchets" },
+              runCheck: true,
+              runAttempt: 1,
+            })),
+      );
+      expect(nodeOwners.length + extraOwners.length, file).toBe(1);
+    }
+  });
+
+  it.each([
+    { eventName: "pull_request", runCheck: true },
+    { eventName: "pull_request", runCheck: false },
+    { eventName: "push", runCheck: false },
+    { eventName: "push", ref: "refs/heads/release" },
+    { eventName: "push", repository: "fixture/openclaw" },
+    { eventName: "workflow_dispatch", releaseGate: false },
+    { eventName: "workflow_dispatch", releaseGate: true },
+  ] as const)("retains the startup corpus outside full canonical main: %j", (scenario) => {
+    const steps: WorkflowStep[] = readCiWorkflow().jobs["checks-fast-core"].steps;
+    const selected = steps.filter(
+      (step) =>
+        step.run?.includes("src/config/state-startup-corpus.test.ts") &&
+        (!step.if ||
+          evaluateWorkflowExpression(`\${{ ${step.if} }}`, {
+            repository: "openclaw/openclaw",
+            matrix: { task: "baseline-ratchets" },
+            runAttempt: 1,
+            ...scenario,
+          })),
+    );
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.run).toContain("src/config/config-startup-corpus.test.ts");
+  });
 
   it("runs all baseline ratchets against the exact tested tree", () => {
     const workflow = readCiWorkflow();


### PR DESCRIPTION
## What Problem This Solves

Full canonical main CI runs the same startup corpus twice: through the Node runtime-config suite and again after baseline ratchets. The duplicate invocation recently occupied 579–639 seconds in the ratchet command. This adds work without exercising a different source tree or test contract.

## Why This Change Was Made

Give full canonical main pushes one corpus owner: the existing Node suite. Move the explicit corpus command into a separately visible step and skip it only when the existing preflight output selects full Node coverage on main.

Other baseline-ratchet runs retain that explicit step. Pull requests can select only changed tests, and release-gate dispatches can validate a different merge tree. All static ratchets still run.

## User Impact

CI avoids duplicate migration/startup execution on full main pushes. All 58 corpus cases, both prior-release snapshots, both state repair passes, and their state-integrity assertions remain. Runner counts, shard counts, workers, deadlines, and test inventory are unchanged.

## Evidence

The executable workflow/planner regression observed two corpus owners before the change and exactly one afterward. Independent P2 review is clean. Nine focused cases pass, including precise/fast-only PRs, non-main and noncanonical pushes, manual dispatch, release-gate dispatch, and the existing merge-tree ratchet guard. The test uses the canonical Vitest router and Node planner to establish retained corpus membership.

Targeted root-test types, lint, formatting, generated CI Git ownership, composite-action interpolation, and conflict-marker checks pass. Pinned actionlint passed. The full local workflow checker then stopped because its package index could not resolve the pinned pre-commit 4.6.2 bootstrap dependency; no substitute or bypass was used. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34623667685) is green on `f136bec9fba3a691b6b2973b79390d2655110357`; all 149 checks are terminal without failures.

This is a routing change: corpus bodies and fixtures are untouched. The historical command timings are not a measured post-change CI saving, and removing the duplicate does not by itself establish the eight-minute goal.

Runtime code delta is zero; workflow +5 net lines supplies the conditional visible step, docs +7, tests +65. The old unconditional command is removed.
