### PR TITLE
refactor(goals): simplify goal state handling

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1977,7 +1977,7 @@ src/agents/tools/dashboard-tool.ts	2
 src/agents/tools/embedded-gateway-stub.ts	7
 src/agents/tools/gateway-tool.ts	5
 src/agents/tools/gateway.ts	1
-src/agents/tools/goal-tools.ts	4
+src/agents/tools/goal-tools.ts	2
 src/agents/tools/heartbeat-response-tool.ts	1
 src/agents/tools/image-generate-tool.ts	2
 src/agents/tools/image-tool.helpers.ts	2

--- a/src/agents/tools/goal-tools.ts
+++ b/src/agents/tools/goal-tools.ts
@@ -123,12 +123,11 @@ export function createUpdateGoalTool(options: GoalToolOptions): AnyAgentTool {
     parameters: UpdateGoalToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
-      const status = readToolStringParam(params, "status", { required: true });
-      if (
-        !MODEL_UPDATABLE_SESSION_GOAL_STATUSES.includes(
-          status as (typeof MODEL_UPDATABLE_SESSION_GOAL_STATUSES)[number],
-        )
-      ) {
+      const requestedStatus = readToolStringParam(params, "status", { required: true });
+      const status = MODEL_UPDATABLE_SESSION_GOAL_STATUSES.find(
+        (candidate) => candidate === requestedStatus,
+      );
+      if (status === undefined) {
         throw new ToolInputError(
           `status must be one of ${MODEL_UPDATABLE_SESSION_GOAL_STATUSES.join(", ")}`,
         );
@@ -139,7 +138,7 @@ export function createUpdateGoalTool(options: GoalToolOptions): AnyAgentTool {
         const goal = await updateSessionGoalStatus({
           ...scope,
           actor: { type: "agent", id: scope.sessionKey },
-          status: status as (typeof MODEL_UPDATABLE_SESSION_GOAL_STATUSES)[number],
+          status,
           ...(note ? { note } : {}),
         });
         return jsonResult({

--- a/src/config/sessions/goals-transitions.ts
+++ b/src/config/sessions/goals-transitions.ts
@@ -21,12 +21,6 @@ function resolveEntryFreshTotalTokens(
   return normalizeTokenCount(resolveFreshSessionTotalTokens(entry));
 }
 
-function resolveEntryGoalStartTokens(
-  entry: Pick<SessionEntry, "totalTokens" | "totalTokensFresh" | "totalTokensVersion">,
-): number {
-  return resolveEntryFreshTotalTokens(entry) ?? 0;
-}
-
 function normalizeTokenBudget(value: number | undefined): number | undefined {
   const normalized = normalizeTokenCount(value);
   return normalized && normalized > 0 ? normalized : undefined;
@@ -86,7 +80,7 @@ export function buildCreatedSessionGoal(
     throw new SessionGoalTransitionError("goal already exists");
   }
   const tokenBudget = normalizeTokenBudget(options.tokenBudget);
-  const tokenStartFresh = resolveEntryFreshTotalTokens(entry) !== undefined;
+  const tokenStart = resolveEntryFreshTotalTokens(entry);
   return {
     schemaVersion: 1,
     id: crypto.randomUUID(),
@@ -94,8 +88,8 @@ export function buildCreatedSessionGoal(
     status: "active",
     createdAt: now,
     updatedAt: now,
-    tokenStart: resolveEntryGoalStartTokens(entry),
-    tokenStartFresh,
+    tokenStart: tokenStart ?? 0,
+    tokenStartFresh: tokenStart !== undefined,
     tokensUsed: 0,
     ...(tokenBudget ? { tokenBudget } : {}),
     continuationTurns: 0,

--- a/src/config/sessions/goals.ts
+++ b/src/config/sessions/goals.ts
@@ -81,16 +81,16 @@ export function formatSessionGoalStatus(goal: SessionGoal | undefined): string {
   const budget =
     goal.tokenBudget === undefined
       ? ""
-      : `\nToken budget: ${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`;
-  const note = goal.lastStatusNote ? `\nNote: ${goal.lastStatusNote}` : "";
+      : `Token budget: ${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`;
+  const note = goal.lastStatusNote ? `Note: ${goal.lastStatusNote}` : "";
   const commands = resolveGoalCommandHint(goal.status);
   return [
     "Goal",
     `Status: ${goal.status}`,
     `Objective: ${goal.objective}`,
     `Tokens used: ${formatTokenCount(goal.tokensUsed)}`,
-    ...(budget ? [budget.slice(1)] : []),
-    ...(note ? [note.slice(1)] : []),
+    ...(budget ? [budget] : []),
+    ...(note ? [note] : []),
     "",
     `Commands: ${commands}`,
   ].join("\n");


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of goal state handling after #145041. Goal status validation used two unnecessary assertions, creation resolved the same fresh token baseline twice, and status formatting added newlines only to slice them off immediately.

## Why This Change Was Made

Derive the validated status directly from the existing allowed-status tuple, resolve the creation baseline once, and build the optional display lines directly. Lower the assertion ratchet from four to two for the removed casts. Production code shrinks by seven lines.

## User Impact

Goal statuses, token-baseline behavior, operator controls, and status text retain their existing behavior. The implementation is simpler to inspect and maintain. This does not redesign consumed-token accounting.

## Evidence

- 52 focused tests passed locally and in Crabbox: goal storage/transitions, operation receipts, model tools, and goal commands.
- Changed checks passed, including types, lint, dead exports, and the exact shrink-only assertion baseline.
- Independent Codex review found no actionable P0–P2 issues.
- Blacksmith Testbox via Crabbox verified base `3b2dbc82f1bab7d42872413411e8c6fe345eb7ec` plus the cleanup overlay; all three changed production-file hashes matched before execution. Full `pnpm build` passed remotely.
- Stress: 160 goal lifecycle cycles across 16 sessions, 640 competing create calls with one winner per cycle, 800 read-only checks, plus edit/pause/resume/repeated-completion/clear assertions. All passed.
- Live OpenAI API-key stress: 12 isolated `agent exec` runs at concurrency three, covering omitted, null, and explicit positive budgets. All 12 preserved the exact multiline/Unicode objective, budget setting, completed state, and visible final reply. Each used create/get/update goal tools with zero failures.
- API keys came from the existing Testbox hydration profile and were never printed. Temporary runtime state was removed and the lease was stopped.

[Crabbox environment run](https://github.com/openclaw/openclaw/actions/runs/34629694735), lease `tbx_01m28sa7tq3e4vq3x8hfe5qd0e`, provider `blacksmith-testbox`. The Crabbox command returned exit 0; the environment workflow may show cancellation during normal lease cleanup.
