### PR TITLE
fix(usage): explain why a provider is missing from status --usage

### DIFF
--- a/src/infra/provider-usage.auth.plugin.test.ts
+++ b/src/infra/provider-usage.auth.plugin.test.ts
@@ -568,3 +568,41 @@ describe("resolveProviderAuths plugin boundary", () => {
     expect(providerCalls(resolveProviderUsageAuthWithPluginMock)).toEqual(["anthropic"]);
   });
 });
+
+describe("resolveProviderAuths diagnostics", () => {
+  beforeAll(async () => {
+    ({ resolveProviderAuths } = await import("./provider-usage.auth.js"));
+  });
+
+  it("logs the profile it skipped when credential resolution throws", async () => {
+    const { authProfilesLog } = await import("../agents/auth-profiles/constants.js");
+    const debugSpy = vi.spyOn(authProfilesLog, "debug").mockImplementation(() => {});
+
+    hasAnyAuthProfileStoreSourceMock.mockReturnValue(true);
+    resolveAuthProfileOrderMock.mockReturnValue(["anthropic:pro1"]);
+    const storeWithFailingProfile = {
+      profiles: {
+        "anthropic:pro1": { type: "oauth", provider: "anthropic", access: "unused" },
+      },
+    };
+    ensureAuthProfileStoreMock.mockReturnValue(storeWithFailingProfile);
+    ensureAuthProfileStoreWithoutExternalProfilesMock.mockReturnValue(storeWithFailingProfile);
+    resolveApiKeyForProfileMock.mockRejectedValue(
+      new Error('Secret surface unavailable for "store:teamstore:ANTHROPIC_PRO1_TOKEN"'),
+    );
+
+    await withTempHome(async (homeDir) => {
+      await resolveProviderAuthsForTest({ providers: ["anthropic"], agentDir: homeDir });
+    });
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      "usage auth: skipped auth profile that failed to resolve",
+      expect.objectContaining({
+        profileId: "anthropic:pro1",
+        provider: "anthropic",
+        error: 'Secret surface unavailable for "store:teamstore:ANTHROPIC_PRO1_TOKEN"',
+      }),
+    );
+    debugSpy.mockRestore();
+  });
+});

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -8,6 +8,7 @@ import {
   resolveApiKeyForProfile,
   resolveAuthProfileOrder,
 } from "../agents/auth-profiles.js";
+import { authProfilesLog } from "../agents/auth-profiles/constants.js";
 import { resolveEnvApiKey } from "../agents/model-auth-env.js";
 import { isNonSecretApiKeyMarker } from "../agents/model-auth-markers.js";
 import { resolveUsableCustomProviderApiKey } from "../agents/model-auth.js";
@@ -351,8 +352,17 @@ async function resolveOAuthToken(params: {
         // identity for static bearer profiles whose tokens expose no claims.
         ...(cred.email ? { email: cred.email } : {}),
       };
-    } catch {
-      // ignore
+    } catch (error) {
+      // Skipping the profile is intentional: one unusable credential must not
+      // abort usage collection for the remaining candidates. Log it, though —
+      // an unmaterialized SecretRef here is otherwise invisible, and the
+      // provider just disappears from `status --usage` with no explanation.
+      authProfilesLog.debug("usage auth: skipped auth profile that failed to resolve", {
+        profileId,
+        provider: params.provider,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a provider silently disappears from
`openclaw status --usage` with no explanation available anywhere — no error, no
warning, and nothing in the logs at any verbosity level.

Operators see a provider they have credentials for simply stop being listed.
There is no way to tell whether the credential expired, the store is broken, a
SecretRef failed to materialise, or the provider was never configured.

## Why This Change Was Made

Usage collection deliberately skips any auth profile it cannot resolve, so that
one unusable credential does not abort collection for the remaining candidates.
That behaviour is correct and unchanged here.

The skip happened inside an empty `catch {}`, which also discarded the reason.
This change logs the profile id, provider and error message at debug level
before continuing. Control flow and return values are identical; debug level
keeps it out of normal output, and `authProfilesLog` is the logger the
auth-profile subsystem already uses.

## User Impact

Operators debugging a missing provider can now run the gateway with debug
logging and see exactly which profile was skipped and why, instead of bisecting
runtime state.

No behaviour change otherwise. Nothing new appears at default log levels.

## Evidence

**Captured output from the changed path.** The second commit adds a regression
test that drives `resolveProviderAuths()` with a profile whose credential
resolution throws, and asserts the diagnostic. This is the `ctx` object the new
`authProfilesLog.debug` call emitted, captured verbatim from that run:

```json
[
  "usage auth: skipped auth profile that failed to resolve",
  {
    "profileId": "anthropic:pro1",
    "provider": "anthropic",
    "error": "Secret surface unavailable for \"store:teamstore:ANTHROPIC_PRO1_TOKEN\""
  }
]
```

Before this change the same run produced no output at all — the exception was
consumed by the empty `catch`.

**Environment and invocation.** Node 24.19.0 in the official
`ghcr.io/openclaw/openclaw` image, repository at merge-base with `main`
(`3415f22f`):

```
pnpm vitest run src/infra/provider-usage.auth.plugin.test.ts
  Test Files  1 passed (1)
       Tests  16 passed (16)
```

The new case is `resolveProviderAuths diagnostics > logs the profile it skipped
when credential resolution throws`; the other 15 are the pre-existing cases in
that file, unchanged.

**Correction to the original body.** My first version of this section quoted an
illustrative log line and referenced `provider-usage.auth.test.ts`, which does
not exist. ClawSweeper was right to flag that the excerpt was not captured
output from the changed path. The block above is real; the file name is
corrected to `provider-usage.auth.plugin.test.ts`, where the harness for this
function already lives.

**Real-world origin.** The case that prompted this: a dead `env:` SecretRef
belonging to an unrelated provider aborted batch secret materialisation
(`errorMode: "stop"`), leaving another provider's tokens unmaterialised. The
resulting `SecretSurfaceUnavailableError` was swallowed here, and the provider
vanished from `--usage` with no trace. Diagnosing it took hours; with this
change it is one debug line.
