### PR TITLE
fix: hide dismissed snapshot builds when refresh fails

### DIFF
--- a/ui/src/pages/cloud-workers/cloud-worker-snapshot-builds.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-snapshot-builds.test.ts
@@ -520,11 +520,23 @@ describe("Snapshot builds", () => {
     }
   });
 
-  it("dismisses a failed build the Gateway still records and keeps it hidden on refresh", async () => {
+  it("dismisses a failed build before refresh finishes and keeps it hidden after refresh fails", async () => {
     const environments = [buildFixture("failed", "Gateway is only bound to loopback")];
+    const destruction = deferred<Record<string, never>>();
+    const refresh = deferred<{ environments: typeof environments }>();
+    let refreshPending = false;
     const fixture = mountPage(buildMethods, {
       result: { ...snapshotListFixture(), images: [] },
-      response: (method) => (method === "environments.list" ? { environments } : undefined),
+      response: (method) => {
+        if (method === "environments.list") {
+          return refreshPending ? refresh.promise : { environments };
+        }
+        if (method === "environments.destroy") {
+          refreshPending = true;
+          return destruction.promise;
+        }
+        return undefined;
+      },
     });
     try {
       const snapshots = await openSnapshots(fixture);
@@ -533,16 +545,28 @@ describe("Snapshot builds", () => {
       );
       expect(snapshots.querySelectorAll(".settings-summary dd")[3]?.textContent).toBe("1");
       button(snapshots, "Dismiss").click();
+      await waitForFast(() =>
+        expect(fixture.request).toHaveBeenCalledWith("environments.destroy", {
+          environmentId: "build-app",
+        }),
+      );
+      expect(snapshots.textContent).toContain("build-app");
+      expect(snapshots.querySelectorAll(".settings-summary dd")[3]?.textContent).toBe("1");
+      destruction.resolve({});
       await waitForFast(() => expect(snapshots.textContent).toContain("Failed build dismissed"));
       expect(vi.mocked(showConfirmDialog)).toHaveBeenCalledWith(
         expect.objectContaining({ title: "Dismiss failed build", details: "build-app" }),
       );
-      expect(fixture.request).toHaveBeenCalledWith("environments.destroy", {
-        environmentId: "build-app",
-      });
+      expect(snapshots.textContent).not.toContain("build-app");
+      expect(snapshots.querySelectorAll(".settings-summary dd")[3]?.textContent).toBe("0");
+      refresh.reject(new Error("Build inventory is unavailable"));
+      await waitForFast(() =>
+        expect(snapshots.textContent).toContain("Build inventory is unavailable"),
+      );
       expect(snapshots.textContent).not.toContain("build-app");
       expect(snapshots.querySelectorAll(".settings-summary dd")[3]?.textContent).toBe("0");
       // The Gateway keeps terminal build records until retention; the row must stay cleared.
+      refreshPending = false;
       const listed = fixture.request.mock.calls.filter(
         ([method]) => method === "environments.list",
       ).length;
@@ -554,6 +578,8 @@ describe("Snapshot builds", () => {
       );
       expect(snapshots.textContent).not.toContain("build-app");
     } finally {
+      destruction.resolve({});
+      refresh.resolve({ environments });
       fixture.dispose();
     }
   });

--- a/ui/src/pages/cloud-workers/cloud-worker-snapshots.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-snapshots.ts
@@ -308,6 +308,7 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
         // clearing the row is a local view decision that lasts until this page reloads.
         if (dismiss) {
           this.dismissed.add(environment.id);
+          this.failedBuilds = this.failedBuilds.filter((build) => build.id !== environment.id);
         }
         this.notice = t(
           `cloudWorkersPage.snapshots.${dismiss ? "buildDismissed" : "buildCancelled"}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users dismissing a failed build in **Settings → Cloud workers → Snapshots** would still see its row and an unchanged **Needs attention** count when the follow-up inventory refresh stalled or failed, despite the success confirmation.

## Why This Change Was Made

Update the page's displayed failed-build list as soon as confirmed destruction succeeds. The existing dismissal set keeps the row hidden on later refreshes; Gateway record retention remains unchanged.

## User Impact

Dismissed builds disappear immediately, while inventory refresh errors remain visible. Pending or failed destruction still leaves the build available for retry.

## Evidence

The strengthened mounted-page regression failed before the fix; all 34 related page and snapshot tests pass afterward. It covers pending destruction, pending and rejected refresh, and a later successful refresh that still returns the retained build record.

Real Chromium with synthetic data and a mocked Gateway performed one confirmed dismissal per run. Before the fix, the row remained both while refresh was pending and after it failed; afterward it was absent in both states. Neither run produced a page error. The captures below show the failed-refresh state, with both the success confirmation and inventory error preserved.

| Before | After |
| --- | --- |
| ![Dismissal confirmation with the failed build still visible](https://github.com/user-attachments/assets/a39463af-1285-4715-a303-f53aed826d5c) | ![Dismissed build removed while the refresh error remains visible](https://github.com/user-attachments/assets/e77bf59e-8c0a-492e-8311-0708910fdc0d) |

Canonical changed-file checks and the UI production build pass.
Independent managed review completed without actionable findings.
