### PR TITLE
perf(anthropic): limit MIME sniff decoding to a canonical prefix

### DIFF
--- a/src/llm/ai-transport-host.test.ts
+++ b/src/llm/ai-transport-host.test.ts
@@ -1,5 +1,7 @@
+import { FILE_TYPE_SNIFF_MAX_BYTES } from "@openclaw/media-core/mime";
 import { Type } from "typebox";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getAiTransportHost } from "../../packages/ai/src/host.js";
 import { convertMessages } from "../../packages/ai/src/openai-completions-messages.js";
 import { streamSimpleAnthropic } from "../../packages/ai/src/providers/anthropic.js";
 import { extractToolResultText } from "../../packages/ai/src/providers/tool-result-text.js";
@@ -10,9 +12,128 @@ import { createOpenClawReadTool } from "../agents/agent-tools.read.js";
 import { createZeroUsageFixture } from "../agents/test-helpers/usage-fixtures.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
+import {
+  createSolidPngBuffer,
+  createTinyJpegBuffer,
+} from "../plugin-sdk/test-helpers/image-fixtures.js";
 import "./ai-transport-host.js";
 
 afterEach(resetSecretRedactionRegistryForTest);
+
+describe("OpenClaw Anthropic inline images", () => {
+  it("keeps complete canonical user and tool-result images through the installed host", async () => {
+    const jpeg = Buffer.alloc(FILE_TYPE_SNIFF_MAX_BYTES + 32);
+    createTinyJpegBuffer().copy(jpeg);
+    jpeg.write("user-image-tail", jpeg.length - 15);
+    const png = Buffer.alloc(FILE_TYPE_SNIFF_MAX_BYTES + 33);
+    createSolidPngBuffer(1, 1, { r: 18, g: 52, b: 86 }).copy(png);
+    png.write("tool-image-tail", png.length - 15);
+    const jpegData = jpeg.toString("base64");
+    const pngData = png.toString("base64");
+    const model = {
+      id: "claude-test",
+      name: "Claude test",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: false,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 16_000,
+      maxTokens: 1_024,
+    } satisfies Model<"anthropic-messages">;
+    const network = vi.fn<typeof fetch>().mockRejectedValue(new Error("unexpected network"));
+    const fetchPolicy = vi.spyOn(getAiTransportHost(), "buildModelFetch").mockReturnValue(network);
+    let payload: unknown;
+    try {
+      const stream = streamSimpleAnthropic(
+        model,
+        {
+          messages: [
+            {
+              role: "user",
+              timestamp: 0,
+              content: [
+                { type: "text", text: "user image" },
+                {
+                  type: "image",
+                  data: ` ${jpegData.slice(0, 80)}\n${jpegData.slice(80)} `,
+                  mimeType: "image/png",
+                },
+              ],
+            },
+            {
+              role: "assistant",
+              api: "anthropic-messages",
+              provider: "anthropic",
+              model: model.id,
+              content: [{ type: "toolCall", id: "image-1", name: "read", arguments: {} }],
+              usage: createZeroUsageFixture(),
+              stopReason: "toolUse",
+              timestamp: 1,
+            },
+            {
+              role: "toolResult",
+              toolCallId: "image-1",
+              toolName: "read",
+              isError: false,
+              timestamp: 2,
+              content: [
+                { type: "text", text: "before tool image" },
+                { type: "image", data: pngData.replace(/=+$/, ""), mimeType: "image/jpeg" },
+                { type: "text", text: "after tool image" },
+              ],
+            },
+          ],
+        },
+        {
+          apiKey: "test-provider-key",
+          reasoning: "off",
+          onPayload: (value) => {
+            payload = value;
+            throw new Error("payload captured");
+          },
+        },
+      );
+      expect((await stream.result()).stopReason).toBe("error");
+      expect(network).not.toHaveBeenCalled();
+      expect(payload).toMatchObject({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "user image" },
+              {
+                type: "image",
+                source: { type: "base64", media_type: "image/jpeg", data: jpegData },
+              },
+            ],
+          },
+          { role: "assistant", content: [{ type: "tool_use", id: "image-1" }] },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "image-1",
+                content: [
+                  { type: "text", text: "before tool image" },
+                  {
+                    type: "image",
+                    source: { type: "base64", media_type: "image/png", data: pngData },
+                  },
+                  { type: "text", text: "after tool image" },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    } finally {
+      fetchPolicy.mockRestore();
+    }
+  });
+});
 
 describe("OpenClaw provider error redaction", () => {
   it("preserves a nested transport code after installed host redaction", () => {

--- a/src/media/anthropic-inline-images.test.ts
+++ b/src/media/anthropic-inline-images.test.ts
@@ -1,3 +1,4 @@
+import { FILE_TYPE_SNIFF_MAX_BYTES } from "@openclaw/media-core/mime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { convertImageToJpegMock, convertImageToPngMock, detectMimeMock } = vi.hoisted(() => ({
@@ -6,9 +7,9 @@ const { convertImageToJpegMock, convertImageToPngMock, detectMimeMock } = vi.hoi
   detectMimeMock: vi.fn(),
 }));
 
-vi.mock("@openclaw/media-core/mime", () => ({
+vi.mock("@openclaw/media-core/mime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@openclaw/media-core/mime")>()),
   detectMime: detectMimeMock,
-  normalizeMimeType: (value?: string | null) => value?.split(";", 1)[0]?.trim().toLowerCase(),
 }));
 
 vi.mock("./image-ops.js", () => ({
@@ -27,23 +28,29 @@ describe("normalizeAnthropicInlineContentBlocks", () => {
     detectMimeMock.mockReset();
   });
 
-  it("converts detected unsupported bytes despite a supported declaration", async () => {
-    detectMimeMock.mockResolvedValue("image/tiff");
-    const tiffData = Buffer.from("tiff-bytes").toString("base64");
+  it.each([32, FILE_TYPE_SNIFF_MAX_BYTES + 3])(
+    "converts all %i unsupported bytes despite a supported declaration",
+    async (size) => {
+      detectMimeMock.mockResolvedValue("image/tiff");
+      const original = Buffer.alloc(size, 0xa7);
+      original.write("tiff-bytes", 0);
+      original.write("complete-image-tail", size - 19);
+      const tiffData = original.toString("base64");
 
-    await expect(
-      normalizeAnthropicInlineContentBlocks([
-        { type: "image", data: tiffData, mimeType: "image/jpeg" },
-      ]),
-    ).resolves.toEqual([
-      {
-        type: "image",
-        data: Buffer.from("converted-jpeg").toString("base64"),
-        mimeType: "image/jpeg",
-      },
-    ]);
-    expect(convertImageToJpegMock).toHaveBeenCalledOnce();
-  });
+      await expect(
+        normalizeAnthropicInlineContentBlocks([
+          { type: "image", data: tiffData, mimeType: "image/jpeg" },
+        ]),
+      ).resolves.toEqual([
+        {
+          type: "image",
+          data: Buffer.from("converted-jpeg").toString("base64"),
+          mimeType: "image/jpeg",
+        },
+      ]);
+      expect(convertImageToJpegMock).toHaveBeenCalledExactlyOnceWith(original);
+    },
+  );
 
   it("uses a supported declaration when byte detection is inconclusive", async () => {
     detectMimeMock.mockResolvedValue(undefined);
@@ -63,11 +70,38 @@ describe("normalizeAnthropicInlineContentBlocks", () => {
 
     await expect(
       normalizeAnthropicInlineContentBlocks([
+        { type: "image", data: "QQ==", mimeType: "image/png" },
         { type: "image", data: "A".repeat(encodedLength), mimeType: "image/tiff" },
       ]),
     ).rejects.toThrow("10 MB decoded safety limit");
     expect(detectMimeMock).not.toHaveBeenCalled();
     expect(convertImageToJpegMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["ZE==", "ZE", "-_8=", "Q!Q==", "QQ==QQ==", "QQ===", "S", "", " \n\t"])(
+    "preserves permissive decoding and output data for %j",
+    async (data) => {
+      detectMimeMock.mockResolvedValue(undefined);
+      await expect(
+        normalizeAnthropicInlineContentBlocks([{ type: "image", data, mimeType: "image/png" }]),
+      ).resolves.toEqual([{ type: "image", data: data.trim(), mimeType: "image/png" }]);
+      expect(detectMimeMock).toHaveBeenCalledExactlyOnceWith({
+        buffer: Buffer.from(data.trim(), "base64"),
+      });
+      expect(convertImageToJpegMock).not.toHaveBeenCalled();
+      expect(convertImageToPngMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("validates the complete input before choosing a MIME prefix", async () => {
+    const original = Buffer.alloc(FILE_TYPE_SNIFF_MAX_BYTES * 2, 0xa7);
+    const data = `${original.toString("base64")}!`;
+    detectMimeMock.mockResolvedValue(undefined);
+
+    await expect(
+      normalizeAnthropicInlineContentBlocks([{ type: "image", data, mimeType: "image/png" }]),
+    ).resolves.toEqual([{ type: "image", data, mimeType: "image/png" }]);
+    expect(detectMimeMock).toHaveBeenCalledExactlyOnceWith({ buffer: original });
   });
 
   it("routes detected BMP bytes through the fallback-capable PNG converter", async () => {

--- a/src/media/anthropic-inline-images.ts
+++ b/src/media/anthropic-inline-images.ts
@@ -1,5 +1,9 @@
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
-import { detectMime, normalizeMimeType } from "@openclaw/media-core/mime";
+import {
+  detectMime,
+  FILE_TYPE_SNIFF_MAX_BYTES,
+  normalizeMimeType,
+} from "@openclaw/media-core/mime";
 import { convertImageToJpeg, convertImageToPng } from "./image-ops.js";
 
 const ANTHROPIC_SUPPORTED_IMAGE_MIMES = [
@@ -10,6 +14,7 @@ const ANTHROPIC_SUPPORTED_IMAGE_MIMES = [
 ] as const;
 // Match OpenClaw's decoded inbound-image hard cap before any copy or native decode.
 const ANTHROPIC_INLINE_IMAGE_DECODE_SAFETY_BYTES = 10 * 1024 * 1024;
+const ANTHROPIC_MIME_PREFIX_BASE64_CHARS = 4 * Math.ceil(FILE_TYPE_SNIFF_MAX_BYTES / 3);
 
 type AnthropicSupportedImageMime = (typeof ANTHROPIC_SUPPORTED_IMAGE_MIMES)[number];
 type AnthropicInlineTextBlock = { type: "text"; text: string };
@@ -34,21 +39,25 @@ async function normalizeAnthropicInlineImage(block: AnthropicInlineImageBlock): 
   data: string;
   mimeType: AnthropicSupportedImageMime;
 }> {
-  const canonicalData = canonicalizeBase64(block.data) ?? block.data.trim();
-  const buffer = Buffer.from(canonicalData, "base64");
+  const canonicalData = canonicalizeBase64(block.data);
+  const data = canonicalData ?? block.data.trim();
+  // Only canonical input can be truncated without changing permissive base64 decoding.
+  const sniffData = canonicalData?.slice(0, ANTHROPIC_MIME_PREFIX_BASE64_CHARS) ?? data;
+  const buffer = Buffer.from(sniffData, "base64");
   const declaredMime = normalizeMimeType(block.mimeType);
   const detectedMime = normalizeMimeType(await detectMime({ buffer }));
   if (isAnthropicSupportedImageMime(detectedMime)) {
-    return { data: canonicalData, mimeType: detectedMime };
+    return { data, mimeType: detectedMime };
   }
   if (!detectedMime && isAnthropicSupportedImageMime(declaredMime)) {
-    return { data: canonicalData, mimeType: declaredMime };
+    return { data, mimeType: declaredMime };
   }
 
   const convertToPng = detectedMime === "image/bmp";
+  const conversionBuffer = sniffData.length === data.length ? buffer : Buffer.from(data, "base64");
   const normalizedBuffer = convertToPng
-    ? await convertImageToPng(buffer)
-    : await convertImageToJpeg(buffer);
+    ? await convertImageToPng(conversionBuffer)
+    : await convertImageToJpeg(conversionBuffer);
   if (normalizedBuffer.byteLength > ANTHROPIC_INLINE_IMAGE_DECODE_SAFETY_BYTES) {
     throw new Error("Normalized Anthropic inline image exceeds the 10 MB decoded safety limit.");
   }


### PR DESCRIPTION
Closes #145276

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Anthropic inline-image preparation fully decodes large supported images just to determine MIME type, even though the detector only reads a one-MiB prefix.

## Why This Change Was Made

Canonicalize the complete input, then decode a quartet-aligned prefix for MIME detection. Supported images retain their complete encoded output; conversions still receive all original bytes. Malformed input keeps the original full permissive decode, and short conversions reuse the already complete buffer.

## User Impact

Image content, MIME decisions and conversion results remain unchanged. The existing normalizer still owns the path, with no dependency, configuration, protocol or persistence change. The change adds nine net production lines and 155 net test lines. Input/output limits remain 10 MiB, with the 64 MiB aggregate limit unchanged.

## Evidence

All **28 before/after operation cases** preserve output hashes and MIME results on the same runtime and dependencies. The final **25 tests across three core, host and package suites**, full selected changed gate against explicit base `ad439abc01eb575399fa2c9d0d892668ddb99403`, and independent P2 review pass. The installed-host case captures complete canonical user and tool-result image payloads before dispatch and verifies that no network request occurs.

Observed decoded Buffer materialization is:

| Synthetic case | Before | After |
| --- | ---: | ---: |
| Supported 3 MiB + 1 byte image | 3,145,729 bytes | 1,048,578 bytes |
| Supported image at the 10 MiB input boundary | 10,485,760 bytes | 1,048,578 bytes |
| Long BMP/TIFF conversion | 3,145,729 bytes | 1,048,578-byte prefix, then full 3,145,729-byte decode |
| Malformed long input | 3,145,729 bytes | 3,145,729 bytes |
| Short BMP conversion | 58 bytes | 58 bytes |

The prefix is **1 MiB + 2 bytes** because base64 decoding stays quartet-aligned; MIME detection still consumes its existing one-MiB limit. Cases cover supported formats, whitespace/unpadded input, quartet boundaries, malformed suffixes and conversions. Input preflight rejection performs no decode, and aggregate rejection performs no normalizer calls.

This measures decoded Buffer materialization only. Full encoded strings remain retained and fully validated. Long conversions perform an extra bounded prefix decode before their required full decode, so no universal allocation or memory reduction is claimed. No timing, RSS, retained-heap, live-provider or channel measurement was made.
