### PR TITLE
fix(state): retain avatar database identity across fetch

### DIFF
--- a/src/state/user-profiles.avatar-lifetime.test.ts
+++ b/src/state/user-profiles.avatar-lifetime.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "./openclaw-state-db.js";
+import {
+  adoptTailscaleProfileAvatar,
+  ensureProfileForEmail,
+  getProfileAvatar,
+  listProfiles,
+  setDisplayName,
+} from "./user-profiles.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    cleanup();
+  });
+});
+
+it.each([false, true])(
+  "keeps avatar adoption on its original database after handle replacement (fetched=%s)",
+  async (fetched) => {
+    const originalDirectory = tempDirs.make("openclaw-avatar-original-");
+    const otherDirectory = tempDirs.make("openclaw-avatar-other-");
+    const env = { OPENCLAW_STATE_DIR: originalDirectory };
+    const options = { env };
+    const profile = ensureProfileForEmail("avatar-lifetime@example.test", options);
+    const original = openOpenClawStateDatabase(options);
+    const originalOptions = { path: original.path };
+    const entered = createDeferredCore();
+    const response = createDeferredCore<Response>();
+    const pending = adoptTailscaleProfileAvatar(
+      profile.id,
+      "https://avatars.example.test/profile",
+      options,
+      {
+        fetchImpl: vi.fn(async () => {
+          entered.resolve();
+          return response.promise;
+        }),
+      },
+    );
+    try {
+      await entered.promise;
+      closeOpenClawStateDatabaseForTest();
+      expect(original.db.isOpen).toBe(false);
+      setDisplayName(profile.id, "Edited during fetch", originalOptions);
+      env.OPENCLAW_STATE_DIR = otherDirectory;
+      const other = ensureProfileForEmail("other@example.test", options);
+      const bytes = readFileSync(join(process.cwd(), "ui/public/favicon-32.png"));
+      response.resolve(
+        fetched
+          ? new Response(Uint8Array.from(bytes).buffer, {
+              headers: { "content-type": "image/png" },
+            })
+          : new Response("unavailable", { status: 503 }),
+      );
+
+      await expect(pending).resolves.toMatchObject({
+        id: profile.id,
+        displayName: "Edited during fetch",
+        avatarMime: fetched ? "image/png" : null,
+      });
+      expect(getProfileAvatar(profile.id, originalOptions)?.bytes).toEqual(
+        fetched ? Uint8Array.from(bytes) : undefined,
+      );
+      expect(listProfiles(options)).toEqual([
+        expect.objectContaining({ id: other.id, hasAvatar: false }),
+      ]);
+    } finally {
+      response.resolve(new Response("unavailable", { status: 503 }));
+      await Promise.allSettled([pending]);
+    }
+  },
+);

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -460,15 +460,19 @@ async function adoptAvatarIfEmpty(params: {
   options: OpenClawStateDatabaseOptions;
   fetchOptions: TailscaleAvatarFetchOptions;
 }): Promise<UserProfile> {
-  const { db } = openOpenClawStateDatabase(params.options);
-  const beforeFetch = requireResolvedUserProfileById(db, params.profileId);
+  const database = openOpenClawStateDatabase(params.options);
+  const beforeFetch = requireResolvedUserProfileById(database.db, params.profileId);
   if (beforeFetch.avatar !== null || !params.profilePic) {
     return toUserProfile(beforeFetch);
   }
+  // Remote work may outlive a cached handle or a change to the state-directory selector.
+  const options = { ...params.options, path: database.path };
   const avatar = await fetchTailscaleAvatar(params.profilePic, params.fetchOptions);
   if (!avatar) {
+    const { db } = openOpenClawStateDatabase(options);
     return toUserProfile(requireResolvedUserProfileById(db, params.profileId));
   }
+  const sha256 = createHash("sha256").update(avatar.bytes).digest("hex");
   const now = Date.now();
   return runOpenClawStateWriteTransaction(
     ({ db: transactionDb }) => {
@@ -476,7 +480,6 @@ async function adoptAvatarIfEmpty(params: {
       if (profile.avatar !== null) {
         return toUserProfile(profile);
       }
-      const sha256 = createHash("sha256").update(avatar.bytes).digest("hex");
       executeSqliteQuerySync(
         transactionDb,
         userProfilesDb(transactionDb)
@@ -498,7 +501,7 @@ async function adoptAvatarIfEmpty(params: {
         updated_at: now,
       });
     },
-    params.options,
+    options,
     { operationLabel: "user-profiles.adopt-avatar" },
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Tailscale avatar adoption could fail after its remote download outlived a cached SQLite handle. The failed-download path read that closed handle; the successful path resolved the database again from mutable state-directory settings and could target a different store.

## Why This Change Was Made

Bind the adoption to its original resolved database path before fetching, reacquire through the existing database owner when the fetch produces no avatar, and prepare the bounded avatar hash before the synchronous transaction. Current profile data is still reread after the download, and a concurrent user-uploaded avatar remains authoritative. Public APIs, persistent schemas, transaction boundaries, and native database ownership are unchanged.

## Evidence

Validation: a delayed-fetch regression fails on the original code with `database is not open` for a failed fetch and `UserProfileNotFoundError` after successful-fetch retargeting. The repaired code passes all 116 tests across user profiles, owner identities, preferences, and personal model accounts, including the existing concurrent-upload case. The final focused lifetime/profile suites passed 56 tests after the regression moved into its own file. The complete changed gate passed, including production and test typechecking, lint, dead-export scans, schema parity, and runtime import guards. Independent P2 review was scoped-clean.

## User Impact

This is an asynchronous lifetime correctness repair. Native SQLite execution remains synchronous; this change does not introduce a database worker.
