### PR TITLE
fix: attribute Codex usage to OpenClaw tasks

### DIFF
--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -169,6 +169,7 @@ export type CodexTurnEnvironmentParams = JsonObject & {
 };
 
 export type CodexThreadStartParams = JsonObject & {
+  threadSource?: string | null;
   input?: CodexUserInput[];
   cwd?: string;
   projectId?: string | null;
@@ -375,6 +376,7 @@ type CodexTurnInterruptParams = JsonObject & {
 
 export type CodexTurnStartParams = JsonObject & {
   threadId: string;
+  turnTrigger?: string | null;
   input: CodexUserInput[];
   additionalContext?: Record<string, { kind: "untrusted" | "application"; value: string }>;
   cwd?: string;

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -59,6 +59,43 @@ type CodexThreadLifecycleTimingLogger = NonNullable<
 const PROGRESS_CARD_SYSTEM_PROMPT =
   "During multi-step work, keep your progress card current with the progress_card tool; the user follows it instead of reading the transcript.";
 
+describe("Codex usage attribution", () => {
+  it("labels new OpenClaw threads without rewriting resumed thread attribution", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    const appServer = createAppServerOptions() as never;
+    const start = buildThreadStartParams(params, { appServer, cwd: "/repo", dynamicTools: [] });
+    const resume = buildThreadResumeParams(params, { appServer, threadId: "thread-1" });
+
+    expect(start.threadSource).toBe("openclaw");
+    expect(resume).not.toHaveProperty("threadSource");
+  });
+
+  it.each(["user", "cron", "heartbeat", "manual", "memory", "overflow"] as const)(
+    "preserves the %s run trigger on each new turn",
+    (trigger) => {
+      const params = { ...createAttemptParams({ provider: "openai" }), trigger };
+      const request = buildTurnStartParams(params, {
+        appServer: createAppServerOptions() as never,
+        threadId: "existing-thread",
+        cwd: "/repo",
+      });
+
+      expect(request.turnTrigger).toBe(trigger);
+    },
+  );
+
+  it("does not guess a human trigger when the caller supplied none", () => {
+    const params = { ...createAttemptParams({ provider: "openai" }), trigger: undefined };
+    const request = buildTurnStartParams(params, {
+      appServer: createAppServerOptions() as never,
+      threadId: "existing-thread",
+      cwd: "/repo",
+    });
+
+    expect(request).not.toHaveProperty("turnTrigger");
+  });
+});
+
 describe("Codex incognito thread persistence", () => {
   it("marks only incognito-shaped harness sessions ephemeral", () => {
     const appServer = createAppServerOptions() as never;

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -207,6 +207,7 @@ export function buildThreadStartParams(
       : {}),
     personality: CODEX_NATIVE_PERSONALITY_NONE,
     serviceName: "OpenClaw",
+    threadSource: "openclaw",
     ...(ringZeroActive ? { baseInstructions: CODEX_RING_ZERO_BASE_INSTRUCTIONS } : {}),
     config: buildCodexRuntimeThreadConfigForRun(params, options.config, {
       nativeCodeModeEnabled: options.nativeCodeModeEnabled,

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -88,6 +88,7 @@ export function buildTurnStartParams(
     : undefined;
   return {
     threadId: options.threadId,
+    ...(params.trigger ? { turnTrigger: params.trigger } : {}),
     // codex-rs/app-server-protocol/src/protocol/v2/turn.rs:292-324 at 91d6f48992ad defines
     // UserInput::Skill; skills/src/selection.rs:60-92 blocks those names from duplicate text
     // selection while leaving unmatched Codex-native-only names scannable.

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=06972ffbe455b1f47bfad48ed6e66b6b6261922984fadb4896f427d9eaf3a045
-+++ discord-group-codex-message-tool.md	sha256=17258491c63ddb03227afa5f821272959865ce5768375d7eb2fe4de8bb17782a
+--- telegram-direct-codex-message-tool.md	sha256=31428689ba91efb29f385d8026b2985860170aa05ff9574cc659cf03791c6331
++++ discord-group-codex-message-tool.md	sha256=cd7cb4621570c916b41bb531328b69890506637b55e6133c74d9ec55112cde46
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -16,44 +16,44 @@
 @@ -30,1 +30,1 @@
 -  "toolSnapshot": "codex-dynamic-tools.telegram-direct.json",
 +  "toolSnapshot": "codex-dynamic-tools.discord-group.json",
-@@ -134,1 +134,1 @@
+@@ -135,1 +135,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-discord-group-codex-message-tool"
-@@ -145,1 +145,1 @@
+@@ -146,1 +146,1 @@
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
 +      "value": "{\"sender\":{\"id\":\"424242\",\"name\":\"Pash\",\"username\":\"pash\"}}"
-@@ -172,1 +172,1 @@
--  "threadId": "thread-telegram-direct-codex-message-tool"
-+  "threadId": "thread-discord-group-codex-message-tool"
-@@ -209,1 +209,1 @@
+@@ -173,1 +173,1 @@
+-  "threadId": "thread-telegram-direct-codex-message-tool",
++  "threadId": "thread-discord-group-codex-message-tool",
+@@ -211,1 +211,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
-@@ -237,2 +237,2 @@
+@@ -239,2 +239,2 @@
 -    "chars": 55731,
 -    "roughTokens": 13933
 +    "chars": 56311,
 +    "roughTokens": 14078
-@@ -241,2 +241,2 @@
+@@ -243,2 +243,2 @@
 -    "chars": 3224,
 -    "roughTokens": 806
 +    "chars": 4333,
 +    "roughTokens": 1084
-@@ -245,2 +245,2 @@
+@@ -247,2 +247,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 28650,
 +    "roughTokens": 7163
-@@ -249,2 +249,2 @@
+@@ -251,2 +251,2 @@
 -    "chars": 82903,
 -    "roughTokens": 20726
 +    "chars": 84963,
 +    "roughTokens": 21241
-@@ -253,2 +253,2 @@
+@@ -255,2 +255,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1234,
 +    "roughTokens": 309
-@@ -462,4 +462,4 @@
+@@ -464,4 +464,4 @@
 -  "channel": "telegram",
 -  "provider": "telegram",
 -  "surface": "telegram",
@@ -62,21 +62,21 @@
 +  "provider": "discord",
 +  "surface": "discord",
 +  "chat_type": "group"
-@@ -470,1 +470,3 @@
+@@ -472,1 +472,3 @@
 -You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 +You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to this group chat. Be extremely selective: reply only when directly addressed or clearly helpful.
 +
 +Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.
-@@ -526,1 +528,1 @@
+@@ -528,1 +530,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"channel:987654321","message_id":"discord-msg-0001","conversation_label":"OpenClaw/#agent-sandbox","sender":{"id":"424242","name":"Pash","username":"pash"},"group_subject":"OpenClaw maintainers","group_channel":"#agent-sandbox","group_space":"OpenClaw","is_group_chat":true,"was_mentioned":true,"history_count":2}
-@@ -529,1 +531,5 @@
+@@ -531,1 +533,5 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Chat history since last reply: ⟦openclaw:ctx⟧
 +Peter: I pushed the Discord-side message-tool bridge.
 +Pash: @OpenClaw please verify the Codex happy path too.
 +
 +can you audit whether this prompt path has conflicting silence instructions?
-@@ -534,1 +540,1 @@
+@@ -536,1 +542,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.discord-group.json` (base: `codex-dynamic-tools.telegram-direct.json`)

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -100,7 +100,8 @@
   "model": "gpt-5.5",
   "personality": "none",
   "sandbox": "danger-full-access",
-  "serviceName": "OpenClaw"
+  "serviceName": "OpenClaw",
+  "threadSource": "openclaw"
 }
 ```
 
@@ -169,7 +170,8 @@
   "sandboxPolicy": {
     "type": "dangerFullAccess"
   },
-  "threadId": "thread-telegram-direct-codex-message-tool"
+  "threadId": "thread-telegram-direct-codex-message-tool",
+  "turnTrigger": "user"
 }
 ```
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=06972ffbe455b1f47bfad48ed6e66b6b6261922984fadb4896f427d9eaf3a045
-+++ telegram-heartbeat-codex-tool.md	sha256=f6e596c0745cbd1990e5698266a1ae95888504b4c1289855fd44da673d8eda78
+--- telegram-direct-codex-message-tool.md	sha256=31428689ba91efb29f385d8026b2985860170aa05ff9574cc659cf03791c6331
++++ telegram-heartbeat-codex-tool.md	sha256=e0b771d7031ca594f118e9bc7bf3fb5fda0000e38a5202cabcb3578e59f18c62
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -15,54 +15,56 @@
 +  "trigger": "heartbeat"
 @@ -96,0 +97,1 @@
 +    "heartbeat_respond",
-@@ -134,1 +135,1 @@
+@@ -135,1 +136,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -142,6 +142,0 @@
+@@ -143,6 +143,0 @@
 -  "additionalContext": {
 -    "openclaw_current_sender": {
 -      "kind": "untrusted",
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
 -    }
 -  },
-@@ -172,1 +167,1 @@
--  "threadId": "thread-telegram-direct-codex-message-tool"
-+  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -209,1 +204,1 @@
+@@ -173,2 +168,2 @@
+-  "threadId": "thread-telegram-direct-codex-message-tool",
+-  "turnTrigger": "user"
++  "threadId": "thread-telegram-heartbeat-codex-tool",
++  "turnTrigger": "heartbeat"
+@@ -211,1 +206,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
-@@ -237,2 +232,2 @@
+@@ -239,2 +234,2 @@
 -    "chars": 55731,
 -    "roughTokens": 13933
 +    "chars": 57224,
 +    "roughTokens": 14306
-@@ -245,2 +240,2 @@
+@@ -247,2 +242,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 27512,
 +    "roughTokens": 6878
-@@ -249,2 +244,2 @@
+@@ -251,2 +246,2 @@
 -    "chars": 82903,
 -    "roughTokens": 20726
 +    "chars": 84738,
 +    "roughTokens": 21185
-@@ -253,2 +248,2 @@
+@@ -255,2 +250,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1205,
 +    "roughTokens": 302
-@@ -526,1 +521,1 @@
+@@ -528,1 +523,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"user:1000001","message_id":"heartbeat-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
-@@ -529,1 +524,1 @@
+@@ -531,1 +526,1 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Follow the heartbeat monitor scratch context when provided. Recurring tasks are automations; create or change their schedules with the automations tool, not heartbeat scratch. Do not infer or repeat old tasks from prior chats. Use heartbeat_respond to report the wake outcome. Set notify=false when nothing needs the user's attention. Set notify=true with notificationText only when the user should be interrupted.
-@@ -534,1 +529,1 @@
+@@ -536,1 +531,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dynamic-tools.telegram-direct.json`)
-@@ -554,0 +550,1 @@
+@@ -556,0 +552,1 @@
 +  "heartbeat_respond",
-@@ -701,0 +698,39 @@
+@@ -703,0 +700,39 @@
 +  },
 +  {
 +    "description": "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only.",


### PR DESCRIPTION
Codex usage reports could not identify OpenClaw task threads or tell what started their turns, even though OpenClaw already records the run trigger.

Mark new task threads with `threadSource: "openclaw"` and pass the existing run trigger to `turn/start`. Resuming a thread preserves its original source, and callers without a known trigger leave it unspecified. This only adds analytics metadata; it does not change scheduling, models, permissions, or message delivery.
