### PR TITLE
perf(cli): reuse command metadata across completion cache writes

### DIFF
--- a/src/cli/completion-bash.ts
+++ b/src/cli/completion-bash.ts
@@ -1,14 +1,13 @@
 // Bash completion owns shell-word normalization and Readline insertion spans.
-import type { Command } from "commander";
-import {
-  collectShellCompletionCommandTree,
-  type ShellCompletionContext,
+import type {
+  ShellCompletionCommandTree,
+  ShellCompletionContext,
 } from "./completion-command-tree.js";
 import { quoteCliArg } from "./quote-cli-arg.js";
 
-export function generateBashCompletion(program: Command): string {
-  const rootCmd = program.name();
-  const { root, descendants: contexts } = collectShellCompletionCommandTree(program);
+export function generateBashCompletion(tree: ShellCompletionCommandTree): string {
+  const { root, descendants: contexts } = tree;
+  const rootCmd = root.command.name();
   const commandPathUpdate = generateBashCommandPathUpdate(contexts);
   const choiceCompletion = generateBashOptionChoiceCompletion([root, ...contexts]);
   return `

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -12,6 +12,7 @@ import {
   commandNameVariants,
   completionFlags,
   visibleCompletionCommands,
+  type ShellCompletionCommandTree,
   type ShellCompletionContext,
 } from "./completion-command-tree.js";
 import {
@@ -34,16 +35,24 @@ import { removeCommandGroupNames } from "./program/register-command-groups.js";
 import { getSubCliCompletionGroups } from "./program/register.subclis-core.js";
 
 export function getCompletionScript(shell: CompletionShell, program: Command): string {
-  if (shell === "zsh") {
-    return generateZshCompletion(program);
-  }
-  if (shell === "bash") {
-    return generateBashCompletion(program);
-  }
-  if (shell === "powershell") {
-    return generatePowerShellCompletion(program);
-  }
-  return generateFishCompletion(program);
+  return createCompletionScriptGenerator(program)(shell);
+}
+
+function createCompletionScriptGenerator(program: Command): (shell: CompletionShell) => string {
+  let tree: ShellCompletionCommandTree | undefined;
+  return (shell) => {
+    if (shell === "zsh") {
+      return generateZshCompletion(program);
+    }
+    tree ??= collectShellCompletionCommandTree(program);
+    if (shell === "bash") {
+      return generateBashCompletion(tree);
+    }
+    if (shell === "powershell") {
+      return generatePowerShellCompletion(tree);
+    }
+    return generateFishCompletion(tree);
+  };
 }
 
 function preferredCompletionFlag(option: Option): string {
@@ -135,8 +144,9 @@ async function writeCompletionCache(params: {
   shells: CompletionShell[];
   binName: string;
 }): Promise<void> {
+  const generateScript = createCompletionScriptGenerator(params.program);
   for (const shell of params.shells) {
-    const script = getCompletionScript(shell, params.program);
+    const script = generateScript(shell);
     await publishOutputFileAtomically({
       filePath: resolveCompletionCachePath(shell, params.binName),
       tempPrefix: ".openclaw-completion-cache",
@@ -396,14 +406,14 @@ ${funcName}() {
   return segments.join("");
 }
 
-function generatePowerShellCompletion(program: Command): string {
-  const rootCmd = program.name();
+function generatePowerShellCompletion(tree: ShellCompletionCommandTree): string {
+  const { root, descendants: contexts } = tree;
+  const rootCmd = root.command.name();
   const completionBodies: string[] = [];
   const formatPowerShellArray = (entries: string[]) =>
     entries.length > 0
       ? `@(${entries.map((entry) => `'${entry.replaceAll("'", "''")}'`).join(",")})`
       : "@()";
-  const { root, descendants: contexts } = collectShellCompletionCommandTree(program);
   const rootValueOptions = root.valueOptions;
   const commandPathCases = contexts
     .flatMap((context) =>
@@ -552,9 +562,9 @@ ${choiceCompletion}
 `;
 }
 
-function generateFishCompletion(program: Command): string {
-  const rootCmd = program.name();
-  const { root, descendants } = collectShellCompletionCommandTree(program);
+function generateFishCompletion(tree: ShellCompletionCommandTree): string {
+  const { root, descendants } = tree;
+  const rootCmd = root.command.name();
   const segments: string[] = [generateFishPathHelper(rootCmd, descendants)];
 
   for (const context of [root, ...descendants]) {

--- a/src/cli/completion-command-tree.ts
+++ b/src/cli/completion-command-tree.ts
@@ -14,7 +14,7 @@ export type ShellCompletionContext = {
   valueChoices: ShellCompletionValueChoice[];
 };
 
-type ShellCompletionCommandTree = {
+export type ShellCompletionCommandTree = {
   root: ShellCompletionContext;
   descendants: ShellCompletionContext[];
 };


### PR DESCRIPTION
Closes #145278

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Generating completion caches for all shells repeats command-metadata preparation for Bash, Fish and PowerShell, even though they use the same registered command program during that write.

## Why This Change Was Made

One private generator owns dispatch and lazy metadata for each cache write. Bash, Fish and PowerShell consume its prepared tree; Zsh retains its direct path. Standalone generation creates a new generator on every call, so changes to the same program remain visible. Nine net production lines express this lifecycle, with no test edits or global cache.

## User Impact

Generated completion scripts retain their bytes and behavior. Core/sub-CLI/plugin registration is still awaited, Zsh remains first, and publication stays serial and atomic. Alias and hidden-value grammar, choices, warnings and errors retain their existing owners. The prepared tree keeps Commander references rather than becoming a frozen deep snapshot.

## Evidence

- The focused run passed 132 tests across seven files. Native Bash and Zsh cases ran; 107 optional native Fish/PowerShell cases skipped because those binaries were unavailable.
- Two sequential supported forced builds bound the before/after actual CLI runs. All four generated shell files matched exactly, totaling 2,225,187 bytes. This proves generated output parity for Fish and PowerShell without claiming native execution of their skipped cases.
- Same-program standalone freshness checks passed in both versions. Stale completion-cache sentinels were overwritten, while config and profile sentinels remained unchanged.
- The selected changed gate and P2 review passed.

The three-to-one tree-preparation reduction per all-shell write is source-derived, not an instrumented count or benchmark. Zsh-only generation prepares no tree. No measured timing or memory improvement is claimed.
