### PR TITLE
fix: preserve dashboard HTTP errors when diagnostics fail

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -54,6 +54,9 @@ use `url`. If the Gateway is not ready or a browser handoff cannot be issued, th
 `{"ok":false,"reason":"..."}` and exits non-zero. SecretRef-managed shared tokens are never included
 in `url`.
 
+For terminal HTTP failures, an unreadable repair diagnostic leaves the observed HTTP status
+in `reason` (for example, `HTTP 503`).
+
 Notes:
 
 - Resolves configured `gateway.auth.token` SecretRefs when possible.

--- a/src/commands/control-ui-handoff.test.ts
+++ b/src/commands/control-ui-handoff.test.ts
@@ -2,13 +2,17 @@ import { execFile } from "node:child_process";
 import { X509Certificate } from "node:crypto";
 import fs from "node:fs/promises";
 import { createServer } from "node:https";
+import type { Socket } from "node:net";
 import path from "node:path";
 import type { PeerCertificate } from "node:tls";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
-import type { fetchConfiguredLocalOriginWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { fetchConfiguredLocalOriginWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { resolveSystemBin } from "../infra/resolve-system-bin.js";
+import { withServer } from "../plugin-sdk/test-helpers/http-test-server.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import { resolveControlUiHandoffTarget, waitForControlUiDocument } from "./control-ui-handoff.js";
 
@@ -302,6 +306,109 @@ describe("waitForControlUiDocument", () => {
     expect(head.release).toHaveBeenCalledOnce();
     expect(diagnostic.release).toHaveBeenCalledOnce();
   });
+
+  it.each(["request", "body"] as const)(
+    "keeps the observed HTTP failure when the diagnostic %s fails",
+    async (failure) => {
+      const head = guardedResponse(new Response(null, { status: 503 }));
+      const diagnostic = guardedResponse(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              controller.error(new Error("diagnostic body failed"));
+            },
+          }),
+          { status: 503, headers: { "content-type": "text/plain" } },
+        ),
+      );
+      const fetch = vi.fn().mockResolvedValueOnce(head);
+      if (failure === "request") {
+        fetch.mockRejectedValueOnce(new Error("diagnostic request failed"));
+      } else {
+        fetch.mockResolvedValueOnce(diagnostic);
+      }
+
+      await expect(
+        waitForControlUiDocument({ url: documentUrl, deps: { fetch } }),
+      ).resolves.toEqual({
+        ready: false,
+        reason: "Control UI dashboard is unavailable (HTTP 503).",
+        status: 503,
+      });
+      expect(fetch.mock.calls.map(([request]) => request.init.method)).toEqual(["HEAD", "GET"]);
+      expect(head.release).toHaveBeenCalledOnce();
+      expect(diagnostic.release).toHaveBeenCalledTimes(failure === "body" ? 1 : 0);
+    },
+  );
+
+  it.each(["complete", "broken"] as const)(
+    "preserves a real HTTP failure with a %s diagnostic body",
+    async (body) => {
+      const methods: string[] = [];
+      const responses: Array<{ method: string; status: number }> = [];
+      const releases: string[] = [];
+      const diagnosticSocket = createDeferredCore<Socket>();
+      const diagnosticClosed = createDeferredCore();
+      await withEnvAsync({ no_proxy: "127.0.0.1" }, async () => {
+        await withServer(
+          (request, response) => {
+            methods.push(request.method ?? "");
+            response.writeHead(503, { "content-type": "text/plain", connection: "close" });
+            if (request.method === "HEAD") {
+              response.end();
+              return;
+            }
+            diagnosticSocket.resolve(request.socket);
+            request.socket.once("close", () => diagnosticClosed.resolve());
+            response.write("Asset build failed");
+            if (body === "complete") {
+              response.end();
+            }
+          },
+          async (baseUrl) => {
+            const result = await waitForControlUiDocument({
+              url: `${baseUrl}/dashboard/`,
+              deps: {
+                fetch: async (request) => {
+                  const guarded = await fetchConfiguredLocalOriginWithSsrFGuard(request);
+                  const method = String(request.init?.method);
+                  responses.push({ method, status: guarded.response.status });
+                  if (method === "GET" && body === "broken") {
+                    // Fault the real body only after guarded fetch has delivered its headers.
+                    (await diagnosticSocket.promise).destroy();
+                  }
+                  return {
+                    ...guarded,
+                    release: async () => {
+                      await guarded.release();
+                      releases.push(method);
+                    },
+                  };
+                },
+              },
+            });
+            await diagnosticClosed.promise;
+
+            expect(result).toEqual({
+              ready: false,
+              reason:
+                body === "complete"
+                  ? "Asset build failed"
+                  : "Control UI dashboard is unavailable (HTTP 503).",
+              status: 503,
+            });
+            expect(methods).toEqual(["HEAD", "GET"]);
+            expect(responses).toEqual([
+              { method: "HEAD", status: 503 },
+              { method: "GET", status: 503 },
+            ]);
+            // Observe release and socket closure before withServer tears the fixture down.
+            expect(releases).toEqual(["GET", "HEAD"]);
+          },
+        );
+      });
+    },
+  );
 
   it("does not expose HTML when a terminal failure becomes ready during diagnostic fetch", async () => {
     const head = guardedResponse(new Response(null, { status: 503 }));

--- a/src/commands/control-ui-handoff.ts
+++ b/src/commands/control-ui-handoff.ts
@@ -244,8 +244,8 @@ export async function waitForControlUiDocument(params: {
         if (request.response.status !== 503 || !retryAfter || params.waitForPending === false) {
           let detail: string | undefined;
           if (request.response.status === 503 && !retryAfter) {
-            // HEAD has no body; one bounded, credential-free GET preserves the
-            // Gateway owner's configured-root/build-failure repair diagnostic.
+            // One bounded, credential-free GET may add the Gateway owner's repair
+            // diagnostic; a failed request or body must preserve the HEAD result.
             const diagnostic = await requestDocument("GET", Math.max(1, deadline - now())).catch(
               () => undefined,
             );
@@ -261,7 +261,7 @@ export async function waitForControlUiDocument(params: {
                     maxBytes: CONTROL_UI_DOCUMENT_ERROR_MAX_BYTES,
                     maxChars: CONTROL_UI_DOCUMENT_ERROR_MAX_BYTES,
                     timeoutMs: CONTROL_UI_DOCUMENT_REQUEST_TIMEOUT_MS,
-                  });
+                  }).catch(() => undefined);
                   detail = snippet ? sanitizeTerminalText(snippet) : undefined;
                 }
               } finally {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository and is writable by its maintainers.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw dashboard` lose an observed HTTP 503 diagnostic when the optional repair-message body fails to download. Instead of reporting the unavailable dashboard's HTTP status, text and JSON output replace it with a secondary error such as “request timed out” or “terminated.”

## Why This Change Was Made

The shared document-readiness owner already treats a diagnostic GET request as optional. It now applies that same rule to the bounded diagnostic-body read, allowing the existing HEAD result to remain authoritative. Both HTTP request releases remain outside the new catch. Finite repair messages, pending-asset retries, TLS verification, limits, failure exits and the point at which browser pairing can begin remain unchanged.

The existing owner absorbs the correction: production delta is zero (+3/-3), tests net +107, docs +3. No new helper, fallback path, setting, protocol or persistence change is introduced. The same defective owner is present in the current stable `v2026.9.4` source.

## User Impact

Dashboard text and JSON failures retain the useful HTTP status even when the optional repair message cannot be read. A readable repair message still takes precedence. Existing timeout diagnostics on stderr remain unchanged.

## Evidence

- Tests-only baseline at `202696784ec12d84f5b9958af15cb62419d206dc`: two intended failures and 16 passing controls. One failing case uses a real HTTP response and destroys its socket only after the guarded GET has returned its headers.
- Candidate: 77 tests passed across the readiness owner, dashboard text/JSON callers and shared response reader. Full changed-file checks passed.
- Baseline and candidate `pnpm build ciArtifacts` passed (173s and 97.6s).
- Ordinary built CLI with a unique profile and private HOME/state/config, driven by a synthetic loopback HTTP/WebSocket fixture: all four cases per phase completed. Finite and stalled bodies were tested in both text and JSON modes. Baseline stalled cases lost HTTP 503; candidate stalled cases retained it. All eight CLI executions exited 1 as expected for an unavailable dashboard.
- Before/after runtime hashes and resolved Undici/ws package inventories matched. Each phase verified response/socket closure before fixture teardown, normal fixture exits, and absence of child process groups. Owner tests separately verify both awaited HTTP request releases.
- Independent Codex review of the complete final diff, owner/caller/sibling code and direct Undici source found no actionable P0–P2 findings.

Observed stalled-body JSON output:

```text
Before: {"ok":false,"reason":"Control UI dashboard is unavailable: request timed out"}
After:  {"ok":false,"reason":"Control UI dashboard is unavailable (HTTP 503)."}
```

Finite bodies retained `Asset build failed` in both phases. Stalled requests emitted the existing two timeout warnings in both phases. An initial baseline attempt reached the defect but failed the proof script's incorrect silent-stderr expectation; that attempt was retained and the complete matrix was rerun after qualifying the existing warning format against its source. No product timeout or logging behavior was changed.

The CLI fixture rejects the correlated connection request and grants no authenticated Gateway session. This proves the ordinary CLI with synthetic transport, not real Gateway authentication or successful browser handoff. The post-header owner test provides direct coverage of the body-read catch. Build/live evidence is tied to the uncommitted final source tree subsequently committed; it is not a claimed postcommit rerun. Required hosted CI must pass before landing.
