### PR TITLE
fix(ui): preserve plugin URLs on reload

### DIFF
--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -479,6 +479,9 @@ for a tab with an available slug is replaced once in browser history with
 `/<slug>`, preserving `p.*` parameters and the fragment. Tabs without an available
 slug keep the generic URL. Both forms mount the same plugin page inside the
 Control UI shell; slugs do not create plugin HTTP routes.
+Opening or reloading a slug keeps that destination while the Gateway connects,
+even when the browser remembers a chat session. Unknown slugs fall back to chat
+after the Gateway supplies its plugin tabs.
 
 Automation links open the exact job independently of the current list filters or
 loaded page. Adding `run` opens its run history and highlights the matching loaded

--- a/ui/src/app/app-host-route-state.ts
+++ b/ui/src/app/app-host-route-state.ts
@@ -35,7 +35,9 @@ export function selectShellRouteState(routerState: RouterState<RouteId>): ShellR
           location: match.location,
           routeFailed: match.status === "error" || match.status === "notFound",
         }
-      : {}),
+      : routerState.status === "notFound"
+        ? { routeFailed: true }
+        : {}),
     ...(committedMatch
       ? { committedRouteId: committedMatch.routeId, committedLocation: committedMatch.location }
       : {}),

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -95,6 +95,7 @@ i18n.setLocaleLoadRecovery({
 function equalShellRouteState(previous: ShellRouteState, next: ShellRouteState): boolean {
   return (
     previous.routeId === next.routeId &&
+    previous.routeFailed === next.routeFailed &&
     previous.location?.pathname === next.location?.pathname &&
     previous.location?.search === next.location?.search &&
     previous.location?.hash === next.location?.hash &&

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -121,7 +121,7 @@ export function renderApplicationShell(host: ShellViewHost) {
   if (!context || !runtime) {
     return nothing;
   }
-  if (host.routeState.routeId === undefined) {
+  if (host.routeState.routeId === undefined && !host.routeState.routeFailed) {
     return renderConnectingSplash();
   }
   const gatewaySnapshot = context.gateway.snapshot;

--- a/ui/src/app/bootstrap-location.ts
+++ b/ui/src/app/bootstrap-location.ts
@@ -1,7 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import type { SessionsResolveResult } from "../../../packages/gateway-protocol/src/index.js";
 import type { AgentsListResult } from "../api/types.ts";
-import { pathForRoute } from "../app-route-paths.ts";
+import { pathForRoute, pluginSlugCandidate } from "../app-route-paths.ts";
 import { routeIdFromPath } from "../app-routes.ts";
 import { pathForSession } from "../app-session-path-builder.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
@@ -24,11 +24,12 @@ type ReleasedSessionQuery = {
   sessionKey: string;
 };
 
-// Saved selection only fills an implicit landing. Agent paths remain explicit,
-// even when first-run setup is eligible to run on that same path.
+// Saved selection only fills an implicit landing. Agent paths and plugin slug
+// candidates remain explicit, even before Gateway hello registers plugin tabs.
 function isPersistedSessionLanding(location: RouteLocation, basePath: string): boolean {
   return (
     !new URLSearchParams(location.search + "&" + location.hash.slice(1)).has("session") &&
+    !pluginSlugCandidate(location.pathname, basePath) &&
     (routeIdFromPath(location.pathname, basePath) === null ||
       /^\/chat\/?$/u.test(location.pathname.slice(basePath.length)))
   );

--- a/ui/src/e2e/plugin-tab-slugs.e2e.test.ts
+++ b/ui/src/e2e/plugin-tab-slugs.e2e.test.ts
@@ -1,7 +1,10 @@
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import type { PluginPage } from "../pages/plugin/plugin-page.ts";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiBundledSettingsStorageKey,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
 import {
   createControlUiE2eContextOptions,
   createControlUiE2eSuite,
@@ -60,10 +63,13 @@ suite.define(() => {
   });
 
   it.each(["reports", "reports/"])(
-    "keeps a cold %s deep link until hello resolves the tab",
+    "keeps a cold %s deep link over the remembered session until hello resolves the tab",
     async (path) => {
       await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
         const gateway = await installReports(page, true);
+        await page.addInitScript((settingsKey) => {
+          localStorage.setItem(settingsKey, JSON.stringify({ sessionKey: "agent:main:main" }));
+        }, controlUiBundledSettingsStorageKey(suite.server.baseUrl));
         const paths: string[] = [];
         page.on("framenavigated", (frame) => {
           if (frame === page.mainFrame()) {
@@ -75,8 +81,13 @@ suite.define(() => {
         expect(new URL(page.url()).pathname).toBe(`/${path}`);
         expect(await page.locator("openclaw-plugin-page").count()).toBe(0);
         await gateway.resolveDeferred("connect");
-        await expectReports(page, `/${path}`);
+        await expectReports(page);
         expect(paths).not.toContain("/chat");
+        await page.reload();
+        await gateway.waitForRequest("connect");
+        expect(new URL(page.url()).pathname).toBe("/reports");
+        await gateway.resolveDeferred("connect");
+        await expectReports(page);
       });
     },
   );

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -1,4 +1,5 @@
 import type { RouteLocation, RouterHistory } from "@openclaw/uirouter";
+import { pluginSlugCandidate } from "../../app-route-paths.ts";
 import { sameRouteLocation, type RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
@@ -11,6 +12,7 @@ export function isDefaultChatLanding(
 ): boolean {
   return (
     !new URLSearchParams(location.search + "&" + location.hash.slice(1)).has("session") &&
+    !pluginSlugCandidate(location.pathname, basePath) &&
     (routeIdFromPath(location.pathname, basePath) === null ||
       /^\/chat(?:\/main)?\/?$/u.test(location.pathname.slice(basePath.length)))
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reopening or reloading a plugin page such as `/reports` could return to their remembered chat or remain on the startup screen.

## Why This Change Was Made

Bootstrap now preserves explicit plugin-slug candidates while the Gateway supplies the available tabs. Initial not-found state reaches the existing router outlet recovery instead of being hidden behind the startup skeleton; remembered-session and first-run redirects no longer replace the requested plugin page.

## User Impact

Short plugin URLs work across cold starts and reloads. Unknown slugs retain the existing chat fallback after the Gateway responds, and legacy query-string URLs keep their page parameters and fragment when canonicalized.

## Evidence

- The existing cold-link browser cases failed against the original code with `/chat/main` instead of `/reports` or `/reports/` after adding remembered-session state.
- The updated production-bundle browser suite passes all 5 cases, including actual reloads, trailing-slash canonicalization, unknown-slug fallback, sidebar selection, and legacy-link state preservation.
- 214 focused bootstrap, shell, router, and model-setup tests pass.
- Full selected `check:changed` passes, including core-test/UI typechecks, lint, formatting, i18n, and dead-export checks. Independent autoreview is scoped-clean through P2.

Before: the held-connection regression had already changed the URL to the remembered chat while the startup surface was blank. The URL assertions above are the primary evidence.

![Before: plugin URL lost during startup](https://github.com/user-attachments/assets/77579939-5a57-460f-9b4f-ed6c7ed8ca45)

After: the synthetic Reports page remains selected after a real browser reload with a remembered chat.

![After: Reports remains active after reload](https://github.com/user-attachments/assets/82f6380e-0e71-45ea-8d93-7b55a8dc9b57)
