### PR TITLE
perf: reduce cold imports during provider discovery

### DIFF
--- a/docs/plugins/sdk-overview/imports.md
+++ b/docs/plugins/sdk-overview/imports.md
@@ -60,6 +60,13 @@ do. Do not copy those import paths into new plugins; use injected runtime helper
 and generic channel SDK subpaths instead.
 </Warning>
 
+For provider discovery that only needs credential values, use
+`openclaw/plugin-sdk/secret-input` for `readProviderEnvValue`,
+`resolveNonEnvSecretRefApiKeyMarker`, and SecretRef coercion/normalization.
+These helpers do not load profile stores, provider transports, or web-search
+execution. Use `provider-web-search-config-contract` to read plugin-owned
+web-search config. Keep full auth and search runtime imports in execution paths.
+
 ## Subpath reference
 
 The plugin SDK is exposed as a set of narrow subpaths grouped by area (plugin

--- a/extensions/cloudflare-ai-gateway/catalog-provider.ts
+++ b/extensions/cloudflare-ai-gateway/catalog-provider.ts
@@ -5,7 +5,7 @@
 import {
   coerceSecretRef,
   resolveNonEnvSecretRefApiKeyMarker,
-} from "openclaw/plugin-sdk/provider-auth";
+} from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildCloudflareAiGatewayModelDefinition,

--- a/extensions/xai/provider-discovery.ts
+++ b/extensions/xai/provider-discovery.ts
@@ -1,6 +1,6 @@
 // Xai provider module implements model/runtime integration.
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import { readProviderEnvValue } from "openclaw/plugin-sdk/provider-web-search";
+import { readProviderEnvValue } from "openclaw/plugin-sdk/secret-input";
 import { resolveFallbackXaiAuth } from "./src/tool-auth-shared.js";
 
 const PROVIDER_ID = "xai";

--- a/extensions/xai/src/tool-auth-shared.test.ts
+++ b/extensions/xai/src/tool-auth-shared.test.ts
@@ -1,6 +1,6 @@
 // Xai tests cover tool auth shared plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { NON_ENV_SECRETREF_MARKER } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { resolveNonEnvSecretRefApiKeyMarker } from "openclaw/plugin-sdk/secret-input";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isXaiToolEnabled,
@@ -54,7 +54,7 @@ describe("xai tool auth helpers", () => {
         plugins: xaiWebSearchSecretRefPlugins("file", "vault", "/xai/tool-key"),
       }),
     ).toEqual({
-      apiKey: NON_ENV_SECRETREF_MARKER,
+      apiKey: resolveNonEnvSecretRefApiKeyMarker("file"),
       source: "plugins.entries.xai.config.webSearch.apiKey",
     });
   });

--- a/extensions/xai/src/tool-auth-shared.ts
+++ b/extensions/xai/src/tool-auth-shared.ts
@@ -1,14 +1,12 @@
 // Xai plugin module implements tool auth shared behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveProviderWebSearchPluginConfig } from "openclaw/plugin-sdk/provider-web-search-config-contract";
 import {
   coerceSecretRef,
-  resolveNonEnvSecretRefApiKeyMarker,
-} from "openclaw/plugin-sdk/provider-auth";
-import {
+  normalizeSecretInputString,
   readProviderEnvValue,
-  resolveProviderWebSearchPluginConfig,
-} from "openclaw/plugin-sdk/provider-web-search";
-import { normalizeSecretInputString } from "openclaw/plugin-sdk/secret-input";
+  resolveNonEnvSecretRefApiKeyMarker,
+} from "openclaw/plugin-sdk/secret-input";
 import {
   resolveReadOnlyEnvSecretRef,
   type ReadOnlyEnvSecretRefResolution,

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -366,7 +366,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: canonical runtime-context classifier for native history projection.
       // +1: prepared model-specific runtime choices for channel consumers.
       // +3: public provider-owned asynchronous embedding batch contract.
-      4451,
+      // +2: canonical credential-value functions through the narrow secret-input surface.
+      4453,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -499,7 +500,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: approved bounded TAR inspection through the archive admission owner.
       // +1: canonical runtime-context classifier for native history projection.
       // +1: prepared model-specific runtime choice reader.
-      2630,
+      // +2: canonical env-value reader and managed SecretRef marker constructor.
+      2632,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/model-auth-markers.test.ts
+++ b/src/agents/model-auth-markers.test.ts
@@ -4,6 +4,10 @@
  */
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  NON_ENV_SECRETREF_MARKER,
+  resolveNonEnvSecretRefApiKeyMarker,
+} from "../secrets/provider-credential-values.js";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 
 const BUNDLED_PLUGINS_DIR = fileURLToPath(new URL("../../extensions/", import.meta.url));
@@ -33,7 +37,6 @@ function cleanPluginManifestEnv(): Record<
 let listKnownProviderEnvApiKeyNames: typeof import("./model-auth-env-vars.js").listKnownProviderEnvApiKeyNames;
 let CODEX_APP_SERVER_AUTH_MARKER: typeof import("./model-auth-markers.js").CODEX_APP_SERVER_AUTH_MARKER;
 let GCP_VERTEX_CREDENTIALS_MARKER: typeof import("./model-auth-markers.js").GCP_VERTEX_CREDENTIALS_MARKER;
-let NON_ENV_SECRETREF_MARKER: typeof import("./model-auth-markers.js").NON_ENV_SECRETREF_MARKER;
 let isKnownEnvApiKeyMarker: typeof import("./model-auth-markers.js").isKnownEnvApiKeyMarker;
 let isNonSecretApiKeyMarker: typeof import("./model-auth-markers.js").isNonSecretApiKeyMarker;
 let resolveOAuthApiKeyMarker: typeof import("./model-auth-markers.js").resolveOAuthApiKeyMarker;
@@ -50,7 +53,6 @@ async function loadMarkerModules() {
   listKnownProviderEnvApiKeyNames = envVarsModule.listKnownProviderEnvApiKeyNames;
   CODEX_APP_SERVER_AUTH_MARKER = markersModule.CODEX_APP_SERVER_AUTH_MARKER;
   GCP_VERTEX_CREDENTIALS_MARKER = markersModule.GCP_VERTEX_CREDENTIALS_MARKER;
-  NON_ENV_SECRETREF_MARKER = markersModule.NON_ENV_SECRETREF_MARKER;
   isKnownEnvApiKeyMarker = markersModule.isKnownEnvApiKeyMarker;
   isNonSecretApiKeyMarker = markersModule.isNonSecretApiKeyMarker;
   resolveOAuthApiKeyMarker = markersModule.resolveOAuthApiKeyMarker;
@@ -61,6 +63,13 @@ beforeAll(async () => {
 });
 
 describe("model auth markers", () => {
+  it.each(["file", "exec", "store"] as const)(
+    "keeps the persisted %s SecretRef marker stable",
+    (source) => {
+      expect(resolveNonEnvSecretRefApiKeyMarker(source)).toBe("secretref-managed");
+    },
+  );
+
   it("recognizes explicit non-secret markers", () => {
     withEnv(cleanPluginManifestEnv(), () => {
       expect(isNonSecretApiKeyMarker(NON_ENV_SECRETREF_MARKER)).toBe(true);

--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/string-normalization";
 import type { SecretRefSource } from "../config/types.secrets.js";
 import { listOpenClawPluginManifestMetadata } from "../plugins/manifest-metadata-scan.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import { listKnownProviderEnvApiKeyNames } from "./model-auth-env-vars.js";
 
 /** @deprecated MiniMax provider-owned marker; do not use from third-party plugins. */
@@ -23,8 +24,6 @@ export const CUSTOM_LOCAL_AUTH_MARKER = "custom-local";
 export const CODEX_APP_SERVER_AUTH_MARKER = "codex-app-server";
 /** Marker for Google Vertex credentials resolved outside plain API-key env vars. */
 export const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
-/** Marker for a secret-ref-managed credential that is not stored as an env var. */
-export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
 /** Prefix for secret-ref header markers that name an env-backed source. */
 export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
 
@@ -96,11 +95,6 @@ export function resolveOAuthApiKeyMarker(providerId: string): string {
 /** Return true when a marker value points at provider OAuth auth. */
 export function isOAuthApiKeyMarker(value: string): boolean {
   return value.trim().startsWith(OAUTH_API_KEY_MARKER_PREFIX);
-}
-
-/** Resolve the API-key placeholder for a non-env secret-ref source. */
-export function resolveNonEnvSecretRefApiKeyMarker(_source: SecretRefSource): string {
-  return NON_ENV_SECRETREF_MARKER;
 }
 
 /** Resolve the header-value placeholder for a non-env secret-ref source. */

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -17,6 +17,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import { canResolveEnvSecretRefInReadOnlyPath } from "../plugin-sdk/secret-ref-readonly.internal.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import { SecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
@@ -31,7 +32,6 @@ import {
   CUSTOM_LOCAL_AUTH_MARKER,
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
-  NON_ENV_SECRETREF_MARKER,
   SECRETREF_ENV_HEADER_MARKER_PREFIX,
 } from "./model-auth-markers.js";
 import {

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -4,15 +4,12 @@ import { fileURLToPath } from "node:url";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig, OpenClawConfig } from "../config/config.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import { resolveAuthProfileSecretOwnerId } from "../secrets/runtime-auth-profile-owner.js";
 import type { SecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
-import {
-  CUSTOM_LOCAL_AUTH_MARKER,
-  GCP_VERTEX_CREDENTIALS_MARKER,
-  NON_ENV_SECRETREF_MARKER,
-} from "./model-auth-markers.js";
+import { CUSTOM_LOCAL_AUTH_MARKER, GCP_VERTEX_CREDENTIALS_MARKER } from "./model-auth-markers.js";
 import {
   attachModelProviderRequestTransport,
   getModelProviderRequestTransport,

--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -1,9 +1,8 @@
 // Verifies models.json provider/model merge behavior and secret preservation.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import type { ExistingProviderConfig } from "./models-config.merge.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
-
-let NON_ENV_SECRETREF_MARKER: typeof import("./model-auth-markers.js").NON_ENV_SECRETREF_MARKER;
 let mergeProviderModels: typeof import("./models-config.merge.js").mergeProviderModels;
 let mergeProviders: typeof import("./models-config.merge.js").mergeProviders;
 let mergeWithExistingProviderSecrets: typeof import("./models-config.merge.js").mergeWithExistingProviderSecrets;
@@ -12,7 +11,6 @@ async function loadMergeModules() {
   // Merge helpers depend on real manifest registry behavior; undo previous
   // mocks before importing the module under test.
   vi.doUnmock("../plugins/manifest-registry.js");
-  ({ NON_ENV_SECRETREF_MARKER } = await import("./model-auth-markers.js"));
   ({ mergeProviderModels, mergeProviders, mergeWithExistingProviderSecrets } =
     await import("./models-config.merge.js"));
 }

--- a/src/agents/models-config.ollama-secretref.test.ts
+++ b/src/agents/models-config.ollama-secretref.test.ts
@@ -8,6 +8,7 @@ import { clearLiveCatalogCacheForTests } from "../plugin-sdk/provider-catalog-sh
 import { loadBundledPluginPublicSurface } from "../plugin-sdk/test-helpers/public-surface-loader.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import type { OpenClawPluginDefinition, ProviderPlugin } from "../plugins/types.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import {
@@ -15,7 +16,6 @@ import {
   setRuntimeAuthProfileStoreSnapshot,
 } from "./auth-profiles/runtime-snapshots.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import { planOpenClawModelsJson } from "./models-config.plan.js";
 import { encodePluginModelCatalogRelativePath } from "./plugin-model-catalog.js";
 

--- a/src/agents/models-config.providers.auth-provenance.test.ts
+++ b/src/agents/models-config.providers.auth-provenance.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderPlugin } from "../plugins/types.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
 
@@ -57,7 +58,6 @@ vi.mock("./provider-auth-aliases.js", () => ({
 
 type ProviderRuntimeModule = typeof import("../plugins/provider-runtime.js");
 
-let NON_ENV_SECRETREF_MARKER: typeof import("./model-auth-markers.js").NON_ENV_SECRETREF_MARKER;
 let CUSTOM_LOCAL_AUTH_MARKER: typeof import("./model-auth-markers.js").CUSTOM_LOCAL_AUTH_MARKER;
 let resolveApiKeyFromCredential: typeof import("./models-config.providers.secret-helpers.js").resolveApiKeyFromCredential;
 let createProviderApiKeyResolver: typeof import("./models-config.providers.secrets.js").createProviderApiKeyResolver;
@@ -84,7 +84,6 @@ async function loadProviderAuthModules() {
     providerRuntimeModule.resolveProviderSyntheticAuthWithPlugin,
   );
   CUSTOM_LOCAL_AUTH_MARKER = markersModule.CUSTOM_LOCAL_AUTH_MARKER;
-  NON_ENV_SECRETREF_MARKER = markersModule.NON_ENV_SECRETREF_MARKER;
   resolveApiKeyFromCredential = helperModule.resolveApiKeyFromCredential;
   createProviderApiKeyResolver = secretsModule.createProviderApiKeyResolver;
   createProviderAuthResolver = secretsModule.createProviderAuthResolver;

--- a/src/agents/models-config.providers.cloudflare-ai-gateway.test.ts
+++ b/src/agents/models-config.providers.cloudflare-ai-gateway.test.ts
@@ -1,8 +1,8 @@
 // Covers Cloudflare AI Gateway profile provenance and generated provider config.
 import { describe, expect, it } from "vitest";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import { captureEnv } from "../test-utils/env.js";
 import type { ApiKeyCredential } from "./auth-profiles/types.js";
-import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import { resolveApiKeyFromCredential } from "./models-config.providers.secret-helpers.js";
 
 function expectedCloudflareGatewayBaseUrl(accountId: string, gatewayId: string): string {

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -25,12 +25,10 @@ import {
 import { matchesProviderPluginRef } from "../plugins/provider-registry-shared.js";
 import { prepareProviderExternalAuthWithPlugin } from "../plugins/provider-runtime.js";
 import { resolveManifestSyntheticAuthProviderRefState } from "../plugins/synthetic-auth.runtime.js";
+import { resolveNonEnvSecretRefApiKeyMarker } from "../secrets/provider-credential-values.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store-runtime.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import {
-  isNonSecretApiKeyMarker,
-  resolveNonEnvSecretRefApiKeyMarker,
-} from "./model-auth-markers.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { parseConfiguredModelVisibilityEntries } from "./model-selection-shared.js";
 import { mergeProviderModels, type SourceModelFields } from "./models-config.merge.js";
 import {

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -9,8 +9,8 @@ import { readConfigFileSnapshotFromContext } from "../config/io.snapshot.js";
 import { ModelsConfigSchema } from "../config/zod-schema.core.js";
 import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import {
   materializeConfiguredProviderCatalogModels,
   normalizeProviderCatalogModelsForConfig,

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -5,6 +5,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
+import { resolveNonEnvSecretRefApiKeyMarker } from "../secrets/provider-credential-values.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { listProfilesForProvider } from "./auth-profiles/profile-list.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
@@ -12,7 +13,6 @@ import { resolveEnvApiKey, type EnvApiKeyLookupOptions } from "./model-auth-env.
 import {
   isNonSecretApiKeyMarker,
   resolveEnvSecretRefHeaderValueMarker,
-  resolveNonEnvSecretRefApiKeyMarker,
   resolveNonEnvSecretRefHeaderValueMarker,
 } from "./model-auth-markers.js";
 import { resolveAwsSdkEnvVarName } from "./model-auth-runtime-shared.js";

--- a/src/agents/models-config.providers.secrets.bedrock-apikey.test.ts
+++ b/src/agents/models-config.providers.secrets.bedrock-apikey.test.ts
@@ -1,6 +1,6 @@
 // Covers Bedrock AWS SDK auth markers and marker-backed discovery secret guardrails.
 import { describe, expect, it } from "vitest";
-import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import type { ProviderConfig } from "./models-config.providers.secret-helpers.js";
 import {
   resolveApiKeyFromCredential,

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -7,6 +7,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../plugins/provider-runtime.js";
+import { resolveNonEnvSecretRefApiKeyMarker } from "../secrets/provider-credential-values.js";
 import type { ProviderAuthEvidence } from "../secrets/provider-env-vars.js";
 import { secretRefKey } from "../secrets/ref-contract.js";
 import { SecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
@@ -18,7 +19,6 @@ import {
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
   resolveOAuthApiKeyMarker,
-  resolveNonEnvSecretRefApiKeyMarker,
 } from "./model-auth-markers.js";
 import { resolveDirectProviderCredentialMode } from "./model-auth-runtime-shared.js";
 import {

--- a/src/agents/models-config.providers.source-managed.ts
+++ b/src/agents/models-config.providers.source-managed.ts
@@ -4,9 +4,9 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
  */
 import { resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveNonEnvSecretRefApiKeyMarker } from "../secrets/provider-credential-values.js";
 import { isRecord } from "../utils.js";
 import {
-  resolveNonEnvSecretRefApiKeyMarker,
   resolveNonEnvSecretRefHeaderValueMarker,
   resolveEnvSecretRefHeaderValueMarker,
 } from "./model-auth-markers.js";

--- a/src/agents/models-config.providers.vercel-ai-gateway.test.ts
+++ b/src/agents/models-config.providers.vercel-ai-gateway.test.ts
@@ -1,7 +1,6 @@
 // Verifies Vercel AI Gateway auth marker resolution from env and profiles.
 import { beforeAll, describe, expect, it, vi } from "vitest";
-
-let NON_ENV_SECRETREF_MARKER: typeof import("./model-auth-markers.js").NON_ENV_SECRETREF_MARKER;
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 let createProviderAuthResolver: typeof import("./models-config.providers.secrets.js").createProviderAuthResolver;
 
 async function loadModules() {
@@ -10,11 +9,7 @@ async function loadModules() {
   vi.doUnmock("../plugins/provider-runtime.js");
   vi.doUnmock("../secrets/provider-env-vars.js");
   vi.resetModules();
-  const [markersModule, secretsModule] = await Promise.all([
-    import("./model-auth-markers.js"),
-    import("./models-config.providers.secrets.js"),
-  ]);
-  NON_ENV_SECRETREF_MARKER = markersModule.NON_ENV_SECRETREF_MARKER;
+  const secretsModule = await import("./models-config.providers.secrets.js");
   createProviderAuthResolver = secretsModule.createProviderAuthResolver;
 }
 

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -2,8 +2,8 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import { createFixtureSuite } from "../test-utils/fixture-suite.js";
-import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import {
   installModelsConfigTestHooks,
   MODELS_CONFIG_IMPLICIT_ENV_VARS,

--- a/src/agents/prepared-model-catalog-worker.secrets.test.ts
+++ b/src/agents/prepared-model-catalog-worker.secrets.test.ts
@@ -13,13 +13,13 @@ import {
   setRuntimeConfigSnapshot,
 } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
 import { clearRuntimeAuthProfileStoreSnapshots } from "./auth-profiles/runtime-snapshots.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import { resolveUsableCustomProviderApiKey } from "./model-auth-provider-config.js";
 import * as modelsConfig from "./models-config.js";
 import { createPreparedModelCatalogWorkerInput } from "./prepared-model-catalog-worker.js";

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -73,16 +73,6 @@ export function readConfiguredSecretString(value: unknown, path: string): string
   return normalizeSecretInput(normalizeResolvedSecretInputString({ value, path })) || undefined;
 }
 
-export function readProviderEnvValue(envVars: string[]): string | undefined {
-  for (const envVar of envVars) {
-    const value = normalizeSecretInput(process.env[envVar]);
-    if (value) {
-      return value;
-    }
-  }
-  return undefined;
-}
-
 export async function withTrustedWebSearchEndpoint<T>(
   params: WebSearchEndpointOptions,
   run: (response: Response) => Promise<T>,

--- a/src/commands/models/list.auth-overview.secret-ref.test.ts
+++ b/src/commands/models/list.auth-overview.secret-ref.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.js";
+import { NON_ENV_SECRETREF_MARKER } from "../../secrets/provider-credential-values.js";
 import { resolveProviderAuthOverview } from "./list.auth-overview.js";
 
 const credential = "synthetic-resolved-provider-credential";

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -1,11 +1,11 @@
 // Model auth overview tests cover provider auth overview rows for model listings.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import { resolveEnvApiKey } from "../../agents/model-auth.js";
 import {
   createConfigResolutionFacts,
   setConfigResolutionFacts,
 } from "../../config/resolution-facts.js";
+import { NON_ENV_SECRETREF_MARKER } from "../../secrets/provider-credential-values.js";
 import { withEnv } from "../../test-utils/env.js";
 import {
   formatProviderAuthProfileCounts,

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -11,11 +11,7 @@ import { loadPersistedAuthProfileStore } from "../../agents/auth-profiles/persis
 import { listProfilesForProvider } from "../../agents/auth-profiles/profiles.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
-import {
-  isNonSecretApiKeyMarker,
-  isOAuthApiKeyMarker,
-  NON_ENV_SECRETREF_MARKER,
-} from "../../agents/model-auth-markers.js";
+import { isNonSecretApiKeyMarker, isOAuthApiKeyMarker } from "../../agents/model-auth-markers.js";
 import { resolveProviderConfigSecretInput } from "../../agents/model-auth-provider-config.js";
 import { resolveManagedSecretRefRuntimeProviderAuth } from "../../agents/model-auth-runtime-config.js";
 import {
@@ -24,6 +20,7 @@ import {
   resolveUsableCustomProviderApiKey,
 } from "../../agents/model-auth.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { NON_ENV_SECRETREF_MARKER } from "../../secrets/provider-credential-values.js";
 import type { ProviderAuthEvidence } from "../../secrets/provider-env-vars.js";
 import { maskApiKey } from "../../security/secret-mask.js";
 import { shortenHomePath } from "../../utils.js";

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -11,7 +11,6 @@ import {
   type AuthProfileStore,
   type RuntimeAuthProfileStore,
 } from "../../agents/auth-profiles.js";
-import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   resetConfigRuntimeState,
@@ -21,6 +20,7 @@ import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { UsageSummary } from "../../infra/provider-usage.types.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../../plugins/installed-plugin-index-policy.js";
 import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { NON_ENV_SECRETREF_MARKER } from "../../secrets/provider-credential-values.js";
 import { resolveProviderAuthLookupMaps } from "../../secrets/provider-env-vars.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { createChatRunState } from "../server-chat-state.js";

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -25,10 +25,7 @@ import {
   type RuntimeAuthProfileStore,
 } from "../../agents/auth-profiles.js";
 import { getRuntimeExternalCliProfileIds } from "../../agents/auth-profiles/runtime-external-profile-references.js";
-import {
-  isNonSecretApiKeyMarker,
-  NON_ENV_SECRETREF_MARKER,
-} from "../../agents/model-auth-markers.js";
+import { isNonSecretApiKeyMarker } from "../../agents/model-auth-markers.js";
 import {
   type ProviderAuthAliasLookupParams,
   resolveProviderIdForAuth,
@@ -38,6 +35,7 @@ import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import { providerUsageLabel, resolveUsageProviderId } from "../../infra/provider-usage.shared.js";
 import type { UsageProviderId } from "../../infra/provider-usage.types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { NON_ENV_SECRETREF_MARKER } from "../../secrets/provider-credential-values.js";
 import { refreshActiveProviderAuthRuntimeSnapshot } from "../../secrets/runtime.js";
 import { abortChatRunsForProvider, type ChatAbortOps } from "../chat-abort.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";

--- a/src/infra/provider-usage.auth.normalizes-keys.test.ts
+++ b/src/infra/provider-usage.auth.normalizes-keys.test.ts
@@ -2,13 +2,13 @@
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import { NON_ENV_SECRETREF_MARKER } from "../agents/model-auth-markers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type {
   ProviderResolveUsageAuthContext,
   ProviderResolvedUsageAuth,
 } from "../plugins/types.js";
+import { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 
 const authProfileMocks = vi.hoisted(() => {

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -18,7 +18,7 @@ export {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,
 } from "../agents/api-key-rotation.js";
-export { NON_ENV_SECRETREF_MARKER } from "../agents/model-auth-markers.js";
+export { NON_ENV_SECRETREF_MARKER } from "../secrets/provider-credential-values.js";
 export {
   isProviderAuthError,
   requireApiKey,

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -25,6 +25,7 @@ import {
   type CachedCopilotToken,
 } from "./provider-auth-copilot-cache.js";
 
+export { resolveNonEnvSecretRefApiKeyMarker } from "../secrets/provider-credential-values.js";
 export type { OpenClawConfig } from "../config/config.js";
 export type { CachedCopilotToken } from "./provider-auth-copilot-cache.js";
 export type { SecretInput } from "../config/types.secrets.js";
@@ -56,7 +57,6 @@ export {
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
   resolveOAuthApiKeyMarker,
-  resolveNonEnvSecretRefApiKeyMarker,
 } from "../agents/model-auth-markers.js";
 export {
   formatApiKeyPreview,

--- a/src/plugin-sdk/provider-web-search.ts
+++ b/src/plugin-sdk/provider-web-search.ts
@@ -7,6 +7,7 @@ import type {
   WebSearchProviderToolDefinition,
   WebSearchProviderToolExecutionContext,
 } from "../plugins/types.js";
+export { readProviderEnvValue } from "../secrets/provider-credential-values.js";
 export {
   jsonResult,
   readNonNegativeIntegerParam,
@@ -29,7 +30,6 @@ export {
   parseWebSearchTimeFilters,
   readCachedSearchPayload,
   readConfiguredSecretString,
-  readProviderEnvValue,
   resolveSearchCacheTtlMs,
   resolveSearchCount,
   resolveSearchTimeoutSeconds,

--- a/src/plugin-sdk/secret-input.test.ts
+++ b/src/plugin-sdk/secret-input.test.ts
@@ -2,6 +2,7 @@
  * Tests secret input parsing, normalization, and configured secret resolution.
  */
 import { describe, expect, it } from "vitest";
+import { withEnv } from "../test-utils/env.js";
 import {
   INVALID_EXEC_SECRET_REF_IDS,
   VALID_EXEC_SECRET_REF_IDS,
@@ -11,9 +12,31 @@ import {
   buildOptionalSecretInputSchema,
   buildSecretInputArraySchema,
   normalizeSecretInputString,
+  readProviderEnvValue,
 } from "./secret-input.js";
 
 describe("plugin-sdk secret input helpers", () => {
+  it.each([
+    { primary: " first ", fallback: "second", expected: "first" },
+    { primary: " \n ", fallback: " usable\r\nkey ", expected: "usablekey" },
+    { primary: "\u2028\u200b", fallback: undefined, expected: undefined },
+  ])("reads the first normalized nonempty provider env value ($expected)", (testCase) => {
+    withEnv(
+      {
+        OPENCLAW_TEST_PROVIDER_PRIMARY: testCase.primary,
+        OPENCLAW_TEST_PROVIDER_FALLBACK: testCase.fallback,
+      },
+      () => {
+        expect(
+          readProviderEnvValue([
+            "OPENCLAW_TEST_PROVIDER_PRIMARY",
+            "OPENCLAW_TEST_PROVIDER_FALLBACK",
+          ]),
+        ).toBe(testCase.expected);
+      },
+    );
+  });
+
   it.each([
     {
       name: "accepts undefined for optional secret input",

--- a/src/plugin-sdk/secret-input.ts
+++ b/src/plugin-sdk/secret-input.ts
@@ -12,6 +12,11 @@ import { isBuiltInDefaultSecretProviderRef, isValidSecretRef } from "../secrets/
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import { buildSecretInputSchema, registerSensitiveConfigSchema } from "./secret-input-schema.js";
 
+export {
+  readProviderEnvValue,
+  resolveNonEnvSecretRefApiKeyMarker,
+} from "../secrets/provider-credential-values.js";
+
 export type {
   SecretInput,
   SecretInputStringResolution,

--- a/src/secrets/provider-credential-values.ts
+++ b/src/secrets/provider-credential-values.ts
@@ -1,0 +1,21 @@
+/** Local credential values for discovery, without profile or transport loading. */
+import type { SecretRefSource } from "../config/types.secrets.js";
+import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+
+/** Marker for a secret-ref-managed credential that is not stored as an env var. */
+export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
+
+/** Resolve the API-key placeholder for a non-env secret-ref source. */
+export function resolveNonEnvSecretRefApiKeyMarker(_source: SecretRefSource): string {
+  return NON_ENV_SECRETREF_MARKER;
+}
+
+export function readProviderEnvValue(envVars: string[]): string | undefined {
+  for (const envVar of envVars) {
+    const value = normalizeSecretInput(process.env[envVar]);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What Problem This Solves

Provider discovery paid the cost of loading profile stores and web-search execution just to read environment values and represent managed credentials. In the measured first-run migration case, loading the xAI descriptor alone took 49–56 seconds.

## Why This Change Was Made

Move the existing credential-value functions into one dependency-light owner and expose them through the existing `secret-input` SDK entrypoint. xAI discovery and Cloudflare catalog metadata use that narrow surface; xAI config lookup uses the existing config-contract entrypoint. Internal consumers move to the canonical owner, while existing public SDK exports remain available.

Function bodies, credential precedence, blocked SecretRefs, synthetic auth hooks and stored marker values are unchanged. The two required narrow exports increase the public/callable SDK budgets by exactly two each; all other budgets stay unchanged. No new runtime configuration, cache, dependency, deadline, or shard is introduced.

## User Impact

Cold provider discovery does less unrelated module loading. This also shortens the migration test without replacing real provider/auth behavior with mocks. Compatibility normalization remains a separate measured hotspot.

## Evidence

Same-main, same-case local A/B/A on base `58a6953549d011ffe44dcc3a7f3290b50e64b349`, retaining existing caches:

| Measurement | Original A1 | Candidate B | Original A2 |
| --- | ---: | ---: | ---: |
| Selected migration case | 87.55s | 47.09s | 102.74s |
| Whole invocation | 118.89s | 101.99s | 127.47s |
| xAI descriptor loading | 49.14s | 0.159s | 55.93s |

All arms passed with the same case digest, five configured models, three generated catalogs, and both synthetic auth hooks. Unchanged normalization took 41.92s in B and 41.75s in A2. Invocation startup varied, so these results do not establish an overall CI reduction.

Validation: 428 focused semantic/sibling cases passed; 41 revised marker/xAI/SDK cases and two selected SDK budget guards passed. Current-source `ciArtifacts` build passed, including public SDK declarations/export validation. Typechecks, lint, boundary and cycle checks passed. Independent P2 review completed all three passes with no findings.

Local validation is composite: an earlier full build passed before removal of an unused export alias, and the initial changed gate correctly failed at the SDK budget. After the exact budget follow-through, all 28 failed/unrun check components passed. The subsequent exact-head hosted full build passed on `5998ee08a269`. Its only two failing jobs used a shared tooling fixture that lacked the new commit-author lookup response. Main `03234b508109` already fixed that fixture; the identical optimization patch was rebased to include the fix. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34643168858) now passes on `9ff5cd7a1e0ee7b9848687dbd75902f343f72b09`: all 190 checks are terminal without failures, including the full build.

Production delta: +46/-45 (net +1), tooling +4/-2, tests +52/-31, documentation +7. The production change moves existing functions and rewires imports; the small growth provides the canonical lightweight boundary. Persisted SecretRef marker tests independently pin file/exec/store wire values. No changelog edit is needed before release generation.

Maintainer compatibility decision: accept and support the two documented `secret-input` export locations. They expose the same canonical functions as the existing public paths, which remain supported. The exact +2 public/+2 callable budgets account for that deliberate additive contract.

The requested RSS follow-through uses a separate post-build matched pair on the same `5998ee08a269` checkout, with existing built artifacts and caches retained. The original control reverses only this PR’s 36 paths; both arms execute the same selected case with 37 trace records and unchanged model/catalog/auth-hook results. `/usr/bin/time -l` maximum resident set size: original 2,320,531,456bytes (2213.03MiB), candidate 2,298,658,816bytes (2192.17MiB). That 0.94% difference is too small to claim a strong memory improvement from one pair. This is the invocation’s reported maximum RSS, not simultaneous summed process-tree memory.

In that post-build pair the case took 61.22s original versus 15.28s candidate, and the invocation 72.82s versus 24.66s. Those timings have a different built-artifact state from the historical A/B/A above and are not pooled with it. Telegram doctor loading remained about 8s in both arms and is a separate follow-up.
