### PR TITLE
perf(ui): reuse browser tab selection within each pane render

### DIFF
--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -123,6 +123,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
         state.requestUpdate?.();
       }}
     ></openclaw-chat-outbox-recovery>`;
+    const latestBrowserTabs = latestBrowserTabCards(chatProps.messages, chatProps.toolMessages);
     const chat = renderChat({
       ...chatProps,
       pluginToolIcons: this.toolIcons.icons,
@@ -131,7 +132,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
         this.presented &&
         this.visuallyPresented &&
         isSidebarSlotVisible(sidebarLayout, "conversation"),
-      browserTabPreviewsActive: this.active && this.presented,
+      latestBrowserTabs: this.active && this.presented ? latestBrowserTabs : undefined,
       historyState: catalog ? undefined : state,
       header: nothing,
     });
@@ -172,9 +173,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       agentId: currentAgentId,
       browserPresented,
       browserRefreshOnPresentation: !this.pendingPanelToggleRequests.has("browser"),
-      preferredBrowserTab: [
-        ...latestBrowserTabCards(chatProps.messages, chatProps.toolMessages).values(),
-      ].at(-1),
+      preferredBrowserTab: [...latestBrowserTabs.values()].at(-1),
       desktopPresented,
       desktopRefreshOnPresentation,
       desktopAvailable,

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -9,6 +9,7 @@ import type {
   SessionsListResult,
 } from "../../../api/types.ts";
 import type { QuestionPrompt } from "../../../app/question-prompt.ts";
+import type { BrowserTabSelection } from "../../../components/browser/browser-target.ts";
 import { copyMarkdownLabel, handleCopyButton } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
@@ -92,7 +93,7 @@ export type ChatThreadProps = ChatSendStatusActions & {
   historyPagination?: ChatHistoryBoundaryProps;
   messages: unknown[];
   toolMessages: unknown[];
-  browserTabPreviewsActive?: boolean;
+  latestBrowserTabs?: ReadonlyMap<string, BrowserTabSelection>;
   guardianNotices?: ChatGuardianNotice[];
   streamSegments: ChatStreamSegment[];
   stream: string | null;

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -2,7 +2,6 @@
 import { nothing } from "lit";
 import { classifySessionKind } from "../../../../../src/sessions/classify-session-kind.js";
 import { i18n, t } from "../../../i18n/index.ts";
-import { latestBrowserTabCards } from "../../../lib/chat/browser-tab-preview.ts";
 import type { ChatItem, MessageGroup } from "../../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../../lib/chat/message-extract.ts";
 import { formatSessionArchiveReason } from "../../../lib/sessions/session-archive-reason.ts";
@@ -153,10 +152,7 @@ export function projectChatTranscript(
   const runOutputTokens = workingIndicator?.runId
     ? (props.runUsageById?.get(workingIndicator.runId)?.outputTokens ?? null)
     : null;
-  const latestBrowserTabs =
-    props.browserTabPreviewsActive === false
-      ? latestBrowserTabCards([], [])
-      : latestBrowserTabCards(props.messages, props.toolMessages);
+  const latestBrowserTabs = props.latestBrowserTabs;
   syncToolCardExpansionState(
     props.sessionKey,
     chatItems,
@@ -650,7 +646,7 @@ export function projectChatTranscript(
     getChatMediaRenderVersion(),
     // The host minute poll requests an update; this key crosses row guard() memoization.
     Math.floor(Date.now() / 60_000),
-    JSON.stringify([...latestBrowserTabs]),
+    JSON.stringify([...(latestBrowserTabs ?? [])]),
     props.sessionKey,
     props.presented,
     props.transcriptVisible,

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -3,6 +3,7 @@
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../../../api/types.ts";
+import { latestBrowserTabCards } from "../../../lib/chat/browser-tab-preview.ts";
 import { createTestGatewayClient } from "../../../test-helpers/gateway-client.ts";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
 import { getChatSessionProjection, reduceChatSessionProjection } from "../history-merge.ts";
@@ -343,7 +344,7 @@ describe("chat transcript rendering", () => {
       ];
       const props = {
         ...threadProps("pane-browser-work", "agent:main:dashboard:browser", messages),
-        browserTabPreviewsActive: active,
+        latestBrowserTabs: active ? latestBrowserTabCards(messages, []) : undefined,
         showToolCalls: true,
       };
       const transcript = createTestTranscript();


### PR DESCRIPTION
Closes #145274

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Rendering an active chat pane repeats the work needed to choose the latest browser tabs for its transcript thumbnails and Browser panel. Both surfaces use the same conversation history, so the second preparation is unnecessary.

## Why This Change Was Made

The pane layout prepares one selection map from the full, unfiltered message and live tool-message history, then shares it with the Browser panel and active, presented transcript. This removes the projection's duplicate scan and the old activation flag while preserving value-based render invalidation; no cache or retained state is added.

## User Impact

Browser cards, tab preference and explicit selection behave as before. Latest-successful and history-before-live ordering, host/node/profile identity, URL-less tab actions and request/capture identity checks remain intact. Inactive transcript thumbnails relinquish ownership while retaining the panel's tab preference. The change removes four net production lines and adds one net test line; the existing hidden-preview assertions are unchanged.

## Evidence

A source-Vite Chromium comparison exercises the actual pane with an isolated synthetic mock Gateway. CDP precise function counters record one explicit pane render and **two selection preparations before, one afterward**. Both arms retain the latest managed card and let a newer URL-less node tab own panel preference. Making the pane inactive removes thumbnail ownership while preserving that preference; neither arm causes implicit tab focus or page errors.

The retained before/after synthetic captures are byte-identical. They establish visual preservation; the function counters establish the reduced work. The measurement covers one explicit pane update and makes no timing, allocation-byte, RSS or retained-heap claim. No operator data or live browser target was used.

All 64 existing owner tests pass across the selector, browser-card, transcript and panel-route suites. The production Control UI build and five bundled route/URL E2Es pass, along with the full selected changed gate and a fresh independent P2 review with no actionable findings. The source-Vite count comparison is separate from the bundled build/E2E evidence. Earlier attempts were stopped before execution by the proof-capacity guard; they were not failed tests.

![Before: synthetic behavior preservation](https://github.com/user-attachments/assets/ac7890de-22df-4545-bb38-df9a2113e42c)

![After: synthetic behavior preservation](https://github.com/user-attachments/assets/4c52cce8-1ef0-449c-8df4-ac54277d4b32)