### PR TITLE
fix(ui): hide owner-filtered catalogs from sidebar peers

### DIFF
--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -82,6 +82,8 @@ Session previews are hidden by default for compact, single-line rows. Enable **S
 
 Enable **Hide empty groups** in the same menu to hide custom groups with no sessions in the current sidebar view. It is off by default, and the browser remembers your choice. Collapsed groups with sessions stay visible. Hidden groups keep their membership and order and remain available in **Move to group**; turn the setting off to use their headers as drag targets again.
 
+Native CLI catalogs with no rows matching the owner filter are hidden unless they have more pages to load or a discovery error to show. Hidden catalogs do not keep the **Other** heading visible when it is the only remaining section.
+
 **Mark as unread** creates a reminder that remains unread while the current chat stays open, including while a run streams or completes. Leave and reopen the session, or choose **Mark as read**, to clear it.
 
 Opening a read-only or suggestion session as a viewer leaves its unread marker intact. Draft sessions acknowledge reads automatically only for their owner or an administrator.

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -37,7 +37,7 @@ import {
   normalizeCatalogTimestamp,
   type CatalogBackingSessionDisplay,
   type CatalogSessionMenuRequest,
-  visibleCatalogHosts,
+  type SidebarSessionCatalog,
 } from "./app-sidebar-session-catalogs.ts";
 import { renderSidebarSessionSectionHeader } from "./app-sidebar-session-section-header.ts";
 import { icons } from "./icons.ts";
@@ -47,7 +47,7 @@ import { renderSessionGlyph } from "./session-glyph.ts";
 import { renderSessionRowBadges } from "./session-row-badges.ts";
 
 type SessionCatalogGroupsParams = {
-  catalogs: readonly SessionCatalog[];
+  catalogs: readonly SidebarSessionCatalog[];
   connected: boolean;
   basePath: string;
   routeSessionKey: string;
@@ -58,7 +58,6 @@ type SessionCatalogGroupsParams = {
   visibleSessionLimits: ReadonlyMap<string, number>;
   projectGrouping: CatalogProjectGrouping;
   liveRows: readonly GatewaySessionRow[];
-  ownerId?: string | null;
   renderLiveRow: (row: GatewaySessionRow, display: CatalogBackingSessionDisplay) => unknown;
   onToggleSection: (sectionId: string) => void;
   draggingSectionId: string | null;
@@ -167,23 +166,16 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
   // Adopted rows use canonical local labels and title snapshots; native catalog
   // refreshes must not rename them or replace the regular session presentation.
   const liveRowsByKey = new Map<string, GatewaySessionRow>();
-  const liveOwnerIdBySessionKey = new Map<string, string | undefined>();
   for (const row of params.liveRows) {
     if (!liveRowsByKey.has(row.key)) {
       liveRowsByKey.set(row.key, row);
-      liveOwnerIdBySessionKey.set(row.key, row.owner?.actor.id);
     }
   }
   return params.catalogs.map((catalog) => {
     const sectionId = `catalog:${catalog.id}`;
     const collapsed = params.collapsedSections.has(sectionId);
-    const hosts = catalog.hosts;
-    // Catalog providers own host identity; the sidebar only removes hosts with no visible rows.
-    const visibleHosts = visibleCatalogHosts(hosts, params.ownerId, liveOwnerIdBySessionKey);
-    const rows = visibleHosts.flatMap((host) =>
-      host.sessions.map((session) => ({ host, session })),
-    );
-    const liveRows = rows.flatMap(({ session }) => {
+    const rows = catalog.visibleHosts.flatMap((host) => host.sessions);
+    const liveRows = rows.flatMap((session) => {
       const row = session.sessionKey ? liveRowsByKey.get(session.sessionKey) : undefined;
       return row ? [row] : [];
     });
@@ -191,15 +183,10 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     const hasUnread = liveRows.some((row) => row.unread === true);
     const hasBrandIcon = hasProviderBrandIcon(catalog.id);
     const loadingMore = params.loadingMoreCatalogIds.has(catalog.id);
-    const hasMore = hosts.some((host) => Boolean(host.nextCursor));
+    const hasMore = catalog.hosts.some((host) => Boolean(host.nextCursor));
     const canCreateSession = catalog.capabilities.startTerminal === true;
     const errorMessages = catalogErrorMessages(catalog);
     const hasError = errorMessages.length > 0;
-    // Keep provider failures distinguishable from successful empty results.
-    // Hiding both states would silently mask unavailable session sources.
-    if (rows.length === 0 && !hasMore && !hasError) {
-      return nothing;
-    }
     const errorMessage = errorMessages.join("; ");
     const errorHelp = t("chat.sidebar.catalogDiscoveryHelp", { error: errorMessage });
     const sectionClass = [
@@ -330,7 +317,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
           collapsed
             ? nothing
             : html`<div class="sidebar-recent-sessions__list">
-                  ${visibleHosts.map((host) =>
+                  ${catalog.visibleHosts.map((host) =>
                     renderCatalogHostGroup(catalog, host, liveRowsByKey, params),
                   )}
                 </div>

--- a/ui/src/components/app-sidebar-session-catalogs.test.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.test.ts
@@ -8,7 +8,7 @@ import { i18n } from "../i18n/index.ts";
 import {
   findCatalogSessionHovercardRow,
   formatSidebarTimestamp,
-  visibleCatalogHosts,
+  projectSidebarSessionCatalogs,
 } from "./app-sidebar-session-catalogs.ts";
 
 describe("formatSidebarTimestamp", () => {
@@ -134,7 +134,13 @@ describe("findCatalogSessionHovercardRow", () => {
   });
 });
 
-describe("visibleCatalogHosts", () => {
+describe("projectSidebarSessionCatalogs", () => {
+  const catalog = (hosts: SessionCatalogHost[]): SessionCatalog => ({
+    id: "codex",
+    label: "Codex",
+    capabilities: { continueSession: true, archive: false },
+    hosts,
+  });
   const session = (threadId: string, name: string) => ({
     threadId,
     name,
@@ -162,7 +168,9 @@ describe("visibleCatalogHosts", () => {
       },
     ];
 
-    expect(visibleCatalogHosts(hosts)).toEqual([hosts[0]]);
+    expect(projectSidebarSessionCatalogs([catalog(hosts)], null, [])).toEqual([
+      { ...catalog(hosts), visibleHosts: [hosts[0]] },
+    ]);
   });
 
   it("filters sessions by effective owner without inferring host identity", () => {
@@ -185,8 +193,8 @@ describe("visibleCatalogHosts", () => {
       },
     ];
 
-    expect(visibleCatalogHosts(hosts, "operator:mine")).toEqual([
-      { ...hosts[0]!, sessions: [hosts[0]!.sessions[0]!] },
+    expect(projectSidebarSessionCatalogs([catalog(hosts)], "operator:mine", [])).toEqual([
+      { ...catalog(hosts), visibleHosts: [{ ...hosts[0]!, sessions: [hosts[0]!.sessions[0]!] }] },
     ]);
   });
 
@@ -209,7 +217,14 @@ describe("visibleCatalogHosts", () => {
     ];
 
     expect(
-      visibleCatalogHosts(hosts, "operator:owner", new Map([[adoptedKey, "operator:owner"]])),
-    ).toEqual(hosts);
+      projectSidebarSessionCatalogs([catalog(hosts)], "operator:owner", [
+        {
+          key: adoptedKey,
+          kind: "direct",
+          updatedAt: 1,
+          owner: { actor: { type: "human", id: "operator:owner" } },
+        },
+      ]),
+    ).toEqual([{ ...catalog(hosts), visibleHosts: hosts }]);
   });
 });

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -4,6 +4,7 @@ import type {
   SessionCatalogHost,
   SessionCatalogSession,
 } from "../../../packages/gateway-protocol/src/index.ts";
+import type { GatewaySessionRow } from "../api/types.ts";
 import type { ApplicationNavigationOptions } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
@@ -137,17 +138,24 @@ export function catalogErrorMessages(catalog: SessionCatalog): string[] {
   return [...messages];
 }
 
-/**
- * A catalog earns a sidebar section through rows, further pages, or a provider
- * failure. A successful empty catalog stays out of the sidebar even when it can
- * start sessions: the new-session page still lists it as a target, and hiding
- * it here keeps the zone peer list and the rendered sections in agreement.
- */
-export function catalogSectionHasContent(catalog: SessionCatalog): boolean {
-  return (
-    catalog.hosts.some((host) => host.sessions.length > 0 || Boolean(host.nextCursor)) ||
-    catalogErrorMessages(catalog).length > 0
-  );
+export type SidebarSessionCatalog = SessionCatalog & { visibleHosts: SessionCatalogHost[] };
+
+/** Section peers and rendering share owner-filtered rows; paging and failures remain visible. */
+export function projectSidebarSessionCatalogs(
+  catalogs: readonly SessionCatalog[],
+  ownerId: string | null,
+  liveRows: readonly GatewaySessionRow[],
+): SidebarSessionCatalog[] {
+  // The current list wins over cached agent lists, including an unset live owner.
+  const liveOwners = new Map(liveRows.toReversed().map(({ key, owner }) => [key, owner?.actor.id]));
+  return catalogs.flatMap((catalog) => {
+    const visibleHosts = visibleCatalogHosts(catalog.hosts, ownerId, liveOwners);
+    return visibleHosts.length > 0 ||
+      catalog.hosts.some((host) => Boolean(host.nextCursor)) ||
+      catalogErrorMessages(catalog).length > 0
+      ? [{ ...catalog, visibleHosts }]
+      : [];
+  });
 }
 
 export function visibleCatalogHosts(

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -158,7 +158,7 @@ export function projectSidebarSessionCatalogs(
   });
 }
 
-export function visibleCatalogHosts(
+function visibleCatalogHosts(
   hosts: readonly SessionCatalogHost[],
   ownerId?: string | null,
   liveOwnerIdBySessionKey: ReadonlyMap<string, string | undefined> = new Map(),

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -1,6 +1,5 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
-import type { SessionCatalog } from "../../../packages/gateway-protocol/src/index.ts";
 import { presenceUserKey } from "../../../src/shared/presence-user.ts";
 import type { GatewaySessionRow } from "../api/types.ts";
 import type { CatalogOpenTarget } from "../app/settings.ts";
@@ -15,6 +14,7 @@ import type { CatalogProjectGrouping } from "../lib/sessions/catalog-project-gro
 import { openCatalogSessionInTerminal } from "../lib/sessions/catalog-terminal.ts";
 import type { SidebarSessionSection } from "../lib/sessions/grouping.ts";
 import type { SessionCatalogGroupsRenderer } from "./app-sidebar-session-catalog-render.ts";
+import type { SidebarSessionCatalog } from "./app-sidebar-session-catalogs.ts";
 import {
   renderChildSessionLoadError,
   renderRecentSession,
@@ -45,7 +45,7 @@ type SidebarSessionListHost = SessionListHost & {
 };
 
 type SessionCatalogRenderSnapshot = {
-  catalogs: readonly SessionCatalog[];
+  catalogs: readonly SidebarSessionCatalog[];
   basePath: string;
   routeSessionKey: string;
   newSessionAgentId: string;
@@ -54,7 +54,6 @@ type SessionCatalogRenderSnapshot = {
   projectGrouping: CatalogProjectGrouping;
   liveRows: readonly GatewaySessionRow[];
   toSidebarSession: (row: GatewaySessionRow) => SidebarRecentSession;
-  ownerId: string | null;
   catalogOpenTarget: CatalogOpenTarget;
   terminalAvailable: boolean;
 };
@@ -443,7 +442,7 @@ function renderSessionPagination(params: {
 function renderSessionCatalog(params: {
   host: SessionListHost;
   snapshot: SessionCatalogRenderSnapshot;
-  catalog: SessionCatalog;
+  catalog: SidebarSessionCatalog;
   renderer: SessionCatalogGroupsRenderer;
 }) {
   const { host, snapshot, catalog, renderer } = params;
@@ -465,7 +464,6 @@ function renderSessionCatalog(params: {
       visibleSessionLimits: host.sessionData.visibleSessionLimits,
       projectGrouping: snapshot.projectGrouping,
       liveRows: snapshot.liveRows,
-      ownerId: snapshot.ownerId,
       renderLiveRow: (row, display) =>
         renderRecentSession({
           host,

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -25,7 +25,7 @@ import { AppSidebarBase } from "./app-sidebar-base.ts";
 import { projectSidebarArchiveVisibility } from "./app-sidebar-session-archive-visibility.ts";
 import {
   adoptedCatalogSessionKeys,
-  catalogSectionHasContent,
+  projectSidebarSessionCatalogs,
   visibleSessionCatalogProjection,
 } from "./app-sidebar-session-catalogs.ts";
 import {
@@ -178,6 +178,18 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       this.sessionData.sessionCatalogs,
       this.hiddenSessionCatalogIds,
       this.sessionsStatusFilter === "archived",
+    );
+
+  protected catalogLiveRows = () => [
+    ...(this.sessionData.sessionsResult?.sessions ?? []),
+    ...Object.values(this.sessionData.sessionResultsByAgent).flatMap((result) => result.sessions),
+  ];
+
+  protected sidebarSessionCatalogs = () =>
+    projectSidebarSessionCatalogs(
+      this.visibleSessionCatalogs(),
+      this.activeSessionOwnerId,
+      this.catalogLiveRows(),
     );
 
   private sessionSelectionAnchor: string | null = null;
@@ -344,7 +356,10 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
   };
 
   /** Collapsed zones keep full rows for true header counts and status dots. */
-  protected zonedVisibleSections(rows: SidebarRecentSession[]): SidebarVisibleSections {
+  protected zonedVisibleSections(
+    rows: SidebarRecentSession[],
+    catalogs = this.sidebarSessionCatalogs(),
+  ): SidebarVisibleSections {
     const grouping = this.effectiveSessionsGrouping();
     return this.sessionProjection.project({
       rows,
@@ -353,12 +368,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       selfOwnerId: this.context?.gateway.snapshot.selfUser?.id ?? null,
       // Normalize gateway order without dropping catalog-lagging categories.
       sectionOrder: this.knownSectionOrder(),
-      catalogIds:
-        this.sessionsStatusFilter === "archived"
-          ? []
-          : this.visibleSessionCatalogs()
-              .filter(catalogSectionHasContent)
-              .map((catalog) => catalog.id),
+      catalogIds: catalogs.map((catalog) => catalog.id),
       collapsedSections: this.collapsedSessionSections,
       hideEmptyGroups: this.sessionsHideEmptyGroups || this.sessionOwnerFilterActive,
       visibleSessionLimits: this.sessionData.visibleSessionLimits,

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -36,6 +36,7 @@ import {
 } from "./app-sidebar-render.ts";
 import type { SessionCatalogGroupsRenderer } from "./app-sidebar-session-catalog-render.ts";
 import type { CatalogSessionMenuRequest } from "./app-sidebar-session-catalogs.ts";
+import type { SidebarSessionCatalog } from "./app-sidebar-session-catalogs.ts";
 import { renderSessionList } from "./app-sidebar-session-list-render.ts";
 import type {
   SidebarNarrationSyncInput,
@@ -137,6 +138,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   private narrationLoad: Promise<void> | null = null;
   private sessionNavigationState: SidebarSessionNavigationState | undefined;
   private projectedSessionRows: SidebarRecentSession[] | undefined;
+  private projectedSessionCatalogs: SidebarSessionCatalog[] = [];
   private projectedSessionSections: SidebarVisibleSections = {
     sections: [],
     expandedRows: [],
@@ -230,7 +232,9 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     ]);
     this.sessionNavigationState = super.getSessionNavigationState();
     this.projectedSessionRows = super.selectedAgentSessionRows(this.sessionNavigationState);
-    this.projectedSessionSections = super.zonedVisibleSections(this.projectedSessionRows);
+    const catalogs = this.sidebarSessionCatalogs();
+    this.projectedSessionCatalogs = catalogs;
+    this.projectedSessionSections = super.zonedVisibleSections(this.projectedSessionRows, catalogs);
     // An open switcher tracks roster/reconnect updates; otherwise only hydrate
     // the active card and avoid background RPCs for every configured agent.
     const identityIds =
@@ -527,16 +531,9 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     const navigationState = this.getSessionNavigationState();
     const visibleSessions = this.selectedAgentSessionRows(navigationState);
     const expandedAgentId = this.expandedAgentId();
-    const liveRows = [
-      ...(this.sessionData.sessionsResult?.sessions ?? []),
-      ...Object.values(this.sessionData.sessionResultsByAgent).flatMap((result) => result.sessions),
-    ];
-    const { sections: allSections } = this.zonedVisibleSections(visibleSessions);
-    const catalogs = this.visibleSessionCatalogs();
-    const visibleCatalogIds = new Set(catalogs.map((catalog) => catalog.id));
-    const sections = allSections.filter(
-      (section) => !section.id.startsWith("catalog:") || visibleCatalogIds.has(section.id.slice(8)),
-    );
+    const liveRows = this.catalogLiveRows();
+    const catalogs = this.projectedSessionCatalogs;
+    const { sections } = this.zonedVisibleSections(visibleSessions);
     if (
       !this.catalogRenderer &&
       (catalogs.length > 0 || this.sessionData.sessionCatalogRefreshStatus.error !== null)
@@ -566,7 +563,6 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
           projectGrouping: this.catalogProjectGrouping,
           liveRows,
           toSidebarSession: navigationState.toSidebarSession,
-          ownerId: this.activeSessionOwnerId,
           catalogOpenTarget: this.catalogOpenTarget,
           terminalAvailable: this.terminalAvailable,
         },

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -35,8 +35,10 @@ import {
   renderAppSidebarZoneEntry,
 } from "./app-sidebar-render.ts";
 import type { SessionCatalogGroupsRenderer } from "./app-sidebar-session-catalog-render.ts";
-import type { CatalogSessionMenuRequest } from "./app-sidebar-session-catalogs.ts";
-import type { SidebarSessionCatalog } from "./app-sidebar-session-catalogs.ts";
+import type {
+  CatalogSessionMenuRequest,
+  SidebarSessionCatalog,
+} from "./app-sidebar-session-catalogs.ts";
 import { renderSessionList } from "./app-sidebar-session-list-render.ts";
 import type {
   SidebarNarrationSyncInput,
@@ -530,8 +532,6 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   private renderSessions() {
     const navigationState = this.getSessionNavigationState();
     const visibleSessions = this.selectedAgentSessionRows(navigationState);
-    const expandedAgentId = this.expandedAgentId();
-    const liveRows = this.catalogLiveRows();
     const catalogs = this.projectedSessionCatalogs;
     const { sections } = this.zonedVisibleSections(visibleSessions);
     if (
@@ -557,11 +557,11 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
           catalogs,
           basePath: this.basePath,
           routeSessionKey: isSessionRouteId(this.activeRouteId) ? this.getRouteSessionKey() : "",
-          newSessionAgentId: expandedAgentId,
+          newSessionAgentId: this.expandedAgentId(),
           mainKey: this.sessionMainKey(),
           loadingMoreCatalogIds: this.sessionData.loadingMoreSessionCatalogIds,
           projectGrouping: this.catalogProjectGrouping,
-          liveRows,
+          liveRows: this.catalogLiveRows(),
           toSidebarSession: navigationState.toSidebarSession,
           catalogOpenTarget: this.catalogOpenTarget,
           terminalAvailable: this.terminalAvailable,

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-ownership.ts
@@ -1,10 +1,69 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
-import { catalogPage, createGatewayHarness, createSessions, mountSidebar } from "../app-sidebar.ts";
+import {
+  catalogPage,
+  createGateway,
+  createGatewayHarness,
+  createSessions,
+  createSessionsHarness,
+  mountSidebar,
+} from "../app-sidebar.ts";
+import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar session catalog ownership", () => {
+  it.each([false, true])(
+    "omits the lone Other header when owner filtering hides every catalog row (adopted: %s)",
+    async (adopted) => {
+      const ownKey = "agent:main:own-task";
+      const catalogKey = "agent:main:catalog-task";
+      const harness = createSessionsHarness("main", [ownKey, ...(adopted ? [catalogKey] : [])]);
+      const result = harness.sessions.state.result!;
+      const ada = { type: "human", id: "profile-ada", label: "Ada" } as const;
+      const bob = { type: "human", id: "profile-bob", label: "Bob" } as const;
+      result.owners = [ada, bob];
+      for (const row of result.sessions) {
+        row.owner = { actor: row.key === ownKey ? ada : bob };
+      }
+      const { sidebar } = await mountSidebar(
+        createGateway({} as GatewayBrowserClient),
+        harness.sessions,
+      );
+      const page = catalogPage([
+        {
+          threadId: "other-thread",
+          name: "Other owner's session",
+          sessionKey: adopted ? catalogKey : undefined,
+        },
+      ]);
+      // Adoption replaces creator provenance with the loaded session's owner.
+      page.catalogs[0]!.hosts[0]!.sessions[0]!.createdActor = adopted ? ada : bob;
+      sidebar.sessionData.sessionCatalogs = page.catalogs;
+      sidebar.sessionData.requestSessionDataUpdate();
+      await sidebar.updateComplete;
+      const header = () =>
+        sidebar.querySelector('[data-session-section="ungrouped"] .sidebar-recent-sessions__head');
+      expect(header()).not.toBeNull();
+      expect(sidebar.querySelector('[data-session-section="catalog:codex"]')).not.toBeNull();
+
+      sidebar.setSessionOwnerFilter(ada.id);
+      await sidebar.updateComplete;
+      await waitForFast(() => expect(sidebar.sessionData.sessionsLoading).toBe(false));
+      await sidebar.updateComplete;
+      expect(sidebar.querySelector(`[data-session-key="${ownKey}"]`)).not.toBeNull();
+      expect(sidebar.querySelector('[data-session-section="catalog:codex"]')).toBeNull();
+      expect(header()).toBeNull();
+
+      sidebar.setSessionOwnerFilter(null);
+      await sidebar.updateComplete;
+      await waitForFast(() => expect(sidebar.sessionData.sessionsLoading).toBe(false));
+      await sidebar.updateComplete;
+      expect(sidebar.querySelector('[data-session-section="catalog:codex"]')).not.toBeNull();
+      expect(header()).not.toBeNull();
+    },
+  );
+
   it.each([
     { owner: "the selected agent", assistantAgentId: null },
     { owner: "the advertised catalog capability", assistantAgentId: "main" },

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -70,6 +70,7 @@ export type SidebarLifecycleState = HTMLElement & {
   onUpdateSidebarEntries?: (entries: string[]) => void;
   pinnedAgentIds: readonly string[];
   readonly sessionOwnerFilterId: string | null;
+  setSessionOwnerFilter: AppSidebarSessionNavigationElement["setSessionOwnerFilter"];
   sessionKey: string;
   onNavigate: (
     routeId: string,


### PR DESCRIPTION
Related: #145054

## What Problem This Solves

Fixes an issue where selecting an owner in the sessions sidebar hid every native CLI catalog row but left the lone **Other** heading visible.

## Why This Change Was Made

Prepare owner-filtered catalog hosts once per sidebar update and share that catalog list with section projection and rendering. Adopted sessions use current live ownership before creator provenance. Catalogs with further pages or discovery errors remain visible, and hidden/archived catalog adoption behavior stays unchanged.

The duplicated renderer visibility decision and post-projection catalog filtering are removed. Production TypeScript is net **−1 line**.

## User Impact

A lone Other section remains headerless when owner filtering hides all native catalogs. Clearing the filter restores catalog sections and the Other heading.

## Evidence

- The native and adopted regression cases both failed on the original code at the remaining Other heading assertion.
- `node scripts/run-vitest.mjs run ui/src/components/app-sidebar.test.ts ui/src/components/app-sidebar-session-catalog-live.test.ts` — 368 tests passed.
- `pnpm tsgo:ui` — passed.
- Independent Codex review — no actionable P0–P2 findings.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34625510991) — passed. One unchanged database-verifier IPC fixture failed on the first run and passed on a focused same-commit shard retry; all UI and UI E2E checks passed.
- Projection unit tests — 7 passed; 375 tests passed when run with the requested suites.
- Changed-file checks completed with focused reruns after fixing the unused helper export and duplicate type import: dead-export scans, targeted lint/style lint, formatting, and typechecks passed.
- Real Chromium against the synthetic mocked Gateway: select Ada through the Owners menu; the catalog disappears and Planning notes remains. Before: one Other heading. After: no Other heading.

| Before | After |
| --- | --- |
| ![Before: filtered catalog leaves Other heading](https://github.com/user-attachments/assets/1286b2c0-3942-4b13-946a-e366d440ab34) | ![After: lone session remains without Other heading](https://github.com/user-attachments/assets/a168501a-3588-47a5-a6cc-e1685c946766) |
