### PR TITLE
fix(update): dev updates can mix checkouts and accept timed-out checks

### DIFF
--- a/docs/cli/update/how-updates-run.md
+++ b/docs/cli/update/how-updates-run.md
@@ -71,6 +71,10 @@ available, preserving bundled trust. External path installs keep their existing
 classification. The live plugin files and host links stay unchanged. Channels,
 cron, automatic updates, and other side services are suppressed in this canary.
 
+Candidate build and rehearsal processes resolve source-linked plugin SDKs from
+the candidate root, even when the serving source launcher passed its own checkout
+root. This keeps candidate assets and validation independent of the old checkout.
+
 Snapshot preparation budgets time for the SQLite database and journal bytes,
 including copying and verification passes, with a five-minute startup floor.
 It uses the larger of that allowance and the configured per-step timeout.

--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -385,6 +385,9 @@ export function resolveBuildAllEnvironment(
   // Updates need runtime artifacts; explicit declaration/package builds still win.
   if (buildEnv.OPENCLAW_UPDATE_IN_PROGRESS === "1") {
     buildEnv[RUN_NODE_SKIP_DTS_BUILD_ENV] ??= "1";
+    // Published updaters can still pass the serving checkout's source root.
+    // Rebind before plugin asset hooks resolve SDK aliases in this candidate.
+    buildEnv.OPENCLAW_DEV_SOURCE_ROOT = process.cwd();
   }
   return buildEnv;
 }

--- a/src/infra/update-candidate-canary.test.ts
+++ b/src/infra/update-candidate-canary.test.ts
@@ -102,6 +102,60 @@ afterEach(async () => {
 });
 
 describe("update candidate canary", () => {
+  it("keeps snapshot and validation source selection inside the candidate", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ status: "started", ready: true })),
+    );
+    const servingRoot = path.join(root, "installed");
+    const env = { OPENCLAW_DEV_SOURCE_ROOT: servingRoot };
+    const result = await validateUpdateCandidateCanary({
+      root,
+      stateDir: root,
+      config: {},
+      env,
+      timeoutMs: 3000,
+    });
+    expect(result.status).toBe("ok");
+    expect(mocks.snapshot.mock.calls[0]?.[1].baseEnv.OPENCLAW_DEV_SOURCE_ROOT).toBe(root);
+    expect(mocks.spawn.mock.calls.length).toBeGreaterThan(0);
+    for (const call of mocks.spawn.mock.calls) {
+      expect(call[2].env.OPENCLAW_DEV_SOURCE_ROOT).toBe(root);
+    }
+    expect(env.OPENCLAW_DEV_SOURCE_ROOT).toBe(servingRoot);
+  });
+
+  it("classifies a deadline before teardown when SIGTERM closes the child with zero", async () => {
+    let now = 2_000_000;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ status: "started", ready: true })),
+    );
+    mocks.spawn.mockImplementationOnce((_command, _args, options) => {
+      const child = new FakeChild(nextPid++);
+      children.set(child.pid, child);
+      childEnv = options.env;
+      now += 899;
+      return child;
+    });
+    try {
+      const result = await validateUpdateCandidateCanary({
+        root,
+        stateDir: root,
+        config: {},
+        env: {},
+        timeoutMs: 1_000,
+      });
+      expect(result).toMatchObject({ status: "error", phase: "doctor" });
+      expect(result.logTail.join("\n")).toContain("deadline exceeded");
+      expect(result.steps.at(-1)).toMatchObject({ exitCode: 1 });
+      expect(result.steps.at(-1)?.stderrTail).toContain("deadline exceeded");
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
   it("preserves the runtime validation budget after a snapshot exceeds five minutes", async () => {
     const now = Date.now.bind(Date);
     let snapshotElapsed = 0;

--- a/src/infra/update-candidate-canary.ts
+++ b/src/infra/update-candidate-canary.ts
@@ -45,22 +45,22 @@ type CanaryResult = {
     }
 );
 
-async function waitBounded(
-  promise: Promise<unknown>,
+async function waitBounded<T>(
+  promise: Promise<T>,
   milliseconds: number,
   signal?: AbortSignal,
-): Promise<void> {
+): Promise<{ status: "completed"; value: T } | { status: "deadline" | "aborted" }> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let abort: (() => void) | undefined;
   try {
-    await Promise.race([
-      promise,
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, Math.max(0, milliseconds));
-        abort = resolve;
+    return await Promise.race([
+      promise.then((value) => ({ status: "completed" as const, value })),
+      new Promise<{ status: "deadline" | "aborted" }>((resolve) => {
+        timer = setTimeout(() => resolve({ status: "deadline" }), Math.max(0, milliseconds));
+        abort = () => resolve({ status: "aborted" });
         signal?.addEventListener("abort", abort, { once: true });
         if (signal?.aborted) {
-          resolve();
+          abort();
         }
       }),
     ]);
@@ -317,17 +317,17 @@ export async function validateUpdateCandidateCanary(params: {
       const commandStart = Date.now();
       const running = launch(command.entry ?? entry, command.args);
       let code: number | null = null;
+      let timedOut = false;
       try {
-        await waitBounded(
-          running.closed.then((value) => {
-            code = value;
-          }),
-          remaining(),
-          params.signal,
-        );
+        const outcome = await waitBounded(running.closed, remaining(), params.signal);
+        // Freeze the winning outcome before teardown can make a killed child
+        // emit a successful close event.
+        code = outcome.status === "completed" ? outcome.value : 1;
+        timedOut = outcome.status === "deadline";
       } finally {
         await terminateCanary(running.child, running.closed, deadline);
       }
+      params.signal?.throwIfAborted();
       if (code === 0 && phase === "plugins") {
         const inventory: unknown = running.outputExceeded()
           ? undefined
@@ -370,9 +370,7 @@ export async function validateUpdateCandidateCanary(params: {
       };
       steps.push(step);
       if (code !== 0) {
-        throw new Error(
-          `Candidate ${phase} failed${running.hasExited() ? "" : " (deadline exceeded)"}`,
-        );
+        throw new Error(`Candidate ${phase} failed${timedOut ? " (deadline exceeded)" : ""}`);
       }
       params.onStep?.(step);
     }

--- a/src/infra/update-candidate-rehearsal.ts
+++ b/src/infra/update-candidate-rehearsal.ts
@@ -149,6 +149,8 @@ export async function prepareUpdateCandidateRehearsal(params: {
       XDG_STATE_HOME: path.join(tempDir, "state"),
       OPENCLAW_HOME: tempDir,
       OPENCLAW_STATE_DIR: tempDir,
+      // Validation must resolve the candidate SDK, not the source launcher's checkout.
+      OPENCLAW_DEV_SOURCE_ROOT: params.candidateRoot,
       OPENCLAW_CONFIG_PATH: configPath,
       OPENCLAW_WORKSPACE_DIR: workspaceDir,
       OPENCLAW_AGENT_DIR: copiedAgentDir(sourceEnv.OPENCLAW_AGENT_DIR),

--- a/src/infra/update-runner-git-candidate.test.ts
+++ b/src/infra/update-runner-git-candidate.test.ts
@@ -254,6 +254,30 @@ describe("Git candidate activation", () => {
     },
   );
 
+  it("keeps build and exposure source selection in the admitted candidate", async () => {
+    vi.stubEnv("OPENCLAW_DEV_SOURCE_ROOT", root);
+    await advanceRemote();
+    const execute = runCommand;
+    let built = false;
+    let exposed = false;
+    runCommand = async (argv, options) => {
+      if (argv[0] === "pnpm" && argv[1] === "build") {
+        built = true;
+        expect(options.env?.OPENCLAW_DEV_SOURCE_ROOT).toBe(options.cwd);
+      }
+      return execute(argv, options);
+    };
+    const result = await update({
+      prepareGitExposure: async (candidateRoot, _sha, env) => {
+        exposed = true;
+        expect(env?.OPENCLAW_DEV_SOURCE_ROOT).toBe(candidateRoot);
+      },
+    });
+    expect(result.status).toBe("ok");
+    expect(built && exposed).toBe(true);
+    expect(process.env.OPENCLAW_DEV_SOURCE_ROOT).toBe(root);
+  });
+
   it("falls back when only the latest dev candidate requires an incompatible Node runtime", async () => {
     const requiredMajor = Number.parseInt(process.versions.node.split(".")[0]!, 10) + 1;
     const requiredEngine = `>=${requiredMajor}.0.0`;

--- a/src/infra/update-runner-git-command-env.test.ts
+++ b/src/infra/update-runner-git-command-env.test.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { prepareCandidateCommandEnv } from "./update-runner-git-commands.js";
+import type { CommandRunner } from "./update-runner-types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.unstubAllEnvs());
+
+describe("candidate command source isolation", () => {
+  it.each(["pnpm", "npm", "bun"] as const)(
+    "binds %s commands to candidate source without changing the caller",
+    async (manager) => {
+      const candidate = tempDirs.make("candidate-command-env-");
+      const env = { OPENCLAW_DEV_SOURCE_ROOT: path.join(candidate, "installed"), KEEP: "value" };
+      const original = { ...env };
+      const runCommand = vi.fn<CommandRunner>().mockResolvedValue({
+        code: 0,
+        stdout: "",
+        stderr: "",
+      });
+      const prepared = await prepareCandidateCommandEnv(manager, env, candidate, runCommand, 1000);
+      expect(prepared.env).toMatchObject({ OPENCLAW_DEV_SOURCE_ROOT: candidate, KEEP: "value" });
+      expect(prepared.env).not.toBe(env);
+      expect(env).toEqual(original);
+    },
+  );
+
+  it("replaces an ambient serving source root when no command env was supplied", async () => {
+    const candidate = tempDirs.make("candidate-command-env-");
+    const serving = path.join(candidate, "installed");
+    vi.stubEnv("OPENCLAW_DEV_SOURCE_ROOT", serving);
+    const runCommand = vi.fn<CommandRunner>();
+    const prepared = await prepareCandidateCommandEnv(
+      "npm",
+      undefined,
+      candidate,
+      runCommand,
+      1000,
+    );
+    expect(prepared.env?.OPENCLAW_DEV_SOURCE_ROOT).toBe(candidate);
+    expect(process.env.OPENCLAW_DEV_SOURCE_ROOT).toBe(serving);
+  });
+});

--- a/src/infra/update-runner-git-commands.ts
+++ b/src/infra/update-runner-git-commands.ts
@@ -88,11 +88,16 @@ export async function prepareCandidateCommandEnv(
   cwd: string,
   runCommand: CommandRunner,
   timeoutMs: number,
-): Promise<{ env: NodeJS.ProcessEnv | undefined; restoreWorkspace?: () => Promise<void> }> {
+): Promise<{ env: NodeJS.ProcessEnv; restoreWorkspace?: () => Promise<void> }> {
+  // Source launchers select the serving checkout; candidate builds must not
+  // resolve their plugin SDK or bundled sources through that inherited root.
+  const effectiveEnv: NodeJS.ProcessEnv = {
+    ...(env ?? process.env),
+    OPENCLAW_DEV_SOURCE_ROOT: cwd,
+  };
   if (manager !== "pnpm") {
-    return { env };
+    return { env: effectiveEnv };
   }
-  const effectiveEnv = env ?? process.env;
   const hasExplicitPreferOffline =
     effectiveEnv.pnpm_config_prefer_offline !== undefined ||
     effectiveEnv.PNPM_CONFIG_PREFER_OFFLINE !== undefined;
@@ -100,7 +105,7 @@ export async function prepareCandidateCommandEnv(
     ? false
     : await hasExplicitPnpmPreferOfflineConfig({ runCommand, cwd, timeoutMs, env: effectiveEnv });
   const candidateEnv: NodeJS.ProcessEnv = {
-    ...resolvePnpmCandidateEnv(env, "node_modules/.pnpm"),
+    ...resolvePnpmCandidateEnv(effectiveEnv, "node_modules/.pnpm"),
     PNPM_CONFIG_RESOLUTION_MODE: env?.PNPM_CONFIG_RESOLUTION_MODE ?? "highest",
     npm_config_resolution_mode: env?.npm_config_resolution_mode ?? "highest",
     pnpm_config_resolution_mode: env?.pnpm_config_resolution_mode ?? "highest",

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -975,6 +975,36 @@ describe("resolveBuildAllSteps", () => {
   });
 
   describe.each(["full", "package"])("%s runner build environment", (profile) => {
+    it.each([undefined, "1"])("isolates update build children with marker %s", async (marker) => {
+      const env = {
+        OPENCLAW_DEV_SOURCE_ROOT: "/serving-checkout",
+        OPENCLAW_UPDATE_IN_PROGRESS: marker,
+      };
+      const originalEnv = { ...env };
+      const invocations: ReturnType<typeof resolveBuildAllStep>[] = [];
+      const result = await runBuildAllSteps(profile, {
+        cacheEnabled: false,
+        env,
+        logger: { error: vi.fn(), warn: vi.fn() },
+        memoryLimit: buildMemoryLimit(5),
+        now: () => 0,
+        resolveCacheState: () => ({ cacheable: false, fresh: false, reason: "no-cache" }),
+        runStep(invocation) {
+          invocations.push(invocation);
+          return { status: 0 };
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.timings.map((timing) => timing.label)).toContain("plugins:assets:build");
+      expect(invocations.length).toBeGreaterThan(0);
+      for (const invocation of invocations) {
+        expect(invocation.options.env.OPENCLAW_DEV_SOURCE_ROOT).toBe(
+          marker === "1" ? process.cwd() : "/serving-checkout",
+        );
+      }
+      expect(env).toEqual(originalEnv);
+    });
+
     it.each([
       { name: "ordinary build", env: {}, runtimeOnly: false, skipDts: undefined },
       {


### PR DESCRIPTION
Related: #144898

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers will remain enabled when this PR is opened.

</details>

## What Problem This Solves

Fixes an issue where users running development-channel updates from a source checkout could have a valid candidate rejected because its build resolved plugin SDK code from the serving checkout. It also fixes a validation race where a command that had already exceeded its deadline could be recorded as successful if the child returned exit code zero during termination.

Both defects undermine the same decision: whether the selected candidate, rather than a mixture of checkouts or a late teardown result, actually passed validation. The original `doctor-failed` report is context, not a claim that every failure with that reason has this cause.

## Why This Change Was Made

Bind candidate build and rehearsal environments to their own source root at the existing environment producers, without mutating the caller's environment; freeze the completion/deadline/abort outcome before terminating a validation child. The updater retains ownership of validation, activation and cleanup, and the size/progress-based snapshot budgets landed in #144901 remain unchanged.

For the first upgrade from an already-published driver, the candidate's existing build-environment owner also rebinds the source root when the shipped `OPENCLAW_UPDATE_IN_PROGRESS` marker is present. This happens before plugin asset hooks resolve SDK aliases. Ordinary builds retain explicit source-root overrides; the published driver itself is not patched.

This is a narrow follow-up to Peter Steinberger and Vincent Koc's snapshot repair, not another budget implementation. The candidate-source invariant also matches the already-merged QA fix in #137449; this patch covers the Git updater's separate command and rehearsal producers. #144367 repaired a different Doctor alias-removal defect and is already merged.

## User Impact

The affected Git-based development-update paths build and validate against the candidate they selected. Expired validation commands remain failures even if shutdown produces a zero exit code; completed commands and cancellation retain their existing outcomes.

No new option, environment-variable contract, dependency, schema, validation bypass, or lease/retention policy. Candidate cleanliness and source checks remain enabled. The candidate honors an existing marker; no code is retrofitted into an already-published updater.

## Evidence

Frozen candidate: `69b8d1606c4f878dc04776108e9ae4337647fc3d`, based on `6e8f2cc73780b2e44e76dd220ef4883ffd929f8f`. Platform: macOS arm64, Node 26.8.2, pnpm 12.3.4.

### Published-driver compatibility

An unmodified official `v2026.9.4` driver (`3a9d69db306cd7f081e06254cb89c4bcc14a7107`) fetched and built the earlier candidate `2f9c2c54` itself, but rejected it because the Workboard manifest changed during the build. That clean, unassisted failure exposed the missing first-upgrade boundary and motivated the candidate-side build fix above. The target object was absent before the attempt; no mid-run repair was performed.

The fresh unmodified-release-to-`69b8d160` run **succeeded**. The target object was again absent immediately before execution, with only the candidate remote configured beforehand. The native driver fetched the target itself, installed dependencies, built it, completed migration rehearsal, Doctor/config/plugin validation and the Gateway canary, passed candidate cleanliness/source checks, and activated the selected commit. No code/config repair or object preload was performed during the run. Earlier manually assisted attempts are diagnostic only and excluded from this proof.

```sh
OPENCLAW_UPDATE_DEV_TARGET_REF=69b8d1606c4f878dc04776108e9ae4337647fc3d \
  pnpm openclaw update --channel dev --yes --json --no-restart
```

Selected native result fields (host-specific data omitted):

```json
{
  "status": "ok",
  "before": {"sha": "3a9d69db306cd7f081e06254cb89c4bcc14a7107", "version": "2026.9.4"},
  "after": {
    "sha": "69b8d1606c4f878dc04776108e9ae4337647fc3d",
    "version": "2026.9.4",
    "buildId": "2026.9.4-69b8d1606c4f-2026-09-11T22-44-44.969Z"
  },
  "durationMs": 646844,
  "run": {"phase": "finished", "status": "succeeded", "reason": null},
  "postUpdate": {"plugins": {"status": "ok", "changed": false, "warnings": [], "integrityDrifts": []}}
}
```

The process exited zero in 649.563 seconds including launcher overhead. Candidate clean/source checks both exited zero with empty output. A before-update OCM snapshot retained the synthetic baseline; all 23 workspace files remained byte-identical, the configured agent/workspace and disabled external session catalogs were preserved, and no channels were configured. Config and SQLite files changed during the native lifecycle; byte-identical database preservation is not claimed. This fixture had no chat history or provider credentials, so it does not prove populated-history migration, semantic memory search or external model delivery.

After activation, the official OCM foreground launcher served the candidate: `health --json` returned `ok: true` with no plugin errors/unavailable plugins, `/readyz` returned `ready: true`, `failing: []`, and `/startupz` reported started. Native `gateway call status --json` reported no degraded plugins/secrets or task errors. The listening process's checkout and build metadata matched `69b8d160`; tracked source remained clean.

**Observed limits:** the native command deliberately used `--no-restart` to avoid the personal service. The existing shared OCM supervisor did not launch this fixture within 90 seconds; its pending request was stopped, without refreshing the shared daemon. Health was then verified with OCM's official foreground command, not a managed-service restart. That official launcher synchronized missing postbuild outputs and the Gateway rebuilt Control UI assets at startup; no source edits were made, and the build ID consequently advanced to `2026.9.4-69b8d1606c4f-2026-09-11T22-53-10.165Z`. The updater also retained a recoverable Doctor warning for loopback-only node hosting. Missing provider credentials/optional skills were expected in the secretless fixture and were not patched away.

### Failing-before controls and final-head regressions

Keeping the new tests but restoring the three production files to the exact base produced **7 failures and 67 passes**. Restoring the correction made the full five-suite selection pass **114/114**. Production hashes were checked after the baseline run to verify exact restoration.

The additional build-boundary regression failed in both full/package update cases before its production change (**2 failed, 98 passed**), then passed **100/100**. It checks every emitted build-child environment, including plugin assets, and preserves ordinary overrides and caller state. The combined final-source run passed **215/215 across seven files**, including the real-process canary integration; the official runner rebuilt the runtime successfully first.

| Contract | Failing-before observation | Corrected result |
| --- | --- | --- |
| A deadline cannot become success during cleanup | A synthetic child emitted `close(0)` when terminated after the deadline; the regression rejected the recorded success. | The deadline winner is retained and reported as a failure. |
| Candidate commands cannot inherit the serving checkout as source authority | Six regressions rejected the inherited source root across npm/Bun/pnpm environment preparation, Git candidate build orchestration and rehearsal children. | Each environment selects the candidate; caller and ambient environments remain unchanged. |

The tests are synthetic regression/orchestration evidence. Separately, the real-process candidate-canary integration passed **1/1** after the official runner built the runtime. Existing snapshot-duration and cleanup coverage remains in place; no timeout or assertion was relaxed.

Historical source-selection diagnosis used the official browser bundle builder with `write: false`: changing only the inherited source-root selector changed the Workboard JavaScript from 878,258 to 930,360 bytes and reproduced the manifest mismatch rejected by native preflight. Binding the candidate source restored the original hash. That controlled asset measurement predates this residual recomposition; it is supporting origin evidence, not a measurement of the final head.

### Historical native update and live verification (`2f9c2c54`)

**Scope:** the starting driver was a locally patched 2026.9.3 source installation, not an unmodified published release. This proves personal native adoption and exact running identity, not the repository's separate published-driver × candidate compatibility cell.

The native updater completed a real source installation's update to the earlier `2f9c2c54` candidate in **980.589 seconds**, including dependency installation, build, migration rehearsal, Doctor, configuration validation, plugin resolution, the Gateway canary, candidate clean/source checks, activation, installed Doctor, restart and final verification. No standalone Doctor, manual runtime promotion or manual Gateway restart was used in the successful attempt. This is historical evidence, not final-head proof.

The command selected the existing native exact-target path:

```sh
OPENCLAW_UPDATE_DEV_TARGET_REF=2f9c2c54e3c3c0f8805a3cc274c5c245ed880afe \
  pnpm openclaw update --channel dev --yes --json
```

Selected fields from the recorded native result, with host-specific paths and identifiers omitted:

```json
{
  "status": "ok",
  "before": {
    "sha": "9d3738407a3f1e7649461475532800726251da3d",
    "version": "2026.9.3"
  },
  "after": {
    "sha": "2f9c2c54e3c3c0f8805a3cc274c5c245ed880afe",
    "version": "2026.9.4",
    "buildId": "2026.9.4-2f9c2c54e3c3-2026-09-11T20-25-44.855Z"
  },
  "run": {
    "status": "succeeded",
    "phase": "finished",
    "verification": {
      "runningVersion": "2026.9.4",
      "runningBuildId": "2026.9.4-2f9c2c54e3c3-2026-09-11T20-25-44.855Z",
      "serviceRunning": true,
      "versionMatch": true,
      "pluginErrors": [],
      "channelsReady": true,
      "readyz": true,
      "settled": true
    }
  }
}
```

Independent checks after completion returned `openclaw health --json` → `ok: true`, `/startupz` → HTTP 200 with version `2026.9.4`, and `/readyz` → HTTP 200, `ready: true`, `failing: []`, with no degraded event loop. The source checkout and runtime build ID matched the candidate and the checkout remained clean. Channel connection health is not end-to-end message-delivery proof.

The run started after a stale update reservation had been cleared separately with operator authorization; this patch does not repair that lifecycle policy. Earlier failed attempts are not counted as successful update evidence.

### Source checks and integration status

- On the final source, the complete official changed-file gate passed, including Core/test/script types, type-aware lint, format, boundary guards and dead-export scans. The candidate-side follow-up received an independent Codex review with no P0–P2 findings; it is not maintainer approval.
- Fresh source inspection at upstream `a4391c7bae673f07d2aa85b1337d35cf94a7bed8` still showed the inherited-root and mutable-timeout mechanisms, including the missing build-entry rebind. The canonical issue remains open. This is source evidence, not a test run on that later main.

Historical checks for `2f9c2c54`:

- Core production types and the infrastructure-test type graph passed.
- Type-aware lint passed on all six changed TypeScript files: zero errors/warnings, 263 rules. Formatting and `git diff --check` passed.
- A local AI-assisted review of the frozen seven-file diff reported no P0–P2 findings. This is supporting local review, not maintainer approval or CI evidence; an earlier invalidated attempt is not counted.
- Complete native changed-file gate passed (exit 0, 967.729 seconds), including all 17 core-test type graphs, boundary/dependency guards, formatting, deprecated-API and dead-export checks, and changed-file lint.
- Compared with pinned upstream `b462a6b8597fe24d58d3c1c86459e7718d8fc5c2`: all seven touched paths are unchanged from the tested base, and `git merge-tree --write-tree` completed without conflicts. This is source/merge compatibility evidence, not a test run on that later revision; package/lockfile and shared test configuration changes exist elsewhere.
- These historical checks do not establish final-head CI or maintainer approval; the published-driver result above is separate, newer evidence.

<details>
<summary>Regression and type-check commands</summary>

Run from the candidate's independently installed source checkout:

```sh
node scripts/run-vitest.mjs run \
  src/infra/update-candidate-canary.test.ts \
  src/infra/update-runner-git-candidate.test.ts \
  src/infra/update-runner-git-command-env.test.ts \
  src/infra/update-candidate-state.test.ts \
  src/infra/update-candidate-state.cleanup.test.ts \
  test/scripts/build-all.test.ts --reporter=dot

node scripts/run-vitest.mjs run \
  src/infra/update-candidate-canary.integration.test.ts --reporter=dot

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental \
  --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.infra.json --builders 1
node scripts/check-changed.mjs \
  --base 6e8f2cc73780b2e44e76dd220ef4883ffd929f8f --timed
git diff --check
```

For the failing-before control, retain the candidate tests and restore only `update-candidate-canary.ts`, `update-candidate-rehearsal.ts` and `update-runner-git-commands.ts` to the stated base in a disposable worktree. Run the first three suites; do not perform this control against a serving installation.

</details>

## Maintainer Docker verification

<!-- maintainer-docker-proof:145300:69b8d1606c4f878dc04776108e9ae4337647fc3d -->

Independent Linux arm64 proof used Node 24.19.0, pnpm 12.3.4, synthetic configuration with bundled Workboard enabled, and the repository's systemd service fixture with real Gateway processes. Live providers and channels were disabled. The final serving tree used Docker's filesystem; the earlier controls used a host-mounted tree.

| Installed driver | Candidate | Observed result |
| --- | --- | --- |
| Unmodified `v2026.9.4` (`3a9d69db`) | Pre-fix main base `6e8f2cc7` | Doctor/config/plugin/continuation checks and Gateway canary completed; candidate clean check rejected the changed Workboard manifest. The original Gateway stayed ready. |
| Same unmodified release | Original PR head `2f9c2c54` | Same rejection and preserved serving health. Those driver-side changes could not replace the already-running published updater. |
| Original PR source, with an empty local child commit to force an update | `2f9c2c54` | Candidate validation and activation completed; a separate post-activation executor-probe failure prevented restart. This control is not counted as successful end-to-end proof. |
| Unmodified `v2026.9.4` (`3a9d69db`) | Final head `69b8d1606c4f878dc04776108e9ae4337647fc3d` | **Succeeded**, including candidate validation, clean/source checks, activation, fixture-managed restart, and settled Gateway verification. |

The final target object was absent from the serving repository before invocation. The published updater fetched it itself; no manual source/config repair or object injection occurred during the run:

```sh
OPENCLAW_UPDATE_DEV_TARGET_REF=69b8d1606c4f878dc04776108e9ae4337647fc3d \
  pnpm openclaw update --channel dev --yes --json
```

The final result reported `status: ok`, `run.status: succeeded`, `run.phase: finished`, and the exact requested `after.sha`. Runtime identity matched `2026.9.4-69b8d1606c4f-2026-09-11T23-47-09.735Z`; `serviceRunning`, `versionMatch`, `channelsReady`, `readyz`, and `settled` were true, with `pluginErrors: []`. The service supervisor changed from PID 1224 to 6576. The update took **586.997 seconds**, with **95.852 seconds** recorded downtime. Independent `/startupz` and `/readyz` reads then reported started/ready, no failing checks, and no degraded event loop.

Process-environment observations and the real Workboard builder tied the failure to checkout selection. Both unmodified-driver negative cells resolved the build SDK from the serving checkout and changed the committed asset hash from `97b95a…` to `c8a722…`. With the final candidate's build bridge, Workboard build children selected the temporary candidate root and retained `97b95a…`. The full Gateway rehearsal completed in the negative cells too; the rejection was the final source cleanliness guard, which remains enabled.

The normal rehearsal Doctor is covered by the shared rehearsal environment producer. Deadline classification and that parent-owned rehearsal change take effect when the repaired updater itself runs; the already-published parent cannot execute those new functions on its first hop. The candidate-side build bridge uses its existing update marker to cover the first-hop asset failure.

### Independent regression results

- Original regressions, three production fixes reversed: all seven new regressions failed for their intended reasons. Overall: **8 failed, 66 passed**; the extra failure was an existing fixture's initial Git commit, before updater execution.
- Restored original fixes, five owner/snapshot suites: **113 passed, 1 skipped**. The existing case-insensitive-filesystem test skipped on Linux; the earlier Git fixture case passed.
- New build-bridge regression with only the production bridge reversed: **2 failed, 2 passed** selected cases. Restoring it produced **4 passed**. The other 96 tests were excluded by the name filter.
- Fresh nine-file autoreview was scoped-clean through P2. The final head had 180 successful checks, 57 skipped checks, and one neutral check before merge. No assertion, timeout, baseline, or ignore rule was relaxed.

The bridge command was:

```sh
node scripts/run-vitest.mjs run test/scripts/build-all.test.ts \
  -t 'isolates update build children' --reporter=dot
```

The separate restart control exposed an additional machine-output issue: the executor capability command can print an “Update history” notice before its otherwise valid JSON. A read-only replay exited zero with normal process cleanup, but its mixed stdout failed the capability parser; adding the existing `--json` option produced clean capability JSON. This service-command issue was left for a separate repair. The final published-driver-to-final-head cell above passed its restart and health checks.

## ClawSweeper review

1. **Real behavior proof:** the unmodified published driver fetched, built, validated, activated, and restarted the exact final candidate in Docker; negative cells independently reproduced the asset mismatch.
2. **Compatibility risk:** the candidate honors the marker shipped drivers already send, without patching the driver. The remaining parent-only deadline/rehearsal limitation is stated explicitly.
3. **Next step:** final-head proof and CI are recorded. The contributor's re-review was completed on `69b8d160…`, and the PR merged while this independent proof was running; no duplicate post-merge re-review request was sent.

Thanks @TheAngryPit for the repair and the first-hop follow-up.
