### PR TITLE
fix(browser): warn when response bodies are truncated

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -358,6 +358,10 @@ openclaw browser trace start
 openclaw browser trace stop --out trace.zip
 ```
 
+`responsebody` writes the bounded response prefix to stdout and warns on stderr
+when it is truncated. `--json` includes the response metadata and `truncated`
+flag without a separate warning. Use `--max-chars` to select the prefix limit.
+
 ## Existing Chrome via MCP
 
 Use the built-in `user` profile, or create your own `existing-session` profile:

--- a/extensions/browser/src/cli/browser-cli-actions-observe.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-observe.test.ts
@@ -86,6 +86,50 @@ describe("browser action observe commands", () => {
   });
 
   it.each([
+    { label: "truncated prefix", body: "ABC", truncated: true, json: false },
+    { label: "empty truncated prefix", body: "", truncated: true, json: false },
+    { label: "complete at the limit", body: "ABC", truncated: undefined, json: false },
+    { label: "explicitly complete", body: "ABC", truncated: false, json: false },
+    { label: "empty complete body", body: "", truncated: undefined, json: false },
+    { label: "JSON truncated prefix", body: "ABC", truncated: true, json: true },
+  ])("reports completeness for $label without changing body output", async (testCase) => {
+    const program = createActionObserveProgram();
+    const result = {
+      ok: true,
+      response: {
+        url: "https://example.com/api",
+        status: 200,
+        body: testCase.body,
+        ...(testCase.truncated === undefined ? {} : { truncated: testCase.truncated }),
+      },
+    };
+    mocks.callBrowserRequest.mockResolvedValueOnce(result);
+
+    await program.parseAsync(
+      [
+        "browser",
+        ...(testCase.json ? ["--json"] : []),
+        "responsebody",
+        "**/api",
+        "--max-chars",
+        "3",
+      ],
+      { from: "user" },
+    );
+
+    const { runtimeLogs, runtimeErrors } = getBrowserCliRuntimeCapture();
+    expect(runtimeLogs).toHaveLength(1);
+    if (testCase.json) {
+      expect(JSON.parse(runtimeLogs[0]!)).toEqual(result);
+    } else {
+      expect(runtimeLogs).toEqual([testCase.body]);
+    }
+    expect(runtimeErrors).toEqual(
+      testCase.truncated && !testCase.json ? [expect.stringMatching(/truncat/i)] : [],
+    );
+  });
+
+  it.each([
     {
       label: "default",
       timeout: undefined,

--- a/extensions/browser/src/cli/browser-cli-actions-observe.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-observe.ts
@@ -100,7 +100,9 @@ export function registerBrowserActionObserveCommands(
       await runBrowserObserve(async () => {
         const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : undefined;
         const maxChars = Number.isFinite(opts.maxChars) ? opts.maxChars : undefined;
-        const result = await callBrowserRequest<{ response: { body: string } }>(
+        const result = await callBrowserRequest<{
+          response: { body: string; truncated?: boolean };
+        }>(
           parent,
           {
             method: "POST",
@@ -119,6 +121,11 @@ export function registerBrowserActionObserveCommands(
           return;
         }
         defaultRuntime.log(result.response.body);
+        if (result.response.truncated === true) {
+          defaultRuntime.error(
+            "Warning: response body is a truncated prefix. Use --json to inspect response metadata.",
+          );
+        }
       });
     });
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository and is writable by its maintainers.

</details>

## What Problem This Solves

Fixes an issue where users reading `openclaw browser responsebody` output could mistake a truncated response for a complete body. With `--max-chars 3`, both a complete `ABC` response and an `ABCDE` response printed only `ABC`. A Unicode-safe prefix can also be empty even when the response is not.

## Why This Change Was Made

The browser producer already records whether the response was truncated, and the Gateway preserves that fact. The CLI output handler now consumes it and emits one stderr warning for an explicitly truncated plain-text response. Body-only stdout, successful exit status, JSON metadata, request limits, and cancellation behavior stay intact.

The existing output owner absorbs the repair; no helper, fallback, configuration, protocol, or persistence path is added. Production delta is +7 lines to carry the existing flag into the type and render the notice; tests add 44 lines and docs add four.

## User Impact

Operators can tell when the displayed body is only a prefix without changing scripts that read stdout. `--json` continues to provide response metadata without a separate warning.

## Evidence

- Tests-only baseline at `48a32fc72206a8a33b997a65276facc147ccfdfc`: the two missing-warning cases failed and 13 controls passed.
- Repaired CLI output and response deadline/cancellation suites: 23 tests passed. Changed-file checks and `pnpm build ciArtifacts` passed; the baseline full `pnpm build` also passed.
- Ordinary built CLI → isolated loopback Gateway → managed Chrome → synthetic HTTP responses: six cases per phase, covering truncated ASCII, complete ASCII at the limit, and an empty Unicode-safe prefix, each in plain and JSON mode. Baseline reproduced exactly two missing notices; the candidate passed all six cases. Each phase ran 19 successful commands, with normal Gateway/Chrome shutdown and unchanged runtime hashes afterward.
- Candidate build/live evidence used the uncommitted three-file source tree based on the baseline above; that exact tree was then committed. This is source-bound precommit proof, not a claimed postcommit rerun.
- Independent Codex review of the complete final diff and source/dependency evidence: no actionable P0–P2 findings.

Observed plain-text output for a truncated `ABCDE` response with `--max-chars 3`:

```text
Before stdout: ABC
Before stderr: (empty)
After stdout:  ABC
After stderr:  Warning: response body is a truncated prefix. Use --json to inspect response metadata.
```

Complete responses and all JSON cases emitted no stderr in either phase. Hosted checks must pass on the pushed head before landing.


The first hosted CI run failed two native merge tests because its merge snapshot preceded an already-landed shared GitHub fixture repair (`03234b50810910cd0075a5a325073f28123d51d3`). The browser branch was rebased onto `97e6e3cd4e400529ff729119f5aa030e33196037` as `b3ef7e5d2f3fe3f46c8f82d21cc3bf16acd5a50a`; its patch is byte-for-byte identical. Both original failing cases pass on this head (64 unrelated cases were not selected), and all 23 browser CLI/producer tests pass again. Original build/live proof remains bound to its original tree; these are separate rebase verification results.
