### PR TITLE
fix: prepare Bun SQLite before Vitest workers

### DIFF
--- a/src/infra/bun-sqlite-library.ts
+++ b/src/infra/bun-sqlite-library.ts
@@ -2,7 +2,6 @@ import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { posix } from "node:path";
 import { getEnvironmentData, isMainThread, setEnvironmentData } from "node:worker_threads";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { isSqliteWalResetSafeVersion } from "./sqlite-runtime-version.js";
 
@@ -158,20 +157,25 @@ function inheritedSelection(): SqliteLibrarySelection | undefined {
   if (value === undefined) {
     return undefined;
   }
-  if (isRecord(value)) {
-    if (value.source === "runtime") {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const source = "source" in value ? value.source : undefined;
+    if (source === "runtime") {
       return { source: "runtime" };
     }
+    const path = "path" in value ? value.path : undefined;
+    const version = "version" in value ? value.version : undefined;
+    const extensionLoadingSupported =
+      "extensionLoadingSupported" in value ? value.extensionLoadingSupported : undefined;
     if (
-      (value.source === "env" || value.source === "discovered") &&
-      typeof value.path === "string" &&
-      typeof value.version === "string" &&
-      value.extensionLoadingSupported === true
+      (source === "env" || source === "discovered") &&
+      typeof path === "string" &&
+      typeof version === "string" &&
+      extensionLoadingSupported === true
     ) {
       return {
-        source: value.source,
-        path: value.path,
-        version: value.version,
+        source,
+        path,
+        version,
         extensionLoadingSupported: true,
       };
     }

--- a/src/infra/sqlite-worker-store.test.ts
+++ b/src/infra/sqlite-worker-store.test.ts
@@ -68,6 +68,8 @@ function read(store: SqliteWorkerStore<FixtureOperations>) {
   return store.execute({ type: "read", input: undefined });
 }
 
+const nodeIt = process.versions.bun ? it.skip : it;
+
 describe("SQLite worker store", () => {
   it.each(["memory", "absolute memory", "memory URI", "incognito", "empty"] as const)(
     "rejects a %s locator before creating a file or dispatching a worker request",
@@ -275,7 +277,7 @@ describe("SQLite worker store", () => {
     expect(await read(await open(file))).toEqual(["before close", "still open"]);
   });
 
-  it("keeps a newly admitted database usable while another worker retires at capacity", async () => {
+  nodeIt("keeps a new database usable while another worker retires at capacity", async () => {
     const first = await open(databasePath());
     // Fill the documented four-worker budget before retiring an otherwise idle worker.
     for (let index = 0; index < 3; index += 1) {
@@ -395,7 +397,7 @@ describe("SQLite worker store", () => {
     expect(await read(survivor)).toEqual(["write before close", "after failed admission"]);
   });
 
-  it("rejects an overloaded actor admission without retiring healthy shared workers or writes", async () => {
+  nodeIt("rejects an overloaded admission without retiring healthy workers or writes", async () => {
     const active: SqliteWorkerStore<FixtureOperations>[] = [];
     for (let index = 0; index < 4; index += 1) {
       active.push(await open(databasePath()));

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,8 @@
 // Default test setup installs the shared test environment.
+import { ensureSqliteLibrarySelected } from "../src/infra/bun-sqlite-library.js";
 import { installSharedTestSetup } from "./setup.shared.js";
 
+if (process.versions.bun) {
+  ensureSqliteLibrarySelected();
+}
 installSharedTestSetup();

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -12,6 +12,7 @@ import {
   resolveLocalVitestScheduling,
 } from "../../scripts/lib/vitest-local-scheduling.mts";
 import type { LocalVitestScheduling } from "../../scripts/lib/vitest-local-scheduling.mts";
+import { ensureSqliteLibrarySelected } from "../../src/infra/bun-sqlite-library.ts";
 import {
   BUNDLED_PLUGIN_ROOT_DIR,
   BUNDLED_PLUGIN_TEST_GLOB,
@@ -20,6 +21,11 @@ import { loadVitestPerformanceConfig } from "./vitest.performance-config.ts";
 import { shouldPrintVitestThrottle } from "./vitest.system-load.ts";
 import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "./vitest.timeouts.ts";
 import { compiledSubprocessesPlugin } from "./vitest.worker-artifacts.ts";
+
+if (process.versions.bun) {
+  // Removal: delete this Vitest bootstrap after oven-sh/bun#42349 ships in supported Bun.
+  ensureSqliteLibrarySelected();
+}
 
 export type { LocalVitestScheduling };
 

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -12,7 +12,6 @@ import {
   resolveLocalVitestScheduling,
 } from "../../scripts/lib/vitest-local-scheduling.mts";
 import type { LocalVitestScheduling } from "../../scripts/lib/vitest-local-scheduling.mts";
-import { ensureSqliteLibrarySelected } from "../../src/infra/bun-sqlite-library.ts";
 import {
   BUNDLED_PLUGIN_ROOT_DIR,
   BUNDLED_PLUGIN_TEST_GLOB,
@@ -24,6 +23,7 @@ import { compiledSubprocessesPlugin } from "./vitest.worker-artifacts.ts";
 
 if (process.versions.bun) {
   // Removal: delete this Vitest bootstrap after oven-sh/bun#42349 ships in supported Bun.
+  const { ensureSqliteLibrarySelected } = await import("../../src/infra/bun-sqlite-library.ts");
   ensureSqliteLibrarySelected();
 }
 


### PR DESCRIPTION
## Problem

OpenClaw now publishes Bun's validated, process-wide SQLite library choice through worker environment data. Vitest did not select that library before creating its worker pool, so the first test worker selected it too late for child storage workers. Those workers then repeated Bun's one-shot SQLite initialization and failed with `SQLite already loaded`. A worker-thread mock also hid `isMainThread` before the selector was initialized.

## Solution

Select SQLite in the Vitest config host before workers start, then preload the inherited choice in each test worker before test modules and mocks. Keep the selector usable during config loading by validating the inherited record without importing a workspace package that Vite cannot resolve that early.

Two worker-reuse tests now remain Node-only because Bun deliberately uses one worker per distinct database and caps that pool at four. The Bun-specific coverage added in #145046 continues to enforce that documented limit and worker cleanup behavior.

The bootstrap carries a removal note for oven-sh/bun#42349, which makes repeated selection of the same custom library idempotent.

## Validation

- Custom Bun `1.4.3-canary.1+13bd48ed7`: 195 passed, 2 documented Bun-cap skips across selector, generic SQLite store, heartbeat, transcript archive/reconciliation, Team Reports, and Memory lifecycle tests.
- Node: 53 passed across the same selector, generic store, and heartbeat boundaries; both Node worker-reuse cases executed.
- Node minimal-repository Vitest configuration and cleanup fixtures: 76 passed.
- `pnpm check:changed`
- Independent P0-P2 autoreview: clean
