### PR TITLE
fix: keep earlier messages selected during chat refresh

### DIFF
--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -51,7 +51,8 @@ cancellation or a Gateway restart interrupts that wait,
 the message stays readable with its recorded disposition and is never resent
 automatically. Copy it into the composer to start a new attempt. **Show earlier
 messages** pages through messages that are still waiting or were stopped before
-processing; **Show latest messages** returns to the newest page. A long message
+processing; **Show latest messages** returns to the newest page. Incoming activity
+refreshes the page you are reading without changing your selection. A long message
 uses the normal full-message reader without becoming a transcript reply, fork,
 or rewind target.
 

--- a/ui/src/pages/chat/chat-pending-inputs.pagination.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.pagination.test.ts
@@ -1,0 +1,338 @@
+/* @vitest-environment jsdom */
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatPendingInputsPage } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { loadChatHistory } from "./chat-history.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
+import {
+  input,
+  makeChatPageHost,
+  page,
+  sessionId,
+  sessionKey,
+} from "./chat-pending-inputs.test-support.ts";
+import {
+  applyChatPendingInputs,
+  clearChatPendingInputs,
+  getChatPendingInputs,
+  loadChatPendingInputs,
+} from "./chat-pending-inputs.ts";
+import { admitQueuedMessageForSession } from "./chat-queue.ts";
+import { retireDeliveredQueuedUserTurn } from "./chat-send-support.ts";
+import { handlePageGatewayEvent } from "./chat-state-events.ts";
+import { resetChatThreadState } from "./chat-thread.ts";
+import { listStoredChatOutboxes } from "./composer-persistence.ts";
+import { cacheChatSessionSnapshot, type ChatMessageCache } from "./session-message-cache.ts";
+
+beforeEach(() => {
+  vi.stubGlobal("sessionStorage", createStorageMock());
+});
+afterEach(() => {
+  resetChatThreadState();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("server-owned pending input pagination", () => {
+  it("pages custody without replacing transcript or applying a stale physical-session response", async () => {
+    let resolve!: (value: unknown) => void;
+    const response = new Promise((done) => {
+      resolve = done;
+    });
+    const host = makeChatHost({
+      sessionKey,
+      currentSessionId: sessionId,
+      requestHandlers: { "chat.history": () => response },
+    });
+    const history = [{ role: "user", content: "Canonical history" }];
+    host.chatMessages = history;
+    applyChatPendingInputs(host, page);
+    const loading = loadChatPendingInputs(host, 2);
+    expect(host.request).toHaveBeenCalledWith(
+      "chat.history",
+      expect.objectContaining({ pendingBefore: 2 }),
+    );
+    host.currentSessionId = "replacement-session";
+    resolve({ sessionId, pendingInputs: { items: [], total: 2 } });
+    await loading;
+    expect(host.chatMessages).toBe(history);
+    expect(getChatPendingInputs(host)).toBeUndefined();
+    expect(host.request).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(
+    ["page", "delta"].flatMap((delivery) =>
+      ["pagination-first", "refresh-first"].map((order) => ({ delivery, order })),
+    ),
+  )(
+    "preserves pending-input navigation through a $delivery refresh ($order)",
+    async ({ delivery, order }) => {
+      const navigation = createDeferred<unknown>();
+      const refresh = createDeferred<unknown>();
+      const canonical = {
+        role: "user",
+        content: "Canonical transcript stays visible",
+        __openclaw: { id: "canonical", seq: 1 },
+      };
+      const latestPage: ChatPendingInputsPage = {
+        items: [
+          {
+            ...input,
+            id: "latest-input",
+            runId: "latest-run",
+            message: {
+              role: "user",
+              content: "Newest retained input",
+              timestamp: 100,
+              __openclaw: { id: "pending:latest-input" },
+            },
+          },
+        ],
+        total: 21,
+        nextBefore: 21,
+      };
+      const olderPage: ChatPendingInputsPage = { items: [input], total: 21 };
+      const refreshedOlderPage: ChatPendingInputsPage = {
+        items: [{ ...input, state: "cancelled" }],
+        total: 21,
+      };
+      const sessionInfo = {
+        key: sessionKey,
+        sessionId,
+        hasActiveRun: true,
+        status: "running",
+      };
+      const cache: ChatMessageCache = new Map();
+      let olderReads = 0;
+      let refreshFinished = false;
+      const host = makeChatPageHost({
+        sessionKey,
+        currentSessionId: sessionId,
+        chatRunId: "active-run",
+        chatStream: "Live output",
+        chatMessages: [canonical],
+        chatHistoryPagination: { hasMore: false, completeSnapshot: true },
+        chatMessagesBySession: cache,
+        requestHandlers: {
+          "chat.history": (params: { pendingBefore?: number }) =>
+            params.pendingBefore === 21
+              ? ++olderReads === 1
+                ? navigation.promise
+                : { sessionId, pendingInputs: refreshedOlderPage }
+              : refreshFinished
+                ? { sessionId, pendingInputs: latestPage }
+                : refresh.promise,
+        },
+      });
+      cacheChatSessionSnapshot(
+        cache,
+        host,
+        { sessionKey },
+        {
+          messages: [canonical],
+          sessionId,
+          pagination: host.chatHistoryPagination,
+          ...(delivery === "delta" ? { deltaCursor: "previous" } : {}),
+        },
+      );
+      const consumedSource: ChatQueueItem = {
+        id: "consumed-source",
+        sendRunId: "consumed-source",
+        sessionKey,
+        sessionId,
+        text: "Locally retained until consumption",
+        createdAt: 101,
+        sendAttempts: 1,
+        sendState: "waiting-reconnect",
+      };
+      expect(
+        admitQueuedMessageForSession(
+          host,
+          captureChatOutboxAdmission(host, sessionKey),
+          consumedSource,
+        ),
+      ).toBe(true);
+      const outbox = expectDefined(listStoredChatOutboxes(host)[0], "retained input outbox");
+      expect(
+        await retireDeliveredQueuedUserTurn(host, consumedSource.sendRunId, outbox, {
+          retainUntilConsumed: true,
+        }),
+      ).toBe("retained");
+      expect(listStoredChatOutboxes(host)[0]?.queue.map((item) => item.id)).toEqual([
+        consumedSource.id,
+      ]);
+      expect(host.chatMessages).toHaveLength(2);
+      applyChatPendingInputs(host, latestPage);
+      const paging = loadChatPendingInputs(host, 21);
+      if (order === "pagination-first") {
+        navigation.resolve({ sessionId, pendingInputs: olderPage });
+        await paging;
+        expect(getChatPendingInputs(host)?.before).toBe(21);
+      }
+
+      handlePageGatewayEvent(host, {
+        type: "event",
+        event: "sessions.changed",
+        payload: { sessionKey, agentId: "main", reason: "send", hasActiveRun: true },
+      });
+      const refreshing = loadChatHistory(host, { deferBranches: true });
+      refresh.resolve({
+        ...(delivery === "delta"
+          ? { kind: "delta", deltaCursor: "next", messages: [] }
+          : { sessionId, messages: [canonical] }),
+        sessionInfo,
+        pendingInputs: latestPage,
+        inputReceipts: [
+          { runId: "consumed-source", state: "consumed", consumedByEventId: "aggregate" },
+        ],
+      });
+      await refreshing;
+      refreshFinished = true;
+      if (order === "refresh-first") {
+        navigation.resolve({ sessionId, pendingInputs: olderPage });
+        await paging;
+      }
+
+      await vi.waitFor(() => {
+        expect(getChatPendingInputs(host)?.before).toBe(21);
+        expect(getChatPendingInputs(host)?.page).toEqual(refreshedOlderPage);
+      });
+      expect(host.chatMessages).toEqual([canonical]);
+      expect(host.chatQueue).toEqual([]);
+      expect(listStoredChatOutboxes(host)).toEqual([]);
+      expect(host.chatRunId).toBe("active-run");
+      expect(host.chatStream).toBe("Live output");
+      expect(host.request.mock.calls.some(([method]) => method === "chat.send")).toBe(false);
+
+      await loadChatPendingInputs(host);
+      expect(getChatPendingInputs(host)?.before).toBeUndefined();
+      expect(getChatPendingInputs(host)?.page).toEqual(latestPage);
+    },
+  );
+
+  it.each(["refresh-first", "latest-first"])(
+    "lets latest navigation replace a coalesced background custody refresh (%s)",
+    async (order) => {
+      const refresh = createDeferred<unknown>();
+      const latest = createDeferred<unknown>();
+      const olderPage: ChatPendingInputsPage = { items: [input], total: 2 };
+      const latestPage: ChatPendingInputsPage = { items: [], total: 0 };
+      let olderReads = 0;
+      const host = makeChatHost({
+        sessionKey,
+        currentSessionId: sessionId,
+        requestHandlers: {
+          "chat.history": (params: { pendingBefore?: number }) =>
+            params.pendingBefore === 2
+              ? ++olderReads === 1
+                ? { sessionId, pendingInputs: olderPage }
+                : refresh.promise
+              : latest.promise,
+        },
+      });
+      expect(
+        admitQueuedMessageForSession(host, captureChatOutboxAdmission(host, sessionKey), {
+          id: "retained-source",
+          sendRunId: input.runId,
+          sessionKey,
+          sessionId,
+          text: "Retained payload",
+          createdAt: 100,
+          sendState: "waiting-reconnect",
+        }),
+      ).toBe(true);
+      applyChatPendingInputs(host, page);
+      await loadChatPendingInputs(host, 2);
+
+      for (let index = 0; index < 3; index++) {
+        applyChatPendingInputs(host, latestPage);
+      }
+      expect(olderReads).toBe(2);
+      expect(getChatPendingInputs(host)?.loading).toBe(false);
+      expect(getChatPendingInputs(host)?.before).toBe(2);
+      const showLatest = loadChatPendingInputs(host);
+      const settleRefresh = async () => {
+        refresh.resolve({
+          sessionId,
+          pendingInputs: { items: [{ ...input, state: "cancelled" }], total: 1 },
+        });
+        // Let the superseded transport response finish without observing private request state.
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
+      };
+      if (order === "refresh-first") {
+        await settleRefresh();
+        expect(getChatPendingInputs(host)?.loading).toBe(true);
+      }
+      latest.resolve({ sessionId, pendingInputs: latestPage });
+      await showLatest;
+      if (order === "latest-first") {
+        await settleRefresh();
+      }
+
+      expect(getChatPendingInputs(host)?.page).toEqual(latestPage);
+      expect(getChatPendingInputs(host)?.before).toBeUndefined();
+      expect(getChatPendingInputs(host)?.loading).toBe(false);
+      expect(host.chatQueue.some((item) => item.id === "retained-source")).toBe(true);
+      expect(olderReads).toBe(2);
+    },
+  );
+
+  it.each(["connection", "source"])(
+    "stops invalidated custody rereads after the %s changes",
+    async (change) => {
+      const response = createDeferred<unknown>();
+      const host = makeChatHost({
+        sessionKey,
+        currentSessionId: sessionId,
+        requestHandlers: { "chat.history": () => response.promise },
+      });
+      applyChatPendingInputs(host, page);
+      const paging = loadChatPendingInputs(host, 2);
+      applyChatPendingInputs(host, page);
+      if (change === "connection") {
+        host.connectionEpoch += 1;
+      } else {
+        clearChatPendingInputs(host);
+        applyChatPendingInputs(host, page);
+      }
+      response.resolve({ sessionId, pendingInputs: { items: [], total: 0 } });
+      await paging;
+
+      expect(getChatPendingInputs(host)?.page).toEqual(page);
+      expect(getChatPendingInputs(host)?.before).toBeUndefined();
+      expect(getChatPendingInputs(host)?.loading).toBe(false);
+      expect(host.request).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("keeps the displayed custody page and reports a failed navigation without retrying", async () => {
+    const response = createDeferred<unknown>();
+    const olderPage: ChatPendingInputsPage = { items: [input], total: 2 };
+    const host = makeChatHost({
+      sessionKey,
+      currentSessionId: sessionId,
+      requestHandlers: {
+        "chat.history": (params: { pendingBefore?: number }) =>
+          params.pendingBefore === 2 ? { sessionId, pendingInputs: olderPage } : response.promise,
+      },
+    });
+    applyChatPendingInputs(host, page);
+    await loadChatPendingInputs(host, 2);
+    const paging = loadChatPendingInputs(host);
+    applyChatPendingInputs(host, page);
+    response.reject(new Error("Could not load latest messages"));
+    await paging;
+
+    expect(getChatPendingInputs(host)?.page).toEqual(olderPage);
+    expect(getChatPendingInputs(host)?.before).toBe(2);
+    expect(getChatPendingInputs(host)?.error).toContain("Could not load latest messages");
+    expect(getChatPendingInputs(host)?.loading).toBe(false);
+    expect(host.request).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/pages/chat/chat-pending-inputs.test-support.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test-support.ts
@@ -1,0 +1,37 @@
+import { vi } from "vitest";
+import type { ChatPendingInputsPage } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
+import { makeChatHost } from "./chat-host.test-support.ts";
+import { createInitializationContext } from "./chat-pane.test-support.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { createPageState } from "./chat-state-page.ts";
+
+export const sessionKey = "agent:main:accepted-inputs";
+export const sessionId = "accepted-input-session";
+export const input: ChatPendingInputsPage["items"][number] = {
+  id: "input-1",
+  runId: "run-queued",
+  acceptedAt: 100,
+  state: "interrupted",
+  message: {
+    role: "user",
+    content: "Keep my accepted input",
+    timestamp: 100,
+    __openclaw: { id: "pending:input-1" },
+  },
+};
+export const page: ChatPendingInputsPage = { items: [input], total: 2, nextBefore: 2 };
+
+export function makeChatPageHost({
+  requestHandlers,
+  ...overrides
+}: Partial<ChatPageHost> & { requestHandlers: Record<string, unknown> }) {
+  const { client, hello, request, sessions } = makeChatHost({ requestHandlers });
+  const context = { ...createInitializationContext(), sessions };
+  const host = createPageState(
+    context,
+    { invalidate: vi.fn(), afterCommit: () => () => {} },
+    { dispatchEvent: () => true, querySelector: () => null },
+  );
+  Object.assign(host, { client, hello, connected: true }, overrides);
+  return Object.assign(host, { request });
+}

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -18,18 +18,21 @@ import { createStorageMock } from "../../test-helpers/storage.ts";
 import { getChatHistoryLoadState } from "./chat-history-state.ts";
 import { loadChatHistory } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
-import { createInitializationContext } from "./chat-pane.test-support.ts";
+import {
+  input,
+  makeChatPageHost,
+  page,
+  sessionId,
+  sessionKey,
+} from "./chat-pending-inputs.test-support.ts";
 import {
   applyChatPendingInputs,
   buildPendingInputItems,
   getChatPendingInputs,
-  loadChatPendingInputs,
 } from "./chat-pending-inputs.ts";
 import { admitQueuedMessageForSession, readChatQueueForScope } from "./chat-queue.ts";
 import { retireDeliveredQueuedUserTurn } from "./chat-send-support.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
-import type { ChatPageHost } from "./chat-state-host.ts";
-import { createPageState } from "./chat-state-page.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
 import { resetChatThreadState } from "./chat-thread.ts";
 import { listStoredChatOutboxes, loadChatComposerSnapshot } from "./composer-persistence.ts";
@@ -46,22 +49,6 @@ import {
   type ChatMessageCache,
 } from "./session-message-cache.ts";
 import { buildInitialChatSubmission, buildLocalUserMessage } from "./user-message-content.ts";
-
-const sessionKey = "agent:main:accepted-inputs";
-const sessionId = "accepted-input-session";
-const input: ChatPendingInputsPage["items"][number] = {
-  id: "input-1",
-  runId: "run-queued",
-  acceptedAt: 100,
-  state: "interrupted",
-  message: {
-    role: "user",
-    content: "Keep my accepted input",
-    timestamp: 100,
-    __openclaw: { id: "pending:input-1" },
-  },
-};
-const page: ChatPendingInputsPage = { items: [input], total: 2, nextBefore: 2 };
 
 async function retainDeliveredUserTurn(
   host: Parameters<typeof retireDeliveredQueuedUserTurn>[0],
@@ -81,21 +68,6 @@ async function retainDeliveredUserTurn(
   );
   expect(await retireDeliveredQueuedUserTurn(host, item.sendRunId, outbox)).toBe("retired");
   return outbox;
-}
-
-function makeChatPageHost({
-  requestHandlers,
-  ...overrides
-}: Partial<ChatPageHost> & { requestHandlers: Record<string, unknown> }) {
-  const { client, hello, request, sessions } = makeChatHost({ requestHandlers });
-  const context = { ...createInitializationContext(), sessions };
-  const host = createPageState(
-    context,
-    { invalidate: vi.fn(), afterCommit: () => () => {} },
-    { dispatchEvent: () => true, querySelector: () => null },
-  );
-  Object.assign(host, { client, hello, connected: true }, overrides);
-  return Object.assign(host, { request });
 }
 
 beforeEach(() => {
@@ -866,32 +838,6 @@ describe("server-owned pending input display", () => {
       }
     },
   );
-
-  it("pages custody without replacing transcript or applying a stale physical-session response", async () => {
-    let resolve!: (value: unknown) => void;
-    const response = new Promise((done) => {
-      resolve = done;
-    });
-    const host = makeChatHost({
-      sessionKey,
-      currentSessionId: sessionId,
-      requestHandlers: { "chat.history": () => response },
-    });
-    const history = [{ role: "user", content: "Canonical history" }];
-    host.chatMessages = history;
-    applyChatPendingInputs(host, page);
-    const loading = loadChatPendingInputs(host, 2);
-    expect(host.request).toHaveBeenCalledWith(
-      "chat.history",
-      expect.objectContaining({ pendingBefore: 2 }),
-    );
-    host.currentSessionId = "replacement-session";
-    resolve({ sessionId, pendingInputs: { items: [], total: 2 } });
-    await loading;
-    expect(host.chatMessages).toBe(history);
-    expect(getChatPendingInputs(host)).toBeUndefined();
-    expect(host.request).toHaveBeenCalledTimes(1);
-  });
 
   it("replaces a server pending bubble with canonical persistence exactly once", () => {
     const promoted = {

--- a/ui/src/pages/chat/chat-pending-inputs.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.ts
@@ -20,14 +20,23 @@ import {
   reconcileChatInputCustody,
 } from "./history-merge.ts";
 
+type PendingInputRequest = {
+  before?: number;
+  kind: "navigation" | "refresh";
+  client: NonNullable<ChatState["client"]>;
+  connectionEpoch: number;
+};
+
 type PendingInputView = {
   sessionKey: string;
   sessionId: string | null;
   agentId: string | undefined;
   page: ChatPendingInputsPage;
   before?: number;
-  loading: boolean;
+  readonly loading: boolean;
   error?: string;
+  revision: number;
+  request?: PendingInputRequest;
 };
 const pendingInputViews = new WeakMap<ChatState, PendingInputView>();
 
@@ -124,22 +133,14 @@ export function readChatInputRunIds(state: ChatState): string[] {
     .slice(0, CHAT_INPUT_RECEIPT_MAX_RUN_IDS);
 }
 
-export function applyChatPendingInputs(
+function reconcilePendingInputPage(
   state: ChatState,
   page: ChatPendingInputsPage | undefined,
-  options: { before?: number; receipts?: ChatInputReceipts } = {},
-): void {
-  const { page: displayPage } = reconcileChatInputCustody(state, page, options.receipts);
-  pendingInputViews.set(state, {
-    sessionKey: state.sessionKey,
-    sessionId: state.currentSessionId ?? null,
-    agentId: resolveUiSelectedSessionAgentId(state),
-    page: displayPage,
-    before: options.before,
-    loading: false,
-  });
+  receipts?: ChatInputReceipts,
+): ChatPendingInputsPage {
+  const { page: displayPage } = reconcileChatInputCustody(state, page, receipts);
   const settled = new Set([
-    ...(options.receipts ?? [])
+    ...(receipts ?? [])
       .filter((receipt) => receipt.state === "consumed")
       .map((receipt) => receipt.runId),
     ...displayPage.items.filter((input) => input.state === "cancelled").map((input) => input.runId),
@@ -157,45 +158,120 @@ export function applyChatPendingInputs(
       removeQueuedMessage(state, item.id);
     }
   }
+  return displayPage;
+}
+
+function ownsPendingInputRequest(
+  state: ChatState,
+  view: PendingInputView,
+  request: PendingInputRequest,
+): boolean {
+  return (
+    getChatPendingInputs(state) === view &&
+    view.request === request &&
+    state.client === request.client &&
+    state.connected &&
+    state.connectionEpoch === request.connectionEpoch
+  );
+}
+
+export function applyChatPendingInputs(
+  state: ChatState,
+  page: ChatPendingInputsPage | undefined,
+  options: { receipts?: ChatInputReceipts } = {},
+): void {
+  const displayPage = reconcilePendingInputPage(state, page, options.receipts);
+  let view = getChatPendingInputs(state);
+  if (!view) {
+    view = {
+      sessionKey: state.sessionKey,
+      sessionId: state.currentSessionId ?? null,
+      agentId: resolveUiSelectedSessionAgentId(state),
+      page: displayPage,
+      revision: 0,
+      get loading() {
+        return this.request?.kind === "navigation";
+      },
+    };
+    pendingInputViews.set(state, view);
+  } else {
+    view.revision += 1;
+    if (view.request && !ownsPendingInputRequest(state, view, view.request)) {
+      view.request = undefined;
+    }
+    if (view.before === undefined) {
+      view.page = displayPage;
+      view.error = undefined;
+    }
+    // Latest custody updates ownership immediately, but cannot take over browsing.
+    if (view.before !== undefined && !view.request) {
+      void requestPendingInputPage(state, view.before, "refresh");
+    }
+  }
   state.requestUpdate?.();
 }
 
-export async function loadChatPendingInputs(state: ChatState, before?: number): Promise<void> {
+async function requestPendingInputPage(
+  state: ChatState,
+  before: number | undefined,
+  kind: PendingInputRequest["kind"],
+): Promise<void> {
   const view = getChatPendingInputs(state);
   const client = state.client;
-  if (!view || view.loading || !client || !state.connected) {
+  if (!view || !client || !state.connected) {
     return;
   }
-  const connectionEpoch = state.connectionEpoch;
-  view.loading = true;
+  if (
+    view.request &&
+    ownsPendingInputRequest(state, view, view.request) &&
+    (kind === "refresh" || view.request.kind === "navigation")
+  ) {
+    return;
+  }
+  const request = { before, kind, client, connectionEpoch: state.connectionEpoch };
+  view.request = request;
   view.error = undefined;
-  state.requestUpdate?.();
-  const current = () =>
-    getChatPendingInputs(state) === view &&
-    state.client === client &&
-    state.connected &&
-    state.connectionEpoch === connectionEpoch;
+  if (kind === "navigation") {
+    state.requestUpdate?.();
+  }
+  const current = () => ownsPendingInputRequest(state, view, request);
   try {
-    const result = await client.request<{
-      sessionId?: string;
-      pendingInputs?: ChatPendingInputsPage;
-    }>("chat.history", {
-      sessionKey: state.sessionKey,
-      agentId: view.agentId,
-      limit: 20,
-      ...(before === undefined ? {} : { pendingBefore: before }),
-    });
-    if (current() && result.sessionId === view.sessionId) {
-      applyChatPendingInputs(state, result.pendingInputs, { before });
+    while (current()) {
+      const revision = view.revision;
+      const result = await client.request<{
+        sessionId?: string;
+        pendingInputs?: ChatPendingInputsPage;
+      }>("chat.history", {
+        sessionKey: view.sessionKey,
+        agentId: view.agentId,
+        limit: 20,
+        ...(request.before === undefined ? {} : { pendingBefore: request.before }),
+      });
+      if (!current() || result.sessionId !== view.sessionId) {
+        return;
+      }
+      // Coalesce newer custody publications into a fresh read of the same target.
+      if (view.revision !== revision) {
+        continue;
+      }
+      view.page = reconcilePendingInputPage(state, result.pendingInputs);
+      view.before = request.before;
+      return;
     }
   } catch (error) {
     if (current()) {
       view.error = formatUiError(error);
     }
   } finally {
-    view.loading = false;
-    if (current()) {
-      state.requestUpdate?.();
+    if (view.request === request) {
+      view.request = undefined;
+      if (getChatPendingInputs(state) === view) {
+        state.requestUpdate?.();
+      }
     }
   }
+}
+
+export function loadChatPendingInputs(state: ChatState, before?: number): Promise<void> {
+  return requestPendingInputPage(state, before, "navigation");
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading earlier retained messages in Chat would be returned to the latest page when new activity refreshed the conversation. A refresh arriving during pagination could also discard the requested earlier page.

## Why This Change Was Made

The existing pending-input view now retains the selected cursor and owns request freshness. Incoming custody updates still reconcile delivery receipts immediately, then refresh the selected page. New observations coalesce into a current read, and an explicit return to Latest supersedes background pagination.

## User Impact

Users can keep reading earlier messages while activity continues. Their recorded dispositions stay current, the conversation and live output remain visible, and a delayed older response cannot undo a return to Latest. A failed page request leaves the previous page readable with an error.

## Evidence

All four page/delta and request-order regressions fail on the original code. All 485 related tests pass across six files, including receipt-driven outbox retirement, request supersession, connection changes, and failed navigation. Canonical changed checks, the UI build, and four independent review passes also passed.

Chromium proof uses a synthetic Gateway and the actual paging controls. Before, incoming activity removes the older row and Latest button. After, the older row remains selected with its updated disposition; Latest remains selected after a delayed older response. Transcript, live output, and Stop controls stay present throughout.

![Before: activity resets the selected page](https://github.com/user-attachments/assets/4f42d829-bbc2-4d7b-882f-fedc6eebd922)

![After: the selected earlier page refreshes in place](https://github.com/user-attachments/assets/575bd8cf-989f-4ad1-83a9-63a36fc4675f)
