### PR TITLE
fix(ui): unify chat collapse chevron direction (right closed, down open)

### DIFF
--- a/ui/src/pages/chat/components/chat-message-text.ts
+++ b/ui/src/pages/chat/components/chat-message-text.ts
@@ -195,7 +195,7 @@ export function renderMessageMarkdown(
         aria-expanded=${String(expanded)}
         @click=${() => opts.onToggleUserMessageExpanded?.(disclosureId)}
       >
-        ${expanded ? icons.chevronUp : icons.chevronDown}
+        ${expanded ? icons.chevronDown : icons.chevronRight}
       </button>
     </div>
   `;

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -724,10 +724,6 @@
   height: 14px;
 }
 
-.session-progress-card--composer[open] .session-progress-card__summary-chevron {
-  transform: rotate(180deg);
-}
-
 .session-progress-card__summary-indicator {
   position: relative;
   display: inline-grid;


### PR DESCRIPTION
Closes #145161

## What Problem This Solves

Fixes an issue where users reading the chat page would see three different chevron conventions for the same collapse gesture: the long-message "show more" toggle pointed down when collapsed and up when expanded, the task progress card pointed right when collapsed and up when expanded, and the sidebar session groups pointed right when collapsed and down when expanded. Reported by digitalnav on Discord.

## Why This Change Was Made

Align these two chat collapse chevrons with the convention the sidebar and the other chat disclosures (tool rows, JSON collapse, notices, task suggestions) already use: right when collapsed, down when expanded. The show-more toggle now swaps `chevronRight`/`chevronDown` instead of `chevronDown`/`chevronUp`, and the composer progress card drops the `[open]` rule that rotated its chevron 180°, since the base icon is already `chevronDown` and the collapsed state still rotates it -90°. Sidebar session groups are unchanged. Chat error details and the workspace conflict notice still use down/up and are noted in #145161 as a follow-up.

## User Impact

Long-message and task-progress disclosures now use the same convention as sidebar session groups: a right-pointing chevron means "collapsed, click to expand", a down-pointing chevron means "expanded, click to collapse". No behavior change, no layout change.

## Evidence

### Before and after

Actual Control UI rendered in Chromium against the deterministic mock Gateway, dark theme, desktop 1280×900, cropped around each toggle. Every image was inspected.

**Task progress card** (composer): collapsed stays right; expanded goes from up to down.

<table>
<tr><th></th><th>Before</th><th>After</th></tr>
<tr><td>Collapsed</td><td><a href="https://github.com/user-attachments/assets/50c4de91-303b-4c3a-a1cc-eb28b4c4ce0a"><img src="https://github.com/user-attachments/assets/50c4de91-303b-4c3a-a1cc-eb28b4c4ce0a" alt="Task progress collapsed, before" width="400"></a><br><a href="https://github.com/user-attachments/assets/50c4de91-303b-4c3a-a1cc-eb28b4c4ce0a">View image</a></td><td><a href="https://github.com/user-attachments/assets/2a0b4768-48a9-4cb6-8117-cc761ea807bc"><img src="https://github.com/user-attachments/assets/2a0b4768-48a9-4cb6-8117-cc761ea807bc" alt="Task progress collapsed, after" width="400"></a><br><a href="https://github.com/user-attachments/assets/2a0b4768-48a9-4cb6-8117-cc761ea807bc">View image</a></td></tr>
<tr><td>Expanded</td><td><a href="https://github.com/user-attachments/assets/0596c434-0f5a-4b92-b3aa-c1475e4c67ab"><img src="https://github.com/user-attachments/assets/0596c434-0f5a-4b92-b3aa-c1475e4c67ab" alt="Task progress expanded, before" width="400"></a><br><a href="https://github.com/user-attachments/assets/0596c434-0f5a-4b92-b3aa-c1475e4c67ab">View image</a></td><td><a href="https://github.com/user-attachments/assets/b0ef4507-0e30-4775-884d-8489b62a4cda"><img src="https://github.com/user-attachments/assets/b0ef4507-0e30-4775-884d-8489b62a4cda" alt="Task progress expanded, after" width="400"></a><br><a href="https://github.com/user-attachments/assets/b0ef4507-0e30-4775-884d-8489b62a4cda">View image</a></td></tr>
</table>

**Long user message "show more"**: collapsed goes from down to right; expanded goes from up to down.

<table>
<tr><th></th><th>Before</th><th>After</th></tr>
<tr><td>Collapsed</td><td><a href="https://github.com/user-attachments/assets/7afda2ab-48bd-434c-9387-2a51846338eb"><img src="https://github.com/user-attachments/assets/7afda2ab-48bd-434c-9387-2a51846338eb" alt="Show more collapsed, before" width="400"></a><br><a href="https://github.com/user-attachments/assets/7afda2ab-48bd-434c-9387-2a51846338eb">View image</a></td><td><a href="https://github.com/user-attachments/assets/894b6888-f148-4c8d-b080-7dcf258a812b"><img src="https://github.com/user-attachments/assets/894b6888-f148-4c8d-b080-7dcf258a812b" alt="Show more collapsed, after" width="400"></a><br><a href="https://github.com/user-attachments/assets/894b6888-f148-4c8d-b080-7dcf258a812b">View image</a></td></tr>
<tr><td>Expanded</td><td><a href="https://github.com/user-attachments/assets/0edf0c1e-87c2-42be-b845-31aa9ec89b01"><img src="https://github.com/user-attachments/assets/0edf0c1e-87c2-42be-b845-31aa9ec89b01" alt="Show more expanded, before" width="400"></a><br><a href="https://github.com/user-attachments/assets/0edf0c1e-87c2-42be-b845-31aa9ec89b01">View image</a></td><td><a href="https://github.com/user-attachments/assets/4002202c-2135-476e-b234-01b2cfeb797d"><img src="https://github.com/user-attachments/assets/4002202c-2135-476e-b234-01b2cfeb797d" alt="Show more expanded, after" width="400"></a><br><a href="https://github.com/user-attachments/assets/4002202c-2135-476e-b234-01b2cfeb797d">View image</a></td></tr>
</table>

**Sidebar session group** (unchanged, reference for the target convention):

<table>
<tr><th>Collapsed</th><th>Expanded</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/897077a5-16e5-4430-a90c-71a1e329eed5"><img src="https://github.com/user-attachments/assets/897077a5-16e5-4430-a90c-71a1e329eed5" alt="Session group collapsed" width="400"></a><br><a href="https://github.com/user-attachments/assets/897077a5-16e5-4430-a90c-71a1e329eed5">View image</a></td><td><a href="https://github.com/user-attachments/assets/ebc01af1-a72b-4e1b-b6ab-d62eccd898ef"><img src="https://github.com/user-attachments/assets/ebc01af1-a72b-4e1b-b6ab-d62eccd898ef" alt="Session group expanded" width="400"></a><br><a href="https://github.com/user-attachments/assets/ebc01af1-a72b-4e1b-b6ab-d62eccd898ef">View image</a></td></tr>
</table>

### Validation

- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34724753104) passed for `5f0d09c2570691ff31c34d1f8be5d8bb77ba1992`, including all three UI shards, all seven UI E2E shards, and real-Gateway E2E.

- Prior supplied validation includes `oxfmt --check` on the two changed files.
- Prior validation supplied for this revision reports 273 passing tests across two files covering chat messages and session progress after rebase. This landing review did not rerun those tests.
- Production LOC: +1/−5 (net −4). Tests: none changed; no test asserts the glyph.

## Risk and coverage

The change is limited to icon direction in two existing disclosures. Click handlers, expansion state, labels, and layout are unchanged. All ten supplied screenshots were reinspected during landing and show the intended right/down states; no new browser capture was made during this review.

Source review covered each consumer of the shared message renderer: chat message bubbles receive the corrected user-message icons; session-rail questions and answers and the new-session draft preview do not enable this disclosure; task activity renders assistant text and does not enter the changed user-message branch. The composer progress card uses the existing down icon and retains the shared closed-state rotation. Sidebar session groups were checked as the unchanged visual reference.

Existing interaction coverage and the supplied desktop dark-theme captures cover the focused change. No targeted mobile or other-theme recapture or operator Gateway session was performed during landing; hosted real-Gateway E2E passed. Chat error details and the workspace conflict notice remain follow-ups in #145161.
