### PR TITLE
refactor(tests): remove unused ACP bootstrap mock default

### DIFF
--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -49,19 +49,7 @@ const mockState = vi.hoisted(() => ({
     resolve: () => void;
     promise: Promise<void>;
   } | null,
-  resolveGatewayClientBootstrap: vi.fn<ResolveGatewayClientBootstrap>(async (_params) => ({
-    url: "ws://127.0.0.1:18789",
-    urlSource: "local loopback",
-    connectionDetails: {
-      url: "ws://127.0.0.1:18789",
-      urlSource: "local loopback",
-      message: "Gateway target: ws://127.0.0.1:18789",
-    },
-    auth: {
-      token: undefined,
-      password: undefined,
-    },
-  })),
+  resolveGatewayClientBootstrap: vi.fn<ResolveGatewayClientBootstrap>(),
 }));
 
 vi.mock("node:stream", async (importOriginal) => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The ACP startup test initializes its Gateway bootstrap mock twice. The first response is never used, but must be maintained alongside the response installed before every test.

## Why This Change Was Made

Remove only the unused initial callback while keeping the existing function type and the suite's reset/default hook. All case-specific responses, assertions and async operations remain unchanged. This removes 12 test lines without adding a helper.

## User Impact

No user-visible behavior changes. Startup, TLS, credential, logging, buffered-input and shutdown coverage stays intact with one owner for the default mock response.

## Evidence

- The complete startup suite passes before and after: the same 23 ordered cases, all passed on Node 24.19.
- Restoring the removed initializer reconstructs the original full test byte for byte; formatting leaves the reviewed projection unchanged.
- The complete changed-file gate passes, including mapped core-test typechecking, lint, formatting, boundary and dead-export guards.
- Independent P2 review inspected the complete original test and server owner and found no issues. No whole-suite performance improvement is claimed.
