### PR TITLE
fix: keep optional heartbeat finalization silent

### DIFF
--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -506,6 +506,107 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     },
   );
 
+  it.each([
+    {
+      name: "optional authored silence",
+      text: SILENT_REPLY_TOKEN,
+      optional: true,
+      allowed: true,
+      failedTool: false,
+      silent: true,
+    },
+    {
+      name: "mandatory reply",
+      text: SILENT_REPLY_TOKEN,
+      optional: false,
+      allowed: true,
+      failedTool: false,
+      silent: false,
+    },
+    {
+      name: "silence disabled",
+      text: SILENT_REPLY_TOKEN,
+      optional: true,
+      allowed: false,
+      failedTool: false,
+      silent: false,
+    },
+    {
+      name: "blank output",
+      text: "",
+      optional: true,
+      allowed: true,
+      failedTool: false,
+      silent: false,
+    },
+    {
+      name: "failed tool",
+      text: SILENT_REPLY_TOKEN,
+      optional: true,
+      allowed: true,
+      failedTool: true,
+      silent: false,
+    },
+  ])(
+    "honors the finalization silence contract: $name",
+    async ({ text, optional, allowed, failedTool, silent }) => {
+      const attempt = failedTool ? settledFailedAttempt() : createSettledProviderFailureAttempt();
+      const input = finalizationInput(attempt);
+      Object.assign(input.terminalBase.runParams, {
+        trigger: "heartbeat",
+        terminalReplyExpectation: optional ? "optional" : "required",
+        allowEmptyAssistantReplyAsSilent: allowed,
+        sourceReplyDeliveryMode: "automatic",
+      });
+      backendMocks.runSettledFinalization.mockResolvedValue({
+        outcome: "empty",
+        result: { assistant: buildEmbeddedRunnerAssistant({ content: [{ type: "text", text }] }) },
+      });
+      const result = await prepareTerminalWithSettledTurnFinalization(input);
+      expect(backendMocks.runSettledFinalization).toHaveBeenCalledTimes(silent ? 1 : 2);
+      if (silent) {
+        expect(result.finalizationOutcome).toBe("answered");
+        expect(result.attempt.assistantTexts).toEqual([SILENT_REPLY_TOKEN]);
+        expect(result.prepared.payloadsWithToolMedia ?? []).toEqual([]);
+        expect(transcriptMocks.appendAssistantMirrorMessageByIdentity).not.toHaveBeenCalled();
+      } else if (failedTool) {
+        expect(result.finalizationOutcome).toBe("failed");
+        expect(result.attempt).toBe(attempt);
+        expect(result.prepared.payloadsWithToolMedia?.[0]).toMatchObject({ isError: true });
+      } else {
+        expect(result.finalizationOutcome).toBe("completed-empty");
+        expect(result.prepared.payloadsWithToolMedia).toEqual([
+          expect.objectContaining({ text: SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT }),
+        ]);
+      }
+    },
+  );
+
+  it("does not accept optional authored silence after an original timeout", async () => {
+    const attempt = createSettledProviderFailureAttempt();
+    attempt.terminal = { kind: "timeout", phase: "prompt", source: "idle" };
+    const input = finalizationInput(attempt);
+    Object.assign(input.terminalBase.runParams, {
+      trigger: "heartbeat",
+      terminalReplyExpectation: "optional",
+      allowEmptyAssistantReplyAsSilent: true,
+      sourceReplyDeliveryMode: "automatic",
+    });
+    backendMocks.runSettledFinalization.mockResolvedValue({
+      outcome: "empty",
+      result: {
+        assistant: buildEmbeddedRunnerAssistant({
+          content: [{ type: "text", text: SILENT_REPLY_TOKEN }],
+        }),
+      },
+    });
+
+    const result = await prepareTerminalWithSettledTurnFinalization(input);
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledTimes(2);
+    expect(result.finalizationOutcome).not.toBe("answered");
+  });
+
   it("persists fallback with the queue signal after the original attempt aborts", async () => {
     const attempt = settledSuccessfulAttempt();
     const emptyAssistant = buildEmbeddedRunnerAssistant({

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -3,6 +3,7 @@ import {
   setReplyPayloadMetadata,
   type ReplyPayloadMetadata,
 } from "../../../auto-reply/reply-payload.js";
+import { isSilentReplyText } from "../../../auto-reply/tokens.js";
 import {
   SessionTranscriptWriterClaimReboundError,
   withOwnedSessionTranscriptWrites,
@@ -33,9 +34,14 @@ import {
   resolveRuntimeModelAttempt,
   runEmbeddedSettledTurnFinalizationWithBackend,
 } from "./backend.js";
-import { resolveSettledToolBatchEvidence } from "./incomplete-turn-recovery.js";
+import { resolveFinalAssistantVisibleText } from "./helpers.js";
+import {
+  resolveSettledToolBatchEvidence,
+  shouldTreatEmptyAssistantReplyAsSilent,
+} from "./incomplete-turn-recovery.js";
 import type { createEmbeddedRunLaneController } from "./lane-controller.js";
 import {
+  isEmbeddedRunTerminalTimeout,
   resolveEmbeddedRunAttemptTerminalOutcome,
   type EmbeddedRunTerminalState,
 } from "./terminal-outcome.js";
@@ -174,6 +180,24 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       });
       assertFinalizationActive();
       attempt = finalization.attempt;
+      // The harness retains authored silence as an empty result; only the host
+      // owns the optional terminal reply contract and the settled tool failures.
+      if (
+        finalization.outcome === "empty" &&
+        runParams.terminalReplyExpectation === "optional" &&
+        !initial.attempt.lastToolError &&
+        shouldTreatEmptyAssistantReplyAsSilent({
+          allowEmptyAssistantReplyAsSilent: runParams.allowEmptyAssistantReplyAsSilent,
+          terminalReplyExpectation: runParams.terminalReplyExpectation,
+          onlyExplicitSilentReply: true,
+          payloadCount: 0,
+          aborted: input.finalization.abortSignal.aborted,
+          timedOut: isEmbeddedRunTerminalTimeout(initial.terminalState.outcome),
+          attempt,
+        })
+      ) {
+        finalization.outcome = "answered";
+      }
       mergeUsageIntoAccumulator(input.terminalBase.usageAccumulator, attempt.attemptUsage);
       mergeAttemptRunStatsIntoAccumulator(input.terminalBase.usageAccumulator, attempt);
       lastRunPromptUsage = attempt.attemptUsage ?? lastRunPromptUsage;
@@ -429,7 +453,13 @@ function buildSettledTurnFinalizationAttemptResult(input: {
   runtimePlan?: EmbeddedRunAttemptParams["runtimePlan"];
 }): EmbeddedRunAttemptWithReceiptEvidence {
   const { result, settledAttempt } = input;
-  const text = input.outcome === "empty" ? "" : resolveSettledTurnFinalizationText(result);
+  const authoredText = resolveFinalAssistantVisibleText(result.assistant) ?? "";
+  const text =
+    input.outcome === "empty"
+      ? isSilentReplyText(authoredText)
+        ? authoredText
+        : ""
+      : resolveSettledTurnFinalizationText(result);
   // Finalization replaces terminal ownership, not host-private facts from settled tools.
   // Its response model does not replace the original runtime-owned selection.
   // Replay, abort, and lifecycle state remain finalizer-local.


### PR DESCRIPTION
Related: #143580

## What Problem This Solves

Fixes an issue where users receive an unnecessary missing-summary warning after a heartbeat's tool-free finalizer explicitly chooses `NO_REPLY`, even though the run permits silence.

## Why This Change Was Made

The host retains the authored silent token through finalizer projection and accepts it under the existing optional/allowed-silence contract. Required replies, genuinely blank output, original tool failures, original timeouts, and cancellation cannot use this exception. No new API or policy flag is introduced.

This is a narrow unwanted-chatter repair, not a claim to fix the reported transcript loss, prolonged wedge, or duplicate delivery. The separate timeout-retention change in #141072 is complementary; combined execution has not been tested.

## User Impact

Quiet heartbeat results stay quiet without a second finalizer request or a synthetic fallback warning. Legitimate alerts and HEARTBEAT_OK behavior remain unchanged.

## Evidence

- Real loopback HTTP proof traverses the built-in restricted finalizer and actual persisted history assembly. Before the fix, authored NO_REPLY makes two requests and emits a missing-summary warning; after the fix, it makes one request, offers no tools, and produces no payload. HEARTBEAT_OK and alert controls pass.
- Rebased targeted verification: 53 tests across five files passed. Independent review reran 31 tests and found no blocking defect. The requested original-timeout + optional-NO_REPLY regression was added afterward; the focused suite passes 32/32.
- Focused core lint, formatting, and diff checks pass. Tests use artifact-only aliases to existing dependency bytes; full build/typecheck is not claimed because the local dependency graph has pre-existing missing links/types.
- Proof is synthetic HTTP transport and local terminal assembly, not production provider/channel delivery or browser rendering.

AI-assisted


### Inspectable loopback execution output

Head: `953c3fbf55f099944acd41e5dc2fd2b9304280f2`. The excerpts below are copied from the existing exact-head run (September 12, 00:13 CEST), not a new run or inferred source behavior. The task-only test uses real SQLite transcript persistence, built-in restricted finalization, history assembly and HTTP/SSE transport to a local synthetic responder. Auth availability is supplied by a synthetic registry; the responder emits a fixed assistant text and `finish_reason=stop`. No real credentials, external provider or live channel is involved.

Invocation: `node node_modules/vitest/vitest.mjs run --config <artifact-dir>/fix.config.mts`. The artifact config extends the repository Vitest config and aliases missing workspace links to existing installed package bytes; it is not a standard clean-install run.

<details>
<summary>Captured NO_REPLY request and resulting terminal payloads</summary>

The responder's assistant text is `NO_REPLY`. This is the complete saved request/outcome JSON: one HTTP request, no offered tools, retained synthetic completed-tool history and no emitted payload. `answered` is the internal finalization classification that ends retries, not a visible answer.

```json
{
  "finalizationOutcome": "answered",
  "payloads": [],
  "requests": [
    {
      "model": "synthetic",
      "messages": [
        {
          "role": "user",
          "content": "Heartbeat monitor: check the synthetic inbox. If nothing needs attention reply HEARTBEAT_OK."
        },
        {
          "role": "assistant",
          "content": null,
          "tool_calls": [
            {
              "id": "inbox",
              "type": "function",
              "function": {
                "name": "exec",
                "arguments": "{\"command\":\"synthetic-inbox\"}"
              }
            }
          ]
        },
        {
          "role": "tool",
          "content": "[] (synthetic inbox empty)",
          "tool_call_id": "inbox"
        },
        {
          "role": "user",
          "content": "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch. Tools are unavailable in this step: it is a text-only pass, so reply with plain text and do not attempt any tool call."
        }
      ],
      "stream": true,
      "stream_options": {
        "include_usage": true
      },
      "max_completion_tokens": 2048
    }
  ]
}
```

</details>

<details>
<summary>Acknowledgment/alert controls and exact-head terminal output</summary>

Projected from the saved control request/outcome JSON (only request count, payloads and outcome shown):

```json
{
  "ok": {
    "requestCount": 1,
    "payloads": [
      {
        "text": "HEARTBEAT_OK",
        "replyToTag": false
      }
    ],
    "finalizationOutcome": "answered"
  },
  "alert": {
    "requestCount": 1,
    "payloads": [
      {
        "text": "Synthetic alert: inbox needs attention",
        "replyToTag": false
      }
    ],
    "finalizationOutcome": "answered"
  }
}
```

Copied terminal output; local checkout prefix removed:

```text
 ✓ |agents-embedded-agent-run| src/agents/embedded-agent-runner/run/heartbeat-finalization.proof.test.ts > captures heartbeat finalization for HEARTBEAT_OK 547ms
 ✓ |agents-embedded-agent-run| src/agents/embedded-agent-runner/run/heartbeat-finalization.proof.test.ts > captures heartbeat finalization for Synthetic alert: inbox needs attention 257ms
 ✓ |agents-embedded-agent-run| src/agents/embedded-agent-runner/run/heartbeat-finalization.proof.test.ts > captures heartbeat finalization for NO_REPLY 242ms
 Test Files  5 passed (5)
      Tests  53 passed (53)
   Start at  00:13:32
   Duration  20.03s (transform 48%, tests 35%, import 14%, worker 2%, setup 1%)
```

Earlier red run against the unfixed implementation (before rebase; not exact-head):

```text
FAIL captures heartbeat finalization for NO_REPLY
AssertionError: expected 'completed-empty' to be 'answered'
Expected: "answered"
Received: "completed-empty"
Test Files  1 failed (1)
Tests  1 failed | 2 passed (3)
```

The earlier pre-fix raw request snapshot was overwritten by successful captures; the retained red assertion above is the directly inspectable pre-fix evidence. The exact-head capture and passing assertions establish one request and zero payloads after the fix. This does not establish the reporter's transcript-loss, wedge or duplicate-delivery scenario.

</details>

Hosted verification at this checkpoint: [CI run](https://github.com/openclaw/openclaw/actions/runs/34653188751), including `openclaw/ci-gate`, production/test typechecks and lint, passed. Local full build/typecheck limitations above remain disclosed.

---

## What Problem This Solves

A quiet heartbeat can send “The tool run finished, but no final summary was produced” after its finalizer deliberately returns `NO_REPLY`.

## Why This Change Was Made

The built-in runtime now retains that authored token and accepts it through the existing optional-reply policy. The host finalization owner makes this decision; no new setting or state store is added.

## User Impact

Quiet heartbeats stay quiet with one finalizer request. Alerts still arrive. Required replies, blank output, tool failures, original timeouts, and cancellation retain their existing checks.

## Evidence

Independently executed head `953c3fbf55f099944acd41e5dc2fd2b9304280f2` through a real Gateway heartbeat and leased Discord bots:

| Synthetic capture | Finalizer requests | Heartbeat message |
| --- | ---: | --- |
| Main, `NO_REPLY` | 2 | Missing-summary warning |
| Candidate, `NO_REPLY` | 1 | None |
| Candidate, alert | 1 | “Synthetic alert: inbox needs attention.” |
| Candidate, `HEARTBEAT_OK` | 1 | None, as configured |

The quiet run completed successfully and retained one `NO_REPLY` in history. Each recording lasted three minutes. Ordinary retries before finalization are separate and unchanged.

Candidate owner checks: 69 passed. Fresh-merge checks: 401 passed; one fallback-notice assertion failed identically on plain main and the relevant prior-merge parent. Test routing, changed-file lint, and formatting passed. [Hosted CI gate passed](https://github.com/openclaw/openclaw/actions/runs/34653188751/job/103444673175).

## Consumers

Optional finalizers, reply shaping, heartbeat delivery, background completion, and terminal snapshots retain the same silence contract. Writer authority and failure handling remain intact; derived output is rebuilt per attempt.

This proof covers the built-in runtime. A separate plugin still erases silent tokens before host finalization; that pre-existing limit remains. This does not fix lost history, long stalls, or duplicate delivery in the linked report.

AI-assisted.

Latest exact-head hosted verification: [CI run 34786156188](https://github.com/openclaw/openclaw/actions/runs/34786156188), successful at `953c3fbf55f099944acd41e5dc2fd2b9304280f2`.
