### PR TITLE
improve(chat): show how each provider is signed in inside the model picker

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 353694,
-  "reason": "Main-area /terminal route adds eager route registration, the dynamic session-path bridge, and catalog navigation glue for native CLI sessions; measured 353694 B startup gzip in CI on the rebased tree. Fixed 358400 B cap retained.",
+  "startupJsGzipBytes": 354540,
+  "reason": "Main crossed the startup enforcement limit after concurrent landings (main alone 354388 B vs 354270 B limit); this PR adds 119 B for provider auth markers in the model picker; measured 354540 B on the rebased tree. Fixed 358400 B cap retained.",
   "updatedAt": "2026-09-11"
 }

--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -33,7 +33,7 @@ navigable without a card; links to other origins keep normal browser behavior.
 Document-relative hrefs are never session links; file references such as
 `src/utils/foo.ts` retain workspace file handling.
 
-The chat model picker shows each provider’s subscription plan (or **Subscription**) or **API** beside its name when authentication status is available. With multiple subscription accounts, the heading and **Account** rows also show the account email when the Gateway supplies it. Hover over a truncated heading to read the full plan and email.
+When authentication status is available, each provider heading in the chat model picker says how that provider is signed in: **API** for an API key (or an explicitly selected API-key account), the plan name for a provider with one subscription, and **Subscription** for a provider with several. With several subscriptions, the heading adds the email of an explicitly selected account when the Gateway supplies it, and the **Account** rows show each account's email; automatic selection shows no account identity. Hover a truncated heading to read the full text.
 
 ## Composer capability menu
 

--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -33,6 +33,8 @@ navigable without a card; links to other origins keep normal browser behavior.
 Document-relative hrefs are never session links; file references such as
 `src/utils/foo.ts` retain workspace file handling.
 
+The chat model picker shows each provider’s subscription plan (or **Subscription**) or **API** beside its name when authentication status is available. With multiple subscription accounts, the heading and **Account** rows also show the account email when the Gateway supplies it. Hover over a truncated heading to read the full plan and email.
+
 ## Composer capability menu
 
 Select **+** beside the chat composer to open attachments and session capabilities in one menu:

--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -167,6 +167,31 @@ suite.define(() => {
           deferredMethods: ["sessions.patch"],
           methodResponses: {
             "sessions.list": sessionList,
+            "models.authStatus": {
+              ts: 1,
+              providers: [
+                {
+                  provider: "openai",
+                  displayName: "OpenAI",
+                  status: "ok",
+                  profiles: [
+                    {
+                      profileId: personal.authProfileId,
+                      type: "oauth",
+                      status: "ok",
+                      email: "personal@example.com",
+                    },
+                    {
+                      profileId: work.authProfileId,
+                      type: "oauth",
+                      status: "ok",
+                      email: "work@example.com",
+                    },
+                  ],
+                  usage: { providerId: "openai", windows: [], plan: "ChatGPT Pro" },
+                },
+              ],
+            },
             "models.list": {
               commands: [],
               models,
@@ -190,12 +215,23 @@ suite.define(() => {
         const model = composer.locator('[data-chat-model-select="true"]');
         await expect.poll(() => model.getAttribute("aria-busy")).toBe("false");
         await model.click();
+        const heading = composer.locator('[data-chat-model-provider="openai"]');
+        await expect
+          .poll(() => heading.textContent())
+          .toContain("ChatGPT Pro · personal@example.com");
         const account = composer.locator("[data-chat-account-selection]");
         const picker = account;
         const trigger = picker.locator("[data-chat-account-group-toggle]");
         await expect.poll(() => trigger.textContent()).toContain(personal.label);
         for (const width of [320, 768, 1280]) {
           await page.setViewportSize({ width, height: 900 });
+          expect(await heading.getAttribute("title")).toBe("ChatGPT Pro · personal@example.com");
+          expect(
+            await heading.locator(".chat-controls__auth-meta svg").evaluate((icon) => ({
+              width: getComputedStyle(icon).width,
+              height: getComputedStyle(icon).height,
+            })),
+          ).toEqual({ width: "13px", height: "13px" });
           await expect
             .poll(async () => {
               const box = await account.boundingBox();
@@ -212,6 +248,9 @@ suite.define(() => {
         await trigger.click();
         const more = picker.locator('[data-chat-account-option="more"]');
         await expect.poll(() => more.isVisible()).toBe(true);
+        expect(
+          await picker.locator('[data-chat-account-option="current"]').textContent(),
+        ).toContain("personal@example.com");
         await trigger.click();
         await expect.poll(() => more.isVisible()).toBe(false);
         await expect.poll(() => account.isVisible()).toBe(true);
@@ -240,6 +279,7 @@ suite.define(() => {
           `[data-chat-account-option="account:${work.authProfileId}"]`,
         );
         await expect.poll(() => workOption.isVisible()).toBe(true);
+        expect(await workOption.textContent()).toContain("work@example.com");
         if (artifactDir) {
           await page.screenshot({
             animations: "disabled",
@@ -279,6 +319,7 @@ suite.define(() => {
           reason: "patch",
         });
         await expect.poll(() => trigger.textContent()).toContain(work.label);
+        await expect.poll(() => heading.textContent()).toContain("ChatGPT Pro · work@example.com");
         expect(await gateway.getRequests("users.selectModelAccount")).toHaveLength(0);
         expect(await gateway.getRequests("users.unlinkAuthProfile")).toHaveLength(0);
         if (artifactDir) {

--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -218,14 +218,14 @@ suite.define(() => {
         const heading = composer.locator('[data-chat-model-provider="openai"]');
         await expect
           .poll(() => heading.textContent())
-          .toContain("ChatGPT Pro · personal@example.com");
+          .toContain("Subscription · personal@example.com");
         const account = composer.locator("[data-chat-account-selection]");
         const picker = account;
         const trigger = picker.locator("[data-chat-account-group-toggle]");
         await expect.poll(() => trigger.textContent()).toContain(personal.label);
         for (const width of [320, 768, 1280]) {
           await page.setViewportSize({ width, height: 900 });
-          expect(await heading.getAttribute("title")).toBe("ChatGPT Pro · personal@example.com");
+          expect(await heading.getAttribute("title")).toBe("Subscription · personal@example.com");
           expect(
             await heading.locator(".chat-controls__auth-meta svg").evaluate((icon) => ({
               width: getComputedStyle(icon).width,
@@ -319,7 +319,7 @@ suite.define(() => {
           reason: "patch",
         });
         await expect.poll(() => trigger.textContent()).toContain(work.label);
-        await expect.poll(() => heading.textContent()).toContain("ChatGPT Pro · work@example.com");
+        await expect.poll(() => heading.textContent()).toContain("Subscription · work@example.com");
         expect(await gateway.getRequests("users.selectModelAccount")).toHaveLength(0);
         expect(await gateway.getRequests("users.unlinkAuthProfile")).toHaveLength(0);
         if (artifactDir) {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5458,6 +5458,8 @@ export const en: TranslationMap & {
       closeVideoPreview: "Close video preview",
     },
     modelControls: {
+      subscription: "Subscription",
+      api: "API",
       default: "Default",
       effort: "Effort",
       faster: "Faster",

--- a/ui/src/lib/model-auth.test.ts
+++ b/ui/src/lib/model-auth.test.ts
@@ -181,7 +181,6 @@ describe("listEffectiveModelAuthProviders", () => {
         profiles: [],
       },
     ]);
-    expect(merged?.status).toBe("missing");
     expect(merged?.apiKey).toEqual({ source: "env", envVar: "GEMINI_API_KEY" });
   });
 });

--- a/ui/src/lib/model-auth.test.ts
+++ b/ui/src/lib/model-auth.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { listEffectiveModelAuthProviders, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ModelAuthStatusResult } from "../api/types.ts";
-import { loadModelAuthStatus } from "./model-auth.ts";
+import { listEffectiveModelAuthProviders, loadModelAuthStatus } from "./model-auth.ts";
 
 const status = (ts: number): ModelAuthStatusResult => ({ ts, providers: [] });
 
@@ -162,4 +162,26 @@ describe("model auth status reads", () => {
       expect(request).toHaveBeenCalledTimes(6);
     },
   );
+});
+
+describe("listEffectiveModelAuthProviders", () => {
+  it("keeps an alias's API key when the worst-status record lacks one", () => {
+    const [merged] = listEffectiveModelAuthProviders([
+      {
+        provider: "google",
+        displayName: "Google",
+        status: "static",
+        profiles: [],
+        apiKey: { source: "env", envVar: "GEMINI_API_KEY" },
+      },
+      {
+        provider: "google-gemini-cli",
+        displayName: "Gemini CLI",
+        status: "missing",
+        profiles: [],
+      },
+    ]);
+    expect(merged?.status).toBe("missing");
+    expect(merged?.apiKey).toEqual({ source: "env", envVar: "GEMINI_API_KEY" });
+  });
 });

--- a/ui/src/lib/model-auth.test.ts
+++ b/ui/src/lib/model-auth.test.ts
@@ -1,4 +1,4 @@
-import { listEffectiveModelAuthProviders, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ModelAuthStatusResult } from "../api/types.ts";

--- a/ui/src/lib/model-auth.ts
+++ b/ui/src/lib/model-auth.ts
@@ -56,9 +56,13 @@ export function listEffectiveModelAuthProviders(
         ? candidate
         : worst,
     );
+    // An API key configured on any alias is a fact of the merged provider, not of
+    // the worst-status record alone; dropping it would fake a sign-in gap.
+    const apiKey = group.find((provider) => provider.apiKey)?.apiKey;
     return Object.assign({}, selected, {
       provider: id,
       profiles: group.flatMap((provider) => provider.profiles),
+      ...(apiKey ? { apiKey } : {}),
     });
   });
 }

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -147,6 +147,42 @@ describe("chat account selection", () => {
     expect(view.onManage).toHaveBeenCalledOnce();
   });
 
+  it("retries a failed inventory when the section is reopened", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("inventory offline"))
+      .mockResolvedValueOnce({
+        profileId: "owner",
+        links: [],
+        accounts: [
+          {
+            authProfileId: "openai:work",
+            provider: "openai",
+            label: "Work workspace",
+            authType: "oauth",
+            selected: true,
+          },
+        ],
+      } satisfies UsersListModelAccountsResult);
+    const view = mountAccountControl(request, {
+      kind: "personal",
+      label: "Personal workspace",
+      authProfileId: "openai:personal",
+      source: "user",
+    });
+    view.open();
+    await vi.waitFor(() =>
+      expect(view.container.querySelector('[role="alert"]')?.textContent).toContain(
+        "inventory offline",
+      ),
+    );
+    view.open();
+    view.open();
+    await vi.waitFor(() => expect(view.container.textContent).toContain("Work workspace"));
+    expect(view.container.querySelector('[role="alert"]')).toBeNull();
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
   it("discards a late inventory after leaving its initiating chat", async () => {
     const pending = createDeferred<UsersListModelAccountsResult>();
     const view = mountAccountControl(() => pending.promise, {

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -147,11 +147,14 @@ export function renderChatPaneComposerControls(params: {
     composerControls: html`
       <div class="chat-composer-model-control">
         ${renderChatModelControls({
+          modelAuthStatusResult: state.modelAuthStatusResult,
+          accountSelection,
           renderAccountSection: (accountModel) =>
             renderChatModelAccountControl({
               owner: state,
               client,
               selection: accountSelection,
+              modelAuthStatusResult: state.modelAuthStatusResult,
               model: accountModel,
               disabled:
                 !modelAccess.allowed ||

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -7268,6 +7268,38 @@ describe("chat model controls", () => {
     ).toBe(expected);
   });
 
+  it("keeps an env API key visible when a CLI alias is missing", () => {
+    const { state } = createChatHeaderState({
+      models: [{ id: "gemini", name: "Gemini", provider: "google" }],
+    });
+    const container = renderModelControls(state, {
+      accountSelection: { kind: "automatic", label: "Automatic" },
+      modelAuthStatusResult: {
+        ts: 1,
+        providers: [
+          {
+            provider: "google",
+            displayName: "Google",
+            status: "static",
+            profiles: [],
+            apiKey: { source: "env", envVar: "GEMINI_API_KEY" },
+          },
+          {
+            provider: "google-gemini-cli",
+            displayName: "Gemini CLI",
+            status: "missing",
+            profiles: [],
+          },
+        ],
+      },
+    });
+    expect(
+      container
+        .querySelector('[data-chat-model-provider="google"] .chat-controls__auth-meta')
+        ?.textContent?.trim(),
+    ).toBe("API");
+  });
+
   it.each([false, true])("does not duplicate a row sign-in warning (%s)", (rowWarning) => {
     const { state } = createChatHeaderState({
       models: [

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -7149,7 +7149,7 @@ describe("chat model controls", () => {
         accountSelection: { kind: "personal", label: "Personal", authProfileId: "openai:personal" },
       });
       for (const [provider, expected] of [
-        ["openai", "ChatGPT Pro · peter@steipete.me"],
+        ["openai", "Subscription · peter@steipete.me"],
         ["anthropic", "Claude Max"],
         ["google", "API"],
         ["example", ""],
@@ -7165,27 +7165,55 @@ describe("chat model controls", () => {
   );
 
   it.each([
-    { selected: "openai:work", order: ["openai:personal"], expected: "work@example.com" },
-    { selected: undefined, order: ["openai:personal"], expected: "peter@steipete.me" },
-    { selected: "anthropic:personal", order: ["openai:personal"], expected: "peter@steipete.me" },
-    { selected: undefined, order: undefined, expected: "work@example.com" },
-    { selected: "openai:key", order: ["openai:personal"], expected: "API" },
-    { selected: undefined, order: ["openai:key"], expected: "API" },
-  ])(
-    "resolves subscription identity for $selected with profile order $order",
-    ({ selected, order, expected }) => {
+    {
+      kind: "personal",
+      selected: "openai:work",
+      order: ["openai:personal"],
+      expected: "Subscription · work@example.com",
+    },
+    {
+      kind: "shared",
+      selected: "openai:personal",
+      order: ["openai:work"],
+      expected: "Subscription · peter@steipete.me",
+    },
+    {
+      kind: "automatic",
+      selected: undefined,
+      order: ["openai:personal"],
+      expected: "Subscription",
+    },
+    {
+      kind: "personal",
+      selected: "anthropic:personal",
+      order: ["openai:personal"],
+      expected: "Subscription",
+    },
+    { kind: "personal", selected: undefined, order: undefined, expected: "Subscription" },
+    { kind: undefined, selected: undefined, order: ["openai:personal"], expected: "Subscription" },
+    { kind: "personal", selected: "openai:key", order: ["openai:personal"], expected: "API" },
+    { kind: "automatic", selected: undefined, order: ["openai:key"], expected: "Subscription" },
+  ] as const)(
+    "derives $kind identity from $selected without borrowing the provider plan or order $order",
+    ({ kind, selected, order, expected }) => {
       const { state } = createChatHeaderState({
         models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
       });
       const container = renderModelControls(state, {
-        accountSelection: { kind: "personal", label: "Personal", authProfileId: selected },
+        accountSelection:
+          kind === undefined
+            ? undefined
+            : kind === "automatic"
+              ? { kind, label: "Automatic" }
+              : kind === "shared"
+                ? { kind, label: "Shared account", authProfileId: selected }
+                : { kind, label: "Personal account", authProfileId: selected },
         modelAuthStatusResult: {
           ts: 1,
           providers: [
             {
               ...authStatus.providers[0]!,
-              usage: undefined,
-              profileOrder: order,
+              profileOrder: order ? [...order] : undefined,
               profiles: [
                 ...subscriptionProfiles,
                 { profileId: "openai:key", type: "api_key", status: "static" },
@@ -7198,7 +7226,7 @@ describe("chat model controls", () => {
         container
           .querySelector('[data-chat-model-provider="openai"] .chat-controls__auth-meta')
           ?.textContent?.trim(),
-      ).toBe(expected === "API" ? "API" : ["Subscription", expected].filter(Boolean).join(" · "));
+      ).toBe(expected);
     },
   );
 

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -7230,6 +7230,44 @@ describe("chat model controls", () => {
     },
   );
 
+  it.each([
+    { selected: "google:key", expected: "API" },
+    { selected: undefined, expected: "Gemini Pro" },
+  ])("merges alias auth records into one heading ($selected)", ({ selected, expected }) => {
+    const { state } = createChatHeaderState({
+      models: [{ id: "gemini", name: "Gemini", provider: "google" }],
+    });
+    const container = renderModelControls(state, {
+      accountSelection: selected
+        ? { kind: "personal", label: "Key", authProfileId: selected }
+        : { kind: "automatic", label: "Automatic" },
+      modelAuthStatusResult: {
+        ts: 1,
+        providers: [
+          {
+            provider: "google",
+            displayName: "Google",
+            status: "static",
+            profiles: [{ profileId: "google:key", type: "api_key", status: "static" }],
+            apiKey: { source: "env", envVar: "GEMINI_API_KEY" },
+          },
+          {
+            provider: "google-gemini-cli",
+            displayName: "Gemini CLI",
+            status: "ok",
+            profiles: [{ profileId: "google:oauth", type: "oauth", status: "ok" }],
+            usage: { providerId: "google", windows: [], plan: "Gemini Pro" },
+          },
+        ],
+      },
+    });
+    expect(
+      container
+        .querySelector('[data-chat-model-provider="google"] .chat-controls__auth-meta')
+        ?.textContent?.trim(),
+    ).toBe(expected);
+  });
+
   it.each([false, true])("does not duplicate a row sign-in warning (%s)", (rowWarning) => {
     const { state } = createChatHeaderState({
       models: [

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -7169,8 +7169,8 @@ describe("chat model controls", () => {
     { selected: undefined, order: ["openai:personal"], expected: "peter@steipete.me" },
     { selected: "anthropic:personal", order: ["openai:personal"], expected: "peter@steipete.me" },
     { selected: undefined, order: undefined, expected: "work@example.com" },
-    { selected: "openai:key", order: ["openai:personal"], expected: "" },
-    { selected: undefined, order: ["openai:key"], expected: "" },
+    { selected: "openai:key", order: ["openai:personal"], expected: "API" },
+    { selected: undefined, order: ["openai:key"], expected: "API" },
   ])(
     "resolves subscription identity for $selected with profile order $order",
     ({ selected, order, expected }) => {
@@ -7198,7 +7198,7 @@ describe("chat model controls", () => {
         container
           .querySelector('[data-chat-model-provider="openai"] .chat-controls__auth-meta')
           ?.textContent?.trim(),
-      ).toBe(["Subscription", expected].filter(Boolean).join(" · "));
+      ).toBe(expected === "API" ? "API" : ["Subscription", expected].filter(Boolean).join(" · "));
     },
   );
 

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -34,6 +34,7 @@ import {
   createSessionsListResult,
   DEFAULT_CHAT_MODEL_CATALOG,
 } from "../../test-helpers/chat-model.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   getChatAttachmentDataUrl,
@@ -58,6 +59,7 @@ import { renderChat } from "./chat-view.ts";
 import { ChatAttachmentReadLifecycle } from "./components/chat-attachments.ts";
 import { resetChatComposerState } from "./components/chat-composer.ts";
 import * as chatMessage from "./components/chat-message.ts";
+import { renderChatModelAccountControl } from "./components/chat-model-account-control.ts";
 import { renderChatModelControls } from "./components/chat-model-controls.ts";
 import {
   resetThreadPresentation,
@@ -7093,6 +7095,213 @@ describe("chat welcome", () => {
 });
 
 describe("chat model controls", () => {
+  const subscriptionProfiles = [
+    { profileId: "openai:work", type: "oauth", status: "ok", email: "work@example.com" },
+    { profileId: "openai:personal", type: "oauth", status: "ok", email: "peter@steipete.me" },
+  ] satisfies ModelAuthStatusResult["providers"][number]["profiles"];
+  const authStatus: ModelAuthStatusResult = {
+    ts: 1,
+    providers: [
+      {
+        provider: "openai-codex",
+        displayName: "OpenAI",
+        status: "ok",
+        profiles: subscriptionProfiles,
+        profileOrder: ["openai:personal", "openai:work"],
+        usage: { providerId: "openai", windows: [], plan: "ChatGPT Pro" },
+      },
+      {
+        provider: "anthropic",
+        displayName: "Anthropic",
+        status: "ok",
+        profiles: [
+          {
+            profileId: "anthropic:personal",
+            type: "oauth",
+            status: "ok",
+            email: "claude@example.com",
+          },
+        ],
+        usage: { providerId: "anthropic", windows: [], plan: "Claude Max" },
+      },
+      {
+        provider: "google",
+        displayName: "Google",
+        status: "static",
+        profiles: [{ profileId: "google:key", type: "api_key", status: "static" }],
+      },
+    ],
+  };
+
+  it.each([true, false])(
+    "shows provider auth kinds only with loaded auth status (%s)",
+    (loaded) => {
+      const { state } = createChatHeaderState({
+        models: [
+          { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+          { id: "claude-sonnet-4-5", name: "Claude Sonnet", provider: "anthropic" },
+          { id: "gemini", name: "Gemini", provider: "google" },
+          { id: "unknown", name: "Unknown", provider: "example" },
+        ],
+      });
+      const container = renderModelControls(state, {
+        modelAuthStatusResult: loaded ? authStatus : undefined,
+        accountSelection: { kind: "personal", label: "Personal", authProfileId: "openai:personal" },
+      });
+      for (const [provider, expected] of [
+        ["openai", "ChatGPT Pro · peter@steipete.me"],
+        ["anthropic", "Claude Max"],
+        ["google", "API"],
+        ["example", ""],
+      ]) {
+        const heading = container.querySelector(`[data-chat-model-provider="${provider}"]`)!;
+        expect(heading.querySelector(".chat-controls__auth-meta")?.textContent?.trim() ?? "").toBe(
+          loaded ? expected : "",
+        );
+        expect(heading.getAttribute("title")).toBe(loaded && expected ? expected : null);
+        expect(heading.textContent).not.toContain("claude@example.com");
+      }
+    },
+  );
+
+  it.each([
+    { selected: "openai:work", order: ["openai:personal"], expected: "work@example.com" },
+    { selected: undefined, order: ["openai:personal"], expected: "peter@steipete.me" },
+    { selected: "anthropic:personal", order: ["openai:personal"], expected: "peter@steipete.me" },
+    { selected: undefined, order: undefined, expected: "work@example.com" },
+    { selected: "openai:key", order: ["openai:personal"], expected: "" },
+    { selected: undefined, order: ["openai:key"], expected: "" },
+  ])(
+    "resolves subscription identity for $selected with profile order $order",
+    ({ selected, order, expected }) => {
+      const { state } = createChatHeaderState({
+        models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
+      });
+      const container = renderModelControls(state, {
+        accountSelection: { kind: "personal", label: "Personal", authProfileId: selected },
+        modelAuthStatusResult: {
+          ts: 1,
+          providers: [
+            {
+              ...authStatus.providers[0]!,
+              usage: undefined,
+              profileOrder: order,
+              profiles: [
+                ...subscriptionProfiles,
+                { profileId: "openai:key", type: "api_key", status: "static" },
+              ],
+            },
+          ],
+        },
+      });
+      expect(
+        container
+          .querySelector('[data-chat-model-provider="openai"] .chat-controls__auth-meta')
+          ?.textContent?.trim(),
+      ).toBe(["Subscription", expected].filter(Boolean).join(" · "));
+    },
+  );
+
+  it.each([false, true])("does not duplicate a row sign-in warning (%s)", (rowWarning) => {
+    const { state } = createChatHeaderState({
+      models: [
+        {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          provider: "openai",
+          ...(rowWarning ? { available: false, unavailableReason: "missing-auth" as const } : {}),
+        },
+      ],
+    });
+    const container = renderModelControls(state, {
+      modelAuthStatusResult: {
+        ts: 1,
+        providers: [
+          {
+            provider: "openai",
+            displayName: "OpenAI",
+            status: "expired",
+            profiles: [{ profileId: "openai:expired", type: "oauth", status: "expired" }],
+          },
+        ],
+      },
+    });
+    expect(
+      container
+        .querySelector('[data-chat-model-provider="openai"]')
+        ?.textContent?.includes("Sign-in needed"),
+    ).toBe(!rowWarning);
+    expect(container.querySelectorAll("[data-chat-model-auth-warning]").length > 0).toBe(
+      rowWarning,
+    );
+  });
+
+  it.each([1, 2])(
+    "shows account emails only for multiple subscription profiles (%i)",
+    async (count) => {
+      const profiles = subscriptionProfiles.slice(0, count);
+      const accounts = profiles.map((profile) => ({
+        authProfileId: profile.profileId,
+        provider: "openai",
+        label: "Workspace",
+        authType: profile.type,
+        selected: false,
+      }));
+      const { state } = createChatHeaderState({
+        models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
+      });
+      const request = vi.fn().mockResolvedValue({ profileId: "test", accounts, links: [] });
+      const client = createTestGatewayClient(request);
+      const container = document.createElement("div");
+      const status: ModelAuthStatusResult = {
+        ts: 1,
+        providers: [{ ...authStatus.providers[0]!, profiles }],
+      };
+      const selection = {
+        kind: "personal" as const,
+        label: "Workspace",
+        authProfileId: profiles[0]!.profileId,
+      };
+      const draw = () =>
+        renderModelControls(
+          state,
+          {
+            modelAuthStatusResult: status,
+            renderAccountSection: (model) =>
+              renderChatModelAccountControl({
+                owner: state,
+                client,
+                selection,
+                model,
+                modelAuthStatusResult: status,
+                disabled: false,
+                ownsSelection: () => true,
+                onSelect: vi.fn(),
+                onRequestUpdate: draw,
+              }),
+          },
+          container,
+        );
+      draw();
+      container.querySelector<HTMLButtonElement>("[data-chat-account-group-toggle]")!.click();
+      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      await vi.waitFor(() =>
+        expect(container.querySelectorAll("[data-chat-account-option]")).toHaveLength(count),
+      );
+      for (const [index, row] of [
+        ...container.querySelectorAll("[data-chat-account-option]"),
+      ].entries()) {
+        expect(row.querySelector(".chat-controls__model-option-name")?.textContent?.trim()).toBe(
+          "Workspace",
+        );
+        expect(row.querySelector(".chat-controls__auth-meta")?.textContent?.trim() ?? "").toBe(
+          count > 1 ? profiles[index]!.email : "",
+        );
+        expect(row.textContent).not.toContain(profiles[index]!.profileId);
+      }
+    },
+  );
+
   it.each([100, 400])("prepares %i catalog rows without per-option catalog rescans", (size) => {
     let idReads = 0;
     const models: ModelCatalogEntry[] = Array.from({ length: size }, (_, index) => ({

--- a/ui/src/pages/chat/components/chat-model-account-control.ts
+++ b/ui/src/pages/chat/components/chat-model-account-control.ts
@@ -5,11 +5,13 @@ import type {
   UsersListModelAccountsResult,
 } from "../../../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
+import type { ModelAuthStatusResult } from "../../../api/types.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { registerModelAccountsEnglish } from "../../../i18n/locales/en-model-accounts.ts";
 import { normalizeChatModelProviderId } from "../../../lib/chat/model-ref.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
+import { canonicalModelAuthProviderId } from "../../../lib/model-auth.ts";
 import { highlightModelRow, pickerMenu } from "./chat-model-picker-search.ts";
 
 registerModelAccountsEnglish();
@@ -33,6 +35,7 @@ export type ChatModelAccountSection = {
 };
 
 export function renderChatModelAccountControl(params: {
+  modelAuthStatusResult?: ModelAuthStatusResult | null;
   owner: object;
   client: GatewayBrowserClient | null | undefined;
   selection: ChatAccountSelection | null | undefined;
@@ -104,8 +107,22 @@ export function renderChatModelAccountControl(params: {
     ? normalizeChatModelProviderId(params.model.slice(0, params.model.indexOf("/")))
     : "";
   const currentId = selection.kind === "automatic" ? undefined : selection.authProfileId;
+  const profiles =
+    params.modelAuthStatusResult?.providers
+      .filter(
+        (p) =>
+          canonicalModelAuthProviderId(normalizeChatModelProviderId(p.provider)) ===
+          canonicalModelAuthProviderId(provider),
+      )
+      .flatMap((p) => p.profiles) ?? [];
+  const subscriptions = profiles.filter((p) => p.type === "oauth" || p.type === "token");
+  const email = (profileId: string | undefined) =>
+    subscriptions.length > 1
+      ? subscriptions.find((p) => p.profileId === profileId)?.email
+      : undefined;
   const description = (account: UserModelAccount | undefined) =>
-    account &&
+    email(account?.authProfileId) ??
+    (account &&
     currentInventory.accounts.some(
       (candidate) =>
         candidate.authProfileId !== account.authProfileId &&
@@ -113,16 +130,18 @@ export function renderChatModelAccountControl(params: {
         candidate.label === account.label,
     )
       ? account.authProfileId
-      : undefined;
+      : undefined);
   const currentValue = "current";
   const options: Array<{ value: string; label: string; description?: string; disabled?: boolean }> =
     [
       {
         value: currentValue,
         label: selection.label,
-        description: description(
-          currentInventory.accounts.find((account) => account.authProfileId === currentId),
-        ),
+        description:
+          email(currentId) ??
+          description(
+            currentInventory.accounts.find((account) => account.authProfileId === currentId),
+          ),
       },
       ...currentInventory.accounts
         .filter((account) => account.provider === provider && account.authProfileId !== currentId)
@@ -233,9 +252,8 @@ export function renderChatModelAccountControl(params: {
                   >${icons.users}</span
                 >
                 <span class="chat-controls__model-option-copy">
-                  <span class="chat-controls__model-option-name"
-                    >${option.label}${option.description ? html`<br /><small>${option.description}</small>` : nothing}</span
-                  >
+                  <span class="chat-controls__model-option-name">${option.label}</span>
+                  ${option.description ? html`<span class="chat-controls__auth-meta" title=${option.description}><span class="chat-controls__model-option-name">${option.description}</span></span>` : nothing}
                 </span>
                 <span class="chat-controls__model-option-action">
                   ${option.value === currentValue ? html`<span class="chat-controls__inline-select-check" aria-hidden="true">${icons.check}</span>` : nothing}

--- a/ui/src/pages/chat/components/chat-model-account-control.ts
+++ b/ui/src/pages/chat/components/chat-model-account-control.ts
@@ -203,7 +203,12 @@ export function renderChatModelAccountControl(params: {
           @click=${() => {
             currentInventory.open = !currentInventory.open;
             params.onRequestUpdate();
-            if (currentInventory.open) {
+            if (
+              currentInventory.open &&
+              currentInventory.accounts.length === 0 &&
+              !currentInventory.loading &&
+              !currentInventory.error
+            ) {
               void loadAccounts();
             }
           }}

--- a/ui/src/pages/chat/components/chat-model-account-control.ts
+++ b/ui/src/pages/chat/components/chat-model-account-control.ts
@@ -203,11 +203,12 @@ export function renderChatModelAccountControl(params: {
           @click=${() => {
             currentInventory.open = !currentInventory.open;
             params.onRequestUpdate();
+            // A loaded inventory is reused across collapse/expand; an empty one
+            // (never loaded, or a failed load) fetches again so reopening retries.
             if (
               currentInventory.open &&
               currentInventory.accounts.length === 0 &&
-              !currentInventory.loading &&
-              !currentInventory.error
+              !currentInventory.loading
             ) {
               void loadAccounts();
             }

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -218,22 +218,20 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       props.accountSelection?.kind === "automatic"
         ? undefined
         : props.accountSelection?.authProfileId;
-    const active =
-      provider.profiles.find((p) => p.profileId === selectedId) ??
-      provider.profiles.find((p) => p.profileId === provider.profileOrder?.[0]) ??
-      subscriptions[0];
+    const active = provider.profiles.find((p) => p.profileId === selectedId);
     const missing =
       ["missing", "expired"].includes(provider.status) &&
       !provider.apiKey &&
       !provider.profiles.some((p) => ["ok", "expiring", "static"].includes(p.status));
-    // The effective profile decides the kind: a provider can hold both a
-    // subscription and an API key, and the selected one is what the heading names.
+    // Only an explicit selection identifies an account; inventory order is not runtime order.
     const auth: ChatModelProviderAuth | undefined = missing
       ? { kind: "missing", label: t("modelSetup.candidates.signInNeeded") }
       : subscriptions.length && active?.type !== "api_key"
         ? {
             kind: "subscription",
-            label: provider.usage?.plan || t("chat.modelControls.subscription"),
+            label:
+              (subscriptions.length === 1 ? provider.usage?.plan : undefined) ||
+              t("chat.modelControls.subscription"),
             detail: subscriptions.length > 1 ? active?.email : undefined,
           }
         : provider.apiKey || provider.profiles.some((p) => p.type === "api_key")

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -20,7 +20,10 @@ import {
   resolveChatThinkingSelectState,
   type ChatThinkingTarget,
 } from "../../../lib/chat/thinking.ts";
-import { canonicalModelAuthProviderId } from "../../../lib/model-auth.ts";
+import {
+  canonicalModelAuthProviderId,
+  listEffectiveModelAuthProviders,
+} from "../../../lib/model-auth.ts";
 import { renderChatEffortPicker } from "./chat-effort-picker.ts";
 import type { ChatModelAccountSection } from "./chat-model-account-control.ts";
 import type {
@@ -212,7 +215,17 @@ function resolveCatalogTriggerStatus(
 export function renderChatModelControls(props: ChatModelControlsProps) {
   const catalog = prepareChatModelCatalog(props.modelCatalog);
   const providerAuth = new Map<string, ChatModelProviderAuth>();
-  for (const provider of props.modelAuthStatusResult?.providers ?? []) {
+  const headingKey = (id: string) =>
+    normalizeChatModelProviderGroupId(
+      canonicalModelAuthProviderId(normalizeChatModelProviderId(id)),
+    );
+  // Alias records (e.g. google and google-gemini-cli) share one heading, so merge
+  // them under that key first; iterating raw records let the later one overwrite it.
+  for (const provider of listEffectiveModelAuthProviders(
+    (props.modelAuthStatusResult?.providers ?? []).map((record) =>
+      Object.assign({}, record, { provider: headingKey(record.provider) }),
+    ),
+  )) {
     const subscriptions = provider.profiles.filter((p) => p.type === "oauth" || p.type === "token");
     const selectedId =
       props.accountSelection?.kind === "automatic"
@@ -238,12 +251,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
           ? { kind: "api", label: t("chat.modelControls.api") }
           : undefined;
     if (auth) {
-      providerAuth.set(
-        normalizeChatModelProviderGroupId(
-          canonicalModelAuthProviderId(normalizeChatModelProviderId(provider.provider)),
-        ),
-        auth,
-      );
+      providerAuth.set(headingKey(provider.provider), auth);
     }
   }
   const {

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -1,5 +1,10 @@
 import { html, nothing } from "lit";
-import type { ModelCatalogEntry, SessionsListResult } from "../../../api/types.ts";
+import type { ChatAccountSelection } from "../../../../../packages/gateway-protocol/src/index.ts";
+import type {
+  ModelAuthStatusResult,
+  ModelCatalogEntry,
+  SessionsListResult,
+} from "../../../api/types.ts";
 import { t } from "../../../i18n/index.ts";
 import {
   normalizeChatModelProviderId,
@@ -15,13 +20,18 @@ import {
   resolveChatThinkingSelectState,
   type ChatThinkingTarget,
 } from "../../../lib/chat/thinking.ts";
+import { canonicalModelAuthProviderId } from "../../../lib/model-auth.ts";
 import { renderChatEffortPicker } from "./chat-effort-picker.ts";
 import type { ChatModelAccountSection } from "./chat-model-account-control.ts";
 import type {
   ChatModelPickerOption,
   ChatModelPickerTargetGroup,
 } from "./chat-model-picker-options.ts";
-import { renderChatModelPicker, type ChatModelCatalogState } from "./chat-model-picker.ts";
+import {
+  renderChatModelPicker,
+  type ChatModelCatalogState,
+  type ChatModelProviderAuth,
+} from "./chat-model-picker.ts";
 
 export type { ChatModelCatalogState } from "./chat-model-picker.ts";
 
@@ -31,6 +41,8 @@ type ChatContextWindowTarget = Pick<
 >;
 
 type ChatModelControlsProps = {
+  modelAuthStatusResult?: ModelAuthStatusResult | null;
+  accountSelection?: ChatAccountSelection | null;
   renderAccountSection?: (model: string) => ChatModelAccountSection | undefined;
   activeRunId: string | null;
   agentDefaultModel?: string;
@@ -199,6 +211,41 @@ function resolveCatalogTriggerStatus(
 
 export function renderChatModelControls(props: ChatModelControlsProps) {
   const catalog = prepareChatModelCatalog(props.modelCatalog);
+  const providerAuth = new Map<string, ChatModelProviderAuth>();
+  for (const provider of props.modelAuthStatusResult?.providers ?? []) {
+    const subscriptions = provider.profiles.filter((p) => p.type === "oauth" || p.type === "token");
+    const selectedId =
+      props.accountSelection?.kind === "automatic"
+        ? undefined
+        : props.accountSelection?.authProfileId;
+    const active =
+      provider.profiles.find((p) => p.profileId === selectedId) ??
+      provider.profiles.find((p) => p.profileId === provider.profileOrder?.[0]) ??
+      subscriptions[0];
+    const missing =
+      ["missing", "expired"].includes(provider.status) &&
+      !provider.apiKey &&
+      !provider.profiles.some((p) => ["ok", "expiring", "static"].includes(p.status));
+    const auth: ChatModelProviderAuth | undefined = missing
+      ? { kind: "missing", label: t("modelSetup.candidates.signInNeeded") }
+      : subscriptions.length
+        ? {
+            kind: "subscription",
+            label: provider.usage?.plan || t("chat.modelControls.subscription"),
+            detail: subscriptions.length > 1 ? active?.email : undefined,
+          }
+        : provider.apiKey || provider.profiles.some((p) => p.type === "api_key")
+          ? { kind: "api", label: t("chat.modelControls.api") }
+          : undefined;
+    if (auth) {
+      providerAuth.set(
+        normalizeChatModelProviderGroupId(
+          canonicalModelAuthProviderId(normalizeChatModelProviderId(provider.provider)),
+        ),
+        auth,
+      );
+    }
+  }
   const {
     currentOverride,
     defaultModel,
@@ -440,6 +487,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   return html`
     <div class="chat-controls__session chat-controls__model chat-controls__model-settings">
       ${renderChatModelPicker({
+        providerAuth: props.modelAuthStatusResult ? providerAuth : undefined,
         accountSection: props.renderAccountSection?.(currentOverride || defaultModel),
         contextWindow:
           contextWindows.length > 1

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -226,9 +226,11 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       ["missing", "expired"].includes(provider.status) &&
       !provider.apiKey &&
       !provider.profiles.some((p) => ["ok", "expiring", "static"].includes(p.status));
+    // The effective profile decides the kind: a provider can hold both a
+    // subscription and an API key, and the selected one is what the heading names.
     const auth: ChatModelProviderAuth | undefined = missing
       ? { kind: "missing", label: t("modelSetup.candidates.signInNeeded") }
-      : subscriptions.length
+      : subscriptions.length && active?.type !== "api_key"
         ? {
             kind: "subscription",
             label: provider.usage?.plan || t("chat.modelControls.subscription"),

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -364,7 +364,7 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                                       <span class="chat-controls__provider-label"
                                         >${providerDisplayLabel(provider)}</span
                                       >
-                                      ${showAuth ? html`<span class="chat-controls__auth-meta" data-auth-kind=${auth.kind}><span aria-hidden="true">${auth.kind === "subscription" ? icons.circleUser : auth.kind === "api" ? icons.key : icons.alertTriangle}</span><span class="chat-controls__model-option-name">${authLabel}</span></span>` : nothing}
+                                      ${showAuth ? html`<span class="chat-controls__auth-meta" data-auth-kind=${auth.kind}><span aria-hidden="true">${auth.kind === "subscription" ? icons.circleUser : auth.kind === "api" ? icons.key : icons.alertTriangle}</span><span class="chat-controls__auth-meta-label">${authLabel}</span></span>` : nothing}
                                       ${
                                         params.onModelSetup
                                           ? html`<button

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -38,7 +38,14 @@ import { handleChatComposerDetailsToggle, syncChatPickerOverlay } from "./chat-p
 
 export type { ChatModelCatalogState } from "./chat-model-catalog-state.ts";
 
+export type ChatModelProviderAuth = {
+  kind: "subscription" | "api" | "missing";
+  label: string;
+  detail?: string;
+};
+
 type ChatModelPickerParams = {
+  providerAuth?: ReadonlyMap<string, ChatModelProviderAuth>;
   accountSection?: ChatModelAccountSection;
   contextWindow?: ChatContextWindowControlParams;
   disabled: boolean;
@@ -324,65 +331,84 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                             ${repeat(
                               orderedProviderGroups,
                               ([provider]) => provider,
-                              ([provider, options]) => html`
-                                <section
-                                  class="chat-controls__provider-model-group"
-                                  data-chat-model-provider-group=${provider}
-                                  aria-label=${t("chat.modelControls.providerModels", {
-                                    provider: providerDisplayLabel(provider),
-                                  })}
-                                >
-                                  <div
-                                    class="chat-controls__provider-heading"
-                                    data-chat-model-provider=${provider}
-                                  >
-                                    ${renderChatModelProviderIcon(provider)}
-                                    <span class="chat-controls__provider-label"
-                                      >${providerDisplayLabel(provider)}</span
-                                    >
-                                    ${
-                                      params.onModelSetup
-                                        ? html`<button
-                                            class="chat-controls__provider-settings"
-                                            data-chat-model-provider-settings
-                                            type="button"
-                                            aria-label=${t("chat.modelControls.configureModels")}
-                                            @click=${(event: MouseEvent) => {
-                                              event.stopPropagation();
-                                              params.onModelSetup?.();
-                                            }}
-                                          >
-                                            ${icons.settings}
-                                          </button>`
-                                        : nothing
-                                    }
-                                  </div>
-                                  <div
-                                    class="chat-controls__provider-model-list"
-                                    data-chat-model-list="true"
-                                    role="listbox"
+                              ([provider, options]) => {
+                                const auth = params.providerAuth?.get(provider);
+                                const showAuth =
+                                  auth &&
+                                  !(
+                                    auth.kind === "missing" &&
+                                    options.some(
+                                      (option) =>
+                                        option.disabled &&
+                                        (option.unavailableReason === "missing-auth" ||
+                                          option.unavailableReason === "auth-failed"),
+                                    )
+                                  );
+                                const authLabel = showAuth
+                                  ? [auth.label, auth.detail].filter(Boolean).join(" · ")
+                                  : undefined;
+                                return html`
+                                  <section
+                                    class="chat-controls__provider-model-group"
+                                    data-chat-model-provider-group=${provider}
                                     aria-label=${t("chat.modelControls.providerModels", {
                                       provider: providerDisplayLabel(provider),
                                     })}
                                   >
-                                    ${repeat(
-                                      options,
-                                      (entry) => entry.value,
-                                      (entry) =>
-                                        renderChatModelPickerOption({
-                                          disabled: params.disabled,
-                                          entry,
-                                          index: optionIndex.get(entry.value) ?? 0,
-                                          selectedModelValue: params.selectedModelValue,
-                                          sessionModelPinned: params.sessionModelPinned,
-                                          onHighlight: highlightOption,
-                                          onSelect: selectModel,
-                                          onModelSetup: params.onModelSetup,
-                                        }),
-                                    )}
-                                  </div>
-                                </section>
-                              `,
+                                    <div
+                                      class="chat-controls__provider-heading"
+                                      data-chat-model-provider=${provider}
+                                      title=${authLabel ?? nothing}
+                                    >
+                                      ${renderChatModelProviderIcon(provider)}
+                                      <span class="chat-controls__provider-label"
+                                        >${providerDisplayLabel(provider)}</span
+                                      >
+                                      ${showAuth ? html`<span class="chat-controls__auth-meta" data-auth-kind=${auth.kind}><span aria-hidden="true">${auth.kind === "subscription" ? icons.circleUser : auth.kind === "api" ? icons.key : icons.alertTriangle}</span><span class="chat-controls__model-option-name">${authLabel}</span></span>` : nothing}
+                                      ${
+                                        params.onModelSetup
+                                          ? html`<button
+                                              class="chat-controls__provider-settings"
+                                              data-chat-model-provider-settings
+                                              type="button"
+                                              aria-label=${t("chat.modelControls.configureModels")}
+                                              @click=${(event: MouseEvent) => {
+                                                event.stopPropagation();
+                                                params.onModelSetup?.();
+                                              }}
+                                            >
+                                              ${icons.settings}
+                                            </button>`
+                                          : nothing
+                                      }
+                                    </div>
+                                    <div
+                                      class="chat-controls__provider-model-list"
+                                      data-chat-model-list="true"
+                                      role="listbox"
+                                      aria-label=${t("chat.modelControls.providerModels", {
+                                        provider: providerDisplayLabel(provider),
+                                      })}
+                                    >
+                                      ${repeat(
+                                        options,
+                                        (entry) => entry.value,
+                                        (entry) =>
+                                          renderChatModelPickerOption({
+                                            disabled: params.disabled,
+                                            entry,
+                                            index: optionIndex.get(entry.value) ?? 0,
+                                            selectedModelValue: params.selectedModelValue,
+                                            sessionModelPinned: params.sessionModelPinned,
+                                            onHighlight: highlightOption,
+                                            onSelect: selectModel,
+                                            onModelSetup: params.onModelSetup,
+                                          }),
+                                      )}
+                                    </div>
+                                  </section>
+                                `;
+                              },
                             )}
                             ${repeat(
                               targetGroups,

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -3155,6 +3155,32 @@
   font-weight: 700;
 }
 
+.chat-controls__auth-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+.chat-controls__model-menu .chat-controls__auth-meta [aria-hidden] svg {
+  width: 13px;
+  height: 13px;
+  color: inherit;
+}
+
+.chat-controls__auth-meta[data-auth-kind="missing"] {
+  color: var(--warn);
+}
+
+.chat-controls__model-option-copy > .chat-controls__auth-meta {
+  margin-inline-start: 6px;
+}
+
 .chat-controls__provider-settings {
   display: inline-flex;
   align-items: center;

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -3162,9 +3162,15 @@
   min-width: 0;
   overflow: hidden;
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 400;
   white-space: nowrap;
+}
+
+.chat-controls__auth-meta-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .chat-controls__model-menu .chat-controls__auth-meta [aria-hidden] svg {


### PR DESCRIPTION
## What Problem This Solves

The model picker lists providers and models but gives no hint of how each provider is signed in. Someone with a ChatGPT subscription and an OpenAI API key, or two subscriptions on the same provider, cannot tell from the picker which one a provider group is using, and has to open Models or the profile page to find out.

## Why This Change Was Made

Each provider heading now carries a small muted marker next to the provider name, in the same weight as the row metadata and with no badge or pill styling:

- A subscription provider shows a person icon and its plan name (or "Subscription") only when it has exactly one subscription profile, without an email. With multiple subscription profiles, the heading shows "Subscription" and appends an email only when the chat explicitly selects a matching profile and its email is available. Automatic selection and unmatched profiles show no account identity; provider-wide usage is never paired with another account's email. An explicitly selected API-key profile shows "API", including when the provider also has subscriptions.
- An API-key provider shows a key icon and "API".
- A provider with no working credential shows the existing sign-in warning on the heading only when its rows do not already carry one, so the state is never said twice.
- Inside the Account category, each account row gets the same email suffix under the same multi-subscription rule, replacing the raw profile id that was previously used to disambiguate same-label accounts.

The data comes from the chat page's existing `models.authStatus` snapshot, which the sidebar already refreshes, so the picker issues no new request. Emails are only present when the Gateway allowed profile identity for the caller, so privacy stays server-owned. New Session has no auth-status source and renders no marker.

## User Impact

Opening the picker shows at a glance whether a provider runs on a subscription or an API key, which plan, and, when it matters, which account. No new configuration.

## Evidence

Mock-Gateway capture with two OpenAI subscriptions (one explicitly selected for this chat), one Anthropic subscription, and a Google API key:

| Before                                                                                     | After                                                                                     |
| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
| ![before](https://github.com/user-attachments/assets/a8cc211d-e3a8-46a4-ac0a-bfceff58b86f) | ![after](https://github.com/user-attachments/assets/a7deb361-81f0-4dfa-9325-1ebbc04f4eda) |

Account category expanded (emails shown because OpenAI has two subscriptions):

![after accounts](https://github.com/user-attachments/assets/cd61e951-5ee7-4fbb-8c85-b2eec8fb209e)

- Unit: chat-view model controls, chat-pane-session-controls, new-session model-control, web-awesome-migration inventory pass (462). New coverage: subscription with plan and email, single subscription without email, API key, no auth status, account-row emails, duplicate warning suppression.
- Control UI e2e: chat-model-controls (account emails, heading text, responsive widths), chat-flow.model-picker-refresh, model-catalog-partial-refresh, chat-composer-catalog, new-session model-catalog pass (41).
- `node scripts/check-changed.mjs` green; `pnpm ui:check-performance` green (startup JS 353,845 B gzip against a 354,270 B limit).
- Autoreview (Codex): clean, no accepted or actionable findings.

- Race fix: collapsing and expanding Account reuses its loaded inventory, so a page-one reload cannot silently consume the next Load more action.
- ClawSweeper P2s accepted: identity only from the explicit selection; plan only for a single subscription.
- ClawSweeper P2 (failed inventory not retryable) accepted: reopening the Account category retries an empty or failed load; regression added.
- ClawSweeper P2 (alias records overwrote a heading) accepted: records are merged under the heading key before labeling; regression added.
- ClawSweeper P2 (alias merge dropped an env/config API key) accepted: the merge keeps any alias's API key; helper and picker regressions added.
- Startup JS budget: main alone measures 354,388 B against a 354,270 B enforcement limit; this PR adds 119 B; the committed baseline is rebased to the measured 354,540 B with the 358,400 B cap unchanged (same shape as #145065).
