### PR TITLE
improve: reduce config snapshot work for selected model providers

### DIFF
--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -16,6 +16,7 @@ import {
   applyMessageDefaults,
 } from "./defaults.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "./runtime-snapshot.js";
+import type { ModelProviderConfig } from "./types.models.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 const mocks = vi.hoisted(() => ({
@@ -26,8 +27,9 @@ vi.mock("./provider-policy.js", () => ({
   applyProviderConfigDefaultsForConfig: (
     ...args: Parameters<typeof mocks.applyProviderConfigDefaultsForConfig>
   ) => mocks.applyProviderConfigDefaultsForConfig(...args),
-  normalizeProviderConfigForConfigDefaults: (_params: { providerConfig: unknown }) =>
-    _params.providerConfig,
+  normalizeProviderConfigForConfigDefaults: vi.fn(
+    (_params: { providerConfig: unknown }) => _params.providerConfig,
+  ),
 }));
 
 describe("config defaults", () => {
@@ -153,7 +155,7 @@ describe("applyModelDefaults catalog seeding", () => {
         id: "openai",
         modelCatalog: {
           providers: {
-            openai: {
+            " OpenAI ": {
               models: [
                 {
                   id: "gpt-5.6-sol",
@@ -169,6 +171,9 @@ describe("applyModelDefaults catalog seeding", () => {
                 },
               ],
             },
+            openai: {
+              models: [{ id: "gpt-5.6-sol", reasoning: false, input: ["text"] }],
+            },
           },
         },
       },
@@ -179,43 +184,54 @@ describe("applyModelDefaults catalog seeding", () => {
   // Regression: an override entry pinning only sizing fields materialized as a
   // text-only, non-reasoning, zero-cost model, silently dropping vision-gated
   // tools (like `computer`) for that model downstream.
-  it("fills omitted fields from the owning catalog row before generic defaults", async () => {
-    const { applyModelDefaults } = await import("./defaults.js");
-    const cfg = applyModelDefaults(
-      {
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://api.openai.com/v1",
-              models: [
-                // SAFETY: mirrors a real operator config entry that omits input/reasoning/cost.
-                {
-                  id: "gpt-5.6-sol",
-                  name: "GPT-5.6",
-                  contextWindow: 1_050_000,
-                  contextTokens: 922_000,
-                } as never,
-              ],
+  it.each([
+    { providerId: "openai", generatedRows: false },
+    { providerId: " OpenAI ", generatedRows: true },
+  ])(
+    "seeds $providerId models (normalizer supplies rows: $generatedRows)",
+    async ({ providerId, generatedRows }) => {
+      const { applyModelDefaults } = await import("./defaults.js");
+      const { normalizeProviderConfigForConfigDefaults } = await import("./provider-policy.js");
+      // SAFETY: config schema accepts omitted model metadata before materialization.
+      const models = [
+        {
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6",
+          contextWindow: 1_050_000,
+          contextTokens: 922_000,
+        },
+      ] as ModelProviderConfig["models"];
+      vi.mocked(normalizeProviderConfigForConfigDefaults).mockImplementationOnce((params) =>
+        generatedRows ? { ...params.providerConfig, models } : params.providerConfig,
+      );
+      const cfg = applyModelDefaults(
+        {
+          models: {
+            providers: {
+              [providerId]: {
+                baseUrl: "https://api.openai.com/v1",
+                models: generatedRows ? [] : models,
+              },
             },
           },
         },
-      },
-      { manifestRegistry: catalogRegistry },
-    );
-    const model = expectDefined(
-      cfg.models?.providers?.openai?.models?.[0],
-      "materialized model entry",
-    );
-    expect(model.input).toEqual(["text", "image"]);
-    expect(model.reasoning).toBe(true);
-    expect(model.cost).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
-    expect(model.maxTokens).toBe(128_000);
-    expect(model.thinkingLevelMap).toEqual({ off: "none" });
-    // Authored fields stay authoritative.
-    expect(model.contextWindow).toBe(1_050_000);
-    expect(model.contextTokens).toBe(922_000);
-    expect(model.name).toBe("GPT-5.6");
-  });
+        { manifestRegistry: catalogRegistry },
+      );
+      const model = expectDefined(
+        cfg.models?.providers?.[providerId]?.models?.[0],
+        "materialized model entry",
+      );
+      expect(model.input).toEqual(["text", "image"]);
+      expect(model.reasoning).toBe(true);
+      expect(model.cost).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
+      expect(model.maxTokens).toBe(128_000);
+      expect(model.thinkingLevelMap).toEqual({ off: "none" });
+      // Authored fields stay authoritative.
+      expect(model.contextWindow).toBe(1_050_000);
+      expect(model.contextTokens).toBe(922_000);
+      expect(model.name).toBe("GPT-5.6");
+    },
+  );
 
   it("keeps authored metadata authoritative over the catalog row", async () => {
     const { applyModelDefaults } = await import("./defaults.js");

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -176,6 +176,7 @@ type CatalogSeedModel = Pick<
 function buildManifestCatalogModelLookup(
   manifestRegistry: Pick<PluginManifestRegistry, "plugins"> | undefined,
   policies: ReturnType<typeof collectManifestModelIdNormalizationPolicies> | undefined,
+  configuredProviderIds: ReadonlySet<string>,
 ): (providerId: string, modelId: string) => Partial<CatalogSeedModel> | undefined {
   const plugins = manifestRegistry?.plugins;
   if (!plugins || plugins.length === 0) {
@@ -193,6 +194,9 @@ function buildManifestCatalogModelLookup(
         for (const [catalogProviderId, provider] of Object.entries(
           plugin.modelCatalog?.providers ?? {},
         )) {
+          if (!configuredProviderIds.has(normalizeProviderId(catalogProviderId))) {
+            continue;
+          }
           for (const model of provider.models) {
             const key = keyFor(catalogProviderId, model.id);
             if (!index.has(key)) {
@@ -223,6 +227,7 @@ export function applyModelDefaults(
     const resolveCatalogModel = buildManifestCatalogModelLookup(
       manifestRegistry,
       modelIdNormalizationPolicies,
+      new Set(Object.keys(providerConfig).map(normalizeProviderId)),
     );
     const nextProviders = { ...providerConfig };
     for (const [providerId, provider] of Object.entries(providerConfig)) {


### PR DESCRIPTION
## What Problem This Solves

Config snapshots index model seed rows for every manifest provider even when the configuration uses only a small subset. A broad catalog therefore adds unnecessary work to repeated config reads.

## Why This Change Was Made

Restrict the existing operation-local seed index to normalized configured provider IDs. Selected providers retain their original row order, first-winner precedence, model-ID policies, authored overrides, and cloned metadata. Provider normalization can still supply rows for initially empty configurations. No persistent cache or second metadata owner is introduced.

## User Impact

Config reads do less work when a broad catalog supplies defaults for a small configured-provider subset. This does not establish a whole-Gateway startup improvement.

## Evidence

The actual `readConfigFileSnapshotWithPluginMetadata` boundary was measured using 32 providers and 4,097 model IDs, with one/all/no configured-provider cases. Each fresh process retained a cold sample, three warmups, and ten warm samples. B1→C1 and C2→B2 orders used the same corrected fixture and source inputs.

With one configured provider, the pooled warm snapshot median was 3.549 ms before and 0.781 ms after (78.0% lower); CPU median was 4.269 ms before and 1.428 ms after. The benefit appeared in both orders:

| Case | Original 1 | Candidate 1 | Candidate 2 | Original 2 |
| --- | ---: | ---: | ---: | ---: |
| One provider, warm wall median | 3.407 ms | 0.793 ms | 0.748 ms | 3.621 ms |
| All providers, warm wall median | 6.462 ms | 6.657 ms | 6.340 ms | 7.247 ms |
| No providers, warm wall median | 0.557 ms | 0.495 ms | 0.565 ms | 0.567 ms |

Controls were mixed: the first all-provider comparison became slightly slower, and some whole-process RSS observations increased. No consistent control-path or memory improvement is claimed. Cold observations and all native wall/CPU/RSS values remain retained separately; they are not pooled into the warm result.

All 12 child processes closed successfully. Full source/runtime configuration JSON and V8-encoded values matched across versions for each case. Normalized first-winner selection and nested mutation isolation passed; all diagnostics and stderr were empty. The synthetic plugin runtime throws if evaluated, so this exercises metadata without provider execution.

The initial fixture was rejected because its 879,607-byte manifest exceeded the existing 256 KiB limit. That failure was retained. The corrected fixture preserves all provider/model IDs and full metadata on configured and collision rows, using supported id-only records elsewhere; its manifest is 82,455 bytes. No production limit or path validation was changed, and all comparisons above use the corrected run only.

All 83 focused defaults/provider/snapshot tests and repository-selected changed checks passed. Independent Codex review was clean through P2. The full suite was not run locally; hosted CI remains a landing gate.

## Update behavior

This changes only which unused rows an ephemeral lookup indexes. It adds no schema, configuration option, persisted representation, migration, or altered defaulting behavior. Existing operator configuration and manifest inputs produce the same source/runtime values; cloning and authored precedence remain unchanged. Release-note context stays in this PR because the changelog is release-owned.

## CI follow-up

The initial CI run failed in two unrelated PR-tooling fixtures because their fake GitHub API lacked a commit-author endpoint. The branch was rebased onto an existing main revision containing that fixture repair; both failed test cases then passed locally. The optimization patch and both changed file hashes are identical across the rebase. The original failed CI logs are retained, and fresh hosted CI must pass before landing.

Performance evidence compares the frozen baseline with this same source delta; it was not rerun or relabeled to hide the CI failure.

The refreshed CI run then hit a one-second watchdog in the unchanged OpenAI speech runtime contract. This TTS-only fixture directly registers its provider and never enters model catalog defaulting. The log does not establish whether setup, transport, or cleanup stalled. The original failure is retained; the single failed shard passed on one unchanged re-run, with no timeout or assertion changes. All required checks are now green at the reviewed head.
