### PR TITLE
fix(doctor): discover historical Workshop workspace setup before migrating its records

### DIFF
--- a/docs/tools/skill-workshop/troubleshooting.md
+++ b/docs/tools/skill-workshop/troubleshooting.md
@@ -20,6 +20,17 @@ read_when:
 
 ### Legacy ownership warnings during an update
 
+Doctor discovers historical workspace setup files from retained Workshop proposals
+and collection backups, even when the agent now uses a different workspace. It
+imports valid setup history before relocating Workshop records, preserving the
+original timestamps and an archived copy without changing workspace configuration.
+
+If an unconfigured historical workspace has missing or unreadable setup state,
+Doctor preserves its files and reports a warning. Obsolete proposals become stale;
+proposals with unfinished apply recovery and ambiguous collection backups remain
+available for manual review. Configured workspace failures and failures after an
+import has begun still block repair.
+
 Doctor leaves legacy proposal metadata and collection backups in place when
 their workspace has no configured owner or maps to more than one agent. The
 warning names the retained path and candidate agents. These ownership warnings
@@ -28,8 +39,9 @@ do not stop the other migrations or later Doctor repairs.
 Review the retained proposal or backup manifest alongside the configured agent
 workspaces. Correct a workspace mapping only when it identifies the actual
 owner; do not assign an arbitrary agent or delete the artifacts to clear the
-warning. Rerun Doctor after resolving ownership. Invalid metadata, failed writes,
-and unfinished recovery remain migration failures.
+warning. Rerun Doctor after resolving ownership. Outside the historical-workspace
+deferrals above, invalid metadata, failed writes, and unfinished recovery remain
+migration failures.
 
 A retarget count describes proposals changed during that pass. Any remaining
 external targets can belong to different proposals whose migration is blocked.

--- a/src/commands/doctor-skill-workshop-collection-backups.ts
+++ b/src/commands/doctor-skill-workshop-collection-backups.ts
@@ -34,20 +34,38 @@ export type LegacyCollectionBackupRoot =
     }
   | { legacyRoot: string; warning: string; recoverable?: true };
 
-export async function listPendingLegacyCollectionBackupRoots(
-  config: OpenClawConfig,
-  env: NodeJS.ProcessEnv,
-): Promise<LegacyCollectionBackupRoot[]> {
+async function listLegacyCollectionBackupRoots(env: NodeJS.ProcessEnv): Promise<string[]> {
   const backupRoot = path.join(resolveStateDir(env), "skill-workshop", "collection-backups");
   if (!(await pathExists(backupRoot))) {
     return [];
   }
-  const names = (await fs.readdir(backupRoot, { withFileTypes: true }))
+  return (await fs.readdir(backupRoot, { withFileTypes: true }))
     .filter((entry) => entry.isDirectory() && /^[a-f0-9]{16}$/u.test(entry.name))
-    .map((entry) => entry.name);
+    .map((entry) => path.join(backupRoot, entry.name));
+}
+
+export async function listLegacyCollectionBackupWorkspaceDirs(
+  env: NodeJS.ProcessEnv,
+): Promise<string[]> {
+  const workspaces = new Set<string>();
+  for (const legacyRoot of await listLegacyCollectionBackupRoots(env)) {
+    try {
+      for (const backup of await readLegacyCollectionBackups(legacyRoot)) {
+        workspaces.add(backup.workspaceDir);
+      }
+    } catch {
+      // The migration reports invalid manifests; they cannot establish a workspace.
+    }
+  }
+  return [...workspaces];
+}
+
+export async function listPendingLegacyCollectionBackupRoots(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): Promise<LegacyCollectionBackupRoot[]> {
   const roots: LegacyCollectionBackupRoot[] = [];
-  for (const name of names) {
-    const legacyRoot = path.join(backupRoot, name);
+  for (const legacyRoot of await listLegacyCollectionBackupRoots(env)) {
     try {
       const backups = await readLegacyCollectionBackups(legacyRoot);
       if (backups.length === 0) {

--- a/src/commands/doctor-skill-workshop-relocation.ts
+++ b/src/commands/doctor-skill-workshop-relocation.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { assertWorkspaceStateMigrationReady } from "../agents/workspace-legacy-state.js";
-import { resolveCanonicalWorkspacePath } from "../agents/workspace-state-identity.js";
+import {
+  resolveCanonicalWorkspacePath,
+  resolveWorkspaceStateIdentity,
+} from "../agents/workspace-state-identity.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isMissingPathError } from "../infra/errors.js";
 import { pathExists } from "../infra/fs-safe.js";
@@ -186,6 +189,7 @@ type WorkshopRelocationPlan = {
   source: string;
   deferred: boolean;
   workspaceDir: string | undefined;
+  unavailableReason?: string;
   ownerAgentId?: string;
   unconfiguredOwnerAgentId?: string;
   relocation?: WorkshopRelocation;
@@ -276,6 +280,8 @@ export async function planWorkshopRelocation(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv,
   deferredSources: ReadonlySet<string> = new Set(),
+  unavailableWorkspaceDirs: ReadonlyMap<string, string> = new Map(),
+  recoverableDeferredSources: ReadonlySet<string> = new Set(),
 ) {
   const { candidates, external } = classifyWorkshopRelocation(
     records,
@@ -284,9 +290,13 @@ export async function planWorkshopRelocation(
     deferredSources,
   );
   const warnings: string[] = [];
+  let recoverableWarningCount = 0;
   const deferredWorkspaces = new Set<string>();
   for (const workspaceDir of new Set(external.map((plan) => plan.workspaceDir))) {
-    if (!workspaceDir) {
+    if (
+      !workspaceDir ||
+      unavailableWorkspaceDirs.has(resolveWorkspaceStateIdentity(workspaceDir).workspacePath)
+    ) {
       continue;
     }
     try {
@@ -304,6 +314,9 @@ export async function planWorkshopRelocation(
   }
   const relocations = new Map<string, WorkshopRelocation>();
   for (const plan of external) {
+    plan.unavailableReason = plan.workspaceDir
+      ? unavailableWorkspaceDirs.get(resolveWorkspaceStateIdentity(plan.workspaceDir).workspacePath)
+      : undefined;
     plan.deferred ||= Boolean(plan.workspaceDir && deferredWorkspaces.has(plan.workspaceDir));
     if (!plan.ownerAgentId || (plan.record.status === "applied" && !plan.workspaceDir)) {
       continue;
@@ -328,6 +341,13 @@ export async function planWorkshopRelocation(
   const moves: WorkshopMove[] = [];
   for (const relocation of relocations.values()) {
     if (relocation.plans.some((plan) => plan.deferred)) {
+      continue;
+    }
+    const unavailableReason = relocation.plans.find(
+      (plan) => plan.unavailableReason,
+    )?.unavailableReason;
+    if (unavailableReason) {
+      relocation.rejection = unavailableReason;
       continue;
     }
     const plan = relocation.plans.find(
@@ -425,6 +445,7 @@ export async function planWorkshopRelocation(
     .map((plan) => ({
       source: resolveCanonicalWorkspacePath(plan.source),
       destination: plan.relocation?.target.skillDir,
+      recoverable: recoverableDeferredSources.has(resolveCanonicalWorkspacePath(plan.source)),
     }));
   const deferredMoves = new Set<WorkshopMove>();
   // Deferred sources still reserve their paths and destinations. Carry those
@@ -438,7 +459,14 @@ export async function planWorkshopRelocation(
           isPathInside(source, reservation.source))
       ) {
         deferredMoves.add(move);
-        deferredReservations.push({ source, destination: move.destination });
+        deferredReservations.push({
+          source,
+          destination: move.destination,
+          recoverable: reservation.recoverable,
+        });
+        if (reservation.recoverable) {
+          recoverableWarningCount += 1;
+        }
         warnings.push(
           `Skill Workshop left ${move.source} in place because a connected skill still needs migration or recovery.`,
         );
@@ -484,7 +512,8 @@ export async function planWorkshopRelocation(
       updates.push({
         record: staleWorkshopProposal(
           record,
-          conflictReason ??
+          plan.unavailableReason ??
+            conflictReason ??
             (ownerAgentId
               ? "Skill Workshop could not identify the legacy workspace; the path stays in place and the proposal is stale."
               : plan.unconfiguredOwnerAgentId
@@ -516,5 +545,6 @@ export async function planWorkshopRelocation(
     ),
     updates,
     warnings,
+    recoverableWarningCount,
   };
 }

--- a/src/commands/doctor-skill-workshop-sources.ts
+++ b/src/commands/doctor-skill-workshop-sources.ts
@@ -1,0 +1,104 @@
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { pathExists, root, type Root } from "../infra/fs-safe.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { readAppliedSkillProposalEvents } from "../skills/workshop/store-sqlite-event.js";
+import { validateSkillProposalRecord } from "../skills/workshop/store.js";
+import type { SkillProposalEvent } from "../skills/workshop/types.js";
+import { withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync } from "../state/openclaw-state-db-readonly.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
+import { listLegacyCollectionBackupWorkspaceDirs } from "./doctor-skill-workshop-collection-backups.js";
+import {
+  classifyWorkshopRelocation,
+  type LegacyWorkshopProposal,
+} from "./doctor-skill-workshop-relocation.js";
+
+export const LEGACY_WORKSHOP_PROPOSALS_DIR = "skill-workshop/proposals";
+export const LEGACY_WORKSHOP_MAX_RECORD_BYTES = 1024 * 1024;
+export const LEGACY_WORKSHOP_PROPOSAL_ID_PATTERN = /^[a-z0-9][a-z0-9-]{5,120}$/;
+
+export async function readLegacyWorkshopJson(
+  rootDir: Root,
+  relativePath: string,
+  maxBytes: number,
+): Promise<unknown> {
+  const read = await rootDir.read(relativePath, {
+    hardlinks: "reject",
+    maxBytes,
+    symlinks: "reject",
+  });
+  return JSON.parse(read.buffer.toString("utf8"));
+}
+
+export async function readWorkshopMigrationRecords(env: NodeJS.ProcessEnv, includeEvents = false) {
+  const stored = await withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(
+    (database) => {
+      let records: LegacyWorkshopProposal[] = [];
+      let appliedEvents: SkillProposalEvent[] = [];
+      if (tableExists(database.db, "skill_workshop_proposals")) {
+        const kysely = getNodeSqliteKysely<Pick<OpenClawStateDatabase, "skill_workshop_proposals">>(
+          database.db,
+        );
+        const rows = executeSqliteQuerySync(
+          database.db,
+          kysely.selectFrom("skill_workshop_proposals").select(["record_json", "owner_agent_id"]),
+        ).rows;
+        records = rows.flatMap((row) => {
+          try {
+            const parsed = validateSkillProposalRecord(JSON.parse(row.record_json));
+            return parsed.ok ? [{ record: parsed.value, ownerAgentId: row.owner_agent_id }] : [];
+          } catch {
+            return [];
+          }
+        });
+        if (includeEvents && tableExists(database.db, "skill_workshop_proposal_events")) {
+          appliedEvents = readAppliedSkillProposalEvents(database.db);
+        }
+      }
+      return { records, appliedEvents };
+    },
+    { env },
+  );
+  return stored ?? { records: [], appliedEvents: [] };
+}
+
+export async function listLegacySkillWorkshopWorkspaceDirs(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): Promise<string[]> {
+  const { records } = await readWorkshopMigrationRecords(env);
+  const stateDir = resolveStateDir(env);
+  if (await pathExists(path.join(stateDir, LEGACY_WORKSHOP_PROPOSALS_DIR))) {
+    const stateRoot = await root(stateDir);
+    for (const entry of await stateRoot.list(LEGACY_WORKSHOP_PROPOSALS_DIR, {
+      withFileTypes: true,
+    })) {
+      if (!entry.isDirectory || !LEGACY_WORKSHOP_PROPOSAL_ID_PATTERN.test(entry.name)) {
+        continue;
+      }
+      try {
+        const parsed = validateSkillProposalRecord(
+          await readLegacyWorkshopJson(
+            stateRoot,
+            `${LEGACY_WORKSHOP_PROPOSALS_DIR}/${entry.name}/proposal.json`,
+            LEGACY_WORKSHOP_MAX_RECORD_BYTES,
+          ),
+        );
+        if (parsed.ok && parsed.value.id === entry.name) {
+          records.push({ record: parsed.value, ownerAgentId: null });
+        }
+      } catch {
+        // Missing or invalid sidecars cannot establish a workspace; import owns their diagnostics.
+      }
+    }
+  }
+  const { external } = classifyWorkshopRelocation(records, config, env);
+  return [
+    ...new Set([
+      ...external.flatMap(({ workspaceDir }) => (workspaceDir ? [workspaceDir] : [])),
+      ...(await listLegacyCollectionBackupWorkspaceDirs(env)),
+    ]),
+  ];
+}

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { assertWorkspaceStateMigrationReady } from "../agents/workspace-legacy-state.js";
-import { resolveCanonicalWorkspacePath } from "../agents/workspace-state-identity.js";
+import {
+  resolveCanonicalWorkspacePath,
+  resolveWorkspaceStateIdentity,
+} from "../agents/workspace-state-identity.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasErrnoCode, isMissingPathError } from "../infra/errors.js";
@@ -21,7 +24,6 @@ import type { MigrationMessages } from "../infra/state-migrations.types.js";
 import { transitionPendingSkillProposalToStale } from "../skills/workshop/apply-transition.js";
 import { reconcileInterruptedSkillProposalApply } from "../skills/workshop/reconcile-transition.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
-import { readAppliedSkillProposalEvents } from "../skills/workshop/store-sqlite-event.js";
 import {
   parseSkillProposalRow,
   readStoredProposal,
@@ -38,15 +40,10 @@ import {
   validateSkillProposalRecord,
   validateSkillProposalRollback,
 } from "../skills/workshop/store.js";
-import type {
-  SkillProposalEvent,
-  SkillProposalRecord,
-  SkillProposalRollback,
-} from "../skills/workshop/types.js";
+import type { SkillProposalRecord, SkillProposalRollback } from "../skills/workshop/types.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
 import {
-  openExistingOpenClawStateDatabaseReadOnly,
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
@@ -67,26 +64,29 @@ import {
   planWorkshopRelocation,
   readLegacyWorkshopSourceStat,
   resolveLegacyWorkshopWorkspaceDir,
-  type LegacyWorkshopProposal,
   type WorkshopProposalUpdate,
 } from "./doctor-skill-workshop-relocation.js";
+import {
+  LEGACY_WORKSHOP_PROPOSALS_DIR as PROPOSALS_DIR,
+  LEGACY_WORKSHOP_MAX_RECORD_BYTES as MAX_RECORD_BYTES,
+  LEGACY_WORKSHOP_PROPOSAL_ID_PATTERN as PROPOSAL_ID_PATTERN,
+  readLegacyWorkshopJson as readJson,
+  readWorkshopMigrationRecords,
+} from "./doctor-skill-workshop-sources.js";
 import {
   finishWorkshopWorkspaceRelocations,
   prepareWorkshopWorkspaceRelocation,
 } from "./doctor-skill-workshop-workspaces.js";
 
 const WORKSHOP_DIR = "skill-workshop";
-const PROPOSALS_DIR = `${WORKSHOP_DIR}/proposals`;
 const MANIFEST_PATH = `${WORKSHOP_DIR}/proposals.json`;
 // Preserve incomplete proposal artifacts outside active discovery so Doctor
 // does not retry an impossible import on every run.
 const RECOVERY_DIR = `${WORKSHOP_DIR}/recovery`;
 const RECOVERY_PROPOSALS_DIR = `${RECOVERY_DIR}/proposals`;
-const MAX_RECORD_BYTES = 1024 * 1024;
 // Legacy rollback JSON can expand control characters sixfold across 1 MiB of
 // SKILL.md plus 64 existing 256 KiB support targets.
 const MAX_ROLLBACK_BYTES = 128 * 1024 * 1024;
-const PROPOSAL_ID_PATTERN = /^[a-z0-9][a-z0-9-]{5,120}$/;
 
 type MigrationResult = MigrationMessages & {
   detected: number;
@@ -111,47 +111,12 @@ export type LegacyWorkshopMigrationInspection = {
   automationReferences?: WorkshopAutomationReference[];
 };
 
-async function readJson(rootDir: Root, relativePath: string, maxBytes: number): Promise<unknown> {
-  const read = await rootDir.read(relativePath, {
-    hardlinks: "reject",
-    maxBytes,
-    symlinks: "reject",
-  });
-  return JSON.parse(read.buffer.toString("utf8"));
-}
-
 export async function inspectLegacySkillWorkshopMigration(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): Promise<LegacyWorkshopMigrationInspection> {
   const env = params.env ?? process.env;
-  const database = await openExistingOpenClawStateDatabaseReadOnly({ env });
-  let records: LegacyWorkshopProposal[] = [];
-  let appliedEvents: SkillProposalEvent[] = [];
-  try {
-    if (database && tableExists(database.db, "skill_workshop_proposals")) {
-      const kysely = getNodeSqliteKysely<Pick<OpenClawStateDatabase, "skill_workshop_proposals">>(
-        database.db,
-      );
-      const rows = executeSqliteQuerySync(
-        database.db,
-        kysely.selectFrom("skill_workshop_proposals").select(["record_json", "owner_agent_id"]),
-      ).rows;
-      records = rows.flatMap((row) => {
-        try {
-          const parsed = validateSkillProposalRecord(JSON.parse(row.record_json));
-          return parsed.ok ? [{ record: parsed.value, ownerAgentId: row.owner_agent_id }] : [];
-        } catch {
-          return [];
-        }
-      });
-      if (tableExists(database.db, "skill_workshop_proposal_events")) {
-        appliedEvents = readAppliedSkillProposalEvents(database.db);
-      }
-    }
-  } finally {
-    database?.walMaintenance.close();
-  }
+  const { records, appliedEvents } = await readWorkshopMigrationRecords(env, true);
   // Lint needs ownership counts, not adoption verification through writable recovery readers.
   const { external } = classifyWorkshopRelocation(records, params.config, env);
   const backups = await listPendingLegacyCollectionBackupRoots(params.config, env);
@@ -193,6 +158,7 @@ async function relocateLegacyWorkshopTargets(
   env: NodeJS.ProcessEnv,
   retireMissingDrafts: boolean,
   backupRoots: readonly LegacyCollectionBackupRoot[],
+  unavailableWorkspaceDirs: ReadonlyMap<string, string> = new Map(),
 ): Promise<WorkshopRelocationResult> {
   const database = openOpenClawStateDatabase({ env });
   const kysely = getNodeSqliteKysely<
@@ -208,13 +174,38 @@ async function relocateLegacyWorkshopTargets(
         ).rows
       : [];
   const deferredSources = new Set<string>();
+  const recoverableDeferredSources = new Set<string>();
+  const hasRollback = (proposalId: string) =>
+    tableExists(database.db, "skill_workshop_proposal_rollbacks") &&
+    executeSqliteQueryTakeFirstSync(
+      database.db,
+      kysely
+        .selectFrom("skill_workshop_proposal_rollbacks")
+        .select("proposal_id")
+        .where("proposal_id", "=", proposalId),
+    ) !== undefined;
   const recoveryWarnings: string[] = [];
   let missingDraftsRetired = 0;
+  let recoverableWarningCount = 0;
   // Settle writes while their proposal and rollback still name the same files.
   // Recovery can establish a create's ownership or restore a partial update.
   for (const row of readRows()) {
     const record = parseSkillProposalRow(row);
     if (!record || record.status !== "pending") {
+      continue;
+    }
+    const workspaceDir = resolveLegacyWorkshopWorkspaceDir(record.target.skillDir, config, env);
+    const unavailableReason =
+      workspaceDir &&
+      unavailableWorkspaceDirs.get(resolveWorkspaceStateIdentity(workspaceDir).workspacePath);
+    if (unavailableReason && hasRollback(record.id)) {
+      const source = resolveCanonicalWorkspacePath(record.target.skillDir);
+      deferredSources.add(source);
+      recoverableDeferredSources.add(source);
+      recoveryWarnings.push(
+        `Preserved Skill Workshop proposal ${record.id} and its unfinished apply recovery for manual review: ${unavailableReason}`,
+      );
+      recoverableWarningCount += 1;
       continue;
     }
     if (retireMissingDrafts) {
@@ -230,14 +221,7 @@ async function relocateLegacyWorkshopTargets(
         }
         // Any rollback row can describe an interrupted write. Keep it pending
         // for recovery rather than treating its missing draft as abandoned work.
-        const rollback = executeSqliteQueryTakeFirstSync(
-          database.db,
-          kysely
-            .selectFrom("skill_workshop_proposal_rollbacks")
-            .select("proposal_id")
-            .where("proposal_id", "=", record.id),
-        );
-        if (rollback) {
+        if (hasRollback(record.id)) {
           recoveryWarnings.push(
             `Skill Workshop proposal ${record.id} has a missing draft and unfinished apply recovery; restore its draft before retrying Doctor.`,
           );
@@ -254,7 +238,6 @@ async function relocateLegacyWorkshopTargets(
         continue;
       }
     }
-    const workspaceDir = resolveLegacyWorkshopWorkspaceDir(record.target.skillDir, config, env);
     const { ownerAgentId } = inferOwnerAgentId({
       record,
       config,
@@ -348,7 +331,14 @@ async function relocateLegacyWorkshopTargets(
       { operationLabel: "skill-workshop.relocation.commit" },
     );
   };
-  const plan = await planWorkshopRelocation(records, config, env, deferredSources);
+  const plan = await planWorkshopRelocation(
+    records,
+    config,
+    env,
+    deferredSources,
+    unavailableWorkspaceDirs,
+    recoverableDeferredSources,
+  );
   const workspaceMoves = new Map<string, typeof plan.moves>();
   for (const move of plan.moves) {
     // Adopted sources are already absent. Only pending filesystem moves can
@@ -383,7 +373,10 @@ async function relocateLegacyWorkshopTargets(
     staleProposals: staleProposals + missingDraftsRetired,
     migratedBackupRoots: backupMigration.migrated,
     warnings: [...recoveryWarnings, ...plan.warnings, ...backupMigration.warnings],
-    recoverableWarningCount: backupMigration.recoverableWarningCount,
+    recoverableWarningCount:
+      recoverableWarningCount +
+      plan.recoverableWarningCount +
+      backupMigration.recoverableWarningCount,
   };
 }
 
@@ -694,6 +687,7 @@ export async function migrateLegacySkillWorkshopProposals(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   retireMissingDrafts?: boolean;
+  unavailableWorkspaceDirs?: ReadonlyMap<string, string>;
 }): Promise<MigrationResult> {
   const env = params.env ?? process.env;
   // Plain Doctor can reach automatic migration without its repair scope.
@@ -709,6 +703,7 @@ export async function migrateLegacySkillWorkshopProposals(params: {
       env,
       params.retireMissingDrafts === true,
       backupRoots,
+      params.unavailableWorkspaceDirs,
     );
     if (
       relocation.movedSkills > 0 ||

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -1993,6 +1993,7 @@ function buildLegacyStateMigrationSteps(
         message: "Channel pairing account discovery is deferred to plugin validation.",
       }
     : undefined;
+  let unavailableWorkshopWorkspaces: ReadonlyMap<string, string> | undefined;
   const finalSteps: LegacyStateMigrationStep[] = [
     ownerStep("restart-sentinel", detected.restartSentinel, migrateLegacyRestartSentinel),
     {
@@ -2002,7 +2003,9 @@ function buildLegacyStateMigrationSteps(
         if (isDoctor) {
           await params.beforeWorkspaceStateMigration?.(params.sessionConfig ?? params.config);
         }
-        return migrateLegacyWorkspaceState(options);
+        const result = await migrateLegacyWorkspaceState(options);
+        unavailableWorkshopWorkspaces = result.unavailableWorkshopWorkspaces;
+        return result;
       }),
       runWithoutFileDetection: isDoctor && params.beforeWorkspaceStateMigration !== undefined,
     },
@@ -2014,6 +2017,7 @@ function buildLegacyStateMigrationSteps(
           config: params.sessionConfig ?? params.config,
           env: { ...env, OPENCLAW_STATE_DIR: stateDir },
           retireMissingDrafts: isDoctor,
+          unavailableWorkspaceDirs: unavailableWorkshopWorkspaces,
         }),
       ),
       runWithoutFileDetection: true,

--- a/src/infra/state-migrations.lock.test.ts
+++ b/src/infra/state-migrations.lock.test.ts
@@ -97,12 +97,19 @@ describe("legacy state migration ownership", () => {
       beforeRelease: () => {
         throw new Error("nested release failed");
       },
-      run: async () => ({ changes: ["imported"], warnings: [] }),
+      run: async () => ({
+        changes: ["imported"],
+        warnings: ["retained historical source"],
+        warningDisposition: "recoverable",
+      }),
     });
 
     expect(result).toEqual({
       changes: ["imported"],
-      warnings: ["Example migration lock release failed: nested release failed"],
+      warnings: [
+        "retained historical source",
+        "Example migration lock release failed: nested release failed",
+      ],
     });
     await expectStateOwnershipReleased(options.env);
   });

--- a/src/infra/state-migrations.lock.ts
+++ b/src/infra/state-migrations.lock.ts
@@ -71,6 +71,7 @@ export async function withLegacyMigrationStateLock(
     }
   }
   if (releaseError) {
+    delete result.warningDisposition;
     result.warnings.push(
       `${options.releaseLabel} migration lock release failed: ${formatErrorMessage(releaseError)}`,
     );

--- a/src/infra/state-migrations.skill-workshop.test.ts
+++ b/src/infra/state-migrations.skill-workshop.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
 import {
   inspectLegacySkillWorkshopMigration,
   migrateLegacySkillWorkshopProposals,
@@ -13,7 +14,12 @@ import {
   listSkillProposals,
   proposeCreateSkill,
 } from "../skills/workshop/service.js";
-import { updateSkillProposalRecord } from "../skills/workshop/store.js";
+import { readStoredProposal } from "../skills/workshop/store-sqlite-record.js";
+import {
+  importLegacySkillProposal,
+  readSkillProposalRollback,
+  updateSkillProposalRecord,
+} from "../skills/workshop/store.js";
 import {
   SKILL_WORKSHOP_ROLLBACK_SCHEMA,
   type SkillProposalRollback,
@@ -60,6 +66,209 @@ describe("automatic Skill Workshop migration", () => {
     await state.writeText(`${relativeDir}/PROPOSAL.md`, content);
     return { record, file, metadata };
   }
+
+  it.each(
+    (["sqlite", "sqlite-no-rollback", "sidecar", "backup"] as const).flatMap((source) =>
+      (["valid", "missing", "invalid"] as const).map((setupKind) => ({ source, setupKind })),
+    ),
+  )(
+    "settles $setupKind historical workspace setup referenced by a retained $source before Workshop migration",
+    async ({ source, setupKind }) => {
+      const historicalWorkspace = state.path("historical-cafe\u0301");
+      const currentWorkspace = path.join(historicalWorkspace, "current");
+      const config: OpenClawConfig = {
+        agents: { defaults: { workspace: currentWorkspace }, entries: { main: {} } },
+      };
+      await fs.mkdir(currentWorkspace, { recursive: true });
+      await state.writeConfig(config);
+      const setup = {
+        bootstrapSeededAt: "2026-09-01T10:00:00.000Z",
+        setupCompletedAt: "2026-09-01T10:01:00.000Z",
+      };
+      const setupPath = path.join(historicalWorkspace, "openclaw-workspace-state.json");
+      const setupText = JSON.stringify({ version: 1, ...setup });
+      if (setupKind !== "missing") {
+        await fs.writeFile(setupPath, setupKind === "valid" ? setupText : "{invalid");
+      }
+      const proposal = await seedSidecar("historical", historicalWorkspace);
+      const ownedRecord = { ...proposal.record, origin: { agentId: "main" } };
+      if (source === "sidecar") {
+        await fs.writeFile(proposal.file, JSON.stringify(ownedRecord));
+      } else {
+        await fs.unlink(proposal.file);
+        if (source === "sqlite" || source === "sqlite-no-rollback") {
+          importLegacySkillProposal({
+            record: ownedRecord,
+            ownerAgentId: "main",
+            store: { env: state.env },
+          });
+          if (source === "sqlite-no-rollback") {
+            openOpenClawStateDatabase({ env: state.env }).db.exec(
+              "DROP TABLE skill_workshop_proposal_rollbacks",
+            );
+            closeOpenClawStateDatabaseForTest();
+          }
+        } else {
+          await state.writeText(
+            "skill-workshop/collection-backups/0000000000000000/legacy-backup/manifest.json",
+            JSON.stringify({
+              schema: "openclaw.skill-collection-backup.v1",
+              id: "legacy-backup",
+              createdAt: "2026-09-01T00:00:00.000Z",
+              workspaceDir: historicalWorkspace,
+              skillDirs: [],
+              resultSkillDirs: [],
+              resultSkillHashes: {},
+            }),
+          );
+        }
+      }
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const result = await autoMigrateLegacyState({
+          cfg: config,
+          env: state.env,
+          homedir: () => state.home,
+          doctorOnlyStateMigrations: true,
+          legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+        });
+        expect(
+          () => throwIfDoctorStateMigrationRefused(result.stepReceipts),
+          result.warnings.join("\n"),
+        ).not.toThrow();
+        if (setupKind === "valid") {
+          await expect(
+            readWorkspaceStateSnapshot(historicalWorkspace, { env: state.env }),
+          ).resolves.toMatchObject({ setup });
+        } else if (attempt === 0) {
+          expect(result.warnings.join("\n")).toContain(historicalWorkspace);
+        }
+        if (source === "backup") {
+          expect(result.warnings.join("\n")).toContain("candidate agents: none");
+        } else {
+          await expect(
+            inspectSkillProposal(proposal.record.id, { config, agentId: "main", env: state.env }),
+          ).resolves.toMatchObject({
+            record:
+              setupKind === "valid"
+                ? { status: "pending", target: { source: "openclaw-workshop" } }
+                : { status: "stale", statusReason: expect.stringContaining(historicalWorkspace) },
+          });
+        }
+      }
+      if (setupKind === "invalid") {
+        await expect(fs.readFile(setupPath, "utf8")).resolves.toBe("{invalid");
+      } else {
+        await expect(fs.access(setupPath)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      if (setupKind === "valid") {
+        const archives = (await fs.readdir(historicalWorkspace)).filter((name) =>
+          name.startsWith("openclaw-workspace-state.json.migrated."),
+        );
+        expect(archives).toHaveLength(1);
+        await expect(
+          fs.readFile(path.join(historicalWorkspace, archives[0]!), "utf8"),
+        ).resolves.toBe(setupText);
+        expect(
+          openOpenClawStateDatabase({ env: state.env })
+            .db.prepare("SELECT removed_source FROM migration_sources WHERE source_path = ?")
+            .get(setupPath),
+        ).toEqual({ removed_source: 1 });
+      }
+      expect(config.agents?.defaults?.workspace).toBe(currentWorkspace);
+    },
+  );
+
+  it.each(["valid", "malformed", "connected"] as const)(
+    "preserves %s unfinished apply recovery at an unusable historical workspace",
+    async (recoveryKind) => {
+      const historicalWorkspace = state.workspaceDir;
+      const config = {
+        agents: {
+          defaults: { workspace: path.join(historicalWorkspace, "current") },
+          entries: { main: {} },
+        },
+      };
+      await state.writeConfig(config);
+      const proposal = await seedSidecar("unfinished", historicalWorkspace);
+      await fs.unlink(proposal.file);
+      await fs.writeFile(
+        path.join(historicalWorkspace, "openclaw-workspace-state.json"),
+        "{invalid",
+      );
+      const rollback: SkillProposalRollback = {
+        schema: SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+        proposalId: proposal.record.id,
+        writtenAt: "2026-09-01T00:00:00.000Z",
+        targetSkillFile: proposal.record.target.skillFile,
+        action: "create",
+        supportFiles: [],
+      };
+      importLegacySkillProposal({
+        record: proposal.record,
+        rollback,
+        ownerAgentId: "main",
+        store: { env: state.env },
+      });
+      const database = openOpenClawStateDatabase({ env: state.env }).db;
+      if (recoveryKind === "malformed") {
+        database
+          .prepare(
+            "UPDATE skill_workshop_proposal_rollbacks SET support_files_json = ? WHERE proposal_id = ?",
+          )
+          .run("{}", proposal.record.id);
+      }
+      const rollbackBefore = database
+        .prepare("SELECT * FROM skill_workshop_proposal_rollbacks WHERE proposal_id = ?")
+        .get(proposal.record.id);
+      const connectedContent =
+        "---\nname: unfinished\ndescription: Connected procedure\n---\n\n# Procedure\n";
+      const connected = createAppliedLegacyProposal({
+        id: "connected-20260901-1234567890",
+        title: "Connected",
+        description: "Connected proposal",
+        content: connectedContent,
+        target: {
+          skillKey: "unfinished",
+          skillDir: path.join(config.agents.defaults.workspace, "skills", "unfinished"),
+        },
+      });
+      if (recoveryKind === "connected") {
+        await fs.mkdir(connected.target.skillDir, { recursive: true });
+        await fs.writeFile(connected.target.skillFile, connectedContent);
+        importLegacySkillProposal({
+          record: connected,
+          ownerAgentId: "main",
+          store: { env: state.env },
+        });
+      }
+      const before = readStoredProposal(proposal.record.id, { env: state.env });
+      const result = await autoMigrateLegacyState({
+        cfg: config,
+        env: state.env,
+        homedir: () => state.home,
+        doctorOnlyStateMigrations: true,
+        legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+      });
+      expect(() => throwIfDoctorStateMigrationRefused(result.stepReceipts)).not.toThrow();
+      expect(readStoredProposal(proposal.record.id, { env: state.env })).toEqual(before);
+      expect(result.warnings.join("\n")).toContain("unfinished apply recovery");
+      expect(
+        database
+          .prepare("SELECT * FROM skill_workshop_proposal_rollbacks WHERE proposal_id = ?")
+          .get(proposal.record.id),
+      ).toEqual(rollbackBefore);
+      if (recoveryKind !== "malformed") {
+        await expect(
+          readSkillProposalRollback(proposal.record.id, { env: state.env }),
+        ).resolves.toEqual(rollback);
+      }
+      if (recoveryKind === "connected") {
+        expect(readStoredProposal(connected.id, { env: state.env })?.record).toEqual(connected);
+        await expect(fs.access(connected.target.skillFile)).resolves.toBeUndefined();
+      }
+    },
+  );
 
   it.each([
     { item: "proposal", candidates: ["alpha", "beta"] },

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -15,6 +15,8 @@ import {
 } from "../agents/workspace-legacy-state.js";
 import { listWorkspaceStateDirs } from "../agents/workspace-state-dirs.js";
 import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
+import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
+import { listLegacySkillWorkshopWorkspaceDirs } from "../commands/doctor-skill-workshop-sources.js";
 import { resolveLegacyStateDirs } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "./errors.js";
@@ -340,6 +342,17 @@ export async function detectLegacyWorkspaceState(params: {
   if (sharedWorkspace) {
     workspaceDirs.add(resolveUserPath(sharedWorkspace, env, homedir));
   }
+  const configuredPaths = new Set(
+    [...workspaceDirs].map((directory) => resolveWorkspaceStateIdentity(directory).workspacePath),
+  );
+  const historicalWorkspaceDirs = [];
+  for (const workspaceDir of await listLegacySkillWorkshopWorkspaceDirs(params.cfg, env)) {
+    const canonicalPath = resolveWorkspaceStateIdentity(workspaceDir).workspacePath;
+    if (!configuredPaths.has(canonicalPath)) {
+      historicalWorkspaceDirs.push(workspaceDir);
+    }
+    workspaceDirs.add(workspaceDir);
+  }
   for (const workspaceDir of workspaceDirs) {
     addLegacyWorkspaceSources({ workspaceDir, env, homedir, add });
   }
@@ -353,17 +366,11 @@ export async function detectLegacyWorkspaceState(params: {
       left.workspaceKey.localeCompare(right.workspaceKey) ||
       left.sourcePath.localeCompare(right.sourcePath),
   );
-  return { sources, hasLegacy: sources.length > 0 };
-}
-
-function formatLegacyWorkspaceReadWarning(
-  source: LegacyWorkspaceStateSource,
-  error: unknown,
-): string {
-  return formatDoctorStateRepairFailure(
-    `Failed reading legacy workspace state at ${source.sourcePath}: ${formatErrorMessage(error)}`,
-    "Stop the Gateway. Restore this source or its .doctor-importing claim from a verified backup, or rename the unreadable source or claim with a .rejected-<timestamp> suffix to retain its bytes if its setup/attestation history can be discarded. Then rerun openclaw doctor --fix against the same state/config.",
-  );
+  return {
+    sources,
+    hasLegacy: sources.length > 0 || historicalWorkspaceDirs.length > 0,
+    ...(historicalWorkspaceDirs.length > 0 ? { historicalWorkspaceDirs } : {}),
+  };
 }
 
 function assertConfiguredWorkspaceIdentity(source: LegacyWorkspaceStateSource): void {
@@ -490,11 +497,24 @@ async function cleanupReceiptSource(params: {
 async function migrateOneSource(params: {
   source: LegacyWorkspaceStateSource;
   env: NodeJS.ProcessEnv;
+  historical?: boolean;
   beforeClaim?: (source: LegacyWorkspaceStateSource) => void;
   removeSource?: (sourcePath: string) => Promise<void> | void;
 }): Promise<MigrationMessages> {
   let sourceClaim: LegacyMigrationSourceClaim<SourceSnapshot>;
   let sourceRoot: Root;
+  const unreadable = (error: unknown): MigrationMessages => ({
+    changes: [],
+    warnings: [
+      params.historical
+        ? `Preserved historical Workshop workspace setup at ${params.source.sourcePath} for manual review: ${formatErrorMessage(error)}.`
+        : formatDoctorStateRepairFailure(
+            `Failed reading legacy workspace state at ${params.source.sourcePath}: ${formatErrorMessage(error)}`,
+            "Stop the Gateway. Restore this source or its .doctor-importing claim from a verified backup, or rename the unreadable source or claim with a .rejected-<timestamp> suffix to retain its bytes if its setup/attestation history can be discarded. Then rerun openclaw doctor --fix against the same state/config.",
+          ),
+    ],
+    ...(params.historical ? { warningDisposition: "recoverable" as const } : {}),
+  });
   try {
     assertConfiguredWorkspaceIdentity(params.source);
     sourceRoot = await root(params.source.rootDir, {
@@ -503,10 +523,7 @@ async function migrateOneSource(params: {
     });
     sourceClaim = createLegacySourceClaim(sourceRoot, params.source);
   } catch (error) {
-    return {
-      changes: [],
-      warnings: [formatLegacyWorkspaceReadWarning(params.source, error)],
-    };
+    return unreadable(error);
   }
   const receipt = readReceipt(params.source, params.env);
   let hasSource: boolean;
@@ -515,10 +532,7 @@ async function migrateOneSource(params: {
     hasSource = await sourceClaim.exists();
     hasClaim = await sourceClaim.exists(true);
   } catch (error) {
-    return {
-      changes: [],
-      warnings: [formatLegacyWorkspaceReadWarning(params.source, error)],
-    };
+    return unreadable(error);
   }
   // One artifact after verified removal is a new generation, including a source
   // already renamed before a crash. Collisions keep the stricter receipt check.
@@ -534,6 +548,9 @@ async function migrateOneSource(params: {
     });
   }
   if (hasSource && hasClaim) {
+    if (params.historical) {
+      return unreadable(new Error("source and interrupted claim both exist"));
+    }
     return {
       changes: [],
       warnings: [
@@ -614,13 +631,14 @@ async function migrateOneSource(params: {
         ],
       };
     }
+    if (!operation) {
+      return unreadable(error);
+    }
     const restoreError = claimAttempted ? await sourceClaim.restore() : null;
     return {
       changes: [],
       warnings: [
-        operation
-          ? `Failed ${operation}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`
-          : formatLegacyWorkspaceReadWarning(params.source, error),
+        `Failed ${operation}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
       ],
     };
   }
@@ -652,7 +670,7 @@ export async function migrateLegacyWorkspaceState(params: {
   env?: NodeJS.ProcessEnv;
   beforeClaim?: (source: LegacyWorkspaceStateSource) => void;
   removeSource?: (sourcePath: string) => Promise<void> | void;
-}): Promise<MigrationMessages> {
+}): Promise<MigrationMessages & { unavailableWorkshopWorkspaces?: ReadonlyMap<string, string> }> {
   const detected = params.detected;
   if (!detected?.hasLegacy) {
     return { changes: [], warnings: [] };
@@ -667,18 +685,51 @@ export async function migrateLegacyWorkspaceState(params: {
       const changes: string[] = [];
       const warnings: string[] = [];
       const notices: string[] = [];
+      const historical = new Map(
+        (detected.historicalWorkspaceDirs ?? []).map((directory) => [
+          resolveWorkspaceStateIdentity(directory).workspacePath,
+          directory,
+        ]),
+      );
+      const unavailableWorkshopWorkspaces = new Map<string, string>();
+      let blockingWarnings = 0;
       for (const source of detected.sources) {
         const result = await migrateOneSource({
           source,
           env,
+          historical: source.workspaceDir !== undefined && historical.has(source.workspaceDir),
           ...(params.beforeClaim ? { beforeClaim: params.beforeClaim } : {}),
           ...(params.removeSource ? { removeSource: params.removeSource } : {}),
         });
         changes.push(...result.changes);
         warnings.push(...result.warnings);
         notices.push(...(result.notices ?? []));
+        if (result.warningDisposition === "recoverable" && source.workspaceDir) {
+          unavailableWorkshopWorkspaces.set(source.workspaceDir, result.warnings.join("\n"));
+        } else {
+          blockingWarnings += result.warnings.length;
+        }
       }
-      return notices.length > 0 ? { changes, warnings, notices } : { changes, warnings };
+      for (const [workspacePath, workspaceDir] of historical) {
+        if (unavailableWorkshopWorkspaces.has(workspacePath)) {
+          continue;
+        }
+        const snapshot = await readWorkspaceStateSnapshot(workspaceDir, { env, readOnly: true });
+        if (!snapshot.setupExists && !snapshot.attestation) {
+          const warning = `Historical Workshop workspace ${workspaceDir} has no usable setup state. Preserved its files; obsolete proposals will be retired and unfinished recovery retained for manual review.`;
+          unavailableWorkshopWorkspaces.set(workspacePath, warning);
+          warnings.push(warning);
+        }
+      }
+      return {
+        changes,
+        warnings,
+        ...(notices.length > 0 ? { notices } : {}),
+        ...(warnings.length > 0 && blockingWarnings === 0
+          ? { warningDisposition: "recoverable" as const }
+          : {}),
+        ...(unavailableWorkshopWorkspaces.size > 0 ? { unavailableWorkshopWorkspaces } : {}),
+      };
     },
   });
 }

--- a/src/infra/state-migrations.workspace-setup.types.ts
+++ b/src/infra/state-migrations.workspace-setup.types.ts
@@ -12,4 +12,5 @@ export type LegacyWorkspaceStateSource = {
 export type LegacyWorkspaceStateDetection = {
   sources: LegacyWorkspaceStateSource[];
   hasLegacy: boolean;
+  historicalWorkspaceDirs?: string[];
 };


### PR DESCRIPTION
Fixes #145050

## What Problem This Solves

Fixes an issue where users updating an existing installation would hit a Doctor refusal when retained Skill Workshop records referenced a former parent workspace and the agent now used a child workspace. The historical workspace's valid setup file was present, but Doctor skipped it before Workshop required it to be migrated.

## Why This Change Was Made

Workshop's retained SQLite proposals, legacy proposal sidecars, and collection manifests now feed setup discovery through their existing path and metadata owners. The guarded setup importer preserves original timestamps, archives, and receipts before Workshop handles those records; agent workspace configuration stays unchanged.

Unconfigured historical roots with unusable setup state produce recoverable warnings. Obsolete proposals become stale, while retained backups and unfinished apply recovery remain available for review. Configured-workspace failures and failures after source inspection remain blocking. Recovery reservations preserve that distinction for connected proposals, and lock-release failures cannot inherit a recoverable classification.

## User Impact

Updates can complete when an agent has moved away from an old Workshop workspace. Doctor no longer asks users to restore a valid setup file it omitted from discovery, and reports retained historical artifacts that need manual attention. No proposal is applied or published.

Thanks to @compoodment for the detailed reproduction and recovery evidence.

Thanks to @compoodment for the red-phase reproduction in #145066, which is superseded by this fix.

## Evidence

- Original three-variant regression on pre-fix main: 3 failures, including the historical setup readiness refusal for SQLite and sidecar proposals and missing imported timestamps for collection manifests.
- Regression coverage preserves setup timestamps, the archived original, the source-removal receipt, current workspace routing, and second-run convergence. It also covers Unicode paths, missing/invalid setup, optional rollback-table absence, malformed retained rollback rows, and connected recovery reservations.
- All 80 files matching `src/commands/doctor-skill-workshop*.test.ts` and `src/infra/state-migrations*.test.ts`, executed through `node scripts/run-vitest.mjs` in three disjoint runs with separate module caches: **1,028 passed, 4 skipped; 79 files passed, 1 platform-specific file skipped**.
- `node scripts/check-changed.mjs`: passed, including core/test typechecking, lint, import-cycle, and persistence guards. `git diff --check`: passed.
- Packaged Docker control: exact published 2026.9.2 plus a retained v15 SQLite proposal, historical `/home/appuser/example/workspace`, and configured child `/current` updated to pre-fix main `1846735b5d41`. Doctor refused the present setup file; update exited 1, package rollback restored 9.2, and the Gateway remained inactive.
- Identical Docker fixture updated to this candidate: update and Doctor exited **0**, installed version became **2026.9.4**, and the real Gateway passed HTTP health with a replacement managed PID. Both original setup timestamps remained intact; the proposal stayed pending and was retargeted to the agent's Workshop directory. Full update took 44.8 seconds.
- Both candidates passed canonical full builds and package-integrity checks. The fixed artifact was built before commit; its base-plus-patch attribution and hashes of all 11 changed files were verified against this committed tree. Installed build-info matched the selected tarball. Task containers were removed after verification.

## Known gaps

The published 2026.9.2 driver still cannot guarantee automatic restart after an unrelated candidate Doctor refusal. It marks the live package mutated before Doctor (`v2026.9.2:src/infra/package-update-steps.ts:1389`), returns `serviceRestartSafe: false` after failure (`:1042`), and consequently skips restart (`v2026.9.2:src/cli/update-cli/update-command-post-update.ts:183`). Restarting inside Doctor would race the parent's subsequent package rollback. This PR fixes the unnecessary refusal; it does not replace that shipped driver.

Related #144005 explicitly documents the older-updater limitation at [`src/commands/doctor-update-recovery.ts:292`](https://github.com/openclaw/openclaw/blob/2d1d919ce8ae5c40baddbd62ae0498a8b6c918ce/src/commands/doctor-update-recovery.ts#L292).

Docker proof uses the repository's managed-service fixture with real packaged Gateway processes and HTTP health checks; it is not a native systemd integration test.
