### PR TITLE
perf(ui): reuse file reads across memory search matches

### DIFF
--- a/ui/src/pages/config/memory-memories.test.ts
+++ b/ui/src/pages/config/memory-memories.test.ts
@@ -60,6 +60,21 @@ const result = {
   source: "memory" as const,
 };
 
+function memoryFileResponse(content: string, path = result.path) {
+  return {
+    agentId: "main",
+    file: {
+      path,
+      name: path.split("/").at(-1),
+      size: content.length,
+      updatedAtMs: 1,
+      mimeType: "text/plain",
+      encoding: "utf8",
+      content,
+    },
+  };
+}
+
 describe("MemoryMemoriesElement", () => {
   it("renders idle and gateway-update-required states", async () => {
     const current = createElement(vi.fn(() => Promise.resolve({})));
@@ -152,41 +167,50 @@ describe("MemoryMemoriesElement", () => {
     }
   });
 
-  it("loads a row file once, highlights the matched range, and keeps one row open", async () => {
-    const second = { ...result, path: "memory/projects/Open Claw.md", startLine: 1, endLine: 1 };
-    const request = vi.fn((method: string) => {
+  it("shares pending and loaded files across matches while keeping each row's highlight", async () => {
+    const second = { ...result, startLine: 1, endLine: 1 };
+    const third = { ...second, path: "memory/projects/Open Claw.md" };
+    const pending = deferred<unknown>();
+    const fileResponse = memoryFileResponse("first\nmatched two\nmatched three\nfourth");
+    const request = vi.fn((method: string, params: Record<string, unknown>) => {
       if (method === "memory.search") {
         return Promise.resolve({
           agentId: "main",
           provider: "local",
           searchMode: "hybrid",
-          results: [result, second],
+          results: [result, second, third],
         });
       }
-      return Promise.resolve({
-        agentId: "main",
-        file: {
-          path: result.path,
-          name: "ada.md",
-          size: 30,
-          updatedAtMs: 1,
-          mimeType: "text/plain",
-          encoding: "utf8",
-          content: "first\nmatched two\nmatched three\nfourth",
-        },
-      });
+      return params.path === result.path
+        ? pending.promise
+        : Promise.resolve(memoryFileResponse("Another memory file", third.path));
     });
     const element = createElement(request);
     try {
       await typeQuery(element, "Ada");
       submit(element);
-      await waitForFast(() => expect(element.querySelectorAll("article")).toHaveLength(2));
+      await waitForFast(() => expect(element.querySelectorAll("article")).toHaveLength(3));
 
       const rows = element.querySelectorAll<HTMLButtonElement>("article > button");
       rows[0]?.click();
       await waitForFast(() =>
-        expect(element.querySelector('[data-memory-match="true"]')).toBeTruthy(),
+        expect(element.textContent).toContain("Loading the full memory file"),
       );
+      rows[1]?.click();
+      await element.updateComplete;
+      expect(rows[0]?.getAttribute("aria-expanded")).toBe("false");
+      expect(rows[1]?.getAttribute("aria-expanded")).toBe("true");
+      expect(element.querySelectorAll(".memory-memories__detail")).toHaveLength(1);
+      expect(
+        request.mock.calls.filter(([method]) => method === "agents.workspace.get"),
+      ).toHaveLength(1);
+
+      pending.resolve(fileResponse);
+      await waitForFast(() =>
+        expect(element.querySelector('[data-memory-match="true"]')?.textContent).toBe("first"),
+      );
+      rows[0]?.click();
+      await element.updateComplete;
       expect(element.querySelector('[data-memory-match="true"]')?.textContent).toBe(
         "matched two\nmatched three",
       );
@@ -202,12 +226,15 @@ describe("MemoryMemoriesElement", () => {
         path: result.path,
       });
 
-      rows[1]?.click();
+      rows[2]?.click();
       await element.updateComplete;
       expect(rows[0]?.getAttribute("aria-expanded")).toBe("false");
-      expect(rows[1]?.getAttribute("aria-expanded")).toBe("true");
-      expect(rows[1]?.getAttribute("aria-controls")).toBe("memory-detail-1");
-      expect(element.querySelector("#memory-detail-1")).not.toBeNull();
+      expect(rows[2]?.getAttribute("aria-expanded")).toBe("true");
+      expect(rows[2]?.getAttribute("aria-controls")).toBe("memory-detail-2");
+      expect(element.querySelector("#memory-detail-2")).not.toBeNull();
+      expect(
+        request.mock.calls.filter(([method]) => method === "agents.workspace.get"),
+      ).toHaveLength(2);
     } finally {
       element.remove();
     }
@@ -298,6 +325,59 @@ describe("MemoryMemoriesElement", () => {
       element.remove();
     }
   });
+
+  it.each(["resolves", "rejects"] as const)(
+    "keeps the current file read when an earlier search's read %s",
+    async (outcome) => {
+      const previous = deferred<unknown>();
+      const current = deferred<unknown>();
+      let fileReads = 0;
+      const request = vi.fn((method: string) => {
+        if (method === "memory.search") {
+          return Promise.resolve({
+            agentId: "main",
+            provider: "local",
+            searchMode: "hybrid",
+            results: [result],
+          });
+        }
+        return fileReads++ === 0 ? previous.promise : current.promise;
+      });
+      const element = createElement(request);
+      try {
+        for (const query of ["Ada", "Ada again"]) {
+          await typeQuery(element, query);
+          submit(element);
+          await element.updateComplete;
+          await waitForFast(() => expect(element.querySelector("article > button")).not.toBeNull());
+          element.querySelector<HTMLButtonElement>("article > button")?.click();
+          await waitForFast(() =>
+            expect(element.textContent).toContain("Loading the full memory file"),
+          );
+        }
+        expect(fileReads).toBe(2);
+
+        if (outcome === "resolves") {
+          previous.resolve(memoryFileResponse("Retired content"));
+        } else {
+          previous.reject(new Error("Retired read failure"));
+        }
+        await previous.promise.catch(() => undefined);
+        await element.updateComplete;
+        expect(element.textContent).toContain("Loading the full memory file");
+        expect(element.textContent).not.toContain("Retired");
+
+        current.resolve(memoryFileResponse("first\nFresh matched content\nthird"));
+        await waitForFast(() =>
+          expect(element.querySelector('[data-memory-match="true"]')?.textContent).toBe(
+            "Fresh matched content\nthird",
+          ),
+        );
+      } finally {
+        element.remove();
+      }
+    },
+  );
 
   it.each([false, true])(
     "shows stale guidance alongside results and clears it after a fresh search (hits=%s)",

--- a/ui/src/pages/config/memory-memories.ts
+++ b/ui/src/pages/config/memory-memories.ts
@@ -61,7 +61,6 @@ class MemoryMemoriesElement extends OpenClawLightDomElement {
   @state() private details = new Map<string, DetailState>();
 
   private searchRequest: object | null = null;
-  private detailRequests = new Map<string, object>();
 
   protected override updated(changed: PropertyValues<this>) {
     if (
@@ -76,7 +75,6 @@ class MemoryMemoriesElement extends OpenClawLightDomElement {
 
   private resetSearch() {
     this.searchRequest = null;
-    this.detailRequests.clear();
     this.query = "";
     this.searchState = { kind: "idle" };
     this.openResultKey = null;
@@ -96,7 +94,6 @@ class MemoryMemoriesElement extends OpenClawLightDomElement {
     this.searchState = { kind: "loading", query: normalizedQuery };
     this.openResultKey = null;
     this.details = new Map();
-    this.detailRequests.clear();
     try {
       const result = await client.request<MemorySearchResponse>("memory.search", {
         query: normalizedQuery,
@@ -125,45 +122,40 @@ class MemoryMemoriesElement extends OpenClawLightDomElement {
       return;
     }
     this.openResultKey = key;
-    if (!this.details.has(key)) {
-      void this.loadDetail(key, result);
+    if (!this.details.has(result.path)) {
+      void this.loadDetail(result.path);
     }
   }
 
-  private async loadDetail(key: string, result: SearchResult) {
+  private async loadDetail(path: string) {
     const client = this.connected ? this.client : null;
     const agentId = this.agentId;
     if (!client || !agentId) {
       return;
     }
-    const request = { client, agentId, path: result.path };
-    this.detailRequests.set(key, request);
-    this.details = new Map(this.details).set(key, { kind: "loading" });
+    const pending: DetailState = { kind: "loading" };
+    this.details = new Map(this.details).set(path, pending);
     try {
       const response = await client.request<AgentsWorkspaceGetResult>("agents.workspace.get", {
         agentId,
-        path: result.path,
+        path,
       });
-      if (this.detailRequests.get(key) !== request || this.agentId !== agentId) {
+      if (this.details.get(path) !== pending || this.agentId !== agentId) {
         return;
       }
       const detail: DetailState =
         response.file.encoding === "utf8"
           ? { kind: "ready", content: response.file.content }
           : { kind: "error", message: t("memoryPage.memories.fileUnsupported") };
-      this.details = new Map(this.details).set(key, detail);
+      this.details = new Map(this.details).set(path, detail);
     } catch (error) {
-      if (this.detailRequests.get(key) !== request || this.agentId !== agentId) {
+      if (this.details.get(path) !== pending || this.agentId !== agentId) {
         return;
       }
-      this.details = new Map(this.details).set(key, {
+      this.details = new Map(this.details).set(path, {
         kind: "error",
         message: formatUiError(error),
       });
-    } finally {
-      if (this.detailRequests.get(key) === request) {
-        this.detailRequests.delete(key);
-      }
     }
   }
 
@@ -171,7 +163,7 @@ class MemoryMemoriesElement extends OpenClawLightDomElement {
     if (this.openResultKey !== key) {
       return nothing;
     }
-    const detail = this.details.get(key);
+    const detail = this.details.get(result.path);
     return html`<div id=${panelId} class="memory-memories__detail">
       ${
         !detail || detail.kind === "loading"


### PR DESCRIPTION
Closes #145237

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening different Memory search matches from the same file caused duplicate full-file reads, including when the first preview request was still pending.

## Why This Change Was Made

Key preview state by exact file path and use the pending detail entry itself to identify the current request, removing the separate request-marker map. All ranges from a file intentionally share pending, loaded, or error state until the existing new-search or scope reset; expansion and highlighting remain keyed to the selected result.

## User Impact

Opening another range from the same file reuses its pending request or cached result. A new search or scope reset clears that shared state, including errors, and stale completions remain unable to replace the current entry.

## Evidence

- The pending same-file regression fails on the original with two workspace reads instead of one. All 12 candidate owner tests pass.
- A real Chromium page with a synthetic mock Gateway records pending and loaded reads of two → one. Both versions retain one expanded result, the same file path and highlighted lines 5–6. The inspected full-page and result-detail screenshot pairs are byte-identical.
- Managed P2 review and the selected UI/core-test gate pass. The gate used default `origin/main`; its resolved execution SHA was not recorded. Native exact-head/base guards remain required before landing, and no exact-base gate result is inferred from today's reference.

Proof covers request counts and preserved presentation using the source-Vite mock Gateway. No live Gateway, retained-heap, RSS or timing improvement is claimed.

![Before: synthetic behavior preservation](https://github.com/user-attachments/assets/7c8d75ad-8153-4bed-a489-f86cf2b9fd04)

![After: synthetic behavior preservation](https://github.com/user-attachments/assets/9e383f20-3400-4fac-a3f2-e81932ba3ec7)