### PR TITLE
perf(build): reuse static asset discovery during postbuild

### DIFF
--- a/scripts/runtime-postbuild.mts
+++ b/scripts/runtime-postbuild.mts
@@ -21,6 +21,7 @@ import {
 import {
   copyStaticExtensionAssets,
   copyStaticExtensionAssetsToRuntimeOverlay,
+  discoverStaticExtensionAssets,
 } from "./lib/static-extension-assets.mts";
 import {
   isUpdateCompatibilityChunk,
@@ -785,8 +786,12 @@ export function runRuntimePostBuild(params: RuntimePostBuildParams = {}) {
     if (!shouldCopyStaticExtensionAssets(phaseParams)) {
       return;
     }
-    copyStaticExtensionAssets(phaseParams);
-    copyStaticExtensionAssetsToRuntimeOverlay(phaseParams);
+    const assetParams = {
+      ...phaseParams,
+      assets: discoverStaticExtensionAssets(phaseParams),
+    };
+    copyStaticExtensionAssets(assetParams);
+    copyStaticExtensionAssetsToRuntimeOverlay(assetParams);
   });
   runPhase("stable root runtime imports", () =>
     rewriteRootRuntimeImportsToStableAliases(phaseParams),


### PR DESCRIPTION
Closes #145249

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Runtime postbuild repeats static-asset discovery while producing the main distribution and runtime overlay, even though both copy steps use the same source inventory.

## Why This Change Was Made

Prepare one inventory after the static-asset phase is enabled and pass it to both existing copy owners. The overlay still merges current-dist metadata independently and retains its source-to-restored-dist fallback. The inventory lives only for this synchronous phase; no retained cache is added.

## User Impact

Static output bytes and update-compatibility outputs remain unchanged. Selected root, filesystem, environment, warnings, disabled gating, phase order and final provenance keep their existing contracts. The change adds seven production lines and removes two in one file, with no test changes.

## Evidence

All **175 existing tests across three postbuild/staging/build suites** pass. The full changed gate explicitly targeted this file against base `ad439abc01eb575399fa2c9d0d892668ddb99403`; the normal build and fresh independent P2 review pass. The build completed declarations, SDK declarations, runtime postbuild, Control UI and final metadata, including validation of 53 built plugin modules. Nonfatal dependency bundler warnings did not require source changes.

The actual full-postbuild entry point was exercised with three synthetic cases:

| Case | Discovery calls before → after | Static outputs |
| --- | ---: | --- |
| Source assets | 2 → 1 | Identical in dist and dist-runtime |
| Restored dist, sources absent | 2 → 1 | Identical in dist and dist-runtime |
| Static copying disabled | 0 → 0 | Both absent |

All enabled static outputs match SHA-256 `3ecd246d751fa30e0393f228ab9c93e0cb1ab3d0632aa46902cb635b10e32ae8`. Positive V8 coverage binds the exact discovery function. V8 omits wholly unexecuted modules, so disabled zero is supported by those positive controls, the absent owner, executed postbuild/gate anchors and absent outputs—not measured return-branch coverage.

The initial comparison failed because its harness required a coverage record for that disabled, uncalled owner. Its raw evidence remains preserved. Only the external probe was corrected; production was unchanged, and the corrected comparison passed with candidate restoration verified. These results establish discovery-call reduction and synthetic byte parity, not measured latency, allocation, RSS, real Git-child savings or published-update behavior.

[Package Acceptance run 34645562326](https://github.com/openclaw/openclaw/actions/runs/34645562326) passed on attempt 1 for exact source `ae44ae710443be05cbb8f40e8c77e6ad236359da`, package version `2026.9.4`, using trusted tooling `ad439abc01eb575399fa2c9d0d892668ddb99403` through `codex/perf19-package-acceptance-tooling`. The source-built package SHA-256 is `eb495cafe6222d6f65cc25c9fd511117d44f518bf8116c5cb2d0b15e72f840a6`. Producer metadata, source admissions and the matching uploaded/downloaded artifact digest bind that package; the audit did not download or locally rehash the root tarball.

The custom, non-advisory run used artifact-only images and one `openclaw@2026.9.3` × `legacy-operator-state` cell. Package integrity, npm-12 installer acceptance and logged migration, cron-owner, plugin, mocked candidate-turn, health and no-op-update checks passed. Its manual `--no-restart` path proves package/state transition and subsequent candidate loading, not updater-owned Gateway replacement; no live-provider or Telegram coverage is claimed. Detailed raw successful scenario phase/schema files remain outside the frozen upload path. The retained package/admission identities and aggregate lane results/logs support the scoped conclusion, with that omission disclosed.
