### PR TITLE
perf(cron): reuse the time-zone formatter within each parse

### DIFF
--- a/src/infra/format-time/parse-offsetless-zoned-datetime.ts
+++ b/src/infra/format-time/parse-offsetless-zoned-datetime.ts
@@ -12,17 +12,28 @@ export function parseOffsetlessIsoDateTimeInTimeZone(raw: string, timeZone: stri
     return null;
   }
   try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      era: "short",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    });
     // Probe both sides of the local day so non-hour DST folds use their first
     // real occurrence while nonexistent spring-forward times remain rejected.
     // At Date-range endpoints, one side of the probe window may be out of range.
     const matchingInstants = [-86_400_000, 0, 86_400_000]
       .map((shiftMs) => asDateTimestampMs(naiveMs + shiftMs))
       .filter((probeMs) => probeMs !== undefined)
-      .map((probeMs) => naiveMs - (getZonedWallTimeMs(probeMs, timeZone) - probeMs))
+      .map((probeMs) => naiveMs - (getZonedWallTimeMs(probeMs, formatter) - probeMs))
       .filter(
         (candidateMs) =>
           asDateTimestampMs(candidateMs) !== undefined &&
-          getZonedWallTimeMs(candidateMs, timeZone) === naiveMs,
+          getZonedWallTimeMs(candidateMs, formatter) === naiveMs,
       );
     return matchingInstants.length > 0
       ? new Date(Math.min(...matchingInstants)).toISOString()
@@ -32,19 +43,9 @@ export function parseOffsetlessIsoDateTimeInTimeZone(raw: string, timeZone: stri
   }
 }
 
-function getZonedWallTimeMs(utcMs: number, timeZone: string): number {
+function getZonedWallTimeMs(utcMs: number, formatter: Intl.DateTimeFormat): number {
   const utcDate = new Date(utcMs);
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    era: "short",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hourCycle: "h23",
-  }).formatToParts(utcDate);
+  const parts = formatter.formatToParts(utcDate);
   const getNumericPart = (type: string) => {
     const part = parts.find((candidate) => candidate.type === type);
     return Number.parseInt(part?.value ?? "0", 10);


### PR DESCRIPTION
Closes #145230

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Parsing a date and time in an explicit time zone repeats formatter setup while checking candidate instants. Cron scheduling and CLI date parsing incur that work even though the time zone and formatting options stay the same throughout each parse.

## Why This Change Was Made

The parser now reuses one identically configured `Intl.DateTimeFormat` within each call. Its private projection helper consumes that formatter, and no cache survives the call. Calendar validation, Date-range handling, era and milliseconds, ambiguous-time selection, nonexistent-time rejection, and null-on-error behavior stay unchanged.

## User Impact

Zoned date parsing does less formatter setup work while producing the same results. Existing CLI and scheduler callers are unchanged, including selection of the first occurrence when clocks move back and rejection of local times skipped when clocks move forward.

## Evidence

All 271 existing parser, cron schedule, and cron CLI tests passed. The selected changed gate passed, and the P2 review completed with no actionable findings. No tests changed.

The 16 exported-parser probe cases produced identical outputs and checksums. Formatter constructor attempts per case-set pass fell from 71 to 14. In three fresh processes per version, the synthetic 3,200-call workload's median elapsed time fell from 404.69 ms to 117.97 ms. Timing excluded the constructor observer and allocation profiler. The environment was Node 26.8.1 on macOS arm64, ICU 78.3, and time-zone data 2026a.

The comparison is scoped to this synthetic parser workload. Sampled isolate-wide V8 allocation remained roughly flat and variable; it does not establish a material allocation saving. No native ICU allocation, retained-memory, RSS, or scheduler-wide improvement is claimed.
