### PR TITLE
fix(workers): avoid repeated checkpoint cleanup during startup

### DIFF
--- a/src/gateway/worker-environments/session-repository-checkpoints.test.ts
+++ b/src/gateway/worker-environments/session-repository-checkpoints.test.ts
@@ -182,6 +182,44 @@ it("recovers a published artifact after the acceptance transaction fails, withou
   expect((await snapshot.readEntry(snapshot.changedEntries[0]!)).toString()).toBe("recover me\n");
 });
 
+it("retries failed candidate cleanup and keeps completed cleanup independent of later Git locks", async () => {
+  const { remote, store, workspace, stage } = await fixture();
+  await fs.writeFile(path.join(remote, "edit.txt"), "recover after cleanup\n");
+  const prepared = await stage("turn-cleanup-retry");
+  const artifact = store.artifactPath(workspace.workspaceId);
+  const candidate = await requireWorkspaceResultGit(artifact, [
+    "for-each-ref",
+    "--format=%(refname)",
+    "refs/openclaw/worker-result-candidates/",
+  ]);
+  expect(candidate).not.toBe("");
+  const lockPath = path.join(artifact, `${candidate}.lock`);
+  await fs.writeFile(lockPath, "another Git writer\n", { flag: "wx" });
+  const attempts = await Promise.allSettled([prepared.discard(), prepared.discard()]);
+  expect(attempts.map((attempt) => attempt.status)).toEqual(["rejected", "rejected"]);
+  expect(await hasWorkerWorkspaceResultRef({ root: artifact, stagedResultRef: candidate })).toBe(
+    true,
+  );
+  await fs.rm(lockPath);
+  await Promise.all([prepared.discard(), prepared.discard()]);
+  expect(await hasWorkerWorkspaceResultRef({ root: artifact, stagedResultRef: candidate })).toBe(
+    false,
+  );
+
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  await fs.writeFile(lockPath, "another Git writer\n", { flag: "wx" });
+  await Promise.all([prepared.discard(), prepared.discard()]);
+  const accepted = await prepared.publish();
+  expect(accepted.checkpointRef).toBe(prepared.checkpointRef);
+  const snapshot = await readSessionRepositoryCheckpoint({
+    store,
+    workspaceId: workspace.workspaceId,
+  });
+  expect((await snapshot.readEntry(snapshot.changedEntries[0]!)).toString()).toBe(
+    "recover after cleanup\n",
+  );
+});
+
 it.each([false, true])(
   "retains independent raw recovery when the forked publication companion is corrupt: %s",
   async (corrupt) => {
@@ -207,7 +245,26 @@ it.each([false, true])(
       publicationStagingRoot,
       publicationDigest: hash(metadata),
     });
+    const sourceArtifact = store.artifactPath(workspace.workspaceId);
+    const candidates = (
+      await requireWorkspaceResultGit(sourceArtifact, [
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/openclaw/worker-result-candidates/",
+      ])
+    ).split("\n");
+    expect(candidates).toHaveLength(2);
     await prepared.publish();
+    for (const candidate of candidates) {
+      await fs.mkdir(path.dirname(path.join(sourceArtifact, candidate)), { recursive: true });
+      await fs.writeFile(path.join(sourceArtifact, `${candidate}.lock`), "another Git writer\n", {
+        flag: "wx",
+      });
+    }
+    await Promise.all([prepared.discard(), prepared.discard()]);
+    for (const candidate of candidates) {
+      await fs.rm(path.join(sourceArtifact, `${candidate}.lock`));
+    }
     const fork = await forkSessionRepositoryWorkspace({
       store,
       sourceWorkspaceId: workspace.workspaceId,

--- a/src/gateway/worker-environments/session-repository-checkpoints.ts
+++ b/src/gateway/worker-environments/session-repository-checkpoints.ts
@@ -22,6 +22,7 @@ import {
 import { readActualWorkspaceManifest } from "./workspace-reconcile-core.js";
 import {
   requireWorkspaceResultGit,
+  updateWorkspaceResultRefs,
   withWorkspaceResultRefMutation,
 } from "./workspace-result-git.js";
 import {
@@ -311,9 +312,18 @@ export async function stageSessionRepositoryCheckpoint(
   assertRevision();
   await fs.mkdir(root, { recursive: true, mode: 0o700 });
   await requireWorkspaceResultGit(root, ["init", "--quiet", "--bare", "--object-format=sha1"]);
-  const discard = async () => {
-    await deleteStagedWorkerWorkspaceResult({ root, stagedResultRef: candidateRef });
-    await deleteStagedWorkerWorkspaceResult({ root, stagedResultRef: companionCandidate });
+  let discardPromise: Promise<void> | undefined;
+  const discard = () => {
+    // These candidates are never recreated after preparation. Share completed
+    // cleanup across publish/finally, but leave failed Git cleanup retryable.
+    discardPromise ??= updateWorkspaceResultRefs(root, [
+      { ref: candidateRef },
+      { ref: companionCandidate },
+    ]).catch((error: unknown) => {
+      discardPromise = undefined;
+      throw error;
+    });
+    return discardPromise;
   };
   try {
     await workerWorkspaceResultStaging.stageWorkerWorkspaceResult({


### PR DESCRIPTION
Related: #145302, #134931

## What Problem This Solves

Prepared repository startup repeats successful cleanup of temporary checkpoint refs: publication removes them, then the startup finalizer removes them again. Each cleanup also invokes Git separately for its two candidates.

## Why This Change Was Made

The existing checkpoint owner now batches both temporary refs through the existing Git mutation queue and shares in-flight and completed cleanup. A failed attempt clears the shared promise so cleanup can be retried. Preparation creates these UUID-owned candidate refs before exposing the handle; later verification only reads them, and publication creates separate canonical refs, so completed candidate cleanup cannot need repeating.

This preserves the accepted recovery/publication refs, SQLite acceptance, revision and authority checks, quiescence fences, and retention. No schema, persisted format, or migration changes are involved.

## User Impact

Repository checkpoint startup performs six fewer local Git subprocesses. Repeated finalization reuses the successful cleanup result instead of acquiring the ref queue and filesystem locks again.

## Evidence

- 32 focused checkpoint, prepared-startup/recovery, and publication tests passed. Three new or extended cases failed on the original code when repeated cleanup reacquired a real Git ref lock; the candidate passes, including failed-cleanup retry, concurrent calls, canonical snapshot preservation, and publish/recovery after cleanup.
- Three interleaved baseline/candidate pairs exercised the real prepared Node runtime, loopback transfer, Git artifacts, and SQLite checkpoint acceptance. All six accepted the expected checkpoint, with the preceding author-binding optimization held constant.
- Gateway-side Git subprocesses fell from 29 to 23; cleanup subprocesses fell from eight to two. Remote workspace commands remained nine.
- Repeated final cleanup measured 69.84 ms before versus 0.04 ms after (medians). Overall startup varied under host contention, so its total difference is not attributed to this change. These are local boundary measurements, not a new cloud dispatch benchmark.
- Independent review through P2 found no actionable issue. Changed-code checks passed, including core/test typechecking, lint, and repository guards.
- [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/34652085484) passed on the reviewed head. Attempt 1 had one failure in the unchanged OpenAI speech timeout test; all 17 speech contract tests passed locally, and rerunning only the failed shard and its dependent gate succeeded without changing source, assertions, or timeouts.

Focused command: `node scripts/run-vitest.mjs src/gateway/worker-environments/session-repository-checkpoints.test.ts src/gateway/worker-environments/repository-workspace-startup.test.ts src/gateway/worker-environments/node-worker-workspace-publication.test.ts`.
