### PR TITLE
perf(agents): compact transport replay messages in place

### DIFF
--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -60,6 +60,53 @@ function assistantToolCall(
 }
 
 describe("transformTransportMessages synthetic tool-result policy", () => {
+  it.each(["openai-completions", "openai-responses"] as const)(
+    "compacts sparse %s history without changing the source or sharing assistant arrays",
+    (api) => {
+      const hidden = makeAssistantMessageFixture({
+        api,
+        content: [{ type: "thinking", thinking: "unfinished reasoning" }],
+      });
+      const failed = makeAssistantMessageFixture({
+        api,
+        content: [{ type: "text", text: "unfinished answer" }],
+      });
+      const retained = makeAssistantMessageFixture({
+        api,
+        stopReason: "stop",
+        content: [{ type: "text", text: "completed answer" }],
+      });
+      const user: Context["messages"][number] = {
+        role: "user",
+        content: "continue",
+        timestamp: 1,
+      };
+      const messages: Context["messages"] = [];
+      messages[1] = hidden;
+      messages[3] = failed;
+      messages[4] = retained;
+      messages[6] = user;
+      messages.length = 8;
+      const original = structuredClone(messages);
+
+      const result = transformTransportMessages(messages, makeModel(api, "openai", "test-model"));
+
+      expect(result).toStrictEqual([
+        { ...failed, content: [{ type: "text", text: EXPECTED_FAILURE_MARKER }] },
+        retained,
+        user,
+      ]);
+      const replayedAssistant = result[1];
+      if (replayedAssistant?.role !== "assistant") {
+        throw new Error("expected the completed assistant turn");
+      }
+      replayedAssistant.stopReason = "length";
+      replayedAssistant.content.push({ type: "text", text: "replay-only addition" });
+      result.pop();
+      expect(messages).toStrictEqual(original);
+    },
+  );
+
   it("preserves unframed tool results only for a selected compaction replay window", () => {
     const model = makeModel("openai-responses", "openai", "gpt-5.4");
     const messages = [

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -161,34 +161,39 @@ export function transformTransportMessages(
   // their adjacent results together; pre-filtering the call can misattribute its result
   // to an older turn that reused the same provider id.
   const requiresPairing = allowSyntheticToolResults || hasCrossModelAsyncCalls;
-  const replayable = transformed.flatMap((msg, index) => {
+  let replayLength = 0;
+  transformed.forEach((msg, index) => {
     const original = messages[index];
-    if (!original) {
-      return [msg];
+    let replayMessage = msg;
+    if (original) {
+      if (isReasoningOnlyLengthAssistantTurn(original)) {
+        return;
+      }
+      switch (resolveFailedAssistantReplay(original, { pairingAware: requiresPairing })) {
+        case "drop":
+          return;
+        case "marker":
+          replayMessage = {
+            ...msg,
+            content: [{ type: "text", text: FAILED_ASSISTANT_REPLAY_TEXT }],
+          };
+          break;
+        case "keep":
+          break;
+      }
     }
-    if (isReasoningOnlyLengthAssistantTurn(original)) {
-      return [];
-    }
-    switch (resolveFailedAssistantReplay(original, { pairingAware: requiresPairing })) {
-      case "drop":
-        return [];
-      case "marker":
-        return [
-          { ...msg, content: [{ type: "text" as const, text: FAILED_ASSISTANT_REPLAY_TEXT }] },
-        ];
-      default:
-        return [msg];
-    }
+    transformed[replayLength++] = replayMessage;
   });
+  transformed.length = replayLength;
 
   if (!requiresPairing) {
-    return replayable;
+    return transformed;
   }
 
   // The local transport transform can synthesize missing results, but it does not move
   // displaced real results back before an intervening user turn. Shared repair
   // handles both and drops aborted/error turns together with their owned results.
-  return repairToolUseResultPairing(replayable, {
+  return repairToolUseResultPairing(transformed, {
     erroredAssistantResultPolicy: "drop",
     missingToolResultText: syntheticToolResultText,
     preserveUnframedToolResults: options?.preserveUnframedToolResults,


### PR DESCRIPTION
Closes #145264

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Preparing long conversation histories for provider requests does unnecessary work before dispatch. This change reduces that preparation cost while preserving replay content and the caller's history.

## Why This Change Was Made

The transport transform compacts its fresh, invocation-owned normalized array instead of allocating per-entry arrays and a second result array. Existing failed-turn handling, model-bound normalization and shared tool-call/result pairing remain the owners of replay policy; sparse entries are skipped and assistant envelopes/content arrays remain independent of the source.

## User Impact

There is no intentional change to conversation content, tool-result ordering or stored transcripts. The exercised long-history workloads allocate less during replay preparation; no live-provider latency or general process-memory improvement is claimed. The change adds five net production lines and 47 test lines, with no new cache, configuration or persistence contract.

## Evidence

The same 108 focused tests pass on the original and candidate implementations: 57 core/async cases, 49 Responses caller cases and two Google caller cases. Added coverage protects sparse histories, failure markers and source/assistant-array independence. Only two Google cases ran; two additional requested name alternatives did not match the runner's truncated interpolated titles.

The first changed gate failed because the switch omitted an explicit `keep` case. Adding `case "keep": break` fixed the lint failure, and the full selected gate passed on the final source. The focused tests precede that no-op repair and were accepted for reuse; the final source has a fresh clean independent P2 review. The first candidate launch did not record its driver hash: the retained reconstruction is not a contemporaneous attestation. Final gate and comparison receipts do record the driver, proof and source hashes.

The actual Responses transport produces identical pre-dispatch payloads for five fixtures: plain history, failed turns, repeated tool-call IDs, displaced results and cross-model async calls. The proof asserts that the registered runtime transform is the implementation under comparison and captures each payload through `onPayload`, deliberately stopping before network dispatch. The shared payload SHA-256 is `bd3a8cee7809a05e3073f0ce3970e6f07250dc785857c2578294f666a56000ae`.

**Bootstrap qualification:** both payload arms logged an unrelated visible-checkout OpenAI plugin bootstrap `SyntaxError`. Runtime transform identity and the captured payloads remain valid evidence, but these runs do not prove successful plugin bootstrap, completed wire dispatch or live-provider behavior.

The synthetic benchmark uses Node v26.8.1 and 4,096-message histories. Sampling directly calls the actual transform. Each arm runs in one fresh process, baseline first, with 100 warm-up calls per scenario and **seven warm 200-call timing batches in that same process**. A separate 200-call allocation interval samples every 16 KiB and includes objects collected by minor or major GC.

| Scenario | Median per 200 calls, before → after | Median reduction | Sampled bytes, before → after | Allocation reduction |
| --- | ---: | ---: | ---: | ---: |
| No pairing | 117.198417 → 109.705166 ms | 6.39% | 489,463,784 → 427,488,800 | 12.66% |
| Pairing | 146.620666 → 138.144125 ms | 5.78% | 575,260,744 → 510,057,360 | 11.33% |
| Pairing with failures | 152.035958 → 141.664916 ms | 6.82% | 605,792,272 → 535,725,560 | 11.57% |

These are warm direct-transform observations from one process per arm, not seven fresh-process trials or a randomized repeated-process comparison. Sampled allocation is not retained heap. Whole-arm maximum RSS was 742,572,032 → 741,572,608 bytes; that near-flat, whole-process observation does not establish an RSS improvement or isolate the transform. The no-pairing scenario’s RSS endpoint actually rose from 732,561,408 to 733,380,608 bytes while sampled allocation fell. Whole-arm page faults also differed (3,275 before versus 96 after), so the sequential timing comparison does not control process/cache conditioning. Neither end-to-end provider performance nor successful live dispatch was measured.
