### PR TITLE
improve: reduce repeated fence searches while splitting replies

### DIFF
--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -524,12 +524,26 @@ function pickSafeBreakIndex(
   end: number,
   spans: ReturnType<typeof parseFenceSpans>,
 ): number {
-  const { lastNewline, lastWhitespace } = scanParenAwareBreakpoints(
-    text,
-    start,
-    end,
-    (index) => findFenceSpanAt(spans, index)?.end,
-  );
+  // Windows may overlap after a soft break, so seek once before advancing through their fences.
+  let fenceIndex = 0;
+  let high = spans.length;
+  while (fenceIndex < high) {
+    const mid = Math.floor((fenceIndex + high) / 2);
+    const span = spans[mid];
+    if (span && span.end <= start) {
+      fenceIndex = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  let fence = fenceIndex < spans.length ? spans[fenceIndex] : undefined;
+  const { lastNewline, lastWhitespace } = scanParenAwareBreakpoints(text, start, end, (index) => {
+    while (fence && fence.end <= index) {
+      fenceIndex += 1;
+      fence = fenceIndex < spans.length ? spans[fenceIndex] : undefined;
+    }
+    return fence && index > fence.start ? fence.end : undefined;
+  });
 
   if (lastNewline > start) {
     return lastNewline;


### PR DESCRIPTION
## What Problem This Solves

Markdown reply splitting repeatedly searches the complete fence list at each candidate character. Long replies containing many code blocks pay for the same lookup throughout each chunk window.

## Why This Change Was Made

Seek the first relevant fence once per window, then advance a local cursor as the existing scanner moves forward. Reset the cursor for each window because soft breaks can overlap. Bound the initial and advancing array reads so exhausted fence lists do not perform terminal out-of-bounds reads.

The common parenthesis/whitespace scanner is unchanged. Strict fence containment, fence endpoints, UTF-16 handling, reply-to consumption, and limit normalization retain their existing behavior. No cache or alternate parser is added.

## User Impact

Less CPU work when splitting Markdown replies containing many fences. This is a reply-planning improvement, not a claim about provider latency or whole-Gateway speed.

## Evidence

The actual outbound message planner and reply-to policy were measured with the same fixtures in four fresh processes: original, candidate, candidate, original. Each process checked 250 complete output values and timed 50 cases using two warmups and eight measured batches. All output units, metadata, consumption records, and subsequent reply-policy state matched. All child processes closed and candidate source was restored.

At a 2,000-character limit, many-fence length-mode planning improved 62.7% and 65.0% in the two orders; sparse-fence length mode improved 31.6% and 36.8%. Whole-process user CPU fell 22.9% and 23.2% in this workload.

Results are mixed outside the target: 13 of 50 wall-time case medians were adverse in each order. For example, 16 KiB prose in newline mode at an 800-character limit was 20.3% and 7.8% slower. First-order kernel peak RSS increased about 2.0%; reverse-order RSS decreased. Plain-text controls improved in this run, but their scanner is unchanged and the timings varied, so no general plain-text or memory improvement is claimed.

Earlier experiments that regressed plain-text controls are retained separately. A diagnostic trace localized an out-of-bounds cursor read; the final comparison uses ordinary untraced execution and unchanged fixtures/repetition counts. No earlier or adverse results were discarded.

All 108 existing focused chunk/planner tests passed. Independent Codex review is clean through P2. Repository-selected changed checks passed on Linux Testbox, including core and core-test typechecks, scoped lint, and repository guards. The full suite was not run locally; exact-head hosted CI remains required before landing.

The changelog is release-owned; this PR retains the performance and behavior context for release notes.

The first hosted CI attempt timed out in the unrelated declaration fixture test `reuses unaffected canonical groups while rebuilding runtime after input edits`. That fixture does not copy or execute this PR's chunking owner. The unchanged test passed in an isolated Linux/Node 24.19.0 diagnostic restricted to two CPUs: 34.797 seconds under the original 120-second test budget, retaining all 16 compiler assertions. This does not explain the original full-shard timeout. The diagnostic and original failure are retained; one unchanged failed-job rerun passed. No test timeout, assertion, baseline, or retry policy was changed.
