### PR TITLE
refactor(plugins): deprecate synchronous keyed storage

### DIFF
--- a/docs/plugins/compatibility.md
+++ b/docs/plugins/compatibility.md
@@ -126,6 +126,17 @@ cleared; the existing `--fail-on-eligible-compat` gate continues to apply only
 to dated `deprecated` records. Reader references are surface-token matches for
 triage; use the published-artifact sweep before authorizing removal.
 
+### Synchronous plugin state
+
+`plugin-state-sync-keyed-store` names the existing synchronous keyed-store adapter.
+Its September 11, 2026 deprecation uses the `next-plugin-sdk-major` removal gate,
+with editor annotations and documentation rather than new runtime warnings.
+Existing synchronous methods, plugin trust eligibility, and transactional callback
+semantics remain unchanged. Migrate to awaited `openKeyedStore` operations using
+the [state-store migration guide](/plugins/sdk-runtime/state-and-system#synchronous-keyed-store-migration).
+Removal still requires a supported external-plugin migration and explicit
+breaking-release approval.
+
 ### Session agent resolution aliases
 
 New plugins should use `resolveSessionAgentIdsStrict` or

--- a/docs/plugins/sdk-migration/removal-timeline.md
+++ b/docs/plugins/sdk-migration/removal-timeline.md
@@ -17,7 +17,7 @@ The dates and gates that govern when deprecated surfaces become removable. Part 
 | **Pending owner decision**                               | Records without `removeAfter` or `removalGate` remain deprecated and ineligible until their owner publishes a gate.                                                          |
 | **Day after a `deprecated` record's `removeAfter` date** | At 00:00 UTC, that record becomes date-eligible and `pnpm plugins:boundary-report --fail-on-eligible-compat` exits non-zero. The date itself is the final compatibility day. |
 | **A `removal-pending` record's `removeAfter` date**      | At 00:00 UTC, the report marks the record due for review and lists its blockers. It does not trigger the compatibility fail flag.                                            |
-| **Next Plugin SDK major**                                | `inbound-reply-dispatch` reaches its explicit `next-plugin-sdk-major` gate; it is not date-eligible before that version boundary.                                            |
+| **Next Plugin SDK major**                                | `inbound-reply-dispatch` and synchronous plugin keyed stores reach their explicit `next-plugin-sdk-major` gate; neither is date-eligible before that version boundary.       |
 
 The remaining public SDK subpaths below have registry-backed removal windows.
 The July 30 rows were removed after their early maintainer-authorized sweep:
@@ -35,7 +35,7 @@ until the next Plugin SDK major.
 | Removal gate            | Tier                               | SDK subpaths                                                                                                                                                                        |
 | ----------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `2026-10-01`            | Earlier compatibility deprecations | `channel-lifecycle`, `channel-message`, `channel-reply-pipeline`, `config-runtime`, `infra-runtime`                                                                                 |
-| `next-plugin-sdk-major` | Major-version compatibility gate   | `inbound-reply-dispatch`                                                                                                                                                            |
+| `next-plugin-sdk-major` | Major-version compatibility gate   | `inbound-reply-dispatch`; `api.runtime.state.openSyncKeyedStore` and `PluginStateSyncKeyedStore`                                                                                    |
 | `2026-10-01`            | Media legacy projection            | `agent-media-payload`, plus the non-subpath `MsgContext Media*` fields, channel inbound media payload builders, `buildMediaPayload`, hook media aliases, and `{{Media*}}` templates |
 
 The five September 1 subpaths remain available in 2026.8.2 under an approved

--- a/docs/plugins/sdk-runtime/state-and-system.md
+++ b/docs/plugins/sdk-runtime/state-and-system.md
@@ -132,7 +132,7 @@ The runtime config snapshot, durable plugin-scoped storage, system utilities, ev
 
     Current host factories provide `lookupMany`, but the public store types keep it optional for existing third-party adapters and declared older host versions. A plugin supporting those hosts must check the method and use its existing sequential `lookup` path when absent; never retry a failed bulk read through that path. Matrix, Microsoft Teams, and Voice Call retain this compatibility until their declared minimum host supplies the capability. Do not import a new helper export from an older host just to detect this method.
 
-    `openSyncKeyedStore<T>(...)` returns the same store shape with synchronous methods (`register`, `registerIfAbsent`, `deleteIf`, `lookup`, `lookupMany`, `consume`, `clear` all return values directly instead of promises) for callers that cannot await.
+    `openSyncKeyedStore<T>(...)` remains available for callers that cannot await, with its existing synchronous return values and errors. It is deprecated through the `next-plugin-sdk-major` compatibility gate. See [Synchronous keyed store migration](/plugins/sdk-runtime/state-and-system#synchronous-keyed-store-migration).
 
     `openBlobStore<TMetadata>(...)` stores bounded binary payloads in shared SQLite without base64 or file sidecars. It requires per-entry, per-namespace byte, and row limits; copies byte arrays at the API boundary; and lists metadata without loading every BLOB. `register(...)` is an explicit upsert, including for expired keys. `registerIfAbsent(...)` provides collision-safe creation: an expired key remains occupied until its owner claims it with `deleteExpiredKey(key)` or `deleteExpired()`, preserving metadata needed to remove related named artifacts after the SQLite commit. Any row with a TTL is transient and excluded from backup/restore even before it expires; omit TTL for durable, restorable state. Host fuses cap each BLOB at 100 MiB, each plugin at 512 MiB of physically stored BLOBs, and each plugin at 50,000 physically stored rows, including expired rows awaiting owner cleanup. Use `registerIfAbsent(...)` with `overflowPolicy: "reject-new"` when external materializations must not be silently orphaned by replacement or eviction.
 
@@ -148,3 +148,39 @@ The runtime config snapshot, durable plugin-scoped storage, system utilities, ev
 
   </Accordion>
 </AccordionGroup>
+
+## Synchronous keyed store migration
+
+`api.runtime.state.openSyncKeyedStore` and `PluginStateSyncKeyedStore` are deprecated
+as of September 11, 2026. The existing `createPluginStateSyncKeyedStore` factory is
+the named `plugin-state-sync-keyed-store` compatibility adapter. Existing methods
+remain supported through the next Plugin SDK major; removal also requires a
+supported external-plugin migration and explicit breaking-release approval.
+
+Use `api.runtime.state.openKeyedStore` with the same namespace and options, then
+await its operations. The opener itself still returns a store synchronously.
+Both interfaces use the same plugin-scoped data, so no data migration is needed.
+
+```typescript
+const store = api.runtime.state.openKeyedStore<MyRecord>({
+  namespace: "my-feature",
+  maxEntries: 200,
+});
+await store.register("key-1", { value: "hello" });
+const value = await store.lookup("key-1");
+```
+
+The async store's `update` updater and `deleteIf` predicate remain synchronous
+callbacks inside the transaction containing the authoritative read and mutation.
+Finish asynchronous planning before calling these methods; do not make their
+callbacks async or replace atomic operations with separate lookups and writes.
+Returning `undefined` from an updater leaves the entry unchanged. `update`,
+`deleteIf`, and `lookupMany` remain optional in public store types, so preserve
+capability checks for supported older hosts and third-party adapters.
+
+This deprecation adds editor annotations, documentation, and compatibility
+inventory metadata. It adds no runtime warning and changes no trust eligibility:
+the runtime openers remain limited to bundled plugins and trusted official
+installations. Runtime warnings should wait for an actionable supported upgrade.
+The async interface does not promise off-thread SQL or change callback execution;
+callback-free worker capabilities are a separate contract.

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -368,7 +368,11 @@ export function createPluginStateKeyedStore<T>(
   return createKeyedStoreForPluginId<T>(pluginId, options);
 }
 
-/** Opens a sync plugin-state namespace for a non-core plugin id. */
+/**
+ * Named adapter for the plugin-state-sync-keyed-store compatibility contract.
+ * @deprecated Plugin runtimes should use api.runtime.state.openKeyedStore and
+ * await its operations. This sync adapter remains through the next Plugin SDK major.
+ */
 export function createPluginStateSyncKeyedStore<T>(
   pluginId: string,
   options: OpenKeyedStoreOptions,

--- a/src/plugin-state/plugin-state-store.types.ts
+++ b/src/plugin-state/plugin-state-store.types.ts
@@ -13,12 +13,13 @@ export type PluginStateEntry<T> = {
 export type PluginStateKeyedStore<T> = {
   register(key: string, value: T, opts?: { ttlMs?: number }): Promise<void>;
   registerIfAbsent(key: string, value: T, opts?: { ttlMs?: number }): Promise<boolean>;
+  /** The updater runs synchronously in the transaction; undefined leaves the entry unchanged. */
   update?: (
     key: string,
     updateValue: (current: T | undefined) => T | undefined,
     opts?: { ttlMs?: number },
   ) => Promise<boolean>;
-  /** Atomically deletes an existing entry when its current value matches. */
+  /** The synchronous predicate and conditional deletion run in one transaction. */
   deleteIf?: (key: string, predicate: (current: T) => boolean) => Promise<boolean>;
   lookup(key: string): Promise<T | undefined>;
   /** Positional outcomes for at most 10,000 keys; missing/expired values are undefined. */
@@ -31,7 +32,11 @@ export type PluginStateKeyedStore<T> = {
   clear(): Promise<void>;
 };
 
-/** Sync plugin state API used by trusted core/plugin bootstrap paths. */
+/**
+ * Synchronous plugin-state compatibility contract.
+ * @deprecated Use PluginStateKeyedStore from api.runtime.state.openKeyedStore
+ * and await its operations. Retained through the next Plugin SDK major.
+ */
 export type PluginStateSyncKeyedStore<T> = {
   register(key: string, value: T, opts?: { ttlMs?: number }): void;
   registerIfAbsent(key: string, value: T, opts?: { ttlMs?: number }): boolean;

--- a/src/plugins/compat/registry-records.ts
+++ b/src/plugins/compat/registry-records.ts
@@ -12,6 +12,36 @@ export const PLUGIN_COMPAT_RECORDS = [
   ...DEPRECATION_MARKING_COMPAT_RECORDS,
   MEDIA_LEGACY_PROJECTION_COMPAT_RECORD,
   {
+    code: "plugin-state-sync-keyed-store",
+    status: "deprecated",
+    owner: "sdk",
+    introduced: "2026-05-29",
+    deprecated: "2026-09-11",
+    warningStarts: "2026-09-11",
+    removalGate: "next-plugin-sdk-major",
+    replacement:
+      "`api.runtime.state.openKeyedStore` and `PluginStateKeyedStore`; await operations while keeping transactional callbacks synchronous. Retain the sync adapter until a supported external-plugin migration and explicit breaking-release approval.",
+    docsPath: "/plugins/sdk-runtime/state-and-system#synchronous-keyed-store-migration",
+    surfaces: [
+      "api.runtime.state.openSyncKeyedStore",
+      "PluginStateSyncKeyedStore",
+      "createPluginStateSyncKeyedStore",
+    ],
+    diagnostics: [
+      "TypeScript @deprecated annotations and state-store migration documentation",
+      "plugin compatibility inventory; no new runtime warnings",
+    ],
+    tests: [
+      "src/plugins/compat/registry.test.ts",
+      "src/plugin-state/plugin-state-store.test.ts",
+      "src/plugin-state/plugin-state-store.runtime.test.ts",
+      "src/plugin-sdk/plugin-state-store-runtime.test.ts",
+      "src/plugins/loader.runtime-registry.test.ts",
+    ],
+    releaseNote:
+      "Synchronous plugin keyed stores remain supported through the next Plugin SDK major while plugins migrate to awaited keyed-store operations; trust eligibility and transactional callbacks are unchanged.",
+  },
+  {
     code: "memory-read-result-statusless-success",
     status: "deprecated",
     owner: "sdk",

--- a/src/plugins/compat/registry.test.ts
+++ b/src/plugins/compat/registry.test.ts
@@ -129,6 +129,20 @@ describe("plugin compatibility registry", () => {
       removalGate: "next-plugin-sdk-major",
       removeAfter: undefined,
     });
+    expect(records.get("plugin-state-sync-keyed-store")).toMatchObject({
+      status: "deprecated",
+      owner: "sdk",
+      deprecated: "2026-09-11",
+      warningStarts: "2026-09-11",
+      removalGate: "next-plugin-sdk-major",
+      docsPath: "/plugins/sdk-runtime/state-and-system#synchronous-keyed-store-migration",
+      surfaces: [
+        "api.runtime.state.openSyncKeyedStore",
+        "PluginStateSyncKeyedStore",
+        "createPluginStateSyncKeyedStore",
+      ],
+    });
+    expect(records.get("plugin-state-sync-keyed-store")?.removeAfter).toBeUndefined();
     expect(records.get("agent-harness-sdk-alias")?.surfaces).toEqual([
       "openclaw/plugin-sdk/agent-harness",
       "openclaw/plugin-sdk/agent-harness-runtime",

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -510,6 +510,10 @@ export type PluginRuntimeCore = {
     openKeyedStore: <T>(
       options: import("../../plugin-state/plugin-state-store.types.js").OpenKeyedStoreOptions,
     ) => import("../../plugin-state/plugin-state-store.types.js").PluginStateKeyedStore<T>;
+    /**
+     * @deprecated Use openKeyedStore and await its operations. The synchronous
+     * compatibility adapter remains through the next Plugin SDK major.
+     */
     openSyncKeyedStore: <T>(
       options: import("../../plugin-state/plugin-state-store.types.js").OpenKeyedStoreOptions,
     ) => import("../../plugin-state/plugin-state-store.types.js").PluginStateSyncKeyedStore<T>;


### PR DESCRIPTION
## What Problem This Solves

Plugin authors need an explicit migration path away from synchronous keyed-state operations without losing existing host compatibility or atomic callback behavior.

## Why This Change Was Made

The compatibility registry now names the existing synchronous store factory as the `plugin-state-sync-keyed-store` adapter, with a `next-plugin-sdk-major` removal gate. TypeScript annotations and migration documentation guide callers toward `openKeyedStore` and awaited operations. Removal still requires a supported external-plugin migration and explicit breaking-release approval.

## User Impact

Existing synchronous methods remain available with their current signatures, errors and trust eligibility. No runtime warnings are added. Both APIs share the existing namespace data; no migration copy is needed. Updater and predicate callbacks remain synchronous within their transaction, and optional capabilities remain optional. Callback-free worker operations are a separate contract.

## Evidence

Compiler token comparison confirms runtime code and public types are unchanged while all three deprecation annotations are recognized. Existing real SQLite, runtime trust, CJS/TypeScript loader, SDK type and compatibility tests pass, covering 86 cases with the final metadata recheck. Full changed-file checks and fresh Codex review pass.

Changed pages pass MDX checks. Both new migration links resolve; the global anchor audit's 54 unrelated failures exactly match the untouched baseline. No baseline or runtime behavior was changed to hide those failures.
