### PR TITLE
test(pr): mock published commit authors

### DIFF
--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -433,6 +433,11 @@ if (args[0] === 'pr' && args[1] === 'view') {
       head: { sha: control.metadata.headRefOid, ref: 'topic', repo: { full_name: 'fixture/repo' } },
       base: { sha: baseSha },
     };
+  } else if (/^repos\\/fixture\\/repo\\/commits\\/[0-9a-f]{40}$/.test(endpoint)) {
+    value = {
+      commit: { author: { name: 'OpenClaw Test', email: 'test@example.invalid' } },
+      author: { login: 'fixture', type: 'User' },
+    };
   } else if (endpoint.endsWith('/actions/workflows/ci.yml/runs')) {
     event({ kind: 'ci-watched' });
     value = { workflow_runs: [{ id: 1, conclusion: null }] };


### PR DESCRIPTION
## Summary

- teach the native PR test fixture to answer published commit-author lookups
- preserve the synthetic contributor identity used by squash-body generation
- unblock the complete main-refresh and hosted-merge fixture suites

## Validation

- `node scripts/run-vitest.mjs --config test/vitest/vitest.tooling.config.ts test/scripts/pr-main-refresh.test.ts test/scripts/pr-merge-hosted.test.ts` (66/66)
- `node scripts/check-changed.mjs`

## Release context

This fixes the two deterministic tooling-test failures blocking generated native-locale PR #145110.
