### PR TITLE
fix(usage): provider quota reverts to another agent after switching agents

### DIFF
--- a/src/gateway/server-methods/models-auth-status-usage-cache.ts
+++ b/src/gateway/server-methods/models-auth-status-usage-cache.ts
@@ -248,8 +248,15 @@ export async function loadUsageStatusStaleWhileRevalidate(options: {
   config: OpenClawConfig;
   coldRead?: "refresh-marker";
   now?: number;
+  agentId?: string;
 }): Promise<UsageSummary> {
-  const snapshot = getProviderUsageRuntimeSnapshot({ config: options.config });
+  // Without an agentId the snapshot falls back to the default agent, so a
+  // caller viewing another agent gets that agent's auth profile order applied
+  // to someone else's quota windows.
+  const snapshot = getProviderUsageRuntimeSnapshot({
+    config: options.config,
+    ...(options.agentId ? { agentId: options.agentId } : {}),
+  });
   const params: ProviderUsageCacheParams = {
     agentId: snapshot.agentId,
     agentDir: snapshot.agentDir,

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -107,7 +107,7 @@ export const testApi = {
 export type { SessionUsageEntry, SessionsUsageAggregates, SessionsUsageResult };
 
 export const usageHandlers: GatewayRequestHandlers = {
-  "usage.status": async ({ respond, context, client }) => {
+  "usage.status": async ({ respond, params, context, client }) => {
     // Only clients with bounded retry machinery may receive an incomplete cold result.
     // In-process dispatch reuses the originating request's client, capabilities
     // included, so a plugin proxying this method inside a capable UI request
@@ -119,9 +119,13 @@ export const usageHandlers: GatewayRequestHandlers = {
     )
       ? ("refresh-marker" as const)
       : undefined;
+    // Quota windows belong to the auth profile the agent resolves, so a viewer
+    // scoped to one agent must not be served the default agent's numbers.
+    const agentId = normalizeOptionalString(params?.agentId);
     const summary = await loadUsageStatusStaleWhileRevalidate({
       config: context.getRuntimeConfig(),
       coldRead,
+      ...(agentId ? { agentId } : {}),
     });
     respond(true, summary, undefined);
   },

--- a/ui/src/lib/provider-usage-request.ts
+++ b/ui/src/lib/provider-usage-request.ts
@@ -11,12 +11,16 @@ export type ProviderUsageRequestResult = Result<UsageSummary, ProviderUsageReque
 
 export async function requestProviderUsage(
   client: GatewayBrowserClient,
-  opts?: { signal?: AbortSignal },
+  opts?: { signal?: AbortSignal; agentId?: string },
 ): Promise<ProviderUsageRequestResult> {
   try {
+    // usage.status without an agentId resolves the default agent, and this
+    // snapshot overrides the per-agent one from models.authStatus - so the
+    // page would settle on the default agent's quota after a moment.
+    const params = opts?.agentId ? { agentId: opts.agentId } : undefined;
     const summary = opts?.signal
-      ? await client.request<UsageSummary>("usage.status", undefined, { signal: opts.signal })
-      : await client.request<UsageSummary>("usage.status");
+      ? await client.request<UsageSummary>("usage.status", params, { signal: opts.signal })
+      : await client.request<UsageSummary>("usage.status", params);
     return ok<UsageSummary, ProviderUsageRequestFailure>(summary);
   } catch (error) {
     if (opts?.signal?.aborted) {

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -133,8 +133,9 @@ export async function loadModelProvidersData(
 export function loadModelProviderUsage(
   client: GatewayBrowserClient,
   signal: AbortSignal,
+  agentId?: string,
 ): Promise<ProviderUsageRequestResult> {
-  return requestProviderUsage(client, { signal });
+  return requestProviderUsage(client, { signal, ...(agentId ? { agentId } : {}) });
 }
 
 export function loadModelProviderCost(

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -125,6 +125,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     setData: (data) => (this.data = data),
     setDataClient: (client) => (this.dataClient = client),
     refreshPolicy: this.refreshPolicy,
+    getAgentId: () => this.selectedAgentId,
   });
   private readonly catalogDiscovery = createCatalogDiscoveryController({
     getGateway: () => this.gateway,

--- a/ui/src/pages/model-providers/supplemental-load.ts
+++ b/ui/src/pages/model-providers/supplemental-load.ts
@@ -19,6 +19,8 @@ type SupplementalOptions = {
   setData: (data: ModelProvidersData) => void;
   setDataClient: (client: GatewayBrowserClient | null) => void;
   refreshPolicy: UsageRefreshPolicy;
+  /** Scopes usage.status; without it the Gateway answers for the default agent. */
+  getAgentId: () => string | undefined;
 };
 
 type SupplementalKind = "usage" | "cost";
@@ -43,7 +45,7 @@ export class ModelProviderSupplementalLoader {
     this.usageTask = this.createTask(
       host,
       "usage",
-      loadModelProviderUsage,
+      (client, signal) => loadModelProviderUsage(client, signal, this.options.getAgentId()),
       (providerUsage) => ({ providerUsage }),
       (providerUsage, epoch) =>
         this.options.refreshPolicy.markProviderUsage(providerUsage, Date.now(), epoch),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who switch the selected agent on
**Settings → Model Providers** would see the correct per-agent provider quota
for a few seconds, and then watch it silently revert to a different agent's
numbers without touching anything. Reloading the page does not help.

The result is a dashboard that reports one account's remaining quota under
another account's name, while `openclaw status --usage --agent <id>` on the CLI
reports it correctly — so the two surfaces disagree and neither looks
trustworthy.

## Why This Change Was Made

The page fetches quota through two methods. `models.authStatus` accepts and
honours `agentId`. `usage.status` never read `params` at all, so it always
resolved the default agent — and its snapshot deliberately overrides the
agent-scoped one, because it carries cost history and errors the other drops.
That precedence is reasonable; being agent-blind is not.

This change threads `agentId` through the `usage.status` path, mirroring what
`usage.cost` already does: the Control UI sends the page's existing
`selectedAgentId`, the handler reads it, and the runtime snapshot receives it.
Omitting `agentId` still resolves the default agent, so existing callers keep
their behaviour. The usage cache was already keyed per agent, so it needed no
changes.

## User Impact

Operators running several agents with different credentials for one provider —
for example one Claude subscription per agent — now see each agent's real quota
in the Control UI, matching what the CLI reports.

Anyone running a single agent sees no change.

## Evidence

Before, every call returned the default agent regardless of selection:

```
$ openclaw gateway call usage.status
  5h: 90% left | Week: 96% left
```

After:

```
$ openclaw gateway call usage.status --params '{"agentId":"main"}'
  5h: 85% left | Week: 96% left

$ openclaw gateway call usage.status --params '{"agentId":"rak-gary"}'
  5h: 100% left | Week: 64% left

$ openclaw gateway call usage.status            # no agentId -> default agent
  5h: 85% left | Week: 96% left
```

Both match `openclaw status --usage --agent <id>`. Verified in the browser: the
selected agent's quota now stays put instead of reverting.

Tests: 103/103 on the touched suites (`src/gateway/server-methods/usage`,
`ui/src/pages/model-providers`); typecheck clean for `tsconfig.json` and
`tsconfig.ui.json`.

The UI suite also reports 7 `ERR_UNKNOWN_BUILTIN_MODULE` errors. These are
pre-existing — I confirmed they reproduce on a clean tree with this change
stashed — and they do not fail the run.

Two notes for reviewers: session spend ("Global session spend · 30d") is
aggregated across agents by design and correctly stays constant when switching,
so only the quota windows were affected. And
`model-providers-page.usage.test.ts` only exercises `agentId: "main"`, so agent
switching has no test coverage; happy to add one if wanted, though it needs a
harness that can drive the agent selector.

Found on 2026.9.3.
