### PR TITLE
fix(codex): skip custom messages in settled-turn projection instead of rejecting the turn

### DIFF
--- a/extensions/codex/src/app-server/settled-turn-projection.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.test.ts
@@ -366,4 +366,37 @@ describe("projectSettledCodexMessages", () => {
       "byte_limit",
     );
   });
+
+  it("skips OpenClaw custom messages instead of rejecting the history", () => {
+    expect(
+      projectSettledCodexMessages([
+        message({
+          role: "custom",
+          customType: "openclaw.runtime-context",
+          content: "If nothing needs attention, reply HEARTBEAT_OK.",
+          details: { runtimeContextCarrier: true },
+        }),
+        message({ role: "user", content: "Send the update." }),
+        toolCall(),
+        toolResult(),
+      ]),
+    ).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Send the update." }],
+      },
+      {
+        type: "function_call",
+        call_id: "call-1",
+        name: "message",
+        arguments: '{"action":"send"}',
+      },
+      {
+        type: "function_call_output",
+        call_id: "call-1",
+        output: "Message sent.",
+      },
+    ]);
+  });
 });

--- a/extensions/codex/src/app-server/settled-turn-projection.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.test.ts
@@ -367,14 +367,13 @@ describe("projectSettledCodexMessages", () => {
     );
   });
 
-  it("skips OpenClaw custom messages instead of rejecting the history", () => {
+  it("skips transient runtime-context custom messages instead of rejecting the history", () => {
     expect(
       projectSettledCodexMessages([
         message({
           role: "custom",
           customType: "openclaw.runtime-context",
           content: "If nothing needs attention, reply HEARTBEAT_OK.",
-          details: { runtimeContextCarrier: true },
         }),
         message({ role: "user", content: "Send the update." }),
         toolCall(),
@@ -398,5 +397,15 @@ describe("projectSettledCodexMessages", () => {
         output: "Message sent.",
       },
     ]);
+  });
+
+  it("keeps durable custom notes fail-closed rather than silently dropping them", () => {
+    expect(() =>
+      projectSettledCodexMessages([
+        message({ role: "custom", customType: "note", content: "Durable operator note." }),
+        toolCall(),
+        toolResult(),
+      ]),
+    ).toThrow("unsupported_content");
   });
 });

--- a/extensions/codex/src/app-server/settled-turn-projection.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.ts
@@ -1,7 +1,9 @@
 import { Buffer } from "node:buffer";
-import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  type AgentMessage,
+  isOpenClawRuntimeContextCustomMessage,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { isCodexDurableCustomMessage } from "./context-engine-projection.js";
 import { CodexHistoryRejection } from "./history-rejection.js";
 import type { JsonValue } from "./protocol.js";
 import { readUpstreamUserText } from "./upstream-prompt-provenance.js";
@@ -288,12 +290,13 @@ class HistoryProjection {
     } else if (message.role === "toolResult") {
       projectToolResult(message, this);
     } else if (message.role === "custom") {
-      // Transient runtime-context carriers (e.g. the heartbeat prompt) are
-      // current-turn only, not part of the replayable transcript, so skip them
-      // like context-engine-projection does. Durable custom notes carry
-      // meaningful context and stay fail-closed rather than being silently
-      // dropped.
-      if (!isCodexDurableCustomMessage(message)) {
+      // Transient runtime-context carriers (e.g. the heartbeat prompt) and
+      // context-excluded customs are current-turn only, not part of the
+      // replayable transcript, so skip them (matching how context-engine
+      // projection excludes them via isCodexDurableCustomMessage). Durable
+      // custom notes carry meaningful context and stay fail-closed rather than
+      // being silently dropped.
+      if (message.excludeFromContext === true || isOpenClawRuntimeContextCustomMessage(message)) {
         return;
       }
       throw new CodexHistoryRejection("unsupported_content");

--- a/extensions/codex/src/app-server/settled-turn-projection.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isCodexDurableCustomMessage } from "./context-engine-projection.js";
 import { CodexHistoryRejection } from "./history-rejection.js";
 import type { JsonValue } from "./protocol.js";
 import { readUpstreamUserText } from "./upstream-prompt-provenance.js";
@@ -287,11 +288,15 @@ class HistoryProjection {
     } else if (message.role === "toolResult") {
       projectToolResult(message, this);
     } else if (message.role === "custom") {
-      // Custom messages (e.g. openclaw.runtime-context carriers such as the
-      // heartbeat prompt) are OpenClaw-internal annotations, not part of the
-      // user/assistant/tool transcript Codex replays. Skip them like private
-      // reasoning rather than rejecting the entire history.
-      return;
+      // Transient runtime-context carriers (e.g. the heartbeat prompt) are
+      // current-turn only, not part of the replayable transcript, so skip them
+      // like context-engine-projection does. Durable custom notes carry
+      // meaningful context and stay fail-closed rather than being silently
+      // dropped.
+      if (!isCodexDurableCustomMessage(message)) {
+        return;
+      }
+      throw new CodexHistoryRejection("unsupported_content");
     } else {
       throw new CodexHistoryRejection("unsupported_content");
     }

--- a/extensions/codex/src/app-server/settled-turn-projection.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.ts
@@ -286,6 +286,12 @@ class HistoryProjection {
       projectAssistantMessage(message, this);
     } else if (message.role === "toolResult") {
       projectToolResult(message, this);
+    } else if (message.role === "custom") {
+      // Custom messages (e.g. openclaw.runtime-context carriers such as the
+      // heartbeat prompt) are OpenClaw-internal annotations, not part of the
+      // user/assistant/tool transcript Codex replays. Skip them like private
+      // reasoning rather than rejecting the entire history.
+      return;
     } else {
       throw new CodexHistoryRejection("unsupported_content");
     }


### PR DESCRIPTION
Closes #145134

## What Problem This Solves

Fixes an issue where agents on the Codex (OpenAI-subscription) runtime intermittently fail turns with a user-visible "Bash failed" message (and heartbeat `agent-tool-failure`). Any turn whose settled-turn finalization history contains a transient `custom_message` — for example the built-in heartbeat's `openclaw.runtime-context` prompt — is rejected, so scheduled automations and interactive replies surface a tool failure instead of their result. Plain-text turns finalize normally, which is why it presents as intermittent.

## Why This Change Was Made

`HistoryProjection.append()` in the codex settled-turn projector routes messages by role and rejects any role outside `user`/`assistant`/`toolResult` with `CodexHistoryRejection("unsupported_content")`. `CustomMessage` uses `role: "custom"`, so a transient runtime-context carrier anywhere in a turn's projected history invalidated the whole history and failed finalization.

The fix skips **only transient** custom carriers during projection, reusing the existing `isCodexDurableCustomMessage` predicate so it mirrors `context-engine-projection` (which already excludes runtime-context carriers but keeps durable notes). **Durable** custom notes stay fail-closed rather than being silently dropped. This parallels how private `thinking`/`reasoning` parts are already skipped. Non-goal: it does not change how custom messages are stored or shown elsewhere.

## User Impact

Agents on the OpenAI-subscription/Codex runtime finalize turns normally even when the session history includes runtime-context messages. The built-in heartbeat and channel-delivering automations stop emitting spurious "Bash failed" messages, while durable custom context is preserved.

## Evidence

- Root cause, logs, and reproduction in #145134: gateway logs `codex settled-turn finalization context capture failed {reason: "unsupported_content"}` followed by `context is unavailable`, and the offending `custom_message` (`customType: "openclaw.runtime-context"`) is present in `transcript_events`.
- Tests on the patched build (run locally via `node scripts/run-vitest.mjs`), all green:
  - `settled-turn-projection.test.ts` — 24/24, incl. new cases: a transient runtime-context custom message is skipped while the surrounding user/tool exchange still projects, and a durable custom note stays fail-closed.
  - `settled-turn-finalizer.test.ts` — 28/28.
  - `run-attempt.durable-context.test.ts` — 4/4 (durable custom context still reaches both started and resumed threads — no regression).
- Spun up the patched build and exercised it live against the OpenAI (Codex) subscription: the gateway started clean and completed a real turn end-to-end through the codex runtime.
- `git diff --check` clean; CI green on the PR head.

Captured output (redacted):

```console
# patched build running against the live OpenAI/Codex subscription
[gateway] [plugins] duplicate plugin id detected; global plugin will be overridden by bundled plugin (.../dist/extensions/codex/index.js) (plugin=codex)
[gateway] agent model: openai/<subscription-model> (thinking=low, fast=off)
[gateway] http server listening (21 plugins: ..., codex, ...; 2.7s)
[gateway] ready

$ openclaw agent --message "Reply with exactly: proof-turn-ok"
proof-turn-ok

# finalizer-path tests on the patched build
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/settled-turn-projection.test.ts
 ✓ skips transient runtime-context custom messages instead of rejecting the history
 ✓ keeps durable custom notes fail-closed rather than silently dropping them
 Test Files  1 passed (1)
       Tests  24 passed (24)

$ node scripts/run-vitest.mjs extensions/codex/src/app-server/settled-turn-finalizer.test.ts
 Test Files  1 passed (1)
       Tests  28 passed (28)

$ node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.durable-context.test.ts
 Test Files  1 passed (1)
       Tests  4 passed (4)
```
