### PR TITLE
fix(delivery): join pending queue reads before shutdown

### DIFF
--- a/src/infra/session-delivery-queue-runtime.test.ts
+++ b/src/infra/session-delivery-queue-runtime.test.ts
@@ -469,6 +469,83 @@ describe("session delivery queue runtime", () => {
     });
   });
 
+  it.each([
+    { mode: "lookup", failure: false },
+    { mode: "lookup", failure: true },
+    { mode: "scan", failure: false },
+    { mode: "scan", failure: true },
+  ])("joins a retired owner's delayed $mode (failure: $failure)", async ({ mode, failure }) => {
+    vi.useFakeTimers();
+    await withRuntime(async (startRuntime) => {
+      const id = await enqueueSessionDelivery({
+        kind: "systemEvent",
+        sessionKey: "agent:main:main",
+        text: "delivery awaiting queue lookup",
+      });
+      const oldRead = createDeferredCore();
+      const newRead = createDeferredCore();
+      const deliver = vi.fn(async () => {});
+      const waitForOldRead = async () => {
+        await oldRead.promise;
+        if (failure) {
+          throw new Error("delayed database read failure");
+        }
+      };
+      const stopOld = startRuntime({
+        deliver,
+        log: logger,
+        reloadPending: async (entryId) => {
+          await waitForOldRead();
+          return loadPendingSessionDelivery(entryId);
+        },
+        listPending: async () => {
+          await waitForOldRead();
+          return loadPendingSessionDeliveries();
+        },
+      });
+      const scheduling =
+        mode === "lookup" ? scheduleSessionDelivery(id) : schedulePendingSessionDeliveries();
+      let stopNew: ReturnType<typeof startSessionDeliveryRuntime> | undefined;
+      let newScheduling: Promise<void> | undefined;
+      try {
+        let stopped = false;
+        const stopping = stopOld().then(() => {
+          stopped = true;
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(stopped).toBe(false);
+        await expect(scheduleSessionDelivery(id)).resolves.toBe(false);
+
+        stopNew = startRuntime({
+          deliver,
+          log: logger,
+          listPending: async () => {
+            await newRead.promise;
+            return loadPendingSessionDeliveries();
+          },
+        });
+        newScheduling = schedulePendingSessionDeliveries();
+        oldRead.resolve();
+        await scheduling;
+        await stopping;
+        expect(logger.error).toHaveBeenCalledTimes(failure ? 1 : 0);
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(deliver).not.toHaveBeenCalled();
+        expect(await loadPendingSessionDelivery(id)).not.toBeNull();
+
+        newRead.resolve();
+        await newScheduling;
+        await vi.advanceTimersByTimeAsync(0);
+        expect(deliver).toHaveBeenCalledOnce();
+        expect(await loadPendingSessionDeliveries()).toStrictEqual([]);
+      } finally {
+        oldRead.resolve();
+        newRead.resolve();
+        await Promise.all([scheduling, newScheduling, stopOld(), stopNew?.()]);
+      }
+    });
+  });
+
   it("retries a transient startup pending-entry scan failure", async () => {
     vi.useFakeTimers();
     await withRuntime(async (startRuntime) => {

--- a/src/infra/session-delivery-queue-runtime.ts
+++ b/src/infra/session-delivery-queue-runtime.ts
@@ -23,7 +23,12 @@ type SessionDeliveryRuntime = {
 };
 
 const RUNTIME_RELOAD_RETRY_MS = 1_000;
-let runtime: (SessionDeliveryRuntime & { runningEntries: Map<string, Promise<void>> }) | undefined;
+let runtime:
+  | (SessionDeliveryRuntime & {
+      runningEntries: Map<string, Promise<void>>;
+      pendingSchedules: Set<Promise<void>>;
+    })
+  | undefined;
 let runtimeGeneration = 0;
 const scheduledEntries = new Map<string, { timer: ReturnType<typeof setTimeout>; dueAt: number }>();
 let pendingScanTimer: ReturnType<typeof setTimeout> | undefined;
@@ -143,12 +148,16 @@ async function runScheduledSessionDelivery(id: string, generation: number): Prom
   }
 }
 
-/** Register delivery callbacks; stop fences scheduling synchronously and joins admitted drains. */
+/** Register callbacks; stop fences scheduling and joins admitted reads and drains. */
 export function startSessionDeliveryRuntime(params: SessionDeliveryRuntime): () => Promise<void> {
   runtimeGeneration += 1;
   const generation = runtimeGeneration;
   clearScheduledEntries();
-  const activeRuntime = { ...params, runningEntries: new Map<string, Promise<void>>() };
+  const activeRuntime = {
+    ...params,
+    runningEntries: new Map<string, Promise<void>>(),
+    pendingSchedules: new Set<Promise<void>>(),
+  };
   runtime = activeRuntime;
   let stopPromise: Promise<void> | undefined;
   return () => {
@@ -157,9 +166,12 @@ export function startSessionDeliveryRuntime(params: SessionDeliveryRuntime): () 
       runtime = undefined;
       clearScheduledEntries();
     }
-    // A replacement owns its own drains. Retained stops join only this owner,
-    // including settlement writes after its delivery callback has returned.
-    stopPromise ??= Promise.all(activeRuntime.runningEntries.values()).then(() => {});
+    // A replacement owns its own work. Join this owner's reads and settlement
+    // writes before its queue database or environment can be disposed.
+    stopPromise ??= Promise.all([
+      ...activeRuntime.runningEntries.values(),
+      ...activeRuntime.pendingSchedules,
+    ]).then(() => {});
     return stopPromise;
   };
 }
@@ -171,19 +183,26 @@ export async function scheduleSessionDelivery(id: string): Promise<boolean> {
   if (!activeRuntime) {
     return false;
   }
-  let entry: QueuedSessionDelivery | null;
+  const settled = createDeferredCore();
+  activeRuntime.pendingSchedules.add(settled.promise);
   try {
-    entry = await (activeRuntime.reloadPending ?? loadPendingSessionDelivery)(id);
-  } catch (error) {
-    activeRuntime.log.error(`session delivery: failed to load ${id}: ${String(error)}`);
-    armSessionDeliveryId(id, RUNTIME_RELOAD_RETRY_MS, generation);
+    let entry: QueuedSessionDelivery | null;
+    try {
+      entry = await (activeRuntime.reloadPending ?? loadPendingSessionDelivery)(id);
+    } catch (error) {
+      activeRuntime.log.error(`session delivery: failed to load ${id}: ${String(error)}`);
+      armSessionDeliveryId(id, RUNTIME_RELOAD_RETRY_MS, generation);
+      return true;
+    }
+    if (!entry || !runtime || generation !== runtimeGeneration) {
+      return !entry;
+    }
+    armSessionDelivery(entry, generation);
     return true;
+  } finally {
+    activeRuntime.pendingSchedules.delete(settled.promise);
+    settled.resolve();
   }
-  if (!entry || !runtime || generation !== runtimeGeneration) {
-    return !entry;
-  }
-  armSessionDelivery(entry, generation);
-  return true;
 }
 
 /** Schedule every pending entry after startup recovery installs the runtime owner. */
@@ -193,18 +212,25 @@ export async function schedulePendingSessionDeliveries(): Promise<void> {
   if (!activeRuntime) {
     return;
   }
-  let entries: QueuedSessionDelivery[];
+  const settled = createDeferredCore();
+  activeRuntime.pendingSchedules.add(settled.promise);
   try {
-    entries = await (activeRuntime.listPending ?? loadPendingSessionDeliveries)();
-  } catch (error) {
-    activeRuntime.log.error(`session delivery: failed to scan pending entries: ${String(error)}`);
-    armPendingScan(generation);
-    return;
-  }
-  if (!runtime || generation !== runtimeGeneration) {
-    return;
-  }
-  for (const entry of entries) {
-    armSessionDelivery(entry, generation);
+    let entries: QueuedSessionDelivery[];
+    try {
+      entries = await (activeRuntime.listPending ?? loadPendingSessionDeliveries)();
+    } catch (error) {
+      activeRuntime.log.error(`session delivery: failed to scan pending entries: ${String(error)}`);
+      armPendingScan(generation);
+      return;
+    }
+    if (!runtime || generation !== runtimeGeneration) {
+      return;
+    }
+    for (const entry of entries) {
+      armSessionDelivery(entry, generation);
+    }
+  } finally {
+    activeRuntime.pendingSchedules.delete(settled.promise);
+    settled.resolve();
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Session delivery runtime shutdown joined active delivery drains but could return while an admitted queue lookup or pending-entry scan was still awaiting storage. Disposing the queue or its environment after that stop could race the unfinished read and its error handling.

## Why This Change Was Made

Track scheduling operations before their first read and release them after scheduling or error handling finishes. Stop still fences admission immediately, then joins this runtime's reads and delivery settlement. Existing generation checks prevent a retired read from scheduling into a replacement runtime, and old stop handles do not wait for replacement work.

## Evidence

Validation: all four delayed lookup/scan × success/failure regressions fail on the original code and pass with this change; 55 tests across runtime, recovery, storage, and real SQLite retry-persistence failure suites pass. A standalone Node smoke run with real timers and synthetic SQLite state passed the same four cases and delivered each retained row once after restart. Independent P2 review is clean. The complete changed-scope gate passed, including core and core test typechecks, lint, and all routed guards. After the patch-identical rebase onto current main, the runtime suite passed all 18 cases and the real-timer SQLite smoke passed all four cases again. The old CI failure was an unrelated missing commit-author fixture, repaired upstream in #145170 and included by this rebase.

## User Impact

This is a shutdown prerequisite for asynchronous storage. SQLite execution, transactions, schema, public APIs, and retry policy remain unchanged. Production grows by 26 lines to track previously unowned operations; tests grow by 77 lines.
