### PR TITLE
fix(ui): release retired Automation page state

### DIFF
--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -60,7 +60,7 @@ class CronPage extends OpenClawLightDomElement {
   @state() private heartbeatScratch = "";
 
   private pendingRouteData: ReturnType<typeof resolveCronRouteData> | null = null;
-  private routeJobState: CronState | null = null;
+  private routeJobRequested = false;
   private highlightedRunId: string | null = null;
   private pendingRunScroll = false;
   private modelSuggestionsRequest: { state: CronState; agentId: string } | null = null;
@@ -156,6 +156,7 @@ class CronPage extends OpenClawLightDomElement {
     });
     cron.canRefresh = () => this.canRefreshCron(cron);
     this.cron = cron;
+    this.routeJobRequested = false;
     this.pageHidden = document.visibilityState === "hidden";
     this.cron.cronAgentId = this.context.agentSelection.state.scopeId;
     this.agentsList = connected ? this.context.agents.state.agentsList : null;
@@ -202,7 +203,7 @@ class CronPage extends OpenClawLightDomElement {
       this.cron.cronError = null;
       const routeData = resolveCronRouteData(this.routeSearch);
       this.pendingRouteData = routeData.jobId ? routeData : null;
-      this.routeJobState = null;
+      this.routeJobRequested = false;
       this.highlightedRunId = null;
       this.pendingRunScroll = false;
     }
@@ -224,8 +225,8 @@ class CronPage extends OpenClawLightDomElement {
     }
     const routeData = this.pendingRouteData;
     const client = this.cron.client;
-    if (routeData && client && this.cron.connected && this.routeJobState !== this.cron) {
-      this.routeJobState = this.cron;
+    if (routeData && client && this.cron.connected && !this.routeJobRequested) {
+      this.routeJobRequested = true;
       void this.runCronTask(async (current) => {
         const isCurrent = () =>
           this.isConnected && this.cron === current && this.pendingRouteData === routeData;


### PR DESCRIPTION
Closes #145235

Related: #137411.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening a linked automation and then switching agents would leave the previous Automation page state retained after its requests had settled, even though the new agent's page was already displayed.

## Why This Change Was Made

Replace the request marker's strong `CronState` reference with a boolean, reset on route changes and Gateway-state replacement. Duplicate lookup suppression and the existing current-state/route async fences remain intact; the change adds one net production line and no tests.

## User Impact

The Automation page no longer retains the previous scope solely through this request marker. Linked-job navigation and the current agent's jobs, controls and editing state retain their behavior.

## Evidence

- All 51 existing Cron owner/lifecycle tests pass, along with the full selected changed gate and managed P2 review with no findings.
- The source-bound before/after Chromium flow opens the actual linked-job route and switches through the real agent picker. Both arms make exactly one job lookup, show Writer with one current job and no editing job, and report zero page errors.
- After requests settle, the original retains the old state containing one fixture job and one run; the candidate allows that state to be collected. The proof uses an isolated synthetic Gateway and no operator task data.
- The selected before/after captures preserve the same Writer task, count and controls. Retention is established by the GC report, not by visible screenshot differences. No heap-byte, RSS, allocation-timing, latency or unbounded-growth claim is made.

Preserve the known #137411 overlap during integration. This patch remains limited to the request latch and does not replace that separate work.

![Before: synthetic behavior preservation](https://github.com/user-attachments/assets/5df7948b-5a59-4169-a5b8-495161249b35)

![After: synthetic behavior preservation](https://github.com/user-attachments/assets/5e26030c-2643-4285-b542-324ccdd1800d)