### PR TITLE
fix: show loading feedback for Gateway host stats

### DIFF
--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -72,7 +72,7 @@ the configured secret. After a successful token-mode connection, the UI remember
 the secret in session storage for the current browser tab and Gateway only.
 Passwords stay in memory and are never persisted.
 
-Open **Settings → Gateway** to see the **Gateway Host** card with the Gateway machine, LAN address, operating system, runtime, uptime, CPU load, memory, and space for each mounted local disk. The card refreshes every 10 seconds while visible through the `system.info` Gateway RPC, which requires the `operator.read` scope. If mounted-disk discovery is unavailable, the card retains the state-directory disk reading when available. Connections without the required scope omit the card.
+Open **Settings → Gateway** to see the **Gateway Host** card with the Gateway machine, LAN address, operating system, runtime, uptime, CPU load, memory, and space for each mounted local disk. The card refreshes every 10 seconds while visible through the `system.info` Gateway RPC, which requires the `operator.read` scope. If mounted-disk discovery is unavailable, the card retains the state-directory disk reading when available. Connections without the required scope omit the card. A loading indicator appears while stats are being fetched; refreshes keep the previous readings visible. Disk paths appear in their labels without duplicate tooltips.
 
 ## Language support
 

--- a/ui/src/pages/connection/connection-page.test.ts
+++ b/ui/src/pages/connection/connection-page.test.ts
@@ -162,6 +162,40 @@ describe("ConnectionPage credentials", () => {
 });
 
 describe("ConnectionPage Gateway lifecycle", () => {
+  it("shows pending host reads and keeps the last stats visible during refresh", async () => {
+    vi.useFakeTimers();
+    const firstResponse = deferred<SystemInfoResult>();
+    const refreshResponse = deferred<SystemInfoResult>();
+    const request = vi
+      .fn()
+      .mockReturnValueOnce(firstResponse.promise)
+      .mockReturnValueOnce(refreshResponse.promise);
+    const current = source({ request } as unknown as GatewayBrowserClient);
+    const { page } = await mount(current.gateway);
+    const host = () => page.querySelector("#settings-connection-host");
+    const loading = () => host()?.querySelector('[role="status"]');
+    expect(loading()?.textContent).toContain("Loading…");
+    expect(host()?.getAttribute("aria-busy")).toBe("true");
+
+    firstResponse.resolve(deviceSystemInfo);
+    await settleLitElement(page);
+    expect(loading()).toBeNull();
+    expect(host()?.getAttribute("aria-busy")).toBe("false");
+    expect(host()?.textContent).toContain("Gateway");
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await settleLitElement(page);
+    expect(loading()?.textContent).toContain("Loading…");
+    expect(page.querySelector(".config-host__name")?.textContent?.trim()).toBe("Gateway");
+    expect(page.querySelectorAll('[role="meter"]').length).toBeGreaterThan(0);
+
+    refreshResponse.reject(new Error("temporarily unavailable"));
+    await settleLitElement(page);
+    expect(loading()).toBeNull();
+    expect(host()?.getAttribute("aria-busy")).toBe("false");
+    expect(page.querySelector(".config-host__name")?.textContent?.trim()).toBe("Gateway");
+  });
+
   it("keeps an edited draft through reconnect and resets it for a replacement source", async () => {
     const request = vi.fn().mockResolvedValue(deviceSystemInfo);
     const client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/pages/connection/connection-page.ts
+++ b/ui/src/pages/connection/connection-page.ts
@@ -37,11 +37,11 @@ export class ConnectionPage extends OpenClawLightDomElement {
   @state() private gatewaySecretVisible = false;
   @state() private systemInfo: SystemInfoResult | null = null;
   @state() private systemInfoUnavailable = false;
+  @state() private systemInfoLoading = false;
 
   // Distinguishes an operator-edited session key from the stored selection so
   // Connect only overrides the per-gateway selection after an explicit edit.
   private sessionKeyDirty = false;
-  private systemInfoLoading = false;
 
   private readonly systemInfoPolling = new PollController(
     this,
@@ -212,6 +212,7 @@ export class ConnectionPage extends OpenClawLightDomElement {
       secret: this.settings.token || this.password,
       lastError: gateway.lastError,
       systemInfo: this.systemInfo,
+      systemInfoLoading: this.systemInfoLoading,
       systemInfoUnavailable: this.systemInfoUnavailable,
       dirty,
       showGatewaySecret: this.gatewaySecretVisible,

--- a/ui/src/pages/connection/system-section.ts
+++ b/ui/src/pages/connection/system-section.ts
@@ -13,6 +13,7 @@ import { CONNECTION_SETTINGS_TARGET_IDS } from "../config/settings-targets.ts";
 type SystemSectionProps = {
   systemInfo?: SystemInfoResult | null;
   systemInfoUnavailable?: boolean;
+  systemInfoLoading?: boolean;
 };
 
 type SystemStat = {
@@ -60,7 +61,7 @@ function renderSystemMeter(label: string, fraction: number) {
 function renderSystemStat(stat: SystemStat) {
   const label = stat.path ? `${stat.label} ${stat.path}` : stat.label;
   return html`
-    <div class="config-host__stat" title=${stat.path ?? stat.title ?? ""}>
+    <div class="config-host__stat" title=${stat.title ?? nothing}>
       <div class="config-host__stat-label">
         ${stat.label}${
           stat.path ? html` <span class="config-host__stat-path">${stat.path}</span>` : nothing
@@ -106,7 +107,6 @@ function buildSystemStats(info: SystemInfoResult): SystemStat[] {
           label: t("quickSettings.system.cpu"),
           value: coresLabel,
           detail: info.cpuModel,
-          title: cpuTitle,
         }
       : {
           label: t("quickSettings.system.cpu"),
@@ -174,15 +174,20 @@ export function renderSystemSection(props: SystemSectionProps) {
   // kept as custom markup inside the single group with row-matched paddings.
   const sectionProps: SettingsSectionProps = {
     title: t("quickSettings.system.gatewayHost"),
-    actions: info
-      ? renderSettingsStatus({
-          kind: "ok",
-          label: t("quickSettings.system.up", { duration: formatDurationHuman(info.uptimeMs) }),
-        })
-      : undefined,
+    actions: props.systemInfoLoading
+      ? html`<span class="settings-status" role="status">
+          <span class="btn__spinner" aria-hidden="true"></span>
+          ${t("common.loading")}
+        </span>`
+      : info
+        ? renderSettingsStatus({
+            kind: "ok",
+            label: t("quickSettings.system.up", { duration: formatDurationHuman(info.uptimeMs) }),
+          })
+        : undefined,
   };
   return html`
-    <div id=${CONNECTION_SETTINGS_TARGET_IDS.host}>
+    <div id=${CONNECTION_SETTINGS_TARGET_IDS.host} aria-busy=${Boolean(props.systemInfoLoading)}>
       ${renderSettingsSection(
         sectionProps,
         html`

--- a/ui/src/pages/connection/view.render.test.ts
+++ b/ui/src/pages/connection/view.render.test.ts
@@ -31,6 +31,7 @@ function createConnectionProps(overrides: Partial<ConnectionProps> = {}): Connec
     lastError: null,
     systemInfo: null,
     systemInfoUnavailable: false,
+    systemInfoLoading: false,
     dirty: false,
     showGatewaySecret: false,
     onConnectionChange: () => undefined,
@@ -252,7 +253,7 @@ describe("connection view rendering", () => {
     expect(disk.querySelector(".config-host__stat-detail")?.textContent?.trim()).toBe(
       "463 GB free of 926 GB",
     );
-    expect(disk.getAttribute("title")).toBe("/");
+    expect(disk.hasAttribute("title")).toBe(false);
     expect(disk.querySelector('[role="meter"]')?.getAttribute("aria-label")).toBe("Disk / usage");
     const archive = expectStatByLabel(container, "Disk /Volumes/Archive");
     expect(archive.querySelector(".config-host__stat-detail")?.textContent?.trim()).toBe(

--- a/ui/src/pages/connection/view.ts
+++ b/ui/src/pages/connection/view.ts
@@ -30,6 +30,7 @@ type ConnectionProps = {
   lastError: string | null;
   systemInfo: SystemInfoResult | null;
   systemInfoUnavailable: boolean;
+  systemInfoLoading: boolean;
   /** True when the draft differs from the live connection. */
   dirty: boolean;
   showGatewaySecret: boolean;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening **Settings → Gateway** saw only dashes while Gateway host stats were loading. Disk tooltips also repeated the paths already visible in their labels.

## Why This Change Was Made

Connect the existing request-owned loading state to the view. A spinner and localized “Loading…” status appear beside **Gateway Host** while a read is pending, including refreshes; existing readings remain visible. The indicator respects reduced-motion preferences and exposes a busy state to assistive technology.

Remove redundant disk-path tooltips and the CPU-model tooltip when the model is already visible. Keep CPU model/load-average and distinct hostname tooltips when they add information.

## User Impact

Users can tell when host stats are being fetched without losing the last readings during a refresh, and hovering over disks no longer covers the card with duplicate path labels. No Gateway polling or permission changes.

## Evidence

- Both regressions reproduced against the original code, then all 24 focused Connection page/view tests passed.
- Coverage includes initial loading, successful completion, retained readings during refresh, failure cleanup, connection lifecycle, and tooltip behavior.
- Independent review found no actionable findings through P2; ClawSweeper also completed review with no findings and sufficient visual proof.
- Synthetic Chromium proof mounts the actual Connection page and request lifecycle. It confirms delayed initial fetch, the automatic 10-second refresh retaining stats, failed-refresh cleanup, and absence of disk titles.
- Targeted lint/style checks, formatting, translation verification, and repository guards passed. Local typecheck is blocked by the worktree's borrowed dependency installation; [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34651824744) passed, including UI suites, end-to-end tests, build, production/test typechecks, and the required aggregate gate.
- Signed-in Chrome verification was blocked by the shared automation relay's client-identity mismatch; no live Gateway was changed.

Before, with a pending stats request:

![Before: no loading feedback](https://github.com/user-attachments/assets/f7702edc-9ea7-49fa-9fcb-728c39203f88)

After, with the same pending request:

![After: visible loading feedback](https://github.com/user-attachments/assets/e9ebc07d-1667-4b56-921e-58d5e045db4b)

Automatic refresh retains the previous readings:

![Refresh with readings retained](https://github.com/user-attachments/assets/940b9433-5ef1-45c5-ace0-b16f3e11bae0)
