### PR TITLE
fix(matrix): preserve native relations in recovered receipts

### DIFF
--- a/extensions/matrix/src/matrix/delivery-plan.test.ts
+++ b/extensions/matrix/src/matrix/delivery-plan.test.ts
@@ -213,64 +213,84 @@ describe("Matrix durable delivery plans", () => {
     });
   });
 
-  it("preserves ordered typed receipt parts and the final event identity", async () => {
-    const deliveryIdentity = identity("queue-multi-event");
-    const plannedEvents = createMatrixPlannedEvents({
-      identity: deliveryIdentity,
-      events: [
-        { receiptKind: "media", content: { msgtype: "m.image", body: "caption" } },
-        { receiptKind: "text", content: { msgtype: "m.text", body: "follow-up" } },
-      ],
-    });
-    await persistMatrixDeliveryPlan({
-      identity: deliveryIdentity,
-      accountId: "default",
-      roomId: "!room:example.org",
-      transactionScopeId: "scope-1",
-      wireEventType: "m.room.message",
-      events: plannedEvents,
-      dispatch: {
-        roomId: "!room:example.org",
-        eventType: "m.room.message",
-        transactionId: plannedEvents[0]!.transactionId,
-        requestPath: `/_matrix/client/v3/rooms/!room%3Aexample.org/send/m.room.message/${plannedEvents[0]!.transactionId}`,
-      },
-    });
-    client.sendMessage.mockResolvedValueOnce("$media-event").mockResolvedValueOnce("$text-event");
-
-    await expect(
-      reconcileMatrixUnknownSend({
-        ...reconciliationContext("queue-multi-event"),
-        effectiveReplyToId: "$reply",
-        threadId: "$thread",
-      }),
-    ).resolves.toMatchObject({
-      status: "sent",
-      messageId: "$text-event",
-      receipt: {
-        primaryPlatformMessageId: "$media-event",
-        platformMessageIds: ["$media-event", "$text-event"],
-        replyToId: "$reply",
-        threadId: "$thread",
-        parts: [
+  it.each([false, true])(
+    "preserves ordered typed receipt parts and the final event identity (duplicate ID: %s)",
+    async (duplicateId) => {
+      const deliveryIdentity = identity("queue-multi-event");
+      const relation = {
+        rel_type: "m.thread" as const,
+        event_id: "$thread",
+        "m.in_reply_to": { event_id: "$reply" },
+      };
+      const plannedEvents = createMatrixPlannedEvents({
+        identity: deliveryIdentity,
+        events: [
           {
-            platformMessageId: "$media-event",
-            kind: "media",
-            index: 0,
-            replyToId: "$reply",
-            threadId: "$thread",
+            receiptKind: "media",
+            content: { msgtype: "m.image", body: "caption", "m.relates_to": relation },
           },
           {
-            platformMessageId: "$text-event",
-            kind: "text",
-            index: 1,
-            replyToId: "$reply",
-            threadId: "$thread",
+            receiptKind: "text",
+            content: { msgtype: "m.text", body: "follow-up", "m.relates_to": relation },
           },
         ],
-      },
-    });
-  });
+      });
+      await persistMatrixDeliveryPlan({
+        identity: deliveryIdentity,
+        accountId: "default",
+        roomId: "!room:example.org",
+        transactionScopeId: "scope-1",
+        wireEventType: "m.room.message",
+        events: plannedEvents,
+        dispatch: {
+          roomId: "!room:example.org",
+          eventType: "m.room.message",
+          transactionId: plannedEvents[0]!.transactionId,
+          requestPath: `/_matrix/client/v3/rooms/!room%3Aexample.org/send/m.room.message/${plannedEvents[0]!.transactionId}`,
+        },
+      });
+      client.sendMessage
+        .mockResolvedValueOnce("$media-event")
+        .mockResolvedValueOnce(duplicateId ? "$media-event" : "$text-event");
+
+      await expect(
+        reconcileMatrixUnknownSend({
+          ...reconciliationContext("queue-multi-event"),
+          effectiveReplyToId: "$reply",
+          threadId: "$thread",
+        }),
+      ).resolves.toMatchObject({
+        status: "sent",
+        messageId: duplicateId ? "$media-event" : "$text-event",
+        receipt: {
+          primaryPlatformMessageId: "$media-event",
+          platformMessageIds: duplicateId ? ["$media-event"] : ["$media-event", "$text-event"],
+          replyToId: "$reply",
+          threadId: "$thread",
+          parts: [
+            {
+              platformMessageId: "$media-event",
+              kind: "media",
+              index: 0,
+              replyToId: "$reply",
+              threadId: "$thread",
+            },
+            ...(duplicateId
+              ? []
+              : [
+                  {
+                    platformMessageId: "$text-event",
+                    kind: "text",
+                    index: 1,
+                    replyToId: "$reply",
+                    threadId: "$thread",
+                  },
+                ]),
+          ],
+        },
+      });
+    },
+  );
 
   it("fails closed without provider I/O when any expected part plan is missing", async () => {
     const incompleteIdentity = identity("queue-incomplete", 0, 2);

--- a/extensions/matrix/src/matrix/delivery-plan.ts
+++ b/extensions/matrix/src/matrix/delivery-plan.ts
@@ -3,14 +3,15 @@ import { createHash } from "node:crypto";
 import type {
   ChannelMessageUnknownSendContext,
   ChannelMessageUnknownSendReconciliationResult,
-  MessageReceipt,
   MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { getMatrixRuntime } from "../runtime.js";
+import { resolveMatrixReplyToEventId, resolveMatrixThreadRootId } from "./relations.js";
 import type { MatrixClient } from "./sdk.js";
 import type { MatrixMessageWireDispatch } from "./sdk/client-base.js";
 import { withResolvedMatrixSendClient } from "./send/client.js";
+import { createMatrixSendReceipt, type MatrixReceiptEvent } from "./send/receipt.js";
 import { resolveMatrixRoomId } from "./send/targets.js";
 import type { MatrixOutboundContent } from "./send/types.js";
 
@@ -351,39 +352,6 @@ function assertCompletePartTopology(plans: readonly MatrixDeliveryPlan[]): void 
   }
 }
 
-function createReconciledMatrixReceipt(params: {
-  results: readonly { eventId: string; receiptKind: MessageReceiptPartKind }[];
-  replyToId?: string;
-  threadId?: string;
-}): MessageReceipt {
-  const uniqueResults = params.results.filter(
-    (result, index, results) =>
-      results.findIndex((entry) => entry.eventId === result.eventId) === index,
-  );
-  const platformMessageIds = uniqueResults.map((result) => result.eventId);
-  return {
-    ...(platformMessageIds[0] ? { primaryPlatformMessageId: platformMessageIds[0] } : {}),
-    platformMessageIds,
-    parts: uniqueResults.map((result, index) => {
-      const part: NonNullable<MessageReceipt["parts"]>[number] = {
-        platformMessageId: result.eventId,
-        kind: result.receiptKind,
-        index,
-      };
-      if (params.replyToId) {
-        part.replyToId = params.replyToId;
-      }
-      if (params.threadId) {
-        part.threadId = params.threadId;
-      }
-      return part;
-    }),
-    ...(params.replyToId ? { replyToId: params.replyToId } : {}),
-    ...(params.threadId ? { threadId: params.threadId } : {}),
-    sentAt: Date.now(),
-  };
-}
-
 async function requireTransactionScope(client: MatrixClient): Promise<string> {
   const scope = (await client.getTransactionScopeId()).trim();
   if (!scope) {
@@ -417,10 +385,7 @@ export async function reconcileMatrixUnknownSend(
         const roomId = await resolveMatrixRoomId(client, ctx.to);
         const wireEventType = await client.getMessageWireEventType(roomId);
         const orderedPlans = [...plans].toSorted((left, right) => left.partIndex - right.partIndex);
-        const results: Array<{
-          eventId: string;
-          receiptKind: MessageReceiptPartKind;
-        }> = [];
+        const results = new Map<string, MatrixReceiptEvent>();
         for (const plan of orderedPlans) {
           assertPlanIdentity(plan, {
             identity: plan,
@@ -430,38 +395,36 @@ export async function reconcileMatrixUnknownSend(
             wireEventType,
           });
           for (const event of plan.events) {
-            results.push({
-              eventId: await client.sendMessage(
-                roomId,
-                event.content,
-                event.transactionId,
-                async (dispatch) => {
-                  await persistMatrixDeliveryPlan({
-                    identity: plan,
-                    accountId: ctx.accountId,
-                    roomId,
-                    transactionScopeId,
-                    wireEventType,
-                    events: plan.events,
-                    dispatch,
-                  });
-                },
-              ),
-              receiptKind: event.receiptKind,
-            });
+            const messageId = await client.sendMessage(
+              roomId,
+              event.content,
+              event.transactionId,
+              async (dispatch) => {
+                await persistMatrixDeliveryPlan({
+                  identity: plan,
+                  accountId: ctx.accountId,
+                  roomId,
+                  transactionScopeId,
+                  wireEventType,
+                  events: plan.events,
+                  dispatch,
+                });
+              },
+            );
+            if (!results.has(messageId)) {
+              const replyToId = resolveMatrixReplyToEventId(event.content);
+              results.set(messageId, {
+                messageId,
+                kind: event.receiptKind,
+                ...(replyToId ? { replyToId } : {}),
+              });
+            }
           }
         }
-        const replyToId =
-          ctx.effectiveReplyToId !== undefined
-            ? ctx.effectiveReplyToId
-            : ctx.replyToMode === "off"
-              ? undefined
-              : ctx.replyToId;
-        const threadId = ctx.threadId == null ? undefined : String(ctx.threadId);
-        const receipt = createReconciledMatrixReceipt({
-          results,
-          ...(replyToId ? { replyToId } : {}),
-          ...(threadId ? { threadId } : {}),
+        const receipt = createMatrixSendReceipt({
+          roomId,
+          events: [...results.values()],
+          threadId: resolveMatrixThreadRootId(orderedPlans[0]!.events[0]!.content),
         });
         return {
           status: "sent",

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -10,10 +10,14 @@ import {
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime } from "../../runtime-api.js";
-import { setMatrixRuntime } from "../runtime.js";
+import { getMatrixRuntime, setMatrixRuntime } from "../runtime.js";
 import { installMatrixTestRuntime } from "../test-runtime.js";
 import { voteMatrixPoll } from "./actions/polls.js";
-import { loadMatrixDeliveryPlan, resolveMatrixDurableDeliveryIdentity } from "./delivery-plan.js";
+import {
+  loadMatrixDeliveryPlan,
+  reconcileMatrixUnknownSend,
+  resolveMatrixDurableDeliveryIdentity,
+} from "./delivery-plan.js";
 import { markdownToMatrixBody, markdownToMatrixHtml } from "./format.js";
 import { createBundledReplacementEvent } from "./monitor/test-events.js";
 import { matrixEventToRaw } from "./sdk/event-helpers.js";
@@ -477,6 +481,7 @@ describe("sendMessageMatrix durable delivery", () => {
       cfg: {},
       channel: runtimeStub.channel,
     });
+    setMatrixRuntime({ ...getMatrixRuntime(), media: runtimeStub.media });
   });
 
   afterEach(() => {
@@ -590,6 +595,99 @@ describe("sendMessageMatrix durable delivery", () => {
     expect(result.messageId).toBe("$event-1");
     expect(dispatch).toHaveBeenCalledOnce();
     expect(sendMessage.mock.calls[0]?.[2]).toMatch(/^oc_/);
+  });
+
+  it("recovers actual media reply relations after losing the overflow response", async () => {
+    const { client, sendMessage, uploadContent } = makeClient();
+    resolveTextChunkLimitMock.mockReturnValue(6);
+    chunkMarkdownTextWithModeMock.mockImplementation((text: string) => text.split("|"));
+    const acceptedTransactions = new Map<string, string>();
+    sendMessage.mockImplementation(
+      async (
+        roomId: string,
+        _content: unknown,
+        transactionId?: string,
+        beforeWireDispatch?: (dispatch: {
+          roomId: string;
+          eventType: "m.room.message";
+          transactionId: string;
+          requestPath: string;
+        }) => Promise<void>,
+      ) => {
+        if (!transactionId || !beforeWireDispatch) {
+          throw new Error("expected durable Matrix dispatch context");
+        }
+        await beforeWireDispatch({
+          roomId,
+          eventType: "m.room.message",
+          transactionId,
+          requestPath: `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${transactionId}`,
+        });
+        const existingId = acceptedTransactions.get(transactionId);
+        if (existingId) {
+          return existingId;
+        }
+        const eventId = acceptedTransactions.size === 0 ? "$image" : "$overflow";
+        acceptedTransactions.set(transactionId, eventId);
+        if (eventId === "$overflow") {
+          throw new Error("provider response lost");
+        }
+        return eventId;
+      },
+    );
+    const payload = { text: "first|second", mediaUrl: "file:///tmp/photo.png" };
+    await expect(
+      sendMessageMatrix("room:!room:example", payload.text, {
+        client,
+        cfg: {},
+        accountId: "default",
+        mediaUrl: payload.mediaUrl,
+        replyToId: "$reply",
+        deliveryQueueId: "queue-media",
+        deliveryPartIndex: 0,
+        deliveryPartCount: 1,
+      }),
+    ).rejects.toThrow("provider response lost");
+    expect(sentContent(sendMessage, 0)["m.relates_to"]).toEqual({
+      "m.in_reply_to": { event_id: "$reply" },
+    });
+    expect(sentContent(sendMessage, 1)).not.toHaveProperty("m.relates_to");
+    withResolvedRuntimeMatrixClientMock.mockImplementationOnce(
+      async (_opts: unknown, run: (resolved: typeof client) => Promise<unknown>) =>
+        await run(client),
+    );
+
+    const recovered = await reconcileMatrixUnknownSend({
+      cfg: {},
+      queueId: "queue-media",
+      channel: "matrix",
+      to: "room:!room:example",
+      accountId: "default",
+      enqueuedAt: 1,
+      payloads: [payload],
+      retryCount: 0,
+      effectiveReplyToId: "$reply",
+    });
+
+    expect(recovered.status).toBe("sent");
+    if (recovered.status !== "sent") {
+      throw new Error("expected recovered Matrix delivery");
+    }
+    expect(uploadContent).toHaveBeenCalledOnce();
+    expect(acceptedTransactions.size).toBe(2);
+    expect(sendMessage.mock.calls.slice(2).map((call) => call.slice(0, 3))).toEqual(
+      sendMessage.mock.calls.slice(0, 2).map((call) => call.slice(0, 3)),
+    );
+    expect(recovered.messageId).toBe("$overflow");
+    expect(recovered.receipt).toMatchObject({
+      primaryPlatformMessageId: "$image",
+      platformMessageIds: ["$image", "$overflow"],
+      parts: [
+        { platformMessageId: "$image", kind: "media", index: 0, replyToId: "$reply" },
+        { platformMessageId: "$overflow", kind: "text", index: 1 },
+      ],
+    });
+    expect(recovered.receipt?.parts[1]).not.toHaveProperty("replyToId");
   });
 });
 

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -1,8 +1,4 @@
-// Matrix plugin module implements send behavior.
-import {
-  createMessageReceiptFromOutboundResults,
-  type MessageReceiptPartKind,
-} from "openclaw/plugin-sdk/channel-outbound";
+import type { MessageReceiptPartKind } from "openclaw/plugin-sdk/channel-outbound";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { PollInput } from "openclaw/plugin-sdk/poll-runtime";
 import type { CoreConfig } from "../types.js";
@@ -40,6 +36,7 @@ import {
   resolveMediaDurationMs,
   uploadMediaWithEncryption,
 } from "./send/media.js";
+import { createMatrixSendReceipt, type MatrixReceiptEvent } from "./send/receipt.js";
 import { normalizeThreadId, resolveMatrixRoomId } from "./send/targets.js";
 import {
   EventType,
@@ -63,42 +60,6 @@ type MatrixClientResolveOpts = {
   timeoutMs?: number;
   accountId?: string | null;
 };
-
-type MatrixReceiptEvent = {
-  messageId: string;
-  kind: MessageReceiptPartKind;
-  replyToId?: string;
-};
-
-function createMatrixSendReceipt(params: {
-  roomId: string;
-  events: readonly MatrixReceiptEvent[];
-  threadId?: string | null;
-}) {
-  const firstEvent = params.events[0];
-  const receipt = createMessageReceiptFromOutboundResults({
-    kind: firstEvent?.kind ?? "text",
-    ...(firstEvent?.replyToId ? { replyToId: firstEvent.replyToId } : {}),
-    ...(params.threadId ? { threadId: params.threadId } : {}),
-    results: params.events.map(({ messageId }) => ({
-      channel: "matrix",
-      messageId,
-      roomId: params.roomId,
-    })),
-  });
-  // Caption overflow is not a native reply; never copy the first event's relation onto later parts.
-  receipt.parts = receipt.parts.map((part, index) => {
-    const event = params.events[index]!;
-    const actualPart = { ...part, kind: event.kind };
-    if (event.replyToId) {
-      actualPart.replyToId = event.replyToId;
-    } else {
-      delete actualPart.replyToId;
-    }
-    return actualPart;
-  });
-  return receipt;
-}
 
 function isMatrixClient(value: MatrixClient | MatrixClientResolveOpts): value is MatrixClient {
   return typeof (value as { sendEvent?: unknown }).sendEvent === "function";

--- a/extensions/matrix/src/matrix/send/receipt.ts
+++ b/extensions/matrix/src/matrix/send/receipt.ts
@@ -1,0 +1,40 @@
+import {
+  createMessageReceiptFromOutboundResults,
+  type MessageReceiptPartKind,
+} from "openclaw/plugin-sdk/channel-outbound";
+
+export type MatrixReceiptEvent = {
+  messageId: string;
+  kind: MessageReceiptPartKind;
+  replyToId?: string;
+};
+
+export function createMatrixSendReceipt(params: {
+  roomId: string;
+  events: readonly MatrixReceiptEvent[];
+  threadId?: string | null;
+}) {
+  const firstEvent = params.events[0];
+  const receipt = createMessageReceiptFromOutboundResults({
+    kind: firstEvent?.kind ?? "text",
+    ...(firstEvent?.replyToId ? { replyToId: firstEvent.replyToId } : {}),
+    ...(params.threadId ? { threadId: params.threadId } : {}),
+    results: params.events.map(({ messageId }) => ({
+      channel: "matrix",
+      messageId,
+      roomId: params.roomId,
+    })),
+  });
+  // Caption overflow is not a native reply; never copy the first event's relation onto later parts.
+  receipt.parts = receipt.parts.map((part, index) => {
+    const event = params.events[index]!;
+    const actualPart = { ...part, kind: event.kind };
+    if (event.replyToId) {
+      actualPart.replyToId = event.replyToId;
+    } else {
+      delete actualPart.replyToId;
+    }
+    return actualPart;
+  });
+  return receipt;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix delivery recovery would label caption-overflow text as replying to the original message even though that native event had no reply relation. The media event and its follow-up text could therefore have correct platform content but inaccurate returned delivery evidence.

## Why This Change Was Made

Normal sends and reconciliation now share the Matrix receipt builder. Recovery reads each saved event's native reply relation and thread placement, while preserving event ordering, the primary ID, and first-occurrence ID deduplication. This removes 36 production lines and the parallel request-based receipt builder.

## User Impact

Recovered receipts accurately distinguish a media reply from its ordinary caption-overflow text. Clients consuming those receipts receive the same event-specific metadata as normal sends.

## Evidence

A regression exercises an ordinary durable media send, simulates a lost overflow response, and reconciles through the actual send/recovery owners. It failed before the fix on the invented overflow reply ID. The replay retains the original event content and transaction IDs and uploads the media once.

All 192 selected owner and sibling tests pass, including repeated event IDs, partial delivery, and adapter receipt forwarding. Tests use mocked Matrix transport/media and isolated state. Canonical checks, the full build, and both independent managed review passes also pass.
