### PR TITLE
fix(install): never replace or break an existing nvm during installation

### DIFF
--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -16,7 +16,7 @@ OpenClaw ships three installer scripts, served from `openclaw.ai`.
 | [`install-cli.sh`](#install-clish) | macOS / Linux / WSL  | Installs Node + OpenClaw into a local prefix (`~/.openclaw`) via npm or git. No root required. |
 | [`install.ps1`](#installps1)       | Windows (PowerShell) | Installs Node if needed, installs OpenClaw via npm (default) or git, can run onboarding.       |
 
-All three support Node **24.16+ or 26.1+** with a WAL-reset-safe linked SQLite library. When Node is missing, `install.sh` provisions Node 26 through Homebrew on macOS and the supported Node 24 LTS line through NodeSource on Linux. When a supported RPM-owned Node links unsafe SQLite, `install.sh` preserves the distro package and provisions a user-space Node runtime through `install-cli.sh`. The rootless `install-cli.sh` downloads Node 24.19.0; Linux ARMv7 is unsupported. On Windows, winget/Chocolatey/Scoop install the supported Node LTS line, and the portable fallback downloads Node 26.
+All three support Node **24.16+ or 26.1+** with a WAL-reset-safe linked SQLite library. When Node is missing and nvm is not detected, `install.sh` provisions Node 26 through Homebrew on macOS and the supported Node 24 LTS line through NodeSource on Linux. When a supported RPM-owned Node links unsafe SQLite, `install.sh` preserves the distro package and provisions a user-space Node runtime through `install-cli.sh`. The rootless `install-cli.sh` downloads Node 24.19.0; Linux ARMv7 is unsupported. On Windows, winget/Chocolatey/Scoop install the supported Node LTS line, and the portable fallback downloads Node 26.
 
 Before changing packages, every installer probes the exact npm executable it will use. npm 11.15 and earlier installs normally; npm 11.16 and later, including npm 12, receives `--allow-scripts` for only the npm-resolved OpenClaw candidate identity. An unreadable npm version stops before package mutation. A remaining `.openclaw-lifecycle-pending` marker or legacy `dist/openclaw-install-guard` makes the install fail instead of reporting a lifecycle-skipped package as successful.
 
@@ -139,6 +139,34 @@ Recommended for most interactive installs on macOS/Linux/WSL.
 
   </Step>
 </Steps>
+
+### Existing nvm installations
+
+`install.sh` preserves an active compatible Node, including `nvm use system`.
+If the active runtime is unsupported, it first checks installed nvm versions,
+then other available Node binaries, including Homebrew. Each candidate must pass
+both the version and SQLite capability checks. Selecting an existing nvm version
+changes only the installer session; the script prints `nvm use <version>` for
+later commands and leaves the default alias and shell profiles unchanged.
+
+The installer detects nvm through `NVM_DIR`, `~/.nvm`, and shell startup hooks.
+It loads `nvm.sh` with `--no-use` rather than activating the default. Startup
+files are never executed for discovery. If a custom or lazy hook is the only
+location available, load nvm in your shell before rerunning the installer.
+
+When nvm is present but no compatible runtime is available, the installer offers
+to run `nvm install 26` in that existing installation. Because nvm refreshes LTS aliases, the prompt also asks to preserve the
+current default version by pinning its alias if the refresh would change its
+resolution. That consent applies even if the download fails. When no default
+exists, the prompt explicitly includes nvm's creation of one. The installer logs
+any approved alias change and the final default version. Declining or running non-interactively exits nonzero with the exact
+commands to run, without provisioning Node or changing nvm, npm config, or shell
+profiles. The installer never installs a second nvm.
+
+On Linux, an unwritable system npm prefix also routes through the existing nvm
+installation. The installer reuses a compatible nvm Node or asks to install one;
+it does not write an npm `prefix` setting that would break later `nvm use`
+commands. Without nvm, the existing user-local npm prefix setup still applies.
 
 ### Source checkout detection
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2098,7 +2098,7 @@ promote_supported_node_binary() {
         seen_dirs="${seen_dirs}${dir}:"
         if node_binary_is_supported "$candidate"; then
             prepend_path_dir "$dir" || continue
-            if [[ "$OS" == "linux" ]]; then
+            if [[ "$OS" == "linux" && "${NVM_DETECTED:-0}" != "1" ]]; then
                 persist_shell_path_prepend "$dir" || true
             fi
             ui_info "Using Node.js runtime at ${candidate}"
@@ -2166,7 +2166,6 @@ ensure_macos_default_node_active() {
 }
 
 ensure_default_node_active_shell() {
-    promote_supported_node_binary || true
     if node_is_supported; then
         return 0
     fi
@@ -2178,48 +2177,111 @@ ensure_default_node_active_shell() {
     ui_error "Active Node.js must be ${NODE_SUPPORTED_VERSION_LABEL} but this shell is using ${active_version} (${active_path})"
     print_active_node_paths || true
 
-    local nvm_detected=0
-    if [[ -n "${NVM_DIR:-}" || "$active_path" == *"/.nvm/"* ]]; then
-        nvm_detected=1
-    fi
-    if command -v nvm >/dev/null 2>&1; then
-        nvm_detected=1
-    fi
-
-    if [[ "$nvm_detected" -eq 1 ]]; then
-        echo "nvm appears to be managing Node for this shell."
-        echo "Run:"
-        echo "  nvm install ${NODE_DEFAULT_MAJOR}"
-        echo "  nvm use ${NODE_DEFAULT_MAJOR}"
-        echo "  nvm alias default ${NODE_DEFAULT_MAJOR}"
-        echo "Then open a new shell and rerun:"
-        echo "  curl -fsSL https://openclaw.ai/install.sh | bash"
-    else
-        echo "Install/select Node.js ${NODE_DEFAULT_MAJOR} and ensure it is first on PATH, then rerun installer."
-    fi
-
+    echo "Install/select Node.js ${NODE_DEFAULT_MAJOR} and ensure it is first on PATH, then rerun installer."
     return 1
 }
 
 load_nvm_for_node_detection() {
-    local nvm_dir="${NVM_DIR:-}"
-    if [[ -n "$nvm_dir" && ! -s "$nvm_dir/nvm.sh" ]]; then
-        nvm_dir=""
+    NVM_DETECTED=0
+    local nvm_dir="${NVM_DIR:-}" profile
+    if [[ -n "$nvm_dir" || -d "$HOME/.nvm" ]] || command -v nvm >/dev/null 2>&1; then
+        NVM_DETECTED=1
     fi
-    if [[ -z "$nvm_dir" && -s "$HOME/.nvm/nvm.sh" ]]; then
+    # Detect custom/lazy hooks without executing arbitrary shell startup files.
+    for profile in "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile" \
+        "${ZDOTDIR:-$HOME}/.zshrc" "${ZDOTDIR:-$HOME}/.zprofile"; do
+        if [[ -r "$profile" ]] && grep -Eq '^[[:space:]]*([^#[:space:]].*)?(NVM_DIR|nvm[.]sh)' "$profile"; then
+            NVM_DETECTED=1
+        fi
+    done
+    if [[ ! -s "$nvm_dir/nvm.sh" && -s "$HOME/.nvm/nvm.sh" ]]; then
         nvm_dir="$HOME/.nvm"
     fi
-    if [[ -z "$nvm_dir" || ! -s "$nvm_dir/nvm.sh" ]]; then
-        return 0
-    fi
-
-    export NVM_DIR="$nvm_dir"
-    # shellcheck disable=SC1090,SC1091
-    . "$NVM_DIR/nvm.sh" --no-use >/dev/null 2>&1 || . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true
-    if command -v nvm >/dev/null 2>&1; then
-        nvm use default --silent >/dev/null 2>&1 || nvm use node --silent >/dev/null 2>&1 || true
+    if [[ -n "$nvm_dir" && -s "$nvm_dir/nvm.sh" ]]; then
+        NVM_DETECTED=1
+        export NVM_DIR="$nvm_dir"
+        # --no-use preserves the caller's selected system or managed runtime.
+        # shellcheck disable=SC1090,SC1091
+        if ! . "$NVM_DIR/nvm.sh" --no-use; then
+            ui_error "Could not load existing nvm at ${NVM_DIR}; load it in your shell and rerun the installer"
+            return 1
+        fi
     fi
     refresh_shell_command_cache
+}
+
+use_supported_nvm_node() {
+    command -v nvm >/dev/null 2>&1 || return 1
+    local candidate version
+    for candidate in "${NVM_DIR:-$HOME/.nvm}"/versions/node/*/bin/node; do
+        [[ -x "$candidate" ]] || continue
+        node_binary_is_supported "$candidate" || continue
+        version="${candidate%/bin/node}"
+        version="${version##*/}"
+        nvm use --silent "$version" || return 1
+        refresh_shell_command_cache
+        node_is_supported || return 1
+        ui_info "Using existing nvm Node.js ${version} for this installation (${NVM_DIR})"
+        echo "  Shell profiles and the nvm default are unchanged. For later commands, run: nvm use ${version}"
+        return 0
+    done
+    return 1
+}
+
+install_node_with_existing_nvm() {
+    local reason="${1:-no compatible Node.js runtime is available}"
+    local default_version="" default_note="Your existing default alias setting will be preserved."
+    if command -v nvm >/dev/null 2>&1; then
+        default_version="$(nvm version default 2>/dev/null || true)"
+    fi
+    case "$default_version" in
+        v*|system) default_note="Keep current default ${default_version}; if nvm refreshes aliases, pin default to ${default_version}." ;;
+        *)
+            if [[ -n "${NVM_DIR:-}" && ! -e "$NVM_DIR/alias/default" ]]; then
+                default_note="nvm will also create its currently unset default alias."
+            fi
+            ;;
+    esac
+    ui_warn "Existing nvm detected; ${reason}"
+    echo "Load your existing nvm in your shell, then run:"
+    echo "  nvm install ${NODE_DEFAULT_MAJOR}"
+    echo "  nvm use ${NODE_DEFAULT_MAJOR}"
+    echo "nvm install can refresh LTS aliases; check your default with: nvm version default"
+    echo "Then rerun the installer. Shell profiles will not be changed."
+
+    local answer=""
+    if command -v nvm >/dev/null 2>&1 && is_promptable; then
+        answer="$(prompt_choice "Install Node.js ${NODE_DEFAULT_MAJOR} in your existing nvm (${NVM_DIR}) for this session? ${default_note} [y/N]" || true)"
+    fi
+    case "$answer" in
+        y|Y|yes|YES)
+            ui_info "Installing Node.js ${NODE_DEFAULT_MAJOR} in existing nvm (${NVM_DIR}). ${default_note}"
+            local install_result=0
+            nvm install "$NODE_DEFAULT_MAJOR" || install_result=$?
+            # Remote LTS metadata can move an existing default even on download failure.
+            case "$default_version" in
+                v*|system)
+                    if [[ "$(nvm version default 2>/dev/null || true)" != "$default_version" ]]; then
+                        ui_info "Preserving the previous default: nvm alias default ${default_version} (approved)"
+                        nvm alias default "$default_version" || return 1
+                    fi
+                    ;;
+            esac
+            if [[ "$install_result" -ne 0 ]]; then
+                ui_error "nvm install failed; any downloaded files remain in ${NVM_DIR}. Fix the reported error and rerun the command above."
+                return 1
+            fi
+            nvm use --silent "$NODE_DEFAULT_MAJOR" || return 1
+            refresh_shell_command_cache
+            ensure_default_node_active_shell || return 1
+            ui_info "nvm default now resolves to: $(nvm version default 2>/dev/null || true)"
+            ui_success "Using nvm Node.js $(node -v) for this installation; shell profiles unchanged"
+            ;;
+        *)
+            ui_error "Installation stopped without changing Node.js; run the nvm commands above to continue"
+            return 1
+            ;;
+    esac
 }
 
 check_node() {
@@ -2507,6 +2569,18 @@ fix_npm_permissions() {
 
     if [[ -w "$npm_prefix" || -w "$npm_prefix/lib" ]]; then
         return 0
+    fi
+
+    if [[ "${NVM_DETECTED:-0}" == "1" ]]; then
+        # npm's persistent prefix setting makes subsequent nvm use commands fail.
+        ui_warn "npm global prefix is not writable: ${npm_prefix}; preserving nvm-compatible npm settings"
+        use_supported_nvm_node || install_node_with_existing_nvm "the active npm prefix is not writable" || return 1
+        npm_prefix="$(npm config get prefix 2>/dev/null || true)"
+        if [[ -n "$npm_prefix" && ( -w "$npm_prefix" || -w "$npm_prefix/lib" ) ]]; then
+            return 0
+        fi
+        ui_error "The selected nvm runtime still has an unwritable npm prefix (${npm_prefix}); check your npm config before rerunning"
+        return 1
     fi
 
     ui_warn "npm global prefix is not writable: ${npm_prefix}"
@@ -3091,6 +3165,15 @@ warn_shell_path_missing_dir() {
         return 0
     fi
     if path_has_dir "$ORIGINAL_PATH" "$dir"; then
+        return 0
+    fi
+
+    if [[ -n "${NVM_DIR:-}" && "$dir" == "$NVM_DIR"/versions/node/*/bin ]]; then
+        local version="${dir%/bin}"
+        version="${version##*/}"
+        ui_info "OpenClaw was installed under nvm Node.js ${version}"
+        echo "  For this shell and future shells, run: nvm use ${version}"
+        echo "  Shell profiles were not changed."
         return 0
     fi
 
@@ -3893,12 +3976,18 @@ main() {
 
     # Step 1: Node.js. macOS package-manager branches install Homebrew lazily
     # only when they are about to call brew.
-    load_nvm_for_node_detection
-    if ! check_node; then
-        install_homebrew
-        install_node
+    load_nvm_for_node_detection || exit 1
+    if ! node_is_supported; then
+        use_supported_nvm_node || activate_supported_node_on_path || true
     fi
-    activate_supported_node_on_path || true
+    if ! check_node; then
+        if [[ "${NVM_DETECTED:-0}" == "1" ]]; then
+            install_node_with_existing_nvm || exit 1
+        else
+            install_homebrew
+            install_node
+        fi
+    fi
     if ! ensure_default_node_active_shell; then
         exit 1
     fi
@@ -3927,7 +4016,7 @@ main() {
         fi
 
         # Step 4: npm permissions (Linux)
-        fix_npm_permissions
+        fix_npm_permissions || exit 1
 
         # Step 5: OpenClaw
         prepare_git_wrapper_backup_for_npm || return $?

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -16,10 +16,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { isSupportedOpenClawNodeVersion } from "../../node-version.mjs";
 import { requireNodeTool } from "../helpers/node-toolchain.js";
 import { NODE_RELEASE_VERSION_CASES } from "../helpers/node-version-cases.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { createInstallGitCommitFixtureScript } from "./install-git-fixtures.js";
 import {
   writeNpmBeforePolicyFixture,
@@ -2945,71 +2946,223 @@ EOF
     }
   });
 
-  it("loads nvm before checking Node.js so stale system Node does not win", () => {
-    expect(script).toMatch(
-      /# Step 1: Node\.js[\s\S]*?load_nvm_for_node_detection\s+if ! check_node; then/,
-    );
+  const nvmTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-nvm-"));
-    const home = join(tmp, "home");
-    const systemBin = join(tmp, "system-bin");
-    const nvmBin = join(home, ".nvm/versions/node/v24.16.0/bin");
-    mkdirSync(systemBin, { recursive: true });
-    mkdirSync(nvmBin, { recursive: true });
-    mkdirSync(join(home, ".nvm"), { recursive: true });
-
-    const systemNode = join(systemBin, "node");
-    const nvmNode = join(nvmBin, "node");
-    writeFileSync(systemNode, "#!/bin/sh\necho v8.11.3\n");
-    writeFileSync(nvmNode, "#!/bin/sh\necho v24.16.0\n");
-    chmodSync(systemNode, 0o755);
-    chmodSync(nvmNode, 0o755);
-    writeFileSync(
-      join(home, ".nvm/nvm.sh"),
-      [
-        'NVM_DIR="${NVM_DIR:-$HOME/.nvm}"',
-        "export NVM_DIR",
-        "nvm() {",
-        '  if [ "$1" = "use" ]; then',
-        '    export PATH="$NVM_DIR/versions/node/v24.16.0/bin:$PATH"',
-        "    return 0",
-        "  fi",
-        "  return 0",
-        "}",
-        "",
-      ].join("\n"),
-    );
-
-    let result: ReturnType<typeof runInstallShell> | undefined;
-    try {
-      result = runInstallShell(
-        [
-          `cd ${JSON.stringify(process.cwd())}`,
-          `source ${JSON.stringify(SCRIPT_PATH)}`,
-          "set +e",
-          "load_nvm_for_node_detection",
-          "check_node",
-          "status=$?",
-          'printf "status=%s\\npath=%s\\nversion=%s\\n" "$status" "$(command -v node)" "$(node -v)"',
-          "exit $status",
-        ].join("\n"),
+  it.each([
+    { os: "linux", active: "v26.8.2", managed: "v24.14.1", location: "env", expected: "system" },
+    { os: "macos", active: "v26.8.2", managed: "v24.14.1", location: "home", expected: "system" },
+    { os: "linux", active: "v20.20.0", managed: "v24.16.0", location: "env", expected: "managed" },
+    { os: "macos", active: "v20.20.0", managed: "v24.16.0", location: "home", expected: "managed" },
+    { os: "linux", active: "v20.20.0", managed: "v24.14.1", location: "env", expected: "refuse" },
+    { os: "macos", active: "v20.20.0", managed: "v24.14.1", location: "home", expected: "refuse" },
+    { os: "linux", active: "v20.20.0", managed: "v24.16.0", location: "hook", expected: "refuse" },
+    {
+      os: "linux",
+      active: "v20.20.0",
+      managed: "v24.14.1",
+      location: "env",
+      expected: "installed",
+      answer: "y",
+    },
+    {
+      os: "linux",
+      active: "v20.20.0",
+      managed: "v24.14.1",
+      location: "env",
+      expected: "refuse",
+      answer: "n",
+    },
+    {
+      os: "linux",
+      active: "v20.20.0",
+      managed: "v24.14.1",
+      location: "env",
+      expected: "installed",
+      answer: "y",
+      missingDefault: true,
+    },
+    {
+      os: "linux",
+      active: "v20.20.0",
+      managed: "v24.14.1",
+      location: "env",
+      expected: "refuse",
+      answer: "n",
+      missingDefault: true,
+    },
+    {
+      os: "linux",
+      active: "v20.20.0",
+      managed: "v24.14.1",
+      location: "env",
+      expected: "refuse",
+      answer: "y",
+      installFails: true,
+    },
+    {
+      os: "linux",
+      active: "v20.20.0",
+      managed: "v24.16.0",
+      location: "env",
+      expected: "refuse",
+      unsafeSqlite: true,
+    },
+  ])(
+    "preserves existing nvm: $os, $active, $managed, $location, consent=$answer, unsafe=$unsafeSqlite, missing-default=$missingDefault, install-fails=$installFails",
+    ({
+      os,
+      active,
+      managed,
+      location,
+      expected,
+      answer,
+      unsafeSqlite,
+      missingDefault,
+      installFails,
+    }) => {
+      const home = nvmTempDirs.make("openclaw-install-nvm-");
+      const systemBin = join(home, "system-bin");
+      const nvmDir = join(home, location === "home" ? ".nvm" : "custom-nvm");
+      const nvmBin = join(nvmDir, "versions/node", managed, "bin");
+      mkdirSync(systemBin, { recursive: true });
+      mkdirSync(nvmBin, { recursive: true });
+      mkdirSync(join(nvmDir, "alias"));
+      const defaultAlias = join(nvmDir, "alias/default");
+      if (!missingDefault) {
+        writeFileSync(defaultAlias, "lts/*\n");
+      }
+      for (const { bin, version } of [
+        { bin: systemBin, version: active },
+        { bin: nvmBin, version: managed },
+      ]) {
+        writeFileSync(
+          join(bin, "node"),
+          `#!/bin/sh\nif [ "$1" = "-v" ]; then echo ${version}; fi\n`,
+          { mode: 0o755 },
+        );
+      }
+      const rc = `export NVM_DIR="${nvmDir}"\n[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"\n`;
+      writeFileSync(join(home, ".bashrc"), rc);
+      writeFileSync(join(home, ".zshrc"), rc);
+      writeFileSync(
+        join(nvmDir, "nvm.sh"),
+        `
+      nvm() {
+        printf '%s\\n' "$*" >> "$HOME/nvm-calls"
+        case "$1" in
+          use)
+            version="${managed}"
+            if [ "\${3:-}" = 26 ]; then version=v26.8.2; fi
+            export PATH="$NVM_DIR/versions/node/$version/bin:$PATH"
+            ;;
+          version)
+            value="$(cat "$NVM_DIR/alias/default" 2>/dev/null || true)"
+            case "$value" in
+              'lts/*')
+                if [ -e "$NVM_DIR/remote-updated" ]; then echo N/A; else echo v24.14.1; fi ;;
+              26) echo v26.8.2 ;;
+              '') echo N/A ;;
+              *) echo "$value" ;;
+            esac
+            ;;
+          alias) printf '%s\\n' "$3" > "$NVM_DIR/alias/default" ;;
+          install)
+            touch "$NVM_DIR/remote-updated"
+            ${installFails ? "return 42" : ""}
+            if [ ! -e "$NVM_DIR/alias/default" ]; then printf '26\\n' > "$NVM_DIR/alias/default"; fi
+            mkdir -p "$NVM_DIR/versions/node/v26.8.2/bin"
+            printf '#!/bin/sh\\nif [ "$1" = "-v" ]; then echo v26.8.2; fi\\n' > "$NVM_DIR/versions/node/v26.8.2/bin/node"
+            chmod +x "$NVM_DIR/versions/node/v26.8.2/bin/node"
+            ;;
+          *) return 1 ;;
+        esac
+      }
+      if [ "\${1:-}" != --no-use ]; then nvm use default; fi
+    `,
+      );
+      const result = runInstallShell(
+        `
+      source "${SCRIPT_PATH}"
+      OS=${os}
+      bootstrap_gum_temp() { :; }
+      print_installer_banner() { :; }
+      print_gum_status() { :; }
+      detect_os_or_die() { :; }
+      detect_openclaw_checkout() { :; }
+      show_install_plan() { :; }
+      check_existing_openclaw() { return 1; }
+      # Only the fixture's binaries exist in this simulated runtime inventory.
+      node_binary_has_safe_sqlite() { ${unsafeSqlite ? "return 1" : '[[ "$1" == node || "$1" == "$HOME/"* ]]'}; }
+      ${answer !== undefined ? `has_controlling_tty() { return 0; }; prompt_choice() { printf '%s' "$1" > "$HOME/prompt"; printf '%s' '${answer}'; }` : ""}
+      install_homebrew() { echo unexpected-homebrew; exit 91; }
+      install_node() { echo unexpected-system-install; exit 92; }
+      ui_stage() {
+        if [[ "$1" == "Installing OpenClaw" ]]; then
+          printf 'selected=%s\\n' "$(command -v node)"
+          exit 0
+        fi
+      }
+      main
+    `,
         {
           HOME: home,
-          NVM_DIR: join(tmp, "stale-nvm"),
+          NVM_DIR: location === "env" ? nvmDir : "",
           PATH: `${systemBin}:/usr/bin:/bin`,
+          SHELL: os === "macos" ? "/bin/zsh" : "/bin/bash",
+          OPENCLAW_NO_PROMPT: answer === undefined ? "1" : "0",
           TERM: "dumb",
         },
       );
-    } finally {
-      rmSync(tmp, { force: true, recursive: true });
-    }
-
-    expect(result?.status).toBe(0);
-    const output = result?.stdout ?? "";
-    expect(output).toContain("status=0");
-    expect(output).toContain(`path=${nvmNode}`);
-    expect(output).toContain("version=v24.16.0");
-  });
+      const output = result.stdout + result.stderr;
+      expect(output).not.toContain("unexpected-system-install");
+      expect(output).not.toContain("unexpected-homebrew");
+      expect(result.status, output).toBe(expected === "refuse" ? 1 : 0);
+      if (expected === "refuse") {
+        expect(output).toContain("nvm install 26");
+      } else {
+        const selectedBin =
+          expected === "installed"
+            ? join(nvmDir, "versions/node/v26.8.2/bin")
+            : expected === "system"
+              ? systemBin
+              : nvmBin;
+        expect(output).toContain(`selected=${join(selectedBin, "node")}`);
+      }
+      expect(readFileSync(join(home, ".bashrc"), "utf8")).toBe(rc);
+      expect(readFileSync(join(home, ".zshrc"), "utf8")).toBe(rc);
+      if (missingDefault && expected !== "installed") {
+        expect(existsSync(defaultAlias)).toBe(false);
+      } else {
+        expect(readFileSync(defaultAlias, "utf8")).toBe(
+          missingDefault ? "26\n" : answer === "y" ? "v24.14.1\n" : "lts/*\n",
+        );
+      }
+      if (answer !== undefined) {
+        expect(readFileSync(join(home, "prompt"), "utf8")).toContain(
+          missingDefault ? "create its currently unset default alias" : "pin default to v24.14.1",
+        );
+      }
+      expect(readFileSync(join(systemBin, "node"), "utf8")).toContain(active);
+      const calls = existsSync(join(home, "nvm-calls"))
+        ? readFileSync(join(home, "nvm-calls"), "utf8")
+        : "";
+      expect(calls).not.toContain("use default");
+      if (answer === "y") {
+        expect(calls).toContain("install 26");
+        if (!missingDefault) {
+          expect(calls).toContain("alias default v24.14.1");
+        }
+      } else {
+        expect(calls).not.toMatch(/install|^alias/m);
+      }
+      if (expected === "managed") {
+        expect(calls).toContain(`use --silent ${managed}`);
+      }
+      if (location !== "home") {
+        expect(existsSync(join(home, ".nvm"))).toBe(false);
+      }
+    },
+  );
 
   it("installs Homebrew lazily before macOS Git installs", () => {
     const result = runInstallShell(`
@@ -3319,6 +3472,34 @@ EOF
     expect(result?.status).toBe(0);
     expect(result?.stdout).toContain(`first=export PATH="${installedBin}:$PATH"`);
     expect(result?.stdout).toContain(`node=${installedNode}`);
+  });
+
+  it("preserves nvm when a system npm prefix is not writable", () => {
+    const result = runInstallShell(
+      `
+      source "${SCRIPT_PATH}"
+      OS=linux
+      NVM_DETECTED=1
+      NO_PROMPT=1
+      printf 'fund=false\\n' > "$HOME/.npmrc"
+      npm() {
+        case "$*" in
+          'config get prefix') printf '%s' "$HOME/missing-system-prefix" ;;
+          'config set prefix'*) printf 'prefix=%s\\n' "$4" >> "$HOME/.npmrc" ;;
+          *) return 1 ;;
+        esac
+      }
+      fix_npm_permissions || result=$?
+      printf 'result=%s\\n' "\${result:-0}"
+      cat "$HOME/.npmrc"
+    `,
+      { NVM_DIR: "" },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("result=1");
+    expect(result.stdout).toContain("nvm install 26");
+    expect(result.stdout).not.toContain("prefix=");
+    expect(result.stdout).toContain("fund=false");
   });
 
   it("warns before redirecting an unwritable npm prefix", () => {


### PR DESCRIPTION
Fixes #145292

## What Problem This Solves

Fixes an issue where users running the website installer with an existing nvm would have their system Node replaced and later `nvm use` commands fail. With `nvm use system` selecting Node 26.8.2 and an older nvm default of 24.14.1, the installer activated the older default, unnecessarily ran NodeSource, changed shell profiles, and wrote an incompatible npm `prefix` setting.

Thanks to @jb-lopez for the report and before/after diagnostics.

## Why This Change Was Made

Load nvm with `--no-use`, retain a compatible active runtime, and search installed nvm versions and other existing runtimes before provisioning. Detect nvm through its environment, home directory, and startup hooks without executing startup files. An existing nvm prevents system Node provisioning and persistent npm-prefix changes: use a supported nvm version or ask before installing through that same nvm. Non-interactive runs print the exact command and stop before mutation when provisioning is needed.

Only explicit consent can install a new nvm Node or change its default. The consent prompt includes preserving the current effective default: nvm itself refreshes LTS aliases, even on a failed download, so pin the prior default version only if that refresh changes its resolution. Log that approved change. If no default exists, the prompt discloses nvm's creation of one. Existing-runtime selection never changes defaults or shell profiles. All runtime candidates retain the numeric version and SQLite capability checks.

## User Impact

Existing nvm installations, system Node binaries, and npm settings remain usable. A supported nvm runtime can be selected just for installation, with an explicit `nvm use <version>` instruction for subsequent commands. No installer flags or dependencies are added.

The same selection fix protects Homebrew Node on macOS. If only a custom/lazy shell hook identifies nvm, users must load nvm in their shell before rerunning; the installer does not execute arbitrary startup files to discover its location.

## Evidence

The shell-driven main-flow regressions fail before the repair and pass afterward:

```text
node scripts/run-vitest.mjs test/scripts/install-sh.test.ts -t 'preserves.*nvm'
Before: Tests 14 failed | 206 skipped
After:  Tests 14 passed | 206 skipped
```

The full installer suite passes all 220 tests. Shell syntax, ShellCheck, formatting, root-test typechecking, targeted lint, and the changed-file checks pass.

[Website Installer Sync verification](https://github.com/openclaw/openclaw/actions/runs/34650888139) passed on head `58e9f08540022977996e3a77ec0201b1822599b2`: all nine verification jobs are green, including Debian, Linux Docker/non-root, Fedora root/non-root, macOS, and Windows. Website publication was correctly skipped for this unmerged PR.

[Main CI](https://github.com/openclaw/openclaw/actions/runs/34650947230) is green on the same head. `node scripts/watch-pr-ci.mjs 145317 58e9f08540022977996e3a77ec0201b1822599b2` completed with `rollup=green`, `pending=0`, and `GREEN`.

Real Debian trixie proof uses a normal user, nvm 0.40.3, nvm Node 24.14.1, system Node 26.8.2, and the actual installer entry point. The OpenClaw tarball is a synthetic version-check CLI so the proof isolates provisioning and npm installation. The original installer reproduces both system replacement and broken nvm:

```text
Before original installer:
  v24.14.1
  -> system (Node v26.8.2)
After original installer:
  v24.14.1
  -> system (Node v24.21.0)
  ~/.npmrc: prefix=/home/app/.npm-global
  nvm use 24.14.1: prefix setting is incompatible with nvm
```

The original also prepends these lines to `.bashrc`, `.profile`, and `.zshrc`:

```sh
export PATH="$HOME/.npm-global/bin:$PATH"
export PATH="/usr/bin:$PATH"
```

The candidate preserves the original rc bytes, npm config, nvm files/aliases, and system Node checksum. The reporter's LTS-default candidate cell retains:

```text
Before = after:
  v24.14.1
  -> system (Node v26.8.2)
  default -> lts/* -> lts/krypton -> v24.14.1
  ~/.npmrc: absent
  nvm use 24.14.1: succeeds
```

Additional real-nvm cells cover supported installed nvm selection, non-interactive refusal, an unwritable system npm prefix, consent with LTS-default preservation, and consent to create an initially absent default. The macOS probe uses real Homebrew Node 26.8.2 and nvm Node 24.14.1 in an isolated home: original exits at an unexpected Homebrew-provisioning tripwire; candidate keeps `/opt/homebrew/bin/node`, with unchanged rc/default files.

Limitations: no Gateway/onboarding or full release-package claim; macOS proof ends after runtime selection. The evidence shows Node replacement and npm configuration breaking nvm, not installation of a second nvm or deletion of nvm-managed versions. The campaign lead owns autoreview and landing.

After merge, Website Installer Sync must propagate `scripts/install.sh` to `openclaw/openclaw.ai`'s `public/install.sh`; verify that sync and the served installer before treating this as deployed.


## ClawSweeper review

Reviewed head: `58e9f08540022977996e3a77ec0201b1822599b2`. No code findings to apply. Both merge-risk items are skipped as landing blockers by maintainer decision: unattended refusal when existing nvm has no usable runtime or writable npm prefix is the intended, documented protection, with exact preparation commands; Website Installer Sync propagation is a post-merge release-ops follow-up owned by the campaign lead. No code changed and no re-review is requested.
