### PR TITLE
fix(clawrouter): avoid repeated provider names in model labels

### DIFF
--- a/docs/providers/clawrouter.md
+++ b/docs/providers/clawrouter.md
@@ -204,7 +204,8 @@ the next catalog refresh (cached 60 seconds per credential scope) discovers
 it. A model that needs a new wire protocol requires plugin support first.
 
 A model's optional `displayName` is its picker label; without it, OpenClaw uses
-the provider display name and catalog `id`. The label never changes model
+the provider display name and catalog `id`, omitting a repeated `<provider>/`
+prefix from the label (for example, `Anthropic · claude-sonnet-4-6`). The label never changes model
 identity. Responses and Chat Completions send the catalog `id` unchanged;
 only native Anthropic and Gemini routes use `upstream` at dispatch. A facade
 that exposes an alias must return only safe catalog metadata, including that

--- a/extensions/clawrouter/provider-catalog.test.ts
+++ b/extensions/clawrouter/provider-catalog.test.ts
@@ -162,7 +162,7 @@ describe("ClawRouter provider catalog", () => {
     ]);
     const openai = provider.models.find((model) => model.id === "openai/gpt-5.6");
     expect(openai).toMatchObject({
-      name: "OpenAI · openai/gpt-5.6",
+      name: "OpenAI · gpt-5.6",
       api: "openai-responses",
       baseUrl: "https://clawrouter.example/v1",
       reasoning: true,
@@ -185,16 +185,21 @@ describe("ClawRouter provider catalog", () => {
       supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
     });
     const deepseek = provider.models.find((model) => model.id === "deepseek/deepseek-v4-flash");
-    expect(deepseek).toMatchObject({ api: "openai-completions" });
+    expect(deepseek).toMatchObject({
+      name: "DeepSeek · deepseek-v4-flash",
+      api: "openai-completions",
+    });
     expect(deepseek?.compat).toBeUndefined();
     expect(deepseek?.thinkingLevelMap).toBeUndefined();
     expect(
       provider.models.find((model) => model.id === "anthropic/claude-sonnet-4-6"),
     ).toMatchObject({
+      name: "Anthropic · claude-sonnet-4-6",
       api: "anthropic-messages",
       baseUrl: "https://clawrouter.example/v1/native/anthropic",
     });
     expect(provider.models.find((model) => model.id === "google/gemini-3.5-flash")).toMatchObject({
+      name: "Google Gemini · google/gemini-3.5-flash",
       api: "google-generative-ai",
       baseUrl: "https://clawrouter.example/v1/native/google-gemini/v1beta",
     });

--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -300,9 +300,14 @@ function buildRoutedModel(
     upstreamModel = model.upstream;
   }
 
+  const providerPrefix = `${provider.id}/`;
+  const modelLabel = model.id.startsWith(providerPrefix)
+    ? model.id.slice(providerPrefix.length)
+    : model.id;
+
   return {
     id: model.id,
-    name: model.displayName ?? `${provider.displayName} · ${model.id}`,
+    name: model.displayName ?? `${provider.displayName} · ${modelLabel}`,
     api,
     baseUrl,
     reasoning:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users choosing a ClawRouter model see the provider twice, such as `Anthropic · anthropic/claude-sonnet-4-6`, making the picker harder to scan.

## Why This Change Was Made

Fallback labels omit the catalog ID's exact repeated provider prefix, producing `Anthropic · claude-sonnet-4-6`. Explicit display names remain authoritative, other namespaces stay intact, and routing IDs and native dispatch are unchanged.

## User Impact

ClawRouter model choices have shorter, clearer labels without changing which model receives a request.

## Evidence

- The catalog regression failed against the original implementation; all 23 catalog and plugin-index tests pass with the fix.
- Formatting, diff checks, six doctor-contract tests, and independent code review pass.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34652168243) passed, including build, type, lint, documentation, baseline, and test lanes. This supplies the hosted proof after local changed-file/type preparation was limited by an existing compatibility-record expiry and borrowed worktree dependencies.

Synthetic local Control UI proof using the actual catalog builders and mock Gateway; routing IDs are identical before and after. These captures contain only public fixture models and do not represent a live deployment.

Before:

![ClawRouter picker before the fix](https://github.com/user-attachments/assets/02429be9-32de-4843-9c6a-9f90ac683d2d)

After:

![ClawRouter picker after the fix](https://github.com/user-attachments/assets/309cb830-1c5f-4843-8e8f-aa6340bcbd0e)
