### PR TITLE
refactor(agents): remove retired session statistics method

### DIFF
--- a/src/agents/sessions/agent-session-inspection.ts
+++ b/src/agents/sessions/agent-session-inspection.ts
@@ -3,7 +3,6 @@ import { dirname, resolve } from "node:path";
 import { isCompactionReplayCheckpoint } from "@openclaw/ai/transports";
 import { calculateContextTokens, estimateContextTokens } from "../runtime/index.js";
 import { AgentSessionModels } from "./agent-session-models.js";
-import type { SessionStats } from "./agent-session-types.js";
 import {
   estimateMessagesFromContent,
   extractTextContent,
@@ -23,54 +22,6 @@ export abstract class AgentSessionInspection extends AgentSessionModels {
   setSessionName(name: string): void {
     this.sessionManager.appendSessionInfo(name);
     this.emit({ type: "session_info_changed", name: this.sessionManager.getSessionName() });
-  }
-
-  /**
-   * Get session statistics.
-   */
-  getSessionStats(): SessionStats {
-    const state = this.state;
-    const userMessages = state.messages.filter((m) => m.role === "user").length;
-    const assistantMessages = state.messages.filter((m) => m.role === "assistant").length;
-    const toolResults = state.messages.filter((m) => m.role === "toolResult").length;
-
-    let toolCalls = 0;
-    let totalInput = 0;
-    let totalOutput = 0;
-    let totalCacheRead = 0;
-    let totalCacheWrite = 0;
-    let totalCost = 0;
-
-    for (const message of state.messages) {
-      if (message.role === "assistant") {
-        const assistantMsg = message;
-        toolCalls += assistantMsg.content.filter((c) => c.type === "toolCall").length;
-        totalInput += assistantMsg.usage.input;
-        totalOutput += assistantMsg.usage.output;
-        totalCacheRead += assistantMsg.usage.cacheRead;
-        totalCacheWrite += assistantMsg.usage.cacheWrite;
-        totalCost += assistantMsg.usage.cost.total;
-      }
-    }
-
-    return {
-      sessionFile: this.sessionFile,
-      sessionId: this.sessionId,
-      userMessages,
-      assistantMessages,
-      toolCalls,
-      toolResults,
-      totalMessages: state.messages.length,
-      tokens: {
-        input: totalInput,
-        output: totalOutput,
-        cacheRead: totalCacheRead,
-        cacheWrite: totalCacheWrite,
-        total: totalInput + totalOutput + totalCacheRead + totalCacheWrite,
-      },
-      cost: totalCost,
-      contextUsage: this.getContextUsage(),
-    };
   }
 
   getContextUsage(): ContextUsage | undefined {

--- a/src/agents/sessions/agent-session-types.ts
+++ b/src/agents/sessions/agent-session-types.ts
@@ -7,7 +7,6 @@ import type {
   ThinkingLevel,
 } from "../runtime/index.js";
 import type {
-  ContextUsage,
   ExtensionCommandContextActions,
   ExtensionErrorListener,
   ExtensionRunner,
@@ -124,18 +123,4 @@ export interface ModelCycleResult {
   thinkingLevel: ThinkingLevel;
   /** Whether the cycle used the scoped model list. */
   isScoped: boolean;
-}
-
-/** Session statistics exposed to session commands. */
-export interface SessionStats {
-  sessionFile: string | undefined;
-  sessionId: string;
-  userMessages: number;
-  assistantMessages: number;
-  toolCalls: number;
-  toolResults: number;
-  totalMessages: number;
-  tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
-  cost: number;
-  contextUsage?: ContextUsage;
 }


### PR DESCRIPTION
## What Problem This Solves

The agent-session implementation still carries an unused statistics method and result type after their public SDK exposure was retired. Keeping them adds dead runtime and type surface for maintainers to understand.

## Why This Change Was Made

Remove `getSessionStats`, `SessionStats`, and their now-unused imports. The SDK barrel deliberately stopped exporting the session class and type in #108440; both v2026.8.1 and v2026.9.4 already contain that cutover. Current extension contexts expose the active `getContextUsage` operation, which remains unchanged.

## User Impact

No user-visible behavior change. This removes 64 production lines and 2,017 source bytes, with no replacement helper, compatibility alias, or new state. It is a cleanup, not a measured request-latency improvement.

## Evidence

Repository references, current package/SDK exports, extension-context construction, and the historical barrel narrowing were checked. No consumer of the removed method or type remains. Independent Codex review is clean through P2.

All five existing context-usage tests passed against the candidate in isolated Linux/Node 24.19.0 validation. Formatting, diff checks, and the first 13 repository-selected changed checks passed. The fixed validation supervisor stopped the remaining check command at its 64-process observation cap during the core tsgo boundary check; core typechecking and later selected checks are not claimed as locally completed. All observed children closed and the Testbox lease was stopped. Exact-head hosted CI is required before landing.

An initial transport attempt failed while staging, before executing source or tests; its failure is retained separately. No source change, weakened assertion, raised resource cap, or timeout increase was used to get the passing focused tests.

The first hosted CI attempt hit the OpenAI telephony headers-stall test's one-second watchdog. The removed method/type are not on that path, and the speech test/provider/transport source are unchanged by this PR. The original failure is retained. One unchanged failed-job rerun passed, and exact-head hosted CI is green; no timeout or assertion was changed.
