### PR TITLE
fix(scripts): drop unverified local git identities from squash co-author credit

### DIFF
--- a/scripts/pr-lib/merge-body.mjs
+++ b/scripts/pr-lib/merge-body.mjs
@@ -71,6 +71,9 @@ const MACHINE_CREDIT_EMAILS = new Set([
   "309084314+roboclaw-bot@users.noreply.github.com",
 ]);
 const GITHUB_APP_BOT_EMAIL = /^(?:\d+\+)?[^@\s]*\[bot\]@users\.noreply\.github\.com$/;
+const LOCAL_CREDIT_EMAIL =
+  /@(?:[^@]*\.)?(?:local|localhost|internal|lan|home|test|invalid|example)\.?$/;
+const NOREPLY_EMAIL = /(?:^|[.@])(?:no-?reply)(?:[.@]|$)/;
 
 function isCredit(line) {
   return /^Co-authored-by:/i.test(line);
@@ -104,7 +107,7 @@ function splitLines(text) {
 // including an indented key line or a trailer folded onto indented
 // continuation lines. The identity is checked at every unfolding step so
 // indented text after a complete trailer cannot hide it.
-function machineCreditLines(lines) {
+function machineCreditLines(lines, isExcludedCredit) {
   const indexes = new Set();
   for (let index = 0; index < lines.length; index += 1) {
     let unfolded = lines[index].trim();
@@ -112,7 +115,7 @@ function machineCreditLines(lines) {
       continue;
     }
     for (let end = index; ; end += 1) {
-      if (isMachineCredit(unfolded)) {
+      if (isExcludedCredit(unfolded)) {
         for (let line = index; line <= end; line += 1) {
           indexes.add(line);
         }
@@ -171,29 +174,50 @@ function prunePreview(lines, unsupported, machineIndexes) {
   return body;
 }
 
-function compose({ preview, source, authors, captured, queue }) {
+function compose({ preview, source, authors, prAuthor, captured, queue }) {
   const explicit = captured !== "";
   const sourceTrailers = source.split("\n").filter(Boolean);
-  const eligibleEmails = new Set(
-    authors
-      .split("\n")
-      .map((email) => email.trim().toLowerCase())
-      .filter(Boolean),
-  );
+  const eligibleEmails = new Set();
+  const unverifiedEmails = new Set();
+  for (const { name, email, user } of authors) {
+    const normalized = email.trim().toLowerCase();
+    const linkedHuman = user?.type === "User" && Boolean(user.login);
+    const prAuthorMatch =
+      user === null &&
+      prAuthor?.__typename === "User" &&
+      name.trim().toLowerCase() === prAuthor.login.toLowerCase() &&
+      !NOREPLY_EMAIL.test(normalized);
+    if (linkedHuman || prAuthorMatch) {
+      eligibleEmails.add(normalized);
+    } else {
+      unverifiedEmails.add(normalized);
+    }
+  }
+  const dropped = new Set();
+  const isExcludedCredit = (line) => {
+    const email = creditEmail(line);
+    const excluded =
+      email !== undefined &&
+      (isMachineCredit(line) || LOCAL_CREDIT_EMAIL.test(email) || unverifiedEmails.has(email));
+    if (excluded) {
+      dropped.add(line);
+    }
+    return excluded;
+  };
   for (const line of sourceTrailers) {
-    if (isCredit(line) && !isMachineCredit(line)) {
+    if (isCredit(line) && !isExcludedCredit(line)) {
       eligibleEmails.add(coauthorEmail(line));
     }
   }
   const previewCredits = trailers(preview).filter(isCredit);
   const unsupportedPreviewCredits = previewCredits.filter(
-    (line) => !isMachineCredit(line) && !eligibleEmails.has(coauthorEmail(line)),
+    (line) => !isExcludedCredit(line) && !eligibleEmails.has(coauthorEmail(line)),
   );
   const retainedPreviewCredits = previewCredits.filter(
-    (line) => !isMachineCredit(line) && eligibleEmails.has(coauthorEmail(line)),
+    (line) => !isExcludedCredit(line) && eligibleEmails.has(coauthorEmail(line)),
   );
   const previewLines = splitLines(preview);
-  const previewMachineLines = machineCreditLines(previewLines);
+  const previewMachineLines = machineCreditLines(previewLines, isExcludedCredit);
   // Queue admission cannot override GitHub's message, so a preview that needs
   // editing must stop here instead of merging with the wrong credit.
   if (queue && (unsupportedPreviewCredits.length > 0 || previewMachineLines.size > 0)) {
@@ -210,21 +234,21 @@ function compose({ preview, source, authors, captured, queue }) {
     // Reviewed bytes are never rewritten, so machine credit anywhere in them,
     // not only in the parsed terminal block, is the operator's to remove.
     body = Buffer.from(JSON.parse(captured).base64, "base64").toString("utf8");
-    if (machineCreditLines(splitLines(body)).size > 0) {
+    if (machineCreditLines(splitLines(body), isExcludedCredit).size > 0) {
       throw machineCreditError();
     }
   } else {
     body = prunePreview(previewLines, unsupportedPreviewCredits, previewMachineLines);
   }
   const original = trailers(body);
-  if (original.some(isMachineCredit)) {
+  if (original.some(isExcludedCredit)) {
     throw machineCreditError();
   }
   const required = [
     ...original,
     ...(explicit ? retainedPreviewCredits : []),
     ...sourceTrailers,
-  ].filter((line) => !isMachineCredit(line));
+  ].filter((line) => !isExcludedCredit(line));
   const missing = [...new Set(required)].filter((line) => !original.includes(line));
   if (queue && missing.length > 0) {
     throw new Error("Cannot queue a squash message that omits required co-author credit.");
@@ -233,7 +257,7 @@ function compose({ preview, source, authors, captured, queue }) {
   // credit before that suffix so all parsed trailers remain one terminal block.
   const suffix = explicit ? (body.match(/(?:\r?\n[ \t]*)+$/)?.[0] ?? "") : "\n";
   if (explicit && missing.length === 0) {
-    return body;
+    return { body, dropped: [...dropped] };
   }
   body = explicit
     ? body.slice(0, body.length - suffix.length)
@@ -255,14 +279,18 @@ function compose({ preview, source, authors, captured, queue }) {
   ) {
     throw new Error("Cannot remove unsupported squash preview credit.");
   }
-  return body;
+  return { body, dropped: [...dropped] };
 }
 
 try {
   if (process.argv[2] === "read") {
     process.stdout.write(JSON.stringify(snapshot(process.argv[3])));
   } else if (process.argv[2] === "compose") {
-    process.stdout.write(compose(JSON.parse(readFileSync(0, "utf8"))));
+    const { body, dropped } = compose(JSON.parse(readFileSync(0, "utf8")));
+    if (dropped.length > 0) {
+      console.error(`Dropped squash co-author credit: ${JSON.stringify(dropped)}`);
+    }
+    process.stdout.write(body);
   } else {
     throw new Error("Expected read or compose.");
   }

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -342,7 +342,7 @@ snapshot_merge_body() {
 
 prepare_squash_merge_body() {
   local pr="$1" captured="${2:-}" source_head="${LOCAL_PREP_HEAD_SHA:-$PREP_HEAD_SHA}"
-  local source_trailers author_emails
+  local source_trailers author_commits authors
   # GraphQL publication can collapse local fixups. Preserve their reviewed
   # trailers, excluding main's ancestry, rather than inspecting current HEAD.
   source_trailers=$(git -c trailer.separators=: -c trailer.co-authored-by.key=Co-authored-by log --reverse \
@@ -350,13 +350,21 @@ prepare_squash_merge_body() {
     --format='%(trailers:key=Co-authored-by,only,unfold)' "$PR_MAIN_SHA..$source_head") || return 1
   # A merge commit can reflect whoever refreshed the branch, not a contributor.
   # Preview credit must be backed by a published non-merge commit or explicit trailer.
-  author_emails=$(git log --no-merges --reverse --format='%ae' "$PR_MAIN_SHA..$PREP_HEAD_SHA") ||
-    return 1
+  author_commits=$(git log --no-merges --reverse --no-show-signature --no-notes \
+    --no-color --no-decorate --format='%H' "$PR_MAIN_SHA..$PREP_HEAD_SHA") || return 1
 
   local repo_nwo preview
   repo_nwo=$(gh repo view --json nameWithOwner --jq .nameWithOwner) || return 1
+  # A git identity alone cannot establish a human contributor. Resolve the
+  # published commits through GitHub, which leaves unlinked authors null.
+  authors=$(printf '%s\n' "$author_commits" | while IFS= read -r oid; do
+    [ -n "$oid" ] || continue
+    gh api "repos/$repo_nwo/commits/$oid" --jq \
+      '{name:.commit.author.name,email:.commit.author.email,user:(.author | if . == null then null else {login,type} end)}' || exit 1
+  done) || return 1
+  authors=$(printf '%s\n' "$authors" | jq -s .) || return 1
   preview=$(gh_plain api graphql \
-    -f 'query=query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){headRefOid isMergeQueueEnabled viewerMergeBodyText(mergeType:SQUASH)}}}' \
+    -f 'query=query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){headRefOid author{login __typename} isMergeQueueEnabled viewerMergeBodyText(mergeType:SQUASH)}}}' \
     -f owner="${repo_nwo%/*}" -f name="${repo_nwo#*/}" -F number="$pr") || return 1
   if ! printf '%s\n' "$preview" | jq -e --arg head "$PREP_HEAD_SHA" '
     .data.repository.pullRequest | .headRefOid == $head and
@@ -376,9 +384,9 @@ prepare_squash_merge_body() {
   local body_file
   body_file=$(mktemp .local/merge-body.XXXXXX) || return 1
   printf '%s\n' "$preview" | jq -c \
-    --arg source "$source_trailers" --arg authors "$author_emails" --arg captured "$captured" \
+    --arg source "$source_trailers" --argjson authors "$authors" --arg captured "$captured" \
     --argjson queue "$queue_enabled" '
-    {preview:.data.repository.pullRequest.viewerMergeBodyText,source:$source,authors:$authors,captured:$captured,queue:$queue}
+    {preview:.data.repository.pullRequest.viewerMergeBodyText,prAuthor:.data.repository.pullRequest.author,source:$source,authors:$authors,captured:$captured,queue:$queue}
   ' | node "${BASH_SOURCE[0]%/*}/merge-body.mjs" compose > "$body_file" || return 1
   # Queue admission cannot accept an override, but its preview still needs validation.
   if [ "$queue_enabled" = true ]; then

--- a/test/scripts/pr-crabbox-merge-bypass.test.ts
+++ b/test/scripts/pr-crabbox-merge-bypass.test.ts
@@ -392,6 +392,7 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
   }
   const prefix = "repos/openclaw/openclaw/";
   if (endpoint === prefix + "pulls/131091") out(value.pullRequest);
+  else if (endpoint === prefix + "commits/" + value.headSha && args.includes("--jq")) out({name:"Fixture Contributor",email:"fixture@example.com",user:{login:"fixture-contributor",type:"User"}});
   else if (endpoint === prefix + "issues/131091/comments?per_page=100") out(reviewComments);
   else if (endpoint === prefix + "commits/" + value.headSha + "/check-runs?filter=latest&per_page=100") out(value.checkRuns.check_runs.map(check => ({check_runs:[check]})));
   else if (endpoint === prefix + "actions/workflows/pr-crabbox-gate-publisher.yml/runs") out({workflow_runs:value.dispatched ? [{...value.publisherRun,html_url:repo.url+"/actions/runs/8001",display_title:"PR Crabbox gate #131091 / "+value.headSha}] : []});
@@ -423,7 +424,7 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
       fetch|cat-file|merge-base) exit 0;;
       merge-tree) echo candidate-tree;;
       rev-parse) echo main-tree;;
-      log) echo fixture@example.com;;
+      log) echo '${headSha}';;
       # The trailer parser writes stdin; drain it before exit to avoid EPIPE.
       -c) cat >/dev/null; exit 0;;
       *) echo "unexpected fixture git: $*" >&2; exit 19;;

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -176,6 +176,7 @@ function fixture(
       headRefOid: head,
       baseRefName: "main",
       isDraft: false,
+      author: { login: "fixture-contributor", __typename: "User" },
       mergeCommit: null as { oid: string } | null,
       autoMergeRequest: null as { mergeMethod: string } | null,
       isInMergeQueue: false,
@@ -378,6 +379,9 @@ else if(args[0]==="pr"&&args[1]==="view") {
     save();
     out([[...s.issueComments,...s.comments]]);
   }
+} else if(args[0]==="api"&&new RegExp("^repos/fixture/repo/commits/[0-9a-f]{40}$").test(args[1])&&args.includes("--jq")) {
+  const oid=args[1].split("/").at(-1);
+  out({name:git(["show","-s","--format=%an",oid]),email:git(["show","-s","--format=%ae",oid]),user:{login:s.pr.author.login,type:"User"}});
 } else if(args.some(x=>x.includes("/commits/"))) {
   if(s.audit) fail("audit unavailable");
   out({parents:[{sha:git(["rev-parse",s.pr.mergeCommit.oid+"^1"])}]});
@@ -2015,7 +2019,7 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
   ])(
     "submits verified attribution with pinned head for %j",
     ({ auto, admin, mergeState, route }) => {
-      const credit = "Co-authored-by: Fixture Contributor <contributor@example.invalid>";
+      const credit = "Co-authored-by: Fixture Contributor <contributor@example.com>";
       const f = fixture(`Source change\n\n${credit}\n`);
       f.save({
         ...f.state(),

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -13,6 +13,7 @@ type BodyScenario = {
   sourceCommits?: Array<{
     message: string;
     author?: { name: string; email: string };
+    githubAuthor?: { login: string; type: string } | null;
   }>;
   refreshMergeAuthor?: { name: string; email: string };
   refreshMergeMessage?: string;
@@ -24,6 +25,8 @@ type BodyScenario = {
   previewHead?: string;
   previewQueue?: boolean;
   previewError?: boolean;
+  authorReadError?: boolean;
+  prAuthor?: string;
   sourceReadError?: boolean;
   configuredTrailer?: boolean;
   signedSource?: boolean;
@@ -43,6 +46,7 @@ function prepareBody(scenario: BodyScenario) {
   }
   let localHead = headSha;
   let publishedHead = headSha;
+  const githubCommits: Record<string, unknown> = {};
   if (scenario.sourceMessages || scenario.sourceCommits) {
     mkdirSync(sourceRepo);
     const git = (args: string[], env?: NodeJS.ProcessEnv) => {
@@ -103,7 +107,7 @@ function prepareBody(scenario: BodyScenario) {
         message,
       })) ??
       [];
-    for (const { message, author } of sourceCommits) {
+    for (const { message, author, githubAuthor } of sourceCommits) {
       git(
         [
           "-c",
@@ -122,6 +126,11 @@ function prepareBody(scenario: BodyScenario) {
             }
           : undefined,
       );
+      githubCommits[git(["rev-parse", "HEAD"])] = {
+        name: author?.name ?? "Maintainer",
+        email: author?.email ?? "maintainer@example.com",
+        user: githubAuthor === undefined ? { login: "fixture-human", type: "User" } : githubAuthor,
+      };
     }
     if (scenario.refreshMergeAuthor) {
       const author = scenario.refreshMergeAuthor;
@@ -181,7 +190,14 @@ git() {
 }
 PR_MAIN_SHA=$(git rev-parse --verify refs/remotes/origin/main)
 gh_plain() { [ "$BODY_PREVIEW_ERROR" = false ] || return 1; printf '%s\\n' "$BODY_PREVIEW"; }
-gh() { printf 'fixture/repo\\n'; }
+gh() {
+  if [ "$1" = api ]; then
+    [ "$BODY_AUTHOR_READ_ERROR" = false ] || return 1
+    printf '%s\\n' "$BODY_COMMITS" | jq -ce --arg sha "\${2##*/}" '.[$sha]'
+  else
+    printf 'fixture/repo\\n'
+  fi
+}
 mktemp() { [ "$BODY_WRITE_ERROR" = false ] || return 1; command mktemp "$@"; }
 snapshot=""
 [ -z "$BODY_OVERRIDE" ] || snapshot=$(snapshot_merge_body "$BODY_OVERRIDE")
@@ -220,10 +236,13 @@ file=$(prepare_squash_merge_body 123 "$snapshot")
       BODY_READ_ERROR: String(scenario.sourceReadError ?? false),
       BODY_WRITE_ERROR: String(scenario.bodyWriteError ?? false),
       BODY_PREVIEW_ERROR: String(scenario.previewError ?? false),
+      BODY_AUTHOR_READ_ERROR: String(scenario.authorReadError ?? false),
+      BODY_COMMITS: JSON.stringify(githubCommits),
       BODY_PREVIEW: JSON.stringify({
         data: {
           repository: {
             pullRequest: {
+              author: { login: scenario.prAuthor ?? "maintainer", __typename: "User" },
               headRefOid: scenario.previewHead ?? publishedHead,
               isMergeQueueEnabled: scenario.previewQueue ?? false,
               viewerMergeBodyText:
@@ -244,6 +263,76 @@ file=$(prepare_squash_merge_body 123 "$snapshot")
 }
 
 describePosix("native squash attribution", () => {
+  it("drops the unlinked local author in the #145094 shape and keeps the PR author", () => {
+    const humanCredit = "Co-authored-by: Contributor <123+contributor@users.noreply.github.com>";
+    const machineCredit = "Co-authored-by: local-agent <local-agent@openclaw.local>";
+    const result = prepareBody({
+      prAuthor: "contributor",
+      sourceCommits: [
+        {
+          message: `Repair\n\n${humanCredit}`,
+          author: { name: "local-agent", email: "local-agent@openclaw.local" },
+          githubAuthor: null,
+        },
+      ],
+      previewBody: `Repair\n\n${humanCredit}\n${machineCredit}`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(`Repair\n\n${humanCredit}\n`);
+    expect(result.stderr.trim()).toBe(
+      `Dropped squash co-author credit: ${JSON.stringify([machineCredit])}`,
+    );
+  });
+
+  it.each([
+    "agent@host.local",
+    "agent@localhost",
+    "agent@host.LOCALHOST",
+    "agent@host.internal",
+    "agent@host.lan",
+    "agent@host.home",
+    "agent@host.test",
+    "agent@host.invalid",
+    "agent@host.example",
+    "unknown@users.noreply.github.com",
+    "123+unknown@users.noreply.github.com",
+    "unlinked@example.com",
+  ])("drops unverified commit-author credit from both preview and source: %s", (email) => {
+    const credit = `Co-authored-by: Local Author <${email}>`;
+    const result = prepareBody({
+      sourceCommits: [
+        {
+          message: `Repair\n\n${credit}`,
+          author: { name: "Local Author", email },
+          githubAuthor: null,
+        },
+      ],
+      previewBody: `Repair\n\n${credit}`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe("Repair\n");
+    expect(result.stderr.trim()).toBe(
+      `Dropped squash co-author credit: ${JSON.stringify([credit])}`,
+    );
+  });
+
+  it.each([
+    { email: "contributor@example.com", keep: true },
+    { email: "contributor@host.local", keep: false },
+    { email: "contributor@users.noreply.github.com", keep: false },
+  ])("limits the unlinked PR-login exception: %j", ({ email, keep }) => {
+    const credit = `Co-authored-by: Contributor <${email}>`;
+    const result = prepareBody({
+      prAuthor: "contributor",
+      sourceCommits: [
+        { message: "Repair", author: { name: "Contributor", email }, githubAuthor: null },
+      ],
+      previewBody: `Repair\n\n${credit}`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(keep ? `Repair\n\n${credit}\n` : "Repair\n");
+  });
+
   it("omits preview credit backed only by a refresh merge author", () => {
     const previewCredit = "Co-authored-by: Vincent Koc <vincent@example.com>";
     const result = prepareBody({
@@ -260,21 +349,25 @@ describePosix("native squash attribution", () => {
     expect(result.mergeBody).toBe("Repair summary\n");
   });
 
-  it("retains preview credit backed by a non-merge PR commit author", () => {
-    const previewCredit = "Co-authored-by: Second Author <second@example.com>";
-    const result = prepareBody({
-      sourceCommits: [
-        { message: "Repair" },
-        {
-          message: "Second repair",
-          author: { name: "Second Author", email: "SECOND@example.com" },
-        },
-      ],
-      previewBody: `Repair summary\n\n${previewCredit}`,
-    });
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.mergeBody).toBe(`Repair summary\n\n${previewCredit}\n`);
-  });
+  it.each(["second@example.com", "123+second-author@users.noreply.github.com"])(
+    "retains preview credit backed by a linked human non-merge PR commit author: %s",
+    (email) => {
+      const previewCredit = `Co-authored-by: Second Author <${email}>`;
+      const result = prepareBody({
+        sourceCommits: [
+          { message: "Repair" },
+          {
+            message: "Second repair",
+            author: { name: "Second Author", email: email.toUpperCase() },
+            githubAuthor: { login: "second-author", type: "User" },
+          },
+        ],
+        previewBody: `Repair summary\n\n${previewCredit}`,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.mergeBody).toBe(`Repair summary\n\n${previewCredit}\n`);
+    },
+  );
 
   it.each([
     { name: "Codex", email: "codex@openai.com" },
@@ -687,7 +780,13 @@ describePosix("native squash attribution", () => {
         input: JSON.stringify({
           preview: "Repair\n\nCo-authored-by: Contributor <contributor@example.com>\n",
           source: "Co-authored-by: Pair Partner <pair@example.com>\n",
-          authors: "contributor@example.com\n",
+          authors: [
+            {
+              name: "Contributor",
+              email: "contributor@example.com",
+              user: { login: "contributor", type: "User" },
+            },
+          ],
           captured: "",
           queue: true,
         }),
@@ -906,6 +1005,7 @@ describePosix("native squash attribution", () => {
     { previewHead: "b".repeat(40) },
     { previewQueue: true },
     { sourceReadError: true },
+    { authorReadError: true },
     { bodyWriteError: true },
   ])("refuses before merge when attribution evidence is unavailable: %j", (failure) => {
     for (const overrideBody of [undefined, "Explicit corrected prose"]) {


### PR DESCRIPTION
Refs #145094

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where maintainers landing a PR could include a contributor's unlinked local machine identity as a squash co-author. PR #145094 credited its human author correctly but also carried the local git identity into the landed commit.

## Why This Change Was Made

The squash composer now qualifies commit-derived credit using GitHub's linked author for each published non-merge commit. It drops reserved/local-domain identities, unlinked authors, and unresolved noreply identities, while retaining linked humans and the narrow unlinked-name match to the human PR author's login. Existing verified bot exclusions remain in place. The merge-outcome and Crabbox authorization fixtures now model the commit-author API response; their authorization and attribution assertions remain intact.

The composer filters matching preview/source trailers and reports removed credit in one preparation-log line. PR-author credit, reviewed-body byte preservation, and merge-queue admission rules retain their existing ownership. No update runtime behavior changes.

## User Impact

Squash messages preserve human contributor credit without adding local machine identities. No migration or configuration change is needed; this affects the maintainer landing wrapper only.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/pr-merge.test.ts -t '#145094 shape'` failed before the production fix: the actual body contained an extra `Co-authored-by: local-agent <local-agent@openclaw.local>` trailer.
- `node scripts/run-vitest.mjs test/scripts/pr-merge.test.ts`: **121 passed**, including the regression, linked human/public noreply addresses, all requested reserved domains, unlinked authors, the PR-login exception, and existing verified-bot cases.
- The existing signed-commit test caught signature-display text entering the new commit-ID read. Disabling Git presentation output for that read fixed it; the full file passed afterward.
- Read-only replay of the published squash message from `6c4fe0c1157`, using GitHub author evidence for `79fb949be8`, removed its local co-author trailer and preserved `Thanks @eleqtrizit.`
- `node scripts/check-changed.mjs`: passed (formatting, root-test types, tooling/test lint, dependency and dead-export guards).
- `node scripts/run-vitest.mjs test/scripts/pr-crabbox-merge-bypass.test.ts`: **38 passed**.
- `node scripts/run-vitest.mjs test/scripts/pr-merge-outcome.test.ts -t 'snapshots corrected squash|submits verified attribution|retains confirmed admin merge before failed post-merge audit|keeps unapplied uncertainty'`: **11 passed**. The full local sweep was stopped to update the second fixture; the final exact-head CI run passed.
- Follow-up `node scripts/check-changed.mjs -- <fixture-path>` checks passed separately for both updated fixture files.
- Initial CI exposed a stale merge-outcome commit-API fixture. A sibling Crabbox fixture had the same mismatch (3 failing cases reproduced locally); both adapters now distinguish author lookup from the existing audit request.
- Final exact-head [CI run 34633282466](https://github.com/openclaw/openclaw/actions/runs/34633282466) completed successfully for `767b983e7c24c1bc509b8e4ce3f1fb18efb7aca5`. The native watcher returned `GREEN` with zero pending checks after reconciling 13 superseded checks; GitHub's raw rollup still retains those older failures.
- `git diff --check` and `/bin/bash -n scripts/pr-lib/merge.sh`: passed.

Known limits: GitHub author reads are required for published non-merge commits; unavailable evidence stops preparation. Existing explicit human/source credit rules remain unchanged apart from filtering the identified excluded addresses. No merge or live Gateway operation was performed. Maintainer review and landing are pending.
