### PR TITLE
fix(workers): reduce prepared repository startup delay

### DIFF
--- a/src/gateway/worker-environments/node-worker-repository-preparation.test.ts
+++ b/src/gateway/worker-environments/node-worker-repository-preparation.test.ts
@@ -325,7 +325,12 @@ it("prepares and reuses an exact repository commit without a Gateway workspace",
     ),
   ).rejects.toThrow("session binding failed");
   expect(await git(remoteWorkspaceDir, "branch", "--show-current")).toBe("");
-  const bound = await repository.bindPreparedRepository({ ...source, branch }, preparedWorkspace);
+  const author = { name: 'Prepared "Name"', email: "prepared+session@example.invalid" };
+  const bound = await repository.bindPreparedRepository(
+    { ...source, branch },
+    preparedWorkspace,
+    author,
+  );
   expect(bound).toMatchObject({
     mode: "repository",
     baseCommit: commit,
@@ -333,6 +338,8 @@ it("prepares and reuses an exact repository commit without a Gateway workspace",
     remoteWorkspaceDir,
   });
   expect(await git(remoteWorkspaceDir, "symbolic-ref", "--short", "HEAD")).toBe(branch);
+  expect(await git(remoteWorkspaceDir, "config", "--local", "user.name")).toBe(author.name);
+  expect(await git(remoteWorkspaceDir, "config", "--local", "user.email")).toBe(author.email);
   await fs.writeFile(path.join(remoteWorkspaceDir, "session-only.txt"), "discard on replacement");
 
   const offlineOrigin = `${origin}-offline`;

--- a/src/gateway/worker-environments/node-worker-repository-preparation.ts
+++ b/src/gateway/worker-environments/node-worker-repository-preparation.ts
@@ -43,7 +43,7 @@ process.exitCode = result.status ?? 1;`;
 
 const BIND_PREPARED_REPOSITORY_JS = String.raw`const fs = require("node:fs");
 const { spawnSync } = require("node:child_process");
-const { origin, commit, branch, workspaceDir } = JSON.parse(fs.readFileSync(0, "utf8"));
+const { origin, commit, branch, workspaceDir, author } = JSON.parse(fs.readFileSync(0, "utf8"));
 if (fs.realpathSync(process.cwd()) !== fs.realpathSync(workspaceDir)) throw Error("Prepared repository workspace changed");
 const env = { ...process.env };
 for (const key of Object.keys(env)) if (/^(GIT_|GH_TOKEN$|GITHUB_TOKEN$)/i.test(key)) delete env[key];
@@ -64,6 +64,9 @@ const current = git(["symbolic-ref", "--quiet", "--short", "HEAD"], true);
 if (current !== branch) {
   if (current !== undefined) throw Error("Prepared repository already belongs to another session branch");
   git(["checkout", "-b", branch, commit]);
+}
+for (const [key, value] of Object.entries(author ?? {})) {
+  if (value) git(["config", "--local", "user." + key, value]);
 }
 `;
 
@@ -192,12 +195,13 @@ export function createNodeWorkerRepositoryPreparation(exec: NodeWorkerRepository
     bindPreparedRepository: async (
       identity: RepositoryIdentity & { commit: string; branch: string },
       prepared: PreparedRepositoryWorkspace,
+      author?: { name?: string; email?: string },
     ): Promise<WorkerWorkspaceSyncResult & { mode: "repository" }> => {
       if (identity.commit !== prepared.baseCommit) {
         throw new Error("Prepared repository does not match the pinned session commit");
       }
-      // Binding changes only the session branch. It must never fetch, reset, or
-      // reseed the fixed workspace that already owns reusable build outputs.
+      // Bind the branch and author in one remote command without fetching,
+      // resetting, or reseeding the workspace that owns reusable build outputs.
       const bound = await exec({
         argv: ["node", "-e", BIND_PREPARED_REPOSITORY_JS],
         input: JSON.stringify({
@@ -205,6 +209,7 @@ export function createNodeWorkerRepositoryPreparation(exec: NodeWorkerRepository
           commit: identity.commit,
           branch: identity.branch,
           workspaceDir: prepared.workspaceDir,
+          author,
         }),
         timeoutMs: GIT_TIMEOUT_MS,
         transportRetry: "never",

--- a/src/gateway/worker-environments/node-worker-workspace-actions.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-actions.ts
@@ -384,6 +384,7 @@ export function createNodeWorkerWorkspaceActions(params: {
       baseline = await repository.bindPreparedRepository(
         { ...identity, commit: source.baseCommit },
         source.prepared,
+        request.gitAuthor,
       );
     } else {
       const prepared = await repository.prepareRepository(identity);
@@ -398,7 +399,7 @@ export function createNodeWorkerWorkspaceActions(params: {
       baseline.mode === "repository" ? baseline.baseManifestRef : baseline.manifestRef;
     const baseCommit = baseline.baseCommit;
     const remoteWorkspaceDir = baseline.remoteWorkspaceDir;
-    if (request.gitAuthor) {
+    if (request.gitAuthor && !source.prepared) {
       await repository.configureAuthor(remoteWorkspaceDir, request.gitAuthor);
     }
     await params.workspaceTransfer.prepareRepository({

--- a/src/gateway/worker-environments/repository-workspace-startup.test.ts
+++ b/src/gateway/worker-environments/repository-workspace-startup.test.ts
@@ -401,6 +401,12 @@ it("adopts completed setup, restores accepted repository edits, and retains the 
   try {
     const initial = await f.start({ recovery: true, preparedRepository });
     expect(initial.manifestRef).toBe(completed.manifestRef);
+    expect(await requireWorkspaceResultGit(f.remote, ["config", "--local", "user.name"])).toBe(
+      gitAuthor.name,
+    );
+    expect(await requireWorkspaceResultGit(f.remote, ["config", "--local", "user.email"])).toBe(
+      gitAuthor.email,
+    );
     const initialCheckpoint = f.store.get(f.repository.workspaceId)!;
     await fs.writeFile(path.join(f.remote, "tracked.txt"), "accepted session edit\n");
     const edited = await readActualWorkspaceManifest({ root: f.remote, baseCommit: f.baseCommit });


### PR DESCRIPTION
Related: #134931, #143410

## What Problem This Solves

Users starting a session on an already prepared cloud worker still wait for separate remote calls that only configure the Git author name and email.

## Why This Change Was Made

Apply the author settings in the existing prepared repository branch-binding command. Prepared workspace startup now uses nine remote workspace commands instead of eleven, while retaining source verification, branch ownership, recovery, and checkpoint fences. Ordinary repository preparation keeps its existing author configuration path.

Compatibility: the added `author` member is transient stdin JSON sent together with its consuming `node -e` script in the same existing workspace-command request. It is not stored in a snapshot or database, and the generic command envelope already forwards optional string input to the process. The change writes the same repository-local `user.name` and `user.email` values through Git. It changes no schema, checkpoint format, prepared-workspace record, or wire-envelope version, so no migration is required. The prepared startup test restores an accepted checkpoint and reopens the bound worker state; the binding test also proves replay without a supplied author preserves session edits.

## User Impact

Prepared repository sessions avoid two sequential network round trips and two Node command startups. Author values, session edits, and prepared build output are preserved.

## Evidence

- 39 focused tests passed across repository preparation, startup/recovery, and synchronization. The extended real-Git regression failed on the original implementation and passed after the change.
- Changed-code checks passed, including core/test typechecking, lint, and repository guards. Independent review found no actionable P0–P2 issues.
- Twelve isolated runs using the real prepared Node workspace runtime, loopback transfer service, quiescence, and durable SQLite/Git checkpoint acceptance all passed with matching declared dependencies. Every baseline used 11 workspace commands; every candidate used 9.
- With an explicitly simulated 150 ms delay per remote call, prepared repository sync measured 740 ms before versus 277 ms after (medians of three samples). Two removed calls eliminate 300 ms of the imposed network delay. Host variance affects the remaining elapsed-time difference; these are local boundary measurements, not a new cloud dispatch benchmark.

Focused command: `node scripts/run-vitest.mjs src/gateway/worker-environments/node-worker-repository-preparation.test.ts src/gateway/worker-environments/repository-workspace-startup.test.ts src/gateway/worker-environments/node-worker-repository-sync.test.ts`.
