### PR TITLE
fix(update): allow launcher symlink backups across macOS umasks

### DIFF
--- a/src/infra/package-update-integrity.ts
+++ b/src/infra/package-update-integrity.ts
@@ -329,17 +329,19 @@ export function createPackageIntegrityReader(timeoutMs = MAX_SCAN_MS) {
 
   async function launcher(file: string): Promise<string> {
     const stat = await read(() => fs.lstat(file, { bigint: true }));
-    const contents = stat.isSymbolicLink()
+    const isSymlink = stat.isSymbolicLink();
+    const contents = isSymlink
       ? await read(() => fs.readlink(file))
       : (await hashFile(file, stat, MAX_LAUNCHER_BYTES)).digest;
     if (!unchanged(stat, await read(() => fs.lstat(file, { bigint: true })))) {
       throw new Error("Package rollback launcher changed during verification");
     }
-    // Launchers are copied, unlike the package tree. Their copy is compared
-    // with the captured contents/target and permissions, not the new inode.
+    // Launchers are copied, unlike the package tree. Symlink modes are applied
+    // from the copying process's umask on macOS, so they are not stable
+    // identity; regular-file permissions remain part of the fingerprint.
     return JSON.stringify([
-      stat.isSymbolicLink() ? "symlink" : "file",
-      stat.mode.toString(),
+      isSymlink ? "symlink" : "file",
+      isSymlink ? null : stat.mode.toString(),
       stat.uid.toString(),
       stat.gid.toString(),
       contents,

--- a/src/infra/package-update-swap.integrity.test.ts
+++ b/src/infra/package-update-swap.integrity.test.ts
@@ -81,6 +81,34 @@ describe("retained npm package integrity", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "accepts a launcher symlink copied under a different umask",
+    async () => {
+      const originalUmask = process.umask();
+      try {
+        await withTestDir({ prefix: "openclaw-launcher-symlink-umask-" }, async (base) => {
+          const fixture = await createPackageSwapFixture(base);
+          await fs.unlink(fixture.launcher);
+          process.umask(0o077);
+          await fs.symlink("../lib/node_modules/openclaw/openclaw.mjs", fixture.launcher);
+          const sourceMode = (await fs.lstat(fixture.launcher)).mode & 0o777;
+          process.umask(0o022);
+
+          const result = await swapStagedPackageInstall(fixture.params);
+
+          if (process.platform === "darwin") {
+            expect(sourceMode).toBe(0o700);
+          }
+          expect(result.status, result.step.stderrTail ?? "").toBe("committed");
+          expect(result.step.stderrTail ?? "").not.toContain("launcher backup changed");
+          await expect(fs.readFile(fixture.launcher, "utf8")).resolves.toBe("candidate launcher\n");
+        });
+      } finally {
+        process.umask(originalUmask);
+      }
+    },
+  );
+
   it.each([false, true])(
     "preserves the retained npm link if its executor is revoked after observation (relative=%s)",
     async (relative) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw update` on macOS would see `Package rollback launcher backup changed` during the global npm install swap when the installed launcher symlink and its backup were created under different umasks.

Fixes #145072

## Why This Change Was Made

Launcher symlink modes on macOS reflect the process umask, so they are not stable identity data across the update copy boundary. The launcher fingerprint now preserves the symlink type, owner, group, and target while ignoring only symlink mode; regular-file permission fingerprints and changed-target checks remain unchanged.

## User Impact

Global npm updates on macOS no longer abort for an equivalent launcher symlink whose mode changed during backup. Actual launcher target changes and regular-file integrity changes continue to be rejected.

## Evidence

- Focused test: `pnpm test src/infra/package-update-swap.integrity.test.ts` — 38 tests passed.
- Real production module proof at the pinned validation base `d781c156cb7738ce64eba162178bef85e715a989`: source mode `0700`, backup mode `0755`, same target, `fingerprintEqual=false`, and the changed-target negative control was rejected.
- The same proof at the exact head SHA `4cdbf2fcb1b8a707e5db5205235d4a8b9719f663` reports `fingerprintEqual=true` for the equivalent symlink and still rejects the changed-target negative control.
- The proof exercises the production `copyPackagePathEntry` and `createPackageIntegrityReader().launcher` call chain at the local filesystem/npm-swap boundary.
- This reuses the existing launcher integrity contract: symlink type, owner, group, and target remain protected while regular-file mode remains fingerprinted.
- Published-updater × candidate proof on Darwin arm64 (Node `v24.18.0`, npm `11.17.0`): the candidate tarball was built from exact head `4cdbf2fcb1b8a707e5db5205235d4a8b9719f663` (SHA-256 `d6ffd22ec8e79311f1263de3c8432217d8a287df3123d5c8d013dba5fb9553d6`) and exercised through the real global npm update pipeline under isolated state/config paths.

```text
$ production-module proof runner (same invocation and local filesystem boundary on base and head)
entrypoint: copyPackagePathEntry -> createPackageIntegrityReader().launcher
base: d781c156cb7738ce64eba162178bef85e715a989 => before-fix fingerprintEqual=false; negativeControlRejected=true
head: 4cdbf2fcb1b8a707e5db5205235d4a8b9719f663 => after-fix fingerprintEqual=true; negativeControlRejected=true

$ published-updater x candidate (launcher installed at umask 022 => 0755; update run at umask 077 => 0700)
result: published openclaw@2026.9.3 (1391f7c) -> candidate: candidate install/migration/doctor/config/plugin/gateway checks passed; global install swap failed only with "Package rollback launcher backup changed"; version remained 2026.9.3 and recovery remained safe
result: candidate openclaw@2026.9.4 (4cdbf2f) -> same candidate: global install swap passed ("replaced openclaw"); doctor and post-update verification passed; version remained 2026.9.4 and resulting launcher was 0700
```

The first row is intentional: an already-installed pre-fix updater cannot repair its own fingerprint comparison on the first hop. The second row proves the repaired updater tolerates the macOS umask-only symlink-mode difference while preserving symlink type, owner, group, and target. Service management was skipped because the proof used isolated state/config paths; package swap and recovery were exercised directly.

<details>
<summary>Testing proof</summary>

```ts
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";

const { createPackageIntegrityReader } = await import("./src/infra/package-update-integrity.ts");
const { copyPackagePathEntry } = await import("./src/infra/package-update-filesystem.ts");

const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-145072-proof-"));
const source = path.join(root, "openclaw");
const backup = path.join(root, "backup", "openclaw");
const negative = path.join(root, "negative");
const originalUmask = process.umask();
try {
  await fs.mkdir(path.dirname(backup), { recursive: true });
  process.umask(0o077);
  await fs.symlink("../lib/node_modules/openclaw/openclaw.mjs", source);
  const sourceMode = (await fs.lstat(source)).mode & 0o777;
  process.umask(0o022);
  await copyPackagePathEntry(source, backup);
  const backupMode = (await fs.lstat(backup)).mode & 0o777;
  const reader = createPackageIntegrityReader();
  const sourceFingerprint = await reader.launcher(source);
  const backupFingerprint = await reader.launcher(backup);
  await fs.symlink("../lib/node_modules/openclaw/other.mjs", negative);
  const negativeFingerprint = await reader.launcher(negative);
  console.log(JSON.stringify({
    platform: process.platform,
    sourceMode,
    backupMode,
    sourceAndBackupHaveSameTarget: (await fs.readlink(source)) === (await fs.readlink(backup)),
    fingerprintEqual: sourceFingerprint === backupFingerprint,
    negativeControlRejected: sourceFingerprint !== negativeFingerprint,
  }));
} finally {
  process.umask(originalUmask);
  await fs.rm(root, { recursive: true, force: true });
}
```

</details>

<details>
<summary>Published updater proof runner</summary>

The following is the redacted runner used for the published-updater × candidate cell. `CANDIDATE_TGZ` is the candidate tarball built from the exact head SHA above.

```bash
#!/usr/bin/env bash
set -euo pipefail

: "${CANDIDATE_TGZ:?set CANDIDATE_TGZ to the candidate .tgz}"
PROOF_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-145288-proof.XXXXXX")"
OLD_PREFIX="$PROOF_DIR/old-prefix"
OLD_HOME="$PROOF_DIR/old-home"
CANDIDATE_PREFIX="$PROOF_DIR/candidate-prefix"
CANDIDATE_HOME="$PROOF_DIR/candidate-home"
mkdir -p "$OLD_PREFIX" "$OLD_HOME" "$CANDIDATE_PREFIX" "$CANDIDATE_HOME"

NPM_ARGS=(--allow-scripts=openclaw,@google/genai,koffi,tree-sitter-bash,protobufjs --no-audit --no-fund)
export PATH="$OLD_PREFIX/bin:${PATH}"

umask 022
HOME="$OLD_HOME" npm install --global --prefix "$OLD_PREFIX" openclaw@2026.9.3 "${NPM_ARGS[@]}"
OLD_MODE="$(stat -f '%Sp' "$OLD_PREFIX/bin/openclaw")"

umask 077
set +e
OLD_JSON="$(
  NPM_CONFIG_PREFIX="$OLD_PREFIX" npm_config_prefix="$OLD_PREFIX" \
  HOME="$OLD_HOME" OPENCLAW_CONFIG_PATH="$OLD_HOME/openclaw.json" \
  OPENCLAW_STATE_DIR="$OLD_HOME/openclaw-state" \
  OPENCLAW_UPDATE_PACKAGE_SPEC="file:$CANDIDATE_TGZ" \
  "$OLD_PREFIX/bin/openclaw" update --yes --tag="file:$CANDIDATE_TGZ" --json \
  2>"$PROOF_DIR/old.stderr"
)"
OLD_STATUS=$?
set -e

umask 022
HOME="$CANDIDATE_HOME" npm install --global --prefix "$CANDIDATE_PREFIX" "file:$CANDIDATE_TGZ" "${NPM_ARGS[@]}"
umask 077
CANDIDATE_JSON="$(
  NPM_CONFIG_PREFIX="$CANDIDATE_PREFIX" npm_config_prefix="$CANDIDATE_PREFIX" \
  HOME="$CANDIDATE_HOME" OPENCLAW_CONFIG_PATH="$CANDIDATE_HOME/openclaw.json" \
  OPENCLAW_STATE_DIR="$CANDIDATE_HOME/openclaw-state" \
  OPENCLAW_UPDATE_PACKAGE_SPEC="file:$CANDIDATE_TGZ" \
  "$CANDIDATE_PREFIX/bin/openclaw" update --yes --tag="file:$CANDIDATE_TGZ" --json \
  2>"$PROOF_DIR/candidate.stderr"
)"
CANDIDATE_MODE="$(stat -f '%Sp' "$CANDIDATE_PREFIX/bin/openclaw")"

printf 'platform=%s old_mode=%s old_status=%s candidate_mode=%s\n' \
  "$(uname -s -m)" "$OLD_MODE" "$OLD_STATUS" "$CANDIDATE_MODE"
printf '%s\n' "$OLD_JSON" | tail -n 1
printf '%s\n' "$CANDIDATE_JSON" | tail -n 1
```

</details>

- Adjacent update-budget PRs #144925 and #145219 were reviewed; they do not change launcher fingerprint fields and are not duplicates of this fix.

AI-assisted: built with Codex
