### PR TITLE
refactor(tlon): remove unused private media writer

### DIFF
--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -354,7 +354,6 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       try {
         ({ attachments, unavailableCount: unavailableMediaCount } = await downloadMessageImages(
           messageContent,
-          undefined,
           account.mediaMaxBytes,
         ));
         if (attachments.length > 0) {

--- a/extensions/tlon/src/monitor/media.test.ts
+++ b/extensions/tlon/src/monitor/media.test.ts
@@ -1,19 +1,12 @@
-// Tlon tests cover media plugin behavior.
-import {
-  readRemoteMediaBuffer,
-  MAX_IMAGE_BYTES,
-  saveRemoteMedia,
-} from "openclaw/plugin-sdk/media-runtime";
+import { MAX_IMAGE_BYTES, saveRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTlonInboundMediaPrompt, downloadMessageImages } from "./media.js";
 
 vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
   MAX_IMAGE_BYTES: 6 * 1024 * 1024,
-  readRemoteMediaBuffer: vi.fn(),
   saveRemoteMedia: vi.fn(),
 }));
 
-const readRemoteMediaBufferMock = vi.mocked(readRemoteMediaBuffer);
 const saveRemoteMediaMock = vi.mocked(saveRemoteMedia);
 
 describe("tlon monitor media", () => {
@@ -66,35 +59,42 @@ describe("tlon monitor media", () => {
     });
   });
 
-  it("stores fetched media through the shared inbound media store with the image cap", async () => {
-    saveRemoteMediaMock.mockResolvedValue({
-      id: "photo---uuid.png",
-      path: "/tmp/openclaw/media/inbound/photo---uuid.png",
-      size: "image-data".length,
-      contentType: "image/png",
-    });
+  it.each([
+    { maxBytes: undefined, expectedMaxBytes: MAX_IMAGE_BYTES },
+    { maxBytes: 1024, expectedMaxBytes: 1024 },
+    { maxBytes: MAX_IMAGE_BYTES * 2, expectedMaxBytes: MAX_IMAGE_BYTES },
+  ])(
+    "stores fetched media with the effective $expectedMaxBytes byte cap",
+    async ({ maxBytes, expectedMaxBytes }) => {
+      saveRemoteMediaMock.mockResolvedValue({
+        id: "photo---uuid.png",
+        path: "/tmp/openclaw/media/inbound/photo---uuid.png",
+        size: "image-data".length,
+        contentType: "image/png",
+      });
 
-    const result = await downloadMessageImages([
-      { block: { image: { src: "https://example.com/photo.png" } } },
-    ]);
+      const result = await downloadMessageImages(
+        [{ block: { image: { src: "https://example.com/photo.png" } } }],
+        maxBytes,
+      );
 
-    expect(readRemoteMediaBufferMock).not.toHaveBeenCalled();
-    expect(saveRemoteMediaMock).toHaveBeenCalledTimes(1);
-    expect(saveRemoteMediaMock).toHaveBeenCalledWith({
-      url: "https://example.com/photo.png",
-      maxBytes: MAX_IMAGE_BYTES,
-      responseHeaderTimeoutMs: 120_000,
-      readIdleTimeoutMs: 30_000,
-      ssrfPolicy: undefined,
-      requestInit: { method: "GET" },
-    });
-    expect(result).toEqual({
-      attachments: [
-        { path: "/tmp/openclaw/media/inbound/photo---uuid.png", contentType: "image/png" },
-      ],
-      unavailableCount: 0,
-    });
-  });
+      expect(saveRemoteMediaMock).toHaveBeenCalledTimes(1);
+      expect(saveRemoteMediaMock).toHaveBeenCalledWith({
+        url: "https://example.com/photo.png",
+        maxBytes: expectedMaxBytes,
+        responseHeaderTimeoutMs: 120_000,
+        readIdleTimeoutMs: 30_000,
+        ssrfPolicy: undefined,
+        requestInit: { method: "GET" },
+      });
+      expect(result).toEqual({
+        attachments: [
+          { path: "/tmp/openclaw/media/inbound/photo---uuid.png", contentType: "image/png" },
+        ],
+        unavailableCount: 0,
+      });
+    },
+  );
 
   it("reports an unavailable image when the fetch exceeds the image cap", async () => {
     saveRemoteMediaMock.mockRejectedValue(
@@ -108,6 +108,5 @@ describe("tlon monitor media", () => {
     ]);
 
     expect(result).toEqual({ attachments: [], unavailableCount: 1 });
-    expect(readRemoteMediaBufferMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -1,15 +1,5 @@
-// Tlon plugin module implements media behavior.
-import { randomUUID } from "node:crypto";
-import { mkdir, writeFile } from "node:fs/promises";
-import * as path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
-import {
-  readRemoteMediaBuffer,
-  MAX_IMAGE_BYTES,
-  saveRemoteMedia,
-} from "openclaw/plugin-sdk/media-runtime";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { MAX_IMAGE_BYTES, saveRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import { TLON_MEDIA_FETCH_TIMEOUTS } from "../media-fetch-timeouts.js";
 
 const MAX_IMAGES_PER_MESSAGE = 8;
@@ -66,11 +56,7 @@ function extractImageBlocks(content: unknown): ExtractedImages {
  * Download a media file from URL to local storage.
  * Returns the local path where the file was saved.
  */
-async function downloadMedia(
-  url: string,
-  mediaDir?: string,
-  maxBytes?: number,
-): Promise<DownloadedMedia | null> {
+async function downloadMedia(url: string, maxBytes?: number): Promise<DownloadedMedia | null> {
   try {
     // Validate URL is http/https before fetching
     const parsedUrl = new URL(url);
@@ -79,60 +65,19 @@ async function downloadMedia(
       return null;
     }
 
-    const fetchOptions = {
+    const saved = await saveRemoteMedia({
       url,
       maxBytes: Math.min(maxBytes ?? MAX_IMAGE_BYTES, MAX_IMAGE_BYTES),
       ...TLON_MEDIA_FETCH_TIMEOUTS,
       ssrfPolicy: undefined,
       requestInit: { method: "GET" },
-    };
-
-    if (!mediaDir) {
-      const saved = await saveRemoteMedia(fetchOptions);
-      return {
-        localPath: saved.path,
-        contentType: saved.contentType ?? "application/octet-stream",
-      };
-    }
-
-    const fetched = await readRemoteMediaBuffer(fetchOptions);
-    await mkdir(mediaDir, { recursive: true });
-    const ext =
-      getExtensionFromFileName(fetched.fileName) ||
-      getExtensionFromContentType(fetched.contentType ?? "") ||
-      getExtensionFromUrl(url) ||
-      "bin";
-    const localPath = path.join(mediaDir, `${randomUUID()}.${ext}`);
-    await writeFile(localPath, fetched.buffer);
-
+    });
     return {
-      localPath,
-      contentType: fetched.contentType ?? "application/octet-stream",
+      localPath: saved.path,
+      contentType: saved.contentType ?? "application/octet-stream",
     };
   } catch (error: unknown) {
     console.error(`[tlon-media] Error downloading ${url}: ${formatErrorMessage(error)}`);
-    return null;
-  }
-}
-
-function getExtensionFromFileName(fileName?: string): string | null {
-  if (!fileName) {
-    return null;
-  }
-  const ext = path.extname(fileName).replace(/^\./, "");
-  return ext || null;
-}
-
-function getExtensionFromContentType(contentType: string): string | null {
-  return extensionForMime(contentType)?.replace(/^\./u, "") ?? null;
-}
-
-function getExtensionFromUrl(url: string): string | null {
-  try {
-    const pathname = new URL(url).pathname;
-    const match = pathname.match(/\.([a-z0-9]+)$/i);
-    return match ? normalizeLowercaseStringOrEmpty(match[1]) : null;
-  } catch {
     return null;
   }
 }
@@ -143,7 +88,6 @@ function getExtensionFromUrl(url: string): string | null {
  */
 export async function downloadMessageImages(
   content: unknown,
-  mediaDir?: string,
   maxBytes?: number,
 ): Promise<TlonInboundMediaDownload> {
   const { images, unavailableCount: overCapCount } = extractImageBlocks(content);
@@ -151,7 +95,7 @@ export async function downloadMessageImages(
   let unavailableCount = overCapCount;
 
   for (const image of images) {
-    const downloaded = await downloadMedia(image.url, mediaDir, maxBytes);
+    const downloaded = await downloadMedia(image.url, maxBytes);
     if (downloaded) {
       attachments.push({
         path: downloaded.localPath,


### PR DESCRIPTION
Closes #145232

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Tlon's inbound-media flow has an unused custom-directory storage path alongside the shared media store it actually uses. Keeping that dormant path adds maintenance work without serving a current monitor workflow.

## Why This Change Was Made

Remove the private `mediaDir` argument, buffer/file writer, three filename helpers, and unused imports; keep `saveRemoteMedia` as the single active storage operation. The sole monitor caller now passes `account.mediaMaxBytes` as the second argument.

No source caller supplies a custom directory, and the helper is private under the plugin's documented contract rather than promoted through `api.ts`. The package has no exports map, so deep imports are not claimed to be technically blocked.

## User Impact

No user-visible behavior change is intended. Inbound images retain the same URL checks, GET and SSRF options, header and idle deadlines, effective byte cap, first-eight ordering, MIME fallback, unavailable-media reporting, and exact prompt output. No updater, Doctor, configuration, schema, retention, or state contract changes.

## Evidence

- Recorded focused media-helper and monitor suites passed: 38 tests before and 40 after. The final cases verify absent, lower, and above-ceiling account limits.
- The selected changed-file gate passed, including extension type/import/lint guards; the scoped P2 review completed with no actionable findings. The final source was unchanged after review, and the recorded diff check passed.
- Across three files, the change removes 57 production lines and one test line net.

The boundary tests exercise the monitor/helper flow with synthetic transport and mocked `saveRemoteMedia`; they do not prove live downloads or filesystem persistence. No allocation, retained-memory, or runtime-speed improvement is claimed. No additional build was run because package/build outputs, lazy loading, and public SDK surfaces are unchanged.
