### PR TITLE
fix: Gemini and Vertex AI turns fail instead of retrying when the response stream is cut mid-event

### DIFF
--- a/docs/concepts/retry.md
+++ b/docs/concepts/retry.md
@@ -37,7 +37,7 @@ Agent runs automatically recover from temporary rate limits, overloads, and prov
 
 Recovery continues the existing transcript with an instruction to preserve completed work and inspect interrupted actions before deciding whether to repeat them. It can recover a throttle after tool activity or partial output without resubmitting the original user request. The run shows one transient retry indicator while waiting and remains cancellable. Recovered attempts do not leave persisted assistant errors; only terminal failure retains one error. Billing failures, authentication errors, and provider refusals do not use this transient retry budget.
 
-A Responses stream that ends before its terminal event also qualifies for transient recovery, including when a tool call is still unfinished. Partial tool arguments are never executed. A completed response with inconsistent tool-call identities does not qualify as a disconnected stream.
+A Responses stream that ends before its terminal event also qualifies for transient recovery, including when a tool call is still unfinished. Partial tool arguments are never executed. A completed response with inconsistent tool-call identities does not qualify as a disconnected stream. A Gemini or Vertex AI stream that ends partway through an event frame qualifies the same way; a complete frame containing malformed JSON does not.
 
 Exhausted subscription, daily, weekly, or monthly usage windows go directly to eligible auth-profile or model fallback. A long `Retry-After` value alone does not establish usage-window exhaustion: temporary throttles still honor the provider's minimum wait.
 

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1589,7 +1589,8 @@ describe("google transport stream", () => {
     const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
 
     expect(result.stopReason).toBe("error");
-    expect(result.errorMessage).toContain("incomplete");
+    // Agent retry classifies this exact text as a transient disconnect.
+    expect(result.errorMessage).toBe("Google SSE stream ended with an incomplete frame");
   });
 
   it.each([

--- a/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
@@ -83,6 +83,11 @@ describe("settled post-tool turn finalization context", () => {
       captures: true,
     },
     {
+      kind: "google-sse-eof-incomplete-frame",
+      error: new Error("Google SSE stream ended with an incomplete frame"),
+      captures: true,
+    },
+    {
       kind: "terminated-word-variant",
       error: new Error("the request was terminated by the server"),
       captures: false,

--- a/src/agents/failover/failover-classification.overflow-server-misc.cases.ts
+++ b/src/agents/failover/failover-classification.overflow-server-misc.cases.ts
@@ -82,6 +82,18 @@ export const overflowServerMiscCases = [
     },
     expected: null,
   },
+  {
+    id: "google-sse-eof-incomplete-frame",
+    source: "extensions/google/transport-stream.ts",
+    signal: { provider: "google", message: "Google SSE stream ended with an incomplete frame" },
+    expected: reason("timeout"),
+  },
+  {
+    id: "google-sse-malformed-json-frame",
+    source: "extensions/google/transport-stream.ts",
+    signal: { provider: "google", message: "Google SSE stream returned malformed JSON" },
+    expected: null,
+  },
   ...failoverSignalRows(billingSource, reason("timeout"), [
     ["billing-deadline-exceeded", { message: "deadline exceeded" }],
     ["billing-no-stream-chunks", { message: "request ended without sending any chunks" }],

--- a/src/agents/failover/failover-retry.expected.test-support.ts
+++ b/src/agents/failover/failover-retry.expected.test-support.ts
@@ -8,6 +8,8 @@ export const failoverRetryExpectations = {
   "openai-responses-incomplete-terminal-stream": true,
   "openai-responses-eof-with-unresolved-tools": true,
   "openai-responses-completed-with-unresolved-tools": false,
+  "google-sse-eof-incomplete-frame": true,
+  "google-sse-malformed-json-frame": false,
   "proxy-incomplete-terminal-stream": true,
   "billing-context-input-length-model-limit": false,
   "retry-go-usage-limit": false,

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -41,8 +41,10 @@ export function isProviderRequestSizeCeilingError(errorMessage?: string): boolea
 // match — those are not assistant-stream contracts.
 // Responses EOF can leave a tool call open; a completed response with unresolved
 // calls instead indicates an inconsistent terminal payload, not a disconnect.
+// Google SSE EOF can cut an event frame; malformed JSON in a delimited frame is
+// a payload defect, not a disconnect.
 export const INCOMPLETE_ASSISTANT_STREAM_RE =
-  /^(?:[\w -]*stream ended (?:before (?:message_?stop|(?:a )?terminal (?:finish reason|response event|event))|without (?:a terminal )?finish[_ ]reason)|Responses stream ended with unresolved tool calls)[.!]?$/i;
+  /^(?:[\w -]*stream ended (?:before (?:message_?stop|(?:a )?terminal (?:finish reason|response event|event))|without (?:a terminal )?finish[_ ]reason)|Responses stream ended with unresolved tool calls|Google SSE stream ended with an incomplete frame)[.!]?$/i;
 // Undici ends a stream body with this exact bare transport message. Keep it
 // anchored so unrelated failures that merely contain the word do not match.
 export const TERMINATED_TRANSPORT_MESSAGE_RE = /^terminated$/i;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gemini and Vertex AI turns would fail with `Google SSE stream ended with an incomplete frame` and keep only partial output when the response stream was cut partway through an event frame, for example in the middle of a streamed tool call. Agent auto-retry did not run, and the error got no failover reason. The same disconnect on a frame boundary was already classified as `timeout`, retried, and recovered. Whether a turn recovered depended only on where in the byte stream the connection happened to end.

## User Impact

When a Gemini or Vertex AI stream ends mid-event, OpenClaw now treats it like any other transient stream disconnect. The turn is retried under the normal retry budget and, when retries run out, is eligible for the same timeout failover as a frame-boundary cut. Users no longer get a truncated reply and an error. As with the existing Responses behavior, partial tool-call arguments are never executed. Malformed-JSON responses still fail as before.

## Why This Change Was Made

The shared incomplete-stream pattern now also matches the exact text `Google SSE stream ended with an incomplete frame`. This is the same end-of-stream family that https://github.com/openclaw/openclaw/pull/144583 extended for Responses streams. All three consumers of that pattern pick it up together: failover classification (`timeout`), transient retry evidence, and settled post-tool turn finalization.

A frame-boundary cut already recovers because its message, `Google stream ended before a terminal finish reason`, matches that pattern. The mid-frame throw uses different wording and carries no error code, so no classifier reaches it. Aligning the message pattern is what makes the two agree.

The match is exact, not a new substring rule. `Google SSE stream returned malformed JSON` stays non-retryable, because that is a complete frame with a bad payload, not a disconnect. The Google transport and its error text are unchanged. The existing transport test now pins that exact string, since the classifier depends on it.

## Evidence

**End-to-end, before and after.** A harness runs the real Google managed SSE transport inside a real `AgentSession` with `retry: { enabled: true, maxRetries: 1 }` against a loopback HTTP server. The first response ends cleanly after one text frame. In the `frame-boundary` case the cut lands there. In the `mid-frame` case the body continues into a partial `functionCall` frame, `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"read","args":{"path":`. The second response is a normal `finishReason: STOP` answer. The harness was run from `src/agents/sessions/` and was not committed. Both runs below are on this branch's merge base, with the branch's change to `src/agents/failover/message-patterns.ts` reverted for the "without this change" column.

| Cut | Without this change | With this change |
| --- | --- | --- |
| `frame-boundary` (`Google stream ended before a terminal finish reason`, code `STREAM_INCOMPLETE`) | 2 requests, final text `Recovered.`, retryable `true`, failover `timeout` | unchanged |
| `mid-frame` (`Google SSE stream ended with an incomplete frame`, no code) | **1 request, final text `partial answer`**, retryable `false`, failover `null`, `shouldRetryFailoverSignal` `false` | **2 requests, final text `Recovered.`**, retryable `true`, failover `timeout`, `shouldRetryFailoverSignal` `true` |

Without the change the `mid-frame` case fails with `expected 1 to be 2`. With it, both cases pass (`Tests 2 passed (2)`).

**Regression tests.** New rows:

- `google-sse-eof-incomplete-frame` in the failover classification corpus (expected `timeout`) and in the retry expectations (expected `true`).
- `google-sse-malformed-json-frame` as a boundary row (expected `null` / `false`).
- `google-sse-eof-incomplete-frame` in `attempt.settled-turn-finalization-context.test.ts` (captures settled context).

With only `src/agents/failover/message-patterns.ts` reverted to the merge base, each new positive row fails for the intended reason:

- `src/llm/utils/retry.test.ts`: `preserves the retry decision for google-sse-eof-incomplete-frame`, `expected false to be true` (`Tests 1 failed | 634 passed (635)`).
- `src/agents/failover/failover-classification.corpus.test.ts`: `google-sse-eof-incomplete-frame`, `expected null to deeply equal { kind: 'reason', reason: 'timeout' }` (`Tests 1 failed | 642 passed (643)`).
- `src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts`: `Expected the built-in settled transcript context` (`Tests 1 failed | 8 passed (9)`).

**Focused tests on this branch.** `node scripts/run-vitest.mjs src/agents/failover/failover-classification.corpus.test.ts src/llm/utils/retry.test.ts src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts extensions/google/transport-stream.test.ts`: all 4 shards pass. The corpus has 643 passed, retry has 635 passed, settled-turn has 9 passed, and the Google transport has 173 passed.

**Changed gate.** Every `node scripts/check-changed.mjs` lane for the changed files passes: `conflict markers`, `max-lines suppression ratchet`, `assertion SAFETY comment ratchet`, `changelog attributions`, `doctor deprecation registry`, `guarded extension wildcard re-exports`, `plugin-sdk wildcard re-exports`, `extension test core imports`, `duplicate scan target coverage`, `dependency pin guard`, `format changed files` (`oxfmt --check`), `config docs`, `plugin boundary report`, `wrapper shadowing`, `dependency patches`, `test temp creations`, `core tsgo graph boundary`, `typecheck core`, `typecheck core tests`, `typecheck extension tests`, `coercion helper declaration guard`, `deprecated API usage`, `deadcode exports`, `oxlint` on the changed core and extension files, `native state schema version`, `database-first legacy stores`, `media download helpers`, `runtime sidecar loaders`, `import cycles`, and the webhook and auth lint guards. `git diff --check` is clean.

**Two environment caveats, neither caused by this diff.** The `line-cap growth ratchet` lane calls `git cat-file --batch -z` in `scripts/lib/shrink-ratchet.mts`, and the Git installed here rejects that flag for any blob before reading a single file, so that one lane could not be run. Separately, the typecheck lanes, the extension oxlint lane and the compiled Vitest worker build fail on the merge base itself, in files this diff does not touch: `src/config/mutate.include-io.ts` imports `rejectConfigNonFiniteNumbers` from `./io.read-helpers.js`, which does not export it (it is defined in `./value-tree.js`), and `src/config/mutate.ts` imports the same symbol without using it. That surfaces as `TS2305` and `TS6133` from `tsgo` and as a rolldown `MISSING_EXPORT` from the test-worker build. With only those two base imports corrected locally, outside this branch, all of those lanes and every focused test shard pass.

**Not run.** The fix was not tested against the live Gemini or Vertex AI API, which needs paid credentials. The loopback server reproduces a clean end of body mid-frame. Only the `google-generative-ai` API was exercised. `google-vertex` models use the same managed transport and SSE parser.
