### PR TITLE
refactor(memory): await generation lease cleanup

### DIFF
--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -547,7 +547,7 @@ describe("memory manager database publication", () => {
     try {
       cleanupAgedMemoryReindexTempFiles(databasePath);
     } finally {
-      lock.release();
+      await lock.release();
     }
 
     await expectPathMissing(oldShadow);

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -170,7 +170,7 @@ export async function resetMemoryDatabase(params: {
       }),
     );
   } finally {
-    lock.release();
+    await lock.release();
   }
 }
 

--- a/extensions/memory-core/src/memory/manager-index-generation-lease.async.test.ts
+++ b/extensions/memory-core/src/memory/manager-index-generation-lease.async.test.ts
@@ -1,0 +1,138 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  acquireMemoryIndexReadGeneration,
+  withMemoryIndexPublishGeneration,
+} from "./manager-index-generation-lease.js";
+import type { MemorySqliteLeaseHandle } from "./manager-sqlite-lease.js";
+
+const leases = vi.hoisted(() => ({
+  acquire: vi.fn<typeof import("./manager-sqlite-lease.js").tryAcquireMemorySqliteLease>(),
+  acquireWriter: vi.fn<typeof import("./manager-sqlite-lease.js").acquireMemorySqliteWriterLease>(),
+}));
+vi.mock("./manager-sqlite-lease.js", () => ({
+  tryAcquireMemorySqliteLease: leases.acquire,
+  acquireMemorySqliteWriterLease: leases.acquireWriter,
+}));
+
+beforeEach(() => {
+  leases.acquire.mockReset();
+  leases.acquireWriter.mockReset();
+});
+
+describe("memory generation lease cleanup", () => {
+  it.each([false, true])(
+    "keeps publication and queued readers waiting for both releases (release failure: %s)",
+    async (failRelease) => {
+      const generationStarted = createDeferred<void>();
+      const generationGate = createDeferred<void>();
+      const admissionStarted = createDeferred<void>();
+      const admissionGate = createDeferred<void>();
+      const releaseError = new Error("generation release failed");
+      const events: string[] = [];
+      leases.acquire.mockResolvedValueOnce({
+        release: async () => {
+          generationStarted.resolve();
+          await generationGate.promise;
+          if (failRelease) {
+            throw releaseError;
+          }
+        },
+      });
+      leases.acquire.mockResolvedValue({ release: async () => {} });
+      leases.acquireWriter.mockResolvedValue({
+        release: async () => {
+          admissionStarted.resolve();
+          await admissionGate.promise;
+        },
+      });
+      const databasePath = `/memory-generation-release-${failRelease}.sqlite`;
+      const publication = withMemoryIndexPublishGeneration(databasePath, async () => {
+        events.push("published");
+      }).then(
+        () => events.push("released"),
+        (error: unknown) => {
+          events.push("release-failed");
+          return error;
+        },
+      );
+      await generationStarted.promise;
+      const nextReader = acquireMemoryIndexReadGeneration(databasePath).then(async (release) => {
+        events.push("next-reader");
+        await release();
+      });
+      try {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(events).toEqual(["published"]);
+        expect(leases.acquire).toHaveBeenCalledTimes(1);
+        generationGate.resolve();
+        await admissionStarted.promise;
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(events).toEqual(["published"]);
+        expect(leases.acquire).toHaveBeenCalledTimes(1);
+      } finally {
+        generationGate.resolve();
+        admissionGate.resolve();
+        await Promise.all([publication, nextReader]);
+      }
+      expect(events).toContain("next-reader");
+      if (failRelease) {
+        expect(await publication).toBe(releaseError);
+      } else {
+        expect(events).toContain("released");
+      }
+    },
+  );
+
+  it("drains a lease delivered after cancellation before admitting the next local publisher", async () => {
+    const acquired = createDeferred<MemorySqliteLeaseHandle>();
+    const acquisitionStarted = createDeferred<void>();
+    const releaseStarted = createDeferred<void>();
+    const releaseGate = createDeferred<void>();
+    const admissionRelease = vi.fn(async () => {});
+    const generationRelease = vi.fn(async () => {
+      releaseStarted.resolve();
+      await releaseGate.promise;
+    });
+    leases.acquire
+      .mockResolvedValueOnce({ release: admissionRelease })
+      .mockImplementationOnce(async () => {
+        acquisitionStarted.resolve();
+        return acquired.promise;
+      })
+      .mockResolvedValue({ release: async () => {} });
+    const abortReason = new Error("search canceled");
+    const controller = new AbortController();
+    const databasePath = "/memory-generation-late-acquisition.sqlite";
+    const reader = acquireMemoryIndexReadGeneration(databasePath, controller.signal).catch(
+      (error: unknown) => error,
+    );
+    await acquisitionStarted.promise;
+    controller.abort(abortReason);
+    acquired.resolve({ release: generationRelease });
+    await releaseStarted.promise;
+    let published = false;
+    leases.acquireWriter.mockResolvedValue({ release: async () => {} });
+    const nextPublication = withMemoryIndexPublishGeneration(databasePath, async () => {
+      published = true;
+    });
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(published).toBe(false);
+      expect(admissionRelease).not.toHaveBeenCalled();
+    } finally {
+      releaseGate.resolve();
+      await nextPublication;
+    }
+    expect(await reader).toMatchObject({ cause: abortReason });
+    expect(generationRelease).toHaveBeenCalledTimes(1);
+    expect(admissionRelease).toHaveBeenCalledTimes(1);
+    expect(published).toBe(true);
+  });
+});

--- a/extensions/memory-core/src/memory/manager-index-generation-lease.test.ts
+++ b/extensions/memory-core/src/memory/manager-index-generation-lease.test.ts
@@ -121,7 +121,7 @@ async function withReadGeneration<T>(key: string, run: () => Promise<T>): Promis
   try {
     return await run();
   } finally {
-    release();
+    await release();
   }
 }
 
@@ -209,12 +209,12 @@ describe("memory index generation lease", () => {
     try {
       expect(await readChildLine(child)).toBe("contended");
       const acquired = readChildLine(child);
-      release();
+      await release();
       released = true;
       expect(await acquired).toBe("acquired");
     } finally {
       if (!released) {
-        release();
+        await release();
       }
       await stopChild(child);
     }
@@ -284,14 +284,10 @@ describe("memory index generation lease", () => {
     const publisher = spawnLeaseFixture("write", databasePath);
     const controller = new AbortController();
     const abortError = new Error("memory search cancelled while waiting for publication");
-    const acquireWithSignal = acquireMemoryIndexReadGeneration as (
-      path: string,
-      signal: AbortSignal,
-    ) => Promise<() => void>;
-    let pendingReader: Promise<() => void> | undefined;
+    let pendingReader: ReturnType<typeof acquireMemoryIndexReadGeneration> | undefined;
     try {
       expect(await readChildLine(publisher)).toBe("acquired");
-      pendingReader = acquireWithSignal(databasePath, controller.signal);
+      pendingReader = acquireMemoryIndexReadGeneration(databasePath, controller.signal);
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 50);
       });
@@ -309,7 +305,7 @@ describe("memory index generation lease", () => {
     } finally {
       await stopChild(publisher);
       const release = await pendingReader?.catch(() => undefined);
-      release?.();
+      await release?.();
     }
   });
 });

--- a/extensions/memory-core/src/memory/manager-index-generation-lease.ts
+++ b/extensions/memory-core/src/memory/manager-index-generation-lease.ts
@@ -41,10 +41,10 @@ async function acquireCrossProcessLease(
   ): Promise<MemorySqliteLeaseHandle> => {
     while (true) {
       throwIfGenerationLeaseAborted(signal);
-      const lease = tryAcquireMemorySqliteLease(location, mode);
+      const lease = await tryAcquireMemorySqliteLease(location, mode);
       if (lease) {
         if (signal?.aborted) {
-          lease.release();
+          await lease.release();
           throw createGenerationLeaseAbortError(signal);
         }
         return lease;
@@ -76,28 +76,28 @@ async function acquireCrossProcessLease(
       kind === "read" ? "shared" : "exclusive",
     );
   } catch (err) {
-    admission.release();
+    await admission.release();
     throw err;
   }
   if (kind === "read") {
     try {
-      admission.release();
+      await admission.release();
     } catch (err) {
-      generation.release();
+      await generation.release();
       throw err;
     }
     if (signal?.aborted) {
-      generation.release();
+      await generation.release();
       throw createGenerationLeaseAbortError(signal);
     }
     return generation;
   }
   return {
-    release: () => {
+    release: async () => {
       try {
-        generation.release();
+        await generation.release();
       } finally {
-        admission.release();
+        await admission.release();
       }
     },
   };
@@ -205,7 +205,7 @@ async function acquire(
   databasePath: string,
   kind: Waiter["kind"],
   signal?: AbortSignal,
-): Promise<() => void> {
+): Promise<() => Promise<void>> {
   const key = resolveUserPath(databasePath);
   const releaseLocal = await acquireLocal(key, kind, signal);
   let crossProcess: MemorySqliteLeaseHandle;
@@ -213,16 +213,16 @@ async function acquire(
     throwIfGenerationLeaseAborted(signal);
     crossProcess = await acquireCrossProcessLease(key, kind, signal);
     if (signal?.aborted) {
-      crossProcess.release();
+      await crossProcess.release();
       throw createGenerationLeaseAbortError(signal);
     }
   } catch (err) {
     releaseLocal();
     throw err;
   }
-  return () => {
+  return async () => {
     try {
-      crossProcess.release();
+      await crossProcess.release();
     } finally {
       releaseLocal();
     }
@@ -234,14 +234,14 @@ async function withLease<T>(key: string, kind: Waiter["kind"], run: () => Promis
   try {
     return await run();
   } finally {
-    release();
+    await release();
   }
 }
 
 export async function acquireMemoryIndexReadGeneration(
   databasePath: string,
   signal?: AbortSignal,
-): Promise<() => void> {
+): Promise<() => Promise<void>> {
   return await acquire(databasePath, "read", signal);
 }
 

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle-leases.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle-leases.test.ts
@@ -1,8 +1,10 @@
 // Memory Core tests cover manager provider lifecycle lease behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { hashText } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it, vi } from "vitest";
+import * as generationLease from "./manager-index-generation-lease.js";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
@@ -225,6 +227,19 @@ describe("memory index", () => {
       return [];
     };
 
+    const generationReleaseStarted = createDeferred<void>();
+    const generationReleaseGate = createDeferred<void>();
+    const acquireGeneration = generationLease.acquireMemoryIndexReadGeneration;
+    vi.spyOn(generationLease, "acquireMemoryIndexReadGeneration").mockImplementationOnce(
+      async (...args) => {
+        const release = await acquireGeneration(...args);
+        return async () => {
+          generationReleaseStarted.resolve();
+          await generationReleaseGate.promise;
+          await release();
+        };
+      },
+    );
     const searchPromise = manager.search("alpha");
     await vectorSearchStarted;
     const closePromise = manager.close();
@@ -243,8 +258,17 @@ describe("memory index", () => {
       expect(fields.closing).toBe(true);
       expect(fields.closed).toBe(false);
       expect(providerFixture.providerCloseCalls).toBe(0);
+      releaseVectorSearch();
+      await generationReleaseStarted.promise;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(closeSettled).toBe(false);
+      expect(providerFixture.providerCloseCalls).toBe(0);
     } finally {
       releaseVectorSearch();
+      generationReleaseGate.resolve();
+      await Promise.allSettled([searchPromise, closePromise]);
     }
 
     await expect(searchPromise).resolves.toBeDefined();

--- a/extensions/memory-core/src/memory/manager-reindex-lock.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-lock.ts
@@ -9,10 +9,6 @@ export type MemoryReindexLockHandle = MemorySqliteLeaseHandle;
 const REINDEX_LOCK_WAIT_TIMEOUT_MS = 2_000;
 const REINDEX_LOCK_RETRY_DELAY_MS = 25;
 
-function resolveMemoryReindexLockPath(dbPath: string): string {
-  return `${dbPath}.reindex-lock.sqlite`;
-}
-
 async function sleepAsync(ms: number): Promise<void> {
   await new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
@@ -26,24 +22,19 @@ function createMemoryReindexBusyError(lockPath: string): Error & { code: string 
   );
 }
 
-/** Try to acquire the build lock without locking readers of the live agent database. */
-function tryAcquireMemoryReindexLock(dbPath: string): MemoryReindexLockHandle | undefined {
-  return tryAcquireMemorySqliteLease(resolveMemoryReindexLockPath(dbPath), "exclusive");
-}
-
 /** Wait asynchronously for the exclusive build lock without blocking the Node event loop. */
 export async function waitForMemoryReindexLock(dbPath: string): Promise<MemoryReindexLockHandle> {
-  const lockPath = resolveMemoryReindexLockPath(dbPath);
+  const lockPath = `${dbPath}.reindex-lock.sqlite`;
   const deadline = Date.now() + REINDEX_LOCK_WAIT_TIMEOUT_MS;
   do {
-    const lock = tryAcquireMemoryReindexLock(dbPath);
+    const lock = await tryAcquireMemorySqliteLease(lockPath, "exclusive");
     if (lock) {
       return lock;
     }
     await sleepAsync(REINDEX_LOCK_RETRY_DELAY_MS);
   } while (Date.now() < deadline);
 
-  const finalLock = tryAcquireMemoryReindexLock(dbPath);
+  const finalLock = await tryAcquireMemorySqliteLease(lockPath, "exclusive");
   if (finalLock) {
     return finalLock;
   }

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -83,8 +83,8 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
     normalizedQuery: string,
     opts?: MemoryIndexSearchOptions,
   ): Promise<MemorySearchResult[]> {
-    let releaseGeneration: (() => void) | undefined;
-    return await this.withManagerOperation(async () => {
+    let releaseGeneration: (() => Promise<void>) | undefined;
+    const runSearch = async () => {
       opts?.onDebug?.({ backend: "builtin" });
       if (this.providerRequirement.mode === "required") {
         await this.ensureProviderInitialized();
@@ -254,8 +254,9 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         if (leasedIdentity.status === "valid") {
           break;
         }
-        releaseGeneration();
+        const release = releaseGeneration;
         releaseGeneration = undefined;
+        await release();
         if (
           identityAttempt > 0 ||
           leasedIdentity.status !== "mismatched" ||
@@ -473,8 +474,13 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         maxResults,
         minScore,
       });
-    }).finally(() => {
-      releaseGeneration?.();
+    };
+    return await this.withManagerOperation(async () => {
+      try {
+        return await runSearch();
+      } finally {
+        await releaseGeneration?.();
+      }
     });
   }
 

--- a/extensions/memory-core/src/memory/manager-sqlite-lease.ts
+++ b/extensions/memory-core/src/memory/manager-sqlite-lease.ts
@@ -5,7 +5,7 @@ import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 
 export type MemorySqliteLeaseHandle = {
-  release: () => void;
+  release: () => Promise<void>;
 };
 
 const MEMORY_SQLITE_LEASE_RETRY_DELAY_MS = 25;
@@ -35,7 +35,7 @@ function createMemorySqliteLeaseHandle(
   transactionActive: boolean,
 ): MemorySqliteLeaseHandle {
   return {
-    release: () => {
+    release: async () => {
       let releaseError: unknown;
       if (transactionActive) {
         try {
@@ -56,10 +56,10 @@ function createMemorySqliteLeaseHandle(
   };
 }
 
-export function tryAcquireMemorySqliteLease(
+export async function tryAcquireMemorySqliteLease(
   location: string,
   mode: "shared" | "exclusive",
-): MemorySqliteLeaseHandle | undefined {
+): Promise<MemorySqliteLeaseHandle | undefined> {
   const database = openMemoryLeaseDatabase(location);
   try {
     if (mode === "exclusive") {
@@ -109,13 +109,13 @@ export async function acquireMemorySqliteWriterLease(
         return createMemorySqliteLeaseHandle(database, false);
       } catch (err) {
         if (!isSqliteBusyError(err)) {
-          createMemorySqliteLeaseHandle(database, true).release();
+          await createMemorySqliteLeaseHandle(database, true).release();
           throw err;
         }
         try {
           await sleepWithAbort(MEMORY_SQLITE_LEASE_RETRY_DELAY_MS, signal);
         } catch (sleepError) {
-          createMemorySqliteLeaseHandle(database, true).release();
+          await createMemorySqliteLeaseHandle(database, true).release();
           throw sleepError;
         }
       }

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -581,7 +581,7 @@ describe("memory manager reindex recovery", () => {
         /another reindex is active/,
       );
     } finally {
-      lock.release();
+      await lock.release();
     }
   });
 
@@ -663,13 +663,13 @@ describe("memory manager reindex recovery", () => {
 
       await timer;
       expect(timerFired).toBe(true);
-      lock.release();
+      await lock.release();
       lockReleased = true;
       const waitedLock = await wait;
-      waitedLock.release();
+      await waitedLock.release();
     } finally {
       if (!lockReleased) {
-        lock.release();
+        await lock.release();
       }
     }
   });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -422,7 +422,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
             this.endSyncProviderGeneration();
           }
         } finally {
-          lock.release();
+          await lock.release();
         }
       };
       try {


### PR DESCRIPTION
## What Problem This Solves

Memory search and reindex cleanup assume coordination leases release immediately. An asynchronous lease owner could therefore let manager shutdown or queued publication finish before search cleanup has settled.

## Why This Change Was Made

Make private lease acquisition and release asynchronous and await cleanup throughout generation admission, search, reset, and reindex. Search retains its existing manager operation until generation cleanup finishes; cancellation and release failures drain held resources before releasing local queue ownership. Remove redundant reindex forwarding helpers and an obsolete test cast.

## User Impact

Prepares memory storage for asynchronous execution while preserving SQLite schema, retention, writer preference, and publication behavior. Physical SQLite work and coordination locks keep their current shared lifetime. Moving those locks to a separate worker requires the protected database work to move with them or an enforceable publication fence.

## Evidence

- The real-manager delayed-release regression failed before the repair because shutdown completed early.
- 73 focused tests passed, including real manager search, cross-process writer preference, reset, and reindex recovery; the 30 directly affected tests passed again after the final lint repair.
- Standalone real SQLite admission, publication, reopen, and integrity proof passed. A separate failure probe reproduced why a lease-only worker cannot safely protect surviving parent publication.
- Full `node scripts/check-changed.mjs`, `git diff --check`, and isolated Codex review through P2 passed.
