### PR TITLE
fix(tasks): explain when completion wins cancellation

### DIFF
--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -25,6 +25,7 @@ import {
   markTaskTerminalById,
   recordTaskProgressByRunId,
 } from "../../tasks/runtime-internal.js";
+import { updateTaskStateByRunId } from "../../tasks/task-registry-record-api.js";
 import { reloadTaskRegistryFromStore } from "../../tasks/task-registry.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import {
@@ -905,6 +906,52 @@ describe("tasks gateway handlers", () => {
     expect(payload?.task?.status).toBe("running");
     expect(payload?.task?.error).toBeUndefined();
   });
+
+  it.each([
+    ["succeeded", "completed"],
+    ["failed", "failed"],
+    ["timed_out", "timed_out"],
+    ["lost", "failed"],
+    ["cancelled", "cancelled"],
+  ] as const)(
+    "tasks.cancel preserves ACP %s and explains refused cancellation",
+    async (status, wireStatus) => {
+      const runId = "run-acp-cancel-race";
+      const task = createSnapshotTask({
+        runtime: "acp",
+        runId,
+        notifyPolicy: "silent",
+        childSessionKey: "agent:main:acp:cancel-race",
+        agentId: "main",
+      });
+      seedTaskRegistryRowsForTests([task]);
+      reloadTaskRegistryFromStore();
+      cancelSessionMock.mockImplementationOnce(async () => {
+        updateTaskStateByRunId({
+          runId,
+          runtime: "acp",
+          sessionKey: task.childSessionKey,
+          status,
+          endedAt: 2_000,
+        });
+      });
+
+      const { calls, payload } = await runTaskHandler("tasks.cancel", { taskId: task.taskId });
+
+      expect(calls[0]?.[0]).toBe(true);
+      expect(payload).toMatchObject({ found: true, cancelled: status === "cancelled" });
+      if (status === "cancelled") {
+        expect(payload).not.toHaveProperty("reason");
+      } else {
+        expect(payload).toHaveProperty(
+          "reason",
+          `Task became ${status} while cancellation was in progress.`,
+        );
+      }
+      expect(payload?.task).toMatchObject({ id: task.taskId, status: wireStatus, endedAt: 2_000 });
+      expect(getTaskById(task.taskId)).toMatchObject({ status, endedAt: 2_000 });
+    },
+  );
 
   it("cancels ACP tasks through the live Gateway handler and control runtime", async () => {
     const task = createSnapshotTask({

--- a/src/tasks/task-registry-cancel.ts
+++ b/src/tasks/task-registry-cancel.ts
@@ -177,11 +177,9 @@ export async function cancelTaskById(params: {
         // The run owns terminal outcomes published while backend cancellation waits.
         const current = tasks.get(task.taskId);
         if (current && isTerminalTaskStatus(current.status)) {
-          return {
-            found: true,
-            cancelled: current.status === "cancelled",
-            task: cloneTaskRecord(current),
-          };
+          return current.status === "cancelled"
+            ? { found: true, cancelled: true, task: cloneTaskRecord(current) }
+            : notCancelled(`Task became ${current.status} while cancellation was in progress.`);
         }
       } else if (task.runtime === "subagent") {
         const { killSubagentRunAdmin } = await loadTaskRegistryControlRuntime();

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -4738,7 +4738,14 @@ describe("task-registry", () => {
 
         const result = await cancelTask(task.taskId);
 
-        expectRecordFields(result, { found: true, cancelled: status === "cancelled" });
+        expectRecordFields(result, {
+          found: true,
+          cancelled: status === "cancelled",
+          reason:
+            status === "cancelled"
+              ? undefined
+              : `Task became ${status} while cancellation was in progress.`,
+        });
         for (const record of [result.task, getTaskById(task.taskId)]) {
           expectRecordFields(record, {
             status,


### PR DESCRIPTION
## What Problem This Solves

Cancelling a background task could report only “Could not cancel task” when the task finished while cancellation was pending.

## Why This Change Was Made

Terminal reconciliation now uses the existing refusal helper to include the recorded outcome. This completes the result contract introduced in #144949 without changing stored status, timestamps, or successful cancellation.

## User Impact

The CLI, Gateway, subagents tool, and Tasks page explain why cancellation did not occur. Existing exit codes and completed task presentation remain unchanged.

## Evidence

Real Gateway, CLI, and registered subagents cancellation flows reproduced missing reasons before the fix and passed afterward. Browser captures cover both completion and cancellation winning the race. Registered Gateway tests passed 37 cases, task-registry tests 159, and cancellation-manager tests five. Chat task-panel presentation remains unverified; Workboard does not display the reason.

Consumers: cancellation responses now include the terminal-outcome reason for CLI, Gateway, subagents, and Tasks page users.

Related: #144949. Thanks @Gabrielnkl for the original cancellation-race work.
