### PR TITLE
refactor(tests): reuse storage fixture in update report tests

### DIFF
--- a/ui/src/app/overlays-update-report.test.ts
+++ b/ui/src/app/overlays-update-report.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
 import { createUpdateRunFixture } from "../test-helpers/update-run.ts";
 import type { ApplicationGatewaySnapshot } from "./gateway.ts";
 import {
@@ -48,12 +49,7 @@ function harnessFor(request: RequestFn) {
 }
 
 beforeEach(() => {
-  const values = new Map<string, string>();
-  vi.stubGlobal("sessionStorage", {
-    getItem: (key: string) => values.get(key) ?? null,
-    setItem: (key: string, value: string) => values.set(key, value),
-    removeItem: (key: string) => values.delete(key),
-  });
+  vi.stubGlobal("sessionStorage", createStorageMock());
   reportUpdateFailure.mockReset();
 });
 


### PR DESCRIPTION
## What Problem This Solves

Update-report tests duplicate a small session-storage fixture already provided by the UI test helpers.

## Why This Change Was Made

Use `createStorageMock` in the existing per-test setup. Preserve assertions, fresh storage for each test, and cleanup. Production code and shared helpers are unchanged.

## User Impact

No user-facing behavior change. One test file adds 2 lines and removes 6; no cases are removed.

## Evidence

The changed suite and unchanged update-run-receipts sibling passed before and after: all 40 cases (27 + 13), with identical inventory, order, and statuses. Independent review found no actionable issues through P2.

All 18 ordinary changed-file checks passed, including the affected UI test type graph, i18n, lint, and unused-export checks. Source and installed dependencies remained unchanged.
