### PR TITLE
fix(models): preserve replacement keys during removal

### DIFF
--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -100,8 +100,8 @@ function resolveProviderSourceConfig(cfg: OpenClawConfig | undefined, provider: 
 export function resolveProviderConfigSecretInput(
   cfg: OpenClawConfig | undefined,
   provider: string,
+  sourceConfig = resolveProviderSourceConfig(cfg, provider),
 ) {
-  const sourceConfig = resolveProviderSourceConfig(cfg, provider);
   const entry = resolveMergedModelProviderEntry(sourceConfig, provider);
   const path = entry ? `models.providers.${entry.providerKey}.apiKey` : "";
   const resolvedEnvRef = entry ? getResolvedConfigEnvSecretRef(sourceConfig, path) : null;
@@ -405,11 +405,16 @@ export function canUseProfileAsProviderEntryApiKey(params: {
 /** Classifies a provider entry apiKey as literal/profile/marker before resolving secrets. */
 export function resolveProviderEntryApiKeyProfileReference(params: {
   cfg?: OpenClawConfig;
+  sourceConfig?: OpenClawConfig;
   authAliasLookupParams?: ProviderAuthAliasLookupParams;
   provider: string;
   store: AuthProfileStore;
 }): ProviderEntryApiKeyProfileReference {
-  const { providerConfig, ref } = resolveProviderConfigSecretInput(params.cfg, params.provider);
+  const { providerConfig, ref } = resolveProviderConfigSecretInput(
+    params.cfg,
+    params.provider,
+    params.sourceConfig,
+  );
   if (ref) {
     return { kind: "none" };
   }

--- a/src/commands/models/auth-logout.test.ts
+++ b/src/commands/models/auth-logout.test.ts
@@ -97,12 +97,12 @@ function storeWith(profileIds: string[]): AuthProfileStore {
 /** Runs the config mutator captured by the mocked updateConfig. */
 function applyCapturedConfigUpdate(cfg: OpenClawConfig): OpenClawConfig {
   const mutator = mocks.updateConfig.mock.calls[0]?.[0] as
-    | ((current: OpenClawConfig) => OpenClawConfig)
+    | ((current: OpenClawConfig, context: { runtimeConfig: OpenClawConfig }) => OpenClawConfig)
     | undefined;
   if (!mutator) {
     throw new Error("expected updateConfig to be called");
   }
-  return mutator(cfg);
+  return mutator(cfg, { runtimeConfig: cfg });
 }
 
 async function withStdinIsTty<T>(isTTY: boolean, run: () => Promise<T>): Promise<T> {
@@ -304,8 +304,13 @@ describe("models auth logout", () => {
       profiles: { [profileId]: credential },
     });
     mocks.updateConfig.mockImplementation(
-      async (mutator: (current: OpenClawConfig) => OpenClawConfig | Promise<OpenClawConfig>) => {
-        liveConfig = await mutator(liveConfig);
+      async (
+        mutator: (
+          current: OpenClawConfig,
+          context: { runtimeConfig: OpenClawConfig },
+        ) => OpenClawConfig | Promise<OpenClawConfig>,
+      ) => {
+        liveConfig = await mutator(liveConfig, { runtimeConfig: liveConfig });
         return liveConfig;
       },
     );
@@ -361,8 +366,13 @@ describe("models auth logout", () => {
       profiles: { [survivorId]: survivor },
     });
     mocks.updateConfig.mockImplementation(
-      async (mutator: (current: OpenClawConfig) => OpenClawConfig | Promise<OpenClawConfig>) => {
-        liveConfig = await mutator(liveConfig);
+      async (
+        mutator: (
+          current: OpenClawConfig,
+          context: { runtimeConfig: OpenClawConfig },
+        ) => OpenClawConfig | Promise<OpenClawConfig>,
+      ) => {
+        liveConfig = await mutator(liveConfig, { runtimeConfig: liveConfig });
         return liveConfig;
       },
     );
@@ -434,8 +444,13 @@ describe("models auth logout", () => {
       profiles: { [keyId]: key, [tokenId]: token },
     });
     mocks.updateConfig.mockImplementation(
-      async (mutator: (current: OpenClawConfig) => OpenClawConfig | Promise<OpenClawConfig>) => {
-        liveConfig = await mutator(liveConfig);
+      async (
+        mutator: (
+          current: OpenClawConfig,
+          context: { runtimeConfig: OpenClawConfig },
+        ) => OpenClawConfig | Promise<OpenClawConfig>,
+      ) => {
+        liveConfig = await mutator(liveConfig, { runtimeConfig: liveConfig });
         return liveConfig;
       },
     );

--- a/src/commands/models/auth-logout.test.ts
+++ b/src/commands/models/auth-logout.test.ts
@@ -1,11 +1,17 @@
 // Covers `models auth logout`: store removal, config-reference cleanup, and refusals.
+import { expectDefined } from "@openclaw/normalization-core";
+import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileCredential, AuthProfileStore } from "../../agents/auth-profiles.js";
+import { registerModelsCli } from "../../cli/models-cli.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import { createDirectChatContext } from "../../gateway/server-chat.agent-events.test-helpers.js";
+import { handleGatewayRequest } from "../../gateway/server-methods.js";
+import type { RespondFn } from "../../gateway/server-methods/types.js";
+import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 
 const mocks = vi.hoisted(() => ({
-  ensureAuthProfileStoreWithoutExternalProfiles: vi.fn(),
+  ensureAuthProfileStoreWithoutExternalProfiles: vi.fn<() => AuthProfileStore>(),
   listProfilesForProvider: vi.fn(() => [] as string[]),
   removeAuthProfilesAcrossOwnerStores: vi.fn(
     async (params: {
@@ -26,13 +32,19 @@ const mocks = vi.hoisted(() => ({
   confirm: vi.fn(async () => true),
 }));
 
-vi.mock("../../agents/auth-profiles.js", () => ({
-  ensureAuthProfileStoreWithoutExternalProfiles:
-    mocks.ensureAuthProfileStoreWithoutExternalProfiles,
-  listProfilesForProvider: mocks.listProfilesForProvider,
-  loadAuthProfileStoreWithoutExternalProfiles: mocks.ensureAuthProfileStoreWithoutExternalProfiles,
-  removeAuthProfilesAcrossOwnerStores: mocks.removeAuthProfilesAcrossOwnerStores,
-}));
+vi.mock("../../agents/auth-profiles.js", async () => {
+  const { clearRuntimeAuthProfileStoreSnapshots } =
+    await import("../../agents/auth-profiles/runtime-snapshots.js");
+  return {
+    clearRuntimeAuthProfileStoreSnapshots,
+    ensureAuthProfileStoreWithoutExternalProfiles:
+      mocks.ensureAuthProfileStoreWithoutExternalProfiles,
+    listProfilesForProvider: mocks.listProfilesForProvider,
+    loadAuthProfileStoreWithoutExternalProfiles:
+      mocks.ensureAuthProfileStoreWithoutExternalProfiles,
+    removeAuthProfilesAcrossOwnerStores: mocks.removeAuthProfilesAcrossOwnerStores,
+  };
+});
 
 vi.mock("./load-config.js", () => ({
   loadModelsConfig: mocks.loadModelsConfig,
@@ -54,6 +66,11 @@ vi.mock("./auth-refresh.js", () => ({
   refreshRunningGatewayAuthState: mocks.refreshRunningGatewayAuthState,
 }));
 
+vi.mock("../../gateway/server-methods/models-auth-refresh.js", () => ({
+  modelsAuthRefreshHandlers: {},
+  refreshModelAuthStateAfterMutation: vi.fn(async () => undefined),
+}));
+
 vi.mock("../../config/logging.js", () => ({
   logConfigUpdated: mocks.logConfigUpdated,
 }));
@@ -62,7 +79,63 @@ vi.mock("../../wizard/clack-prompter.js", () => ({
   createClackPrompter: () => ({ confirm: mocks.confirm }),
 }));
 
-const { modelsAuthLogoutCommand, removeModelAuthCredentials } = await import("./auth-logout.js");
+const { modelsAuthLogoutCommand } = await import("./auth-logout.js");
+
+async function runRegisteredLogout(profileId: string): Promise<void> {
+  const errors: string[] = [];
+  const error = vi.spyOn(defaultRuntime, "error").mockImplementation((message) => {
+    errors.push(String(message));
+  });
+  const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => {
+    throw new Error(errors.join("\n"));
+  });
+  try {
+    const program = new Command().exitOverride();
+    registerModelsCli(program);
+    await program.parseAsync(["models", "auth", "logout", profileId, "--yes"], { from: "user" });
+  } finally {
+    error.mockRestore();
+    exit.mockRestore();
+  }
+}
+
+async function dispatchAuthLogout(
+  cfg: OpenClawConfig,
+  selection: { profileIds?: string[]; credentialType?: "api_key" },
+): Promise<void> {
+  mocks.listProfilesForProvider.mockReturnValue(
+    Object.keys(mocks.ensureAuthProfileStoreWithoutExternalProfiles().profiles),
+  );
+  const respond = vi.fn<RespondFn>();
+  await handleGatewayRequest({
+    req: {
+      type: "req",
+      id: crypto.randomUUID(),
+      method: "models.authLogout",
+      params: { provider: "openai", agentId: "main", ...selection },
+    },
+    respond,
+    client: {
+      connId: crypto.randomUUID(),
+      connect: {
+        role: "operator",
+        scopes: ["operator.admin"],
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: { id: "cli", version: "test", platform: "test", mode: "cli" },
+      },
+    },
+    isWebchatConnect: () => false,
+    context: createDirectChatContext({
+      getRuntimeConfig: () => ({ ...cfg, agents: { entries: { main: {} } } }),
+    }),
+  });
+  expect(respond).toHaveBeenCalledOnce();
+  const [ok, , error] = expectDefined(respond.mock.calls[0], "Gateway logout response");
+  if (!ok) {
+    throw new Error(expectDefined(error, "Gateway logout error").message);
+  }
+}
 
 function createRuntime(): RuntimeEnv & { logs: string[] } {
   const logs: string[] = [];
@@ -323,13 +396,10 @@ describe("models auth logout", () => {
       return false;
     });
 
-    await expect(
-      removeModelAuthCredentials({
-        cfg: liveConfig,
-        agentDir: "/tmp/agent-main",
-        profileIds: [profileId],
-      }),
-    ).rejects.toThrow(throws ? "store write failed" : "could not be removed");
+    mocks.loadModelsConfig.mockImplementation(async () => liveConfig);
+    await expect(runRegisteredLogout(profileId)).rejects.toThrow(
+      throws ? "store write failed" : "could not be removed",
+    );
 
     expect(liveConfig.auth?.profiles?.[profileId]).toEqual({
       provider: "openai",
@@ -363,7 +433,7 @@ describe("models auth logout", () => {
     };
     mocks.ensureAuthProfileStoreWithoutExternalProfiles.mockReturnValue({
       version: 1,
-      profiles: { [survivorId]: survivor },
+      profiles: { [removedId]: { ...survivor, key: "synthetic-removed" }, [survivorId]: survivor },
     });
     mocks.updateConfig.mockImplementation(
       async (
@@ -380,20 +450,24 @@ describe("models auth logout", () => {
       .mockReset()
       .mockImplementationOnce(async (params) => {
         await params.beforeRemove?.(params.profileIds);
+        mocks.ensureAuthProfileStoreWithoutExternalProfiles.mockReturnValue({
+          version: 1,
+          profiles: { [survivorId]: survivor },
+        });
         await params.onIncomplete?.(new Map([[survivorId, survivor]]));
         return false;
       })
       .mockImplementationOnce(async (params) => {
         await params.beforeRemove?.(params.profileIds);
+        mocks.ensureAuthProfileStoreWithoutExternalProfiles.mockReturnValue({
+          version: 1,
+          profiles: {},
+        });
         return true;
       });
 
     await expect(
-      removeModelAuthCredentials({
-        cfg: liveConfig,
-        agentDir: "/tmp/agent-main",
-        profileIds: [removedId, survivorId],
-      }),
+      dispatchAuthLogout(liveConfig, { profileIds: [removedId, survivorId] }),
     ).rejects.toThrow("could not be removed");
 
     expect(liveConfig.auth?.profiles).toEqual({
@@ -402,11 +476,7 @@ describe("models auth logout", () => {
     expect(liveConfig.auth?.order?.openai).toEqual([survivorId]);
     expect(liveConfig.models?.providers?.openai?.apiKey).toBe(survivorId);
 
-    await removeModelAuthCredentials({
-      cfg: liveConfig,
-      agentDir: "/tmp/agent-main",
-      profileIds: [survivorId],
-    });
+    await dispatchAuthLogout(liveConfig, { profileIds: [survivorId] });
     expect(liveConfig.auth?.profiles).toEqual({});
     expect(liveConfig.auth?.order).toBeUndefined();
     expect(liveConfig.models?.providers?.openai?.apiKey).toBeUndefined();
@@ -457,23 +527,22 @@ describe("models auth logout", () => {
     mocks.removeAuthProfilesAcrossOwnerStores
       .mockReset()
       .mockImplementationOnce(async (params) => {
-        await params.beforeRemove?.([keyId]);
+        await params.beforeRemove?.(params.profileIds);
         await params.onIncomplete?.(new Map([[keyId, key]]));
         return false;
       })
       .mockImplementationOnce(async (params) => {
-        await params.beforeRemove?.([keyId]);
+        await params.beforeRemove?.(params.profileIds);
+        mocks.ensureAuthProfileStoreWithoutExternalProfiles.mockReturnValue({
+          version: 1,
+          profiles: { [tokenId]: token },
+        });
         return true;
       });
 
-    await expect(
-      removeModelAuthCredentials({
-        cfg: liveConfig,
-        agentDir: "/tmp/agent-main",
-        profileIds: [keyId],
-        apiKeyProvider: "openai",
-      }),
-    ).rejects.toThrow("could not be removed");
+    await expect(dispatchAuthLogout(liveConfig, { credentialType: "api_key" })).rejects.toThrow(
+      "could not be removed",
+    );
     expect(liveConfig.auth?.profiles).toEqual({
       [keyId]: { provider: "openai", mode: "api_key" },
       [tokenId]: { provider: "openai", mode: "token" },
@@ -481,12 +550,7 @@ describe("models auth logout", () => {
     expect(liveConfig.auth?.order?.openai).toEqual([keyId, tokenId]);
     expect(liveConfig.models?.providers?.openai?.apiKey).toBe(tokenId);
 
-    await removeModelAuthCredentials({
-      cfg: liveConfig,
-      agentDir: "/tmp/agent-main",
-      profileIds: [keyId],
-      apiKeyProvider: "openai",
-    });
+    await dispatchAuthLogout(liveConfig, { credentialType: "api_key" });
     expect(liveConfig.auth?.profiles).toEqual({
       [tokenId]: { provider: "openai", mode: "token" },
     });

--- a/src/commands/models/auth-logout.ts
+++ b/src/commands/models/auth-logout.ts
@@ -8,7 +8,10 @@ import {
   loadAuthProfileStoreWithoutExternalProfiles,
   removeAuthProfilesAcrossOwnerStores,
 } from "../../agents/auth-profiles.js";
-import { resolveProviderEntryApiKeyProfileReference } from "../../agents/model-auth-provider-config.js";
+import {
+  resolveProviderConfigSecretInput,
+  resolveProviderEntryApiKeyProfileReference,
+} from "../../agents/model-auth-provider-config.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { logConfigUpdated } from "../../config/logging.js";
@@ -114,6 +117,7 @@ function restoreSurvivingProfileOrder(params: {
 
 function removeCredentialConfigReferences(params: {
   current: OpenClawConfig;
+  runtimeConfig: OpenClawConfig;
   profileIds: readonly string[];
   store: AuthProfileStore;
   apiKeyProvider?: string;
@@ -131,7 +135,8 @@ function removeCredentialConfigReferences(params: {
     if (
       resolveProviderIdForAuth(provider, { config: next }) === owner &&
       resolveProviderEntryApiKeyProfileReference({
-        cfg: next,
+        cfg: params.runtimeConfig,
+        sourceConfig: params.runtimeConfig,
         provider,
         store: params.store,
       }).kind === "literal"
@@ -152,6 +157,32 @@ export async function removeModelAuthCredentials(params: {
   provider?: string;
 }): Promise<void> {
   const apiKeyProvider = params.apiKeyProvider;
+  const keyBindings = (cfg: OpenClawConfig, sourceConfig?: OpenClawConfig) => {
+    const owner =
+      apiKeyProvider === undefined
+        ? undefined
+        : resolveProviderIdForAuth(apiKeyProvider, { config: cfg });
+    return {
+      owner,
+      bindings: Object.fromEntries(
+        Object.entries(cfg.models?.providers ?? {})
+          .filter(
+            ([provider, entry]) =>
+              entry.apiKey !== undefined &&
+              resolveProviderIdForAuth(provider, { config: cfg }) === owner,
+          )
+          .map(([provider]) => {
+            const { providerConfig, ref } = resolveProviderConfigSecretInput(
+              cfg,
+              provider,
+              sourceConfig,
+            );
+            return [provider, ref ?? providerConfig?.apiKey];
+          }),
+      ),
+    };
+  };
+  const expectedBindings = apiKeyProvider === undefined ? undefined : keyBindings(params.cfg);
   let cleanup:
     | {
         before: OpenClawConfig;
@@ -160,7 +191,15 @@ export async function removeModelAuthCredentials(params: {
       }
     | undefined;
   const beforeRemove = async (profileIds: readonly string[]) => {
-    await updateConfig((current) => {
+    await updateConfig((current, { runtimeConfig }) => {
+      if (
+        expectedBindings &&
+        !isDeepStrictEqual(keyBindings(runtimeConfig, runtimeConfig), expectedBindings)
+      ) {
+        throw new Error(
+          "The key changed while removing it. Nothing was removed. Reload Models and retry removal.",
+        );
+      }
       const store = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
         allowKeychainPrompt: false,
       });
@@ -182,6 +221,7 @@ export async function removeModelAuthCredentials(params: {
       }
       const next = removeCredentialConfigReferences({
         current,
+        runtimeConfig,
         profileIds,
         store,
         ...(apiKeyProvider !== undefined ? { apiKeyProvider } : {}),

--- a/src/commands/models/auth-logout.ts
+++ b/src/commands/models/auth-logout.ts
@@ -15,11 +15,16 @@ import {
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { logConfigUpdated } from "../../config/logging.js";
+import {
+  attachRuntimeConfigWriteApplication,
+  createRuntimeConfigWriteApplication,
+} from "../../config/runtime-write-application.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   configReferencesAuthProfile,
   removeAuthProfileConfig,
 } from "../../plugins/provider-auth-helpers.js";
+import { captureGatewayRootWorkAdmissionContinuationScope } from "../../process/gateway-work-admission.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { refreshRunningGatewayAuthState } from "./auth-refresh.js";
@@ -155,7 +160,7 @@ export async function removeModelAuthCredentials(params: {
   profileIds: readonly string[];
   apiKeyProvider?: string;
   provider?: string;
-}): Promise<void> {
+}): Promise<string | undefined> {
   const apiKeyProvider = params.apiKeyProvider;
   const keyBindings = (cfg: OpenClawConfig, sourceConfig?: OpenClawConfig) => {
     const owner =
@@ -183,6 +188,10 @@ export async function removeModelAuthCredentials(params: {
     };
   };
   const expectedBindings = apiKeyProvider === undefined ? undefined : keyBindings(params.cfg);
+  const application = createRuntimeConfigWriteApplication(
+    captureGatewayRootWorkAdmissionContinuationScope()?.run,
+  );
+  let configChanged = false;
   let cleanup:
     | {
         before: OpenClawConfig;
@@ -191,44 +200,50 @@ export async function removeModelAuthCredentials(params: {
       }
     | undefined;
   const beforeRemove = async (profileIds: readonly string[]) => {
-    await updateConfig((current, { runtimeConfig }) => {
-      if (
-        expectedBindings &&
-        !isDeepStrictEqual(keyBindings(runtimeConfig, runtimeConfig), expectedBindings)
-      ) {
-        throw new Error(
-          "The key changed while removing it. Nothing was removed. Reload Models and retry removal.",
-        );
-      }
-      const store = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
-        allowKeychainPrompt: false,
-      });
-      if (
-        apiKeyProvider !== undefined &&
-        profileIds.some((id) => {
-          const credential = store.profiles[id];
-          return (
-            credential?.type !== "api_key" ||
-            Boolean(credential.keyRef) ||
-            resolveProviderIdForAuth(credential.provider, {
-              config: current,
-              storedCredential: true,
-            }) !== resolveProviderIdForAuth(apiKeyProvider, { config: current })
+    await updateConfig(
+      (current, { runtimeConfig }) => {
+        if (
+          expectedBindings &&
+          !isDeepStrictEqual(keyBindings(runtimeConfig, runtimeConfig), expectedBindings)
+        ) {
+          throw new Error(
+            "The key changed while removing it. Nothing was removed. Reload Models and retry removal.",
           );
-        })
-      ) {
-        throw new Error("The selected API key changed. Reload Models and retry removal.");
-      }
-      const next = removeCredentialConfigReferences({
-        current,
-        runtimeConfig,
-        profileIds,
-        store,
-        ...(apiKeyProvider !== undefined ? { apiKeyProvider } : {}),
-      });
-      cleanup = { before: current, after: next, profileIds };
-      return next;
-    });
+        }
+        const store = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
+          allowKeychainPrompt: false,
+        });
+        if (
+          apiKeyProvider !== undefined &&
+          profileIds.some((id) => {
+            const credential = store.profiles[id];
+            return (
+              credential?.type !== "api_key" ||
+              Boolean(credential.keyRef) ||
+              resolveProviderIdForAuth(credential.provider, {
+                config: current,
+                storedCredential: true,
+              }) !== resolveProviderIdForAuth(apiKeyProvider, { config: current })
+            );
+          })
+        ) {
+          throw new Error("The selected API key changed. Reload Models and retry removal.");
+        }
+        const next = removeCredentialConfigReferences({
+          current,
+          runtimeConfig,
+          profileIds,
+          store,
+          ...(apiKeyProvider !== undefined ? { apiKeyProvider } : {}),
+        });
+        cleanup = { before: current, after: next, profileIds };
+        configChanged = !isDeepStrictEqual(current, next);
+        return next;
+      },
+      undefined,
+      undefined,
+      attachRuntimeConfigWriteApplication({}, application),
+    );
   };
   const restoreIncompleteRemoval = async (
     survivingProfiles: ReadonlyMap<string, AuthProfileCredential>,
@@ -273,6 +288,10 @@ export async function removeModelAuthCredentials(params: {
   if (!removed) {
     throw new Error("Saved credentials could not be removed. Wait a moment and retry.");
   }
+  if (configChanged && !(application.claimed && (await application.result) === "applied")) {
+    return "Credentials were removed, but the Gateway has not confirmed applying the change. Run `openclaw gateway restart` to apply it.";
+  }
+  return undefined;
 }
 
 /** Removes a saved auth profile from the agent auth store and from config. */
@@ -320,12 +339,15 @@ export async function modelsAuthLogoutCommand(
   // store, and a failed config write after the credential is gone would leave a
   // dangling reference that logout can no longer repair (the profile lookup
   // above would then fail). This order makes a partial failure retryable.
-  await removeModelAuthCredentials({ cfg, agentDir, profileIds: [profileId] });
+  const warning = await removeModelAuthCredentials({ cfg, agentDir, profileIds: [profileId] });
   if (configReferencesAuthProfile(cfg, profileId)) {
     logConfigUpdated(runtime);
   }
 
   await refreshRunningGatewayAuthState(agentId, "logout", runtime);
+  if (warning) {
+    runtime.error(warning);
+  }
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Removed auth profile: ${description}`);

--- a/src/gateway/server-methods/models-auth-removal.integration.test.ts
+++ b/src/gateway/server-methods/models-auth-removal.integration.test.ts
@@ -1,0 +1,191 @@
+import { withTimeout } from "@openclaw/fs-safe/advanced";
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import { registerConfigCli } from "../../cli/config-cli.js";
+import { readConfigFileSnapshot } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import * as configLock from "../../config/write-lock.js";
+import { defaultRuntime } from "../../runtime.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "../test-helpers.e2e.js";
+
+describe("models.authLogout with a concurrent registered config set", () => {
+  it.each([
+    {
+      name: "preserves a replacement key and refuses stale removal",
+      updatedProvider: "fixture",
+      replacement: "synthetic-inline-B",
+      selectedKey: "synthetic-inline-B",
+      conflict: true,
+    },
+    {
+      name: "removes the selected key after an unrelated provider changes",
+      updatedProvider: "other-fixture",
+      replacement: "synthetic-unrelated-B",
+      selectedKey: undefined,
+      conflict: false,
+    },
+    {
+      name: "preserves a replacement secret reference and refuses stale removal",
+      updatedProvider: "fixture",
+      replacement: { source: "env", provider: "default", id: "INLINE_REMOVAL_TEST_KEY" },
+      selectedKey: { source: "env", provider: "default", id: "INLINE_REMOVAL_TEST_KEY" },
+      conflict: true,
+    },
+    {
+      name: "preserves a replacement env reference with the same resolved key",
+      updatedProvider: "fixture",
+      replacement: "${INLINE_REMOVAL_SAME_KEY}",
+      selectedKey: "synthetic-inline-A",
+      conflict: true,
+    },
+  ])("$name", async ({ updatedProvider, replacement, selectedKey, conflict }) => {
+    const state = await createOpenClawTestState({
+      label: "models-auth-removal",
+      env: {
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        INLINE_REMOVAL_TEST_KEY: "synthetic-secret-B",
+        INLINE_REMOVAL_SAME_KEY: "synthetic-inline-A",
+      },
+    });
+    const token = "inline-removal-gateway-token";
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { workspace: state.workspaceDir } } },
+      plugins: { enabled: false },
+      gateway: { mode: "local", auth: { mode: "token", token }, reload: { mode: "off" } },
+      models: {
+        providers: {
+          fixture: {
+            baseUrl: "http://127.0.0.1:9/v1",
+            api: "openai-completions",
+            apiKey: "synthetic-inline-A",
+            models: [],
+          },
+          FIXTURE: {
+            baseUrl: "http://127.0.0.1:9/v1",
+            api: "openai-completions",
+            apiKey: "${INLINE_REMOVAL_TEST_KEY}",
+            models: [{ id: "fixture-model", name: "Fixture" }],
+          },
+          "other-fixture": {
+            baseUrl: "http://127.0.0.1:9/v1",
+            api: "openai-completions",
+            apiKey: "synthetic-unrelated-A",
+            models: [],
+          },
+        },
+      },
+    };
+    try {
+      const { client, server } = await startGatewayWithClient({
+        cfg,
+        configPath: state.configPath,
+        token,
+        scopes: ["operator.admin"],
+      });
+      const acquired = Promise.withResolvers<void>();
+      const save = Promise.withResolvers<void>();
+      const attempted = Promise.withResolvers<void>();
+      let performSave = false;
+      let writer: Promise<void> | undefined;
+      let logout: Promise<unknown> | undefined;
+      try {
+        await server.startupSettled;
+        vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
+          throw new Error(`Registered config command exited with ${code}`);
+        });
+        const withConfigWriteLock = configLock.withConfigWriteLock;
+        writer = withConfigWriteLock(state.configPath, async () => {
+          acquired.resolve();
+          await save.promise;
+          if (!performSave) {
+            return;
+          }
+          const program = new Command().exitOverride();
+          registerConfigCli(program);
+          await program.parseAsync(
+            [
+              "config",
+              "set",
+              `models.providers.${updatedProvider}.apiKey`,
+              JSON.stringify(replacement),
+              "--strict-json",
+            ],
+            { from: "user" },
+          );
+          const committed = await readConfigFileSnapshot();
+          expect(committed.parsed).toMatchObject({
+            models: { providers: { [updatedProvider]: { apiKey: replacement } } },
+          });
+        });
+        await withTimeout(acquired.promise, 10_000, "fixture config lock");
+        const observation = vi
+          .spyOn(configLock, "withConfigWriteLock")
+          .mockImplementation(
+            async <T>(...args: Parameters<typeof withConfigWriteLock<T>>): Promise<T> => {
+              if (args[0] === state.configPath) {
+                attempted.resolve();
+              }
+              return await withConfigWriteLock<T>(...args);
+            },
+          );
+        // Observe scheduling only; both registered commands retain the real write owners.
+        logout = client
+          .request("models.authLogout", {
+            provider: "fixture",
+            agentId: "main",
+            credentialType: "api_key",
+          })
+          .then(
+            (value) => ({ ok: true, value }),
+            (error: unknown) => ({ ok: false, error }),
+          );
+        await withTimeout(attempted.promise, 10_000, "pending removal config lock");
+        observation.mockRestore();
+        performSave = true;
+        save.resolve();
+        await writer;
+        const outcome = await logout;
+        expect(outcome).toMatchObject(
+          conflict
+            ? {
+                ok: false,
+                error: expect.objectContaining({
+                  message: expect.stringContaining(
+                    "Nothing was removed. Reload Models and retry removal.",
+                  ),
+                }),
+              }
+            : { ok: true, value: { removedProfiles: [] } },
+        );
+        const settled = await readConfigFileSnapshot();
+        if (conflict) {
+          expect(settled.parsed).toMatchObject({
+            models: { providers: { fixture: { apiKey: replacement } } },
+          });
+        }
+        expect(settled.parsed).toMatchObject({
+          models: { providers: { FIXTURE: { apiKey: "${INLINE_REMOVAL_TEST_KEY}" } } },
+        });
+        expect(settled.sourceConfig.models?.providers?.fixture?.apiKey).toEqual(selectedKey);
+        expect(settled.sourceConfig.models?.providers?.["other-fixture"]?.apiKey).toBe(
+          conflict ? "synthetic-unrelated-A" : "synthetic-unrelated-B",
+        );
+      } finally {
+        save.resolve();
+        await writer?.catch(() => undefined);
+        await logout?.catch(() => undefined);
+        vi.restoreAllMocks();
+        await disconnectGatewayClient(client);
+        await server.close();
+      }
+    } finally {
+      await state.cleanup();
+    }
+  });
+});

--- a/src/gateway/server-methods/models-auth-removal.integration.test.ts
+++ b/src/gateway/server-methods/models-auth-removal.integration.test.ts
@@ -39,153 +39,189 @@ describe("models.authLogout with a concurrent registered config set", () => {
       selectedKey: "synthetic-inline-A",
       conflict: true,
     },
-  ])("$name", async ({ updatedProvider, replacement, selectedKey, conflict }) => {
-    const state = await createOpenClawTestState({
-      label: "models-auth-removal",
-      env: {
-        OPENCLAW_SKIP_CHANNELS: "1",
-        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
-        OPENCLAW_SKIP_CRON: "1",
-        OPENCLAW_SKIP_CANVAS_HOST: "1",
-        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-        INLINE_REMOVAL_TEST_KEY: "synthetic-secret-B",
-        INLINE_REMOVAL_SAME_KEY: "synthetic-inline-A",
-      },
-    });
-    const token = "inline-removal-gateway-token";
-    const cfg: OpenClawConfig = {
-      agents: { entries: { main: { workspace: state.workspaceDir } } },
-      plugins: { enabled: false },
-      gateway: { mode: "local", auth: { mode: "token", token }, reload: { mode: "off" } },
-      models: {
-        providers: {
-          fixture: {
-            baseUrl: "http://127.0.0.1:9/v1",
-            api: "openai-completions",
-            apiKey: "synthetic-inline-A",
-            models: [],
-          },
-          FIXTURE: {
-            baseUrl: "http://127.0.0.1:9/v1",
-            api: "openai-completions",
-            apiKey: "${INLINE_REMOVAL_TEST_KEY}",
-            models: [{ id: "fixture-model", name: "Fixture" }],
-          },
-          "other-fixture": {
-            baseUrl: "http://127.0.0.1:9/v1",
-            api: "openai-completions",
-            apiKey: "synthetic-unrelated-A",
-            models: [],
+    {
+      name: "publishes removal before returning when config reload is enabled",
+      updatedProvider: "other-fixture",
+      replacement: "synthetic-unrelated-B",
+      selectedKey: undefined,
+      conflict: false,
+      reloadMode: "hybrid" as const,
+    },
+  ])(
+    "$name",
+    async ({ updatedProvider, replacement, selectedKey, conflict, reloadMode = "off" }) => {
+      const state = await createOpenClawTestState({
+        label: "models-auth-removal",
+        env: {
+          OPENCLAW_SKIP_CHANNELS: "1",
+          OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+          OPENCLAW_SKIP_CRON: "1",
+          OPENCLAW_SKIP_CANVAS_HOST: "1",
+          OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
+          INLINE_REMOVAL_TEST_KEY: "synthetic-secret-B",
+          INLINE_REMOVAL_SAME_KEY: "synthetic-inline-A",
+        },
+      });
+      const token = "inline-removal-gateway-token";
+      const cfg: OpenClawConfig = {
+        agents: { entries: { main: { workspace: state.workspaceDir } } },
+        plugins: { enabled: false },
+        gateway: { mode: "local", auth: { mode: "token", token }, reload: { mode: reloadMode } },
+        models: {
+          providers: {
+            fixture: {
+              baseUrl: "http://127.0.0.1:9/v1",
+              api: "openai-completions",
+              apiKey: "synthetic-inline-A",
+              models: [],
+            },
+            FIXTURE: {
+              baseUrl: "http://127.0.0.1:9/v1",
+              api: "openai-completions",
+              apiKey: "${INLINE_REMOVAL_TEST_KEY}",
+              models: [{ id: "fixture-model", name: "Fixture" }],
+            },
+            "other-fixture": {
+              baseUrl: "http://127.0.0.1:9/v1",
+              api: "openai-completions",
+              apiKey: "synthetic-unrelated-A",
+              models: [],
+            },
           },
         },
-      },
-    };
-    try {
-      const { client, server } = await startGatewayWithClient({
-        cfg,
-        configPath: state.configPath,
-        token,
-        scopes: ["operator.admin"],
-      });
-      const acquired = Promise.withResolvers<void>();
-      const save = Promise.withResolvers<void>();
-      const attempted = Promise.withResolvers<void>();
-      let performSave = false;
-      let writer: Promise<void> | undefined;
-      let logout: Promise<unknown> | undefined;
+      };
+      const hotReloadRecovery = vi.fn(() => ({ status: "emitted" as const }));
       try {
-        await server.startupSettled;
-        vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
-          throw new Error(`Registered config command exited with ${code}`);
+        const { client, server } = await startGatewayWithClient({
+          cfg,
+          configPath: state.configPath,
+          token,
+          scopes: ["operator.admin"],
+          hotReloadRecovery,
         });
-        const withConfigWriteLock = configLock.withConfigWriteLock;
-        writer = withConfigWriteLock(state.configPath, async () => {
-          acquired.resolve();
-          await save.promise;
-          if (!performSave) {
-            return;
+        const acquired = Promise.withResolvers<void>();
+        const save = Promise.withResolvers<void>();
+        const attempted = Promise.withResolvers<void>();
+        let performSave = false;
+        let writer: Promise<void> | undefined;
+        let logout: Promise<unknown> | undefined;
+        try {
+          await server.startupSettled;
+          vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
+            throw new Error(`Registered config command exited with ${code}`);
+          });
+          const withConfigWriteLock = configLock.withConfigWriteLock;
+          writer = withConfigWriteLock(state.configPath, async () => {
+            acquired.resolve();
+            await save.promise;
+            if (!performSave) {
+              return;
+            }
+            const program = new Command().exitOverride();
+            registerConfigCli(program);
+            await program.parseAsync(
+              [
+                "config",
+                "set",
+                `models.providers.${updatedProvider}.apiKey`,
+                JSON.stringify(replacement),
+                "--strict-json",
+              ],
+              { from: "user" },
+            );
+            const committed = await readConfigFileSnapshot();
+            expect(committed.parsed).toMatchObject({
+              models: { providers: { [updatedProvider]: { apiKey: replacement } } },
+            });
+          });
+          await withTimeout(acquired.promise, 10_000, "fixture config lock");
+          const observation = vi
+            .spyOn(configLock, "withConfigWriteLock")
+            .mockImplementation(
+              async <T>(...args: Parameters<typeof withConfigWriteLock<T>>): Promise<T> => {
+                if (args[0] === state.configPath) {
+                  attempted.resolve();
+                }
+                return await withConfigWriteLock<T>(...args);
+              },
+            );
+          // Observe scheduling only; both registered commands retain the real write owners.
+          logout = client
+            .request("models.authLogout", {
+              provider: "fixture",
+              agentId: "main",
+              credentialType: "api_key",
+            })
+            .then(
+              (value) => ({ ok: true, value }),
+              (error: unknown) => ({ ok: false, error }),
+            );
+          await withTimeout(attempted.promise, 10_000, "pending removal config lock");
+          observation.mockRestore();
+          performSave = true;
+          save.resolve();
+          await writer;
+          const outcome = await logout;
+          expect(outcome).toMatchObject(
+            conflict
+              ? {
+                  ok: false,
+                  error: expect.objectContaining({
+                    message: expect.stringContaining(
+                      "Nothing was removed. Reload Models and retry removal.",
+                    ),
+                  }),
+                }
+              : { ok: true, value: { removedProfiles: [] } },
+          );
+          const settled = await readConfigFileSnapshot();
+          if (!conflict) {
+            if (reloadMode === "off") {
+              expect(outcome).toMatchObject({
+                value: { warning: expect.stringContaining("gateway restart") },
+              });
+            } else {
+              expect(outcome, JSON.stringify(outcome)).not.toMatchObject({
+                value: { warning: expect.any(String) },
+              });
+              await expect(
+                client.request("models.authStatus", { agentId: "main" }),
+              ).resolves.toMatchObject({
+                providers: expect.not.arrayContaining([
+                  expect.objectContaining({
+                    provider: "fixture",
+                    apiKey: expect.objectContaining({ source: "config" }),
+                  }),
+                ]),
+              });
+            }
           }
-          const program = new Command().exitOverride();
-          registerConfigCli(program);
-          await program.parseAsync(
-            [
-              "config",
-              "set",
-              `models.providers.${updatedProvider}.apiKey`,
-              JSON.stringify(replacement),
-              "--strict-json",
-            ],
-            { from: "user" },
-          );
-          const committed = await readConfigFileSnapshot();
-          expect(committed.parsed).toMatchObject({
-            models: { providers: { [updatedProvider]: { apiKey: replacement } } },
-          });
-        });
-        await withTimeout(acquired.promise, 10_000, "fixture config lock");
-        const observation = vi
-          .spyOn(configLock, "withConfigWriteLock")
-          .mockImplementation(
-            async <T>(...args: Parameters<typeof withConfigWriteLock<T>>): Promise<T> => {
-              if (args[0] === state.configPath) {
-                attempted.resolve();
-              }
-              return await withConfigWriteLock<T>(...args);
-            },
-          );
-        // Observe scheduling only; both registered commands retain the real write owners.
-        logout = client
-          .request("models.authLogout", {
-            provider: "fixture",
-            agentId: "main",
-            credentialType: "api_key",
-          })
-          .then(
-            (value) => ({ ok: true, value }),
-            (error: unknown) => ({ ok: false, error }),
-          );
-        await withTimeout(attempted.promise, 10_000, "pending removal config lock");
-        observation.mockRestore();
-        performSave = true;
-        save.resolve();
-        await writer;
-        const outcome = await logout;
-        expect(outcome).toMatchObject(
-          conflict
-            ? {
-                ok: false,
-                error: expect.objectContaining({
-                  message: expect.stringContaining(
-                    "Nothing was removed. Reload Models and retry removal.",
-                  ),
-                }),
-              }
-            : { ok: true, value: { removedProfiles: [] } },
-        );
-        const settled = await readConfigFileSnapshot();
-        if (conflict) {
+          if (conflict) {
+            expect(settled.parsed).toMatchObject({
+              models: { providers: { fixture: { apiKey: replacement } } },
+            });
+          }
           expect(settled.parsed).toMatchObject({
-            models: { providers: { fixture: { apiKey: replacement } } },
+            models: { providers: { FIXTURE: { apiKey: "${INLINE_REMOVAL_TEST_KEY}" } } },
           });
+          expect(settled.sourceConfig.models?.providers?.fixture?.apiKey).toEqual(selectedKey);
+          expect(settled.sourceConfig.models?.providers?.["other-fixture"]?.apiKey).toBe(
+            conflict ? "synthetic-unrelated-A" : "synthetic-unrelated-B",
+          );
+          expect(hotReloadRecovery).not.toHaveBeenCalled();
+        } finally {
+          save.resolve();
+          await writer?.catch(() => undefined);
+          await logout?.catch(() => undefined);
+          vi.restoreAllMocks();
+          await disconnectGatewayClient(client);
+          await server.close();
         }
-        expect(settled.parsed).toMatchObject({
-          models: { providers: { FIXTURE: { apiKey: "${INLINE_REMOVAL_TEST_KEY}" } } },
-        });
-        expect(settled.sourceConfig.models?.providers?.fixture?.apiKey).toEqual(selectedKey);
-        expect(settled.sourceConfig.models?.providers?.["other-fixture"]?.apiKey).toBe(
-          conflict ? "synthetic-unrelated-A" : "synthetic-unrelated-B",
-        );
       } finally {
-        save.resolve();
-        await writer?.catch(() => undefined);
-        await logout?.catch(() => undefined);
-        vi.restoreAllMocks();
-        await disconnectGatewayClient(client);
-        await server.close();
+        await state.cleanup();
       }
-    } finally {
-      await state.cleanup();
-    }
-  });
+    },
+  );
 });

--- a/src/gateway/server-methods/models-auth-removal.integration.test.ts
+++ b/src/gateway/server-methods/models-auth-removal.integration.test.ts
@@ -101,9 +101,9 @@ describe("models.authLogout with a concurrent registered config set", () => {
           scopes: ["operator.admin"],
           hotReloadRecovery,
         });
-        const acquired = createDeferredCore<void>();
-        const save = createDeferredCore<void>();
-        const attempted = createDeferredCore<void>();
+        const acquired = createDeferredCore();
+        const save = createDeferredCore();
+        const attempted = createDeferredCore();
         let performSave = false;
         let writer: Promise<void> | undefined;
         let logout: Promise<unknown> | undefined;

--- a/src/gateway/server-methods/models-auth-removal.integration.test.ts
+++ b/src/gateway/server-methods/models-auth-removal.integration.test.ts
@@ -3,9 +3,9 @@ import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
 import { registerConfigCli } from "../../cli/config-cli.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import * as configLock from "../../config/write-lock.js";
 import { defaultRuntime } from "../../runtime.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { disconnectGatewayClient, startGatewayWithClient } from "../test-helpers.e2e.js";
 
@@ -65,7 +65,7 @@ describe("models.authLogout with a concurrent registered config set", () => {
         },
       });
       const token = "inline-removal-gateway-token";
-      const cfg: OpenClawConfig = {
+      const cfg = {
         agents: { entries: { main: { workspace: state.workspaceDir } } },
         plugins: { enabled: false },
         gateway: { mode: "local", auth: { mode: "token", token }, reload: { mode: reloadMode } },
@@ -101,9 +101,9 @@ describe("models.authLogout with a concurrent registered config set", () => {
           scopes: ["operator.admin"],
           hotReloadRecovery,
         });
-        const acquired = Promise.withResolvers<void>();
-        const save = Promise.withResolvers<void>();
-        const attempted = Promise.withResolvers<void>();
+        const acquired = createDeferredCore<void>();
+        const save = createDeferredCore<void>();
+        const attempted = createDeferredCore<void>();
         let performSave = false;
         let writer: Promise<void> | undefined;
         let logout: Promise<unknown> | undefined;

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -513,7 +513,7 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
         return;
       }
       const { removeModelAuthCredentials } = await import("../../commands/models/auth-logout.js");
-      await removeModelAuthCredentials({
+      const configWarning = await removeModelAuthCredentials({
         cfg,
         agentDir,
         profileIds: removedProfiles,
@@ -534,7 +534,8 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
               agentId: scope.agentId,
               stopReason: "auth-revoked",
             });
-      const warning = await refreshAfterCredentialMutation(context, "logout", scope.agentId);
+      const refreshWarning = await refreshAfterCredentialMutation(context, "logout", scope.agentId);
+      const warning = [configWarning, refreshWarning].filter(Boolean).join(" ");
       const result: ModelAuthLogoutResult = {
         provider,
         removedProfiles,

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -32,7 +32,7 @@ import {
 } from "../utils/message-channel.js";
 import type { GatewayClient } from "./client.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
-import { startGatewayServer } from "./server.js";
+import { startGatewayServer, type GatewayServerOptions } from "./server.js";
 import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "./test-helpers.env.js";
 
 /** Reserve a deterministic free port block for Gateway E2E tests. */
@@ -277,6 +277,7 @@ export async function startGatewayWithClient(params: {
   clientDisplayName?: string;
   scopes?: string[];
   onEvent?: (evt: { event?: string; payload?: unknown }) => void;
+  hotReloadRecovery?: GatewayServerOptions["hotReloadRecovery"];
 }) {
   const gatewayStartupEnv = captureEnv([
     ...GATEWAY_STARTUP_MUTATED_ENV_KEYS,
@@ -295,6 +296,7 @@ export async function startGatewayWithClient(params: {
       bind: "loopback",
       auth: { mode: "token", token: params.token },
       controlUiEnabled: false,
+      hotReloadRecovery: params.hotReloadRecovery,
     });
     server = startedServer;
     const client = await connectGatewayClient({


### PR DESCRIPTION
## What Problem This Solves

Removing a key from Models could delete a replacement saved by another client while removal was pending.

## Why This Change Was Made

The shared removal owner compares current credential bindings under the config writer before cleanup and rejects changed bindings, including references resolving to the same value. It waits for config application and reports restart guidance when application is unconfirmed. This corrects the cleanup introduced in #144420.

## User Impact

Concurrent replacements survive removal. Externally managed keys keep their source ownership. Normal removal reports current status; disabled reload produces a restart warning. No configuration or schema change is required.

## Evidence

Real Gateway logout and CLI config-save races reproduced deletion before the fix and preserved the replacement afterward. Browser Remove key captures verify the error and restart guidance. Registered Gateway/CLI regressions, auth and provenance tests passed. Previous-release key removal and restart passed; the config startup corpus passed after documented repair of its legacy fixture.

Related: #144420.
