### PR TITLE
refactor: derive status report inputs from table helpers

### DIFF
--- a/src/commands/status-all/report-lines.ts
+++ b/src/commands/status-all/report-lines.ts
@@ -19,45 +19,17 @@ import { appendStatusReportHeading, appendStatusReportTable } from "./text-repor
 
 type OverviewRow = { Item: string; Value: string };
 
-type ChannelsTable = {
-  rows: Array<{
-    id: string;
-    label: string;
-    enabled: boolean;
-    state: "ok" | "warn" | "off" | "setup";
-    detail: string;
-  }>;
-  details: Array<{
-    title: string;
-    columns: string[];
-    rows: Array<Record<string, string>>;
-  }>;
-};
-
-type ChannelIssueLike = {
-  channel: string;
-  message: string;
-};
-
-type AgentStatusLike = {
-  agents: Array<{
-    id: string;
-    name?: string | null;
-    bootstrapPending?: boolean | null;
-    sessionsCount: number;
-    lastActiveAgeMs?: number | null;
-    sessionsPath: string;
-  }>;
-};
-
 /** Builds the complete status-all text report, including overview tables and diagnosis lines. */
 export async function buildStatusAllReportLines(params: {
   progress: ProgressReporter;
   configDiagnostics: BestEffortConfigSnapshot["configDiagnostics"];
   overviewRows: OverviewRow[];
-  channels: ChannelsTable;
-  channelIssues: ChannelIssueLike[];
-  agentStatus: AgentStatusLike;
+  channels: {
+    rows: Array<Parameters<typeof buildStatusChannelsTableRows>[0]["rows"][number]>;
+    details: Parameters<typeof buildStatusChannelDetailSections>[0]["details"];
+  };
+  channelIssues: Array<Parameters<typeof buildStatusChannelsTableRows>[0]["channelIssues"][number]>;
+  agentStatus: Parameters<typeof buildStatusAgentTableRows>[0]["agentStatus"];
   connectionDetailsForReport: string;
   diagnosis: Omit<
     Parameters<typeof appendStatusAllDiagnosis>[0],

--- a/src/commands/status.command-report-data.ts
+++ b/src/commands/status.command-report-data.ts
@@ -69,18 +69,9 @@ export async function buildStatusCommandReportData(params: {
     agents: AgentLocalStatus[];
   };
   channels: {
-    rows: Array<{
-      id: string;
-      label: string;
-      enabled: boolean;
-      state: "ok" | "warn" | "off" | "setup";
-      detail: string;
-    }>;
+    rows: Array<Parameters<typeof buildStatusChannelsTableRows>[0]["rows"][number]>;
   };
-  channelIssues: Array<{
-    channel: string;
-    message: string;
-  }>;
+  channelIssues: Array<Parameters<typeof buildStatusChannelsTableRows>[0]["channelIssues"][number]>;
   memory: MemoryStatusSnapshot | null;
   memoryPlugin: MemoryPluginStatus;
   pluginCompatibility: PluginCompatibilityNotice[];


### PR DESCRIPTION
## What Problem This Solves

This maintainer-requested cleanup removes duplicate input type definitions from the standard and full `openclaw status` reports. Those copies describe data already accepted by the table helpers, leaving multiple places to maintain the same contract. It is not a claimed runtime bug fix.

## Why This Change Was Made

The report inputs derive their channel-row, channel-issue, channel-detail and minimal agent shapes from the existing consuming helpers. Mutable outer arrays remain mutable, and optional fields and nullable values retain their existing contracts. The full renderer is not changed to require a producer's entire return type.

Only two production files change relative to the refreshed base: **+8/−45, net −37 lines**. No runtime expressions, imports, dependencies, configuration, public aliases or output formatting change in this cleanup. No test edits are added by the cleanup; the refreshed base includes the canonical upstream fixture repairs described below. The separate private diagnosis annotation and the standard renderer's minimal optional inputs remain intact.

## User Impact

No intended user-visible change. Standard and full status reports keep their current output and accepted inputs; developers have fewer duplicate type definitions to maintain. Update behavior is unchanged: no updater, Doctor, service lifecycle, config/state migration or plugin-loading runtime code is changed by these two type-only edits.

## Evidence

The refreshed signed source commit is `422693167914ca466d47161ffa8eade7e2481dce`, with sole raw parent `3111f4a1eb164f5da6cecd5834dc5ddcd19a3035` and tree `62331cba78362f2cd536330ac78f2a4339560f4d`. All **41,065** tracked physical entries were checked against that parent plus exactly the two reviewed afterimages. Both afterimages are byte-identical to the original published cleanup; the following fresh proof is bound to this new source rather than relabeled from the original run.

- **Fresh compiler contract comparison:** six actual-module TypeScript 6.0.3 programs on the normally installed Node 26.8.2 cover original/candidate in both exact-optional-property modes and ten negative controls per mode. Literal shape, requiredness, optionality, mutability, state values, `any`/`never`, and whole exported function/namespace contracts are checked. All four positive witnesses pass, and all twenty controls are detected. Complete normalized source diagnostic arrays match at **1 with EOPT off and 16,943 with EOPT on**. Both full-program results remain non-green: this is contract equality, not a clean whole-project TypeScript build. All four whole-module isolated JavaScript outputs match, and a runtime-edit polarity control changes the output. Input and installed-file/link bindings were verified at completion.
- **Fresh runtime composition:** the same ordinary eight-file selection passes **51 cases** on signed4226, through the normal unit-fast8 and commands43 owners, with no internal retry, skipped case or unhandled error. Per-file ordered case arrays and duplicate multiplicities match the historical original/candidate pair, which separately passed51 on each side under Node26.8.1. The fresh Node26.8.2 run includes main's canonical typed runtime helper in the existing statusCommand fixture; it is not a fabricated new paired baseline. It exercises real statusCommand/data/renderer/table code with synthetic scan/service/Gateway inputs, not an installed package or live Gateway. Global scheduling order and speedup are not claimed. Native process groups joined and the owned generation was removed.
- **Fresh required changed checks:** all **28 configured checks passed** on exact4226/tree62331 in [Blacksmith Testbox run34650734560](https://github.com/openclaw/openclaw/actions/runs/34650734560), including core/core-test typechecks, lint, import cycles and the selected guards. Remote proof used Linux Node24.19.0/pnpm12.3.4; native and observer exits were0. A separate status read confirmed the exact lease completed, its snapshot/private Git metadata were removed, and recorded processes were absent. The runner's targeted-sync fallback and post-success runner-portal timeout warning are retained. The successful inner command and completed lease are distinct from the backing Actions workflow: normal one-shot cleanup stopped the Testbox after success, and that outer workflow was observed cancelled. No successful outer workflow is claimed. No manual retry or provider/base/cache/worker/timeout override occurred. This gate does not erase the separate compiler comparison's baseline diagnostics.
- **Fresh exact-commit review:** a complete P0–P2 managed Codex review of signed4226 completed all **three** passes, with no actionable findings and a validated scoped-clean status. Source, refs, index and every sealed input remained unchanged. Complete affected source/callers, full impacted raw diagnostics, all six program summaries, exact comparator/contracts, runtime51 and gate28/cleanup evidence were supplied. The unrelated complete whole-program graphs and installed inventories remain hash-bound local evidence, not a claim that the model read every raw graph. Three passes are not represented as one model call seeing every context simultaneously.

### Why the base was refreshed

The original exact-head [CI run34639849880](https://github.com/openclaw/openclaw/actions/runs/34639849880) retained109 successful jobs and17 skipped jobs, but two native-PR merge tests failed, making the aggregate gate fail. Both failures came from the same shared fake-GitHub fixture rejecting the commit-author lookup introduced by [#145128](https://github.com/openclaw/openclaw/pull/145128): `pr-main-refresh.test.ts` and `pr-merge-hosted.test.ts` could not complete their intended merge-success scenarios.

The canonical shared-fixture repair already landed in [#145170](https://github.com/openclaw/openclaw/pull/145170), commit `03234b50810910cd0075a5a325073f28123d51d3`. Its raw-parent patch adds the missing commit-author response and PR-author type without weakening assertions or changing production credit rules. The branch was rebased once onto a base containing that repair, preserving only the identical two-file Status patch. No duplicate fixture edit, old-CI rerun, timeout change or flake attribution was used. The old CI checkout/relation are retained from its complete job logs; its raw merge object was unavailable locally, so an independent whole-tree comparison of that CI object is not claimed.

No package/tsdown or declaration-emission build was run, and no screenshot is needed for this type-only change. Earlier runtime-pin refusals stopped before compiler programs; the fresh comparison used the normally selected Node26.8.2 rather than a forced binary. Historical Node26.8.1 results and their1/16,903 diagnostic counts remain historical. Exact-head [GitHub CI run34656209083](https://github.com/openclaw/openclaw/actions/runs/34656209083), attempt1, has now completed SUCCESS on signed4226: **130 jobs, 113 successful and17 skipped**, including both previously failing native merge-fixture shards and the required `openclaw/ci-gate`. No manual CI rerun occurred. The latest completed ClawSweeper review (Revision3, exact4226) reports no findings and no pre-merge actions. Its cancelled outer Testbox observation is retained and distinguished from the independently recorded successful inner28 checks and normal lease cleanup above. Native landing is not yet complete; current-source, actor, rules, process, mandatory hosted preparation and merge gates remain required.
