### PR TITLE
fix: recover orphan task deliveries during Doctor repair

### DIFF
--- a/docs/reference/database-schemas/integrity-and-recovery.md
+++ b/docs/reference/database-schemas/integrity-and-recovery.md
@@ -69,6 +69,34 @@ The heartbeat proves ownership, not migration progress. A live but stuck mainten
 
 `SQLite read-only worker` failures append `code` and numeric SQLite `errcode` diagnostics when the underlying error supplies valid values, including through a bounded cause chain. Report the full code suffix when investigating a failure. Snapshot and integrity-child timeout errors include the applied budget and source file size; snapshot timeouts report an unknown size if the source stat failed. Integrity-child timeouts also retain `lastObservedPhase`. A generic `disk I/O error` or `SQLITE_IOERR` alone does not prove the disk is full.
 
+### Doctor reports orphan task delivery rows
+
+If `foreign_key_check` names `task_delivery_state` referencing `task_runs`,
+stop the Gateway and run `openclaw doctor --fix`. Doctor can recover this known
+relation when the database is structurally intact and has no unrelated
+foreign-key violations or unrecognized delivery-table schema or triggers.
+
+Before removing any orphan rows, Doctor preserves a complete WAL-aware database
+copy and a lossless row export in a private `openclaw-task-delivery-recovery-*`
+directory beside the shared database. Its report names that directory. It contains:
+
+- `database.sqlite`: the pre-repair database, including the orphan rows.
+- `orphan-rows.jsonl`: the original delivery payload, with SQLite integers encoded
+  as decimal strings to avoid precision loss.
+- `manifest.json`: file hashes, row count, and preservation metadata.
+
+Doctor removes only delivery rows whose task no longer exists, within the existing
+repair transaction, and requires clean integrity and foreign-key checks before
+commit. It does not fabricate tasks or replay deliveries. If preservation or a
+later repair step fails, row removal rolls back and any recovery artifacts remain.
+A manifest proves preservation, not that the repair committed; rerun Doctor to
+verify completion.
+
+Keep these files private: they can contain delivery destinations and other user
+data. Retain them until the updated Gateway is verified and any needed payload
+has been recovered. Do not overwrite newer runtime state with this original
+copy. This recovery does not establish which writer created the orphan rows.
+
 ### Why you cannot go back after updating to 2026.7.2
 
 Every release through `v2026.7.1` used agent schema 1 and state schema 1. The 2026.7.2 release train (starting with `v2026.7.2-beta.1`) migrates your databases forward on first start. That migration is one-way: the data is rewritten into the newer schema, and installing an older OpenClaw afterwards does not undo it. The older build refuses to start with a `newer schema version` error that names the build that owns the database.

--- a/scripts/check-kysely-guardrails.mts
+++ b/scripts/check-kysely-guardrails.mts
@@ -127,6 +127,8 @@ const rawSqliteAllowPathGroups = {
     "src/infra/state-migrations.media-persistence.ts",
     "src/infra/state-migrations.transcript-directives-archives.ts",
     "src/infra/state-migrations.transcript-directives.ts",
+    // Doctor integrity PRAGMAs and lossless native 64-bit orphan-row preservation.
+    "src/state/openclaw-state-db-task-delivery-recovery.ts",
   ],
   "session entry cache connection-local validity counters": [
     "src/config/sessions/session-accessor.sqlite-entry-cache.ts",

--- a/src/state/openclaw-state-db-task-delivery-recovery.ts
+++ b/src/state/openclaw-state-db-task-delivery-recovery.ts
@@ -160,8 +160,12 @@ export function recoverOrphanTaskDeliveryRows(database: DatabaseSync, pathname: 
       }
       const sourceHash = createHash("sha256");
       const snapshotHash = createHash("sha256");
-      for (const row of orphanRows(database)) sourceHash.update(encodeOrphanRow(row));
-      for (const row of orphanRows(snapshot)) snapshotHash.update(encodeOrphanRow(row));
+      for (const row of orphanRows(database)) {
+        sourceHash.update(encodeOrphanRow(row));
+      }
+      for (const row of orphanRows(snapshot)) {
+        snapshotHash.update(encodeOrphanRow(row));
+      }
       if (sourceHash.digest("hex") !== snapshotHash.digest("hex")) {
         throw new Error("Orphan task delivery snapshot does not preserve the current payload.");
       }

--- a/src/state/openclaw-state-db-task-delivery-recovery.ts
+++ b/src/state/openclaw-state-db-task-delivery-recovery.ts
@@ -1,0 +1,256 @@
+// Doctor owns preservation-first recovery of delivery metadata whose task no longer exists.
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { requireDirectorySync, syncDirectorySync } from "../infra/directory-durability.js";
+import { hashFileDescriptorSync } from "../infra/file-descriptor.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
+import { createPrivateSqliteTempDirectorySync } from "../infra/sqlite-private-directory.js";
+import { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-snapshot-source.js";
+import { tableExists } from "./openclaw-state-db-schema-helpers.js";
+
+const ORPHAN_PREDICATE =
+  "NOT EXISTS (SELECT 1 FROM task_runs WHERE task_runs.task_id = task_delivery_state.task_id)";
+
+type OrphanDeliveryRow = {
+  rowid: bigint;
+  task_id: string;
+  requester_origin_json: string | null;
+  last_notified_event_at: bigint | null;
+};
+
+function orphanRows(database: DatabaseSync): Iterable<OrphanDeliveryRow> {
+  const statement = database.prepare(`SELECT rowid, * FROM task_delivery_state
+    WHERE ${ORPHAN_PREDICATE} ORDER BY rowid`);
+  statement.setReadBigInts(true);
+  // SAFETY: The caller checks the supported schema; encodeOrphanRow validates every legacy value before preservation or removal.
+  return statement.iterate() as Iterable<OrphanDeliveryRow>;
+}
+
+function encodeOrphanRow(row: OrphanDeliveryRow): string {
+  if (
+    typeof row.rowid !== "bigint" ||
+    typeof row.task_id !== "string" ||
+    (row.requester_origin_json !== null && typeof row.requester_origin_json !== "string") ||
+    (row.last_notified_event_at !== null && typeof row.last_notified_event_at !== "bigint")
+  ) {
+    throw new Error("Orphan task delivery values do not match the supported recovery contract.");
+  }
+  return `${JSON.stringify(row, (_key, value: unknown) => (typeof value === "bigint" ? value.toString() : value))}\n`;
+}
+
+function assertRecoveryShape(database: DatabaseSync): void {
+  const columns = database.prepare("PRAGMA table_xinfo(task_delivery_state)").all();
+  const expected = [
+    { cid: 0, name: "task_id", type: "TEXT", notnull: 1, dflt_value: null, pk: 1, hidden: 0 },
+    {
+      cid: 1,
+      name: "requester_origin_json",
+      type: "TEXT",
+      notnull: 0,
+      dflt_value: null,
+      pk: 0,
+      hidden: 0,
+    },
+    {
+      cid: 2,
+      name: "last_notified_event_at",
+      type: "INTEGER",
+      notnull: 0,
+      dflt_value: null,
+      pk: 0,
+      hidden: 0,
+    },
+  ];
+  const foreignKeys = database.prepare("PRAGMA foreign_key_list(task_delivery_state)").all();
+  const canonicalForeignKey = [
+    {
+      id: 0,
+      seq: 0,
+      table: "task_runs",
+      from: "task_id",
+      to: "task_id",
+      on_update: "NO ACTION",
+      on_delete: "CASCADE",
+      match: "NONE",
+    },
+  ];
+  const triggers = database
+    .prepare(
+      "SELECT 1 FROM sqlite_schema WHERE type = 'trigger' AND tbl_name = 'task_delivery_state'",
+    )
+    .get();
+  if (
+    JSON.stringify(columns) !== JSON.stringify(expected) ||
+    JSON.stringify(foreignKeys) !== JSON.stringify(canonicalForeignKey) ||
+    triggers
+  ) {
+    throw new Error(
+      "Orphan task delivery recovery refused an unrecognized table, foreign key, or trigger.",
+    );
+  }
+}
+
+function assertKnownOrphanIntegrity(database: DatabaseSync): number {
+  const structural = database.prepare("PRAGMA integrity_check").all();
+  if (structural.length !== 1 || structural[0]?.integrity_check !== "ok") {
+    throw new Error("Orphan task delivery recovery requires a structurally intact database.");
+  }
+  let count = 0;
+  const check = database.prepare("PRAGMA foreign_key_check");
+  check.setReadBigInts(true);
+  for (const violation of check.iterate()) {
+    if (
+      violation.table !== "task_delivery_state" ||
+      violation.parent !== "task_runs" ||
+      violation.fkid !== 0n ||
+      typeof violation.rowid !== "bigint"
+    ) {
+      throw new Error(
+        "Orphan task delivery recovery refused unrelated foreign-key violations; preserve the database for supported recovery.",
+      );
+    }
+    count += 1;
+  }
+  return count;
+}
+
+function syncAndHash(filePath: string) {
+  const descriptor = fs.openSync(filePath, "r+");
+  try {
+    fs.fsyncSync(descriptor);
+    return hashFileDescriptorSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+/**
+ * Caller holds Doctor's ownership/schema fences and its immediate write transaction.
+ * Foreign-key actions stay disabled: inbound dependents must fail the post-check,
+ * never cascade into unrelated data. The caller rolls back any failed check.
+ */
+export function recoverOrphanTaskDeliveryRows(database: DatabaseSync, pathname: string): string[] {
+  if (
+    !tableExists(database, "task_delivery_state") ||
+    !tableExists(database, "task_runs") ||
+    !database.prepare(`SELECT 1 FROM task_delivery_state WHERE ${ORPHAN_PREDICATE} LIMIT 1`).get()
+  ) {
+    return [];
+  }
+  assertRecoveryShape(database);
+  const count = assertKnownOrphanIntegrity(database);
+  if (!database.isTransaction) {
+    throw new Error("Orphan task delivery recovery requires the Doctor write transaction.");
+  }
+
+  // The existing worker copies WAL/rollback state in another process. Opening and
+  // closing source file descriptors here could release this process's SQLite locks.
+  const prepared = prepareSqliteReadOnlyLocationSync(pathname);
+  let recoveryDirectory: string | undefined;
+  try {
+    const snapshot = openNodeSqliteDatabase(prepared.location);
+    try {
+      snapshot.exec("PRAGMA journal_mode = DELETE;");
+      assertRecoveryShape(snapshot);
+      if (assertKnownOrphanIntegrity(snapshot) !== count) {
+        throw new Error("Orphan task delivery snapshot changed before preservation.");
+      }
+      const sourceHash = createHash("sha256");
+      const snapshotHash = createHash("sha256");
+      for (const row of orphanRows(database)) sourceHash.update(encodeOrphanRow(row));
+      for (const row of orphanRows(snapshot)) snapshotHash.update(encodeOrphanRow(row));
+      if (sourceHash.digest("hex") !== snapshotHash.digest("hex")) {
+        throw new Error("Orphan task delivery snapshot does not preserve the current payload.");
+      }
+    } finally {
+      snapshot.close();
+    }
+    recoveryDirectory = createPrivateSqliteTempDirectorySync(
+      path.dirname(pathname),
+      "openclaw-task-delivery-recovery-",
+    );
+    const backupPath = path.join(recoveryDirectory, "database.sqlite");
+    const expectedBackup = syncAndHash(prepared.location);
+    fs.copyFileSync(prepared.location, backupPath, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(backupPath, 0o600);
+    if (JSON.stringify(syncAndHash(backupPath)) !== JSON.stringify(expectedBackup)) {
+      throw new Error("Orphan task delivery backup verification failed.");
+    }
+    const exportPath = path.join(recoveryDirectory, "orphan-rows.jsonl");
+    const exportDescriptor = fs.openSync(exportPath, "wx+", 0o600);
+    const exportHash = createHash("sha256");
+    let exportedCount = 0;
+    try {
+      for (const row of orphanRows(database)) {
+        const encoded = encodeOrphanRow(row);
+        fs.writeFileSync(exportDescriptor, encoded);
+        exportHash.update(encoded);
+        exportedCount += 1;
+      }
+      fs.fsyncSync(exportDescriptor);
+      if (hashFileDescriptorSync(exportDescriptor).sha256 !== exportHash.digest("hex")) {
+        throw new Error("Orphan task delivery export verification failed.");
+      }
+    } finally {
+      fs.closeSync(exportDescriptor);
+    }
+    if (exportedCount !== count) {
+      throw new Error(
+        "Orphan task delivery export did not account for every foreign-key violation.",
+      );
+    }
+    fs.writeFileSync(
+      path.join(recoveryDirectory, "manifest.json"),
+      JSON.stringify(
+        {
+          format: "openclaw.task-delivery-recovery.v1",
+          state: "preserved-before-repair",
+          sourcePath: pathname,
+          backup: {
+            file: "database.sqlite",
+            ...expectedBackup,
+            integrity: "structural-ok-known-orphans",
+          },
+          export: {
+            file: "orphan-rows.jsonl",
+            ...syncAndHash(exportPath),
+            count,
+            integerEncoding: "decimal-string",
+          },
+          relation: "task_delivery_state.task_id -> task_runs.task_id",
+          createdAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+      { flag: "wx", mode: 0o600, flush: true },
+    );
+    requireDirectorySync(syncDirectorySync(recoveryDirectory), "Task delivery recovery directory");
+    requireDirectorySync(
+      syncDirectorySync(path.dirname(recoveryDirectory)),
+      "Task delivery recovery parent",
+    );
+    // Retained artifacts are recovery evidence, never a claim that this transaction committed.
+    // Any later migration or integrity failure rolls the row removal back, not the backup.
+    const removed = database
+      .prepare(`DELETE FROM task_delivery_state WHERE ${ORPHAN_PREDICATE}`)
+      .run();
+    if (Number(removed.changes) !== count) {
+      throw new Error("Orphan task delivery recovery removed an unexpected number of rows.");
+    }
+    assertSqliteIntegrity(database, pathname);
+    return [
+      `Preserved and recovered ${count} orphan task delivery rows; backup and row export: ${recoveryDirectory}`,
+    ];
+  } catch (error) {
+    throw new Error(
+      `Task delivery recovery failed without committing row removal${recoveryDirectory ? `; retained artifacts: ${recoveryDirectory}` : ""}: ${String(error)}`,
+      { cause: error },
+    );
+  } finally {
+    prepared.cleanup();
+  }
+}

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -6499,8 +6499,9 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         );
         if (variant === "export failure") {
           fileOpen.mockImplementation((...args: Parameters<typeof fs.openSync>) => {
-            if (String(args[0]).endsWith("orphan-rows.jsonl"))
+            if (String(args[0]).endsWith("orphan-rows.jsonl")) {
               throw new Error("ENOSPC: synthetic export failure");
+            }
             return openSync(...args);
           });
         } else {

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -6334,42 +6334,224 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     );
   });
 
-  it("rejects current-schema foreign-key violations before exposure", () => {
-    const stateDir = createTempStateDir();
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const { DatabaseSync } = requireNodeSqlite();
-    const corrupted = new DatabaseSync(databasePath);
-    try {
-      corrupted.exec("PRAGMA foreign_keys = OFF;");
-      corrupted.prepare("INSERT INTO task_delivery_state (task_id) VALUES (?)").run("missing-task");
-      expect(corrupted.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
-      expect(corrupted.prepare("PRAGMA integrity_check").get()).toEqual({
-        integrity_check: "ok",
-      });
-      expect(corrupted.prepare("PRAGMA foreign_key_check").get()).toEqual({
-        table: "task_delivery_state",
-        rowid: 1,
-        parent: "task_runs",
-        fkid: 0,
-      });
-    } finally {
-      corrupted.close();
-    }
+  it.each(["current", "2026.7.1-2"])(
+    "preserves orphan delivery payload before Doctor recovery from %s",
+    (version) => {
+      const stateDir = createTempStateDir();
+      const databasePath =
+        version === "current"
+          ? materializeCurrentStateDatabase(stateDir)
+          : materializeV2026_7_1_2StateDatabase(stateDir).databasePath;
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const { DatabaseSync } = requireNodeSqlite();
+      const corrupted = new DatabaseSync(databasePath);
+      const payload = '  {"channel":"synthetic","to":"recover-me"}\n\u0000';
+      const timestamp = 9007199254740993n;
+      try {
+        corrupted.exec(
+          "PRAGMA foreign_keys = OFF; PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;",
+        );
+        corrupted.exec(`INSERT INTO task_runs
+          (task_id,runtime,owner_key,scope_kind,task,status,delivery_status,notify_policy,created_at)
+          VALUES ('healthy-task','subagent','synthetic-owner','session','keep me','completed','delivered','silent',1);
+          INSERT INTO task_delivery_state(task_id) VALUES ('healthy-task');`);
+        const insert = corrupted.prepare(`INSERT INTO task_delivery_state
+          (task_id,requester_origin_json,last_notified_event_at) VALUES (?,?,?)`);
+        for (let index = 0; index < 18; index += 1) {
+          insert.run(`missing-task-${index}`, payload, timestamp);
+        }
+        expect(corrupted.prepare("PRAGMA integrity_check").get()).toEqual({
+          integrity_check: "ok",
+        });
+        expect(corrupted.prepare("PRAGMA foreign_key_check").all()).toHaveLength(18);
+        expect(fs.statSync(`${databasePath}-wal`).size).toBeGreaterThan(0);
+        const failure = /foreign_key_check failed.*task_delivery_state.*references task_runs/iu;
+        expect(() => openOpenClawStateDatabase(options)).toThrow(failure);
+        const checkpointCallback = vi.fn();
+        expect(() =>
+          withOpenClawStateStartupMigrationCheckpointDatabase(checkpointCallback, options),
+        ).toThrow(failure);
+        expect(checkpointCallback).not.toHaveBeenCalled();
 
-    const failure =
-      /foreign_key_check failed.*task_delivery_state row 1 references task_runs \(foreign key 0\)/iu;
-    expect(() => openOpenClawStateDatabase(options)).toThrow(failure);
-    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
-      changes: [],
-      warnings: [expect.stringMatching(failure)],
-    });
-    const checkpointCallback = vi.fn();
-    expect(() =>
-      withOpenClawStateStartupMigrationCheckpointDatabase(checkpointCallback, options),
-    ).toThrow(failure);
-    expect(checkpointCallback).not.toHaveBeenCalled();
-  });
+        const result = repairOpenClawStateDatabaseSchema(options);
+        expect(result.warnings).toEqual([]);
+        expect(result.changes).toContainEqual(
+          expect.stringContaining("Preserved and recovered 18 orphan task delivery rows"),
+        );
+        const recoveryDirs = fs
+          .readdirSync(path.dirname(databasePath))
+          .filter((name) => name.startsWith("openclaw-task-delivery-recovery-"));
+        expect(recoveryDirs).toHaveLength(1);
+        const recoveryDir = path.join(path.dirname(databasePath), recoveryDirs[0]!);
+        const backup = new DatabaseSync(path.join(recoveryDir, "database.sqlite"), {
+          readOnly: true,
+        });
+        try {
+          expect(backup.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+          expect(backup.prepare("PRAGMA foreign_key_check").all()).toHaveLength(18);
+          const row = backup.prepare(
+            "SELECT requester_origin_json,last_notified_event_at FROM task_delivery_state WHERE task_id = ?",
+          );
+          row.setReadBigInts(true);
+          expect(row.get("missing-task-0")).toEqual({
+            requester_origin_json: payload,
+            last_notified_event_at: timestamp,
+          });
+        } finally {
+          backup.close();
+        }
+        const exported = fs
+          .readFileSync(path.join(recoveryDir, "orphan-rows.jsonl"), "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(exported).toHaveLength(18);
+        expect(exported[0]).toMatchObject({
+          requester_origin_json: payload,
+          last_notified_event_at: timestamp.toString(),
+        });
+        const repaired = openOpenClawStateDatabase(options);
+        expect(repaired.db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+        expect(repaired.db.prepare("PRAGMA integrity_check").get()).toEqual({
+          integrity_check: "ok",
+        });
+        expect(repaired.db.prepare("SELECT task_id FROM task_delivery_state").all()).toContainEqual(
+          {
+            task_id: "healthy-task",
+          },
+        );
+        expect(
+          repaired.db
+            .prepare("SELECT 1 FROM task_delivery_state WHERE task_id LIKE 'missing-task-%'")
+            .all(),
+        ).toEqual([]);
+        expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+        expect(
+          fs
+            .readdirSync(path.dirname(databasePath))
+            .filter((name) => name.startsWith("openclaw-task-delivery-recovery-")),
+        ).toEqual(recoveryDirs);
+      } finally {
+        corrupted.close();
+      }
+    },
+  );
+
+  it.each(["unrelated foreign key", "trigger", "generated column"])(
+    "refuses orphan delivery recovery with %s without changing data",
+    (variant) => {
+      const stateDir = createTempStateDir();
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const seed = new DatabaseSync(databasePath);
+      try {
+        seed.exec(
+          "PRAGMA foreign_keys = OFF; INSERT INTO task_delivery_state(task_id, requester_origin_json) VALUES ('orphan', 'preserve me')",
+        );
+        if (variant === "unrelated foreign key") {
+          seed.exec(
+            "CREATE TABLE other_child(task_id TEXT REFERENCES task_runs(task_id)); INSERT INTO other_child VALUES ('unrelated-orphan')",
+          );
+        } else if (variant === "trigger") {
+          seed.exec(
+            "CREATE TRIGGER unknown_delivery_cleanup AFTER DELETE ON task_delivery_state BEGIN DELETE FROM task_runs; END",
+          );
+        } else {
+          seed.exec(
+            "ALTER TABLE task_delivery_state ADD COLUMN extra TEXT GENERATED ALWAYS AS (task_id) VIRTUAL",
+          );
+        }
+        const before = seed.prepare("PRAGMA foreign_key_check").all();
+        const result = repairOpenClawStateDatabaseSchema({ env: { OPENCLAW_STATE_DIR: stateDir } });
+        expect(result.changes).toEqual([]);
+        expect(result.warnings.join("\n")).toMatch(/refused (unrelated|an unrecognized)/);
+        expect(
+          seed
+            .prepare(
+              "SELECT requester_origin_json FROM task_delivery_state WHERE task_id = 'orphan'",
+            )
+            .get(),
+        ).toEqual({ requester_origin_json: "preserve me" });
+        expect(seed.prepare("PRAGMA foreign_key_check").all()).toEqual(before);
+        expect(
+          fs
+            .readdirSync(path.dirname(databasePath))
+            .filter((name) => name.startsWith("openclaw-task-delivery-recovery-")),
+        ).toEqual([]);
+      } finally {
+        seed.close();
+      }
+    },
+  );
+
+  it.each(["export failure", "post-delete integrity failure", "CASCADE", "SET NULL"])(
+    "rolls back orphan delivery recovery after %s and retains the original backup",
+    (variant) => {
+      const stateDir = createTempStateDir();
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const seed = new DatabaseSync(databasePath);
+      const openSync = fs.openSync;
+      const fileOpen = vi.spyOn(fs, "openSync");
+      try {
+        seed.exec(
+          "PRAGMA foreign_keys = OFF; INSERT INTO task_delivery_state(task_id, requester_origin_json) VALUES ('orphan', 'preserve me')",
+        );
+        if (variant === "export failure") {
+          fileOpen.mockImplementation((...args: Parameters<typeof fs.openSync>) => {
+            if (String(args[0]).endsWith("orphan-rows.jsonl"))
+              throw new Error("ENOSPC: synthetic export failure");
+            return openSync(...args);
+          });
+        } else {
+          seed.exec(
+            `CREATE TABLE delivery_dependent(task_id TEXT REFERENCES task_delivery_state(task_id)${variant === "CASCADE" || variant === "SET NULL" ? ` ON DELETE ${variant}` : ""}); INSERT INTO delivery_dependent VALUES ('orphan')`,
+          );
+        }
+        const result = repairOpenClawStateDatabaseSchema({ env: { OPENCLAW_STATE_DIR: stateDir } });
+        expect(result.changes).toEqual([]);
+        expect(result.warnings.join("\n")).toMatch(
+          variant === "export failure" ? /ENOSPC/ : /foreign_key_check failed.*delivery_dependent/,
+        );
+        expect(
+          seed
+            .prepare(
+              "SELECT requester_origin_json FROM task_delivery_state WHERE task_id = 'orphan'",
+            )
+            .get(),
+        ).toEqual({ requester_origin_json: "preserve me" });
+        expect(seed.prepare("PRAGMA foreign_key_check").all()).toHaveLength(1);
+        if (variant !== "export failure") {
+          expect(seed.prepare("SELECT task_id FROM delivery_dependent").all()).toEqual([
+            { task_id: "orphan" },
+          ]);
+        }
+        const artifacts = fs
+          .readdirSync(path.dirname(databasePath))
+          .filter((name) => name.startsWith("openclaw-task-delivery-recovery-"));
+        expect(artifacts).toHaveLength(1);
+        const backup = new DatabaseSync(
+          path.join(path.dirname(databasePath), artifacts[0]!, "database.sqlite"),
+          { readOnly: true },
+        );
+        try {
+          expect(
+            backup
+              .prepare(
+                "SELECT requester_origin_json FROM task_delivery_state WHERE task_id = 'orphan'",
+              )
+              .get(),
+          ).toEqual({ requester_origin_json: "preserve me" });
+          expect(backup.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+        } finally {
+          backup.close();
+        }
+      } finally {
+        fileOpen.mockRestore();
+        seed.close();
+      }
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "recovers a hot rollback journal privately before writable recovery",

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -90,6 +90,7 @@ import {
   withOpenClawStateStartupCheckpointConnection,
 } from "./openclaw-state-db-startup-checkpoint.js";
 import * as retirements from "./openclaw-state-db-table-retirements.js";
+import { recoverOrphanTaskDeliveryRows } from "./openclaw-state-db-task-delivery-recovery.js";
 import {
   runCoordinatedStateTransaction,
   withSharedStateWriteCoordinator,
@@ -151,6 +152,7 @@ function repairStateSchema(
       pathname,
       () => {
         const applied = repairAdmittedSchema();
+        applied.push(...recoverOrphanTaskDeliveryRows(db, pathname));
         const previousVersion = readStateSchemaMigrationVersion(db);
         if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
           for (const name of verifyAndRepairCanonicalSqliteIndexes(


### PR DESCRIPTION
Related: #142586

## What Problem This Solves

Fixes an issue where users upgrading an existing installation would get stuck in Doctor when `task_delivery_state` contained rows whose `task_runs` parents no longer existed. Stable 2026.9.4 still refuses this condition. The original producer is unknown.

## Why This Change Was Made

Doctor's existing fenced repair transaction now preserves a verified, complete WAL-aware database copy and a lossless row export before removing confirmed orphan delivery rows. It reuses existing SQLite snapshot, private-directory, durability, and integrity mechanisms. Normal runtime and healthy-backup admission remain strict.

This is the narrowly authorized preservation-first recovery for #142586. Storage/migration owners confirmed its scope is independent of rollback work. It does not reconstruct tasks, replay deliveries, change schema versions, or remove recovery artifacts. Unknown schemas/triggers, unrelated FK damage, preservation failures, and failed final integrity checks still refuse and roll back.

## User Impact

Affected operators can complete supported Doctor recovery while retaining the original database and all recoverable delivery payload. Doctor reports the recovery directory. The recovery manifest records preservation, not a claim that the transaction committed. Recovery does not prove that the unknown orphan-producing sequence is prevented.

## Evidence

- Pinned main `58a6953549d011ffe44dcc3a7f3290b50e64b349` reproduces refusal; preservation tests fail before the change and pass after it using both current state and the released 2026.7.1-2 schema fixture.
- Seven preservation controls passed, including committed WAL-only rows, all 18 orphan payloads, exact large integers/raw JSON, healthy siblings, unknown schema/trigger and unrelated-FK refusal, export failure, and post-delete rollback.
- Shared-state suite: 196 passed, one existing skip. Task-store suite: 51 passed.
- Real process-death proof: SIGKILL after DELETE and before COMMIT retains original rows and recovery files; retry succeeds with clean integrity/FK checks.
- Independent review raised an inbound-cascade scenario. The actual caller disables FK actions during repair; four rollback controls, including `CASCADE` and `SET NULL`, pass with both original and dependent rows intact. The raw review was retained and this finding was adjudicated against the caller and executable controls.
- Rebased onto inspected main `9762b9ec1e44c3149bc828b7e2229862cd03cbd3` for relevant SQLite/Doctor/build changes.
- Final head `bbf6ddb5e846dd787b0a81af2bde2f5c49407f6f`: full package build passed, supported final runtime build passed, canonical workspace-bundled tarball passed package integrity/import-graph checks. Tarball SHA-256 `aa5f444537775fb9ec70920e16515c878173ae37e0b95b2aadc177fb2155d9ec`.
- Actual installed published `2026.7.1-2` / `0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c` passed `tasks list` on the historical-schema input before injection of 18 orphans. Its unmodified `update --yes --no-restart --tag file:<candidate.tgz> --json` returned 0, installed the exact final head, and ran candidate Doctor successfully. Both healthy delivery rows stayed byte-for-byte equivalent; all 18 raw JSON/NUL and large-integer orphan payloads remain in the verified full backup and JSONL export. Full FK/integrity checks pass.
- Installed repeat Doctor returned 0 and created no extra recovery archive. The actual updated foreground Gateway reached ready; `/healthz`, `gateway health --json`, and `tasks list --json` passed. Only disposable prefixes/state were used, with no live deployment.
- Runtime fixture qualification: the upstream schema fixture deliberately contains synthetic rows, including two enum values invalid in both the tagged and current task parsers. The operator cell normalized only those synthetic task values before injection, then validated them through the actual old runtime. Separate preservation tests retain the raw fixture unchanged. Earlier packaging and test-input failures are retained, not counted as successful operator proof.
- Required changed-source checks completed through a retained passing prefix plus explicit 15-stage continuation, including core/core-test/scripts types, format, scoped lints, zero-unused-export scans and architecture guards. The interrupted aggregate check is not reported as passed. Both patch-caused CI failures were fixed with braces and exact registration in the existing Doctor SQLite maintenance group; compiled-JS equivalence confirms the braces change no runtime behavior.

## Known gap and coordinated follow-up

This PR repairs the Doctor owner. A separate update-admission lane is stacked on it: newer installed updaters can refuse these orphans while opening the update ledger, before Doctor or candidate code runs. That lane will reuse this recovery owner and retain the recovery-directory evidence in its ledger. It is not included here. An affected already-installed driver that refuses before candidate execution needs the corrective release installed manually, followed by `openclaw doctor --fix`, for its first hop. The original 2026.7.1-2 published-driver cell passed separately, as recorded above. Keep #142586 open until the coordinated admission gap is resolved.
