### PR TITLE
refactor(tests): share sidebar narration initialization

### DIFF
--- a/ui/src/components/app-sidebar-session-narration.test.ts
+++ b/ui/src/components/app-sidebar-session-narration.test.ts
@@ -41,6 +41,21 @@ function gatewayEvent(eventName: string, payload: unknown): GatewayEventFrame {
   return { event: eventName, payload } as GatewayEventFrame;
 }
 
+function createRunningNarrationController(source: SessionCapability) {
+  const updates: Array<ReadonlyMap<string, string>> = [];
+  const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
+  controller.sync({
+    enabled: true,
+    connected: true,
+    connectionIdentity: {},
+    source,
+    openSessionKey: "",
+    rows: [runningRow("agent:main:run")],
+    agentId: "main",
+  });
+  return { controller, updates };
+}
+
 describe("sidebar narration derivation", () => {
   it("uses the last paragraph and sentence while removing markdown", () => {
     expect(
@@ -259,17 +274,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("chat", {
@@ -292,17 +297,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("agent", {
@@ -330,17 +325,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("agent", {
@@ -363,17 +348,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("agent", {
@@ -405,17 +380,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("agent", {
@@ -443,17 +408,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("chat", {
@@ -490,17 +445,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("agent", {
@@ -550,17 +495,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("agent", {
@@ -588,17 +523,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     // First observed event is a bare delta: it could be the inside of an
     // internal-context block whose opening delimiter predates the join.
@@ -629,17 +554,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("chat", {
@@ -669,17 +584,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("agent", {
@@ -795,17 +700,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("chat", {
@@ -879,17 +774,7 @@ describe("SidebarSessionNarrationController", () => {
       subscribeMessages: vi.fn(() => Promise.resolve({ key: "agent:main:run", agentId: null })),
       unsubscribeMessages: vi.fn(() => Promise.resolve()),
     } as unknown as SessionCapability;
-    const updates: Array<ReadonlyMap<string, string>> = [];
-    const controller = new SidebarSessionNarrationController((lines) => updates.push(lines));
-    controller.sync({
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      openSessionKey: "",
-      rows: [runningRow("agent:main:run")],
-      agentId: "main",
-    });
+    const { controller, updates } = createRunningNarrationController(source);
 
     controller.handleEvent(
       gatewayEvent("chat", {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Thirteen sidebar narration cases repeat the same controller initialization, making their event sequences and assertions harder to scan.

## Why This Change Was Made

A private helper accepts each case's existing source and synchronously creates a fresh update array, controller, connection identity, and running-session row before syncing. All source stubs and existing casts remain in their original cases. Different subscription and ownership setups remain explicit. This removes 115 net test lines.

## User Impact

No UI behavior or appearance changes. The narration tests retain their event, timer, subscription, and cleanup assertions with less repeated setup.

## Evidence

The complete narration file passed the same 21 cases in the same order before and after on Node 24.19.0. Expanding the helper calls restores the original file byte-for-byte, including every source stub and cast. The mapped changed gate passed UI i18n, typechecking, guards, dead-export scans, and lint. Independent review found no issues. No runtime-speed improvement is claimed.
