### PR TITLE
perf: defer migration runtimes during Doctor config repair

### DIFF
--- a/extensions/codex/doctor-contract-api.cold.test.ts
+++ b/extensions/codex/doctor-contract-api.cold.test.ts
@@ -9,6 +9,32 @@ vi.mock("openclaw/plugin-sdk/session-store-runtime", () => {
   throw new Error("legacy file detection must not load the session runtime");
 });
 
+it("normalizes config without loading sidecar migration code", async () => {
+  vi.resetModules();
+  vi.doMock("./src/migration/session-binding-sidecars.js", () => {
+    throw new Error("config normalization must not load sidecar migrations");
+  });
+  try {
+    const { normalizeCompatibilityConfig } = await import("./doctor-contract-api.js");
+    const result = normalizeCompatibilityConfig({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: {
+              config: { codexDynamicToolsProfile: "openclaw-compat", retained: true },
+            },
+          },
+        },
+      },
+    });
+    expect(result.config.plugins?.entries?.codex?.config).toEqual({ retained: true });
+    expect(result.changes).toHaveLength(1);
+  } finally {
+    vi.doUnmock("./src/migration/session-binding-sidecars.js");
+    vi.resetModules();
+  }
+});
+
 it("detects Codex sidecars without loading session storage", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-cold-"));
   const stateDir = path.join(root, "state");

--- a/extensions/codex/doctor-contract-api.ts
+++ b/extensions/codex/doctor-contract-api.ts
@@ -5,7 +5,6 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { codexOrphanedSessionBindingMigration } from "./src/migration/session-binding-orphans.js";
-import { stateMigrations as legacyStateMigrations } from "./src/migration/session-binding-sidecars.js";
 
 type LegacyConfigRule = {
   path: string[];
@@ -172,6 +171,19 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
 }
 
 export const stateMigrations: PluginDoctorStateMigration[] = [
-  ...legacyStateMigrations,
+  {
+    id: "codex-app-server-sidecars-to-plugin-state",
+    label: "Codex app-server thread bindings",
+    // Config normalization loads this artifact too; state-only imports belong
+    // behind the detection and migration callbacks.
+    detectLegacyState: async (params) =>
+      (
+        await import("./src/migration/session-binding-sidecars.js")
+      ).detectLegacySessionBindingSidecars(params),
+    migrateLegacyState: async (params) =>
+      (
+        await import("./src/migration/session-binding-sidecars.js")
+      ).migrateLegacySessionBindingSidecars(params),
+  },
   codexOrphanedSessionBindingMigration,
 ];

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -821,76 +821,70 @@ function isSafeLegacySessionId(value: unknown): value is string {
   );
 }
 
-export const stateMigrations: PluginDoctorStateMigration[] = [
-  {
-    id: "codex-app-server-sidecars-to-plugin-state",
-    label: "Codex app-server thread bindings",
-    async detectLegacyState(params) {
-      const { sources } = await collectLegacyBindingSources(params, { firstOnly: true });
-      return sources.length > 0
-        ? {
-            preview: [
-              `- Codex app-server bindings: legacy sidecar -> plugin state (${CODEX_APP_SERVER_BINDING_NAMESPACE})`,
-            ],
-          }
-        : null;
-    },
-    async migrateLegacyState(params) {
-      const changes: string[] = [];
-      const warnings: string[] = [];
-      const notices: string[] = [];
-      const { sources, surfaces } = await collectLegacyBindingSources(params);
-      if (sources.length === 0) {
-        return { changes, warnings };
+export async function detectLegacySessionBindingSidecars(params: MigrationParams) {
+  const { sources } = await collectLegacyBindingSources(params, { firstOnly: true });
+  return sources.length > 0
+    ? {
+        preview: [
+          `- Codex app-server bindings: legacy sidecar -> plugin state (${CODEX_APP_SERVER_BINDING_NAMESPACE})`,
+        ],
       }
-      const ownerCollection = await collectBindingOwners(sources, surfaces, params);
-      if (ownerCollection.failures.length > 0) {
-        warnings.push(
-          `Left ${sources.length} Codex binding sidecar(s) in place because session ownership is indeterminate: ${ownerCollection.failures.join("; ")}`,
-        );
-        return { changes, warnings };
-      }
-      const store = params.context.openPluginStateKeyedStore<MigratedBindingRow>({
-        namespace: CODEX_APP_SERVER_BINDING_NAMESPACE,
-        maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
-        overflowPolicy: "reject-new",
-      });
-      let migrated = 0;
-      let partialImports = 0;
-      for (const source of sources) {
-        const candidates =
-          ownerCollection.owners.get(
-            await canonicalPathFromExistingAncestor(source.transcriptPath),
-          ) ?? [];
-        const result = await migrateSource(source, candidates, params, store);
-        if (result.warning) {
-          warnings.push(result.warning);
-        }
-        if (result.notice) {
-          notices.push(result.notice);
-        }
-        if (result.archived) {
-          migrated++;
-        } else {
-          partialImports += result.importedKeys;
-        }
-      }
-      if (migrated > 0) {
-        changes.push(
-          `Migrated ${migrated} Codex app-server binding sidecar(s) to plugin state and archived the legacy sources`,
-        );
-      }
-      if (partialImports > 0) {
-        changes.push(
-          `Migrated ${partialImports} safe Codex app-server binding row(s) to plugin state; retained legacy sidecars needing review`,
-        );
-      }
-      return {
-        changes,
-        warnings,
-        ...(notices.length > 0 ? { notices } : {}),
-      };
-    },
-  },
-];
+    : null;
+}
+
+export async function migrateLegacySessionBindingSidecars(params: MigrationParams) {
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const notices: string[] = [];
+  const { sources, surfaces } = await collectLegacyBindingSources(params);
+  if (sources.length === 0) {
+    return { changes, warnings };
+  }
+  const ownerCollection = await collectBindingOwners(sources, surfaces, params);
+  if (ownerCollection.failures.length > 0) {
+    warnings.push(
+      `Left ${sources.length} Codex binding sidecar(s) in place because session ownership is indeterminate: ${ownerCollection.failures.join("; ")}`,
+    );
+    return { changes, warnings };
+  }
+  const store = params.context.openPluginStateKeyedStore<MigratedBindingRow>({
+    namespace: CODEX_APP_SERVER_BINDING_NAMESPACE,
+    maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
+  });
+  let migrated = 0;
+  let partialImports = 0;
+  for (const source of sources) {
+    const candidates =
+      ownerCollection.owners.get(await canonicalPathFromExistingAncestor(source.transcriptPath)) ??
+      [];
+    const result = await migrateSource(source, candidates, params, store);
+    if (result.warning) {
+      warnings.push(result.warning);
+    }
+    if (result.notice) {
+      notices.push(result.notice);
+    }
+    if (result.archived) {
+      migrated++;
+    } else {
+      partialImports += result.importedKeys;
+    }
+  }
+  if (migrated > 0) {
+    changes.push(
+      `Migrated ${migrated} Codex app-server binding sidecar(s) to plugin state and archived the legacy sources`,
+    );
+  }
+  if (partialImports > 0) {
+    changes.push(
+      `Migrated ${partialImports} safe Codex app-server binding row(s) to plugin state; retained legacy sidecars needing review`,
+    );
+  }
+  return {
+    changes,
+    warnings,
+    ...(notices.length > 0 ? { notices } : {}),
+  };
+}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/telegram/doctor-contract-api.ts
+++ b/extensions/telegram/doctor-contract-api.ts
@@ -1,6 +1,5 @@
 // Telegram API module exposes the plugin public contract.
 import { definePluginDoctorMigrationFromPlans } from "openclaw/plugin-sdk/runtime-doctor-migrations";
-import { detectTelegramLegacyStateMigrations } from "./src/state-migrations.js";
 
 export { normalizeCompatibilityConfig, legacyConfigRules } from "./config-doctor-api.js";
 
@@ -8,6 +7,11 @@ export const stateMigrations = [
   definePluginDoctorMigrationFromPlans({
     id: "telegram-legacy-state",
     label: "Telegram legacy state",
-    resolvePlans: detectTelegramLegacyStateMigrations,
+    // Config repair enumerates this artifact too; load the detector only when
+    // detection or migration resolves plans.
+    resolvePlans: async (params) => {
+      const { detectTelegramLegacyStateMigrations } = await import("./src/state-migrations.js");
+      return detectTelegramLegacyStateMigrations(params);
+    },
   }),
 ];

--- a/extensions/telegram/src/state-migrations.import-boundary.test.ts
+++ b/extensions/telegram/src/state-migrations.import-boundary.test.ts
@@ -45,7 +45,10 @@ function collectPluginLocalClosure(entryFile: string): string[] {
     }
     visited.add(fileName);
     for (const specifier of listStaticRelativeImports(path.join(SOURCE_DIR, fileName))) {
-      const resolved = `${specifier.replace(/^\.\//, "").replace(/\.js$/, "")}.ts`;
+      const resolved = path.relative(
+        SOURCE_DIR,
+        path.resolve(SOURCE_DIR, path.dirname(fileName), specifier.replace(/\.js$/, ".ts")),
+      );
       if (fs.existsSync(path.join(SOURCE_DIR, resolved))) {
         pending.push(resolved);
       }
@@ -55,6 +58,15 @@ function collectPluginLocalClosure(entryFile: string): string[] {
 }
 
 describe("telegram state migration import boundary", () => {
+  it("keeps state detection off the config repair artifact closure", () => {
+    const closure = collectPluginLocalClosure("../doctor-contract-api.ts");
+
+    expect(closure).not.toContain("state-migrations.ts");
+    expect(closure).toEqual(
+      expect.arrayContaining(["../config-doctor-api.ts", "doctor-contract.ts"]),
+    );
+  });
+
   it("keeps runtime stores off the doctor discovery closure", () => {
     const closure = collectPluginLocalClosure("state-migrations.ts");
 

--- a/extensions/telegram/src/state-migrations.test.ts
+++ b/extensions/telegram/src/state-migrations.test.ts
@@ -1,11 +1,14 @@
 // Telegram tests cover state migrations plugin behavior.
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { buildLegacyMigrationPreview } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -262,7 +265,7 @@ describe("telegram state migrations", () => {
     }
   });
 
-  it("detects legacy bot-info cache import", async () => {
+  it("imports legacy bot-info through the doctor contract and archives the sidecar", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-state-migration-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
     const persistedPath = resolveTelegramBotInfoCachePath("ops", env);
@@ -325,7 +328,41 @@ describe("telegram state migrations", () => {
           },
         },
       });
+      const migration = stateMigrations[0];
+      if (!migration) {
+        throw new Error("expected Telegram migration");
+      }
+      const input = {
+        config: cfg,
+        env,
+        stateDir: dir,
+        oauthDir: path.join(dir, "credentials"),
+        context: {
+          openPluginStateKeyedStore: <T>(
+            options: Parameters<typeof createPluginStateKeyedStoreForTests>[1],
+          ) => createPluginStateKeyedStoreForTests<T>("telegram", { ...options, env }),
+        },
+      };
+      const migrated = await migration.migrateLegacyState(input);
+      expect(migrated.warnings).toEqual([]);
+      expect(migrated.changes).toContain(
+        "Migrated 1 Telegram startup bot info cache entry → plugin state",
+      );
+      const store = createPluginStateKeyedStoreForTests("telegram", {
+        namespace: botInfoPlan.namespace,
+        maxEntries: botInfoPlan.maxEntries,
+        env,
+      });
+      expect(await store.lookup("ops")).toMatchObject({
+        tokenFingerprint: "token:fingerprint",
+        botInfo: { id: 123456, username: "openclaw_bot" },
+      });
+      await expect(access(persistedPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(access(`${persistedPath}.migrated`)).resolves.toBeUndefined();
+      expect(await migration.detectLegacyState(input)).toBeNull();
+      expect(await migration.migrateLegacyState(input)).toEqual({ changes: [], warnings: [] });
     } finally {
+      resetPluginStateStoreForTests();
       await rm(dir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## What Problem This Solves

Doctor config normalization loaded heavy Telegram and Codex sidecar migration implementations while only reading configuration repair metadata. Those implementations pull in agent, session and state-related dependencies before any state migration is requested.

## Why This Change Was Made

Telegram now resolves its existing migration plans lazily through the same adapter pattern already used by iMessage. The Codex Doctor entry owns its existing migration descriptor and lazily calls two named functions in the same sidecar implementation. Their bodies are unchanged; the obsolete internal descriptor array is removed.

Config normalization, migration IDs/labels/order/default flags, ownership checks, archival behavior and stored data remain unchanged. The Codex orphan migration retains its existing descriptor and phase. This does not change generic artifact selection, hashes, freshness, schemas, public SDK exports, native Codex APIs, or configuration options.

## User Impact

Reading Doctor config repair metadata avoids unrelated state-runtime loading. Actual state detection and migration still run the same implementations when requested.

## Evidence

One matched, instrumented local pair on base `d781c156cb7738ce64eba162178bef85e715a989`, with the same tests, artifacts and cache policy; the control reverses only the three production files:

| Measurement | Original | Candidate |
| --- | ---: | ---: |
| Channel normalization | 18.290s | 1.901s |
| Complete compatibility normalization | 24.349s | 12.374s |
| Selected migration case | 35.299s | 26.772s |
| Whole wrapper | 58.327s | 66.408s |
| BSD time maximum RSS | 2,301,575,168 bytes | 2,287,009,792 bytes |

The wrapper was slower: its pre-case worker interval grew from 17.492s to 34.951s. That interval remains unattributed. These results support the measured normalization boundary improvement, not a whole-invocation or overall CI-speedup claim. The small RSS difference does not establish a memory reduction. Both arms passed the same case with identical digest, 45 timing records, five configured models, three generated catalogs and both synthetic auth hooks. Earlier exploratory pairs remain separate from this comparison.

The new cold metadata regression failed on the original eager Codex import; the candidate passes it and the unchanged real detection/migration/ownership/archive suite (39 cases). Telegram owner/import/Doctor checks pass (46 cases), as do four shared-adapter cases. Existing Telegram bot-info coverage now also exercises the exported migration, persisted row, archival and repeat no-op.

The complete changed gate and standard build passed, including Doctor declaration/closure checks, all declaration partitions, native loading of 53 built control-plane modules, types, lint, boundaries, SDK export checks and startup metadata. Independent P2 review is clean. The six source files remained unchanged after review/build. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34652410718) passed all 123 checks with no failures.

Direct native-contract inspection used public upstream Codex commit `e3a52b87b28760413eafa340e2ab23d653f0bbe7`: [thread resume parameters](https://github.com/openai/codex/blob/e3a52b87b28760413eafa340e2ab23d653f0bbe7/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L335), [thread read parameters](https://github.com/openai/codex/blob/e3a52b87b28760413eafa340e2ab23d653f0bbe7/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L1667), [thread metadata](https://github.com/openai/codex/blob/e3a52b87b28760413eafa340e2ab23d653f0bbe7/codex-rs/state/src/model/thread_metadata.rs#L125), and [native thread lookup](https://github.com/openai/codex/blob/e3a52b87b28760413eafa340e2ab23d653f0bbe7/codex-rs/state/src/runtime/threads.rs#L9). OpenClaw’s plugin binding rows remain distinct from native thread storage. No live Telegram message or native Codex request was changed or exercised; the real local config/migration contracts are the tested surface.

Production delta: +10 net lines for the lazy owner boundary; tests +75. Migration bodies and literals are preserved, apart from formatting. No dependency, runner, shard or deadline change.

## Upgrade and data-model review

The automated persisted-table warning is a false positive from moving existing migration callbacks. This patch changes no SQLite schema, stored row representation, schema version, migration SQL, ownership check, or archival policy. The detection/migration bodies and literals are preserved, and the real migration, ownership, archive and repeat-no-op tests pass.

The required published-driver × candidate check passed in [Package Acceptance34655268388](https://github.com/openclaw/openclaw/actions/runs/34655268388/job/103450245422), with zero retries. Published `openclaw@2026.9.3` ran its installed updater against candidate `2026.9.4` at `ef6f80b23d2013dc5c9c095e0b99041b29c77181`. Trusted tooling was pinned to `98ac734316fd358fb04baf54fcb61fbde1ecba14`; candidate tarball SHA-256 was `0206b7dfcd53af501ec8a093ae1b441c6c992aea5cb135d1a361f93144825d44`.

The legacy-operator-state scenario passed in 306s: baseline-created state survived, candidate schema and automatic migration checks passed, cron owners remained correct, mobile pairing survived restart, the Gateway served candidate2026.9.4, and a synthetic agent turn succeeded. A second update reported already-current without package mutations or repair, followed by a clean Doctor check. Formerly bundled plugin Doctor repair also passed. Startup was7s, healthz1s, readyz1s and status2s. This is the packaged Docker upgrade proof, not a live external-provider/channel claim. [Retained scenario logs and summary](https://github.com/openclaw/openclaw/actions/runs/34655268388/artifacts/10285726700) contain the result. Package integrity and npm12 installer acceptance passed as well. This satisfies the latest review's published-updater before-merge item and rank-up request.
