### PR TITLE
perf(gateway): avoid unused tool-event copies

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -5013,7 +5013,7 @@ describe("agent event handler", () => {
 
   it.each([
     {
-      name: "keeps tool output for Control UI recipients when verbose is on",
+      name: "keeps tool output only for Control UI recipients when verbose is on",
       runId: "run-tool-on",
       toolCallId: "t3",
       verboseLevel: "on",
@@ -5027,7 +5027,7 @@ describe("agent event handler", () => {
       partialResult: undefined,
     },
   ] as const)("$name", ({ runId, toolCallId, verboseLevel, partialResult }) => {
-    const { broadcastToConnIds, toolEventRecipients, handler } = createHarness({
+    const { broadcastToConnIds, nodeSendToSession, toolEventRecipients, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-1",
     });
     const result = { content: [{ type: "text", text: "secret" }] };
@@ -5047,6 +5047,10 @@ describe("agent event handler", () => {
     };
     expect(payload.data?.result).toEqual(result);
     expect(payload.data?.partialResult).toEqual(partialResult);
+    const nodePayload = requireMockPayload(nodeSendToSession, 0, 2, "node tool output payload");
+    const nodeData = requireRecord(nodePayload.data, "node tool output data");
+    expect(nodeData.result).toEqual(verboseLevel === "full" ? result : undefined);
+    expect(nodeData.partialResult).toBeUndefined();
   });
 
   it("preserves sanitized outcome-unknown exec details for Control UI recipients", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1386,7 +1386,7 @@ export function createAgentEventHandler({
       return runVerbose ?? "off";
     }
     try {
-      const { cfg, entry } = loadGatewaySessionEntryReadOnly(sessionKey);
+      const { cfg, entry } = loadGatewaySessionEntryReadOnly(sessionKey, { clone: false });
       const sessionVerbose = normalizeVerboseLevel(entry?.verboseLevel);
       const sessionUpdatedAt = typeof entry?.updatedAt === "number" ? entry.updatedAt : undefined;
       const sessionChangedAfterRunStarted =
@@ -1495,17 +1495,6 @@ export function createAgentEventHandler({
     const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
     const suppressHeartbeatToolEvents =
       isToolEvent && shouldSuppressHeartbeatToolEvents(clientRunId, evt.runId);
-    // Channel/node subscribers respect verbose; authenticated Control UI
-    // recipients need tool result payloads to render live tool cards.
-    const channelToolPayload =
-      isToolEvent && toolVerbose !== "full"
-        ? (() => {
-            const data = evt.data ? { ...evt.data } : {};
-            delete data.result;
-            delete data.partialResult;
-            return { ...agentPayload, data };
-          })()
-        : agentPayload;
     if (last > 0 && evt.seq !== last + 1 && isControlUiVisible) {
       flushBufferedAgentDeltaIfNeeded(clientRunId);
       broadcast(
@@ -1772,6 +1761,15 @@ export function createAgentEventHandler({
         !suppressHeartbeatToolEvents &&
         toolVerbose !== "off"
       ) {
+        // Channel/node subscribers respect verbose; authenticated Control UI
+        // recipients need tool result payloads to render live tool cards.
+        let channelToolPayload = agentPayload;
+        if (toolVerbose !== "full") {
+          const data = evt.data ? { ...evt.data } : {};
+          delete data.result;
+          delete data.partialResult;
+          channelToolPayload = { ...agentPayload, data };
+        }
         sendNodeSessionPayloadForAgent(
           sessionKey,
           "agent",


### PR DESCRIPTION
Closes #145270

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Gateway tool-event handling can copy a full session entry just to read verbosity and prepare node output that will not be sent. Saved session prompts make that unnecessary copying more expensive in the measured workload.

## Why This Change Was Made

Borrow the existing full selected-session read synchronously with `clone: false`, and prepare stripped node payloads only inside their verbose-enabled send branch. The borrowed entry is not mutated; query, projection, cache and persistence semantics stay unchanged, as does the reader's default owned-copy behavior.

## User Impact

Tool cards and node delivery retain their existing behavior: live verbosity changes, session-versus-run precedence, heartbeat suppression, Control UI partial output, and stripped versus full node output remain covered. No new list projection or cache is introduced.

## Evidence

- The same 493 focused tests pass before and after, along with the full selected core/core-test gate and final P2 review.
- The actual event handler and canonical session reader run against isolated synthetic SQLite state with in-process sinks. The declared serialized tool-event envelope matches, input values remain unchanged, and default owned-read isolation remains covered. Dynamic session display timestamps and other snapshot metadata are outside the cross-process envelope hash.
- The final narrowed comparison shows 8.5–17.1% lower sampled JavaScript allocation in saved-prompt scenarios. Session prompt parsing volume is unchanged; the improvement does not come from a reduced session projection.
- Counter-results are retained: no-prompt timing rises 4.45%, full-verbose timing rises 10.92%, and process peak RSS rises 22.06 MiB, including imports/profiling. No-prompt sampled allocation is effectively flat.
- Each arm uses one process, with three unprofiled 500-event timing batches, a separate 500-event sampled-allocation batch, and a separate 10-event count batch per scenario. Per-arm Node version/binary identity was not recorded; three batches are not three independent process samples.

These scoped observations do not establish universal speed, retained-heap or RSS improvements. No live socket, channel or provider request was exercised. No separate build was run because the change adds no import, lazy-loading or artifact boundary; the full selected gate passed.
