### PR TITLE
refactor(policy): reuse diagnostic finding construction

### DIFF
--- a/extensions/policy/src/doctor/agent-workspace-findings.ts
+++ b/extensions/policy/src/doctor/agent-workspace-findings.ts
@@ -2,6 +2,7 @@ import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PolicyAgentWorkspaceEvidence, PolicyEvidence } from "../policy-state.js";
 import { CHECK_IDS } from "./check-ids.js";
+import { policyEvidenceFinding } from "./policy-evidence-finding.js";
 import { agentScopedPolicyTargets, scopedWorkspaceAgentMatches } from "./policy-scope.js";
 import { posturePolicyShapeFinding } from "./posture-shapes.js";
 import { hasValidScopedPolicy } from "./scoped-policy-shape.js";
@@ -69,17 +70,16 @@ function agentWorkspaceAccessFindings(
         ? `sandbox mode '${entry.sandboxMode ?? "off"}'`
         : `sandbox workspaceAccess '${entry.value ?? ""}'`;
       const ocPath = sandboxDisabled ? (entry.sandboxModeSource ?? entry.source) : entry.source;
-      return {
-        checkId: CHECK_IDS.policyAgentsWorkspaceAccessDenied,
-        severity: "error",
-        message: `${label} ${observed} is not allowed by policy.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath,
-        target: ocPath,
-        requirement: `oc://${policyDocName}/${requirementPath}`,
-        fixHint: "Enable sandbox mode with workspaceAccess none/ro or update policy after review.",
-      };
+      return policyEvidenceFinding(
+        { source: ocPath },
+        {
+          checkId: CHECK_IDS.policyAgentsWorkspaceAccessDenied,
+          message: `${label} ${observed} is not allowed by policy.`,
+          requirement: `oc://${policyDocName}/${requirementPath}`,
+          fixHint:
+            "Enable sandbox mode with workspaceAccess none/ro or update policy after review.",
+        },
+      );
     });
 }
 
@@ -106,18 +106,13 @@ function agentWorkspaceToolDenyFindings(
     )
     .map((entry): HealthFinding => {
       const label = entry.agentId === undefined ? "agents.defaults" : `agent '${entry.agentId}'`;
-      return {
+      return policyEvidenceFinding(entry, {
         checkId: CHECK_IDS.policyAgentsToolNotDenied,
-        severity: "error",
         message: `${label} does not deny required tool '${entry.tool ?? ""}'.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: entry.source,
-        target: entry.source,
         requirement: `oc://${policyDocName}/${requirementPath}`,
         fixHint:
           "Add the tool to tools.deny or agents.entries.<id>.tools.deny, or update policy after review.",
-      };
+      });
     });
 }
 

--- a/extensions/policy/src/doctor/data-auth-findings.ts
+++ b/extensions/policy/src/doctor/data-auth-findings.ts
@@ -183,18 +183,13 @@ function secretManagedProviderFindings(
           !providerKeys.has(`${secret.refSource}:${secret.refProvider}`)),
     )
     .map((secret): HealthFinding => {
-      return {
+      return policyEvidenceFinding(secret, {
         checkId: CHECK_IDS.policySecretsUnmanagedProvider,
-        severity: "error",
         message: `SecretRef uses unmanaged provider '${secret.refProvider ?? "default"}'.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: secret.source,
-        target: secret.source,
         requirement: `oc://${policyDocName}/secrets/requireManagedProviders`,
         fixHint:
           "Declare the referenced provider under secrets.providers or update policy after review.",
-      };
+      });
     });
 }
 
@@ -214,17 +209,12 @@ function secretDeniedSourceFindings(
     })
     .map((secret): HealthFinding => {
       const source = secret.kind === "provider" ? secret.providerSource : secret.refSource;
-      return {
+      return policyEvidenceFinding(secret, {
         checkId: CHECK_IDS.policySecretsDeniedProviderSource,
-        severity: "error",
         message: `Secret ${secret.kind} '${secret.id}' uses denied source '${source}'.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: secret.source,
-        target: secret.source,
         requirement: `oc://${policyDocName}/secrets/denySources`,
         fixHint: "Move this secret to an approved source or update policy after review.",
-      };
+      });
     });
 }
 
@@ -239,17 +229,12 @@ function secretInsecureProviderFindings(
   return (evidence.secrets ?? [])
     .filter((secret) => secret.kind === "provider" && (secret.insecure?.length ?? 0) > 0)
     .map((secret): HealthFinding => {
-      return {
+      return policyEvidenceFinding(secret, {
         checkId: CHECK_IDS.policySecretsInsecureProvider,
-        severity: "error",
         message: `Secret provider '${secret.id}' enables insecure posture: ${(secret.insecure ?? []).join(", ")}.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: secret.source,
-        target: secret.source,
         requirement: `oc://${policyDocName}/secrets/allowInsecureProviders`,
         fixHint: "Remove insecure provider overrides or update policy after review.",
-      };
+      });
     });
 }
 
@@ -270,17 +255,12 @@ function authProfileMetadataFindings(
       return [];
     }
     return [
-      {
+      policyEvidenceFinding(profile, {
         checkId: CHECK_IDS.policyAuthProfileInvalidMetadata,
-        severity: "error",
         message: `Auth profile '${profile.id}' is missing required metadata: ${missing.join(", ")}.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: profile.source,
-        target: profile.source,
         requirement: `oc://${policyDocName}/auth/profiles/requireMetadata`,
         fixHint: "Set auth.profiles.<id>.provider and a supported auth profile mode.",
-      },
+      }),
     ];
   });
 }
@@ -297,16 +277,11 @@ function authProfileModeFindings(
   return (evidence.authProfiles ?? [])
     .filter((profile) => profile.mode !== undefined && !allowedModes.has(profile.mode))
     .map((profile): HealthFinding => {
-      return {
+      return policyEvidenceFinding(profile, {
         checkId: CHECK_IDS.policyAuthProfileUnapprovedMode,
-        severity: "error",
         message: `Auth profile '${profile.id}' uses mode '${profile.mode}' outside the policy allowlist.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: profile.source,
-        target: profile.source,
         requirement: `oc://${policyDocName}/auth/profiles/allowModes`,
         fixHint: "Change the auth profile mode or update policy after review.",
-      };
+      });
     });
 }

--- a/extensions/policy/src/doctor/evaluation.ts
+++ b/extensions/policy/src/doctor/evaluation.ts
@@ -17,6 +17,7 @@ import { dataHandlingFindings, secretAuthProvenanceFindings } from "./data-auth-
 import { execApprovalsFindings } from "./exec-approval-findings.js";
 import { ingressFindings } from "./ingress-findings.js";
 import { SUPPORTED_TOOL_METADATA } from "./policy-constants.js";
+import { policyEvidenceFinding } from "./policy-evidence-finding.js";
 import {
   execApprovalsDisplayName,
   parsePolicyFile,
@@ -351,19 +352,14 @@ function channelFindings(
       return [];
     }
     return [
-      {
+      policyEvidenceFinding(channel, {
         checkId: CHECK_IDS.policyDeniedChannelProvider,
-        severity: "error",
         message: `Channel '${channel.id}' uses denied provider '${channel.provider}'.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: channel.source,
-        target: channel.source,
         requirement: rule.requirement,
         fixHint:
           rule.reason ??
           "Disable this channel, remove it from config, or update the policy deny rule.",
-      },
+      }),
     ];
   });
 }

--- a/extensions/policy/src/doctor/scopes/gateway.ts
+++ b/extensions/policy/src/doctor/scopes/gateway.ts
@@ -5,6 +5,7 @@ import type { PolicyEvidence } from "../../policy-state.js";
 import { repairPolicyAutomaticNarrower } from "../automatic-repairs.js";
 import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
+import { policyEvidenceFinding } from "../policy-evidence-finding.js";
 import { previewPolicyReviewRequiredRepair } from "../review-required-repairs.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 import { readPolicyBoolean, readStringList } from "../utils.js";
@@ -85,20 +86,15 @@ function gatewayNonLoopbackBindFindings(
   return (evidence.gatewayExposure ?? [])
     .filter((entry) => entry.kind === "bind" && entry.nonLoopback === true)
     .map((entry): HealthFinding => {
-      return {
+      return policyEvidenceFinding(entry, {
         checkId: CHECK_IDS.policyGatewayNonLoopbackBind,
-        severity: "error",
         message:
           entry.explicit === false
             ? "Gateway bind is omitted while the runtime default can permit non-loopback exposure."
             : `Gateway bind setting '${entry.id}' permits non-loopback exposure.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: entry.source,
-        target: entry.source,
         requirement: `oc://${policyDocName}/gateway/exposure/allowNonLoopbackBind`,
         fixHint: "Use gateway.bind=loopback or update policy after review.",
-      };
+      });
     });
 }
 
@@ -113,17 +109,12 @@ function gatewayAuthFindings(
       ...(evidence.gatewayExposure ?? [])
         .filter((entry) => entry.kind === "auth" && entry.value === "none")
         .map((entry): HealthFinding => {
-          return {
+          return policyEvidenceFinding(entry, {
             checkId: CHECK_IDS.policyGatewayAuthDisabled,
-            severity: "error",
             message: "Gateway authentication is disabled.",
-            source: "policy",
-            path: "openclaw config",
-            ocPath: entry.source,
-            target: entry.source,
             requirement: `oc://${policyDocName}/gateway/auth/requireAuth`,
             fixHint: "Set gateway.auth.mode to token, password, or trusted-proxy.",
-          };
+          });
         }),
     );
   }
@@ -132,17 +123,12 @@ function gatewayAuthFindings(
       ...(evidence.gatewayExposure ?? [])
         .filter((entry) => entry.kind === "authRateLimit" && entry.explicit !== true)
         .map((entry): HealthFinding => {
-          return {
+          return policyEvidenceFinding(entry, {
             checkId: CHECK_IDS.policyGatewayRateLimitMissing,
-            severity: "error",
             message: "Gateway authentication rate-limit posture is not explicit.",
-            source: "policy",
-            path: "openclaw config",
-            ocPath: entry.source,
-            target: entry.source,
             requirement: `oc://${policyDocName}/gateway/auth/requireExplicitRateLimit`,
             fixHint: "Configure gateway.auth.rateLimit or update policy after review.",
-          };
+          });
         }),
     );
   }
@@ -167,17 +153,12 @@ function gatewayControlUiFindings(
           entry.id === "gateway-control-ui-host-origin-fallback"),
     )
     .map((entry): HealthFinding => {
-      return {
+      return policyEvidenceFinding(entry, {
         checkId: CHECK_IDS.policyGatewayControlUiInsecure,
-        severity: "error",
         message: `Gateway Control UI insecure toggle '${entry.id}' is enabled.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: entry.source,
-        target: entry.source,
         requirement: `oc://${policyDocName}/gateway/controlUi/allowInsecure`,
         fixHint: "Disable the insecure Control UI toggle or update policy after review.",
-      };
+      });
     });
 }
 
@@ -192,17 +173,12 @@ function gatewayTailscaleFindings(
   return (evidence.gatewayExposure ?? [])
     .filter((entry) => entry.kind === "tailscale" && entry.value === "funnel")
     .map((entry): HealthFinding => {
-      return {
+      return policyEvidenceFinding(entry, {
         checkId: CHECK_IDS.policyGatewayTailscaleFunnel,
-        severity: "error",
         message: "Gateway Tailscale Funnel exposure is enabled.",
-        source: "policy",
-        path: "openclaw config",
-        ocPath: entry.source,
-        target: entry.source,
         requirement: `oc://${policyDocName}/gateway/exposure/allowTailscaleFunnel`,
         fixHint: "Use tailscale serve/off or update policy after review.",
-      };
+      });
     });
 }
 
@@ -217,17 +193,12 @@ function gatewayRemoteFindings(
   return (evidence.gatewayExposure ?? [])
     .filter((entry) => entry.kind === "remote")
     .map((entry): HealthFinding => {
-      return {
+      return policyEvidenceFinding(entry, {
         checkId: CHECK_IDS.policyGatewayRemoteEnabled,
-        severity: "error",
         message: `Gateway remote posture '${entry.id}' is enabled.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: entry.source,
-        target: entry.source,
         requirement: `oc://${policyDocName}/gateway/remote/allow`,
         fixHint: "Disable remote gateway mode/config or update policy after review.",
-      };
+      });
     });
 }
 
@@ -252,17 +223,12 @@ function gatewayHttpEndpointFindings(
         denied.has(entry.endpoint.toLowerCase()),
     )
     .map((entry): HealthFinding => {
-      return {
+      return policyEvidenceFinding(entry, {
         checkId: CHECK_IDS.policyGatewayHttpEndpointEnabled,
-        severity: "error",
         message: `Gateway HTTP endpoint '${entry.endpoint ?? entry.id}' is denied by policy.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: entry.source,
-        target: entry.source,
         requirement: `oc://${policyDocName}/gateway/http/denyEndpoints`,
         fixHint: "Disable the HTTP endpoint or update policy after review.",
-      };
+      });
     });
 }
 
@@ -277,17 +243,12 @@ function gatewayHttpUrlFetchFindings(
   return (evidence.gatewayExposure ?? [])
     .filter((entry) => entry.kind === "httpUrlFetch" && entry.hasAllowlist !== true)
     .map((entry): HealthFinding => {
-      return {
+      return policyEvidenceFinding(entry, {
         checkId: CHECK_IDS.policyGatewayHttpUrlFetchUnrestricted,
-        severity: "error",
         message: `Gateway HTTP URL-fetch input '${entry.id}' has no URL allowlist.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: entry.source,
-        target: entry.source,
         requirement: `oc://${policyDocName}/gateway/http/requireUrlAllowlists`,
         fixHint: "Add a urlAllowlist for this URL-fetch input or update policy after review.",
-      };
+      });
     });
 }
 
@@ -313,17 +274,15 @@ function gatewayNodeCommandFindings(
   return policyDenied
     .filter((command) => !configDenied.has(command))
     .map((command): HealthFinding => {
-      return {
-        checkId: CHECK_IDS.policyGatewayNodeCommandDenied,
-        severity: "error",
-        message: `Gateway node command '${command}' is denied by policy but not denied by OpenClaw config.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: "oc://openclaw.config/gateway/nodes/commands/deny",
-        target: "oc://openclaw.config/gateway/nodes/commands/deny",
-        requirement: `oc://${policyDocName}/gateway/nodes/denyCommands`,
-        fixHint: `Add '${command}' to gateway.nodes.commands.deny or update policy after review.`,
-      };
+      return policyEvidenceFinding(
+        { source: "oc://openclaw.config/gateway/nodes/commands/deny" },
+        {
+          checkId: CHECK_IDS.policyGatewayNodeCommandDenied,
+          message: `Gateway node command '${command}' is denied by policy but not denied by OpenClaw config.`,
+          requirement: `oc://${policyDocName}/gateway/nodes/denyCommands`,
+          fixHint: `Add '${command}' to gateway.nodes.commands.deny or update policy after review.`,
+        },
+      );
     });
 }
 

--- a/extensions/policy/src/doctor/scopes/model-network.ts
+++ b/extensions/policy/src/doctor/scopes/model-network.ts
@@ -4,6 +4,7 @@ import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import type { PolicyEvidence } from "../../policy-state.js";
 import { createPolicyScopedChecks } from "../check-factory.js";
 import { CHECK_IDS } from "../check-ids.js";
+import { policyEvidenceFinding } from "../policy-evidence-finding.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 import { readPolicyBoolean, readStringList } from "../utils.js";
 
@@ -43,31 +44,25 @@ export function mcpServerFindings(
 
   for (const server of evidence.mcpServers) {
     if (denied.has(server.id)) {
-      findings.push({
-        checkId: CHECK_IDS.policyDeniedMcpServer,
-        severity: "error",
-        message: `MCP server '${server.id}' is denied by policy.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: server.source,
-        target: server.source,
-        requirement: `oc://${policyDocName}/mcp/servers/deny`,
-        fixHint: "Remove this configured MCP server or update the policy after review.",
-      });
+      findings.push(
+        policyEvidenceFinding(server, {
+          checkId: CHECK_IDS.policyDeniedMcpServer,
+          message: `MCP server '${server.id}' is denied by policy.`,
+          requirement: `oc://${policyDocName}/mcp/servers/deny`,
+          fixHint: "Remove this configured MCP server or update the policy after review.",
+        }),
+      );
       continue;
     }
     if (allowedSet.size > 0 && !allowedSet.has(server.id)) {
-      findings.push({
-        checkId: CHECK_IDS.policyUnapprovedMcpServer,
-        severity: "error",
-        message: `MCP server '${server.id}' is not in the policy allowlist.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: server.source,
-        target: server.source,
-        requirement: `oc://${policyDocName}/mcp/servers/allow`,
-        fixHint: "Use an approved MCP server or update the policy after review.",
-      });
+      findings.push(
+        policyEvidenceFinding(server, {
+          checkId: CHECK_IDS.policyUnapprovedMcpServer,
+          message: `MCP server '${server.id}' is not in the policy allowlist.`,
+          requirement: `oc://${policyDocName}/mcp/servers/allow`,
+          fixHint: "Use an approved MCP server or update the policy after review.",
+        }),
+      );
     }
   }
 
@@ -106,30 +101,24 @@ function modelProviderConformanceFindings(
 ): readonly HealthFinding[] {
   const findings: HealthFinding[] = [];
   if (denied.has(provider.id)) {
-    findings.push({
-      checkId: CHECK_IDS.policyDeniedModelProvider,
-      severity: "error",
-      message: `Model provider '${provider.id}' is denied by policy.`,
-      source: "policy",
-      path: "openclaw config",
-      ocPath: provider.source,
-      target: provider.source,
-      requirement: `oc://${policyDocName}/models/providers/deny`,
-      fixHint: "Remove this configured provider or update the policy after review.",
-    });
+    findings.push(
+      policyEvidenceFinding(provider, {
+        checkId: CHECK_IDS.policyDeniedModelProvider,
+        message: `Model provider '${provider.id}' is denied by policy.`,
+        requirement: `oc://${policyDocName}/models/providers/deny`,
+        fixHint: "Remove this configured provider or update the policy after review.",
+      }),
+    );
   }
   if (!denied.has(provider.id) && allowed.size > 0 && !allowed.has(provider.id)) {
-    findings.push({
-      checkId: CHECK_IDS.policyUnapprovedModelProvider,
-      severity: "error",
-      message: `Model provider '${provider.id}' is not in the policy allowlist.`,
-      source: "policy",
-      path: "openclaw config",
-      ocPath: provider.source,
-      target: provider.source,
-      requirement: `oc://${policyDocName}/models/providers/allow`,
-      fixHint: "Use an approved model provider or update the policy after review.",
-    });
+    findings.push(
+      policyEvidenceFinding(provider, {
+        checkId: CHECK_IDS.policyUnapprovedModelProvider,
+        message: `Model provider '${provider.id}' is not in the policy allowlist.`,
+        requirement: `oc://${policyDocName}/models/providers/allow`,
+        fixHint: "Use an approved model provider or update the policy after review.",
+      }),
+    );
   }
   return findings;
 }
@@ -142,30 +131,24 @@ function modelRefConformanceFindings(
 ): readonly HealthFinding[] {
   const findings: HealthFinding[] = [];
   if (denied.has(modelRef.provider)) {
-    findings.push({
-      checkId: CHECK_IDS.policyDeniedModelProvider,
-      severity: "error",
-      message: `Model ref '${modelRef.ref}' uses denied provider '${modelRef.provider}'.`,
-      source: "policy",
-      path: "openclaw config",
-      ocPath: modelRef.source,
-      target: modelRef.source,
-      requirement: `oc://${policyDocName}/models/providers/deny`,
-      fixHint: "Select an approved model provider or update the policy after review.",
-    });
+    findings.push(
+      policyEvidenceFinding(modelRef, {
+        checkId: CHECK_IDS.policyDeniedModelProvider,
+        message: `Model ref '${modelRef.ref}' uses denied provider '${modelRef.provider}'.`,
+        requirement: `oc://${policyDocName}/models/providers/deny`,
+        fixHint: "Select an approved model provider or update the policy after review.",
+      }),
+    );
   }
   if (!denied.has(modelRef.provider) && allowed.size > 0 && !allowed.has(modelRef.provider)) {
-    findings.push({
-      checkId: CHECK_IDS.policyUnapprovedModelProvider,
-      severity: "error",
-      message: `Model ref '${modelRef.ref}' uses unapproved provider '${modelRef.provider}'.`,
-      source: "policy",
-      path: "openclaw config",
-      ocPath: modelRef.source,
-      target: modelRef.source,
-      requirement: `oc://${policyDocName}/models/providers/allow`,
-      fixHint: "Select an approved model provider or update the policy after review.",
-    });
+    findings.push(
+      policyEvidenceFinding(modelRef, {
+        checkId: CHECK_IDS.policyUnapprovedModelProvider,
+        message: `Model ref '${modelRef.ref}' uses unapproved provider '${modelRef.provider}'.`,
+        requirement: `oc://${policyDocName}/models/providers/allow`,
+        fixHint: "Select an approved model provider or update the policy after review.",
+      }),
+    );
   }
   return findings;
 }
@@ -182,16 +165,11 @@ export function networkFindings(
   return evidence.network
     .filter((setting) => setting.value)
     .map((setting): HealthFinding => {
-      return {
+      return policyEvidenceFinding(setting, {
         checkId: CHECK_IDS.policyPrivateNetworkAccess,
-        severity: "error",
         message: `Network setting '${setting.id}' allows private-network access.`,
-        source: "policy",
-        path: "openclaw config",
-        ocPath: setting.source,
-        target: setting.source,
         requirement: `oc://${policyDocName}/network/privateNetwork/allow`,
         fixHint: "Disable this private-network access setting or update policy after review.",
-      };
+      });
     });
 }


### PR DESCRIPTION
Closes #145313

## What Problem This Solves

Policy Doctor repeats the same diagnostic envelope at 24 construction sites, increasing the maintenance cost of keeping severity, locations, requirement pointers, and repair guidance consistent. This is the maintainer-requested cleanup tracked in #145313.

## Why This Change Was Made

Reuse the existing, unchanged `policyEvidenceFinding` helper across five files. The complete cutover removes 97 production lines and 2,285 bytes while preserving predicates, finding fields and their serialized order, repairs, and registration.

Data-model compatibility: this diff only changes construction of transient `HealthFinding` objects. It changes no SQLite schema, stored format, state writer, migration, backfill, or repair implementation. Existing repair callbacks and attestation processing remain unchanged. Exact serialized parity at all 24 sites and the published-driver update/configuration-preservation cell provide the compatibility proof; no data migration is needed.

## User Impact

No user-visible behavior changes. Policy checks return the same messages, severity, pointers, and fix hints. Policy remains enabled and evaluates the same fixture after an update from the published package.

## Evidence

- The same 303 registered tests pass before and after; all five files pass the complete changed-file gates, including typechecks, lint, Doctor contracts, dead exports, and boundaries.
- Exact-output parity covers all 24 changed construction sites: 52 complete findings across 14 groups, with identical serialized bytes and property order. Isolated review found no actionable issues.
- Canonical package build/tarball validation and the standalone final package checker pass, including installed CLI/Doctor and bundled channel entry smoke.
- [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/34645774892): the real published `openclaw@2026.9.4` updater installed the candidate file artifact. Both packages carry the same version; exact installed entry/runtime hashes prove replacement. Complete plugin, Gateway, and agent configuration, Policy bytes, and a workspace artifact survived. Registered compliant/noncompliant Policy probes returned the exact expected results before and after. Command exit 0; the lease was stopped afterward.

The update fixture uses a supported absolute Policy path and `--no-restart`; it does not cover updater-owned service restart or workspace-relative Policy paths. A loader observer confirms candidate Policy module identity during the full candidate-lint command; the registered CLI probes separately verify evaluation and findings.

Full `pnpm release:check` still exits 1 on existing Control UI fallback/native locale drift at the base commit. The frozen-tree package build passes, and a source audit verified that all 72 direct locale inputs are unchanged. No locale artifacts or baselines were altered. An initial build rejected proof-file creation during compilation; rerunning with the tree fixed resolved that input-seal failure. The first update proof activated the candidate but stopped on default Codex plugin normalization; the successful cell first demonstrated that same normalization through the published baseline Doctor, then retained full post-update configuration equality.
