### PR TITLE
improve: reduce copying during Anthropic tool schema preparation

### DIFF
--- a/packages/ai/src/providers/anthropic-tool-projection.test.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.test.ts
@@ -91,6 +91,11 @@ describe("projectAnthropicTools", () => {
             items: [{ type: "integer" }, { type: "integer" }],
             additionalItems: false,
           },
+          Trailing: {
+            ...(dialect ? { $schema: dialect } : {}),
+            type: "array",
+            items: [],
+          },
         },
       };
       const original = structuredClone(parameters);
@@ -111,6 +116,7 @@ describe("projectAnthropicTools", () => {
             prefixItems: [{ type: "integer" }, { type: "integer" }],
             items: false,
           },
+          Trailing: { type: "array", prefixItems: [] },
         },
       });
       expect(parameters).toEqual(original);

--- a/packages/ai/src/providers/anthropic-tool-projection.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.ts
@@ -110,57 +110,52 @@ const schemaMapKeywords = new Set([
   "properties",
 ]);
 
-function normalizeAnthropicJsonSchema(schema: unknown): unknown {
+/** Normalize the detached JSON projection and report tuple changes to enclosing schemas. */
+function normalizeAnthropicJsonSchema(schema: unknown): boolean {
   if (!isRecord(schema)) {
-    return schema;
+    return false;
   }
 
   let changed = false;
-  const normalized: Record<string, unknown> = { ...schema };
   for (const [key, value] of Object.entries(schema)) {
     if (schemaValueKeywords.has(key) && !Array.isArray(value)) {
-      const next = normalizeAnthropicJsonSchema(value);
-      normalized[key] = next;
-      changed ||= next !== value;
+      changed = normalizeAnthropicJsonSchema(value) || changed;
       continue;
     }
     if (schemaArrayKeywords.has(key) && Array.isArray(value)) {
-      const next = value.map(normalizeAnthropicJsonSchema);
-      normalized[key] = next;
-      changed ||= next.some((entry, index) => entry !== value[index]);
+      for (const entry of value) {
+        changed = normalizeAnthropicJsonSchema(entry) || changed;
+      }
       continue;
     }
     if (schemaMapKeywords.has(key) && isRecord(value)) {
-      const next = Object.fromEntries(
-        Object.entries(value).map(([entryKey, entryValue]) => [
-          entryKey,
-          normalizeAnthropicJsonSchema(entryValue),
-        ]),
-      );
-      normalized[key] = next;
-      changed ||= Object.entries(value).some(
-        ([entryKey, entryValue]) => next[entryKey] !== entryValue,
-      );
+      for (const entry of Object.values(value)) {
+        changed = normalizeAnthropicJsonSchema(entry) || changed;
+      }
     }
   }
 
   if (Array.isArray(schema.items)) {
-    normalized.prefixItems = schema.items.map(normalizeAnthropicJsonSchema);
+    for (const entry of schema.items) {
+      normalizeAnthropicJsonSchema(entry);
+    }
+    schema.prefixItems = schema.items;
     const additionalItems = schema.additionalItems;
     if (typeof additionalItems === "boolean" || isRecord(additionalItems)) {
-      normalized.items = normalizeAnthropicJsonSchema(additionalItems);
+      normalizeAnthropicJsonSchema(additionalItems);
+      schema.items = additionalItems;
     } else {
-      delete normalized.items;
+      delete schema.items;
     }
-    delete normalized.additionalItems;
+    delete schema.additionalItems;
     changed = true;
   }
 
   if (changed) {
     // Converted tuples use 2020-12 syntax, including inside referenced schema resources.
-    delete normalized.$schema;
+    delete schema.$schema;
   }
-  return changed ? normalized : schema;
+  return changed;
 }
 
 /** Snapshots direct/custom tool descriptors before Anthropic payload construction. */
@@ -188,11 +183,8 @@ export function projectAnthropicTools(
         unavailableOriginalNames.add(name);
         continue;
       }
-      const anthropicSchema = normalizeAnthropicJsonSchema(schemaProjection.schema);
-      if (!isRecord(anthropicSchema)) {
-        unavailableOriginalNames.add(name);
-        continue;
-      }
+      const anthropicSchema = schemaProjection.schema;
+      normalizeAnthropicJsonSchema(anthropicSchema);
       const properties = anthropicSchema.properties;
       const required = anthropicSchema.required;
       if (


### PR DESCRIPTION
## What Problem This Solves

Anthropic tool-schema normalization rebuilds schema objects, maps, and arrays while walking them, then discards those copies when nothing changed. The input to this private normalizer is already a fresh JSON projection owned by this request.

## Why This Change Was Made

Normalize that detached JSON tree in place and propagate a boolean indicating tuple conversion. Every schema child is still visited; keyword boundaries, property insertion order, tuple conversion, ancestor dialect removal, quarantine, wire-name collisions, and stable tool ordering remain unchanged. The redundant second root-object guard is removed because normalization cannot replace the validated root.

The existing JSON serialization boundary still isolates caller-owned descriptors and separate tool projections. No cache, dependency, or public API is added. Production code is eight lines shorter. An existing tuple-definition fixture now also covers a trailing empty tuple after the first conversion.

## User Impact

Less schema-preparation work before Anthropic requests, particularly for larger tool lists and nested schemas. No provider/network latency improvement is claimed.

## Evidence

Four fresh Linux Node processes ran the real `convertAnthropicTools` boundary in original/candidate/candidate/original order. Sixteen cases covered ordinary schemas, nested and sibling tuples, both definition forms, schema keywords, literal instance data, OAuth names, eager-input flags, and duplicate names. Each case used two warmups and seven measured batches. Full serialized wire output, caller immutability, detached repeated/shared projections, quarantine, and collision results matched.

Median milliseconds per full conversion:

| Case | Original 1 | Candidate 1 | Candidate 2 | Original 2 |
| --- | ---: | ---: | ---: | ---: |
| 100 tools × 8 properties | 0.8806 | 0.7733 | 0.7608 | 0.8771 |
| Deep tuple siblings | 0.0697 | 0.0580 | 0.0597 | 0.0691 |
| Definition resources | 0.0214 | 0.0178 | 0.0184 | 0.0200 |
| 10 tools × 20 properties | 0.2280 | 0.1629 | 0.1994 | 0.1765 |

Thirteen cases improved in both orders and three were mixed. The 100-tool case improved 12.2%/13.3%; the 10-tool case above was 13.0% slower in the reverse order. CPU for a single empty-schema tool increased in both orders. Whole-process wall time improved 9.3% in the first order and worsened 2.2% in reverse; RSS was mixed. All observations are retained, and no uniform startup or memory improvement is claimed.

All native children closed. Candidate restoration, evidence collection, subsequent baseline restoration, and normal worktree removal were verified; the one-shot Testbox lease is closed. The proof compares a frozen source revision with this exact production body. The author base includes a later unrelated `import-meta-resolve` dependency addition; the converter and its schema/sorting owners are unchanged.

Formatting, 146 focused projection/transport tests, targeted lint, and independent Codex review through P2 passed. The existing AI-package typecheck exceeded the fixed 6 GiB process-tree memory cap before emitting diagnostics and was stopped with complete cleanup. It was not retried with a larger cap. All required hosted CI and typecheck lanes are now green at the reviewed head. The standalone local command remains recorded as resource-limited; it was not silently rerun with a larger cap.

The changelog is release-owned; this PR retains the performance and behavior context for release notes.
