### PR TITLE
refactor(tests): reuse deferred fixtures in plugin lifecycle tests

### DIFF
--- a/src/plugins/hooks.before-dispatch.test.ts
+++ b/src/plugins/hooks.before-dispatch.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { createHookRunner } from "./hooks.js";
 import { createMockPluginRegistry } from "./hooks.test-fixtures.js";
 import {
@@ -6,14 +7,6 @@ import {
   resolvePluginSubagentCompletionRequester,
   type PluginSubagentRequesterContext,
 } from "./runtime/subagent-requester-context.js";
-
-function deferred() {
-  let resolve: () => void = () => {};
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
 
 function getActiveRequester(): PluginSubagentRequesterContext | undefined {
   try {
@@ -33,9 +26,9 @@ describe("before_dispatch requester authority", () => {
       throw new Error("expected valid requester context");
     }
 
-    const detachedGate = deferred();
-    const secondStarted = deferred();
-    const releaseSecond = deferred();
+    const detachedGate = createDeferred();
+    const secondStarted = createDeferred();
+    const releaseSecond = createDeferred();
     let detachedRead: Promise<PluginSubagentRequesterContext | undefined> | undefined;
     const registry = createMockPluginRegistry([
       {

--- a/src/plugins/runtime/runtime-embedded-agent.runtime.test.ts
+++ b/src/plugins/runtime/runtime-embedded-agent.runtime.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DecisionReceiptV1 } from "../../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { AdmittedRunContext } from "../../agents/admitted-run-context.js";
 import { configureRuntimeActionDecisionSink } from "../../audit/runtime-action-decision.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -31,14 +32,6 @@ vi.mock("../../agents/embedded-agent.js", () => ({
 vi.mock("../../config/config.js", () => ({ getRuntimeConfig: mocks.getRuntimeConfig }));
 
 import { runPluginEmbeddedAgent } from "./runtime-embedded-agent.runtime.js";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 const config = {} as OpenClawConfig;
 const params = {
@@ -169,7 +162,7 @@ describe("plugin embedded-agent runtime admission", () => {
   });
 
   it("revokes admission immediately when a pending plugin run aborts", async () => {
-    const core = deferred<{ payloads: never[] }>();
+    const core = createDeferred<{ payloads: never[] }>();
     const admittedRunContext: AdmittedRunContext = {
       operationalRunInstance: { instanceId: "instance:run-plugin", runId: "run-plugin" },
       executionIdentityToken: {

--- a/src/plugins/runtime/subagent-requester-context.test.ts
+++ b/src/plugins/runtime/subagent-requester-context.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   createPluginSubagentRequesterContext,
   resolvePluginSubagentCompletionRequester,
@@ -62,20 +63,17 @@ describe("plugin subagent requester context", () => {
       throw new Error("expected valid requester context");
     }
 
-    let releaseDetachedRead: (() => void) | undefined;
-    const detachedGate = new Promise<void>((resolve) => {
-      releaseDetachedRead = resolve;
-    });
+    const detachedGate = createDeferred();
     let detachedRead: Promise<PluginSubagentRequesterContext | undefined> | undefined;
     await withPluginSubagentRequesterContext(requester, async () => {
       expect(getActiveRequester()).toBe(requester);
       detachedRead = (async () => {
-        await detachedGate;
+        await detachedGate.promise;
         return getActiveRequester();
       })();
     });
 
-    releaseDetachedRead?.();
+    detachedGate.resolve();
     await expect(detachedRead).resolves.toBeUndefined();
     expect(getActiveRequester()).toBeUndefined();
   });
@@ -93,34 +91,25 @@ describe("plugin subagent requester context", () => {
       throw new Error("expected valid requester contexts");
     }
 
-    let release: (() => void) | undefined;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    let firstReady: (() => void) | undefined;
-    let secondReady: (() => void) | undefined;
-    const firstStarted = new Promise<void>((resolve) => {
-      firstReady = resolve;
-    });
-    const secondStarted = new Promise<void>((resolve) => {
-      secondReady = resolve;
-    });
+    const gate = createDeferred();
+    const firstStarted = createDeferred();
+    const secondStarted = createDeferred();
 
     const firstRun = withPluginSubagentRequesterContext(first, async () => {
       expect(getActiveRequester()).toBe(first);
-      firstReady?.();
-      await gate;
+      firstStarted.resolve();
+      await gate.promise;
       expect(getActiveRequester()).toBe(first);
     });
     const secondRun = withPluginSubagentRequesterContext(second, async () => {
       expect(getActiveRequester()).toBe(second);
-      secondReady?.();
-      await gate;
+      secondStarted.resolve();
+      await gate.promise;
       expect(getActiveRequester()).toBe(second);
     });
 
-    await Promise.all([firstStarted, secondStarted]);
-    release?.();
+    await Promise.all([firstStarted.promise, secondStarted.promise]);
+    gate.resolve();
     await Promise.all([firstRun, secondRun]);
     expect(getActiveRequester()).toBeUndefined();
   });


### PR DESCRIPTION
## What Problem This Solves

Plugin lifecycle tests repeat deferred-promise constructors and optional resolver variables that an existing test helper already owns.

## Why This Change Was Made

Reuse `createDeferred` at the same synchronization points in three test files. Keep every assertion and the existing expiry, concurrent-run, abort, and cleanup ordering. No production or helper changes.

## User Impact

No user-facing behavior change. Test code adds 19 lines and removes 44; no cases are added or removed.

## Evidence

All four complete suites passed before and after: the same 30 cases, order, and statuses. The normal runner selected unit-fast, plugins, unit-fast, and plugins respectively. Source and dependency checks and owned temporary-root cleanup passed.

All 20 selected changed-file checks passed, including test typechecking, boundary guards, dead-export scans, formatting, and lint. Independent review found no actionable issues through P2. No full runtime build or live-provider proof is claimed.
