### PR TITLE
ci(android): retain existing test timing reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5626,6 +5626,18 @@ jobs:
               ;;
           esac
 
+      - name: Upload Android test reports
+        if: ${{ !cancelled() && startsWith(matrix.task, 'test-') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: android-test-reports-${{ matrix.task }}-${{ needs.preflight.outputs.checkout_revision }}-${{ github.run_attempt }}
+          path: |
+            apps/android/app/build/test-results/test*UnitTest/TEST-*.xml
+            apps/android/wear/build/test-results/test*UnitTest/TEST-*.xml
+            apps/android/wear-shared/build/test-results/test*UnitTest/TEST-*.xml
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Save Robolectric Maven cache
         if: success() && startsWith(matrix.task, 'test-') && needs.preflight.outputs.cache_write_allowed == 'true' && steps.robolectric-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/docs/ci/pipeline.md
+++ b/docs/ci/pipeline.md
@@ -161,6 +161,17 @@ Run the timing helper locally; there is no in-workflow timing-summary job (a per
 
 The `Run Node test shard` step prints Bash `time -p` totals: elapsed (`real`), user CPU (`user`), and system CPU (`sys`) seconds, including waited-for child processes. Compare CPU totals with elapsed time across equivalent runs to distinguish extra CPU work from slower execution with similar CPU work. These totals alone do not establish runner contention.
 
+Android test rows retain their existing Gradle JUnit XML for 14 days in
+`android-test-reports-<task>-<checkout-revision>-<run-attempt>` artifacts, including
+failed runs unless canceled. Reports identify test cases and durations; compilation,
+lint, setup, and queue time remain separate in the job log. Read the XML alongside
+that attempt's Gradle task outcomes: reports restored by `FROM-CACHE` or reused by
+`UP-TO-DATE` describe an earlier execution, so their times are historical. They do
+not show fresh test execution or a speedup in the current run. A failure before
+Gradle writes XML can leave no artifact; the upload warns without replacing the
+original failure. The artifact contains only phone and Wear unit-test XML, not
+dependency caches or application build outputs.
+
 Node test shards that need a built CLI run `pnpm build qaRuntime` before starting
 Vitest. This profile builds runtime JavaScript, plugin assets, and freshness and
 provenance metadata. Private QA shards select their private runtime entries. The

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -8616,6 +8616,60 @@ server.listen(0, "127.0.0.1", () => {
     expect(runStep.run).not.toMatch(/\bretry\b/iu);
   });
 
+  it("retains Android test XML after failures without collecting caches or canceled jobs", () => {
+    const steps = readCiWorkflow().jobs.android.steps as WorkflowStep[];
+    const runIndex = steps.findIndex((step) => step.name === "Run Android ${{ matrix.task }}");
+    const uploadIndex = steps.findIndex((step) => step.name === "Upload Android test reports");
+    const upload = expectDefined(steps[uploadIndex], "Android test reports");
+    expect(uploadIndex).toBeGreaterThan(runIndex);
+    // A status function prevents Actions' implicit success() from hiding failed-test evidence.
+    expect(upload.if).toMatch(/\b(?:always|cancelled|failure|success)\(\)/u);
+    for (const [task, failed, cancelled, expected] of [
+      ["test-play", false, false, true],
+      ["test-play", true, false, true],
+      ["test-play-compat", true, false, true],
+      ["test-third-party", true, false, true],
+      ["test-wear", false, false, true],
+      ["test-wear", true, true, false],
+      ["test-play", false, true, false],
+      ["build-play", false, false, false],
+      ["build-wear", true, false, false],
+      ["ktlint", false, false, false],
+    ] as const) {
+      expect(
+        evaluateWorkflowExpression(upload.if, {
+          eventName: "push",
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+          matrix: { task },
+          failed,
+          cancelled,
+        }),
+        `${task}: failed=${failed}, cancelled=${cancelled}`,
+      ).toBe(expected);
+    }
+    const root = tempDirs.make("openclaw-android-test-reports-");
+    const reports = [
+      "apps/android/app/build/test-results/testPlayDebugUnitTest/TEST-Play.xml",
+      "apps/android/app/build/test-results/testThirdPartyDebugUnitTest/TEST-ThirdParty.xml",
+      "apps/android/wear/build/test-results/testDebugUnitTest/TEST-Wear.xml",
+      "apps/android/wear-shared/build/test-results/testDebugUnitTest/TEST-Shared.xml",
+    ];
+    const unrelated = [
+      "apps/android/app/build/test-results/testPlayDebugUnitTest/binary/results.bin",
+      "apps/android/app/build/reports/lint-results-playDebug.xml",
+      "apps/android/app/build/outputs/apk/play/debug/app.apk",
+      "apps/android/benchmark/build/test-results/testDebugUnitTest/TEST-Benchmark.xml",
+      ".gradle/caches/TEST-cached.xml",
+    ];
+    for (const file of [...reports, ...unrelated]) {
+      mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+      writeFileSync(path.join(root, file), "synthetic report fixture");
+    }
+    const patterns = String(upload.with?.path).trim().split("\n");
+    expect(globSync(patterns, { cwd: root }).toSorted()).toEqual(reports.toSorted());
+  });
+
   it("never keys a Blacksmith sticky disk by unbounded run dimensions", () => {
     // Blacksmith caps backing disks per installation; per-PR, per-commit,
     // per-run, or per-hash key segments mint disks until every mount 429s.


### PR DESCRIPTION
## What Problem This Solves

Android CI logs show long test commands without identifying slow test cases. A recent successful Play run spent 10m08s compiling/running unit tests plus 3m21s in required lint. The approximately 7m25s interval after the test-task announcement needs per-case evidence, but that run retained no test-result artifacts.

## Why This Change Was Made

Retain the Gradle JUnit XML that the existing phone and Wear test jobs already produce. The upload runs after successful or failed test rows, excludes canceled jobs and non-test rows, and names artifacts by task, checkout revision, and attempt. It uses the existing pinned artifact action and 14-day retention convention.

## User Impact

Maintainers can find slow cases from otherwise-required Android runs. This adds no jobs, test invocations, shards, runner capacity, or caching infrastructure. Reports restored by `FROM-CACHE` or reused by `UP-TO-DATE` contain historical durations; the accompanying job log remains necessary to identify fresh execution.

## Evidence

33 focused workflow/Android guards pass, including executable success/failure/cancellation routing and filesystem checks limiting uploads to the intended JUnit XML. Typed lint, formatting, pinned actionlint, generated Git-owner/interpolation checks, and independent P2 review pass.

The full local workflow helper stopped at the known unavailable pinned pre-commit 4.6.2 bootstrap dependency; no substitute or bypass was used. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34632184674) is green on `d7e899ad97fd15e08e7502fed290cff55302607c`; all 149 checks are terminal without failures. Actual artifact creation will be checked on an otherwise-required Android run; no Android rerun or runtime speedup is claimed here.

Runtime production code is unchanged. The workflow adds one upload step; docs explain interpretation and the guard protects reporting and output selection. A failure before Gradle produces XML yields a warning while retaining the original job failure.
