### PR TITLE
fix(cron): deliver overdue one-shot output

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -2142,37 +2142,40 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     );
   });
 
-  it("retains a stale one-shot transcript without delivery or a fallback summary", async () => {
+  it("delivers a stale one-shot with a late-delivery annotation", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
 
     const params = makeBaseParams({ synthesizedText: "Yesterday's morning briefing." });
     params.agentSessionKey = "agent:main:cron:test-job";
+    (params.job as { schedule?: { kind: "at"; at: string } }).schedule = {
+      kind: "at",
+      at: "2026-03-18T13:59:59.999Z",
+    };
     params.job.deleteAfterRun = true;
     params.beforeSessionDelete = vi.fn();
+    vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ ok: true } as never]);
     (params.job as { state?: { nextRunAtMs?: number } }).state = {
       nextRunAtMs: Date.now() - (3 * 60 * 60_000 + 1),
     };
 
     const state = await dispatchCronDelivery(params);
 
-    const deliveryError = expect.stringContaining(
-      "scheduled at 2026-03-18T13:59:59.999Z, started 180m late",
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.deliveryError).toBeUndefined();
+    expect(deliverOutboundPayloads).toHaveBeenCalledOnce();
+    expect(deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [expect.objectContaining({ text: expect.stringContaining("Delivered late:") })],
+      }),
     );
-    expectResultFields(state.result, {
-      status: "ok",
-      delivered: false,
-      deliveryAttempted: true,
-      deliveryError,
-    });
-    expect(state.deliveryError).toEqual(deliveryError);
-    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
-    expect(state.deliveryState.status).toBe("not-delivered");
-    expect(state.deliveryState.delivered).toBe(false);
-    expect(state.deliveryState.error).toEqual(deliveryError);
-    expect(state.deliveryState.deliverySuppressionReason).toBeUndefined();
-    expect(params.beforeSessionDelete).not.toHaveBeenCalled();
-    expect(callGateway).not.toHaveBeenCalled();
+    expect(state.deliveryState.status).toBe("delivered");
+    expect(state.deliveryState.delivered).toBe(true);
+    expect(state.deliveryState.error).toBeUndefined();
+    expect(params.beforeSessionDelete).toHaveBeenCalledOnce();
+    expect(callGateway).toHaveBeenCalledOnce();
   });
 
   it("still delivers when the run started on time but finished more than three hours later", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,3 +1,4 @@
+import { copyReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 /** Dispatches isolated cron output to direct delivery, mirrors, and follow-up queues. */
 import type { NormalizeReplySkipReason } from "../../auto-reply/reply/normalize-reply-skip-reason.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
@@ -234,6 +235,7 @@ export async function dispatchCronDelivery(
       return null;
     }
     const identity = resolveAgentOutboundIdentity(params.cfgWithAgentDefaults, params.agentId);
+    let lateDeliveryNotice: string | undefined;
     try {
       if (params.isAborted()) {
         return params.withRunSession({
@@ -250,7 +252,6 @@ export async function dispatchCronDelivery(
           runStartedAt: params.runStartedAt,
         })
       ) {
-        deliveryAttempted = true;
         const nowMs = Date.now();
         const scheduledAtMs = resolveCronDeliveryScheduledAtMs({
           job: params.job,
@@ -261,17 +262,24 @@ export async function dispatchCronDelivery(
           runStartedAt: params.runStartedAt,
         });
         const deliveryError = `skipping stale delivery scheduled at ${new Date(scheduledAtMs).toISOString()}, started ${Math.round(startDelayMs / 60_000)}m late, current age ${Math.round((nowMs - scheduledAtMs) / 60_000)}m`;
-        recordDelivery("not-delivered", deliveryError);
-        await logCronDeliveryWarn(`[cron:${params.job.id}] ${deliveryError}`);
-        return params.withRunSession({
-          status: "ok",
-          summary,
-          outputText,
-          deliveryAttempted,
-          delivered: false,
-          deliveryError,
-          ...params.telemetry,
-        });
+        if (params.job.schedule.kind !== "at") {
+          deliveryAttempted = true;
+          recordDelivery("not-delivered", deliveryError);
+          await logCronDeliveryWarn(`[cron:${params.job.id}] ${deliveryError}`);
+          return params.withRunSession({
+            status: "ok",
+            summary,
+            outputText,
+            deliveryAttempted,
+            delivered: false,
+            deliveryError,
+            ...params.telemetry,
+          });
+        }
+        lateDeliveryNotice = `Delivered late: this one-shot automation started ${Math.round(startDelayMs / 60_000)} minutes after its scheduled time.`;
+        await logCronDeliveryWarn(
+          `[cron:${params.job.id}] overdue one-shot completed; delivering with late annotation (scheduled at ${new Date(scheduledAtMs).toISOString()}, started ${Math.round(startDelayMs / 60_000)}m late)`,
+        );
       }
       const payloadsForDelivery = (
         await maybeApplyTtsToCronPayloads({
@@ -285,6 +293,16 @@ export async function dispatchCronDelivery(
       if (payloadsForDelivery.length === 0) {
         recordDelivery("not-delivered", "cron delivery payload was empty after TTS");
         return null;
+      }
+      if (lateDeliveryNotice) {
+        const index = payloadsForDelivery.findLastIndex((payload) => payload.text?.trim());
+        if (index >= 0) {
+          const payload = payloadsForDelivery[index]!;
+          payloadsForDelivery[index] = copyReplyPayloadMetadata(payload, {
+            ...payload,
+            text: `${payload.text}\n\n${lateDeliveryNotice}`,
+          });
+        }
       }
       const linkedPayloadsForDelivery = appendCronRunInspectionLink(
         payloadsForDelivery,


### PR DESCRIPTION
Closes #131491

## What Problem This Solves

Fixes an issue where users with one-shot `agentTurn` automations would receive no report when the run started after the stale-delivery threshold, even though the run completed successfully and performed its work.

## Why This Change Was Made

Overdue one-shot jobs now continue through direct delivery instead of being discarded by the recurring-job staleness guard. The delivered report receives a clear late annotation so operators understand the timing; recurring schedules retain the existing stale-delivery protection.

## User Impact

Revived or delayed one-shot automations can deliver their completed output instead of silently recording success while losing the user-visible result.

## Evidence

## Real Behavior Proof

**HEAD:** `7a45afa9d54a910b109161fce125736c72802c2c`

**Claim:** A stale one-shot cron run still delivers its completed report and marks the delivery successful, with a visible late annotation.

**Exercised surface:** `dispatchCronDelivery` → direct one-shot stale-delivery branch in `src/cron/isolated-agent/delivery-dispatch.ts`. The focused regression invokes the production dispatch entry point and real payload normalization/session-cleanup path; its outbound adapter and gateway call are controlled test doubles, so this is controlled production-path evidence, not live-channel proof.

**Environment:** Linux x86_64; Node `v24.19.0`; pnpm workspace; isolated worktree `fix/cron-stale-delivery-131491` at the HEAD above.

**Scenario:**
1. Create an isolated one-shot `{kind: \"at\"}` cron job with a text report and direct delivery enabled.
2. Set the scheduled time three hours in the past while the run starts late.
3. Exercise `dispatchCronDelivery` through the stale-delivery branch.
4. Observe the outbound payload, delivery state, successful result, and delete-after-run cleanup.
5. Compare the same scenario on the unfixed parent and the final HEAD.

**Command:**

```console
node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts -t 'delivers a stale one-shot'
```

**Relevant output:**

```text
Baseline c0df18eb55ecec92716ddc2d05d6f4092c1706cf: FAIL — received status=ok, delivered=false, deliveryError=\"skipping stale delivery scheduled at 2026-03-18T13:59:59.999Z, started 180m late, current age 180m\"; expected delivery.
Final 7a45afa9d54a910b109161fce125736c72802c2c: PASS — Test Files 1 passed; Tests 1 passed | 163 skipped.
```

**Artifact:** Inline output above; no generated proof files committed. GitHub Actions results for this exact HEAD will be linked here after completion.

**Observed result:** The unfixed code discards the overdue one-shot report. The final code delivers it once, appends \"Delivered late: ...\", records delivered=true, and performs normal cleanup.

**Not tested:** A live external channel, a real provider/model turn, long-running process timing, concurrent delivery races, Windows/macOS packaging, and the remote Crabbox environment. The controlled test intentionally uses adapter/gateway doubles; those limits remain separate from the production-path regression proof.

## Separate Review Blockers

- Live external-channel/Crabbox proof is not available locally and remains a coverage gap for ClawSweeper review.
- No correctness, security, ownership, or scope blocker is known from the current local review.

## Sources

- Current issue: https://github.com/openclaw/openclaw/issues/131491
- Published proof contract at pinned revision: https://github.com/openclaw/clawsweeper/blob/e74b07a40a6ecb1c9743e17201ecca0d6114bce5/AGENTS.md
- Actual review flow: https://docs.openclaw.ai/reference/pull-request-review-flow

## Completion Target

This PR is not considered done until the exact current head has green CI/CD,
ClawSweeper rates it platinum or better, and ClawSweeper marks it ready for
maintainer look.

No visual changes.
