### PR TITLE
refactor(usage): await database admission and retain cache ownership

### DIFF
--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -123,6 +123,15 @@ validation. After removing a derived archive file, pruning reacquires before the
 canonical row-deletion transaction; an acquisition failure propagates without
 deleting that recovery row.
 
+Usage-cache rollup writes, pruning, and refresh-lock changes use the same async
+agent-database admission. A cold mutation waits for the existing integrity worker;
+its compare-and-set transaction remains synchronous on the admitted connection.
+Refresh completion and cleanup await persistence. Operations capture their resolved
+database path before admission, and refresh-lock release retains that path and its
+original environment when the caller's directory or environment changes. Doctor reports rejected
+pruning operations before continuing to the next agent. Read-only cache snapshots
+retain their existing synchronous owner and do not create missing databases.
+
 ### Preserve the data and concurrency contracts
 
 An adapter must make these contracts explicit and verify them against a real

--- a/src/commands/doctor-agent-database-operation.ts
+++ b/src/commands/doctor-agent-database-operation.ts
@@ -13,10 +13,30 @@ export function runDoctorAgentDatabaseOperation<T>(params: {
   try {
     return { ok: true, value: params.run() };
   } catch (error) {
-    note(
-      `- Agent ${params.agentId} database ${shortenHomePath(params.path)}: ${formatErrorMessage(error)}`,
-      "Doctor warnings",
-    );
+    noteDoctorAgentDatabaseFailure(params, error);
     return { ok: false };
   }
+}
+
+export async function runDoctorAgentDatabaseOperationAsync<T>(params: {
+  agentId: string;
+  path: string;
+  run: () => Promise<T>;
+}): Promise<DoctorAgentDatabaseOperationResult<T>> {
+  try {
+    return { ok: true, value: await params.run() };
+  } catch (error) {
+    noteDoctorAgentDatabaseFailure(params, error);
+    return { ok: false };
+  }
+}
+
+function noteDoctorAgentDatabaseFailure(
+  params: { agentId: string; path: string },
+  error: unknown,
+): void {
+  note(
+    `- Agent ${params.agentId} database ${shortenHomePath(params.path)}: ${formatErrorMessage(error)}`,
+    "Doctor warnings",
+  );
 }

--- a/src/commands/doctor-usage-cost-cache.test.ts
+++ b/src/commands/doctor-usage-cost-cache.test.ts
@@ -102,35 +102,52 @@ describe("legacy usage-cost cache cleanup", () => {
     await expect(fs.readFile(path.join(external, "keep.txt"), "utf8")).resolves.toBe("keep");
   });
 
-  it("removes retired usage rows from every registered agent database", async () => {
-    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-usage-cost-sqlite-doctor-"));
-    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
-    const databases = ["main", "worker"].map((agentId) =>
-      openOpenClawAgentDatabase({ agentId, env }),
-    );
-    for (const database of databases) {
-      const insert = database.db.prepare(
-        "INSERT INTO cache_entries (scope, key, value_json, blob, expires_at, updated_at) VALUES (?, ?, ?, NULL, NULL, 1)",
-      );
-      insert.run("session-cost-usage-rollup-v1", "retired", '{"pricingFingerprint":"large"}');
-      insert.run("session-cost-usage-rollup-v2", "current", "{}");
-      insert.run("session-cost-usage", "cache", "{}");
-      insert.run("session-cost-usage", "refresh-lock", "{}");
-      insert.run("other", "keep", "{}");
-    }
+  it.each([false, true])(
+    "continues retired-row cleanup after a rejected write (rejectFirst=%s)",
+    async (rejectFirst) => {
+      root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-usage-cost-sqlite-doctor-"));
+      const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+      const firstDatabase = openOpenClawAgentDatabase({ agentId: "main", env });
+      const databases = [firstDatabase, openOpenClawAgentDatabase({ agentId: "worker", env })];
+      for (const database of databases) {
+        const insert = database.db.prepare(
+          "INSERT INTO cache_entries (scope, key, value_json, blob, expires_at, updated_at) VALUES (?, ?, ?, NULL, NULL, 1)",
+        );
+        insert.run("session-cost-usage-rollup-v1", "retired", '{"pricingFingerprint":"large"}');
+        insert.run("session-cost-usage-rollup-v2", "current", "{}");
+        insert.run("session-cost-usage", "cache", "{}");
+        insert.run("session-cost-usage", "refresh-lock", "{}");
+        insert.run("other", "keep", "{}");
+      }
 
-    await maybeRepairLegacyRuntimeFiles(true, env);
+      if (rejectFirst) {
+        firstDatabase.db.exec(`
+        CREATE TEMP TRIGGER reject_usage_pruning BEFORE DELETE ON cache_entries
+        BEGIN SELECT RAISE(ABORT, 'pruning rejected'); END;
+      `);
+      }
+      await maybeRepairLegacyRuntimeFiles(true, env);
 
-    for (const database of databases) {
-      expect(
-        database.db.prepare("SELECT scope, key FROM cache_entries ORDER BY scope, key").all(),
-      ).toEqual([
-        { key: "keep", scope: "other" },
-        { key: "refresh-lock", scope: "session-cost-usage" },
-        { key: "current", scope: "session-cost-usage-rollup-v2" },
-      ]);
-    }
-  });
+      if (rejectFirst) {
+        expect(note).toHaveBeenCalledWith(
+          expect.stringContaining("pruning rejected"),
+          "Doctor warnings",
+        );
+        expect(
+          firstDatabase.db.prepare("SELECT count(*) AS count FROM cache_entries").get(),
+        ).toEqual({ count: 5 });
+      }
+      for (const database of rejectFirst ? databases.slice(1) : databases) {
+        expect(
+          database.db.prepare("SELECT scope, key FROM cache_entries ORDER BY scope, key").all(),
+        ).toEqual([
+          { key: "keep", scope: "other" },
+          { key: "refresh-lock", scope: "session-cost-usage" },
+          { key: "current", scope: "session-cost-usage-rollup-v2" },
+        ]);
+      }
+    },
+  );
 
   it.each([
     [

--- a/src/commands/doctor-usage-cost-cache.ts
+++ b/src/commands/doctor-usage-cost-cache.ts
@@ -8,7 +8,7 @@ import { formatErrorMessage, hasErrnoCode } from "../infra/errors.js";
 import { deleteSessionCostUsageRollupsExcept } from "../infra/session-cost-usage-cache.sqlite.js";
 import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db.js";
 import { shortenHomePath } from "../utils.js";
-import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
+import { runDoctorAgentDatabaseOperationAsync } from "./doctor-agent-database-operation.js";
 import { maybeScrubConfigAuditLog } from "./doctor-config-audit-scrub.js";
 
 const LEGACY_USAGE_COST_TEMP_GRACE_MS = 10_000;
@@ -175,12 +175,13 @@ export async function maybeRepairLegacyRuntimeFiles(
   if (shouldRepair) {
     for (const entry of listOpenClawRegisteredAgentDatabases({ env })) {
       if ((await fs.stat(entry.path).catch(() => null))?.isFile()) {
-        runDoctorAgentDatabaseOperation({
+        await runDoctorAgentDatabaseOperationAsync({
           agentId: entry.agentId,
           path: entry.path,
           run: () =>
             deleteSessionCostUsageRollupsExcept({
               agentId: entry.agentId,
+              env,
               databasePath: entry.path,
               liveKeys: new Set(),
               // Doctor retires old scopes only; current v2 rows are not prune candidates.

--- a/src/infra/session-cost-usage-aggregation.ts
+++ b/src/infra/session-cost-usage-aggregation.ts
@@ -584,8 +584,11 @@ export async function refreshCostUsageCacheForAgent(params: {
   sessionFiles?: string[];
   startMs?: number;
 }): Promise<UsageCostRefreshResult> {
-  const databasePath = params.databasePath ?? resolveUsageCostCacheDatabasePath(params.agentId);
-  const lock = acquireSessionCostUsageRefreshLock(params.agentId, databasePath);
+  const databasePath = resolveOpenClawAgentSqlitePath({
+    agentId: normalizeAgentId(params.agentId),
+    path: params.databasePath,
+  });
+  const lock = await acquireSessionCostUsageRefreshLock(params.agentId, databasePath);
   if (!lock.acquired) {
     return "busy";
   }
@@ -613,7 +616,7 @@ export async function refreshCostUsageCacheForAgent(params: {
       filesByPath.set(file.filePath, file);
     }
     const files = [...filesByPath.values()];
-    deleteSessionCostUsageRollupsExcept({
+    await deleteSessionCostUsageRollupsExcept({
       agentId: params.agentId,
       databasePath,
       liveKeys: new Set(files.map((file) => file.filePath)),
@@ -648,7 +651,7 @@ export async function refreshCostUsageCacheForAgent(params: {
         resolveCost,
       });
       const valueJson = JSON.stringify(entry);
-      const written = writeSessionCostUsageRollup({
+      const written = await writeSessionCostUsageRollup({
         agentId: params.agentId,
         databasePath,
         rollupId: file.filePath,
@@ -664,6 +667,6 @@ export async function refreshCostUsageCacheForAgent(params: {
     }
     return "refreshed";
   } finally {
-    lock.release();
+    await lock.release();
   }
 }

--- a/src/infra/session-cost-usage-cache-runtime.ts
+++ b/src/infra/session-cost-usage-cache-runtime.ts
@@ -85,7 +85,7 @@ export async function loadCostUsageSummary(params: {
     refreshing:
       result === "busy" ||
       isUsageCostRefreshQueued(databasePath) ||
-      isSessionCostUsageRefreshRunning(params.agentId, databasePath),
+      (await isSessionCostUsageRefreshRunning(params.agentId, databasePath)),
   });
 }
 
@@ -130,7 +130,7 @@ export async function loadCostUsageSummaryFromCache(params: {
     dayBucket: params.dayBucket,
     refreshing:
       isUsageCostRefreshQueued(databasePath) ||
-      isSessionCostUsageRefreshRunning(params.agentId, databasePath),
+      (await isSessionCostUsageRefreshRunning(params.agentId, databasePath)),
   });
 }
 
@@ -189,7 +189,7 @@ export async function loadSessionCostSummariesFromCache(params: {
       sessionFiles: [...staleFiles],
     });
   }
-  const refreshRunning = isSessionCostUsageRefreshRunning(params.agentId, databasePath);
+  const refreshRunning = await isSessionCostUsageRefreshRunning(params.agentId, databasePath);
   return {
     summaries,
     cacheStatus: {

--- a/src/infra/session-cost-usage-cache.admission.test.ts
+++ b/src/infra/session-cost-usage-cache.admission.test.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import {
+  closeOpenClawAgentDatabasesAsync,
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  withOpenClawAgentDatabaseAsync,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { refreshCostUsageCacheForAgent } from "./session-cost-usage-aggregation.js";
+import {
+  acquireSessionCostUsageRefreshLock,
+  isSessionCostUsageRefreshRunning,
+  readSessionCostUsageRollupRows,
+  writeSessionCostUsageRollup,
+} from "./session-cost-usage-cache.sqlite.js";
+import * as integrityWorker from "./sqlite-integrity-worker.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await closeOpenClawAgentDatabasesAsync();
+  closeOpenClawStateDatabaseForTest();
+});
+
+it.each([
+  { closing: false, retarget: false, refresh: false },
+  { closing: true, retarget: false, refresh: false },
+  { closing: false, retarget: true, refresh: false },
+  { closing: false, retarget: true, refresh: true },
+])(
+  "joins pending native admission before a usage write (closing=$closing, retarget=$retarget, refresh=$refresh)",
+  async ({ closing, retarget, refresh }) => {
+    const root = tempDirs.make("openclaw-usage-admission-");
+    await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => {
+      const agentId = "usage-test";
+      const databasePath = openOpenClawAgentDatabase({ agentId }).path;
+      closeOpenClawAgentDatabasesForTest();
+      const cwd = retarget
+        ? vi.spyOn(process, "cwd").mockReturnValue(path.dirname(databasePath))
+        : undefined;
+      const retargeted = path.join(root, "other-cwd");
+      if (retarget) {
+        fs.mkdirSync(retargeted);
+      }
+      const sessionsDir = path.join(root, "sessions");
+      const sessionFile = path.join(sessionsDir, "session.jsonl");
+      if (refresh) {
+        fs.mkdirSync(sessionsDir);
+        fs.writeFileSync(
+          sessionFile,
+          JSON.stringify({ message: { role: "user", content: "hello" } }),
+        );
+      }
+      const cachePath = retarget ? path.basename(databasePath) : databasePath;
+      const nativeFinished = createDeferredCore();
+      const release = createDeferredCore();
+      const check = integrityWorker.assertSqliteIntegrityInWorker;
+      vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker").mockImplementation(
+        async (...args) => {
+          try {
+            await check(...args);
+            nativeFinished.resolve();
+            await release.promise;
+          } catch (error) {
+            nativeFinished.reject(error);
+            throw error;
+          }
+        },
+      );
+      const opening = withOpenClawAgentDatabaseAsync(
+        { agentId, path: databasePath },
+        () => undefined,
+      );
+      const opened = Promise.allSettled([opening]);
+      let writeSettled = false;
+      const writing = Promise.resolve()
+        .then(async () =>
+          refresh
+            ? await refreshCostUsageCacheForAgent({
+                agentId,
+                databasePath: cachePath,
+                sessionsDir,
+                agentDir: path.join(root, "agent-config"),
+              })
+            : await writeSessionCostUsageRollup({
+                agentId,
+                databasePath: cachePath,
+                rollupId: "session.jsonl",
+                previousValueJson: null,
+                valueJson: '{"totalTokens":7}',
+                updatedAt: 1,
+              }),
+        )
+        .finally(() => {
+          writeSettled = true;
+        });
+      const written = Promise.allSettled([writing]);
+      let drain: Promise<void> | undefined;
+      let drained = false;
+      try {
+        await nativeFinished.promise;
+        await setImmediate();
+        expect(writeSettled).toBe(false);
+        expect(readSessionCostUsageRollupRows(agentId, databasePath)).toEqual([]);
+        cwd?.mockReturnValue(retargeted);
+        if (closing) {
+          drain = closeOpenClawAgentDatabasesAsync(root).then(() => {
+            drained = true;
+          });
+          await setImmediate();
+          expect(drained).toBe(false);
+        }
+        release.resolve();
+        await opened;
+        const [outcome] = await written;
+        if (closing) {
+          await drain;
+          expect(outcome.status).toBe("rejected");
+          expect(readSessionCostUsageRollupRows(agentId, databasePath)).toEqual([]);
+        } else {
+          expect(outcome).toEqual({ status: "fulfilled", value: refresh ? "refreshed" : true });
+          expect(fs.existsSync(path.join(retargeted, path.basename(databasePath)))).toBe(false);
+          const rows = readSessionCostUsageRollupRows(agentId, databasePath);
+          if (refresh) {
+            expect(rows.map((row) => row.key)).toEqual([sessionFile]);
+          } else {
+            expect(rows).toEqual([
+              { key: "session.jsonl", valueJson: '{"totalTokens":7}', updatedAt: 1 },
+            ]);
+          }
+        }
+      } finally {
+        release.resolve();
+        await opened;
+        await written;
+        await drain;
+      }
+    });
+  },
+);
+
+it("keeps refresh ownership after a rejected release until deletion commits", async () => {
+  const root = tempDirs.make("openclaw-usage-lock-release-");
+  await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => {
+    const agentId = "usage-test";
+    const owners = await Promise.all([
+      acquireSessionCostUsageRefreshLock(agentId),
+      acquireSessionCostUsageRefreshLock(agentId),
+    ]);
+    expect(owners.map((owner) => owner.acquired)).toEqual([true, false]);
+    await owners[1].release();
+    expect(await isSessionCostUsageRefreshRunning(agentId)).toBe(true);
+    const database = openOpenClawAgentDatabase({ agentId });
+    database.db.exec(`
+      CREATE TEMP TRIGGER reject_refresh_release BEFORE DELETE ON cache_entries
+      WHEN OLD.scope = 'session-cost-usage' AND OLD.key = 'refresh-lock'
+      BEGIN SELECT RAISE(ABORT, 'release rejected'); END;
+    `);
+    await expect(owners[0].release()).rejects.toThrow("release rejected");
+    expect(await isSessionCostUsageRefreshRunning(agentId)).toBe(true);
+    database.db.exec("DROP TRIGGER reject_refresh_release");
+    await owners[0].release();
+    expect(await isSessionCostUsageRefreshRunning(agentId)).toBe(false);
+    const replacement = await acquireSessionCostUsageRefreshLock(agentId);
+    expect(replacement.acquired).toBe(true);
+    await owners[0].release();
+    expect(await isSessionCostUsageRefreshRunning(agentId)).toBe(true);
+    await replacement.release();
+  });
+});
+
+it("reports a live refresh that replaces the stale lock before cleanup admission", async () => {
+  const root = tempDirs.make("openclaw-usage-status-race-");
+  await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => {
+    const agentId = "usage-test";
+    const database = openOpenClawAgentDatabase({ agentId });
+    database.db
+      .prepare("INSERT INTO cache_entries (scope, key, value_json, updated_at) VALUES (?, ?, ?, ?)")
+      .run("session-cost-usage", "refresh-lock", "{}", 1);
+    const acquiring = acquireSessionCostUsageRefreshLock(agentId);
+    const running = isSessionCostUsageRefreshRunning(agentId);
+    const [owner, observedRunning] = await withEnvAsync(
+      { OPENCLAW_STATE_DIR: path.join(root, "other-env") },
+      () => Promise.all([acquiring, running]),
+    );
+    try {
+      expect(owner.acquired).toBe(true);
+      expect(observedRunning).toBe(true);
+    } finally {
+      await owner.release();
+    }
+  });
+});
+
+it("releases the acquired refresh lock after the caller changes its state directory", async () => {
+  const originalRoot = tempDirs.make("openclaw-usage-lock-origin-");
+  const otherRoot = tempDirs.make("openclaw-usage-lock-other-");
+  const agentId = "usage-test";
+  await withEnvAsync({ OPENCLAW_STATE_DIR: originalRoot }, async () => {
+    const databasePath = openOpenClawAgentDatabase({ agentId }).path;
+    const original = await acquireSessionCostUsageRefreshLock(agentId);
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: otherRoot }, async () => {
+        const other = await acquireSessionCostUsageRefreshLock(agentId);
+        try {
+          await original.release();
+          expect(await isSessionCostUsageRefreshRunning(agentId, databasePath)).toBe(false);
+          expect(await isSessionCostUsageRefreshRunning(agentId)).toBe(true);
+        } finally {
+          await other.release();
+        }
+      });
+    } finally {
+      await original.release();
+    }
+  });
+});

--- a/src/infra/session-cost-usage-cache.sqlite.test.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.test.ts
@@ -11,7 +11,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
-import { withEnv } from "../test-utils/env.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   deleteSessionCostUsageRollupsExcept,
   isSessionCostUsageRefreshRunning,
@@ -38,12 +38,12 @@ afterEach(() => {
 });
 
 describe("session cost usage SQLite cache", () => {
-  it("reads only requested rollups, including an empty selection", () => {
+  it("reads only requested rollups, including an empty selection", async () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-selection-");
-    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
       const agentId = "worker-1";
       for (const rollupId of ["selected.jsonl", "unrelated.jsonl"]) {
-        writeSessionCostUsageRollup({
+        await writeSessionCostUsageRollup({
           agentId,
           rollupId,
           previousValueJson: null,
@@ -59,10 +59,10 @@ describe("session cost usage SQLite cache", () => {
     });
   });
 
-  it("removes a persisted refresh lock owned by a Linux zombie", () => {
+  it("removes a persisted refresh lock owned by a Linux zombie", async () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-zombie-lock-");
 
-    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
       const agentId = "worker-1";
       const zombiePid = 4242;
       const database = openOpenClawAgentDatabase({ agentId });
@@ -83,7 +83,7 @@ describe("session cost usage SQLite cache", () => {
         return `Name:\tworker\nState:\tZ (zombie)\nPid:\t${zombiePid}\nThreads:\t1\n`;
       });
 
-      expect(isSessionCostUsageRefreshRunning(agentId, database.path)).toBe(false);
+      expect(await isSessionCostUsageRefreshRunning(agentId, database.path)).toBe(false);
       expect(
         database.db
           .prepare("SELECT value_json FROM cache_entries WHERE scope = ? AND key = ?")
@@ -92,23 +92,23 @@ describe("session cost usage SQLite cache", () => {
     });
   });
 
-  it("returns empty values without creating a missing agent database", () => {
+  it("returns empty values without creating a missing agent database", async () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-missing-");
 
-    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
       const databasePath = resolveOpenClawAgentSqlitePath({ agentId: "worker-1" });
 
       expect(readSessionCostUsageRollupRows("worker-1", databasePath)).toEqual([]);
-      expect(isSessionCostUsageRefreshRunning("worker-1", databasePath)).toBe(false);
+      expect(await isSessionCostUsageRefreshRunning("worker-1", databasePath)).toBe(false);
       expect(fs.existsSync(databasePath)).toBe(false);
       expect(fs.existsSync(path.join(stateDir, "state", "openclaw.sqlite"))).toBe(false);
     });
   });
 
-  it("does not register readonly cache reads while writes still register", () => {
+  it("does not register readonly cache reads while writes still register", async () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-registry-");
 
-    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
       const agentId = "worker-1";
       const database = openOpenClawAgentDatabase({ agentId });
       const databasePath = database.path;
@@ -119,11 +119,11 @@ describe("session cost usage SQLite cache", () => {
       expect(countRegisteredAgentDatabases()).toBe(0);
 
       expect(readSessionCostUsageRollupRows(agentId, databasePath)).toEqual([]);
-      expect(isSessionCostUsageRefreshRunning(agentId, databasePath)).toBe(false);
+      expect(await isSessionCostUsageRefreshRunning(agentId, databasePath)).toBe(false);
       expect(countRegisteredAgentDatabases()).toBe(0);
 
       expect(
-        writeSessionCostUsageRollup({
+        await writeSessionCostUsageRollup({
           agentId,
           databasePath,
           rollupId: "session.jsonl",
@@ -139,57 +139,51 @@ describe("session cost usage SQLite cache", () => {
   it.each([
     { label: "changed totals", refreshedValue: '{"totalTokens":2}' },
     { label: "unchanged totals at a newer revision", refreshedValue: '{"totalTokens":1}' },
-  ])("preserves a refreshed usage rollup with $label during pruning", ({ refreshedValue }) => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-prune-race-");
+  ])(
+    "preserves a refreshed usage rollup with $label during pruning",
+    async ({ refreshedValue }) => {
+      const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-prune-race-");
 
-    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
-      const agentId = "worker-1";
-      const rollupId = "session.jsonl";
-      const staleValue = '{"totalTokens":1}';
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const agentId = "worker-1";
+        const rollupId = "session.jsonl";
+        const staleValue = '{"totalTokens":1}';
 
-      expect(
-        writeSessionCostUsageRollup({
+        expect(
+          await writeSessionCostUsageRollup({
+            agentId,
+            rollupId,
+            previousValueJson: null,
+            valueJson: staleValue,
+            updatedAt: 1,
+          }),
+        ).toBe(true);
+        const rows = readSessionCostUsageRollupRows(agentId);
+
+        const refreshed = writeSessionCostUsageRollup({
           agentId,
           rollupId,
-          previousValueJson: null,
-          valueJson: staleValue,
-          updatedAt: 1,
-        }),
-      ).toBe(true);
-      const rows = readSessionCostUsageRollupRows(agentId);
+          previousValueJson: staleValue,
+          valueJson: refreshedValue,
+          updatedAt: 2,
+        });
+        await deleteSessionCostUsageRollupsExcept({ agentId, liveKeys: new Set(), rows });
+        expect(await refreshed).toBe(true);
 
-      const liveKeys = new (class extends Set<string> {
-        override has(key: string): boolean {
-          if (key === rollupId) {
-            expect(
-              writeSessionCostUsageRollup({
-                agentId,
-                rollupId,
-                previousValueJson: staleValue,
-                valueJson: refreshedValue,
-                updatedAt: 2,
-              }),
-            ).toBe(true);
-          }
-          return false;
-        }
-      })();
+        expect(readSessionCostUsageRollupRows(agentId)).toEqual([
+          { key: rollupId, updatedAt: 2, valueJson: refreshedValue },
+        ]);
+      });
+    },
+  );
 
-      deleteSessionCostUsageRollupsExcept({ agentId, liveKeys, rows });
-
-      expect(readSessionCostUsageRollupRows(agentId)).toEqual([
-        { key: rollupId, updatedAt: 2, valueJson: refreshedValue },
-      ]);
-    });
-  });
-
-  it("reads only v2 rollups and prunes retired usage cache rows by scope", () => {
+  it("reads only v2 rollups and prunes retired usage cache rows by scope", async () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-retired-");
 
-    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
       const agentId = "worker-1";
       expect(
-        writeSessionCostUsageRollup({
+        await writeSessionCostUsageRollup({
           agentId,
           rollupId: "current.jsonl",
           previousValueJson: null,
@@ -209,7 +203,7 @@ describe("session cost usage SQLite cache", () => {
       const rows = readSessionCostUsageRollupRows(agentId);
       expect(rows).toEqual([{ key: "current.jsonl", updatedAt: 2, valueJson: '{"version":2}' }]);
 
-      deleteSessionCostUsageRollupsExcept({
+      await deleteSessionCostUsageRollupsExcept({
         agentId,
         liveKeys: new Set(["current.jsonl"]),
         rows,

--- a/src/infra/session-cost-usage-cache.sqlite.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.ts
@@ -3,7 +3,11 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import { isPidAlive } from "../shared/pid-alive.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
-import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
+import {
+  runOpenClawAgentWriteTransaction,
+  resolveOpenClawAgentSqlitePath,
+  withOpenClawAgentDatabaseAsync,
+} from "../state/openclaw-agent-db.js";
 import { chunkItems } from "../utils/chunk-items.js";
 // Per-agent SQLite storage for rebuildable per-session usage rollups.
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
@@ -28,6 +32,28 @@ type SessionCostUsageRollupRow = {
   updatedAt: number;
   valueJson: string;
 };
+
+function captureCacheDatabaseOptions(
+  inputOptions: Parameters<typeof runOpenClawAgentWriteTransaction>[1],
+) {
+  const options = { ...inputOptions, env: { ...(inputOptions.env ?? process.env) } };
+  return { ...options, path: resolveOpenClawAgentSqlitePath(options) };
+}
+
+function runCacheWriteTransaction<T>(
+  operation: Parameters<typeof runOpenClawAgentWriteTransaction<T>>[0],
+  inputOptions: Parameters<typeof runOpenClawAgentWriteTransaction>[1],
+  transactionOptions: Parameters<typeof runOpenClawAgentWriteTransaction>[2],
+): Promise<T> {
+  const options = captureCacheDatabaseOptions(inputOptions);
+  return withOpenClawAgentDatabaseAsync(options, (database) =>
+    runOpenClawAgentWriteTransaction(
+      operation,
+      { ...options, path: database.path },
+      transactionOptions,
+    ),
+  );
+}
 
 function readCacheDatabase<T>(
   agentId: string | undefined,
@@ -72,14 +98,15 @@ function readCacheValue(
   );
 }
 
-function deleteCacheValueIfUnchanged(params: {
+async function deleteCacheValueIfUnchanged(params: {
   agentId?: string;
+  env?: NodeJS.ProcessEnv;
   databasePath?: string;
   scope: string;
   key: string;
   valueJson: string;
-}): void {
-  runOpenClawAgentWriteTransaction(
+}): Promise<void> {
+  await runCacheWriteTransaction(
     (database) => {
       const kysely = getNodeSqliteKysely<AgentCacheDatabase>(database.db);
       executeSqliteQuerySync(
@@ -93,6 +120,7 @@ function deleteCacheValueIfUnchanged(params: {
     },
     {
       agentId: normalizeAgentId(params.agentId),
+      env: params.env,
       ...(params.databasePath ? { path: params.databasePath } : {}),
     },
     { operationLabel: `session-cost-usage.${params.key}.delete` },
@@ -127,15 +155,15 @@ export function readSessionCostUsageRollupRows(
   );
 }
 
-export function writeSessionCostUsageRollup(params: {
+export async function writeSessionCostUsageRollup(params: {
   agentId?: string;
   databasePath?: string;
   rollupId: string;
   previousValueJson: string | null;
   valueJson: string;
   updatedAt: number;
-}): boolean {
-  return runOpenClawAgentWriteTransaction(
+}): Promise<boolean> {
+  return runCacheWriteTransaction(
     (database) => {
       const kysely = getNodeSqliteKysely<AgentCacheDatabase>(database.db);
       const currentValueJson =
@@ -182,14 +210,15 @@ export function writeSessionCostUsageRollup(params: {
   );
 }
 
-export function deleteSessionCostUsageRollupsExcept(params: {
+export async function deleteSessionCostUsageRollupsExcept(params: {
   agentId?: string;
+  env?: NodeJS.ProcessEnv;
   databasePath?: string;
   liveKeys: ReadonlySet<string>;
   rows: readonly SessionCostUsageRollupRow[];
-}): void {
+}): Promise<void> {
   const existing = params.rows.filter((row) => !params.liveKeys.has(row.key));
-  runOpenClawAgentWriteTransaction(
+  await runCacheWriteTransaction(
     (database) => {
       const kysely = getNodeSqliteKysely<AgentCacheDatabase>(database.db);
       for (const row of existing) {
@@ -219,6 +248,7 @@ export function deleteSessionCostUsageRollupsExcept(params: {
     },
     {
       agentId: normalizeAgentId(params.agentId),
+      env: params.env,
       ...(params.databasePath ? { path: params.databasePath } : {}),
     },
     { operationLabel: "session-cost-usage.rollup.prune" },
@@ -249,29 +279,50 @@ function parseRefreshLock(raw: string | null): SessionCostUsageRefreshLock | nul
   }
 }
 
-export function isSessionCostUsageRefreshRunning(agentId?: string, databasePath?: string): boolean {
-  const raw = readCacheValue(agentId, LEGACY_CACHE_SCOPE, REFRESH_LOCK_KEY, databasePath);
+export async function isSessionCostUsageRefreshRunning(
+  agentId?: string,
+  databasePath?: string,
+): Promise<boolean> {
+  const options = captureCacheDatabaseOptions({
+    agentId: normalizeAgentId(agentId),
+    path: databasePath,
+  });
+  const raw = readCacheValue(options.agentId, LEGACY_CACHE_SCOPE, REFRESH_LOCK_KEY, options.path);
   const lock = parseRefreshLock(raw);
   if (lock && isPidAlive(lock.pid)) {
     return true;
   }
   if (raw !== null) {
-    deleteCacheValueIfUnchanged({
-      agentId,
-      databasePath,
+    await deleteCacheValueIfUnchanged({
+      agentId: options.agentId,
+      databasePath: options.path,
+      env: options.env,
       scope: LEGACY_CACHE_SCOPE,
       key: REFRESH_LOCK_KEY,
       valueJson: raw,
     });
+    const currentLock = parseRefreshLock(
+      readCacheValue(options.agentId, LEGACY_CACHE_SCOPE, REFRESH_LOCK_KEY, options.path),
+    );
+    return currentLock !== null && isPidAlive(currentLock.pid);
   }
   return false;
 }
 
-export function acquireSessionCostUsageRefreshLock(
+export async function acquireSessionCostUsageRefreshLock(
   agentId?: string,
   databasePath?: string,
-): { acquired: boolean; release: () => void } {
-  const previousRaw = readCacheValue(agentId, LEGACY_CACHE_SCOPE, REFRESH_LOCK_KEY, databasePath);
+): Promise<{ acquired: boolean; release: () => Promise<void> }> {
+  const options = captureCacheDatabaseOptions({
+    agentId: normalizeAgentId(agentId),
+    path: databasePath,
+  });
+  const previousRaw = readCacheValue(
+    options.agentId,
+    LEGACY_CACHE_SCOPE,
+    REFRESH_LOCK_KEY,
+    options.path,
+  );
   const previousLock = parseRefreshLock(previousRaw);
   // Process liveness is resolved before BEGIN. The transaction only compares
   // the authoritative row and commits the prepared replacement synchronously.
@@ -282,7 +333,7 @@ export function acquireSessionCostUsageRefreshLock(
     ownerNonce: `${process.pid}:${Date.now()}:${process.hrtime.bigint()}`,
   };
   const lockJson = JSON.stringify(lock);
-  const acquired = runOpenClawAgentWriteTransaction(
+  const acquired = await runCacheWriteTransaction(
     (database) => {
       const kysely = getNodeSqliteKysely<AgentCacheDatabase>(database.db);
       const currentRaw =
@@ -321,19 +372,17 @@ export function acquireSessionCostUsageRefreshLock(
       );
       return true;
     },
-    {
-      agentId: normalizeAgentId(agentId),
-      ...(databasePath ? { path: databasePath } : {}),
-    },
+    options,
     { operationLabel: "session-cost-usage.refresh-lock.acquire" },
   );
   return {
     acquired,
-    release: () => {
+    release: async () => {
       if (acquired) {
-        deleteCacheValueIfUnchanged({
-          agentId,
-          databasePath,
+        await deleteCacheValueIfUnchanged({
+          agentId: options.agentId,
+          databasePath: options.path,
+          env: options.env,
           scope: LEGACY_CACHE_SCOPE,
           key: REFRESH_LOCK_KEY,
           valueJson: lockJson,

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -2,6 +2,7 @@
 import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { markInboundContextLabel } from "../auto-reply/reply/inbound-context-marker.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -1160,7 +1161,7 @@ describe("session cost usage", () => {
       currentRollup.version = 3;
       currentRollup.rollup.untimestamped.totals.totalTokens = 9_999;
       expect(
-        writeSessionCostUsageRollup({
+        await writeSessionCostUsageRollup({
           agentId: "main",
           rollupId: sessionFile,
           previousValueJson: currentRow.valueJson,
@@ -1947,15 +1948,18 @@ describe("session cost usage", () => {
     );
 
     await withStateDir(root, async () => {
-      const lock = acquireSessionCostUsageRefreshLock("main");
+      const lock = await acquireSessionCostUsageRefreshLock("main");
       expect(lock.acquired).toBe(true);
-      const releaseTimer = setTimeout(lock.release, 40);
+      const released = delay(40).then(lock.release);
       try {
-        const summary = await loadSessionCostSummary({ agentId: "main", sessionFile });
+        const [summary] = await Promise.all([
+          loadSessionCostSummary({ agentId: "main", sessionFile }),
+          released,
+        ]);
         expect(summary?.totalTokens).toBe(12);
       } finally {
-        clearTimeout(releaseTimer);
-        lock.release();
+        await released;
+        await lock.release();
       }
     });
   });

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -1244,11 +1244,13 @@ describe("TUI PTY real backends", () => {
         );
         const databasePath = resolveOpenClawAgentSqlitePath({ agentId, env: fixture.env });
         const selectedSession = { agentId, sessionKey, storePath: databasePath };
-        let refreshOwner: ReturnType<typeof acquireSessionCostUsageRefreshLock> | undefined;
+        let refreshOwner:
+          | Awaited<ReturnType<typeof acquireSessionCostUsageRefreshLock>>
+          | undefined;
         // Repeated teardown must not reopen the removed root through release().
         cleanupState.run = createIdempotentCleanup(() =>
           runQaGatewayFixture(
-            async () => withEnv(fixture.env, () => refreshOwner?.release()),
+            async () => withEnvAsync(fixture.env, async () => await refreshOwner?.release()),
             () => fixture.run.dispose(),
             () =>
               withEnvAsync(fixture.env, () =>
@@ -1260,14 +1262,14 @@ describe("TUI PTY real backends", () => {
         await runQaGatewayFixture(
           async () => {
             await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
-            withEnv(fixture.env, () => {
+            await withEnvAsync(fixture.env, async () => {
               // An empty existing row still makes the direct Session reader wait.
               expect(loadSessionEntry(selectedSession)).toBeUndefined();
               if (cacheState === "refreshing") {
-                refreshOwner = acquireSessionCostUsageRefreshLock(agentId, databasePath);
+                refreshOwner = await acquireSessionCostUsageRefreshLock(agentId, databasePath);
                 expect(refreshOwner.acquired).toBe(true);
               }
-              expect(isSessionCostUsageRefreshRunning(agentId, databasePath)).toBe(
+              expect(await isSessionCostUsageRefreshRunning(agentId, databasePath)).toBe(
                 cacheState === "refreshing",
               );
             });
@@ -1297,9 +1299,9 @@ describe("TUI PTY real backends", () => {
             ].join(" ");
             expect(text).toContain(expected);
             expect(fixture.mockModel.requests()).toHaveLength(0);
-            withEnv(fixture.env, () => {
+            await withEnvAsync(fixture.env, async () => {
               expect(loadSessionEntry(selectedSession)).toBeUndefined();
-              expect(isSessionCostUsageRefreshRunning(agentId, databasePath)).toBe(
+              expect(await isSessionCostUsageRefreshRunning(agentId, databasePath)).toBe(
                 cacheState === "refreshing",
               );
             });


### PR DESCRIPTION
## What Problem This Solves

Usage reports can interrupt a database's pending cold-open checks when a cache refresh starts. A refresh can also follow a changed relative path, and Doctor must finish rejected cache cleanup before continuing to another agent.

## Why This Change Was Made

Cache mutations join the canonical per-agent database's asynchronous admission. Each operation and the complete refresh retain their resolved database location; lock release retains the acquired environment and path. Existing synchronous transactions and compare-and-set predicates remain intact. Doctor awaits each cleanup and reports failures through its per-agent warning handler. This adds no database schema, configuration option, retention policy, or external SDK compatibility change.

## User Impact

Cold cache refreshes cooperate with database opening, refresh status remains accurate when a stale lock is replaced, and a failed Doctor cleanup does not prevent the next agent's cleanup. Native cache queries and transactions remain synchronous; cold integrity admission uses the existing child process.

## Evidence

- 111 focused tests passed; final admission tests, the full changed-file gate, and independent P2 review passed on `95101214d263d3a2067e0000289f87350076dd56`.
- Native failing-before controls cover pending-open revocation, stale-lock replacement, delayed path retargeting, lock release under another environment, and the full refresh entry point.
- The [published 2026.9.3 updater](https://www.npmjs.com/package/openclaw/v/2026.9.3), source `1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7`, ran the actual `update --tag file:<candidate.tgz> --yes --no-restart --json` flow against the packed candidate `95101214` (`2026.9.4`). This supplies the published-driver × candidate Doctor cell required by [AGENTS.md:69](https://github.com/openclaw/openclaw/blob/95101214d263d3a2067e0000289f87350076dd56/AGENTS.md#L69).

| Update cell | Updater | Candidate Doctor | Cache rows |
| --- | --- | --- | --- |
| Normal | `ok`, exit 0; 96.499 s | Four observed processes, all exit 0 | Both agents: 5 → 3 |
| Native SQLite rejection | `ok`, exit 0; 77.269 s | Four observed processes, all exit 0 | Denied agent: 5 → 5; later sibling: 5 → 3 |

Both cells preserved current v2 payloads and timestamps, refresh-lock rows, and unrelated rows; only retired v1 and legacy aggregate rows were pruned. The negative cell used a scoped SQLite authorization denial at the cleanup DELETE, preserving the durable schema, and captured `Doctor warnings … not authorized`. Published backups were verified before updating. All observed processes settled; private service profiles remained absent. This was local macOS/Node 24.20.0 subprocess proof with isolated state and no real credentials or Gateway/service restart.

Candidate tarball SHA-256: `f0501dee6ef07c3ba6db6667f9fe412e8c7d3fe67403c1c45e10da8a7bf9235c`.

The packaged proof remains bound to pre-rebase `95101214`. The single commit rebased patch-identically onto `21b105c0f33f567e433ab700c8e3e00404d5db32`, which includes the upstream author-fixture repair in `03234b50810910cd0075a5a325073f28123d51d3`. Range-diff is unchanged and stable patch-id is `2b975ed178128c904dbc2a318715e5ca73b16295`; current head is `99fbe7f585929a585c2aa54a9c80efa52100f72e`. Exact-head CI is required for landing.

All five changed production modules are byte-identical across the rebase. A conservative relative static/literal-dynamic import scan after TypeScript erasure found upstream runtime changes (72 changed modules and three added modules in the reachable closure), so this is not a whole-package equivalence claim. The published-updater tarball result stays pinned to `95101214`; fresh CI checks the rebased head.

Exact rebased-head CI passed for `99fbe7f` ([run34649560189](https://github.com/openclaw/openclaw/actions/runs/34649560189)). The first attempt had one 120-second timeout in the unchanged profiling CLI validation harness; all six validation cases passed locally, and the exact failed job passed on one targeted rerun without source, assertion, or timeout changes. The 16 usage admission/Doctor tests also passed on the rebased head.
