### PR TITLE
fix(gateway): cancel dashboard preparation during shutdown

### DIFF
--- a/src/gateway/server-control-ui-root.resolve.test.ts
+++ b/src/gateway/server-control-ui-root.resolve.test.ts
@@ -1,6 +1,13 @@
 /** Tests the Gateway-owned Control UI root and background asset lifecycle. */
 import fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  getActiveGatewayRootWorkCount,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+  runWithGatewayIndependentRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
 
 const controlUiAssetsMocks = vi.hoisted(() => ({
   ensureControlUiAssetsBuilt: vi.fn(),
@@ -128,6 +135,65 @@ describe("createGatewayControlUiRootLifecycle", () => {
 
     expect(warn).not.toHaveBeenCalled();
   });
+
+  test.each(["retention", "build"] as const)(
+    "cancels %s during Gateway drain while retaining its cleanup root across generations",
+    async (phase) => {
+      if (phase === "retention") {
+        controlUiAssetsMocks.resolveControlUiRootSync.mockReturnValue("/repo/dist/control-ui");
+        controlUiAssetsMocks.isPackageProvenControlUiRootSync.mockReturnValue(true);
+      }
+      const { lifecycle, warn } = createLifecycle();
+      const rootReference = lifecycle.state;
+      try {
+        for (let generation = 0; generation < 2; generation++) {
+          resetGatewayWorkAdmission();
+          const cleanup = createDeferred();
+          let preparationSignal: AbortSignal | undefined;
+          const prepare = async (signal: AbortSignal | undefined) => {
+            preparationSignal = signal;
+            await cleanup.promise;
+            signal?.throwIfAborted();
+          };
+          if (phase === "retention") {
+            retentionMocks.prepare.mockImplementationOnce((options) => prepare(options?.signal));
+          } else {
+            controlUiAssetsMocks.ensureControlUiAssetsBuilt.mockImplementationOnce(
+              async (_runtime, options) => {
+                await prepare(options.signal);
+                return { ok: true, built: true, assets: readyAssets() };
+              },
+            );
+          }
+          const work = runWithGatewayIndependentRootWorkAdmission(
+            lifecycle.start,
+            "startup:sidecars.control-ui-assets",
+          );
+          try {
+            await vi.waitFor(() => expect(preparationSignal).toBeDefined());
+            expect(preparationSignal?.aborted).toBe(false);
+            expect(getActiveGatewayRootWorkCount()).toBe(1);
+            markGatewayRestartDraining();
+            expect(preparationSignal?.aborted).toBe(true);
+            await new Promise<void>((resolve) => {
+              setImmediate(resolve);
+            });
+            expect(getActiveGatewayRootWorkCount()).toBe(1);
+          } finally {
+            cleanup.resolve();
+            await work;
+          }
+          expect(getActiveGatewayRootWorkCount()).toBe(0);
+          expect(lifecycle.state).toBe(rootReference);
+          expect(lifecycle.state.kind).toBe(phase === "retention" ? "bundled" : "preparing");
+          expect(warn).not.toHaveBeenCalled();
+        }
+      } finally {
+        await lifecycle.stop();
+        resetGatewayWorkAdmission();
+      }
+    },
+  );
 
   test("rebuilds incomplete auto-discovered roots before publishing them", async () => {
     controlUiAssetsMocks.resolveControlUiRootSync.mockReturnValue("/repo/dist/control-ui");

--- a/src/gateway/server-control-ui-root.ts
+++ b/src/gateway/server-control-ui-root.ts
@@ -8,7 +8,10 @@ import {
   resolveControlUiRootOverrideSync,
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
-import { runOutsideGatewayRootWorkAdmission } from "../process/gateway-work-admission.js";
+import {
+  getGatewayRestartDrainSignal,
+  runOutsideGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveRuntimeServiceBuildId } from "../version.js";
 import { createControlUiAssetRetention } from "./control-ui-asset-retention.js";
@@ -178,8 +181,11 @@ export function createGatewayControlUiRootLifecycle(
         : preparation.promise;
     }
     const controller = new AbortController();
+    // Root drain precedes sidecar.stop; cancel preparation before that wait.
+    // Capture the current generation on each start, including re-enabled dashboards.
+    const signal = AbortSignal.any([controller.signal, getGatewayRestartDrainSignal()]);
     const promise = runOutsideGatewayRootWorkAdmission(() =>
-      Promise.resolve().then(() => prepare(controller.signal)),
+      Promise.resolve().then(() => prepare(signal)),
     ).finally(() => {
       preparation = undefined;
     });


### PR DESCRIPTION
Related: #144252

## What Problem This Solves

Fixes an issue where stopping a Gateway soon after startup could wait for background dashboard asset preparation before reaching the cleanup that cancels it. On a busy host this could exceed the process supervisor’s shutdown grace period.

## Why This Change Was Made

Each Control UI preparation now observes the current Gateway drain signal alongside its existing stop/disable signal. The Gateway still counts and awaits cleanup; a later preparation captures its own drain generation.

## User Impact

Shutdown cancels unfinished dashboard builds and asset retention instead of waiting for that background work to finish normally. Existing cancellation, publication fencing, and dashboard re-enablement remain intact.

## Evidence

Both build and retention regressions fail on the original owner. The candidate passes 35 lifecycle, serving-identity, and real-retention tests, plus the selected type, lint, and repository checks. Independent Codex review completed scoped-clean through P2.

Real filesystem integration on this main-based candidate interrupted a copy after 6.1 MiB: cleanup left zero admitted roots, no staging directory or late publication, and no warnings. A fresh generation then retained and hash-verified two assets totaling 80 MiB. The process exited naturally and all synthetic fixtures were removed. This exercises the actual source owner and filesystem, not a compiled full-Gateway run.

The original investigation’s three native scenarios served plugin RPCs and health successfully but exceeded their unchanged ten-second shutdown grace. An observation-only replay identified this asset-preparation root and later exited naturally; those earlier failures remain qualified evidence rather than passing candidate runs.

Production grows by six lines to compose the existing cancellation signals; tests grow by 66. No configuration, schema, or timeout changes.

Exact-head required CI passed on `ac36b193` in [run 34630743135, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34630743135). Attempt 1 timed out in the unchanged profiler CLI help test; its single retry passed without changing the test or timeout. Follow-up: investigate the profiler-help startup hang if it recurs; its cause remains unattributed.
