### PR TITLE
fix(update): accept failed systemd unit state in managed update park and recovery

### DIFF
--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -140,6 +140,49 @@ export function registerManagedSystemdHandoffConvergenceTests(
     expect(sentinel).toBeNull();
   });
 
+  itUnix("accepts a failed unit that retained the parked generation after activation", async () => {
+    // A Gateway main process that exits non-zero during KillMode=mixed stop settles
+    // the unit into ActiveState=failed with the parked identity retained; the exact
+    // parked unit is still verified, so activation must proceed.
+    const { commands, sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
+      systemdPostExitStates: [
+        { activeState: "failed", generation: "parked", invocation: "parked", mainPid: "none" },
+      ],
+      updaterExitCode: 0,
+      updaterResult: { status: "ok", mode: "npm" },
+    });
+
+    expect(commands.map((command) => command.split(" ")[1])).toEqual(["show", "stop", "show"]);
+    expect(state).toMatchObject({ parked: true, postExitShows: 1, stopCompleted: true });
+    expect(sentinel).toBeNull();
+  });
+
+  itUnix("restores a failed unit that retained the parked generation", async () => {
+    const { commands, sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
+      cancelAfterPark: true,
+      systemdPostExitStates: [
+        { activeState: "failed", generation: "parked", invocation: "parked", mainPid: "none" },
+      ],
+    });
+    const verbs = commands.map((command) =>
+      command.split(" ").find((part) => ["show", "stop", "reset-failed", "start"].includes(part)),
+    );
+
+    expect(verbs).toEqual(["show", "stop", "show", "start", "show"]);
+    expect(state).toMatchObject({ parked: true, restored: true });
+    expect(sentinel).toMatchObject({
+      payload: {
+        status: "skipped",
+        stats: {
+          reason: "managed-service-handoff-cancelled",
+          steps: expect.arrayContaining([
+            expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
+          ]),
+        },
+      },
+    });
+  });
+
   itUnix.each([
     [
       "an inactive replacement generation",
@@ -161,7 +204,15 @@ export function registerManagedSystemdHandoffConvergenceTests(
     ["a replacement main PID", { activeState: "deactivating", mainPid: "replacement" }],
     ["an active service", { activeState: "active", mainPid: "replacement" }],
     ["a restarting service", { activeState: "activating", mainPid: "none" }],
-    ["a failed service", { activeState: "failed", mainPid: "none" }],
+    [
+      "a failed service with a replacement generation",
+      {
+        activeState: "failed",
+        generation: "replacement",
+        invocation: "replacement",
+        mainPid: "none",
+      },
+    ],
     ["an inactive service retaining a main PID", { activeState: "inactive", mainPid: "parent" }],
     ["a replaced service unit", { activeState: "inactive", id: "replacement.service" }],
     ["an unloaded service unit", { activeState: "inactive", loadState: "not-found" }],

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -944,10 +944,14 @@ async function restoreGatewayService(reason, decision = params.recovery, childSt
     const retained = parked?.ExecMainStartTimestampMonotonic === parkedServiceGeneration &&
       parked?.InvocationID === parkedServiceInvocation;
     const cleared = parked?.ExecMainStartTimestampMonotonic === "0" && !parked?.InvocationID;
-    // An owned candidate boot can advance inactive-unit metadata. Only a verified
-    // full-generation rollback permits recovering that later stopped invocation.
+    // A Gateway that exits non-zero during the stop (KillMode=mixed) settles the unit
+    // into ActiveState=failed with the parked identity retained; that is still the
+    // exact parked generation and recovery stays safe. An owned candidate boot can
+    // advance inactive-unit metadata. Only a verified full-generation rollback
+    // permits recovering that later stopped invocation.
     if (!parked || parked.Id !== recovery.unit || parked.LoadState !== "loaded" ||
-      parked.ActiveState !== "inactive" || parked.MainPID !== "0" || !(previousGeneration || retained || cleared) ||
+      (parked.ActiveState !== "inactive" && parked.ActiveState !== "failed") ||
+      parked.MainPID !== "0" || !(previousGeneration || retained || cleared) ||
       !ownsRecovery()) {
       appendLog("recovery refused: parked systemd service identity changed or stop is incomplete");
       record(false);
@@ -1084,7 +1088,12 @@ async function finishGatewayServicePark() {
         Date.now() >= params.parentExitDeadlineAt) {
         throw new Error("systemd service remained active or changed execution generation");
       }
-      if (current.ActiveState === "inactive" && current.MainPID === "0") {
+      if ((current.ActiveState === "inactive" || current.ActiveState === "failed") &&
+        current.MainPID === "0") {
+        // KillMode=mixed units settle into ActiveState=failed instead of inactive
+        // when the Gateway main process exits non-zero during the stop. The parked
+        // generation/invocation stays retained in that state, so it is still the
+        // exact parked unit and activation may proceed.
         const retainedIdentity =
           current.ExecMainStartTimestampMonotonic === parkedServiceGeneration &&
           current.InvocationID === parkedServiceInvocation;


### PR DESCRIPTION
## Summary

A managed update whose Gateway shutdown exits non-zero during the handoff's `systemctl stop` settles the systemd unit into `ActiveState=failed` (with the parked generation/invocation retained), but the handoff helper only accepts `inactive`/`deactivating`, so activation throws, the updater is killed, and recovery is refused — leaving the Gateway stopped until a manual update. This change accepts a `failed` unit with `MainPID=0` and retained or cleared parked identity as a parked terminal state in both the park validation and the recovery path.

## What was wrong

1. `finishGatewayServicePark` in the embedded helper script (`src/infra/update-managed-service-handoff.ts`) loops until the unit reports `inactive` (retained or cleared identity) or `deactivating` (retained identity); any other state — including `failed` — immediately throws `systemd service remained active or changed execution generation`.
2. `restoreGatewayService` in the same script rejects the parked unit unless `parked.ActiveState === "inactive"`, logging `recovery refused: parked systemd service identity changed or stop is incomplete` and recording `managed-service-handoff-restore-failed`.
3. With the common `KillMode=mixed` unit configuration, a non-zero Gateway exit during the stop (e.g., from any shutdown-step failure) produces exactly the rejected state: empirically, a throwaway user unit with `Restart=always` + `KillMode=mixed` whose main process traps `SIGTERM` and exits 1 settles into `ActiveState=failed`, `SubState=failed`, `MainPID=0`, `Result=exit-code`, with `ExecMainStartTimestampMonotonic` and `InvocationID` retained — the exact parked identity.

Net effect: any clean-stop shutdown failure cascades into `managed-service-handoff-restore-failed` and leaves the Gateway down, even though the parked service identity was verified intact and recovery was safe.

## Why this design

- Keep the identity contract intact: `failed` is only accepted with `MainPID=0` plus the retained parked generation/invocation or fully cleared metadata — the same identity predicate `inactive` already requires. A `failed` unit reporting a replacement generation still fails closed.
- Treat `failed` symmetrically with `inactive`: systemd's `start` clears a failed state, so no `reset-failed` call is added and no new control surface is introduced.
- Do not retry or wait on `failed`: unlike `deactivating`, `failed` is terminal, so it is handled in the same accepted-terminal branch as `inactive`.

## Evidence

| Path | Exercised level | Outcome |
| --- | --- | --- |
| `update-managed-service-handoff-lifecycle.test.ts` — "accepts a failed unit that retained the parked generation after activation" | Real embedded helper script, cross-process, fake systemd manager boundary reporting `ActiveState=failed` with parked generation/invocation | Activation completes, updater runs, no failure sentinel |
| Same file — "restores a failed unit that retained the parked generation" | Same boundary, cancelled-handoff restore path | Recovery proceeds: `systemctl start` issued, service restored, `service-restore` step exitCode 0 |
| Same file — "fails closed … a failed service with a replacement generation" | Same boundary, `failed` state with replacement generation/invocation | Still refused with `managed-service-handoff-restore-failed` |
| Full suite | `src/infra/update-managed-service-handoff-lifecycle.test.ts` via the repository test runner (infra project) | 177/177 passed; typecheck green |

The fake manager boundary drives the real detached helper process end to end (park → parent exit → park validation → update command → recovery), so the assertions cover the production script, not a reimplementation.

## Testing

- Two new convergence tests cover the accepted `failed` terminal state (activation path and restore path); the fails-closed parameterization gains a `failed` + replacement-identity case that must keep refusing recovery.
- Unchanged-green: the remaining 174 tests in the lifecycle suite, including the existing `deactivating`-transition, deadline, launchd, and triage suites.
