### PR TITLE
fix(update): keep the candidate canary off the live Gateway's configured listener ports

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -41,6 +41,11 @@ downtime through convergence and final verification, plus verification
 results. See
 [Validation and activation](/cli/update#validation-and-activation) for the checks.
 
+The canary uses a temporary loopback Gateway port and suppresses background
+listeners, including the MCP Apps sandbox, browser control, and channel services.
+This lets validation run while the serving Gateway keeps its configured ports.
+The activated Gateway retains your normal listener settings.
+
 Package updates also check npm availability for enabled configured plugins before
 stopping the serving Gateway or replacing the installed core. Registry targets
 are checked early; explicit package artifacts are checked using the privately

--- a/src/gateway/server-runtime-state.test.ts
+++ b/src/gateway/server-runtime-state.test.ts
@@ -546,30 +546,33 @@ describe("createGatewayRuntimeState", () => {
     );
   });
 
-  it("starts the shared sandbox host on a dedicated adjacent-port origin", async () => {
-    const runtimeState = await createGatewayRuntimeStateForTest(undefined, {
-      cfg: { mcp: { apps: { enabled: true } } },
-      port: 18789,
-    });
+  it.each([undefined, 19100])(
+    "starts the normal sandbox host with configured port %s",
+    async (sandboxPort) => {
+      const runtimeState = await createGatewayRuntimeStateForTest(undefined, {
+        cfg: { mcp: { apps: { enabled: true, sandboxPort } } },
+        port: 18789,
+      });
 
-    expect(runtimeState.getMcpAppSandboxPort()).toBeUndefined();
-    await runtimeState.startListening();
+      expect(runtimeState.getMcpAppSandboxPort()).toBeUndefined();
+      await runtimeState.startListening();
 
-    expect(runtimeState.getMcpAppSandboxPort()).toBe(18790);
-    expect(runtimeState.httpServers).toHaveLength(2);
-    expect(mocks.listenGatewayHttpServer).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ bindHost: "127.0.0.1", port: 18789 }),
-    );
-    expect(mocks.listenGatewayHttpServer).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        bindHost: "127.0.0.1",
-        port: 18790,
-        retryEaddrinuse: false,
-      }),
-    );
-  });
+      expect(runtimeState.getMcpAppSandboxPort()).toBe(sandboxPort ?? 18790);
+      expect(runtimeState.httpServers).toHaveLength(2);
+      expect(mocks.listenGatewayHttpServer).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ bindHost: "127.0.0.1", port: 18789 }),
+      );
+      expect(mocks.listenGatewayHttpServer).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          bindHost: "127.0.0.1",
+          port: sandboxPort ?? 18790,
+          retryEaddrinuse: false,
+        }),
+      );
+    },
+  );
 
   it("starts the shared sandbox host lazily when MCP Apps are disabled", async () => {
     const runtimeState = await createGatewayRuntimeStateForTest(undefined, {
@@ -588,6 +591,25 @@ describe("createGatewayRuntimeState", () => {
     expect(mocks.listenGatewayHttpServer).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ bindHost: "127.0.0.1", port: 18790 }),
+    );
+  });
+
+  it("keeps an update canary off the configured sandbox listener, including lazy acquisition", async () => {
+    const runtimeState = await createGatewayRuntimeStateForTest(undefined, {
+      cfg: { mcp: { apps: { enabled: true, sandboxPort: 18790 } } },
+      port: 19000,
+      updateCanary: true,
+    });
+
+    await runtimeState.startListening();
+
+    expect(runtimeState.getMcpAppSandboxPort()).toBeUndefined();
+    expect(runtimeState.httpServers).toHaveLength(1);
+    await expect(runtimeState.ensureSandboxHostPort()).rejects.toThrow(
+      "Sandbox host is disabled during update validation",
+    );
+    expect(mocks.listenGatewayHttpServer).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ bindHost: "127.0.0.1", port: 19000 }),
     );
   });
 

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -106,6 +106,7 @@ export async function createGatewayHttpTransport(params: {
   getRuntimeConfig?: () => import("../config/config.js").OpenClawConfig;
   bindHost: string;
   port: number;
+  updateCanary?: boolean;
   controlUiEnabled?: boolean;
   controlUiBasePath: string;
   controlUiRoot?: ControlUiRootState;
@@ -413,6 +414,9 @@ export async function createGatewayHttpTransport(params: {
   let startListeningPromise: Promise<void> | null = null;
   let startListeningComplete = false;
   const startSandboxHost = async (): Promise<number> => {
+    if (params.updateCanary) {
+      throw new Error("Sandbox host is disabled during update validation");
+    }
     if (sandboxHostStartPromise) {
       return await sandboxHostStartPromise;
     }
@@ -557,7 +561,8 @@ export async function createGatewayHttpTransport(params: {
       if (httpBindHosts.length === 0) {
         throw new Error("Gateway HTTP server failed to start");
       }
-      if (params.cfg.mcp?.apps?.enabled === true) {
+      // Published updaters retain the live sandbox port but already pass --update-canary.
+      if (!params.updateCanary && params.cfg.mcp?.apps?.enabled === true) {
         await startSandboxHost();
       }
       startListeningComplete = true;

--- a/src/gateway/server-start.ts
+++ b/src/gateway/server-start.ts
@@ -64,6 +64,7 @@ async function startGatewayServerWithSdkHost(
   try {
     const transport = await createGatewayHttpTransport({
       ...gatewayKernel.createHttpTransportOptions(),
+      updateCanary: opts.updateCanary,
       ...(!gatewayKernel.minimalTestGateway && gatewayKernel.tailscaleMode !== "off"
         ? {
             prepareManagedTailscaleIngress: async (backend) => {

--- a/src/infra/update-candidate-canary.integration.test.ts
+++ b/src/infra/update-candidate-canary.integration.test.ts
@@ -1,9 +1,16 @@
 import * as childProcess from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { validateUpdateCandidateCanary } from "./update-candidate-canary.js";
+import {
+  prepareUpdateCandidateRehearsal,
+  type UpdateCandidateRehearsal,
+} from "./update-candidate-rehearsal.js";
 
 vi.mock("node:child_process", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:child_process")>();
@@ -11,7 +18,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 });
 
 it(
-  "boots the built candidate to started and ready, then tears down its isolated process group",
+  "boots the built candidate with a published updater's occupied sandbox port, then reaps it",
   { timeout: 330_000 },
   async () => {
     const stateDir = await fs.realpath(
@@ -19,11 +26,33 @@ it(
     );
     const spawned = vi.mocked(childProcess.spawn);
     spawned.mockClear();
+    const occupied = createServer();
+    let rehearsal: UpdateCandidateRehearsal | undefined;
     try {
+      occupied.listen(0, "127.0.0.1");
+      await once(occupied, "listening");
+      const address = occupied.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected an occupied TCP listener");
+      }
+      const config: OpenClawConfig = {
+        gateway: { mode: "local" },
+        mcp: { apps: { enabled: true, sandboxPort: address.port } },
+      };
+      rehearsal = await prepareUpdateCandidateRehearsal({
+        candidateRoot: process.cwd(),
+        stateDir,
+        config,
+        env: { PATH: process.env.PATH },
+      });
+      // Published updaters retain this setting and only supply --update-canary.
+      const copied: OpenClawConfig = JSON.parse(await fs.readFile(rehearsal.configPath, "utf8"));
+      await fs.writeFile(rehearsal.configPath, JSON.stringify({ ...copied, mcp: config.mcp }));
       const result = await validateUpdateCandidateCanary({
         root: process.cwd(),
         stateDir,
-        config: { gateway: { mode: "local" } },
+        config,
+        rehearsal,
         env: { PATH: process.env.PATH },
         timeoutMs: 300_000,
       });
@@ -32,6 +61,8 @@ it(
       expect(phases).toHaveLength(2);
       expect(phases[0]).toContain("startupz: started");
       expect(phases[1]).toContain("readyz: ready");
+      expect(occupied.listening).toBe(true);
+      await rehearsal.cleanup();
       expect(await fs.readdir(stateDir)).toEqual([]);
       const callIndex = spawned.mock.calls.findIndex(
         ([, args]) => Array.isArray(args) && args.includes("--update-canary"),
@@ -46,6 +77,12 @@ it(
         code: "ENOENT",
       });
     } finally {
+      await rehearsal?.cleanup();
+      if (occupied.listening) {
+        await new Promise<void>((resolve, reject) => {
+          occupied.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
       spawned.mockClear();
       await fs.rm(stateDir, { recursive: true, force: true });
     }

--- a/src/infra/update-candidate-canary.test.ts
+++ b/src/infra/update-candidate-canary.test.ts
@@ -267,6 +267,7 @@ describe("update candidate canary", () => {
     );
     const original = {
       gateway: { port: 18789 },
+      mcp: { apps: { enabled: true, sandboxPort: 18790 } },
       cron: { enabled: true },
       agents: {
         entries: { main: { workspace: "/original/workspace", agentDir: "/original/agent" } },
@@ -333,7 +334,14 @@ describe("update candidate canary", () => {
     expect(candidateConfig).toMatchObject({
       cron: { enabled: false },
       gateway: { bind: "loopback" },
+      mcp: { apps: { enabled: false } },
     });
+    expect(result.listenerIsolation).toEqual({
+      gateway: { host: "127.0.0.1", port: expect.any(Number) },
+      mcpAppSandbox: "disabled",
+    });
+    expect(candidateConfig.gateway).toMatchObject({ port: result.listenerIsolation?.gateway.port });
+    expect(original.mcp.apps).toEqual({ enabled: true, sandboxPort: 18790 });
     expect(original.cron.enabled).toBe(true);
     const gatewayPid = [...children.keys()].at(-1)!;
     expect(

--- a/src/infra/update-candidate-canary.ts
+++ b/src/infra/update-candidate-canary.ts
@@ -37,6 +37,10 @@ type CanaryResult = {
   logTail: string[];
   steps: UpdateStepResult[];
   candidateSchemaVersions?: OpenClawSchemaVersions;
+  listenerIsolation?: {
+    gateway: { host: "127.0.0.1"; port: number };
+    mcpAppSandbox: "disabled";
+  };
 } & (
   | { status: "ok" }
   | {
@@ -128,6 +132,7 @@ export async function validateUpdateCandidateCanary(params: {
   const logTail: string[] = [];
   const steps: UpdateStepResult[] = [];
   let candidateSchemaVersions: OpenClawSchemaVersions | undefined;
+  let listenerIsolation: CanaryResult["listenerIsolation"];
   let phase: CanaryPhase = "snapshot";
   let env: NodeJS.ProcessEnv = { ...sourceEnv };
   const capture = (chunk: Buffer | string) => {
@@ -280,6 +285,10 @@ export async function validateUpdateCandidateCanary(params: {
     workDeadline += snapshotDuration;
     env = { ...rehearsal.env };
     const { port } = rehearsal;
+    listenerIsolation = {
+      gateway: { host: "127.0.0.1", port },
+      mcpAppSandbox: "disabled",
+    };
     const commands: Array<{ phase: CanaryPhase; name: string; args: string[]; entry?: string }> = [
       {
         phase: "doctor",
@@ -440,6 +449,7 @@ export async function validateUpdateCandidateCanary(params: {
       durationMs: Date.now() - started,
       logTail,
       candidateSchemaVersions,
+      listenerIsolation,
       steps,
     };
   } catch (error) {
@@ -470,6 +480,7 @@ export async function validateUpdateCandidateCanary(params: {
       durationMs: Date.now() - started,
       logTail,
       candidateSchemaVersions,
+      listenerIsolation,
       steps,
     };
   } finally {

--- a/src/infra/update-candidate-rehearsal.ts
+++ b/src/infra/update-candidate-rehearsal.ts
@@ -110,6 +110,9 @@ function isolatedConfig(
   copied.hooks = { enabled: false, internal: { enabled: false } };
   copied.transcripts = { enabled: false, autoStart: [] };
   copied.discovery = { mdns: { mode: "off" } };
+  if (copied.mcp?.apps) {
+    copied.mcp.apps.enabled = false;
+  }
   return copied;
 }
 


### PR DESCRIPTION
Fixes #145280

## What Problem This Solves

Fixes an issue where users updating a running Gateway with MCP Apps enabled would hit `EADDRINUSE` on their configured sandbox port. The candidate used a temporary Gateway port but tried to claim the live Gateway's `mcp.apps.sandboxPort`, then reported a misleading inference-route repair failure.

Thanks to @Carme99 for the report and the listener/PID evidence.

## Why This Change Was Made

The shared rehearsal config disables MCP Apps for Doctor, repair, and validation. Candidate startup also carries the already-shipped `--update-canary` marker into the HTTP transport, suppressing both eager and lazy sandbox acquisition. The candidate-side guard is essential: installed 2026.9.3 and 2026.9.4 updaters cannot pick up a repair to their own config-copying code before running the candidate.

The canary result records its temporary loopback Gateway endpoint and disabled MCP sandbox as typed isolation facts. Normal Gateway startup still uses configured or default sandbox ports. No new configuration, schema, dependencies, or protocol changes.

The listener audit confirmed that Tailscale and discovery are disabled in the copied config; canvas uses the main HTTP listener; browser, channel webhook, Gmail, and other declared plugin services are suppressed by the existing canary startup gates. Node host is a separate outbound client. Watch-node routes share the Gateway listener, and portals/MCP loopback listeners are on demand and ephemeral. Plugin preflight/listing inspect metadata; Doctor retains its no-service-activation policy.

## User Impact

Updates can validate the candidate while the existing Gateway and its MCP Apps sandbox remain available. The activated Gateway retains the operator's normal MCP Apps settings and listener ports.

## Evidence

- `node scripts/run-vitest.mjs src/infra/update-candidate-canary.test.ts src/gateway/server-runtime-state.test.ts src/gateway/server-kernel.test.ts` — 42 passed.
- `node scripts/run-vitest.mjs src/infra/update-candidate-canary.integration.test.ts` — passed against the built CLI with an occupied sandbox port and the configuration retained by published updaters; startup/readiness and process-group cleanup verified.
- Before the fix, the copied-config regression retained `enabled: true`, the transport regression published port 18790, and the built-CLI regression failed with `EADDRINUSE` before readiness. Each passes after the repair.
- `node scripts/check-changed.mjs`, `pnpm build`, and the canonical Docker package integrity check passed.

Real Linux systemd-user fixtures used Node 24.20.0, a live Gateway on 18789, and MCP Apps enabled on 18790. The live Gateway PID owned both ports.

| Published updater | Published 2026.9.4 candidate | Fixed candidate | Full update outcome |
| --- | --- | --- | --- |
| 2026.9.3 | Canary failed: `EADDRINUSE 127.0.0.1:18790` | Canary passed, 21.1 seconds | Later package swap failed at 30.0 seconds |
| 2026.9.4 | Canary failed: `EADDRINUSE 127.0.0.1:18790` | Canary passed, 10.2 seconds | Later package swap failed at 30.0 seconds |

The original Gateway stayed healthy during validation. A separate normal startup of the exact fixed package also reached readiness, kept `mcp.apps.enabled=true` / `sandboxPort=18790`, and bound both ports in one PID.

Candidate SHA-256: `6f32367e6dfb9fdcb458c1b46e74c1e93d6f03d4743bad4a4ed382c5699d0d3c`. The committed diff exactly matches the source patch used to build that artifact.

## Known Gaps

**Both full updates remained blocked after the canary passed:** the installed drivers failed with `global-install-failed` / `Package rollback verification timed out` / `retained package tree changed`. The published `package-update-integrity.ts` reader caps its scan at 30 seconds. The 2026.9.4 post-failure triage also timed out after saving the update failure. These later owners are outside this listener repair; no retries, larger timeouts, or weaker checks were used.

The isolation covers OpenClaw's declared listener lifecycle. Arbitrary plugin import-time side effects, ports hidden inside operator-provided MCP commands, and inherited Node inspector flags are outside the declared listener lifecycle. The lead’s P1 autoreview of the approved head is scoped-clean.

Review follow-ups: the later 30-second package swap / rollback-verification timeout seen after this canary passes is owned by #145219; this PR stays scoped to the listener collision
