### PR TITLE
fix(telegram): deliver plain text after legacy rich rejection

### DIFF
--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -2882,6 +2882,35 @@ describe("deliverReplies", () => {
     expect(mockCallArg(sendMessage, 0, 2)?.parse_mode).toBeUndefined();
   });
 
+  it("falls back to standard sendMessage when older self-hosted Bot API server rejects rich message as non-empty", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 15,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+    (bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> }).sendRichMessage = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "GrammyError: Call to 'sendRichMessage' failed! (400: Bad Request: rich message must be non-empty)",
+        ),
+      );
+    const text = "system notice delivered through fallback";
+
+    await deliverWith({
+      replies: [{ text }],
+      runtime,
+      bot,
+      richMessages: true,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(firstMockCallArg(sendMessage, 0)).toBe("123");
+    expect(firstMockCallArg(sendMessage, 1)).toBe(text);
+    expect(mockCallArg(sendMessage, 0, 2)?.parse_mode).toBeUndefined();
+  });
+
   it("falls back to plain text before raw rich send when rich markdown renders empty", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/rich-plain-fallback.test.ts
+++ b/extensions/telegram/src/rich-plain-fallback.test.ts
@@ -19,6 +19,12 @@ const fallbackCases = [
     htmlTrigger: "empty-content",
   },
   {
+    name: "rich-message-non-empty",
+    message: "Bad Request: rich message must be non-empty",
+    richTrigger: "rich-content-required",
+    htmlTrigger: "empty-content",
+  },
+  {
     name: "html-parse",
     message: "Bad Request: can't parse entities: unsupported tag",
     richTrigger: "html-parse",
@@ -118,6 +124,7 @@ describe("isTelegramEmptyContentError", () => {
     "Bad Request: message text is empty",
     "Bad Request: text must be non-empty",
     "Bad Request: RICH_MESSAGE_CONTENT_REQUIRED",
+    "Bad Request: rich message must be non-empty",
   ])("recognizes %s", (message) => {
     expect(isTelegramEmptyContentError(new Error(message))).toBe(true);
   });

--- a/extensions/telegram/src/rich-plain-fallback.ts
+++ b/extensions/telegram/src/rich-plain-fallback.ts
@@ -8,8 +8,9 @@ import type { TelegramRichBlocksDegradationReason } from "./rich-block-model.js"
 // plain text; media content validity (e.g. AUDIO_INVALID for a non-decodable
 // file, live-verified) is only knowable server-side.
 const RICH_ENTITY_INVALID_RE = /RICH_MESSAGE_[A-Z_]+_INVALID/i;
-const RICH_CONTENT_REQUIRED_RE = /RICH_MESSAGE_CONTENT_REQUIRED/i;
-const EMPTY_TEXT_RE = /message text is empty|text must be non-empty/i;
+const RICH_CONTENT_REQUIRED_RE = /RICH_MESSAGE_CONTENT_REQUIRED|rich message must be non-empty/i;
+const EMPTY_TEXT_RE =
+  /message text is empty|text must be non-empty|rich message must be non-empty/i;
 // Structural-limit rejections, live-verified against Bot API 10.2 (2026-07-15):
 // >500 recursively counted blocks, >16 depth, oversized text, >50 media, >20 table cols.
 const RICH_STRUCTURE_INVALID_RE =


### PR DESCRIPTION
## What Problem This Solves

Fixes #145201. Older self-hosted Telegram Bot API servers reject rich sends with `rich message must be non-empty`, leaving replies and system notices undelivered.

## Why This Change Was Made

The shared classifier recognizes the rejection once, retaining `rich-content-required` for rich requests and `empty-content` for HTML requests. The empty-content predicate already reads that classifier.

## User Impact

Nonempty messages reach the recipient through the existing plain-text fallback.

## Evidence

`pnpm openclaw message send --channel telegram --target <chat> --message <marker> --json` with rich messages enabled:

- Before: exit 1, one rich rejection, no plain request or recipient marker.
- After: exit 0, one plain send, one accepted receipt and independent recipient readback.

The historical endpoint was unavailable. Its exact rejection was controlled at the HTTP boundary; successful delivery used Telegram's real Test Server. Rich success, unrelated errors and blank text were checked.

## Compatibility

No settings, protocol, schema or dependency changes.

## Consumers

Durable sends, replies and previews share the fallback.

## Invalidation

No new state or cache; acceptance accounting is unchanged.

## Tests

All 284 tests passed in four suites on a fresh merge with the pinned main revision. Its source tree matches this head. Coverage includes ordinary recovery, topics and partial-delivery accounting. Type-aware lint and types passed.

Follow-up: the preview path must recheck send authority before a plain send or edit when the session writer changes while a rich request is pending.
