### PR TITLE
refactor(backups): await recording and prepare status freshness

### DIFF
--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -51,6 +51,14 @@ MCP App pinning retains its existing source-interaction checks. A delayed adapte
 revalidate that source authority at its actual write admission; checking view registration
 alone cannot replace the supported asynchronous interaction policy.
 
+Backup outcome recording and freshness reads expose asynchronous operations from
+the shared-state owner. Archive, SQLite snapshot, and Git backup commands await
+recording before reporting completion; a recording failure remains a warning and
+does not change the backup result. Status and Doctor await freshness before
+formatting it. These operations still execute synchronous SQLite internally;
+they retain the existing insertion-and-pruning transaction, 200-row limit, and
+non-creating freshness reads.
+
 Explicit session deletion, lifecycle-artifact cleanup, and history disk-budget
 eviction prepare their plans inside the session writer queue. When the parent database handle is cold, its
 existing asynchronous admission owner runs the full integrity and foreign-key

--- a/src/commands/backup-git.test.ts
+++ b/src/commands/backup-git.test.ts
@@ -115,9 +115,7 @@ describe("Git backup command agent selection", () => {
   });
 
   it("preserves the Git-specific warning when outcome recording fails", async () => {
-    mocks.recordBackupRunOutcome.mockImplementation(() => {
-      throw new Error("record failed");
-    });
+    mocks.recordBackupRunOutcome.mockRejectedValue(new Error("record failed"));
     const runtime = createTestRuntime();
 
     await backupGitCreateCommand(runtime, {

--- a/src/commands/backup-git.ts
+++ b/src/commands/backup-git.ts
@@ -147,7 +147,7 @@ export async function backupGitCreateCommand(runtime: RuntimeEnv, options: Backu
     });
     // A completed local backup remains successful even when requested remote replication fails;
     // pushFailed records that durable degradation without discarding the recoverable local commit.
-    recordBackupOutcomeBestEffort(runtime, {
+    await recordBackupOutcomeBestEffort(runtime, {
       kind: "git",
       archivePath: repositoryPath,
       status: "ok",
@@ -167,7 +167,7 @@ export async function backupGitCreateCommand(runtime: RuntimeEnv, options: Backu
     }
     return result;
   } catch (error) {
-    recordBackupOutcomeBestEffort(runtime, {
+    await recordBackupOutcomeBestEffort(runtime, {
       kind: "git",
       archivePath: repositoryPath,
       status: "failed",

--- a/src/commands/backup-health.ts
+++ b/src/commands/backup-health.ts
@@ -1,36 +1,13 @@
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import {
-  readLatestBackupRun,
-  readLatestSuccessfulBackupRun,
-  type BackupRunRecord,
-} from "../state/backup-run-records.js";
-import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { readBackupRunFreshness, type BackupRunFreshness } from "../state/backup-run-records.js";
 
 // Backups older than two weeks no longer provide a useful routine recovery point.
 const BACKUP_STALE_AFTER_MS = 14 * 24 * 60 * 60 * 1_000;
 
-type BackupFreshness = {
-  latest?: BackupRunRecord;
-  latestOk?: BackupRunRecord;
-};
-
-/** Read backup freshness without creating or repairing an absent state database. */
-export function readBackupFreshness(env: NodeJS.ProcessEnv): BackupFreshness {
-  return (
-    withExistingOpenClawStateDatabaseReadOnly(
-      ({ db }) => ({
-        latest: readLatestBackupRun(db),
-        latestOk: readLatestSuccessfulBackupRun(db),
-      }),
-      { env },
-    ) ?? {}
-  );
-}
-
 /** Format the compact status overview value for the latest backup attempt. */
 export function buildBackupStatusValue(params: {
-  freshness: BackupFreshness;
+  freshness: BackupRunFreshness;
   now?: number;
   formatTimeAgo: (ageMs: number) => string;
 }): string {
@@ -46,7 +23,7 @@ export function buildBackupStatusValue(params: {
 
 /** Build the informational Doctor hint for missing or stale successful backups. */
 function buildBackupDoctorHint(params: {
-  freshness: BackupFreshness;
+  freshness: BackupRunFreshness;
   now?: number;
 }): string | null {
   const latestOk = params.freshness.latestOk;
@@ -71,8 +48,8 @@ function buildBackupDoctorHint(params: {
 }
 
 /** Emit the non-repairing backup freshness hint when it applies. */
-export function noteBackupDoctorHint(env: NodeJS.ProcessEnv): void {
-  const hint = buildBackupDoctorHint({ freshness: readBackupFreshness(env) });
+export async function noteBackupDoctorHint(env: NodeJS.ProcessEnv): Promise<void> {
+  const hint = buildBackupDoctorHint({ freshness: await readBackupRunFreshness(env) });
   if (hint) {
     note(hint, "Backups");
   }

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -44,14 +44,14 @@ import { resolveStartupConfigSnapshot } from "./doctor/shared/automatic-startup-
 // Keep bounded headroom without disabling node-tar's decompression bomb guard.
 export const BACKUP_MAX_DECOMPRESSION_RATIO = 1100;
 
-export function recordBackupOutcomeBestEffort(
+export async function recordBackupOutcomeBestEffort(
   runtime: RuntimeEnv,
   params: Parameters<typeof recordBackupRunOutcome>[0],
-): void {
+): Promise<void> {
   try {
     // A rejected private input must not be reopened for best-effort outcome writes.
     assertNotUpdateCapturePath(resolveOpenClawStateSqlitePath(), resolveStateDir());
-    recordBackupRunOutcome(params);
+    await recordBackupRunOutcome(params);
   } catch (error) {
     const label = params.kind === "git" ? "Git backup" : "backup";
     runtime.error(

--- a/src/commands/backup-sqlite.ts
+++ b/src/commands/backup-sqlite.ts
@@ -89,7 +89,7 @@ export async function backupSqliteCreateCommand(
       snapshotPath: result.ref.path,
       manifest: result.manifest,
     };
-    recordBackupOutcomeBestEffort(runtime, {
+    await recordBackupOutcomeBestEffort(runtime, {
       kind: "sqlite-snapshot",
       archivePath: report.snapshotPath,
       status: "ok",
@@ -97,7 +97,7 @@ export async function backupSqliteCreateCommand(
     writeCreateResult(runtime, options, report);
     return report;
   } catch (error) {
-    recordBackupOutcomeBestEffort(runtime, {
+    await recordBackupOutcomeBestEffort(runtime, {
       kind: "sqlite-snapshot",
       archivePath: repositoryPath,
       status: "failed",

--- a/src/commands/backup.create-verify.test.ts
+++ b/src/commands/backup.create-verify.test.ts
@@ -1,5 +1,6 @@
 // Backup create/verify tests cover archive creation, runtime output, and verification failure handling.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { backupCreateCommand } from "./backup.js";
 import { createTestRuntime } from "./test-runtime-config-helpers.js";
@@ -49,7 +50,7 @@ describe("backupCreateCommand verify wrapper", () => {
     recordBackupRunOutcomeMock.mockReset();
   });
 
-  it("optionally verifies the archive after writing it", async () => {
+  it("verifies the archive and settles outcome recording before reporting completion", async () => {
     createBackupArchiveMock.mockResolvedValue({
       archivePath: "/tmp/openclaw-backup.tar.gz",
       archiveRoot: "openclaw-backup",
@@ -68,8 +69,19 @@ describe("backupCreateCommand verify wrapper", () => {
       archivePath: "/tmp/openclaw-backup.tar.gz",
     });
 
+    const recording = createDeferred();
+    const recordingStarted = createDeferred();
+    recordBackupRunOutcomeMock.mockImplementationOnce(() => {
+      recordingStarted.resolve();
+      return recording.promise;
+    });
     const runtime = createTestRuntime();
-    const result = await backupCreateCommand(runtime, { verify: true });
+    const pending = backupCreateCommand(runtime, { verify: true });
+    await recordingStarted.promise;
+    expect(runtime.log).not.toHaveBeenCalled();
+    recording.resolve();
+    const result = await pending;
+    expect(runtime.log).toHaveBeenCalledWith("backup ok");
 
     expect(result.verified).toBe(true);
     expect(backupVerifyCommandMock).toHaveBeenCalledOnce();
@@ -91,9 +103,7 @@ describe("backupCreateCommand verify wrapper", () => {
   it("does not claim completion when both backup and outcome recording fail", async () => {
     const backupError = new Error("snapshot failed");
     createBackupArchiveMock.mockRejectedValue(backupError);
-    recordBackupRunOutcomeMock.mockImplementation(() => {
-      throw new Error("record failed");
-    });
+    recordBackupRunOutcomeMock.mockRejectedValue(new Error("record failed"));
     const runtime = createTestRuntime();
 
     await expect(backupCreateCommand(runtime)).rejects.toBe(backupError);

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -44,7 +44,7 @@ export async function backupCreateCommand(
       result.verified = true;
     }
     if (!opts.dryRun) {
-      recordBackupOutcomeBestEffort(runtime, {
+      await recordBackupOutcomeBestEffort(runtime, {
         kind: "archive",
         archivePath,
         status: "ok",
@@ -58,7 +58,7 @@ export async function backupCreateCommand(
     return result;
   } catch (error) {
     if (!opts.dryRun) {
-      recordBackupOutcomeBestEffort(runtime, {
+      await recordBackupOutcomeBestEffort(runtime, {
         kind: "archive",
         archivePath,
         status: "failed",

--- a/src/commands/status-json-runtime.test.ts
+++ b/src/commands/status-json-runtime.test.ts
@@ -5,7 +5,7 @@ import { createStatusScanResultFixture } from "./status.test-support.ts";
 
 const mocks = vi.hoisted(() => ({
   buildStatusJsonPayload: vi.fn((input) => ({ built: true, input })),
-  readBackupFreshness: vi.fn(() => ({
+  readBackupRunFreshness: vi.fn(async () => ({
     latest: {
       id: "backup-1",
       createdAt: 123,
@@ -17,8 +17,8 @@ const mocks = vi.hoisted(() => ({
   resolveStatusRuntimeSnapshot: vi.fn(),
 }));
 
-vi.mock("./backup-health.js", () => ({
-  readBackupFreshness: mocks.readBackupFreshness,
+vi.mock("../state/backup-run-records.js", () => ({
+  readBackupRunFreshness: mocks.readBackupRunFreshness,
 }));
 
 vi.mock("./status-json-payload.ts", () => ({
@@ -106,7 +106,7 @@ describe("status-json-runtime", () => {
       suppressHealthErrors: undefined,
     });
     expect(mocks.buildStatusJsonPayload).toHaveBeenCalledOnce();
-    expect(mocks.readBackupFreshness).toHaveBeenCalledWith(scan.env);
+    expect(mocks.readBackupRunFreshness).toHaveBeenCalledWith(scan.env);
     const payloadInput = requireStatusPayloadInput();
     expect(payloadInput.surface.gatewayConnection).toStrictEqual({
       url: "ws://127.0.0.1:18789",
@@ -132,7 +132,7 @@ describe("status-json-runtime", () => {
     expect(result).toEqual({
       built: true,
       input: payloadInput,
-      backups: mocks.readBackupFreshness(),
+      backups: await mocks.readBackupRunFreshness(),
     });
   });
 
@@ -165,7 +165,7 @@ describe("status-json-runtime", () => {
       suppressHealthErrors: undefined,
     });
     expect(mocks.buildStatusJsonPayload).toHaveBeenCalledOnce();
-    expect(mocks.readBackupFreshness).toHaveBeenCalledWith({});
+    expect(mocks.readBackupRunFreshness).toHaveBeenCalledWith({});
     const payloadInput = requireStatusPayloadInput();
     expect(payloadInput.surface.gatewayProbeAuth).toStrictEqual({ token: "tok" });
     expect(payloadInput.securityAudit).toBeUndefined();

--- a/src/commands/status-json-runtime.ts
+++ b/src/commands/status-json-runtime.ts
@@ -1,7 +1,7 @@
 // Resolves runtime-only inputs for status JSON after the fast scan completes.
 // Keeps gateway health, usage, security audit, and service summaries behind explicit option gates.
 
-import { readBackupFreshness } from "./backup-health.js";
+import { readBackupRunFreshness } from "../state/backup-run-records.js";
 import { buildStatusJsonPayload } from "./status-json-payload.ts";
 import { buildStatusOverviewSurfaceFromScan } from "./status-overview-surface.ts";
 import { resolveStatusRuntimeSnapshot } from "./status-runtime-shared.ts";
@@ -53,7 +53,7 @@ export async function resolveStatusJsonOutput(params: {
     lastHeartbeat,
     pluginCompatibility: params.includePluginCompatibility ? scan.pluginCompatibility : undefined,
   });
-  const backups = readBackupFreshness(scan.env ?? {});
+  const backups = await readBackupRunFreshness(scan.env ?? {});
   if (backups.latest || backups.latestOk) {
     Object.assign(payload, { backups });
   }

--- a/src/commands/status-overview-rows.ts
+++ b/src/commands/status-overview-rows.ts
@@ -6,9 +6,10 @@ import { resolveIsNixMode } from "../config/paths.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
+import type { BackupRunFreshness } from "../state/backup-run-records.js";
 import type { StatusSummary } from "../status/types.js";
 import { VERSION } from "../version.js";
-import { buildBackupStatusValue, readBackupFreshness } from "./backup-health.js";
+import { buildBackupStatusValue } from "./backup-health.js";
 import type { HealthSummary } from "./health.js";
 import {
   buildStatusOverviewRowsFromSurface,
@@ -82,6 +83,7 @@ function buildStatusDegradationRows(
 export function buildStatusCommandOverviewRows(
   params: {
     env: NodeJS.ProcessEnv;
+    backupFreshness: BackupRunFreshness;
     opts: {
       deep?: boolean;
     };
@@ -191,7 +193,7 @@ export function buildStatusCommandOverviewRows(
       {
         Item: "Backups",
         Value: buildBackupStatusValue({
-          freshness: readBackupFreshness(params.env),
+          freshness: params.backupFreshness,
           formatTimeAgo: params.formatTimeAgo,
         }),
       },

--- a/src/commands/status.command-report-data.test.ts
+++ b/src/commands/status.command-report-data.test.ts
@@ -2,6 +2,8 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import * as backupRunRecords from "../state/backup-run-records.js";
 import { buildStatusCommandReportData } from "./status.command-report-data.ts";
 import { createStatusCommandReportDataParams } from "./status.test-support.ts";
 
@@ -52,6 +54,25 @@ describe("buildStatusCommandReportData", () => {
       expect(stripAnsi(row.Value)).toBe(expected);
     },
   );
+
+  it("awaits backup freshness before assembling the overview", async () => {
+    const freshness = createDeferred<backupRunRecords.BackupRunFreshness>();
+    vi.spyOn(backupRunRecords, "readBackupRunFreshness").mockReturnValueOnce(freshness.promise);
+    const pending = buildStatusCommandReportData(createStatusCommandReportDataParams());
+    freshness.resolve({
+      latest: {
+        id: "failed-backup",
+        createdAt: Date.now(),
+        archivePath: "/backups/archive.tar.gz",
+        status: "failed",
+        kind: "archive",
+      },
+    });
+    const report = await pending;
+    expect(report.overviewRows.find(({ Item }) => Item === "Backups")?.Value).toBe(
+      "last attempt failed just now (archive)",
+    );
+  });
 
   it("builds report inputs from shared status surfaces", async () => {
     const baseParams = createStatusCommandReportDataParams();

--- a/src/commands/status.command-report-data.ts
+++ b/src/commands/status.command-report-data.ts
@@ -17,6 +17,7 @@ import {
 import { formatPluginCompatibilityNotice } from "../plugins/status-compatibility.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
 import type { SecurityAuditReport } from "../security/audit.js";
+import { readBackupRunFreshness } from "../state/backup-run-records.js";
 import type { StatusSummary } from "../status/types.js";
 import { formatHealthChannelLines } from "./health-format.js";
 import type { HealthSummary } from "./health.js";
@@ -89,6 +90,7 @@ export async function buildStatusCommandReportData(params: {
   const muted = (value: string) => theme.muted(value);
   const overviewRows = buildStatusCommandOverviewRows({
     env: params.env,
+    backupFreshness: await readBackupRunFreshness(params.env),
     opts: params.opts,
     surface: params.surface,
     osLabel: params.osSummary.label,

--- a/src/commands/status.test-support.ts
+++ b/src/commands/status.test-support.ts
@@ -257,6 +257,7 @@ export function createStatusCommandOverviewRowsParams(
   overrides: Partial<StatusCommandOverviewRowsParams> = {},
 ): StatusCommandOverviewRowsParams {
   return {
+    backupFreshness: {},
     env: { OPENCLAW_STATE_DIR: STATUS_TEST_STATE_DIR },
     opts: { deep: true },
     surface: baseStatusOverviewSurface,

--- a/src/commands/status.usage-routing.test.ts
+++ b/src/commands/status.usage-routing.test.ts
@@ -85,9 +85,9 @@ vi.mock("./status-all/gateway.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./status-all/gateway.js")>()),
   readFileTailLines: async () => [],
 }));
-vi.mock("./backup-health.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./backup-health.js")>()),
-  readBackupFreshness: () => ({}),
+vi.mock("../state/backup-run-records.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../state/backup-run-records.js")>()),
+  readBackupRunFreshness: async () => ({}),
 }));
 vi.mock("../security/audit.runtime.js", () => ({
   runSecurityAudit: async () => ({

--- a/src/flows/doctor-health-contribution-runners.state.ts
+++ b/src/flows/doctor-health-contribution-runners.state.ts
@@ -101,7 +101,7 @@ export async function runStateIntegrityHealth(ctx: DoctorHealthFlowContext): Pro
   await noteStateIntegrity(ctx.cfg, ctx.prompter, ctx.configPath, {
     stateDirExistedAtStart: ctx.stateDirExistedAtStart,
   });
-  noteBackupDoctorHint(ctx.env ?? process.env);
+  await noteBackupDoctorHint(ctx.env ?? process.env);
 }
 
 export async function runCodexSessionRouteHealth(ctx: DoctorHealthFlowContext): Promise<void> {

--- a/src/snapshot/git-backup.test.ts
+++ b/src/snapshot/git-backup.test.ts
@@ -6,9 +6,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/engine-storage.js";
 import { formatCliOperatorError } from "../cli/failure-output.js";
 import { backupGitCreateCommand, backupGitLogCommand } from "../commands/backup-git.js";
-import { readBackupFreshness } from "../commands/backup-health.js";
 import { createTestRuntime } from "../commands/test-runtime-config-helpers.js";
 import { executeGitCommand, requireGitCommand as requireGit } from "../infra/git-exec.js";
+import { readBackupRunFreshness } from "../state/backup-run-records.js";
 import { writeConfigMachineState } from "../state/config-machine-state-write.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
@@ -600,7 +600,7 @@ describe("Git-backed SQLite snapshots", () => {
         `Warning: Git backup committed, but push failed: ${result.pushWarning}`,
       );
 
-      const persisted = readBackupFreshness(process.env).latest?.error;
+      const persisted = (await readBackupRunFreshness(process.env)).latest?.error;
       expect(persisted).toBe(result.pushWarning);
     });
   });
@@ -767,7 +767,7 @@ describe("Git-backed SQLite snapshots", () => {
 
       expect(result).toMatchObject({ noChanges: false, pushed: false, pushWarning: warning });
       expect(result.commit).toMatch(/^[a-f0-9]{40}$/u);
-      expect(readBackupFreshness(process.env)).toMatchObject({
+      expect(await readBackupRunFreshness(process.env)).toMatchObject({
         latest: { status: "ok", kind: "git", pushFailed: true, error: warning },
         latestOk: { status: "ok", kind: "git", pushFailed: true, error: warning },
       });

--- a/src/state/backup-run-records.test.ts
+++ b/src/state/backup-run-records.test.ts
@@ -2,12 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  buildBackupStatusValue,
-  noteBackupDoctorHint,
-  readBackupFreshness,
-} from "../commands/backup-health.js";
-import { recordBackupRunOutcome } from "./backup-run-records.js";
+import { buildBackupStatusValue, noteBackupDoctorHint } from "../commands/backup-health.js";
+import { readBackupRunFreshness, recordBackupRunOutcome } from "./backup-run-records.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -44,7 +40,7 @@ afterEach(async () => {
 describe("backup run records", () => {
   it("records archive and Git outcomes and prunes the operational log to 200 rows", async () => {
     const env = await testEnv({ bootstrap: true });
-    recordBackupRunOutcome({
+    await recordBackupRunOutcome({
       env,
       archivePath: "/backups/archive.tar.gz",
       status: "failed",
@@ -53,7 +49,7 @@ describe("backup run records", () => {
       createdAt: 1,
     });
     for (let index = 2; index <= 202; index += 1) {
-      recordBackupRunOutcome({
+      await recordBackupRunOutcome({
         env,
         archivePath: "/backups/git",
         status: "ok",
@@ -80,15 +76,39 @@ describe("backup run records", () => {
       target: "commit-202",
       pushFailed: true,
     });
-    expect(readBackupFreshness(env)).toMatchObject({
-      latest: { createdAt: 202, pushFailed: true },
+    await recordBackupRunOutcome({
+      env,
+      archivePath: "/backups/failed.tar.gz",
+      kind: "archive",
+      status: "failed",
+      createdAt: 203,
+    });
+    expect(await readBackupRunFreshness(env)).toMatchObject({
+      latest: { createdAt: 203, status: "failed" },
       latestOk: { createdAt: 202, pushFailed: true },
     });
   });
 
+  it("binds each outcome and read to its requested state directory", async () => {
+    const firstEnv = await testEnv({ bootstrap: true });
+    const secondEnv = await testEnv({ bootstrap: true });
+    const mutableEnv = { ...firstEnv };
+    const pending = recordBackupRunOutcome({
+      env: mutableEnv,
+      archivePath: "/backups/first.tar.gz",
+      status: "ok",
+      kind: "archive",
+    });
+    mutableEnv.OPENCLAW_STATE_DIR = secondEnv.OPENCLAW_STATE_DIR;
+    await pending;
+    const reading = readBackupRunFreshness(firstEnv);
+    expect(await readBackupRunFreshness(secondEnv)).toEqual({});
+    expect(await reading).toMatchObject({ latest: { archivePath: "/backups/first.tar.gz" } });
+  });
+
   it("does not split surrogate pairs at the persisted diagnostic limit", async () => {
     const env = await testEnv({ bootstrap: true });
-    recordBackupRunOutcome({
+    await recordBackupRunOutcome({
       env,
       archivePath: "/backups/git",
       status: "ok",
@@ -98,7 +118,7 @@ describe("backup run records", () => {
       createdAt: 1,
     });
 
-    const persisted = readBackupFreshness(env).latest?.error;
+    const persisted = (await readBackupRunFreshness(env)).latest?.error;
     expect(persisted).toBe("x".repeat(1_199));
   });
 
@@ -110,12 +130,18 @@ describe("backup run records", () => {
     const raw = new DatabaseSync(resolveOpenClawStateSqlitePath(env));
     raw.exec("DROP TABLE backup_runs");
     raw.close();
-    expect(readBackupFreshness(env)).toEqual({});
+    expect(await readBackupRunFreshness(env)).toEqual({});
   });
 
   it("keeps absent status reads read-only and formats none, failed, fresh, and stale states", async () => {
     const env = await testEnv();
-    expect(readBackupFreshness(env)).toEqual({});
+    await recordBackupRunOutcome({
+      env,
+      archivePath: "/backups/failed.tar.gz",
+      kind: "archive",
+      status: "failed",
+    });
+    expect(await readBackupRunFreshness(env)).toEqual({});
     await expect(fs.access(resolveOpenClawStateSqlitePath(env))).rejects.toMatchObject({
       code: "ENOENT",
     });
@@ -135,7 +161,7 @@ describe("backup run records", () => {
         formatTimeAgo,
       }),
     ).toBe("last attempt failed 72h ago (archive)");
-    noteBackupDoctorHint(env);
+    await noteBackupDoctorHint(env);
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("No successful backup is recorded."),
       "Backups",
@@ -145,7 +171,7 @@ describe("backup run records", () => {
     // recording phase the way a real gateway host already has.
     runOpenClawStateWriteTransaction(() => undefined, { env });
     vi.spyOn(Date, "now").mockReturnValue(1_000);
-    recordBackupRunOutcome({
+    await recordBackupRunOutcome({
       env,
       archivePath: "/backup",
       status: "ok",
@@ -153,17 +179,17 @@ describe("backup run records", () => {
       createdAt: 1,
     });
     mocks.note.mockClear();
-    noteBackupDoctorHint(env);
+    await noteBackupDoctorHint(env);
     expect(mocks.note).not.toHaveBeenCalled();
 
     vi.mocked(Date.now).mockReturnValue(1 + 15 * 24 * 3_600_000);
-    noteBackupDoctorHint(env);
+    await noteBackupDoctorHint(env);
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("more than 14 days old"),
       "Backups",
     );
 
-    recordBackupRunOutcome({
+    await recordBackupRunOutcome({
       env,
       archivePath: "/backups/git",
       status: "ok",
@@ -171,7 +197,7 @@ describe("backup run records", () => {
       pushFailed: true,
       createdAt: 2,
     });
-    const pushFailed = readBackupFreshness(env);
+    const pushFailed = await readBackupRunFreshness(env);
     expect(
       buildBackupStatusValue({
         freshness: pushFailed,
@@ -181,7 +207,7 @@ describe("backup run records", () => {
     ).toBe("last ok 1h ago (git, push failing)");
     mocks.note.mockClear();
     vi.mocked(Date.now).mockReturnValue(3_600_002);
-    noteBackupDoctorHint(env);
+    await noteBackupDoctorHint(env);
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringMatching(/configured Git remote.*\/backups\/git/su),
       "Backups",

--- a/src/state/backup-run-records.ts
+++ b/src/state/backup-run-records.ts
@@ -8,6 +8,7 @@ import {
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { BACKUP_RUN_ERROR_MAX_LENGTH } from "./backup-run-records.contract.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateDatabase } from "./openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
@@ -17,7 +18,7 @@ type BackupRunDatabase = Pick<OpenClawStateDatabase, "backup_runs">;
 
 type BackupRunKind = "archive" | "sqlite-snapshot" | "git";
 
-export type BackupRunRecord = {
+type BackupRunRecord = {
   id: string;
   createdAt: number;
   archivePath: string;
@@ -26,6 +27,11 @@ export type BackupRunRecord = {
   target?: string;
   error?: string;
   pushFailed?: true;
+};
+
+export type BackupRunFreshness = {
+  latest?: BackupRunRecord;
+  latestOk?: BackupRunRecord;
 };
 
 function boundedText(value: string | undefined, maxLength: number): string | undefined {
@@ -69,7 +75,7 @@ function parseBackupRun(row: {
 }
 
 /** Record one best-effort backup outcome in the shared bounded operational log. */
-export function recordBackupRunOutcome(params: {
+export async function recordBackupRunOutcome(params: {
   archivePath: string;
   status: "ok" | "failed";
   kind: BackupRunKind;
@@ -78,11 +84,12 @@ export function recordBackupRunOutcome(params: {
   pushFailed?: boolean;
   createdAt?: number;
   env?: NodeJS.ProcessEnv;
-}): void {
+}): Promise<void> {
+  const databasePath = resolveOpenClawStateSqlitePath(params.env ?? process.env);
   // Best-effort log only: never bootstrap an absent state database to record an
   // outcome, or a failed backup on a fresh host would create a blank DB that a
   // retry then treats as real backup input.
-  if (!existsSync(resolveOpenClawStateSqlitePath(params.env ?? process.env))) {
+  if (!existsSync(databasePath)) {
     return;
   }
   const manifest = JSON.stringify({
@@ -93,19 +100,17 @@ export function recordBackupRunOutcome(params: {
       : {}),
     ...(params.pushFailed === true ? { pushFailed: true } : {}),
   });
+  const row = {
+    id: randomUUID(),
+    created_at: params.createdAt ?? Date.now(),
+    archive_path: params.archivePath,
+    status: params.status,
+    manifest_json: manifest,
+  };
   runOpenClawStateWriteTransaction(
     ({ db }) => {
       const kysely = getNodeSqliteKysely<BackupRunDatabase>(db);
-      executeSqliteQuerySync(
-        db,
-        kysely.insertInto("backup_runs").values({
-          id: randomUUID(),
-          created_at: params.createdAt ?? Date.now(),
-          archive_path: params.archivePath,
-          status: params.status,
-          manifest_json: manifest,
-        }),
-      );
+      executeSqliteQuerySync(db, kysely.insertInto("backup_runs").values(row));
       // This is a bounded operational log. Hourly scheduled backups must not grow it forever.
       executeSqliteQuerySync(
         db,
@@ -124,7 +129,7 @@ export function recordBackupRunOutcome(params: {
           ),
       );
     },
-    { env: params.env },
+    { env: params.env, path: databasePath },
   );
 }
 
@@ -147,12 +152,12 @@ function readBackupRun(database: DatabaseSync, status?: "ok"): BackupRunRecord |
   return row ? parseBackupRun(row) : undefined;
 }
 
-/** Read the newest recorded backup attempt from an already-open database. */
-export function readLatestBackupRun(database: DatabaseSync): BackupRunRecord | undefined {
-  return readBackupRun(database);
-}
-
-/** Read the newest successful backup from an already-open database. */
-export function readLatestSuccessfulBackupRun(database: DatabaseSync): BackupRunRecord | undefined {
-  return readBackupRun(database, "ok");
+/** Read backup freshness without creating or repairing an absent state database. */
+export async function readBackupRunFreshness(env: NodeJS.ProcessEnv): Promise<BackupRunFreshness> {
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(
+      ({ db }) => ({ latest: readBackupRun(db), latestOk: readBackupRun(db, "ok") }),
+      { env, path: resolveOpenClawStateSqlitePath(env) },
+    ) ?? {}
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

Backup commands and status reporting must wait for storage results as the shared SQLite owner adopts asynchronous execution. The current archive, SQLite snapshot, Git, status, and Doctor callers assume that backup outcome writes and freshness reads finish synchronously.

## Why This Change Was Made

The backup state owner now exposes asynchronous outcome recording and a single freshness operation that reads the latest attempt and latest successful run together. Backup commands await recording inside the existing best-effort error boundary; status and Doctor await freshness before formatting it. The synchronous overview renderer receives prepared facts instead of reading SQLite.

## User Impact

This is a prerequisite for moving shared-state operations off the main thread. SQLite still executes synchronously in this change. Backup output and the bounded 200-attempt history remain unchanged, missing databases are not created for logging or status, and a recording failure remains a warning without changing the backup result.

## Evidence

- Current-head hosted CI passed: [run 34666772631](https://github.com/openclaw/openclaw/actions/runs/34666772631), including Windows and the required aggregate gate.

- Current refreshed graph: 23 selected backup-recording, archive-ordering, text-status, and Commander-routing cases passed. The core typecheck shard-boundary guard and diff whitespace check also passed.
- Earlier retained backup, JSON/status, and Doctor sibling proof: 48 passed, with one existing Windows-only Git case skipped on macOS; the final focused follow-up passed 11 cases.
- The delayed-recording regression fails with the original archive command because success is printed before recording settles; the candidate passes.
- Independent P2 review was scoped-clean. The latest prerequisite rebase preserves the entire patch and all 19 candidate file contents; it introduces no new backup implementation changes.
- Earlier full changed-code checks passed, including production/test types, dead exports, lint, schema/legacy-store guards, and import cycles.
- An earlier canonical package build, tarball integrity, and import-graph check passed. The published 2026.9.3 updater installed that candidate package and completed candidate Doctor subprocesses; archive and SQLite backups recorded outcomes, JSON status returned freshness, and copied state passed integrity checks.

The latest head is based on main 47ce03dbc699 and includes the functional UI repair from #145415, speech-fixture ownership repair from #145406, and test-shard rebalance from #145431. The rebalance preserves exact test coverage and the existing 720-root cap. This is a prerequisite refresh, not an unchanged retry. Earlier speech watchdog failures and the successful unchanged rerun are retained; the original hosted timeout cause remains unproven, and the fixture repair adds ownership and diagnostic stage evidence.

Package/update proof remains bound to its recorded package and source, which used agent schema v19. Current main independently uses agent schema v20 and shared-state schema v17. The earlier matrix is not represented as a test of the v20 migration or a rebuild of this graph. Current-head CI completed successfully before native landing.

