### PR TITLE
perf(matrix): reuse spoiler source analysis during formatting

### DIFF
--- a/extensions/matrix/src/matrix/format-spoiler-ranges.ts
+++ b/extensions/matrix/src/matrix/format-spoiler-ranges.ts
@@ -104,9 +104,7 @@ function findInlineMetadataRanges(
   return ranges;
 }
 
-export function findMatrixMarkdownMetadataRanges(
-  markdown: string,
-): Array<{ start: number; end: number }> {
+export function prepareMatrixMarkdownSource(markdown: string) {
   const env: Env = {};
   const tokens = spoilerParser.parse(markdown, env);
   const references = new Set(Object.keys(env.references ?? {}));
@@ -117,17 +115,21 @@ export function findMatrixMarkdownMetadataRanges(
     }
   }
   lineStarts.push(markdown.length);
-  const ranges = tokens.flatMap((token) => {
+  const inlineRanges = tokens.flatMap((token) => {
+    // Table-cell inline tokens have no source map because pipes belong to GFM table grammar.
     if (token.type !== "inline" || !token.map) {
       return [];
     }
     const start = lineStarts[token.map[0]] ?? 0;
     const end = lineStarts[token.map[1]] ?? markdown.length;
-    return findInlineMetadataRanges(markdown.slice(start, end), references).map((range) => ({
+    return [{ start, end }];
+  });
+  const ranges = inlineRanges.flatMap(({ start, end }) =>
+    findInlineMetadataRanges(markdown.slice(start, end), references).map((range) => ({
       start: start + range.start,
       end: start + range.end,
-    }));
-  });
+    })),
+  );
   for (const match of markdown.matchAll(/^\s*\[[^\]\n]+\]:\s*.+$/gmu)) {
     const start = match.index ?? 0;
     const labelEnd = match[0].indexOf("]:");
@@ -147,44 +149,31 @@ export function findMatrixMarkdownMetadataRanges(
       ranges.push({ start: match.index, end: match.lastIndex });
     }
   }
-  return ranges;
+  return {
+    markdown,
+    inlineRanges,
+    metadataRanges: ranges,
+    codeRegions,
+    underlineTags: [...tokenizeHtmlTags(markdown)].filter(
+      (tag) => tag.name === "u" || tag.name === "ins",
+    ),
+  };
 }
 
-export function findMatrixSpoilerDelimiterOffsets(markdown: string): number[] {
-  const projected = projectMatrixMarkdown(markdown);
-  if (!projected.includes("||")) {
-    return [];
-  }
-  const tokens = spoilerParser.parse(projected, {});
-  const lineStarts = [0];
-  for (let index = 0; index < projected.length; index += 1) {
-    if (projected[index] === "\n") {
-      lineStarts.push(index + 1);
-    }
-  }
-  lineStarts.push(projected.length);
-  const excludedRanges = [
-    ...findCodeRegions(projected),
-    ...findMatrixMarkdownMetadataRanges(projected),
-    ...[...tokenizeHtmlTags(projected)].flatMap((tag) =>
-      tag.name === "u" || tag.name === "ins" ? [{ start: tag.start, end: tag.end }] : [],
-    ),
-  ];
+type MatrixMarkdownSource = ReturnType<typeof prepareMatrixMarkdownSource>;
+
+function findMatrixSpoilerDelimiterOffsets(source: MatrixMarkdownSource): number[] {
+  const { markdown, inlineRanges, codeRegions, metadataRanges, underlineTags } = source;
+  const excludedRanges = [...codeRegions, ...metadataRanges, ...underlineTags];
   const offsets: number[] = [];
-  for (const token of tokens) {
-    // Table-cell inline tokens have no source map because pipes belong to GFM table grammar.
-    if (token.type !== "inline" || !token.map) {
-      continue;
-    }
-    const start = lineStarts[token.map[0]] ?? 0;
-    const end = lineStarts[token.map[1]] ?? projected.length;
+  for (const { start, end } of inlineRanges) {
     const candidates: number[] = [];
     for (let index = start; index < end - 1; index += 1) {
-      if (projected[index] !== "|" || projected[index + 1] !== "|") {
+      if (markdown[index] !== "|" || markdown[index + 1] !== "|") {
         continue;
       }
       const excluded = excludedRanges.some((range) => index >= range.start && index < range.end);
-      if (isMarkdownEscaped(projected, index) || excluded) {
+      if (isMarkdownEscaped(markdown, index) || excluded) {
         continue;
       }
       candidates.push(index);
@@ -196,28 +185,28 @@ export function findMatrixSpoilerDelimiterOffsets(markdown: string): number[] {
   return [...new Set(offsets)].toSorted((left, right) => left - right);
 }
 
-export function hasMatrixSpoilerMetadataCollision(markdown: string): boolean {
-  const projected = projectMatrixMarkdown(markdown);
-  if (!projected.includes("||")) {
-    return false;
-  }
-  const ordinary = new Set(findMatrixSpoilerDelimiterOffsets(projected));
-  const underlineTags = [...tokenizeHtmlTags(projected)].filter(
-    (tag) => (tag.name === "u" || tag.name === "ins") && !isMarkdownEscaped(projected, tag.start),
+function hasMatrixSpoilerMetadataCollision(
+  source: MatrixMarkdownSource,
+  offsets: number[],
+): boolean {
+  const { markdown, codeRegions } = source;
+  const ordinary = new Set(offsets);
+  const underlineTags = source.underlineTags.filter(
+    (tag) => !isMarkdownEscaped(markdown, tag.start),
   );
   // Matrix consumes underline tags before parsing inline code, so backticks
   // inside their attributes cannot make a literal code region.
   const literalRanges = [
-    ...findMatrixTableSourceRanges(projected),
-    ...findCodeRegions(projected).filter(
+    ...findMatrixTableSourceRanges(markdown),
+    ...codeRegions.filter(
       (code) => !underlineTags.some((tag) => code.start > tag.start && code.start < tag.end),
     ),
   ];
-  for (let index = 0; index < projected.length - 1; index += 1) {
-    if (projected[index] !== "|" || projected[index + 1] !== "|") {
+  for (let index = 0; index < markdown.length - 1; index += 1) {
+    if (markdown[index] !== "|" || markdown[index + 1] !== "|") {
       continue;
     }
-    if (ordinary.has(index) || isMarkdownEscaped(projected, index)) {
+    if (ordinary.has(index) || isMarkdownEscaped(markdown, index)) {
       continue;
     }
     if (literalRanges.some((range) => index >= range.start && index < range.end)) {
@@ -226,4 +215,24 @@ export function hasMatrixSpoilerMetadataCollision(markdown: string): boolean {
     return true;
   }
   return false;
+}
+
+export type MatrixSpoilerAnalysis = {
+  markdown: string;
+  delimiterOffsets: number[];
+  metadataCollision: boolean;
+};
+
+export function analyzeMatrixSpoilers(markdown: string): MatrixSpoilerAnalysis {
+  const projected = projectMatrixMarkdown(markdown);
+  if (!projected.includes("||")) {
+    return { markdown: projected, delimiterOffsets: [], metadataCollision: false };
+  }
+  const source = prepareMatrixMarkdownSource(projected);
+  const delimiterOffsets = findMatrixSpoilerDelimiterOffsets(source);
+  return {
+    markdown: projected,
+    delimiterOffsets,
+    metadataCollision: hasMatrixSpoilerMetadataCollision(source, delimiterOffsets),
+  };
 }

--- a/extensions/matrix/src/matrix/format.test.ts
+++ b/extensions/matrix/src/matrix/format.test.ts
@@ -1,6 +1,6 @@
 // Matrix tests cover format plugin behavior.
 import { describe, expect, it } from "vitest";
-import { findMatrixSpoilerDelimiterOffsets } from "./format-spoiler-ranges.js";
+import { analyzeMatrixSpoilers } from "./format-spoiler-ranges.js";
 import {
   MATRIX_FORMAT_PROFILE,
   markdownToMatrixBody,
@@ -134,7 +134,7 @@ describe("Matrix formatting migration goldens", () => {
 
   it("does not treat pipes in link destinations as spoiler delimiters", () => {
     const markdown = "[docs\nmore](https://example.test/a(b)||literal||) ||secret||";
-    expect(findMatrixSpoilerDelimiterOffsets(markdown)).toEqual([
+    expect(analyzeMatrixSpoilers(markdown).delimiterOffsets).toEqual([
       markdown.indexOf("||secret||"),
       markdown.lastIndexOf("||"),
     ]);
@@ -237,7 +237,7 @@ describe("Matrix formatting migration goldens", () => {
 
   it("leaves compact empty-cell pipes to native table grammar", () => {
     const markdown = "| A | B | C |\n|---|---|---|\n| x || y || z |";
-    expect(findMatrixSpoilerDelimiterOffsets(markdown)).toEqual([]);
+    expect(analyzeMatrixSpoilers(markdown).delimiterOffsets).toEqual([]);
     expect(markdownToMatrixHtml(markdown)).toContain("<table>");
     expect(markdownToMatrixBody(markdown)).toBe(markdown);
   });

--- a/extensions/matrix/src/matrix/format.ts
+++ b/extensions/matrix/src/matrix/format.ts
@@ -8,16 +8,9 @@ import {
   renderMarkdownWithMarkers,
   tokenizeHtmlTags,
 } from "openclaw/plugin-sdk/text-chunking";
-import {
-  createMatrixPrivateMarkers,
-  MATRIX_FORMAT_PROFILE,
-  projectMatrixMarkdown,
-} from "./format-profile.js";
+import { createMatrixPrivateMarkers, MATRIX_FORMAT_PROFILE } from "./format-profile.js";
 import type { MatrixSpoilerMarkers, MatrixSpoilerProtection } from "./format-profile.js";
-import {
-  findMatrixSpoilerDelimiterOffsets,
-  hasMatrixSpoilerMetadataCollision,
-} from "./format-spoiler-ranges.js";
+import { analyzeMatrixSpoilers, type MatrixSpoilerAnalysis } from "./format-spoiler-ranges.js";
 import type { MatrixClient } from "./sdk.js";
 import { isMatrixQualifiedUserId } from "./target-ids.js";
 
@@ -488,16 +481,19 @@ export function markdownToMatrixHtml(
   markdown: string,
   options: { tableMode?: MarkdownTableMode } = {},
 ): string {
-  if (hasMatrixSpoilerMetadataCollision(markdown)) {
-    return renderMatrixFallbackHtml(markdown);
+  const analysis = analyzeMatrixSpoilers(markdown);
+  if (analysis.metadataCollision) {
+    return renderMatrixFallbackHtml(analysis);
   }
-  const tokens = parseMatrixMarkdown(projectMatrixMarkdown(markdown), options.tableMode);
+  const tokens = parseMatrixMarkdown(analysis, options.tableMode);
   compactLooseListTokens(tokens);
   return md.renderer.render(tokens, md.options, {}).trimEnd();
 }
 
-export function protectMatrixSpoilerDelimiters(markdown: string): MatrixSpoilerProtection {
-  const offsets = findMatrixSpoilerDelimiterOffsets(markdown);
+export function protectMatrixSpoilerDelimiters(
+  analysis: MatrixSpoilerAnalysis,
+): MatrixSpoilerProtection {
+  const { markdown, delimiterOffsets: offsets } = analysis;
   if (offsets.length === 0) {
     return { markdown };
   }
@@ -516,8 +512,11 @@ export function protectMatrixSpoilerDelimiters(markdown: string): MatrixSpoilerP
   return { markdown: protectedMarkdown, markers };
 }
 
-function parseMatrixMarkdown(markdown: string, tableMode?: MarkdownTableMode): MarkdownToken[] {
-  const protectedSpoilers = protectMatrixSpoilerDelimiters(markdown);
+function parseMatrixMarkdown(
+  analysis: MatrixSpoilerAnalysis,
+  tableMode?: MarkdownTableMode,
+): MarkdownToken[] {
+  const protectedSpoilers = protectMatrixSpoilerDelimiters(analysis);
   if (tableMode === "off") {
     md.disable("table");
   }
@@ -533,9 +532,11 @@ function parseMatrixMarkdown(markdown: string, tableMode?: MarkdownTableMode): M
 }
 
 export function markdownToMatrixBody(markdown: string): string {
-  const projected = projectMatrixMarkdown(markdown);
-  const offsets = findMatrixSpoilerDelimiterOffsets(projected);
-  const metadataCollision = hasMatrixSpoilerMetadataCollision(projected);
+  return renderMatrixBody(analyzeMatrixSpoilers(markdown));
+}
+
+export function renderMatrixBody(analysis: MatrixSpoilerAnalysis): string {
+  const { markdown: projected, delimiterOffsets: offsets, metadataCollision } = analysis;
   if (offsets.length === 0 && !metadataCollision) {
     return projected;
   }
@@ -563,16 +564,16 @@ export function markdownToMatrixBody(markdown: string): string {
   );
 }
 
-function renderMatrixFallbackHtml(markdown: string): string {
-  return `<p>${escapeHtml(markdownToMatrixBody(markdown)).replaceAll("\n", "<br>\n")}</p>`;
+function renderMatrixFallbackHtml(analysis: MatrixSpoilerAnalysis): string {
+  return `<p>${escapeHtml(renderMatrixBody(analysis)).replaceAll("\n", "<br>\n")}</p>`;
 }
 
 async function resolveMarkdownMentionState(params: {
-  markdown: string;
+  analysis: MatrixSpoilerAnalysis;
   client: MatrixClient;
   tableMode?: MarkdownTableMode;
 }): Promise<{ tokens: MarkdownToken[]; mentions: MatrixMentions }> {
-  const tokens = parseMatrixMarkdown(projectMatrixMarkdown(params.markdown), params.tableMode);
+  const tokens = parseMatrixMarkdown(params.analysis, params.tableMode);
   const selfUserId = await resolveMatrixSelfUserId(params.client);
   const userIds: string[] = [];
   const seenUserIds = new Set<string>();
@@ -609,7 +610,10 @@ export async function resolveMatrixMentionsInMarkdown(params: {
   markdown: string;
   client: MatrixClient;
 }): Promise<MatrixMentions> {
-  const state = await resolveMarkdownMentionState(params);
+  const state = await resolveMarkdownMentionState({
+    analysis: analyzeMatrixSpoilers(params.markdown),
+    client: params.client,
+  });
   return state.mentions;
 }
 
@@ -618,14 +622,15 @@ export async function renderMarkdownToMatrixHtmlWithMentions(params: {
   client: MatrixClient;
   tableMode?: MarkdownTableMode;
 }): Promise<{ html?: string; mentions: MatrixMentions }> {
-  const state = await resolveMarkdownMentionState(params);
-  if (hasMatrixSpoilerMetadataCollision(params.markdown)) {
-    const redacted = markdownToMatrixBody(params.markdown);
+  const analysis = analyzeMatrixSpoilers(params.markdown);
+  const state = await resolveMarkdownMentionState({ ...params, analysis });
+  if (analysis.metadataCollision) {
+    const redacted = renderMatrixBody(analysis);
     const redactedState = await resolveMarkdownMentionState({
       ...params,
-      markdown: redacted,
+      analysis: analyzeMatrixSpoilers(redacted),
     });
-    return { html: renderMatrixFallbackHtml(params.markdown), mentions: redactedState.mentions };
+    return { html: renderMatrixFallbackHtml(analysis), mentions: redactedState.mentions };
   }
   compactLooseListTokens(state.tokens);
   const html = md.renderer.render(state.tokens, md.options, {}).trimEnd();

--- a/extensions/matrix/src/matrix/send/chunking.ts
+++ b/extensions/matrix/src/matrix/send/chunking.ts
@@ -1,7 +1,7 @@
 // Matrix helper module prepares and chunks outbound formatted text.
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
-import { findCodeRegions, isInsideCode, tokenizeHtmlTags } from "openclaw/plugin-sdk/text-chunking";
+import { isInsideCode } from "openclaw/plugin-sdk/text-chunking";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { CoreConfig } from "../../types.js";
 import {
@@ -10,15 +10,13 @@ import {
   type MatrixSpoilerMarkers,
   type MatrixSpoilerProtection,
 } from "../format-profile.js";
-import {
-  findMatrixMarkdownMetadataRanges,
-  hasMatrixSpoilerMetadataCollision,
-} from "../format-spoiler-ranges.js";
+import { analyzeMatrixSpoilers, prepareMatrixMarkdownSource } from "../format-spoiler-ranges.js";
 import { findMatrixTableSourceRanges } from "../format-table-ranges.js";
 import {
   markdownToMatrixBody,
   MATRIX_FORMAT_PROFILE,
   protectMatrixSpoilerDelimiters,
+  renderMatrixBody,
   renderMatrixMarkdownTables,
 } from "../format.js";
 
@@ -54,11 +52,9 @@ function resolveMatrixChunkOverflow(chunk: string, limit: number): number {
 }
 
 function protectMatrixUnderlineTags(markdown: string): MatrixSpoilerProtection {
-  const codeRegions = findCodeRegions(markdown);
-  const metadataRanges = findMatrixMarkdownMetadataRanges(markdown);
-  const tags = [...tokenizeHtmlTags(markdown)].filter(
+  const { codeRegions, metadataRanges, underlineTags } = prepareMatrixMarkdownSource(markdown);
+  const tags = underlineTags.filter(
     (tag) =>
-      (tag.name === "u" || tag.name === "ins") &&
       !tag.selfClosing &&
       !isInsideCode(tag.start, codeRegions) &&
       !isMarkdownEscaped(markdown, tag.start) &&
@@ -224,15 +220,17 @@ export function chunkMatrixText(
   }
   const cfg = requireRuntimeConfig(opts.cfg, "Matrix text chunking") as CoreConfig;
   const chunkMode = getMatrixRuntime().channel.text.resolveChunkMode(cfg, "matrix", opts.accountId);
-  const collisionRedacted = hasMatrixSpoilerMetadataCollision(preparedText.convertedText)
-    ? markdownToMatrixBody(preparedText.convertedText)
-    : undefined;
+  const analysis = analyzeMatrixSpoilers(preparedText.convertedText);
+  const collisionRedacted = analysis.metadataCollision ? renderMatrixBody(analysis) : undefined;
   const chunkSegment = (segmentText: string): string[] => {
-    const sourceText = hasMatrixSpoilerMetadataCollision(segmentText)
-      ? markdownToMatrixBody(segmentText)
+    const segmentAnalysis = analyzeMatrixSpoilers(segmentText);
+    const sourceText = segmentAnalysis.metadataCollision
+      ? renderMatrixBody(segmentAnalysis)
       : segmentText;
     const protectedUnderline = protectMatrixUnderlineTags(sourceText);
-    const protectedSpoilers = protectMatrixSpoilerDelimiters(protectedUnderline.markdown);
+    const protectedSpoilers = protectMatrixSpoilerDelimiters(
+      analyzeMatrixSpoilers(protectedUnderline.markdown),
+    );
     const wrapperReserve =
       (protectedSpoilers.markers ? 4 : 0) + (protectedUnderline.markers ? 7 : 0);
     const privateMarkers = [protectedSpoilers.markers, protectedUnderline.markers].flatMap(


### PR DESCRIPTION
Closes #145260

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Preparing outgoing Matrix messages with spoilers performs avoidable work before sending, especially across plain-text, rich-mention and chunking paths.

## Why This Change Was Made

Reuse prepared source facts for spoiler delimiters, metadata collisions and underline handling, and pass the resulting spoiler analysis through formatting consumers. Remove the private string-taking rediscovery paths. Table grammar, per-inline-slice code/HTML semantics and final rendering keep their distinct parsers; transformed text receives fresh analysis. This adds no event-wide cache or public SDK/configuration contract.

## User Impact

Spoiler-containing messages need fewer preparation parses while preserving spoiler redaction, formatting, mentions and chunking behavior. No-spoiler body preparation remains parse-free; standalone mention resolution remains at three Markdown-it parses.

## Evidence

All 40 serialized output-parity cases matched. The same 208 tests passed before and after across four files exercising real formatter, send and automatic-reply entrypoints with synthetic Matrix clients. Selected extension formatting, type, lint, boundary, import and guard checks passed, and the final scoped review reported no actionable findings.

Typical spoiler-body preparation fell from four Markdown-it parses to one, and total parses on that path fell from six to three. Timing used one warmed process per arm, a separate 400-call warmup, and five measured 400-call mixed batches: 200 body and 200 rich-mention rendering calls per batch across ten fixtures. Median batch time fell from 339.880 ms to 131.154 ms (61.4%).

This is a synthetic formatter workload, not a memory, whole-Gateway latency or live Matrix delivery measurement.
