### PR TITLE
fix(computer): preserve CUA input evidence and scope guidance

### DIFF
--- a/docs/nodes/computer-use.md
+++ b/docs/nodes/computer-use.md
@@ -77,6 +77,10 @@ Loopback is also reachability, not identity: any process on the machine can conn
 
 The CUA descriptor advertises window, element, and browser targets; background and foreground delivery; image, accessibility, and browser observations; and recording. Peekaboo remains the default provider and does not advertise recording.
 
+CUA desktop input uses the foreground desktop route. `deliveryMode` selects a route only for window-targeted input; switching it on a desktop action does not change how that action is delivered. Desktop results preserve native effect and escalation evidence, identify their desktop scope, and indicate when a requested delivery mode is not applicable. An acknowledged input is not proof that the application responded: verify the intended visible change before repeating it.
+
+The pinned CUA driver supports key taps, not sustained keyboard holds. Its Linux `left_mouse_down` and `left_mouse_up` actions require a background window pixel target with `windowRef` and a current image-bearing `observationId`; desktop and element targets do not support those holds. Use only actions exposed by the selected node. For interactive applications, first verify that movement, activation, or another intended control changes the observed state before attempting a longer task.
+
 #### Browser profiles
 
 `browser_prepare` can launch a separate driver-owned Chromium process with a new ephemeral profile or a named isolated profile. It never modifies, copies, terminates, or attaches to the selected browser's existing profile. Existing-profile/CDP attachment is not exposed by this adapter; browser preparation is limited to isolated profiles.

--- a/extensions/cua-computer/src/commands.desktop.test.ts
+++ b/extensions/cua-computer/src/commands.desktop.test.ts
@@ -8,6 +8,63 @@ import { driver, execution, macOsEndpoint, result } from "./commands.test-helper
 import { ClickButton, ScrollDirection } from "./driver-client.js";
 
 describe("cua-computer desktop frames", () => {
+  it.each([
+    { action: "key", method: "pressKey", params: { keys: "up" } },
+    { action: "type", method: "typeText", params: { text: "hello" } },
+    { action: "left_click", method: "click", params: { x: 10, y: 20 } },
+    { action: "mouse_move", method: "moveCursor", params: { x: 10, y: 20 } },
+    {
+      action: "scroll",
+      method: "scroll",
+      params: { x: 10, y: 20, scrollDirection: "down" },
+    },
+    {
+      action: "left_click_drag",
+      method: "drag",
+      params: { fromX: 1, fromY: 2, x: 10, y: 20 },
+    },
+  ] as const)(
+    "preserves native effect evidence for desktop $action",
+    async ({ action, method, params }) => {
+      const input = driver();
+      input[method].mockResolvedValue({
+        ...result({}),
+        action: {
+          effect: 3,
+          route: 2,
+          delivery: { mode: 1 },
+          escalation: { target: 3, reason: 3 },
+        },
+      });
+      const computer = await execution(input.session);
+      try {
+        const screen = JSON.parse(await computer.snapshot('{"format":"png","maxWidth":100}'));
+        const frame =
+          action === "key" || action === "type"
+            ? {}
+            : { displayFrameId: screen.displayFrameId, refWidth: screen.width };
+        const response = JSON.parse(
+          await computer.act(
+            JSON.stringify({ action, ...params, ...frame, deliveryMode: "background" }),
+          ),
+        );
+        expect(response).toMatchObject({
+          ok: true,
+          effect: "suspected_noop",
+          escalation: { recommended: "desktop", reasonCode: "suspected_noop" },
+          details: {
+            route: "global_input",
+            deliveryMode: "foreground",
+            scope: "desktop",
+            deliveryModeApplicable: false,
+          },
+        });
+      } finally {
+        await computer.close("completion");
+      }
+    },
+  );
+
   it.each(
     (
       [

--- a/extensions/cua-computer/src/commands.ts
+++ b/extensions/cua-computer/src/commands.ts
@@ -19,7 +19,7 @@ import {
   type CuaDriverSession,
   type CuaToolResult,
 } from "./driver-client.js";
-import { platformActions, projectedToolDetails } from "./driver-result.js";
+import { actionEnvelope, platformActions, projectedToolDetails } from "./driver-result.js";
 import { createLazyCuaExecutionResources } from "./execution-resources.js";
 import {
   adoptGeneration,
@@ -264,33 +264,35 @@ async function handleDesktopAct(
   params: ComputerActParams,
   signal?: AbortSignal,
 ): Promise<string> {
+  // `wait` is local pacing in core and never reaches the native wire.
   if (!(CUA_WIRE_ACTION_NAMES as readonly string[]).includes(params.action)) {
     throw new Error(`COMPUTER_UNSUPPORTED_ACTION: ${params.action}`);
   }
   const desktopParams = params as CuaComputerActParams;
   assertPrimaryDisplay(desktopParams.screenIndex);
-  // `wait` never reaches the wire: core sleeps locally and the Swift wire enum
-  // has no wait case, so accepting it here would fork the computer.act contract.
-  if (
-    desktopParams.action === "hold_key" ||
-    desktopParams.action === "left_mouse_down" ||
-    desktopParams.action === "left_mouse_up"
-  ) {
-    // Upstream has no desktop keyboard-down API, and its Linux mouse hold tools
-    // are window-only, so these actions cannot preserve desktop-scope semantics.
-    throw new Error(`COMPUTER_UNSUPPORTED_ACTION: ${desktopParams.action}`);
+  if (desktopParams.action === "hold_key") {
+    throw new Error("COMPUTER_UNSUPPORTED_ACTION: hold_key; this driver supports key taps only");
+  }
+  if (desktopParams.action === "left_mouse_down" || desktopParams.action === "left_mouse_up") {
+    throw new Error(
+      `COMPUTER_UNSUPPORTED_ACTION: ${desktopParams.action}; ` +
+        (platform === "linux"
+          ? "requires a background window pixel target with windowRef and observationId"
+          : "held mouse buttons are unavailable on this platform"),
+    );
   }
 
   // Every action targets the primary desktop, a global SendInput/XTest/wayland_desktop
   // injection that is inherently foreground and ignores delivery_mode (that
   // background-vs-foreground contract is window-targeted only). We deliberately
   // never send delivery_mode.
+  let result: CuaToolResult;
   switch (desktopParams.action) {
     case "type": {
       if (!desktopParams.text) {
         throw new Error("COMPUTER_INVALID_REQUEST: text is required for type");
       }
-      assertToolSuccess(await driver.typeText(desktopParams.text, signal), "type_text");
+      result = assertToolSuccess(await driver.typeText(desktopParams.text, signal), "type_text");
       break;
     }
     case "key": {
@@ -298,7 +300,7 @@ async function handleDesktopAct(
       // and native Wayland by internally promoting a modifier chord to
       // hotkey_focused. No separate hotkey call is needed for chords.
       const chord = parseKeyChord(desktopParams.keys, platform);
-      assertToolSuccess(await driver.pressKey(chord, signal), "press_key");
+      result = assertToolSuccess(await driver.pressKey(chord, signal), "press_key");
       break;
     }
     case "scroll": {
@@ -322,7 +324,7 @@ async function handleDesktopAct(
         left: ScrollDirection.Left,
         right: ScrollDirection.Right,
       }[desktopParams.scrollDirection];
-      assertToolSuccess(
+      result = assertToolSuccess(
         await driver.scroll(
           {
             direction,
@@ -356,7 +358,7 @@ async function handleDesktopAct(
               : desktopParams.action === "triple_click"
                 ? 3
                 : 1;
-          assertToolSuccess(
+          result = assertToolSuccess(
             await driver.click(clickArgs(platform, frame, desktopParams, button, count), signal),
             "click",
           );
@@ -364,13 +366,13 @@ async function handleDesktopAct(
         }
         case "mouse_move": {
           const point = scalePoint(frame, desktopParams.x, desktopParams.y, desktopParams.action);
-          assertToolSuccess(await driver.moveCursor(point, signal), "move_cursor");
+          result = assertToolSuccess(await driver.moveCursor(point, signal), "move_cursor");
           break;
         }
         case "left_click_drag": {
           const from = scalePoint(frame, desktopParams.fromX, desktopParams.fromY, "drag start");
           const to = scalePoint(frame, desktopParams.x, desktopParams.y, "drag end");
-          assertToolSuccess(
+          result = assertToolSuccess(
             await driver.drag(
               {
                 fromX: from.x,
@@ -394,7 +396,12 @@ async function handleDesktopAct(
       }
     }
   }
-  return JSON.stringify({ ok: true });
+  return JSON.stringify(
+    actionEnvelope(result, {
+      scope: "desktop",
+      ...(desktopParams.deliveryMode ? { deliveryModeApplicable: false } : {}),
+    }),
+  );
 }
 
 export function createCuaComputerProvider(

--- a/src/agents/tools/computer-tool-guidance.test.ts
+++ b/src/agents/tools/computer-tool-guidance.test.ts
@@ -33,6 +33,7 @@ describe("computer tool guidance", () => {
     expect(description).toContain("observationId for window input");
     expect(description).toContain('`effect:"confirmed"` > `unverifiable` > `suspected_noop`');
     expect(description).toContain("never blind-retry a mutation");
+    expect(description).toContain("For window input");
     expect(description).toContain("untrusted input");
     expect(description).not.toMatch(
       /cua|peekaboo|\b(?:cli|mcp|daemon|socket|install(?:ation|ing)?)\b|verify_state|start_session|end_session|element_token|snapshot_id|window_id|delivery_mode/iu,
@@ -67,5 +68,14 @@ describe("computer tool guidance", () => {
     expect(windowBackground).toContain('deliveryMode:"background"');
     expect(windowBackground).toContain("background_occluded");
     expect(windowBackground).not.toMatch(/desktop coordinates|foreground|frameId/);
+  });
+
+  it("distinguishes key taps from advertised held-key support", () => {
+    const taps = buildComputerToolDescription(descriptor(["screenshot", "key"]));
+    expect(taps).toContain("key taps only");
+    expect(taps).not.toContain("`hold_key`");
+    const holds = buildComputerToolDescription(descriptor(["screenshot", "key", "hold_key"]));
+    expect(holds).toContain("`hold_key`");
+    expect(holds).not.toContain("key taps only");
   });
 });

--- a/src/agents/tools/computer-tool-guidance.ts
+++ b/src/agents/tools/computer-tool-guidance.ts
@@ -126,8 +126,12 @@ export function buildComputerToolDescription(
     hasImageObservation &&
     capabilities.targets.includes("screen") &&
     hasPixelAction;
-  const hasBackground = capabilities.deliveryModes.includes("background") && hasDeliveryAction;
-  const hasForeground = capabilities.deliveryModes.includes("foreground") && hasDeliveryAction;
+  const hasWindowDelivery =
+    hasWindowState && (capabilities.targets.includes("window") || hasElementTarget);
+  const hasBackground =
+    hasWindowDelivery && capabilities.deliveryModes.includes("background") && hasDeliveryAction;
+  const hasForeground =
+    hasWindowDelivery && capabilities.deliveryModes.includes("foreground") && hasDeliveryAction;
   const targetOrder = [
     ...(hasElementTarget ? ["elementRef from the latest observation"] : []),
     ...(hasWindowPixelTarget ? ["window coordinates from the latest observation"] : []),
@@ -152,9 +156,14 @@ export function buildComputerToolDescription(
       ? "Window inputs follow `details.coordinateSpace`: `image-pixels` uses the delivered image; accessibility bounds retain provider-native units."
       : "",
     hasBackground && hasForeground
-      ? 'Use `deliveryMode:"background"` first. Escalate to foreground only after that attempt reports ineffective or refused.'
+      ? 'For window input, use `deliveryMode:"background"` first. Escalate to foreground only after that attempt reports ineffective or refused.'
       : hasBackground
-        ? 'Use the advertised `deliveryMode:"background"` path.'
+        ? 'For window input, use the advertised `deliveryMode:"background"` path.'
+        : "",
+    advertisesAction(capabilities, "hold_key")
+      ? "Use `hold_key` for a bounded keyboard hold when sustained input is needed."
+      : advertisesAction(capabilities, "key")
+        ? "This node supports key taps only; sustained keyboard input is unavailable."
         : "",
     hasMutation
       ? 'Result precedence is `effect:"confirmed"` > `unverifiable` > `suspected_noop`; action evidence alone does not prove the user\'s goal. Re-observe before another mutation, and never blind-retry a mutation.'

--- a/src/agents/tools/computer-tool-schema.ts
+++ b/src/agents/tools/computer-tool-schema.ts
@@ -41,6 +41,7 @@ export function createComputerToolSchema(
   actions: readonly ComputerUseV2ActionName[],
   targetScope: "paired" | "session" = "paired",
 ) {
+  const supportsHold = actions.includes("hold_key");
   return Type.Object({
     action: stringEnum(actions),
     ...(targetScope === "paired"
@@ -80,7 +81,7 @@ export function createComputerToolSchema(
     text: Type.Optional(
       Type.String({
         description:
-          'type: text to type; key/hold_key: key combo such as "cmd+shift+t" or "Return"; ' +
+          `type: text to type; ${supportsHold ? "key/hold_key" : "key"}: key combo such as "cmd+shift+t" or "Return"; ` +
           'click/scroll actions: modifier keys to hold ("shift", "ctrl", "alt", "cmd").',
       }),
     ),
@@ -92,7 +93,9 @@ export function createComputerToolSchema(
     duration: optionalFiniteNumberSchema({
       minimum: 0,
       maximum: MAX_WAIT_SECONDS,
-      description: `Seconds. hold_key: >0 to ${MAX_HOLD_SECONDS}; wait: 0 to ${MAX_WAIT_SECONDS}.`,
+      description: supportsHold
+        ? `Seconds. hold_key: >0 to ${MAX_HOLD_SECONDS}; wait: 0 to ${MAX_WAIT_SECONDS}.`
+        : `Seconds. wait: 0 to ${MAX_WAIT_SECONDS}; this does not extend a key tap.`,
     }),
     screenIndex: optionalNonNegativeIntegerSchema(),
     frameId: Type.Optional(
@@ -122,7 +125,10 @@ export function createComputerToolSchema(
           "Window/browser input: observation id from the latest targeted observation; a desktop frameId cannot replace it.",
       }),
     ),
-    deliveryMode: optionalStringEnum(["background", "foreground"] as const),
+    deliveryMode: optionalStringEnum(["background", "foreground"] as const, {
+      description:
+        "Window-targeted input delivery. This does not turn desktop input into background window input.",
+    }),
     query: Type.Optional(Type.String()),
     depth: Type.Optional(Type.Integer({ minimum: 0, maximum: 64 })),
     maxElements: Type.Optional(Type.Integer({ minimum: 1, maximum: 2_000 })),

--- a/src/agents/tools/computer-tool.schema.test.ts
+++ b/src/agents/tools/computer-tool.schema.test.ts
@@ -102,6 +102,19 @@ describe("createComputerTool schema", () => {
     }
   });
 
+  it("does not describe held-key input when the selected session only supports taps", () => {
+    const tool = createComputerTool({
+      transport: {
+        computerUse: v2Descriptor(["screenshot", "key"]),
+        resolveNode: async () => ({ nodeId: "session-desktop" }),
+        invoke: async () => undefined,
+      },
+    });
+    expect(JSON.stringify(tool.parameters)).not.toContain("hold_key");
+    expect(readActionEnum(tool)).toContain("wait");
+    expect(JSON.stringify(createComputerTool().parameters)).toContain("hold_key");
+  });
+
   it("publishes Codex-compatible fixed-size coordinate arrays", () => {
     const properties = (
       createComputerTool().parameters as {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where CUA desktop actions discarded native effect and escalation evidence and returned only `ok:true`. Agents also saw held-key guidance on nodes that only support taps, and generic background-delivery advice encouraged changing a setting that does not affect CUA desktop input.

## Why This Change Was Made

Project direct SDK action results through the same existing action envelope as targeted window actions. Preserve effect, route, delivery and escalation evidence, identify desktop scope, and explicitly mark a requested delivery mode as inapplicable there.

Build held-key descriptions from the selected node's action list, scope background-delivery guidance to window input, and give actionable errors for unsupported desktop holds. This preserves Linux background window mouse holds and the existing native driver pin. No new held-input API or permission path is introduced.

## User Impact

Agents can distinguish a suspected no-op from an acknowledged input, see the actual delivery evidence, and avoid repeatedly toggling delivery mode on the same desktop route. Tap-only nodes no longer suggest that a duration parameter provides a sustained key hold.

## Evidence

- Regression tests failed before repair for all six direct SDK action paths because effect/escalation evidence was missing.
- Schema/guidance regressions failed before repair when a selected tap-only node still described `hold_key`.
- Focused desktop, modifier, CUA command, public computer schema, and guidance tests pass. Existing frame-authority and targeted-window behavior remain covered.
- Changed-file checks and independent P0–P2 review passed. Hosted CI is still running on the current head.
- This is adapter/contract proof against the existing driver. It does not claim that Doom is playable or that timed holds exist in CUA0.22.2.
