### PR TITLE
refactor(hooks): await policy preparation through relay lifetime

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1640,7 +1640,7 @@ src/agents/cli-credentials.ts	9
 src/agents/cli-executable-identity.ts	3
 src/agents/cli-output-records.ts	1
 src/agents/cli-runner.ts	1
-src/agents/cli-runner/bundle-mcp-codex.ts	4
+src/agents/cli-runner/bundle-mcp-codex.ts	3
 src/agents/cli-runner/bundle-mcp-gemini.ts	4
 src/agents/cli-runner/bundle-mcp-runtime.ts	1
 src/agents/cli-runner/bundle-mcp.ts	6

--- a/docs/plugins/codex-harness-runtime/hooks.md
+++ b/docs/plugins/codex-harness-runtime/hooks.md
@@ -61,12 +61,17 @@ plugin behavior. For the native tool and permission bridge, OpenClaw injects
 per-thread Codex config for `PreToolUse`, `PostToolUse`, `PermissionRequest`,
 and `Stop`.
 
-Before starting or resuming a thread, OpenClaw waits for the native relay's
-direct publication attempt and rechecks the current run's authority. If the
-listener or SQLite locator is unavailable, hook commands can use the existing
-Gateway fallback. A relay without a listening direct bridge can still renew its
-logical expiry; a listening bridge updates its stored locator before extending
-the visible expiry. Unregistering invalidates foreground access
+Before starting or resuming a thread, OpenClaw prepares the native relay's
+stored MCP approval snapshot and direct publication attempt, then rechecks the
+current run's authority. If the listener or SQLite locator is unavailable, hook
+commands can use the existing Gateway fallback. Policy preparation must still
+succeed; Gateway invocation waits for that snapshot independently of publication.
+Registration returns a synchronous handle whose optional `deferMcpToolApprovals`
+field remains undefined until policy preparation finishes.
+
+A relay without a listening direct bridge can still renew its logical expiry;
+a listening bridge updates its stored locator before extending the visible
+expiry. Unregistering invalidates foreground access
 immediately. Cleanup drains accepted locator writes and, once the relay is
 retired, listener closure. Existing grace windows for late hooks and direct
 children retained after a successful yield are preserved; draining pending

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -152,47 +152,6 @@ export function injectCodexMcpConfigArgs(
   return [...(args ?? []), "-c", `mcp_servers=${overrides}`];
 }
 
-/**
- * Codex app-server runtime (extensions/codex) receives its thread config as a
- * JSON object through JSON-RPC `thread/start`/`thread/resume`, not as `-c` CLI
- * args. This returns a thread-config patch projecting user-configured
- * `cfg.mcp.servers` entries into Codex's `mcp_servers` table using the same
- * per-server normalization the CLI path uses, so app-server agents see the
- * same user MCP servers the CLI runtime exposes via `injectCodexMcpConfigArgs`.
- *
- * Only user-configured servers (`cfg.mcp.servers`) are projected. Plugin-
- * curated app-server apps are already attached separately through the codex
- * plugin thread-config `apps` patch, so they must not be re-projected here.
- */
-export function buildCodexUserMcpServersThreadConfigPatch(
-  cfg: OpenClawConfig | undefined,
-  options?: CodexUserMcpServersProjectionOptions,
-): { mcp_servers: CodexThreadConfigObject } | undefined {
-  const entries = Object.entries(selectCodexProjectableMcpServers(cfg, options));
-  if (entries.length === 0) {
-    return undefined;
-  }
-  const grants = options?.agentId ? loadMcpToolGrants(options.agentId) : [];
-  // Collected as entries: a server literally named `__proto__` would hit the
-  // prototype setter under plain assignment and vanish from the patch.
-  const projected: [string, CodexThreadConfigObject][] = [];
-  for (const [name, server] of entries) {
-    projected.push([
-      name,
-      normalizeCodexMcpServerConfig(
-        name,
-        applyCodexSessionMcpToolDenials(name, server, options?.toolOverrides),
-        grants,
-      ) as CodexThreadConfigObject,
-    ]);
-  }
-  const mcp_servers: CodexThreadConfigObject = Object.fromEntries(projected);
-  if (Object.keys(mcp_servers).length === 0) {
-    return undefined;
-  }
-  return { mcp_servers };
-}
-
 /** Async runtime projection that resolves OpenClaw-managed MCP bearer tokens. */
 export async function buildCodexUserMcpServersThreadConfigPatchForRuntime(
   cfg: OpenClawConfig | undefined,
@@ -213,7 +172,7 @@ export async function buildCodexUserMcpServersThreadConfigPatchForRuntime(
   if (Object.keys(allowedServers).length === 0) {
     return undefined;
   }
-  const grants = options?.agentId ? loadMcpToolGrants(options.agentId) : [];
+  const grants = options?.agentId ? await loadMcpToolGrants(options.agentId) : [];
   const resolvedConfig = await resolveMcpBearerBundleConfig({
     config: { mcpServers: allowedServers },
     cfg,

--- a/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
@@ -1,20 +1,17 @@
 /** Tests projecting OpenClaw user MCP servers into Codex app-server config. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  buildCodexUserMcpServersThreadConfigPatch,
-  buildCodexUserMcpServersThreadConfigPatchForRuntime,
-} from "./bundle-mcp-codex.js";
+import { buildCodexUserMcpServersThreadConfigPatchForRuntime } from "./bundle-mcp-codex.js";
 
 const authMocks = vi.hoisted(() => ({
-  loadExecApprovalsReadOnly: vi.fn(),
+  loadExecApprovalsReadOnlyAsync: vi.fn(),
   loadAuthProfileStoreForSecretsRuntime: vi.fn(),
   resolveApiKeyForProfile: vi.fn(),
   resolveMcpOAuthAccessToken: vi.fn(),
 }));
 
 vi.mock("../../infra/exec-approvals-store.js", () => ({
-  loadExecApprovalsReadOnly: authMocks.loadExecApprovalsReadOnly,
+  loadExecApprovalsReadOnlyAsync: authMocks.loadExecApprovalsReadOnlyAsync,
 }));
 
 vi.mock("../auth-profiles/store-runtime.js", () => ({
@@ -29,84 +26,86 @@ vi.mock("../mcp-oauth.js", () => ({
   resolveMcpOAuthAccessToken: authMocks.resolveMcpOAuthAccessToken,
 }));
 
-describe("buildCodexUserMcpServersThreadConfigPatch", () => {
+describe("buildCodexUserMcpServersThreadConfigPatchForRuntime", () => {
   beforeEach(() => {
-    authMocks.loadExecApprovalsReadOnly.mockReset().mockReturnValue({ version: 1, agents: {} });
+    authMocks.loadExecApprovalsReadOnlyAsync
+      .mockReset()
+      .mockResolvedValue({ version: 1, agents: {} });
     authMocks.loadAuthProfileStoreForSecretsRuntime.mockReset();
     authMocks.resolveApiKeyForProfile.mockReset();
     authMocks.resolveMcpOAuthAccessToken.mockReset();
   });
 
-  it.each(["configured", "runtime"])(
-    "projects exact-agent durable grants with server policy precedence in %s preparation",
-    async (preparation) => {
-      const grants = ["auto", "unspecified", "prompt", "approve", "missing"].map((server) => ({
-        server,
-        tool: "write.raw_tool",
-        source: "allow-always",
-        addedAt: 1,
-      }));
-      authMocks.loadExecApprovalsReadOnly.mockReturnValue({
-        version: 1,
-        agents: {
-          main: { mcpTools: grants },
-          other: { mcpTools: [{ ...grants[0], tool: "other_tool" }] },
-          "*": { mcpTools: [{ ...grants[0], tool: "wildcard_tool" }] },
+  it("projects exact-agent durable grants with server policy precedence in runtime preparation", async () => {
+    const grants = ["auto", "unspecified", "prompt", "approve", "missing"].map((server) => ({
+      server,
+      tool: "write.raw_tool",
+      source: "allow-always",
+      addedAt: 1,
+    }));
+    authMocks.loadExecApprovalsReadOnlyAsync.mockResolvedValue({
+      version: 1,
+      agents: {
+        main: { mcpTools: grants },
+        other: { mcpTools: [{ ...grants[0], tool: "other_tool" }] },
+        "*": { mcpTools: [{ ...grants[0], tool: "wildcard_tool" }] },
+      },
+    });
+    const cfg = {
+      mcp: {
+        servers: {
+          auto: { command: "mcp", codex: { defaultToolsApprovalMode: "auto" } },
+          unspecified: { command: "mcp", toolFilter: { exclude: ["write.raw_tool"] } },
+          prompt: { command: "mcp", codex: { defaultToolsApprovalMode: "prompt" } },
+          approve: { command: "mcp", codex: { defaultToolsApprovalMode: "approve" } },
         },
-      });
-      const cfg = {
-        mcp: {
-          servers: {
-            auto: { command: "mcp", codex: { defaultToolsApprovalMode: "auto" } },
-            unspecified: { command: "mcp", toolFilter: { exclude: ["write.raw_tool"] } },
-            prompt: { command: "mcp", codex: { defaultToolsApprovalMode: "prompt" } },
-            approve: { command: "mcp", codex: { defaultToolsApprovalMode: "approve" } },
-          },
-        },
-      } satisfies OpenClawConfig;
-      const prepare =
-        preparation === "runtime"
-          ? buildCodexUserMcpServersThreadConfigPatchForRuntime
-          : buildCodexUserMcpServersThreadConfigPatch;
+      },
+    } satisfies OpenClawConfig;
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime(cfg, {
+      agentId: "main",
+    });
 
-      const patch = await prepare(cfg, { agentId: "main" });
-
-      expect(patch?.mcp_servers.auto).toEqual({
-        command: "mcp",
-        default_tools_approval_mode: "auto",
-        tools: { "write.raw_tool": { approval_mode: "approve" } },
-      });
-      expect(patch?.mcp_servers.unspecified).toEqual({
-        command: "mcp",
-        disabled_tools: ["write.raw_tool"],
-        tools: { "write.raw_tool": { approval_mode: "approve" } },
-      });
-      expect(patch?.mcp_servers.prompt).toEqual({
-        command: "mcp",
-        default_tools_approval_mode: "prompt",
-      });
-      expect(patch?.mcp_servers.approve).toEqual({
-        command: "mcp",
-        default_tools_approval_mode: "approve",
-      });
-      expect(patch?.mcp_servers.missing).toBeUndefined();
-      expect(authMocks.loadExecApprovalsReadOnly).toHaveBeenCalledTimes(1);
-      expect((await prepare(cfg))?.mcp_servers.auto).not.toHaveProperty("tools");
-    },
-  );
-
-  it("returns undefined when cfg has no mcp.servers (regression: #80814)", () => {
-    expect(buildCodexUserMcpServersThreadConfigPatch(undefined)).toBeUndefined();
-    expect(buildCodexUserMcpServersThreadConfigPatch({} as OpenClawConfig)).toBeUndefined();
+    expect(patch?.mcp_servers.auto).toEqual({
+      command: "mcp",
+      default_tools_approval_mode: "auto",
+      tools: { "write.raw_tool": { approval_mode: "approve" } },
+    });
+    expect(patch?.mcp_servers.unspecified).toEqual({
+      command: "mcp",
+      disabled_tools: ["write.raw_tool"],
+      tools: { "write.raw_tool": { approval_mode: "approve" } },
+    });
+    expect(patch?.mcp_servers.prompt).toEqual({
+      command: "mcp",
+      default_tools_approval_mode: "prompt",
+    });
+    expect(patch?.mcp_servers.approve).toEqual({
+      command: "mcp",
+      default_tools_approval_mode: "approve",
+    });
+    expect(patch?.mcp_servers.missing).toBeUndefined();
+    expect(authMocks.loadExecApprovalsReadOnlyAsync).toHaveBeenCalledTimes(1);
     expect(
-      buildCodexUserMcpServersThreadConfigPatch({ mcp: {} } as OpenClawConfig),
+      (await buildCodexUserMcpServersThreadConfigPatchForRuntime(cfg))?.mcp_servers.auto,
+    ).not.toHaveProperty("tools");
+  });
+
+  it("returns undefined when cfg has no mcp.servers (regression: #80814)", async () => {
+    expect(await buildCodexUserMcpServersThreadConfigPatchForRuntime(undefined)).toBeUndefined();
+    expect(
+      await buildCodexUserMcpServersThreadConfigPatchForRuntime({} as OpenClawConfig),
     ).toBeUndefined();
     expect(
-      buildCodexUserMcpServersThreadConfigPatch({ mcp: { servers: {} } } as OpenClawConfig),
+      await buildCodexUserMcpServersThreadConfigPatchForRuntime({ mcp: {} } as OpenClawConfig),
+    ).toBeUndefined();
+    expect(
+      await buildCodexUserMcpServersThreadConfigPatchForRuntime({
+        mcp: { servers: {} },
+      } as OpenClawConfig),
     ).toBeUndefined();
   });
 
-  it("projects session server and tool overrides into user MCP config", () => {
+  it("projects session server and tool overrides into user MCP config", async () => {
     const cfg = {
       mcp: {
         servers: {
@@ -124,7 +123,7 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
       },
     } satisfies OpenClawConfig;
 
-    const patch = buildCodexUserMcpServersThreadConfigPatch(cfg, {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime(cfg, {
       toolOverrides: {
         mcpServers: { disabledDocs: true, search: false },
         mcpToolsDeny: { disabledDocs: ["delete_page"] },
@@ -144,8 +143,8 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     });
   });
 
-  it("projects a stdio user MCP server entry into mcp_servers (regression: #80814)", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch({
+  it("projects a stdio user MCP server entry into mcp_servers (regression: #80814)", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime({
       mcp: {
         servers: {
           outlook: {
@@ -168,8 +167,8 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     });
   });
 
-  it("projects a streamable-http user MCP server with bearer auth into mcp_servers", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch({
+  it("projects a streamable-http user MCP server with bearer auth into mcp_servers", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime({
       mcp: {
         servers: {
           notes: {
@@ -194,8 +193,8 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     });
   });
 
-  it("projects Codex-specific default tool approval mode", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch({
+  it("projects Codex-specific default tool approval mode", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime({
       mcp: {
         servers: {
           search: {
@@ -218,8 +217,8 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     });
   });
 
-  it("projects exact OpenClaw MCP tool filters into Codex-native tool filters", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch({
+  it("projects exact OpenClaw MCP tool filters into Codex-native tool filters", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime({
       mcp: {
         servers: {
           docs: {
@@ -244,9 +243,9 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     });
   });
 
-  it("rejects wildcard OpenClaw MCP tool filters that Codex cannot project exactly", () => {
-    expect(() =>
-      buildCodexUserMcpServersThreadConfigPatch({
+  it("rejects wildcard OpenClaw MCP tool filters that Codex cannot project exactly", async () => {
+    await expect(
+      buildCodexUserMcpServersThreadConfigPatchForRuntime({
         mcp: {
           servers: {
             docs: {
@@ -259,13 +258,13 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
           },
         },
       } as unknown as OpenClawConfig),
-    ).toThrow(
+    ).rejects.toThrow(
       'Cannot project mcp.servers.docs.toolFilter.include pattern "search_*" into Codex enabled_tools',
     );
   });
 
-  it("uses the Codex-native approval spelling when configured", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch({
+  it("uses the Codex-native approval spelling when configured", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime({
       mcp: {
         servers: {
           search: {
@@ -284,7 +283,7 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     });
   });
 
-  it("filters Codex-scoped user MCP servers by OpenClaw agent id", () => {
+  it("filters Codex-scoped user MCP servers by OpenClaw agent id", async () => {
     // Agent-scoped MCP servers should follow the active OpenClaw agent, while
     // unscoped servers remain global.
     const cfg = {
@@ -309,7 +308,9 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
       },
     } as unknown as OpenClawConfig;
 
-    const atlasPatch = buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "atlas" });
+    const atlasPatch = await buildCodexUserMcpServersThreadConfigPatchForRuntime(cfg, {
+      agentId: "atlas",
+    });
     expect(Object.keys(atlasPatch!.mcp_servers).toSorted()).toEqual(["atlas", "global"]);
     expect(atlasPatch!.mcp_servers.atlas).toMatchObject({ url: "https://atlas.example.com/mcp" });
     expect(atlasPatch!.mcp_servers.global).toMatchObject({
@@ -317,13 +318,15 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
       args: ["global-mcp.js"],
     });
 
-    const apoloPatch = buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "apolo" });
+    const apoloPatch = await buildCodexUserMcpServersThreadConfigPatchForRuntime(cfg, {
+      agentId: "apolo",
+    });
     expect(Object.keys(apoloPatch!.mcp_servers).toSorted()).toEqual(["apolo", "global"]);
     expect(apoloPatch!.mcp_servers.apolo).toMatchObject({ url: "https://apolo.example.com/mcp" });
   });
 
-  it("returns undefined when all user MCP servers are scoped to other agents", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch(
+  it("returns undefined when all user MCP servers are scoped to other agents", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime(
       {
         mcp: {
           servers: {
@@ -340,8 +343,8 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     expect(patch).toBeUndefined();
   });
 
-  it("omits disabled user MCP servers from Codex app-server projection", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch({
+  it("omits disabled user MCP servers from Codex app-server projection", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime({
       mcp: {
         servers: {
           disabled: {
@@ -368,8 +371,8 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     });
   });
 
-  it("normalizes Codex agent scopes before matching", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch(
+  it("normalizes Codex agent scopes before matching", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime(
       {
         mcp: {
           servers: {
@@ -388,7 +391,7 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     });
   });
 
-  it("fails closed for empty or invalid Codex agent scopes", () => {
+  it("fails closed for empty or invalid Codex agent scopes", async () => {
     const cfg = {
       mcp: {
         servers: {
@@ -416,7 +419,9 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
       },
     } as unknown as OpenClawConfig;
 
-    const patch = buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "atlas" });
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime(cfg, {
+      agentId: "atlas",
+    });
     expect(patch).toStrictEqual({
       mcp_servers: {
         global: {
@@ -427,8 +432,8 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     });
   });
 
-  it("omits scoped Codex MCP servers when no OpenClaw agent id is available", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch({
+  it("omits scoped Codex MCP servers when no OpenClaw agent id is available", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime({
       mcp: {
         servers: {
           atlas: {
@@ -442,8 +447,8 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     expect(patch).toBeUndefined();
   });
 
-  it("preserves multiple user MCP servers as independent mcp_servers entries", () => {
-    const patch = buildCodexUserMcpServersThreadConfigPatch({
+  it("preserves multiple user MCP servers as independent mcp_servers entries", async () => {
+    const patch = await buildCodexUserMcpServersThreadConfigPatchForRuntime({
       mcp: {
         servers: {
           one: { transport: "stdio", command: "one" },

--- a/src/agents/codex-mcp-config.test.ts
+++ b/src/agents/codex-mcp-config.test.ts
@@ -13,7 +13,7 @@ import {
 import { createMcpProofPluginRegistry } from "./mcp-connection-resolver.test-fixtures.js";
 
 const mocks = vi.hoisted(() => ({
-  loadExecApprovalsReadOnly: vi.fn(),
+  loadExecApprovalsReadOnlyAsync: vi.fn(),
   loadCalls: [] as Array<Record<string, unknown>>,
   bundleMcp: {
     config: {
@@ -25,7 +25,7 @@ const mocks = vi.hoisted(() => ({
 const tempDirs: string[] = [];
 
 vi.mock("../infra/exec-approvals-store.js", () => ({
-  loadExecApprovalsReadOnly: mocks.loadExecApprovalsReadOnly,
+  loadExecApprovalsReadOnlyAsync: mocks.loadExecApprovalsReadOnlyAsync,
 }));
 
 vi.mock("../plugins/bundle-mcp.js", () => ({
@@ -36,7 +36,7 @@ vi.mock("../plugins/bundle-mcp.js", () => ({
 }));
 
 beforeEach(() => {
-  mocks.loadExecApprovalsReadOnly.mockReset().mockReturnValue({ version: 1, agents: {} });
+  mocks.loadExecApprovalsReadOnlyAsync.mockReset().mockResolvedValue({ version: 1, agents: {} });
   mocks.loadCalls.length = 0;
   mocks.bundleMcp = {
     config: {
@@ -105,13 +105,13 @@ describe("buildCodexMcpServersConfig", () => {
 });
 
 describe("loadCodexBundleMcpThreadConfigCore", () => {
-  it("projects durable grants only for configured bundle names and fingerprints their removal", () => {
+  it("projects durable grants only for configured bundle names and fingerprints their removal", async () => {
     mocks.bundleMcp.config.mcpServers = {
       configured: { command: "mcp" },
       prompt: { command: "mcp" },
       pluginOnly: { command: "mcp" },
     };
-    mocks.loadExecApprovalsReadOnly.mockReturnValue({
+    mocks.loadExecApprovalsReadOnlyAsync.mockResolvedValue({
       version: 1,
       agents: {
         main: {
@@ -137,24 +137,24 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
       },
     };
 
-    const granted = loadCodexBundleMcpThreadConfigCore(params);
+    const granted = await loadCodexBundleMcpThreadConfigCore(params);
 
     expect(granted.configPatch?.mcp_servers).toEqual({
       configured: { command: "mcp", tools: { "write.raw_tool": { approval_mode: "approve" } } },
       prompt: { command: "mcp" },
       pluginOnly: { command: "mcp" },
     });
-    expect(mocks.loadExecApprovalsReadOnly).toHaveBeenCalledTimes(1);
-    mocks.loadExecApprovalsReadOnly.mockReturnValue({ version: 1, agents: {} });
-    const revoked = loadCodexBundleMcpThreadConfigCore(params);
+    expect(mocks.loadExecApprovalsReadOnlyAsync).toHaveBeenCalledTimes(1);
+    mocks.loadExecApprovalsReadOnlyAsync.mockResolvedValue({ version: 1, agents: {} });
+    const revoked = await loadCodexBundleMcpThreadConfigCore(params);
     expect(revoked.configPatch?.mcp_servers.configured).not.toHaveProperty("tools");
     expect(revoked.fingerprint).not.toBe(granted.fingerprint);
   });
 
-  it("forwards a prepared manifest registry to bundle loading", () => {
+  it("forwards a prepared manifest registry to bundle loading", async () => {
     const manifestRegistry = { plugins: [] };
 
-    loadCodexBundleMcpThreadConfigCore({ workspaceDir: "/workspace", manifestRegistry });
+    await loadCodexBundleMcpThreadConfigCore({ workspaceDir: "/workspace", manifestRegistry });
 
     expect(mocks.loadCalls).toEqual([
       expect.objectContaining({ workspaceDir: "/workspace", manifestRegistry }),
@@ -190,7 +190,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
       broken: { default_tools_approval_mode: undefined },
     });
     await expect(fs.stat(dataDir)).rejects.toMatchObject({ code: "ENOENT" });
-    const loaded = loadCodexBundleMcpThreadConfigCore({ workspaceDir: "/workspace" });
+    const loaded = await loadCodexBundleMcpThreadConfigCore({ workspaceDir: "/workspace" });
 
     expect((await fs.stat(dataDir)).isDirectory()).toBe(true);
     expect(loaded.configPatch?.mcp_servers.weather).toMatchObject({ command: "node" });
@@ -203,7 +203,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
     ]);
   });
 
-  it("loads enabled bundled MCP servers as a Codex thread config patch", () => {
+  it("loads enabled bundled MCP servers as a Codex thread config patch", async () => {
     mocks.bundleMcp = {
       config: {
         mcpServers: {
@@ -216,7 +216,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
       diagnostics: [],
     };
 
-    const loaded = loadCodexBundleMcpThreadConfigCore({
+    const loaded = await loadCodexBundleMcpThreadConfigCore({
       workspaceDir: "/workspace",
       cfg: {
         plugins: {
@@ -238,7 +238,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
     expect(loaded.staticServerNames).toEqual(["search"]);
   });
 
-  it("applies session server and tool denials to bundled Codex MCP config", () => {
+  it("applies session server and tool denials to bundled Codex MCP config", async () => {
     mocks.bundleMcp = {
       config: {
         mcpServers: {
@@ -254,7 +254,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
       diagnostics: [],
     };
 
-    const loaded = loadCodexBundleMcpThreadConfigCore({
+    const loaded = await loadCodexBundleMcpThreadConfigCore({
       workspaceDir: "/workspace",
       cfg: {},
       toolOverrides: {
@@ -276,7 +276,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
     });
   });
 
-  it("lets user config disable a same-named bundled server unless the session enables it", () => {
+  it("lets user config disable a same-named bundled server unless the session enables it", async () => {
     mocks.bundleMcp = {
       config: {
         mcpServers: {
@@ -294,14 +294,16 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
     };
 
     expect(
-      loadCodexBundleMcpThreadConfigCore({ workspaceDir: "/workspace", cfg }).configPatch,
+      (await loadCodexBundleMcpThreadConfigCore({ workspaceDir: "/workspace", cfg })).configPatch,
     ).toBeUndefined();
     expect(
-      loadCodexBundleMcpThreadConfigCore({
-        workspaceDir: "/workspace",
-        cfg,
-        toolOverrides: { mcpServers: { docs: true } },
-      }).configPatch,
+      (
+        await loadCodexBundleMcpThreadConfigCore({
+          workspaceDir: "/workspace",
+          cfg,
+          toolOverrides: { mcpServers: { docs: true } },
+        })
+      ).configPatch,
     ).toEqual({
       mcp_servers: {
         docs: { url: "https://bundled.example.com/mcp" },
@@ -309,10 +311,10 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
     });
   });
 
-  it("leaves user mcp.servers to the Codex user MCP projection path", () => {
+  it("leaves user mcp.servers to the Codex user MCP projection path", async () => {
     // User MCP config is projected elsewhere; this loader only injects bundled
     // MCP servers so the same server does not appear twice in Codex.
-    const loaded = loadCodexBundleMcpThreadConfigCore({
+    const loaded = await loadCodexBundleMcpThreadConfigCore({
       workspaceDir: "/workspace",
       cfg: {
         mcp: {
@@ -334,7 +336,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
     expect(loaded.userStaticServerNames).toEqual(["search"]);
   });
 
-  it("returns an evaluated empty MCP config when no bundle MCP runtime is needed", () => {
+  it("returns an evaluated empty MCP config when no bundle MCP runtime is needed", async () => {
     const cfg = {
       mcp: {
         servers: {
@@ -352,7 +354,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
       { toolsEnabled: true, toolsAllow: [] },
       { toolsEnabled: true, toolsAllow: ["memory_search"] },
     ]) {
-      const loaded = loadCodexBundleMcpThreadConfigCore({
+      const loaded = await loadCodexBundleMcpThreadConfigCore({
         workspaceDir: "/workspace",
         cfg,
         ...params,
@@ -365,8 +367,8 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
     }
   });
 
-  it("omits the config patch when no MCP servers are configured", () => {
-    const loaded = loadCodexBundleMcpThreadConfigCore({
+  it("omits the config patch when no MCP servers are configured", async () => {
+    const loaded = await loadCodexBundleMcpThreadConfigCore({
       workspaceDir: "/workspace",
       cfg: {},
       toolsEnabled: true,
@@ -377,9 +379,9 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
     expect(loaded.evaluated).toBe(true);
   });
 
-  it("excludes requester-scoped servers from projection and fingerprint", () => {
+  it("excludes requester-scoped servers from projection and fingerprint", async () => {
     const resolverRegistry = createMcpProofPluginRegistry();
-    withPluginRuntimeRegistryScope(resolverRegistry.registry, () => {
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
       const resolverApi = resolverRegistry.apiFor("test-plugin");
       resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
@@ -401,7 +403,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
         diagnostics: [],
       };
 
-      const loaded = loadCodexBundleMcpThreadConfigCore({
+      const loaded = await loadCodexBundleMcpThreadConfigCore({
         workspaceDir: "/workspace",
         cfg: {},
         toolsEnabled: true,
@@ -418,7 +420,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
         },
         diagnostics: [],
       };
-      const withoutScopedConfig = loadCodexBundleMcpThreadConfigCore({
+      const withoutScopedConfig = await loadCodexBundleMcpThreadConfigCore({
         workspaceDir: "/workspace",
         cfg: {},
         toolsEnabled: true,
@@ -439,7 +441,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
     });
   });
 
-  it("keeps static projection byte-identical when no resolver exists", () => {
+  it("keeps static projection byte-identical when no resolver exists", async () => {
     mocks.bundleMcp = {
       config: {
         mcpServers: {
@@ -452,12 +454,12 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
       diagnostics: [],
     };
 
-    const a = loadCodexBundleMcpThreadConfigCore({
+    const a = await loadCodexBundleMcpThreadConfigCore({
       workspaceDir: "/workspace",
       cfg: {},
       toolsEnabled: true,
     });
-    const b = loadCodexBundleMcpThreadConfigCore({
+    const b = await loadCodexBundleMcpThreadConfigCore({
       workspaceDir: "/workspace",
       cfg: {},
       toolsEnabled: true,

--- a/src/agents/codex-mcp-config.ts
+++ b/src/agents/codex-mcp-config.ts
@@ -227,9 +227,9 @@ function fingerprintCodexMcpServersConfig(config: CodexMcpServersConfig): string
 }
 
 /** Load bundle MCP config for one Codex app-server thread. */
-export function loadCodexBundleMcpThreadConfigCore(
+export async function loadCodexBundleMcpThreadConfigCore(
   params: LoadCodexBundleMcpThreadConfigParams,
-): CodexBundleMcpThreadConfig {
+): Promise<CodexBundleMcpThreadConfig> {
   const shouldCreateRuntime = shouldCreateBundleMcpRuntimeForAttempt({
     toolsEnabled: params.toolsEnabled ?? true,
     disableTools: params.disableTools,
@@ -286,7 +286,7 @@ export function loadCodexBundleMcpThreadConfigCore(
     prepareDataDirsByServer: bundleMcp.prepareDataDirsByServer ?? {},
   });
   const diagnostics = [...bundleMcp.diagnostics, ...preparedDataDirs.diagnostics];
-  const grants = params.agentId ? loadMcpToolGrants(params.agentId) : [];
+  const grants = params.agentId ? await loadMcpToolGrants(params.agentId) : [];
   const configuredGrants = grants.filter((grant) => {
     const server = Object.hasOwn(configuredMcp, grant.server)
       ? configuredMcp[grant.server]

--- a/src/agents/harness/native-hook-relay-bridge.ts
+++ b/src/agents/harness/native-hook-relay-bridge.ts
@@ -40,7 +40,7 @@ export {
   NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
 } from "./native-hook-relay-client.js";
 
-const { relays, relayBridges, pendingBridgeOperations } = nativeHookRelayState;
+const { relays, relayBridges, pendingOperations } = nativeHookRelayState;
 
 type InvokeNativeHookRelay = (
   params: InvokeNativeHookRelayParams,
@@ -106,22 +106,19 @@ export function registerNativeHookRelayBridge(
     });
   });
   bridge.pending = bridge.ready;
-  retainNativeHookRelayBridgeOperation(bridge, bridge.ready);
+  retainNativeHookRelayOperation(bridge.relayId, bridge.ready);
   server.listen(0, "127.0.0.1");
   server.unref();
   return bridge;
 }
 
-function retainNativeHookRelayBridgeOperation(
-  bridge: NativeHookRelayBridgeRegistration,
-  operation: Promise<void>,
-): void {
-  pendingBridgeOperations.add(operation);
+export function retainNativeHookRelayOperation(relayId: string, operation: Promise<void>): void {
+  pendingOperations.add(operation);
   void operation.then(
-    () => pendingBridgeOperations.delete(operation),
+    () => pendingOperations.delete(operation),
     (error: unknown) => {
-      pendingBridgeOperations.delete(operation);
-      log.debug("native hook relay bridge operation failed", { error, relayId: bridge.relayId });
+      pendingOperations.delete(operation);
+      log.debug("native hook relay operation failed", { error, relayId });
     },
   );
 }
@@ -222,7 +219,7 @@ export async function renewNativeHookRelayBridgeRecord(
         : "ownership-changed";
     });
   bridge.pending = renewal.then(() => undefined);
-  retainNativeHookRelayBridgeOperation(bridge, bridge.pending);
+  retainNativeHookRelayOperation(bridge.relayId, bridge.pending);
   return await renewal;
 }
 
@@ -273,7 +270,7 @@ export function unregisterNativeHookRelayBridge(
       }
     });
   bridge.pending = bridge.closing;
-  retainNativeHookRelayBridgeOperation(bridge, bridge.closing);
+  retainNativeHookRelayOperation(bridge.relayId, bridge.closing);
   return bridge.closing;
 }
 
@@ -387,8 +384,8 @@ export async function clearNativeHookRelayBridgesForTests(): Promise<void> {
   for (const relayId of relayBridges.keys()) {
     void unregisterNativeHookRelayBridge(relayId);
   }
-  while (pendingBridgeOperations.size > 0) {
-    await Promise.allSettled(pendingBridgeOperations);
+  while (pendingOperations.size > 0) {
+    await Promise.allSettled(pendingOperations);
   }
   await clearNativeHookRelayBridgeRecordsForTests();
 }

--- a/src/agents/harness/native-hook-relay-state.ts
+++ b/src/agents/harness/native-hook-relay-state.ts
@@ -10,7 +10,7 @@ function getNativeHookRelaySharedState(): NativeHookRelaySharedState {
   globalRecord[NATIVE_HOOK_RELAY_STATE_SYMBOL] ??= {
     relays: new Map(),
     relayBridges: new Map(),
-    pendingBridgeOperations: new Set(),
+    pendingOperations: new Set(),
     invocations: [],
     pendingPermissionApprovals: new Map(),
     pendingPreToolUseApprovals: new Map(),

--- a/src/agents/harness/native-hook-relay-types.ts
+++ b/src/agents/harness/native-hook-relay-types.ts
@@ -213,11 +213,11 @@ export type ActiveNativeHookRelayRegistrationHandle = NativeHookRelayRegistratio
 };
 
 export type OwnedNativeHookRelayRegistrationHandle = ActiveNativeHookRelayRegistrationHandle & {
-  /** Strict direct-listener and locator publication result. */
+  /** Strict policy preparation and direct publication result. */
   ready: Promise<void>;
   /** Requires current foreground authority; direct publication may use the Gateway fallback. */
   prepareInvocation: () => Promise<void>;
-  /** Joins accepted publication, renewal and cleanup without retiring retained children. */
+  /** Joins accepted policy, publication, renewal and cleanup without retiring retained children. */
   drain: () => Promise<void>;
 };
 
@@ -271,7 +271,7 @@ export type NativeHookRelayBridgeRegistration = {
 export type NativeHookRelaySharedState = {
   relays: Map<string, ActiveNativeHookRelayRegistration>;
   relayBridges: Map<string, NativeHookRelayBridgeRegistration>;
-  pendingBridgeOperations: Set<Promise<unknown>>;
+  pendingOperations: Set<Promise<unknown>>;
   invocations: NativeHookRelayInvocation[];
   pendingPermissionApprovals: Map<string, Promise<NativeHookRelayPermissionApprovalResult>>;
   pendingPreToolUseApprovals: Map<string, NativeHookRelayPreToolUseApproval>;

--- a/src/agents/harness/native-hook-relay-work.ts
+++ b/src/agents/harness/native-hook-relay-work.ts
@@ -1,13 +1,61 @@
+import { loadMcpToolGrants } from "../../infra/exec-approvals-mcp.js";
+import { resolveProjectedMcpCodexToolApprovalMode } from "../mcp-codex-tool-approval.js";
 import { drainNativeHookRelayBridge } from "./native-hook-relay-bridge.js";
-import type { NativeHookRelayBridgeRegistration } from "./native-hook-relay-types.js";
+import { nativeHookRelayState } from "./native-hook-relay-state.js";
+import type {
+  ActiveNativeHookRelayRegistration,
+  NativeHookRelayBridgeRegistration,
+  RegisterNativeHookRelayParams,
+} from "./native-hook-relay-types.js";
+
+const { relays } = nativeHookRelayState;
+
+/** Capture synchronous inputs before the relay owner admits its deferred policy read. */
+export function prepareNativeHookRelayMcpPolicy(
+  params: Pick<
+    RegisterNativeHookRelayParams,
+    "agentId" | "autoApproveMcpTools" | "config" | "projectedMcpServers"
+  >,
+  stateDbPath: string,
+  isCurrent: () => boolean,
+): Promise<boolean | undefined> {
+  const agentId = params.agentId;
+  const autoApproveMcpTools = params.autoApproveMcpTools === true;
+  const configuredMcpToolApprovals = Object.keys({
+    ...params.projectedMcpServers,
+    ...params.config?.mcp?.servers,
+  }).some(
+    (serverName) =>
+      resolveProjectedMcpCodexToolApprovalMode(
+        serverName,
+        params.config?.mcp?.servers?.[serverName] ?? {},
+        params.projectedMcpServers?.[serverName],
+      ) !== undefined,
+  );
+  return Promise.resolve().then(async () => {
+    if (!isCurrent()) {
+      return undefined;
+    }
+    // Native names lose raw identity; Codex applies its prepared per-tool approval config.
+    return (
+      autoApproveMcpTools ||
+      (agentId ? (await loadMcpToolGrants(agentId, { path: stateDbPath })).length > 0 : false) ||
+      configuredMcpToolApprovals
+    );
+  });
+}
 
 /** Preserve the first failure while joining work admitted during a pending drain. */
 export async function drainNativeHookRelayWork(params: {
+  policyReady: Promise<void>;
   bridge: NativeHookRelayBridgeRegistration;
   readRenewal: () => Promise<void>;
 }): Promise<void> {
   let renewal: Promise<void>;
   let failure: { error: unknown } | undefined;
+  await params.policyReady.catch((error: unknown) => {
+    failure = { error };
+  });
   do {
     renewal = params.readRenewal();
     try {
@@ -23,5 +71,20 @@ export async function drainNativeHookRelayWork(params: {
   } while (renewal !== params.readRenewal());
   if (failure) {
     throw failure.error;
+  }
+}
+
+export function assertNativeHookRelayForegroundCurrent(
+  registration: ActiveNativeHookRelayRegistration,
+  lifetime: { foregroundOpen: boolean; foregroundToken: symbol },
+  foregroundToken: symbol,
+): void {
+  if (relays.get(registration.relayId) !== registration || Date.now() > registration.expiresAtMs) {
+    throw new Error("native hook relay registration is inactive");
+  }
+  registration.signal?.throwIfAborted();
+  registration.assertActive?.();
+  if (!lifetime.foregroundOpen || lifetime.foregroundToken !== foregroundToken) {
+    throw new Error("native hook relay foreground invocation not allowed");
   }
 }

--- a/src/agents/harness/native-hook-relay.approval-wait.test.ts
+++ b/src/agents/harness/native-hook-relay.approval-wait.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { callGatewayTool } from "../tools/gateway.js";
-import { invokeNativeHookRelay, registerNativeHookRelay, testing } from "./native-hook-relay.js";
+import {
+  invokeNativeHookRelay,
+  registerNativeHookRelay,
+  registerOwnedNativeHookRelay,
+  testing,
+} from "./native-hook-relay.js";
 
 vi.mock("../tools/gateway.js", () => ({
   callGatewayTool: vi.fn(),
@@ -11,6 +16,7 @@ const approvalMocks = vi.hoisted(() => ({ loadExecApprovalsReadOnly: vi.fn() }))
 
 vi.mock("../../infra/exec-approvals-store.js", () => ({
   loadExecApprovalsReadOnly: approvalMocks.loadExecApprovalsReadOnly,
+  loadExecApprovalsReadOnlyAsync: async () => approvalMocks.loadExecApprovalsReadOnly(),
 }));
 
 beforeEach(() => {
@@ -31,12 +37,13 @@ describe("native hook relay approval wait handling", () => {
       agents: { main: { mcpTools: [grant] }, "*": { mcpTools: [grant] } },
     });
     mockCallGatewayTool.mockResolvedValue({ id: "unexpected-approval", decision: "deny" });
-    const relay = registerNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       agentId: "main",
       sessionId: "session-1",
       runId: "run-1",
     });
+    await relay.ready;
     approvalMocks.loadExecApprovalsReadOnly.mockReturnValue({ version: 1, agents: {} });
     for (const toolName of [
       "mcp__raw_server__raw_tool",

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -4,10 +4,8 @@ import {
   MAX_TIMER_TIMEOUT_MS,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
-import { loadMcpToolGrants } from "../../infra/exec-approvals-mcp.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
-import { resolveProjectedMcpCodexToolApprovalMode } from "../mcp-codex-tool-approval.js";
 import { retainBeforeToolCallForNativeHookRelay } from "./host-private-capabilities.js";
 import {
   clearNativeHookRelayBridgesForTests,
@@ -15,6 +13,7 @@ import {
   NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
   readNativeHookRelayBridgeRecordIfExists,
   registerNativeHookRelayBridge,
+  retainNativeHookRelayOperation,
   renewNativeHookRelayBridgeRecord,
   unregisterNativeHookRelayBridge,
   isRetryableNativeHookRelayBridgeLookupError,
@@ -65,7 +64,11 @@ import {
   readNonEmptyString,
   snapshotNativeHookRelayPayload,
 } from "./native-hook-relay-utils.js";
-import { drainNativeHookRelayWork } from "./native-hook-relay-work.js";
+import {
+  assertNativeHookRelayForegroundCurrent,
+  drainNativeHookRelayWork,
+  prepareNativeHookRelayMcpPolicy,
+} from "./native-hook-relay-work.js";
 export { buildNativeHookRelayCommand } from "./native-hook-relay-command.js";
 export { resolveNativeHookRelayDeferredToolApproval } from "./native-hook-relay-permissions.js";
 export type {
@@ -82,6 +85,7 @@ const { relays, relayBridges, invocations } = nativeHookRelayState;
 type RelayLifetime = {
   foregroundOpen: boolean;
   foregroundToken: symbol;
+  policyReady: Promise<void>;
   retained?: ReturnType<typeof retainBeforeToolCallForNativeHookRelay>;
   retention?: NativeHookRelayRetention;
   removeAbortListener?: () => void;
@@ -182,16 +186,22 @@ function registerNativeHookRelayInternal(
   }
   const allowedEvents = normalizeAllowedEvents(params.allowedEvents);
   const stateDbPath = resolveOpenClawStateSqlitePath();
+  let partialRegistration: ActiveNativeHookRelayRegistration | undefined;
+  const policy = prepareNativeHookRelayMcpPolicy(
+    params,
+    stateDbPath,
+    () => partialRegistration !== undefined && relays.get(relayId) === partialRegistration,
+  );
   const deliverReplacedRegistrationUnregister = unregisterNativeHookRelay(relayId, undefined, {
     deferListenerCloseMs: NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
     deferOnUnregister: true,
   });
-  let partialRegistration: ActiveNativeHookRelayRegistration | undefined;
   try {
     const retained =
       params.runBeforeToolCall && retention
         ? retainBeforeToolCallForNativeHookRelay(params.runBeforeToolCall)
         : undefined;
+    let deferMcpToolApprovals: boolean | undefined;
     const registration = {
       relayId,
       provider: params.provider,
@@ -203,18 +213,9 @@ function registerNativeHookRelayInternal(
       sessionId: params.sessionId,
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       ...(params.config ? { config: params.config } : {}),
-      deferMcpToolApprovals:
-        params.autoApproveMcpTools === true ||
-        // Native hook names lose raw identity; let Codex apply the prepared per-tool config.
-        (params.agentId ? loadMcpToolGrants(params.agentId).length > 0 : false) ||
-        Object.keys({ ...params.projectedMcpServers, ...params.config?.mcp?.servers }).some(
-          (serverName) =>
-            resolveProjectedMcpCodexToolApprovalMode(
-              serverName,
-              params.config?.mcp?.servers?.[serverName] ?? {},
-              params.projectedMcpServers?.[serverName],
-            ) !== undefined,
-        ),
+      get deferMcpToolApprovals() {
+        return deferMcpToolApprovals;
+      },
       runId: params.runId,
       ...(params.channelId ? { channelId: params.channelId } : {}),
       ...(params.requester ? { requester: params.requester } : {}),
@@ -231,9 +232,14 @@ function registerNativeHookRelayInternal(
     } as ActiveNativeHookRelayRegistration;
     partialRegistration = registration;
     relays.set(relayId, registration);
+    const policyReady = policy.then((prepared) => {
+      deferMcpToolApprovals = prepared;
+    });
+    retainNativeHookRelayOperation(relayId, policyReady);
     setRelayLifetime(registration, {
       foregroundOpen: true,
       foregroundToken: Symbol("native-hook-relay-foreground"),
+      policyReady,
       ...(retained ? { retained } : {}),
       ...(retention ? { retention } : {}),
     });
@@ -250,10 +256,16 @@ function registerNativeHookRelayInternal(
     const bridge = registerNativeHookRelayBridge(registration, stateDbPath, invokeNativeHookRelay);
     scheduleNativeHookRelayExpiry(relayId, registration);
     let pendingRenewal = Promise.resolve();
+    const ready = Promise.all([bridge.ready, policyReady]).then(() => undefined);
+    // Component owners report failure even when a public synchronous caller never awaits readiness.
+    void ready.catch(() => undefined);
     const handle: OwnedNativeHookRelayRegistrationHandle = {
       ...registration,
       ...buildNativeHookRelayCommandPlan({ ...params, relayId, generation }),
-      ready: bridge.ready,
+      get deferMcpToolApprovals() {
+        return deferMcpToolApprovals;
+      },
+      ready,
       prepareInvocation: async () => {
         const lifetime = readRelayLifetime(registration);
         if (!lifetime) {
@@ -261,12 +273,13 @@ function registerNativeHookRelayInternal(
         }
         const foregroundToken = lifetime.foregroundToken;
         assertNativeHookRelayForegroundCurrent(registration, lifetime, foregroundToken);
-        // A failed direct locator can still use the CLI's Gateway route. Keep
-        // its strict result on ready and revalidate admission after it settles.
+        await policyReady;
+        // Only direct transport failure may use the existing Gateway route.
         await bridge.ready.catch(() => undefined);
         assertNativeHookRelayForegroundCurrent(registration, lifetime, foregroundToken);
       },
-      drain: () => drainNativeHookRelayWork({ bridge, readRenewal: () => pendingRenewal }),
+      drain: () =>
+        drainNativeHookRelayWork({ policyReady, bridge, readRenewal: () => pendingRenewal }),
       renew: (ttlMs) => {
         const current = relays.get(relayId);
         if (current !== registration) {
@@ -418,6 +431,11 @@ async function resolveNativeHookRelayInvocationBinding(
   if (!lifetime) {
     throw new Error("native hook relay registration is inactive");
   }
+  // Gateway fallback shares policy readiness without depending on HTTP locator publication.
+  await lifetime.policyReady;
+  if (relays.get(registration.relayId) !== registration || Date.now() > registration.expiresAtMs) {
+    throw new Error("native hook relay registration is inactive");
+  }
   const claim = lifetime.retention?.readClaim(rawPayload);
   if (claim && event === "pre_tool_use" && lifetime.retained && lifetime.retention) {
     const retained = lifetime.retained;
@@ -461,21 +479,6 @@ async function resolveNativeHookRelayInvocationBinding(
   const assertActive = () =>
     assertNativeHookRelayForegroundCurrent(registration, lifetime, foregroundToken);
   return { ...registration, assertActive };
-}
-
-function assertNativeHookRelayForegroundCurrent(
-  registration: ActiveNativeHookRelayRegistration,
-  lifetime: RelayLifetime,
-  foregroundToken: symbol,
-): void {
-  if (relays.get(registration.relayId) !== registration || Date.now() > registration.expiresAtMs) {
-    throw new Error("native hook relay registration is inactive");
-  }
-  registration.signal?.throwIfAborted();
-  registration.assertActive?.();
-  if (!lifetime.foregroundOpen || lifetime.foregroundToken !== foregroundToken) {
-    throw new Error("native hook relay foreground invocation not allowed");
-  }
 }
 
 function normalizeRelayKey(

--- a/src/gateway/operator-approval-mcp-grants.test.ts
+++ b/src/gateway/operator-approval-mcp-grants.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildCodexUserMcpServersThreadConfigPatch } from "../agents/cli-runner/bundle-mcp-codex.js";
+import { buildCodexUserMcpServersThreadConfigPatchForRuntime } from "../agents/cli-runner/bundle-mcp-codex.js";
 import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
@@ -168,10 +168,14 @@ describe("gateway MCP tool grants", () => {
       aux.pluginApprovalManager.runtimeEpoch,
     );
     expect(loadExecApprovalsReadOnly().agents).toEqual({ main: { mcpTools: [expected] } });
-    expect(buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "main" })).toMatchObject({
+    expect(
+      await buildCodexUserMcpServersThreadConfigPatchForRuntime(cfg, { agentId: "main" }),
+    ).toMatchObject({
       mcp_servers: { "project.docs": { tools: { write_note: { approval_mode: "approve" } } } },
     });
-    expect(buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "other" })).not.toMatchObject({
+    expect(
+      await buildCodexUserMcpServersThreadConfigPatchForRuntime(cfg, { agentId: "other" }),
+    ).not.toMatchObject({
       mcp_servers: { "project.docs": { tools: { write_note: { approval_mode: "approve" } } } },
     });
   });

--- a/src/gateway/server-methods/native-hook-relay.test.ts
+++ b/src/gateway/server-methods/native-hook-relay.test.ts
@@ -2,9 +2,24 @@
  * Tests for relaying native hook events through gateway request handlers.
  */
 
+import fs from "node:fs";
+import { Server } from "node:http";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { testing, registerNativeHookRelay } from "../../agents/harness/native-hook-relay.js";
+import {
+  testing,
+  registerNativeHookRelay,
+  registerOwnedNativeHookRelay,
+} from "../../agents/harness/native-hook-relay.js";
+import { resolveExecApprovalsPath } from "../../infra/exec-approvals-config.js";
+import * as mcpGrants from "../../infra/exec-approvals-mcp.js";
+import { ExecApprovalsMigrationRequiredError } from "../../infra/exec-approvals-migration-gate.js";
+import { saveExecApprovals } from "../../infra/exec-approvals-store.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { nativeHookRelayHandlers } from "./native-hook-relay.js";
 
 const POST_TOOL_USE_PAYLOAD = {
@@ -15,9 +30,365 @@ const POST_TOOL_USE_PAYLOAD = {
 
 afterEach(async () => {
   await testing.clearNativeHookRelaysForTests();
+  vi.restoreAllMocks();
 });
 
 describe("native hook relay gateway method", () => {
+  it("returns its synchronous handle before reading stored MCP policy", async () => {
+    await withOpenClawTestState({ label: "relay-policy-registration" }, async () => {
+      const read = vi.spyOn(mcpGrants, "loadMcpToolGrants");
+      const relay = registerOwnedNativeHookRelay({
+        provider: "codex",
+        agentId: "main",
+        sessionId: "policy-registration",
+        runId: "policy-registration",
+      });
+      try {
+        expect(typeof relay.commandForEvent("permission_request")).toBe("string");
+        expect(read.mock.calls.length).toBe(0);
+        await relay.ready;
+        expect(read.mock.calls.length).toBe(1);
+      } finally {
+        relay.unregister();
+        await relay.drain();
+      }
+    });
+  });
+
+  it("waits for stored policy through Gateway when the locator cannot publish", async () => {
+    await withOpenClawTestState({ label: "relay-policy-gateway-fallback" }, async () => {
+      saveExecApprovals({
+        version: 1,
+        agents: {
+          main: {
+            mcpTools: [{ server: "fixture", tool: "read", source: "allow-always", addedAt: 1 }],
+          },
+        },
+      });
+      const { entered, resume, completed, read } = pauseMcpPolicyRead();
+      const listenerFailure = new Error("fixture listener unavailable");
+      vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server) {
+        queueMicrotask(() => this.emit("error", listenerFailure));
+        return this;
+      });
+      const requester = vi.fn(async () => "deny" as const);
+      testing.setNativeHookRelayPermissionApprovalRequesterForTests(requester);
+      const relay = registerOwnedNativeHookRelay({
+        provider: "codex",
+        agentId: "main",
+        sessionId: "policy-fallback",
+        runId: "policy-fallback",
+      });
+      let settled = false;
+      let preparationSettled = false;
+      const preparation = relay.prepareInvocation();
+      void preparation.then(
+        () => {
+          preparationSettled = true;
+        },
+        () => {
+          preparationSettled = true;
+        },
+      );
+      const invocation = invokeNativeHook({
+        provider: "codex",
+        relayId: relay.relayId,
+        generation: relay.generation,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          tool_name: "mcp__fixture__read",
+          tool_use_id: "policy-fallback-call",
+          tool_input: {},
+        },
+      }).then((respond) => {
+        settled = true;
+        return respond;
+      });
+      try {
+        await expect(relay.ready).rejects.toBe(listenerFailure);
+        await entered.promise;
+        await setImmediate();
+        expect(settled).toBe(false);
+        expect(preparationSettled).toBe(false);
+        expect(requester.mock.calls.length).toBe(0);
+        expect(relay.deferMcpToolApprovals).toBeUndefined();
+        resume.resolve();
+        await expect(preparation).resolves.toBeUndefined();
+        const respond = await invocation;
+        expect(respond).toHaveBeenCalledWith(true, { stdout: "", stderr: "", exitCode: 0 });
+        expect(relay.deferMcpToolApprovals).toBe(true);
+        expect(read.mock.calls.length).toBe(1);
+        expect(requester.mock.calls.length).toBe(0);
+      } finally {
+        resume.resolve();
+        await completed.promise;
+        await Promise.allSettled([preparation, invocation]);
+        relay.unregister();
+        await relay.drain();
+      }
+    });
+  });
+
+  it("preserves a pending legacy-policy failure after direct publication has failed", async () => {
+    await withOpenClawTestState({ label: "relay-policy-migration-fallback" }, async () => {
+      const legacyPath = resolveExecApprovalsPath();
+      const legacyPolicy = JSON.stringify({ version: 1, agents: {} });
+      fs.writeFileSync(legacyPath, legacyPolicy);
+      const paused = pauseMcpPolicyRead();
+      const listenerFailure = new Error("fixture listener unavailable");
+      vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server) {
+        queueMicrotask(() => this.emit("error", listenerFailure));
+        return this;
+      });
+      const requester = vi.fn(async () => "allow" as const);
+      testing.setNativeHookRelayPermissionApprovalRequesterForTests(requester);
+      const relay = registerOwnedNativeHookRelay({
+        provider: "codex",
+        agentId: "main",
+        sessionId: "policy-migration-fallback",
+        runId: "policy-migration-fallback",
+      });
+      let preparationSettled = false;
+      const preparation = relay.prepareInvocation();
+      void preparation.then(
+        () => {
+          preparationSettled = true;
+        },
+        () => {
+          preparationSettled = true;
+        },
+      );
+      const invocation = invokeNativeHook({
+        provider: "codex",
+        relayId: relay.relayId,
+        generation: relay.generation,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          tool_name: "mcp__fixture__read",
+          tool_use_id: "policy-migration-fallback-call",
+          tool_input: {},
+        },
+      });
+      try {
+        await expect(relay.ready).rejects.toBe(listenerFailure);
+        await paused.entered.promise;
+        await setImmediate();
+        expect(preparationSettled).toBe(false);
+        expect(requester.mock.calls.length).toBe(0);
+        paused.resume.resolve();
+        await expect(preparation).rejects.toBeInstanceOf(ExecApprovalsMigrationRequiredError);
+        const respond = await invocation;
+        expectInvalidRequest(respond, `Legacy exec approvals exist at ${legacyPath}`);
+        expect(relay.deferMcpToolApprovals).toBeUndefined();
+        expect(requester.mock.calls.length).toBe(0);
+        expect(fs.readFileSync(legacyPath, "utf8")).toBe(legacyPolicy);
+      } finally {
+        paused.resume.resolve();
+        await paused.completed.promise;
+        await Promise.allSettled([preparation, invocation]);
+        relay.unregister();
+        await expect(relay.drain()).rejects.toBeInstanceOf(ExecApprovalsMigrationRequiredError);
+      }
+    });
+  });
+
+  it("keeps registration option values when the caller later mutates its input", async () => {
+    await withOpenClawTestState({ label: "relay-policy-options" }, async () => {
+      const requester = vi.fn(async () => "deny" as const);
+      testing.setNativeHookRelayPermissionApprovalRequesterForTests(requester);
+      const params: Parameters<typeof registerNativeHookRelay>[0] = {
+        provider: "codex",
+        agentId: "main",
+        sessionId: "policy-options",
+        runId: "policy-options",
+        autoApproveMcpTools: false,
+      };
+      const relay = registerNativeHookRelay(params);
+      params.autoApproveMcpTools = true;
+      try {
+        await invokeNativeHook({
+          provider: "codex",
+          relayId: relay.relayId,
+          generation: relay.generation,
+          event: "permission_request",
+          rawPayload: {
+            hook_event_name: "PermissionRequest",
+            tool_name: "mcp__fixture__read",
+            tool_use_id: "policy-options-call",
+            tool_input: {},
+          },
+        });
+        expect(requester.mock.calls.length).toBe(1);
+        expect(relay.deferMcpToolApprovals).toBe(false);
+      } finally {
+        relay.unregister();
+        await testing.clearNativeHookRelaysForTests();
+      }
+    });
+  });
+
+  it("drains admitted policy work after listener failure and unregister", async () => {
+    await withOpenClawTestState({ label: "relay-policy-drain" }, async () => {
+      const paused = pauseMcpPolicyRead();
+      const listenerFailure = new Error("fixture listener unavailable");
+      vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server) {
+        queueMicrotask(() => this.emit("error", listenerFailure));
+        return this;
+      });
+      const relay = registerOwnedNativeHookRelay({
+        provider: "codex",
+        agentId: "main",
+        sessionId: "policy-drain",
+        runId: "policy-drain",
+      });
+      await expect(relay.ready).rejects.toBe(listenerFailure);
+      await paused.entered.promise;
+      relay.unregister();
+      let drained = false;
+      const draining = relay.drain().then(() => {
+        drained = true;
+      });
+      try {
+        await setImmediate();
+        expect(drained).toBe(false);
+        paused.resume.resolve();
+        await draining;
+        expect(paused.read.mock.calls.length).toBe(1);
+      } finally {
+        paused.resume.resolve();
+        await paused.completed.promise;
+        await draining;
+      }
+    });
+  });
+
+  it.each(["unregister", "owner-close", "abort"] as const)(
+    "revalidates native authority after policy readiness during %s",
+    async (closure) => {
+      await withOpenClawTestState({ label: `relay-policy-${closure}` }, async () => {
+        const paused = pauseMcpPolicyRead();
+        const listenerFailure = new Error("fixture listener unavailable");
+        vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server) {
+          queueMicrotask(() => this.emit("error", listenerFailure));
+          return this;
+        });
+        const requester = vi.fn(async () => "deny" as const);
+        testing.setNativeHookRelayPermissionApprovalRequesterForTests(requester);
+        const abort = new AbortController();
+        let active = true;
+        const relay = registerOwnedNativeHookRelay({
+          provider: "codex",
+          agentId: "main",
+          sessionId: "policy-authority",
+          runId: "policy-authority",
+          signal: abort.signal,
+          assertActive: () => {
+            if (!active) {
+              throw new Error("fixture native owner closed");
+            }
+          },
+        });
+        let preparationSettled = false;
+        const preparation = relay.prepareInvocation();
+        void preparation.then(
+          () => {
+            preparationSettled = true;
+          },
+          () => {
+            preparationSettled = true;
+          },
+        );
+        const invocation = invokeNativeHook({
+          provider: "codex",
+          relayId: relay.relayId,
+          generation: relay.generation,
+          event: "permission_request",
+          rawPayload: {
+            hook_event_name: "PermissionRequest",
+            tool_name: "mcp__fixture__read",
+            tool_use_id: "policy-authority-call",
+            tool_input: {},
+          },
+        });
+        try {
+          await expect(relay.ready).rejects.toBe(listenerFailure);
+          await paused.entered.promise;
+          await setImmediate();
+          expect(preparationSettled).toBe(false);
+          if (closure === "unregister") {
+            relay.unregister();
+          } else if (closure === "abort") {
+            abort.abort();
+          } else {
+            active = false;
+          }
+          paused.resume.resolve();
+          const expectedError =
+            closure === "owner-close" ? "fixture native owner closed" : "registration is inactive";
+          await expect(preparation).rejects.toThrow(expectedError);
+          const respond = await invocation;
+          expectInvalidRequest(respond, expectedError);
+          expect(requester.mock.calls.length).toBe(0);
+        } finally {
+          paused.resume.resolve();
+          await paused.completed.promise;
+          await Promise.allSettled([preparation, invocation]);
+          relay.unregister();
+          await relay.drain();
+        }
+      });
+    },
+  );
+
+  it("keeps the original database and legacy gate after the ambient state directory changes", async () => {
+    await withOpenClawTestState({ label: "relay-policy-state-owner" }, async (state) => {
+      saveExecApprovals({
+        version: 1,
+        agents: {
+          main: {
+            mcpTools: [{ server: "fixture", tool: "read", source: "allow-always", addedAt: 1 }],
+          },
+        },
+      });
+      const foreign = path.join(state.root, "foreign");
+      fs.mkdirSync(foreign);
+      fs.writeFileSync(resolveExecApprovalsPath({ OPENCLAW_STATE_DIR: foreign }), "{}");
+      const relay = registerOwnedNativeHookRelay({
+        provider: "codex",
+        agentId: "main",
+        sessionId: "policy-state-owner",
+        runId: "policy-state-owner",
+      });
+      vi.stubEnv("OPENCLAW_STATE_DIR", foreign);
+      try {
+        await relay.ready;
+        const respond = await invokeNativeHook({
+          provider: "codex",
+          relayId: relay.relayId,
+          generation: relay.generation,
+          event: "permission_request",
+          rawPayload: {
+            hook_event_name: "PermissionRequest",
+            tool_name: "mcp__fixture__read",
+            tool_use_id: "policy-state-owner-call",
+            tool_input: {},
+          },
+        });
+        expect(respond).toHaveBeenCalledWith(true, { stdout: "", stderr: "", exitCode: 0 });
+        expect(relay.deferMcpToolApprovals).toBe(true);
+        expect(fs.existsSync(resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: foreign }))).toBe(
+          false,
+        );
+      } finally {
+        relay.unregister();
+        vi.unstubAllEnvs();
+        await relay.drain();
+      }
+    });
+  });
+
   it("accepts a live relay invocation", async () => {
     const relay = registerNativeHookRelay({
       provider: "codex",
@@ -106,4 +477,21 @@ function expectInvalidRequest(respond: ReturnType<typeof viRespond>, message: st
 
 function viRespond() {
   return vi.fn();
+}
+
+function pauseMcpPolicyRead() {
+  const entered = createDeferredCore();
+  const resume = createDeferredCore();
+  const completed = createDeferredCore();
+  const load = mcpGrants.loadMcpToolGrants;
+  const read = vi.spyOn(mcpGrants, "loadMcpToolGrants").mockImplementation(async (...args) => {
+    entered.resolve();
+    await resume.promise;
+    try {
+      return await load(...args);
+    } finally {
+      completed.resolve();
+    }
+  });
+  return { entered, resume, completed, read };
 }

--- a/src/infra/exec-approvals-config.ts
+++ b/src/infra/exec-approvals-config.ts
@@ -113,8 +113,8 @@ export function resolveExecApprovalsSocketPath(): string {
   return path.join(resolveExecApprovalsStateDir().path, EXEC_APPROVALS_SOCKET);
 }
 
-export function resolveExecApprovalsDisplayPath(): string {
-  const stateDir = resolveExecApprovalsStateDir().displayPath;
+export function resolveExecApprovalsDisplayPath(env: NodeJS.ProcessEnv = process.env): string {
+  const stateDir = resolveExecApprovalsStateDir(env).displayPath;
   const locator = path.join("state", "openclaw.sqlite#exec_approvals_config");
   return stateDir === DEFAULT_EXEC_APPROVALS_STATE_DIR
     ? `${stateDir}/${locator}`

--- a/src/infra/exec-approvals-mcp.ts
+++ b/src/infra/exec-approvals-mcp.ts
@@ -1,9 +1,15 @@
-import { loadExecApprovalsReadOnly } from "./exec-approvals-store.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
+import { loadExecApprovalsReadOnlyAsync } from "./exec-approvals-store.js";
 import type { McpToolGrant } from "./exec-approvals.types.js";
 
 export type { McpToolGrant } from "./exec-approvals.types.js";
 
 /** Snapshot exact-agent grants at thread/registration preparation, never on tool calls. */
-export function loadMcpToolGrants(agentId: string): readonly McpToolGrant[] {
-  return agentId === "*" ? [] : (loadExecApprovalsReadOnly().agents?.[agentId]?.mcpTools ?? []);
+export async function loadMcpToolGrants(
+  agentId: string,
+  options?: Pick<OpenClawStateDatabaseOptions, "path" | "env">,
+): Promise<readonly McpToolGrant[]> {
+  return agentId === "*"
+    ? []
+    : ((await loadExecApprovalsReadOnlyAsync(options)).agents?.[agentId]?.mcpTools ?? []);
 }

--- a/src/infra/exec-approvals-migration-gate.ts
+++ b/src/infra/exec-approvals-migration-gate.ts
@@ -15,22 +15,27 @@ const legacyAbsenceCache = new Set<string>();
  * Name the directory whenever this process is scoped to a non-default one. Say it in
  * prose rather than as a `VAR=value cmd` one-liner, which no Windows shell accepts.
  */
-function doctorFixInstruction(filePath: string): string {
+function doctorFixInstruction(filePath: string, env: NodeJS.ProcessEnv): string {
   const command = "Run `openclaw doctor --fix`";
-  return process.env.OPENCLAW_STATE_DIR?.trim()
+  return env.OPENCLAW_STATE_DIR?.trim()
     ? `${command} with OPENCLAW_STATE_DIR set to ${path.dirname(filePath)}`
     : command;
 }
 
 export class ExecApprovalsMigrationRequiredError extends Error {
-  constructor(filePath: string, operation?: "doctor", problem = "Legacy exec approvals exist") {
+  constructor(
+    filePath: string,
+    operation?: "doctor",
+    problem = "Legacy exec approvals exist",
+    env: NodeJS.ProcessEnv = process.env,
+  ) {
     super(
       operation === "doctor"
         ? formatDoctorStateRepairFailure(
             `${problem} at ${filePath}`,
             "Stop the Gateway and node hosts, then reconcile this file with a verified copy of the intended exec policy; preserve existing SQLite policy.",
           )
-        : `${problem} at ${filePath}. ${doctorFixInstruction(filePath)} before using exec approvals.`,
+        : `${problem} at ${filePath}. ${doctorFixInstruction(filePath, env)} before using exec approvals.`,
     );
     this.name = "ExecApprovalsMigrationRequiredError";
   }
@@ -38,9 +43,13 @@ export class ExecApprovalsMigrationRequiredError extends Error {
 
 /** Refuse runtime access until Doctor owns the one-time legacy import. */
 export function assertNoPendingLegacyExecApprovals(
-  options: { pathMayExist?: (filePath: string) => boolean; operation?: "doctor" } = {},
+  options: {
+    pathMayExist?: (filePath: string) => boolean;
+    operation?: "doctor";
+    env?: NodeJS.ProcessEnv;
+  } = {},
 ): void {
-  const sourcePath = resolveExecApprovalsPath();
+  const sourcePath = resolveExecApprovalsPath(options.env);
   if (legacyAbsenceCache.has(sourcePath)) {
     return;
   }
@@ -55,6 +64,8 @@ export function assertNoPendingLegacyExecApprovals(
         ? `${sourcePath}${DOCTOR_CLAIM_SUFFIX}`
         : sourcePath,
       options.operation,
+      undefined,
+      options.env,
     );
   }
   legacyAbsenceCache.add(sourcePath);

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -25,6 +25,7 @@ import {
   ensureExecApprovals,
   loadExecApprovals,
   loadExecApprovalsReadOnly,
+  loadExecApprovalsReadOnlyAsync,
   readExecApprovalsSnapshot,
   restoreExecApprovalsSnapshot,
   restoreExecApprovalsSnapshotLocked,
@@ -104,38 +105,74 @@ afterEach(() => {
   }
 });
 
+const readOnlyLoaders = [
+  { name: "synchronous", load: loadExecApprovalsReadOnly },
+  { name: "asynchronous", load: loadExecApprovalsReadOnlyAsync },
+];
+
 describe("exec approvals SQLite store", () => {
-  it("does not create shared state for a read-only load", () => {
-    const statePath = resolveOpenClawStateSqlitePath();
-    expect(fs.existsSync(statePath)).toBe(false);
+  it.each(readOnlyLoaders)(
+    "does not create shared state for a $name read-only load",
+    async ({ load }) => {
+      const statePath = resolveOpenClawStateSqlitePath();
+      expect(fs.existsSync(statePath)).toBe(false);
 
-    expect(loadExecApprovalsReadOnly()).toMatchObject({
-      version: 1,
-      agents: {},
-    });
-    expect(fs.existsSync(statePath)).toBe(false);
-  });
+      expect(await load()).toMatchObject({
+        version: 1,
+        agents: {},
+      });
+      expect(fs.existsSync(statePath)).toBe(false);
+    },
+  );
 
-  it("does not migrate older shared state for a read-only load", () => {
-    saveExecApprovals({
-      version: 1,
-      defaults: { security: "allowlist" },
-      agents: {},
-    });
-    const statePath = resolveOpenClawStateSqlitePath();
-    closeOpenClawStateDatabaseForTest();
-    const older = new DatabaseSync(statePath);
-    older.exec(`
+  it.each(readOnlyLoaders)(
+    "does not migrate older shared state for a $name read-only load",
+    async ({ load }) => {
+      saveExecApprovals({
+        version: 1,
+        defaults: { security: "allowlist" },
+        agents: {},
+      });
+      const statePath = resolveOpenClawStateSqlitePath();
+      closeOpenClawStateDatabaseForTest();
+      const older = new DatabaseSync(statePath);
+      older.exec(`
       PRAGMA user_version = 7;
       UPDATE schema_meta SET schema_version = 7 WHERE meta_key = 'primary';
     `);
-    older.close();
+      older.close();
 
-    expect(loadExecApprovalsReadOnly().defaults?.security).toBe("allowlist");
+      expect((await load()).defaults?.security).toBe("allowlist");
 
-    const after = new DatabaseSync(statePath, { readOnly: true });
-    expect(after.prepare("PRAGMA user_version").get()).toEqual({ user_version: 7 });
-    after.close();
+      const after = new DatabaseSync(statePath, { readOnly: true });
+      expect(after.prepare("PRAGMA user_version").get()).toEqual({ user_version: 7 });
+      after.close();
+    },
+  );
+
+  it.each(readOnlyLoaders)(
+    "fails closed for an unavailable $name read-only owner",
+    async ({ load }) => {
+      makeStateDatabaseUnavailable();
+      expect((await load()).defaults).toMatchObject({ security: "deny", ask: "off" });
+      expect(loggerWarn).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("keeps the captured legacy gate and repair directory when an async read resumes elsewhere", async () => {
+    const original = process.env.OPENCLAW_STATE_DIR;
+    if (!original) {
+      throw new Error("missing test state dir");
+    }
+    fs.writeFileSync(path.join(original, "exec-approvals.json"), "{}");
+    const loaded = loadExecApprovalsReadOnlyAsync();
+    const foreign = createStateDir();
+    await expect(loaded).rejects.toMatchObject({
+      name: "ExecApprovalsMigrationRequiredError",
+      message: expect.stringContaining(`OPENCLAW_STATE_DIR set to ${original}`),
+    });
+    expect(fs.existsSync(path.join(original, "state", "openclaw.sqlite"))).toBe(false);
+    expect(fs.existsSync(path.join(foreign, "state", "openclaw.sqlite"))).toBe(false);
   });
 
   it("uses a permissive missing-row default without creating the row", () => {

--- a/src/infra/exec-approvals-store.ts
+++ b/src/infra/exec-approvals-store.ts
@@ -7,11 +7,13 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
+import { resolveDatabasePath } from "../state/openclaw-state-db-maintenance.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateDirForDatabasePath } from "../state/openclaw-state-db.paths.js";
 import { formatErrorMessage } from "./errors.js";
 import {
   createFailClosedExecApprovalsFallback,
@@ -64,9 +66,10 @@ function warnFailClosed(message: string, error?: unknown): void {
 
 function snapshotFromExecApprovalsDatabase(
   db: ReturnType<typeof openOpenClawStateDatabase>["db"],
+  displayPath = resolveExecApprovalsDisplayPath(),
 ): ExecApprovalsSnapshot {
   return snapshotFromExecApprovalsRow({
-    path: resolveExecApprovalsDisplayPath(),
+    path: displayPath,
     row: readExecApprovalsConfigRow(db),
     onMalformed: () =>
       warnFailClosed("exec approvals SQLite row is malformed; denying host execution"),
@@ -80,14 +83,16 @@ function readExecApprovalsSnapshotFromDatabase(
   return snapshotFromExecApprovalsDatabase(openOpenClawStateDatabase(options).db);
 }
 
-function readExecApprovalsSnapshotFromDatabaseReadOnly(): ExecApprovalsSnapshot {
-  assertNoPendingLegacyExecApprovals();
+function readExecApprovalsSnapshotFromDatabaseReadOnly(
+  options: OpenClawStateDatabaseOptions,
+): ExecApprovalsSnapshot {
+  assertNoPendingLegacyExecApprovals({ env: options.env });
+  const displayPath = resolveExecApprovalsDisplayPath(options.env);
   return (
-    withExistingOpenClawStateDatabaseReadOnly(({ db }) => snapshotFromExecApprovalsDatabase(db)) ??
-    snapshotFromExecApprovalsRow({
-      path: resolveExecApprovalsDisplayPath(),
-      row: undefined,
-    })
+    withExistingOpenClawStateDatabaseReadOnly(
+      ({ db }) => snapshotFromExecApprovalsDatabase(db, displayPath),
+      options,
+    ) ?? snapshotFromExecApprovalsRow({ path: displayPath, row: undefined })
   );
 }
 
@@ -121,10 +126,11 @@ export function loadExecApprovals(): ExecApprovalsFile {
   }
 }
 
-/** Loads exec approvals without creating or migrating shared state. */
-export function loadExecApprovalsReadOnly(): ExecApprovalsFile {
+function loadExecApprovalsReadOnlyWithOptions(
+  options: Pick<OpenClawStateDatabaseOptions, "path" | "env">,
+): ExecApprovalsFile {
   try {
-    return readExecApprovalsSnapshotFromDatabaseReadOnly().file;
+    return readExecApprovalsSnapshotFromDatabaseReadOnly(options).file;
   } catch (error) {
     if (error instanceof ExecApprovalsMigrationRequiredError) {
       throw error;
@@ -132,6 +138,24 @@ export function loadExecApprovalsReadOnly(): ExecApprovalsFile {
     warnFailClosed("exec approvals SQLite state is unavailable; denying host execution", error);
     return createFailClosedExecApprovalsFallback();
   }
+}
+
+/** Loads exec approvals without creating or migrating shared state. */
+export function loadExecApprovalsReadOnly(): ExecApprovalsFile {
+  return loadExecApprovalsReadOnlyWithOptions({});
+}
+
+/** Capture the policy owner before yielding; reads never initialize or migrate state. */
+export async function loadExecApprovalsReadOnlyAsync(
+  options: Pick<OpenClawStateDatabaseOptions, "path" | "env"> = {},
+): Promise<ExecApprovalsFile> {
+  const stateDbPath = resolveDatabasePath(options);
+  const owner = {
+    path: stateDbPath,
+    env: { OPENCLAW_STATE_DIR: resolveOpenClawStateDirForDatabasePath(stateDbPath) },
+  };
+  await Promise.resolve();
+  return loadExecApprovalsReadOnlyWithOptions(owner);
 }
 
 export async function loadExecApprovalsAsync(): Promise<ExecApprovalsFile> {

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -52,7 +52,6 @@ export function resolveCodexTtsProvenanceTransfer(
 }
 
 export {
-  buildCodexUserMcpServersThreadConfigPatch,
   buildCodexUserMcpServersThreadConfigPatchForRuntime,
   buildCodexUserMcpServersThreadConfigPatchForRun,
   resolveCodexMcpToolOverridesForAgent,


### PR DESCRIPTION
## What Problem This Solves

Native hook setup still reads stored MCP approval policy synchronously. Moving that storage work behind an asynchronous API requires a clear boundary: an unavailable direct relay must not hide a pending or failed policy read, and cancellation must not leave the read outside its native owner.

## Why This Change Was Made

The relay lifetime owns one prepared policy snapshot. Private startup preparation waits for policy separately from direct publication, then rechecks the live owner. Gateway invocation also waits for policy independently of the locator. Cleanup joins policy, renewal and listener work while preserving errors. Read-only preparation captures the original database and legacy-migration owner before yielding.

MCP callers now await the canonical reader; the unused private synchronous projection is removed. The shared SQLite worker cutover remains separate: SQL still runs on the caller thread in this change. No schema, native hook payload or approval-policy change is included.

## User Impact

Registration and command getters remain synchronous. The optional `deferMcpToolApprovals` field stays undefined until preparation finishes, while native dispatch waits internally. Healthy Gateway fallback remains available after direct transport failure, but failed policy, cancellation and closed ownership cannot produce a late tool decision.

## Evidence

Omitting the policy await from the combined implementation reproduced five premature-admission failures. Restoring it passes successful-policy, real legacy-policy failure and held-read cancellation/closure controls. All **487 selected tests**, the full changed-code gate, fresh Codex review and the normal build passed.

The unchanged emitted build passed the existing five policy/SQLite modes and three generated cold-CLI modes. A separate real Gateway authentication/dispatch proof verified successful prepared policy after actual listener failure, the specific legacy-policy rejection through a cold CLI, and cancellation reaching the healthy Gateway's rejection without invoking policy. Observed SQLite handles closed and reopened with integrity intact and no locators; all source and artifact hashes remained unchanged.

The real Gateway policy flows took approximately 779 ms, 847 ms and 704 ms. These are instrumented timings, not a speedup claim. Proof used isolated synthetic state and finite failing deadlines; it does not claim native model inference or worker-thread SQL execution.
