### PR TITLE
refactor(memory): own source indexing on its database

### DIFF
--- a/extensions/memory-core/src/memory-entry-origins.ts
+++ b/extensions/memory-core/src/memory-entry-origins.ts
@@ -9,6 +9,10 @@ import {
   withOpenClawAgentDatabaseReadOnly,
 } from "openclaw/plugin-sdk/sqlite-runtime";
 import { DREAMS_FILENAMES, readDreamsFile } from "./dreaming-dreams-file.js";
+import {
+  ensureMemorySessionTombstones,
+  memorySessionTombstonesExist,
+} from "./memory-session-tombstones.js";
 import { extractPromotionKeys } from "./short-term-promotion-memory-write.js";
 
 type MemoryOriginClass = "owner" | "agent" | "untrusted" | "system";
@@ -52,7 +56,6 @@ type MemoryOriginDatabase = {
   memory_index_chunks: { text: string; source: string };
 };
 const ensuredDatabases = new WeakSet<DatabaseSync>();
-const ensuredTombstoneDatabases = new WeakSet<DatabaseSync>();
 
 function openMemoryOriginDatabase(agentId: string): DatabaseSync {
   const db = openOpenClawAgentDatabase({ agentId }).db;
@@ -121,7 +124,7 @@ export function listMemorySessionTombstones(params: {
     return [];
   }
   const result = withOpenClawAgentDatabaseReadOnly(({ db }) => {
-    if (!ensuredTombstoneDatabases.has(db) && !tableExists(db, "memory_session_tombstones")) {
+    if (!memorySessionTombstonesExist(db)) {
       return [];
     }
     const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
@@ -153,15 +156,7 @@ export function recordMemorySessionTombstones(params: {
     return 0;
   }
   const db = openOpenClawAgentDatabase({ agentId: params.agentId }).db;
-  if (!ensuredTombstoneDatabases.has(db)) {
-    db.exec(`CREATE TABLE IF NOT EXISTS memory_session_tombstones (
-      session_id TEXT NOT NULL PRIMARY KEY,
-      agent_id TEXT NOT NULL,
-      reason TEXT NOT NULL,
-      created_at INTEGER NOT NULL
-    ) STRICT`);
-    ensuredTombstoneDatabases.add(db);
-  }
+  ensureMemorySessionTombstones(db);
   const reason = params.reason ?? "forgotten";
   const createdAt = params.createdAt ?? Date.now();
   return runSqliteImmediateTransactionSync(db, () => {
@@ -195,27 +190,6 @@ export function recordMemorySessionTombstones(params: {
     }
     return recorded;
   });
-}
-
-export function hasMemorySessionTombstone(
-  db: DatabaseSync,
-  agentId: string,
-  sessionId: string,
-): boolean {
-  if (!ensuredTombstoneDatabases.has(db) && !tableExists(db, "memory_session_tombstones")) {
-    return false;
-  }
-  const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
-  return (
-    executeSqliteQuerySync(
-      db,
-      kysely
-        .selectFrom("memory_session_tombstones")
-        .select("session_id")
-        .where("agent_id", "=", agentId)
-        .where("session_id", "=", sessionId),
-    ).rows.length > 0
-  );
 }
 
 export function recordMemoryEntryOrigins(params: {

--- a/extensions/memory-core/src/memory-session-tombstones.ts
+++ b/extensions/memory-core/src/memory-session-tombstones.ts
@@ -1,0 +1,49 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+  tableExists,
+} from "openclaw/plugin-sdk/sqlite-runtime";
+
+type TombstoneDatabase = {
+  memory_session_tombstones: { session_id: string; agent_id: string };
+};
+
+const ensuredDatabases = new WeakSet<DatabaseSync>();
+
+export function memorySessionTombstonesExist(db: DatabaseSync): boolean {
+  return ensuredDatabases.has(db) || tableExists(db, "memory_session_tombstones");
+}
+
+export function ensureMemorySessionTombstones(db: DatabaseSync): void {
+  if (ensuredDatabases.has(db)) {
+    return;
+  }
+  db.exec(`CREATE TABLE IF NOT EXISTS memory_session_tombstones (
+      session_id TEXT NOT NULL PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    ) STRICT`);
+  ensuredDatabases.add(db);
+}
+
+export function hasMemorySessionTombstone(
+  db: DatabaseSync,
+  agentId: string,
+  sessionId: string,
+): boolean {
+  if (!memorySessionTombstonesExist(db)) {
+    return false;
+  }
+  return (
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<TombstoneDatabase>(db)
+        .selectFrom("memory_session_tombstones")
+        .select("session_id")
+        .where("agent_id", "=", agentId)
+        .where("session_id", "=", sessionId),
+    ).rows.length > 0
+  );
+}

--- a/extensions/memory-core/src/memory/manager-chunk-writer.test.ts
+++ b/extensions/memory-core/src/memory/manager-chunk-writer.test.ts
@@ -11,10 +11,12 @@ const CHUNK_WRITE_TABLES = [
   "memory_index_chunk_provenance",
 ];
 
+const PREPARED_WRITE_TABLES = [...CHUNK_WRITE_TABLES, "memory_index_chunks_fts"];
+
 function chunkWriteTables(sqls: string[]): string[] {
   return sqls.flatMap((sql) => {
     const table = /^\s*INSERT INTO "?(\w+)"?\s*\(/i.exec(sql)?.[1];
-    return table && CHUNK_WRITE_TABLES.includes(table) ? [table] : [];
+    return table && PREPARED_WRITE_TABLES.includes(table) ? [table] : [];
   });
 }
 
@@ -82,7 +84,7 @@ describe("memory chunk publication", () => {
         const nonemptyFiles = db
           .prepare("SELECT DISTINCT path, source FROM memory_index_chunks")
           .all().length;
-        for (const table of CHUNK_WRITE_TABLES) {
+        for (const table of PREPARED_WRITE_TABLES) {
           expect(
             preparedTables.filter((prepared) => prepared === table),
             table,

--- a/extensions/memory-core/src/memory/manager-database-context.ts
+++ b/extensions/memory-core/src/memory/manager-database-context.ts
@@ -2,8 +2,10 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import { closeMemoryDatabase } from "./manager-db.js";
+import { MemorySourceIndexKernel } from "./manager-source-index-kernel.js";
 
 export class MemoryIndexDatabase {
+  readonly sourceIndex: MemorySourceIndexKernel;
   readonly vector: {
     enabled: boolean;
     available: boolean | null;
@@ -26,7 +28,9 @@ export class MemoryIndexDatabase {
     readonly db: DatabaseSync,
     readonly release: () => void = () => closeMemoryDatabase(db),
     readonly readOnly = false,
-  ) {}
+  ) {
+    this.sourceIndex = new MemorySourceIndexKernel(db, this);
+  }
 }
 
 // One process-lifetime container; stores belong only to their awaited rebuild.

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -18,8 +18,6 @@ import {
   hashText,
   isFileMissingError,
   MEMORY_EMBEDDING_CACHE_TABLE,
-  MEMORY_INDEX_FTS_TABLE,
-  MEMORY_INDEX_VECTOR_TABLE,
   MEMORY_SEARCH_DEADLINE_CONTROL,
   remapChunkLines,
   retryTransientMemoryRead,
@@ -37,11 +35,11 @@ import {
   runSqliteImmediateTransactionSync,
 } from "openclaw/plugin-sdk/sqlite-runtime";
 import { chunkItems } from "openclaw/plugin-sdk/text-chunking";
-import { hasMemorySessionTombstone } from "../memory-entry-origins.js";
+import { hasMemorySessionTombstone } from "../memory-session-tombstones.js";
 import { withMemoryWorkspaceLock } from "../memory-workspace-lock.js";
 import { readSessionResetRecallCutoffMetadata } from "../session-reset-recall-metadata.js";
 import type { EmbeddingProvider } from "./embeddings.js";
-import { createMemoryChunkWriter, type IndexedMemoryChunk } from "./manager-chunk-writer.js";
+import type { IndexedMemoryChunk } from "./manager-chunk-writer.js";
 import { readMemoryDatabaseRevision } from "./manager-db.js";
 import {
   clearMemoryEmbeddingCacheIdentities,
@@ -71,11 +69,8 @@ import {
   type MemorySyncProviderGeneration,
 } from "./manager-sync-ops.js";
 import { logMemoryVectorDegradedWrite } from "./manager-vector-warning.js";
-import { replaceMemoryVectorRow } from "./manager-vector-write.js";
 import { resolveMemoryPathClassification } from "./memory-path-provenance.js";
 
-const VECTOR_TABLE = MEMORY_INDEX_VECTOR_TABLE;
-const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const EMBEDDING_CACHE_PRUNE_BATCH_SIZE = 100;
 const EMBEDDING_BATCH_MAX_TOKENS = 8000;
@@ -921,18 +916,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  private upsertFileRecord(entry: MemoryIndexEntry, source: MemorySource): void {
-    this.db
-      .prepare(
-        `INSERT INTO memory_index_sources (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(path, source) DO UPDATE SET
-           hash=excluded.hash,
-           mtime=excluded.mtime,
-           size=excluded.size`,
-      )
-      .run(entry.path, source, entry.hash, entry.mtimeMs, entry.size);
-  }
-
   private async writeChunks(
     { entry, source, chunks }: PreparedMemoryIndexEntry,
     generation: MemorySyncProviderGeneration | null,
@@ -959,55 +942,30 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         }
         const now = Date.now();
         const model = generation?.provider?.model ?? "fts-only";
-        const needsVectorRebuild =
-          !vectorReady && embeddings.some((embedding) => embedding.length > 0);
         return () => {
-          if (source === "sessions") {
-            const sessionId = expectDefined(entry.sessionId, "memory index session identity");
-            // Embedding and vector setup may await while a purge completes. Read the
-            // live owner, never the shadow index, immediately before publishing.
-            if (
-              hasMemorySessionTombstone(generation?.database.db ?? this.db, this.agentId, sessionId)
-            ) {
-              this.markFailedFullReindexRetry({ memory: false, sessions: true });
-              throw new Error(
-                "A session was forgotten while memory indexing was running; retry the memory index.",
-              );
-            }
-          }
-          this.clearIndexedFileData(entry.path, source);
-          const writeChunk = createMemoryChunkWriter(this.db, {
-            path: entry.path,
-            source,
-            model,
-            now,
-          });
-          for (const [i, chunk] of chunks.entries()) {
-            const embedding = embeddings[i] ?? [];
-            const id = hashText(
-              `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
+          const result = this.database.sourceIndex.replace(
+            {
+              entry,
+              chunks,
+              embeddings,
+              model,
+              now,
+              vectorReady,
+              ...(source === "sessions"
+                ? {
+                    source,
+                    agentId: this.agentId,
+                    sessionId: expectDefined(entry.sessionId, "memory index session identity"),
+                  }
+                : { source }),
+            },
+            (generation?.database ?? this.database).sourceIndex,
+          );
+          if (result === "forgotten") {
+            this.markFailedFullReindexRetry({ memory: false, sessions: true });
+            throw new Error(
+              "A session was forgotten while memory indexing was running; retry the memory index.",
             );
-            writeChunk(id, chunk, embedding);
-            if (vectorReady && embedding.length > 0) {
-              replaceMemoryVectorRow({
-                db: this.db,
-                tableName: VECTOR_TABLE,
-                id,
-                embedding,
-              });
-            }
-            if (this.fts.enabled && this.fts.available) {
-              this.db
-                .prepare(
-                  `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
-                    ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
-                )
-                .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
-            }
-          }
-          this.upsertFileRecord(entry, source);
-          if (needsVectorRebuild) {
-            this.markVectorRebuildRequired();
           }
           return true;
         };

--- a/extensions/memory-core/src/memory/manager-memory-source-race.test.ts
+++ b/extensions/memory-core/src/memory/manager-memory-source-race.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { DatabaseSync } from "node:sqlite";
+import { DatabaseSync } from "node:sqlite";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { hashText } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
@@ -131,4 +132,65 @@ describe("memory source changes during indexing", () => {
       }
     },
   );
+
+  it("revalidates the file after a real SQLite BEGIN collision before replacing its index", async () => {
+    const memoryPath = path.join(fixture.paths.memory, "contended.md");
+    await fs.writeFile(memoryPath, "Original indexed source.");
+    const manager = await fixture.getFreshManager(
+      fixture.createConfig({ provider: "none", sources: ["memory"], vectorEnabled: false }),
+      "cli",
+    );
+    await manager.sync({ reason: "baseline", force: true });
+    await fs.writeFile(memoryPath, "Obsolete source waiting for the writer.");
+    Reflect.set(manager, "dirty", true);
+    const databasePath = manager.status().dbPath;
+    if (!databasePath) {
+      throw new Error("Expected a memory index database path");
+    }
+    const db = Reflect.get(manager, "db") as DatabaseSync;
+    const peer = new DatabaseSync(databasePath);
+    const collision = createDeferred<void>();
+    let collisionObserved = false;
+    const exec = db.exec.bind(db);
+    const execSpy = vi.spyOn(db, "exec").mockImplementation((sql) => {
+      try {
+        exec(sql);
+      } catch (error) {
+        if (sql === "BEGIN IMMEDIATE") {
+          collisionObserved = true;
+          collision.resolve();
+        }
+        throw error;
+      }
+    });
+    peer.exec("BEGIN IMMEDIATE");
+    const sync = manager.sync({ reason: "watch" });
+    try {
+      await Promise.race([collision.promise, sync]);
+      expect(collisionObserved).toBe(true);
+      expect(peer.isTransaction).toBe(true);
+      await fs.writeFile(memoryPath, "Current source after the writer collision.");
+      peer.exec("ROLLBACK");
+      await sync;
+      expect(
+        db
+          .prepare("SELECT text FROM memory_index_chunks WHERE path = ?")
+          .all("memory/contended.md"),
+      ).toEqual([{ text: "Original indexed source." }]);
+      expect(manager.status().dirty).toBe(true);
+      await manager.sync({ reason: "retry-current-source" });
+      expect(
+        db
+          .prepare("SELECT text FROM memory_index_chunks WHERE path = ?")
+          .all("memory/contended.md"),
+      ).toEqual([{ text: "Current source after the writer collision." }]);
+    } finally {
+      if (peer.isTransaction) {
+        peer.exec("ROLLBACK");
+      }
+      await sync.catch(() => undefined);
+      execSpy.mockRestore();
+      peer.close();
+    }
+  });
 });

--- a/extensions/memory-core/src/memory/manager-source-index-kernel.test.ts
+++ b/extensions/memory-core/src/memory/manager-source-index-kernel.test.ts
@@ -1,0 +1,171 @@
+import { DatabaseSync } from "node:sqlite";
+import {
+  ensureMemoryIndexSchema,
+  loadSqliteVecExtension,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { runSqliteImmediateTransactionSync } from "openclaw/plugin-sdk/sqlite-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureMemorySessionTombstones } from "../memory-session-tombstones.js";
+import { MemoryIndexDatabase } from "./manager-database-context.js";
+import type { MemorySourceIndexReplacement } from "./manager-source-index-kernel.js";
+
+const databases: MemoryIndexDatabase[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) {
+    database.release();
+  }
+});
+
+async function createDatabase(): Promise<MemoryIndexDatabase> {
+  const db = new DatabaseSync(":memory:", { allowExtension: true });
+  const database = new MemoryIndexDatabase(db);
+  databases.push(database);
+  const schema = ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true });
+  expect(schema.ftsAvailable).toBe(true);
+  const vector = await loadSqliteVecExtension({ db });
+  expect(vector.ok).toBe(true);
+  db.exec(
+    "CREATE VIRTUAL TABLE memory_index_chunks_vec USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[3])",
+  );
+  database.fts.enabled = true;
+  database.fts.available = true;
+  database.vector.enabled = true;
+  database.vector.available = true;
+  return database;
+}
+
+function replacement(path: string, hash = "original"): MemorySourceIndexReplacement {
+  return {
+    source: "memory",
+    entry: { path, hash, mtimeMs: 100.25, size: 12 },
+    model: "test-model",
+    now: 100,
+    vectorReady: true,
+    embeddings: [[1, 0, 0]],
+    chunks: [
+      {
+        startLine: 1,
+        endLine: 1,
+        text: `${hash} indexed text`,
+        hash,
+        importance: 7,
+        triggers: "indexed",
+        projectKey: "project",
+        provenance: { originClass: "owner", sessionKind: "interactive", observedAt: 90 },
+      },
+    ],
+  };
+}
+
+function write(database: MemoryIndexDatabase, value: MemorySourceIndexReplacement) {
+  return runSqliteImmediateTransactionSync(database.db, () =>
+    database.sourceIndex.replace(value, database.sourceIndex),
+  );
+}
+
+function snapshot(db: DatabaseSync) {
+  return [
+    "memory_index_sources",
+    "memory_index_chunks",
+    "memory_index_chunk_recall_metadata",
+    "memory_index_chunk_provenance",
+    "memory_index_chunks_fts",
+    "memory_index_paths_fts",
+    "memory_index_state",
+  ]
+    .map((table) => db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all())
+    .concat([
+      db
+        .prepare("SELECT id, hex(embedding) AS embedding FROM memory_index_chunks_vec ORDER BY id")
+        .all(),
+    ]);
+}
+
+describe("memory source index native kernel", () => {
+  it("rolls back every index representation when the final source upsert fails", async () => {
+    const database = await createDatabase();
+    const beforeValue = replacement("memory/current.md");
+    write(database, beforeValue);
+    write(database, replacement("memory/sibling.md"));
+    const before = snapshot(database.db);
+    database.db.exec(`CREATE TRIGGER fail_source_update
+      AFTER UPDATE ON memory_index_sources
+      BEGIN SELECT RAISE(FAIL, 'source upsert failed'); END`);
+    expect(() => write(database, replacement(beforeValue.entry.path, "updated"))).toThrow(
+      "source upsert failed",
+    );
+    expect(snapshot(database.db)).toEqual(before);
+    database.db.exec("DROP TRIGGER fail_source_update");
+    expect(write(database, replacement(beforeValue.entry.path, "updated"))).toBe("replaced");
+    expect(database.db.prepare("SELECT text FROM memory_index_chunks ORDER BY path").all()).toEqual(
+      [{ text: "updated indexed text" }, { text: "original indexed text" }],
+    );
+  });
+
+  it("conditionally removes all source representations while retaining a sibling", async () => {
+    const database = await createDatabase();
+    write(database, replacement("memory/current.md"));
+    write(database, replacement("memory/sibling.md"));
+    const before = snapshot(database.db);
+    const remove = (expectedHash: string) =>
+      runSqliteImmediateTransactionSync(database.db, () =>
+        database.sourceIndex.deleteIfCurrent({
+          path: "memory/current.md",
+          source: "memory",
+          expectedHash,
+        }),
+      );
+    expect(remove("stale")).toBe(false);
+    expect(snapshot(database.db)).toEqual(before);
+    expect(remove("original")).toBe(true);
+    for (const table of [
+      "memory_index_sources",
+      "memory_index_chunks",
+      "memory_index_chunks_fts",
+      "memory_index_paths_fts",
+    ]) {
+      expect(database.db.prepare(`SELECT path FROM ${table}`).all()).toEqual([
+        { path: "memory/sibling.md" },
+      ]);
+    }
+    for (const table of [
+      "memory_index_chunk_recall_metadata",
+      "memory_index_chunk_provenance",
+      "memory_index_chunks_vec",
+    ]) {
+      expect(database.db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()).toEqual({
+        count: 1,
+      });
+    }
+  });
+
+  it("checks the canonical tombstone connection before changing a shadow index", async () => {
+    const canonical = await createDatabase();
+    const shadow = await createDatabase();
+    const value: MemorySourceIndexReplacement = {
+      ...replacement("sessions/current.jsonl"),
+      source: "sessions",
+      agentId: "main",
+      sessionId: "session-one",
+    };
+    write(shadow, value);
+    const before = snapshot(shadow.db);
+    ensureMemorySessionTombstones(canonical.db);
+    canonical.db
+      .prepare("INSERT INTO memory_session_tombstones VALUES (?, ?, ?, ?)")
+      .run("session-one", "main", "forgotten", 200);
+    expect(
+      runSqliteImmediateTransactionSync(shadow.db, () =>
+        shadow.sourceIndex.replace(
+          { ...value, entry: { ...value.entry, hash: "updated" } },
+          canonical.sourceIndex,
+        ),
+      ),
+    ).toBe("forgotten");
+    expect(snapshot(shadow.db)).toEqual(before);
+    expect(canonical.db.prepare("SELECT COUNT(*) AS count FROM memory_index_chunks").get()).toEqual(
+      { count: 0 },
+    );
+  });
+});

--- a/extensions/memory-core/src/memory/manager-source-index-kernel.ts
+++ b/extensions/memory-core/src/memory/manager-source-index-kernel.ts
@@ -1,0 +1,190 @@
+import type { DatabaseSync, StatementSync } from "node:sqlite";
+import {
+  hashText,
+  MEMORY_INDEX_FTS_TABLE,
+  MEMORY_INDEX_VECTOR_TABLE,
+  type MemorySource,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "openclaw/plugin-sdk/sqlite-runtime";
+import { hasMemorySessionTombstone } from "../memory-session-tombstones.js";
+import { createMemoryChunkWriter, type IndexedMemoryChunk } from "./manager-chunk-writer.js";
+import {
+  markMemoryVectorRebuildRequired,
+  memoryTableExists,
+} from "./manager-vector-rebuild-state.js";
+import { replaceMemoryVectorRow } from "./manager-vector-write.js";
+
+export type MemorySourceIndexReplacement = {
+  entry: { path: string; hash: string; mtimeMs: number; size: number };
+  chunks: IndexedMemoryChunk[];
+  embeddings: number[][];
+  model: string;
+  now: number;
+  vectorReady: boolean;
+} & ({ source: "memory" } | { source: "sessions"; agentId: string; sessionId: string });
+
+type SourceIndexDatabase = {
+  memory_index_sources: {
+    path: string;
+    source: MemorySource;
+    hash: string;
+    mtime: number;
+    size: number;
+  };
+  memory_index_chunks: { path: string; source: MemorySource };
+};
+
+type SourceIndexState = {
+  vector: { enabled: boolean; available: boolean | null };
+  fts: { enabled: boolean; available: boolean };
+};
+
+export function readMemorySourceHash(
+  db: DatabaseSync,
+  source: MemorySource,
+  path: string,
+): string | undefined {
+  return executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<SourceIndexDatabase>(db)
+      .selectFrom("memory_index_sources")
+      .select("hash")
+      .where("path", "=", path)
+      .where("source", "=", source),
+  )?.hash;
+}
+
+// The caller retains transaction admission and repeats file validation before
+// each BEGIN attempt. This kernel runs only inside that admitted native transaction.
+export class MemorySourceIndexKernel {
+  constructor(
+    private readonly database: DatabaseSync,
+    private readonly state: SourceIndexState,
+  ) {}
+
+  replace(
+    params: MemorySourceIndexReplacement,
+    sessionAuthority: MemorySourceIndexKernel,
+  ): "replaced" | "forgotten" {
+    const { entry, source, chunks, embeddings, model, now, vectorReady } = params;
+    // A shadow index must consult the live generation's tombstones at publication.
+    if (
+      params.source === "sessions" &&
+      hasMemorySessionTombstone(sessionAuthority.database, params.agentId, params.sessionId)
+    ) {
+      return "forgotten";
+    }
+    this.clear(entry.path, source);
+    const writeChunk = createMemoryChunkWriter(this.database, {
+      path: entry.path,
+      source,
+      model,
+      now,
+    });
+    let ftsStatement: StatementSync | undefined;
+    for (const [index, chunk] of chunks.entries()) {
+      const embedding = embeddings[index] ?? [];
+      const id = hashText(
+        `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
+      );
+      writeChunk(id, chunk, embedding);
+      if (vectorReady && embedding.length > 0) {
+        replaceMemoryVectorRow({
+          db: this.database,
+          tableName: MEMORY_INDEX_VECTOR_TABLE,
+          id,
+          embedding,
+        });
+      }
+      if (this.state.fts.enabled && this.state.fts.available) {
+        ftsStatement ??= this.database.prepare(
+          `INSERT INTO ${MEMORY_INDEX_FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
+            ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        );
+        ftsStatement.run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
+      }
+    }
+    const db = getNodeSqliteKysely<SourceIndexDatabase>(this.database);
+    executeSqliteQuerySync(
+      this.database,
+      db
+        .insertInto("memory_index_sources")
+        .values({
+          path: entry.path,
+          source,
+          hash: entry.hash,
+          mtime: entry.mtimeMs,
+          size: entry.size,
+        })
+        .onConflict((conflict) =>
+          conflict.columns(["path", "source"]).doUpdateSet((eb) => ({
+            hash: eb.ref("excluded.hash"),
+            mtime: eb.ref("excluded.mtime"),
+            size: eb.ref("excluded.size"),
+          })),
+        ),
+    );
+    if (!vectorReady && embeddings.some((embedding) => embedding.length > 0)) {
+      markMemoryVectorRebuildRequired(this.database);
+    }
+    return "replaced";
+  }
+
+  deleteIfCurrent(params: {
+    path: string;
+    source: MemorySource;
+    expectedHash: string | undefined;
+  }): boolean {
+    if (readMemorySourceHash(this.database, params.source, params.path) !== params.expectedHash) {
+      return false;
+    }
+    this.clear(params.path, params.source);
+    executeSqliteQuerySync(
+      this.database,
+      getNodeSqliteKysely<SourceIndexDatabase>(this.database)
+        .deleteFrom("memory_index_sources")
+        .where("path", "=", params.path)
+        .where("source", "=", params.source),
+    );
+    return true;
+  }
+
+  private clear(pathname: string, source: MemorySource): void {
+    if (memoryTableExists(this.database, MEMORY_INDEX_VECTOR_TABLE)) {
+      if (!this.state.vector.enabled || this.state.vector.available !== true) {
+        markMemoryVectorRebuildRequired(this.database);
+      } else {
+        try {
+          this.database
+            .prepare(
+              `DELETE FROM ${MEMORY_INDEX_VECTOR_TABLE} WHERE id IN (
+               SELECT id FROM memory_index_chunks WHERE path = ? AND source = ?
+             )`,
+            )
+            .run(pathname, source);
+        } catch {
+          markMemoryVectorRebuildRequired(this.database);
+        }
+      }
+    }
+    if (this.state.fts.enabled && this.state.fts.available) {
+      try {
+        // Lexical search is model-agnostic; remove every model for this source.
+        this.database
+          .prepare(`DELETE FROM ${MEMORY_INDEX_FTS_TABLE} WHERE path = ? AND source = ?`)
+          .run(pathname, source);
+      } catch {}
+    }
+    executeSqliteQuerySync(
+      this.database,
+      getNodeSqliteKysely<SourceIndexDatabase>(this.database)
+        .deleteFrom("memory_index_chunks")
+        .where("path", "=", pathname)
+        .where("source", "=", source),
+    );
+  }
+}

--- a/extensions/memory-core/src/memory/manager-source-state.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.ts
@@ -10,10 +10,10 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   executeSqliteQuerySync,
-  executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
   sqliteStringSet,
 } from "openclaw/plugin-sdk/sqlite-runtime";
+import { readMemorySourceHash } from "./manager-source-index-kernel.js";
 
 export type MemorySourceFileStateRow = {
   path: string;
@@ -120,12 +120,5 @@ export function resolveMemorySourceExistingHash(params: {
   if (params.existingHashes) {
     return params.existingHashes.get(params.path);
   }
-  return executeSqliteQueryTakeFirstSync(
-    params.db,
-    getNodeSqliteKysely<MemorySourceDatabase>(params.db)
-      .selectFrom("memory_index_sources")
-      .select("hash")
-      .where("path", "=", params.path)
-      .where("source", "=", params.source),
-  )?.hash;
+  return readMemorySourceHash(params.db, params.source, params.path);
 }

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -6,7 +6,6 @@ import {
   type SessionTranscriptCorpusEntry,
 } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import {
-  MEMORY_INDEX_FTS_TABLE,
   runWithConcurrency,
   type MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
@@ -30,7 +29,6 @@ import type {
   MemorySyncProgressState,
 } from "./manager-sync-base.js";
 
-const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const SOURCE_SYNC_YIELD_EVERY = 10;
 const SOURCE_WIDE_SESSION_INDEX_FLUSH_FILES = 128;
 const log = createSubsystemLogger("memory");
@@ -48,36 +46,13 @@ function createSourceSyncYield(total: number): () => Promise<void> {
 }
 
 export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyncOps {
-  protected clearIndexedFileData(pathname: string, source: MemorySource): void {
-    this.deleteVectorRowsForSource(pathname, source);
-    if (this.fts.enabled && this.fts.available) {
-      try {
-        // Lexical search is model-agnostic; remove every model for this source.
-        this.db
-          .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
-          .run(pathname, source);
-      } catch {}
-    }
-    this.db
-      .prepare("DELETE FROM memory_index_chunks WHERE path = ? AND source = ?")
-      .run(pathname, source);
-  }
-
   protected async deleteIndexedFile(
     pathname: string,
     source: MemorySource,
     expectedHash = resolveMemorySourceExistingHash({ db: this.db, path: pathname, source }),
   ): Promise<void> {
     await runSqliteImmediateTransaction(this.db, async () => () => {
-      if (
-        resolveMemorySourceExistingHash({ db: this.db, path: pathname, source }) !== expectedHash
-      ) {
-        return;
-      }
-      this.clearIndexedFileData(pathname, source);
-      this.db
-        .prepare("DELETE FROM memory_index_sources WHERE path = ? AND source = ?")
-        .run(pathname, source);
+      this.database.sourceIndex.deleteIfCurrent({ path: pathname, source, expectedHash });
     });
   }
 

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -40,11 +40,7 @@ import {
   type MemoryIndexProviderIdentity,
 } from "./manager-reindex-state.js";
 import { MemorySyncOutcomeLedger } from "./manager-sync-outcome.js";
-import {
-  markMemoryVectorRebuildRequired,
-  memoryTableExists,
-  requiresMemoryVectorRebuild,
-} from "./manager-vector-rebuild-state.js";
+import { memoryTableExists, requiresMemoryVectorRebuild } from "./manager-vector-rebuild-state.js";
 import { buildMemorySourceFilter } from "./source-filter.js";
 import type { MemoryWatchSettleQueue } from "./watch-settle.js";
 
@@ -520,31 +516,6 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
       log.warn(`sqlite-vec unavailable: ${message}`);
       return false;
     }
-  }
-
-  protected deleteVectorRowsForSource(pathname: string, source: MemorySource): void {
-    if (!memoryTableExists(this.db, VECTOR_TABLE)) {
-      return;
-    }
-    if (!this.vector.enabled || this.vector.available !== true) {
-      this.markVectorRebuildRequired();
-      return;
-    }
-    try {
-      this.db
-        .prepare(
-          `DELETE FROM ${VECTOR_TABLE} WHERE id IN (
-             SELECT id FROM memory_index_chunks WHERE path = ? AND source = ?
-           )`,
-        )
-        .run(pathname, source);
-    } catch {
-      this.markVectorRebuildRequired();
-    }
-  }
-
-  protected markVectorRebuildRequired(): void {
-    markMemoryVectorRebuildRequired(this.db);
   }
 
   private hasVectorRebuildMarker(): boolean {

--- a/extensions/memory-core/src/memory/manager.borrowed-connection.test.ts
+++ b/extensions/memory-core/src/memory/manager.borrowed-connection.test.ts
@@ -206,7 +206,7 @@ describe("memory manager shared agent connection", () => {
     closeOpenClawAgentDatabasesForTest();
     expect(originalDb.isOpen).toBe(false);
     const replacement = await fixture.getFreshManager(createConfig());
-    expect(replacement).not.toBe(first);
+    expect(replacement === first).toBe(false);
     const shared = sqliteRuntime.openOpenClawAgentDatabase({ agentId: "main" });
     expect(managerDatabase(replacement) === shared.db).toBe(true);
     await first.close();


### PR DESCRIPTION
## What Problem This Solves

One memory source update currently spreads its SQL across embedding and synchronization code. That makes it difficult to move database execution while preserving the complete chunk, source, recall, provenance, FTS, and vector mutation.

## Why This Change Was Made

Give the existing memory database owner a connection-bound source-index kernel for complete replacement and conditional deletion. Ordinary source writes use Kysely, existing prepared chunk writers remain shared, and FTS insertion is prepared once per nonempty file. The native tombstone reader and its unchanged schema guard now live apart from database-opening code.

The existing admission loop still validates filesystem content after every failed BEGIN attempt. Session writes consult the explicit canonical authority connection while updating a shadow. Native transaction callbacks, retry marking, vector rebuild markers, and cleanup behavior remain intact.

## User Impact

Memory indexing keeps its current SQLite data and publication behavior, with fewer FTS statement preparations for multi-chunk files. This prepares a complete native operation for the future shared database worker owner; physical execution remains on the current owner.

## Evidence

- Manager, source-race, session-forget, origins, reindex recovery, and native kernel tests passed: 84 initial cases, the added real SQLite contention case, and final affected/native reruns.
- Native rollback proof covers all index representations after a late source upsert failure. Conditional deletion preserves siblings, and canonical tombstones refuse shadow writes before mutation.
- A real manager retry after a SQLite BEGIN collision revalidates changed filesystem content before indexing it.
- A standalone writer performed 20 ten-chunk source replacements; a fresh process reopened exact source, chunk, recall, provenance, FTS, and vector data and passed integrity checks.
- Full `node scripts/check-changed.mjs`, `git diff --check`, and fresh isolated Codex review through P2 passed.

Measured on the loaded local host: 20 synthetic ten-chunk replacements had a 7.01 ms median and 13.48 ms p95. These describe the candidate workload; they are not a before/after speedup claim.

CI on the original feature head exposed Vitest 5's eager deep-equality diagnostics in `expect(replacement).not.toBe(first)`: the diagnostic traversal inspected the revoked native handle. The assertion now uses the adjacent strict boolean-identity pattern. Its original shared-handle, old-release, replacement sync, and search assertions remain intact. The complete borrowed-connection file and native/publication/reindex/search owners passed all 60 tests; the full repaired candidate gate and fresh P2 review passed.

Both commits were rebased onto `21b105c0f33f567e433ab700c8e3e00404d5db32`, which includes the upstream CI fixture repair and awaited memory lease cleanup. The authored patch and all 12 file hashes are unchanged by that rebase.

On the rebased candidate, all 43 coupling tests passed across borrowed connections, native source mutations, generation admission/release, cancellation, and manager teardown.

Storage compatibility: the `memory_session_tombstones` DDL literal is byte-identical between pre-change `3ac42154d14a98ab2393e68bb3285df77c512b14` and this candidate. A synthetic database created from that prior definition, closed, and reopened with the candidate helper preserved its existing row and schema, retained agent-scoped tombstone lookup, and passed SQLite integrity checking. This verifies the relocated table contract; the refactor introduces no migration.
