### PR TITLE
fix(auto-reply): report rejected partial question answers instead of failing dispatch

### DIFF
--- a/src/agents/harness/gateway-question.ts
+++ b/src/agents/harness/gateway-question.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import type { GatewayClientRequestError } from "../../../packages/gateway-client/src/request-error.js";
 import type {
   QuestionAnswers,
   QuestionRequestQuestion,
@@ -112,7 +113,11 @@ function isTerminalAgentQuestionError(error: unknown): boolean {
  * pending, so the same source can submit a corrected answer. Reply owners
  * surface this rejection instead of failing the whole channel dispatch.
  */
-export function isQuestionAnswerValidationError(error: unknown): boolean {
+export function isQuestionAnswerValidationError(
+  error: unknown,
+): error is GatewayClientRequestError {
+  // The name marker below is the runtime check for this class across the
+  // gateway protocol boundary, where instanceof is not reliable.
   return readQuestionRejection(error)?.reason === "QUESTION_INVALID_ANSWER";
 }
 

--- a/src/agents/harness/gateway-question.ts
+++ b/src/agents/harness/gateway-question.ts
@@ -107,6 +107,15 @@ function isTerminalAgentQuestionError(error: unknown): boolean {
   return reason !== undefined && TERMINAL_QUESTION_ERROR_REASONS.has(reason);
 }
 
+/**
+ * Resolve rejections for malformed or incomplete answers leave the question
+ * pending, so the same source can submit a corrected answer. Reply owners
+ * surface this rejection instead of failing the whole channel dispatch.
+ */
+export function isQuestionAnswerValidationError(error: unknown): boolean {
+  return readQuestionRejection(error)?.reason === "QUESTION_INVALID_ANSWER";
+}
+
 type QuestionInputAuthority = { kind: "run" | "source-bound"; assertCurrent: () => void };
 
 /** One reservation owns both dispatch refusal and the prompt's release notification. */

--- a/src/auto-reply/reply/agent-runner-question-input.ts
+++ b/src/auto-reply/reply/agent-runner-question-input.ts
@@ -2,7 +2,10 @@ import {
   QuestionAnswerUnconfirmedError,
   QuestionDispatchRefusedError,
 } from "../../agents/harness/gateway-question-dispatch.js";
-import { claimPendingAgentQuestionAnswerFromCaller } from "../../agents/harness/gateway-question.js";
+import {
+  claimPendingAgentQuestionAnswerFromCaller,
+  isQuestionAnswerValidationError,
+} from "../../agents/harness/gateway-question.js";
 import { logVerbose } from "../../globals.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
@@ -93,6 +96,20 @@ export async function runReplyQuestionInput(
         handled: true,
         payload: markReplyPayloadForSourceSuppressionDelivery({
           text: `The answer was not sent: ${error.message}. Use the question controls in the Control UI, or check the active run and your permissions before retrying.`,
+          isError: true,
+        }),
+      };
+    }
+    // A rejected partial answer leaves its question pending; a visible rejection
+    // lets the same chat retry instead of failing dispatch into ingress retries.
+    if (isQuestionAnswerValidationError(error)) {
+      if (state) {
+        state.admission = { status: "skipped", reason: "question-response-refused" };
+      }
+      return {
+        handled: true,
+        payload: markReplyPayloadForSourceSuppressionDelivery({
+          text: `The answer was not accepted: ${error.message}. The question is still open, so reply again with answers for every question.`,
           isError: true,
         }),
       };

--- a/src/auto-reply/reply/agent-runner-steer-adoption.question-recovery.test.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.question-recovery.test.ts
@@ -335,6 +335,77 @@ describe("question response custody through reply adoption", () => {
     },
   );
 
+  it("reports a rejected partial answer instead of failing the channel dispatch", async () => {
+    const key = "agent:main:question-partial-answer";
+    const run = createQueueTestRun({ prompt: text });
+    run.run.senderIsOwner = true;
+    run.run.traceAuthorized = true;
+    run.run.messageProvider = "webchat";
+    run.run.config = { tools: { toolsBySender: { "*": { allow: [] } } } };
+    await withQuestionCreator(key, run, async (operation) => {
+      const source = new AbortController();
+      const gatewayCall: AgentQuestionDispatcher = {
+        version: 2,
+        call: async ({ method, authority }) => {
+          expect(method).toBe("question.resolve");
+          expect(authority.kind).toBe("source-bound");
+          await Promise.resolve();
+          if (authority.kind === "source-bound") {
+            authority.assertCurrent();
+          }
+          // The wire rejection question.resolve returns for a question with no answer.
+          return Promise.reject(
+            Object.assign(new Error("question 'scope' requires an answer"), {
+              name: "GatewayClientRequestError",
+              gatewayCode: "INVALID_REQUEST",
+              details: { reason: "QUESTION_INVALID_ANSWER" },
+            }),
+          );
+        },
+      };
+      const claim = registerPendingAgentQuestion({
+        questionId: "ask_partial_answer",
+        sessionKey: key,
+        questions: [
+          { id: "format", header: "Format", question: "Which format?" },
+          { id: "scope", header: "Scope", question: "What scope?" },
+        ],
+        gatewayCall,
+        answer: Promise.resolve({ status: "pending" }),
+      });
+      claim.attachRegistration(Promise.resolve());
+      const adopted = vi.fn(async () => {});
+      const settled = vi.fn();
+      const state: ReplyOperationRunState = {};
+      const incoming: FollowupRun = {
+        ...run,
+        turnAdoptionLifecycle: { onAdopted: adopted, onSettled: settled },
+      };
+      try {
+        const result = await runReplyQuestionInput({
+          commandBody: "a plain line answering only the format question",
+          followupRun: incoming,
+          sessionKey: key,
+          sessionCtx: { Provider: "webchat" },
+          opts: { abortSignal: source.signal, [REPLY_OPERATION_RUN_STATE]: state },
+        });
+        expect(result).toMatchObject({ handled: true, payload: { isError: true } });
+        if (result.handled && result.payload) {
+          expect(result.payload.text).toContain("question 'scope' requires an answer");
+        }
+        expect(state.admission).toEqual({
+          status: "skipped",
+          reason: "question-response-refused",
+        });
+        expect(adopted).not.toHaveBeenCalled();
+        expect(settled).not.toHaveBeenCalled();
+        expect(claim.isResolving()).toBe(false);
+      } finally {
+        claim.dispose();
+      }
+    });
+  });
+
   it.each(["next-model", "tool-cap", "permission", "sender", "source-closure"] as const)(
     "uses creator policy and incoming source authority for %s",
     async (change) => {


### PR DESCRIPTION
## What Problem This Solves

When an agent asks two or more questions in one `ask_user` call and the user replies with one unkeyed line that answers only some of them, the reply is dropped with no visible outcome:

- `buildAgentHarnessUserInputAnswers` maps an unkeyed reply by line, so the unanswered question gets an empty answer (`src/agents/harness/user-input-bridge.ts`).
- `question.resolve` rejects the partial submission with `question '<id>' requires an answer` (`QUESTION_INVALID_ANSWER`), leaving the question pending.
- `claimPendingAgentQuestionAnswer` rethrows that rejection unwrapped so the question stays claimable (intended; covered by `gateway-question-dispatch.test.ts` "releases a rejected answer without waiting for the human question deadline").
- `runReplyQuestionInput` only converts `QuestionDispatchRefusedError` into a visible reply and rethrows everything else, so the raw rejection fails the whole channel dispatch.

The channel ingress then keeps the update for retry; every retry fails the same way until ingress gives up. The user hears nothing until the question deadline expires and the agent proceeds "as if nobody answered". Reported in #145126 with gateway journal evidence of 10 failed retries over 13 minutes.

## Solution

`runReplyQuestionInput` already owns the contract of turning recoverable question-flow refusals into a visible error reply for the same chat. This extends that contract to answer-validation rejections:

- `gateway-question.ts` exports `isQuestionAnswerValidationError`, a narrow check for the `QUESTION_INVALID_ANSWER` resolve-rejection reason (malformed or incomplete answers only; terminal and authority failures keep their existing paths).
- The check is a type predicate (`error is GatewayClientRequestError`): the runtime name marker it validates is exactly the marker of that class across the gateway protocol boundary, so the reply layer reads `error.message` through the validated error contract instead of an unchecked cast.
- The reply layer surfaces `The answer was not accepted: question '<id>' requires an answer. The question is still open, so reply again with answers for every question.`, marks the payload as an error, and records the same `question-response-refused` admission-skip the dispatch-refused path uses.

The rejection stays a raw transport error at the claim layer, so the pending question remains claimable and a corrected reply still resolves it. Terminal reasons (`QUESTION_NOT_FOUND`, `QUESTION_ALREADY_TERMINAL`), unconfirmed answers, and authority refusals are untouched.

## Impact

A partial unkeyed answer now produces an immediate visible chat reply naming the unanswered question, the question stays open for a corrected reply, and the ingress no longer retries a doomed dispatch.

## Evidence

New regression test `reports a rejected partial answer instead of failing the channel dispatch` (`agent-runner-steer-adoption.question-recovery.test.ts`):

- **Pre-fix** (production change reverted, test present): the raw rejection propagates out of `runReplyQuestionInput` and the test fails with `GatewayClientRequestError: question 'scope' requires an answer` — the exact dispatch failure from the report.
- **Post-fix**: the full file passes (20/20), including the new test asserting a handled result with an error payload naming `question 'scope' requires an answer`, `admission = { status: "skipped", reason: "question-response-refused" }`, no steer adoption, and the claim left non-resolving.
- `gateway-question-dispatch.test.ts` passes unchanged (42/42), confirming the claim layer still rethrows the raw rejection shape and the question stays pending for a corrected answer.
- **Typecheck** (predicate fix at `ab6359f1a4b`): `tsgo -p tsconfig.core.json` failed before the fix with `src/auto-reply/reply/agent-runner-question-input.ts(112,49): error TS18046: 'error' is of type 'unknown'` and passes after it; `test/tsconfig/tsconfig.test.root.json` and type-aware lint pass on the touched files too; `gateway-question.test.ts` + `gateway-question-dispatch.test.ts` (66/66) and the question-recovery file (20/20) stay green.

Closes #145126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
