### PR TITLE
refactor(tests): type runtime mocks through vi.fn generics

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2471,7 +2471,6 @@ src/commands/system-agent-with-inference.ts	2
 src/commands/tasks-json.ts	2
 src/commands/tasks.ts	2
 src/commands/telemetry-exporter-summary.ts	3
-src/commands/test-runtime-config-helpers.ts	3
 src/config/agent-dirs.ts	1
 src/config/allowed-values.ts	1
 src/config/bundled-channel-config-metadata.generated.ts	1

--- a/src/commands/test-runtime-config-helpers.ts
+++ b/src/commands/test-runtime-config-helpers.ts
@@ -91,9 +91,9 @@ type CapturingTestRuntime = {
 
 /** Creates a mocked runtime whose calls can be asserted by Vitest tests. */
 export function createTestRuntime(): TestRuntime {
-  const log = vi.fn() as MockFn<RuntimeEnv["log"]>;
-  const error = vi.fn() as MockFn<RuntimeEnv["error"]>;
-  const exit = vi.fn((_code: number) => undefined) as MockFn<RuntimeEnv["exit"]>;
+  const log = vi.fn<RuntimeEnv["log"]>();
+  const error = vi.fn<RuntimeEnv["error"]>();
+  const exit = vi.fn<RuntimeEnv["exit"]>((_code: number) => undefined);
   return {
     log,
     error,


### PR DESCRIPTION
## What Problem This Solves

The shared command runtime fixture uses three type assertions to describe mock signatures instead of checking those signatures when the mocks are created.

## Why This Change Was Made

Replace those assertions with typed `vi.fn` calls. Retain the named `TestRuntime` return and `MockFn` boundary established for declaration portability, along with the exact nonthrowing exit callback. Runtime calls, imports, exports, and consumer assertions are unchanged. Remove the corresponding three-assertion allowance row from the assertion-safety baseline, as required when its count reaches zero.

## User Impact

No runtime behavior change. Mock construction now checks the existing runtime contract directly. Three test-support lines replace three lines; production and test-support line counts are unchanged, and no tests are removed. The baseline metadata loses one line.

## Evidence

All three complete consumer suites passed before and after: the same 63 cases and statuses. Declaration-only compilation passed in both phases; the helper and `MockFn` declarations were nonempty and byte-identical. This directly checks the retained declaration boundary rather than inferring emission from a no-emit typecheck.

The initial changed gate correctly rejected the stale three-assertion allowance. The exact allowance row was then removed without altering other baseline entries; the canonical assertion ratchet passed. Original consumer and declaration proof covers the unchanged helper inputs, before this metadata-only correction.

All 29 selected checks passed, including production and test typechecking, core and script lint, dead-export scans, and the assertion ratchet. Independent review found no actionable issues through P2. No production build or live-provider run was performed.
