### PR TITLE
fix(codex): preserve refusals when fallback access is denied

### DIFF
--- a/docs/plugins/codex-harness/runtime-behavior.md
+++ b/docs/plugins/codex-harness/runtime-behavior.md
@@ -144,7 +144,9 @@ Authorization stays server-owned. `model/list` advertises Daybreak to every
 client, so catalog presence does not prove entitlement: an unentitled workspace
 still receives `401`/`403` on use, and each such attempt costs the transport's
 full reconnect ladder. OpenClaw therefore treats the retry itself as the only
-evidence and reports an `unavailable` notice rather than a silent block.
+evidence and reports an `unavailable` notice rather than a silent block. If the
+fallback target is unavailable, OpenClaw keeps the original refusal even when
+the fallback produced no assistant message.
 
 Because entitlement belongs to the authenticated workspace and the target model
 rather than to any one conversation, an unauthorized target is remembered once
@@ -164,10 +166,10 @@ A closed, replaced, or retired client still cannot complete a stale handoff.
 
 After a completed provider failure, you can continue in the same chat with its
 existing configuration. OpenClaw retains the configured native thread, including
-for `/codex resume` of that chat's already-bound thread. Provider policy refusals
-end the current request without automatic retry or model fallback. A later user
-message is a separate turn; it does not supply a native policy override or user
-confirmation.
+for `/codex resume` of that chat's already-bound thread. Native provider policy refusals
+end the current attempt without a native retry. OpenClaw's configured cyber
+fallback described above is a separate attempt. A later user message is a
+separate turn; it does not supply a native policy override or user confirmation.
 
 With Codex app-server `0.153.4`, first-time adoption or changed configuration of a
 loaded failed thread still requires native unloading. OpenClaw preserves the

--- a/docs/plugins/codex-harness/runtime-behavior.md
+++ b/docs/plugins/codex-harness/runtime-behavior.md
@@ -124,7 +124,9 @@ work that was actually refused:
 - A turn already running on the configured Daybreak model is never escalated.
 - A turn that already acted is never retried. Escalation requires the attempt's
   own replay-safe verdict, so a turn refused after it sent a message, added a
-  cron entry, spawned a session, or generated media keeps its refusal.
+  cron entry, spawned a session, started a native continuation, or generated
+  media keeps its result. Cancellation, timeout, or a later failure also prevents
+  escalation even if the result retains a refusal diagnostic.
 - Only a refused turn is ever routed to Daybreak. Every turn starts on the model
   the session selected, and a turn that was not refused never reaches the weaker
   tier.
@@ -145,8 +147,10 @@ client, so catalog presence does not prove entitlement: an unentitled workspace
 still receives `401`/`403` on use, and each such attempt costs the transport's
 full reconnect ladder. OpenClaw therefore treats the retry itself as the only
 evidence and reports an `unavailable` notice rather than a silent block. If the
-fallback target is unavailable, OpenClaw keeps the original refusal even when
-the fallback produced no assistant message.
+fallback target is denied without tool activity, side effects, native
+continuation, or interruption, OpenClaw keeps the original refusal even when
+the fallback produced no assistant message. Otherwise, its result is preserved
+so those facts reach the runner.
 
 Because entitlement belongs to the authenticated workspace and the target model
 rather than to any one conversation, an unauthorized target is remembered once

--- a/extensions/codex/harness.cyber-failover.test.ts
+++ b/extensions/codex/harness.cyber-failover.test.ts
@@ -1,0 +1,154 @@
+import { vi } from "vitest";
+import {
+  buildEmptyToolTelemetry,
+  createParams,
+  createProjector,
+  describe,
+  expect,
+  forCurrentTurn,
+  it,
+  registerCodexEventProjectorTestLifecycle,
+  turnCompleted,
+  TURN_ID,
+} from "./src/app-server/event-projector.test-harness.js";
+import type { runCodexAppServerAttempt } from "./src/app-server/run-attempt.js";
+
+const runAttempt = vi.hoisted(() => vi.fn<typeof runCodexAppServerAttempt>());
+vi.mock("./src/app-server/run-attempt.js", () => ({ runCodexAppServerAttempt: runAttempt }));
+
+import { createCodexAppServerAgentHarness } from "./harness.js";
+import { testCodexAppServerBindingStore } from "./src/app-server/session-binding.test-helpers.js";
+
+registerCodexEventProjectorTestLifecycle();
+
+const PRIMARY = "gpt-5.6-sol";
+const FALLBACK = "gpt-5.6-terra";
+
+type AttemptParams = Awaited<ReturnType<typeof createParams>>;
+
+async function paramsForWorkspace(agentId: string, sessionId: string) {
+  const params = await createParams();
+  return {
+    ...params,
+    agentId,
+    authProfileId: "synthetic-profile",
+    sessionId,
+    modelId: PRIMARY,
+    model: { ...params.model, id: PRIMARY, name: PRIMARY },
+    config: {
+      plugins: {
+        entries: {
+          codex: {
+            config: {
+              appServer: { cyberFailover: { mode: "auto" as const, model: FALLBACK } },
+            },
+          },
+        },
+      },
+    },
+    onAgentEvent: vi.fn(),
+  };
+}
+
+async function failedTurn(params: AttemptParams, message: string, codexErrorInfo: string) {
+  const projector = await createProjector(params);
+  const error = { message, codexErrorInfo };
+  await projector.handleNotification(forCurrentTurn("error", { error, willRetry: false }));
+  await projector.handleNotification(
+    forCurrentTurn("turn/completed", {
+      turn: { id: TURN_ID, status: "failed", items: [], error },
+    }),
+  );
+  return projector.buildResult(buildEmptyToolTelemetry());
+}
+
+async function refusedTurn(params: AttemptParams) {
+  return failedTurn(params, "The provider refused this request.", "cyberPolicy");
+}
+
+describe("Codex fallback terminal results", () => {
+  it.each([401, 403])(
+    "keeps the refusal and avoids repeating a target denied with %i before assistant output",
+    async (status) => {
+      const firstParams = await paramsForWorkspace(`denied-${status}`, "first");
+      const nextParams = await paramsForWorkspace(`denied-${status}`, "next");
+      const refusal = await refusedTurn(firstParams);
+      const nextRefusal = await refusedTurn(nextParams);
+      const denied = await failedTurn(
+        firstParams,
+        `Unexpected status ${status}: configured target is not authorized`,
+        "other",
+      );
+      expect(denied.terminal).toMatchObject({ kind: "failed", source: "prompt" });
+      expect(denied.currentAttemptAssistant).toBeUndefined();
+      expect(denied.lastAssistant).toBeUndefined();
+      firstParams.onAgentEvent.mockClear();
+      nextParams.onAgentEvent.mockClear();
+      runAttempt
+        .mockReset()
+        .mockResolvedValueOnce(refusal)
+        .mockResolvedValueOnce(denied)
+        .mockResolvedValueOnce(nextRefusal)
+        .mockResolvedValue(denied);
+      const harness = createCodexAppServerAgentHarness({
+        bindingStore: testCodexAppServerBindingStore,
+      });
+
+      const firstResult = await harness.runAttempt?.(firstParams);
+      const nextResult = await harness.runAttempt?.(nextParams);
+
+      expect(runAttempt.mock.calls.map(([, options]) => options.runtimeModelId)).toEqual([
+        PRIMARY,
+        FALLBACK,
+        PRIMARY,
+      ]);
+      expect(firstResult).toBe(refusal);
+      expect(nextResult).toBe(nextRefusal);
+      expect(runAttempt.mock.calls[1]?.[0]).toEqual({
+        ...firstParams,
+        suppressNextUserMessagePersistence: true,
+      });
+      for (const params of [firstParams, nextParams]) {
+        expect(params.onAgentEvent).toHaveBeenCalledWith({
+          stream: "notice",
+          data: {
+            phase: "provider_policy",
+            category: "cyber",
+            state: "unavailable",
+            provider: "openai",
+            model: PRIMARY,
+            fallbackModel: FALLBACK,
+          },
+        });
+        expect(params.model.id).toBe(PRIMARY);
+      }
+
+      const otherParams = await paramsForWorkspace(`other-${status}`, "other");
+      const otherRefusal = await refusedTurn(otherParams);
+      const answeredProjector = await createProjector(otherParams);
+      await answeredProjector.handleNotification(
+        turnCompleted([{ type: "agentMessage", id: "reply", text: "Synthetic fallback reply" }]),
+      );
+      const answer = answeredProjector.buildResult(buildEmptyToolTelemetry());
+      otherParams.onAgentEvent.mockClear();
+      runAttempt.mockReset().mockResolvedValueOnce(otherRefusal).mockResolvedValueOnce(answer);
+
+      await expect(harness.runAttempt?.(otherParams)).resolves.toBe(answer);
+      expect(runAttempt.mock.calls.map(([, options]) => options.runtimeModelId)).toEqual([
+        PRIMARY,
+        FALLBACK,
+      ]);
+      expect(otherParams.onAgentEvent).toHaveBeenCalledWith({
+        stream: "notice",
+        data: {
+          phase: "provider_policy",
+          category: "cyber",
+          state: "escalated",
+          provider: "openai",
+          model: PRIMARY,
+          fallbackModel: FALLBACK,
+        },
+      });
+    },
+  );
+});

--- a/extensions/codex/harness.cyber-failover.test.ts
+++ b/extensions/codex/harness.cyber-failover.test.ts
@@ -17,6 +17,7 @@ const runAttempt = vi.hoisted(() => vi.fn<typeof runCodexAppServerAttempt>());
 vi.mock("./src/app-server/run-attempt.js", () => ({ runCodexAppServerAttempt: runAttempt }));
 
 import { createCodexAppServerAgentHarness } from "./harness.js";
+import { attemptTerminal } from "./src/app-server/attempt-terminal.js";
 import { testCodexAppServerBindingStore } from "./src/app-server/session-binding.test-helpers.js";
 
 registerCodexEventProjectorTestLifecycle();
@@ -50,7 +51,12 @@ async function paramsForWorkspace(agentId: string, sessionId: string) {
   };
 }
 
-async function failedTurn(params: AttemptParams, message: string, codexErrorInfo: string) {
+async function failedTurn(
+  params: AttemptParams,
+  message: string,
+  codexErrorInfo: string,
+  telemetry = buildEmptyToolTelemetry(),
+) {
   const projector = await createProjector(params);
   const error = { message, codexErrorInfo };
   await projector.handleNotification(forCurrentTurn("error", { error, willRetry: false }));
@@ -59,7 +65,7 @@ async function failedTurn(params: AttemptParams, message: string, codexErrorInfo
       turn: { id: TURN_ID, status: "failed", items: [], error },
     }),
   );
-  return projector.buildResult(buildEmptyToolTelemetry());
+  return projector.buildResult(telemetry);
 }
 
 async function refusedTurn(params: AttemptParams) {
@@ -67,6 +73,130 @@ async function refusedTurn(params: AttemptParams) {
 }
 
 describe("Codex fallback terminal results", () => {
+  it.each(["message", "spawn", "native continuation", "abort", "timeout"] as const)(
+    "retains a denied fallback's result after a %s",
+    async (effect) => {
+      const params = await paramsForWorkspace(`acted-${effect}`, "first");
+      const refusal = await refusedTurn(params);
+      const telemetry = buildEmptyToolTelemetry();
+      if (effect === "message") {
+        telemetry.didSendViaMessagingTool = true;
+        telemetry.sourceReplyDelivered = true;
+        telemetry.messagingToolSentTexts = ["Synthetic delivered update"];
+      } else if (effect === "spawn") {
+        telemetry.acceptedSessionSpawns = [
+          { runId: "child-run", childSessionKey: "agent:main:subagent:child" },
+        ];
+      }
+      const denied = await failedTurn(
+        params,
+        "Unexpected status 403: forbidden",
+        "other",
+        telemetry,
+      );
+      if (effect === "native continuation") {
+        // The attempt finalizer adds this after the projector computes replay metadata.
+        denied.runtimeContinuationStarted = true;
+      } else if (effect === "abort" || effect === "timeout") {
+        denied.terminal = attemptTerminal.normalize({
+          aborted: true,
+          timedOut: effect === "timeout",
+          promptError: "Unexpected status 403: forbidden",
+          promptErrorSource: "prompt",
+        });
+      }
+      expect(denied.currentAttemptAssistant).toBeUndefined();
+      expect(denied.lastAssistant).toBeUndefined();
+      params.onAgentEvent.mockClear();
+      runAttempt.mockReset().mockResolvedValueOnce(refusal).mockResolvedValueOnce(denied);
+      const harness = createCodexAppServerAgentHarness({
+        bindingStore: testCodexAppServerBindingStore,
+      });
+
+      await expect(harness.runAttempt?.(params)).resolves.toBe(denied);
+      expect(runAttempt).toHaveBeenCalledTimes(2);
+      expect(params.onAgentEvent).toHaveBeenCalledWith({
+        stream: "notice",
+        data: {
+          phase: "provider_policy",
+          category: "cyber",
+          state: "unavailable",
+          provider: "openai",
+          model: PRIMARY,
+          fallbackModel: FALLBACK,
+        },
+      });
+    },
+  );
+
+  it("retains read-only tool progress before a fallback authorization failure", async () => {
+    const params = await paramsForWorkspace("read-only-progress", "first");
+    const refusal = await refusedTurn(params);
+    const projector = await createProjector(params);
+    projector.recordDynamicToolCall({
+      callId: "read-1",
+      tool: "read",
+      arguments: { path: "a.txt" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "read-1",
+      tool: "read",
+      success: true,
+      contentItems: [{ type: "inputText", text: "Synthetic file contents" }],
+    });
+    const error = { message: "Unexpected status 403: forbidden", codexErrorInfo: "other" };
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: { id: TURN_ID, status: "failed", items: [], error },
+      }),
+    );
+    const denied = projector.buildResult(buildEmptyToolTelemetry());
+    expect(denied.replayMetadata?.replaySafe).toBe(true);
+    expect(denied.toolMetas).toHaveLength(1);
+    runAttempt.mockReset().mockResolvedValueOnce(refusal).mockResolvedValueOnce(denied);
+    const harness = createCodexAppServerAgentHarness({
+      bindingStore: testCodexAppServerBindingStore,
+    });
+
+    await expect(harness.runAttempt?.(params)).resolves.toBe(denied);
+    expect(runAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not replay a refused primary after its native continuation started", async () => {
+    const params = await paramsForWorkspace("primary-continuation", "first");
+    const refusal = await refusedTurn(params);
+    refusal.runtimeContinuationStarted = true;
+    expect(refusal.replayMetadata?.replaySafe).toBe(true);
+    runAttempt.mockReset().mockResolvedValue(refusal);
+    const harness = createCodexAppServerAgentHarness({
+      bindingStore: testCodexAppServerBindingStore,
+    });
+
+    await expect(harness.runAttempt?.(params)).resolves.toBe(refusal);
+    expect(runAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["abort", "timeout", "failure"] as const)(
+    "does not replay a primary refusal superseded by %s",
+    async (terminal) => {
+      const params = await paramsForWorkspace(`primary-${terminal}`, "first");
+      const refusal = await refusedTurn(params);
+      refusal.terminal = attemptTerminal.normalize({
+        aborted: terminal === "abort",
+        timedOut: terminal === "timeout",
+        promptError: terminal === "failure" ? "Native connection closed" : undefined,
+        promptErrorSource: "prompt",
+      });
+      runAttempt.mockReset().mockResolvedValue(refusal);
+      const harness = createCodexAppServerAgentHarness({
+        bindingStore: testCodexAppServerBindingStore,
+      });
+
+      await expect(harness.runAttempt?.(params)).resolves.toBe(refusal);
+      expect(runAttempt).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it.each([401, 403])(
     "keeps the refusal and avoids repeating a target denied with %i before assistant output",
     async (status) => {

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -181,7 +181,7 @@ describe("Codex agent harness supports()", () => {
   });
 
   it("uses the attempt-scoped Codex config before the live Gateway config", async () => {
-    runCodexAppServerAttempt.mockResolvedValueOnce({ stopReason: "stop" });
+    runCodexAppServerAttempt.mockResolvedValueOnce({ terminal: { kind: "ok" } });
     const attemptHarness = createCodexAppServerAgentHarness({
       bindingStore: testCodexAppServerBindingStore,
       pluginConfig: { appServer: { homeScope: "agent" } },

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -377,9 +377,17 @@ export function createCodexAppServerAgentHarness(
           fallbackModel: plan.model,
         });
       }
-      // A Daybreak target the workspace cannot use leaves the original refusal
-      // as the honest outcome for this turn.
-      return outcome.unavailable ? result : escalated;
+      // Preserve the fallback's result identity for effects, tool progress, or
+      // interruption; its receipts and continuation ownership must reach the runner.
+      if (
+        outcome.unavailable &&
+        outcome.replaySafe &&
+        escalated.terminal.kind === "failed" &&
+        escalated.toolMetas.length === 0
+      ) {
+        return result;
+      }
+      return escalated;
     },
     runIsolatedCompletionV2: async (params) => {
       if (params.authorization.owner === "host") {

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -846,7 +846,7 @@ describe("codex plugin", () => {
       pluginConfig: { appServer: {} },
       bindingStore: testCodexAppServerBindingStore,
     });
-    const result = { success: true };
+    const result = { terminal: { kind: "ok" as const } };
     runCodexAppServerAttemptMock.mockResolvedValueOnce(result);
 
     await expect(harness.runAttempt({ prompt: "hello" } as never)).resolves.toBe(result);
@@ -912,7 +912,7 @@ describe("codex plugin", () => {
     const harness = mockCallArg(registerAgentHarness) as ReturnType<
       typeof createCodexAppServerAgentHarness
     >;
-    const result = { success: true };
+    const result = { terminal: { kind: "ok" as const } };
     runCodexAppServerAttemptMock.mockResolvedValueOnce(result);
 
     await expect(harness.runAttempt({ prompt: "calendar" } as never)).resolves.toBe(result);

--- a/extensions/codex/src/app-server/cyber-failover.test.ts
+++ b/extensions/codex/src/app-server/cyber-failover.test.ts
@@ -2,6 +2,7 @@
  * Daybreak cyber-failover policy: what may escalate, and for how long a
  * workspace that cannot use the target stops trying.
  */
+import { makeAgentAssistantMessage } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import {
   planCodexCyberEscalation,
@@ -10,6 +11,7 @@ import {
   reserveCodexCyberProbe,
   resolveCodexCyberFailoverConfig,
   type CodexCyberFailoverConfig,
+  type CodexCyberAttemptOutcome,
 } from "./cyber-failover.js";
 
 const DAYBREAK = "gpt-daybreak-blue-latest";
@@ -27,15 +29,24 @@ function config(overrides: Partial<CodexCyberFailoverConfig> = {}): CodexCyberFa
   return { mode: "auto", model: DAYBREAK, cooloffMs: 600_000, ...overrides };
 }
 
-function refusal(category: string, provider = "openai") {
+function outcome(overrides: Partial<CodexCyberAttemptOutcome> = {}): CodexCyberAttemptOutcome {
   return {
-    currentAttemptAssistant: {
-      role: "assistant",
-      stopReason: "error",
-      diagnostics: [{ type: "provider_refusal", details: { provider, category } }],
-    },
-    replayMetadata: { replaySafe: true },
+    terminal: { kind: "ok" },
+    lastAssistant: undefined,
+    replayMetadata: { replaySafe: false, hadPotentialSideEffects: false },
+    ...overrides,
   };
+}
+
+function refusal(category: string, provider = "openai") {
+  return outcome({
+    currentAttemptAssistant: makeAgentAssistantMessage({
+      content: [],
+      stopReason: "error",
+      diagnostics: [{ type: "provider_refusal", timestamp: 0, details: { provider, category } }],
+    }),
+    replayMetadata: { replaySafe: true, hadPotentialSideEffects: false },
+  });
 }
 
 describe("config", () => {
@@ -61,69 +72,72 @@ describe("attempt verdict", () => {
     expect(readCodexCyberAttemptVerdict(refusal("cyber")).cyberRefused).toBe(true);
     expect(readCodexCyberAttemptVerdict(refusal("bio")).cyberRefused).toBe(false);
     expect(readCodexCyberAttemptVerdict(refusal("misalignment")).cyberRefused).toBe(false);
-    // Another provider's cyber refusal must not reroute a prompt to OpenAI's tier.
     expect(readCodexCyberAttemptVerdict(refusal("cyber", "other")).cyberRefused).toBe(false);
-    // A previous turn's row must not escalate an attempt that produced none.
     expect(
-      readCodexCyberAttemptVerdict({
-        lastAssistant: {
-          role: "assistant",
-          diagnostics: [
-            { type: "provider_refusal", details: { provider: "openai", category: "cyber" } },
-          ],
-        },
-      }).cyberRefused,
+      readCodexCyberAttemptVerdict(
+        outcome({ lastAssistant: refusal("cyber").currentAttemptAssistant }),
+      ).cyberRefused,
     ).toBe(false);
     expect(readCodexCyberAttemptVerdict(undefined).cyberRefused).toBe(false);
   });
 
-  it("treats a missing replay verdict as unsafe", () => {
-    expect(readCodexCyberAttemptVerdict({ replayMetadata: { replaySafe: true } }).replaySafe).toBe(
-      true,
-    );
-    expect(readCodexCyberAttemptVerdict({ replayMetadata: { replaySafe: false } }).replaySafe).toBe(
-      false,
-    );
-    expect(readCodexCyberAttemptVerdict({}).replaySafe).toBe(false);
+  it("requires an affirmative replay verdict", () => {
+    expect(
+      readCodexCyberAttemptVerdict(
+        outcome({ replayMetadata: { replaySafe: true, hadPotentialSideEffects: false } }),
+      ).replaySafe,
+    ).toBe(true);
+    expect(readCodexCyberAttemptVerdict(outcome()).replaySafe).toBe(false);
+    expect(readCodexCyberAttemptVerdict(undefined).replaySafe).toBe(false);
   });
 
   it("counts only a real reply as answered", () => {
     expect(
-      readCodexCyberAttemptVerdict({
-        currentAttemptAssistant: { role: "assistant", stopReason: "stop" },
-      }).answered,
+      readCodexCyberAttemptVerdict(
+        outcome({
+          currentAttemptAssistant: makeAgentAssistantMessage({
+            content: [{ type: "text", text: "Reply" }],
+          }),
+        }),
+      ).answered,
     ).toBe(true);
-    // A transport failure is not a reply, even carrying no refusal.
-    expect(readCodexCyberAttemptVerdict({ promptError: "stream disconnected" }).answered).toBe(
-      false,
-    );
     expect(
-      readCodexCyberAttemptVerdict({
-        currentAttemptAssistant: { role: "assistant", stopReason: "aborted" },
-      }).answered,
+      readCodexCyberAttemptVerdict(
+        outcome({ terminal: { kind: "failed", source: "prompt", error: "stream disconnected" } }),
+      ).answered,
     ).toBe(false);
-    // A bio or misalignment refusal is still a refusal, never an answer.
+    expect(
+      readCodexCyberAttemptVerdict(
+        outcome({
+          terminal: { kind: "aborted", source: "runtime" },
+          currentAttemptAssistant: makeAgentAssistantMessage({
+            content: [],
+            stopReason: "aborted",
+          }),
+        }),
+      ).answered,
+    ).toBe(false);
     expect(readCodexCyberAttemptVerdict(refusal("bio")).answered).toBe(false);
-    expect(readCodexCyberAttemptVerdict({}).answered).toBe(false);
+    expect(readCodexCyberAttemptVerdict(outcome()).answered).toBe(false);
   });
 
-  it("reads an unauthorized target from the attempt outcome", () => {
+  it.each([
+    "unexpected status 403 Forbidden: target is not authorized",
+    new Error("unexpected status 401 Unauthorized: not authorized to access this model."),
+  ])("reads an unauthorized target from the canonical terminal", (error) => {
     expect(
-      readCodexCyberAttemptVerdict({
-        currentAttemptAssistant: {
-          role: "assistant",
-          errorMessage: "unexpected status 401 Unauthorized: not authorized to access this model.",
-        },
-      }).unavailable,
+      readCodexCyberAttemptVerdict(
+        outcome({ terminal: { kind: "failed", source: "prompt", error } }),
+      ).unavailable,
     ).toBe(true);
+  });
+
+  it("does not record other terminal failures as target denials", () => {
     expect(
-      readCodexCyberAttemptVerdict({
-        promptError: "unexpected status 403 Forbidden: Cyber access program is not authorized",
-      }).unavailable,
-    ).toBe(true);
-    expect(readCodexCyberAttemptVerdict({ promptError: "stream disconnected" }).unavailable).toBe(
-      false,
-    );
+      readCodexCyberAttemptVerdict(
+        outcome({ terminal: { kind: "failed", source: "prompt", error: "stream disconnected" } }),
+      ).unavailable,
+    ).toBe(false);
   });
 });
 

--- a/extensions/codex/src/app-server/cyber-failover.ts
+++ b/extensions/codex/src/app-server/cyber-failover.ts
@@ -14,6 +14,7 @@
  * remembered per workspace so siblings do not each pay for it.
  */
 
+import { attemptTerminal, type EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { readCodexPluginConfig } from "./config-parsing.js";
 
 export type CodexCyberFailoverConfig = {
@@ -157,24 +158,10 @@ export function planCodexCyberEscalation(params: {
   return { kind: "escalate", model: config.model };
 }
 
-/**
- * Structural view of the attempt outcome this owner reads. The runner's
- * `EmbeddedRunAttemptResult` satisfies it, so callers pass the real result and
- * the compiler still checks these accesses.
- */
-type AttemptMessage = {
-  role?: string;
-  diagnostics?: readonly { type: string; details?: Record<string, unknown> }[];
-  errorMessage?: string;
-  stopReason?: string;
-};
-
-export type CodexCyberAttemptOutcome = {
-  lastAssistant?: AttemptMessage | undefined;
-  currentAttemptAssistant?: AttemptMessage | undefined;
-  promptError?: unknown;
-  replayMetadata?: { replaySafe?: boolean } | undefined;
-};
+export type CodexCyberAttemptOutcome = Pick<
+  EmbeddedRunAttemptResult,
+  "terminal" | "lastAssistant" | "currentAttemptAssistant" | "replayMetadata"
+>;
 
 export type CodexCyberAttemptVerdict = {
   /** OpenAI refused this attempt under its cyber policy. */
@@ -204,7 +191,7 @@ export function readCodexCyberAttemptVerdict(
       d.details?.category === "cyber" &&
       d.details?.provider === "openai",
   );
-  const promptError = result?.promptError;
+  const promptError = result ? attemptTerminal.project(result.terminal).promptError : undefined;
   const failed = promptError !== undefined && promptError !== null;
   // Any refusal category is a refusal, not an answer, so bio and misalignment
   // never look like a successful escalation either.

--- a/extensions/codex/src/app-server/cyber-failover.ts
+++ b/extensions/codex/src/app-server/cyber-failover.ts
@@ -160,7 +160,11 @@ export function planCodexCyberEscalation(params: {
 
 export type CodexCyberAttemptOutcome = Pick<
   EmbeddedRunAttemptResult,
-  "terminal" | "lastAssistant" | "currentAttemptAssistant" | "replayMetadata"
+  | "terminal"
+  | "lastAssistant"
+  | "currentAttemptAssistant"
+  | "replayMetadata"
+  | "runtimeContinuationStarted"
 >;
 
 export type CodexCyberAttemptVerdict = {
@@ -185,12 +189,16 @@ export function readCodexCyberAttemptVerdict(
   // costs nothing and stops an earlier refusal from rerouting a later turn.
   const message = result?.currentAttemptAssistant;
   const refusals = message?.role === "assistant" ? (message.diagnostics ?? []) : [];
-  const cyberRefused = refusals.some(
-    (d) =>
-      d.type === "provider_refusal" &&
-      d.details?.category === "cyber" &&
-      d.details?.provider === "openai",
-  );
+  // Finalization can supersede a refusal with an interruption or failure while
+  // retaining its diagnostic; only an otherwise completed refusal may escalate.
+  const cyberRefused =
+    result?.terminal.kind === "ok" &&
+    refusals.some(
+      (d) =>
+        d.type === "provider_refusal" &&
+        d.details?.category === "cyber" &&
+        d.details?.provider === "openai",
+    );
   const promptError = result ? attemptTerminal.project(result.terminal).promptError : undefined;
   const failed = promptError !== undefined && promptError !== null;
   // Any refusal category is a refusal, not an answer, so bio and misalignment
@@ -210,7 +218,8 @@ export function readCodexCyberAttemptVerdict(
   return {
     cyberRefused,
     // Absence of an explicit safe verdict counts as unsafe.
-    replaySafe: result?.replayMetadata?.replaySafe === true,
+    replaySafe:
+      result?.replayMetadata?.replaySafe === true && result.runtimeContinuationStarted !== true,
     answered,
     unavailable: errorTexts.some((t) => t !== undefined && AUTHORIZATION_FAILURE_RE.test(t)),
   };


### PR DESCRIPTION
## Problem

A configured Codex fallback denied with 401/403 before assistant output could escape unavailable-target classification. The plugin read an obsolete top-level error field while the runner produced a canonical terminal result, so later refused turns repeated the denied target and the unavailable notice was missed.

## Changes

Read failure details through the canonical terminal projection and derive the classifier input type from the runner contract. Preserve the original refusal for an unavailable target only when the fallback has a normal failure, affirmative replay safety, and no tool progress. Otherwise return the entire fallback result so delivery receipts, tool activity, native continuation and interruption reach the outer runner with their original identity.

Native continuation also prevents replaying an already-active primary attempt, and canonical cancellation, timeout or another failure supersedes a retained refusal diagnostic. The workspace cooldown, one-attempt fallback limit, prompt-persistence suppression and stored model selection remain unchanged. Runtime docs describe these outcomes and distinguish the plugin fallback from native retry handling.

## Validation

- Before the original repair, real-projector harness cases for 401 and 403 made four native-attempt calls across two same-workspace refusals instead of three.
- Seven preservation regressions failed before the corrective guard: messaging and accepted-child effects, native continuation, abort, timeout, read-only tool progress, and primary continuation replay. Three additional primary-refusal cases proved that cancellation, timeout or another failure caused an unwanted second attempt; the canonical terminal eligibility check repairs those cases. All 97 focused tests now pass across four files.
- The tests exercise the actual projector, harness, classifier, planner, cache and notices. Native execution is mocked. Continuation and interruption cases inject canonical finalizer-owned result facts at the runner seam; they do not execute live cancellation or the full finalizer.
- Two public-entry tests used obsolete success-only result fixtures; both reproduced the missing-terminal error and pass with canonical terminal fixtures.
- The existing separate-workspace case verifies a successful fallback remains eligible. Tests also check notice emission, original-result identity for a simple denial, prompt persistence and unchanged model selection.
- The full changed-code gate passed, including both extension typechecks, lint, dependency and storage guards, dead-code scans, and zero runtime import cycles. Fresh independent review is clean through P2.
- [Final-head CI](https://github.com/openclaw/openclaw/actions/runs/34632038851) passed. The [first Linux job](https://github.com/openclaw/openclaw/actions/runs/34632038851/job/103371204420) and [second Linux job](https://github.com/openclaw/openclaw/actions/runs/34632038851/job/103371204447) executed all 97 focused cases on Ubuntu 24.04.3 / Node 24.19.0. All seven PR file blobs match between the head and the executed CI merge.
- Two standalone remote leases failed during setup before dispatching their test commands; both were stopped and their workflows are cancelled. Those attempts remain failures and are not counted as passing proof.

Native source was inspected for the failed-turn and refusal contracts. Installed binary parity, live entitlement, reconnect latency and real model execution were not verified. General multi-attempt usage aggregation is an existing limitation outside this change. No configuration defaults, schema, dependencies or additional retries are introduced.
