### PR TITLE
fix(doctor): keep host-rebuilt Codex authoritative on git/dev checkouts

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -8,6 +8,7 @@ import {
   normalizeUpdateChannel,
   resolveRegistryUpdateChannel,
 } from "../../../infra/update-channels.js";
+import { isUsableSourceCheckoutBundledPluginRoot } from "../../../plugins/bundled-dir.js";
 import {
   resolveDefaultPluginExtensionsDir,
   resolvePluginInstallDir,
@@ -90,9 +91,15 @@ export async function resolveConfiguredPluginInstallContext(params: {
     snapshot,
     configuredChannelIds: params.configuredChannelIds,
   });
+  const hostAuthoritativeVersionBoundRuntimePluginIds =
+    collectHostAuthoritativeVersionBoundRuntimePluginIds(currentBundledPlugins);
   const bundledPluginsById = new Map<string, BundledPluginPackageDescriptor>(
     currentBundledPlugins
-      .filter((plugin) => !isExternallyDistributedPlugin(plugin))
+      .filter(
+        (plugin) =>
+          !isExternallyDistributedPlugin(plugin) ||
+          hostAuthoritativeVersionBoundRuntimePluginIds.has(plugin.pluginId),
+      )
       .map((plugin) => [plugin.pluginId, { packageName: plugin.packageName }] as const),
   );
   const configuredPluginIdsWithStaleDescriptors =
@@ -120,6 +127,7 @@ export async function resolveConfiguredPluginInstallContext(params: {
       installRecords: records,
       configuredPluginIds: params.configuredPluginIds,
       currentVersion,
+      hostAuthoritativePluginIds: hostAuthoritativeVersionBoundRuntimePluginIds,
     });
   const installedPluginIdsWithRepairablePackages = new Set([
     ...installedPluginIdsWithRepairablePackageDiagnostics,
@@ -190,6 +198,7 @@ export async function resolveConfiguredPluginInstallContext(params: {
     installedPluginIdsWithStaleVersionBoundRuntimePackages,
     installedPluginIdsWithRepairablePackages,
     officialReplacementPluginIds,
+    hostAuthoritativeVersionBoundRuntimePluginIds,
   };
 }
 
@@ -533,11 +542,37 @@ function installedRuntimePackageVersionIsStale(params: {
   return comparison === null ? params.installedVersion !== params.currentVersion : comparison < 0;
 }
 
+function collectHostAuthoritativeVersionBoundRuntimePluginIds(
+  currentBundledPlugins: ReadonlyArray<{
+    pluginId: string;
+    origin?: string;
+    rootDir?: string;
+  }>,
+): Set<string> {
+  const pluginIds = new Set<string>();
+  for (const plugin of currentBundledPlugins) {
+    const rootDir = plugin.rootDir?.trim();
+    // Official-external version-bound plugins stay npm-owned on package hosts.
+    // A source-checkout tree rebuilt with this host is the admitted Codex owner.
+    if (
+      !VERSION_BOUND_RUNTIME_PLUGIN_IDS.has(plugin.pluginId) ||
+      plugin.origin !== "bundled" ||
+      !rootDir ||
+      !isUsableSourceCheckoutBundledPluginRoot(rootDir)
+    ) {
+      continue;
+    }
+    pluginIds.add(plugin.pluginId);
+  }
+  return pluginIds;
+}
+
 function collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages(params: {
   snapshot: PluginMetadataSnapshot;
   installRecords: Record<string, PluginInstallRecord>;
   configuredPluginIds: ReadonlySet<string>;
   currentVersion: string;
+  hostAuthoritativePluginIds: ReadonlySet<string>;
 }): Set<string> {
   const pluginIds = new Set<string>();
   const currentVersion = normalizeOptionalLowercaseString(params.currentVersion);
@@ -547,7 +582,8 @@ function collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages(params: {
   for (const candidate of CONFIGURED_RUNTIME_PLUGIN_INSTALL_CANDIDATES) {
     if (
       !VERSION_BOUND_RUNTIME_PLUGIN_IDS.has(candidate.pluginId) ||
-      !params.configuredPluginIds.has(candidate.pluginId)
+      !params.configuredPluginIds.has(candidate.pluginId) ||
+      params.hostAuthoritativePluginIds.has(candidate.pluginId)
     ) {
       continue;
     }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -7,6 +7,7 @@ import { compareOpenClawReleaseVersions } from "../../../infra/npm-registry-spec
 import {
   normalizeUpdateChannel,
   resolveRegistryUpdateChannel,
+  type UpdateChannel,
 } from "../../../infra/update-channels.js";
 import { isUsableSourceCheckoutBundledPluginRoot } from "../../../plugins/bundled-dir.js";
 import {
@@ -91,8 +92,13 @@ export async function resolveConfiguredPluginInstallContext(params: {
     snapshot,
     configuredChannelIds: params.configuredChannelIds,
   });
+  const currentVersion = params.coreVersion ?? resolveCompatibilityHostVersion(params.env);
+  const updateChannel = resolveRegistryUpdateChannel({
+    configChannel: normalizeUpdateChannel(params.cfg.update?.channel),
+    currentVersion,
+  });
   const hostAuthoritativeVersionBoundRuntimePluginIds =
-    collectHostAuthoritativeVersionBoundRuntimePluginIds(currentBundledPlugins);
+    collectHostAuthoritativeVersionBoundRuntimePluginIds(currentBundledPlugins, updateChannel);
   const bundledPluginsById = new Map<string, BundledPluginPackageDescriptor>(
     currentBundledPlugins
       .filter(
@@ -110,11 +116,6 @@ export async function resolveConfiguredPluginInstallContext(params: {
     });
   const records =
     params.baselineRecords ?? (await loadInstalledPluginIndexInstallRecords({ env: params.env }));
-  const currentVersion = params.coreVersion ?? resolveCompatibilityHostVersion(params.env);
-  const updateChannel = resolveRegistryUpdateChannel({
-    configChannel: normalizeUpdateChannel(params.cfg.update?.channel),
-    currentVersion,
-  });
   const installedPluginIdsWithRepairablePackageDiagnostics =
     collectInstalledPluginIdsWithRepairablePackageDiagnostics({
       snapshot,
@@ -548,12 +549,18 @@ function collectHostAuthoritativeVersionBoundRuntimePluginIds(
     origin?: string;
     rootDir?: string;
   }>,
+  updateChannel: UpdateChannel,
 ): Set<string> {
   const pluginIds = new Set<string>();
+  // Automatic bundled Codex ownership is reserved for the git/dev channel.
+  // Release channels keep a healthy matching npm install record intact.
+  if (updateChannel !== "dev") {
+    return pluginIds;
+  }
   for (const plugin of currentBundledPlugins) {
     const rootDir = plugin.rootDir?.trim();
     // Official-external version-bound plugins stay npm-owned on package hosts.
-    // A source-checkout tree rebuilt with this host is the admitted Codex owner.
+    // A git/dev source-checkout tree rebuilt with this host is the admitted Codex owner.
     if (
       !VERSION_BOUND_RUNTIME_PLUGIN_IDS.has(plugin.pluginId) ||
       plugin.origin !== "bundled" ||

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -189,6 +189,7 @@ async function repairMissingPluginInstallsWithLease(
     installedPluginIdsWithStaleVersionBoundRuntimePackages,
     installedPluginIdsWithRepairablePackages,
     officialReplacementPluginIds,
+    hostAuthoritativeVersionBoundRuntimePluginIds,
   } = await resolveConfiguredPluginInstallContext({
     cfg: params.cfg,
     env,
@@ -246,7 +247,11 @@ async function repairMissingPluginInstallsWithLease(
       nextRecords = { ...records };
     }
     delete nextRecords[pluginId];
-    changes.push(`Removed stale managed install record for bundled plugin "${pluginId}".`);
+    changes.push(
+      hostAuthoritativeVersionBoundRuntimePluginIds.has(pluginId)
+        ? `Kept host-rebuilt bundled plugin "${pluginId}" authoritative on this source checkout; ignored npm install that would shadow it.`
+        : `Removed stale managed install record for bundled plugin "${pluginId}".`,
+    );
   }
 
   for (const pluginId of stalePathInstallPluginIds) {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -249,7 +249,7 @@ async function repairMissingPluginInstallsWithLease(
     delete nextRecords[pluginId];
     changes.push(
       hostAuthoritativeVersionBoundRuntimePluginIds.has(pluginId)
-        ? `Kept host-rebuilt bundled plugin "${pluginId}" authoritative on this source checkout; ignored npm install that would shadow it.`
+        ? `Kept host-rebuilt bundled plugin "${pluginId}" authoritative on this git/dev checkout; ignored npm install that would shadow it.`
         : `Removed stale managed install record for bundled plugin "${pluginId}".`,
     );
   }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -9,7 +9,10 @@ import {
   resolveEffectiveEnableState,
 } from "../../../plugins/config-state.js";
 import { PLUGIN_INSTALL_ERROR_CODE } from "../../../plugins/install-types.js";
+import { listRecoveredManagedNpmInstallCandidates } from "../../../plugins/installed-plugin-index-record-reader.js";
 import { writePersistedInstalledPluginIndexInstallRecords } from "../../../plugins/installed-plugin-index-records.js";
+import { RETAINED_MANAGED_NPM_KEEP_FILES_REASON } from "../../../plugins/managed-npm-retention-contract.js";
+import { markRetainedManagedNpmInstall } from "../../../plugins/managed-npm-retention.js";
 import { isPayloadMissing } from "../../../plugins/payload-verification.js";
 import { withPluginLifecycleLease } from "../../../plugins/plugin-lifecycle-lease.js";
 import { updateNpmInstalledPlugins, type PluginUpdateOutcome } from "../../../plugins/update.js";
@@ -238,6 +241,15 @@ async function repairMissingPluginInstallsWithLease(
     failedPlugins.set(pluginId, outcome);
   };
 
+  const retiredBundledPluginIds = new Set<string>();
+  const retiredManagedNpmInstalls = new Map<string, string>();
+  const rememberRetiredManagedNpmInstall = (pluginId: string, installPath?: string) => {
+    const packageDir = installPath?.trim();
+    if (!packageDir) {
+      return;
+    }
+    retiredManagedNpmInstalls.set(resolveUserPath(packageDir, env), pluginId);
+  };
   for (const [pluginId, record] of Object.entries(records)) {
     const bundled = bundledPluginsById.get(pluginId);
     if (!bundled || !recordMatchesBundledPackage(record, bundled)) {
@@ -247,11 +259,32 @@ async function repairMissingPluginInstallsWithLease(
       nextRecords = { ...records };
     }
     delete nextRecords[pluginId];
+    retiredBundledPluginIds.add(pluginId);
+    rememberRetiredManagedNpmInstall(pluginId, record.installPath);
     changes.push(
       hostAuthoritativeVersionBoundRuntimePluginIds.has(pluginId)
         ? `Kept host-rebuilt bundled plugin "${pluginId}" authoritative on this git/dev checkout; ignored npm install that would shadow it.`
         : `Removed stale managed install record for bundled plugin "${pluginId}".`,
     );
+  }
+  if (retiredBundledPluginIds.size > 0) {
+    const recoveredStoreOptions = {
+      env,
+      ...(env.OPENCLAW_STATE_DIR ? { stateDir: env.OPENCLAW_STATE_DIR } : {}),
+    };
+    for (const candidate of listRecoveredManagedNpmInstallCandidates(recoveredStoreOptions)) {
+      if (retiredBundledPluginIds.has(candidate.pluginId)) {
+        rememberRetiredManagedNpmInstall(candidate.pluginId, candidate.installRecord.installPath);
+      }
+    }
+    await params.beforePersistentEffect?.();
+    for (const [packageDir, pluginId] of retiredManagedNpmInstalls) {
+      await markRetainedManagedNpmInstall({
+        packageDir,
+        pluginId,
+        reason: RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+      });
+    }
   }
 
   for (const pluginId of stalePathInstallPluginIds) {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -283,6 +283,7 @@ async function repairMissingPluginInstallsWithLease(
         packageDir,
         pluginId,
         reason: RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+        beforePersistentEffect: params.beforePersistentEffect,
       });
     }
   }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../../plugins/install-channel-specs.js";
 import type { PluginInstallArtifactConsentHandler } from "../../../plugins/install-types.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../../../plugins/installed-plugin-index-policy.js";
+import { hasRetainedManagedNpmInstallMarker } from "../../../plugins/managed-npm-retention.js";
 import { isTrustedOfficialPluginInstallRecord } from "../../../plugins/official-external-install-records.js";
 import type { BundledProviderPolicySurface } from "../../../plugins/provider-policy-surface.js";
 import { createColdPluginFixture } from "../../../plugins/test-helpers/cold-plugin-fixtures.js";
@@ -197,13 +198,51 @@ function writeSourceCheckoutBundledCodex(version = VERSION): string {
   return pluginDir;
 }
 
-function mockSourceCheckoutBundledCodexNpmRecord(installedVersion: string) {
-  const bundledRoot = writeSourceCheckoutBundledCodex();
-  const installDir = tempDirs.make("openclaw-codex-npm-shadow-");
-  fs.writeFileSync(
-    path.join(installDir, "package.json"),
-    JSON.stringify({ name: "@openclaw/codex", version: installedVersion }),
+function writeRecoverableManagedCodexNpmInstall(params: {
+  stateDir: string;
+  version: string;
+  projectName?: string;
+}): string {
+  const projectRoot = path.join(
+    params.stateDir,
+    "npm",
+    "projects",
+    params.projectName ?? "openclaw-codex-shadow",
   );
+  const packageDir = path.join(projectRoot, "node_modules", "@openclaw", "codex");
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({
+      private: true,
+      dependencies: { "@openclaw/codex": params.version },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "@openclaw/codex",
+      version: params.version,
+      openclaw: { extensions: ["./index.js"] },
+    }),
+  );
+  fs.writeFileSync(path.join(packageDir, "openclaw.plugin.json"), JSON.stringify({ id: "codex" }));
+  fs.writeFileSync(path.join(packageDir, "index.js"), "export {};\n");
+  return packageDir;
+}
+
+function mockSourceCheckoutBundledCodexNpmRecord(
+  installedVersion: string,
+  options: { installPath?: string } = {},
+) {
+  const bundledRoot = writeSourceCheckoutBundledCodex();
+  const installDir = options.installPath ?? tempDirs.make("openclaw-codex-npm-shadow-");
+  if (!options.installPath) {
+    fs.writeFileSync(
+      path.join(installDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: installedVersion }),
+    );
+  }
   const records = {
     codex: {
       source: "npm",
@@ -2173,6 +2212,89 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       expect(result.pluginInventoryChanged).toBe(true);
     },
   );
+
+  it("retires shadowed Codex npm generations so recovery cannot resurrect them on git/dev", async () => {
+    const stateDir = tempDirs.make("openclaw-codex-host-authority-retire-");
+    const env = { ...testEnv, OPENCLAW_STATE_DIR: stateDir };
+    const installedVersion = "2026.5.6";
+    const packageDir = writeRecoverableManagedCodexNpmInstall({
+      stateDir,
+      version: installedVersion,
+      projectName: "openclaw-codex-shadow-recent",
+    });
+    const siblingPackageDir = writeRecoverableManagedCodexNpmInstall({
+      stateDir,
+      version: "2026.4.1",
+      projectName: "openclaw-codex-shadow-older",
+    });
+    const recentStamp = new Date("2026-09-11T00:00:00.000Z");
+    const olderStamp = new Date("2026-08-01T00:00:00.000Z");
+    fs.utimesSync(
+      path.join(stateDir, "npm", "projects", "openclaw-codex-shadow-recent", "package.json"),
+      recentStamp,
+      recentStamp,
+    );
+    fs.utimesSync(
+      path.join(stateDir, "npm", "projects", "openclaw-codex-shadow-older", "package.json"),
+      olderStamp,
+      olderStamp,
+    );
+    mockSourceCheckoutBundledCodexNpmRecord(installedVersion, {
+      installPath: packageDir,
+    });
+    const actualRecords = await vi.importActual<
+      typeof import("../../../plugins/installed-plugin-index-records.js")
+    >("../../../plugins/installed-plugin-index-records.js");
+    mocks.writePersistedInstalledPluginIndexInstallRecords.mockImplementation(
+      (nextRecords, options) =>
+        actualRecords.writePersistedInstalledPluginIndexInstallRecords(nextRecords, options),
+    );
+    const emitWarning = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
+
+    try {
+      const recoveredBefore = await actualRecords.loadInstalledPluginIndexInstallRecords({
+        stateDir,
+        env,
+      });
+      expectRecordFields(recoveredBefore.codex, {
+        installPath: packageDir,
+        resolvedVersion: installedVersion,
+      });
+
+      const { repairMissingConfiguredPluginInstalls } =
+        await import("./missing-configured-plugin-install.js");
+      const cfg = {
+        plugins: { entries: { codex: { enabled: true } } },
+        agents: { defaults: { model: "openai/gpt-5.5" } },
+        update: { channel: "dev" as const },
+      };
+      const result = await repairMissingConfiguredPluginInstalls({ cfg, env });
+
+      expect(result.records).toEqual({});
+      expect(mocks.writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith(
+        {},
+        { config: cfg, env },
+      );
+      expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(true);
+      expect(hasRetainedManagedNpmInstallMarker(siblingPackageDir)).toBe(true);
+      expect(fs.existsSync(packageDir)).toBe(true);
+      expect(fs.existsSync(siblingPackageDir)).toBe(true);
+
+      emitWarning.mockClear();
+      const recoveredAfter = await actualRecords.loadInstalledPluginIndexInstallRecords({
+        stateDir,
+        env,
+      });
+      expect(recoveredAfter.codex).toBeUndefined();
+      expect(emitWarning).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ code: "OPENCLAW_PLUGIN_INSTALL_RECOVERY_FALLBACK" }),
+      );
+    } finally {
+      actualRecords.clearLoadInstalledPluginIndexInstallRecordsCache();
+      closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath(env));
+    }
+  });
 
   it.each(["stable", "beta"] as const)(
     "retains a healthy same-version npm Codex record on %s source checkouts",

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -174,12 +174,27 @@ vi.mock("../../../plugins/capability-consent.js", async (importOriginal) => ({
   prepareManagedPluginArtifactConsentHandler,
 }));
 
-function mockCurrentBundledPlugin(pluginId: string, packageName: string): void {
+function mockCurrentBundledPlugin(pluginId: string, packageName: string, rootDir?: string): void {
   mocks.loadInstalledPluginIndex.mockReturnValue({
-    plugins: [{ pluginId, origin: "bundled", packageName }],
+    plugins: [{ pluginId, origin: "bundled", packageName, ...(rootDir ? { rootDir } : {}) }],
     diagnostics: [],
     installRecords: {},
   });
+}
+
+function writeSourceCheckoutBundledCodex(version = VERSION): string {
+  const repoRoot = tempDirs.make("openclaw-source-codex-");
+  fs.mkdirSync(path.join(repoRoot, "src"));
+  fs.mkdirSync(path.join(repoRoot, "extensions", "codex"), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, "pnpm-workspace.yaml"), "packages:\n  - .\n");
+  const pluginDir = path.join(repoRoot, "dist", "extensions", "codex");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "package.json"),
+    JSON.stringify({ name: "@openclaw/codex", version }),
+  );
+  fs.writeFileSync(path.join(pluginDir, "openclaw.plugin.json"), JSON.stringify({ id: "codex" }));
+  return pluginDir;
 }
 
 function writeLegacyNpmDeclarationStub(params: {
@@ -2072,6 +2087,87 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     },
   );
 
+  it.each(["stale", "same-version"] as const)(
+    "keeps host-rebuilt bundled Codex authoritative on source checkouts (%s npm record)",
+    async (versionRelation) => {
+      const bundledRoot = writeSourceCheckoutBundledCodex();
+      const installedVersion = versionRelation === "stale" ? "2026.5.6" : VERSION;
+      const installDir = tempDirs.make("openclaw-codex-npm-shadow-");
+      fs.writeFileSync(
+        path.join(installDir, "package.json"),
+        JSON.stringify({ name: "@openclaw/codex", version: installedVersion }),
+      );
+      const records = {
+        codex: {
+          source: "npm",
+          spec: "@openclaw/codex",
+          resolvedName: "@openclaw/codex",
+          resolvedSpec: `@openclaw/codex@${installedVersion}`,
+          resolvedVersion: installedVersion,
+          version: installedVersion,
+          installPath: installDir,
+        },
+      };
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      mocks.loadPluginMetadataSnapshot.mockReturnValue({
+        plugins: [
+          {
+            id: "codex",
+            packageVersion: installedVersion,
+            providers: ["codex"],
+          },
+        ],
+        diagnostics: [],
+        byPluginId: new Map([
+          [
+            "codex",
+            {
+              id: "codex",
+              packageVersion: installedVersion,
+              providers: ["codex"],
+            },
+          ],
+        ]),
+      });
+      mockCurrentBundledPlugin("codex", "@openclaw/codex", bundledRoot);
+      mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+        officialPluginEntry({ id: "codex", npmSpec: "@openclaw/codex" }),
+      ]);
+
+      const { detectConfiguredPluginInstallHealthIssues, repairMissingConfiguredPluginInstalls } =
+        await import("./missing-configured-plugin-install.js");
+      const cfg = {
+        plugins: { entries: { codex: { enabled: true } } },
+        agents: { defaults: { model: "openai/gpt-5.5" } },
+      };
+      const issues = await detectConfiguredPluginInstallHealthIssues({
+        cfg,
+        env: testEnv,
+      });
+      const targets = await collectConfiguredNpmPluginTargets({
+        config: cfg,
+        env: testEnv,
+        targetVersion: VERSION,
+        channel: "stable",
+      });
+      const result = await repairMissingConfiguredPluginInstalls({
+        cfg,
+        env: testEnv,
+      });
+
+      expect(issues).toEqual([]);
+      expect(targets).toEqual([]);
+      expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+      expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+      expect(result.changes).toEqual([
+        'Kept host-rebuilt bundled plugin "codex" authoritative on this source checkout; ignored npm install that would shadow it.',
+      ]);
+      expect(result.records).toEqual({});
+      expect(result.warnings).toEqual([]);
+      expect(result.pluginInventoryChanged).toBe(true);
+    },
+  );
+
   it("installs an official external plugin when only a stale bundled descriptor remains", async () => {
     mocks.loadPluginMetadataSnapshot.mockReturnValue({
       plugins: [
@@ -3386,6 +3482,88 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       });
     },
   );
+
+  it("still refreshes stale Codex from npm when bundled Codex is not a source-checkout tree", async () => {
+    const packagedRoot = tempDirs.make("openclaw-packaged-codex-");
+    const bundledDir = path.join(packagedRoot, "dist", "extensions", "codex");
+    fs.mkdirSync(bundledDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(bundledDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: VERSION }),
+    );
+    const installDir = tempDirs.make("openclaw-packaged-codex-npm-");
+    fs.writeFileSync(
+      path.join(installDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: "2026.5.6" }),
+    );
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue({
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        resolvedName: "@openclaw/codex",
+        resolvedSpec: "@openclaw/codex@2026.5.6",
+        resolvedVersion: "2026.5.6",
+        version: "2026.5.6",
+        integrity: "sha512-old-codex",
+        installPath: installDir,
+      },
+    });
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "codex",
+          packageVersion: "2026.5.6",
+          providers: ["codex"],
+        },
+      ],
+      diagnostics: [],
+      byPluginId: new Map([
+        [
+          "codex",
+          {
+            id: "codex",
+            packageVersion: "2026.5.6",
+            providers: ["codex"],
+          },
+        ],
+      ]),
+    });
+    mockCurrentBundledPlugin("codex", "@openclaw/codex", bundledDir);
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
+      successfulInstall({
+        pluginId: "codex",
+        npmSpec: "@openclaw/codex",
+        version: VERSION,
+        resolution: { integrity: "sha512-new-codex" },
+      }),
+    );
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      officialPluginEntry({ id: "codex", npmSpec: "@openclaw/codex" }),
+    ]);
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+          },
+        },
+      },
+      env: testEnv,
+    });
+
+    expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledOnce();
+    expect(result.changes).toEqual([
+      `Refreshed stale configured plugin "codex" from @openclaw/codex@${VERSION}.`,
+    ]);
+    expectRecordFields(result.records.codex, {
+      source: "npm",
+      spec: "@openclaw/codex",
+      version: VERSION,
+    });
+  });
 
   it.each(
     // prettier-ignore

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -2296,6 +2296,73 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     }
   });
 
+  it("does not publish further Codex recovery-exclusion markers after updater authority is revoked", async () => {
+    const stateDir = tempDirs.make("openclaw-codex-host-authority-revoke-");
+    const env = { ...testEnv, OPENCLAW_STATE_DIR: stateDir };
+    const installedVersion = "2026.5.6";
+    const packageDir = writeRecoverableManagedCodexNpmInstall({
+      stateDir,
+      version: installedVersion,
+      projectName: "openclaw-codex-shadow-recent",
+    });
+    const siblingPackageDir = writeRecoverableManagedCodexNpmInstall({
+      stateDir,
+      version: "2026.4.1",
+      projectName: "openclaw-codex-shadow-older",
+    });
+    mockSourceCheckoutBundledCodexNpmRecord(installedVersion, {
+      installPath: packageDir,
+    });
+    const actualRecords = await vi.importActual<
+      typeof import("../../../plugins/installed-plugin-index-records.js")
+    >("../../../plugins/installed-plugin-index-records.js");
+    mocks.writePersistedInstalledPluginIndexInstallRecords.mockImplementation(
+      (nextRecords, options) =>
+        actualRecords.writePersistedInstalledPluginIndexInstallRecords(nextRecords, options),
+    );
+    const expired = new Error("approved operation owner expired");
+    let ownerActive = true;
+    const writeFile = fs.promises.writeFile.bind(fs.promises);
+    const writeSpy = vi
+      .spyOn(fs.promises, "writeFile")
+      .mockImplementation(async (file, data, options) => {
+        const result = await writeFile(file, data, options);
+        if (String(file).includes(".openclaw-retained-npm-installs")) {
+          ownerActive = false;
+        }
+        return result;
+      });
+
+    try {
+      const { repairMissingConfiguredPluginInstalls } =
+        await import("./missing-configured-plugin-install.js");
+      const cfg = {
+        plugins: { entries: { codex: { enabled: true } } },
+        agents: { defaults: { model: "openai/gpt-5.5" } },
+        update: { channel: "dev" as const },
+      };
+      await expect(
+        repairMissingConfiguredPluginInstalls({
+          cfg,
+          env,
+          beforePersistentEffect: () => {
+            if (!ownerActive) {
+              throw expired;
+            }
+          },
+        }),
+      ).rejects.toBe(expired);
+      expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(true);
+      expect(hasRetainedManagedNpmInstallMarker(siblingPackageDir)).toBe(false);
+      expect(fs.existsSync(packageDir)).toBe(true);
+      expect(fs.existsSync(siblingPackageDir)).toBe(true);
+    } finally {
+      writeSpy.mockRestore();
+      actualRecords.clearLoadInstalledPluginIndexInstallRecordsCache();
+      closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath(env));
+    }
+  });
+
   it.each(["stable", "beta"] as const)(
     "retains a healthy same-version npm Codex record on %s source checkouts",
     async (channel) => {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -197,6 +197,52 @@ function writeSourceCheckoutBundledCodex(version = VERSION): string {
   return pluginDir;
 }
 
+function mockSourceCheckoutBundledCodexNpmRecord(installedVersion: string) {
+  const bundledRoot = writeSourceCheckoutBundledCodex();
+  const installDir = tempDirs.make("openclaw-codex-npm-shadow-");
+  fs.writeFileSync(
+    path.join(installDir, "package.json"),
+    JSON.stringify({ name: "@openclaw/codex", version: installedVersion }),
+  );
+  const records = {
+    codex: {
+      source: "npm",
+      spec: "@openclaw/codex",
+      resolvedName: "@openclaw/codex",
+      resolvedSpec: `@openclaw/codex@${installedVersion}`,
+      resolvedVersion: installedVersion,
+      version: installedVersion,
+      installPath: installDir,
+    },
+  };
+  mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+  mocks.loadPluginMetadataSnapshot.mockReturnValue({
+    plugins: [
+      {
+        id: "codex",
+        packageVersion: installedVersion,
+        providers: ["codex"],
+      },
+    ],
+    diagnostics: [],
+    byPluginId: new Map([
+      [
+        "codex",
+        {
+          id: "codex",
+          packageVersion: installedVersion,
+          providers: ["codex"],
+        },
+      ],
+    ]),
+  });
+  mockCurrentBundledPlugin("codex", "@openclaw/codex", bundledRoot);
+  mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+    officialPluginEntry({ id: "codex", npmSpec: "@openclaw/codex" }),
+  ]);
+  return records;
+}
+
 function writeLegacyNpmDeclarationStub(params: {
   pluginDir: string;
   pluginId: string;
@@ -2088,57 +2134,17 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   );
 
   it.each(["stale", "same-version"] as const)(
-    "keeps host-rebuilt bundled Codex authoritative on source checkouts (%s npm record)",
+    "keeps host-rebuilt bundled Codex authoritative on git/dev source checkouts (%s npm record)",
     async (versionRelation) => {
-      const bundledRoot = writeSourceCheckoutBundledCodex();
       const installedVersion = versionRelation === "stale" ? "2026.5.6" : VERSION;
-      const installDir = tempDirs.make("openclaw-codex-npm-shadow-");
-      fs.writeFileSync(
-        path.join(installDir, "package.json"),
-        JSON.stringify({ name: "@openclaw/codex", version: installedVersion }),
-      );
-      const records = {
-        codex: {
-          source: "npm",
-          spec: "@openclaw/codex",
-          resolvedName: "@openclaw/codex",
-          resolvedSpec: `@openclaw/codex@${installedVersion}`,
-          resolvedVersion: installedVersion,
-          version: installedVersion,
-          installPath: installDir,
-        },
-      };
-      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
-      mocks.loadPluginMetadataSnapshot.mockReturnValue({
-        plugins: [
-          {
-            id: "codex",
-            packageVersion: installedVersion,
-            providers: ["codex"],
-          },
-        ],
-        diagnostics: [],
-        byPluginId: new Map([
-          [
-            "codex",
-            {
-              id: "codex",
-              packageVersion: installedVersion,
-              providers: ["codex"],
-            },
-          ],
-        ]),
-      });
-      mockCurrentBundledPlugin("codex", "@openclaw/codex", bundledRoot);
-      mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
-        officialPluginEntry({ id: "codex", npmSpec: "@openclaw/codex" }),
-      ]);
+      mockSourceCheckoutBundledCodexNpmRecord(installedVersion);
 
       const { detectConfiguredPluginInstallHealthIssues, repairMissingConfiguredPluginInstalls } =
         await import("./missing-configured-plugin-install.js");
       const cfg = {
         plugins: { entries: { codex: { enabled: true } } },
         agents: { defaults: { model: "openai/gpt-5.5" } },
+        update: { channel: "dev" as const },
       };
       const issues = await detectConfiguredPluginInstallHealthIssues({
         cfg,
@@ -2160,11 +2166,36 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
       expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
       expect(result.changes).toEqual([
-        'Kept host-rebuilt bundled plugin "codex" authoritative on this source checkout; ignored npm install that would shadow it.',
+        'Kept host-rebuilt bundled plugin "codex" authoritative on this git/dev checkout; ignored npm install that would shadow it.',
       ]);
       expect(result.records).toEqual({});
       expect(result.warnings).toEqual([]);
       expect(result.pluginInventoryChanged).toBe(true);
+    },
+  );
+
+  it.each(["stable", "beta"] as const)(
+    "retains a healthy same-version npm Codex record on %s source checkouts",
+    async (channel) => {
+      const records = mockSourceCheckoutBundledCodexNpmRecord(VERSION);
+
+      const { repairMissingConfiguredPluginInstalls } =
+        await import("./missing-configured-plugin-install.js");
+      const result = await repairMissingConfiguredPluginInstalls({
+        cfg: {
+          plugins: { entries: { codex: { enabled: true } } },
+          agents: { defaults: { model: "openai/gpt-5.5" } },
+          update: { channel },
+        },
+        env: testEnv,
+      });
+
+      expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+      expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+      expect(result.changes).toEqual([]);
+      expect(result.records).toEqual(records);
+      expect(result.warnings).toEqual([]);
+      expect(result.pluginInventoryChanged).toBeUndefined();
     },
   );
 

--- a/src/plugins/bundled-dir.test.ts
+++ b/src/plugins/bundled-dir.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as openClawRoot from "../infra/openclaw-root.js";
 import {
+  isUsableSourceCheckoutBundledPluginRoot,
   resolveBundledPluginsDir,
   resolveSourceCheckoutDependencyDiagnostic,
 } from "./bundled-dir.js";
@@ -351,6 +352,40 @@ describe("resolveBundledPluginsDir", () => {
       repoRoot,
       expectedRelativeDir: path.join("dist-runtime", "extensions"),
     });
+  });
+
+  it("admits usable source-checkout bundled plugin roots and rejects packaged trees", () => {
+    const checkoutRoot = createOpenClawRoot({
+      prefix: "openclaw-bundled-dir-source-plugin-",
+      hasExtensions: true,
+      hasSrc: true,
+      hasDistExtensions: true,
+      hasPnpmWorkspace: true,
+    });
+    seedBundledPluginTree(checkoutRoot, path.join("dist", "extensions"), "codex");
+    seedBundledPluginTree(checkoutRoot, "extensions", "codex");
+    const packagedRoot = createOpenClawRoot({
+      prefix: "openclaw-bundled-dir-packaged-plugin-",
+      hasDistExtensions: true,
+    });
+    seedBundledPluginTree(packagedRoot, path.join("dist", "extensions"), "codex");
+
+    expect(
+      isUsableSourceCheckoutBundledPluginRoot(
+        path.join(checkoutRoot, "dist", "extensions", "codex"),
+      ),
+    ).toBe(true);
+    expect(
+      isUsableSourceCheckoutBundledPluginRoot(path.join(checkoutRoot, "extensions", "codex")),
+    ).toBe(true);
+    expect(
+      isUsableSourceCheckoutBundledPluginRoot(
+        path.join(packagedRoot, "dist", "extensions", "codex"),
+      ),
+    ).toBe(false);
+    expect(
+      isUsableSourceCheckoutBundledPluginRoot(path.join(checkoutRoot, "dist", "extensions")),
+    ).toBe(false);
   });
 
   it("reports missing pnpm workspace deps for source checkouts", () => {

--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -49,6 +49,39 @@ function isSourceCheckoutRoot(packageRoot: string): boolean {
   );
 }
 
+function bundledPluginRootHasUsableTree(pluginDir: string): boolean {
+  return (
+    pluginCacheExistsSync(path.join(pluginDir, "package.json")) ||
+    pluginCacheExistsSync(path.join(pluginDir, "openclaw.plugin.json"))
+  );
+}
+
+/**
+ * True when `rootDir` is a usable bundled plugin tree owned by a source checkout.
+ * Package hosts and official-external npm installs do not satisfy this.
+ */
+export function isUsableSourceCheckoutBundledPluginRoot(rootDir: string): boolean {
+  const resolved = path.resolve(rootDir);
+  if (!bundledPluginRootHasUsableTree(resolved)) {
+    return false;
+  }
+  let cursor = resolved;
+  for (let i = 0; i < 6; i += 1) {
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    if (
+      isSourceCheckoutRoot(parent) &&
+      isPluginInPackageBundledRoots({ rootDir: resolved, packageRoot: parent })
+    ) {
+      return true;
+    }
+    cursor = parent;
+  }
+  return false;
+}
+
 export function shouldTrustTestBundledPluginsDirOverride(env: NodeJS.ProcessEnv): boolean {
   const isVitestProcess = isVitestRuntimeEnv(env) || isVitestRuntimeEnv(process.env);
   return (

--- a/src/plugins/managed-npm-retention.test.ts
+++ b/src/plugins/managed-npm-retention.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   resolvePluginNpmGenerationProjectDir,
@@ -145,4 +145,105 @@ describe("managed npm retention", () => {
       expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(true);
     },
   );
+
+  it.each(["stat", "mkdir"] as const)(
+    "does not publish a retention marker when authority is revoked after %s",
+    async (phase) => {
+      const stateDir = retentionTempDirs.make("openclaw-retention-revoke-");
+      const npmDir = path.join(stateDir, "npm");
+      const packageDir = path.join(npmDir, "node_modules", "@openclaw", "codex");
+      fs.mkdirSync(packageDir, { recursive: true });
+      const expired = new Error("approved operation owner expired");
+      let ownerActive = true;
+      const beforePersistentEffect = () => {
+        if (!ownerActive) {
+          throw expired;
+        }
+      };
+      const revokeAfterAwait = () => {
+        ownerActive = false;
+      };
+      const stat = fs.promises.stat.bind(fs.promises);
+      const mkdir = fs.promises.mkdir.bind(fs.promises);
+      const spy =
+        phase === "stat"
+          ? vi.spyOn(fs.promises, "stat").mockImplementation(async (...args) => {
+              try {
+                return await stat(...args);
+              } finally {
+                revokeAfterAwait();
+              }
+            })
+          : vi.spyOn(fs.promises, "mkdir").mockImplementation(async (...args) => {
+              try {
+                return await mkdir(...args);
+              } finally {
+                revokeAfterAwait();
+              }
+            });
+
+      try {
+        await expect(
+          markRetainedManagedNpmInstall({
+            packageDir,
+            pluginId: "codex",
+            reason: RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+            beforePersistentEffect,
+          }),
+        ).rejects.toBe(expired);
+        expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(false);
+      } finally {
+        spy.mockRestore();
+      }
+    },
+  );
+
+  it("does not publish further retention markers after authority is revoked mid-loop", async () => {
+    const stateDir = retentionTempDirs.make("openclaw-retention-revoke-loop-");
+    const npmDir = path.join(stateDir, "npm");
+    const firstPackageDir = path.join(npmDir, "node_modules", "@openclaw", "codex");
+    const secondPackageDir = path.join(npmDir, "node_modules", "@openclaw", "codex-older");
+    fs.mkdirSync(firstPackageDir, { recursive: true });
+    fs.mkdirSync(secondPackageDir, { recursive: true });
+    const expired = new Error("approved operation owner expired");
+    let ownerActive = true;
+    const beforePersistentEffect = () => {
+      if (!ownerActive) {
+        throw expired;
+      }
+    };
+    const writeFile = fs.promises.writeFile.bind(fs.promises);
+    const spy = vi
+      .spyOn(fs.promises, "writeFile")
+      .mockImplementation(async (file, data, options) => {
+        const result = await writeFile(file, data, options);
+        if (String(file).includes(".openclaw-retained-npm-installs")) {
+          ownerActive = false;
+        }
+        return result;
+      });
+
+    try {
+      await expect(
+        markRetainedManagedNpmInstall({
+          packageDir: firstPackageDir,
+          pluginId: "codex",
+          reason: RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+          beforePersistentEffect,
+        }),
+      ).resolves.toBe(true);
+      await expect(
+        markRetainedManagedNpmInstall({
+          packageDir: secondPackageDir,
+          pluginId: "codex",
+          reason: RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+          beforePersistentEffect,
+        }),
+      ).rejects.toBe(expired);
+      expect(hasRetainedManagedNpmInstallMarker(firstPackageDir)).toBe(true);
+      expect(hasRetainedManagedNpmInstallMarker(secondPackageDir)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/src/plugins/managed-npm-retention.ts
+++ b/src/plugins/managed-npm-retention.ts
@@ -92,6 +92,7 @@ export async function markRetainedManagedNpmInstall(params: {
   pluginId: string;
   retainedAt?: string;
   reason: string;
+  beforePersistentEffect?: () => void | Promise<void>;
 }): Promise<boolean> {
   const info = resolveRetainedManagedNpmInstallPackageInfo(params.packageDir);
   if (!info) {
@@ -109,7 +110,10 @@ export async function markRetainedManagedNpmInstall(params: {
   if (!stat.isDirectory()) {
     return false;
   }
+  // Recheck after the stat await: a revoked updater must not publish markers.
+  await params.beforePersistentEffect?.();
   await fs.promises.mkdir(path.dirname(info.markerPath), { recursive: true });
+  await params.beforePersistentEffect?.();
   await fs.promises.writeFile(
     info.markerPath,
     `${JSON.stringify(


### PR DESCRIPTION
Closes #145266

## What Problem This Solves

On git/dev source checkouts, Doctor’s post-core convergence treated a version-bound Codex npm install as `stale-version-bound-runtime` whenever the calendar version lagged the host, then refreshed from `@openclaw/codex`. The published npm tarball can share the host version string while still importing a pre-#144828 SDK export (`registerRetainedNativeHookRelayForBundledRuntime`), while the host-rebuilt bundled plugin and SDK use the renamed export. Loader precedence then prefers the npm generation (`origin: global`) and every Codex harness turn fails before reply.

## Why This Change Was Made

Pete’s guidance on #145266: on git/dev installs the plugin rebuilt with the host stays authoritative; an npm generation must not be admitted on the version string alone; record the decision. ClawSweeper review required (1) retirement only on the **dev** registry channel, (2) retained-generation markers so recovery cannot re-admit shadows, (3) per-mutation updater authority rechecks before marker writes, and (4) live loader recovery proof.

## Shipped Solution

- Detect usable source-checkout bundled Codex roots (`isUsableSourceCheckoutBundledPluginRoot`).
- Host-authoritative only when `resolveRegistryUpdateChannel(...) === "dev"`.
- Drop shadowing npm install records; mark retained managed npm generations (including sibling leftover trees).
- Pass `beforePersistentEffect` into `markRetainedManagedNpmInstall` and recheck immediately before each `mkdir` / `writeFile` so a revoked updater cannot publish recovery-exclusion markers.
- Stable/beta source checkouts keep healthy npm Codex records; package hosts keep the existing npm refresh path.

## User Impact

Git/dev updates keep Codex on the host-rebuilt bundle instead of a mismatched npm generation. Release-channel registry selections are preserved. Retention writes respect updater ownership across async filesystem work.

## Behavior proof

Host: git/dev (`/opt/openclaw`), `update.channel: "dev"`, CLI `OpenClaw 2026.9.4 (15285e5)`.

### Pre

Matching [#145266](https://github.com/openclaw/openclaw/issues/145266#issuecomment-5640556765): Codex `origin: global` from npm `…g-1153…@2026.9.4`; host bundle unused; npm imported `registerRetained…` while host SDK exports `registerNative…`; journal showed Doctor refresh then repeated harness failures.

### Post — ledger repair

```text
channel: "dev"
changes: ["Kept host-rebuilt bundled plugin \"codex\" authoritative on this git/dev checkout; ignored npm install that would shadow it."]
reload: hasCodexRecord=false, pluginIds=["discord"], recoveryFallbackWarnings=[]
plugins registry: installRecords.codex absent
```

### Post — gateway reload (loader selection)

`systemctl --user restart openclaw-gateway.service` → new pid `1563882`, connectivity probe ok.

```text
plugins inspect codex:
  origin: bundled
  source/rootDir: /mnt/adata/opt/openclaw/dist/extensions/codex
  install: null
journal: gateway http server listening (... codex ...; 3.8s)
no registerRetained… errors after restart
```

Host SDK exports `registerNativeHookRelayForBundledRuntime` (not Retained). Bundled `thread-lifecycle-*.js` imports Native; dynamic import of that module succeeds (`lifecycle module import: ok`) — the previous crash path.

Authority-chain unit coverage: revocation after `stat` / after `mkdir` / mid-loop does not publish further retention markers (`managed-npm-retention.test.ts`).

### Negative (stable/beta)

Unit: `retains a healthy same-version npm Codex record on %s source checkouts` for `stable` / `beta`.

### Published-driver / fresh-install

Not run on this long-lived git/dev host. Package hosts keep the non-source-checkout npm refresh path covered in unit tests.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/plugins/managed-npm-retention.test.ts src/plugins/bundled-dir.test.ts`
- Live repair + reload proof above (redacted)

## Status

**Draft** — addresses ClawSweeper rev2 ownership fence + loader recovery proof. Request `@clawsweeper re-review` after this body lands if automation does not pick it up.
