### PR TITLE
fix(auth): await durable OAuth refresh transitions

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-fence.async.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-fence.async.test.ts
@@ -7,6 +7,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { withEnvAsync } from "../../test-utils/env.js";
 import {
   observeOAuthRefreshFenceSettlement,
+  observeOAuthRefreshSettlement,
   refreshSerializedOAuthCredential,
 } from "./oauth-refresh-fence.js";
 import { isPendingOAuthRefreshFence } from "./oauth-refresh-marker.js";
@@ -21,6 +22,22 @@ import type { AuthProfileStore, OAuthCredential } from "./types.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("awaited OAuth persistence", () => {
+  it.each([
+    { label: "Error", rejection: new Error("synthetic backend failure") },
+    { label: "primitive", rejection: "synthetic backend failure" },
+    { label: "undefined", rejection: undefined },
+  ])("preserves the original pre-deadline $label rejection", async ({ rejection }) => {
+    const settlement = createDeferredCore<never>();
+    const observing = observeOAuthRefreshSettlement(
+      "synthetic rejection",
+      1_000,
+      settlement.promise,
+    );
+    const rejected = expect(observing).rejects.toBe(rejection);
+    settlement.reject(rejection);
+    await rejected;
+  });
+
   it.each(["stalled read", "expired snapshot", "expired rejection"])(
     "bounds an observer waiting for a %s",
     async (scenario) => {

--- a/src/agents/auth-profiles/oauth-refresh-fence.async.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-fence.async.test.ts
@@ -1,0 +1,200 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import {
+  observeOAuthRefreshFenceSettlement,
+  refreshSerializedOAuthCredential,
+} from "./oauth-refresh-fence.js";
+import { isPendingOAuthRefreshFence } from "./oauth-refresh-marker.js";
+import {
+  closeAuthProfileReadPool,
+  readPersistedAuthProfileStoreRaw,
+  runAuthProfileWriteTransaction,
+  writePersistedAuthProfileStoreRaw,
+} from "./sqlite.js";
+import type { AuthProfileStore, OAuthCredential } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("awaited OAuth persistence", () => {
+  it.each(["stalled read", "expired snapshot", "expired rejection"])(
+    "bounds an observer waiting for a %s",
+    async (scenario) => {
+      vi.useFakeTimers();
+      const reading = createDeferredCore<{ pending: boolean }>();
+      const resolve = vi.fn(async () => "synthetic-access");
+      const observing = observeOAuthRefreshFenceSettlement({
+        label: "synthetic observer",
+        timeoutMs: 100,
+        read: () => reading.promise,
+        isPending: (snapshot) => snapshot.pending,
+        resolve,
+      });
+      const rejected = expect(observing).rejects.toThrow("exceeded hard timeout (100ms)");
+      try {
+        if (scenario === "stalled read") {
+          await vi.advanceTimersByTimeAsync(100);
+        } else {
+          vi.setSystemTime(Date.now() + 101);
+          if (scenario === "expired rejection") {
+            reading.reject(new Error("synthetic late read failure"));
+          } else {
+            reading.resolve({ pending: false });
+          }
+        }
+        await rejected;
+        reading.resolve({ pending: false });
+        await reading.promise.catch(() => {});
+        await vi.advanceTimersByTimeAsync(0);
+        expect(resolve).not.toHaveBeenCalled();
+      } finally {
+        reading.resolve({ pending: false });
+        await observing.catch(() => {});
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(["success", "failure"] as const)(
+    "waits for durable claim and %s settlement before publishing",
+    async (outcome) => {
+      const root = tempDirs.make("oauth-awaited-sqlite-");
+      const agentDir = path.join(root, "agents", "work", "agent");
+      await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => {
+        const profileId = "synthetic:default";
+        const expired: OAuthCredential = {
+          type: "oauth",
+          provider: "synthetic",
+          access: "synthetic-expired-access",
+          refresh: "synthetic-expired-refresh",
+          expires: 1,
+          accountId: "synthetic-account",
+        };
+        const refreshed: OAuthCredential = {
+          ...expired,
+          access: "synthetic-refreshed-access",
+          refresh: "synthetic-refreshed-refresh",
+          expires: Date.now() + 60_000,
+        };
+        const claimEntered = createDeferredCore();
+        const claimRelease = createDeferredCore();
+        const settlementEntered = createDeferredCore();
+        const settlementRelease = createDeferredCore();
+        const providerError = new Error("synthetic provider rejection");
+        let operations = 0;
+        let settled = false;
+        const commit = vi.fn();
+        const refresh = vi.fn(async () => {
+          const current = readPersistedAuthProfileStoreRaw(agentDir) as AuthProfileStore;
+          const credential = current.profiles[profileId];
+          expect(
+            isPendingOAuthRefreshFence(credential?.type === "oauth" ? credential : undefined),
+          ).toBe(true);
+          if (outcome === "failure") {
+            throw providerError;
+          }
+          return { apiKey: refreshed.access, credential: refreshed };
+        });
+        writePersistedAuthProfileStoreRaw(
+          { version: 1, profiles: { [profileId]: expired } },
+          agentDir,
+        );
+        const running = refreshSerializedOAuthCredential({
+          backend: {
+            async withLock<T>(
+              fn: (current: string | undefined) => { result: T; next?: string },
+            ): Promise<T> {
+              operations += 1;
+              if (operations === 2) {
+                claimEntered.resolve();
+                await claimRelease.promise;
+              } else if (operations === 3) {
+                settlementEntered.resolve();
+                await settlementRelease.promise;
+              }
+              return runAuthProfileWriteTransaction(agentDir, (database) => {
+                const current = readPersistedAuthProfileStoreRaw(
+                  agentDir,
+                  database,
+                ) as AuthProfileStore;
+                const update = fn(JSON.stringify(current.profiles));
+                if (update.next !== undefined) {
+                  writePersistedAuthProfileStoreRaw(
+                    { version: 1, profiles: JSON.parse(update.next) },
+                    agentDir,
+                    database,
+                  );
+                }
+                return update.result;
+              });
+            },
+          },
+          provider: "synthetic",
+          profileId,
+          label: "synthetic awaited persistence",
+          timeoutMs: 5_000,
+          parse: (current) => JSON.parse(current ?? "{}") as Record<string, OAuthCredential>,
+          serialize: JSON.stringify,
+          readCredential: (data) => data[profileId],
+          writeCredential: (data, credential) => ({ ...data, [profileId]: credential }),
+          canRefresh: async () => true,
+          refresh,
+          resolve: async (credential) => ({ apiKey: credential.access, credential }),
+          commit,
+        });
+        const observed = running.then(
+          (value) => {
+            settled = true;
+            return { value };
+          },
+          (error: unknown) => {
+            settled = true;
+            return { error };
+          },
+        );
+        try {
+          await Promise.race([claimEntered.promise, observed]);
+          expect(settled).toBe(false);
+          expect(refresh).not.toHaveBeenCalled();
+          expect(commit).not.toHaveBeenCalled();
+          claimRelease.resolve();
+          await Promise.race([settlementEntered.promise, observed]);
+          expect(settled).toBe(false);
+          expect(refresh).toHaveBeenCalledOnce();
+          expect(commit).toHaveBeenCalledTimes(1);
+          settlementRelease.resolve();
+          const result = await observed;
+          expect(commit).toHaveBeenCalledTimes(2);
+          if (outcome === "success") {
+            expect(result).toEqual({ value: { apiKey: refreshed.access, credential: refreshed } });
+          } else {
+            expect(result).toEqual({ error: providerError });
+          }
+          closeAuthProfileReadPool();
+          closeOpenClawAgentDatabasesForTest();
+          const persistedStore = readPersistedAuthProfileStoreRaw(agentDir) as AuthProfileStore;
+          const persisted = persistedStore.profiles[profileId];
+          expect(persisted).toMatchObject({
+            type: "oauth",
+            access:
+              outcome === "success" ? refreshed.access : expect.stringContaining(":failed:access:"),
+          });
+          expect(
+            isPendingOAuthRefreshFence(persisted?.type === "oauth" ? persisted : undefined),
+          ).toBe(false);
+        } finally {
+          claimRelease.resolve();
+          settlementRelease.resolve();
+          await observed;
+          closeAuthProfileReadPool();
+          closeOpenClawAgentDatabasesForTest();
+          closeOpenClawStateDatabaseForTest();
+        }
+      });
+    },
+  );
+});

--- a/src/agents/auth-profiles/oauth-refresh-fence.ts
+++ b/src/agents/auth-profiles/oauth-refresh-fence.ts
@@ -19,7 +19,7 @@ export function isExactOAuthCredential(
 }
 
 type SerializedOAuthRefreshBackend = {
-  withLock<T>(fn: (current: string | undefined) => { result: T; next?: string }): T;
+  withLock<T>(fn: (current: string | undefined) => { result: T; next?: string }): T | Promise<T>;
 };
 
 type SerializedOAuthRefreshResult = {
@@ -60,13 +60,18 @@ function createOAuthRefreshTimeoutError(label: string, timeoutMs: number): Error
 export async function observeOAuthRefreshFenceSettlement<TSnapshot, TResult>(params: {
   label: string;
   timeoutMs: number;
-  read: () => TSnapshot;
+  read: () => TSnapshot | Promise<TSnapshot>;
   isPending: (snapshot: TSnapshot) => boolean;
   resolve: (snapshot: TSnapshot) => Promise<TResult | null>;
 }): Promise<TResult | null> {
   const deadline = Date.now() + params.timeoutMs;
   while (true) {
-    const snapshot = params.read();
+    const snapshot = await observeOAuthRefreshSettlementBeforeDeadline(
+      params.label,
+      params.timeoutMs,
+      deadline,
+      Promise.resolve().then(() => params.read()),
+    );
     if (!params.isPending(snapshot)) {
       return await params.resolve(snapshot);
     }
@@ -148,23 +153,25 @@ export async function refreshSerializedOAuthCredential<TData>(params: {
       },
     });
 
-  const candidate = params.backend.withLock<SerializedOAuthRefreshCandidate<TData>>((current) => {
-    const data = params.parse(current);
-    const credential = params.readCredential(data);
-    if (!credential || credential.provider !== params.provider) {
-      return { result: { kind: "unavailable" } };
-    }
-    if (isPendingOAuthRefreshFence(credential)) {
-      return { result: { kind: "observe", generation: credential } };
-    }
-    if (isOAuthRefreshFence(credential)) {
-      return { result: { kind: "unavailable" } };
-    }
-    if (hasUnexpiredOAuthCredential(credential)) {
-      return { result: { kind: "use", credential, data } };
-    }
-    return { result: { kind: "claimable", credential } };
-  });
+  const candidate = await params.backend.withLock<SerializedOAuthRefreshCandidate<TData>>(
+    (current) => {
+      const data = params.parse(current);
+      const credential = params.readCredential(data);
+      if (!credential || credential.provider !== params.provider) {
+        return { result: { kind: "unavailable" } };
+      }
+      if (isPendingOAuthRefreshFence(credential)) {
+        return { result: { kind: "observe", generation: credential } };
+      }
+      if (isOAuthRefreshFence(credential)) {
+        return { result: { kind: "unavailable" } };
+      }
+      if (hasUnexpiredOAuthCredential(credential)) {
+        return { result: { kind: "use", credential, data } };
+      }
+      return { result: { kind: "claimable", credential } };
+    },
+  );
   if (candidate.kind === "unavailable") {
     return null;
   }
@@ -179,7 +186,7 @@ export async function refreshSerializedOAuthCredential<TData>(params: {
     return null;
   }
 
-  const claim = params.backend.withLock<SerializedOAuthRefreshClaim<TData>>((current) => {
+  const claim = await params.backend.withLock<SerializedOAuthRefreshClaim<TData>>((current) => {
     const data = params.parse(current);
     const credential = params.readCredential(data);
     if (!credential || credential.provider !== params.provider) {
@@ -214,8 +221,8 @@ export async function refreshSerializedOAuthCredential<TData>(params: {
     return await params.resolve(claim.credential);
   }
   params.commit(claim.nextData);
-  const markFailed = () => {
-    const failed = params.backend.withLock<TData | null>((current) => {
+  const markFailed = async () => {
+    const failed = await params.backend.withLock<TData | null>((current) => {
       const data = params.parse(current);
       const authoritative = params.readCredential(data);
       if (!isExactOAuthCredential(authoritative, claim.fence)) {
@@ -229,12 +236,12 @@ export async function refreshSerializedOAuthCredential<TData>(params: {
     }
   };
 
-  const settleFailure = (failure?: { error: unknown }): null => {
+  const settleFailure = async (failure?: { error: unknown }): Promise<null> => {
     const normalizedInitiatingError = failure
       ? toErrorObject(failure.error, "OAuth refresh failed")
       : undefined;
     try {
-      markFailed();
+      await markFailed();
     } catch (cleanupError) {
       const normalizedCleanupError = toErrorObject(
         cleanupError,
@@ -273,7 +280,7 @@ export async function refreshSerializedOAuthCredential<TData>(params: {
       if (!isSafeOAuthOwnerRefreshResult(claim.credential, refreshed.credential)) {
         throw new Error("OAuth refresh returned credentials for a different OAuth account");
       }
-      const settled = params.backend.withLock<{
+      const settled = await params.backend.withLock<{
         credential: OAuthCredential;
         data: TData;
         persisted: boolean;
@@ -312,13 +319,42 @@ export async function observeOAuthRefreshSettlement<T>(
   timeoutMs: number,
   settlement: Promise<T>,
 ): Promise<T> {
+  return await observeOAuthRefreshSettlementBeforeDeadline(
+    label,
+    timeoutMs,
+    Date.now() + timeoutMs,
+    settlement,
+  );
+}
+
+async function observeOAuthRefreshSettlementBeforeDeadline<T>(
+  label: string,
+  timeoutMs: number,
+  deadline: number,
+  settlement: Promise<T>,
+): Promise<T> {
   let timeoutHandle: NodeJS.Timeout | undefined;
   try {
     return await new Promise<T>((resolve, reject) => {
-      timeoutHandle = setTimeout(() => {
-        reject(createOAuthRefreshTimeoutError(label, timeoutMs));
-      }, timeoutMs);
-      settlement.then(resolve, reject);
+      timeoutHandle = setTimeout(
+        () => {
+          reject(createOAuthRefreshTimeoutError(label, timeoutMs));
+        },
+        Math.max(0, deadline - Date.now()),
+      );
+      settlement.then(
+        (value) => {
+          if (Date.now() >= deadline) {
+            reject(createOAuthRefreshTimeoutError(label, timeoutMs));
+          } else {
+            resolve(value);
+          }
+        },
+        (error: unknown) => {
+          // oxlint-disable-next-line typescript/prefer-promise-reject-errors -- Preserve the backend's original rejection before the observation deadline.
+          reject(Date.now() >= deadline ? createOAuthRefreshTimeoutError(label, timeoutMs) : error);
+        },
+      );
     });
   } finally {
     if (timeoutHandle) {

--- a/src/agents/auth-profiles/oauth-refresh-fence.ts
+++ b/src/agents/auth-profiles/oauth-refresh-fence.ts
@@ -342,19 +342,13 @@ async function observeOAuthRefreshSettlementBeforeDeadline<T>(
         },
         Math.max(0, deadline - Date.now()),
       );
-      settlement.then(
-        (value) => {
+      settlement
+        .finally(() => {
           if (Date.now() >= deadline) {
-            reject(createOAuthRefreshTimeoutError(label, timeoutMs));
-          } else {
-            resolve(value);
+            throw createOAuthRefreshTimeoutError(label, timeoutMs);
           }
-        },
-        (error: unknown) => {
-          // oxlint-disable-next-line typescript/prefer-promise-reject-errors -- Preserve the backend's original rejection before the observation deadline.
-          reject(Date.now() >= deadline ? createOAuthRefreshTimeoutError(label, timeoutMs) : error);
-        },
-      );
+        })
+        .then(resolve, reject);
     });
   } finally {
     if (timeoutHandle) {

--- a/src/agents/auth-profiles/oauth-refresh-fence.ts
+++ b/src/agents/auth-profiles/oauth-refresh-fence.ts
@@ -131,6 +131,7 @@ export async function refreshSerializedOAuthCredential<TData>(params: {
     data: TData,
   ) => Promise<SerializedOAuthRefreshResult | null>;
   resolve: (credential: OAuthCredential) => Promise<SerializedOAuthRefreshResult | null>;
+  /** Publish only after the caller validates the snapshot against its current owner. */
   commit: (data: TData) => void;
 }): Promise<SerializedOAuthRefreshResult | null> {
   const observeFence = async (generation: OAuthCredential) =>
@@ -220,7 +221,6 @@ export async function refreshSerializedOAuthCredential<TData>(params: {
     params.commit(claim.data);
     return await params.resolve(claim.credential);
   }
-  params.commit(claim.nextData);
   const markFailed = async () => {
     const failed = await params.backend.withLock<TData | null>((current) => {
       const data = params.parse(current);
@@ -262,6 +262,12 @@ export async function refreshSerializedOAuthCredential<TData>(params: {
     }
     return null;
   };
+
+  try {
+    params.commit(claim.nextData);
+  } catch (error) {
+    return await settleFailure({ error });
+  }
 
   const settlement = (async () => {
     let refreshed: SerializedOAuthRefreshResult | null;

--- a/src/agents/sessions/auth-storage-oauth-refresh.ts
+++ b/src/agents/sessions/auth-storage-oauth-refresh.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import type { OAuthProviderId } from "../../llm/utils/oauth/types.js";
 import { OAUTH_REFRESH_CALL_TIMEOUT_MS } from "../auth-profiles/constants.js";
 import {
@@ -5,6 +6,7 @@ import {
   refreshSerializedOAuthCredential,
 } from "../auth-profiles/oauth-refresh-fence.js";
 import { isOAuthRefreshFence } from "../auth-profiles/oauth-refresh-marker.js";
+import { AuthStoragePersistenceError } from "./auth-storage-error.js";
 import {
   canResolveAuthStoragePluginOAuthRefresh,
   getAuthStorageOAuthProviderRegistry,
@@ -56,7 +58,21 @@ export async function refreshAuthStorageOAuthCredential(params: {
     }),
     canRefresh: async () =>
       Boolean(provider) || (await canResolveAuthStoragePluginOAuthRefresh(params.providerId)),
-    commit: params.commit,
+    commit: (data) => {
+      const expected = params.parse(JSON.stringify(data));
+      const current = params.storage.withLock((raw) => {
+        const authoritative = params.parse(raw);
+        if (!isDeepStrictEqual(authoritative[params.providerId], expected[params.providerId])) {
+          throw new AuthStoragePersistenceError(
+            "Auth storage credentials changed before refresh publication.",
+            undefined,
+          );
+        }
+        return { result: authoritative };
+      });
+      // Backend completion captures credential sources before runtime publication.
+      params.commit(current);
+    },
     refresh: async (credential, data) => {
       const oauthCredentials = Object.fromEntries(
         Object.entries(data).filter((entry): entry is [string, OAuthCredential] => {

--- a/src/agents/sessions/auth-storage.publication.test.ts
+++ b/src/agents/sessions/auth-storage.publication.test.ts
@@ -1,0 +1,297 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { clearAuthProfileMigrationDiagnostics } from "../auth-profiles/legacy-source-diagnostic.js";
+import {
+  createOAuthRefreshFence,
+  isOAuthRefreshFence,
+  isPendingOAuthRefreshFence,
+} from "../auth-profiles/oauth-refresh-marker.js";
+import { loadPersistedAuthProfileStore } from "../auth-profiles/persisted.js";
+import { clearRuntimeAuthProfileStoreSnapshots } from "../auth-profiles/runtime-snapshots.js";
+import { writePersistedAuthProfileStoreRaw } from "../auth-profiles/sqlite.js";
+import type { OAuthCredential } from "../auth-profiles/types.js";
+import { getAuthStorageOAuthProviderRegistry } from "./auth-storage-oauth-registry.js";
+import { AuthStorage, FileAuthStorageBackend } from "./auth-storage.js";
+
+function createCredential(overrides: Partial<OAuthCredential> = {}): OAuthCredential {
+  return {
+    type: "oauth",
+    provider: "test-oauth",
+    access: "synthetic-access-a",
+    refresh: "synthetic-refresh-a",
+    expires: Date.now() + 600_000,
+    ...overrides,
+  };
+}
+
+async function createSqliteAuthRefreshFixture(agentDir: string) {
+  await fs.mkdir(agentDir, { recursive: true });
+  const providerId = "test-oauth";
+  const profileId = `${providerId}:default`;
+  const initial = createCredential({ provider: providerId, expires: 1, accountId: "account-a" });
+  const refreshed = createCredential({
+    provider: providerId,
+    access: "synthetic-refreshed-a",
+    refresh: "synthetic-refresh-a",
+    accountId: "account-a",
+  });
+  const replacement = createCredential({
+    provider: providerId,
+    access: "synthetic-account-b",
+    refresh: "synthetic-refresh-b",
+    accountId: "account-b",
+  });
+  writePersistedAuthProfileStoreRaw(
+    {
+      version: 1,
+      profiles: {
+        [profileId]: initial,
+        "other:default": { type: "api_key", provider: "other", key: "synthetic-other-old" },
+      },
+    },
+    agentDir,
+  );
+  const backend = new FileAuthStorageBackend(path.join(agentDir, "auth.json"));
+  const storage = AuthStorage.fromStorage(backend);
+  const peer = AuthStorage.forAgent(agentDir, {});
+  const refreshToken = vi.fn(async () => refreshed);
+  getAuthStorageOAuthProviderRegistry(storage).register({
+    id: providerId,
+    name: "Test OAuth",
+    async login() {
+      throw new Error("not used");
+    },
+    refreshToken,
+    getApiKey: (credential) => credential.access,
+  });
+  return { backend, storage, peer, providerId, profileId, refreshed, replacement, refreshToken };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearAuthProfileMigrationDiagnostics();
+  clearRuntimeAuthProfileStoreSnapshots();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("AuthStorage OAuth publication", () => {
+  it.each([
+    { phase: "claim", actor: "same", change: "logout" },
+    { phase: "claim", actor: "peer", change: "replace" },
+    { phase: "settlement", actor: "peer", change: "logout" },
+    { phase: "settlement", actor: "same", change: "replace" },
+    { phase: "claim", actor: "same", change: "unrelated" },
+    { phase: "settlement", actor: "peer", change: "unrelated" },
+    { phase: "settlement", actor: "same", change: "unchanged" },
+  ])(
+    "preserves $actor facade $change after durable $phase and before publication",
+    async ({ phase, actor, change }) => {
+      await withOpenClawTestState(
+        { layout: "state-only", prefix: "auth-refresh-publication-" },
+        async (state) => {
+          const agentDir = state.agentDir();
+          const {
+            backend,
+            storage,
+            peer,
+            providerId,
+            profileId,
+            refreshed,
+            replacement,
+            refreshToken,
+          } = await createSqliteAuthRefreshFixture(agentDir);
+          let otherWhenRefreshStarted = storage.get("other");
+          refreshToken.mockImplementation(async () => {
+            otherWhenRefreshStarted = storage.get("other");
+            return refreshed;
+          });
+          const mutate = actor === "same" ? storage : peer;
+          const withLock = backend.withLock.bind(backend);
+          let queued = false;
+          backend.withLock = (fn) => {
+            let wrote = false;
+            const result = withLock((current) => {
+              const update = fn(current);
+              wrote = update.next !== undefined;
+              return update;
+            });
+            if (!queued && wrote) {
+              const durable = loadPersistedAuthProfileStore(agentDir)?.profiles[profileId];
+              if (
+                durable?.type === "oauth" &&
+                (phase === "claim"
+                  ? isPendingOAuthRefreshFence(durable)
+                  : durable.access === refreshed.access)
+              ) {
+                queued = true;
+                queueMicrotask(() => {
+                  if (change === "logout") {
+                    mutate.logout(providerId);
+                  } else if (change === "replace") {
+                    mutate.set(providerId, replacement);
+                  } else if (change === "unrelated") {
+                    mutate.set("other", { type: "api_key", key: "synthetic-other-new" });
+                  }
+                });
+              }
+            }
+            return result;
+          };
+
+          const apiKey = await storage.getApiKey(providerId);
+          expect(queued).toBe(true);
+          const durable = loadPersistedAuthProfileStore(agentDir)?.profiles;
+          if (change === "logout") {
+            expect(apiKey).toBeUndefined();
+            expect(storage.get(providerId)).toBeUndefined();
+            expect(durable?.[profileId]).toBeUndefined();
+          } else if (change === "replace") {
+            expect(apiKey).toBe(replacement.access);
+            expect(storage.get(providerId)).toEqual(replacement);
+            expect(durable?.[profileId]).toEqual(replacement);
+          } else {
+            expect(apiKey).toBe(refreshed.access);
+            expect(storage.get(providerId)).toEqual(refreshed);
+            expect(durable?.[profileId]).toEqual(refreshed);
+          }
+          expect(refreshToken).toHaveBeenCalledTimes(
+            phase === "claim" && (change === "logout" || change === "replace") ? 0 : 1,
+          );
+          const otherKey = change === "unrelated" ? "synthetic-other-new" : "synthetic-other-old";
+          if (phase === "claim" && change === "unrelated") {
+            expect(otherWhenRefreshStarted).toEqual({ type: "api_key", key: otherKey });
+          }
+          expect(storage.get("other")).toEqual({ type: "api_key", key: otherKey });
+          expect(durable?.["other:default"]).toEqual({
+            type: "api_key",
+            provider: "other",
+            key: otherKey,
+          });
+        },
+      );
+    },
+  );
+
+  it.each(["unchanged", "logout", "replace"])(
+    "preserves %s state when an observer publishes a settled credential",
+    async (change) => {
+      await withOpenClawTestState(
+        { layout: "state-only", prefix: "auth-refresh-observer-publication-" },
+        async (state) => {
+          const agentDir = state.agentDir();
+          const {
+            backend,
+            storage,
+            peer,
+            providerId,
+            profileId,
+            refreshed,
+            replacement,
+            refreshToken,
+          } = await createSqliteAuthRefreshFixture(agentDir);
+          peer.set(providerId, createOAuthRefreshFence({ profileId, credential: refreshed }));
+          storage.reload();
+          const withLock = backend.withLock.bind(backend);
+          let settlementQueued = false;
+          let changeQueued = false;
+          backend.withLock = (fn) => {
+            const result = withLock(fn);
+            const durable = loadPersistedAuthProfileStore(agentDir)?.profiles[profileId];
+            if (durable?.type === "oauth") {
+              if (!settlementQueued && isPendingOAuthRefreshFence(durable)) {
+                settlementQueued = true;
+                queueMicrotask(() => peer.set(providerId, refreshed));
+              } else if (!changeQueued && durable.access === refreshed.access) {
+                changeQueued = true;
+                queueMicrotask(() => {
+                  if (change === "logout") {
+                    peer.logout(providerId);
+                  } else if (change === "replace") {
+                    peer.set(providerId, replacement);
+                  }
+                });
+              }
+            }
+            return result;
+          };
+
+          const apiKey = await storage.getApiKey(providerId);
+          expect(settlementQueued).toBe(true);
+          expect(changeQueued).toBe(true);
+          expect(refreshToken).not.toHaveBeenCalled();
+          const expected =
+            change === "logout" ? undefined : change === "replace" ? replacement : refreshed;
+          expect(apiKey).toBe(expected?.access);
+          expect(storage.get(providerId)).toEqual(expected);
+          expect(loadPersistedAuthProfileStore(agentDir)?.profiles[profileId]).toEqual(expected);
+        },
+      );
+    },
+  );
+
+  it.each([false, true])(
+    "settles claim custody when publication read fails (replacement: %s)",
+    async (replace) => {
+      await withOpenClawTestState(
+        { layout: "state-only", prefix: "auth-refresh-publication-read-failure-" },
+        async (state) => {
+          const agentDir = state.agentDir();
+          const { backend, storage, peer, providerId, profileId, replacement, refreshToken } =
+            await createSqliteAuthRefreshFixture(agentDir);
+          const withLock = backend.withLock.bind(backend);
+          const readError = new Error("synthetic publication read failure");
+          let queued = false;
+          let failNextRead = false;
+          backend.withLock = (fn) => {
+            if (failNextRead) {
+              failNextRead = false;
+              throw readError;
+            }
+            let wrote = false;
+            const result = withLock((current) => {
+              const update = fn(current);
+              wrote = update.next !== undefined;
+              return update;
+            });
+            if (!queued && wrote) {
+              const durable = loadPersistedAuthProfileStore(agentDir)?.profiles[profileId];
+              if (durable?.type === "oauth" && isPendingOAuthRefreshFence(durable)) {
+                queued = true;
+                queueMicrotask(() => {
+                  if (replace) {
+                    peer.set(providerId, replacement);
+                  }
+                  failNextRead = true;
+                });
+              }
+            }
+            return result;
+          };
+
+          const apiKey = await storage.getApiKey(providerId);
+          expect(queued).toBe(true);
+          expect(refreshToken).not.toHaveBeenCalled();
+          expect(storage.drainErrors()).toContain(readError);
+          const durable = loadPersistedAuthProfileStore(agentDir)?.profiles[profileId];
+          if (replace) {
+            expect(apiKey).toBe(replacement.access);
+            expect(storage.get(providerId)).toEqual(replacement);
+            expect(durable).toEqual(replacement);
+          } else {
+            expect(apiKey).toBeUndefined();
+            expect(storage.get(providerId)).toBeUndefined();
+            expect(durable?.type).toBe("oauth");
+            if (durable?.type !== "oauth") {
+              throw new Error("Expected the failed refresh to retain a terminal OAuth fence");
+            }
+            expect(isOAuthRefreshFence(durable)).toBe(true);
+            expect(isPendingOAuthRefreshFence(durable)).toBe(false);
+          }
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Asynchronous auth storage needs the refresh protocol to await durable claims and settlements. Runtime publication must also retain the current credential owner and the latest unrelated-provider state when an awaited operation finishes.

## Why This Change Was Made

Await backend reads, claims, success writes, failure fencing, and observer snapshots while retaining synchronous transaction callbacks. Before publishing an AuthStorage refresh snapshot, the existing synchronous backend rereads authoritative state, verifies the provider entry, and publishes the fresh complete map. Failed initial publication runs the existing terminal cleanup before returning.

Observation reads retain their existing absolute deadline. Native Promise settlement preserves the exact original fulfillment or rejection before that deadline, including primitive rejection reasons, without a lint suppression. Observer timeout still stops waiting without abandoning an already-owned durable settlement; this does not extend the provider timeout to initial database admission.

## User Impact

Credential publication follows durable persistence and current ownership. Completed logout and account replacement remain reflected in runtime state, unrelated-provider updates survive publication, and failed publication leaves the refresh claim settled. SQLite schema, credential encoding, namespace, provider timeout scope, and public SDK contracts are unchanged.

The AuthStorage compatibility backend and its final authoritative publication read remain synchronous. This repairs the awaited protocol handoff; it does not move all auth SQLite execution into workers.

## Evidence

The final candidate has 56 passing cases across the async fence, generation fence, AuthStorage refresh, and AuthStorage publication suites. These use isolated synthetic state and native SQLite through the production AuthStorage entry points, with synthetic provider credentials and callbacks. They cover normal refresh, observer completion, current facade/persisted state, unrelated-provider preservation, failed publication cleanup, and rejection identity. Source hashes were captured before and after the run and remained identical. The full changed-code gate also passed on the refreshed main composition with identical before/after source hashes, including core/test types, lint, all Knip scans, storage guards, and zero runtime import cycles.

The original suppression repair separately passed 44 behavior cases plus all four cases in the actual CI suppression owner, with its allowlist unchanged. The existing native SQLite ordering/reopen proof remains applicable to that prerequisite. The final production repair and tests are reviewed together in the index and working source; a fresh isolated Codex review through P2 reports no actionable findings.

No real credentials, external provider calls, Gateway restarts, or schema migrations were used. This is native storage/lifecycle boundary proof, not a claim of an external provider round trip or complete auth worker migration. Exact-head hosted CI and native preparation remain required for landing.


Validated head: `0c5208f694e6de7786b49a1cf1caf9906d311fa2`, rebased patch-identically onto `47ce03dbc6994435af783fecf13d5586e7b307f4`, which includes the shared UI repairs from #145415. All four authored file hashes and the three-commit range-diff are unchanged. All 56 affected cases and the full changed-code gate pass on this composition; exact-head hosted CI remains required for landing.
