### PR TITLE
refactor(tests): reuse runtime fixtures in backup tests

### DIFF
--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -6,7 +6,6 @@ import * as tar from "tar";
 import { describe, expect, it, vi } from "vitest";
 import { createBackupArchive } from "../infra/backup-create.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
-import type { RuntimeEnv } from "../runtime.js";
 import {
   closeOpenClawStateDatabase,
   openOpenClawStateDatabase,
@@ -15,14 +14,7 @@ import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { backupRestoreCommand } from "./backup-restore.js";
 import { buildBackupArchivePath } from "./backup-shared.js";
 import { verifyBackupArchive } from "./backup-verify.js";
-
-function createRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
-}
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 async function listArchiveLeafEntries(archivePath: string): Promise<string[]> {
   const entries: string[] = [];
@@ -152,7 +144,7 @@ describe("backupRestoreCommand", () => {
 
           await expect(verifyBackupArchive(archivePath)).resolves.toMatchObject({ ok: true });
           await expect(
-            backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
+            backupRestoreCommand(createTestRuntime(), { archive: archivePath, target: targetPath }),
           ).resolves.toMatchObject({ ok: true, entryCount: 3 });
           const original = path.join(targetPath, payloadPath);
           const linked = path.join(targetPath, hardlinkPath);
@@ -195,7 +187,7 @@ describe("backupRestoreCommand", () => {
             includeWorkspace: false,
             nowMs: Date.UTC(2026, 7, 12, 12, 0, 0),
           });
-          const runtime = createRuntime();
+          const runtime = createTestRuntime();
           const restored = await backupRestoreCommand(runtime, {
             archive: backup.archivePath,
             target: targetPath,
@@ -327,7 +319,7 @@ describe("backupRestoreCommand", () => {
         expect(archiveEntries.some((entry) => entry.includes("external-runtime"))).toBe(false);
         expect(archiveEntries.some((entry) => entry.endsWith("/sessions/session.json"))).toBe(true);
 
-        const restored = await backupRestoreCommand(createRuntime(), {
+        const restored = await backupRestoreCommand(createTestRuntime(), {
           archive: backup.archivePath,
           target: targetPath,
         });
@@ -395,10 +387,13 @@ describe("backupRestoreCommand", () => {
         await fs.writeFile(path.join(nonEmptyTarget, "keep.txt"), "keep\n");
 
         await expect(
-          backupRestoreCommand(createRuntime(), { archive: archivePath, target: emptyTarget }),
+          backupRestoreCommand(createTestRuntime(), { archive: archivePath, target: emptyTarget }),
         ).resolves.toMatchObject({ targetPath: emptyTarget });
         await expect(
-          backupRestoreCommand(createRuntime(), { archive: archivePath, target: nonEmptyTarget }),
+          backupRestoreCommand(createTestRuntime(), {
+            archive: archivePath,
+            target: nonEmptyTarget,
+          }),
         ).rejects.toThrow(/target directory must be empty/iu);
         await expect(fs.readFile(path.join(nonEmptyTarget, "keep.txt"), "utf8")).resolves.toBe(
           "keep\n",
@@ -421,7 +416,7 @@ describe("backupRestoreCommand", () => {
         await state.writeConfig({ agents: { entries: { main: { agentDir } } } });
 
         await expect(
-          backupRestoreCommand(createRuntime(), {
+          backupRestoreCommand(createTestRuntime(), {
             archive: state.path("missing-backup.tar.gz"),
             target: targetPath,
           }),
@@ -447,7 +442,7 @@ describe("backupRestoreCommand", () => {
         await fs.writeFile(state.configPath, '{"agents":{"entries":', "utf8");
 
         await expect(
-          backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
+          backupRestoreCommand(createTestRuntime(), { archive: archivePath, target: targetPath }),
         ).resolves.toMatchObject({ targetPath });
       },
     );
@@ -474,7 +469,7 @@ describe("backupRestoreCommand", () => {
         await fs.mkdir(targetPath);
 
         await expect(
-          backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
+          backupRestoreCommand(createTestRuntime(), { archive: archivePath, target: targetPath }),
         ).rejects.toThrow(/manifest is not valid JSON/iu);
         await expect(fs.readdir(targetPath)).resolves.toEqual([]);
       },
@@ -555,7 +550,7 @@ describe("backupRestoreCommand", () => {
           });
 
           await expect(
-            backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
+            backupRestoreCommand(createTestRuntime(), { archive: archivePath, target: targetPath }),
           ).rejects.toThrow(error);
           await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
           await new Promise<void>((resolve) => {
@@ -595,7 +590,7 @@ describe("backupRestoreCommand", () => {
         });
 
         await expect(
-          backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
+          backupRestoreCommand(createTestRuntime(), { archive: archivePath, target: targetPath }),
         ).rejects.toThrow(/incomplete target was cleaned/iu);
         await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
         await new Promise<void>((resolve) => {
@@ -635,7 +630,7 @@ describe("backupRestoreCommand", () => {
         const cleanupError = new Error("cleanup denied");
         vi.spyOn(fs, "rm").mockRejectedValueOnce(cleanupError);
 
-        const restoreError = await backupRestoreCommand(createRuntime(), {
+        const restoreError = await backupRestoreCommand(createTestRuntime(), {
           archive: archivePath,
           target: targetPath,
         }).catch((error: unknown) => error);

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -13,6 +13,7 @@ import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { buildBackupArchivePath, buildBackupArchiveRoot } from "./backup-shared.js";
 import type { BackupManifest } from "./backup-verify-manifest.js";
 import { backupVerifyCommand, verifyBackupArchive } from "./backup-verify.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 vi.mock("tar", async (importOriginal) => {
   const actual = await importOriginal<typeof import("tar")>();
@@ -23,12 +24,6 @@ const actualTar = await vi.importActual<typeof import("tar")>("tar");
 
 const TEST_ARCHIVE_ROOT = "2026-03-09T00-00-00.000Z-openclaw-backup";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
-const createBackupVerifyRuntime = () => ({
-  log: vi.fn(),
-  error: vi.fn(),
-  exit: vi.fn(),
-});
 
 function createBackupManifest(
   assetArchivePath: string,
@@ -215,7 +210,7 @@ describe("backupVerifyCommand", () => {
   it("verifies a valid backup archive", async () => {
     const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-verify-out-"));
     try {
-      const runtime = createBackupVerifyRuntime();
+      const runtime = createTestRuntime();
       const nowMs = Date.UTC(2026, 2, 9, 0, 0, 0);
       const archiveRoot = buildBackupArchiveRoot(nowMs);
       const archivePath = path.join(archiveDir, "backup.tar.gz");
@@ -282,7 +277,7 @@ describe("backupVerifyCommand", () => {
   ])("reports an actionable failure for $name", async ({ prepare, detail }) => {
     const tempDir = tempDirs.make("openclaw-backup-verify-input-");
     const archivePath = await prepare(tempDir);
-    const runtime = createBackupVerifyRuntime();
+    const runtime = createTestRuntime();
 
     await runCommandWithRuntime(runtime, async () => {
       await backupVerifyCommand(runtime, { archive: archivePath });
@@ -325,7 +320,7 @@ describe("backupVerifyCommand", () => {
         ]),
       ),
     );
-    const runtime = createBackupVerifyRuntime();
+    const runtime = createTestRuntime();
 
     await runCommandWithRuntime(runtime, async () => {
       await backupVerifyCommand(runtime, { archive: archivePath });
@@ -364,7 +359,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).resolves.toMatchObject(
           {
             ok: true,
@@ -452,7 +447,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).resolves.toMatchObject(
           { ok: true },
         );
@@ -523,7 +518,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(error);
       },
     );
@@ -552,7 +547,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).resolves.toMatchObject(
           { ok: true },
         );
@@ -607,7 +602,7 @@ describe("backupVerifyCommand", () => {
 
           const tmpdirSpy = vi.spyOn(os, "tmpdir").mockReturnValue(verificationTempRoot);
           try {
-            const runtime = createBackupVerifyRuntime();
+            const runtime = createTestRuntime();
             await expect(
               backupVerifyCommand(runtime, { archive: archivePath }),
             ).resolves.toMatchObject({ ok: true });
@@ -653,7 +648,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /Backup SQLite snapshot failed verification.*foreign_key_check failed.*children row 1 references parents \(foreign key 0\)/iu,
         );
@@ -686,7 +681,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).resolves.toMatchObject(
           {
             ok: true,
@@ -718,7 +713,7 @@ describe("backupVerifyCommand", () => {
         const verificationTempRoot = tempDirs.make("openclaw-backup-verify-cleanup-");
         const tmpdirSpy = vi.spyOn(os, "tmpdir").mockReturnValue(verificationTempRoot);
         try {
-          const runtime = createBackupVerifyRuntime();
+          const runtime = createTestRuntime();
           await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
             /Backup SQLite snapshot failed verification.*openclaw\.sqlite/iu,
           );
@@ -748,7 +743,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /SQLite snapshot is empty.*empty\.sqlite/iu,
         );
@@ -789,7 +784,7 @@ describe("backupVerifyCommand", () => {
           ],
         },
         async (archivePath) => {
-          const runtime = createBackupVerifyRuntime();
+          const runtime = createTestRuntime();
           await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
             /contains a SQLite snapshot sidecar.*openclaw\.sqlite-wal/iu,
           );
@@ -837,7 +832,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /contains a SQLite snapshot sidecar.*openclaw-agent\.sqlite-wal/iu,
         );
@@ -871,7 +866,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /case-mangled canonical SQLite path.*State\/OpenClaw\.SQLITE/u,
         );
@@ -902,7 +897,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /case-mangled state asset path.*PAYLOAD.*custom\.sqlite-wal/iu,
         );
@@ -942,7 +937,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /Backup SQLite snapshot failed verification.*corrupt\.sqlite/iu,
         );
@@ -982,7 +977,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /Backup SQLite snapshot failed verification.*corrupt\.sqlite/iu,
         );
@@ -1016,7 +1011,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /has role agent; expected global/iu,
         );
@@ -1107,7 +1102,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /has role global; expected agent/iu,
         );
@@ -1142,7 +1137,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /state asset archivePath does not match its sourcePath/iu,
         );
@@ -1223,7 +1218,7 @@ describe("backupVerifyCommand", () => {
           const extract = vi.mocked(tar.x).mockClear();
 
           await expect(
-            backupVerifyCommand(createBackupVerifyRuntime(), { archive: archivePath }),
+            backupVerifyCommand(createTestRuntime(), { archive: archivePath }),
           ).rejects.toThrow(error);
           expect(mkdtemp).not.toHaveBeenCalled();
           expect(extract).not.toHaveBeenCalled();
@@ -1305,7 +1300,7 @@ describe("backupVerifyCommand", () => {
         ],
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).resolves.toMatchObject(
           {
             ok: true,
@@ -1324,7 +1319,7 @@ describe("backupVerifyCommand", () => {
       await fs.writeFile(path.join(root, "payload", "data.txt"), "x\n", "utf8");
       await tar.c({ file: archivePath, gzip: true, cwd: tempDir }, ["root"]);
 
-      const runtime = createBackupVerifyRuntime();
+      const runtime = createTestRuntime();
       await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
         /expected exactly one backup manifest entry/i,
       );
@@ -1361,7 +1356,7 @@ describe("backupVerifyCommand", () => {
       );
       await tar.c({ file: archivePath, gzip: true, cwd: tempDir }, [rootName]);
 
-      const runtime = createBackupVerifyRuntime();
+      const runtime = createTestRuntime();
       await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
         /missing payload for manifest asset/i,
       );
@@ -1377,7 +1372,7 @@ describe("backupVerifyCommand", () => {
         manifestContent: '{"schemaVersion":1,',
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           `Backup archive verification failed: ${archivePath}. Backup manifest is not valid JSON.`,
         );
@@ -1430,7 +1425,7 @@ describe("backupVerifyCommand", () => {
         manifestContent: JSON.stringify(manifest),
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(error);
       },
     );
@@ -1443,7 +1438,7 @@ describe("backupVerifyCommand", () => {
         manifestContent: "x".repeat(1024 * 1024 + 1),
       },
       async (archivePath) => {
-        const runtime = createBackupVerifyRuntime();
+        const runtime = createTestRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
           /Backup manifest exceeds 1048576 byte limit/,
         );
@@ -1471,7 +1466,7 @@ describe("backupVerifyCommand", () => {
           payloads: [{ fileName: "payload.txt", contents: "payload\n", archivePath }],
         },
         async (brokenArchivePath) => {
-          const runtime = createBackupVerifyRuntime();
+          const runtime = createTestRuntime();
           await expect(
             backupVerifyCommand(runtime, { archive: brokenArchivePath }),
           ).rejects.toThrow(error);
@@ -1515,7 +1510,7 @@ describe("backupVerifyCommand", () => {
     );
 
     await expect(
-      backupVerifyCommand(createBackupVerifyRuntime(), { archive: archivePath }),
+      backupVerifyCommand(createTestRuntime(), { archive: archivePath }),
     ).resolves.toMatchObject({ ok: true, assetCount: 2, symlinkCount: 2 });
 
     archiveEntries.push(
@@ -1530,7 +1525,7 @@ describe("backupVerifyCommand", () => {
       gzipSync(Buffer.concat([...archiveEntries, Buffer.alloc(1024)])),
     );
     await expect(
-      backupVerifyCommand(createBackupVerifyRuntime(), { archive: archivePath }),
+      backupVerifyCommand(createTestRuntime(), { archive: archivePath }),
     ).rejects.toThrow(/symbolic link is outside the declared backup assets/iu);
   });
 
@@ -1557,7 +1552,7 @@ describe("backupVerifyCommand", () => {
       );
       await fs.writeFile(archivePath, archive);
 
-      const runtime = createBackupVerifyRuntime();
+      const runtime = createTestRuntime();
       await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
         /hardlink target.*path traversal segments/i,
       );
@@ -1590,7 +1585,7 @@ describe("backupVerifyCommand", () => {
       );
       await fs.writeFile(archivePath, archive);
 
-      const runtime = createBackupVerifyRuntime();
+      const runtime = createTestRuntime();
       await expect(backupVerifyCommand(runtime, { archive: archivePath })).resolves.toMatchObject({
         ok: true,
       });
@@ -1623,7 +1618,7 @@ describe("backupVerifyCommand", () => {
       );
       await fs.writeFile(archivePath, archive);
 
-      const runtime = createBackupVerifyRuntime();
+      const runtime = createTestRuntime();
       await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
         /hardlink target is missing from archive entries/i,
       );
@@ -1635,7 +1630,7 @@ describe("backupVerifyCommand", () => {
   it("ignores payload manifest.json files when locating the backup manifest", async () => {
     const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-verify-out-"));
     try {
-      const runtime = createBackupVerifyRuntime();
+      const runtime = createTestRuntime();
       const nowMs = Date.UTC(2026, 2, 9, 2, 0, 0);
       const archiveRoot = buildBackupArchiveRoot(nowMs);
       const archivePath = path.join(archiveDir, "backup.tar.gz");
@@ -1748,7 +1743,7 @@ describe("backupVerifyCommand", () => {
           buildTarEntries: options.buildTarEntries,
         },
         async (archivePath) => {
-          const runtime = createBackupVerifyRuntime();
+          const runtime = createTestRuntime();
           await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
             options.error,
           );

--- a/src/commands/backup.atomic.test.ts
+++ b/src/commands/backup.atomic.test.ts
@@ -8,11 +8,11 @@ import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js"
 import {
   backupVerifyCommandMock,
   createMockTarStream,
-  createBackupTestRuntime,
   mockStateOnlyBackupPlan,
   resetBackupTempHome,
   tarCreateMock,
 } from "./backup.test-support.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const sleepMock = vi.hoisted(() => vi.fn(async (_ms: number) => {}));
 
@@ -53,7 +53,7 @@ describe("backupCreateCommand atomic archive write", () => {
     await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
     await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
 
-    const runtime = createBackupTestRuntime();
+    const runtime = createTestRuntime();
     const outputPath = path.join(archiveDir, params.outputName ?? "backup.tar.gz");
 
     await mockStateOnlyBackupPlan(stateDir);

--- a/src/commands/backup.create-verify.test.ts
+++ b/src/commands/backup.create-verify.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import { backupCreateCommand } from "./backup.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const createBackupArchiveMock = vi.hoisted(() => vi.fn());
 const backupVerifyCommandMock = vi.hoisted(() => vi.fn());
@@ -29,14 +30,6 @@ vi.mock("../runtime.js", async () => {
 vi.mock("../state/backup-run-records.js", () => ({
   recordBackupRunOutcome: recordBackupRunOutcomeMock,
 }));
-
-function createRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  } satisfies RuntimeEnv;
-}
 
 function requireBackupVerifyCall(): [RuntimeEnv, Record<string, unknown>] {
   const call = backupVerifyCommandMock.mock.calls[0];
@@ -75,7 +68,7 @@ describe("backupCreateCommand verify wrapper", () => {
       archivePath: "/tmp/openclaw-backup.tar.gz",
     });
 
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     const result = await backupCreateCommand(runtime, { verify: true });
 
     expect(result.verified).toBe(true);
@@ -101,7 +94,7 @@ describe("backupCreateCommand verify wrapper", () => {
     recordBackupRunOutcomeMock.mockImplementation(() => {
       throw new Error("record failed");
     });
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     await expect(backupCreateCommand(runtime)).rejects.toBe(backupError);
 

--- a/src/commands/backup.test-support.ts
+++ b/src/commands/backup.test-support.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { vi } from "vitest";
-import type { RuntimeEnv } from "../runtime.js";
 import { deleteTestEnvValue } from "../test-utils/env.js";
 import * as backupShared from "./backup-shared.js";
 
@@ -39,14 +38,6 @@ vi.mock("tar", () => ({
 vi.mock("./backup-verify.js", () => ({
   backupVerifyCommand: backupTestMocks.backupVerifyCommandMock,
 }));
-
-export function createBackupTestRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  } satisfies RuntimeEnv;
-}
 
 export async function resetBackupTempHome(tempHome: { home: string }) {
   await fs.rm(tempHome.home, { recursive: true, force: true });

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -17,11 +17,11 @@ import {
 import {
   backupVerifyCommandMock,
   createMockTarStream,
-  createBackupTestRuntime,
   mockStateOnlyBackupPlan,
   resetBackupTempHome,
   tarCreateMock,
 } from "./backup.test-support.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const { backupCreateCommand } = await import("./backup.js");
 
@@ -97,7 +97,7 @@ describe("backup commands", () => {
 
     const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH"]);
     setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    const runtime = createBackupTestRuntime();
+    const runtime = createTestRuntime();
     try {
       return await fn(runtime);
     } finally {
@@ -224,7 +224,7 @@ describe("backup commands", () => {
       await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
       await fs.writeFile(path.join(externalWorkspace, "SOUL.md"), "# external\n", "utf8");
 
-      const runtime = createBackupTestRuntime();
+      const runtime = createTestRuntime();
 
       const nowMs = Date.UTC(2026, 2, 9, 0, 0, 0);
       tarCreateMock.mockImplementationOnce(
@@ -326,7 +326,7 @@ describe("backup commands", () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backups-json-"));
     try {
-      const runtime = createBackupTestRuntime();
+      const runtime = createTestRuntime();
       await mockStateOnlyBackupPlan(stateDir);
       tarCreateMock.mockImplementationOnce(
         (
@@ -376,7 +376,7 @@ describe("backup commands", () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
 
-    const runtime = createBackupTestRuntime();
+    const runtime = createTestRuntime();
     await mockStateOnlyBackupPlan(stateDir);
 
     await expect(
@@ -391,7 +391,7 @@ describe("backup commands", () => {
     const outputPath = path.join(tempHome.home, "backups", "daily", "backup.tar.gz");
     await mockStateOnlyBackupPlan(stateDir);
 
-    const result = await backupCreateCommand(createBackupTestRuntime(), { output: outputPath });
+    const result = await backupCreateCommand(createTestRuntime(), { output: outputPath });
 
     expect(result.archivePath).toBe(outputPath);
     expect(await fs.readFile(outputPath, "utf8")).toBe("archive-bytes");
@@ -433,7 +433,7 @@ describe("backup commands", () => {
       }),
     );
 
-    const error = await backupCreateCommand(createBackupTestRuntime(), {
+    const error = await backupCreateCommand(createTestRuntime(), {
       output: outputPath,
     }).catch((caught: unknown) => caught);
 
@@ -453,7 +453,7 @@ describe("backup commands", () => {
     await fs.writeFile(outputParent, "file\n", "utf8");
     await mockStateOnlyBackupPlan(stateDir);
 
-    const error = await backupCreateCommand(createBackupTestRuntime(), {
+    const error = await backupCreateCommand(createTestRuntime(), {
       output: outputPath,
     }).catch((caught: unknown) => caught);
 
@@ -477,7 +477,7 @@ describe("backup commands", () => {
       await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
       await fs.symlink(stateDir, symlinkPath);
 
-      const runtime = createBackupTestRuntime();
+      const runtime = createTestRuntime();
       await mockStateOnlyBackupPlan(stateDir);
 
       await expect(
@@ -500,7 +500,7 @@ describe("backup commands", () => {
     const nowMs = Date.UTC(2026, 2, 9, 1, 2, 3);
     await writeWorkspaceBackupConfig(stateDir, workspaceDir);
 
-    const runtime = createBackupTestRuntime();
+    const runtime = createTestRuntime();
 
     const result = await backupCreateCommand(runtime, { nowMs });
 
@@ -516,7 +516,7 @@ describe("backup commands", () => {
         await fs.symlink(workspaceDir, workspaceLink);
         vi.mocked(process["cwd"]).mockReturnValue(workspaceLink);
         const symlinkNowMs = Date.UTC(2026, 2, 9, 1, 3, 4);
-        const symlinkResult = await backupCreateCommand(createBackupTestRuntime(), {
+        const symlinkResult = await backupCreateCommand(createTestRuntime(), {
           nowMs: symlinkNowMs,
         });
         expect(symlinkResult.archivePath).toBe(
@@ -536,7 +536,7 @@ describe("backup commands", () => {
     await fs.writeFile(existingArchive, "already here", "utf8");
     await mockStateOnlyBackupPlan(stateDir);
 
-    const runtime = createBackupTestRuntime();
+    const runtime = createTestRuntime();
 
     const result = await backupCreateCommand(runtime, {
       output: existingArchive,
@@ -629,7 +629,7 @@ describe("backup commands", () => {
     await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
     await fs.writeFile(path.join(stateDir, "credentials", "oauth.json"), "{}", "utf8");
 
-    const runtime = createBackupTestRuntime();
+    const runtime = createTestRuntime();
 
     const result = await backupCreateCommand(runtime, {
       dryRun: true,


### PR DESCRIPTION
## What Problem This Solves

Backup tests duplicate four runtime factories already provided by the shared command test helper.

## Why This Change Was Made

Use `createTestRuntime` at the existing allocation sites. Keep backup-specific tar mocks, output assertions, and cleanup unchanged; retain the distinct SQLite capture/throwing fixture.

## User Impact

No production behavior change or test cases added/removed. Six test/support files add 70 lines and remove 96.

## Evidence

The original baseline and final candidate each ran all six selected suites: 103 cases, 102 passed and the same Windows-only skip. Case inventory, order, and statuses match. Independent review found no actionable P0–P2 issues.

All 20 normal changed-file checks passed with source and dependencies unchanged.
