### PR TITLE
refactor(system-agent): share setup planner JSON extraction

### DIFF
--- a/src/system-agent/assistant-prompts.ts
+++ b/src/system-agent/assistant-prompts.ts
@@ -1,4 +1,5 @@
 // System-agent prompts drive the OpenClaw conversation with typed-command output.
+import { extractBalancedJsonPrefix } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { SystemAgentGreetingFacts } from "./greeting.js";
 import type { SystemAgentOverview } from "./overview.js";
@@ -242,7 +243,7 @@ export function parseSystemAgentAssistantPlanText(
     return null;
   }
   // Model output may wrap JSON in prose; extraction stays narrow and validation happens after.
-  const jsonText = extractFirstJsonObject(text);
+  const jsonText = extractBalancedJsonPrefix(text, { openers: ["{"] })?.json;
   if (!jsonText) {
     return null;
   }
@@ -266,41 +267,4 @@ export function parseSystemAgentAssistantPlanText(
     ...(command ? { command } : {}),
     ...(reply ? { reply } : {}),
   };
-}
-
-function extractFirstJsonObject(text: string): string | null {
-  // Planner output must be JSON, but this tolerates model wrappers before
-  // re-validating fields. A balanced scan (string-aware) keeps a trailing
-  // prose "}" or a second JSON object from corrupting the first.
-  const start = text.indexOf("{");
-  if (start < 0) {
-    return null;
-  }
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
-  for (let i = start; i < text.length; i += 1) {
-    const char = text[i];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-    } else if (char === "{") {
-      depth += 1;
-    } else if (char === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return text.slice(start, i + 1);
-      }
-    }
-  }
-  return null;
 }

--- a/src/system-agent/assistant.test.ts
+++ b/src/system-agent/assistant.test.ts
@@ -79,6 +79,15 @@ describe("OpenClaw assistant", () => {
     });
   });
 
+  it.each([
+    ['[0] {"reply":"Ready."}', { reply: "Ready." }],
+    ['{"reply":"A } brace."} {"reply":"Later."}', { reply: "A } brace." }],
+    ['prefix "{not-json}" {"reply":"Later."}', null],
+    ['{"reply":"First.","extra":{"nested":true}} trailing }', { reply: "First." }],
+  ])("preserves object-only, first-object extraction: %s", (input, expected) => {
+    expect(parseSystemAgentAssistantPlanText(input)).toEqual(expected);
+  });
+
   it("rejects non-JSON and empty plans but accepts chat-only replies", () => {
     expect(parseSystemAgentAssistantPlanText("I would edit config directly.")).toBeNull();
     expect(parseSystemAgentAssistantPlanText("{}")).toBeNull();


### PR DESCRIPTION
Closes #145181

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Maintaining response handling for fuzzy one-shot setup requests currently requires keeping duplicate JSON extraction logic in sync. This maintainer-requested cleanup reduces that maintenance burden while preserving how the setup planner interprets model replies.

## Why This Change Was Made

The planner now uses the existing `extractBalancedJsonPrefix` export from `@openclaw/normalization-core` with object-only selection. The private scanner is removed; the planner still parses and validates the first extracted object, and the existing typed-operation and approval owners handle any resulting command.

## User Impact

No user-visible behavior change. Prose-wrapped replies, braces inside strings, nested objects, and malformed first objects retain their existing handling. All prompt bytes remain unchanged. The change removes 32 production code lines and adds 8 test code lines, for a net reduction of 24 maintained code lines.

## Evidence

Local proof is bound to commit `6be78adad5975cc7071a7015d255836ce36d9afe`, based on `170b4827c8a8c5f34192b7785eb751e30612b995`. The branch was rebased to main `527859984b7cd6024d24b841c4c9fd0c18ee0db9`, producing head `cb20483e7fca7070833401f00ba949703a1ec932`, to include the independent shared CI fixture repair in #145170. The complete patch and both changed files remain byte-identical to the reviewed version; parser, caller, and package import source have no drift. Existing local proof keeps its original commit/base binding and was not rerun for this rebase. Exact-head hosted CI is tracked separately.

All 53 focused tests passed against the original scanner with the four preservation cases added, then passed again after the cutover with identical test identities:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/system-agent/assistant.test.ts packages/normalization-core/src/balanced-json.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast-isolated.config.ts src/system-agent/assistant.configured.test.ts src/system-agent/system-agent.test.ts
```

The four new cases cover array prefixes, braces in reply strings, malformed first objects inside quoted prose, and nested objects with trailing braces. These preserve existing behavior; they are not bug-regression claims.

`pnpm build`, the complete core/coreTests changed-file gate, `git diff --check`, and the normal commit hook passed. The built normalization package's public root import passed the same four extraction cases. Independent P2 review was clean. Validation used Node 24.20.0 and pnpm 12.3.4.
