### PR TITLE
test(pr): model commit author lookup in merge fixtures

### DIFF
--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -397,6 +397,7 @@ if (args[0] === 'pr' && args[1] === 'view') {
     } else if (args.some(arg => arg.includes('viewerMergeBodyText'))) {
       value = { data: { repository: { pullRequest: {
         headRefOid: control.metadata.headRefOid,
+        author: { login: control.metadata.author.login, __typename: 'User' },
         isMergeQueueEnabled: control.metadata.isMergeQueueEnabled,
         viewerMergeBodyText: 'Reviewed fixture body',
       } } } };
@@ -411,6 +412,15 @@ if (args[0] === 'pr' && args[1] === 'view') {
     }
   } else if (endpoint === 'users/fixture') {
     value = { id: 123 };
+  } else if (/^repos\\/fixture\\/repo\\/commits\\/[0-9a-f]{40}$/.test(endpoint)) {
+    const oid = endpoint.split('/').at(-1);
+    value = {
+      commit: { author: {
+        name: runGit(['-C', origin, 'show', '-s', '--format=%an', oid]),
+        email: runGit(['-C', origin, 'show', '-s', '--format=%ae', oid]),
+      } },
+      author: { login: control.metadata.author.login, type: 'User' },
+    };
   } else if (endpoint === 'repos/fixture/repo/collaborators/fixture/permission') {
     if (control.authorPermission === 'error') process.exit(1);
     value = { permission: control.authorPermission };


### PR DESCRIPTION
## What Problem This Solves

Main now resolves commit authors during native PR landing, but the shared synthetic GitHub fixture rejects that new API call. Two existing merge-workflow tests fail before they reach their assertions; this also blocks unrelated PR CI.

## Why This Change Was Made

Teach the existing fixture the exact commit-author endpoint and the PR author shape returned by the landing metadata query. Read author name/email from the synthetic origin commit instead of inventing attribution. Production landing code and existing assertions remain unchanged.

## User Impact

Restores the merge-workflow regression tests and removes an inherited CI failure affecting unrelated changes. The missing fixture response followed #145128; it was reproduced on current main independently of the delivery changes in #145168.

## Evidence

Both reported cases fail on unchanged main with the unsupported commit endpoint. All 66 tests across the two complete consumer files pass after the ten-line fixture repair. Full changed checks, whitespace checks, and independent review through P2 pass. No checks or production behavior were weakened.
