### PR TITLE
test: reuse compiled modules in native update fixtures

### DIFF
--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -10,6 +10,7 @@ import {
   gatewayDirectStopEntrypoints,
   stateDirGatewayFixtureEntrypoint,
 } from "../../src/cli/cli-entrypoint.test-support.ts";
+import { updateExecutorNativeEntrypoints } from "../../src/cli/update-cli/update-command-executor-native-runtime.test-support.ts";
 import { doctorConfigRuntimeEntrypoints } from "../../src/commands/doctor-config-runtime.test-support.ts";
 import { cronOwnerHardeningEntrypoints } from "../../src/cron/owner-hardening-runtime.test-support.ts";
 import { sessionListCacheRetentionEntrypoint } from "../../src/gateway/server-methods/sessions-list-cache-retention-entrypoint.test-support.ts";
@@ -46,6 +47,7 @@ export const vitestWorkerBuildEntries = {
       ...publishedSdkBridgeEntrypoints,
       mcpProviderCatalogEntrypoint,
       ...Object.values(cliRecoveryEntrypoints),
+      ...Object.values(updateExecutorNativeEntrypoints),
       ...Object.values(gatewayDirectStopEntrypoints),
       stateDirGatewayFixtureEntrypoint,
       ...Object.values(doctorConfigRuntimeEntrypoints),

--- a/scripts/lib/vitest-worker-declarations.mts
+++ b/scripts/lib/vitest-worker-declarations.mts
@@ -10,6 +10,8 @@ export const vitestWorkerDeclarationEntries = {
     "src/infra/update-managed-service-handoff-runtime-assets.ts",
   "infra/triage-runtime.test-support": "src/infra/triage-runtime.test-support.ts",
   "cli/cli-entrypoint.test-support": "src/cli/cli-entrypoint.test-support.ts",
+  "cli/update-cli/update-command-executor-native-runtime.test-support":
+    "src/cli/update-cli/update-command-executor-native-runtime.test-support.ts",
   "commands/doctor-config-runtime.test-support":
     "src/commands/doctor-config-runtime.test-support.ts",
   "test-support/channel-ingress-gateway-restart-entrypoint":

--- a/src/cli/update-cli/update-command-executor-native-runtime.test-support.ts
+++ b/src/cli/update-cli/update-command-executor-native-runtime.test-support.ts
@@ -1,0 +1,40 @@
+// Each fresh child uses one compiled graph for its authority and effect owners.
+const currentModuleUrl = import.meta.url;
+
+export const updateExecutorNativeEntrypoints = {
+  executor: {
+    currentModuleUrl,
+    sourceWorkerName: "update-command-executor",
+    distWorkerPath: "cli/update-cli/update-command-executor.js",
+  },
+  processExec: {
+    currentModuleUrl,
+    sourceWorkerName: "../../process/exec",
+    distWorkerPath: "process/exec.js",
+  },
+  nativeExecutor: {
+    currentModuleUrl,
+    sourceWorkerName: "../daemon-cli/update-executor",
+    distWorkerPath: "cli/daemon-cli/update-executor.js",
+  },
+  nativeExec: {
+    currentModuleUrl,
+    sourceWorkerName: "../../daemon/exec-file",
+    distWorkerPath: "daemon/exec-file.js",
+  },
+  serviceFiles: {
+    currentModuleUrl,
+    sourceWorkerName: "../../daemon/launchd-service-files",
+    distWorkerPath: "daemon/launchd-service-files.js",
+  },
+  serviceAuthority: {
+    currentModuleUrl,
+    sourceWorkerName: "../../daemon/service-update-authority",
+    distWorkerPath: "daemon/service-update-authority.js",
+  },
+  configIO: {
+    currentModuleUrl,
+    sourceWorkerName: "../../config/io.factory",
+    distWorkerPath: "config/io.factory.js",
+  },
+} as const;

--- a/src/cli/update-cli/update-command-executor-native.test.ts
+++ b/src/cli/update-cli/update-command-executor-native.test.ts
@@ -6,15 +6,23 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
 import * as tempRoot from "../../infra/tmp-openclaw-dir.js";
 import { createManagedHandoffLeaseStore } from "../../infra/update-managed-service-handoff-lease.js";
 import * as processTree from "../../process/child-process-tree.js";
 import { runUtf8CommandWithTimeout } from "../../process/exec.js";
 import * as pidAlive from "../../shared/pid-alive.js";
+import { updateExecutorNativeEntrypoints } from "./update-command-executor-native-runtime.test-support.js";
 import {
   withUpdateCommandExecutor,
   withUpdateCommandExecutorChild,
 } from "./update-command-executor.js";
+
+const sourceImportArgs = resolveRuntimeWorkerUrl(
+  updateExecutorNativeEntrypoints.executor,
+).pathname.endsWith(".ts")
+  ? ["--import", path.resolve("scripts/tsx.mjs")]
+  : [];
 
 const dirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => vi.restoreAllMocks());
@@ -28,8 +36,7 @@ it.each(["healthy", "spawner-settled", "root-replaced", "spawner-replaced"] as c
     vi.spyOn(tempRoot, "resolvePreferredOpenClawTmpDir").mockReturnValue(control);
     const proceed = path.join(root, "proceed");
     const effect = path.join(root, "effect");
-    const ownerUrl = new URL("./update-command-executor.ts", import.meta.url).href;
-    const loader = path.resolve("scripts/tsx.mjs");
+    const ownerUrl = resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.executor).href;
     const leaf = `
       import fs from "node:fs";
       import {setTimeout} from "node:timers/promises";
@@ -45,11 +52,11 @@ it.each(["healthy", "spawner-settled", "root-replaced", "spawner-replaced"] as c
     const intermediate = `
       import fs from "node:fs";
       import {withDelegatedUpdateCommandExecutor,withUpdateCommandExecutorChild} from ${JSON.stringify(ownerUrl)};
-      import {runUtf8CommandWithTimeout} from ${JSON.stringify(new URL("../../process/exec.ts", import.meta.url).href)};
+      import {runUtf8CommandWithTimeout} from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.processExec).href)};
       const input=JSON.parse(fs.readFileSync(0,"utf8"));
       await withDelegatedUpdateCommandExecutor(input.grant,input.grant.runId,input.grant.root,async fence=>{
         const result=await withUpdateCommandExecutorChild(fence,input.grant.root,(grant,beforeInput)=>runUtf8CommandWithTimeout(
-          [process.execPath,"--import",${JSON.stringify(loader)},"--input-type=module","-e",${JSON.stringify(leaf)}],
+          [process.execPath,...${JSON.stringify(sourceImportArgs)},"--input-type=module","-e",${JSON.stringify(leaf)}],
           {input:JSON.stringify({...input,grant}),beforeInput,timeoutMs:15000,killProcessTree:true,
            requireProcessTreeExtinction:true,onOutputChunk:chunk=>{process.stdout.write(chunk);}}));
         if(result.code!==0)throw new Error(result.stderr);
@@ -63,7 +70,7 @@ it.each(["healthy", "spawner-settled", "root-replaced", "spawner-replaced"] as c
       const fence = await executor.enter(root);
       const pending = withUpdateCommandExecutorChild(fence, root, (grant, beforeInput) =>
         runUtf8CommandWithTimeout(
-          [process.execPath, "--import", loader, "--input-type=module", "-e", intermediate],
+          [process.execPath, ...sourceImportArgs, "--input-type=module", "-e", intermediate],
           {
             input: JSON.stringify({ grant, proceed, effect }),
             beforeInput,
@@ -182,11 +189,11 @@ it
     const receiver = `
     import fs from "node:fs";
     import {setTimeout} from "node:timers/promises";
-    import {runGatewayServiceUpdateCommand} from ${JSON.stringify(new URL("../daemon-cli/update-executor.ts", import.meta.url).href)};
-    import {execFileUtf8} from ${JSON.stringify(new URL("../../daemon/exec-file.ts", import.meta.url).href)};
-    import {publishLaunchAgentPlist} from ${JSON.stringify(new URL("../../daemon/launchd-service-files.ts", import.meta.url).href)};
-    import {assertGatewayServiceUpdateCurrent} from ${JSON.stringify(new URL("../../daemon/service-update-authority.ts", import.meta.url).href)};
-    import {createConfigIO} from ${JSON.stringify(new URL("../../config/io.factory.ts", import.meta.url).href)};
+    import {runGatewayServiceUpdateCommand} from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.nativeExecutor).href)};
+    import {execFileUtf8} from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.nativeExec).href)};
+    import {publishLaunchAgentPlist} from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.serviceFiles).href)};
+    import {assertGatewayServiceUpdateCurrent} from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.serviceAuthority).href)};
+    import {createConfigIO} from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.configIO).href)};
     const root=${JSON.stringify(root)}, fault=${JSON.stringify(fault)};
     const wait=async name=>{while(!fs.existsSync(root+"/"+name))await setTimeout(10);};
     try { await runGatewayServiceUpdateCommand("run","install",async()=>{
@@ -208,8 +215,8 @@ it
     const spawner = `
     import fs from "node:fs";
     import {spawn} from "node:child_process";
-    import {withDelegatedUpdateCommandExecutor,withUpdateCommandExecutorChild} from ${JSON.stringify(new URL("./update-command-executor.ts", import.meta.url).href)};
-    import {runUtf8CommandWithTimeout} from ${JSON.stringify(new URL("../../process/exec.ts", import.meta.url).href)};
+    import {withDelegatedUpdateCommandExecutor,withUpdateCommandExecutorChild} from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.executor).href)};
+    import {runUtf8CommandWithTimeout} from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.processExec).href)};
     const input=JSON.parse(fs.readFileSync(0,"utf8"));
     try{await withDelegatedUpdateCommandExecutor(input.grant,input.grant.runId,input.grant.root,async fence=>{
       const result=await withUpdateCommandExecutorChild(fence,input.grant.root,async(grant,beforeInput)=>{
@@ -217,14 +224,14 @@ it
         if (${JSON.stringify(fault)} === "spawner-killed") {
           const stderr=fs.openSync(${JSON.stringify(file("receiver.stderr"))},"a");
           return new Promise((resolve,reject)=>{
-            const child=spawn(process.execPath,["--import",${JSON.stringify(path.resolve("scripts/tsx.mjs"))},"--input-type=module","-e",${JSON.stringify(receiver)}],{stdio:["pipe","ignore",stderr],detached:true});
+            const child=spawn(process.execPath,[...${JSON.stringify(sourceImportArgs)},"--input-type=module","-e",${JSON.stringify(receiver)}],{stdio:["pipe","ignore",stderr],detached:true});
             fs.closeSync(stderr);
             child.once("error",reject);
             child.once("spawn",()=>{try{beforeInput(child.pid);child.stdin.end(JSON.stringify({action:"install",targetRoot:input.grant.root,executor:grant}));}catch(e){child.kill("SIGKILL");reject(e);}});
             child.once("exit",code=>resolve({code,stderr:"receiver exited"}));
           });
         }
-        return runUtf8CommandWithTimeout([process.execPath,"--import",${JSON.stringify(path.resolve("scripts/tsx.mjs"))},"--input-type=module","-e",${JSON.stringify(receiver)}],{
+        return runUtf8CommandWithTimeout([process.execPath,...${JSON.stringify(sourceImportArgs)},"--input-type=module","-e",${JSON.stringify(receiver)}],{
           input:JSON.stringify({action:"install",targetRoot:input.grant.root,executor:grant}),beforeInput,timeoutMs:30000,killProcessTree:true,requireProcessTreeExtinction:true});
       });
       if(result.code!==0)throw new Error(result.stderr);
@@ -245,7 +252,7 @@ it
             (resolve, reject) => {
               const child = spawn(
                 process.execPath,
-                ["--import", path.resolve("scripts/tsx.mjs"), "--input-type=module", "-e", spawner],
+                [...sourceImportArgs, "--input-type=module", "-e", spawner],
                 { stdio: ["pipe", "ignore", "pipe"], detached: true },
               );
               let stderr = "";
@@ -271,14 +278,7 @@ it
           );
         }
         return runUtf8CommandWithTimeout(
-          [
-            process.execPath,
-            "--import",
-            path.resolve("scripts/tsx.mjs"),
-            "--input-type=module",
-            "-e",
-            spawner,
-          ],
+          [process.execPath, ...sourceImportArgs, "--input-type=module", "-e", spawner],
           {
             input: JSON.stringify({ grant }),
             beforeInput,


### PR DESCRIPTION
## What Problem This Solves

Native update-executor tests repeatedly transform the same TypeScript modules in fresh nested processes. The nine-case file took 82.6 seconds locally, despite already preparing a compiled worker generation for the invocation.

## Why This Change Was Made

Register the required modules in the existing test-only worker declarations and resolve their URLs through the canonical runtime resolver. Each child loads modules from the shared compiled graph; direct source-mode execution retains its existing TypeScript preload. Package entries and production runtime code are unchanged.

The nine cases still launch independent child processes and retain every original PID-before-input binding, readiness and revocation barrier, native/config effect assertion, and process-extinction check. The finalizer tests retain their source-level hooks; this change does not try to bundle those hooks away.

## User Impact

CI avoids repeated TypeScript setup inside the native fixture children. There is no change to application update behavior or test sharding.

## Evidence

One same-host, same-command local before/after pair, using Node 24 and including generation preparation:

| Measurement | Original | Candidate |
| --- | ---: | ---: |
| Complete nine-case invocation | 82.61s | 25.69s |
| Worker preparation | 6.787s | 4.865s |
| Generation inputs / outputs | 8,848 / 4,498 | 8,849 / 4,504 |
| BSD time maximum RSS | 2,164,424,704 bytes | 2,178,744,320 bytes |

The invocation was 56.92 seconds shorter (68.9%). The preparation difference accounts for only 1.92 seconds; most of the reduction is inside the case bodies. The seven roots mostly share an already-built graph, adding one input and six outputs. Maximum RSS increased 13.66 MiB (0.66%); this is not a memory reduction claim or a simultaneous process-tree peak measurement.

All nine cases passed with identical case inventories and assertions; 36 existing sibling tests passed. Core-test/script types, targeted lint, formatting, and independent P2 review pass. Generation and child cleanup were verified. Caches were retained: this local pair does not establish a cold-cache or whole-CI speedup. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34645579370) now passes on `57e315321ef2444a94115be43d441bd8dfae0831`: all 101 checks are terminal without failures.

Four files change: test rewiring +23/-23, 40 lines of pure test-entry metadata, and four lines in existing test compiler metadata. Production runtime and public API delta are zero. Fresh process and lifecycle coverage remains intact.
