### PR TITLE
perf(tailscale): select primary addresses without unused collections

### DIFF
--- a/src/infra/tailnet.ts
+++ b/src/infra/tailnet.ts
@@ -1,13 +1,9 @@
 // Discovers local Tailscale tailnet addresses.
 import { isIpInCidr } from "@openclaw/net-policy/ip";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { listExternalInterfaceAddresses, readNetworkInterfaces } from "./network-interfaces.js";
-
-/** Tailnet addresses discovered on external local interfaces. */
-type TailnetAddresses = {
-  ipv4: string[];
-  ipv6: string[];
-};
+import {
+  pickMatchingExternalInterfaceAddress,
+  readNetworkInterfaces,
+} from "./network-interfaces.js";
 
 const TAILNET_IPV4_CIDR = "100.64.0.0/10";
 const TAILNET_IPV6_CIDR = "fd7a:115c:a1e0::/48";
@@ -25,29 +21,18 @@ function isTailnetIPv6(address: string): boolean {
   return isIpInCidr(address, TAILNET_IPV6_CIDR);
 }
 
-/** Lists unique Tailscale IPv4/IPv6 addresses from local external interfaces. */
-function listTailnetAddresses(): TailnetAddresses {
-  const ipv4: string[] = [];
-  const ipv6: string[] = [];
-
-  for (const { address, family } of listExternalInterfaceAddresses(readNetworkInterfaces())) {
-    if (family === "IPv4" && isTailnetIPv4(address)) {
-      ipv4.push(address);
-    }
-    if (family === "IPv6" && isTailnetIPv6(address)) {
-      ipv6.push(address);
-    }
-  }
-
-  return { ipv4: uniqueStrings(ipv4), ipv6: uniqueStrings(ipv6) };
-}
-
 /** Returns the first discovered Tailscale IPv4 address, if any. */
 export function pickPrimaryTailnetIPv4(): string | undefined {
-  return listTailnetAddresses().ipv4[0];
+  return pickMatchingExternalInterfaceAddress(readNetworkInterfaces(), {
+    family: "IPv4",
+    matches: isTailnetIPv4,
+  });
 }
 
 /** Returns the first discovered Tailscale IPv6 address, if any. */
 export function pickPrimaryTailnetIPv6(): string | undefined {
-  return listTailnetAddresses().ipv6[0];
+  return pickMatchingExternalInterfaceAddress(readNetworkInterfaces(), {
+    family: "IPv6",
+    matches: isTailnetIPv6,
+  });
 }


### PR DESCRIPTION
Closes #145262

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Primary tailnet address discovery does unnecessary collection work on every lookup, preparing both address families when the caller needs one primary address.

## Why This Change Was Made

Delegate each primary picker to the existing requested-family interface selector. This removes the private dual-family lists and deduplication path while preserving public signatures, CIDRs, first-match order, trimming, family normalization, internal-address filtering and original error propagation.

## User Impact

Address selection remains unchanged, with one fresh interface read per call and fewer temporary collections. The refactor removes 15 production lines; repository tests remain unchanged.

## Evidence

- The same four owner/helper/display/service-probe test files passed all 12 tests before and all 12 after the change.
- In 1,000 IPv4/IPv6 call pairs against a 512-entry synthetic snapshot, Set constructions fell from 4,000 to zero. Both versions made 2,000 fresh synthetic interface-reader calls and produced identical outputs. Boundary checks also preserved changed-snapshot freshness, empty/no-match results and exact thrown-error identity.
- The full selected changed-file gate passed formatting, core and core-test typechecks, dead-export scans, changed-file lint and selected contract guards. Scoped P2 review reported no findings.

The initial local gate stopped before running checks because the proof controller forced CI mode and selected unavailable Corepack. Removing that artifact-only override restored normal routing to installed pnpm; the second gate passed on the same reviewed source. The earlier tests and count comparison remained valid and were not rerun after this correction.

The comparison measures operation counts only. It does not establish timing, allocation-byte, RSS, OS-enumeration or whole-Gateway improvements; the selector still enumerates each fresh snapshot.
