### PR TITLE
refactor(terminal): keep note wrapping in one owner

### DIFF
--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -21,31 +21,6 @@ function isSuppressedByEnv(value: string | undefined): boolean {
   return normalized !== "0" && normalized !== "false" && normalized !== "off";
 }
 
-function splitLongWord(word: string, maxLen: number): string[] {
-  if (maxLen <= 0) {
-    return [word];
-  }
-  // maxLen is a visible-column budget, so accumulate grapheme visible width (CJK/emoji count as 2
-  // columns) instead of code-point count; otherwise a wide-char run overflows the line by up to 2x.
-  const parts: string[] = [];
-  let current = "";
-  let currentWidth = 0;
-  for (const grapheme of iterateGraphemes(word)) {
-    const width = visibleWidth(grapheme);
-    if (current && currentWidth + width > maxLen) {
-      parts.push(current);
-      current = "";
-      currentWidth = 0;
-    }
-    current += grapheme;
-    currentWidth += width;
-  }
-  if (current) {
-    parts.push(current);
-  }
-  return parts.length > 0 ? parts : [word];
-}
-
 function isCopySensitiveToken(word: string): boolean {
   if (!word) {
     return false;
@@ -69,21 +44,6 @@ function isCopySensitiveToken(word: string): boolean {
   }
   // Preserve common file-like tokens (for example administrators_authorized_keys).
   return word.includes("_") && FILE_LIKE_RE.test(word);
-}
-
-function pushWrappedWordSegments(params: {
-  word: string;
-  available: number;
-  firstPrefix: string;
-  continuationPrefix: string;
-  lines: string[];
-}) {
-  const parts = splitLongWord(params.word, params.available);
-  const first = parts.shift() ?? "";
-  params.lines.push(params.firstPrefix + first);
-  for (const part of parts) {
-    params.lines.push(params.continuationPrefix + part);
-  }
 }
 
 function wrapLine(line: string, maxWidth: number): string[] {
@@ -124,13 +84,22 @@ function wrapLine(line: string, maxWidth: number): string[] {
       (isPrintableAscii ? word.length : visibleWidth(word)) > available &&
       !isCopySensitiveToken(word)
     ) {
-      pushWrappedWordSegments({
-        word,
-        available,
-        firstPrefix: prefix,
-        continuationPrefix: nextPrefix,
-        lines,
-      });
+      // Measure whole graphemes in visible columns so CJK/emoji do not overflow.
+      // Keep this word's initial budget for all fragments, even when the next prefix differs.
+      let currentWidth = 0;
+      for (const grapheme of iterateGraphemes(word)) {
+        const width = visibleWidth(grapheme);
+        if (current && currentWidth + width > available) {
+          lines.push(prefix + current);
+          prefix = nextPrefix;
+          current = "";
+          currentWidth = 0;
+        }
+        current += grapheme;
+        currentWidth += width;
+      }
+      lines.push(prefix + current);
+      current = "";
       prefix = nextPrefix;
       available = nextWidth;
       continue;

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -994,12 +994,25 @@ describe("wrapNoteMessage", () => {
     expect(wrapped).toBe(input);
   });
 
-  it("still chunks generic long opaque tokens to avoid pathological line width", () => {
-    const input = "x".repeat(70);
-    const wrapped = wrapNoteMessage(input, { maxWidth: 20, columns: 80 });
-
-    expect(wrapped).toContain("\n");
-    expect(wrapped.replace(/\n/g, "")).toBe(input);
+  const word = "abcdefghijklmnopqrstuvwxyz";
+  it.each<[name: string, input: string, maxWidth: number, expected: string]>([
+    [
+      "opaque token",
+      "x".repeat(70),
+      20,
+      ["x".repeat(20), "x".repeat(20), "x".repeat(20), "x".repeat(10)].join("\n"),
+    ],
+    ["token followed by another word", `${word} tail`, 14, "abcdefghijklmn\nopqrstuvwxyz\ntail"],
+    ["token after a short word", `ok ${word} tail`, 14, "ok\nabcdefghijklmn\nopqrstuvwxyz\ntail"],
+    ["bullet token", `- ${word} tail`, 14, "- abcdefghijkl\n  mnopqrstuvwx\n  yz\n  tail"],
+    [
+      "bullet with wide spacing",
+      `-\u3000${word} tail`,
+      14,
+      "-\u3000abcdefghijk\n  lmnopqrstuv\n  wxyz\n  tail",
+    ],
+  ])("chunks a %s with exact note spacing", (_name, input, maxWidth, expected) => {
+    expect(wrapNoteMessage(input, { maxWidth, columns: 80 })).toBe(expected);
   });
 
   it("wraps bullet lines while preserving bullet indentation", () => {
@@ -1087,7 +1100,7 @@ describe("wrapNoteMessage", () => {
   });
 
   it("keeps wrapped lines within the visible-column budget for wide (CJK) words", () => {
-    // A long CJK run with no separators reaches splitLongWord; each fullwidth char is 2 columns,
+    // A long CJK run with no separators reaches word-fragment wrapping; each fullwidth char is 2 columns,
     // so splitting by code-point count would emit lines up to 2x the budget.
     const input = "東京特許許可局長今日休暇許可局長今日休暇東京特許";
     const lines = wrapNoteMessage(input, { maxWidth: 20, columns: 80 }).split("\n");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer edits remain enabled.

</details>

## What Problem This Solves

This is a maintainer-requested cleanup of CLI and setup note wrapping, with no intended user-visible change. Oversized-word wrapping currently builds an intermediate fragment array in one private helper, then shifts and copies it into the output through another single-caller helper. That splits one formatting decision across three functions even though `wrapLine` already owns the output, prefix, current line, and width budget.

## Why This Change Was Made

Emit complete grapheme fragments directly from `wrapLine` and delete both private helpers. Keep the initial per-word visible-column budget fixed across fragments, preserve first-line and continuation prefixes, and clear the final fragment before processing another word. Two concise comments retain the wide-glyph overflow rationale and the fixed-budget invariant.

Production: **+16/−47, net −31 lines**. Tests: **+20/−7, net +13 lines**. No dependency, public export, option, configuration, suppression, or stream-routing change. Keeping the fragment-array adapter would preserve duplicate ownership; replacing the established width/grapheme dependencies would broaden the change without helping this cleanup.

## User Impact

No intended visual or CLI behavior change. Long words, CJK/emoji graphemes, bullets, indentation, and copy-sensitive URLs/file paths retain their output. The benefit is a simpler formatting owner that is easier to maintain. This PR makes no performance claim.

## Evidence

The final candidate suite and full changed gate ran before the signed save of `d278d9b2b7c78e0839385da7b54c760491d2a94c`, on the exact two afterimages and complete tree later saved. Paired original runs used the recorded parent production; the earlier expanded test representation is distinguished below. This is not a claim that tests or hosted PR CI ran after that commit.

- Pristine original table/note suite: **91 passed**. With five fixed independent expected-output cases replacing one generic case, original and candidate each passed **95**, retaining all 90 unaffected original cases in their original order.
- The final typed-table representation preserved every case name, input byte, width, and expected-output expression. Original production passed its **five changed cases**; candidate production then passed the complete **95-case** suite. Ordinary format and targeted lint checks passed.
- A fixed public `wrapNoteMessage` corpus produced **211 byte-identical original/candidate results**. Actual `noteToStream` and `createClackPrompter.note` calls produced identical unnormalized PTY and pipe output, covering six direct and six wizard calls in each medium. The PTY was 120×40, Node 26.8.1, with the actual inherited no-color terminal settings. This is real terminal/stream behavior proof, not an authenticated Gateway scenario or exhaustive color/platform coverage.
- Two benign fault controls failed the intended assertions: changing the budget mid-word broke wide-spacing bullet output; retaining the final fragment duplicated it before the next word. Restoring the candidate made each selected case pass, followed by all 95 cases.
- The normal configured two-file `check-changed` gate passed all **28 sequential stages** on Linux Node 24.19.0 through [the retained Testbox run](https://github.com/openclaw/openclaw/actions/runs/34612666317). The owned lease and source capsule were stopped/removed. Untimed successful stages do not emit individual timing/exit rows; the native command exit and full ordered stage log are retained.

The first required gate genuinely failed because the expanded object-form test exceeded the existing test-file line limit. A typed tuple table removed scaffolding without dropping coverage, changing expectations, raising the limit, or suppressing lint; the full gate then passed. Earlier local tests also changed one normal Vitest result-cache file; its exact afterimage was retained, not reset or excluded, and the final gate verified the complete current installation unchanged.

Managed pre-commit review returned no findings. The separate exact-commit P0–P2 review completed all five passes with **native exit 1** and one P2 alleging a reachable nonpositive fragment budget. That finding was rejected after independent complete parent/candidate source reads: **both** `firstWidth` and `nextWidth` use `Math.max(10, ...)`, and every assignment to `available` selects one of them. The claimed state cannot enter the split loop. The raw finding and native exit remain preserved; the disposition is **zero accepted actionable findings**, not a native scoped-clean result. No reviewer rerun or source change was used to obtain that disposition.

Historical custody limits remain explicit: the pristine 91-case run finished before its OS PID/temporary namespace could be captured, and an earlier metadata-only census has an unknown native exit. Later native children were captured directly, but sampled descendants can still miss brief or escaped processes. The raw output proof inherits the installed PTY library's normal 200 ms socket-close behavior. These limits were carried into review rather than hidden by replaying proof.

Read-only source qualification against main `7af0464ba9605aba84db3fbdfaa12e5751da9797` found the entire terminal-core tree and 18 of 19 selected caller/dependency/tooling preimages unchanged from the proof parent. The sole root-package change adds executable-file publication metadata; every other package field is unchanged. No rebase or new test execution was performed for that comparison.

Exact-head hosted PR CI, fresh current-main admission, and the ordinary native prepare/merge flow remain required before landing. This first-publication evidence is not a landing receipt.
