### PR TITLE
perf(skills): skip unused execution-workspace collision indexes

### DIFF
--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -322,15 +322,17 @@ function loadLocalSkillTiers(
 function loadSkillEntries(workspaceDir: string, opts?: WorkspaceSkillLoadOptions): SkillEntry[] {
   const tiers = loadLocalSkillTiers(workspaceDir, opts);
   const entries = mergeRemoteNodeSkillEntries(tiers.agent, opts?.eligibility?.nodeSkills);
-  const agentByName = new Map(entries.map((entry) => [entry.skill.name, entry]));
-  // Include node skills in the agent tier before admitting execution-local names.
-  // Agent entries also stay first when the prompt budget truncates the catalog.
-  for (const entry of tiers.execution) {
-    const agentEntry = agentByName.get(entry.skill.name);
-    if (agentEntry) {
-      warnSkillPrecedenceCollision(agentEntry.skill, entry.skill, workspaceDir);
-    } else {
-      entries.push(entry);
+  if (tiers.execution.length > 0) {
+    const agentByName = new Map(entries.map((entry) => [entry.skill.name, entry]));
+    // Include node skills in the agent tier before admitting execution-local names.
+    // Agent entries also stay first when the prompt budget truncates the catalog.
+    for (const entry of tiers.execution) {
+      const agentEntry = agentByName.get(entry.skill.name);
+      if (agentEntry) {
+        warnSkillPrecedenceCollision(agentEntry.skill, entry.skill, workspaceDir);
+      } else {
+        entries.push(entry);
+      }
     }
   }
   if (opts?.librarySelections?.length) {


### PR DESCRIPTION
Closes #145150

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Skill loading does redundant work in single-workspace sessions, even after local discovery is warm and there are no execution-workspace skills to merge.

## Why This Change Was Made

Build the existing collision index only for a nonempty execution tier. The merge itself, remote/agent precedence, collision diagnostics and subsequent pinned-library append stay unchanged; this adds no cache or compatibility path.

## User Impact

No user-visible behavior changes are intended. Skill entries, prompt bytes and ordering, returned-array mutability, watcher refresh and sandbox confinement remain unchanged. The one-file change adds two production lines and changes no tests.

## Evidence

Six fresh processes, three per version, exercised 200 synthetic skills after 200 warmup loads. Each process ran 3,000 sampled loads and a separate 3,000-load timing phase. Entry and snapshot hashes and checksums matched across all runs. Median whole-interval sampled allocation, including collected objects, fell from **102,654,000 to 14,749,792 bytes (85.63%)**. Separate median timings were **23.98 to 7.07 ms** for the 3,000 warm loads.

The same 42 tests across three loader, snapshot and precedence suites pass on both versions, along with the full selected changed gate and independent P2 review. Correctness-suite observations were 9.12 to 7.65 seconds, while maximum RSS rose from 2,122,465,280 to 2,143,993,856 bytes; these single suite runs include imports, caches and worker setup and are not causal performance evidence.

The measured path is warm `loadWorkspaceSkills`, not reusable snapshot-cache hits. No live Gateway, retained-heap or universal RSS improvement is claimed. A normal build was not selected because no lazy-loading, package/artifact or build contract changed.
