### PR TITLE
fix(discord): retire resolved Activity launch records

### DIFF
--- a/extensions/discord/src/activities/store.ts
+++ b/extensions/discord/src/activities/store.ts
@@ -204,8 +204,13 @@ export class DiscordActivityStore {
     // launch cannot poison the next click on a different widget for the whole TTL.
     // Different-widget and ambiguous records stay: their Activities may still query.
     const key = pendingLaunchKey(accountId, channelId, discordUserId);
-    await this.stores.launches.update(key, (existing) =>
-      existing?.state === "single" && existing.widgetId === widgetId ? undefined : existing,
+    const launches = this.stores.launches;
+    if (!launches.deleteIf) {
+      throw new Error("Discord Activities require atomic pending-launch deletion");
+    }
+    await launches.deleteIf(
+      key,
+      (existing) => existing.state === "single" && existing.widgetId === widgetId,
     );
   }
 

--- a/extensions/discord/src/activities/test-helpers.test-support.ts
+++ b/extensions/discord/src/activities/test-helpers.test-support.ts
@@ -36,7 +36,7 @@ export function createMemoryKeyedStore<T>(): PluginStateKeyedStore<T> & {
     async update(key, updateValue) {
       const next = updateValue(values.get(key)?.value);
       if (next === undefined) {
-        return values.delete(key);
+        return false;
       }
       values.set(key, { key, value: next, createdAt: values.get(key)?.createdAt ?? Date.now() });
       return true;
@@ -51,6 +51,10 @@ export function createMemoryKeyedStore<T>(): PluginStateKeyedStore<T> & {
     },
     async delete(key) {
       return values.delete(key);
+    },
+    async deleteIf(key, predicate) {
+      const entry = values.get(key);
+      return entry !== undefined && predicate(entry.value) ? values.delete(key) : false;
     },
     async entries() {
       return [...values.values()];


### PR DESCRIPTION
## What Problem This Solves

Resolving one Discord Activity widget left its pending-launch row behind. A later click on another widget could then lose its association and fall back to the newest channel widget. The owner treated an undefined updater result as deletion, although the storage contract means no change; the test fixture concealed this mismatch.

## Why This Change Was Made

Use the existing atomic conditional-delete operation for the matching single-widget record. Preserve different-widget and ambiguous records. Correct the fixture to follow the real update and conditional-delete contracts.

## User Impact

Resolved launches no longer poison the next widget click. No schema, TTL, retention policy, or SDK removal changes. Missing conditional-delete capability reports through the existing HTTP error path.

## Evidence

Real Node SQLite reproduced the stale row before repair and returned the second widget after repair, preserving unrelated rows and timestamps. The existing registered HTTP regression failed with the corrected fixture before the production repair. All 67 Activities tests, full changed checks, and independent P2 review pass. Synthetic fixtures only; no external Discord messages.
