### PR TITLE
refactor(node-host): trim unused argv preparation inputs

### DIFF
--- a/src/node-host/invoke-system-run-allowlist.test.ts
+++ b/src/node-host/invoke-system-run-allowlist.test.ts
@@ -8,36 +8,16 @@ import { describe, expect, it } from "vitest";
 import { resolveExecApprovalsFromFile, type ExecCommandSegment } from "../infra/exec-approvals.js";
 import { planShellAuthorization } from "../infra/exec-authorization-plan.js";
 import { buildAuthorizedShellCommandFromPlan } from "../infra/exec-authorization-render.js";
-import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
   evaluateSystemRunAllowlist,
   resolveSystemRunExecArgv,
 } from "./invoke-system-run-allowlist.js";
-
-function resolveAllowlistApprovals() {
-  return resolveExecApprovalsFromFile({
-    file: {
-      version: 1,
-      defaults: {
-        security: "allowlist",
-        ask: "off",
-        askFallback: "deny",
-      },
-    },
-  });
-}
 
 function resolveWindowsShellExecArgv(segment: ExecCommandSegment) {
   return resolveSystemRunExecArgv({
     plannedAllowlistArgv: undefined,
     argv: ["powershell.exe", "-Command", "safe --version"],
     security: "allowlist",
-    approvals: resolveAllowlistApprovals(),
-    safeBins: new Set(),
-    safeBinProfiles: {},
-    trustedSafeBinDirs: new Set(),
-    skillBins: [],
-    autoAllowSkills: false,
     isWindows: true,
     policy: {
       approvedByAsk: false,
@@ -48,8 +28,6 @@ function resolveWindowsShellExecArgv(segment: ExecCommandSegment) {
     segments: [segment],
     segmentSatisfiedBy: ["allowlist"],
     authorizationPlan: undefined,
-    cwd: "C:\\workspace",
-    env: undefined,
   });
 }
 
@@ -120,12 +98,6 @@ describe("resolveSystemRunExecArgv", () => {
       plannedAllowlistArgv: undefined,
       argv: ["nu.exe", "--commands", "safe-tool arg"],
       security: "allowlist",
-      approvals: resolveAllowlistApprovals(),
-      safeBins: new Set(),
-      safeBinProfiles: {},
-      trustedSafeBinDirs: new Set(),
-      skillBins: [],
-      autoAllowSkills: false,
       isWindows: true,
       policy: {
         approvedByAsk: false,
@@ -156,8 +128,6 @@ describe("resolveSystemRunExecArgv", () => {
       ],
       segmentSatisfiedBy: ["allowlist"],
       authorizationPlan: undefined,
-      cwd: "C:\\workspace",
-      env: undefined,
     });
 
     expect(result).toBeNull();
@@ -244,12 +214,6 @@ describe("resolveSystemRunExecArgv", () => {
           plannedAllowlistArgv: undefined,
           argv: ["powershell.exe", "-Command", shellCommand],
           security: "allowlist",
-          approvals,
-          safeBins: new Set(),
-          safeBinProfiles: {},
-          trustedSafeBinDirs: new Set(),
-          skillBins: [],
-          autoAllowSkills: false,
           isWindows: true,
           policy: {
             approvedByAsk: false,
@@ -260,8 +224,6 @@ describe("resolveSystemRunExecArgv", () => {
           segments: analysis.segments,
           segmentSatisfiedBy: analysis.segmentSatisfiedBy,
           authorizationPlan: analysis.authorizationPlan,
-          cwd: workspace,
-          env,
         });
         expect(execArgv?.[0]).toBe(fs.realpathSync(trustedExecutable));
 
@@ -277,18 +239,10 @@ describe("resolveSystemRunExecArgv", () => {
   it.runIf(process.platform !== "win32")(
     "fails closed when shell rewriting has no authorization plan",
     async () => {
-      const env = { PATH: "/usr/bin:/bin" };
-
       const result = await resolveSystemRunExecArgv({
         plannedAllowlistArgv: undefined,
         argv: ["/bin/sh", "-lc", "head -c 16"],
         security: "allowlist",
-        approvals: resolveAllowlistApprovals(),
-        safeBins: new Set(),
-        safeBinProfiles: {},
-        trustedSafeBinDirs: new Set(),
-        skillBins: [],
-        autoAllowSkills: false,
         isWindows: false,
         policy: {
           approvedByAsk: false,
@@ -299,8 +253,6 @@ describe("resolveSystemRunExecArgv", () => {
         segments: [],
         segmentSatisfiedBy: ["safeBins"],
         authorizationPlan: undefined,
-        cwd: undefined,
-        env,
       });
 
       expect(result).toBeNull();
@@ -320,9 +272,6 @@ describe("resolveSystemRunExecArgv", () => {
       if (!authorizationPlan.ok) {
         throw new Error(authorizationPlan.reason);
       }
-      const safeBinPolicy = resolveExecSafeBinRuntimePolicy({
-        global: { safeBins: ["head"] },
-      });
       const segmentSatisfiedBy: ["safeBins"] = ["safeBins"];
       const expectedCommand = buildAuthorizedShellCommandFromPlan({
         plan: authorizationPlan,
@@ -338,12 +287,6 @@ describe("resolveSystemRunExecArgv", () => {
         plannedAllowlistArgv: undefined,
         argv: ["/bin/sh", "-lc", "head -c 16"],
         security: "allowlist",
-        approvals: resolveAllowlistApprovals(),
-        safeBins: safeBinPolicy.safeBins,
-        safeBinProfiles: safeBinPolicy.safeBinProfiles,
-        trustedSafeBinDirs: safeBinPolicy.trustedSafeBinDirs,
-        skillBins: [],
-        autoAllowSkills: false,
         isWindows: false,
         policy: {
           approvedByAsk: false,
@@ -356,8 +299,6 @@ describe("resolveSystemRunExecArgv", () => {
         ),
         segmentSatisfiedBy,
         authorizationPlan,
-        cwd: undefined,
-        env,
       });
 
       expect(result).not.toBeNull();
@@ -379,20 +320,11 @@ describe("resolveSystemRunExecArgv", () => {
       if (!authorizationPlan.ok) {
         throw new Error(authorizationPlan.reason);
       }
-      const safeBinPolicy = resolveExecSafeBinRuntimePolicy({
-        global: { safeBins: ["head"] },
-      });
 
       const result = await resolveSystemRunExecArgv({
         plannedAllowlistArgv: undefined,
         argv: ["nu", "--commands", "head -c 16"],
         security: "allowlist",
-        approvals: resolveAllowlistApprovals(),
-        safeBins: safeBinPolicy.safeBins,
-        safeBinProfiles: safeBinPolicy.safeBinProfiles,
-        trustedSafeBinDirs: safeBinPolicy.trustedSafeBinDirs,
-        skillBins: [],
-        autoAllowSkills: false,
         isWindows: false,
         policy: {
           approvedByAsk: false,
@@ -405,8 +337,6 @@ describe("resolveSystemRunExecArgv", () => {
         ),
         segmentSatisfiedBy: ["safeBins"],
         authorizationPlan,
-        cwd: undefined,
-        env,
       });
 
       expect(result).toBeNull();
@@ -431,12 +361,6 @@ describe("resolveSystemRunExecArgv", () => {
         plannedAllowlistArgv: undefined,
         argv: ["nu", "--commands", "head -c 16"],
         security: "allowlist",
-        approvals: resolveAllowlistApprovals(),
-        safeBins: new Set(),
-        safeBinProfiles: {},
-        trustedSafeBinDirs: new Set(),
-        skillBins: [],
-        autoAllowSkills: false,
         isWindows: false,
         policy: {
           approvedByAsk: false,
@@ -449,8 +373,6 @@ describe("resolveSystemRunExecArgv", () => {
         ),
         segmentSatisfiedBy: ["allowlist"],
         authorizationPlan,
-        cwd: undefined,
-        env,
       });
 
       expect(result).toBeNull();

--- a/src/node-host/invoke-system-run-allowlist.ts
+++ b/src/node-host/invoke-system-run-allowlist.ts
@@ -146,12 +146,6 @@ export async function resolveSystemRunExecArgv(params: {
   plannedAllowlistArgv: string[] | undefined;
   argv: string[];
   security: ExecSecurity;
-  approvals: ExecApprovalsResolved;
-  safeBins: ReturnType<typeof resolveExecSafeBinRuntimePolicy>["safeBins"];
-  safeBinProfiles: ReturnType<typeof resolveExecSafeBinRuntimePolicy>["safeBinProfiles"];
-  trustedSafeBinDirs: ReturnType<typeof resolveExecSafeBinRuntimePolicy>["trustedSafeBinDirs"];
-  skillBins: SkillBinTrustEntry[];
-  autoAllowSkills: boolean;
   isWindows: boolean;
   policy: {
     approvedByAsk: boolean;
@@ -162,8 +156,6 @@ export async function resolveSystemRunExecArgv(params: {
   segments: ExecCommandSegment[];
   segmentSatisfiedBy: ExecSegmentSatisfiedBy[];
   authorizationPlan: ExecAuthorizationPlan | undefined;
-  cwd: string | undefined;
-  env: Record<string, string> | undefined;
 }): Promise<string[] | null> {
   let execArgv = params.plannedAllowlistArgv ?? params.argv;
   const transportKind = params.shellCommand

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -29,7 +29,6 @@ import {
   type ExecCommandSegment,
   type ExecSegmentSatisfiedBy,
   type ExecSecurity,
-  type SkillBinTrustEntry,
 } from "../infra/exec-approvals.js";
 import {
   planExecAuthorization,
@@ -156,11 +155,6 @@ type SystemRunPolicyPhase = SystemRunParsePhase & {
   analysisOk: boolean;
   allowlistSatisfied: boolean;
   allowlistAuthorizationSatisfied: boolean;
-  safeBins: ReturnType<typeof resolveExecSafeBinRuntimePolicy>["safeBins"];
-  safeBinProfiles: ReturnType<typeof resolveExecSafeBinRuntimePolicy>["safeBinProfiles"];
-  trustedSafeBinDirs: ReturnType<typeof resolveExecSafeBinRuntimePolicy>["trustedSafeBinDirs"];
-  skillBins: SkillBinTrustEntry[];
-  autoAllowSkills: boolean;
   segments: ExecCommandSegment[];
   segmentSatisfiedBy: ExecSegmentSatisfiedBy[];
   authorizationPlan: ExecAuthorizationPlan | undefined;
@@ -924,11 +918,6 @@ async function evaluateSystemRunPolicyPhase(
     analysisOk,
     allowlistSatisfied,
     allowlistAuthorizationSatisfied,
-    safeBins,
-    safeBinProfiles,
-    trustedSafeBinDirs,
-    skillBins: bins,
-    autoAllowSkills,
     segments,
     segmentSatisfiedBy,
     authorizationPlan: allowlistEvaluation.authorizationPlan,
@@ -1021,20 +1010,12 @@ async function executeSystemRunPhase(
     plannedAllowlistArgv: phase.plannedAllowlistArgv,
     argv: phase.argv,
     security: phase.security,
-    approvals: phase.approvals,
-    safeBins: phase.safeBins,
-    safeBinProfiles: phase.safeBinProfiles,
-    trustedSafeBinDirs: phase.trustedSafeBinDirs,
-    skillBins: phase.skillBins,
-    autoAllowSkills: phase.autoAllowSkills,
     isWindows: phase.isWindows,
     policy: phase.policy,
     shellCommand: phase.shellPayload,
     segments: phase.segments,
     segmentSatisfiedBy: phase.segmentSatisfiedBy,
     authorizationPlan: phase.authorizationPlan,
-    cwd: phase.cwd,
-    env: phase.env,
   });
   if (!execArgv) {
     await sendSystemRunDenied(opts, phase.execution, {


### PR DESCRIPTION
Related: #145157

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update this PR when needed.

</details>

## What Problem This Solves

Node-host execution preparation carries unused policy inputs beyond the authorization phase, making the internal contract and test setup harder to maintain. This maintainer-requested cleanup removes that redundant state from the argv-rendering stage.

## Why This Change Was Made

The resolver already consumes a prepared authorization plan. This change removes its eight unused inputs, the five policy-phase fields carried only for that call, and setup used only to supply those test arguments. Actual authorization evaluation, plan generation, post-await authority checks, and the resolver's executable body and async boundary remain unchanged.

## User Impact

No user-visible behavior changes. Node execution retains its existing approval, executable-binding, and transport behavior. The internal resolver and its tests have a smaller contract to maintain.

## Evidence

Validation was run on the candidate based on `5114fcdbd3402010e2b13fc2675e8025b30e1279`:

- Original and candidate each passed **101 tests**, with the same one native Windows-only skip, using separate caches and the existing allowlist, system-run, and socket suites.
- The full selected `core, coreTests` changed gate passed, including production/test typechecking, lint, formatting, dead-export scans, and the selected guards.
- Independent **P2 review: scoped-clean**, with no actionable findings. The resolver body remains byte-identical; all nine cases and 21 assertion lines in the changed test remain.
- Static integration preflight at `b3ffe8760d734cf98a1567a323cfe2e02842ee0b` found all three modified source files unchanged. This is source compatibility evidence, not a test run on that later main commit.

```sh
node scripts/run-vitest.mjs src/node-host/invoke-system-run-allowlist.test.ts src/node-host/invoke-system-run.test.ts src/node-host/invoke-system-run.socket.test.ts
node scripts/check-changed.mjs -- src/node-host/invoke-system-run-allowlist.ts src/node-host/invoke-system-run.ts src/node-host/invoke-system-run-allowlist.test.ts
```

Canonical cloc 2.10 default counts, including all changed caller and test setup:

| Scope | Code removed | Physical lines removed | Bytes removed |
| --- | ---: | ---: | ---: |
| Production | 27 | 27 | 1,156 |
| Tests | 76 | 78 | 2,352 |

The native Windows executable-shadow test was skipped on macOS; these runs do not establish native Windows execution proof. No new tests, dependencies, configuration, schema, or protocol changes were introduced.
