### PR TITLE
test: avoid repeated worker builds in cache checks

### DIFF
--- a/test/scripts/vitest-worker-artifacts.transforms.test.ts
+++ b/test/scripts/vitest-worker-artifacts.transforms.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect } from "vitest";
+import { describe, expect, vi } from "vitest";
+import { createVitestWorkerRun } from "../../scripts/lib/vitest-worker-run.mts";
 import { createWorkerArtifactTest, workerProbe } from "./vitest-worker-artifacts.test-support.js";
 
 const root = process.cwd();
@@ -12,7 +13,7 @@ describe("fresh compiled subprocess invocation", { concurrent: false }, () => {
     "preserves filesystem transforms across fresh generations, source mode, and edits ($layout)",
     ({ layout }, { workerArtifacts }) =>
       workerArtifacts.fixtureLifetime.run(async () => {
-        const { node } = workerArtifacts.createFixtureCommands();
+        const { node, startBorrower } = workerArtifacts.createFixtureCommands();
         const directory = workerArtifacts.fixtureDirectory();
         const { config, value, configuredValue, parent, cacheDirectory } = workerProbe(
           directory,
@@ -30,88 +31,110 @@ describe("fresh compiled subprocess invocation", { concurrent: false }, () => {
             (ids) => transformed.filter((actual) => ids.includes(actual)).length,
           );
         };
-        const generations: string[] = [];
-        const launch = async (
-          mode: "compiled" | "source",
-          expectedValue = "first",
-          configValue = "first",
-        ) => {
-          const result = await node([
-            mode === "compiled" ? "scripts/run-vitest.mjs" : "node_modules/vitest/vitest.mjs",
-            "run",
-            "--config",
+        const generations = new Set<string>();
+        const owner = createVitestWorkerRun();
+        const preparationLog = vi.spyOn(console, "error");
+        try {
+          const launch = async (
+            mode: "compiled" | "source",
+            expectedValue = "first",
+            configValue = "first",
+          ) => {
+            const args = ["run", "--config", config, "--project", "first"];
+            const reuse = mode === "compiled" && generations.size > 0;
+            const result = reuse
+              ? await startBorrower(owner, args).result
+              : await node([
+                  mode === "compiled" ? "scripts/run-vitest.mjs" : "node_modules/vitest/vitest.mjs",
+                  ...args,
+                ]);
+            expect(result.code, result.stderr + result.stdout).toBe(0);
+            const generation: string = JSON.parse(readLines("generations.jsonl").at(-1)!);
+            const observed = JSON.parse(readLines("observations.jsonl").at(-1)!);
+            expect(observed.value).toBe(expectedValue);
+            expect(observed.configValue).toBe(configValue);
+            if (mode === "compiled") {
+              const generationDirectory = fileURLToPath(new URL("../../", generation));
+              if (reuse) {
+                expect(result.stderr).not.toContain("[vitest-workers] prepared");
+                expect(path.resolve(generationDirectory)).toBe(owner.descriptor.directory);
+              } else {
+                expect(result.stderr.match(/\[vitest-workers\] prepared/g)).toHaveLength(1);
+              }
+              generations.add(generation);
+              expect(path.dirname(generationDirectory)).toBe(
+                path.join(root, ".artifacts", "vitest-workers"),
+              );
+              expect(fileURLToPath(generation)).toBe(
+                path.join(generationDirectory, "dist/infra/sqlite-readonly-location.worker.js"),
+              );
+              expect(observed.args[0]).toBe(
+                path.join(generationDirectory, "dist/infra/sqlite-readonly-location.worker.js"),
+              );
+              expect(fileURLToPath(observed.knn)).toBe(
+                path.join(
+                  generationDirectory,
+                  "dist/extensions/memory-core/memory-search-knn.child.js",
+                ),
+              );
+              // The direct invocation disposes immediately; shared borrowers retain
+              // their owner's unchanged generation until the whole sequence finishes.
+              expect(fs.existsSync(generationDirectory)).toBe(reuse);
+            } else {
+              expect(result.stderr).not.toContain("[vitest-workers] prepared");
+              expect(fileURLToPath(generation)).toBe(
+                path.join(root, "src/infra/sqlite-readonly-location.worker.ts"),
+              );
+              expect(observed.args[0]).toBe("--import");
+              expect(observed.args[1]).toMatch(/^file:\/\//);
+              expect(fileURLToPath(observed.knn)).toBe(
+                path.join(root, "extensions/memory-core/src/memory/manager-search-knn.child.ts"),
+              );
+            }
+            console.log(
+              "cache transport",
+              JSON.stringify({ mode, ...observed, generation, transforms: counts() }),
+            );
+          };
+          await launch("compiled");
+          expect(counts()).toEqual([1, 1]);
+          expect(
+            JSON.parse(fs.readFileSync(path.join(cacheDirectory, "_metadata.json"), "utf8")),
+          ).toEqual({ lockfileHash: expect.stringMatching(/^[a-f\d]{8}$/u) });
+          await launch("compiled");
+          expect(generations.size).toBe(2);
+          expect(counts(), "unchanged parents must reuse filesystem transforms").toEqual([1, 1]);
+          await launch("source");
+          expect(counts()).toEqual([2, 2]);
+          // Switching back with a leaf edit also proves the unchanged parent reuses
+          // its compiled transform, without preparing another complete worker set.
+          fs.writeFileSync(value, 'export const value: string = "second";');
+          await launch("compiled", "second");
+          expect(counts()).toEqual([3, 2]);
+          fs.writeFileSync(
             config,
-            "--project",
-            "first",
-          ]);
-          expect(result.code, result.stderr + result.stdout).toBe(0);
-          const generation: string = JSON.parse(readLines("generations.jsonl").at(-1)!);
-          const observed = JSON.parse(readLines("observations.jsonl").at(-1)!);
-          expect(observed.value).toBe(expectedValue);
-          expect(observed.configValue).toBe(configValue);
-          if (mode === "compiled") {
-            const generationDirectory = fileURLToPath(new URL("../../", generation));
-            expect(result.stderr.match(/\[vitest-workers\] prepared/g)).toHaveLength(1);
-            expect(generations).not.toContain(generation);
-            generations.push(generation);
-            expect(path.dirname(generationDirectory)).toBe(
-              path.join(root, ".artifacts", "vitest-workers"),
-            );
-            expect(fileURLToPath(generation)).toBe(
-              path.join(generationDirectory, "dist/infra/sqlite-readonly-location.worker.js"),
-            );
-            expect(observed.args[0]).toBe(
-              path.join(generationDirectory, "dist/infra/sqlite-readonly-location.worker.js"),
-            );
-            expect(fileURLToPath(observed.knn)).toBe(
-              path.join(
-                generationDirectory,
-                "dist/extensions/memory-core/memory-search-knn.child.js",
+            fs
+              .readFileSync(config, "utf8")
+              .replace(
+                `replacement:${JSON.stringify(value)}`,
+                `replacement:${JSON.stringify(configuredValue)}`,
               ),
-            );
-            // Each completed repository invocation must dispose before the next starts.
-            expect(fs.existsSync(generationDirectory)).toBe(false);
-          } else {
-            expect(result.stderr).not.toContain("[vitest-workers] prepared");
-            expect(fileURLToPath(generation)).toBe(
-              path.join(root, "src/infra/sqlite-readonly-location.worker.ts"),
-            );
-            expect(observed.args[0]).toBe("--import");
-            expect(observed.args[1]).toMatch(/^file:\/\//);
-            expect(fileURLToPath(observed.knn)).toBe(
-              path.join(root, "extensions/memory-core/src/memory/manager-search-knn.child.ts"),
-            );
-          }
-          console.log(
-            "cache transport",
-            JSON.stringify({ mode, ...observed, generation, transforms: counts() }),
           );
-        };
-        await launch("compiled");
-        expect(counts()).toEqual([1, 1]);
-        expect(
-          JSON.parse(fs.readFileSync(path.join(cacheDirectory, "_metadata.json"), "utf8")),
-        ).toEqual({ lockfileHash: expect.stringMatching(/^[a-f\d]{8}$/u) });
-        await launch("compiled");
-        expect(counts(), "unchanged parents must reuse filesystem transforms").toEqual([1, 1]);
-        await launch("source");
-        expect(counts()).toEqual([2, 2]);
-        // Switching back with a leaf edit also proves the unchanged parent reuses
-        // its compiled transform, without preparing another complete worker set.
-        fs.writeFileSync(value, 'export const value: string = "second";');
-        await launch("compiled", "second");
-        expect(counts()).toEqual([3, 2]);
-        fs.writeFileSync(
-          config,
-          fs
-            .readFileSync(config, "utf8")
-            .replace(
-              `replacement:${JSON.stringify(value)}`,
-              `replacement:${JSON.stringify(configuredValue)}`,
+          await launch("compiled", "configured");
+          expect(counts()).toEqual([4, 3]);
+          expect(generations.size).toBe(2);
+          expect(
+            preparationLog.mock.calls.filter(([line]) =>
+              String(line).startsWith("[vitest-workers] prepared"),
             ),
-        );
-        await launch("compiled", "configured");
-        expect(counts()).toEqual([4, 3]);
+          ).toHaveLength(1);
+        } finally {
+          preparationLog.mockRestore();
+          await owner.dispose();
+        }
+        for (const generation of generations) {
+          expect(fs.existsSync(new URL("../../", generation))).toBe(false);
+        }
       }),
   );
 });


### PR DESCRIPTION
## What Problem This Solves

The transform-cache test rebuilt the entire worker generation four times per layout while testing five cache transitions. In a recent Windows run, one layout reached the existing 120-second deadline during its final launch. The same test also spends avoidable time compiling unchanged workers on other platforms.

## Why This Change Was Made

Keep two distinct compiled generations to prove that cached parent transforms survive a generation change. Use the existing worker owner and borrower path to reuse the second generation for the later leaf and configuration edits. Source-mode execution remains a separate process.

Both layouts retain all five cache transitions and their exact transform counts, along with real SQLite snapshot/archive, TUI, compaction, KNN and subprocess observations. The direct invocation still disposes immediately; borrowed children retain their generation until the existing owner joins them and disposes it. The test verifies both generation directories are removed. No production helper, deadline, runner, shard, cache policy or dependency changes.

## User Impact

CI avoids two complete worker builds per layout while keeping the original cache and process-lifecycle coverage. There is no application behavior change.

## Evidence

Same-host, same-command local comparison using Node 24.20.0, including worker preparation:

| Measurement | Original | Candidate |
| --- | ---: | ---: |
| Single layout | 30.414s | 19.936s |
| Projects layout | 29.203s | 20.239s |
| Complete invocation | 61.306s | 41.494s |

The measured invocation is 19.8 seconds shorter (32.3%). Each retained full preparation still covers 8,848 inputs and 4,498 outputs. This is one local pair, not a Windows timing result or a compiler-only speedup estimate.

Both layouts pass all five transitions. Three existing shared-borrower, cancellation and owner-disconnect cases pass; all observed generation directories were removed. Targeted types, lint, formatting and independent P2 review pass. The first candidate run found a trailing-slash difference in the new directory assertion; path normalization fixed the assertion while retaining exact owner equality.

The historical [Windows failure](https://github.com/openclaw/openclaw/actions/runs/34634120965/job/103378031443) timed out after four correct cache observations. A later unchanged Windows run passed, so that history alone does not establish a controlled Windows speedup. Source delta: one test file, +103/-80 (net +23, mostly indentation for owned cleanup); production/helper delta zero.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34644021948) passes on `4e6cb2b8528d268abfcd602f115c092ff361e295`, with all 78 checks terminal without failures. [Windows test 2](https://github.com/openclaw/openclaw/actions/runs/34644021948/job/103410627431) passes the single/projects cases in 57.823s/52.623s, retaining all five cache states. The full job took 19m26s (17m28s test command) on two available CPUs, so this is case-level acceptance rather than an eight-minute Windows job claim.

Windows still emits the existing conservative temporary-namespace retention warning when a non-group launch cannot certify descendant completion. The unchanged owner and its regression test deliberately preserve those namespaces; the original log already contains the warning, while the new in-process borrower calls make some instances directly visible. Generation verification/removal passes, but it is not proof of OS-wide descendant extinction or removal of every temporary namespace.
