### PR TITLE
refactor(tests): share UI command field assertions

### DIFF
--- a/ui/src/lib/chat/commands.test.ts
+++ b/ui/src/lib/chat/commands.test.ts
@@ -2,6 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 // @vitest-environment node
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
+import { expectObjectFields } from "../../../../src/test-utils/mock-call-assertions.js";
 import {
   buildFallbackSlashCommands,
   buildSlashCommandsFromEntries,
@@ -231,10 +232,7 @@ function requireArray(value: unknown, label: string): unknown[] {
 }
 
 function expectRecordFields(value: unknown, label: string, expected: Record<string, unknown>) {
-  const record = requireRecord(value, label);
-  for (const [key, expectedValue] of Object.entries(expected)) {
-    expect(record[key]).toEqual(expectedValue);
-  }
+  expectObjectFields(requireRecord(value, label), expected);
 }
 
 function requireCommandByName(name: string): Record<string, unknown> {
@@ -648,7 +646,7 @@ describe("parseSlashCommand", () => {
     expectRecordFields(requireCommandByName("safe-name"), "safe-name command", {
       name: "safe-name",
     });
-    expect(SLASH_COMMANDS.find((entry) => entry.name === "prose now")).toBeUndefined();
+    expect(SLASH_COMMANDS.find((entry) => entry.name === "draft now")).toBeUndefined();
     expect(SLASH_COMMANDS.find((entry) => entry.name === "bad:alias")).toBeUndefined();
     expectParsedSlash("/safe-name", { name: "safe-name" }, "");
   });

--- a/ui/src/pages/chat/chat-commands.test.ts
+++ b/ui/src/pages/chat/chat-commands.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { expectObjectFields } from "../../../../src/test-utils/mock-call-assertions.js";
 import { createDeferred } from "../../../../test/helpers/promise.js";
+import { createRequireRecord } from "../../../../test/helpers/record.js";
 import { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
 import {
@@ -29,14 +31,10 @@ function requireCommandByName(name: string): Record<string, unknown> {
   return command as unknown as Record<string, unknown>;
 }
 
+const requireRecord = createRequireRecord("record", "expected-label-object");
+
 function expectRecordFields(value: unknown, label: string, expected: Record<string, unknown>) {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`expected ${label} to be an object`);
-  }
-  const record = value as Record<string, unknown>;
-  for (const [key, expectedValue] of Object.entries(expected)) {
-    expect(record[key]).toEqual(expectedValue);
-  }
+  expectObjectFields(requireRecord(value, label), expected);
 }
 
 function connectedSessionAccess() {


### PR DESCRIPTION
## What Problem This Solves

UI command tests duplicate record checks and field assertions already owned by shared test helpers. One negative command-name assertion also checks a stale fixture name.

## Why This Change Was Made

Reuse `createRequireRecord` and `expectObjectFields` while preserving labeled validation and per-field comparisons. Update the negative assertion to check the actual invalid `draft now` fixture. Production code and shared helpers are unchanged.

## User Impact

No user-facing behavior change. The two test files add 8 lines and remove 12; no cases are removed.

## Evidence

The pristine baseline and revised candidate each pass all 162 cases (29 + 133), with identical inventory, order, and statuses.

Independent review is clean through P2. All 18 normal changed-file checks passed, including both affected UI test type graphs, i18n, lint, and unused-export checks. Source and installed dependencies remained unchanged throughout verification.
