### PR TITLE
refactor: reuse ACPX lifecycle test latches

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -2628,10 +2628,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
         list: () => ["codex"],
       },
     });
-    let releaseFirst!: () => void;
-    const firstBlocked = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
+    const { promise: firstBlocked, resolve: releaseFirst } = createDeferred<void>();
     let entered = 0;
     let active = 0;
     let maxActive = 0;
@@ -3080,14 +3077,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       openclawProcessLeaseStore: leaseStore.store,
       openclawWrapperRoot: "/tmp/openclaw/acpx",
     });
-    let markTurnStarted!: () => void;
-    const turnStarted = new Promise<void>((resolve) => {
-      markTurnStarted = resolve;
-    });
-    let releaseTurn!: () => void;
-    const turnBlocked = new Promise<void>((resolve) => {
-      releaseTurn = resolve;
-    });
+    const { promise: turnStarted, resolve: markTurnStarted } = createDeferred<void>();
+    const { promise: turnBlocked, resolve: releaseTurn } = createDeferred<void>();
     vi.spyOn(delegate, "startTurn").mockImplementation((input) => {
       markTurnStarted();
       return makeTurn(input, { result: turnBlocked.then(() => ({ status: "completed" })) });
@@ -3147,14 +3138,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       openclawProcessLeaseStore: leaseStore.store,
       openclawWrapperRoot: "/tmp/openclaw/acpx",
     });
-    let markTurnStarted!: () => void;
-    const turnStarted = new Promise<void>((resolve) => {
-      markTurnStarted = resolve;
-    });
-    let releaseTurn!: () => void;
-    const turnBlocked = new Promise<void>((resolve) => {
-      releaseTurn = resolve;
-    });
+    const { promise: turnStarted, resolve: markTurnStarted } = createDeferred<void>();
+    const { promise: turnBlocked, resolve: releaseTurn } = createDeferred<void>();
     vi.spyOn(delegate, "startTurn").mockImplementation((input) => {
       markTurnStarted();
       return makeTurn(input, { result: turnBlocked.then(() => ({ status: "completed" })) });
@@ -3203,14 +3188,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
         list: () => ["codex"],
       },
     });
-    let markLaunchPersisted!: () => void;
-    const launchPersisted = new Promise<void>((resolve) => {
-      markLaunchPersisted = resolve;
-    });
-    let failLaunch!: () => void;
-    const launchBlocked = new Promise<void>((resolve) => {
-      failLaunch = resolve;
-    });
+    const { promise: launchPersisted, resolve: markLaunchPersisted } = createDeferred<void>();
+    const { promise: launchBlocked, resolve: failLaunch } = createDeferred<void>();
     vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
       const command = runtimeCommand(runtime);
       await wrappedStore.save({
@@ -3222,14 +3201,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       await launchBlocked;
       throw new Error("launch failed");
     });
-    let markControlStarted!: () => void;
-    const controlStarted = new Promise<void>((resolve) => {
-      markControlStarted = resolve;
-    });
-    let releaseControl!: () => void;
-    const controlBlocked = new Promise<void>((resolve) => {
-      releaseControl = resolve;
-    });
+    const { promise: controlStarted, resolve: markControlStarted } = createDeferred<void>();
+    const { promise: controlBlocked, resolve: releaseControl } = createDeferred<void>();
     vi.spyOn(delegate, "setMode").mockImplementation(async () => {
       markControlStarted();
       await controlBlocked;
@@ -3273,14 +3246,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     };
     const leaseStore = makeLeaseStore();
     let leaseLoads = 0;
-    let markRetirementStarted!: () => void;
-    const retirementStarted = new Promise<void>((resolve) => {
-      markRetirementStarted = resolve;
-    });
-    let releaseRetirement!: () => void;
-    const retirementBlocked = new Promise<void>((resolve) => {
-      releaseRetirement = resolve;
-    });
+    const { promise: retirementStarted, resolve: markRetirementStarted } = createDeferred<void>();
+    const { promise: retirementBlocked, resolve: releaseRetirement } = createDeferred<void>();
     leaseStore.store.load.mockImplementation(async (leaseId: string) => {
       leaseLoads += 1;
       if (leaseLoads === 2) {
@@ -3346,14 +3313,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       state: "open",
     });
     let leaseLoads = 0;
-    let markRetirementStarted!: () => void;
-    const retirementStarted = new Promise<void>((resolve) => {
-      markRetirementStarted = resolve;
-    });
-    let releaseRetirement!: () => void;
-    const retirementBlocked = new Promise<void>((resolve) => {
-      releaseRetirement = resolve;
-    });
+    const { promise: retirementStarted, resolve: markRetirementStarted } = createDeferred<void>();
+    const { promise: retirementBlocked, resolve: releaseRetirement } = createDeferred<void>();
     leaseStore.store.load.mockImplementation(async (leaseId: string) => {
       leaseLoads += 1;
       if (leaseLoads === 2) {


### PR DESCRIPTION
Related: #145246

## What Problem This Solves

Six ACPX lifecycle regressions repeat 13 manual promise/resolver setups even though the suite already imports a typed deferred helper. This maintainer-requested test-audit cleanup removes that setup noise while retaining the concurrency and lease-ownership checks.

## Why This Change Was Made

Reuse `createDeferred<void>()` at each original construction point, keeping the promise and resolver names. No awaits, resolver calls, test actions, assertions, imports, production code, or deadlines change.

## User Impact

No runtime behavior changes. The test suite loses 39 net lines and retains its independent lifecycle regression coverage.

## Evidence

- Baseline and updated owner/sibling runs both pass the same 133 cases: 119 runtime, 2 runtime proxy, and 12 session-owner migration cases, with no failures or skips.
- Inverse expansion reconstructs the original file byte-for-byte, preserving all 279 assertion sites and every downstream statement.
- The suite and its setup do not replace the global Promise constructor; the existing helper uses native `Promise.withResolvers`.
- Scoped P0–P2 independent review reports no actionable findings.
- Mapped changed checks pass, including extension test type checking, lint, and all three dead-export scans.
