### PR TITLE
fix: preserve config edits made during Doctor confirmation

### DIFF
--- a/docs/cli/doctor/running.md
+++ b/docs/cli/doctor/running.md
@@ -26,6 +26,12 @@ Use `openclaw doctor --json` when an operator or script wants the advisory Docto
 
 For read-only diagnosis, use `--lint` or bare `--json`. Ordinary `doctor`, including `doctor --non-interactive`, can copy legacy config and migrate state even without `--fix`. `--non-interactive` suppresses prompts, not writes.
 
+When ordinary `doctor` asks **Apply recommended config repairs now?**, it checks
+that the selected root config file still matches the source of that proposal.
+If its contents or selected path changed, Doctor preserves the newer file,
+leaves the pending config fixes unwritten, and exits with an error. Rerun
+`openclaw doctor` to review an updated proposal.
+
 If the shared state database uses a newer schema, Doctor refuses before offering
 an interactive update because update admission also needs that database. Run
 Doctor from the OpenClaw install that wrote the state, or another compatible

--- a/src/commands/doctor-config-flow.conflict.test.ts
+++ b/src/commands/doctor-config-flow.conflict.test.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeOpenClawConfig } from "../config/test-helpers.js";
+import {
+  runInitialConfigWriteHealth,
+  runWriteConfigHealth,
+} from "../flows/doctor-health-contribution-runners.config.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { setTestEnvValue, withEnvAsync } from "../test-utils/env.js";
+import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
+
+const noteMock = vi.hoisted(() => vi.fn<(message: string, title?: string) => void>());
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({
+  note: noteMock,
+}));
+
+function createRepairableConfig(home: string) {
+  return {
+    agents: { entries: { main: { workspace: path.join(home, "workspace") } } },
+    browser: { enabled: false, actionTimeoutMs: 5000 },
+    gateway: { mode: "local" },
+    logging: { level: "info", file: path.join(home, "doctor.log") },
+    plugins: { enabled: false },
+  };
+}
+
+function expectConflictWarning() {
+  const warnings = noteMock.mock.calls
+    .filter(([, title]) => title === "Doctor warnings")
+    .map(([message]) => message)
+    .join("\n");
+  expect(warnings).toContain("changed");
+  expect(warnings).toContain("These config fixes were not written.");
+  expect(warnings).toMatch(/rerun "openclaw doctor"/i);
+  expect(noteMock.mock.calls.some(([, title]) => title === "Doctor changes")).toBe(false);
+}
+
+describe("Doctor repair confirmation conflicts", () => {
+  afterEach(() => {
+    noteMock.mockClear();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it.each([
+    { scenario: "accepting repairs after an edit", saveEdit: true, accept: true },
+    { scenario: "accepting repairs without an edit", saveEdit: false, accept: true },
+    { scenario: "declining repairs after an edit", saveEdit: true, accept: false },
+  ])("preserves saved settings when $scenario", async ({ saveEdit, accept }) => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+        const config = createRepairableConfig(home);
+        const configPath = await writeOpenClawConfig(home, config);
+        const original = await fs.readFile(configPath, "utf8");
+        const edited = JSON.stringify(
+          { ...config, logging: { ...config.logging, level: "debug" } },
+          null,
+          2,
+        );
+        let confirmationShown = false;
+        const ctx = await prepareDoctorContext(configPath, {
+          options: {},
+          confirm: async ({ message }) => {
+            expect(message).toBe("Apply recommended config repairs now?");
+            confirmationShown = true;
+            if (saveEdit) {
+              await fs.writeFile(configPath, edited);
+            }
+            return accept;
+          },
+        });
+        expect(confirmationShown).toBe(true);
+
+        await expect(runInitialConfigWriteHealth(ctx)).resolves.toBeUndefined();
+
+        if (saveEdit) {
+          // The final writer must not revive a declined or refused candidate.
+          await runWriteConfigHealth(ctx);
+          await expect(fs.readFile(configPath, "utf8")).resolves.toBe(edited);
+          await expect(fs.access(`${configPath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+          expect(ctx.configResultWriteCommitted).not.toBe(true);
+          if (accept) {
+            expectConflictWarning();
+          }
+          return;
+        }
+
+        const saved = JSON.parse(await fs.readFile(configPath, "utf8"));
+        expect(saved.browser).toEqual({ enabled: false });
+        expect(saved.logging.level).toBe("info");
+        await expect(fs.readFile(`${configPath}.bak`, "utf8")).resolves.toBe(original);
+        expect(ctx.configResultWriteCommitted).toBe(true);
+
+        // A later health repair is based on the committed candidate, so the
+        // confirmation's original source must no longer block that write.
+        ctx.cfg = { ...ctx.cfg, gateway: { ...ctx.cfg.gateway, bind: "lan" } };
+        await runWriteConfigHealth(ctx);
+        const afterHealthRepair = JSON.parse(await fs.readFile(configPath, "utf8"));
+        expect(afterHealthRepair.gateway.bind).toBe("lan");
+        expect(afterHealthRepair.browser).toEqual({ enabled: false });
+        expect(afterHealthRepair.logging.level).toBe("info");
+      });
+    });
+  });
+
+  it("refuses a config path switch during confirmation even when both files have identical bytes", async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+        const configPath = await writeOpenClawConfig(home, createRepairableConfig(home));
+        const original = await fs.readFile(configPath, "utf8");
+        const otherPath = path.join(path.dirname(configPath), "other.json");
+        await fs.writeFile(otherPath, original);
+
+        await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, async () => {
+          let confirmationShown = false;
+          const ctx = await prepareDoctorContext(configPath, {
+            options: {},
+            confirm: async ({ message }) => {
+              expect(message).toBe("Apply recommended config repairs now?");
+              confirmationShown = true;
+              setTestEnvValue("OPENCLAW_CONFIG_PATH", otherPath);
+              return true;
+            },
+          });
+          expect(confirmationShown).toBe(true);
+
+          await expect(runInitialConfigWriteHealth(ctx)).resolves.toBeUndefined();
+          await runWriteConfigHealth(ctx);
+
+          for (const file of [configPath, otherPath]) {
+            await expect(fs.readFile(file, "utf8")).resolves.toBe(original);
+            await expect(fs.access(`${file}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+          }
+          expect(ctx.configResultWriteCommitted).not.toBe(true);
+          expectConflictWarning();
+        });
+      });
+    });
+  });
+});

--- a/src/commands/doctor-config-flow.test-support.ts
+++ b/src/commands/doctor-config-flow.test-support.ts
@@ -4,13 +4,19 @@ import type { RuntimeEnv } from "../runtime.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
 
-export async function prepareDoctorContext(configPath: string): Promise<DoctorHealthFlowContext> {
+export async function prepareDoctorContext(
+  configPath: string,
+  params: {
+    options?: DoctorOptions;
+    confirm?: Parameters<typeof loadAndMaybeMigrateDoctorConfig>[0]["confirm"];
+  } = {},
+): Promise<DoctorHealthFlowContext> {
   const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
-  const options: DoctorOptions = { nonInteractive: true, repair: true };
+  const options: DoctorOptions = params.options ?? { nonInteractive: true, repair: true };
   const prompter = createDoctorPrompter({ runtime, options });
   const configResult = await loadAndMaybeMigrateDoctorConfig({
     options,
-    confirm: (params) => prompter.confirm(params),
+    confirm: params.confirm ?? ((confirmation) => prompter.confirm(confirmation)),
     runtime,
     prompter,
   });

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1290,6 +1290,7 @@ vi.mock("./doctor/shared/preview-warnings.js", async () => {
 vi.mock("./doctor-config-preflight.js", async () => {
   const fsLocal = await import("node:fs/promises");
   const pathLocal = await import("node:path");
+  const { hashConfigRaw } = await import("../config/io.read-helpers.js");
   const {
     collectRelevantDoctorPluginIds,
     listPluginDoctorLegacyConfigRules,
@@ -1317,12 +1318,12 @@ vi.mock("./doctor-config-preflight.js", async () => {
           : {};
       let injectedEffectiveConfig = injected?.config ? structuredClone(injected.config) : parsed;
       let exists = injected?.exists ?? false;
+      let raw: string | null = exists ? JSON.stringify(parsed) : null;
       if (!injected) {
         try {
-          parsed = JSON.parse(await fsLocal.readFile(configPath, "utf-8")) as Record<
-            string,
-            unknown
-          >;
+          const contents = await fsLocal.readFile(configPath, "utf-8");
+          parsed = JSON.parse(contents) as Record<string, unknown>;
+          raw = contents;
           exists = true;
           injectedEffectiveConfig = parsed;
         } catch {
@@ -1338,6 +1339,8 @@ vi.mock("./doctor-config-preflight.js", async () => {
           snapshot: {
             exists,
             path: configPath,
+            raw,
+            hash: hashConfigRaw(raw),
             parsed,
             agentRosterIncludeOwned: injected?.agentRosterIncludeOwned === true,
             ...(injected?.includeProvenance
@@ -1365,6 +1368,8 @@ vi.mock("./doctor-config-preflight.js", async () => {
         snapshot: {
           exists,
           path: configPath,
+          raw,
+          hash: hashConfigRaw(raw),
           parsed,
           agentRosterIncludeOwned: injected?.agentRosterIncludeOwned === true,
           ...(injected?.includeProvenance ? { includeProvenance: injected.includeProvenance } : {}),

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -669,11 +669,9 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   }
 
   const finalized = await finalizeDoctorConfigFlow({
-    cfg: state.cfg,
-    candidate: state.candidate,
-    pendingChanges: state.pendingChanges,
+    ...state,
+    snapshot,
     shouldRepair,
-    fixHints: state.fixHints,
     confirm: params.confirm,
     note,
   });
@@ -716,7 +714,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   const planBound = preflight.postSessionPluginMigrationPlanBound;
 
   return {
-    cfg,
+    ...finalized,
     ...(pluginInstallConfigImport ? { pluginInstallConfigImport } : {}),
     path: snapshot.path ?? CONFIG_PATH,
     shouldWriteConfig,

--- a/src/commands/doctor/finalize-config-flow.test.ts
+++ b/src/commands/doctor/finalize-config-flow.test.ts
@@ -8,6 +8,7 @@ describe("doctor finalize config flow", () => {
     const result = await finalizeDoctorConfigFlow({
       cfg: { channels: {} },
       candidate: { channels: { signal: { enabled: true } } },
+      snapshot: { path: "/config.json", hash: "source-hash", raw: null },
       pendingChanges: true,
       shouldRepair: false,
       fixHints: ['Run "openclaw doctor --fix" to apply these changes.'],
@@ -18,6 +19,7 @@ describe("doctor finalize config flow", () => {
     expect(result).toEqual({
       cfg: { channels: { signal: { enabled: true } } },
       shouldWriteConfig: true,
+      confirmedConfigSource: { path: "/config.json", hash: "source-hash" },
     });
     expect(note).not.toHaveBeenCalled();
   });
@@ -27,6 +29,7 @@ describe("doctor finalize config flow", () => {
     const result = await finalizeDoctorConfigFlow({
       cfg: { channels: {} },
       candidate: { channels: { signal: { enabled: true } } },
+      snapshot: { path: "/config.json", hash: "source-hash", raw: null },
       pendingChanges: true,
       shouldRepair: false,
       fixHints: ['Run "openclaw doctor --fix" to apply these changes.'],
@@ -48,6 +51,7 @@ describe("doctor finalize config flow", () => {
     const result = await finalizeDoctorConfigFlow({
       cfg: { channels: { signal: { enabled: true } } },
       candidate: { channels: { signal: { enabled: false } } },
+      snapshot: { path: "/config.json", hash: "source-hash", raw: null },
       pendingChanges: true,
       shouldRepair: true,
       fixHints: [],

--- a/src/commands/doctor/finalize-config-flow.ts
+++ b/src/commands/doctor/finalize-config-flow.ts
@@ -1,17 +1,27 @@
 // Final doctor config-write decision after preview/repair mode has collected mutations.
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { hashConfigRaw } from "../../config/io.read-helpers.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../../config/types.openclaw.js";
 
 /** Decide whether doctor should write the repaired candidate config or only print hints. */
 export async function finalizeDoctorConfigFlow(params: {
   cfg: OpenClawConfig;
   candidate: OpenClawConfig;
+  snapshot: Pick<ConfigFileSnapshot, "path" | "hash" | "raw">;
   pendingChanges: boolean;
   shouldRepair: boolean;
   fixHints: string[];
   confirm: (p: { message: string; initialValue: boolean }) => Promise<boolean>;
   note: (message: string, title?: string) => void;
-}): Promise<{ cfg: OpenClawConfig; shouldWriteConfig: boolean }> {
+}): Promise<{
+  cfg: OpenClawConfig;
+  shouldWriteConfig: boolean;
+  confirmedConfigSource?: { path: string; hash: string };
+}> {
   if (!params.shouldRepair && params.pendingChanges) {
+    const confirmedConfigSource = {
+      path: params.snapshot.path,
+      hash: params.snapshot.hash ?? hashConfigRaw(params.snapshot.raw),
+    };
     const shouldApply = await params.confirm({
       message: "Apply recommended config repairs now?",
       initialValue: true,
@@ -20,6 +30,7 @@ export async function finalizeDoctorConfigFlow(params: {
       return {
         cfg: params.candidate,
         shouldWriteConfig: true,
+        confirmedConfigSource,
       };
     }
     if (params.fixHints.length > 0) {

--- a/src/flows/doctor-health-contribution-runners.config.auth-cleanup.test.ts
+++ b/src/flows/doctor-health-contribution-runners.config.auth-cleanup.test.ts
@@ -17,7 +17,8 @@ vi.mock("../commands/doctor/shared/config-flow-steps.js", () => ({
   restoreDoctorConfigEnvRefs: (cfg: OpenClawConfig) => cfg,
 }));
 
-vi.mock("../config/config.js", () => ({
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
   transformConfigFile: async ({
     transform,
     ...options

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -52,11 +52,14 @@ export async function runWriteConfigHealth(
     return;
   }
   const { applyWizardMetadata } = await import("../commands/onboard-helpers.js");
-  const { transformConfigFile } = await import("../config/config.js");
+  const { ConfigMutationConflictError, transformConfigFile } = await import("../config/config.js");
   const { logConfigUpdated } = await import("../config/logging.js");
   const { shortenHomePath } = await import("../utils.js");
   const configResultWritePending =
     ctx.configResult.shouldWriteConfig === true && ctx.configResultWriteCommitted !== true;
+  const confirmedConfigSource = configResultWritePending
+    ? ctx.configResult.confirmedConfigSource
+    : undefined;
   const shouldWriteConfig =
     configResultWritePending || JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
   if (shouldWriteConfig) {
@@ -79,6 +82,7 @@ export async function runWriteConfigHealth(
       await import("../commands/doctor/shared/plugin-registry-migration.js");
     try {
       await transformConfigFile({
+        ...(confirmedConfigSource ? { baseHash: confirmedConfigSource.hash } : {}),
         transform: (_current, { snapshot }, { envSnapshotForRestore }) => {
           // Revalidate the copied source under the config lock; never import after plugin repair.
           assertShippedPluginInstallConfigImportCurrent(
@@ -90,6 +94,7 @@ export async function runWriteConfigHealth(
         },
         afterWrite: { mode: "auto" },
         writeOptions: {
+          ...(confirmedConfigSource ? { expectedConfigPath: confirmedConfigSource.path } : {}),
           auditOrigin: "doctor",
           allowConfigSizeDrop: ctx.configResult.shouldWriteConfig === true || updateDoctorRun,
           skipPluginValidation:
@@ -107,6 +112,18 @@ export async function runWriteConfigHealth(
         },
       });
     } catch (error) {
+      if (confirmedConfigSource && error instanceof ConfigMutationConflictError) {
+        const { note } = await import("../../packages/terminal-core/src/note.js");
+        note(
+          [
+            "The config changed after Doctor prepared these repairs.",
+            'These config fixes were not written. Rerun "openclaw doctor" to review repairs for the current config.',
+          ].join("\n"),
+          "Doctor warnings",
+        );
+        ctx.configWriteRefusal = "config-conflict";
+        return;
+      }
       const { isConfigIncludeOwnershipError, isConfigValidationFailedError } =
         await import("../config/io.write-errors.js");
       // A refused write persisted nothing. Queued "Doctor changes" panels stay
@@ -185,6 +202,7 @@ export async function runWriteConfigHealth(
     ctx.cfgForPersistence = structuredClone(ctx.cfg);
     if (ctx.configResult.shouldWriteConfig === true) {
       ctx.configResultWriteCommitted = true;
+      delete ctx.configResult.confirmedConfigSource;
     }
     // logConfigUpdated already prints the `.bak` backup line when it exists.
     logConfigUpdated(ctx.runtime);

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -20,6 +20,8 @@ type DoctorConfigResult = {
   pluginInstallConfigImport?: ShippedPluginInstallConfigImport;
   path?: string;
   shouldWriteConfig?: boolean;
+  /** Source of the ordinary confirmed proposal, consumed by its initial write. */
+  confirmedConfigSource?: { path: string; hash: string };
   /** Repair panels held back until the atomic config write commits. */
   pendingChangePanels?: readonly string[];
   sourceConfigValid?: boolean;
@@ -55,7 +57,7 @@ export type DoctorHealthFlowContext = {
   /** The finalized config-flow candidate crossed the atomic writer boundary. */
   configResultWriteCommitted?: boolean;
   /** The requested config write was refused; later repairs must not consume its candidate. */
-  configWriteRefusal?: "validation" | "cron-owner-safety" | "include-ownership";
+  configWriteRefusal?: "validation" | "cron-owner-safety" | "include-ownership" | "config-conflict";
   /** One-shot repairs that require a durable config write have completed. */
   postConfigWriteRepairsCommitted?: boolean;
   sourceConfigValid: boolean;

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -518,7 +518,8 @@ vi.mock("../commands/doctor/shared/config-flow-steps.js", () => ({
   restoreDoctorConfigEnvRefs: (cfg: OpenClawConfig) => cfg,
 }));
 
-vi.mock("../config/config.js", () => ({
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
   CONFIG_PATH: "/tmp/fake-openclaw.json",
   transformConfigFile: async ({
     transform,


### PR DESCRIPTION
Closes #145114

<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/openclaw`; repository maintainers can edit it directly.

</details>

## What Problem This Solves

Fixes an issue where users saving config changes while ordinary Doctor waits at **Apply recommended config repairs now?** would lose those edits after accepting the repair. For example, changing `logging.level` from `info` to `debug` could be overwritten by a prepared config that still contained `info`.

## Why This Change Was Made

The confirmation helper now carries the proposal's root config path and content hash to the existing atomic writer, which rejects a changed source under its lock. Doctor consumes the identity after a successful initial write, allowing subsequent repairs to continue.

## User Impact

Doctor preserves a newer root config file, reports that the pending repairs were not written, and exits with an error so the user can rerun it for an updated proposal. Unchanged acceptance and declined repairs retain their existing behavior. Explicit repair and published-updater handoffs retain their existing write policy; included-file ownership rules are unchanged.

The proposal identity is temporary Doctor state. This adds no stored config fields or schema changes.

## Evidence

- All 380 tests in 13 affected files pass on `396a9e501371b906fa7a6e6788d239d2521690a6`, covering confirmation conflicts, refusal paths, migration and persistence siblings, cleanup, and later writes.
- The full changed-path gate passes on that commit: 29 checks, including core typechecking, all 17 core test type graphs, formatting, lint, architecture checks, and Doctor registry checks.
- The four-case conflict regression passes on the candidate. On base `58a6953549d011ffe44dcc3a7f3290b50e64b349`, both file-preservation checks fail while normal acceptance and decline pass. Tests use real config preparation and atomic persistence.
- Independent review of this patch found no actionable P0–P2 issues.
- [CI](https://github.com/openclaw/openclaw/actions/runs/34635295556) and the required merge check pass. [ClawSweeper](https://github.com/openclaw/openclaw/pull/145140#issuecomment-5639014814) rates this commit Platinum with no actionable code findings.
- Real `pnpm openclaw doctor --no-workspace-suggestions` controls pass on Linux at the same commit. Accepting after an external edit exits 1 with the conflict warning, preserves the exact edited bytes, and creates no backup. Unchanged acceptance repairs the config and backs up the original bytes; declining after an edit preserves the edited bytes and creates no backup. Those two controls stop at the observed write or later contribution, respectively; they do not claim a full Doctor run.
- The published `openclaw@2026.9.3` updater successfully installs the candidate package built from this commit. The native base scenario verifies automatic migration before standalone Doctor, config/state survival, and Gateway health/readiness/status. All 11 updater steps and 37 native phases pass; the installed and serving build IDs match the candidate. This cell uses manual Gateway startup and does not test updater-owned restart.
