### PR TITLE
fix(sessions): acquire bulk identity locks without unbounded recursion

### DIFF
--- a/src/sessions/session-lifecycle-locks.test.ts
+++ b/src/sessions/session-lifecycle-locks.test.ts
@@ -1,0 +1,48 @@
+import { expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { StoreWriterQueue } from "../shared/store-writer-queue.js";
+import { createSessionIdentityLockRunner } from "./session-lifecycle-locks.js";
+
+it.each([5_000, 50_000])("acquires and releases %i identity locks", async (count) => {
+  const state = {
+    lifecycleQueues: new Map<string, StoreWriterQueue>(),
+    mutationQueues: new Map<string, StoreWriterQueue>(),
+  };
+  const run = createSessionIdentityLockRunner(state);
+  const identities = Array.from({ length: count }, (_, index) => `session-${index}`);
+  for (const kind of ["lifecycle", "mutation"] as const) {
+    await expect(
+      run(identities, async () => "completed", undefined, undefined, kind),
+    ).resolves.toBe("completed");
+    expect(state.lifecycleQueues.size).toBe(0);
+    expect(state.mutationQueues.size).toBe(0);
+  }
+});
+
+it("retains bulk locks through contention, reentry, and failure", async () => {
+  const state = {
+    lifecycleQueues: new Map<string, StoreWriterQueue>(),
+    mutationQueues: new Map<string, StoreWriterQueue>(),
+  };
+  const run = createSessionIdentityLockRunner(state);
+  const identities = Array.from({ length: 5_000 }, (_, index) => `session-${index}`);
+  const releaseBlocker = createDeferred();
+  const blocker = run([identities[2_500]], async () => await releaseBlocker.promise);
+  const failure = new Error("bulk mutation failed");
+  const order: string[] = [];
+  const bulk = run(identities, async () => {
+    await run([identities[0], identities[2_500], identities[4_999]], async () => {
+      order.push("bulk");
+    });
+    throw failure;
+  });
+  const rejected = expect(bulk).rejects.toBe(failure);
+  const successor = run([identities[0]], async () => {
+    order.push("successor");
+  });
+  expect(order).toEqual([]);
+  releaseBlocker.resolve();
+  await Promise.all([blocker, rejected, successor]);
+  expect(order).toEqual(["bulk", "successor"]);
+  expect(state.lifecycleQueues.size).toBe(0);
+});

--- a/src/sessions/session-lifecycle-locks.test.ts
+++ b/src/sessions/session-lifecycle-locks.test.ts
@@ -27,17 +27,17 @@ it("retains bulk locks through contention, reentry, and failure", async () => {
   const run = createSessionIdentityLockRunner(state);
   const identities = Array.from({ length: 5_000 }, (_, index) => `session-${index}`);
   const releaseBlocker = createDeferred();
-  const blocker = run([identities[2_500]], async () => await releaseBlocker.promise);
+  const blocker = run(["session-2500"], async () => await releaseBlocker.promise);
   const failure = new Error("bulk mutation failed");
   const order: string[] = [];
   const bulk = run(identities, async () => {
-    await run([identities[0], identities[2_500], identities[4_999]], async () => {
+    await run(["session-0", "session-2500", "session-4999"], async () => {
       order.push("bulk");
     });
     throw failure;
   });
   const rejected = expect(bulk).rejects.toBe(failure);
-  const successor = run([identities[0]], async () => {
+  const successor = run(["session-0"], async () => {
     order.push("successor");
   });
   expect(order).toEqual([]);

--- a/src/sessions/session-lifecycle-locks.ts
+++ b/src/sessions/session-lifecycle-locks.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { runQueuedStoreWrite, type StoreWriterQueue } from "../shared/store-writer-queue.js";
 import {
   beginLifecycleDiagnosticQueue,
@@ -14,55 +15,77 @@ export function createSessionIdentityLockRunner(state: {
     diagnostic?: LifecycleDiagnosticOperation,
     entryPhase?: "activation" | "run",
     kind: "lifecycle" | "mutation" = "lifecycle",
-    index = 0,
   ): Promise<T> {
-    const identity = identities[index];
-    if (!identity) {
-      if (entryPhase) {
-        diagnostic?.mark(entryPhase);
-      }
-      return await run();
-    }
-    const queues = kind === "mutation" ? state.mutationQueues : state.lifecycleQueues;
-    const observation =
-      diagnostic && beginLifecycleDiagnosticQueue(diagnostic, kind, queues, identity);
-    const pending = runQueuedStoreWrite({
-      queues,
-      storePath: identity,
-      label:
-        kind === "mutation"
-          ? "runExclusiveSessionLifecycleMutation"
-          : "runExclusiveSessionLifecycle",
-      reentrant: true,
-      timing: observation?.timing,
-      fn: async () => {
-        const releaseObservation = observation?.enter();
-        try {
-          return await runWithSessionIdentityLocks(
-            identities,
-            run,
-            diagnostic,
-            entryPhase,
-            kind,
-            index + 1,
-          );
-        } finally {
-          if (index === 0 && kind === diagnostic?.rootQueue) {
-            diagnostic.mark("release");
-          }
-          // Callback lifetime remains authoritative even if an outer caller cancels.
-          releaseObservation?.();
+    let acquiring = false;
+    let nextAcquisition: (() => void) | undefined;
+
+    function enqueueAcquisition(index: number): Promise<T> {
+      return new Promise<T>((resolve, reject) => {
+        // Keep idle admission synchronous without nesting the acquisition stack.
+        // Each continuation must retain the locks held by its caller.
+        nextAcquisition = AsyncLocalStorage.bind(() => {
+          void acquire(index).then(resolve, reject);
+        });
+        if (acquiring) {
+          return;
         }
-      },
-    });
-    observation?.watch();
-    try {
-      return await pending;
-    } finally {
-      observation?.finish();
-      if (index === 0 && kind === diagnostic?.rootQueue) {
-        diagnostic.finish(observation?.timing.finishedAt);
+        acquiring = true;
+        try {
+          while (nextAcquisition) {
+            const next = nextAcquisition;
+            nextAcquisition = undefined;
+            next();
+          }
+        } finally {
+          acquiring = false;
+        }
+      });
+    }
+
+    async function acquire(index: number): Promise<T> {
+      const identity = identities[index];
+      if (!identity) {
+        if (entryPhase) {
+          diagnostic?.mark(entryPhase);
+        }
+        return await run();
+      }
+      const queues = kind === "mutation" ? state.mutationQueues : state.lifecycleQueues;
+      const observation =
+        diagnostic && beginLifecycleDiagnosticQueue(diagnostic, kind, queues, identity);
+      const pending = runQueuedStoreWrite({
+        queues,
+        storePath: identity,
+        label:
+          kind === "mutation"
+            ? "runExclusiveSessionLifecycleMutation"
+            : "runExclusiveSessionLifecycle",
+        reentrant: true,
+        timing: observation?.timing,
+        fn: async () => {
+          const releaseObservation = observation?.enter();
+          try {
+            return await enqueueAcquisition(index + 1);
+          } finally {
+            if (index === 0 && kind === diagnostic?.rootQueue) {
+              diagnostic.mark("release");
+            }
+            // Callback lifetime remains authoritative even if an outer caller cancels.
+            releaseObservation?.();
+          }
+        },
+      });
+      observation?.watch();
+      try {
+        return await pending;
+      } finally {
+        observation?.finish();
+        if (index === 0 && kind === diagnostic?.rootQueue) {
+          diagnostic.finish(observation?.timing.finishedAt);
+        }
       }
     }
+
+    return await enqueueAcquisition(0);
   };
 }

--- a/src/shared/store-writer-queue.ts
+++ b/src/shared/store-writer-queue.ts
@@ -42,6 +42,10 @@ const activeStoreWriters = resolveGlobalSingleton(
 );
 
 function isActiveStoreWriter(queues: StoreWriterQueues, storePath: string): boolean {
+  // A new lane cannot be reentrant; bulk acquisition must not scan every held lock.
+  if (!queues.has(storePath)) {
+    return false;
+  }
   let active = activeStoreWriters.getStore();
   while (active) {
     if (active.active && active.queues === queues && active.storePath === storePath) {


### PR DESCRIPTION
Fixes #145116

<details>
<summary>Additional instructions</summary>

The branch is in openclaw/openclaw; maintainers can push directly.

</details>

## What Problem This Solves

Fixes an issue where users upgrading to 2026.9.4 could encounter repeated Gateway crashes when startup cleanup acquired thousands of session identity locks. The supplied 5,000-identity reproduction also crashes the checked main revision with `RangeError: Maximum call stack size exceeded`.

One concrete startup caller is memory-core cleanup of narrative sessions persisted by older releases. It passes every matching session key and session ID through the same bulk lifecycle owner. Store projection deletions, historical-generation cleanup, agent-wide purge, and maintenance also use this owner.

## Why This Change Was Made

Acquire locks through an iterative continuation loop, preserving synchronous idle admission, caller async context, reentrancy, and reverse release order. A microtask delay in the shared queue would undo the admission-ordering fix from #131456; its drain already uses a loop.

Skip the shared queue's reentrancy chain scan when the requested lane does not exist. Without that fast path, stack-safe acquisition still performs quadratic scans over already-held locks. No new limits, configuration, dependencies, schema, or retention/recovery changes are needed.

## User Impact

Large stores can complete bulk session operations without exhausting the JavaScript stack. The repair is candidate runtime code and requires no changes to installed update drivers or existing operator state. Recommended for the 2026.9.5 corrective release.

Thanks to @aatreya for the minimal reproduction, release-source verification, and locally tested mitigation.

## Evidence

- Base: `58a6953549d011ffe44dcc3a7f3290b50e64b349`; macOS arm64, Node 26.8.1.
- Before the production change, the issue reproduction and new regression suite both exited 1 with `RangeError: Maximum call stack size exceeded`; Node also reported an async-hook stack corruption during overflow.
- After: the same issue reproduction prints `completed`. The repository source preload is now `scripts/tsx.mjs`.
- `node scripts/run-vitest.mjs src/sessions/session-lifecycle-locks.test.ts src/sessions/session-lifecycle-admission.test.ts src/shared/store-writer-queue.test.ts`: 40 tests passed. Both lifecycle and mutation queues complete 5,000 and 50,000 identities; the 50,000 case took 539 ms on the final focused rerun. Contention, reentry, exception release, caller context, and immediate admission remain covered.
- Synthetic startup helper proof: seeded 20,000 stale narrative sessions in an isolated state directory, then invoked the actual memory-core `scrubDreamingNarrativeArtifacts` helper. It reported `scrubbed 20000 stale session entries and archived 0 orphan transcripts` and exited 0; the fixture was removed afterward.
- Broader proof covers all 28 `src/sessions` test files, the shared queue, and the registered memory-core startup hook: 471 distinct tests passed. The directory-filter run was supplemented with explicit file targets for the unit-fast project.
- `node scripts/check-changed.mjs`: passed, including production/test typechecks, targeted lint, formatting, unused-export scans, and storage/import guards.
- `git diff --check`: passed.
- Exact-head CI: [run 34631802565](https://github.com/openclaw/openclaw/actions/runs/34631802565), head `c1cc8dfebb5beb372ddface37b11b6898fdc5c54`; completed successfully with no failed jobs.

Known gaps: Full reporter-state and service-manager crash-loop reproduction are unavailable; the synthetic proof invokes the startup cleanup helper without starting a listener or touching an operator Gateway.
