### PR TITLE
feat(ui): move the Mac app Gateway picker into the sidebar footer

### DIFF
--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -181,6 +181,13 @@ personal sign-in route continue to use the shared owner profile.
 Open windows for saved Gateway profiles follow sign-in route changes after a
 reconnect. An unchanged route keeps the current dashboard and its navigation.
 
+The account card at the bottom-left of the dashboard shows your name and the
+current Gateway, including its health and primary status. While disconnected,
+it shows **Reconnecting…**. Open the card's **Gateway** section to switch Gateways,
+Command-click or Control-click a Gateway to open it in another window, or choose
+**Gateway settings…**. **Set as primary…** appears when the current Gateway can
+be promoted. These controls are available even with only one saved Gateway.
+
 Opening the embedded dashboard at its default Chat landing restores the last
 page you visited, such as **Usage**, for that Gateway origin. Explicit session
 links and navigation requests take precedence over the remembered page, and

--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -6,6 +6,7 @@ export const uiIsolatedTestFiles = [
   "ui/src/app/bootstrap.gateway-credentials.test.ts",
   "ui/src/app/bootstrap.test.ts",
   "ui/src/app/router-outlet.test.ts",
+  "ui/src/components/app-sidebar-native-gateways.test.ts",
   "ui/src/components/github-link-title-tooltip.test.ts",
   "ui/src/components/markdown-tables.test.ts",
   "ui/src/components/mcp-app-view.test.ts",

--- a/ui/src/app/native-gateways.runtime.ts
+++ b/ui/src/app/native-gateways.runtime.ts
@@ -82,7 +82,7 @@ function createNativeGatewaysCapability(): NativeGatewaysCapability | null {
 
 let singleton: NativeGatewaysCapability | null | undefined;
 
-// Chat-chunk-owned so this capability never enters the QA-smoke startup bundle.
+// Loaded by native chat features and sidebar menus, outside the startup bundle.
 export function nativeGatewaysCapability(): NativeGatewaysCapability | null {
   if (singleton === undefined) {
     singleton = createNativeGatewaysCapability();

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -473,13 +473,16 @@ function renderIdentityGateways(onClose: SidebarIdentityMenuParams["onClose"]) {
         ? html`<wa-dropdown-item
             class="sidebar-customize-menu__item"
             value="command:gateway-set-primary"
-            >${t("nav.gateway.setPrimary")}</wa-dropdown-item
-          >`
+          >
+            <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.star}</span>
+            <span class="sidebar-customize-menu__text">${t("nav.gateway.setPrimary")}</span>
+          </wa-dropdown-item>`
         : nothing
     }
-    <wa-dropdown-item class="sidebar-customize-menu__item" value="command:gateway-settings"
-      >${t("nav.gateway.openSettings")}</wa-dropdown-item
-    >
+    <wa-dropdown-item class="sidebar-customize-menu__item" value="command:gateway-settings">
+      <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.server}</span>
+      <span class="sidebar-customize-menu__text">${t("nav.gateway.openSettings")}</span>
+    </wa-dropdown-item>
     <div class="sidebar-customize-menu__separator" role="separator"></div>
   `;
 }

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -6,6 +6,7 @@ import type { AgentIdentityResult } from "../api/types.ts";
 import { titleForRoute, type NavigationRouteId } from "../app-navigation.ts";
 import { pathForAgentPanel } from "../app-route-paths.ts";
 import type { ApplicationNavigationOptions } from "../app/context.ts";
+import { nativeGatewaysCapability } from "../app/native-gateways.runtime.ts";
 import type { ThemeMode } from "../app/theme.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
@@ -419,6 +420,70 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
   `;
 }
 
+function renderIdentityGateways(onClose: SidebarIdentityMenuParams["onClose"]) {
+  const capability = nativeGatewaysCapability();
+  if (!capability) {
+    return nothing;
+  }
+  const snapshot = capability.snapshot;
+  const current = snapshot?.gateways.find((gateway) => gateway.id === snapshot.currentId);
+  return html`
+    <div class="sidebar-customize-menu__title">${t("nav.gateway.sectionLabel")}</div>
+    ${snapshot?.gateways.map((gateway) => {
+      const selected = gateway.id === snapshot.currentId;
+      const healthLabel =
+        gateway.health === "ok"
+          ? t("nav.gateway.connected")
+          : gateway.health === "error"
+            ? t("nav.gateway.unreachable")
+            : t("nav.gateway.unknown");
+      const openWindow = (event: MouseEvent) => {
+        if (event.metaKey || event.ctrlKey) {
+          event.preventDefault();
+          event.stopPropagation();
+          capability.openWindow(gateway.id);
+          onClose(false);
+        }
+      };
+      return html`<wa-dropdown-item
+        class="sidebar-customize-menu__item"
+        value=${`gateway:${encodeURIComponent(gateway.id)}`}
+        role="menuitemradio"
+        aria-checked=${String(selected)}
+        ${ref((element) => syncDropdownItemRadio(element, selected))}
+        @click=${openWindow}
+        @contextmenu=${openWindow}
+      >
+        <span
+          slot="icon"
+          class="sidebar-gateway-health"
+          data-health=${gateway.health}
+          role="img"
+          aria-label=${healthLabel}
+        ></span>
+        <span class="sidebar-customize-menu__text">${gateway.name}</span>
+        <span slot="details" class="sidebar-gateway-details">
+          ${gateway.isPrimary ? html`<span class="sidebar-gateway-primary">${t("nav.gateway.primaryTag")}</span>` : nothing}
+          ${selected ? html`<span class="sidebar-gateway-check" aria-hidden="true">${icons.check}</span>` : nothing}
+        </span>
+      </wa-dropdown-item>`;
+    })}
+    ${
+      current?.canPromote
+        ? html`<wa-dropdown-item
+            class="sidebar-customize-menu__item"
+            value="command:gateway-set-primary"
+            >${t("nav.gateway.setPrimary")}</wa-dropdown-item
+          >`
+        : nothing
+    }
+    <wa-dropdown-item class="sidebar-customize-menu__item" value="command:gateway-settings"
+      >${t("nav.gateway.openSettings")}</wa-dropdown-item
+    >
+    <div class="sidebar-customize-menu__separator" role="separator"></div>
+  `;
+}
+
 export function renderSidebarIdentityMenu(params: SidebarIdentityMenuParams) {
   const position = params.position;
   const profileName = params.profileViewer?.name ?? params.profileViewer?.email ?? t("nav.owner");
@@ -453,11 +518,31 @@ export function renderSidebarIdentityMenu(params: SidebarIdentityMenuParams) {
           return;
         }
         params.onClose(false);
+        const capability = nativeGatewaysCapability();
+        if (value.startsWith("gateway:")) {
+          const id = decodeURIComponent(value.slice("gateway:".length));
+          if (id !== capability?.snapshot?.currentId) {
+            capability?.select(id);
+          }
+          return;
+        }
         if (value.startsWith(LINK_VALUE_PREFIX)) {
           openExternalUrlSafe(decodeURIComponent(value.slice(LINK_VALUE_PREFIX.length)));
           return;
         }
         switch (value) {
+          case `${COMMAND_VALUE_PREFIX}gateway-set-primary`: {
+            const current = capability?.snapshot?.gateways.find(
+              (gateway) => gateway.id === capability.snapshot?.currentId,
+            );
+            if (current?.canPromote) {
+              capability?.setPrimary(current.id);
+            }
+            break;
+          }
+          case `${COMMAND_VALUE_PREFIX}gateway-settings`:
+            capability?.openSettings();
+            break;
           case `${COMMAND_VALUE_PREFIX}profile`:
             params.onNavigate("profile", { hash: "#settings-profile-identity" });
             break;
@@ -515,6 +600,7 @@ export function renderSidebarIdentityMenu(params: SidebarIdentityMenuParams) {
         </span>
       </wa-dropdown-item>
       <div class="sidebar-customize-menu__separator" role="separator"></div>
+      ${renderIdentityGateways(params.onClose)}
       <wa-dropdown-item class="sidebar-customize-menu__item" value="command:settings">
         <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.settings}</span>
         <span class="sidebar-customize-menu__text">${t("nav.settings")}</span>

--- a/ui/src/components/app-sidebar-native-gateways.test.ts
+++ b/ui/src/components/app-sidebar-native-gateways.test.ts
@@ -1,0 +1,116 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { nativeGatewaysCapability } from "../app/native-gateways.runtime.ts";
+import {
+  createGatewayHarness,
+  createSessions,
+  mountSidebar,
+  setupSidebarTest,
+} from "../test-helpers/app-sidebar.ts";
+import {
+  clearNativeGatewayTestState,
+  setNativeGatewayTestState,
+} from "../test-helpers/native-gateways.ts";
+import "./app-sidebar.ts";
+
+setupSidebarTest();
+afterEach(clearNativeGatewayTestState);
+
+describe("AppSidebar native Gateway menu", () => {
+  it("lists native gateways and dispatches switching, window, primary, and settings actions", async () => {
+    const postMessage = setNativeGatewayTestState("remote")!;
+    const capability = nativeGatewaysCapability()!;
+    const snapshot = {
+      gateways: [
+        capability.snapshot!.gateways[0]!,
+        { ...capability.snapshot!.gateways[1]!, id: "profile:team", health: "error" as const },
+        {
+          ...capability.snapshot!.gateways[1]!,
+          id: "unknown",
+          name: "Unprobed Gateway",
+          health: "unknown" as const,
+        },
+      ],
+      currentId: "profile:team",
+    };
+    const publish = () =>
+      window.dispatchEvent(
+        new CustomEvent("openclaw:native-gateways-changed", { detail: snapshot }),
+      );
+    publish();
+    const { sidebar } = await mountSidebar(
+      createGatewayHarness({ instanceId: "self-instance" } as GatewayBrowserClient).gateway,
+      createSessions("main", ["agent:main:main"]),
+    );
+    const open = async () => {
+      sidebar.querySelector<HTMLButtonElement>(".sidebar-identity-card")!.click();
+      await sidebar.updateComplete;
+      return sidebar.querySelector<HTMLElement>(".sidebar-identity-menu")!;
+    };
+    const choose = async (value: string, modifiers?: MouseEventInit, eventType = "click") => {
+      const menu = await open();
+      const item = menu.querySelector<HTMLElement>(`wa-dropdown-item[value="${value}"]`)!;
+      expect(item).not.toBeNull();
+      if (modifiers) {
+        item.dispatchEvent(
+          new MouseEvent(eventType, { bubbles: true, cancelable: true, ...modifiers }),
+        );
+      } else {
+        // Web Awesome emits wa-select for keyboard activation as well as ordinary clicks.
+        menu.dispatchEvent(new CustomEvent("wa-select", { detail: { item }, bubbles: true }));
+      }
+      await sidebar.updateComplete;
+      expect(sidebar.querySelector(".sidebar-identity-menu")).toBeNull();
+    };
+    const menu = await open();
+    expect(menu.querySelector(".sidebar-customize-menu__title")?.textContent).toBe("Gateway");
+    const rows = snapshot.gateways.map((gateway) =>
+      menu.querySelector<HTMLElement>(
+        `wa-dropdown-item[value="gateway:${encodeURIComponent(gateway.id)}"]`,
+      )!,
+    );
+    expect(
+      rows.map((row) => row.querySelector(".sidebar-customize-menu__text")?.textContent?.trim()),
+    ).toEqual(["Local Gateway", "Remote Gateway", "Unprobed Gateway"]);
+    expect(
+      rows.map((row) => row.querySelector(".sidebar-gateway-health")?.getAttribute("aria-label")),
+    ).toEqual(["Connected", "Unreachable", "Unknown status"]);
+    expect(rows[0]!.querySelector(".sidebar-gateway-primary")?.textContent).toBe("primary");
+    expect(rows[1]!.querySelector(".sidebar-gateway-primary")).toBeNull();
+    expect(rows[1]!.querySelector(".sidebar-gateway-check")).not.toBeNull();
+    expect(rows[0]!.querySelector(".sidebar-gateway-check")).toBeNull();
+    menu.dispatchEvent(new CustomEvent("wa-select", { detail: { item: rows[1] }, bubbles: true }));
+    await sidebar.updateComplete;
+    expect(postMessage).not.toHaveBeenCalled();
+    expect(sidebar.querySelector(".sidebar-identity-menu")).toBeNull();
+
+    await choose("gateway:local");
+    expect(postMessage).toHaveBeenLastCalledWith({ type: "select", id: "local" });
+    for (const modifiers of [{ metaKey: true }, { ctrlKey: true }]) {
+      await choose("gateway:profile%3Ateam", modifiers);
+      expect(postMessage).toHaveBeenLastCalledWith({ type: "open-window", id: "profile:team" });
+    }
+    // macOS sends a contextmenu event for Control-click instead of click.
+    await choose("gateway:profile%3Ateam", { ctrlKey: true }, "contextmenu");
+    expect(postMessage).toHaveBeenLastCalledWith({ type: "open-window", id: "profile:team" });
+    await choose("command:gateway-set-primary");
+    expect(postMessage).toHaveBeenLastCalledWith({ type: "set-primary", id: "profile:team" });
+    await choose("command:gateway-settings");
+    expect(postMessage).toHaveBeenLastCalledWith({ type: "open-settings" });
+    expect(postMessage).toHaveBeenCalledTimes(6);
+
+    snapshot.gateways = [snapshot.gateways[0]!];
+    snapshot.currentId = "local";
+    publish();
+    const singleMenu = await open();
+    expect(singleMenu.querySelector('wa-dropdown-item[value="gateway:local"]')).not.toBeNull();
+    expect(
+      singleMenu.querySelector('wa-dropdown-item[value="command:gateway-set-primary"]'),
+    ).toBeNull();
+    expect(
+      singleMenu.querySelector('wa-dropdown-item[value="command:gateway-settings"]'),
+    ).not.toBeNull();
+  });
+});

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -9,7 +9,7 @@ import {
   type SidebarZoneEntry,
 } from "../app-navigation.ts";
 import { isRouteId, isSessionRouteId } from "../app-route-paths.ts";
-import { isNativeWebChromeHost } from "../app/native-web-chrome.ts";
+import type { NativeGateway, NativeGatewaysSnapshot } from "../app/native-gateways.runtime.ts";
 import { isHomePanelAvailable } from "../app/panel-availability.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../app/user-profile.ts";
 import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
@@ -66,28 +66,13 @@ type AppSidebarRenderHost = AppSidebarSessionNavigationElement & {
   toggleSection(sectionId: string): void;
 };
 
-type SidebarNativeGateway = {
-  id: string;
-  name: string;
-  isPrimary: boolean;
-  health: "ok" | "error" | "unknown";
-};
-
-type SidebarNativeGatewaysSnapshot = {
-  gateways: SidebarNativeGateway[];
-  currentId: string;
-};
-
 // Display-only: read the injected global directly; the capability module must stay
-// chat-chunk-owned to protect the QA smoke startup budget.
-function readSidebarNativeGateway(): SidebarNativeGateway | null {
-  if (!isNativeWebChromeHost()) {
-    return null;
-  }
-  const snapshot = (
-    window as Window & { __OPENCLAW_NATIVE_GATEWAYS__?: SidebarNativeGatewaysSnapshot }
-  )["__OPENCLAW_NATIVE_GATEWAYS__"];
-  if (!snapshot || !Array.isArray(snapshot.gateways) || snapshot.gateways.length < 2) {
+// lazy to protect the startup budget.
+function readSidebarNativeGateway(): NativeGateway | null {
+  const snapshot = (window as Window & { __OPENCLAW_NATIVE_GATEWAYS__?: NativeGatewaysSnapshot })[
+    "__OPENCLAW_NATIVE_GATEWAYS__"
+  ];
+  if (!snapshot || !Array.isArray(snapshot.gateways)) {
     return null;
   }
   return snapshot.gateways.find((gateway) => gateway.id === snapshot.currentId) ?? null;
@@ -406,12 +391,9 @@ export function renderAppSidebarFooterBar(host: AppSidebarRenderHost) {
     name: selfLabel,
     watchedSessions: [],
   };
-  const gateway = host.offline ? null : readSidebarNativeGateway();
+  const gateway = readSidebarNativeGateway();
   const buildSubtitle = formatSidebarBuildSubtitle(CONTROL_UI_BUILD_INFO);
-  // Health is visual-only here by budget decision; the header picker owns health accessibility.
-  const gatewayPrimaryTag = gateway?.isPrimary
-    ? t("chat.sessionHeader.gatewayPicker.primaryTag")
-    : null;
+  const gatewayPrimaryTag = gateway?.isPrimary ? t("nav.gateway.primaryTag") : null;
   const identityMenuLabel = t("profilePage.identity.menuButtonLabel", { name: selfLabel });
   const identityDetail = host.offline
     ? t("connection.reconnecting")
@@ -432,6 +414,21 @@ export function renderAppSidebarFooterBar(host: AppSidebarRenderHost) {
         <openclaw-viewer-avatar .user=${avatarUser} variant="footer"></openclaw-viewer-avatar>
         <span class="sidebar-identity-card__text">
           <span class="sidebar-identity-card__name" title=${selfLabel}>${selfLabel}</span>
+          ${
+            gateway
+              ? html`<span class="sidebar-identity-card__gateway" aria-hidden="true">
+                  ${
+                    host.offline
+                      ? t("connection.reconnecting")
+                      : html`
+                          <span class="sidebar-gateway-health" data-health=${gateway.health}></span>
+                          <span class="sidebar-gateway-name">${gateway.name}</span>
+                          ${gatewayPrimaryTag ? html`<span class="sidebar-gateway-primary">${gatewayPrimaryTag}</span>` : nothing}
+                        `
+                  }
+                </span>`
+              : nothing
+          }
         </span>
       </button>
       ${

--- a/ui/src/components/sidebar-footer-layout.browser.test.ts
+++ b/ui/src/components/sidebar-footer-layout.browser.test.ts
@@ -2,10 +2,22 @@
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures.js";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import {
+  createGateway,
+  createSessions,
+  mountSidebar,
+  setupSidebarTest,
+} from "../test-helpers/app-sidebar.ts";
+import "./app-sidebar.ts";
 import {
   canRunPlaywrightChromium,
   resolvePlaywrightChromiumExecutablePath,
 } from "../test-helpers/control-ui-e2e.ts";
+import {
+  clearNativeGatewayTestState,
+  setNativeGatewayTestState,
+} from "../test-helpers/native-gateways.ts";
 
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
@@ -34,6 +46,7 @@ afterAll(async () => {
 });
 
 describeBrowserLayout("sidebar footer layout", () => {
+  setupSidebarTest();
   beforeAll(async () => {
     if (!chromiumAvailable) {
       return;
@@ -151,5 +164,52 @@ describeBrowserLayout("sidebar footer layout", () => {
     expect(centering?.above).toBeCloseTo(centering?.below ?? 0, 2);
     expect(centering?.actionCenterY).toBeCloseTo(centering?.cardCenterY ?? 0, 2);
     expect(centering?.trailingInset).toBeCloseTo(centering?.leadingInset ?? 0, 2);
+  });
+
+  it("fits the rendered native two-line identity inside the 53px footer", async () => {
+    setNativeGatewayTestState("local");
+    try {
+      const { sidebar } = await mountSidebar(
+        createGateway({} as GatewayBrowserClient),
+        createSessions("main", ["agent:main:main"]),
+      );
+      const card = sidebar.querySelector<HTMLElement>(".sidebar-identity-card")!;
+      const avatar = card.querySelector<HTMLElement & { updateComplete: Promise<unknown> }>(
+        "openclaw-viewer-avatar",
+      )!;
+      await avatar.updateComplete;
+      await page.locator(".sidebar-identity-card").evaluate((element, markup) => {
+        element.outerHTML = markup;
+      }, card.outerHTML);
+      const geometry = await page.evaluate(() => {
+        const box = (selector: string) => {
+          const { top, bottom, right, height } = document
+            .querySelector(selector)!
+            .getBoundingClientRect();
+          return { top, bottom, right, height };
+        };
+        return {
+          footer: box(".sidebar-shell__footer"),
+          card: box(".sidebar-identity-card"),
+          name: box(".sidebar-identity-card__name"),
+          gateway: box(".sidebar-identity-card__gateway"),
+          avatar: box(".sidebar-identity-card .viewer-avatar--footer"),
+        };
+      });
+      expect(geometry.footer.height).toBe(53);
+      expect(geometry.name.height).toBe(18);
+      expect(geometry.gateway.height).toBe(14);
+      expect(geometry.gateway.top).toBeGreaterThanOrEqual(geometry.name.bottom);
+      expect(geometry.avatar.height).toBe(28);
+      expect(geometry.card.top).toBeGreaterThan(geometry.footer.top);
+      expect(geometry.card.bottom).toBeLessThan(geometry.footer.bottom);
+      for (const content of [geometry.name, geometry.gateway, geometry.avatar]) {
+        expect(content.top).toBeGreaterThanOrEqual(geometry.card.top);
+        expect(content.bottom).toBeLessThanOrEqual(geometry.card.bottom);
+        expect(content.right).toBeLessThanOrEqual(geometry.card.right);
+      }
+    } finally {
+      clearNativeGatewayTestState();
+    }
   });
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2211,6 +2211,16 @@ export const en: TranslationMap & {
     blockedAgentFilter: "blocked by agent filter",
   },
   nav: {
+    gateway: {
+      sectionLabel: "Gateway",
+      menuLabel: "Gateway: {gateway}",
+      primaryTag: "primary",
+      setPrimary: "Set as primary…",
+      openSettings: "Gateway settings…",
+      connected: "Connected",
+      unreachable: "Unreachable",
+      unknown: "Unknown status",
+    },
     owner: "Owner",
     back: "Back",
     forward: "Forward",
@@ -4970,15 +4980,6 @@ export const en: TranslationMap & {
       oneMessage: "{count} message",
       messages: "{count} messages",
       activeBranch: "Active branch",
-      gatewayPicker: {
-        menuLabel: "Gateway: {gateway}",
-        primaryTag: "primary",
-        setPrimary: "Set as primary…",
-        openSettings: "Gateway settings…",
-        connected: "Connected",
-        unreachable: "Unreachable",
-        unknown: "Unknown status",
-      },
     },
     board: {
       faceLabel: "Session face",

--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -1,7 +1,6 @@
 import { html, noChange, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import type { ApplicationContext } from "../../app/context.ts";
-import { nativeGatewaysCapability } from "../../app/native-gateways.runtime.ts";
 import type { BoardFace } from "../../lib/board/settings.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import { resolveSessionKey } from "../../lib/sessions/index.ts";
@@ -48,13 +47,11 @@ type ChatPagePaneRenderOptions = {
   ownerKey: string;
   pane: ChatSplitPane;
   sessionSlots: readonly (string | undefined)[];
-  showGatewayPicker: boolean;
   splitMode: boolean;
   weight: number;
 };
 
 export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
-  const nativeGateways = options.showGatewayPicker ? nativeGatewaysCapability() : null;
   const sessions = options.context?.sessions?.state.result?.sessions ?? [];
   return html`
     <div
@@ -122,8 +119,6 @@ export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
               .narrow=${options.narrow}
               .mergedChrome=${options.mergedChrome && active}
               .navDrawerOpen=${options.navDrawerOpen && active}
-              .nativeGateways=${nativeGateways}
-              .gatewaysSnapshot=${nativeGateways?.snapshot ?? null}
               .onboarding=${options.onboarding}
               .onOpenSplitView=${options.onOpenSplitView}
               .onSplitDown=${options.onSplitDown}

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -5,22 +5,13 @@ import { expectDefined } from "@openclaw/normalization-core";
 import type { RouteLocation } from "@openclaw/uirouter";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const nativeGateways = vi.hoisted(() => ({ current: null as NativeGatewaysCapability | null }));
-
 // Keep this complete mock in the dedicated unit-mock-registry project.
 vi.mock("./chat-pane.ts", () => ({}));
-vi.mock("../../app/native-gateways.runtime.ts", () => ({
-  nativeGatewaysCapability: () => nativeGateways.current,
-}));
 
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
-import type {
-  NativeGatewaysCapability,
-  NativeGatewaysSnapshot,
-} from "../../app/native-gateways.runtime.ts";
 import { loadSettings } from "../../app/settings.ts";
 import { UI_COMMAND_EVENT } from "../../components/panel-toggle-contract.ts";
 import {
@@ -60,8 +51,6 @@ type RenderedPane = HTMLElement & {
   paneTitle: string;
   narrow: boolean;
   mergedChrome: boolean;
-  nativeGateways: NativeGatewaysCapability | null;
-  gatewaysSnapshot: NativeGatewaysSnapshot | null;
   onOpenSplitView?: () => void;
   onClosePane?: (paneId: string) => void;
   onFaceChange?: (paneId: string, sessionKey: string, face: "chat" | "dashboard") => void;
@@ -238,7 +227,6 @@ function stubMatchMedia(matches: boolean) {
 
 describe("chat page split layout host", () => {
   beforeEach(() => {
-    nativeGateways.current = null;
     vi.stubGlobal("localStorage", createStorageMock());
     vi.stubGlobal("sessionStorage", createStorageMock());
     localStorage.clear();
@@ -282,35 +270,6 @@ describe("chat page split layout host", () => {
     );
     expect(page.querySelector("resizable-divider")).toBeNull();
     expect(typeof itemAt(panes, 0, "rendered pane").onOpenSplitView).toBe("function");
-  });
-
-  it("passes the chat-owned gateway capability only to the rightmost pane", async () => {
-    const gatewaySnapshot: NativeGatewaysSnapshot = {
-      gateways: [],
-      currentId: "primary",
-    };
-    nativeGateways.current = {
-      snapshot: gatewaySnapshot,
-      subscribe: () => () => undefined,
-      select: vi.fn(),
-      openWindow: vi.fn(),
-      setPrimary: vi.fn(),
-      reconnect: vi.fn(),
-      reconnectCancel: vi.fn(),
-      openSettings: vi.fn(),
-    };
-    const page = new ChatPage();
-    page.data = { sessionKey: "main" };
-    document.body.append(page);
-    setLayout(page, createSplitLayout("main"));
-    await page.updateComplete;
-
-    const panes = [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")];
-    expect(panes).toHaveLength(2);
-    expect(panes[0]?.nativeGateways).toBeNull();
-    expect(panes[0]?.gatewaysSnapshot).toBeNull();
-    expect(panes[1]?.nativeGateways).toBe(nativeGateways.current);
-    expect(panes[1]?.gatewaysSnapshot).toBe(gatewaySnapshot);
   });
 
   it("passes merged chrome from the shared mobile-nav query", async () => {

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -4,7 +4,6 @@ import { property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { mergeChatPageChrome, mobileNavLayoutMediaQuery } from "../../app/mobile-nav-layout.ts";
-import { nativeGatewaysCapability } from "../../app/native-gateways.runtime.ts";
 import "../../components/resizable-divider.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
 import { McpAppUnmountGate } from "../../components/mcp-app-unmount.ts";
@@ -65,14 +64,10 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
     return this.presented && !this.narrow && Boolean(this.data?.sessionKey?.trim());
   }
 
-  private readonly subscriptions = new SubscriptionsController(this)
-    .watch(
-      () => this.context?.sessions,
-      (sessions, notify) => sessions.subscribe(notify),
-    )
-    .watch(nativeGatewaysCapability, (nativeGateways, notify) =>
-      nativeGateways.subscribe(() => notify()),
-    );
+  private readonly subscriptions = new SubscriptionsController(this).watch(
+    () => this.context?.sessions,
+    (sessions, notify) => sessions.subscribe(notify),
+  );
   private mediaQuery: MediaQueryList | null = null;
   private mobileNavMediaQuery: MediaQueryList | null = null;
   private dragDepth = 0;
@@ -570,8 +565,6 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
     splitMode: boolean,
     retainedSessions: ReadonlyMap<string, readonly (string | undefined)[]>,
   ) {
-    const activeLocation = findPane(layout, layout.activePaneId);
-    const rightmostPane = this.narrow ? activeLocation?.pane : layout.columns.at(-1)?.panes.at(-1);
     return html`
       <div class="chat-split-view ${this.narrow ? "chat-split-view--narrow" : ""}">
         ${repeat(
@@ -618,7 +611,6 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
                     ownerKey: JSON.stringify([column.id, pane.id]),
                     pane,
                     sessionSlots: retainedSessions.get(pane.id) ?? [],
-                    showGatewayPicker: pane.id === rightmostPane?.id,
                     splitMode,
                     weight: splitWeight(
                       column.paneWeights,

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -16,10 +16,6 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import { chatInputOwnerForContext, type ChatInputRegion } from "../../app/chat-input-owner.ts";
 import { applicationContext } from "../../app/context.ts";
 import { observeNativeGateway } from "../../app/native-editor-locality.runtime.ts";
-import type {
-  NativeGatewaysCapability,
-  NativeGatewaysSnapshot,
-} from "../../app/native-gateways.runtime.ts";
 import {
   createQuestionPromptState,
   listQuestionPrompts,
@@ -273,8 +269,6 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   @property({ attribute: false }) narrow = false;
   @property({ attribute: false }) mergedChrome = false;
   @property({ attribute: false }) navDrawerOpen = false;
-  @property({ attribute: false }) nativeGateways?: NativeGatewaysCapability | null;
-  @property({ attribute: false }) gatewaysSnapshot?: NativeGatewaysSnapshot | null;
   @property({ attribute: false }) onboarding = false;
   @property({ attribute: false }) onOpenSplitView?: () => void;
   @property({ attribute: false }) onSplitDown?: (paneId: string) => void;

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -650,8 +650,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               .onAction=${(action: HeaderMenuAction) => this.handleHeaderSessionAction(action, row)}
             ></openclaw-chat-header-session-menu>`
           : nothing,
-      nativeGateways: this.nativeGateways,
-      gatewaysSnapshot: this.gatewaysSnapshot,
       onboarding: this.onboarding,
       onBeginRename: () => row && this.beginHeaderRename(row),
       onRenameInput: (value) => {

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1145,75 +1145,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("keeps the native gateway picker as compact as sidebar menus", async () => {
-    const page = await openBrowserPage(800, 600);
-    try {
-      const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
-      await page.setContent(
-        `<!doctype html><html><head><style>${readUiCss()}\n${splitViewCss}</style></head><body>
-          <wa-dropdown class="chat-pane__gateway-menu">
-            <template shadowrootmode="open"><div part="menu">Gateways<slot></slot></div></template>
-            <wa-dropdown-item class="chat-pane__gateway-menu-item">Local Gateway</wa-dropdown-item>
-          </wa-dropdown>
-        </body></html>`,
-      );
-
-      const readGatewayMenuStyles = () =>
-        page.evaluate(() => {
-          const dropdown = document.querySelector<HTMLElement>(".chat-pane__gateway-menu")!;
-          const menu = dropdown.shadowRoot!.querySelector<HTMLElement>('[part="menu"]')!;
-          const item = dropdown.querySelector<HTMLElement>(".chat-pane__gateway-menu-item")!;
-          const menuStyle = getComputedStyle(menu);
-          const itemStyle = getComputedStyle(item);
-          return {
-            menu: {
-              borderRadius: menuStyle.borderRadius,
-              padding: menuStyle.padding,
-            },
-            item: {
-              borderRadius: itemStyle.borderRadius,
-              fontSize: itemStyle.fontSize,
-              minHeight: itemStyle.minHeight,
-              padding: itemStyle.padding,
-            },
-          };
-        });
-
-      const styles = await readGatewayMenuStyles();
-      const menuRadius = 10 * (await readCornerScale(page));
-
-      expect(styles).toEqual({
-        menu: { borderRadius: `${menuRadius}px`, padding: "4px" },
-        item: {
-          // Item radius plus the 4px menu padding equals the panel radius, so
-          // the item edge stays optically parallel to the menu edge.
-          borderRadius: `${menuRadius - 4}px`,
-          fontSize: "13px",
-          minHeight: "28px",
-          padding: "0px 8px",
-        },
-      });
-
-      const session = await page.context().newCDPSession(page);
-      try {
-        await session.send("Emulation.setTouchEmulationEnabled", {
-          enabled: true,
-          maxTouchPoints: 1,
-        });
-        await session.send("Emulation.setEmulatedMedia", {
-          media: "screen",
-          features: [{ name: "pointer", value: "coarse" }],
-        });
-        expect(await page.evaluate(() => matchMedia("(pointer: coarse)").matches)).toBe(true);
-        expect((await readGatewayMenuStyles()).item.minHeight).toBe("44px");
-      } finally {
-        await session.detach();
-      }
-    } finally {
-      await closeBrowserPage(page);
-    }
-  });
-
   it("insets the collapsed session rail from the pane header edge", async () => {
     const page = await openBrowserPage(922, 282);
     try {
@@ -1319,12 +1250,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
               <wa-dropdown class="chat-pane__branches-menu">
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger" type="button">R</button>
               </wa-dropdown>
-              <wa-dropdown class="chat-pane__gateway-menu">
-                <button class="chat-pane__gateway-chip" type="button">
-                  <span class="chat-pane__gateway-health"></span>
-                  <span class="chat-pane__gateway-name">A long native gateway name</span>
-                </button>
-              </wa-dropdown>
               <div class="chat-pane__actions">
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-side-panel-toggle" type="button">L</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down" type="button">V</button>
@@ -1342,7 +1267,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         ".chat-side-panel-toggle",
         ".chat-pane__sharing-menu",
         ".chat-pane__branches-menu",
-        ".chat-pane__gateway-menu",
         ".chat-pane__nav-toggle",
         ".chat-pane__palette-open",
         ".chat-pane__split-down",

--- a/ui/src/pages/chat/components/chat-pane-header.test-support.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test-support.ts
@@ -60,7 +60,6 @@ export function mountChatPaneHeader(
     onBranchSelect: vi.fn(),
     ...patch,
   };
-  props.gatewaysSnapshot ??= props.nativeGateways?.snapshot;
   render(html`${renderChatPaneHeader(props)}`, container);
   return { container, props };
 }

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -3,10 +3,6 @@ import { html, nothing, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { GatewaySessionRow, PresenceEntry, SessionsListResult } from "../../../api/types.ts";
-import type {
-  NativeGatewaysCapability,
-  NativeGatewaysSnapshot,
-} from "../../../app/native-gateways.runtime.ts";
 import {
   COMMAND_PALETTE_OPEN_EVENT,
   SHELL_NAV_DRAWER_TOGGLE_EVENT,
@@ -22,11 +18,7 @@ import {
   mountChatPaneHeader,
   type ChatPaneHeaderProps,
 } from "./chat-pane-header.test-support.ts";
-import {
-  canRevealSessionWorkspace,
-  renderChatPaneHeader,
-  resolveChatPaneParentSession,
-} from "./chat-pane-header.ts";
+import { canRevealSessionWorkspace, resolveChatPaneParentSession } from "./chat-pane-header.ts";
 import { renderChatPanePlacement } from "./chat-pane-placement.ts";
 import { createSessionWorkspaceProps } from "./chat-session-workspace.ts";
 
@@ -37,41 +29,6 @@ afterEach(() => {
   vi.restoreAllMocks();
   Reflect.deleteProperty(window, "__OPENCLAW_NATIVE_WEB_CHROME__");
 });
-
-function nativeGateways(snapshot: NativeGatewaysSnapshot): NativeGatewaysCapability {
-  return {
-    snapshot,
-    subscribe: () => () => undefined,
-    select: vi.fn(),
-    openWindow: vi.fn(),
-    setPrimary: vi.fn(),
-    reconnect: vi.fn(),
-    reconnectCancel: vi.fn(),
-    openSettings: vi.fn(),
-  };
-}
-
-const gatewaySnapshot: NativeGatewaysSnapshot = {
-  gateways: [
-    {
-      id: "primary",
-      name: "Local Gateway",
-      kind: "local",
-      isPrimary: true,
-      canPromote: false,
-      health: "ok",
-    },
-    {
-      id: "profile:studio",
-      name: "Studio",
-      kind: "remote",
-      isPrimary: false,
-      canPromote: true,
-      health: "unknown",
-    },
-  ],
-  currentId: "primary",
-};
 
 function mountHeader(patch: Partial<ChatPaneHeaderProps> = {}) {
   return mountChatPaneHeader(containers, patch);
@@ -126,106 +83,6 @@ function mountIntegratedPresenceHeader(params: {
 }
 
 describe("chat pane header", () => {
-  it("hides the gateway picker without capability and with one gateway", () => {
-    Object.assign(window, { __OPENCLAW_NATIVE_WEB_CHROME__: true });
-    expect(mountHeader().container.querySelector(".chat-pane__gateway-menu")).toBeNull();
-    const one = nativeGateways({ gateways: [gatewaySnapshot.gateways[0]!], currentId: "primary" });
-    expect(
-      mountHeader({ nativeGateways: one }).container.querySelector(".chat-pane__gateway-menu"),
-    ).toBeNull();
-  });
-
-  it("renders gateway rows, primary tag, and current checkmark", () => {
-    Object.assign(window, { __OPENCLAW_NATIVE_WEB_CHROME__: true });
-    const { container } = mountHeader({ nativeGateways: nativeGateways(gatewaySnapshot) });
-    const rows = container.querySelectorAll(".chat-pane__gateway-item");
-    expect(rows).toHaveLength(2);
-    expect(container.querySelectorAll(".chat-pane__gateway-menu-item")).toHaveLength(4);
-    expect(rows[0]?.textContent).toContain("Local Gateway");
-    expect(rows[0]?.textContent).toContain("primary");
-    expect(rows[0]?.querySelector(".chat-pane__gateway-check")).not.toBeNull();
-  });
-
-  it("selects normally and opens a new window on alt-click", () => {
-    Object.assign(window, { __OPENCLAW_NATIVE_WEB_CHROME__: true });
-    const select = vi.fn();
-    const openWindow = vi.fn();
-    const capability = { ...nativeGateways(gatewaySnapshot), select, openWindow };
-    const first = mountHeader({ nativeGateways: capability }).container.querySelectorAll(
-      ".chat-pane__gateway-item",
-    )[1];
-    first?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(select).toHaveBeenCalledWith("profile:studio");
-    const second = mountHeader({ nativeGateways: capability }).container.querySelectorAll(
-      ".chat-pane__gateway-item",
-    )[1];
-    second?.dispatchEvent(new MouseEvent("click", { bubbles: true, altKey: true }));
-    expect(openWindow).toHaveBeenCalledWith("profile:studio");
-  });
-
-  it("opens a new window when alt-clicking the current gateway", () => {
-    Object.assign(window, { __OPENCLAW_NATIVE_WEB_CHROME__: true });
-    const select = vi.fn();
-    const openWindow = vi.fn();
-    const capability = { ...nativeGateways(gatewaySnapshot), select, openWindow };
-    const current = mountHeader({ nativeGateways: capability }).container.querySelector(
-      ".chat-pane__gateway-item",
-    );
-    current?.dispatchEvent(new MouseEvent("click", { bubbles: true, altKey: true }));
-    expect(openWindow).toHaveBeenCalledWith("primary");
-    expect(select).not.toHaveBeenCalled();
-  });
-
-  it("re-renders gateway rows from a changed snapshot property", () => {
-    Object.assign(window, { __OPENCLAW_NATIVE_WEB_CHROME__: true });
-    let current = gatewaySnapshot;
-    const capability = {
-      ...nativeGateways(gatewaySnapshot),
-      get snapshot() {
-        return current;
-      },
-    };
-    const mounted = mountHeader({ nativeGateways: capability, gatewaysSnapshot: current });
-    const next = {
-      ...gatewaySnapshot,
-      gateways: [
-        ...gatewaySnapshot.gateways,
-        {
-          id: "profile:backup",
-          name: "Backup",
-          kind: "remote" as const,
-          isPrimary: false,
-          canPromote: true,
-          health: "unknown" as const,
-        },
-      ],
-    };
-    current = next;
-    window.dispatchEvent(new CustomEvent("openclaw:native-gateways-changed", { detail: next }));
-
-    const props = { ...mounted.props, gatewaysSnapshot: capability.snapshot };
-    render(html`${renderChatPaneHeader(props)}`, mounted.container);
-
-    expect(mounted.container.querySelectorAll(".chat-pane__gateway-item")).toHaveLength(3);
-    expect(mounted.container.textContent).toContain("Backup");
-  });
-
-  it("disables set-primary when the viewed gateway cannot be promoted", () => {
-    Object.assign(window, { __OPENCLAW_NATIVE_WEB_CHROME__: true });
-    const snapshot = {
-      ...gatewaySnapshot,
-      gateways: gatewaySnapshot.gateways.map((gateway) =>
-        Object.assign({}, gateway, { canPromote: false }),
-      ),
-      currentId: "profile:studio",
-    };
-    const { container } = mountHeader({ nativeGateways: nativeGateways(snapshot) });
-    const item = Array.from(container.querySelectorAll("wa-dropdown-item")).find((candidate) =>
-      candidate.textContent?.includes("Set as primary"),
-    );
-    expect(item?.hasAttribute("disabled")).toBe(true);
-  });
-
   it("renders and dispatches merged chrome actions for catalog sessions", () => {
     const drawerEvents: CustomEvent<ShellNavDrawerToggleDetail>[] = [];
     const paletteEvents: Event[] = [];

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -1,12 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
-import { ref } from "lit/directives/ref.js";
 import type { GatewaySessionRow, SessionBranch } from "../../../api/types.ts";
-import type {
-  NativeGatewaysCapability,
-  NativeGatewaysSnapshot,
-  NativeGateway,
-} from "../../../app/native-gateways.runtime.ts";
-import { isNativeWebChromeHost } from "../../../app/native-web-chrome.ts";
 import { beginNativeWindowDrag } from "../../../app/native-window-drag.ts";
 import {
   COMMAND_PALETTE_OPEN_EVENT,
@@ -22,7 +15,6 @@ import {
 import { renderSessionColorDot } from "../../../components/session-color.ts";
 import { renderSessionOwnerChip } from "../../../components/session-owner-chip.ts";
 import { isCloudWorkerPlacementState } from "../../../components/session-row-badges.ts";
-import { syncDropdownItemRadio } from "../../../components/web-awesome.ts";
 import "../../../components/tooltip.ts";
 import "../../../components/workspace-icon.ts";
 import { t } from "../../../i18n/index.ts";
@@ -80,8 +72,6 @@ type ChatPaneHeaderProps = {
   publicAccessIndicator?: TemplateResult | typeof nothing;
   placementControl?: TemplateResult | typeof nothing;
   sessionMenuAction: TemplateResult | typeof nothing;
-  nativeGateways?: NativeGatewaysCapability | null;
-  gatewaysSnapshot?: NativeGatewaysSnapshot | null;
   onboarding?: boolean;
   onBeginRename: () => void;
   onRenameInput: (value: string) => void;
@@ -295,100 +285,6 @@ export function canRevealSessionWorkspace(params: {
   );
 }
 
-function gatewayHealthLabel(gateway: NativeGateway): string {
-  if (gateway.health === "ok") {
-    return t("chat.sessionHeader.gatewayPicker.connected");
-  }
-  if (gateway.health === "error") {
-    return t("chat.sessionHeader.gatewayPicker.unreachable");
-  }
-  return t("chat.sessionHeader.gatewayPicker.unknown");
-}
-
-function renderGatewayPicker(props: ChatPaneHeaderProps) {
-  const capability = props.nativeGateways;
-  const snapshot = props.gatewaysSnapshot;
-  if (
-    !capability ||
-    !snapshot ||
-    snapshot.gateways.length <= 1 ||
-    props.onboarding ||
-    !isNativeWebChromeHost()
-  ) {
-    return nothing;
-  }
-  const current = snapshot.gateways.find((gateway) => gateway.id === snapshot.currentId);
-  if (!current) {
-    return nothing;
-  }
-  const setPrimaryDisabled = current.isPrimary || !current.canPromote;
-  return html`
-    <wa-dropdown class="chat-pane__gateway-menu" placement="bottom-start">
-      <button
-        slot="trigger"
-        class="chat-pane__gateway-chip"
-        type="button"
-        aria-label=${t("chat.sessionHeader.gatewayPicker.menuLabel", { gateway: current.name })}
-      >
-        <span class="chat-pane__gateway-health" data-health=${current.health}></span>
-        <span class="chat-pane__gateway-name">${current.name}</span>
-        <span class="chat-pane__gateway-chevron">${icons.chevronUp}</span>
-      </button>
-      ${snapshot.gateways.map((gateway) => {
-        const selected = gateway.id === snapshot.currentId;
-        return html`<wa-dropdown-item
-          class="chat-pane__gateway-menu-item chat-pane__gateway-item"
-          role="menuitemradio"
-          aria-checked=${String(selected)}
-          ${ref((element) => syncDropdownItemRadio(element, selected))}
-          @click=${(event: MouseEvent) => {
-            if (event.altKey) {
-              capability.openWindow(gateway.id);
-            } else if (!selected) {
-              capability.select(gateway.id);
-            }
-          }}
-        >
-          <span
-            slot="icon"
-            class="chat-pane__gateway-health"
-            data-health=${gateway.health}
-            role="img"
-            aria-label=${gatewayHealthLabel(gateway)}
-          ></span>
-          <span>${gateway.name}</span>
-          <span slot="details" class="chat-pane__gateway-details">
-            ${
-              gateway.isPrimary
-                ? html`<span class="chat-pane__gateway-primary"
-                    >${t("chat.sessionHeader.gatewayPicker.primaryTag")}</span
-                  >`
-                : nothing
-            }
-            ${
-              selected
-                ? html`<span class="chat-pane__gateway-check">${icons.check}</span>`
-                : nothing
-            }
-          </span>
-        </wa-dropdown-item>`;
-      })}
-      <div class="chat-pane__gateway-divider" role="separator"></div>
-      <wa-dropdown-item
-        class="chat-pane__gateway-menu-item"
-        ?disabled=${setPrimaryDisabled}
-        @click=${() => !setPrimaryDisabled && capability.setPrimary(current.id)}
-        >${t("chat.sessionHeader.gatewayPicker.setPrimary")}</wa-dropdown-item
-      >
-      <wa-dropdown-item
-        class="chat-pane__gateway-menu-item"
-        @click=${() => capability.openSettings()}
-        >${t("chat.sessionHeader.gatewayPicker.openSettings")}</wa-dropdown-item
-      >
-    </wa-dropdown>
-  `;
-}
-
 export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
   const copyPathLabel =
     props.copiedAction === "copy-path"
@@ -554,7 +450,6 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
               `
             : nothing
         }
-        ${renderGatewayPicker(props)}
         <div class="chat-pane__actions">
           ${props.panelLayoutActions}
           <fieldset class="chat-pane__actions" ?disabled=${props.actionsDisabled}>

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -63,7 +63,6 @@ openclaw-chat-pane {
     .chat-pane__sharing-menu,
     .chat-pane__draft-indicator,
     .chat-pane__branches-menu,
-    .chat-pane__gateway-menu,
     .chat-pane__actions
   ) {
   display: none;
@@ -459,105 +458,6 @@ openclaw-chat-pane {
   line-height: 1.3;
 }
 
-.chat-pane__gateway-menu {
-  flex: 0 1 auto;
-  min-width: 0;
-}
-
-.chat-pane__gateway-menu::part(menu) {
-  padding: var(--menu-padding);
-  border: 1px solid var(--overlay-border);
-  border-radius: var(--menu-radius);
-  background: var(--bg-elevated);
-  box-shadow: var(--overlay-shadow);
-}
-
-.chat-pane__gateway-menu-item {
-  min-height: var(--menu-item-height);
-  padding: 0 8px;
-  border-radius: var(--menu-item-radius);
-  color: var(--text);
-  font: inherit;
-  font-size: 13px;
-}
-
-.chat-pane__gateway-chip {
-  display: inline-flex;
-  max-width: 170px;
-  height: 28px;
-  align-items: center;
-  gap: 6px;
-  padding: 0 8px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-full);
-  background: var(--panel);
-  color: var(--muted);
-  font-size: 11px;
-  cursor: var(--cursor-action);
-}
-
-.chat-pane__gateway-chip:hover,
-.chat-pane__gateway-chip:focus-visible {
-  border-color: var(--muted-strong);
-  color: var(--text);
-  outline: none;
-}
-
-.chat-pane__gateway-name {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.chat-pane__gateway-health {
-  width: 7px;
-  height: 7px;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  background: var(--muted);
-}
-
-.chat-pane__gateway-health[data-health="ok"] {
-  background: var(--ok);
-}
-
-.chat-pane__gateway-health[data-health="error"] {
-  background: var(--danger);
-}
-
-.chat-pane__gateway-chevron,
-.chat-pane__gateway-check {
-  display: inline-flex;
-}
-
-.chat-pane__gateway-chevron svg,
-.chat-pane__gateway-check svg {
-  width: 12px;
-  height: 12px;
-}
-
-.chat-pane__gateway-chevron svg {
-  transform: rotate(180deg);
-}
-
-.chat-pane__gateway-details {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.chat-pane__gateway-primary {
-  color: var(--muted);
-  font-size: 11px;
-}
-
-.chat-pane__gateway-divider {
-  height: 1px;
-  margin: 4px 0;
-  background: var(--border);
-}
-
 .chat-pane__branches-menu {
   flex: 0 0 auto;
 }
@@ -883,7 +783,6 @@ openclaw-chat-pane {
   .chat-pane__header:has(.chat-pane__close-pane) .chat-side-panel-toggle,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__sharing-menu,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__branches-menu,
-  .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__gateway-menu,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__nav-toggle,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__palette-open,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__participants,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3611,6 +3611,7 @@ openclaw-sidebar-attention {
 
 .sidebar-identity-card__text {
   display: flex;
+  flex-direction: column;
   flex: 1 1 auto;
   min-width: 0;
 }
@@ -3626,6 +3627,56 @@ openclaw-sidebar-attention {
   font-size: calc(13.5px * var(--control-ui-text-scale));
   font-weight: 600;
   line-height: 18px;
+}
+
+.sidebar-identity-card__gateway,
+.sidebar-gateway-details {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sidebar-identity-card__gateway {
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 14px;
+}
+
+.sidebar-gateway-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-gateway-primary {
+  flex: none;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.sidebar-gateway-health {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.sidebar-gateway-health[data-health="ok"] {
+  background: var(--ok);
+}
+
+.sidebar-gateway-health[data-health="error"] {
+  background: var(--danger);
+}
+
+.sidebar-gateway-check {
+  display: inline-flex;
+}
+
+.sidebar-gateway-check svg {
+  width: 12px;
+  height: 12px;
 }
 
 openclaw-tooltip.sidebar-hover-tooltip {

--- a/ui/src/test-helpers/app-sidebar-cases/footer-status.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/footer-status.ts
@@ -87,27 +87,33 @@ describe("AppSidebar gateway footer subtitle", () => {
     expect(sidebar.querySelector(".sidebar-identity-card")?.getAttribute("aria-label")).toBe(
       "Identity and app menu for Owner",
     );
+    expect(sidebar.querySelector(".sidebar-identity-card__gateway")).toBeNull();
   });
 
-  it("stays hidden outside native chrome", async () => {
-    const nativeWindow = window as SidebarNativeGatewayTestWindow;
-    nativeWindow["__OPENCLAW_NATIVE_GATEWAYS__"] = twoGateways;
+  it.each([false, true])("keeps plain web one line (offline: %s)", async (offline) => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    sidebar.offline = offline;
+    await sidebar.updateComplete;
 
     expect(
       sidebar.querySelector(".sidebar-identity-card")?.getAttribute("aria-label"),
     ).not.toContain("Local Gateway");
+    expect(sidebar.querySelector(".sidebar-identity-card__gateway")).toBeNull();
   });
 
-  it("stays hidden with one configured gateway", async () => {
+  it("shows a single configured gateway below the identity name", async () => {
     setNativeGatewayTestState({ gateways: [twoGateways.gateways[0]!], currentId: "local" });
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
 
-    expect(
-      sidebar.querySelector(".sidebar-identity-card")?.getAttribute("aria-label"),
-    ).not.toContain("Local Gateway");
+    expect(sidebar.querySelector(".sidebar-identity-card")?.getAttribute("aria-label")).toBe(
+      "Identity and app menu for Owner: Local Gateway, primary",
+    );
+    expect(sidebar.querySelector(".sidebar-identity-card__name")?.textContent).toBe("Owner");
+    const detail = sidebar.querySelector(".sidebar-identity-card__gateway");
+    expect(detail?.textContent).toContain("Local Gateway");
+    expect(detail?.querySelector(".sidebar-gateway-primary")?.textContent).toBe("primary");
   });
 
   it("shows the current gateway health, name, and primary suffix", async () => {
@@ -119,12 +125,18 @@ describe("AppSidebar gateway footer subtitle", () => {
     expect(sidebar.querySelector(".sidebar-identity-card")?.getAttribute("aria-label")).toBe(
       "Identity and app menu for Owner: Local Gateway, primary",
     );
+    const detail = sidebar.querySelector(".sidebar-identity-card__gateway");
+    expect(detail?.textContent).toContain("Local Gateway");
+    expect(detail?.querySelector(".sidebar-gateway-primary")?.textContent).toBe("primary");
+    expect(detail?.querySelector(".sidebar-gateway-health")?.getAttribute("data-health")).toBe(
+      "ok",
+    );
     expect(
       sidebar.querySelector(".sidebar-identity-card")?.getAttribute("aria-label"),
     ).not.toContain("git@e8cbc62");
   });
 
-  it("shows the visible offline retry pill instead of a hidden reconnecting subtitle", async () => {
+  it("shows reconnecting below the identity name and retains the offline retry action", async () => {
     setControlUiBuildInfo({ commit: CONTROL_UI_TEST_COMMIT, release: false });
     setNativeGatewayTestState(twoGateways);
     const gateway = createGateway({} as GatewayBrowserClient);
@@ -148,6 +160,9 @@ describe("AppSidebar gateway footer subtitle", () => {
     expect(sidebar.querySelector(".sidebar-identity-card")?.getAttribute("aria-label")).toBe(
       "Identity and app menu for Owner: Reconnecting…",
     );
+    const detail = sidebar.querySelector(".sidebar-identity-card__gateway");
+    expect(detail?.textContent?.trim()).toBe("Reconnecting…");
+    expect(detail?.querySelector(".sidebar-gateway-primary")).toBeNull();
     expect(
       sidebar.querySelector(".sidebar-identity-card")?.getAttribute("aria-label"),
     ).not.toContain("git@e8cbc62");
@@ -183,5 +198,11 @@ describe("AppSidebar gateway footer subtitle", () => {
     const ariaLabel = sidebar.querySelector(".sidebar-identity-card")?.getAttribute("aria-label");
     expect(ariaLabel).toContain("Remote Gateway");
     expect(ariaLabel).not.toContain("primary");
+    const detail = sidebar.querySelector(".sidebar-identity-card__gateway");
+    expect(detail?.textContent).toContain("Remote Gateway");
+    expect(detail?.querySelector(".sidebar-gateway-primary")).toBeNull();
+    expect(detail?.querySelector(".sidebar-gateway-health")?.getAttribute("data-health")).toBe(
+      "error",
+    );
   });
 });

--- a/ui/src/test-helpers/native-gateways.ts
+++ b/ui/src/test-helpers/native-gateways.ts
@@ -2,12 +2,12 @@ import { vi } from "vitest";
 import * as nativeGateways from "../app/native-gateways.runtime.ts";
 import type { NativeGateway, NativeGatewaysSnapshot } from "../app/native-gateways.runtime.ts";
 
-export function setNativeGatewayTestState(kind: NativeGateway["kind"] | null): void {
+export function setNativeGatewayTestState(kind: NativeGateway["kind"] | null) {
   if (!kind) {
     Reflect.deleteProperty(window, "__OPENCLAW_NATIVE_GATEWAYS__");
     Reflect.deleteProperty(window, "webkit");
     vi.spyOn(nativeGateways, "nativeGatewaysCapability").mockReturnValue(null);
-    return;
+    return undefined;
   }
   const snapshot: NativeGatewaysSnapshot = {
     gateways: [
@@ -30,11 +30,13 @@ export function setNativeGatewayTestState(kind: NativeGateway["kind"] | null): v
     ],
     currentId: kind,
   };
+  const postMessage = vi.fn();
   Object.assign(window, {
     __OPENCLAW_NATIVE_GATEWAYS__: snapshot,
-    webkit: { messageHandlers: { openclawGateways: { postMessage: vi.fn() } } },
+    webkit: { messageHandlers: { openclawGateways: { postMessage } } },
   });
   window.dispatchEvent(new CustomEvent("openclaw:native-gateways-changed", { detail: snapshot }));
+  return postMessage;
 }
 
 export function clearNativeGatewayTestState(): void {


### PR DESCRIPTION
## What Problem This Solves

The Mac app's Gateway picker lived in the chat header, tied to the rightmost chat pane and hidden when only one Gateway was saved. Gateway identity and switching belong with the persistent account controls at the bottom-left of the dashboard.

## Why This Change Was Made

The footer account card now shows the user name above the current Gateway's health dot, name, and primary tag. Offline state shows Reconnecting…. The footer remains 53px high, with 18px/14px text lines and a 28px avatar; the browser-hosted card remains one line and the existing accessible label is preserved.

The identity menu places a Gateway section after the profile header. It lists every saved Gateway with accessible health labels, primary/current indicators, selection, Command/Control-click to open another window, conditional Set as primary…, and Gateway settings…. Normal actions use the menu's selection event so keyboard activation works; modified context-menu events handle macOS Control-click. The native snapshot and Swift bridge are unchanged. Actions use the existing lazy sidebar-menu boundary, and the display-only footer reads the injected snapshot directly.

The old chat header picker, its property plumbing/subscription, CSS, and tests are removed. English strings moved to `nav.gateway` using the repository's generated, post-merge locale workflow; no locale adapters, translation memory, or budget baselines were edited. The macOS guide documents the new location.

## User Impact

Mac users can see and switch Gateways from the sidebar on every route, including when only one Gateway is configured. Opening the current Gateway normally sends no selection command. All native menu actions close the menu after dispatch.

## Evidence

Inspected synthetic fixtures only, captured in Chromium with the native bridge injected before load, light appearance, 1280×800 viewport, and device scale factor 2.

| Surface | Before | After |
| --- | --- | --- |
| Sidebar footer | ![One-line account card](https://github.com/user-attachments/assets/97e2a8e8-5cdd-41b4-be55-3b43a81b4817) | ![Gateway health, name, and primary tag below the account name](https://github.com/user-attachments/assets/59569520-5803-4e76-bf02-c333184668e3) |
| Gateway controls | ![Gateway picker in the chat header](https://github.com/user-attachments/assets/76d6f527-6d46-42f2-b993-0df809f90150) | ![Gateway section in the sidebar identity menu](https://github.com/user-attachments/assets/ece52be3-57f6-434e-9d09-2e3028c3136b) |

Production LOC: **+176 / −268 = −92**. Tests and test support (including isolated-lane registration): **+212 / −273 = −61**. Documentation: **+7**. Production plus documentation remains **−85**.

| Startup measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| JavaScript gzip | 354,015 B | 354,025 B | +10 B |
| JavaScript requests | 8 | 8 | 0 |
| CSS gzip | 45,742 B | 45,842 B | +100 B |

The committed JavaScript baseline is 353,694 B. The final build is **331 B above baseline**, within the **512 B** allowance (growth limit 354,206 B). No budget or baseline file changed.

Validation commands and outcomes:

```sh
pnpm ui:build
node --import ./scripts/tsx.mjs scripts/check-control-ui-performance.mts --report-only
```

Both pass with the measurements above.

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/components/app-sidebar.test.ts ui/src/components/sidebar-footer-layout.browser.test.ts ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/pages/chat/chat-page.test.ts ui/src/pages/chat/components/chat-pane-header.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/components/app-sidebar.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/components/app-sidebar.test.ts ui/src/components/sidebar-footer-layout.browser.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-isolated.config.ts --configLoader runner ui/src/components/app-sidebar-native-gateways.test.ts ui/src/pages/chat/chat-page.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-isolated.config.ts --configLoader runner ui/src/components/app-sidebar-native-gateways.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/chat/components/chat-pane-header.test.ts
```

Final applicable results: **563 targeted tests pass**: sidebar 361, responsive browser 126, footer browser 3, header 44, chat page 28, native Gateway menu 1. The initial shared run exposed three test-state contamination failures from resetting the native bridge's modules; the new case now has its own isolated entrypoint with the real bridge and a `vi.fn` postMessage stub. The full sidebar rerun passes. The chat-page test belongs to the isolated lane and was run there explicitly.

```sh
STAGE=before OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/zz-gateway-footer.e2e.test.ts
STAGE=after OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/zz-gateway-footer.e2e.test.ts ui/src/e2e/sidebar-account-footer.e2e.test.ts
STAGE=verify node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/zz-gateway-footer.e2e.test.ts
```

Before capture: 1 passed. After capture plus existing account-footer E2E: 4 passed. Final interaction verification: 1 passed, proving actual Enter selection, current-Gateway no-op, Command/Control-click window dispatch, menu closure, and settings dispatch. The interaction probe caught and verified the macOS Control-click context-menu fix. The scratch file is parked outside the tree and is not committed.

```sh
pnpm ui:i18n:baseline
pnpm exec oxfmt $(git diff --name-only) ui/src/components/app-sidebar-native-gateways.test.ts
pnpm exec oxlint $(git diff --cached --name-only -- '*.ts' '*.mjs')
pnpm exec oxlint --type-aware ui/src/test-helpers/native-gateways.ts
git diff --check
```

All pass. The i18n baseline command requires no raw-copy baseline changes; generated translations remain owned by the post-merge refresh. Grepping `ui/src`, `extensions`, and `apps` finds no remaining references to `chat-pane__gateway`, `gatewayPicker`, `showGatewayPicker`, or `gatewaysSnapshot`.

```sh
node scripts/check-changed.mjs
node scripts/check-changed.mjs --timed
```

Both commands pass (exit 0). The timed run completed with every selected lane marked `ok`, including core-test and UI typechecks, all three dead-export scans, core lint, UI style lint, and script lint. The first run caught a test-helper consistent-return error; it is fixed, and focused type-aware lint plus both full reruns pass. This checker suppresses successful tables unless `--timed` is set; the table below was read and verified. The known nested-worktree declaration-path failure did not occur.

<details>
<summary>Completed changed-check timing table</summary>

```text
[check:changed] summary
   3.38s  ok         conflict markers
  41.97s  ok         max-lines suppression ratchet
  16.36s  ok         assertion SAFETY comment ratchet
   184ms  ok         changelog attributions
   206ms  ok         doctor deprecation registry
   321ms  ok         guarded extension wildcard re-exports
   215ms  ok         plugin-sdk wildcard re-exports
   447ms  ok         duplicate scan target coverage
   361ms  ok         dependency pin guard
   330ms  ok         format changed files
   579ms  ok         package patch guard
   2.20s  ok         test temp creation report (warning-only)
  48.19s  ok         core tsgo graph boundary
   4.20s  ok         Control UI i18n catalog
  12.90s  ok         typecheck core tests
   1.75s  ok         typecheck UI
  27.34s  ok         coercion helper declaration guard
  87.91s  ok         dead export scan (skip with OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1)
 225.47s  ok         lint core
   868ms  ok         lint UI changed style files
   671ms  ok         lint UI changed style files
   690ms  ok         lint UI changed style files
  33.72s  ok         lint scripts
```

</details>

Independent Codex autoreview of the final staged diff completed **scoped-clean**, with no accepted/actionable P0–P2 findings. An earlier accessibility concern was checked against the original source: the old chip exposed health labels only in its menu rows, and those labels remain in the new menu. The final review included that comparison evidence.

Scope/proof notes: the native-menu case lives in a dedicated isolated test file instead of the shared identity-menu case file because the real native capability is a singleton. There is no production behavior deviation from the requested design and no STOP condition was hit. Proof uses the mocked Control UI and injected native bridge; the live signed Mac app/WKWebView and the full repository test suite were not run. This PR remains a draft; it is not marked ready or merged.

