### PR TITLE
fix: restore core lint for daemon install tests

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -31,14 +31,7 @@ const hasConfiguredSecretInputMock = vi.hoisted(() =>
     return resolveSecretInputRefMock(value)?.ref != null;
   }),
 );
-const resolveGatewayAuthMock = vi.hoisted(() =>
-  vi.fn<() => ResolvedGatewayAuth>(() => ({
-    mode: "token",
-    token: undefined,
-    password: undefined,
-    allowTailscale: false,
-  })),
-);
+const resolveGatewayAuthMock = vi.hoisted(() => vi.fn<() => ResolvedGatewayAuth>());
 const resolveGatewayBindHostMock = vi.hoisted(() => vi.fn(async () => "127.0.0.1"));
 const resolveSecretRefValuesMock = vi.hoisted(() => vi.fn());
 const randomTokenMock = vi.hoisted(() => vi.fn(() => "generated-token"));


### PR DESCRIPTION
Related: #145106

## What Problem This Solves

Resolves a problem where core lint rejects otherwise unrelated PRs because the daemon-install test exceeds its existing 1,000-line limit by one line.

## Why This Change Was Made

Remove the duplicated initial auth-mock implementation. The suite's `beforeEach` already resets the mock and supplies the same defaults before every case. All test scenarios and assertions remain unchanged; the test falls from 1,001 to 994 counted lines without changing the lint policy.

## User Impact

Restores the affected CI gate. No production behavior changes.

## Evidence

- Reproduced the exact original `eslint(max-lines)` failure and verified focused lint passes after the cleanup.
- Complete daemon-install suite: 42 passing cases before and after, with identical ordered case names and results on Node 24.19.
- Inverse-source comparison verifies every byte outside the one declaration is unchanged.
- Full mapped `check:changed` gate and independent P2 review passed.
