### PR TITLE
improve: speed up generic streaming commentary updates

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
@@ -211,6 +211,7 @@ export function emitAssistantCommentaryStreamData(
   ctx: EmbeddedAgentSubscribeContext,
   message: AssistantMessage,
   finalMessage = false,
+  preparedText?: string,
 ) {
   const isResponsesCommentary = isResponsesApiAssistantMessage(message);
   const { lastAssistantStreamContentIndex: index, lastAssistantStreamItemId: itemId } = ctx.state;
@@ -218,7 +219,10 @@ export function emitAssistantCommentaryStreamData(
   const commentaryMessage = isResponsesCommentary
     ? scopeAssistantMessageToStreamBlock(message, index, itemId)
     : message;
-  const text = extractAssistantCommentaryText(commentaryMessage);
+  const text =
+    !isResponsesCommentary && preparedText !== undefined
+      ? preparedText
+      : extractAssistantCommentaryText(commentaryMessage);
   if (text && (finalMessage || !isResponsesCommentary || ctx.state.deltaBuffer !== text)) {
     // Generic commentary must carry the identity the phase tagger generated so
     // the Control UI can key the live row to the persisted fallback row; without

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -101,7 +101,7 @@ export function handleMessageUpdate(
         delta: "",
         content: commentaryText,
       }));
-      emitAssistantCommentaryStreamData(ctx, msg);
+      emitAssistantCommentaryStreamData(ctx, msg, false, commentaryText);
     }
     return undefined;
   }

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
@@ -338,7 +338,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(subscription.assistantTexts).toEqual([]);
   });
 
-  it("preserves aggregate commentary for providers without Responses item boundaries", async () => {
+  it("preserves current aggregate commentary without Responses item boundaries", async () => {
     const onAgentEvent = vi.fn();
     const { emit, subscription } = createSubscribedSessionHarness({ runId: "run", onAgentEvent });
     const message = {
@@ -356,7 +356,19 @@ describe("subscribeEmbeddedAgentSession", () => {
       message,
       assistantMessageEvent: { type: "toolcall_start", contentIndex: 2, partial: message },
     });
-    emit({ type: "message_end", message });
+    const completed = {
+      ...message,
+      content: [
+        { type: "text", text: "First." },
+        { type: "text", text: "Second. Updated." },
+      ],
+    } as AssistantMessageWithPhase;
+    emit({
+      type: "message_update",
+      message: completed,
+      assistantMessageEvent: { type: "toolcall_start", contentIndex: 2, partial: completed },
+    });
+    emit({ type: "message_end", message: completed });
     await subscription.waitForPendingEvents();
 
     expect(onAgentEvent.mock.calls.map(([event]) => event)).toEqual([
@@ -374,8 +386,17 @@ describe("subscribeEmbeddedAgentSession", () => {
         data: {
           kind: "preamble",
           title: "Preamble",
+          phase: "update",
+          progressText: "First. Second. Updated.",
+        },
+      },
+      {
+        stream: "item",
+        data: {
+          kind: "preamble",
+          title: "Preamble",
           phase: "end",
-          progressText: "First. Second.",
+          progressText: "First. Second. Updated.",
         },
       },
     ]);


### PR DESCRIPTION
## What Problem This Solves

Generic streaming commentary updates repeatedly scan the same cumulative message text before publishing progress, adding avoidable work as commentary grows.

## Why This Change Was Made

Carry the commentary text already extracted for the current update into its existing stream emitter. Reuse it only for generic commentary. Responses continues extracting from its active item scope, and message-end extraction, empty-text handling, emitted identity, and raw-log content retain their existing behavior. Nothing is cached across events.

## User Impact

Generic commentary updates require less event-processing work without changing visible callback output. This does not claim faster provider responses or uniformly faster turns.

## Evidence

All 73 focused tests across five subscription/raw-stream files passed, along with the repository-selected changed checks (core/test typechecks, lint, exports, and guards). Independent Codex review was clean through P2.

A synthetic benchmark exercised the actual subscription boundary with cumulative commentary in 256-character updates, at 4/32/128 KiB. Each fresh process ran one warmup and eight measured rounds; both baseline/candidate and candidate/baseline orders were retained. All 24 processes closed successfully, and all 12 complete callback-sequence comparisons matched byte-for-byte. Message input bytes also remained unchanged.

| Text size | Path | Order | Baseline median | Candidate median |
| --- | --- | --- | ---: | ---: |
| 4 KiB | Generic | B→C | 0.770 ms | 0.517 ms |
| 4 KiB | Generic | C→B | 0.778 ms | 0.525 ms |
| 32 KiB | Generic | B→C | 31.065 ms | 16.555 ms |
| 32 KiB | Generic | C→B | 26.318 ms | 16.746 ms |
| 128 KiB | Generic | B→C | 389.703 ms | 248.288 ms |
| 128 KiB | Generic | C→B | 403.078 ms | 246.963 ms |
| 4 KiB | Responses control | B→C | 0.361 ms | 0.312 ms |
| 4 KiB | Responses control | C→B | 0.302 ms | 0.310 ms |
| 32 KiB | Responses control | B→C | 7.815 ms | 8.092 ms |
| 32 KiB | Responses control | C→B | 7.750 ms | 7.831 ms |
| 128 KiB | Responses control | B→C | 110.210 ms | 110.572 ms |
| 128 KiB | Responses control | C→B | 110.685 ms | 112.070 ms |

Generic event medians improved 32.6–46.7%, with lower measured CPU medians in both orders at every size. The Responses controls include five adverse observations (0.3–3.6%); those are retained, not presented as improvements or assumed to be statistically insignificant.

Timing includes message start, updates, message end, and pending-event settlement. It excludes imports, subscription setup, verification, artifact serialization, and provider/network activity. Whole-process peak RSS was mixed at 4/32 KiB and modestly lower in the generic 128-KiB pairs; it is not a per-event allocation measure. The original samples, native receipts, and full callback artifacts are retained locally. Raw-file-log B/C parity was not measured; separate raw-stream tests cover its snapshot behavior. Hosted CI remains a landing gate, and the full suite was not run locally.

Production changes add four net lines. The existing subscription test now includes a changing cumulative snapshot to guard against stale reuse.
