### PR TITLE
refactor(docs-i18n): remove duplicate translation fixture owners

### DIFF
--- a/scripts/docs-i18n/behavior_baseline_test.go
+++ b/scripts/docs-i18n/behavior_baseline_test.go
@@ -86,7 +86,8 @@ func matchesAll(text string, fragments []string) bool {
 }
 
 func TestDocsI18nBehaviorBaselines(t *testing.T) {
-	t.Parallel()
+	t.Setenv("OPENCLAW_DOCS_I18N_DOC_CHUNK_MAX_BYTES", "4096")
+	t.Setenv("OPENCLAW_DOCS_I18N_DOC_CHUNK_PROMPT_BUDGET", "15000")
 
 	root := filepath.Join("testdata", "behavior")
 	entries, err := os.ReadDir(root)

--- a/scripts/docs-i18n/doc_mode_test.go
+++ b/scripts/docs-i18n/doc_mode_test.go
@@ -103,37 +103,6 @@ func (docFrontmatterFallbackTranslator) TranslateRaw(_ context.Context, text, _,
 
 func (docFrontmatterFallbackTranslator) Close() {}
 
-type docProtocolLeakTranslator struct{}
-
-func (docProtocolLeakTranslator) Translate(_ context.Context, text, _, _ string) (string, error) {
-	return text, nil
-}
-
-func (docProtocolLeakTranslator) TranslateRaw(_ context.Context, text, _, _ string) (string, error) {
-	switch {
-	case strings.Contains(text, "First chunk") && strings.Contains(text, "Second chunk"):
-		return strings.Join([]string{
-			"<frontmatter>",
-			"title: leaked",
-			"</frontmatter>",
-			"",
-			"<body>",
-			"First translated",
-			"",
-			"Second translated",
-			"</body>",
-		}, "\n"), nil
-	default:
-		replacer := strings.NewReplacer(
-			"First chunk", "First translated",
-			"Second chunk", "Second translated",
-		)
-		return replacer.Replace(text), nil
-	}
-}
-
-func (docProtocolLeakTranslator) Close() {}
-
 type docWrappedLeafTranslator struct{}
 
 func (docWrappedLeafTranslator) Translate(_ context.Context, text, _, _ string) (string, error) {
@@ -187,18 +156,6 @@ func (t *docPromptBudgetTranslator) TranslateRaw(_ context.Context, text, _, _ s
 }
 
 func (t *docPromptBudgetTranslator) Close() {}
-
-type uppercaseWrapperTranslator struct{}
-
-func (uppercaseWrapperTranslator) Translate(_ context.Context, text, _, _ string) (string, error) {
-	return text, nil
-}
-
-func (uppercaseWrapperTranslator) TranslateRaw(_ context.Context, text, _, _ string) (string, error) {
-	return "<BODY>\n" + strings.ReplaceAll(text, "Regular paragraph.", "Translated paragraph.") + "\n</BODY>\n", nil
-}
-
-func (uppercaseWrapperTranslator) Close() {}
 
 type boundaryWrapperTranslator struct{}
 
@@ -2183,43 +2140,6 @@ func TestValidateDocChunkTranslationRejectsTopLevelBodyWrapperLeakEvenWhenSource
 	}
 	if !strings.Contains(err.Error(), "protocol token leaked") {
 		t.Fatalf("expected protocol token leakage error, got %v", err)
-	}
-}
-
-func TestTranslateDocBodyChunkedSplitsOnProtocolTokenLeakage(t *testing.T) {
-	body := strings.Join([]string{
-		"First chunk",
-		"",
-		"Second chunk",
-		"",
-	}, "\n")
-
-	t.Setenv("OPENCLAW_DOCS_I18N_DOC_CHUNK_MAX_BYTES", "4096")
-	translated, err := translateDocBodyChunked(context.Background(), docProtocolLeakTranslator{}, "gateway/configuration-reference.md", body, "en", "zh-CN")
-	if err != nil {
-		t.Fatalf("translateDocBodyChunked returned error: %v", err)
-	}
-	if strings.Contains(translated, "<frontmatter>") || strings.Contains(translated, "<body>") || strings.Contains(translated, "[[[FM_") {
-		t.Fatalf("expected protocol wrapper leakage to be removed after split:\n%s", translated)
-	}
-	if !strings.Contains(translated, "First translated") || !strings.Contains(translated, "Second translated") {
-		t.Fatalf("expected split chunks to translate successfully:\n%s", translated)
-	}
-}
-
-func TestTranslateDocBodyChunkedStripsUppercaseBodyWrapper(t *testing.T) {
-	body := "Regular paragraph.\n"
-
-	t.Setenv("OPENCLAW_DOCS_I18N_DOC_CHUNK_MAX_BYTES", "4096")
-	translated, err := translateDocBodyChunked(context.Background(), uppercaseWrapperTranslator{}, "gateway/configuration-reference.md", body, "en", "zh-CN")
-	if err != nil {
-		t.Fatalf("translateDocBodyChunked returned error: %v", err)
-	}
-	if strings.Contains(strings.ToLower(translated), "<body>") {
-		t.Fatalf("expected uppercase wrapper to be stripped:\n%s", translated)
-	}
-	if !strings.Contains(translated, "Translated paragraph.") {
-		t.Fatalf("expected translated body content to survive unwrap:\n%s", translated)
 	}
 }
 


### PR DESCRIPTION
Closes #145272

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Docs-i18n contributors maintain duplicate protocol-leak and uppercase-wrapper recovery coverage, including dedicated translators for standalone replay tests with weaker fragment assertions.

## Why This Change Was Made

Use the existing behavior fixtures as the coverage owner and remove only the two redundant replays and their exclusive translators. Set the parent fixture's existing chunk limits to 4096 bytes and a 15000 prompt budget while preserving parallel child cases, path safeguards and the remaining retry, ambiguity, boundary, frontmatter and continuation coverage.

## User Impact

No production or user-visible behavior changes. The change removes 79 net test/support lines. All four stronger behavior fixtures and all 17 fixture/golden files remain unchanged.

## Evidence

All four Go wrapper partitions (A–F, G–L, M–R and S–Z) executed and passed with Go available; none were skipped. The selected 12-check gate and separate Go formatting check passed, and the final scoped review reported no actionable findings.

Exact before/after transcripts matched for fenced-singleton-retry, frontmatter-fallback, protocol-leak-split and uppercase-wrapper-strip: raw and masked inputs, responses, errors and final results. The fenced retry retained four calls; each other fixture retained one. Existing normalized full-output assertions remain unchanged.

Cross-adapter raw-byte equivalence is explicitly not claimed. The deleted replays differ from the retained fixtures in trailing newlines, an extra blank line before `</BODY>`, and `gateway/configuration-reference.md` versus `help/testing.md`. The proof establishes unchanged retained-fixture behavior. No timing or memory improvement is claimed.
