### PR TITLE
fix(macos): stop dashboard reloads after port ownership rejection

### DIFF
--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -616,7 +616,7 @@ final class ControlChannel {
                     "mode=\(String(describing: mode), privacy: .public) " +
                     "reason=\(reasonText, privacy: .public)")
             if mode == .local {
-                GatewayProcessManager.shared.setActive(true)
+                GatewayProcessManager.shared.setActive(true, source: .recovery)
             }
             if mode == .remote {
                 do {

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -426,7 +426,7 @@ actor GatewayConnection: Observable {
             try requireCurrentShutdownGeneration(shutdownGeneration)
             switch mode {
             case .local:
-                await MainActor.run { GatewayProcessManager.shared.setActive(true) }
+                await MainActor.run { GatewayProcessManager.shared.setActive(true, source: .recovery) }
                 try requireCurrentShutdownGeneration(shutdownGeneration)
 
                 let lastError: Error

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -214,7 +214,12 @@ final class GatewayProcessManager {
         }
     }
 
-    func setActive(_ active: Bool) {
+    enum ActivationSource {
+        case request
+        case recovery
+    }
+
+    func setActive(_ active: Bool, source: ActivationSource = .request) {
         if CommandResolver.connectionModeIsRemote(), !self.hostsLocalGatewayWithRemotePrimary {
             self.desiredActive = false
             self.stop()
@@ -224,6 +229,9 @@ final class GatewayProcessManager {
             return
         }
         if active, self.profilePortConflict != nil {
+            // Background recovery cannot erase an ownership rejection and briefly
+            // publish the rejected endpoint as ready before the next attach fails.
+            guard source != .recovery else { return }
             self.profilePortConflict = nil
             Task { await GatewayEndpointStore.shared.setLocalUnavailableReason(nil) }
         }

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateIsolationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateIsolationTests.swift
@@ -6,6 +6,79 @@ import Testing
 @MainActor
 struct AppStateIsolationTests {
     @Test
+    func `automatic recovery preserves a named profile port ownership failure`() async throws {
+        try #require(AppProfile.current.isActive)
+        let configPath = TestIsolation.tempConfigPath()
+        let marker = URL(fileURLWithPath: configPath + ".disable-launchagent")
+        try Data(#"{"gateway":{"mode":"local"}}"#.utf8).write(to: URL(fileURLWithPath: configPath))
+        try Data().write(to: marker)
+        defer {
+            try? FileManager.default.removeItem(atPath: configPath)
+            try? FileManager.default.removeItem(at: marker)
+        }
+        await TestIsolation.withIsolatedState(
+            env: ["OPENCLAW_CONFIG_PATH": configPath, "OPENCLAW_GATEWAY_PORT": nil],
+            defaults: [connectionModeKey: "local"])
+        {
+            let state = AppStateStore.shared
+            let previousMode = state.connectionMode
+            state.connectionMode = .local
+            let manager = GatewayProcessManager()
+            let connection = GatewayConnection(testEndpointProvider: { throw CancellationError() })
+            manager.setTestingConnection(connection)
+            manager.setTestingSkipControlChannelRefresh(true)
+            GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+            GatewayLaunchAgentManager.setTestingDaemonStatusPayload(#"{"ok":true,"service":{"loaded":false}}"#)
+            GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+            defer {
+                manager.setTestingDesiredActive(false)
+                state.connectionMode = previousMode
+                GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                GatewayLaunchAgentManager.setTestingDaemonStatusPayload(nil)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+            }
+
+            let port = GatewayEnvironment.gatewayPort()
+            await PortGuardian.shared.setTestingDescriptor(
+                .init(pid: 4242, command: "external-gateway", executablePath: "/tmp/external-gateway"),
+                forPort: port)
+            #expect(await manager._testAttachExistingGatewayIfAvailable(port: port))
+            let failure = manager.lastFailureReason ?? ""
+            #expect(failure.contains("already owned by another process"))
+            let endpointState = await GatewayEndpointStore.shared.currentState()
+            let revision = GatewayEndpointStore.shared.routeRevision
+            #expect(endpointState == .unavailable(mode: .local, reason: failure, routeRevision: revision))
+            let failureLog = manager.log
+            let daemonCalls = GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
+
+            for _ in 0..<3 {
+                manager.setActive(true, source: .recovery)
+                #expect(manager.status == .failed(failure))
+                await manager.waitForStartupAttempt()
+                #expect(manager.log == failureLog)
+                #expect(await GatewayEndpointStore.shared.currentState() == endpointState)
+                #expect(GatewayEndpointStore.shared.routeRevision == revision)
+                #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot() == daemonCalls)
+            }
+
+            // An explicit retry still starts a fresh ownership check; it cannot adopt the rejected listener.
+            manager.setActive(true)
+            #expect(manager.status == .starting)
+            await manager.waitForStartupAttempt()
+            #expect(manager.status == .failed(failure))
+            #expect(manager.log != failureLog)
+            #expect(!GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().contains { $0.first == "install" })
+
+            manager.setTestingDesiredActive(false)
+            await connection.shutdown()
+            await PortGuardian.shared.setTestingDescriptor(nil, forPort: port)
+            await GatewayEndpointStore.shared.setLocalUnavailableReason(nil)
+        }
+    }
+
+    @Test
     func `named profile hosting repair requires restart before activation`() async throws {
         try #require(AppProfile.current.isActive)
         let configPath = TestIsolation.tempConfigPath()

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -168,6 +168,12 @@ Launching the app directly with `--attach-only` or `--no-launchd` has the same
 effect. The override persists in `~/.openclaw/disable-launchagent`; remove that
 file to restore app-managed launchd behavior.
 
+Named profiles still require the listener to belong to that profile's Gateway
+service. Attach-only mode does not permit attaching another process or profile.
+If a port ownership conflict occurs, automatic recovery preserves the failure
+instead of repeatedly reopening the dashboard. Resolve the conflict, then
+relaunch the app.
+
 Logging:
 
 - launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use


### PR DESCRIPTION
Related: #145038, #145040

## What Problem This Solves

Fixes repeated dashboard document replacement when a named-profile Mac app rejects a local Gateway listener owned by another process. A standalone attach-only app reproduced the loop with no tests or repeated window-open commands: 31 logged dashboard document loads in one minute, alternating between the live page and `about:blank`.

## Why This Change Was Made

Automatic connection recovery called the same activation path as an explicit request, clearing the ownership failure and briefly making the rejected endpoint ready before the next attachment rejected it again. `GatewayProcessManager` now preserves that failure during automatic recovery; both the control channel and Gateway request recovery identify their activation source. Explicit activation still retries, and the existing profile ownership check remains intact.

This clear/reject cycle predates both linked PRs. Neither PR is claimed as its introduction. The repair belongs to the process manager that publishes availability; dashboard presentation and endpoint revision policy remain unchanged.

## User Impact

An ownership conflict produces a stable failure page instead of repeatedly replacing the dashboard. Resolve the conflict and relaunch to retry. No config, storage, or updater migration is required.

## Evidence

Developer-ID-signed native baseline `cd6fe8252e5` and fixed `6378ff159c6`, running against the same installed CLI/Gateway 2026.9.4 in a disposable macOS 26.6 VM. Each run used a named profile, synthetic credentials and owned state. No Swift tests ran during the measurements; app PID and Gateway health checks passed at each interval end.

| Live scenario | Logged dashboard loads |
| --- | ---: |
| Baseline idle with rejected external listener | 31/minute: 15 HTTP, 16 blank |
| Fixed idle with the same rejection | 0/minute |
| Fixed idle after installing the legitimate profile service and relaunching | 0/minute |
| Explicit app reopen event | 0 over 21 seconds |
| Controlled primary Gateway restart | 0/minute; control connection recovered in about 15 seconds |

The fixed rejected-state startup recorded one ownership rejection and retained the failure page. Healthy retry used the installed CLI's canonical named-profile service; this proves relaunch recovery, not a same-process retry button. App reopen used the AppKit reopen event through Launch Services, not a physical Dock click.

- The new owner-level regression passes with the fix and fails when the old unconditional clearing behavior is restored: repeated recovery changes the failure to starting and issues additional daemon calls.
- Focused VM coverage exercised the endpoint, browser-sign-in policy, launch policy, and window-ownership suites, including concurrent explicit opens. Early harness attempts exposed a named-profile frozen-port assumption and incorrect Keychain bootstrap context; existing assertions were preserved. The required native CI partitions provide the correctly bootstrapped full-suite proof.
- Swift build with tests, Swift lint/format, native localization checks, `node scripts/check-changed.mjs`, and independent Codex review through P2 pass. Native CI passed 2,198 default-profile app tests, all 4 named-profile tests (including the new regression), and 1,695 shared OpenClawKit tests.
- [Required CI](https://github.com/openclaw/openclaw/actions/runs/34652342204) is green on this exact head. Its first native attempt timed out in the untouched media-expiry fixture, whose connection disables shared recovery; one unchanged job rerun passed. No timeouts or assertions were weakened.
- The additional remote-primary/local-hosting toggle lane stopped at the requested Keychain gate during VM setup, before any hosting toggle was exercised. No hosting toggle was exercised live. Source inspection found no retry loop in the local binding or window configuration path. This is an explicit coverage gap, not a passing live result.

Baseline capture includes the unrelated synthetic node-pairing sheet; the log trace above establishes the document-replacement loop. The fixed image shows the stable rejection.

| Baseline | Fixed stable rejection |
| --- | --- |
| ![Baseline dashboard with synthetic pairing sheet](https://github.com/user-attachments/assets/f03f646f-58dd-4495-aada-9cb7752cadda) | ![Stable dashboard failure](https://github.com/user-attachments/assets/c8f882a5-f809-40a6-82fc-abe7867802d7) |

Healthy dashboard after the legitimate profile service was installed and the fixed app relaunched (the notification belongs to that task-created service):

![Healthy dashboard after retry](https://github.com/user-attachments/assets/176b9cfa-78fd-4e6f-8777-ca0c761585db)
