### PR TITLE
fix(ui): keep sidebar tab menus visible over an open Browser

### DIFF
--- a/ui/src/components/menu-surface.ts
+++ b/ui/src/components/menu-surface.ts
@@ -1,40 +1,4 @@
-import { hasNativeBrowserBridge } from "../app/native-browser-host.ts";
-import { acquireNativeOverlayOcclusion } from "../lib/native-overlay-occlusion.ts";
-
-const occludingSurfaces = new WeakSet<HTMLElement>();
-
-function occludeNativeBrowser(element: HTMLElement) {
-  if (!hasNativeBrowserBridge() || !element.isConnected || occludingSurfaces.has(element)) {
-    return;
-  }
-  const release = acquireNativeOverlayOcclusion();
-  const observer = new MutationObserver(() => {
-    if (!element.isConnected) {
-      cleanup();
-    }
-  });
-  const onToggle = (event: ToggleEvent) => {
-    if (event.target === element && event.newState === "closed") {
-      cleanup();
-    }
-  };
-  const cleanup = () => {
-    observer.disconnect();
-    element.removeEventListener("toggle", onToggle);
-    occludingSurfaces.delete(element);
-    release();
-  };
-  occludingSurfaces.add(element);
-  element.addEventListener("toggle", onToggle);
-  // Observe every containing root: document observers cannot see shadow-tree
-  // removals, and an outer host can itself be removed while its tree stays intact.
-  let root = element.getRootNode();
-  observer.observe(root, { childList: true, subtree: true });
-  while (root instanceof ShadowRoot) {
-    root = root.host.getRootNode();
-    observer.observe(root, { childList: true, subtree: true });
-  }
-}
+import { occludeNativeBrowserSurface } from "../lib/native-overlay-occlusion.ts";
 
 /**
  * Promotes a connected element into the browser popover top layer so transient
@@ -43,7 +7,7 @@ function occludeNativeBrowser(element: HTMLElement) {
  * in-flow rendering when the Popover API is unavailable (older engines, jsdom).
  */
 export function promoteToPopoverTopLayer(element: HTMLElement) {
-  occludeNativeBrowser(element);
+  occludeNativeBrowserSurface(element);
   element.setAttribute("popover", "manual");
   if (typeof element.showPopover === "function") {
     try {

--- a/ui/src/components/web-awesome-dropdown.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown.browser.test.ts
@@ -76,12 +76,13 @@ async function reopen(f: Fixture) {
 }
 
 async function closed(f: Fixture) {
-  await expect.poll(() => f.popup.active).toBe(false);
+  // A canceled opening starts with an inactive popup before its close settles.
+  await expect
+    .poll(() => f.events.filter((event) => event.type === "wa-after-hide"))
+    .toEqual([{ type: "wa-after-hide", open: false, connected: true }]);
+  expect(f.popup.active).toBe(false);
   expect(f.dropdown.open).toBe(false);
   expect(f.menu.getAnimations()).toHaveLength(0);
-  expect(f.events.filter((event) => event.type === "wa-after-hide")).toEqual([
-    { type: "wa-after-hide", open: false, connected: true },
-  ]);
 }
 
 function observeNativeOcclusion(native = true) {

--- a/ui/src/components/web-awesome-dropdown.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown.browser.test.ts
@@ -1,5 +1,9 @@
 import type { WaSelectEvent } from "@awesome.me/webawesome/dist/events/select.js";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import {
+  acquireNativeOverlayOcclusion,
+  subscribeNativeOverlayOcclusion,
+} from "../lib/native-overlay-occlusion.ts";
 import { duringElementAnimation } from "../test-helpers/web-awesome-animation.ts";
 import "@awesome.me/webawesome/dist/styles/themes/default.css";
 import "@awesome.me/webawesome/dist/components/popover/popover.js";
@@ -80,9 +84,128 @@ async function closed(f: Fixture) {
   ]);
 }
 
-afterEach(() => document.body.replaceChildren());
+function observeNativeOcclusion(native = true) {
+  vi.stubGlobal(
+    "webkit",
+    native ? { messageHandlers: { openclawBrowser: { postMessage: vi.fn() } } } : undefined,
+  );
+  const states: boolean[] = [];
+  onTestFinished(subscribeNativeOverlayOcclusion((occluded) => states.push(occluded)));
+  return states;
+}
+
+afterEach(async () => {
+  document.body.replaceChildren();
+  // Let removal observers retire native leases before restoring the host bridge.
+  await Promise.resolve();
+  vi.unstubAllGlobals();
+});
 
 describe.runIf(browserMode)("Web Awesome dropdown lifecycle", () => {
+  it("occludes native browser views from trigger opening through the complete hide animation", async () => {
+    const { page } = await import("vitest/browser");
+    const states = observeNativeOcclusion();
+    const f = await fixture();
+    await page.elementLocator(f.trigger).click();
+    await expect.poll(() => count(f, "wa-after-show")).toBe(1);
+    expect(states).toEqual([false, true]);
+    await duringElementAnimation(
+      f.menu,
+      "hide",
+      () => page.elementLocator(f.trigger).click(),
+      () => {
+        expect(count(f, "wa-after-hide")).toBe(0);
+        expect(states).toEqual([false, true]);
+      },
+    );
+    await closed(f);
+    expect(states).toEqual([false, true, false]);
+  });
+
+  it("respects canceled show and hide events without releasing native occlusion on a fast reopen", async () => {
+    const { page } = await import("vitest/browser");
+    const states = observeNativeOcclusion();
+    const f = await fixture();
+    // Cancel after the shared document listener has seen the opening event.
+    document.addEventListener("wa-show", (event) => event.preventDefault(), { once: true });
+    await page.elementLocator(f.trigger).click();
+    await expect.poll(() => count(f, "wa-show")).toBe(1);
+    await closed(f);
+    expect(states).toEqual([false]);
+    // The canceled opening has its own settled close, separate from the reopen below.
+    f.events.length = 0;
+    await page.elementLocator(f.trigger).click();
+    await expect.poll(() => count(f, "wa-after-show")).toBe(1);
+    expect(states).toEqual([false, true]);
+    document.addEventListener("wa-hide", (event) => event.preventDefault(), { once: true });
+    await page.elementLocator(f.trigger).click();
+    await expect.poll(() => f.dropdown.open).toBe(true);
+    await frame();
+    expect(states).toEqual([false, true]);
+    await duringAnimation(f, "hide", () => {
+      f.dropdown.open = true;
+    });
+    await expect.poll(() => count(f, "wa-after-show")).toBe(2);
+    expect(count(f, "wa-after-hide")).toBe(0);
+    expect(states).toEqual([false, true]);
+    f.dropdown.open = false;
+    await closed(f);
+    expect(states).toEqual([false, true, false]);
+  });
+
+  it("keeps the native browser occluded when another overlay outlives the dropdown", async () => {
+    const states = observeNativeOcclusion();
+    const f = await fixture();
+    await open(f);
+    expect(states).toEqual([false, true]);
+    const releaseModal = acquireNativeOverlayOcclusion();
+    onTestFinished(releaseModal);
+    f.dropdown.open = false;
+    await closed(f);
+    expect(states).toEqual([false, true]);
+    releaseModal();
+    expect(states).toEqual([false, true, false]);
+  });
+
+  it("releases and reacquires native occlusion when containing shadow hosts are removed and reconnected", async () => {
+    const states = observeNativeOcclusion();
+    const f = await fixture();
+    const outer = document.createElement("div");
+    const root = outer.attachShadow({ mode: "open" });
+    const inner = document.createElement("div");
+    inner.attachShadow({ mode: "open" }).append(f.host);
+    root.append(inner);
+    document.body.append(outer);
+    await open(f);
+    expect(states).toEqual([false, true]);
+    // Removing inside a shadow root is invisible to a document-only observer.
+    inner.remove();
+    await expect.poll(() => states).toEqual([false, true, false]);
+    root.append(inner);
+    await expect.poll(() => count(f, "wa-after-show")).toBe(2);
+    expect(states).toEqual([false, true, false, true]);
+    // Removing the outer host leaves both inner shadow trees intact.
+    outer.remove();
+    await expect.poll(() => states).toEqual([false, true, false, true, false]);
+    document.body.append(outer);
+    await expect.poll(() => count(f, "wa-after-show")).toBe(3);
+    expect(states).toEqual([false, true, false, true, false, true]);
+    f.dropdown.open = false;
+    await closed(f);
+    expect(states).toEqual([false, true, false, true, false, true, false]);
+  });
+
+  it("keeps ordinary web dropdowns functional without a native browser bridge", async () => {
+    const { page } = await import("vitest/browser");
+    const states = observeNativeOcclusion(false);
+    const f = await fixture();
+    await page.elementLocator(f.trigger).click();
+    await expect.poll(() => count(f, "wa-after-show")).toBe(1);
+    await page.elementLocator(f.outside).click();
+    await closed(f);
+    expect(states).toEqual([false]);
+  });
+
   it.each(["Escape", "pointer", "Tab"] as const)(
     "reacquires %s dismissal after an observed hide/reopen",
     async (dismissal) => {

--- a/ui/src/components/web-awesome.ts
+++ b/ui/src/components/web-awesome.ts
@@ -2,6 +2,7 @@
 // surface-specific registrars so route-only controls stay out of startup.
 import "@awesome.me/webawesome/dist/components/dropdown/dropdown.js";
 import "@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js";
+import { occludeNativeBrowserSurface } from "../lib/native-overlay-occlusion.ts";
 
 const keyboardDismissedDropdowns = new WeakSet<EventTarget>();
 
@@ -112,6 +113,14 @@ function startDropdownLabelSync(event: Event) {
   if (!(dropdown instanceof HTMLElement) || dropdown.localName !== "wa-dropdown") {
     return;
   }
+  // Native NSViews also cover browser top-layer popovers. Wait for all show
+  // listeners to accept opening; retain occlusion through the hide animation.
+  queueMicrotask(() => {
+    // SAFETY: The registered wa-dropdown host exposes its boolean open property.
+    if (!event.defaultPrevented && (dropdown as HTMLElement & { open: boolean }).open) {
+      occludeNativeBrowserSurface(dropdown, "wa-after-hide");
+    }
+  });
   // Reopening must restore the menu before Web Awesome moves focus into it.
   dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]')?.removeAttribute("inert");
   labelDropdownMenu(dropdown);

--- a/ui/src/lib/native-overlay-occlusion.ts
+++ b/ui/src/lib/native-overlay-occlusion.ts
@@ -42,3 +42,46 @@ export function subscribeNativeOverlayOcclusion(listener: (occluded: boolean) =>
     listeners.delete(listener);
   };
 }
+
+const occludingSurfaces = new WeakSet<HTMLElement>();
+
+/** Keep a connected menu above native views through closing and owner removal. */
+export function occludeNativeBrowserSurface(
+  element: HTMLElement,
+  closeEvent: "toggle" | "wa-after-hide" = "toggle",
+) {
+  if (!hasNativeBrowserBridge() || !element.isConnected || occludingSurfaces.has(element)) {
+    return;
+  }
+  const release = acquireNativeOverlayOcclusion();
+  const observer = new MutationObserver(() => {
+    if (!element.isConnected) {
+      cleanup();
+    }
+  });
+  const onClose = (event: Event) => {
+    if (
+      event.target === element &&
+      // SAFETY: The toggle branch receives the Popover API event with newState.
+      (closeEvent !== "toggle" || (event as ToggleEvent).newState === "closed")
+    ) {
+      cleanup();
+    }
+  };
+  const cleanup = () => {
+    observer.disconnect();
+    element.removeEventListener(closeEvent, onClose);
+    occludingSurfaces.delete(element);
+    release();
+  };
+  occludingSurfaces.add(element);
+  element.addEventListener(closeEvent, onClose);
+  // Observe every containing root: document observers cannot see shadow-tree
+  // removals, and an outer host can itself be removed while its tree stays intact.
+  let root = element.getRootNode();
+  observer.observe(root, { childList: true, subtree: true });
+  while (root instanceof ShadowRoot) {
+    root = root.host.getRootNode();
+    observer.observe(root, { childList: true, subtree: true });
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users adding a sidebar tab would find the lower menu options covered when a native Browser tab was already open.

## Why This Change Was Made

Web Awesome dropdowns already use the HTML top layer, but native WKWebViews sit above it. Connect accepted dropdown openings to the existing native-overlay occlusion owner, sharing the lifecycle cleanup already used by other menu surfaces. Keep the Browser hidden through the closing animation, then restore it; removing the menu or its owner also releases the lease. No CSS z-index escalation, native code changes, or page reloads.

## User Impact

All add-tab options remain visible and selectable over an open Browser page. Closing the menu restores the same page. The shared adapter also protects sibling dropdowns; ordinary web-only behavior is unchanged.

## Evidence

Baseline `c06f21ddfad`; candidate `715acb787ac6dbb07feb78e3090f11163e838bc8`.

| Before | After |
| --- | --- |
| ![Native Browser covers lower options](https://github.com/user-attachments/assets/1dc42535-36b0-4f81-8906-364dca0a22a1) | ![All menu options visible](https://github.com/user-attachments/assets/0ab5c9e9-dee4-4fc2-851f-97faf61d7eb6) |

[Escape restores the same Browser page](https://github.com/user-attachments/assets/d1e20b90-f618-4649-b8c5-bb93e0810096).

- **Real native proof:** disposable macOS VM, real Control UI and production Browser host/tab/decoder with an isolated minimal AppKit window/bridge shell; synthetic Gateway data. No native-overlay simulation. Identical 480×500 sidebar crops from a 1440×811 dashboard; unrelated desktop/consent UI excluded. DOM click handlers and dispatched Escape, not hardware input or full-app end-to-end proof.
- Baseline menu leaves `present.visible=true` / `WKWebView.isHidden=false`; candidate sets `false` / `true`. Escape restores the same tab id/URL. Previously covered Side chat selection and Browser reselection verified.
- Actual UI flow at **1440×900 and 390×844** with synthetic native bridge: open menu → Escape → reopen → select Browser → new native tab and restored presentation. Original baseline assertion fails.
- **118 focused tests pass:** 33 real-browser dropdown lifecycle tests and 85 unit tests. Four new native regression cases fail on baseline. Coverage includes animation, canceled show/hide, rapid reopen, overlapping overlays, shadow-host removal/reconnect, and no-native behavior.
- Full selected `check-changed` lane passes (exit 0), including core test typechecks, UI i18n, guards, lint/styles, and dead exports.
- UI production/test typechecks, UI production build/budgets, formatting, targeted lint, and unused-export checks pass. Fresh independent source review: no P0/P1/P2 findings. Autoreview was attempted but its engine exited without a report; not counted as clean.

Native empty/loading/content-heavy page bodies do not affect this menu lease, so duplicate native captures are N/A. Native desktop has no mobile surface; the narrow web flow is verified separately. No full native test-suite result is claimed. Production app/Gateway untouched; disposable proof VM stopped.

### Landing status

Rebased onto `58a6953549d` after #145102 repaired the pre-existing daemon-install max-lines failure. Final head: `8e1e492b1400e3492d7ad7d18b623b59110ba303`. The three changed production files are byte-identical to the native-proof candidate above; the only follow-up is a test helper waiting for `wa-after-hide` instead of treating an initially inactive popup as completed closing after canceled opening. All event/state/animation assertions are preserved.

Post-refresh validation: all 33 dropdown browser tests, UI test typecheck, affected-test lint/format, repaired daemon-install lint, and diff checks pass. Fresh independent review of the test-wait correction found no actionable issues. Required exact-head CI passed, including `openclaw/ci-gate`; ClawSweeper reviewed the final head with no actionable findings. Auto-merged into main on 2026-09-11 at 18:11:28 UTC as [`ebb7cb266fb6`](https://github.com/openclaw/openclaw/commit/ebb7cb266fb6ab0a054399b72f980b4cffa17447). All four changed files match the landed commit exactly. No production deployment or restart was performed.

