### PR TITLE
refactor(tests): share fresh compaction quality runtime setup

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -182,6 +182,17 @@ function createAnthropicModelFixture(overrides: Partial<Model> = {}): Model {
   };
 }
 
+function createQualityGuardSessionManager(): ExtensionContext["sessionManager"] {
+  const sessionManager = stubSessionManager();
+  setCompactionSafeguardRuntime(sessionManager, {
+    model: createAnthropicModelFixture(),
+    recentTurnsPreserve: 0,
+    qualityGuardEnabled: true,
+    qualityGuardMaxRetries: 1,
+  });
+  return sessionManager;
+}
+
 type CompactionHandler = (event: unknown, ctx: unknown) => Promise<unknown>;
 const createCompactionHandler = () => {
   let compactionHandler: CompactionHandler | undefined;
@@ -2435,13 +2446,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     ).toBe(true);
     mockSummarizeInStages.mockResolvedValue(summaryResult(auditValidBeforeFinalization));
 
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      recentTurnsPreserve: 0,
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
+    const sessionManager = createQualityGuardSessionManager();
     const event = {
       ...createCompactionEvent({ messageText: `${latestAsk} ${identifier}`, tokensBefore: 1_500 }),
       preparation: {
@@ -2493,13 +2498,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     ].join("\n");
     mockSummarizeInStages.mockResolvedValue(summaryResult(generatedSummary));
 
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      recentTurnsPreserve: 0,
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
+    const sessionManager = createQualityGuardSessionManager();
     const event = createCompactionEvent({
       messageText: `${latestAsk} ${identifier}`,
       tokensBefore: 1_500,
@@ -2549,13 +2548,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(generatedSummary.length).toBeGreaterThan(MAX_COMPACTION_SUMMARY_CHARS);
     mockSummarizeInStages.mockResolvedValue(summaryResult(generatedSummary));
 
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      recentTurnsPreserve: 0,
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
+    const sessionManager = createQualityGuardSessionManager();
     const event = createCompactionEvent({
       messageText: `${latestAsk} ${identifier}`,
       tokensBefore: 1_500,
@@ -2643,13 +2636,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(generatedSummary.length).toBeLessThan(MAX_COMPACTION_SUMMARY_CHARS);
     mockSummarizeInStages.mockResolvedValue(summaryResult(generatedSummary));
 
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      recentTurnsPreserve: 0,
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
+    const sessionManager = createQualityGuardSessionManager();
     const event = createCompactionEvent({
       messageText: `${latestAsk} ${identifier}`,
       tokensBefore: 1_500,
@@ -2690,13 +2677,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     ].join("\n");
     mockSummarizeInStages.mockResolvedValue(summaryResult(generatedSummary));
 
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      recentTurnsPreserve: 0,
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
+    const sessionManager = createQualityGuardSessionManager();
     const event = createCompactionEvent({
       messageText: `${latestAsk} ${identifier}`,
       tokensBefore: 1_500,
@@ -2731,13 +2712,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     ].join("\n");
     mockSummarizeInStages.mockResolvedValue(summaryResult(generatedSummary));
 
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      recentTurnsPreserve: 0,
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
+    const sessionManager = createQualityGuardSessionManager();
     const event = createCompactionEvent({
       messageText: latestAsk,
       tokensBefore: 1_500,
@@ -2955,13 +2930,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
       .mockResolvedValueOnce(summaryResult("invalid first attempt"))
       .mockResolvedValueOnce(summaryResult(validRetry));
 
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      recentTurnsPreserve: 0,
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
+    const sessionManager = createQualityGuardSessionManager();
     const event = createCompactionEvent({
       messageText: `${latestAsk} ${identifier}`,
       tokensBefore: 1_500,
@@ -3262,13 +3231,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
         ),
       );
 
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      recentTurnsPreserve: 0,
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
+    const sessionManager = createQualityGuardSessionManager();
     const event = createCompactionEvent({ messageText: latestAsk, tokensBefore: 90_000 });
     (event.preparation as { settings?: { reserveTokens: number } }).settings = {
       reserveTokens: 4_000,
@@ -3303,13 +3266,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
         throw new Error("transport closed after abort");
       });
 
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      recentTurnsPreserve: 0,
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
+    const sessionManager = createQualityGuardSessionManager();
     const event = createCompactionEvent({
       messageText: "report deployment status",
       tokensBefore: 1_500,


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Nine compaction safeguard cases repeat the same session-manager and quality-guard setup, obscuring the scenario-specific summary, retry, and cancellation assertions.

## Why This Change Was Made

A private, typed fixture creates a fresh session manager, model, and runtime configuration at each original call site. The four explicit settings and all case-specific mocks, events, assertions, and ordering remain intact. This removes 43 net test lines.

## User Impact

No runtime behavior changes. Compaction tests are easier to maintain without sharing mutable fixture state.

## Evidence

The complete safeguard file passed the same 151 cases in the same order before and after on Node 24.19.0. Expanding the nine helper calls and removing the helper restores the original file byte-for-byte. The mapped core-test changed gate passed, including typechecking, guards, dead-export scans, and lint. Independent review found no issues. No timing improvement is claimed.
