### PR TITLE
improve(ui): use the gear icon for Agent settings in the sidebar agent menu

### DIFF
--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -412,7 +412,7 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
         </span>
       </wa-dropdown-item>
       <wa-dropdown-item class="sidebar-customize-menu__item" value="command:agent-settings">
-        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.users}</span>
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.settings}</span>
         <span class="sidebar-customize-menu__text">${t("agentChip.agentSettings")}</span>
       </wa-dropdown-item>
     </wa-dropdown>


### PR DESCRIPTION
Closes #145293

<details>
<summary>Additional instructions</summary>

The branch is in `openclaw/openclaw`, so repository maintainers can update it directly; this is not a fork PR.

</details>

## What Problem This Solves

Resolves a problem where the **Agent settings** item in the sidebar agent menu showed the "users" (two people) icon, so the only remaining navigation item in that menu after #145062 read as an identity or roster action instead of a settings entry point.

## Why This Change Was Made

Swap the item's icon to the shared gear glyph (`icons.settings`) already used by every other settings entry point in the Control UI. Label, ordering, keyboard behavior and the navigation target are unchanged. Follow-up to #145062.

## User Impact

Operators opening the agent menu see a gear next to **Agent settings**, consistent with Settings elsewhere in the app. No behavior change.

## Evidence

### Before and after

Actual Control UI rendered in Chromium against the deterministic mock Gateway (`installMockGateway`), agent menu opened from the sidebar agent chip. Desktop 1280×900, cropped to the sidebar and open menu.

| | Dark | Light |
|---|---|---|
| Before | ![Before, dark](https://github.com/user-attachments/assets/155c6542-649d-4781-b8ca-827e7462e46a) | ![Before, light](https://github.com/user-attachments/assets/af06fe09-ad92-4062-b162-683d130ba1df) |
| After | ![After, dark](https://github.com/user-attachments/assets/b484bb8d-ff6f-4b5d-8dfa-ffce96f15622) | ![After, light](https://github.com/user-attachments/assets/75a89569-a6db-426c-bb8f-94057f810f00) |

### Validation

- `oxfmt --check` on the changed file.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts -t "AppSidebar agent chip"`: 39 passed, 321 skipped by the name filter (1 file). Autoreview skipped: one-line icon swap, no logic.
- Production LOC: +1/−1 (net 0). Tests: none changed; no test asserts the icon glyph.
