### PR TITLE
feat: add contextual file actions and large text preview controls

### DIFF
--- a/ui/src/components/file-preview-modal.browser.test.ts
+++ b/ui/src/components/file-preview-modal.browser.test.ts
@@ -1,5 +1,6 @@
 import type WaDialog from "@awesome.me/webawesome/dist/components/dialog/dialog.js";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "../i18n/index.ts";
 import { OpenClawFilePreviewModal } from "./file-preview-modal.ts";
 import type { OpenClawModalDialog } from "./modal-dialog.ts";
 import "./file-preview-modal-registration.ts";
@@ -45,13 +46,13 @@ async function resolveRenderedDialog(modal: OpenClawModalDialog) {
   return dialog!;
 }
 
-async function mountPreview(width: number, activePath = initialFilePath) {
+async function mountPreview(width: number, activePath = initialFilePath, previewFiles = files) {
   const { page } = await import("vitest/browser");
   await page.viewport(width, 844);
 
   const preview = document.createElement("openclaw-file-preview-modal") as OpenClawFilePreviewModal;
   preview.style.setProperty("--wa-transition-normal", "150ms");
-  preview.files = files;
+  preview.files = previewFiles;
   preview.activePath = activePath;
   document.body.append(preview);
   await preview.updateComplete;
@@ -236,4 +237,177 @@ describe.runIf(browserMode)("file preview modal responsive layout", () => {
     expect(style.animationName).toBe("openclaw-drawer-in");
     expect(style.animationDuration).toBe("0.2s");
   });
+});
+
+describe.runIf(browserMode)("large file preview interactions", () => {
+  const contents = Array.from({ length: 5000 }, (_, index) => `line ${index + 1}`).join("\n");
+  const largeFiles = [
+    { path: "large-a.txt", size: "50 KB", contents },
+    { path: "large-b.txt", size: "50 KB", contents },
+  ];
+
+  it("offers keyboard access to searchable and selectable full contents", async () => {
+    const { page, userEvent } = await import("vitest/browser");
+    const { preview } = await mountPreview(1280, "large-a.txt", largeFiles);
+    const root = preview.shadowRoot!;
+    expect(root.querySelectorAll(".code-line").length).toBeLessThan(200);
+    const toggle = page.getByRole("button", { name: "Show full content", exact: true });
+    await expect.element(toggle).toBeVisible();
+    toggle.element().focus();
+    await userEvent.keyboard("{Enter}");
+    const full = root.querySelector<HTMLElement>(".code-full")!;
+    expect(full).not.toBeNull();
+    expect(full.textContent).toBe(contents);
+    expect(toggle.element().getAttribute("aria-pressed")).toBe("true");
+    expect(root.querySelector(".code-vscroll")).toBeNull();
+    const range = document.createRange();
+    range.selectNodeContents(full);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(selection.toString()).toBe(contents);
+    selection.removeAllRanges();
+    const nativeFind = (window as Window & { find: (text: string) => boolean }).find;
+    expect(nativeFind.call(window, "line 4999")).toBe(true);
+    selection.removeAllRanges();
+    preview.query = "large-a";
+    await preview.updateComplete;
+    expect(root.querySelector(".code-full")?.textContent).toBe(contents);
+    await page.getByRole("button", { name: "Show full content", exact: true }).click();
+    await expect.poll(() => root.querySelectorAll(".code-line").length).toBeGreaterThan(0);
+    expect(root.querySelectorAll(".code-line").length).toBeLessThan(200);
+    expect(root.querySelector<HTMLElement>(".detail-body")!.scrollTop).toBe(0);
+    await page.getByRole("button", { name: "Show full content", exact: true }).click();
+    preview.query = "";
+    preview.activePath = "large-b.txt";
+    await preview.updateComplete;
+    expect(root.querySelector(".code-full")).toBeNull();
+    expect(root.querySelectorAll(".code-line").length).toBeGreaterThan(0);
+    await toggle.click();
+    expect(root.querySelector(".code-full")).not.toBeNull();
+    preview.remove();
+    document.body.append(preview);
+    await preview.updateComplete;
+    const owner = root.querySelector<OpenClawModalDialog>("openclaw-modal-dialog")!;
+    await resolveRenderedDialog(owner);
+    expect(root.querySelector(".code-full")).toBeNull();
+    expect(toggle.element().getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it.each([320, 390])("keeps large-file controls and scrolling usable at %dpx", async (width) => {
+    const { page } = await import("vitest/browser");
+    const { preview, dialog } = await mountPreview(width, "large-a.txt", largeFiles);
+    const root = preview.shadowRoot!;
+    const toggle = page.getByRole("button", { name: "Show full content", exact: true });
+    const copy = root.querySelector<HTMLButtonElement>(".chat-copy-btn")!;
+    const body = root.querySelector<HTMLElement>(".detail-body")!;
+    for (const control of [toggle.element(), copy]) {
+      const bounds = control.getBoundingClientRect();
+      expect(bounds.left).toBeGreaterThanOrEqual(dialog.getBoundingClientRect().left);
+      expect(bounds.right).toBeLessThanOrEqual(dialog.getBoundingClientRect().right);
+    }
+    expect(body.clientHeight).toBeGreaterThan(0);
+    await toggle.click();
+    expect(body.clientHeight).toBeGreaterThan(0);
+    body.scrollTop = body.scrollHeight;
+    expect(body.scrollTop).toBeGreaterThan(0);
+  });
+
+  it("tabs into the named scrollport and reaches later lines with the keyboard", async () => {
+    const { page, userEvent } = await import("vitest/browser");
+    const { preview } = await mountPreview(1280, "large-a.txt", largeFiles);
+    const body = preview.shadowRoot!.querySelector<HTMLElement>(".detail-body")!;
+    preview.shadowRoot!.querySelector<HTMLButtonElement>(".chat-copy-btn")!.focus();
+    await userEvent.keyboard("{Tab}");
+    expect(preview.shadowRoot!.activeElement).toBe(body);
+    await expect
+      .element(page.getByRole("region", { name: "large-a.txt", exact: true }))
+      .toBeVisible();
+    const selected = vi.fn();
+    preview.addEventListener("file-preview-select", selected);
+    await userEvent.keyboard("{ArrowDown}");
+    await expect.poll(() => body.scrollTop).toBeGreaterThan(0);
+    expect(selected).not.toHaveBeenCalled();
+    await userEvent.keyboard("{PageDown}");
+    await expect.poll(() => body.scrollTop).toBeGreaterThan(0);
+    await userEvent.keyboard("{Control>}{End}{/Control}");
+    await expect
+      .poll(
+        () =>
+          [...preview.shadowRoot!.querySelectorAll<HTMLElement>(".code-line")].at(-1)?.dataset.line,
+      )
+      .toBe("5000");
+    await userEvent.keyboard("{Control>}{Home}{/Control}");
+    await expect.poll(() => body.scrollTop).toBe(0);
+  });
+
+  it.each(["filter", "same-content file", "reconnect"])(
+    "resets the rendered window after %s changes",
+    async (change) => {
+      const { preview } = await mountPreview(1280, "large-a.txt", largeFiles);
+      const body = preview.shadowRoot!.querySelector<HTMLElement>(".detail-body")!;
+      const rows = () => [...preview.shadowRoot!.querySelectorAll<HTMLElement>(".code-line")];
+      await expect.poll(() => rows()[0]?.dataset.line, { timeout: 2000 }).toBe("1");
+      expect(rows().length).toBeLessThan(200);
+      body.scrollTop = 44000;
+      await expect.poll(() => Number(rows()[0]?.dataset.line)).toBeGreaterThan(1900);
+      expect(rows().length).toBeLessThan(200);
+      const visible = rows().find(
+        (row) => row.getBoundingClientRect().top >= body.getBoundingClientRect().top,
+      );
+      expect(visible?.textContent?.trim()).toMatch(/^line 200\d$/);
+      expect(rows()[0]?.getBoundingClientRect().height).toBe(22);
+      if (change === "filter") {
+        preview.query = "large-a";
+      } else if (change === "reconnect") {
+        preview.remove();
+        document.body.append(preview);
+        const owner =
+          preview.shadowRoot!.querySelector<OpenClawModalDialog>("openclaw-modal-dialog")!;
+        await resolveRenderedDialog(owner);
+      } else {
+        preview.activePath = "large-b.txt";
+      }
+      await preview.updateComplete;
+      await expect.poll(() => body.scrollTop).toBe(0);
+      await expect.poll(() => rows()[0]?.dataset.line, { timeout: 2000 }).toBe("1");
+      expect(rows()[0]?.textContent?.trim()).toBe("line 1");
+      expect(rows()[0]?.getBoundingClientRect().top).toBeLessThan(
+        body.getBoundingClientRect().bottom,
+      );
+      body.scrollTop = body.scrollHeight;
+      await expect.poll(() => rows().at(-1)?.dataset.line).toBe("5000");
+      expect(rows().length).toBeLessThan(200);
+    },
+  );
+
+  it("opens an actionable keyboard menu inside the native preview dialog", async () => {
+    const { preview } = await mountPreview(1280);
+    const { page, userEvent } = await import("vitest/browser");
+    const action = vi.fn();
+    preview.onFileAction = action;
+    const item = preview.shadowRoot!.querySelector<HTMLElement>(".item.is-active")!;
+    item.focus();
+    await userEvent.keyboard("{Shift>}{F10}{/Shift}");
+    const menu = page.getByRole("menu", { name: "Workspace file actions" });
+    const first = menu.getByRole("menuitem", { name: "Copy filename", exact: true });
+    await expect.element(first).toBeVisible();
+    expect(preview.shadowRoot!.activeElement?.textContent).toBe("Copy filename");
+    await userEvent.keyboard("{ArrowDown}");
+    expect(preview.shadowRoot!.activeElement?.textContent).toBe("Copy file contents");
+    await userEvent.keyboard("{Escape}");
+    await expect.element(menu).not.toBeInTheDocument();
+    expect(preview.shadowRoot!.activeElement).toBe(item);
+    await userEvent.click(item, { button: "right" });
+    await first.click();
+    expect(action).toHaveBeenCalledWith("copyFilename", files[0]);
+  });
+});
+
+const originalLocale = i18n.getLocale();
+beforeEach(async () => {
+  await i18n.setLocale("en");
+});
+afterEach(async () => {
+  await i18n.setLocale(originalLocale);
 });

--- a/ui/src/components/file-preview-modal.styles.ts
+++ b/ui/src/components/file-preview-modal.styles.ts
@@ -1,0 +1,452 @@
+import { css } from "lit";
+
+export const filePreviewModalStyles = css`
+  :host {
+    display: contents;
+  }
+
+  .modal {
+    width: 100%;
+    height: min(780px, 86vh);
+    background: var(--bg);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+  }
+
+  .search-icon {
+    color: var(--muted);
+    font-size: 18px;
+  }
+
+  .search {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--text-strong);
+    font: inherit;
+    font-size: 18px;
+    font-weight: 400;
+    padding: 4px 0;
+  }
+
+  .search:focus,
+  .search:focus-visible {
+    outline: none;
+    border: none;
+    box-shadow: none;
+  }
+
+  .search::placeholder {
+    color: var(--muted);
+  }
+
+  .state {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--muted);
+    padding: 5px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+  }
+
+  .body {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 360px 1fr;
+    min-height: 0;
+  }
+
+  .list {
+    border-right: 1px solid var(--border);
+    padding: 14px 10px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .list-section {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    padding: 4px 12px 8px;
+  }
+
+  .item {
+    display: grid;
+    grid-template-columns: 16px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    padding: 12px 14px;
+    border-radius: var(--radius-md);
+    border: none;
+    background: transparent;
+    color: var(--text);
+    font: inherit;
+    outline: none;
+    text-align: left;
+  }
+
+  .item:focus-visible {
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent);
+  }
+
+  .item:hover {
+    background: var(--bg-elevated);
+  }
+
+  .item.is-active {
+    background: var(--accent-subtle);
+  }
+
+  .item.is-active .item-name {
+    color: var(--text-strong);
+  }
+
+  .item-icon {
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted);
+    opacity: 0.85;
+  }
+
+  .item.is-active .item-icon {
+    color: var(--accent);
+    opacity: 1;
+  }
+
+  .item-icon svg,
+  .chat-copy-btn svg {
+    width: 16px;
+    height: 16px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 1.5px;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .item-name {
+    font-family: var(--mono);
+    font-size: 14px;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .item-meta {
+    color: var(--muted);
+    font-size: 12px;
+  }
+
+  .empty-list {
+    color: var(--muted);
+    font-size: 13px;
+    padding: 12px;
+  }
+
+  .detail {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .detail.empty {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 24px;
+  }
+
+  .detail-head {
+    padding: 20px 24px 14px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .detail-title-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 10px;
+  }
+
+  .title {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    font-family: var(--mono);
+    font-size: 22px;
+    color: var(--text-strong);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chat-copy-btn {
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+    color: var(--muted);
+  }
+
+  .chat-copy-btn:hover {
+    border-color: var(--border-strong);
+    color: var(--text-strong);
+  }
+
+  .chat-copy-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .chat-copy-btn__icon {
+    display: inline-flex;
+    width: 16px;
+    height: 16px;
+    position: relative;
+  }
+
+  .chat-copy-btn__icon-copy,
+  .chat-copy-btn__icon-check {
+    position: absolute;
+    inset: 0;
+    transition: opacity 150ms ease;
+  }
+
+  .chat-copy-btn__icon-check,
+  .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-copy {
+    opacity: 0;
+  }
+
+  .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-check {
+    opacity: 1;
+  }
+
+  .chat-copy-btn[data-copy-state="copying"] {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .chat-copy-btn[data-copy-state="error"] {
+    border-color: var(--danger-subtle);
+    background: var(--danger-subtle);
+    color: var(--danger);
+  }
+
+  .chat-copy-btn[data-copy-state="copied"] {
+    border-color: var(--ok-subtle);
+    background: var(--ok-subtle);
+    color: var(--ok);
+  }
+
+  .chips {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 11.5px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    color: var(--muted);
+  }
+
+  .chip.accent {
+    background: var(--accent-subtle);
+    border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+    color: var(--accent);
+  }
+
+  .chip.ok {
+    background: color-mix(in srgb, var(--ok) 12%, transparent);
+    border-color: color-mix(in srgb, var(--ok) 30%, transparent);
+    color: var(--ok);
+  }
+
+  .detail-body {
+    flex: 1;
+    overflow-x: auto;
+    overflow-y: auto;
+    padding: 20px 24px 24px;
+  }
+
+  .code-content {
+    min-width: 0;
+  }
+
+  .full-content-hint {
+    color: var(--muted);
+    font-size: 12px;
+    margin: 0 0 10px;
+  }
+
+  .code-full {
+    margin: 0;
+    font-family: var(--mono);
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--text);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  .code-chunk {
+    margin: 0;
+    min-width: 0;
+    font-family: var(--mono);
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--text);
+    white-space: pre-wrap;
+    word-break: break-word;
+    content-visibility: auto;
+    contain-intrinsic-block-size: auto 1414px;
+  }
+
+  /* Large code files use a fixed-height line window.  The scroll container
+       still owns the full height through spacers, so switching files can
+       reset one real scroll position instead of leaving a stale virtual slice. */
+  .code-vscroll {
+    min-width: max-content;
+    font-family: var(--mono);
+    font-size: 13px;
+    line-height: 22px;
+    color: var(--text);
+  }
+
+  .code-line {
+    white-space: pre;
+    min-height: 22px;
+    line-height: 22px;
+  }
+
+  .code-spacer {
+    height: 0;
+    pointer-events: none;
+  }
+
+  .foot {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    padding: 12px 20px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    font-size: 12px;
+    color: var(--muted);
+  }
+
+  .foot-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .kbd {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    padding: 2px 6px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-elevated);
+    color: var(--text);
+  }
+
+  .spacer {
+    flex: 1;
+  }
+
+  .button {
+    height: 36px;
+    padding: 0 14px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    background: var(--bg-elevated);
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .button:hover {
+    border-color: var(--border-strong);
+    color: var(--text-strong);
+  }
+
+  .empty-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-strong);
+    margin: 0 0 8px;
+  }
+
+  .empty-subtitle {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    max-width: 380px;
+  }
+
+  @media (max-width: 640px) {
+    .head {
+      padding: 12px;
+    }
+
+    .body {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: minmax(0, min(180px, 30dvh)) minmax(0, 1fr);
+    }
+
+    .list {
+      min-width: 0;
+      border-right: 0;
+      border-bottom: 1px solid var(--border);
+      padding: 10px 8px;
+    }
+
+    .item {
+      min-width: 0;
+    }
+
+    .foot {
+      gap: 8px;
+      padding: 10px 12px;
+    }
+  }
+`;

--- a/ui/src/components/file-preview-modal.ts
+++ b/ui/src/components/file-preview-modal.ts
@@ -1,17 +1,31 @@
 // Control UI component implements the file preview modal element.
-import { css, html, type PropertyValues, type TemplateResult } from "lit";
+import { html, type PropertyValues, type TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
+import { openFileActionMenu } from "../lib/file-context-menu.ts";
+import {
+  computeCodeWindow,
+  FILE_PREVIEW_LINE_HEIGHT,
+  FILE_PREVIEW_OVERSCAN,
+} from "../lib/file-preview-window.ts";
+import {
+  availableFileActions,
+  isSafeFileReference,
+  type FileAction,
+  type FileReference,
+} from "../lib/file-reference.ts";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
 import { renderCopyButton } from "./copy-button.ts";
 import { type FileKind, fileKindForPath } from "./file-kind.ts";
+import { filePreviewModalStyles } from "./file-preview-modal.styles.ts";
 import { icons } from "./icons.ts";
 import "./modal-dialog.ts";
 
-type FilePreviewModalFile = {
+export type FilePreviewModalFile = {
   path: string;
   size: string;
   contents: string;
+  reference?: FileReference;
 };
 
 export class OpenClawFilePreviewModal extends OpenClawLitElement {
@@ -26,434 +40,37 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
   @property() emptyTitle = "";
   @property() emptySubtitle = "";
   @property() copyLabel = "";
+  /** Called by the shared context menu; the owner performs the Gateway action. */
+  @property({ attribute: false })
+  onFileAction?: (action: FileAction, file: FilePreviewModalFile) => void | Promise<void>;
   @query(".search") private searchInput?: HTMLInputElement;
   @query(".detail-body") private detailBody?: HTMLElement;
 
   private filteredFiles: FilePreviewModalFile[] = [];
   private activeFile?: FilePreviewModalFile;
   private derivedInputsReady = false;
+  private showFullContent = false;
   private codeSource?: string;
   private codeChunks: string[] = [];
+  private codeLines: string[] = [];
+  private codeStart = 0;
+  private codeEnd = 0;
+  private codeFrame: number | null = null;
+  private codeResizeObserver: ResizeObserver | null = null;
+  private codeScrollElement: HTMLElement | null = null;
+  private contextMenuClose: (() => void) | null = null;
+  private readonly codeLineHeight = FILE_PREVIEW_LINE_HEIGHT;
+  private readonly codeOverscan = FILE_PREVIEW_OVERSCAN;
   private resetScrollAfterUpdate = true;
   // Reconnection does not rerun firstUpdated; defer focus until shadow DOM is ready.
   private focusAfterUpdate = false;
 
-  static override styles = css`
-    :host {
-      display: contents;
-    }
-
-    .modal {
-      width: 100%;
-      height: min(780px, 86vh);
-      background: var(--bg);
-      border: 1px solid var(--border-strong);
-      border-radius: var(--radius-lg);
-      box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-    }
-
-    .head {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 16px 20px;
-      border-bottom: 1px solid var(--border);
-      background: var(--bg);
-    }
-
-    .search-icon {
-      color: var(--muted);
-      font-size: 18px;
-    }
-
-    .search {
-      flex: 1;
-      min-width: 0;
-      background: transparent;
-      border: none;
-      outline: none;
-      color: var(--text-strong);
-      font: inherit;
-      font-size: 18px;
-      font-weight: 400;
-      padding: 4px 0;
-    }
-
-    .search:focus,
-    .search:focus-visible {
-      outline: none;
-      border: none;
-      box-shadow: none;
-    }
-
-    .search::placeholder {
-      color: var(--muted);
-    }
-
-    .state {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      font-size: 12px;
-      color: var(--muted);
-      padding: 5px 10px;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-      background: var(--bg-elevated);
-    }
-
-    .body {
-      flex: 1;
-      display: grid;
-      grid-template-columns: 360px 1fr;
-      min-height: 0;
-    }
-
-    .list {
-      border-right: 1px solid var(--border);
-      padding: 14px 10px;
-      overflow-y: auto;
-      display: flex;
-      flex-direction: column;
-      gap: 2px;
-    }
-
-    .list-section {
-      font-size: 11px;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--muted);
-      padding: 4px 12px 8px;
-    }
-
-    .item {
-      display: grid;
-      grid-template-columns: 16px 1fr auto;
-      gap: 12px;
-      align-items: center;
-      padding: 12px 14px;
-      border-radius: var(--radius-md);
-      border: none;
-      background: transparent;
-      color: var(--text);
-      font: inherit;
-      outline: none;
-      text-align: left;
-    }
-
-    .item:focus-visible {
-      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent);
-    }
-
-    .item:hover {
-      background: var(--bg-elevated);
-    }
-
-    .item.is-active {
-      background: var(--accent-subtle);
-    }
-
-    .item.is-active .item-name {
-      color: var(--text-strong);
-    }
-
-    .item-icon {
-      width: 16px;
-      height: 16px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      color: var(--muted);
-      opacity: 0.85;
-    }
-
-    .item.is-active .item-icon {
-      color: var(--accent);
-      opacity: 1;
-    }
-
-    .item-icon svg,
-    .chat-copy-btn svg {
-      width: 16px;
-      height: 16px;
-      stroke: currentColor;
-      fill: none;
-      stroke-width: 1.5px;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-    }
-
-    .item-name {
-      font-family: var(--mono);
-      font-size: 14px;
-      color: var(--text);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .item-meta {
-      color: var(--muted);
-      font-size: 12px;
-    }
-
-    .empty-list {
-      color: var(--muted);
-      font-size: 13px;
-      padding: 12px;
-    }
-
-    .detail {
-      display: flex;
-      flex-direction: column;
-      min-width: 0;
-      min-height: 0;
-    }
-
-    .detail.empty {
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      padding: 24px;
-    }
-
-    .detail-head {
-      padding: 20px 24px 14px;
-      border-bottom: 1px solid var(--border);
-    }
-
-    .detail-title-row {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      margin-bottom: 10px;
-    }
-
-    .title {
-      flex: 1;
-      min-width: 0;
-      margin: 0;
-      font-family: var(--mono);
-      font-size: 22px;
-      color: var(--text-strong);
-      font-weight: 700;
-      letter-spacing: -0.01em;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .chat-copy-btn {
-      width: 32px;
-      height: 32px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      flex: 0 0 auto;
-      padding: 0;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-      background: var(--bg-elevated);
-      color: var(--muted);
-    }
-
-    .chat-copy-btn:hover {
-      border-color: var(--border-strong);
-      color: var(--text-strong);
-    }
-
-    .chat-copy-btn:focus-visible {
-      outline: 2px solid var(--accent);
-      outline-offset: 2px;
-    }
-
-    .chat-copy-btn__icon {
-      display: inline-flex;
-      width: 16px;
-      height: 16px;
-      position: relative;
-    }
-
-    .chat-copy-btn__icon-copy,
-    .chat-copy-btn__icon-check {
-      position: absolute;
-      inset: 0;
-      transition: opacity 150ms ease;
-    }
-
-    .chat-copy-btn__icon-check,
-    .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-copy {
-      opacity: 0;
-    }
-
-    .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-check {
-      opacity: 1;
-    }
-
-    .chat-copy-btn[data-copy-state="copying"] {
-      opacity: 0;
-      pointer-events: none;
-    }
-
-    .chat-copy-btn[data-copy-state="error"] {
-      border-color: var(--danger-subtle);
-      background: var(--danger-subtle);
-      color: var(--danger);
-    }
-
-    .chat-copy-btn[data-copy-state="copied"] {
-      border-color: var(--ok-subtle);
-      background: var(--ok-subtle);
-      color: var(--ok);
-    }
-
-    .chips {
-      display: flex;
-      gap: 6px;
-      flex-wrap: wrap;
-    }
-
-    .chip {
-      display: inline-flex;
-      align-items: center;
-      padding: 3px 10px;
-      border-radius: 999px;
-      font-size: 11.5px;
-      background: var(--bg-elevated);
-      border: 1px solid var(--border);
-      color: var(--muted);
-    }
-
-    .chip.accent {
-      background: var(--accent-subtle);
-      border-color: color-mix(in srgb, var(--accent) 30%, transparent);
-      color: var(--accent);
-    }
-
-    .chip.ok {
-      background: color-mix(in srgb, var(--ok) 12%, transparent);
-      border-color: color-mix(in srgb, var(--ok) 30%, transparent);
-      color: var(--ok);
-    }
-
-    .detail-body {
-      flex: 1;
-      overflow-x: hidden;
-      overflow-y: auto;
-      padding: 20px 24px 24px;
-    }
-
-    .code-content {
-      min-width: 0;
-    }
-
-    .code-chunk {
-      margin: 0;
-      min-width: 0;
-      font-family: var(--mono);
-      font-size: 13px;
-      line-height: 1.7;
-      color: var(--text);
-      white-space: pre-wrap;
-      word-break: break-word;
-      content-visibility: auto;
-      contain-intrinsic-block-size: auto 1414px;
-    }
-
-    .foot {
-      display: flex;
-      align-items: center;
-      gap: 18px;
-      padding: 12px 20px;
-      border-top: 1px solid var(--border);
-      background: var(--bg);
-      font-size: 12px;
-      color: var(--muted);
-    }
-
-    .foot-group {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-    }
-
-    .kbd {
-      font-family: var(--mono);
-      font-size: 10.5px;
-      padding: 2px 6px;
-      border: 1px solid var(--border);
-      border-radius: 4px;
-      background: var(--bg-elevated);
-      color: var(--text);
-    }
-
-    .spacer {
-      flex: 1;
-    }
-
-    .button {
-      height: 36px;
-      padding: 0 14px;
-      border-radius: var(--radius-md);
-      border: 1px solid var(--border);
-      background: var(--bg-elevated);
-      color: var(--text);
-      font-weight: 600;
-    }
-
-    .button:hover {
-      border-color: var(--border-strong);
-      color: var(--text-strong);
-    }
-
-    .empty-title {
-      font-size: 16px;
-      font-weight: 600;
-      color: var(--text-strong);
-      margin: 0 0 8px;
-    }
-
-    .empty-subtitle {
-      margin: 0;
-      font-size: 13px;
-      color: var(--muted);
-      max-width: 380px;
-    }
-
-    @media (max-width: 640px) {
-      .head {
-        padding: 12px;
-      }
-
-      .body {
-        grid-template-columns: minmax(0, 1fr);
-        grid-template-rows: minmax(0, min(180px, 30dvh)) minmax(0, 1fr);
-      }
-
-      .list {
-        min-width: 0;
-        border-right: 0;
-        border-bottom: 1px solid var(--border);
-        padding: 10px 8px;
-      }
-
-      .item {
-        min-width: 0;
-      }
-
-      .foot {
-        gap: 8px;
-        padding: 10px 12px;
-      }
-    }
-  `;
+  static override styles = filePreviewModalStyles;
 
   protected override willUpdate(changed: PropertyValues<this>) {
     const inputsChanged =
       !this.derivedInputsReady ||
+      this.resetScrollAfterUpdate ||
       changed.has("activePath") ||
       changed.has("query") ||
       changed.has("files");
@@ -464,13 +81,20 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
     this.derivedInputsReady = true;
     this.filteredFiles = this.filterFiles();
     const nextActiveFile = this.resolveActiveFile(this.filteredFiles);
+    if (nextActiveFile?.path !== this.activeFile?.path) {
+      this.showFullContent = false;
+    }
     this.activeFile = nextActiveFile;
 
     const nextCodeSource = nextActiveFile?.contents;
     if (nextCodeSource !== this.codeSource) {
       this.codeSource = nextCodeSource;
+      this.codeLines = nextCodeSource === undefined ? [] : nextCodeSource.split("\n");
       this.codeChunks = nextCodeSource === undefined ? [] : chunkFileContents(nextCodeSource);
     }
+    // Reset before rendering even when the selected file's contents are identical.
+    this.codeStart = 0;
+    this.codeEnd = this.visibleCodeEnd();
 
     this.resetScrollAfterUpdate = true;
   }
@@ -520,6 +144,8 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
                           @pointerdown=${this.preventItemPointerFocus}
                           @mousedown=${this.preventItemPointerFocus}
                           @click=${() => this.emitSelect(file.path)}
+                          @contextmenu=${(event: MouseEvent) => this.handleFileContextMenu(event, file)}
+                          @keydown=${(event: KeyboardEvent) => this.handleFileItemKeydown(event, file)}
                         >
                           <span class="item-icon">${iconForFile(file.path)}</span>
                           <span class="item-name">${file.path}</span>
@@ -548,13 +174,37 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       <section class="detail">
         <div class="detail-head">
           <div class="detail-title-row">
-            <h2 class="title">${file.path}</h2>
+            <h2 class="title" id="file-preview-active-title">${file.path}</h2>
+            ${
+              this.codeLines.length >= 2000
+                ? html`
+                    <button
+                      class="button"
+                      type="button"
+                      aria-pressed=${String(this.showFullContent)}
+                      aria-describedby="file-preview-full-content-hint"
+                      @click=${this.toggleFullContent}
+                    >
+                      ${t("filePreview.showFullContent")}
+                    </button>
+                  `
+                : ""
+            }
             ${
               file.contents
                 ? renderCopyButton(file.contents, this.copyLabel || t("filePreview.copyFile"))
                 : ""
             }
           </div>
+          ${
+            this.codeLines.length >= 2000
+              ? html`
+                  <p class="full-content-hint" id="file-preview-full-content-hint">
+                    ${t(this.showFullContent ? "filePreview.fullContentActive" : "filePreview.fullContentHint")}
+                  </p>
+                `
+              : ""
+          }
           <div class="chips">
             <span class="chip accent">${fileKind(file.path)}</span>
             <span class="chip">${file.size}</span>
@@ -562,15 +212,46 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
             ${this.contextLabel ? html`<span class="chip ok">${this.contextLabel}</span>` : ""}
           </div>
         </div>
-        <div class="detail-body">
-          <div class="code-content">
-            ${this.codeChunks.map(
-              (chunk, index) => html`<pre class="code-chunk" data-chunk=${index}>${chunk}</pre>`,
-            )}
-          </div>
+        <div
+          class="detail-body"
+          tabindex="0"
+          role="region"
+          aria-labelledby="file-preview-active-title"
+          @contextmenu=${(event: MouseEvent) => this.handleFileContextMenu(event, file)}
+        >
+          <div class="code-content">${this.renderCode(file)}</div>
         </div>
       </section>
     `;
+  }
+
+  private renderCode(file: FilePreviewModalFile) {
+    if (this.showFullContent) {
+      return html`<pre class="code-full" .textContent=${file.contents}></pre>`;
+    }
+    if (file.contents && this.shouldVirtualizeCode()) {
+      const top = this.codeStart * this.codeLineHeight;
+      const bottom = Math.max(0, this.codeLines.length - this.codeEnd) * this.codeLineHeight;
+      return html`
+        <div class="code-vscroll">
+          <div class="code-spacer" style=${`height:${top}px`}></div>
+          ${this.codeLines
+            .slice(this.codeStart, this.codeEnd)
+            .map(
+              (line, index) =>
+                html`<div
+                  class="code-line"
+                  data-line=${this.codeStart + index + 1}
+                  .textContent=${line || " "}
+                ></div>`,
+            )}
+          <div class="code-spacer" style=${`height:${bottom}px`}></div>
+        </div>
+      `;
+    }
+    return this.codeChunks.map(
+      (chunk, index) => html`<pre class="code-chunk" data-chunk=${index}>${chunk}</pre>`,
+    );
   }
 
   private renderEmpty() {
@@ -599,9 +280,16 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
 
   override connectedCallback() {
     super.connectedCallback();
+    this.showFullContent = false;
     this.resetScrollAfterUpdate = true;
     this.focusAfterUpdate = true;
     this.requestUpdate();
+  }
+
+  override disconnectedCallback() {
+    this.closeContextMenu();
+    this.detachCodeViewport();
+    super.disconnectedCallback();
   }
 
   protected override updated(changed: PropertyValues<this>) {
@@ -612,7 +300,9 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
         body.scrollTop = 0;
         body.scrollLeft = 0;
       }
+      this.resetCodeScroll();
     }
+    this.attachCodeViewport();
     if (changed.has("activePath") || changed.has("query") || changed.has("files")) {
       this.scrollActiveFileIntoView();
     }
@@ -637,7 +327,151 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
     event.preventDefault();
   };
 
+  private toggleFullContent = () => {
+    this.showFullContent = !this.showFullContent;
+    this.detachCodeViewport();
+    this.resetScrollAfterUpdate = true;
+    this.requestUpdate();
+  };
+
+  private shouldVirtualizeCode(): boolean {
+    return !this.showFullContent && this.codeLines.length >= 2000;
+  }
+
+  private detachCodeViewport() {
+    this.codeResizeObserver?.disconnect();
+    this.codeResizeObserver = null;
+    if (this.codeScrollElement) {
+      this.codeScrollElement.removeEventListener("scroll", this.handleCodeScroll);
+      this.codeScrollElement = null;
+    }
+    if (this.codeFrame !== null) {
+      cancelAnimationFrame(this.codeFrame);
+      this.codeFrame = null;
+    }
+  }
+
+  private visibleCodeEnd(): number {
+    const viewport = this.detailBody?.clientHeight || 620;
+    return computeCodeWindow(
+      this.codeLines.length,
+      0,
+      viewport,
+      this.codeLineHeight,
+      this.codeOverscan,
+    ).end;
+  }
+
+  private resetCodeScroll() {
+    this.codeStart = 0;
+    this.codeEnd = this.visibleCodeEnd();
+    if (this.detailBody) {
+      this.detailBody.scrollTop = 0;
+      this.detailBody.scrollLeft = 0;
+    }
+    this.scheduleCodeRange();
+  }
+
+  private attachCodeViewport() {
+    const body = this.detailBody;
+    if (!body || !this.shouldVirtualizeCode()) {
+      this.detachCodeViewport();
+      return;
+    }
+    if (body === this.codeScrollElement) {
+      return;
+    }
+    this.codeScrollElement?.removeEventListener("scroll", this.handleCodeScroll);
+    this.codeScrollElement = body;
+    body.addEventListener("scroll", this.handleCodeScroll, { passive: true });
+    this.codeResizeObserver?.disconnect();
+    if (typeof ResizeObserver === "function") {
+      this.codeResizeObserver = new ResizeObserver(() => this.scheduleCodeRange());
+      this.codeResizeObserver.observe(body);
+    }
+    this.scheduleCodeRange();
+  }
+
+  private handleCodeScroll = () => {
+    this.scheduleCodeRange();
+  };
+
+  private scheduleCodeRange() {
+    if (this.codeFrame !== null || !this.shouldVirtualizeCode()) {
+      return;
+    }
+    this.codeFrame = requestAnimationFrame(() => {
+      this.codeFrame = null;
+      if (!this.isConnected || !this.shouldVirtualizeCode()) {
+        return;
+      }
+      const body = this.codeScrollElement ?? this.detailBody;
+      if (!body) {
+        return;
+      }
+      const { start, end } = computeCodeWindow(
+        this.codeLines.length,
+        body.scrollTop,
+        body.clientHeight,
+        this.codeLineHeight,
+        this.codeOverscan,
+      );
+      if (start !== this.codeStart || end !== this.codeEnd) {
+        this.codeStart = start;
+        this.codeEnd = end;
+        this.requestUpdate();
+      }
+    });
+  }
+
+  private handleFileItemKeydown(event: KeyboardEvent, file: FilePreviewModalFile) {
+    if (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey)) {
+      this.handleFileContextMenu(event, file);
+    }
+  }
+
+  private handleFileContextMenu(event: Event, file: FilePreviewModalFile) {
+    this.closeContextMenu();
+    const actions: readonly FileAction[] =
+      this.onFileAction && file.reference
+        ? isSafeFileReference(file.reference)
+          ? availableFileActions(file.reference, { hasContents: Boolean(file.contents) })
+          : []
+        : this.onFileAction
+          ? ["copyFilename", "copyContents", "download", "refresh"]
+          : ["copyFilename", "copyContents"];
+    const container = this.shadowRoot?.querySelector<HTMLElement>(".modal");
+    if (!container) {
+      return;
+    }
+    this.contextMenuClose = openFileActionMenu({
+      event,
+      actions,
+      container,
+      onAction: async (action) => {
+        if (this.onFileAction) {
+          await this.onFileAction(action, file);
+        } else if (action === "copyFilename") {
+          await navigator.clipboard.writeText(file.path.split(/[\\/]/).pop() ?? file.path);
+        } else if (action === "copyContents") {
+          await navigator.clipboard.writeText(file.contents);
+        }
+      },
+    });
+  }
+
+  private closeContextMenu() {
+    this.contextMenuClose?.();
+    this.contextMenuClose = null;
+  }
   private handleKeydown = (event: KeyboardEvent) => {
+    if (
+      (event.key === "ArrowDown" || event.key === "ArrowUp") &&
+      this.detailBody &&
+      event.composedPath().includes(this.detailBody)
+    ) {
+      return;
+    }
     switch (event.key) {
       case "Escape":
         event.preventDefault();
@@ -649,6 +483,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
         return;
       case "ArrowUp":
         this.moveSelection(-1, event);
+        break;
       default:
     }
   };
@@ -661,7 +496,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
   private moveSelection(offset: number, event: KeyboardEvent) {
     event.preventDefault();
     event.stopPropagation();
-    const files = this.filterFiles();
+    const files = this.filteredFiles;
     if (files.length === 0) {
       return;
     }

--- a/ui/src/e2e/chat-file-links.e2e.test.ts
+++ b/ui/src/e2e/chat-file-links.e2e.test.ts
@@ -43,6 +43,7 @@ describeControlUiE2e("Control UI chat file links", () => {
     "shows Review before file completion and honors the %s intent",
     async (intent) => {
       const context = await browser.newContext({
+        locale: "en-US",
         recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
         viewport: { height: 900, width: 1280 },
       });
@@ -207,6 +208,7 @@ describeControlUiE2e("Control UI chat file links", () => {
 
   it("reveals the selected file from chat in the workspace root after filtering", async () => {
     const context = await browser.newContext({
+      locale: "en-US",
       recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
       viewport: { height: 900, width: 1280 },
     });
@@ -374,6 +376,7 @@ describeControlUiE2e("Control UI chat file links", () => {
       },
     } satisfies Record<string, Record<string, unknown>>;
     const context = await browser.newContext({
+      locale: "en-US",
       recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
       viewport: { height: 900, width: 1280 },
     });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -16,6 +16,14 @@ export const en: TranslationMap & {
   updates: TranslationMap;
   login: TranslationMap;
 } = {
+  fileActions: {
+    copyFullPath: "Copy full path",
+    copyRelativePath: "Copy relative path",
+    copyFilename: "Copy filename",
+    revealInFileManager: "Show in file manager",
+    openWorkspaceRoot: "Open workspace root",
+    failed: "Action failed. Please try again.",
+  },
   pluginUi: {
     customize: "Customize UI",
     selectionScope: "Choose views for this browser window. Built-in views are always available.",
@@ -216,6 +224,11 @@ export const en: TranslationMap & {
     emptyTitle: "No files match",
     emptySubtitle: "Try another file name or content search.",
     copyFile: "Copy file",
+    showFullContent: "Show full content",
+    fullContentHint:
+      "Fast preview shows only nearby lines. Show full content for browser Find, full-text selection, and assistive reading.",
+    fullContentActive:
+      "Full content is shown for browser Find, full-text selection, and assistive reading. Turn off Show full content to return to fast preview.",
     fileCount: "{count} files",
     filteredFileCount: "{count}/{total} files",
     noMatches: "No files match.",

--- a/ui/src/lib/file-context-menu.browser.test.ts
+++ b/ui/src/lib/file-context-menu.browser.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { page, userEvent } from "vitest/browser";
+import { i18n, t } from "../i18n/index.ts";
+import { openFileContextMenu } from "./file-context-menu.ts";
+
+let closeMenu: (() => void) | null = null;
+afterEach(() => {
+  closeMenu?.();
+  closeMenu = null;
+  document.body.replaceChildren();
+});
+
+function mountTrigger(onAction = vi.fn<() => void | Promise<void>>()) {
+  const trigger = document.createElement("button");
+  trigger.textContent = "file.txt";
+  trigger.style.cssText = "position:fixed;left:100px;top:80px;width:120px;height:32px;border:0";
+  const open = (event: Event) => {
+    closeMenu = openFileContextMenu({
+      event,
+      reference: {
+        origin: "session",
+        sessionKey: "test",
+        relativePath: "file.txt",
+        name: "file.txt",
+      },
+      actions: ["preview", "copyFilename", "download"],
+      onAction,
+    });
+  };
+  trigger.addEventListener("contextmenu", open);
+  trigger.addEventListener("keydown", (event) => {
+    if (event.key === "F10" && event.shiftKey) {
+      open(event);
+    }
+  });
+  document.body.append(trigger);
+  return trigger;
+}
+
+const menu = () => page.getByRole("menu", { name: "Workspace file actions" });
+
+describe("file context menu browser interactions", () => {
+  it("resolves labels using the active locale when reopening", async () => {
+    const trigger = mountTrigger();
+    await userEvent.click(trigger, { button: "right" });
+    await expect
+      .element(page.getByRole("menuitem", { name: "Preview", exact: true }))
+      .toBeVisible();
+    closeMenu?.();
+    await i18n.setLocale("zh-CN");
+    expect(t("chat.workspaceFiles.preview")).not.toBe("Preview");
+    await userEvent.click(trigger, { button: "right" });
+    await expect
+      .element(page.getByRole("menuitem", { name: t("chat.workspaceFiles.preview"), exact: true }))
+      .toBeVisible();
+  });
+
+  it("positions the mouse menu inside viewport edges", async () => {
+    await page.viewport(640, 480);
+    const trigger = mountTrigger();
+    await userEvent.click(trigger, { button: "right", position: { x: 20, y: 10 } });
+    let bounds = document.querySelector('[role="menu"]')!.getBoundingClientRect();
+    expect(bounds.left).toBe(120);
+    expect(bounds.top).toBe(90);
+    closeMenu?.();
+    trigger.style.left = "610px";
+    trigger.style.top = "450px";
+    trigger.style.width = "30px";
+    trigger.style.height = "30px";
+    await userEvent.click(trigger, { button: "right", position: { x: 20, y: 20 } });
+    bounds = document.querySelector('[role="menu"]')!.getBoundingClientRect();
+    expect(bounds.left).toBeGreaterThanOrEqual(8);
+    expect(bounds.top).toBeGreaterThanOrEqual(8);
+    expect(bounds.right).toBeLessThanOrEqual(632);
+    expect(bounds.bottom).toBeLessThanOrEqual(472);
+  });
+
+  it("navigates and restores focus for keyboard dismissal and activation", async () => {
+    const onAction = vi.fn();
+    const trigger = mountTrigger(onAction);
+    for (const dismissal of ["Escape", "Tab"]) {
+      trigger.focus();
+      await userEvent.keyboard("{Shift>}{F10}{/Shift}");
+      await expect
+        .element(menu().getByRole("menuitem", { name: "Preview", exact: true }))
+        .toHaveFocus();
+      await userEvent.keyboard("{ArrowUp}");
+      await expect
+        .element(menu().getByRole("menuitem", { name: "Download file", exact: true }))
+        .toHaveFocus();
+      await userEvent.keyboard("{ArrowDown}");
+      await expect
+        .element(menu().getByRole("menuitem", { name: "Preview", exact: true }))
+        .toHaveFocus();
+      await userEvent.keyboard("{End}{Home}{ArrowDown}");
+      await expect
+        .element(menu().getByRole("menuitem", { name: "Copy filename", exact: true }))
+        .toHaveFocus();
+      await userEvent.keyboard(`{${dismissal}}`);
+      expect(document.activeElement).toBe(trigger);
+    }
+    await userEvent.keyboard("{Shift>}{F10}{/Shift}{Enter}");
+    expect(onAction).toHaveBeenCalledWith("preview");
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("does not steal focus when an obsolete async action finishes", async () => {
+    let finish!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const first = mountTrigger(vi.fn(() => pending));
+    await userEvent.click(first, { button: "right" });
+    await menu().getByRole("menuitem", { name: "Preview", exact: true }).click();
+    await userEvent.keyboard("{Escape}");
+    const second = mountTrigger();
+    // Keep the original trigger connected so stale restoration is observable.
+    first.style.left = "300px";
+    await userEvent.click(second, { button: "right" });
+    finish();
+    await pending;
+    await expect
+      .element(menu().getByRole("menuitem", { name: "Preview", exact: true }))
+      .toHaveFocus();
+  });
+  it("shows a safe error and permits retry when an action fails", async () => {
+    const action = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("private fixture detail"))
+      .mockResolvedValue(undefined);
+    const trigger = mountTrigger(action);
+    await userEvent.click(trigger, { button: "right" });
+    const preview = menu().getByRole("menuitem", { name: "Preview", exact: true });
+    await preview.click();
+    await expect
+      .element(menu().getByRole("alert"))
+      .toHaveTextContent("Action failed. Please try again.");
+    expect(document.body.textContent).not.toContain("private fixture detail");
+    await preview.click();
+    expect(action).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+  });
+});
+
+const originalLocale = i18n.getLocale();
+beforeEach(async () => {
+  await i18n.setLocale("en");
+});
+afterEach(async () => {
+  await i18n.setLocale(originalLocale);
+});

--- a/ui/src/lib/file-context-menu.ts
+++ b/ui/src/lib/file-context-menu.ts
@@ -1,0 +1,176 @@
+import { t } from "../i18n/index.ts";
+import {
+  availableFileActions,
+  isSafeFileReference,
+  type FileAction,
+  type FileReference,
+} from "./file-reference.ts";
+
+const FILE_ACTION_LABEL_KEYS: Record<FileAction, string> = {
+  preview: "chat.workspaceFiles.preview",
+  copyFullPath: "fileActions.copyFullPath",
+  copyRelativePath: "fileActions.copyRelativePath",
+  copyFilename: "fileActions.copyFilename",
+  copyContents: "chat.detailPanel.copyContents",
+  download: "chat.toolCards.downloadFile",
+  openInEditor: "chat.sessionDiff.openInEditor",
+  revealInFileManager: "fileActions.revealInFileManager",
+  openWorkspaceRoot: "fileActions.openWorkspaceRoot",
+  refresh: "common.refresh",
+};
+
+let activeClose: (() => void) | null = null;
+
+export interface FileActionMenuOptions {
+  event: Event;
+  /** Focusable control for delegated events and focus restoration. */
+  trigger?: HTMLElement;
+  actions: readonly FileAction[];
+  onAction: (action: FileAction) => void | Promise<void>;
+  /** A modal owner keeps the popover inside its native dialog's active subtree. */
+  container?: HTMLElement;
+}
+
+export interface FileContextMenuOptions extends Omit<FileActionMenuOptions, "actions"> {
+  reference: FileReference;
+  localGateway?: boolean;
+  hasContents?: boolean;
+  actions?: readonly FileAction[];
+}
+
+export function openFileContextMenu(options: FileContextMenuOptions): (() => void) | null {
+  if (!isSafeFileReference(options.reference)) {
+    return null;
+  }
+  return openFileActionMenu({
+    ...options,
+    actions: options.actions ?? availableFileActions(options.reference, options),
+  });
+}
+
+/** Own one keyboard-accessible menu lifecycle for references and loaded previews. */
+export function openFileActionMenu(options: FileActionMenuOptions): (() => void) | null {
+  if (options.actions.length === 0) {
+    return null;
+  }
+  const { event } = options;
+  event.preventDefault();
+  event.stopPropagation();
+  activeClose?.();
+  const trigger =
+    options.trigger ?? (event.currentTarget instanceof HTMLElement ? event.currentTarget : null);
+  const menu = document.createElement("div");
+  menu.className = "chat-workspace-file-menu";
+  menu.role = "menu";
+  menu.ariaLabel = t("chat.workspaceFiles.actions");
+  menu.popover = "manual";
+  // The same styles must work in the document and the preview's shadow root.
+  const style = document.createElement("style");
+  style.textContent = `
+    .chat-workspace-file-menu {
+      position: fixed; inset: auto; margin: 0; box-sizing: border-box;
+      max-width: calc(100vw - 16px); max-height: calc(100dvh - 16px); overflow: auto;
+      padding: 4px; border: 1px solid var(--border-strong, currentColor);
+      border-radius: var(--radius-md, 6px); background: var(--bg, Canvas); color: var(--text, CanvasText);
+    }
+    .chat-workspace-file-menu > button {
+      display: block; width: 100%; text-align: start; padding: 6px 12px;
+      border: 0; border-radius: 3px; background: transparent; color: inherit; font: inherit;
+    }
+    .chat-workspace-file-menu > button:is(:hover, :focus-visible) {
+      background: var(--bg-hover, ButtonFace); outline: 1px solid currentColor;
+    }
+  `;
+  menu.append(style);
+  const error = document.createElement("div");
+  error.role = "alert";
+  error.hidden = true;
+  menu.append(error);
+  let closed = false;
+  const close = () => {
+    // A completed action from an obsolete menu must not restore its old focus.
+    if (closed) {
+      return;
+    }
+    closed = true;
+    menu.remove();
+    document.removeEventListener("pointerdown", onOutside, true);
+    document.removeEventListener("keydown", onKeydown, true);
+    if (activeClose === close) {
+      activeClose = null;
+    }
+    if (trigger?.isConnected) {
+      trigger.focus({ preventScroll: true });
+    }
+  };
+  const onOutside = (pointerEvent: PointerEvent) => {
+    if (!pointerEvent.composedPath().includes(menu)) {
+      close();
+    }
+  };
+  const onKeydown = (keyEvent: KeyboardEvent) => {
+    if (keyEvent.key === "Escape" || keyEvent.key === "Tab") {
+      keyEvent.preventDefault();
+      keyEvent.stopPropagation();
+      close();
+      return;
+    }
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(keyEvent.key)) {
+      return;
+    }
+    keyEvent.preventDefault();
+    keyEvent.stopPropagation();
+    const items = [...menu.querySelectorAll<HTMLButtonElement>("button:not(:disabled)")];
+    const root = menu.getRootNode();
+    const focused =
+      root instanceof Document || root instanceof ShadowRoot ? root.activeElement : null;
+    const current = items.findIndex((item) => item === focused);
+    const index =
+      keyEvent.key === "Home"
+        ? 0
+        : keyEvent.key === "End"
+          ? items.length - 1
+          : (current + (keyEvent.key === "ArrowDown" ? 1 : -1) + items.length) % items.length;
+    items[index]?.focus();
+  };
+  for (const action of options.actions) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.role = "menuitem";
+    button.textContent = t(FILE_ACTION_LABEL_KEYS[action]);
+    const runAction = async () => {
+      button.disabled = true;
+      error.hidden = true;
+      try {
+        await options.onAction(action);
+        close();
+      } catch {
+        if (!closed) {
+          error.textContent = t("fileActions.failed");
+          error.hidden = false;
+          button.disabled = false;
+          button.focus();
+        }
+      }
+    };
+    button.addEventListener("click", (clickEvent) => {
+      // Keep menu activation from also triggering a surrounding openable card.
+      clickEvent.stopPropagation();
+      void runAction();
+    });
+    menu.append(button);
+  }
+  (options.container ?? trigger?.parentElement ?? document.body).append(menu);
+  menu.showPopover();
+  const rect = trigger?.getBoundingClientRect();
+  const mouse = event instanceof MouseEvent ? event : null;
+  const x = mouse && mouse.clientX > 0 ? mouse.clientX : (rect?.left ?? 8);
+  const y = mouse && mouse.clientY > 0 ? mouse.clientY : (rect?.bottom ?? 8);
+  menu.style.left = `${Math.max(8, Math.min(x, innerWidth - menu.offsetWidth - 8))}px`;
+  menu.style.top = `${Math.max(8, Math.min(y, innerHeight - menu.offsetHeight - 8))}px`;
+  document.addEventListener("pointerdown", onOutside, true);
+  document.addEventListener("keydown", onKeydown, true);
+  activeClose = close;
+  menu.querySelector<HTMLButtonElement>("button")?.focus();
+  return close;
+}

--- a/ui/src/lib/file-preview-window.test.ts
+++ b/ui/src/lib/file-preview-window.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { computeCodeWindow } from "./file-preview-window.ts";
+
+describe("computeCodeWindow", () => {
+  it("keeps a bounded visible window for large files", () => {
+    const window = computeCodeWindow(5000, 0, 660);
+    expect(window.start).toBe(0);
+    expect(window.end).toBe(60);
+    expect(window.topSpacer).toBe(0);
+    expect(window.bottomSpacer).toBe(108680);
+  });
+
+  it("moves the window with scroll position and clamps its bounds", () => {
+    const window = computeCodeWindow(1000, 220000, 660);
+    expect(window.start).toBe(970);
+    expect(window.end).toBe(1000);
+    expect(window.bottomSpacer).toBe(0);
+  });
+});

--- a/ui/src/lib/file-preview-window.ts
+++ b/ui/src/lib/file-preview-window.ts
@@ -1,0 +1,31 @@
+export interface CodeWindow {
+  start: number;
+  end: number;
+  topSpacer: number;
+  bottomSpacer: number;
+}
+
+export const FILE_PREVIEW_LINE_HEIGHT = 22;
+export const FILE_PREVIEW_OVERSCAN = 30;
+
+export function computeCodeWindow(
+  totalLines: number,
+  scrollTop: number,
+  viewportHeight: number,
+  lineHeight = FILE_PREVIEW_LINE_HEIGHT,
+  overscan = FILE_PREVIEW_OVERSCAN,
+): CodeWindow {
+  const total = Math.max(0, Math.floor(totalLines));
+  const height = Math.max(1, Number.isFinite(viewportHeight) ? viewportHeight : 1);
+  const offset = Math.max(0, Number.isFinite(scrollTop) ? scrollTop : 0);
+  const firstVisible = Math.min(total, Math.floor(offset / lineHeight));
+  const visibleLines = Math.max(1, Math.ceil(height / lineHeight));
+  const start = Math.max(0, firstVisible - overscan);
+  const end = Math.min(total, firstVisible + visibleLines + overscan);
+  return {
+    start,
+    end,
+    topSpacer: start * lineHeight,
+    bottomSpacer: Math.max(0, total - end) * lineHeight,
+  };
+}

--- a/ui/src/lib/file-reference.test.ts
+++ b/ui/src/lib/file-reference.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { availableFileActions, isSafeFileReference } from "./file-reference.ts";
+
+describe("file reference safety", () => {
+  it("accepts safe relative paths and rejects traversal/absolute paths", () => {
+    const isSafe = (relativePath: string) =>
+      isSafeFileReference({
+        origin: "workspace",
+        sessionKey: "session-1",
+        name: "guide.md",
+        relativePath,
+      });
+    expect(isSafe("docs\\guide.md")).toBe(true);
+    expect(isSafe("./docs/guide.md")).toBe(true);
+    for (const path of [
+      "../secrets.txt",
+      "C:\\secrets.txt",
+      "\\\\server\\share\\file.txt",
+      "/etc/passwd",
+      "docs/../secret",
+      "bad\0name",
+      "",
+    ]) {
+      expect(isSafe(path)).toBe(false);
+    }
+  });
+
+  it.each(["C:secret.txt", "c:secret.txt", "D:relative/file.txt", "Z:"])(
+    "rejects drive-relative references and all their actions: %s",
+    (relativePath) => {
+      const reference = {
+        origin: "workspace" as const,
+        sessionKey: "session-1",
+        name: "secret.txt",
+        relativePath,
+      };
+      expect(isSafeFileReference(reference)).toBe(false);
+      expect(availableFileActions(reference, { localGateway: true, hasContents: true })).toEqual(
+        [],
+      );
+    },
+  );
+
+  it("requires an id for artifacts and a session key for session/workspace files", () => {
+    expect(isSafeFileReference({ origin: "artifact", name: "a.txt" })).toBe(false);
+    expect(
+      isSafeFileReference({ origin: "artifact", artifactId: "artifact-1", name: "a.txt" }),
+    ).toBe(true);
+    expect(isSafeFileReference({ origin: "session", name: "a.txt", relativePath: "a.txt" })).toBe(
+      false,
+    );
+    expect(isSafeFileReference({ origin: "workspace", name: "a.txt", relativePath: "a.txt" })).toBe(
+      false,
+    );
+  });
+
+  it("does not expose host filesystem actions to remote or artifact references", () => {
+    const artifact = { origin: "artifact" as const, artifactId: "a", name: "a.bin" };
+    expect(availableFileActions(artifact, { localGateway: true })).not.toContain(
+      "revealInFileManager",
+    );
+    const workspace = {
+      origin: "workspace" as const,
+      sessionKey: "session-1",
+      relativePath: "a.txt",
+      name: "a.txt",
+    };
+    expect(availableFileActions(workspace, { localGateway: false })).not.toContain("copyFullPath");
+    expect(availableFileActions(workspace, { localGateway: true })).toContain("openWorkspaceRoot");
+  });
+
+  it("offers no actions for invalid references", () => {
+    expect(
+      availableFileActions(
+        { origin: "workspace", sessionKey: "session-1", name: "secret", relativePath: "../secret" },
+        { localGateway: true, hasContents: true },
+      ),
+    ).toEqual([]);
+    expect(availableFileActions({ origin: "artifact", name: "missing-id" })).toEqual([]);
+  });
+});

--- a/ui/src/lib/file-reference.ts
+++ b/ui/src/lib/file-reference.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared file identity and action contract used by chat, workspace and
+ * artifact previews.  A reference never carries an arbitrary local path:
+ * workspace/session entries are relative and artifacts are addressed by id.
+ */
+type FileOrigin = "chat" | "session" | "workspace" | "artifact";
+
+export interface FileReference {
+  origin: FileOrigin;
+  sessionKey?: string;
+  agentId?: string;
+  relativePath?: string;
+  artifactId?: string;
+  name: string;
+  mime?: string;
+  size?: number;
+  hash?: string;
+}
+
+export type FileAction =
+  | "preview"
+  | "copyFullPath"
+  | "copyRelativePath"
+  | "copyFilename"
+  | "copyContents"
+  | "download"
+  | "openInEditor"
+  | "revealInFileManager"
+  | "openWorkspaceRoot"
+  | "refresh";
+
+// Drive-relative paths such as C:notes.txt are not workspace-relative.
+const NON_RELATIVE_PATH = /^(?:[a-z]:|[\\/])/i;
+
+/** Normalize a workspace path without ever resolving it against the host FS. */
+function normalizeRelativePath(value: string): string | null {
+  if (!value || value.includes("\0") || NON_RELATIVE_PATH.test(value)) {
+    return null;
+  }
+  const parts = value.replaceAll("\\", "/").split("/");
+  const normalized: string[] = [];
+  for (const part of parts) {
+    if (!part || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      return null;
+    }
+    normalized.push(part);
+  }
+  return normalized.length > 0 ? normalized.join("/") : null;
+}
+
+export function isSafeFileReference(reference: FileReference): boolean {
+  if (!reference.name || reference.name.includes("\0")) {
+    return false;
+  }
+  if (reference.origin === "artifact") {
+    return typeof reference.artifactId === "string" && reference.artifactId.length > 0;
+  }
+  if (
+    reference.origin === "session" ||
+    reference.origin === "chat" ||
+    reference.origin === "workspace"
+  ) {
+    return (
+      typeof reference.sessionKey === "string" &&
+      reference.sessionKey.length > 0 &&
+      normalizeRelativePath(reference.relativePath ?? "") !== null
+    );
+  }
+  return normalizeRelativePath(reference.relativePath ?? "") !== null;
+}
+
+/** Return only actions which can be handled without an arbitrary filesystem path. */
+export function availableFileActions(
+  reference: FileReference,
+  options: { localGateway?: boolean; hasContents?: boolean } = {},
+): readonly FileAction[] {
+  if (!isSafeFileReference(reference)) {
+    return [];
+  }
+  const actions: FileAction[] = ["preview", "copyFilename", "download", "refresh"];
+  if (options.hasContents) {
+    actions.push("copyContents");
+  }
+  if (reference.origin === "workspace" || reference.origin === "session") {
+    actions.push("copyRelativePath", "openWorkspaceRoot");
+  }
+  if (options.localGateway && reference.origin !== "artifact") {
+    actions.push("copyFullPath", "revealInFileManager");
+  }
+  return actions;
+}

--- a/ui/src/pages/chat/components/chat-attachment-card.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-attachment-card.browser.test.ts
@@ -1,0 +1,153 @@
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { page, userEvent } from "vitest/browser";
+import { i18n } from "../../../i18n/index.ts";
+import { renderCompactAttachmentCard } from "./chat-attachment-card.ts";
+
+let container: HTMLDivElement;
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+});
+
+afterEach(async () => {
+  await userEvent.keyboard("{Escape}");
+  document.body.replaceChildren();
+});
+
+describe("attachment card file actions", () => {
+  it("preserves left-click preview without activating it from inner controls", async () => {
+    const onExpand = vi.fn();
+    render(
+      renderCompactAttachmentCard({
+        kind: "document",
+        label: "report.pdf",
+        onExpand,
+        downloadHref: "#fixture-download",
+      }),
+      container,
+    );
+    const card = document.querySelector<HTMLElement>(".chat-assistant-attachment-card")!;
+    card.style.cssText = "padding: 20px; width: 400px";
+    await page.getByText("report.pdf", { exact: true }).click();
+    expect(onExpand).toHaveBeenCalledTimes(1);
+    await userEvent.click(card, { position: { x: 2, y: 2 } });
+    expect(onExpand).toHaveBeenCalledTimes(2);
+    await page.getByRole("button", { name: "Open report.pdf in the side panel" }).click();
+    expect(onExpand).toHaveBeenCalledTimes(3);
+    // Cancel navigation after the card handler runs, without masking bubbling behavior.
+    container.addEventListener("click", (event) => event.preventDefault(), { once: true });
+    await page.getByRole("link", { name: "Download report.pdf" }).click();
+    expect(onExpand).toHaveBeenCalledTimes(3);
+    page.getByRole("button", { name: "Open report.pdf in the side panel" }).element().focus();
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard(" ");
+    expect(onExpand).toHaveBeenCalledTimes(5);
+  });
+
+  it("opens the existing preview from a card without a workspace reference", async () => {
+    const onExpand = vi.fn();
+    render(
+      renderCompactAttachmentCard({ kind: "document", label: "report.pdf", onExpand }),
+      container,
+    );
+    const card = document.querySelector<HTMLElement>(".chat-assistant-attachment-card")!;
+    await userEvent.click(card, { button: "right" });
+    const menu = page.getByRole("menu", { name: "Workspace file actions" });
+    await expect
+      .element(menu.getByRole("menuitem", { name: "Preview", exact: true }))
+      .toBeVisible();
+    expect(menu.getByRole("menuitem").elements()).toHaveLength(2);
+    await menu.getByRole("menuitem", { name: "Preview", exact: true }).click();
+    expect(onExpand).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(
+      page.getByRole("button", { name: "Workspace file actions", exact: true }).element(),
+    );
+    await userEvent.keyboard("{Shift>}{F10}{/Shift}");
+    await expect
+      .element(menu.getByRole("menuitem", { name: "Preview", exact: true }))
+      .toHaveFocus();
+  });
+
+  it.each([false, true])(
+    "keeps pending downloads unavailable with a custom handler: %s",
+    async (customHandler) => {
+      const onFileAction = customHandler ? vi.fn() : undefined;
+      render(
+        renderCompactAttachmentCard({
+          kind: "document",
+          label: "report.pdf",
+          downloadHref: "https://example.test/report.pdf",
+          downloadPending: true,
+          onFileAction,
+        }),
+        container,
+      );
+      const download = page.getByRole("link", { name: "Download report.pdf" });
+      await expect.element(download).toHaveAttribute("aria-disabled", "true");
+      expect(download.element().hasAttribute("href")).toBe(false);
+      await userEvent.click(
+        document.querySelector<HTMLElement>(".chat-assistant-attachment-card")!,
+        { button: "right" },
+      );
+      const menu = page.getByRole("menu", { name: "Workspace file actions" });
+      await expect.element(menu).toBeVisible();
+      expect(
+        menu.getByRole("menuitem", { name: "Download file", exact: true }).elements(),
+      ).toHaveLength(0);
+      if (onFileAction) {
+        expect(onFileAction).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each(["{Enter}", " "])(
+    "opens file actions through a native menu button with %s",
+    async (key) => {
+      render(renderCompactAttachmentCard({ kind: "document", label: "report.txt" }), container);
+      const trigger = page.getByRole("button", { name: "Workspace file actions", exact: true });
+      expect(trigger.elements()).toHaveLength(1);
+      await expect.element(trigger).toHaveAttribute("aria-haspopup", "menu");
+      expect(document.querySelector<HTMLElement>(".chat-assistant-attachment-card")!.tabIndex).toBe(
+        -1,
+      );
+      trigger.element().focus();
+      await userEvent.keyboard(key);
+      const menu = page.getByRole("menu", { name: "Workspace file actions" });
+      await expect
+        .element(menu.getByRole("menuitem", { name: "Copy filename", exact: true }))
+        .toHaveFocus();
+      await userEvent.keyboard("{Escape}");
+      expect(document.activeElement).toBe(trigger.element());
+    },
+  );
+
+  it("omits unsupported actions and unsafe download URLs", async () => {
+    render(
+      renderCompactAttachmentCard({
+        kind: "document",
+        label: "report.txt",
+        downloadHref: "javascript:void(0)",
+      }),
+      container,
+    );
+    await userEvent.click(document.querySelector<HTMLElement>(".chat-assistant-attachment-card")!, {
+      button: "right",
+    });
+    const menu = page.getByRole("menu", { name: "Workspace file actions" });
+    expect(
+      menu
+        .getByRole("menuitem")
+        .elements()
+        .map((item) => item.textContent),
+    ).toEqual(["Copy filename"]);
+  });
+});
+
+const originalLocale = i18n.getLocale();
+beforeEach(async () => {
+  await i18n.setLocale("en");
+});
+afterEach(async () => {
+  await i18n.setLocale(originalLocale);
+});

--- a/ui/src/pages/chat/components/chat-attachment-card.ts
+++ b/ui/src/pages/chat/components/chat-attachment-card.ts
@@ -2,6 +2,9 @@ import { html, nothing, type TemplateResult } from "lit";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatBytes } from "../../../lib/agents/display.ts";
+import { openFileActionMenu, openFileContextMenu } from "../../../lib/file-context-menu.ts";
+import type { FileAction, FileReference } from "../../../lib/file-reference.ts";
+import { openExternalUrlSafe, resolveSafeExternalUrl } from "../../../lib/open-external-url.ts";
 import {
   renderAttachmentFileIcon,
   resolveAttachmentFileIcon,
@@ -26,6 +29,8 @@ export type AttachmentCardHeaderOptions = {
   onExpand?: () => void;
   visualMode?: AttachmentFileVisualMode;
   voiceNote?: boolean;
+  reference?: FileReference;
+  onFileAction?: (action: FileAction) => void | Promise<void>;
 };
 
 export function renderCompactAttachmentCard(options: AttachmentCardHeaderOptions): TemplateResult {
@@ -33,8 +38,27 @@ export function renderCompactAttachmentCard(options: AttachmentCardHeaderOptions
     class="chat-assistant-attachment-card chat-assistant-attachment-card--compact"
     ?data-openable=${Boolean(options.onExpand)}
     @click=${(event: MouseEvent) => openAttachmentCardFromClick(event, options.onExpand)}
+    @contextmenu=${(event: MouseEvent) => openAttachmentContextMenu(event, options)}
+    @keydown=${(event: KeyboardEvent) => {
+      if (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey)) {
+        openAttachmentContextMenu(event, options);
+      }
+    }}
   >
-    ${renderAttachmentCardHeader({ ...options, visualMode: "large-placeholder" })}
+    ${renderAttachmentCardHeader(
+      { ...options, visualMode: "large-placeholder" },
+      html`
+        <button
+          type="button"
+          class="chat-assistant-attachment-card__action chat-assistant-attachment-card__menu"
+          aria-label=${t("chat.workspaceFiles.actions")}
+          aria-haspopup="menu"
+          @click=${(event: MouseEvent) => openAttachmentContextMenu(event, options)}
+        >
+          ${icons.moreHorizontal}
+        </button>
+      `,
+    )}
   </div>`;
 }
 
@@ -48,6 +72,53 @@ export function renderAttachmentPreviewSkeleton() {
     <div class="skeleton skeleton-line skeleton-line--long" aria-hidden="true"></div>
     <div class="skeleton skeleton-line skeleton-line--medium" aria-hidden="true"></div>
   </div>`;
+}
+
+function openAttachmentContextMenu(event: Event, options: AttachmentCardHeaderOptions) {
+  const target = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+  const trigger =
+    event instanceof KeyboardEvent && event.target instanceof HTMLElement
+      ? event.target
+      : target?.matches("button")
+        ? target
+        : (target?.querySelector<HTMLElement>(".chat-assistant-attachment-card__menu") ??
+          undefined);
+
+  const downloadUrl = options.downloadHref
+    ? resolveSafeExternalUrl(options.downloadHref, window.location.href)
+    : null;
+  const actions: FileAction[] = [];
+  if (options.onExpand || options.onFileAction) {
+    actions.push("preview");
+  }
+  actions.push("copyFilename");
+  if (!options.downloadPending && (downloadUrl || options.onFileAction)) {
+    actions.push("download");
+  }
+  if (options.onFileAction) {
+    actions.push("refresh");
+  }
+  const menuOptions = {
+    event,
+    trigger,
+    actions,
+    onAction: async (action: FileAction) => {
+      if (options.onFileAction) {
+        await options.onFileAction(action);
+      } else if (action === "preview") {
+        options.onExpand?.();
+      } else if (action === "copyFilename") {
+        await navigator.clipboard.writeText(options.reference?.name ?? options.label);
+      } else if (action === "download" && downloadUrl) {
+        openExternalUrlSafe(downloadUrl);
+      }
+    },
+  };
+  // Media cards already own safe URLs and preview callbacks, but do not always
+  // have a workspace/session file identity. Never fabricate a relative path.
+  return options.reference
+    ? openFileContextMenu({ ...menuOptions, reference: options.reference })
+    : openFileActionMenu(menuOptions);
 }
 
 const attachmentCardInteractiveSelector =
@@ -64,7 +135,7 @@ export function openAttachmentCardFromClick(
   const card = event.currentTarget;
   if (target instanceof Element && card instanceof Element) {
     const interactive = target.closest(attachmentCardInteractiveSelector);
-    if (interactive && card.contains(interactive)) {
+    if (interactive && interactive !== card && card.contains(interactive)) {
       return;
     }
   }
@@ -104,7 +175,10 @@ export function renderAttachmentCardIcon(options: {
   });
 }
 
-export function renderAttachmentCardHeader(options: AttachmentCardHeaderOptions): TemplateResult {
+export function renderAttachmentCardHeader(
+  options: AttachmentCardHeaderOptions,
+  trailingAction?: TemplateResult,
+): TemplateResult {
   const skeleton = options.loading ? "skeleton" : "";
   const compactPreview = options.visualMode === "preview-with-favicon";
   const formattedSize =
@@ -197,6 +271,7 @@ export function renderAttachmentCardHeader(options: AttachmentCardHeaderOptions)
               </button>`
             : null
         }
+        ${trailingAction ?? nothing}
       </span>
     </div>
   `;

--- a/ui/src/pages/chat/components/chat-session-workspace-rail.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-rail.browser.test.ts
@@ -1,0 +1,134 @@
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { page, userEvent } from "vitest/browser";
+import { i18n } from "../../../i18n/index.ts";
+import { renderSessionWorkspaceRail } from "./chat-session-workspace-rail.ts";
+import type { SessionWorkspaceProps } from "./chat-session-workspace-types.ts";
+
+function mountWorkspace(overrides: Partial<SessionWorkspaceProps> = {}) {
+  const workspace: SessionWorkspaceProps = {
+    collapsed: false,
+    sessionKey: "agent:main:workspace",
+    list: {
+      sessionKey: "agent:main:workspace",
+      root: "/synthetic/project",
+      files: [{ kind: "modified", name: "edited.ts", path: "src/edited.ts", missing: false }],
+      browser: {
+        path: "",
+        entries: [
+          { kind: "file", name: "browser.ts", path: "src/browser.ts" },
+          { kind: "directory", name: "docs", path: "docs" },
+        ],
+      },
+      artifacts: [
+        {
+          id: "portrait-1",
+          title: "Portrait",
+          mimeType: "image/jpeg",
+          type: "image",
+          download: { mode: "bytes" },
+          sizeBytes: 2048,
+        },
+      ],
+    },
+    loading: false,
+    error: null,
+    activeId: null,
+    filter: "all",
+    browserSearch: "",
+    dock: "right",
+    narrowLayout: false,
+    onToggleCollapsed: vi.fn(),
+    onSetDock: vi.fn(),
+    onRefresh: vi.fn(),
+    onBrowsePath: vi.fn(),
+    onOpenFile: vi.fn(),
+    onSearch: vi.fn(),
+    onSetFilter: vi.fn(),
+    onOpenArtifact: vi.fn(),
+    ...overrides,
+  };
+  const mount = document.body.appendChild(document.createElement("div"));
+  render(renderSessionWorkspaceRail(workspace), mount);
+  return { workspace, mount };
+}
+
+const menu = () => page.getByRole("menu", { name: "Workspace file actions" });
+
+beforeEach(async () => {
+  await i18n.setLocale("en");
+});
+
+afterEach(async () => {
+  // Dismiss through the menu owner so document listeners and focus state are released.
+  await userEvent.keyboard("{Escape}");
+  document.body.replaceChildren();
+});
+
+describe("workspace rail file context menus", () => {
+  it.each([
+    { path: "src/edited.ts", source: "session" as const, browser: false },
+    { path: "src/browser.ts", source: "workspace" as const, browser: true },
+  ])("previews $source files from the row and its preview action", async (testCase) => {
+    const { workspace, mount } = mountWorkspace();
+    const listSelector = testCase.browser
+      ? ".chat-workspace-rail__list--browser"
+      : ".chat-workspace-rail__list:not(.chat-workspace-rail__list--browser)";
+    const row = mount.querySelector<HTMLElement>(`${listSelector} .chat-workspace-rail__file`)!;
+    for (const selector of [".chat-workspace-rail__file-open", 'button[aria-label="Preview"]']) {
+      await userEvent.click(row.querySelector<HTMLButtonElement>(selector)!, { button: "right" });
+      expect(workspace.onOpenFile).not.toHaveBeenCalled();
+      await menu().getByRole("menuitem", { name: "Preview", exact: true }).click();
+      expect(workspace.onOpenFile).toHaveBeenCalledExactlyOnceWith(testCase.path, testCase.source);
+      expect(workspace.onOpenArtifact).not.toHaveBeenCalled();
+      expect(workspace.onBrowsePath).not.toHaveBeenCalled();
+      vi.mocked(workspace.onOpenFile).mockClear();
+    }
+  });
+
+  it("previews the artifact id without offering a relative file path", async () => {
+    const { workspace, mount } = mountWorkspace({ filter: "artifacts" });
+    const trigger = mount.querySelector<HTMLButtonElement>(".chat-workspace-rail__file-open")!;
+    await userEvent.click(trigger, { button: "right" });
+    await expect.element(menu()).toBeVisible();
+    expect(
+      [...document.querySelectorAll('[role="menuitem"]')].map((item) => item.textContent),
+    ).toEqual(["Preview", "Copy filename", "Refresh"]);
+    await menu().getByRole("menuitem", { name: "Preview", exact: true }).click();
+    expect(workspace.onOpenArtifact).toHaveBeenCalledExactlyOnceWith("portrait-1");
+    expect(workspace.onOpenFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps directories as browse targets without file context actions", async () => {
+    const { workspace, mount } = mountWorkspace();
+    const row = mount.querySelector<HTMLElement>(".chat-workspace-rail__file--directory")!;
+    const trigger = row.querySelector<HTMLButtonElement>(".chat-workspace-rail__file-open")!;
+    await userEvent.click(trigger, { button: "right" });
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+    expect(row.querySelector('[aria-label="Preview"]')).toBeNull();
+    trigger.focus();
+    await userEvent.keyboard("{Shift>}{F10}{/Shift}");
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+    await userEvent.keyboard("{Escape}");
+    await userEvent.click(trigger);
+    expect(workspace.onBrowsePath).toHaveBeenCalledExactlyOnceWith("docs");
+    expect(workspace.onOpenFile).not.toHaveBeenCalled();
+  });
+
+  it.each(["Escape", "Tab"])(
+    "restores the rail trigger after keyboard %s dismissal",
+    async (key) => {
+      const { workspace, mount } = mountWorkspace();
+      const trigger = mount.querySelector<HTMLButtonElement>(".chat-workspace-rail__file-open")!;
+      trigger.focus();
+      await userEvent.keyboard("{Shift>}{F10}{/Shift}");
+      await expect
+        .element(menu().getByRole("menuitem", { name: "Preview", exact: true }))
+        .toHaveFocus();
+      await userEvent.keyboard(`{${key}}`);
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+      expect(document.activeElement).toBe(trigger);
+      expect(workspace.onOpenFile).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/ui/src/pages/chat/components/chat-session-workspace-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-rail.ts
@@ -5,6 +5,8 @@ import { icons } from "../../../components/icons.ts";
 import { renderPanelLoadingSkeleton } from "../../../components/panel-loading-skeleton.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
+import { openFileContextMenu } from "../../../lib/file-context-menu.ts";
+import type { FileAction, FileReference } from "../../../lib/file-reference.ts";
 import { formatByteSize } from "../../../lib/format.ts";
 import {
   formatKeyboardShortcutCombo,
@@ -61,6 +63,12 @@ function renderRailHeaderAction({
     : nothing;
 }
 
+function handleFileMenuKeydown(event: KeyboardEvent, onContextMenu?: (event: Event) => void) {
+  if (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey)) {
+    onContextMenu?.(event);
+  }
+}
+
 function renderRailRow({
   icon,
   name,
@@ -69,6 +77,7 @@ function renderRailRow({
   badge = nothing,
   actions = nothing,
   onOpen,
+  onContextMenu,
   active = false,
   directory = false,
 }: {
@@ -79,6 +88,7 @@ function renderRailRow({
   badge?: TemplateResult | typeof nothing;
   actions?: TemplateResult | typeof nothing;
   onOpen: () => void;
+  onContextMenu?: (event: Event) => void;
   active?: boolean;
   directory?: boolean;
 }) {
@@ -88,7 +98,13 @@ function renderRailRow({
       ${active ? "chat-workspace-rail__file--active" : ""}"
       role="listitem"
     >
-      <button class="chat-workspace-rail__file-open" type="button" @click=${onOpen}>
+      <button
+        class="chat-workspace-rail__file-open"
+        type="button"
+        @click=${onOpen}
+        @contextmenu=${onContextMenu}
+        @keydown=${(event: KeyboardEvent) => handleFileMenuKeydown(event, onContextMenu)}
+      >
         <span class="chat-workspace-rail__file-icon">${icon}</span>
         <span class="chat-workspace-rail__file-main">
           <openclaw-tooltip .content=${tooltip}>
@@ -159,7 +175,33 @@ export function renderSessionWorkspaceRail(
   )
     ? sessionWorkspace.filter
     : "all";
-  const renderActions = (onOpen: () => void, path?: string) => html`
+  const createFileMenu = (reference: FileReference, onOpen: () => void) => (event: Event) => {
+    const actions: readonly FileAction[] =
+      reference.origin === "artifact"
+        ? ["preview", "copyFilename", "refresh"]
+        : ["preview", "copyRelativePath", "copyFilename", "refresh"];
+    openFileContextMenu({
+      event,
+      reference,
+      actions,
+      onAction: async (action) => {
+        if (action === "preview") {
+          onOpen();
+        } else if (action === "copyRelativePath" && reference.relativePath !== undefined) {
+          await navigator.clipboard.writeText(reference.relativePath);
+        } else if (action === "copyFilename") {
+          await navigator.clipboard.writeText(reference.name);
+        } else if (action === "refresh") {
+          sessionWorkspace.onRefresh();
+        }
+      },
+    });
+  };
+  const renderActions = (
+    onOpen: () => void,
+    path?: string,
+    onContextMenu?: (event: Event) => void,
+  ) => html`
     <span
       class="chat-workspace-rail__row-actions"
       role="group"
@@ -174,6 +216,8 @@ export function renderSessionWorkspaceRail(
             event.stopPropagation();
             onOpen();
           }}
+          @contextmenu=${onContextMenu}
+          @keydown=${(event: KeyboardEvent) => handleFileMenuKeydown(event, onContextMenu)}
         >
           ${icons.eye}
         </button>
@@ -194,6 +238,15 @@ export function renderSessionWorkspaceRail(
           <div class="chat-workspace-rail__list" role="list">
             ${rows.map((file) => {
               const onOpen = () => sessionWorkspace.onOpenFile(file.path, "session");
+              const onContextMenu = createFileMenu(
+                {
+                  origin: "session",
+                  sessionKey: sessionWorkspace.sessionKey,
+                  relativePath: file.path,
+                  name: file.name || file.path.split(/[\\/]/).pop() || file.path,
+                },
+                onOpen,
+              );
               return renderRailRow({
                 icon: icons.fileText,
                 name: file.path || file.name,
@@ -205,7 +258,8 @@ export function renderSessionWorkspaceRail(
                       >${t("chat.workspaceFiles.missing")}</span
                     >`
                   : nothing,
-                actions: renderActions(onOpen, file.path),
+                onContextMenu,
+                actions: renderActions(onOpen, file.path, onContextMenu),
               });
             })}
           </div>
@@ -238,6 +292,17 @@ export function renderSessionWorkspaceRail(
           directory
             ? sessionWorkspace.onBrowsePath(entry.path)
             : sessionWorkspace.onOpenFile(entry.path, "workspace");
+        const onContextMenu = directory
+          ? undefined
+          : createFileMenu(
+              {
+                origin: "workspace",
+                sessionKey: sessionWorkspace.sessionKey,
+                relativePath: entry.path,
+                name: entry.name || entry.path.split(/[\\/]/).pop() || entry.path,
+              },
+              onOpen,
+            );
         const kind = entry.sessionKind;
         return renderRailRow({
           icon: directory ? icons.folder : icons.fileText,
@@ -255,7 +320,8 @@ export function renderSessionWorkspaceRail(
                 >${t(SESSION_KIND_LABELS[kind])}</span
               >`
             : nothing,
-          actions: directory ? nothing : renderActions(onOpen, entry.path),
+          onContextMenu,
+          actions: directory ? nothing : renderActions(onOpen, entry.path, onContextMenu),
         });
       })}
     </div>
@@ -268,6 +334,14 @@ export function renderSessionWorkspaceRail(
           <div class="chat-workspace-rail__list" role="list">
             ${matchingArtifacts.map((artifact) => {
               const onOpen = () => sessionWorkspace.onOpenArtifact(artifact.id);
+              const onContextMenu = createFileMenu(
+                {
+                  origin: "artifact",
+                  artifactId: artifact.id,
+                  name: artifact.title,
+                },
+                onOpen,
+              );
               return renderRailRow({
                 icon: artifact.mimeType?.startsWith("image/") ? icons.image : icons.paperclip,
                 name: artifact.title,
@@ -276,7 +350,8 @@ export function renderSessionWorkspaceRail(
                   .join(" / "),
                 onOpen,
                 active: `artifact:${artifact.id}` === sessionWorkspace.activeId,
-                actions: renderActions(onOpen),
+                onContextMenu,
+                actions: renderActions(onOpen, undefined, onContextMenu),
               });
             })}
           </div>


### PR DESCRIPTION
Closes #145075

## What Problem This Solves

Control UI file actions are inconsistent between attachment cards, workspace/session files, and the preview dialog. Large text previews render the entire file even when only a small part is visible.

## Why This Change Was Made

Use one contextual file-action menu with validated file identities and native keyboard controls. Window large text previews by default, with an explicit full-content mode for native Find, complete selection, and assistive reading.

## User Impact

Users can open file actions with a menu button, right-click, or the keyboard. Large-file scrolling keeps a bounded set of visible rows, while full-content mode preserves access to the complete text. Existing download-pending, loading, workspace filtering, and directory navigation behavior is preserved.

## Evidence

- 68 focused unit/browser tests passed, plus all 6 production-bundle file-link E2E tests. Chromium coverage includes native keyboard menu activation, focus return, pending downloads, Windows drive-relative path rejection, bounded scrolling, full-content Find/Selection, reconnection, and 320/390px layouts.
- Regression tests failed before their corresponding fixes, including missing full-content access, invalid drive-relative references, missing native menu activation, and a removed pending-download guard.
- UI typechecking, i18n verification, and targeted Oxlint/Stylelint passed. Core-test typechecking and the core graph boundary also passed.
- Production build passed; all 8 changed runtime sources matched their source maps, and all 872 gzip/Brotli assets matched after decompression.
- `check:changed` is not fully green on Windows: its script/full-tree Knip passes report two unchanged baseline exports (`canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs`). Their production consumers exist; the pinned main configuration generates backslash glob entries that fail to match them. The production Knip pass reported zero entries. This PR does not change that configuration.
- Independent review of the complete final diff found no actionable P0-P2 findings.
- These are isolated test-fixture results. No global Gateway deployment or manual screen-reader acceptance is claimed.

Synthetic fixture: attachment actions in the Control UI.

![Attachment actions](https://github.com/user-attachments/assets/c2245d15-8b7f-483e-bc7a-37cf3cce1b05)

Synthetic fixture: full-content mode for a 5,000-line file.

![Full-content file preview](https://github.com/user-attachments/assets/b72e3dac-151e-41d4-a852-b30179d4111d)

