### PR TITLE
improve: speed up search in large model catalogs

### DIFF
--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -38,9 +38,17 @@ suite.define(() => {
       expect(await textarea.inputValue()).toBe("catalog proof");
       const after: typeof before = await cdp.send("Performance.getMetrics");
       const elapsedMs = performance.now() - started;
-      const metric = (name: string) => {
-        const earlier = before.metrics.find((entry) => entry.name === name)?.value ?? 0;
-        const later = after.metrics.find((entry) => entry.name === name)?.value ?? 0;
+      const metric = (name: string, beforeMetrics = before, afterMetrics = after) => {
+        const earlier = beforeMetrics.metrics.find((entry) => entry.name === name)?.value;
+        const later = afterMetrics.metrics.find((entry) => entry.name === name)?.value;
+        if (
+          typeof earlier !== "number" ||
+          !Number.isFinite(earlier) ||
+          typeof later !== "number" ||
+          !Number.isFinite(later)
+        ) {
+          throw new Error(`Missing or invalid CDP metric: ${name}`);
+        }
         return (later - earlier) * 1_000;
       };
       const timings = {
@@ -52,7 +60,22 @@ suite.define(() => {
       };
       console.log(JSON.stringify({ proof: "model-catalog-typing", ...timings }));
       await trigger.click();
-      await picker.locator("[data-chat-model-search]").fill("Model 0999");
+      const search = picker.locator("[data-chat-model-search]");
+      await search.click();
+      expect(await search.evaluate((input) => input === document.activeElement)).toBe(true);
+      const searchBefore: typeof before = await cdp.send("Performance.getMetrics");
+      const searchStarted = performance.now();
+      await search.pressSequentially("Model 0999");
+      expect(await search.inputValue()).toBe("Model 0999");
+      const searchAfter: typeof before = await cdp.send("Performance.getMetrics");
+      const searchTimings = {
+        route,
+        models: models.length,
+        elapsedMs: performance.now() - searchStarted,
+        scriptMs: metric("ScriptDuration", searchBefore, searchAfter),
+        taskMs: metric("TaskDuration", searchBefore, searchAfter),
+      };
+      console.log(JSON.stringify({ proof: "model-catalog-search-typing", ...searchTimings }));
       const result = picker.locator('[data-chat-model-option="example/model-999"]');
       await expect.poll(() => result.isVisible()).toBe(true);
       expect(await picker.locator("[data-chat-model-option]:visible").count()).toBe(1);
@@ -60,6 +83,10 @@ suite.define(() => {
       if (artifactRoot) {
         const dir = createControlUiE2eArtifactDir(`large-model-catalog-${route}`, artifactRoot);
         await writeFile(`${dir}/timings.json`, `${JSON.stringify(timings, null, 2)}\n`);
+        await writeFile(
+          `${dir}/search-timings.json`,
+          `${JSON.stringify(searchTimings, null, 2)}\n`,
+        );
         await page.screenshot({ path: `${dir}/filtered-catalog.png`, animations: "disabled" });
       }
       const selectionBefore: typeof before = await cdp.send("Performance.getMetrics");
@@ -71,11 +98,7 @@ suite.define(() => {
         route,
         models: models.length,
         elapsedMs: performance.now() - selectionStarted,
-        taskMs:
-          (selectionAfter.metrics.find((entry) => entry.name === "TaskDuration")?.value ?? 0) *
-            1_000 -
-          (selectionBefore.metrics.find((entry) => entry.name === "TaskDuration")?.value ?? 0) *
-            1_000,
+        taskMs: metric("TaskDuration", selectionBefore, selectionAfter),
       };
       console.log(JSON.stringify({ proof: "model-catalog-selection", ...selectionTimings }));
       await cdp.detach();

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -7948,14 +7948,21 @@ describe("chat model controls", () => {
     expect(onModelSelect).not.toHaveBeenCalled();
   });
 
-  it("groups models and filters them with keyboard selection", () => {
+  it("groups models and preserves ranked keyboard selection through catalog replacement", async () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",
       modelProvider: "openai",
       models: [
         { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
         { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
-        { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", provider: "google" },
+        { id: "gemini-2.5-pro", name: "Anth model", provider: "google" },
+        {
+          id: "unavailable",
+          name: "Anth unavailable",
+          provider: "google",
+          available: false,
+          unavailableReason: "cooldown",
+        },
       ],
     });
     const onModelSelect = vi.fn(async () => true);
@@ -8003,10 +8010,13 @@ describe("chat model controls", () => {
     ).filter((option) => !option.hidden);
     expect(visibleOptions.map((option) => option.dataset.chatModelOption)).toEqual([
       "anthropic/claude-sonnet-4-6",
+      "google/gemini-2.5-pro",
+      "google/unavailable",
     ]);
-    expect(visibleOptions[0]?.hasAttribute("data-chat-model-highlighted")).toBe(true);
+    expect(visibleOptions[1]?.hasAttribute("data-chat-model-highlighted")).toBe(true);
+    expect(visibleOptions[2]?.disabled).toBe(true);
     expect(
-      visibleOptions[0]
+      visibleOptions[1]
         ?.querySelector("[data-chat-model-shortcut]")
         ?.getAttribute("data-chat-model-shortcut-number"),
     ).toBe("1");
@@ -8016,7 +8026,19 @@ describe("chat model controls", () => {
 
     search!.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
     const highlighted = container.querySelector<HTMLButtonElement>("[data-chat-model-highlighted]");
+    expect(highlighted).toBe(visibleOptions[0]);
     expect(highlighted?.id).not.toBe("");
+    expect(search?.getAttribute("aria-activedescendant")).toBe(highlighted?.id);
+
+    state.chatModelCatalog = [
+      ...state.chatModelCatalog,
+      { id: "new-match", name: "Anth new", provider: "openai" },
+    ];
+    renderModelControls(state, { onModelSelect, onModelSetup, modelPickerOpen: true }, container);
+    await Promise.resolve();
+    expect(container.querySelector("[data-chat-model-search]")).toBe(search);
+    expect(search?.value).toBe("anth");
+    expect(container.querySelector("[data-chat-model-highlighted]")).toBe(highlighted);
     expect(search?.getAttribute("aria-activedescendant")).toBe(highlighted?.id);
 
     search!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));

--- a/ui/src/pages/chat/components/chat-model-picker-search.ts
+++ b/ui/src/pages/chat/components/chat-model-picker-search.ts
@@ -109,14 +109,16 @@ export function updateModelSearch(input: HTMLInputElement, preserveHighlight = f
       matches.push({ row, score, index });
     }
   });
+  const selectableRows: HTMLButtonElement[] = [];
   matches
     .toSorted((left, right) => left.score - right.score || left.index - right.index)
     .forEach(({ row }, rank) => {
       row.dataset.chatModelRank = String(rank);
       row.style.setProperty("--chat-model-rank", String(rank));
+      if (!row.disabled) {
+        selectableRows.push(row);
+      }
     });
-  const visibleRows = visibleModelRows(menu);
-  const selectableRows = selectableModelRows(menu);
   updateModelShortcuts(menu, selectableRows);
   const selected = selectableRows.find((row) => row.getAttribute("aria-selected") === "true");
   const highlighted = preserveHighlight
@@ -128,7 +130,7 @@ export function updateModelSearch(input: HTMLInputElement, preserveHighlight = f
   );
   const empty = menu.querySelector<HTMLElement>("[data-chat-model-search-empty]");
   if (empty) {
-    empty.hidden = !query || visibleRows.length > 0;
+    empty.hidden = !query || matches.length > 0;
   }
 }
 
@@ -162,6 +164,9 @@ export function clearChatModelSearchOnEscape(event: KeyboardEvent): boolean {
 }
 
 export function handleModelSearchKeydown(event: KeyboardEvent): void {
+  if (event.key !== "Enter" && event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+    return;
+  }
   // SAFETY: Bound only to the model-search input’s keydown event.
   const input = event.currentTarget as HTMLInputElement;
   const menu = pickerMenu(input);
@@ -178,9 +183,6 @@ export function handleModelSearchKeydown(event: KeyboardEvent): void {
       event.preventDefault();
       highlighted.click();
     }
-    return;
-  }
-  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
     return;
   }
   event.preventDefault();


### PR DESCRIPTION
## What Problem This Solves

Searching a large model catalog does unnecessary DOM queries and sorting on every keystroke in Chat and New Session.

## Why This Change Was Made

Reuse the ranked matches already computed by the search operation for keyboard selection and shortcuts. Ignore unrelated keydowns before collecting selectable rows. The existing catalog refresh, disabled-row, ranking, and highlight owners remain unchanged; no persistent cache is introduced.

## User Impact

Model search does less scripting work while preserving model order, keyboard selection, shortcuts, and catalog replacement behavior. This is a search-specific improvement, not a claim that every composer action becomes faster.

## Evidence

Two counterbalanced original/candidate pairs used the same installed browser (Chrome 151.0.7922.34), synthetic 1,000-model catalog, test bytes, and typed query on both routes. All 16 selected browser cases passed on the final code. Search scripting time improved by 16.02% and 19.58% on Chat, and 13.24% and 19.29% on New Session.

| Route | Original 1 | Candidate 1 | Candidate 2 | Original 2 |
| --- | ---: | ---: | ---: | ---: |
| Chat search script time | 61.403 ms | 51.569 ms | 45.677 ms | 56.800 ms |
| New Session search script time | 50.363 ms | 43.697 ms | 41.439 ms | 51.340 ms |

Total task time was much less conclusive. New Session's first pair worsened by 1.30%; its mean was essentially flat. Unrelated controls were mixed: Chat selection task time increased from 128.091 to 133.750 ms and from 116.196 to 122.720 ms. These runs support reduced search scripting, not a uniform end-to-end speedup.

The initial original-code run exposed a test interaction error: programmatic focus attempted to type before the popup input was actionable, sending the query to the composer. That failed run was retained. The measurement now clicks the search input and verifies focus before its timing window, without sleeps, retyping, or weaker result assertions. Both variants use the same corrected test. An earlier measured implementation used in-place sorting; lint required retaining `toSorted`, and the final comparison above was rerun after that correction.

Three focused mounted cases passed, covering ranked keyboard selection, disabled matches, and catalog replacement. Repository-selected common guards, core-test/UI typechecks, i18n, export scans, targeted lint, and stylelint passed. Independent Codex review was clean through P2. The full test suite was not run locally; hosted CI remains a landing gate.

The attached original/candidate captures use synthetic data and preserve appearance. Production changes add two net lines; no visual redesign or cache lifecycle changes are included.

![Chat model search before](https://github.com/user-attachments/assets/6141706b-8fc2-4f40-bdf4-a3df118cf431)

![Chat model search after](https://github.com/user-attachments/assets/110160ae-05de-4214-aa98-9f6206b9e0bf)

![New Session model search before](https://github.com/user-attachments/assets/c316db86-721e-4299-8be9-b14e8d1b2667)

![New Session model search after](https://github.com/user-attachments/assets/78b1ef9b-01dd-4727-bf6c-038a70457991)