### PR TITLE
fix(ci): restore native PR merge tests after author verification

### DIFF
--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -397,6 +397,7 @@ if (args[0] === 'pr' && args[1] === 'view') {
     } else if (args.some(arg => arg.includes('viewerMergeBodyText'))) {
       value = { data: { repository: { pullRequest: {
         headRefOid: control.metadata.headRefOid,
+        author: { ...control.metadata.author, __typename: 'User' },
         isMergeQueueEnabled: control.metadata.isMergeQueueEnabled,
         viewerMergeBodyText: 'Reviewed fixture body',
       } } } };
@@ -409,6 +410,15 @@ if (args[0] === 'pr' && args[1] === 'view') {
     } else {
       throw new Error('Unexpected GraphQL request');
     }
+  } else if (new RegExp('^repos/fixture/repo/commits/[0-9a-f]{40}$').test(endpoint)) {
+    const oid = endpoint.split('/').at(-1);
+    value = {
+      commit: { author: {
+        name: runGit(['-C', origin, 'show', '-s', '--format=%an', oid]),
+        email: runGit(['-C', origin, 'show', '-s', '--format=%ae', oid]),
+      } },
+      author: { login: control.metadata.author.login, type: 'User' },
+    };
   } else if (endpoint === 'users/fixture') {
     value = { id: 123 };
   } else if (endpoint === 'repos/fixture/repo/collaborators/fixture/permission') {


### PR DESCRIPTION
Closes #145214

## What Problem This Solves

Resolves a problem where unrelated PRs fail the native merge-success CI tests after #145128 introduced published-commit author verification. The shared fixture rejects the new commit lookup before the synthetic merge can dispatch.

## Why This Change Was Made

Complete the shared fixture’s GitHub response contract: return raw commit-author data from its real Git objects with the synthetic linked user, and include the PR author in the GraphQL squash preview. Its existing output boundary continues to apply `--jq`. The change adds ten test-support lines and preserves production code and every test assertion.

## User Impact

Restores reliable CI coverage for the native PR merge workflow. No product behavior changes.

## Evidence

At base `8b343fce338da60722778eb2e25acdb936c88b40`, the unchanged tests reproduced the [two CI failures](https://github.com/openclaw/openclaw/actions/runs/34635760951): **64 passed, 2 failed**. After the fixture repair, the same 66 cases in the same order **all passed**.

```sh
node scripts/run-vitest.mjs test/scripts/pr-main-refresh.test.ts test/scripts/pr-merge-hosted.test.ts
node scripts/check-changed.mjs -- test/scripts/pr-main-refresh.test-support.ts
```

The selected root-test/tooling gate, formatting, and `git diff --check` passed. Independent review found no actionable issues through P2.
