### PR TITLE
fix(tooling): restore supervised merge fixture after author lookup

### DIFF
--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -136,7 +136,7 @@ export function createMainRefreshFixture(directory: string) {
     isMergeQueueEnabled: false,
     isDraft: false,
     isCrossRepository: false,
-    author: { login: "fixture" },
+    author: { login: "fixture", __typename: "User" },
     baseRefName: "main",
     baseRefOid: main,
     headRefName: "topic",
@@ -397,6 +397,7 @@ if (args[0] === 'pr' && args[1] === 'view') {
     } else if (args.some(arg => arg.includes('viewerMergeBodyText'))) {
       value = { data: { repository: { pullRequest: {
         headRefOid: control.metadata.headRefOid,
+        author: control.metadata.author,
         isMergeQueueEnabled: control.metadata.isMergeQueueEnabled,
         viewerMergeBodyText: 'Reviewed fixture body',
       } } } };
@@ -409,6 +410,16 @@ if (args[0] === 'pr' && args[1] === 'view') {
     } else {
       throw new Error('Unexpected GraphQL request');
     }
+  } else if (new RegExp('^repos/fixture/repo/commits/[0-9a-f]{40}$').test(endpoint)) {
+    const oid = endpoint.split('/').at(-1);
+    value = {
+      commit: { author: {
+        name: runGit(['-C', origin, 'show', '-s', '--format=%an', oid]),
+        email: runGit(['-C', origin, 'show', '-s', '--format=%ae', oid]),
+      } },
+      // The fixture's test@example.invalid identity has no linked GitHub account.
+      author: null,
+    };
   } else if (endpoint === 'users/fixture') {
     value = { id: 123 };
   } else if (endpoint === 'repos/fixture/repo/collaborators/fixture/permission') {


### PR DESCRIPTION
## What Problem This Solves

The supervised merge regression test fails on current main because its fake GitHub API does not handle the commit-author lookup introduced in #145128. This blocks unrelated PR CI, including #145183

## Why This Change Was Made

Update the main-refresh fixture to return commit author metadata from its own Git repository and include the PR author's GraphQL type. Unlinked synthetic commit authors remain `null`, matching GitHub's response; production author verification is unchanged

## User Impact

Restores the merge-tool regression check without changing production behavior

## Evidence

On baseline `1d30025c63f`, the supervised merge test fails with `Unexpected GitHub API endpoint repos/fixture/repo/commits/<sha>`. With the fixture repair, the same test passes. All 49 main-refresh tests and all 17 hosted-merge tests pass. These are the only two consumers of the shared fixture. Focused lint, formatting, and scoped autoreview pass

The original CI failure is [checks-node-compact-small-28](https://github.com/openclaw/openclaw/actions/runs/34637193392/job/103388057313). The fixture and production API caller were unchanged by the UI PR
