### PR TITLE
test: remove unused node approval fixture initializer

### DIFF
--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -135,18 +135,7 @@ const resolveAllowAlwaysPatternCoverageMock = vi.hoisted(() =>
     patterns: [{ pattern: "/trusted/bin/tool" }],
   })),
 );
-const resolveExecApprovalsFromFileMock = vi.hoisted(() =>
-  vi.fn((): MockExecApprovalsResolved => ({
-    allowlist: [],
-    file: { version: 1, agents: {} },
-    agent: {
-      security: "full",
-      ask: "off",
-      askFallback: "deny",
-      autoAllowSkills: false,
-    },
-  })),
-);
+const resolveExecApprovalsFromFileMock = vi.hoisted(() => vi.fn<() => MockExecApprovalsResolved>());
 const requiresExecApprovalMock = vi.hoisted(() =>
   vi.fn((_raw?: RequiresExecApprovalMockParams) => true),
 );


### PR DESCRIPTION
Related: #143529

## What Problem This Solves

The node-host exec tests duplicate a default approval fixture in a hoisted mock initializer even though the suite's unconditional `beforeEach` replaces it before every test. This maintainer-requested cleanup removes that unused setup.

## Why This Change Was Made

Use `vi.fn<() => MockExecApprovalsResolved>()` with the existing exact callable type. Keep the hook-owned fixture, all 19 case overrides, and mocks whose implementations are retained by `mockClear()` unchanged. Only this declaration changes.

## User Impact

No user-visible or runtime behavior change. The test file loses 11 net lines; production code, types, assertions, and test cases are unchanged.

## Evidence

- Node 24.19.0 / pnpm 12.3.4: the complete node-host, phase, and cancellation cohort passed 120 tests before and after the change:
  `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-host-node-phases.test.ts src/agents/bash-tools.exec-host-node.cancellation.test.ts`
- The mapped `coreTests` changed gate passed, including the `agents-root` core-test typecheck and lint. The first formatting check requested a one-line declaration; after Oxfmt, the complete cohort and gate passed.
- Exact declaration inversion reconstructs the original file byte-for-byte. The existing type, hook, overrides, and all bytes outside the declaration are unchanged. Deslop and independent autoreview completed with no actionable findings.

The reported 120-label multiset and per-file order match; the two unchanged sibling file groups swapped order and the target stayed first. Reporter labels may be abbreviated, so this is not a claim of globally ordered or untruncated JSON test identities. The static inverse independently supports unchanged cases. No runtime speedup is claimed.
