### PR TITLE
fix(cron): record designed heartbeat skips as successful no-ops

### DIFF
--- a/src/cron/service.heartbeat-payload.test.ts
+++ b/src/cron/service.heartbeat-payload.test.ts
@@ -96,9 +96,9 @@ describe("heartbeat payload execution", () => {
     {
       label: "disabled skip",
       child: { status: "skipped", reason: "disabled" } as HeartbeatRunResult,
-      expectedStatus: "ok",
-      expectedCompletion: "succeeded",
-      expectedError: undefined,
+      expectedStatus: "skipped",
+      expectedCompletion: "failed",
+      expectedError: "heartbeat skipped: disabled",
       expectedConsecutiveErrors: 0,
     },
     {

--- a/src/cron/service.heartbeat-payload.test.ts
+++ b/src/cron/service.heartbeat-payload.test.ts
@@ -96,9 +96,17 @@ describe("heartbeat payload execution", () => {
     {
       label: "disabled skip",
       child: { status: "skipped", reason: "disabled" } as HeartbeatRunResult,
-      expectedStatus: "skipped",
-      expectedCompletion: "failed",
-      expectedError: "heartbeat skipped: disabled",
+      expectedStatus: "ok",
+      expectedCompletion: "succeeded",
+      expectedError: undefined,
+      expectedConsecutiveErrors: 0,
+    },
+    {
+      label: "empty heartbeat file skip",
+      child: { status: "skipped", reason: "empty-heartbeat-file" } as HeartbeatRunResult,
+      expectedStatus: "ok",
+      expectedCompletion: "succeeded",
+      expectedError: undefined,
       expectedConsecutiveErrors: 0,
     },
   ])("records the settled heartbeat child $label", async (testCase) => {

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -213,7 +213,15 @@ export async function executeJobCore(
           }
         : heartbeatResult.status === "failed"
           ? { status: "error" as const, error: `heartbeat failed: ${heartbeatResult.reason}` }
-          : { status: "skipped" as const, error: `heartbeat skipped: ${heartbeatResult.reason}` };
+          : // Designed no-op skips (empty heartbeat file, no pending event, ...)
+            // are successful runs by definition; recording them as skipped
+            // failures inflated `tasks list --status failed` and failure
+            // alerts (gh-144959). The runner's own state keeps the skipped
+            // counters for `system heartbeat last`.
+            {
+              status: "ok" as const,
+              summary: `heartbeat skipped: ${heartbeatResult.reason}`,
+            };
     return triggerEval ? { ...result, triggerEval } : result;
   }
   if (effectiveJob.sessionTarget === "main") {
@@ -317,8 +325,12 @@ async function executeMainSessionCronJob(
       return { status: "ok", summary: text };
     }
     removeQueuedSystemEvent();
+    if (heartbeatResult.status === "skipped") {
+      // Designed no-op skip; see the interval heartbeat path above (gh-144959).
+      return { status: "ok", summary: `heartbeat skipped: ${heartbeatResult.reason}` };
+    }
     return {
-      status: heartbeatResult.status === "skipped" ? "skipped" : "error",
+      status: "error",
       error: heartbeatResult.reason,
       summary: text,
     };

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -1,6 +1,7 @@
 import type { NormalizeReplySkipReason } from "../../auto-reply/reply/normalize-reply-skip-reason.js";
 import {
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
+  HEARTBEAT_SKIP_NO_PENDING_EVENT,
   type HeartbeatRunResult,
 } from "../../infra/heartbeat-wake.js";
 import type { CommandLaneTaskMarker } from "../../process/command-queue.js";
@@ -36,6 +37,14 @@ import {
   normalizeQueuedSystemEventHandle,
   removeQueuedSystemEventHandle,
 } from "./timer-trigger.js";
+
+// Heartbeat preflight skips that mean "nothing to do by design"; settling them as
+// ok runs keeps failure accounting and alerts focused on real failures (gh-144959).
+// Operator-driven skips ("disabled") stay skipped for visibility.
+const DESIGNED_HEARTBEAT_NOOP_SKIPS = new Set([
+  "empty-heartbeat-file",
+  HEARTBEAT_SKIP_NO_PENDING_EVENT,
+]);
 
 /** Executes a cron job without mutating persisted job state. */
 export async function executeJobCore(
@@ -213,15 +222,16 @@ export async function executeJobCore(
           }
         : heartbeatResult.status === "failed"
           ? { status: "error" as const, error: `heartbeat failed: ${heartbeatResult.reason}` }
-          : // Designed no-op skips (empty heartbeat file, no pending event, ...)
-            // are successful runs by definition; recording them as skipped
-            // failures inflated `tasks list --status failed` and failure
-            // alerts (gh-144959). The runner's own state keeps the skipped
-            // counters for `system heartbeat last`.
-            {
-              status: "ok" as const,
-              summary: `heartbeat skipped: ${heartbeatResult.reason}`,
-            };
+          : DESIGNED_HEARTBEAT_NOOP_SKIPS.has(heartbeatResult.reason)
+            ? // Designed no-op skips are successful runs; recording them as skipped
+              // failures inflated `tasks list --status failed` and failure alerts
+              // (gh-144959). The runner's own state keeps the skipped counters for
+              // `system heartbeat last`.
+              {
+                status: "ok" as const,
+                summary: `heartbeat skipped: ${heartbeatResult.reason}`,
+              }
+            : { status: "skipped" as const, error: `heartbeat skipped: ${heartbeatResult.reason}` };
     return triggerEval ? { ...result, triggerEval } : result;
   }
   if (effectiveJob.sessionTarget === "main") {
@@ -326,8 +336,15 @@ async function executeMainSessionCronJob(
     }
     removeQueuedSystemEvent();
     if (heartbeatResult.status === "skipped") {
-      // Designed no-op skip; see the interval heartbeat path above (gh-144959).
-      return { status: "ok", summary: `heartbeat skipped: ${heartbeatResult.reason}` };
+      if (DESIGNED_HEARTBEAT_NOOP_SKIPS.has(heartbeatResult.reason)) {
+        // Designed no-op skip; see the interval heartbeat path above (gh-144959).
+        return { status: "ok", summary: `heartbeat skipped: ${heartbeatResult.reason}` };
+      }
+      return {
+        status: "skipped",
+        error: heartbeatResult.reason,
+        summary: text,
+      };
     }
     return {
       status: "error",


### PR DESCRIPTION
## What Problem This Solves

An agent whose heartbeat file is intentionally empty (or comments-only) skips every interval by design, but each skip was recorded as a `skipped` cron run, which `resolveCronCompletionStatus` maps to `failed`. `openclaw tasks list --status failed` accrued one row per interval (~48/day) for the heartbeat cron and failure alerts fired, even though `consecutiveErrors` stayed 0 (#144959).

Designed no-op skips now settle as `ok` runs whose summary carries the skip reason (`heartbeat skipped: empty-heartbeat-file`), matching the busy-deferral handoff path that already returned `ok`. The heartbeat runner's own state (`system heartbeat last`, `consecutiveSkipped`) keeps reporting the precise skipped status, so no signal is lost.

## Evidence

- **Real-behavior proof (updated in f8c3fa97 per review):** `src/cron/service.heartbeat-real-preflight.test.ts` wires the **real heartbeat runner** (real preflight, no injected heartbeat results), a **real comments-only scratch row** in the sqlite state store (stock "keep this file empty" content), and the **real cron service**. The two review findings are addressed:
  - **Same-partition fixture:** the sandbox is now selected as the cron partition the preflight actually reads — `OPENCLAW_STATE_DIR` points the default partition (`<state>/cron/jobs.json`) at the seeded `cronStorePath`, so `resolveHeartbeatPreflight` genuinely consumes the seeded comments-only scratch instead of a different store.
  - **Required dependency supplied:** the `CronServiceDeps.requestHeartbeat` member is provided (non-waiting) alongside `requestHeartbeatAndWait`, matching the production contract.
  - **Skip assertions, not just success:** the finished event must carry `summary: "heartbeat skipped: empty-heartbeat-file"`, and the reply/telegram spies must stay unused — so an ordinary successful agent turn can no longer satisfy the test. Paused-reminder recovery stays covered: the operator `disabled` skip keeps its `skipped`/`failed` outcome in the unit matrix.

Runtime output (local vitest run of the file at f8c3fa97, redacted):

```
✓ src/cron/service.heartbeat-real-preflight.test.ts > real heartbeat preflight task accounting > settles a real empty-scratch preflight as a successful no-op task 1066ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- The test also asserts the ledger that feeds `tasks list --status failed` contains zero failed cron rows after the designed skip.
- Unit-level matrix in `service.heartbeat-payload.test.ts` (10/10): designed skips settle `ok`/`succeeded` with `consecutiveErrors: 0`; the operator `disabled` skip keeps its `skipped` outcome for visibility.
- Matches the existing intentional-silence precedent in `resolveCronCompletionStatus`, and the busy-deferral handoff path in `timer-execution.ts` that already returned `ok`. The runner's own state (`system heartbeat last`, `consecutiveSkipped`) continues to report the precise skipped status.
